### PR TITLE
Fix Squarespace import gaps analogous to Wix extraction fixes

### DIFF
--- a/docs/import/hosted-platforms.md
+++ b/docs/import/hosted-platforms.md
@@ -138,7 +138,7 @@ Different platforms use different CDN URL schemes. Strip platform-specific trans
 | --- | --- | --- |
 | Wix | `static.wixstatic.com` | Strip `/v1/fill/...` parameters, append `?w=1200` |
 | Medium | `miro.medium.com` | Strip `/resize:fit:NNNN/` from path |
-| Squarespace | `images.squarespace-cdn.com` | Use as-is (no transforms in URL) |
+| Squarespace | `images.squarespace-cdn.com` | Strip `?format=NNNw` if NNN < 1200 (gallery thumbnails); replace with `?format=2500w` or remove param |
 | WordPress | `site.com/wp-content/uploads/` | Use as-is |
 | Substack | `substackcdn.com` | Use as-is (width params OK at default) |
 | Shopify | `cdn.shopify.com` | Use as-is |

--- a/docs/import/squarespace.md
+++ b/docs/import/squarespace.md
@@ -38,7 +38,9 @@ Parse the WXR XML the same way as a WordPress export:
 
 ### 2. RSS feed
 
-Squarespace blogs publish an RSS feed at `/blog?format=rss`. This contains the 20 most recent posts with content. Useful as a fallback or supplement to the WXR export.
+Squarespace blogs publish an RSS feed at `COLLECTION_URL?format=rss`. The collection URL is **not always `/blog`** — it depends on how the owner configured their site. Common patterns include `/blog`, `/news`, `/journal`, `/posts`, or any custom path. Discover the correct collection URL from the sitemap or homepage navigation links before requesting the RSS feed.
+
+The feed contains up to 20 recent posts with full content. Some sites return fewer (as few as 10). Useful as a fallback or supplement to the WXR export.
 
 ### 3. WebFetch (fallback)
 
@@ -61,24 +63,77 @@ Squarespace images are served from `images.squarespace-cdn.com`. The URLs follow
 https://images.squarespace-cdn.com/content/v1/SITE_ID/ASSET_ID/image.jpg
 ```
 
-Download the URL as-is — no transform parameter stripping needed (unlike Wix).
+### CDN URL normalization
+
+Squarespace adds `?format=NNNw` parameters to control image width. Blog post body images often appear without a format parameter (full size), but **gallery and listing thumbnails** use small widths like `?format=100w` or `?format=300w`. Downloading these gives you a tiny thumbnail, not the original.
+
+**Rules:**
+- If the URL has no `?format=` parameter → use as-is (already full size)
+- If the URL has `?format=NNNw` where NNN < 1200 → strip the parameter or replace with `?format=2500w`
+- If the URL has `?format=originalw` or `?format=original` → use as-is
+
+```
+# Thumbnail (bad — only 100px wide)
+https://images.squarespace-cdn.com/content/v1/SITE_ID/ASSET_ID/image.jpg?format=100w
+
+# Full size (good)
+https://images.squarespace-cdn.com/content/v1/SITE_ID/ASSET_ID/image.jpg?format=2500w
+
+# Also full size (good — no param)
+https://images.squarespace-cdn.com/content/v1/SITE_ID/ASSET_ID/image.jpg
+```
 
 Squarespace CDN URLs expire after cancellation — see the CDN expiration warning in [hosted-platforms.md](hosted-platforms.md).
 
 ## URL patterns for redirects
 
-Squarespace blog posts use `/blog/slug`. Static pages use `/page-name`.
+Squarespace blog post URLs depend on the collection URL and permalink format configured by the owner. Common patterns:
 
-| Squarespace URL | Anglesite URL | Redirect |
+| Squarespace URL | Example | Notes |
+| --- | --- | --- |
+| `/blog/slug` | `/blog/my-great-post` | Default blog collection |
+| `/news/YYYY/M/slug` | `/news/2026/3/my-great-post` | Date-based with custom collection |
+| `/journal/slug` | `/journal/my-great-post` | Custom collection name |
+| `/page-name` | `/about` | Static pages |
+| `/gallery` | `/gallery` | Portfolio/gallery pages |
+
+**Important:** Do not assume `/blog/slug`. Use the actual URLs from the RSS feed, WXR export, or sitemap to determine the pattern. Generate redirect rules from the real old paths.
+
+| Old URL | New URL | Redirect |
 | --- | --- | --- |
 | `/blog/slug` | `/blog/slug` | None needed (same path) |
+| `/news/YYYY/M/slug` | `/blog/slug` | 301 (path changed) |
 | `/page-name` | `/page-name` | None needed if path matches |
 | `/gallery` | `/gallery` or `/` | Depends on site structure |
 
+## Content conversion extras
+
+Beyond the standard conversions in [hosted-platforms.md](hosted-platforms.md), handle these Squarespace-specific patterns:
+
+### Accordion blocks
+
+Squarespace has a native accordion block (`sqs-block-accordion`). When scraping via WebFetch, accordion panels may be collapsed and their content hidden. Look for accordion structures and ensure all panel content is extracted — WebFetch the page and specifically ask for accordion/FAQ content. If content appears truncated, the page likely has collapsed accordions.
+
+### Summary blocks (blog listing excerpts)
+
+Squarespace "summary blocks" show excerpts of blog posts on other pages (e.g., a homepage blog feed). When extracting static page content, strip these — they're duplicates of the blog posts already being imported separately. Look for repeated post titles with truncated text and "Read More" links.
+
+### Tags and categories
+
+Squarespace WXR exports include tags via `<category domain="post_tag">` and categories via `<category domain="category">`. However, RSS feeds often omit categories entirely. When using RSS as the extraction source, check the post page for tags displayed in the footer or sidebar. Common patterns:
+
+- `<a class="blog-tag" href="/blog/tag/TAG">TAG</a>`
+- `<span class="blog-categories-list">` containing tag links
+- Tags may appear under the post body, before the comments section
+
+If no tags are found in either RSS or the page HTML, leave `tags: []`.
+
 ## Common issues
 
-- **Gallery pages not in export**: Squarespace galleries contain images but the export only includes text content. Gallery images must be scraped from the live page before cancellation.
+- **Gallery pages not in export**: Squarespace galleries contain images but the export only includes text content. Gallery images must be scraped from the live page before cancellation. Gallery thumbnails use `?format=100w` — replace with `?format=2500w` to get full-size images.
+- **Blog collection URL varies**: The blog may not be at `/blog`. Check the sitemap or navigation for the actual collection URL before attempting RSS fetch. A 404 on `/blog?format=rss` usually means the collection has a different name.
 - **Custom CSS lost**: Code injection and custom CSS are not exported. The owner should save these manually if they contain brand-specific overrides.
 - **Form submissions lost**: Contact form data is not exported. The owner should export form submissions separately from Settings → Form Submissions.
 - **E-commerce products not in WXR**: Products must be exported separately as CSV from Commerce → Inventory.
 - **Member-only content**: Gated content behind Squarespace's member areas is not included in the public export.
+- **Date-based URLs**: Some Squarespace blogs use `/collection/YYYY/M/slug` URLs. These always need 301 redirects to `/blog/slug` since Anglesite uses flat blog paths.

--- a/skills/import/SKILL.md
+++ b/skills/import/SKILL.md
@@ -268,9 +268,12 @@ and tag names using the ID maps built in Step 1b.
 **Squarespace (WXR export):** The content is already in the XML from Step 1b.
 Use `<content:encoded>` (full HTML).
 
-**Squarespace (RSS fallback):** For posts in the RSS feed, use the `<description>`
-or `<content:encoded>` field. For posts NOT in the RSS feed (older than the 20
-most recent), use WebFetch on the post URL with the extraction prompt below.
+**Squarespace (RSS fallback):** The RSS feed URL is `COLLECTION_URL?format=rss`
+where COLLECTION_URL is the blog collection path discovered in Step 1b (not
+always `/blog` — may be `/news`, `/journal`, or any custom path). For posts in
+the RSS feed, use the `<description>` or `<content:encoded>` field. For posts
+NOT in the RSS feed (older than the most recent 10–20), use WebFetch on the
+post URL with the extraction prompt below.
 
 **Wix:** Use Playwright to extract content and design tokens. WebFetch does
 not work on Wix pages.
@@ -361,7 +364,7 @@ Tell the owner (once, not per-post):
 
 The image URL source depends on the platform:
 - WordPress: `source_url` from the media API response
-- Squarespace: image URLs in the content, typically from `images.squarespace-cdn.com`
+- Squarespace: image URLs in the content, typically from `images.squarespace-cdn.com`. Strip `?format=NNNw` if NNN < 1200 (gallery thumbnails are tiny); replace with `?format=2500w` or remove the param
 - Wix: `<enclosure>` URL from the RSS feed, typically from `static.wixstatic.com`
 
 For Wix images, strip transform parameters: remove everything from `/v1/` onward
@@ -646,14 +649,24 @@ Common patterns:
 Generate a redirect for each post using the actual old URL path.
 
 **Squarespace:**
+
+Squarespace blog URLs depend on the collection name and permalink format. The
+collection may not be `/blog` — it could be `/news`, `/journal`, etc. Some sites
+use date-based URLs like `/news/YYYY/M/slug`. Use the actual URLs from the RSS
+feed or WXR export.
+
 ```
+# Same path (collection is already /blog)
 /blog/slug /blog/slug 200
+
+# Different collection name
+/news/slug /blog/slug 301
+
+# Date-based URLs
+/news/2026/3/slug /blog/slug 301
 ```
 
-If old and new paths match, use `200` (passthrough). If they differ:
-```
-/old-path /blog/slug 301
-```
+If old and new paths match, use `200` (passthrough). If they differ, use `301`.
 
 **Wix:**
 ```

--- a/skills/import/content-discovery.md
+++ b/skills/import/content-discovery.md
@@ -58,17 +58,29 @@ from items where it is "page".
 
 **If they decline or can't export:** Fall back to RSS + sitemap + WebFetch.
 
-```sh
-curl -s "SITE_URL/blog?format=rss"
-```
+First, discover the blog collection URL. Squarespace blogs are not always at
+`/blog` — they can be `/news`, `/journal`, `/posts`, or any custom path.
 
 ```sh
 curl -s SITE_URL/sitemap.xml
 ```
 
-The RSS feed contains the 20 most recent blog posts with full content. The
-sitemap lists all pages. Posts not in the RSS feed will be fetched via WebFetch
-in Step 2.
+Look for blog post URLs in the sitemap to identify the collection path prefix
+(e.g., `/news/2026/3/slug` means the collection is at `/news`). Also check the
+homepage navigation links for the blog link.
+
+Then fetch the RSS feed using the discovered collection URL:
+
+```sh
+curl -s "SITE_URL/COLLECTION_PATH?format=rss"
+```
+
+If the collection path is unknown, try common names: `/blog?format=rss`,
+`/news?format=rss`, `/journal?format=rss`. A 404 means that path isn't the blog.
+
+The RSS feed contains up to 20 recent blog posts with full content (some sites
+return as few as 10). The sitemap lists all pages. Posts not in the RSS feed
+will be fetched via WebFetch in Step 2.
 
 ## Wix
 


### PR DESCRIPTION
## Summary

Tested Squarespace imports against two real sites — [naturestapestry.art](https://naturestapestry.art) (portfolio, 74 images) and [bikesiliconvalley.org](https://bikesiliconvalley.org) (blog with `/news/YYYY/M/slug` URLs) — and found three categories of issues analogous to the Wix fixes in v0.15.0:

- **CDN URL normalization**: Gallery thumbnails use `?format=100w`, downloading tiny images. Docs previously said "use as-is" — now documents stripping small format params and replacing with `?format=2500w`
- **Blog collection URL discovery**: Squarespace blogs are not always at `/blog` (can be `/news`, `/journal`, etc.). RSS at `/blog?format=rss` returns 404 for these sites. Updated content discovery to probe sitemap/nav for the actual collection URL
- **Content extraction extras**: Added guidance for accordion blocks (collapsed content hidden from WebFetch), summary blocks (duplicate excerpts to strip), tag extraction from page HTML (RSS often omits categories), and date-based URL redirect patterns

### Files changed
| File | Change |
|---|---|
| `docs/import/squarespace.md` | CDN normalization rules, accordion/summary/tag sections, variable URL patterns |
| `docs/import/hosted-platforms.md` | Fixed CDN table entry for Squarespace |
| `skills/import/SKILL.md` | Squarespace RSS discovery, image CDN note, redirect patterns |
| `skills/import/content-discovery.md` | Collection URL discovery before RSS fetch |

### Wix fix applicability analysis

| Wix Fix | Applies to Squarespace? |
|---|---|
| Preserve hyperlinks in bodies | No — clean `<a>text</a>`, no nested spans |
| Static page hyperlinks | No — same clean structure |
| Inline body images / CDN normalization | **Yes** — gallery thumbnails need `?format=` stripping |
| Join split-word text | No — Wix Thunderbolt-specific |
| Merge ordinal suffixes | No — Squarespace doesn't split ordinals |
| Extract tags from footers | **Yes** — RSS often omits categories |
| Expand accordions | **Yes** — Squarespace has accordion blocks |
| Rename opaque slugs | No — Squarespace auto-generates meaningful slugs |

## Test plan

- [ ] Run `/anglesite:import https://naturestapestry.art` — verify gallery images download at full size (not 100px thumbnails)
- [ ] Run `/anglesite:import https://bikesiliconvalley.org` — verify RSS discovered at `/news?format=rss`, not 404 on `/blog?format=rss`
- [ ] Verify redirect rules use actual `/news/YYYY/M/slug` paths, not assumed `/blog/slug`
- [ ] Spot-check that accordion content on a Squarespace site with FAQ blocks is extracted

https://claude.ai/code/session_012LQHRKkQwFNi4HyRzgwGLT