### PR TITLE
Optimize plugin instructions: reduce always-loaded tokens by 17%

### DIFF
--- a/bin/build-instructions.ts
+++ b/bin/build-instructions.ts
@@ -127,6 +127,87 @@ export function validateNoDuplication(agentsContent: string, claudeContent: stri
 }
 
 // ---------------------------------------------------------------------------
+// Runtime doc-read analysis — scans skill files for doc references
+// ---------------------------------------------------------------------------
+
+interface SkillDocReads {
+  skill: string;
+  skillBytes: number;
+  referencedDocs: FileInfo[];
+  totalBytes: number;
+  totalTokens: number;
+}
+
+/**
+ * Scan a skill file for `${CLAUDE_PLUGIN_ROOT}/...` references and
+ * measure the total bytes that skill will load at runtime.
+ */
+function analyzeSkillReads(skillName: string): SkillDocReads {
+  const skillPath = join(ROOT, `skills/${skillName}/SKILL.md`);
+  const skillBytes = statSync(skillPath).size;
+  const content = readFileSync(skillPath, "utf-8");
+
+  // Match ${CLAUDE_PLUGIN_ROOT}/path/to/file.md references
+  const refPattern = /\$\{CLAUDE_PLUGIN_ROOT\}\/([\w/.-]+\.md)/g;
+  const seen = new Set<string>();
+  const docs: FileInfo[] = [];
+  let match;
+
+  while ((match = refPattern.exec(content)) !== null) {
+    const relPath = match[1];
+    if (seen.has(relPath)) continue;
+    seen.add(relPath);
+
+    const fullPath = join(ROOT, relPath);
+    if (existsSync(fullPath)) {
+      const bytes = statSync(fullPath).size;
+      docs.push({ path: relPath, label: relPath, bytes, tokens: tokens(bytes) });
+    }
+  }
+
+  // Also check for sub-file references within the skill directory
+  const skillDir = join(ROOT, `skills/${skillName}`);
+  const subFiles = readdirSync(skillDir).filter(
+    f => f.endsWith(".md") && f !== "SKILL.md"
+  );
+  for (const sub of subFiles) {
+    const subPath = `skills/${skillName}/${sub}`;
+    if (seen.has(subPath)) continue;
+    seen.add(subPath);
+
+    // Check if the sub-file is referenced from SKILL.md
+    if (content.includes(sub)) {
+      const bytes = statSync(join(ROOT, subPath)).size;
+      docs.push({ path: subPath, label: sub, bytes, tokens: tokens(bytes) });
+    }
+  }
+
+  // Check for shared skill references
+  const sharedPattern = /\$\{CLAUDE_PLUGIN_ROOT\}\/(skills\/shared\/[\w/.-]+\.md)/g;
+  while ((match = sharedPattern.exec(content)) !== null) {
+    const relPath = match[1];
+    if (seen.has(relPath)) continue;
+    seen.add(relPath);
+
+    const fullPath = join(ROOT, relPath);
+    if (existsSync(fullPath)) {
+      const bytes = statSync(fullPath).size;
+      docs.push({ path: relPath, label: relPath, bytes, tokens: tokens(bytes) });
+    }
+  }
+
+  const totalBytes = skillBytes + docs.reduce((s, d) => s + d.bytes, 0);
+
+  return {
+    skill: skillName,
+    skillBytes,
+    referencedDocs: docs,
+    totalBytes,
+    totalTokens: tokens(totalBytes),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -183,6 +264,19 @@ function main() {
   const totalSkillTokens = skills.reduce((s, f) => s + f.tokens, 0);
   console.log(`  ${"─".repeat(24)} ${"─".repeat(8)}  ${"─".repeat(6)}`);
   console.log(`  ${"Total".padEnd(24)} ${fmtKB(totalSkillBytes).padStart(8)}  ${fmt(totalSkillTokens).padStart(6)} tokens`);
+
+  // --- Runtime doc-read analysis ---
+  console.log("\nRuntime doc reads (SKILL.md + referenced docs):");
+  const skillReads: SkillDocReads[] = [];
+  for (const name of skillDirs) {
+    const reads = analyzeSkillReads(name);
+    skillReads.push(reads);
+    const docCount = reads.referencedDocs.length;
+    const docsLabel = docCount === 0 ? "no refs" : `${docCount} docs`;
+    console.log(
+      `  ${name.padEnd(24)} ${fmtKB(reads.totalBytes).padStart(8)}  ${fmt(reads.totalTokens).padStart(6)} tokens  (${docsLabel})`
+    );
+  }
 
   // --- Template docs ---
   const docsDir = join(ROOT, "template/docs");

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -149,7 +149,7 @@ After the check, tell the owner: "This is the same kind of checkup a good web de
 
 After the audit, if any must-fix issues were found that couldn't be resolved in the current session, file a GitHub issue for each one. Read `GITHUB_REPO` from `.site-config`. If not set, skip this step.
 
-Follow the bug filing workflow in `AGENTS.md`. Use the appropriate label:
+Follow the bug filing workflow in `docs/bug-filing.md`. Use the appropriate label:
 - Accessibility violations → `accessibility`
 - Security findings → `security`
 - Build failures → `build`

--- a/skills/convert/SKILL.md
+++ b/skills/convert/SKILL.md
@@ -227,90 +227,22 @@ mkdir -p public/images/blog
 
 For each post in BLOG_POSTS:
 
-### 2a — Convert content
+Read `${CLAUDE_PLUGIN_ROOT}/skills/shared/content-conversion.md` for the full
+content conversion, image optimization, and `.mdoc` writing procedures.
+
+For each post in BLOG_POSTS:
 
 1. Parse the frontmatter using the field mapping from the platform doc
-2. Convert the body content to clean Markdown:
-   - Strip platform-specific template syntax (shortcodes, Liquid tags, Vue
-     components, Nunjucks tags, admonitions) as documented in the platform doc's
-     "Content conversion" section and `${CLAUDE_PLUGIN_ROOT}/docs/import/ssg-migrations.md`
-   - Convert admonitions (`:::`, `!!!`, custom containers) to blockquotes
-   - Strip MDX/JSX imports and component tags
-   - Remove template expressions (`{{ }}`, `{% %}`, `{{< >}}`)
-   - Keep standard Markdown (headings, lists, links, images, code blocks)
-3. Map frontmatter fields per the platform doc's mapping table
-4. If `description` is missing, generate from the first paragraph
-5. If `publishDate` is missing, use the file's git commit date or modification
-   date as fallback
-
-### 2b — Copy and optimize images
-
-Tell the owner (once, not per-post):
-> "I'm copying images from your project and optimizing them for the web."
-
-The platform doc's "Image handling" section specifies where images are stored
-(e.g., `static/img/` for Docusaurus, `source/images/` for Hexo, `content/` for
-Hugo page bundles).
-
-```sh
-cp SOURCE_IMAGE "public/images/blog/SLUG-hero.ext"
-```
-
-Check file size:
-
-```sh
-wc -c < public/images/blog/SLUG-hero.ext
-```
-
-If over 500,000 bytes, convert and resize using `sharp-cli` (cross-platform):
-
-```sh
-npx sharp-cli -i public/images/blog/SLUG-hero.ext -o public/images/blog/SLUG-hero.webp --width 1200
-```
-
-Update image references in the converted Markdown to use local paths.
-
-### 2c — Write the .mdoc file
-
-Assemble frontmatter fields:
-- `title`: from source frontmatter
-- `description`: from excerpt or generated from first paragraph
-- `publishDate`: in YYYY-MM-DD format
-- `image`: local path after copy, or omit
-- `imageAlt`: derive from post title (e.g., "Hero image for [title]")
-- `tags`: from categories/tags data, or `[]`
-- `draft`: `false`
-- `syndication`: `["ORIGINAL_URL"]` if the old site had a known public URL
-
-Sanitize the slug: lowercase, replace spaces with hyphens, remove characters
-other than `[a-z0-9-]`, trim leading/trailing hyphens. If the slug conflicts
-with an existing file, append `-converted`.
-
-Write to `src/content/posts/SLUG.mdoc`:
-
-```
----
-title: "The Post Title"
-description: "A one or two sentence summary of the post."
-publishDate: "2024-03-15"
-image: "/images/blog/my-post-hero.webp"
-imageAlt: "Hero image for The Post Title"
-tags: []
-draft: false
----
-
-The full post body content in clean Markdown goes here.
-```
-
-Rules for the body content:
-- No HTML tags — convert everything to Markdown equivalents
-- No MDX component syntax — plain Markdown only
-- No platform-specific shortcodes or embeds
-
-### 2d — Progress updates
-
-After every 5 posts, tell the owner:
-> "Converted 10 of 23 posts so far — about halfway done."
+2. Convert body content following the shared conversion procedures — also apply
+   the platform doc's "Content conversion" section and
+   `${CLAUDE_PLUGIN_ROOT}/docs/import/ssg-migrations.md` for platform-specific
+   template syntax stripping
+3. Copy and optimize images per the shared procedures. The platform doc's
+   "Image handling" section specifies where images are stored (e.g.,
+   `static/img/` for Docusaurus, `source/images/` for Hexo, `content/` for
+   Hugo page bundles)
+4. Write the `.mdoc` file per the shared procedures. Use `-converted` suffix
+   for slug conflicts
 
 ## Step 3 — Handle static pages
 
@@ -415,20 +347,9 @@ owner will customize the homepage during the design phase.
 
 ## Step 5 — Build and verify
 
-Tell the owner:
-> "I'm checking that everything converted correctly."
-
-```sh
-npm run build
-```
-
-If the build fails, diagnose and fix. Common causes:
-- Frontmatter doesn't match schema: check `src/content.config.ts` for expected fields
-- Invalid `publishDate` format: must be YYYY-MM-DD string
-- Missing required `description`: add a placeholder and note for review
-- Image path typo: verify file exists in `public/images/`
-
-Fix all build errors before presenting results (ADR-0012).
+Follow the build-and-verify procedure in
+`${CLAUDE_PLUGIN_ROOT}/skills/shared/content-conversion.md`. Fix all build
+errors before presenting results (ADR-0012).
 
 ## Step 6 — Present the results
 
@@ -481,6 +402,9 @@ converted and the date. Example:
 
 ## Edge cases
 
+See `${CLAUDE_PLUGIN_ROOT}/skills/shared/content-conversion.md` for shared edge
+cases (large images, multilingual content, slug conflicts, mixed formats).
+
 ### No blog posts in the project
 
 If BLOG_POSTS is empty after discovery:
@@ -488,32 +412,6 @@ If BLOG_POSTS is empty after discovery:
 > pages and set up redirects."
 
 Continue with Steps 3-4 for pages and redirects only.
-
-### Images still too large after conversion
-
-If the converted image is still over 500KB, do not block the conversion. Advise:
-> "Some images are still large after optimization. You can resize them or
-> replace them with smaller versions."
-
-### Multilingual content
-
-If the project has content in multiple languages:
-> "Your project has content in multiple languages. I'll convert the primary
-> language for now. Setting up multiple languages requires additional planning."
-
-Convert only primary-language content.
-
-### Slug conflicts
-
-Before writing each `.mdoc` file, sanitize the slug (lowercase, hyphens only,
-`[a-z0-9-]`). If it conflicts with an existing file, append `-converted` and
-log the conflict.
-
-### Mixed content formats
-
-Some SSG projects use multiple content formats (`.md`, `.mdx`, `.rst`, `.html`).
-Convert `.md` and `.mdx` files. For `.rst` and `.html`, inform the owner they
-need manual review.
 
 ### Monorepos and nested projects
 

--- a/skills/import/SKILL.md
+++ b/skills/import/SKILL.md
@@ -340,19 +340,9 @@ and continue. Do not stop the import for individual failures.
 
 ### 2b — Convert HTML to Markdown
 
-For WordPress and Squarespace content that arrives as rendered HTML, convert it
-to clean Markdown:
-- `<h2>` → `##`, `<h3>` → `###`, etc.
-- `<p>` → paragraph with blank line separation
-- `<a href="...">text</a>` → `[text](url)`
-- `<img src="..." alt="...">` → `![alt](src)` (download image in step 2c)
-- `<ul>/<li>` → `- item`
-- `<ol>/<li>` → `1. item`
-- `<blockquote>` → `> text`
-- `<strong>` → `**text**`, `<em>` → `*text*`
-- Strip all other HTML tags (`<div>`, `<span>`, `<figure>`, `<section>`, etc.)
-- Strip inline styles, class attributes, and data attributes
-- Strip empty paragraphs and excessive whitespace
+For WordPress and Squarespace content that arrives as rendered HTML, follow the
+HTML-to-Markdown conversion rules in
+`${CLAUDE_PLUGIN_ROOT}/skills/shared/content-conversion.md`.
 
 ### 2c — Download and optimize images
 
@@ -360,96 +350,30 @@ Tell the owner (once, not per-post):
 > "I'm downloading images from your website and converting them to a
 > web-friendly format."
 
-**Hero/featured images:**
+Follow the image optimization procedures in
+`${CLAUDE_PLUGIN_ROOT}/skills/shared/content-conversion.md`, using `curl -L -s`
+to download instead of `cp`.
 
-The image URL source depends on the platform:
-- WordPress: `source_url` from the media API response
-- Squarespace: image URLs in the content, typically from `images.squarespace-cdn.com`. Strip `?format=NNNw` if NNN < 1200 (gallery thumbnails are tiny); replace with `?format=2500w` or remove the param
-- Wix: `<enclosure>` URL from the RSS feed, typically from `static.wixstatic.com`
-
-For Wix images, strip transform parameters: remove everything from `/v1/` onward
-or any query string, then append `?w=1200`. For WordPress and Squarespace, use
-the URL as-is.
-
-```sh
-curl -L -s -o "public/images/blog/SLUG-hero.jpg" "IMAGE_URL"
-```
-
-Check file size:
-
-```sh
-wc -c < public/images/blog/SLUG-hero.jpg
-```
-
-If over 500,000 bytes, convert and resize using `sharp-cli` (cross-platform):
-
-```sh
-npx sharp-cli -i public/images/blog/SLUG-hero.jpg -o public/images/blog/SLUG-hero.webp --width 1200
-```
-
-Verify the conversion:
-
-```sh
-ls public/images/blog/SLUG-hero.webp
-```
-
-If `.webp` exists, set frontmatter `image` to `/images/blog/SLUG-hero.webp`.
-If conversion failed or the original was under 500KB, keep the original file.
+**Platform-specific image URL handling:**
+- WordPress: `source_url` from the media API response — use as-is
+- Squarespace: `images.squarespace-cdn.com` URLs — strip `?format=NNNw` if NNN < 1200; replace with `?format=2500w` or remove the param
+- Wix: `static.wixstatic.com` URLs — strip transform parameters from `/v1/` onward, append `?w=1200`
 
 If the download fails, add to FAILED_IMAGES and omit `image` from frontmatter.
 
-**Inline images:** For images embedded in the post body, download using the same
-approach with a `SLUG-body-N.webp` naming pattern and replace the inline image
+**Inline images:** Download with `SLUG-body-N.webp` naming and replace inline
 URLs with local paths.
 
 ### 2d — Assemble frontmatter and write the .mdoc file
 
-Assemble frontmatter fields:
-- `title`: from API/export/WebFetch
-- `description`: from excerpt or WebFetch summary
-- `publishDate`: in YYYY-MM-DD format
-- `image`: local path after download, or omit
-- `imageAlt`: derive from post title (e.g., "Hero image for [title]")
-- `tags`: from categories/tags data, or `[]`
-- `draft`: `false`
+Follow the `.mdoc` writing procedure in
+`${CLAUDE_PLUGIN_ROOT}/skills/shared/content-conversion.md`. Use `-imported`
+suffix for slug conflicts. Additionally, set:
 - `syndication`: `["ORIGINAL_POST_URL"]` — the URL on the old platform, preserving provenance per ADR-0006
-
-Sanitize the slug before using as filename: lowercase, replace spaces with
-hyphens, remove characters other than `[a-z0-9-]`, trim leading/trailing
-hyphens. If the slug conflicts with an existing file, append `-imported`.
-
-Write to `src/content/posts/SLUG.mdoc`:
-
-```
----
-title: "The Post Title"
-description: "A one or two sentence summary of the post."
-publishDate: "2024-03-15"
-image: "/images/blog/my-post-hero.webp"
-imageAlt: "Hero image for The Post Title"
-tags: []
-draft: false
-syndication: ["https://www.oldsite.com/blog/the-post-slug"]
----
-
-The full post body content in clean Markdown goes here.
-
-## Subheadings use ## syntax
-
-- Lists work as expected
-
-Links look like [this](https://example.com).
-```
-
-Rules for the body content:
-- No HTML tags — convert everything to Markdown equivalents
-- No MDX component syntax — plain Markdown is sufficient for imported content
-- No platform-specific shortcodes or embeds
 
 ### 2e — Progress updates
 
-After every 5 posts, tell the owner:
-> "Imported 10 of 23 posts so far — about halfway done."
+After every 5 posts, tell the owner progress (see shared procedures).
 
 ## Step 2.5 — Newsletter subscriber migration
 
@@ -727,22 +651,10 @@ step. The owner can set up colors and fonts later via `/anglesite:design-intervi
 
 ## Step 6 — Build and verify
 
-Tell the owner:
-> "I'm checking that everything imported correctly."
+Follow the build-and-verify procedure in
+`${CLAUDE_PLUGIN_ROOT}/skills/shared/content-conversion.md`.
 
-```sh
-npm run build
-```
-
-If the build fails, diagnose and fix. Common causes:
-- Frontmatter doesn't match schema: check `src/content.config.ts` for expected fields
-- Invalid `publishDate` format: must be YYYY-MM-DD string
-- Missing required `description`: add a placeholder and note for review
-- Image path typo: verify file exists in `public/images/`
-
-Fix all build errors before presenting results (ADR-0012).
-
-After a clean build, check for remaining external image dependencies:
+After a clean build, also check for remaining external image dependencies:
 
 ```sh
 grep -rE "wixstatic\.com|squarespace-cdn\.com|wp-content/uploads" dist/ --include="*.html"
@@ -837,6 +749,9 @@ imported and the date. Example:
 
 ## Edge cases
 
+See `${CLAUDE_PLUGIN_ROOT}/skills/shared/content-conversion.md` for shared edge
+cases (large images, multilingual content, slug conflicts).
+
 ### No blog on the site
 
 If BLOG_POSTS is empty after discovery:
@@ -845,32 +760,11 @@ If BLOG_POSTS is empty after discovery:
 
 Continue with Steps 3–5 for pages, galleries, and redirects only.
 
-### Images still too large after conversion
-
-If the converted image is still over 500KB, do not block the import. After the import,
-advise the owner:
-> "Some images are still large after optimization. You can resize them in
-> Preview or replace them with smaller versions."
-
-### Multilingual content
-
-If the sitemap or API contains content in multiple languages:
-> "Your site has content in multiple languages. I'll import the primary language
-> for now. Setting up multiple languages requires additional planning."
-
-Import only primary-language content.
-
 ### Platform app pages
 
 Booking, store, event, forum, and member pages cannot be meaningfully imported —
 the content depends on the platform's runtime infrastructure. Redirect to home
 (302) and present replacement options in Step 7.
-
-### Slug conflicts
-
-Before writing each `.mdoc` file, sanitize the slug (lowercase, hyphens only,
-`[a-z0-9-]`). If it conflicts with an existing file, append `-imported` and log
-the conflict.
 
 ### WordPress REST API is disabled
 

--- a/skills/shared/content-conversion.md
+++ b/skills/shared/content-conversion.md
@@ -1,0 +1,146 @@
+# Shared Content Conversion Procedures
+
+These procedures are used by both `/anglesite:import` and `/anglesite:convert`.
+Read this file when converting content from any source into Anglesite `.mdoc` files.
+
+## Convert content to clean Markdown
+
+1. Strip platform-specific template syntax (shortcodes, Liquid tags, Vue
+   components, Nunjucks tags, admonitions) as documented in the platform doc
+2. Convert admonitions (`:::`, `!!!`, custom containers) to blockquotes
+3. Strip MDX/JSX imports and component tags
+4. Remove template expressions (`{{ }}`, `{% %}`, `{{< >}}`)
+5. Keep standard Markdown (headings, lists, links, images, code blocks)
+6. If `description` is missing, generate from the first paragraph
+7. If `publishDate` is missing, use the file's git commit date or modification
+   date as fallback
+
+### HTML-to-Markdown conversion
+
+For content that arrives as rendered HTML:
+- `<h2>` → `##`, `<h3>` → `###`, etc.
+- `<p>` → paragraph with blank line separation
+- `<a href="...">text</a>` → `[text](url)`
+- `<img src="..." alt="...">` → `![alt](src)` (download image separately)
+- `<ul>/<li>` → `- item`
+- `<ol>/<li>` → `1. item`
+- `<blockquote>` → `> text`
+- `<strong>` → `**text**`, `<em>` → `*text*`
+- Strip all other HTML tags (`<div>`, `<span>`, `<figure>`, `<section>`, etc.)
+- Strip inline styles, class attributes, and data attributes
+- Strip empty paragraphs and excessive whitespace
+
+## Copy and optimize images
+
+Ensure the image directory exists:
+
+```sh
+mkdir -p public/images/blog
+```
+
+Copy/download image:
+
+```sh
+cp SOURCE_IMAGE "public/images/blog/SLUG-hero.ext"
+```
+
+Check file size:
+
+```sh
+wc -c < public/images/blog/SLUG-hero.ext
+```
+
+If over 500,000 bytes, convert and resize using `sharp-cli` (cross-platform):
+
+```sh
+npx sharp-cli -i public/images/blog/SLUG-hero.ext -o public/images/blog/SLUG-hero.webp --width 1200
+```
+
+Update image references in the converted Markdown to use local paths.
+
+If the download/copy fails, omit `image` from frontmatter and continue.
+
+## Write the .mdoc file
+
+Assemble frontmatter fields:
+- `title`: from source frontmatter or extraction
+- `description`: from excerpt or generated from first paragraph
+- `publishDate`: in YYYY-MM-DD format
+- `image`: local path after copy, or omit
+- `imageAlt`: derive from post title (e.g., "Hero image for [title]")
+- `tags`: from categories/tags data, or `[]`
+- `draft`: `false`
+- `syndication`: `["ORIGINAL_URL"]` if the old site had a known public URL
+
+Sanitize the slug: lowercase, replace spaces with hyphens, remove characters
+other than `[a-z0-9-]`, trim leading/trailing hyphens. If the slug conflicts
+with an existing file, append `-imported` (for imports) or `-converted` (for
+conversions).
+
+Write to `src/content/posts/SLUG.mdoc`:
+
+```
+---
+title: "The Post Title"
+description: "A one or two sentence summary of the post."
+publishDate: "2024-03-15"
+image: "/images/blog/my-post-hero.webp"
+imageAlt: "Hero image for The Post Title"
+tags: []
+draft: false
+---
+
+The full post body content in clean Markdown goes here.
+```
+
+Rules for the body content:
+- No HTML tags — convert everything to Markdown equivalents
+- No MDX component syntax — plain Markdown only
+- No platform-specific shortcodes or embeds
+
+## Progress updates
+
+After every 5 posts, tell the owner progress:
+> "Converted 10 of 23 posts so far — about halfway done."
+
+## Build and verify
+
+```sh
+npm run build
+```
+
+If the build fails, diagnose and fix. Common causes:
+- Frontmatter doesn't match schema: check `src/content.config.ts` for expected fields
+- Invalid `publishDate` format: must be YYYY-MM-DD string
+- Missing required `description`: add a placeholder and note for review
+- Image path typo: verify file exists in `public/images/`
+
+Fix all build errors before presenting results (ADR-0012).
+
+## Edge cases
+
+### Images still too large after conversion
+
+If the converted image is still over 500KB, do not block the process. Advise:
+> "Some images are still large after optimization. You can resize them or
+> replace them with smaller versions."
+
+### Multilingual content
+
+If the project has content in multiple languages:
+> "Your project has content in multiple languages. I'll convert the primary
+> language for now. Setting up multiple languages requires additional planning."
+
+Convert only primary-language content.
+
+### Slug conflicts
+
+Before writing each `.mdoc` file, sanitize the slug (lowercase, hyphens only,
+`[a-z0-9-]`). If it conflicts with an existing file, append the appropriate
+suffix and log the conflict.
+
+### Mixed content formats
+
+Some projects use multiple content formats (`.md`, `.mdx`, `.rst`, `.html`).
+Convert `.md` and `.mdx` files. For `.rst` and `.html`, inform the owner they
+need manual review.

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -112,6 +112,8 @@ Data is backed up to GitHub (private repo) and deployed to Cloudflare. Every dep
 
 When you encounter a bug you can't explain, file a GitHub issue. Read `docs/bug-filing.md` for the full workflow (duplicate search, labels, issue format).
 
+If you work around unexpected behavior — a build error you patch rather than fix at the source, a missing file you regenerate, a config default that was wrong — tell the owner what happened in plain language and offer to file a bug. Don't file silently; always ask first.
+
 ## Tone
 
 The owner is the expert on their business. You are the expert on their website. Explain what you're doing and why. Celebrate wins. When something breaks, own it, fix it, and explain what happened.

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -110,60 +110,7 @@ Data is backed up to GitHub (private repo) and deployed to Cloudflare. Every dep
 
 ## Bug filing
 
-When you encounter a bug — a build failure you can't explain, a dependency issue, a platform quirk, or anything that seems like it shouldn't happen — file a GitHub issue on the owner's repository. This creates a record for the next session and helps track recurring problems.
-
-Read `GITHUB_REPO` from `.site-config`. If not set, skip bug filing (GitHub backup wasn't configured).
-
-### Before filing
-
-Search for duplicates:
-
-```sh
-gh issue list --repo GITHUB_REPO --search "SEARCH_KEYWORDS" --state open --limit 10
-```
-
-Use 2–4 keywords from the error message or problem description. If a matching issue exists, add a comment with the new occurrence instead of creating a duplicate:
-
-```sh
-gh issue comment ISSUE_NUMBER --repo GITHUB_REPO --body "Encountered again on YYYY-MM-DD: BRIEF_DESCRIPTION"
-```
-
-### Filing a new issue
-
-If no duplicate exists:
-
-```sh
-gh issue create --repo GITHUB_REPO --title "TITLE" --body "BODY" --label LABEL
-```
-
-Choose the label that fits:
-- `bug` — Something is broken (build failure, runtime error, broken page)
-- `accessibility` — WCAG violation or usability issue found during check
-- `security` — Privacy leak, exposed token, CSP violation
-- `content` — Content error, broken links, SEO issues
-- `build` — Build or deploy failure, dependency issue
-
-Write the issue body in plain English. Include:
-1. What happened (the error or problem)
-2. What was being done when it happened (which skill, what action)
-3. Any error message (truncated to the relevant portion)
-4. What was tried to fix it (if anything)
-
-Do not include: customer data, API tokens, or file paths that reveal the owner's system layout.
-
-### When to file
-
-File issues for:
-- Build failures caused by dependency bugs (not user error)
-- Astro, Keystatic, or Wrangler bugs
-- Platform-specific issues (macOS/Linux/Windows differences)
-- Accessibility violations that can't be fixed in the current session
-- Security findings from `/anglesite:check` that need follow-up
-
-Do NOT file issues for:
-- Normal user requests ("make the header blue")
-- Content the owner hasn't written yet
-- Expected behavior (e.g., "build fails because there are no posts")
+When you encounter a bug you can't explain, file a GitHub issue. Read `docs/bug-filing.md` for the full workflow (duplicate search, labels, issue format).
 
 ## Tone
 

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -26,6 +26,7 @@ To write and edit blog posts, they navigate to `https://DEV_HOSTNAME/keystatic` 
 | Topic | File |
 |---|---|
 | GitHub backup and bugs | `docs/github.md` |
+| Bug filing workflow | `docs/bug-filing.md` |
 
 ## Shell commands
 

--- a/template/docs/bug-filing.md
+++ b/template/docs/bug-filing.md
@@ -1,0 +1,56 @@
+# Bug Filing
+
+When you encounter a bug — a build failure you can't explain, a dependency issue, a platform quirk, or anything that seems like it shouldn't happen — file a GitHub issue on the owner's repository. This creates a record for the next session and helps track recurring problems.
+
+Read `GITHUB_REPO` from `.site-config`. If not set, skip bug filing (GitHub backup wasn't configured).
+
+## Before filing
+
+Search for duplicates:
+
+```sh
+gh issue list --repo GITHUB_REPO --search "SEARCH_KEYWORDS" --state open --limit 10
+```
+
+Use 2–4 keywords from the error message or problem description. If a matching issue exists, add a comment with the new occurrence instead of creating a duplicate:
+
+```sh
+gh issue comment ISSUE_NUMBER --repo GITHUB_REPO --body "Encountered again on YYYY-MM-DD: BRIEF_DESCRIPTION"
+```
+
+## Filing a new issue
+
+If no duplicate exists:
+
+```sh
+gh issue create --repo GITHUB_REPO --title "TITLE" --body "BODY" --label LABEL
+```
+
+Choose the label that fits:
+- `bug` — Something is broken (build failure, runtime error, broken page)
+- `accessibility` — WCAG violation or usability issue found during check
+- `security` — Privacy leak, exposed token, CSP violation
+- `content` — Content error, broken links, SEO issues
+- `build` — Build or deploy failure, dependency issue
+
+Write the issue body in plain English. Include:
+1. What happened (the error or problem)
+2. What was being done when it happened (which skill, what action)
+3. Any error message (truncated to the relevant portion)
+4. What was tried to fix it (if anything)
+
+Do not include: customer data, API tokens, or file paths that reveal the owner's system layout.
+
+## When to file
+
+File issues for:
+- Build failures caused by dependency bugs (not user error)
+- Astro, Keystatic, or Wrangler bugs
+- Platform-specific issues (macOS/Linux/Windows differences)
+- Accessibility violations that can't be fixed in the current session
+- Security findings from `/anglesite:check` that need follow-up
+
+Do NOT file issues for:
+- Normal user requests ("make the header blue")
+- Content the owner hasn't written yet
+- Expected behavior (e.g., "build fails because there are no posts")

--- a/template/docs/bug-filing.md
+++ b/template/docs/bug-filing.md
@@ -4,19 +4,46 @@ When you encounter a bug — a build failure you can't explain, a dependency iss
 
 Read `GITHUB_REPO` from `.site-config`. If not set, skip bug filing (GitHub backup wasn't configured).
 
-## Before filing
+## Duplicate detection
 
-Search for duplicates:
+Before creating a new issue, search thoroughly. Duplicates fragment context and make bugs harder to track.
 
-```sh
-gh issue list --repo GITHUB_REPO --search "SEARCH_KEYWORDS" --state open --limit 10
-```
+### Search strategy
 
-Use 2–4 keywords from the error message or problem description. If a matching issue exists, add a comment with the new occurrence instead of creating a duplicate:
+Run at least two searches with different keyword angles:
 
 ```sh
-gh issue comment ISSUE_NUMBER --repo GITHUB_REPO --body "Encountered again on YYYY-MM-DD: BRIEF_DESCRIPTION"
+gh issue list --repo GITHUB_REPO --search "ERROR_MESSAGE_KEYWORDS" --state open --limit 10
+gh issue list --repo GITHUB_REPO --search "COMPONENT_OR_AREA_KEYWORDS" --state open --limit 10
 ```
+
+1. **Error text** — 2–4 keywords from the error message itself (e.g., `"astro build EPERM"`)
+2. **Area or component** — The part of the system affected (e.g., `"keystatic image upload"`, `"cloudflare deploy"`)
+
+If neither finds a match, also check closed issues — the same bug may have resurfaced:
+
+```sh
+gh issue list --repo GITHUB_REPO --search "KEYWORDS" --state closed --limit 5
+```
+
+If a closed issue matches, reopen it rather than filing a new one.
+
+### When a duplicate exists
+
+Add a comment that enriches the issue with whatever you learned this time. Include any of these that are new:
+
+```sh
+gh issue comment ISSUE_NUMBER --repo GITHUB_REPO --body "COMMENT_BODY"
+```
+
+The comment should include whichever of these apply:
+- **Date and frequency** — "Encountered again on YYYY-MM-DD" (helps establish a pattern)
+- **New reproduction context** — Different skill, page, or action that triggered the same bug
+- **Narrower root cause** — If you learned more about why it happens (e.g., "only occurs when the post has no hero image")
+- **Workaround found** — What you did to get past it, so the next session doesn't start from scratch
+- **Environment details** — OS, Node version, or package version if different from the original report
+
+Don't repeat information already in the issue. Read the existing body and comments first.
 
 ## Filing a new issue
 


### PR DESCRIPTION
## Summary

- **Extract bug-filing from AGENTS.md** — moved 800 tokens of bug-filing workflow to `template/docs/bug-filing.md`, loaded on demand instead of every turn
- **Create shared conversion procedures** — `skills/shared/content-conversion.md` deduplicates HTML-to-Markdown rules, image optimization, `.mdoc` writing, build verification, and edge cases between import and convert skills
- **Trim import/SKILL.md and convert/SKILL.md** — reference shared procedures instead of duplicating (~1,600 tokens saved across both)
- **Add runtime doc-read analysis to `build-instructions.ts`** — new report section shows per-skill total token cost including all `${CLAUDE_PLUGIN_ROOT}` doc references

### Token impact

| Metric | Before | After | Change |
|---|---|---|---|
| Always-loaded (every turn) | 2,861 tokens | 2,371 tokens | **-17%** |
| import/SKILL.md | 8,745 tokens | 7,923 tokens | -9% |
| convert/SKILL.md | 4,967 tokens | 4,184 tokens | -16% |
| Codex budget used | 30% | 24% | -6pp |

### New runtime doc-read report

`npx tsx bin/build-instructions.ts` now shows the true per-skill cost including all docs a skill will read:

```
Runtime doc reads (SKILL.md + referenced docs):
  import                    182.1KB  46,621 tokens  (24 docs)
  start                      79.4KB  20,322 tokens  (10 docs)
  convert                   100.7KB  25,785 tokens  (16 docs)
  ...
```

## Test plan

- [ ] Run `npx tsx bin/build-instructions.ts` — should show new "Runtime doc reads" section with no errors
- [ ] Run `npx tsx bin/average-tokens.ts` — should still work (no changes to its inputs)
- [ ] Verify `template/docs/bug-filing.md` contains the full bug-filing workflow
- [ ] Verify `skills/shared/content-conversion.md` covers all shared procedures
- [ ] Grep for orphaned references: no skill should reference removed AGENTS.md sections

https://claude.ai/code/session_01Kw2yeo2mCc7NXTZvKBqZb4