### PR TITLE
Fix marketplace.json to match official schema

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -22,7 +22,7 @@
     {
       "name": "anglesite",
       "description": "Scaffolds, designs, and deploys independent websites",
-      "source": "./",
+      "source": "./.claude-plugin",
       "category": "development"
     }
   ]


### PR DESCRIPTION
## Summary
- Moves `marketplace.json` from `.claude-plugin/` to the repo root, matching the official `anthropics/claude-code` marketplace layout
- Adds required fields (`$schema`, `version`, `description`, plugin `category`) to match the official schema
- Updates plugin `source` path from `"./"` to `"./.claude-plugin"` so it correctly points to where `plugin.json` lives

Fixes #40

## Test plan
- [ ] Run `claude plugin install anglesite@Anglesite/anglesite` and verify it succeeds
- [ ] Add marketplace via Cowork "Add marketplace" UI with `Anglesite/anglesite` and verify sync works
- [ ] Verify `/anglesite:start` still functions after install

https://claude.ai/code/session_01Madeu6NowGtV61YLy6F4W6