### PR TITLE
fix(import): insert inline body images as Markdown in Wix

### DIFF
--- a/scripts/import/wix/wix-extract.js
+++ b/scripts/import/wix/wix-extract.js
@@ -118,6 +118,12 @@ function extractImages(html) {
   return images;
 }
 
+/** Convert <img> elements in a block to Markdown image syntax. Returns [] if no images. */
+function blockImages(blockHtml) {
+  const imgs = extractImages(blockHtml);
+  return imgs.map((img) => `![${img.alt}](${img.src})`);
+}
+
 // Nav items and footer boilerplate to filter from static pages.
 const NAV_WORDS = new Set([
   'home', 'blog', 'about', 'contact', 'more', 'menu', 'search',
@@ -153,12 +159,20 @@ export function extractPost(html) {
   // Extract images from the region
   const images = extractImages(region);
 
-  // Process each rcv-block individually to detect headings vs paragraphs
+  // Process each rcv-block individually to detect headings, images, or paragraphs
   const blocks = [];
   const blockRe = /data-hook="rcv-block[^"]*"[^>]*>([\s\S]*?)(?=data-hook="rcv-block|$)/g;
   let bm;
   while ((bm = blockRe.exec(region)) !== null) {
     const blockHtml = bm[1];
+
+    // Check for inline images first
+    const imgMarkdown = blockImages(blockHtml);
+    if (imgMarkdown.length > 0) {
+      blocks.push(...imgMarkdown);
+      continue;
+    }
+
     const fragments = blockFragments(blockHtml).filter((t) => !isEmpty(t));
     if (fragments.length === 0) continue;
 
@@ -204,11 +218,24 @@ export function extractPage(html) {
   const blocks = [];
   const seen = new Set();
 
-  // Split by top-level divs that contain spans
-  const divRe = /<div[^>]*>([\s\S]*?)<\/div>(?=\s*<div|$)/g;
+  // Split by top-level divs that contain spans or images
+  const divRe = /<div[^>]*>([\s\S]*?)<\/div>(?=\s*<\/?div|$)/g;
   let dm;
   while ((dm = divRe.exec(cleaned)) !== null) {
     const divHtml = dm[0];
+
+    // Check for inline images first
+    const imgMarkdown = blockImages(divHtml);
+    if (imgMarkdown.length > 0) {
+      for (const md of imgMarkdown) {
+        if (!seen.has(md)) {
+          seen.add(md);
+          blocks.push(md);
+        }
+      }
+      continue;
+    }
+
     const fragments = blockFragments(divHtml).filter((t) => !isEmpty(t));
     if (fragments.length === 0) continue;
 

--- a/test/fixtures/wix-blog-post.html
+++ b/test/fixtures/wix-blog-post.html
@@ -50,7 +50,7 @@
 <div data-hook="rcv-block11"><div><span style="font-size:18px"><span>Composting food scraps cut our landfill waste by nearly half overnight.</span></span></div></div>
 <div data-hook="rcv-block12"><div><span style="font-size:18px"><span>Replacing paper towels with cloth rags saved us money and reduced waste significantly.</span></span></div></div>
 <div data-hook="rcv-block13"><div><img src="https://static.wixstatic.com/media/7986bd_abc123~mv2.png/v1/fill/w_600,h_400,al_c,q_85/compost-bin.webp" alt="Our backyard compost bin" loading="lazy"></div></div>
-<div data-hook="rcv-block14"><div><span style="font-size:18px"><span></span></span></div></div>
+<div data-hook="rcv-block14"><div><img src="https://static.wixstatic.com/media/7986bd_def456~mv2.jpg/v1/fill/w_800,h_500,al_c,q_85/waste-chart.webp" alt="Monthly waste reduction chart" loading="lazy"></div></div>
 <div data-hook="rcv-block15"><div><span style="font-size:24px"><span style="font-weight:bold"><span>One Year Later</span></span></span></div></div>
 <div data-hook="rcv-block16"><div><span style="font-size:18px"><span>We're not perfect, and that's okay. Some months we produce more waste than others. But the overall trend has been remarkable. Our family of four now produces less trash in a month than we used to create in a single day.</span></span></div></div>
 <div data-hook="rcv-block17"><div><span style="font-size:18px"><span>If you're thinking about starting your own zero-waste journey, my advice is simple: start small, be patient, and don't let perfection be the enemy of progress.</span></span></div></div>

--- a/test/wix-extract.test.js
+++ b/test/wix-extract.test.js
@@ -39,9 +39,31 @@ describe('extractPost', () => {
 
   it('extracts inline image URLs', () => {
     const result = extractPost(html);
-    expect(result.images.length).toBeGreaterThan(0);
+    expect(result.images.length).toBeGreaterThanOrEqual(2);
     expect(result.images.some((img) => img.src.includes('7986bd_abc123~mv2.png'))).toBe(true);
     expect(result.images.some((img) => img.alt === 'Our backyard compost bin')).toBe(true);
+    expect(result.images.some((img) => img.src.includes('7986bd_def456~mv2.jpg'))).toBe(true);
+    expect(result.images.some((img) => img.alt === 'Monthly waste reduction chart')).toBe(true);
+  });
+
+  it('inserts inline images into body as markdown at the correct position', () => {
+    const result = extractPost(html);
+    // Images should appear as ![alt](src) in the body
+    expect(result.body).toContain('![Our backyard compost bin]');
+    expect(result.body).toContain('![Monthly waste reduction chart]');
+  });
+
+  it('places inline images between surrounding text blocks', () => {
+    const result = extractPost(html);
+    const lines = result.body.split('\n\n');
+    // The compost bin image should appear after the cloth rags paragraph
+    const ragIndex = lines.findIndex((l) => l.includes('cloth rags'));
+    const compostImgIndex = lines.findIndex((l) => l.includes('![Our backyard compost bin]'));
+    expect(compostImgIndex).toBeGreaterThan(ragIndex);
+    // The chart image should appear before "One Year Later"
+    const chartImgIndex = lines.findIndex((l) => l.includes('![Monthly waste reduction chart]'));
+    const oneYearIndex = lines.findIndex((l) => l.includes('One Year Later'));
+    expect(chartImgIndex).toBeLessThan(oneYearIndex);
   });
 
   it('does not include post-footer content in the body', () => {
@@ -109,6 +131,11 @@ describe('extractPage', () => {
     const result = extractPage(html);
     expect(result.images.length).toBeGreaterThan(0);
     expect(result.images.some((img) => img.src.includes('profile123~mv2.jpg'))).toBe(true);
+  });
+
+  it('inserts inline images into body as markdown', () => {
+    const result = extractPage(html);
+    expect(result.body).toContain('![Shiloh Ballard portrait]');
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     tsconfigRaw: "{}",
   },
   test: {
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "test/**/*.test.js"],
     environment: "node",
   },
 });


### PR DESCRIPTION
## Changes

- Add `blockImages()` helper function to convert `<img>` elements to Markdown syntax
- Extract inline images from rcv-blocks in blog posts and preserve them in body content as Markdown
- Extract inline images from divs in static pages and preserve them in body content as Markdown
- Update blog post fixture to include image in rcv-block14
- Add tests verifying inline images appear as Markdown in extracted body content at correct positions
- Fix vitest config to include `.js` test files in addition to `.ts`

## Impact

Inline images in Wix blog posts and pages are now preserved in the extracted body content as Markdown image syntax rather than being dropped.