### PR TITLE
Add full test coverage with Vitest

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "astro-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--prefix", "template"],
+      "port": 4321
+    },
+    {
+      "name": "astro-preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "preview", "--prefix", "template"],
+      "port": 4321
+    }
+  ]
+}

--- a/bin/average-tokens.ts
+++ b/bin/average-tokens.ts
@@ -17,14 +17,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // Tunable constants
 // ---------------------------------------------------------------------------
 
-const SESSION = {
+export const SESSION = {
   turns: 30,
   systemPromptTokens: 2000,
   avgNewContentPerTurn: 850,
   outputTokens: 25_000,
 };
 
-const PRICING: Record<string, { label: string; input: number; output: number; cached: number }> = {
+export const PRICING: Record<string, { label: string; input: number; output: number; cached: number }> = {
   opus:   { label: "Opus",   input: 15,  output: 75, cached: 1.875 },
   sonnet: { label: "Sonnet", input: 3,   output: 15, cached: 0.375 },
 };
@@ -51,21 +51,21 @@ function bytes(relativePath: string): number {
   return statSync(join(PLUGIN_ROOT, relativePath)).size;
 }
 
-function tokens(byteCount: number): number {
+export function tokens(byteCount: number): number {
   return Math.ceil(byteCount / 4);
 }
 
-function fmt(n: number): string {
+export function fmt(n: number): string {
   return n.toLocaleString("en-US");
 }
 
-function fmtK(n: number): string {
+export function fmtK(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
   return fmt(n);
 }
 
-function fmtDollars(n: number): string {
+export function fmtDollars(n: number): string {
   return `$${n.toFixed(2)}`;
 }
 
@@ -73,14 +73,14 @@ function fmtDollars(n: number): string {
 // Measure
 // ---------------------------------------------------------------------------
 
-interface FileMeasurement {
+export interface FileMeasurement {
   label: string;
   path: string;
   bytes: number;
   tokens: number;
 }
 
-interface SmbStats {
+export interface SmbStats {
   count: number;
   totalBytes: number;
   avgBytes: number;
@@ -89,7 +89,7 @@ interface SmbStats {
   maxBytes: number;
 }
 
-interface Measurements {
+export interface Measurements {
   alwaysLoaded: FileMeasurement[];
   command: FileMeasurement[];
   step1: FileMeasurement[];
@@ -149,7 +149,7 @@ function measure(): Measurements {
 // Model
 // ---------------------------------------------------------------------------
 
-interface SessionCost {
+export interface SessionCost {
   label: string;
   cachedInput: number;
   uncachedInput: number;
@@ -158,7 +158,7 @@ interface SessionCost {
   cost: number;
 }
 
-function model(m: Measurements): { contextPerTurn: number; costs: SessionCost[] } {
+export function model(m: Measurements): { contextPerTurn: number; costs: SessionCost[] } {
   const alwaysTokens = SESSION.systemPromptTokens
     + m.alwaysLoaded.reduce((s, f) => s + f.tokens, 0);
 
@@ -347,4 +347,7 @@ function main() {
   console.log("\nREADME.md updated.");
 }
 
-main();
+// Only run when executed directly
+if (process.argv[1]?.endsWith("average-tokens.ts")) {
+  main();
+}

--- a/bin/build-instructions.ts
+++ b/bin/build-instructions.ts
@@ -22,19 +22,19 @@ const ROOT = join(__dirname, "..");
 // Constants
 // ---------------------------------------------------------------------------
 
-const CODEX_MAX_BYTES = 32_768;
-const WARN_SKILL_BYTES = 8_192;
+export const CODEX_MAX_BYTES = 32_768;
+export const WARN_SKILL_BYTES = 8_192;
 
 // Approximate: 1 token ≈ 4 bytes for English text
-function tokens(bytes: number): number {
+export function tokens(bytes: number): number {
   return Math.ceil(bytes / 4);
 }
 
-function fmt(n: number): string {
+export function fmt(n: number): string {
   return n.toLocaleString("en-US");
 }
 
-function fmtKB(bytes: number): string {
+export function fmtKB(bytes: number): string {
   return `${(bytes / 1024).toFixed(1)}KB`;
 }
 
@@ -42,7 +42,7 @@ function fmtKB(bytes: number): string {
 // Measure files
 // ---------------------------------------------------------------------------
 
-interface FileInfo {
+export interface FileInfo {
   path: string;
   label: string;
   bytes: number;
@@ -65,12 +65,12 @@ function measureFile(relativePath: string, label?: string): FileInfo | null {
 // Validation checks
 // ---------------------------------------------------------------------------
 
-interface Issue {
+export interface Issue {
   level: "error" | "warn";
   message: string;
 }
 
-function validateCodexLimit(agentsMd: FileInfo | null): Issue[] {
+export function validateCodexLimit(agentsMd: FileInfo | null): Issue[] {
   if (!agentsMd) return [];
   if (agentsMd.bytes > CODEX_MAX_BYTES) {
     return [{
@@ -87,7 +87,7 @@ function validateCodexLimit(agentsMd: FileInfo | null): Issue[] {
   return [];
 }
 
-function validateImports(content: string, dir: string, label: string): Issue[] {
+export function validateImports(content: string, dir: string, label: string): Issue[] {
   const issues: Issue[] = [];
   const importPattern = /^@(\S+)/gm;
   let match;
@@ -104,7 +104,7 @@ function validateImports(content: string, dir: string, label: string): Issue[] {
   return issues;
 }
 
-function validateNoDuplication(agentsContent: string, claudeContent: string): Issue[] {
+export function validateNoDuplication(agentsContent: string, claudeContent: string): Issue[] {
   const issues: Issue[] = [];
 
   // Extract non-trivial lines (>30 chars, not headers/tables/blank)
@@ -256,4 +256,7 @@ function main() {
   }
 }
 
-main();
+const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
+if (isMain) {
+  main();
+}

--- a/bin/init.js
+++ b/bin/init.js
@@ -23,60 +23,12 @@ const TEMPLATE = join(PACKAGE_ROOT, "template");
 const REFERENCE_DOCS = join(PACKAGE_ROOT, "docs");
 
 // ---------------------------------------------------------------------------
-// Parse args
-// ---------------------------------------------------------------------------
-
-const args = process.argv.slice(2);
-
-if (args.includes("--help") || args.includes("-h")) {
-  console.log(`
-Anglesite — AI webmaster
-
-Usage:
-  npx anglesite init [directory]
-
-Scaffolds a new Astro + Keystatic site with AI agent instructions
-(AGENTS.md, CLAUDE.md, GEMINI.md) and full documentation.
-
-Options:
-  --force    Overwrite existing files
-  --help     Show this help
-`);
-  process.exit(0);
-}
-
-const command = args[0];
-if (command && command !== "init") {
-  console.error(`Unknown command: ${command}\nUsage: npx anglesite init [directory]`);
-  process.exit(1);
-}
-
-const force = args.includes("--force");
-const dest = resolve(args.find(a => a !== "init" && !a.startsWith("-")) || ".");
-
-// ---------------------------------------------------------------------------
-// Validate
-// ---------------------------------------------------------------------------
-
-if (!existsSync(TEMPLATE)) {
-  console.error("Error: template directory not found. The package may be corrupted.");
-  process.exit(1);
-}
-
-mkdirSync(dest, { recursive: true });
-
-// Check if destination has existing files (besides hidden files)
-const existing = readdirSync(dest).filter(f => !f.startsWith("."));
-if (existing.length > 0 && !force) {
-  console.error(`Directory ${dest} is not empty. Use --force to overwrite.`);
-  process.exit(1);
-}
-
-// ---------------------------------------------------------------------------
 // Copy template
 // ---------------------------------------------------------------------------
 
 const EXCLUDES = new Set(["node_modules", "dist", ".astro", ".wrangler", ".certs", ".DS_Store", ".site-config"]);
+
+let force = false;
 
 function copyDir(src, dst) {
   mkdirSync(dst, { recursive: true });
@@ -93,26 +45,86 @@ function copyDir(src, dst) {
   }
 }
 
-copyDir(TEMPLATE, dest);
+export { copyDir, EXCLUDES };
 
-// Copy reference docs (smb/, import/, platforms/, decisions/) into docs/.
-// These live at the package root, not in template/, but npm users need them
-// in their project since they don't have the Claude Code plugin path.
-if (existsSync(REFERENCE_DOCS)) {
-  copyDir(REFERENCE_DOCS, join(dest, "docs"));
+// Only run CLI when executed directly
+const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
+if (isMain) {
+  // ---------------------------------------------------------------------------
+  // Parse args
+  // ---------------------------------------------------------------------------
+
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(`
+Anglesite — AI webmaster
+
+Usage:
+  npx anglesite init [directory]
+
+Scaffolds a new Astro + Keystatic site with AI agent instructions
+(AGENTS.md, CLAUDE.md, GEMINI.md) and full documentation.
+
+Options:
+  --force    Overwrite existing files
+  --help     Show this help
+`);
+    process.exit(0);
+  }
+
+  const command = args[0];
+  if (command && command !== "init") {
+    console.error(`Unknown command: ${command}\nUsage: npx anglesite init [directory]`);
+    process.exit(1);
+  }
+
+  force = args.includes("--force");
+  const dest = resolve(args.find(a => a !== "init" && !a.startsWith("-")) || ".");
+
+  // ---------------------------------------------------------------------------
+  // Validate
+  // ---------------------------------------------------------------------------
+
+  if (!existsSync(TEMPLATE)) {
+    console.error("Error: template directory not found. The package may be corrupted.");
+    process.exit(1);
+  }
+
+  mkdirSync(dest, { recursive: true });
+
+  // Check if destination has existing files (besides hidden files)
+  const existing = readdirSync(dest).filter(f => !f.startsWith("."));
+  if (existing.length > 0 && !force) {
+    console.error(`Directory ${dest} is not empty. Use --force to overwrite.`);
+    process.exit(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Copy template
+  // ---------------------------------------------------------------------------
+
+  copyDir(TEMPLATE, dest);
+
+  // Copy reference docs (smb/, import/, platforms/, decisions/) into docs/.
+  // These live at the package root, not in template/, but npm users need them
+  // in their project since they don't have the Claude Code plugin path.
+  if (existsSync(REFERENCE_DOCS)) {
+    copyDir(REFERENCE_DOCS, join(dest, "docs"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Done
+  // ---------------------------------------------------------------------------
+
+  console.log(`\nAnglesite scaffolded to ${dest}\n`);
+  console.log("Next steps:");
+  console.log(`  cd ${dest === "." ? "." : dest}`);
+  console.log("  npm install");
+  console.log("  npm run dev");
+  console.log("");
+  console.log("AI agent instructions:");
+  console.log("  AGENTS.md  — Any agent (Codex, Cursor, Copilot, etc.)");
+  console.log("  CLAUDE.md  — Claude Code");
+  console.log("  GEMINI.md  — Gemini CLI");
 }
-
-// ---------------------------------------------------------------------------
-// Done
-// ---------------------------------------------------------------------------
-
-console.log(`\nAnglesite scaffolded to ${dest}\n`);
-console.log("Next steps:");
-console.log(`  cd ${dest === "." ? "." : dest}`);
-console.log("  npm install");
-console.log("  npm run dev");
-console.log("");
-console.log("AI agent instructions:");
-console.log("  AGENTS.md  — Any agent (Codex, Cursor, Copilot, etc.)");
-console.log("  CLAUDE.md  — Claude Code");
-console.log("  GEMINI.md  — Gemini CLI");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1592 @@
+{
+  "name": "anglesite",
+  "version": "0.13.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "anglesite",
+      "version": "0.13.2",
+      "license": "ISC",
+      "bin": {
+        "anglesite": "bin/init.js"
+      },
+      "devDependencies": {
+        "vitest": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,14 @@
     "type": "git",
     "url": "https://github.com/Anglesite/anglesite"
   },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "vitest": "^3.1.1"
+  },
   "engines": {
     "node": ">=20"
   }

--- a/template/scripts/check-prereqs.ts
+++ b/template/scripts/check-prereqs.ts
@@ -23,28 +23,13 @@ import {
   mkcertBin as mkcertBinPath,
   needsXcodeTools,
 } from "./platform.js";
+import { readConfig } from "./config.js";
 
 /** Directory this script lives in (`scripts/`). */
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
 /** Project root (one level up from `scripts/`). */
 const PROJECT_DIR = resolve(SCRIPT_DIR, "..");
-
-/** Path to `.site-config` in the project root. */
-const CONFIG_FILE = resolve(PROJECT_DIR, ".site-config");
-
-/**
- * Read a value from `.site-config` (KEY=value, one per line).
- *
- * @param key - Config key to look up
- * @returns The trimmed value, or `undefined` if missing
- */
-function readConfig(key: string): string | undefined {
-  if (!existsSync(CONFIG_FILE)) return undefined;
-  const content = readFileSync(CONFIG_FILE, "utf-8");
-  const match = content.match(new RegExp(`^${key}=(.+)$`, "m"));
-  return match?.[1]?.trim();
-}
 
 /**
  * Run a command and return its first line of stdout, or `null` on failure.

--- a/template/scripts/cleanup.ts
+++ b/template/scripts/cleanup.ts
@@ -24,6 +24,7 @@ import {
   hasPfctl,
   mkcertBin as mkcertBinPath,
 } from "./platform.js";
+import { readConfig } from "./config.js";
 
 /** Directory this script lives in (`scripts/`). */
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -31,24 +32,8 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 /** Project root (one level up from `scripts/`). */
 const PROJECT_DIR = resolve(SCRIPT_DIR, "..");
 
-/** Path to `.site-config` in the project root. */
-const CONFIG_FILE = resolve(PROJECT_DIR, ".site-config");
-
 /** pfctl anchor name used by Anglesite (macOS only). */
 const PFCTL_ANCHOR = "com.anglesite";
-
-/**
- * Read a value from `.site-config` (KEY=value, one per line).
- *
- * @param key - Config key to look up
- * @returns The trimmed value, or `undefined` if missing
- */
-function readConfig(key: string): string | undefined {
-  if (!existsSync(CONFIG_FILE)) return undefined;
-  const content = readFileSync(CONFIG_FILE, "utf-8");
-  const match = content.match(new RegExp(`^${key}=(.+)$`, "m"));
-  return match?.[1]?.trim();
-}
 
 /** Entry point — removes system modifications made by setup. */
 async function main(): Promise<void> {

--- a/template/scripts/config.ts
+++ b/template/scripts/config.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared .site-config parser.
+ *
+ * Reads KEY=value pairs from a flat config file (one per line).
+ * Used by setup, cleanup, check-prereqs, pre-deploy-check, and generate-images.
+ *
+ * @module
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/** Default path to the site config file. */
+const DEFAULT_CONFIG_PATH = resolve(process.cwd(), ".site-config");
+
+/**
+ * Read a value from a KEY=value config file.
+ *
+ * @param key - The key to look up
+ * @param configPath - Path to the config file (defaults to `.site-config` in cwd)
+ * @returns The trimmed value, or undefined if not found or file missing
+ */
+export function readConfig(
+  key: string,
+  configPath: string = DEFAULT_CONFIG_PATH,
+): string | undefined {
+  if (!existsSync(configPath)) return undefined;
+  const content = readFileSync(configPath, "utf-8");
+  return readConfigFromString(content, key);
+}
+
+/**
+ * Parse a KEY=value string and return the value for the given key.
+ * Pure function — no I/O.
+ */
+export function readConfigFromString(
+  content: string,
+  key: string,
+): string | undefined {
+  const match = content.match(new RegExp(`^${key}=(.+)$`, "m"));
+  return match?.[1]?.trim();
+}

--- a/template/scripts/generate-images.ts
+++ b/template/scripts/generate-images.ts
@@ -13,23 +13,14 @@
 import sharp from "sharp";
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { readConfig } from "./config.js";
 
-function readSiteConfig(key: string): string | undefined {
-  try {
-    const config = readFileSync(".site-config", "utf8");
-    const match = config.match(new RegExp(`^${key}=(.+)$`, "m"));
-    return match?.[1]?.trim();
-  } catch {
-    return undefined;
-  }
-}
-
-function readCssVar(css: string, name: string): string | undefined {
+export function readCssVar(css: string, name: string): string | undefined {
   const match = css.match(new RegExp(`${name}:\\s*([^;]+);`));
   return match?.[1]?.trim();
 }
 
-function escapeXml(str: string): string {
+export function escapeXml(str: string): string {
   return str
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
@@ -44,7 +35,7 @@ async function main() {
   const css = existsSync(cssPath) ? readFileSync(cssPath, "utf8") : "";
   const primaryColor = readCssVar(css, "--color-primary") || "#2563eb";
   const bgColor = readCssVar(css, "--color-bg") || "#ffffff";
-  const siteName = readSiteConfig("SITE_NAME") || "My Website";
+  const siteName = readConfig("SITE_NAME") || "My Website";
 
   // --- Apple Touch Icon (180x180) ---
   const faviconPath = resolve(publicDir, "favicon.svg");
@@ -76,7 +67,10 @@ async function main() {
   console.log("Generated og-image.png (1200x630)");
 }
 
-main().catch((err) => {
-  console.error("Image generation failed:", err.message);
-  process.exit(1);
-});
+// Only run when executed directly
+if (process.argv[1]?.endsWith("generate-images.ts")) {
+  main().catch((err) => {
+    console.error("Image generation failed:", err.message);
+    process.exit(1);
+  });
+}

--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -14,43 +14,24 @@
 
 import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
 import { join, extname, resolve } from "node:path";
-
-const DIST = "dist";
-const CONFIG_FILE = resolve(process.cwd(), ".site-config");
-
-if (!existsSync(DIST)) {
-  console.error("dist/ not found — run `npm run build` first.");
-  process.exit(1);
-}
+import { readConfig } from "./config.js";
 
 // ---------------------------------------------------------------------------
-// Config
+// Exported patterns and constants
 // ---------------------------------------------------------------------------
 
-/**
- * Read a value from `.site-config` (KEY=value, one per line).
- */
-function readConfig(key: string): string | undefined {
-  if (!existsSync(CONFIG_FILE)) return undefined;
-  const content = readFileSync(CONFIG_FILE, "utf-8");
-  const match = content.match(new RegExp(`^${key}=(.+)$`, "m"));
-  return match?.[1]?.trim();
-}
-
-/**
- * Emails the site owner has explicitly approved for publication.
- * Set in .site-config as: PII_EMAIL_ALLOW=me@example.com,info@example.com
- */
-const emailAllowlist: string[] = (readConfig("PII_EMAIL_ALLOW") ?? "")
-  .split(",")
-  .map(e => e.trim().toLowerCase())
-  .filter(Boolean);
+export const emailPattern = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+export const emailExcludes = ["charset", "viewport", "@astro", "@import", "@keyframes", "@media", "@font-face", "@layer", "@property"];
+export const phonePattern = /\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/g;
+export const tokenPattern = /(?:pat[A-Za-z0-9]{14,}|sk-[A-Za-z0-9]{20,})/;
+export const scriptSrcPattern = /<script[^>]*src=/gi;
+export const allowedScripts = ["cloudflareinsights", "_astro"];
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function walkHtml(dir: string): string[] {
+export function walkHtml(dir: string): string[] {
   const results: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
@@ -63,7 +44,7 @@ function walkHtml(dir: string): string[] {
   return results;
 }
 
-function walkAll(dir: string): string[] {
+export function walkAll(dir: string): string[] {
   if (!existsSync(dir)) return [];
   const results: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -78,112 +59,147 @@ function walkAll(dir: string): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// Scans
+// Scan functions
 // ---------------------------------------------------------------------------
 
-const failures: string[] = [];
-const warnings: string[] = [];
-
-const htmlFiles = walkHtml(DIST);
-
-// 1. PII scan — emails
-const emailPattern = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
-const emailExcludes = ["charset", "viewport", "@astro", "@import", "@keyframes", "@media", "@font-face", "@layer", "@property"];
-
-for (const file of htmlFiles) {
-  const content = readFileSync(file, "utf-8");
+export function scanEmails(content: string, allowlist: string[]): string[] {
+  emailPattern.lastIndex = 0;
   const matches = content.match(emailPattern) || [];
-  const real = matches.filter(m => {
+  return matches.filter(m => {
     // Skip CSS at-rules and meta tags
     if (emailExcludes.some(ex => m.includes(ex))) return false;
     // Skip emails in mailto: links (intentionally published)
     const idx = content.indexOf(m);
     if (idx >= 7 && content.slice(idx - 7, idx).includes("mailto:")) return false;
     // Skip emails on the allowlist
-    if (emailAllowlist.includes(m.toLowerCase())) return false;
+    if (allowlist.includes(m.toLowerCase())) return false;
     return true;
   });
-  if (real.length > 0) {
-    failures.push(`PII: possible email address in ${file}: ${real.join(", ")}`);
-  }
 }
 
-// 1b. PII scan — phone numbers
-const phonePattern = /\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/g;
-
-for (const file of htmlFiles) {
-  const content = readFileSync(file, "utf-8");
-  if (phonePattern.test(content)) {
-    failures.push(`PII: possible phone number in ${file}`);
-  }
+export function scanPhones(content: string): boolean {
+  // Reset lastIndex since phonePattern has the global flag
+  phonePattern.lastIndex = 0;
+  return phonePattern.test(content);
 }
 
-// 2. Token scan — API keys in dist/, src/, public/
-const tokenPattern = /(?:pat[A-Za-z0-9]{14,}|sk-[A-Za-z0-9]{20,})/;
-const scanDirs = [DIST, "src", "public"].filter(existsSync);
-
-for (const dir of scanDirs) {
-  for (const file of walkAll(dir)) {
-    try {
-      const content = readFileSync(file, "utf-8");
-      if (tokenPattern.test(content)) {
-        failures.push(`TOKEN: API token pattern found in ${file}`);
-      }
-    } catch {
-      // Binary file, skip
-    }
-  }
+export function scanTokens(content: string): boolean {
+  return tokenPattern.test(content);
 }
 
-// 3. Third-party scripts
-const scriptSrcPattern = /<script[^>]*src=/gi;
-const allowedScripts = ["cloudflareinsights", "_astro"];
-
-for (const file of htmlFiles) {
-  const content = readFileSync(file, "utf-8");
+export function scanScripts(content: string): string[] {
+  scriptSrcPattern.lastIndex = 0;
+  const results: string[] = [];
   const matches = content.match(scriptSrcPattern) || [];
   for (const match of matches) {
     const lineIdx = content.indexOf(match);
     const line = content.slice(lineIdx, content.indexOf(">", lineIdx) + 1);
     if (!allowedScripts.some(allowed => line.includes(allowed))) {
+      results.push(line);
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Main script (only runs when executed directly)
+// ---------------------------------------------------------------------------
+
+if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
+  const DIST = "dist";
+
+  if (!existsSync(DIST)) {
+    console.error("dist/ not found — run `npm run build` first.");
+    process.exit(1);
+  }
+
+  /**
+   * Emails the site owner has explicitly approved for publication.
+   * Set in .site-config as: PII_EMAIL_ALLOW=me@example.com,info@example.com
+   */
+  const emailAllowlist: string[] = (readConfig("PII_EMAIL_ALLOW") ?? "")
+    .split(",")
+    .map(e => e.trim().toLowerCase())
+    .filter(Boolean);
+
+  const failures: string[] = [];
+  const warnings: string[] = [];
+
+  const htmlFiles = walkHtml(DIST);
+
+  // 1. PII scan — emails
+  for (const file of htmlFiles) {
+    const content = readFileSync(file, "utf-8");
+    const real = scanEmails(content, emailAllowlist);
+    if (real.length > 0) {
+      failures.push(`PII: possible email address in ${file}: ${real.join(", ")}`);
+    }
+  }
+
+  // 1b. PII scan — phone numbers
+  for (const file of htmlFiles) {
+    const content = readFileSync(file, "utf-8");
+    if (scanPhones(content)) {
+      failures.push(`PII: possible phone number in ${file}`);
+    }
+  }
+
+  // 2. Token scan — API keys in dist/, src/, public/
+  const scanDirs = [DIST, "src", "public"].filter(existsSync);
+
+  for (const dir of scanDirs) {
+    for (const file of walkAll(dir)) {
+      try {
+        const content = readFileSync(file, "utf-8");
+        if (scanTokens(content)) {
+          failures.push(`TOKEN: API token pattern found in ${file}`);
+        }
+      } catch {
+        // Binary file, skip
+      }
+    }
+  }
+
+  // 3. Third-party scripts
+  for (const file of htmlFiles) {
+    const content = readFileSync(file, "utf-8");
+    const unauthorized = scanScripts(content);
+    for (const script of unauthorized) {
       failures.push(`SCRIPT: unauthorized third-party script in ${file}`);
     }
   }
-}
 
-// 4. Keystatic admin routes
-const keystatic = walkAll(DIST).filter(f => f.includes("keystatic"));
-if (keystatic.length > 0) {
-  failures.push(`KEYSTATIC: admin routes found in production build: ${keystatic.join(", ")}`);
-}
-
-// 5. OG image (warn only)
-const hasOgImage = htmlFiles.some(f => readFileSync(f, "utf-8").includes("og:image"));
-if (!hasOgImage) {
-  warnings.push("No og:image meta tag found. Social shares won't show a preview image. Run `npm run ai-images` to generate one.");
-}
-
-// ---------------------------------------------------------------------------
-// Report
-// ---------------------------------------------------------------------------
-
-if (emailAllowlist.length > 0) {
-  console.log(`PII allowlist: ${emailAllowlist.join(", ")}`);
-}
-
-if (warnings.length > 0) {
-  for (const w of warnings) {
-    console.warn(`WARN: ${w}`);
+  // 4. Keystatic admin routes
+  const keystatic = walkAll(DIST).filter(f => f.includes("keystatic"));
+  if (keystatic.length > 0) {
+    failures.push(`KEYSTATIC: admin routes found in production build: ${keystatic.join(", ")}`);
   }
-}
 
-if (failures.length > 0) {
-  console.error("\nDeploy blocked — security scan failed:\n");
-  for (const f of failures) {
-    console.error(`  ${f}`);
+  // 5. OG image (warn only)
+  const hasOgImage = htmlFiles.some(f => readFileSync(f, "utf-8").includes("og:image"));
+  if (!hasOgImage) {
+    warnings.push("No og:image meta tag found. Social shares won't show a preview image. Run `npm run ai-images` to generate one.");
   }
-  console.error("\nFix these issues before deploying.");
-  process.exit(1);
-}
 
-console.log("Pre-deploy security scan passed.");
+  // Report
+  if (emailAllowlist.length > 0) {
+    console.log(`PII allowlist: ${emailAllowlist.join(", ")}`);
+  }
+
+  if (warnings.length > 0) {
+    for (const w of warnings) {
+      console.warn(`WARN: ${w}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error("\nDeploy blocked — security scan failed:\n");
+    for (const f of failures) {
+      console.error(`  ${f}`);
+    }
+    console.error("\nFix these issues before deploying.");
+    process.exit(1);
+  }
+
+  console.log("Pre-deploy security scan passed.");
+}

--- a/template/scripts/setup.ts
+++ b/template/scripts/setup.ts
@@ -42,6 +42,7 @@ import {
   notifyCommand,
   fnmShellInit,
 } from "./platform.js";
+import { readConfig } from "./config.js";
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -52,9 +53,6 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
 /** Project root (one level up from `scripts/`). */
 const PROJECT_DIR = resolve(SCRIPT_DIR, "..");
-
-/** Path to `.site-config` in the project root. */
-const CONFIG_FILE = resolve(PROJECT_DIR, ".site-config");
 
 /** Log directory under the user's home folder. */
 const LOG_DIR = resolve(HOME, ".anglesite/logs");
@@ -75,19 +73,6 @@ const skipped: string[] = [];
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Read a value from `.site-config` (KEY=value, one per line).
- *
- * @param key - Config key to look up
- * @returns The trimmed value, or `undefined` if missing
- */
-function readConfig(key: string): string | undefined {
-  if (!existsSync(CONFIG_FILE)) return undefined;
-  const content = readFileSync(CONFIG_FILE, "utf-8");
-  const match = content.match(new RegExp(`^${key}=(.+)$`, "m"));
-  return match?.[1]?.trim();
-}
 
 /**
  * Append a timestamped message to the log file and display it.

--- a/tests/average-tokens.test.ts
+++ b/tests/average-tokens.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  tokens,
+  fmt,
+  fmtK,
+  fmtDollars,
+  model,
+  SESSION,
+  PRICING,
+  type Measurements,
+} from "../bin/average-tokens.js";
+
+// ---------------------------------------------------------------------------
+// Pure formatting functions
+// ---------------------------------------------------------------------------
+
+describe("tokens", () => {
+  it("converts bytes to tokens at 4:1 ratio", () => {
+    expect(tokens(400)).toBe(100);
+    expect(tokens(4)).toBe(1);
+    expect(tokens(0)).toBe(0);
+  });
+
+  it("rounds up partial tokens", () => {
+    expect(tokens(1)).toBe(1);
+    expect(tokens(5)).toBe(2);
+    expect(tokens(7)).toBe(2);
+  });
+});
+
+describe("fmt", () => {
+  it("formats numbers with locale separators", () => {
+    const result = fmt(1234567);
+    // en-US locale uses commas
+    expect(result).toContain("1");
+    expect(result).toContain("234");
+    expect(result).toContain("567");
+  });
+
+  it("leaves small numbers unchanged", () => {
+    expect(fmt(42)).toBe("42");
+  });
+});
+
+describe("fmtK", () => {
+  it("formats millions with M suffix", () => {
+    expect(fmtK(1_500_000)).toBe("1.5M");
+    expect(fmtK(1_000_000)).toBe("1.0M");
+  });
+
+  it("formats thousands with k suffix", () => {
+    expect(fmtK(5_000)).toBe("5k");
+    expect(fmtK(12_345)).toBe("12k");
+  });
+
+  it("formats small numbers without suffix", () => {
+    expect(fmtK(999)).toBe("999");
+  });
+});
+
+describe("fmtDollars", () => {
+  it("formats as dollar amount with 2 decimal places", () => {
+    expect(fmtDollars(1.5)).toBe("$1.50");
+    expect(fmtDollars(0.1)).toBe("$0.10");
+    expect(fmtDollars(99.999)).toBe("$100.00");
+  });
+
+  it("formats zero", () => {
+    expect(fmtDollars(0)).toBe("$0.00");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session cost model
+// ---------------------------------------------------------------------------
+
+describe("model", () => {
+  it("calculates session costs for known input", () => {
+    const measurements: Measurements = {
+      alwaysLoaded: [
+        { label: "test", path: "test.md", bytes: 4000, tokens: 1000 },
+      ],
+      command: [
+        { label: "cmd", path: "cmd.md", bytes: 2000, tokens: 500 },
+      ],
+      step1: [
+        { label: "s1", path: "s1.md", bytes: 800, tokens: 200 },
+      ],
+      step2: [
+        { label: "s2", path: "s2.md", bytes: 1200, tokens: 300 },
+      ],
+      smb: {
+        count: 10,
+        totalBytes: 40000,
+        avgBytes: 4000,
+        avgTokens: 1000,
+        minBytes: 2000,
+        maxBytes: 6000,
+      },
+    };
+
+    const result = model(measurements);
+
+    // contextPerTurn = systemPromptTokens + alwaysTokens + commandTokens + onDemandTokens
+    // = 2000 + 1000 + 500 + (200 + 1000 + 300) = 5000
+    expect(result.contextPerTurn).toBe(5000);
+
+    // Should have cost entries for each pricing model
+    expect(result.costs).toHaveLength(Object.keys(PRICING).length);
+
+    // Each cost should have positive values
+    for (const cost of result.costs) {
+      expect(cost.cachedInput).toBeGreaterThan(0);
+      expect(cost.uncachedInput).toBeGreaterThan(0);
+      expect(cost.totalInput).toBeGreaterThan(0);
+      expect(cost.totalOutput).toBe(SESSION.outputTokens);
+      expect(cost.cost).toBeGreaterThan(0);
+    }
+  });
+
+  it("Sonnet costs less than Opus", () => {
+    const measurements: Measurements = {
+      alwaysLoaded: [{ label: "t", path: "t", bytes: 400, tokens: 100 }],
+      command: [],
+      step1: [],
+      step2: [],
+      smb: { count: 1, totalBytes: 400, avgBytes: 400, avgTokens: 100, minBytes: 400, maxBytes: 400 },
+    };
+
+    const result = model(measurements);
+    const sonnet = result.costs.find(c => c.label === "Sonnet");
+    const opus = result.costs.find(c => c.label === "Opus");
+
+    expect(sonnet).toBeDefined();
+    expect(opus).toBeDefined();
+    expect(sonnet!.cost).toBeLessThan(opus!.cost);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe("SESSION constants", () => {
+  it("has reasonable default values", () => {
+    expect(SESSION.turns).toBeGreaterThan(0);
+    expect(SESSION.systemPromptTokens).toBeGreaterThan(0);
+    expect(SESSION.avgNewContentPerTurn).toBeGreaterThan(0);
+    expect(SESSION.outputTokens).toBeGreaterThan(0);
+  });
+});
+
+describe("PRICING", () => {
+  it("has entries for opus and sonnet", () => {
+    expect(PRICING.opus).toBeDefined();
+    expect(PRICING.sonnet).toBeDefined();
+  });
+
+  it("cached rate is lower than standard input rate", () => {
+    for (const model of Object.values(PRICING)) {
+      expect(model.cached).toBeLessThan(model.input);
+    }
+  });
+});

--- a/tests/build-instructions.test.ts
+++ b/tests/build-instructions.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  tokens,
+  fmt,
+  fmtKB,
+  validateCodexLimit,
+  validateImports,
+  validateNoDuplication,
+  CODEX_MAX_BYTES,
+  WARN_SKILL_BYTES,
+} from "../bin/build-instructions.js";
+import type { FileInfo } from "../bin/build-instructions.js";
+
+// ---------------------------------------------------------------------------
+// tokens
+// ---------------------------------------------------------------------------
+
+describe("tokens", () => {
+  it("divides bytes by 4", () => {
+    expect(tokens(400)).toBe(100);
+  });
+
+  it("rounds up with Math.ceil", () => {
+    expect(tokens(1)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fmt
+// ---------------------------------------------------------------------------
+
+describe("fmt", () => {
+  it("locale-formats large numbers", () => {
+    expect(fmt(1234567)).toContain("1,234,567");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fmtKB
+// ---------------------------------------------------------------------------
+
+describe("fmtKB", () => {
+  it("formats 1024 bytes as 1.0KB", () => {
+    expect(fmtKB(1024)).toBe("1.0KB");
+  });
+
+  it("formats 2560 bytes as 2.5KB", () => {
+    expect(fmtKB(2560)).toBe("2.5KB");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// constants
+// ---------------------------------------------------------------------------
+
+describe("constants", () => {
+  it("CODEX_MAX_BYTES is 32768", () => {
+    expect(CODEX_MAX_BYTES).toBe(32_768);
+  });
+
+  it("WARN_SKILL_BYTES is 8192", () => {
+    expect(WARN_SKILL_BYTES).toBe(8_192);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCodexLimit
+// ---------------------------------------------------------------------------
+
+describe("validateCodexLimit", () => {
+  it("returns empty array for null", () => {
+    expect(validateCodexLimit(null)).toEqual([]);
+  });
+
+  it("returns empty array when under limit", () => {
+    const info: FileInfo = { path: "test", label: "test", bytes: 1000, tokens: 250 };
+    expect(validateCodexLimit(info)).toEqual([]);
+  });
+
+  it("returns error when over 32KB", () => {
+    const info: FileInfo = { path: "test", label: "test", bytes: 33000, tokens: 8250 };
+    const issues = validateCodexLimit(info);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].level).toBe("error");
+  });
+
+  it("returns warning when over 80% of limit", () => {
+    const info: FileInfo = { path: "test", label: "test", bytes: 27000, tokens: 6750 };
+    const issues = validateCodexLimit(info);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].level).toBe("warn");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateImports
+// ---------------------------------------------------------------------------
+
+describe("validateImports", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-build-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns error for missing import targets", () => {
+    writeFileSync(join(tmpDir, "AGENTS.md"), "# Agents");
+    const content = "@AGENTS.md\n@missing.md";
+    const issues = validateImports(content, tmpDir, "TEST");
+    expect(issues).toHaveLength(1);
+    expect(issues[0].level).toBe("error");
+    expect(issues[0].message).toContain("missing.md");
+  });
+
+  it("returns empty array when no imports exist", () => {
+    const issues = validateImports("No imports here", tmpDir, "TEST");
+    expect(issues).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateNoDuplication
+// ---------------------------------------------------------------------------
+
+describe("validateNoDuplication", () => {
+  it("warns when 4+ long lines are shared", () => {
+    const sharedLine = "This is a long line that is definitely more than thirty characters long for testing.";
+    const agentsContent = [sharedLine, sharedLine + " v2", sharedLine + " v3", sharedLine + " v4"].join("\n");
+    const claudeContent = agentsContent;
+    const issues = validateNoDuplication(agentsContent, claudeContent);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].level).toBe("warn");
+  });
+
+  it("returns empty when 3 or fewer lines are shared", () => {
+    const line1 = "This is a long line that is definitely more than thirty characters.";
+    const line2 = "Another long line that is definitely more than thirty characters.";
+    const line3 = "A third long line that is definitely more than thirty characters.";
+    const agentsContent = [line1, line2, line3].join("\n");
+    const claudeContent = [line1, line2, line3].join("\n");
+    const issues = validateNoDuplication(agentsContent, claudeContent);
+    expect(issues).toEqual([]);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { readConfig, readConfigFromString } from "../template/scripts/config.js";
+
+// ---------------------------------------------------------------------------
+// readConfigFromString — pure, no I/O
+// ---------------------------------------------------------------------------
+
+describe("readConfigFromString", () => {
+  it("returns the value for a matching key", () => {
+    expect(readConfigFromString("FOO=bar", "FOO")).toBe("bar");
+  });
+
+  it("returns undefined for a missing key", () => {
+    expect(readConfigFromString("FOO=bar", "BAZ")).toBeUndefined();
+  });
+
+  it("trims whitespace from the value", () => {
+    expect(readConfigFromString("FOO=  hello  ", "FOO")).toBe("hello");
+  });
+
+  it("handles multi-line configs", () => {
+    const content = "A=1\nB=2\nC=3";
+    expect(readConfigFromString(content, "B")).toBe("2");
+  });
+
+  it("handles values containing equals signs", () => {
+    expect(readConfigFromString("URL=https://example.com?a=1&b=2", "URL")).toBe(
+      "https://example.com?a=1&b=2",
+    );
+  });
+
+  it("returns undefined for empty content", () => {
+    expect(readConfigFromString("", "FOO")).toBeUndefined();
+  });
+
+  it("matches keys at the start of a line only", () => {
+    // "XFOO=bad" should not match key "FOO"
+    expect(readConfigFromString("XFOO=bad\nFOO=good", "FOO")).toBe("good");
+  });
+
+  it("handles comma-separated values", () => {
+    expect(
+      readConfigFromString("PII_EMAIL_ALLOW=a@b.com,c@d.com", "PII_EMAIL_ALLOW"),
+    ).toBe("a@b.com,c@d.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readConfig — file-based
+// ---------------------------------------------------------------------------
+
+describe("readConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads a key from a config file", () => {
+    const configPath = join(tmpDir, ".site-config");
+    writeFileSync(configPath, "SITE_NAME=My Site\nDEV_HOSTNAME=local.test\n");
+    expect(readConfig("SITE_NAME", configPath)).toBe("My Site");
+    expect(readConfig("DEV_HOSTNAME", configPath)).toBe("local.test");
+  });
+
+  it("returns undefined when the file does not exist", () => {
+    expect(readConfig("FOO", join(tmpDir, "nonexistent"))).toBeUndefined();
+  });
+
+  it("returns undefined when the key is not in the file", () => {
+    const configPath = join(tmpDir, ".site-config");
+    writeFileSync(configPath, "A=1\n");
+    expect(readConfig("B", configPath)).toBeUndefined();
+  });
+});

--- a/tests/generate-images.test.ts
+++ b/tests/generate-images.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock sharp — it's a template devDependency, not available at the plugin root
+vi.mock("sharp", () => ({ default: vi.fn() }));
+
+import { readCssVar, escapeXml } from "../template/scripts/generate-images.js";
+
+// ---------------------------------------------------------------------------
+// readCssVar — extract CSS custom property values
+// ---------------------------------------------------------------------------
+
+describe("readCssVar", () => {
+  const sampleCss = `
+    :root {
+      --color-primary: #2563eb;
+      --color-bg: #ffffff;
+      --font-body: "Inter", sans-serif;
+      --spacing-lg: 2rem;
+    }
+  `;
+
+  it("extracts a color value", () => {
+    expect(readCssVar(sampleCss, "--color-primary")).toBe("#2563eb");
+  });
+
+  it("extracts a different color value", () => {
+    expect(readCssVar(sampleCss, "--color-bg")).toBe("#ffffff");
+  });
+
+  it("extracts a font-family value", () => {
+    expect(readCssVar(sampleCss, "--font-body")).toBe('"Inter", sans-serif');
+  });
+
+  it("extracts a spacing value", () => {
+    expect(readCssVar(sampleCss, "--spacing-lg")).toBe("2rem");
+  });
+
+  it("returns undefined for a missing variable", () => {
+    expect(readCssVar(sampleCss, "--color-accent")).toBeUndefined();
+  });
+
+  it("returns undefined for empty CSS", () => {
+    expect(readCssVar("", "--color-primary")).toBeUndefined();
+  });
+
+  it("handles values with extra spaces", () => {
+    const css = "--color-test:   hsl(200, 50%, 50%)  ;";
+    expect(readCssVar(css, "--color-test")).toBe("hsl(200, 50%, 50%)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeXml — XML/SVG entity escaping
+// ---------------------------------------------------------------------------
+
+describe("escapeXml", () => {
+  it("escapes ampersands", () => {
+    expect(escapeXml("A & B")).toBe("A &amp; B");
+  });
+
+  it("escapes angle brackets", () => {
+    expect(escapeXml("<div>")).toBe("&lt;div&gt;");
+  });
+
+  it("escapes double quotes", () => {
+    expect(escapeXml('say "hello"')).toBe("say &quot;hello&quot;");
+  });
+
+  it("handles multiple entities in one string", () => {
+    expect(escapeXml('<a href="x&y">')).toBe("&lt;a href=&quot;x&amp;y&quot;&gt;");
+  });
+
+  it("leaves clean strings unchanged", () => {
+    expect(escapeXml("Hello World")).toBe("Hello World");
+  });
+
+  it("handles empty string", () => {
+    expect(escapeXml("")).toBe("");
+  });
+
+  it("handles string with only special characters", () => {
+    expect(escapeXml('&<>"')).toBe("&amp;&lt;&gt;&quot;");
+  });
+});

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { copyDir, EXCLUDES } from "../bin/init.js";
+
+// ---------------------------------------------------------------------------
+// EXCLUDES
+// ---------------------------------------------------------------------------
+
+describe("EXCLUDES", () => {
+  it("contains expected entries", () => {
+    for (const name of ["node_modules", "dist", ".astro", ".wrangler", ".certs", ".DS_Store", ".site-config"]) {
+      expect(EXCLUDES.has(name), `expected EXCLUDES to contain "${name}"`).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// copyDir
+// ---------------------------------------------------------------------------
+
+describe("copyDir", () => {
+  let tmpDir: string;
+  let src: string;
+  let dst: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-init-test-"));
+    src = join(tmpDir, "src");
+    dst = join(tmpDir, "dst");
+    mkdirSync(src, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("copies files from src to dst", () => {
+    writeFileSync(join(src, "hello.txt"), "world");
+    copyDir(src, dst);
+    expect(existsSync(join(dst, "hello.txt"))).toBe(true);
+    expect(readFileSync(join(dst, "hello.txt"), "utf-8")).toBe("world");
+  });
+
+  it("creates nested directories", () => {
+    mkdirSync(join(src, "a", "b"), { recursive: true });
+    writeFileSync(join(src, "a", "b", "deep.txt"), "nested");
+    copyDir(src, dst);
+    expect(existsSync(join(dst, "a", "b", "deep.txt"))).toBe(true);
+    expect(readFileSync(join(dst, "a", "b", "deep.txt"), "utf-8")).toBe("nested");
+  });
+
+  it("skips excluded directories", () => {
+    mkdirSync(join(src, "node_modules"), { recursive: true });
+    writeFileSync(join(src, "node_modules", "pkg.json"), "{}");
+    writeFileSync(join(src, "keep.txt"), "yes");
+    copyDir(src, dst);
+    expect(existsSync(join(dst, "node_modules"))).toBe(false);
+    expect(existsSync(join(dst, "keep.txt"))).toBe(true);
+  });
+
+  it("skips excluded files", () => {
+    writeFileSync(join(src, ".DS_Store"), "junk");
+    writeFileSync(join(src, "real.txt"), "data");
+    copyDir(src, dst);
+    expect(existsSync(join(dst, ".DS_Store"))).toBe(false);
+    expect(existsSync(join(dst, "real.txt"))).toBe(true);
+  });
+
+  it("does not overwrite existing files when force is false", () => {
+    writeFileSync(join(src, "file.txt"), "new content");
+    mkdirSync(dst, { recursive: true });
+    writeFileSync(join(dst, "file.txt"), "original content");
+    copyDir(src, dst);
+    // force defaults to false at module level, so existing files are preserved
+    expect(readFileSync(join(dst, "file.txt"), "utf-8")).toBe("original content");
+  });
+});

--- a/tests/platform.test.ts
+++ b/tests/platform.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import * as p from "../template/scripts/platform.js";
+
+// ---------------------------------------------------------------------------
+// Derive expected values from the actual process.platform so the tests
+// pass on any OS (macOS in CI, Linux in containers, etc.)
+// ---------------------------------------------------------------------------
+
+const expectedPlatform: p.Platform =
+  process.platform === "win32"
+    ? "windows"
+    : process.platform === "darwin"
+      ? "macos"
+      : "linux";
+
+const onMacos = expectedPlatform === "macos";
+const onLinux = expectedPlatform === "linux";
+const onWindows = expectedPlatform === "windows";
+const HOME = process.env.HOME ?? process.env.USERPROFILE ?? "~";
+
+// ---------------------------------------------------------------------------
+// Platform detection constants
+// ---------------------------------------------------------------------------
+
+describe("platform detection", () => {
+  it("platform matches process.platform", () => {
+    expect(p.platform).toBe(expectedPlatform);
+  });
+
+  it("isMacos is correct", () => {
+    expect(p.isMacos).toBe(onMacos);
+  });
+
+  it("isLinux is correct", () => {
+    expect(p.isLinux).toBe(onLinux);
+  });
+
+  it("isWindows is correct", () => {
+    expect(p.isWindows).toBe(onWindows);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HOME and HOSTS_FILE
+// ---------------------------------------------------------------------------
+
+describe("HOME", () => {
+  it("is a non-empty string", () => {
+    expect(p.HOME).toBeTruthy();
+    expect(typeof p.HOME).toBe("string");
+  });
+});
+
+describe("HOSTS_FILE", () => {
+  it("points to the correct hosts file for the current OS", () => {
+    if (onWindows) {
+      expect(p.HOSTS_FILE).toBe("C:\\Windows\\System32\\drivers\\etc\\hosts");
+    } else {
+      expect(p.HOSTS_FILE).toBe("/etc/hosts");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shellProfile / shellName
+// ---------------------------------------------------------------------------
+
+describe("shellProfile()", () => {
+  it("returns the correct profile path for the current OS", () => {
+    if (onMacos) {
+      expect(p.shellProfile()).toBe(resolve(HOME, ".zshrc"));
+    } else if (onLinux) {
+      expect(p.shellProfile()).toBe(resolve(HOME, ".bashrc"));
+    } else {
+      expect(p.shellProfile()).toBe("");
+    }
+  });
+});
+
+describe("shellName()", () => {
+  it("returns the correct shell name for the current OS", () => {
+    if (onMacos) {
+      expect(p.shellName()).toBe("zsh");
+    } else if (onLinux) {
+      expect(p.shellName()).toBe("bash");
+    } else {
+      expect(p.shellName()).toBe("powershell");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fnmDir / localBinDir
+// ---------------------------------------------------------------------------
+
+describe("fnmDir()", () => {
+  it("returns the correct fnm directory", () => {
+    if (onWindows) {
+      expect(p.fnmDir()).toBe(resolve(HOME, ".fnm"));
+    } else {
+      expect(p.fnmDir()).toBe(resolve(HOME, ".local/share/fnm"));
+    }
+  });
+});
+
+describe("localBinDir()", () => {
+  it("returns ~/.local/bin resolved", () => {
+    expect(p.localBinDir()).toBe(resolve(HOME, ".local/bin"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mkcertBin / mkcertDownloadUrl
+// ---------------------------------------------------------------------------
+
+describe("mkcertBin()", () => {
+  it("returns the correct binary name", () => {
+    const expected = onWindows ? "mkcert.exe" : "mkcert";
+    expect(p.mkcertBin()).toBe(resolve(p.localBinDir(), expected));
+  });
+});
+
+describe("mkcertDownloadUrl()", () => {
+  it("returns arm64 URL for arm64 arch", () => {
+    const url = p.mkcertDownloadUrl("arm64");
+    const os = onWindows ? "windows" : onMacos ? "darwin" : "linux";
+    expect(url).toBe(`https://dl.filippo.io/mkcert/latest?for=${os}/arm64`);
+  });
+
+  it("returns amd64 URL for x64 arch", () => {
+    const url = p.mkcertDownloadUrl("x64");
+    const os = onWindows ? "windows" : onMacos ? "darwin" : "linux";
+    expect(url).toBe(`https://dl.filippo.io/mkcert/latest?for=${os}/amd64`);
+  });
+
+  it("returns amd64 URL for any non-arm64 arch", () => {
+    const url = p.mkcertDownloadUrl("ia32");
+    expect(url).toContain("/amd64");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openCommand
+// ---------------------------------------------------------------------------
+
+describe("openCommand()", () => {
+  it("returns the correct open command for a URL", () => {
+    const url = "https://example.com";
+    if (onMacos) {
+      expect(p.openCommand(url)).toBe(`open ${url}`);
+    } else if (onWindows) {
+      expect(p.openCommand(url)).toBe(`start ${url}`);
+    } else {
+      expect(p.openCommand(url)).toBe(`xdg-open ${url}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// portCheckCommand / dnsCheckCommand
+// ---------------------------------------------------------------------------
+
+describe("portCheckCommand()", () => {
+  it("returns the correct command for a port", () => {
+    const port = 4321;
+    if (onWindows) {
+      expect(p.portCheckCommand(port)).toBe(`netstat -ano | findstr :${port}`);
+    } else {
+      expect(p.portCheckCommand(port)).toBe(`lsof -i :${port}`);
+    }
+  });
+});
+
+describe("dnsCheckCommand()", () => {
+  it("returns the correct command for a hostname", () => {
+    const host = "local.example.com";
+    if (onMacos) {
+      expect(p.dnsCheckCommand(host)).toBe(`dscacheutil -q host -a name ${host}`);
+    } else if (onWindows) {
+      expect(p.dnsCheckCommand(host)).toBe(`nslookup ${host}`);
+    } else {
+      expect(p.dnsCheckCommand(host)).toBe(`getent hosts ${host}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sedInPlace / hasPfctl / needsXcodeTools
+// ---------------------------------------------------------------------------
+
+describe("platform-specific constants", () => {
+  it("sedInPlace is correct", () => {
+    expect(p.sedInPlace).toBe(onMacos ? "-i ''" : "-i");
+  });
+
+  it("hasPfctl is true only on macOS", () => {
+    expect(p.hasPfctl).toBe(onMacos);
+  });
+
+  it("needsXcodeTools is true only on macOS", () => {
+    expect(p.needsXcodeTools).toBe(onMacos);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// notifyCommand
+// ---------------------------------------------------------------------------
+
+describe("notifyCommand()", () => {
+  const title = "Test";
+  const message = "Hello world";
+
+  if (onMacos) {
+    it("returns osascript command on macOS", () => {
+      const result = p.notifyCommand(title, message);
+      expect(result).not.toBeNull();
+      expect(result!.cmd).toBe("osascript");
+      expect(result!.args).toContain("-e");
+      expect(result!.args[1]).toContain(title);
+      expect(result!.args[1]).toContain(message);
+    });
+  } else if (onLinux) {
+    it("returns notify-send command on Linux", () => {
+      const result = p.notifyCommand(title, message);
+      expect(result).not.toBeNull();
+      expect(result!.cmd).toBe("notify-send");
+      expect(result!.args).toEqual([title, message]);
+    });
+  } else {
+    it("returns null on Windows", () => {
+      expect(p.notifyCommand(title, message)).toBeNull();
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// portForwardingInfo
+// ---------------------------------------------------------------------------
+
+describe("portForwardingInfo()", () => {
+  it("returns an object with supported and description", () => {
+    const info = p.portForwardingInfo();
+    expect(info).toHaveProperty("supported");
+    expect(info).toHaveProperty("description");
+    expect(typeof info.supported).toBe("boolean");
+    expect(typeof info.description).toBe("string");
+    expect(info.description.length).toBeGreaterThan(0);
+  });
+
+  it("has correct supported flag for the current OS", () => {
+    const info = p.portForwardingInfo();
+    if (onMacos) {
+      expect(info.supported).toBe(true);
+      expect(info.description).toContain("pfctl");
+    } else {
+      expect(info.supported).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fnmShellInit
+// ---------------------------------------------------------------------------
+
+describe("fnmShellInit()", () => {
+  it("returns an array of strings", () => {
+    const lines = p.fnmShellInit();
+    expect(Array.isArray(lines)).toBe(true);
+    expect(lines.length).toBeGreaterThan(0);
+    lines.forEach((line) => expect(typeof line).toBe("string"));
+  });
+
+  it("includes fnm comment", () => {
+    const lines = p.fnmShellInit();
+    expect(lines.some((l) => l.includes("fnm"))).toBe(true);
+  });
+
+  if (onWindows) {
+    it("includes powershell invocation on Windows", () => {
+      const lines = p.fnmShellInit();
+      expect(lines.some((l) => l.includes("Invoke-Expression"))).toBe(true);
+    });
+  } else {
+    it("includes eval and shell name on Unix", () => {
+      const lines = p.fnmShellInit();
+      const shell = p.shellName();
+      expect(lines.some((l) => l.includes("eval"))).toBe(true);
+      expect(lines.some((l) => l.includes(`--shell ${shell}`))).toBe(true);
+    });
+
+    it("includes fnmDir in PATH export", () => {
+      const lines = p.fnmShellInit();
+      expect(lines.some((l) => l.includes(p.fnmDir()))).toBe(true);
+    });
+  }
+});

--- a/tests/pre-deploy-check.test.ts
+++ b/tests/pre-deploy-check.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  scanEmails,
+  scanPhones,
+  scanTokens,
+  scanScripts,
+  walkHtml,
+  walkAll,
+} from "../template/scripts/pre-deploy-check.js";
+
+// ---------------------------------------------------------------------------
+// scanEmails
+// ---------------------------------------------------------------------------
+
+describe("scanEmails", () => {
+  it("finds real emails", () => {
+    const result = scanEmails("Contact us at user@example.com for info.", []);
+    expect(result).toEqual(["user@example.com"]);
+  });
+
+  it("ignores CSS at-rules: @import", () => {
+    expect(scanEmails("@import url('fonts.css');", [])).toEqual([]);
+  });
+
+  it("ignores CSS at-rules: @media", () => {
+    expect(scanEmails("@media screen and (min-width: 768px)", [])).toEqual([]);
+  });
+
+  it("ignores CSS at-rules: @keyframes", () => {
+    expect(scanEmails("@keyframes fadeIn { from { opacity: 0; } }", [])).toEqual([]);
+  });
+
+  it("ignores CSS at-rules: @font-face", () => {
+    expect(scanEmails("@font-face { font-family: 'Custom'; }", [])).toEqual([]);
+  });
+
+  it("ignores CSS at-rules: @layer", () => {
+    expect(scanEmails("@layer base { h1 { color: red; } }", [])).toEqual([]);
+  });
+
+  it("ignores CSS at-rules: @property", () => {
+    expect(scanEmails("@property --color { syntax: '<color>'; }", [])).toEqual([]);
+  });
+
+  it("excludes mailto: emails", () => {
+    const html = '<a href="mailto:info@example.com">Email us</a>';
+    expect(scanEmails(html, [])).toEqual([]);
+  });
+
+  it("respects allowlist", () => {
+    const result = scanEmails("Reach out to hello@mysite.com today.", ["hello@mysite.com"]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for content with no emails", () => {
+    expect(scanEmails("No email addresses here.", [])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanPhones
+// ---------------------------------------------------------------------------
+
+describe("scanPhones", () => {
+  it("detects (555) 123-4567", () => {
+    expect(scanPhones("Call us at (555) 123-4567")).toBe(true);
+  });
+
+  it("detects 555.123.4567", () => {
+    expect(scanPhones("Phone: 555.123.4567")).toBe(true);
+  });
+
+  it("detects 555-123-4567", () => {
+    expect(scanPhones("Phone: 555-123-4567")).toBe(true);
+  });
+
+  it("returns false for content without phone numbers", () => {
+    expect(scanPhones("No phone numbers here.")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanTokens
+// ---------------------------------------------------------------------------
+
+describe("scanTokens", () => {
+  it("detects pat prefix tokens (14+ alphanumeric chars)", () => {
+    expect(scanTokens("token: patAbcDefGhiJklMn")).toBe(true);
+  });
+
+  it("detects sk- prefix tokens (20+ alphanumeric chars)", () => {
+    expect(scanTokens("key: sk-AbcDefGhiJklMnOpQrStUv")).toBe(true);
+  });
+
+  it("returns false for short pat string", () => {
+    expect(scanTokens("pat123")).toBe(false);
+  });
+
+  it("returns false for short sk- string", () => {
+    expect(scanTokens("sk-abc")).toBe(false);
+  });
+
+  it("returns false for normal content", () => {
+    expect(scanTokens("Just some regular text about patterns.")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanScripts
+// ---------------------------------------------------------------------------
+
+describe("scanScripts", () => {
+  it("detects unauthorized external scripts", () => {
+    const html = '<script src="https://evil.com/script.js"></script>';
+    const result = scanScripts(html);
+    expect(result.length).toBe(1);
+    expect(result[0]).toContain("evil.com");
+  });
+
+  it("allows internal _astro scripts", () => {
+    const html = '<script src="/_astro/hoisted.abc123.js"></script>';
+    expect(scanScripts(html)).toEqual([]);
+  });
+
+  it("allows cloudflareinsights scripts", () => {
+    const html = '<script src="https://static.cloudflareinsights.com/beacon.min.js"></script>';
+    expect(scanScripts(html)).toEqual([]);
+  });
+
+  it("returns empty array for content with no scripts", () => {
+    expect(scanScripts("<p>No scripts here</p>")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// walkHtml / walkAll
+// ---------------------------------------------------------------------------
+
+describe("walkHtml", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-walk-test-"));
+    // Create nested structure
+    mkdirSync(join(tmpDir, "sub"), { recursive: true });
+    writeFileSync(join(tmpDir, "index.html"), "<html></html>");
+    writeFileSync(join(tmpDir, "style.css"), "body {}");
+    writeFileSync(join(tmpDir, "sub", "page.html"), "<html></html>");
+    writeFileSync(join(tmpDir, "sub", "data.json"), "{}");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("only returns .html files", () => {
+    const results = walkHtml(tmpDir);
+    expect(results.length).toBe(2);
+    expect(results.every(f => f.endsWith(".html"))).toBe(true);
+  });
+
+  it("finds nested .html files", () => {
+    const results = walkHtml(tmpDir);
+    expect(results.some(f => f.includes("sub"))).toBe(true);
+  });
+});
+
+describe("walkAll", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-walkall-test-"));
+    mkdirSync(join(tmpDir, "sub"), { recursive: true });
+    mkdirSync(join(tmpDir, ".hidden"), { recursive: true });
+    mkdirSync(join(tmpDir, "node_modules"), { recursive: true });
+    writeFileSync(join(tmpDir, "index.html"), "<html></html>");
+    writeFileSync(join(tmpDir, "style.css"), "body {}");
+    writeFileSync(join(tmpDir, "sub", "page.html"), "<html></html>");
+    writeFileSync(join(tmpDir, ".hidden", "secret.txt"), "hidden");
+    writeFileSync(join(tmpDir, "node_modules", "pkg.js"), "module");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns all files including non-html", () => {
+    const results = walkAll(tmpDir);
+    expect(results.some(f => f.endsWith(".html"))).toBe(true);
+    expect(results.some(f => f.endsWith(".css"))).toBe(true);
+  });
+
+  it("skips dot-directories", () => {
+    const results = walkAll(tmpDir);
+    expect(results.some(f => f.includes(".hidden"))).toBe(false);
+  });
+
+  it("skips node_modules", () => {
+    const results = walkAll(tmpDir);
+    expect(results.some(f => f.includes("node_modules"))).toBe(false);
+  });
+
+  it("returns empty array for non-existent directory", () => {
+    expect(walkAll(join(tmpDir, "nonexistent"))).toEqual([]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "resolveJsonModule": true
+  },
+  "include": ["bin/**/*.ts", "template/scripts/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "template/node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Map template/scripts imports to the actual source
+      "./config.js": resolve(__dirname, "template/scripts/config.ts"),
+      "./platform.js": resolve(__dirname, "template/scripts/platform.ts"),
+    },
+  },
+  esbuild: {
+    // Bypass template/tsconfig.json (which extends astro/tsconfigs/strict)
+    // by providing raw compiler options instead of file-based resolution
+    tsconfigRaw: "{}",
+  },
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary
- Adds **Vitest** test framework with 116 tests across 7 test files covering all TypeScript modules
- Extracts shared `readConfig()` into `template/scripts/config.ts` (deduplicated from 5 copies)
- Exports pure functions from all modules for testability while preserving CLI behavior via `process.argv` guards
- Fixes a **global regex `lastIndex` bug** in `scanPhones`, `scanEmails`, and `scanScripts` that caused inconsistent results across consecutive calls
- Adds `.claude/launch.json` dev server configurations

## Test plan
- [x] `npm test` — all 116 tests pass (278ms)
- [x] `node bin/init.js --help` — CLI still works
- [x] `npx tsx bin/build-instructions.ts` — validation report still works
- [ ] Scaffold to a temp directory and verify scripts run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)