### PR TITLE
Fix documentation reference from step 0b to 0c

### DIFF
--- a/skills/import/SKILL.md
+++ b/skills/import/SKILL.md
@@ -58,7 +58,7 @@ what you're about to do and why. The owner is non-technical.
 Use Glob to check for `src/content/config.ts`.
 
 If it exists, this project has already been scaffolded. Read `.site-config` to
-load `SITE_NAME` and `OWNER_NAME`. Skip to **0b**.
+load `SITE_NAME` and `OWNER_NAME`. Skip to **0c**.
 
 ### 0b — Scaffold if needed
 


### PR DESCRIPTION
## Summary
Updated an incorrect cross-reference in the skill import documentation that was pointing to the wrong step number.

## Changes
- Fixed step reference in `skills/import/SKILL.md` from "0b" to "0c" in the instruction that tells users to skip ahead after checking for existing scaffolding

## Details
The documentation instructs users to skip to a specific step after determining whether a project has already been scaffolded. The reference was pointing to step "0b" (Scaffold if needed) when it should point to step "0c" based on the document structure. This correction ensures users follow the proper workflow sequence.

https://claude.ai/code/session_01PgYW51VT2rgydToEL7SHGP