### PR TITLE
fix(scaffold): append Astro build artifacts to .gitignore

### DIFF
--- a/scripts/scaffold.sh
+++ b/scripts/scaffold.sh
@@ -94,6 +94,22 @@ done
 # Execute rsync
 rsync "${RSYNC_OPTS[@]}" "$TEMPLATE/" "$DEST/"
 
+## Ensure required .gitignore entries exist
+# When scaffolding into an existing project (e.g. SSG conversion), rsync
+# --ignore-existing preserves the old .gitignore. Append any Astro build
+# artifact entries that are missing so they don't get committed.
+if ! $DRY_RUN; then
+  GITIGNORE="$DEST/.gitignore"
+  if [[ -f "$GITIGNORE" ]]; then
+    REQUIRED_ENTRIES=(dist .astro .wrangler .certs)
+    for entry in "${REQUIRED_ENTRIES[@]}"; do
+      if ! grep -qE "^${entry}/?$" "$GITIGNORE"; then
+        printf '\n%s' "$entry" >> "$GITIGNORE"
+      fi
+    done
+  fi
+fi
+
 if $DRY_RUN; then
   echo "Dry-run complete. No files were changed."
 else

--- a/test/scaffold-gitignore.test.js
+++ b/test/scaffold-gitignore.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCAFFOLD_SCRIPT = join(__dirname, '..', 'scripts', 'scaffold.sh');
+
+describe('scaffold.sh .gitignore merging', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'anglesite-scaffold-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('appends Astro build artifacts to an existing .gitignore', () => {
+    // Simulate an Eleventy project with its own .gitignore
+    writeFileSync(
+      join(tmpDir, '.gitignore'),
+      '_site/\nnode_modules\n.env\n',
+    );
+
+    execFileSync('/bin/zsh', [SCAFFOLD_SCRIPT, '--yes', tmpDir], {
+      stdio: 'pipe',
+    });
+
+    const gitignore = readFileSync(join(tmpDir, '.gitignore'), 'utf-8');
+
+    // Must contain Astro build artifacts
+    expect(gitignore).toMatch(/^dist\/?$/m);
+    expect(gitignore).toMatch(/^\.astro\/?$/m);
+
+    // Must preserve existing entries
+    expect(gitignore).toContain('_site/');
+  });
+
+  it('does not duplicate entries already present', () => {
+    // .gitignore that already has the required entries
+    writeFileSync(
+      join(tmpDir, '.gitignore'),
+      'dist\n.astro\nnode_modules\n',
+    );
+
+    execFileSync('/bin/zsh', [SCAFFOLD_SCRIPT, '--yes', tmpDir], {
+      stdio: 'pipe',
+    });
+
+    const gitignore = readFileSync(join(tmpDir, '.gitignore'), 'utf-8');
+    const distMatches = gitignore.match(/^dist\/?$/gm);
+    expect(distMatches).toHaveLength(1);
+  });
+
+  it('handles entries with trailing slashes (dist/ instead of dist)', () => {
+    writeFileSync(
+      join(tmpDir, '.gitignore'),
+      'dist/\n.astro/\nnode_modules\n',
+    );
+
+    execFileSync('/bin/zsh', [SCAFFOLD_SCRIPT, '--yes', tmpDir], {
+      stdio: 'pipe',
+    });
+
+    const gitignore = readFileSync(join(tmpDir, '.gitignore'), 'utf-8');
+    // Should not add a duplicate — dist/ and dist are equivalent in git
+    const distMatches = gitignore.match(/^dist\/?$/gm);
+    expect(distMatches).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Changes

- **scripts/scaffold.sh**: Added logic to ensure required Astro build artifact entries (`dist`, `.astro`, `.wrangler`, `.certs`) are present in `.gitignore` when scaffolding into existing projects
  - Uses `rsync --ignore-existing` to preserve existing `.gitignore` entries
  - Appends missing entries without duplicating existing ones
  - Handles both formats (with and without trailing slashes)

- **test/scaffold-gitignore.test.js**: Added comprehensive test suite covering:
  - Appending Astro artifacts to existing `.gitignore` files
  - Preventing duplicate entries
  - Handling trailing slash variations

## Motivation

When scaffolding into an existing project (e.g., SSG conversion from Eleventy), the old `.gitignore` is preserved. This ensures Astro build artifacts won't accidentally be committed.