### PR TITLE
fix(import): add bundled Wix extraction scripts to replace WebFetch

### DIFF
--- a/docs/import/README.md
+++ b/docs/import/README.md
@@ -17,7 +17,7 @@ These platforms serve content from their own infrastructure. The import skill fe
 
 - [WordPress](wordpress.md) — REST API extraction (best), WXR XML export, or RSS feed
 - [Squarespace](squarespace.md) — WXR XML export (best), RSS feed, or page scraping
-- [Wix](wix.md) — Page scraping via WebFetch (only option — Wix has no content API)
+- [Wix](wix.md) — Bundled extraction scripts parse SSR'd HTML via `curl` (Wix has no content API)
 - [Ghost](ghost.md) — Content API (best), RSS feed, or JSON export
 - [Medium](medium.md) — RSS feed (best), data export, or page scraping
 - [Substack](substack.md) — RSS feed with full content

--- a/docs/import/hosted-platforms.md
+++ b/docs/import/hosted-platforms.md
@@ -9,7 +9,8 @@ Every hosted platform import follows the same preference order. Use the best ava
 1. **Structured API** (WordPress REST, Ghost Content API, Webflow CMS API, Tumblr API, WriteFreely API, Micro.blog API) — Returns JSON with typed fields. Cleanest extraction, easiest to paginate, best metadata. Always prefer when available.
 2. **Structured export file** (WordPress WXR XML, Squarespace WXR, Ghost JSON export, Substack ZIP, Blogger XML backup, Micro.blog ZIP) — Complete snapshot of the site's content. Requires owner action to generate but captures everything including drafts.
 3. **RSS/Atom/JSON Feed** (available on most platforms) — Contains full or partial HTML content. Usually limited to recent posts (10–100). Good fallback when no API access.
-4. **WebFetch page-by-page** (always available as last resort) — Reads the rendered page and extracts content. Slowest, lowest fidelity, but works everywhere. Required for Wix, GoDaddy, and Carrd.
+4. **Bundled extraction scripts** (platform-specific) — For platforms like Wix where content is SSR'd but invisible to AI summarizers, `curl` + regex-based scripts extract content deterministically. See `scripts/import/wix/wix-extract.js`.
+5. **WebFetch page-by-page** (always available as last resort) — Reads the rendered page and extracts content. Slowest, lowest fidelity, but works everywhere. Required for GoDaddy and Carrd.
 
 ### When to ask the owner for help
 

--- a/docs/import/wix.md
+++ b/docs/import/wix.md
@@ -1,6 +1,6 @@
 # Importing from Wix
 
-Wix has the most restrictive content export of any major platform. There is no content API, no full export feature, and pages are JavaScript-rendered (Wix Thunderbolt), making standard HTML scraping unreliable. The import skill uses a combination of sitemaps, RSS metadata, and WebFetch page-by-page extraction.
+Wix has the most restrictive content export of any major platform. There is no content API, no full export feature, and pages are JavaScript-rendered (Wix Thunderbolt). However, Wix SSRs content into deeply nested `<span>` tags that `curl` can retrieve. The import skill uses a combination of sitemaps, RSS metadata, and bundled extraction scripts (`scripts/import/wix/wix-extract.js`) that parse the SSR'd HTML.
 
 See [hosted-platforms.md](hosted-platforms.md) for standard HTML-to-Markdown conversion rules, image optimization pipeline, pagination patterns, and missing field fallbacks. This doc covers only what's specific to Wix.
 
@@ -73,33 +73,64 @@ the owner to create an API key. Don't ask for it unless the site has more than
 20 blog posts (where RSS falls short). The API does **not** cover static pages —
 those still require WebFetch.
 
-### WebFetch for full content (fallback for posts, only option for pages)
+### Bundled extraction scripts (primary method for posts and pages)
 
-Each blog post and static page must be individually fetched via WebFetch. Because Wix pages are JavaScript-rendered (Wix Thunderbolt / React), simple `curl` or HTML parsing won't work — the rendered HTML contains an empty `<div id="SITE_CONTAINER"></div>` until JavaScript executes. The AI-powered WebFetch processes the rendered page and extracts structured content.
+Wix Thunderbolt server-side renders content into deeply nested `<span>` tags
+inside `data-hook="rcv-block*"` elements. Although the top-level HTML appears
+to be an empty `<div id="SITE_CONTAINER">`, `curl -sL` retrieves the SSR'd
+content that WebFetch's AI summarizer cannot parse. The bundled extraction
+scripts handle this reliably.
 
-### Extracting metadata from WebFetch
+**Location:** `${CLAUDE_PLUGIN_ROOT}/scripts/import/wix/wix-extract.js`
 
-When WebFetching each page, also extract:
-- **Meta description** (`<meta name="description">`): Wix generates per-page
-  meta descriptions. Use this as the Anglesite `description` field — it's
-  typically better than generating one from content.
-- **OG tags** (`og:title`, `og:description`, `og:image`): Wix sets these via
-  its Social Share settings. The `og:image` can serve as a fallback hero image
-  if the RSS `<enclosure>` is missing.
-- **Structured data (JSON-LD)**: Wix generates schema.org markup for blog posts
-  (`BlogPosting`), local business pages, and products. Extract `datePublished`,
-  `author.name`, `description`, and `image` from the JSON-LD — these are often
-  more accurate than RSS fields.
+**Workflow for each post or page:**
 
-Include these in the WebFetch prompt for blog posts:
-> "Also extract from the page metadata:
-> 6. The meta description (from the meta tag, not generated)
-> 7. The og:image URL (if different from inline images)
-> 8. Any JSON-LD structured data — especially datePublished and author name"
+```sh
+curl -sL "PAGE_URL" > /tmp/page.html
+node ${CLAUDE_PLUGIN_ROOT}/scripts/import/wix/wix-extract.js post /tmp/page.html
+```
+
+The script outputs JSON to stdout:
+
+```json
+{
+  "body": "Markdown-formatted post body with ## headings...",
+  "images": [{"src": "https://static.wixstatic.com/media/...", "alt": "..."}]
+}
+```
+
+**Available subcommands:**
+
+| Command | Input | Output |
+| --- | --- | --- |
+| `post <file>` | Downloaded blog post HTML | `{body, images}` — body text between `data-hook="post-description"` and `data-hook="post-footer"`, with headings converted to `##` |
+| `page <file>` | Downloaded static page HTML | `{body, images}` — full page text with nav, footer, and duplicates removed |
+| `meta <file>` | Any downloaded HTML | `{title, date, description, author, image}` — from JSON-LD (`BlogPosting`) with OG tag fallback |
+| `image <url>` | Wix CDN URL string | Normalized URL with transforms stripped and `?w=1200` appended |
+
+**How the post extractor works:**
+- Isolates the region between `data-hook="post-description"` and `data-hook="post-footer"` — these are stable Wix conventions
+- Extracts text from nested `<span>` tags within `data-hook="rcv-block*"` elements
+- Detects headings by font-size (24px+) and font-weight (bold)
+- Filters out empty spans, `\xa0` placeholders, and sub-3-char fragments
+- Extracts inline `<img>` elements with src and alt attributes
+
+**How the page extractor works:**
+- Strips `<script>`, `<style>`, `<nav>`, and `<footer>` blocks
+- Extracts span text from remaining `<div>` elements
+- Filters navigation items (Home, Blog, About, Contact, More) and footer boilerplate (copyright, "Paid for by...")
+- Deduplicates text (Wix often renders the same string multiple times in nested spans)
+
+### WebFetch (fallback only)
+
+WebFetch should only be used as a fallback when the extraction scripts return
+empty content (e.g., if Wix changes their HTML structure). In practice, WebFetch
+returns nothing useful for most Wix pages because the AI summarizer sees only
+minified JS and an empty `SITE_CONTAINER` div.
 
 ## Content conversion
 
-WebFetch returns clean Markdown, so minimal conversion is needed. Watch for:
+The extraction scripts return Markdown-ready text with `##` headings. Watch for:
 - Wix embed blocks (videos, maps, social feeds) — note for manual review
 - Wix lightbox image links (`?lightbox=true` parameters) — strip the parameter
 - Wix app content (Booking, Stores, Events) — cannot be imported, flag for replacement
@@ -162,13 +193,13 @@ Wix blog posts always use `/post/slug`:
 
 ## Common issues
 
-- **Full content not available in any feed**: Unlike WordPress and Squarespace, Wix provides no way to get full post content without visiting each page. This makes imports slower (one WebFetch per post).
+- **Full content not available in any feed**: Unlike WordPress and Squarespace, Wix provides no way to get full post content without visiting each page. Use the bundled extraction scripts with `curl` — they are faster and more reliable than WebFetch for Wix.
 - **No categories or tags in RSS**: The RSS feed has no `<category>` elements. Tags must be extracted by WebFetch from the rendered post page.
 - **Image transform parameters**: Failing to strip `/v1/fill/...` from Wix image URLs may result in cropped, sharpened, or low-quality downloads. Also watch for Wix auto-converting to WebP in the URL path.
 - **Multilingual content**: Some Wix sites have content in multiple languages (separate sitemaps like `/es_es-sitemap.xml`). Import the primary language first.
 - **Wix app pages**: Pages powered by Wix Booking, Stores, or Events contain no static content — they're generated at runtime. Flag these for replacement with industry tools.
-- **Rate limiting**: Wix may throttle rapid requests. If WebFetch fails on multiple consecutive pages, pause briefly between requests.
+- **Rate limiting**: Wix may throttle rapid `curl` requests. If downloads fail on multiple consecutive pages, pause briefly between requests.
 - **Dynamic pages missing from sitemap**: Pages powered by Wix collections/databases may not appear in the sitemap at all. Always cross-reference with homepage navigation links.
 - **Canonical tag conflict**: If the owner changed a page's default canonical tag in Wix SEO settings, that page disappears from the sitemap entirely. This can cause pages to be missed during discovery.
-- **RSS feed may degrade**: Wix has been known to disable full-text RSS or revert to links-only if the feed is called too frequently. Don't retry the feed — fall back to WebFetch.
+- **RSS feed may degrade**: Wix has been known to disable full-text RSS or revert to links-only if the feed is called too frequently. Don't retry the feed — fall back to the extraction scripts.
 - **Higher SEO risk than other migrations**: Wix URL structures differ significantly from most platforms (`/post/slug` for blog, flat paths for pages). Comprehensive redirect mapping is critical. Expect a 10–20% traffic dip in the first 4–6 weeks even with perfect redirects — warn the owner about this.

--- a/scripts/import/wix/wix-extract.js
+++ b/scripts/import/wix/wix-extract.js
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+
+// Wix content extraction utilities.
+//
+// Wix Thunderbolt server-side renders content into deeply nested <span> tags
+// inside data-hook="rcv-block*" elements. WebFetch can't parse these, but
+// this module can — using regex on the raw HTML returned by curl.
+//
+// Usage (CLI):
+//   node wix-extract.js post   <file.html>   # Extract blog post body + images
+//   node wix-extract.js page   <file.html>   # Extract static page body + images
+//   node wix-extract.js meta   <file.html>   # Extract JSON-LD / OG metadata
+//   node wix-extract.js image  <url>          # Normalize a Wix CDN image URL
+//
+// All commands output JSON to stdout.
+
+import { readFileSync } from 'node:fs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract all text from <span> tags in an HTML string (non-greedy). */
+function spanTexts(html) {
+  const spans = [];
+  const re = /<span[^>]*>(.*?)<\/span>/gs;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    // Strip any nested HTML tags from the captured content
+    const text = m[1].replace(/<[^>]*>/g, '').trim();
+    spans.push(text);
+  }
+  return spans;
+}
+
+/** True if text is empty, whitespace-only, or just \xa0 */
+function isEmpty(text) {
+  return !text || /^[\s\u00a0]*$/.test(text);
+}
+
+/** Detect if a block contains a heading (bold text at heading font-size). */
+function isHeading(blockHtml) {
+  return /<span[^>]*font-size:\s*2[4-9]px|font-size:\s*3[0-9]px/i.test(blockHtml)
+    && /<span[^>]*font-weight:\s*bold/i.test(blockHtml);
+}
+
+/** Extract <img> elements from HTML, returning [{src, alt}]. */
+function extractImages(html) {
+  const images = [];
+  const re = /<img\s[^>]*>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const tag = m[0];
+    const srcMatch = tag.match(/src=["']([^"']+)["']/);
+    const altMatch = tag.match(/alt=["']([^"']+)["']/);
+    if (srcMatch) {
+      images.push({
+        src: srcMatch[1],
+        alt: altMatch ? altMatch[1] : '',
+      });
+    }
+  }
+  return images;
+}
+
+// Nav items and footer boilerplate to filter from static pages.
+const NAV_WORDS = new Set([
+  'home', 'blog', 'about', 'contact', 'more', 'menu', 'search',
+  'log in', 'sign in', 'sign up',
+]);
+
+function isNavItem(text) {
+  return NAV_WORDS.has(text.toLowerCase().trim());
+}
+
+function isFooterBoilerplate(text) {
+  return /^paid for by\b/i.test(text)
+    || /all rights reserved/i.test(text)
+    || /^\u00a9/i.test(text.trim());
+}
+
+// ---------------------------------------------------------------------------
+// extractPost — blog post body from data-hook="post-description" region
+// ---------------------------------------------------------------------------
+
+export function extractPost(html) {
+  // Isolate the region between post-description and post-footer
+  const descStart = html.indexOf('data-hook="post-description"');
+  const footerStart = html.indexOf('data-hook="post-footer"');
+
+  if (descStart === -1) {
+    return { body: '', images: [] };
+  }
+
+  const regionEnd = footerStart !== -1 ? footerStart : html.length;
+  const region = html.slice(descStart, regionEnd);
+
+  // Extract images from the region
+  const images = extractImages(region);
+
+  // Process each rcv-block individually to detect headings vs paragraphs
+  const blocks = [];
+  const blockRe = /data-hook="rcv-block[^"]*"[^>]*>([\s\S]*?)(?=data-hook="rcv-block|$)/g;
+  let bm;
+  while ((bm = blockRe.exec(region)) !== null) {
+    const blockHtml = bm[1];
+    const texts = spanTexts(blockHtml).filter((t) => !isEmpty(t));
+    if (texts.length === 0) continue;
+
+    const combined = texts.join(' ');
+    if (isHeading(blockHtml)) {
+      blocks.push(`## ${combined}`);
+    } else {
+      blocks.push(combined);
+    }
+  }
+
+  // If no rcv-blocks found, fall back to extracting all spans from the region
+  if (blocks.length === 0) {
+    const allTexts = spanTexts(region).filter((t) => !isEmpty(t));
+    blocks.push(...allTexts);
+  }
+
+  return {
+    body: blocks.join('\n\n'),
+    images,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// extractPage — static page content (no post-description region)
+// ---------------------------------------------------------------------------
+
+export function extractPage(html) {
+  // Remove <script> and <style> blocks
+  let cleaned = html.replace(/<script[\s\S]*?<\/script>/gi, '');
+  cleaned = cleaned.replace(/<style[\s\S]*?<\/style>/gi, '');
+
+  // Remove <nav> blocks
+  cleaned = cleaned.replace(/<nav[\s\S]*?<\/nav>/gi, '');
+
+  // Remove <footer> blocks
+  cleaned = cleaned.replace(/<footer[\s\S]*?<\/footer>/gi, '');
+
+  // Extract images before stripping tags
+  const images = extractImages(cleaned);
+
+  // Process blocks with heading detection
+  const blocks = [];
+  const seen = new Set();
+
+  // Split by top-level divs that contain spans
+  const divRe = /<div[^>]*>([\s\S]*?)<\/div>(?=\s*<div|$)/g;
+  let dm;
+  while ((dm = divRe.exec(cleaned)) !== null) {
+    const divHtml = dm[0];
+    const texts = spanTexts(divHtml).filter((t) => !isEmpty(t));
+    if (texts.length === 0) continue;
+
+    const combined = texts.join(' ');
+
+    // Skip nav items and footer boilerplate
+    if (isNavItem(combined)) continue;
+    if (isFooterBoilerplate(combined)) continue;
+
+    // Deduplicate
+    if (seen.has(combined)) continue;
+    seen.add(combined);
+
+    if (isHeading(divHtml)) {
+      blocks.push(`## ${combined}`);
+    } else {
+      blocks.push(combined);
+    }
+  }
+
+  return {
+    body: blocks.join('\n\n'),
+    images,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// extractMetadata — JSON-LD and OG tag parsing
+// ---------------------------------------------------------------------------
+
+export function extractMetadata(html) {
+  const result = { title: null, date: null, description: null, author: null, image: null };
+
+  // Try JSON-LD first
+  const ldRe = /<script\s+type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi;
+  let ldMatch;
+  while ((ldMatch = ldRe.exec(html)) !== null) {
+    try {
+      const data = JSON.parse(ldMatch[1]);
+      if (data['@type'] === 'BlogPosting' || data['@type'] === 'Article') {
+        result.title = data.headline || data.name || null;
+        if (data.datePublished) {
+          result.date = data.datePublished.slice(0, 10); // YYYY-MM-DD
+        }
+        result.description = data.description || null;
+        if (data.author) {
+          result.author = typeof data.author === 'string'
+            ? data.author
+            : data.author.name || null;
+        }
+        if (data.image) {
+          result.image = typeof data.image === 'string'
+            ? data.image
+            : data.image.url || null;
+        }
+        return result; // BlogPosting found, use it
+      }
+    } catch { /* ignore malformed JSON-LD */ }
+  }
+
+  // Fall back to OG tags
+  const ogTitle = html.match(/<meta\s+property="og:title"\s+content="([^"]+)"/i);
+  const ogDesc = html.match(/<meta\s+property="og:description"\s+content="([^"]+)"/i);
+  const ogImage = html.match(/<meta\s+property="og:image"\s+content="([^"]+)"/i);
+  const metaDesc = html.match(/<meta\s+name="description"\s+content="([^"]+)"/i);
+
+  result.title = ogTitle ? ogTitle[1] : null;
+  result.description = ogDesc ? ogDesc[1] : (metaDesc ? metaDesc[1] : null);
+  result.image = ogImage ? ogImage[1] : null;
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// normalizeImageUrl — strip Wix CDN transforms, append ?w=1200
+// ---------------------------------------------------------------------------
+
+export function normalizeImageUrl(url) {
+  // Only process Wix static URLs
+  if (!url.includes('static.wixstatic.com/media/')) {
+    return url;
+  }
+
+  // Extract the base media path (everything before /v1/ or ?)
+  const mediaPrefix = 'static.wixstatic.com/media/';
+  const mediaStart = url.indexOf(mediaPrefix) + mediaPrefix.length;
+  const afterMedia = url.slice(mediaStart);
+
+  // The asset ID is everything up to /v1/, ?, or end of string
+  const assetEnd = afterMedia.search(/[/?]/);
+  const assetId = assetEnd === -1 ? afterMedia : afterMedia.slice(0, assetEnd);
+
+  return `https://static.wixstatic.com/media/${assetId}?w=1200`;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+const [,, command, arg] = process.argv;
+
+if (command) {
+  if (command === 'image') {
+    console.log(JSON.stringify(normalizeImageUrl(arg)));
+  } else {
+    const html = readFileSync(arg, 'utf-8');
+    let output;
+    switch (command) {
+      case 'post':
+        output = extractPost(html);
+        break;
+      case 'page':
+        output = extractPage(html);
+        break;
+      case 'meta':
+        output = extractMetadata(html);
+        break;
+      default:
+        console.error(`Unknown command: ${command}. Use: post, page, meta, image`);
+        process.exitCode = 1;
+    }
+    if (output) {
+      console.log(JSON.stringify(output, null, 2));
+    }
+  }
+}

--- a/skills/import/SKILL.md
+++ b/skills/import/SKILL.md
@@ -2,7 +2,7 @@
 name: import
 description: "Import content from a website URL (WordPress, Squarespace, Wix, Webflow, GoDaddy, Ghost, Medium, Substack, Blogger, Shopify, Weebly, Tumblr, Micro.blog, WriteFreely, Carrd)"
 argument-hint: "[website URL]"
-allowed-tools: ["WebFetch", "Bash(curl *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(npm run build)", "Bash(npm install)", "Bash(zsh *)", "Bash(git add *)", "Bash(git commit *)", "Bash(ls *)", "Bash(wc *)", "Bash(grep *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Write", "Read", "Glob", "Edit"]
+allowed-tools: ["WebFetch", "Bash(curl *)", "Bash(node *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(npm run build)", "Bash(npm install)", "Bash(zsh *)", "Bash(git add *)", "Bash(git commit *)", "Bash(ls *)", "Bash(wc *)", "Bash(grep *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Write", "Read", "Glob", "Edit"]
 disable-model-invocation: true
 ---
 
@@ -272,7 +272,27 @@ Use `<content:encoded>` (full HTML).
 or `<content:encoded>` field. For posts NOT in the RSS feed (older than the 20
 most recent), use WebFetch on the post URL with the extraction prompt below.
 
-**Wix / Unknown:** Use WebFetch on each post URL with this prompt:
+**Wix:** Use the bundled extraction scripts instead of WebFetch. Wix SSRs
+content into nested `<span>` tags that WebFetch cannot parse, but `curl` +
+the extraction scripts handle reliably.
+
+For each post:
+
+```sh
+curl -sL "POST_URL" > /tmp/wix-post.html
+node ${CLAUDE_PLUGIN_ROOT}/scripts/import/wix/wix-extract.js post /tmp/wix-post.html
+node ${CLAUDE_PLUGIN_ROOT}/scripts/import/wix/wix-extract.js meta /tmp/wix-post.html
+```
+
+The `post` command returns `{body, images}` — Markdown-formatted body with `##`
+headings and a list of inline image URLs. The `meta` command returns
+`{title, date, description, author, image}` from JSON-LD and OG tags.
+
+If extraction returns empty content, fall back to WebFetch as a last resort,
+then add the post to FAILED_POSTS if that also fails. Do not stop the import
+for individual failures.
+
+**Unknown platforms:** Use WebFetch on each post URL with this prompt:
 
 > "Extract the full blog post content from this page. Return:
 > 1. The post title (from the main heading, not browser title)
@@ -440,8 +460,19 @@ Convert HTML to Markdown as in Step 2b.
 Note that Squarespace only exports text blocks — complex layouts (galleries,
 forms, product grids) are not included in the export.
 
+**Wix:** Use the bundled extraction scripts (same as Step 2a):
+
+```sh
+curl -sL "PAGE_URL" > /tmp/wix-page.html
+node ${CLAUDE_PLUGIN_ROOT}/scripts/import/wix/wix-extract.js page /tmp/wix-page.html
+node ${CLAUDE_PLUGIN_ROOT}/scripts/import/wix/wix-extract.js meta /tmp/wix-page.html
+```
+
+The `page` command strips navigation, footer boilerplate, and duplicates
+automatically. If it returns empty content, fall back to WebFetch.
+
 **All other platforms and any page without pre-fetched content:** WebFetch is
-mandatory. This includes Wix, Weebly, GoDaddy, Carrd, Webflow without API,
+mandatory. This includes Weebly, GoDaddy, Carrd, Webflow without API,
 Squarespace without export, and any platform where RSS was the primary blog
 extraction source (RSS never contains static pages).
 

--- a/skills/import/content-discovery.md
+++ b/skills/import/content-discovery.md
@@ -125,11 +125,16 @@ post content with pagination — much faster than WebFetch for large blogs. See
 `${CLAUDE_PLUGIN_ROOT}/docs/import/wix.md` for details. Don't ask for an API
 key if the blog has 20 or fewer posts (RSS + WebFetch is sufficient).
 
-**Metadata extraction:** When WebFetching each post, also extract the meta
-description, `og:image`, and any JSON-LD structured data (`BlogPosting`
-schema) — these provide more accurate dates, descriptions, and author names
-than the RSS feed. See `${CLAUDE_PLUGIN_ROOT}/docs/import/wix.md` for the
-extended WebFetch prompt.
+**Metadata extraction:** When extracting each post, use the bundled extraction
+script to get structured metadata (JSON-LD and OG tags):
+
+```sh
+curl -sL "POST_URL" > /tmp/wix-post.html
+node ${CLAUDE_PLUGIN_ROOT}/scripts/import/wix/wix-extract.js meta /tmp/wix-post.html
+```
+
+This returns `{title, date, description, author, image}` — more accurate than
+RSS fields. See `${CLAUDE_PLUGIN_ROOT}/docs/import/wix.md` for full details.
 
 ## Ghost
 

--- a/test/fixtures/wix-blog-post.html
+++ b/test/fixtures/wix-blog-post.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>My Journey to Sustainable Living | Shiloh's Blog</title>
+<meta name="description" content="How I transformed my household into a zero-waste home over the course of a year.">
+<meta property="og:title" content="My Journey to Sustainable Living">
+<meta property="og:description" content="How I transformed my household into a zero-waste home over the course of a year.">
+<meta property="og:image" content="https://static.wixstatic.com/media/7986bd_f56edc6b839c4e3cb8caa6b922bb612a~mv2.jpg/v1/fill/w_980,h_551,al_c,q_85,usm_0.66_1.00_0.01/sustainable-living.webp">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "My Journey to Sustainable Living",
+  "datePublished": "2025-08-15T10:30:00Z",
+  "dateModified": "2025-08-16T14:00:00Z",
+  "description": "How I transformed my household into a zero-waste home over the course of a year.",
+  "author": {
+    "@type": "Person",
+    "name": "Shiloh Ballard"
+  },
+  "image": {
+    "@type": "ImageObject",
+    "url": "https://static.wixstatic.com/media/7986bd_f56edc6b839c4e3cb8caa6b922bb612a~mv2.jpg/v1/fill/w_980,h_551,al_c,q_85,usm_0.66_1.00_0.01/sustainable-living.webp"
+  }
+}
+</script>
+<style>.some-minified-css{display:block;margin:0}</style>
+<script>window.__THUNDERBOLT_CONFIG__={}</script>
+</head>
+<body>
+<div id="SITE_CONTAINER">
+<div id="site-root">
+<div data-hook="post-header">
+<div><span style="font-size:32px"><span style="font-weight:bold"><span>My Journey to Sustainable Living</span></span></span></div>
+<div><span>Shiloh Ballard</span></div>
+<div><span>Aug 15</span></div>
+</div>
+<div data-hook="post-description">
+<div data-hook="rcv-block1"><div><span style="font-size:18px"><span>It started with a single reusable bag. One year later, our household produces less than a jar of landfill waste per month.</span></span></div></div>
+<div data-hook="rcv-block2"><div><span style="font-size:18px"><span></span></span></div></div>
+<div data-hook="rcv-block3"><div><span style="font-size:24px"><span style="font-weight:bold"><span>The First Steps</span></span></span></div></div>
+<div data-hook="rcv-block4"><div><span style="font-size:18px"><span>When I decided to reduce our waste, I didn't know where to begin. The sheer volume of plastic packaging in our kitchen was overwhelming. I started by auditing our trash for a week, categorizing everything we threw away.</span></span></div></div>
+<div data-hook="rcv-block5"><div><span style="font-size:18px"><span>&#xa0;</span></span></div></div>
+<div data-hook="rcv-block6"><div><span style="font-size:18px"><span>The results were eye-opening. Over 60% of our waste was food packaging. Another 20% was single-use items we could easily replace.</span></span></div></div>
+<div data-hook="rcv-block7"><div><span style="font-size:18px"><span></span></span></div></div>
+<div data-hook="rcv-block8"><div><span style="font-size:24px"><span style="font-weight:bold"><span>What Actually Worked</span></span></span></div></div>
+<div data-hook="rcv-block9"><div><span style="font-size:18px"><span>Here's what made the biggest difference for us:</span></span></div></div>
+<div data-hook="rcv-block10"><div><span style="font-size:18px"><span>Switching to a local co-op that sells in bulk eliminated most of our packaging waste. We bring our own jars and bags.</span></span></div></div>
+<div data-hook="rcv-block11"><div><span style="font-size:18px"><span>Composting food scraps cut our landfill waste by nearly half overnight.</span></span></div></div>
+<div data-hook="rcv-block12"><div><span style="font-size:18px"><span>Replacing paper towels with cloth rags saved us money and reduced waste significantly.</span></span></div></div>
+<div data-hook="rcv-block13"><div><img src="https://static.wixstatic.com/media/7986bd_abc123~mv2.png/v1/fill/w_600,h_400,al_c,q_85/compost-bin.webp" alt="Our backyard compost bin" loading="lazy"></div></div>
+<div data-hook="rcv-block14"><div><span style="font-size:18px"><span></span></span></div></div>
+<div data-hook="rcv-block15"><div><span style="font-size:24px"><span style="font-weight:bold"><span>One Year Later</span></span></span></div></div>
+<div data-hook="rcv-block16"><div><span style="font-size:18px"><span>We're not perfect, and that's okay. Some months we produce more waste than others. But the overall trend has been remarkable. Our family of four now produces less trash in a month than we used to create in a single day.</span></span></div></div>
+<div data-hook="rcv-block17"><div><span style="font-size:18px"><span>If you're thinking about starting your own zero-waste journey, my advice is simple: start small, be patient, and don't let perfection be the enemy of progress.</span></span></div></div>
+</div>
+<div data-hook="post-footer">
+<div><span>Tagged: sustainability, zero-waste, lifestyle</span></div>
+<div><span>Recent Posts</span></div>
+<div><span>See All</span></div>
+</div>
+</div>
+</div>
+</body>
+</html>

--- a/test/fixtures/wix-static-page.html
+++ b/test/fixtures/wix-static-page.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>About Us | Shiloh's Blog</title>
+<meta name="description" content="Learn about Shiloh Ballard and the mission behind this blog.">
+<meta property="og:title" content="About Us">
+<meta property="og:description" content="Learn about Shiloh Ballard and the mission behind this blog.">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "About Us",
+  "description": "Learn about Shiloh Ballard and the mission behind this blog."
+}
+</script>
+<style>.minified{color:#333}</style>
+<script>window.__THUNDERBOLT_CONFIG__={}</script>
+</head>
+<body>
+<div id="SITE_CONTAINER">
+<div id="site-root">
+<nav>
+<div><span>Home</span></div>
+<div><span>Blog</span></div>
+<div><span>About</span></div>
+<div><span>Contact</span></div>
+<div><span>More</span></div>
+</nav>
+<div id="page-content">
+<div><span style="font-size:36px"><span style="font-weight:bold"><span>About Us</span></span></span></div>
+<div><span style="font-size:18px"><span>&#xa0;</span></span></div>
+<div><span style="font-size:18px"><span>Hi, I'm Shiloh Ballard. I'm a sustainability advocate, writer, and mother of two based in San Jose, California.</span></span></div>
+<div><span style="font-size:18px"><span></span></span></div>
+<div><span style="font-size:18px"><span>This blog documents our family's journey toward a more sustainable lifestyle. From zero-waste tips to eco-friendly product reviews, I share what I've learned along the way.</span></span></div>
+<div><span style="font-size:18px"><span>&#xa0;</span></span></div>
+<div><span style="font-size:24px"><span style="font-weight:bold"><span>Our Mission</span></span></span></div>
+<div><span style="font-size:18px"><span>We believe that small, consistent changes can make a big difference. Our goal is to show that sustainable living doesn't have to be complicated or expensive.</span></span></div>
+<div><span style="font-size:18px"><span></span></span></div>
+<div><span style="font-size:24px"><span style="font-weight:bold"><span>Get in Touch</span></span></span></div>
+<div><span style="font-size:18px"><span>Have questions or want to collaborate? Email us at hello@shilohballard.com or find us on social media.</span></span></div>
+<div><img src="https://static.wixstatic.com/media/7986bd_profile123~mv2.jpg/v1/fill/w_300,h_300,al_c,q_85/profile.webp" alt="Shiloh Ballard portrait"></div>
+</div>
+<footer>
+<div><span>Paid for by Friends of Shiloh Ballard 2024, FPPC #1234567</span></div>
+<div><span>hello@shilohballard.com</span></div>
+<div><span>© 2024 Shiloh Ballard. All rights reserved.</span></div>
+</footer>
+</div>
+</div>
+</body>
+</html>

--- a/test/wix-extract.test.js
+++ b/test/wix-extract.test.js
@@ -1,0 +1,178 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  extractPost,
+  extractPage,
+  extractMetadata,
+  normalizeImageUrl,
+} from '../scripts/import/wix/wix-extract.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = (name) => readFileSync(join(__dirname, 'fixtures', name), 'utf-8');
+
+describe('extractPost', () => {
+  const html = fixture('wix-blog-post.html');
+
+  it('extracts the post body text between post-description and post-footer', () => {
+    const result = extractPost(html);
+    assert.ok(result.body.includes('It started with a single reusable bag'));
+    assert.ok(result.body.includes('start small, be patient'));
+  });
+
+  it('filters out empty spans and \\xa0 fragments', () => {
+    const result = extractPost(html);
+    assert.ok(!result.body.includes('\u00a0'));
+    // No lines that are just whitespace between paragraphs
+    const lines = result.body.split('\n').filter((l) => l.trim() === '');
+    // Empty lines are fine as paragraph separators, but no \xa0 content
+    for (const line of result.body.split('\n')) {
+      assert.ok(line.trim() !== '\u00a0', 'Should not contain \\xa0-only lines');
+    }
+  });
+
+  it('extracts headings as markdown headings', () => {
+    const result = extractPost(html);
+    assert.ok(result.body.includes('## The First Steps'));
+    assert.ok(result.body.includes('## What Actually Worked'));
+    assert.ok(result.body.includes('## One Year Later'));
+  });
+
+  it('extracts inline image URLs', () => {
+    const result = extractPost(html);
+    assert.ok(result.images.length > 0);
+    assert.ok(result.images.some((img) => img.src.includes('7986bd_abc123~mv2.png')));
+    assert.ok(result.images.some((img) => img.alt === 'Our backyard compost bin'));
+  });
+
+  it('does not include post-footer content in the body', () => {
+    const result = extractPost(html);
+    assert.ok(!result.body.includes('Recent Posts'));
+    assert.ok(!result.body.includes('See All'));
+  });
+
+  it('does not include post-header content in the body', () => {
+    const result = extractPost(html);
+    // The title should be in the title field, not duplicated in body
+    assert.ok(!result.body.startsWith('My Journey'));
+  });
+});
+
+describe('extractPage', () => {
+  const html = fixture('wix-static-page.html');
+
+  it('extracts the main page content', () => {
+    const result = extractPage(html);
+    assert.ok(result.body.includes("I'm Shiloh Ballard"));
+    assert.ok(result.body.includes('sustainable lifestyle'));
+  });
+
+  it('filters out navigation items', () => {
+    const result = extractPage(html);
+    // Nav items should not appear as standalone content lines
+    const lines = result.body.split('\n').map((l) => l.trim());
+    assert.ok(!lines.includes('Home'));
+    assert.ok(!lines.includes('Blog'));
+    assert.ok(!lines.includes('More'));
+  });
+
+  it('filters out footer boilerplate', () => {
+    const result = extractPage(html);
+    assert.ok(!result.body.includes('Paid for by'));
+    assert.ok(!result.body.includes('All rights reserved'));
+  });
+
+  it('deduplicates repeated text', () => {
+    // Wix often renders the same string multiple times in nested spans
+    const dupeHtml = fixture('wix-static-page.html');
+    const result = extractPage(dupeHtml);
+    const lines = result.body.split('\n').map((l) => l.trim()).filter(Boolean);
+    const uniqueLines = [...new Set(lines)];
+    assert.equal(lines.length, uniqueLines.length, 'No duplicate lines');
+  });
+
+  it('extracts headings as markdown', () => {
+    const result = extractPage(html);
+    assert.ok(result.body.includes('## Our Mission'));
+    assert.ok(result.body.includes('## Get in Touch'));
+  });
+
+  it('extracts inline images', () => {
+    const result = extractPage(html);
+    assert.ok(result.images.length > 0);
+    assert.ok(result.images.some((img) => img.src.includes('profile123~mv2.jpg')));
+  });
+});
+
+describe('extractMetadata', () => {
+  const html = fixture('wix-blog-post.html');
+
+  it('extracts BlogPosting JSON-LD fields', () => {
+    const meta = extractMetadata(html);
+    assert.equal(meta.title, 'My Journey to Sustainable Living');
+    assert.equal(meta.date, '2025-08-15');
+    assert.equal(meta.author, 'Shiloh Ballard');
+    assert.ok(meta.description.includes('zero-waste home'));
+  });
+
+  it('extracts the hero image URL from JSON-LD', () => {
+    const meta = extractMetadata(html);
+    assert.ok(meta.image.includes('7986bd_f56edc6b839c4e3cb8caa6b922bb612a~mv2.jpg'));
+  });
+
+  it('falls back to og: tags when no JSON-LD is present', () => {
+    const noLdHtml = fixture('wix-static-page.html');
+    const meta = extractMetadata(noLdHtml);
+    assert.equal(meta.title, 'About Us');
+    assert.ok(meta.description.includes('Shiloh Ballard'));
+  });
+
+  it('returns null fields when no metadata is found', () => {
+    const meta = extractMetadata('<html><body>nothing</body></html>');
+    assert.equal(meta.title, null);
+    assert.equal(meta.date, null);
+    assert.equal(meta.author, null);
+  });
+});
+
+describe('normalizeImageUrl', () => {
+  it('strips /v1/fill/... transform parameters', () => {
+    const url = 'https://static.wixstatic.com/media/7986bd_f56edc6b~mv2.jpg/v1/fill/w_980,h_551,al_c,q_85,usm_0.66_1.00_0.01/file.webp';
+    const result = normalizeImageUrl(url);
+    assert.equal(result, 'https://static.wixstatic.com/media/7986bd_f56edc6b~mv2.jpg?w=1200');
+  });
+
+  it('strips /v1/fit/... transform parameters', () => {
+    const url = 'https://static.wixstatic.com/media/abc123~mv2.png/v1/fit/w_500,h_300/image.png';
+    const result = normalizeImageUrl(url);
+    assert.equal(result, 'https://static.wixstatic.com/media/abc123~mv2.png?w=1200');
+  });
+
+  it('handles URLs without /v1/ transforms', () => {
+    const url = 'https://static.wixstatic.com/media/abc123~mv2.png';
+    const result = normalizeImageUrl(url);
+    assert.equal(result, 'https://static.wixstatic.com/media/abc123~mv2.png?w=1200');
+  });
+
+  it('handles URLs that already have query params', () => {
+    const url = 'https://static.wixstatic.com/media/abc123~mv2.png?token=xyz';
+    const result = normalizeImageUrl(url);
+    assert.equal(result, 'https://static.wixstatic.com/media/abc123~mv2.png?w=1200');
+  });
+
+  it('detects the original file extension', () => {
+    const jpgUrl = 'https://static.wixstatic.com/media/abc~mv2.jpg/v1/fill/w_100/file.webp';
+    assert.ok(normalizeImageUrl(jpgUrl).includes('abc~mv2.jpg'));
+
+    const pngUrl = 'https://static.wixstatic.com/media/def~mv2.png/v1/fill/w_100/file.webp';
+    assert.ok(normalizeImageUrl(pngUrl).includes('def~mv2.png'));
+  });
+
+  it('passes through non-Wix URLs unchanged', () => {
+    const url = 'https://example.com/image.jpg';
+    assert.equal(normalizeImageUrl(url), 'https://example.com/image.jpg');
+  });
+});


### PR DESCRIPTION
## Summary

- **Adds `scripts/import/wix/wix-extract.js`** — deterministic extraction of blog posts, static pages, JSON-LD metadata, and Wix CDN image URL normalization via `curl` + regex parsing of SSR'd HTML
- **Replaces WebFetch as the primary Wix extraction method** — WebFetch returns nothing useful for Wix sites (empty `SITE_CONTAINER` div), but `curl` retrieves content buried in `data-hook="rcv-block*"` `<span>` elements
- **Updates all import docs and skill files** to route Wix through the bundled scripts, with WebFetch demoted to fallback-only

## Test plan

- [x] 22 tests pass via `node --test test/wix-extract.test.js` covering all four extractors (post, page, metadata, image URL)
- [x] CLI entry point verified (`node wix-extract.js meta`, `node wix-extract.js image`)
- [ ] End-to-end: run `/anglesite:import` against a live Wix site to confirm the full workflow

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)