### PR TITLE
Fix [slug].astro missing prerender = true, breaking dev mode

### DIFF
--- a/skills/convert/SKILL.md
+++ b/skills/convert/SKILL.md
@@ -210,6 +210,10 @@ This value determines:
 - The `href` prefix in homepage and listing templates
 - Whether redirects are needed for blog post URLs
 
+If `POST_URL_PREFIX` is empty and you move `[slug].astro` out of `src/pages/blog/`,
+ensure the new file still includes `export const prerender = true;` in its frontmatter.
+This is required for `getStaticPaths()` to work in dev mode (hybrid output).
+
 ## Step 2 — Convert blog posts
 
 Tell the owner:

--- a/template/src/pages/blog/[slug].astro
+++ b/template/src/pages/blog/[slug].astro
@@ -2,6 +2,8 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getCollection, render } from "astro:content";
 
+export const prerender = true;
+
 export async function getStaticPaths() {
   const posts = await getCollection("posts", ({ data }) => {
     return import.meta.env.PROD ? !data.draft : true;


### PR DESCRIPTION
## Summary

- Add `export const prerender = true;` to `template/src/pages/blog/[slug].astro` so `getStaticPaths()` works in dev mode (hybrid output)
- Update convert skill to instruct the agent to preserve `prerender = true` when relocating `[slug].astro` for non-default `POST_URL_PREFIX`

## Problem

The `astro.config.ts` uses `output: isDev ? "server" : "static"` for Keystatic CMS support. In server mode, `getStaticPaths()` is silently ignored without `export const prerender = true`, so `Astro.props.post` is undefined — causing `RenderUndefinedEntryError` on every post page during `npx astro dev`.

Builds (`npx astro build`) were unaffected since they use static output mode.

Fixes #39

## Test plan

- [ ] Run `npx astro dev` and navigate to a blog post — should render without error
- [ ] Run `npx astro build` — should still build successfully
- [ ] Run `/anglesite:convert` with `POST_URL_PREFIX=` (empty) and verify the generated `[slug].astro` includes `prerender = true`

https://claude.ai/code/session_01REEXE3HuLDiLnMdPpSoKcc