### PR TITLE
Potential fix for code scanning alert no. 1: Disabling certificate validation

### DIFF
--- a/tests/integration/api-integration.test.js
+++ b/tests/integration/api-integration.test.js
@@ -343,7 +343,6 @@ This is a test post for data cascade.
       fs.writeFileSync(path.join(siteDir, 'https-server.js'), httpsScript);
       
       // Test HTTPS server (with self-signed cert warning suppressed)
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
       
       const serverProcess = spawn('node', ['https-server.js'], {
         cwd: siteDir,
@@ -363,7 +362,12 @@ This is a test post for data cascade.
       
       // Test HTTPS request
       const httpsResponse = await new Promise((resolve, reject) => {
-        const req = https.get('https://localhost:8443/', (res) => {
+        const req = https.get({
+          host: 'localhost',
+          port: 8443,
+          path: '/',
+          rejectUnauthorized: false
+        }, (res) => {
           let data = '';
           res.on('data', chunk => data += chunk);
           res.on('end', () => resolve({


### PR DESCRIPTION
Potential fix for [https://github.com/Anglesite/anglesite/security/code-scanning/1](https://github.com/Anglesite/anglesite/security/code-scanning/1)

To fix this problem, we should not disable certificate validation globally for the Node.js process. Instead, we can configure the single HTTPS request that connects to the test server to accept the self-signed certificate by passing `{ rejectUnauthorized: false }` in its request options. Remove the assignment `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';` (line 346). Change the usage of `https.get()` (line 366) to use options including `rejectUnauthorized: false` as shown in the CodeQL recommendation. This tightly scopes the nonstandard certificate trust to only this test HTTPS request, greatly reducing risk.

**Required changes:**
- Remove or comment out line 346: `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';`
- Change the HTTPS request in the test (line 366) to use the options argument: `{ host: 'localhost', port: 8443, path: '/', rejectUnauthorized: false }`
- Do not alter other usages of HTTPS in the file unless needed for this test.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
