### PR TITLE
Add plugin zip packaging and GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release plugin
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Verify versions match
+        run: |
+          PLUGIN_VERSION="$(node -p "require('./.claude-plugin/plugin.json').version")"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$PLUGIN_VERSION" != "$TAG_VERSION" ]]; then
+            echo "::error::plugin.json version ($PLUGIN_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+          if [[ "$PKG_VERSION" != "$TAG_VERSION" ]]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Pack plugin zip
+        run: bash scripts/pack-plugin.sh
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          ZIP="dist/anglesite-${TAG}.zip"
+          gh release create "$TAG" "$ZIP" \
+            --title "Anglesite $TAG" \
+            --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+dist/
 site/
 template/node_modules/
 template/dist/

--- a/scripts/pack-plugin.sh
+++ b/scripts/pack-plugin.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build a distributable .zip of the Anglesite plugin.
+# Usage: bash scripts/pack-plugin.sh          → outputs dist/anglesite-v0.13.0.zip
+#        bash scripts/pack-plugin.sh --dir /tmp → outputs /tmp/anglesite-v0.13.0.zip
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="$(node -p "require('$REPO_ROOT/.claude-plugin/plugin.json').version")"
+OUTDIR="${REPO_ROOT}/dist"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir) OUTDIR="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+ZIPNAME="anglesite-v${VERSION}.zip"
+mkdir -p "$OUTDIR"
+
+# Build zip from repo root, including only plugin-relevant files.
+cd "$REPO_ROOT"
+zip -r "$OUTDIR/$ZIPNAME" \
+  .claude-plugin/ \
+  skills/ \
+  hooks/ \
+  scripts/scaffold.sh \
+  scripts/pre-deploy-check.sh \
+  settings.json \
+  docs/ \
+  template/ \
+  bin/init.js \
+  LICENSE \
+  README.md \
+  -x "docs/.DS_Store" "template/node_modules/*" "**/.DS_Store"
+
+echo "Packed $OUTDIR/$ZIPNAME ($(du -h "$OUTDIR/$ZIPNAME" | cut -f1))"


### PR DESCRIPTION
scripts/pack-plugin.sh builds a distributable .zip containing only plugin-relevant files (skills, hooks, docs, template, scripts, bin). The GitHub Actions workflow runs on version tags, verifies plugin.json and package.json versions match the tag, then creates a GitHub release with the zip attached.

Users can download the zip and drag it into Claude Desktop's plugin upload dialog instead of cloning the repo.

https://claude.ai/code/session_01EjQzQU5Czx6m48bdR6JgV4