### PR TITLE
feat: multi-platform review coaching for reputation skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Anglesite is a Claude Code plugin (and npm package) that scaffolds and manages w
 ```
 ├── .claude-plugin/plugin.json    Plugin manifest (name, version, metadata)
 ├── marketplace.json              Marketplace distribution config
-├── skills/                       Skills (22 total: 11 user-facing, 11 model-only)
+├── skills/                       Skills (23 total: 11 user-facing, 12 model-only)
 │   ├── start/SKILL.md            First-time setup + scaffolding
 │   ├── deploy/SKILL.md           Build, scan, deploy to Cloudflare Pages
 │   ├── check/SKILL.md            Health audit + troubleshooting
@@ -30,6 +30,7 @@ Anglesite is a Claude Code plugin (and npm package) that scaffolds and manages w
 │   ├── business-info/SKILL.md    Hours, location, LocalBusiness JSON-LD (model-only)
 │   ├── themes/SKILL.md           Visual theme picker with tldraw (model-only)
 │   ├── qr/SKILL.md              QR codes + UTM tracking (model-only)
+│   ├── reputation/SKILL.md     Review monitoring + competitive coaching (model-only)
 │   ├── testimonials/SKILL.md    Review collection + display (model-only)
 │   ├── i18n/SKILL.md            Multi-language support (model-only)
 │   └── shared/content-conversion.md  Shared HTML-to-Markdown guidance
@@ -129,6 +130,7 @@ Three levels of agent instructions exist — do not confuse them:
 | `business-info` | Hours, address, phone, LocalBusiness JSON-LD |
 | `themes` | Pre-built visual theme picker with tldraw swatches |
 | `qr` | QR codes, shortlinks, UTM campaign URLs |
+| `reputation` | Review monitoring coaching and competitive awareness |
 | `testimonials` | Customer review collection, moderation, display |
 | `i18n` | Multi-language support with hreflang and language switcher |
 

--- a/docs/smb/accounting.md
+++ b/docs/smb/accounting.md
@@ -35,6 +35,18 @@ Covers: CPA firms, bookkeeping services, tax preparation (seasonal and year-roun
 - **Buttondown** (open source) — Tax deadline reminders, seasonal newsletters.
 - Many small firms run on the professional tax software plus a phone. Don't overcomplicate.
 
+## Review platforms
+
+- **Google Business Profile** — The primary channel for finding local accountants and tax preparers. Clients search "CPA near me" or "tax preparer [city]" and choose based on reviews. Reviews that mention specific situations ("they helped me navigate an audit," "explained everything clearly") are especially persuasive. Respond to every review — it signals professionalism.
+- **Yelp** — Used for accountants and tax preparers in some markets, particularly urban areas. Claim the profile and keep it current. A client who had a good tax season experience is often willing to leave a quick Yelp review if asked.
+- **Google** (again, via search results) — Google sometimes surfaces individual practitioner profiles (not just the business). If the firm has individual CPAs, those profiles should be complete.
+
+The best time to ask for a review is right after a successful tax filing, audit resolution, or first year of bookkeeping. A brief email: "It was great working with you this tax season. If you have a minute, a Google review would help other small businesses find us." Keep it simple. Most clients appreciate the ask.
+
+**Note:** AICPA and state CPA boards have ethics guidance on soliciting testimonials. Reviews from genuinely satisfied clients are generally acceptable; endorsement-style testimonials can require disclosures. Check state board guidance.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Credentials display**: CPA license numbers are state-regulated. Display state(s) of licensure. Enrolled Agents should display EA credentials and PTIN. Non-credentialed preparers must have a PTIN and comply with state registration if required.

--- a/docs/smb/animal-shelter.md
+++ b/docs/smb/animal-shelter.md
@@ -34,6 +34,14 @@ See [nonprofit.md](nonprofit.md) for shared nonprofit traits (donate page, trans
 - **SignUpGenius** (free tier) — Volunteer scheduling.
 - **GiveButter** (free, tips-based) — Fundraising with peer-to-peer support.
 
+## Review platforms
+
+- **Google Business Profile** — People searching for a shelter to adopt from, surrender a pet, or volunteer will often start with a Google search. Reviews here frequently describe the adoption experience and staff compassion. Keep the profile accurate with current hours and respond to all reviews.
+- **Petfinder / Adopt-a-Pet** — These platforms function as both listing directories and review surfaces. Adopters leave feedback on their experience. A well-maintained profile with updated animal listings signals an active, well-run shelter.
+- **Yelp** — Used in some markets for animal shelters and rescues. Reviews often describe the adoption process, shelter conditions, and how staff treated both animals and adopters.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Animal photos and updates**: Animals should be photographed in good light, looking their best. Poor shelter photos reduce adoption rates. This is the most impactful website optimization.

--- a/docs/smb/artist.md
+++ b/docs/smb/artist.md
@@ -69,6 +69,13 @@ Not all makers have a fixed price list. Custom work pricing depends on complexit
 
 Pick whichever model matches how the maker already prices their work. The website should make pricing transparent enough that customers self-qualify — they should know if they're in the right budget range before reaching out.
 
+## Review platforms
+
+- **Google Business Profile** — Essential if the artist has a studio, gallery, or regular in-person presence (markets, fairs, open studio events). People searching "potters near me" or "custom jewelry [city]" will find the listing. Keep it updated with upcoming event dates.
+- **Etsy** — For makers who sell on the platform, Etsy reviews are the most influential trust signal. Highlight standout reviews on the website to bring that credibility to the artist's own home base.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Sales tax**: Applies to physical goods sold in most states. Online sales may trigger nexus in multiple states. Market platforms (Etsy, Big Cartel) handle collection in most cases.

--- a/docs/smb/auto-dealer.md
+++ b/docs/smb/auto-dealer.md
@@ -33,6 +33,18 @@ Covers: used car dealerships, independent auto dealers, specialty/classic car de
 - **Square** (free POS, proprietary) — For smaller operations, down payments, accessories.
 - For very small dealers (10–20 cars), the website is primarily a credibility tool. Most actual inventory browsing happens on listing platforms.
 
+## Review platforms
+
+- **Google Business Profile** — The first place car buyers check when researching a dealership. A dealer with dozens of recent positive reviews (and professional responses to the negatives) builds trust before the customer ever walks on the lot. Used car buyers especially rely on Google to gauge dealer reputation.
+- **Yelp** — Active for dealerships in most markets. Some buyers specifically search Yelp for used car dealers because they perceive its reviews as less filtered than Google. Keep the profile claimed and respond to reviews.
+- **DealerRater** — An automotive-specific review platform used heavily by car buyers. Claim the profile. Customers who had a good experience can be directed here, and some dealers see significant referral traffic from DealerRater listings.
+- **CarGurus** and **Cars.com** — These listing platforms also host dealer reviews. Buyers research dealers on the same platform where they found the inventory listing — reviews here influence the decision to contact you.
+- **Facebook** — Used car communities are active on Facebook Marketplace and Facebook Groups. Dealer pages with reviews are checked. A business page with positive reviews and active posts builds trust with local buyers.
+
+After each successful sale or service visit, ask the customer directly: "If you had a good experience, a Google or DealerRater review really helps us compete with the big lots." Hand them a card with direct links.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **State dealer licensing**: All states require dealer licenses. Display your license number.

--- a/docs/smb/bookshop.md
+++ b/docs/smb/bookshop.md
@@ -37,6 +37,14 @@ Don't try to replicate a full online catalog. The website's job is to get people
 - **IndieBound** — American Booksellers Association directory. Help the owner claim or update their listing.
 - **Eventbrite** (free for free events) or **Cal.com** (open source) — For event RSVPs.
 
+## Review platforms
+
+- **Google Business Profile** — "Bookstores near me" and "used bookstore [city]" are common searches. The profile is also where people check holiday hours before a special trip. Keep it current with photos and respond to reviews.
+- **Yelp** — Many indie bookshop regulars use Yelp and leave detailed reviews about the curation, staff, and experience — the qualities that differentiate an indie shop from Amazon. Worth claiming and maintaining.
+- **Bookshop.org** — The indie bookstore's online sales platform also functions as a directory. Customers who buy through a shop's Bookshop.org affiliate page often leave ratings, and the shop's presence on the platform signals community commitment to indie bookselling.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **ISBN and publisher relationships**: Not a website concern, but if the shop wants to sell online, they'll need proper distribution channels. Link to Bookshop.org rather than building a storefront.

--- a/docs/smb/brewery.md
+++ b/docs/smb/brewery.md
@@ -38,6 +38,14 @@ Covers: craft breweries, microbreweries, brewpubs, wineries, vineyards, distille
 - **Square** (free POS, proprietary) — Good for smaller taprooms. Payments, tabs, basic inventory.
 - **Eventbrite** (free for free events, proprietary) — Event ticketing and promotion.
 
+## Review platforms
+
+- **Google Business Profile** — "Breweries near me" and "taprooms in [city]" are common searches. The profile photo, hours, and review response quality strongly influence whether someone chooses this taproom over the next. Update it whenever tap hours or seasonal offerings change.
+- **Yelp** — Well-used for breweries and taprooms, especially in cities. Yelp reviewers tend to describe the atmosphere, beer quality, and food in detail — the qualities that differentiate a craft taproom.
+- **Untappd** — The dominant beer-specific check-in and review platform. Craft beer fans use Untappd to discover new breweries, track beers they've tried, and share ratings. Claim the brewery page on Untappd and keep the beer list current.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Federal licensing (TTB)**: The Alcohol and Tobacco Tax and Trade Bureau (TTB) issues permits for breweries, wineries, and distilleries. Display your permit type (e.g., Brewer's Notice, Basic Permit).

--- a/docs/smb/campground.md
+++ b/docs/smb/campground.md
@@ -38,6 +38,15 @@ Covers: RV parks, campgrounds, glamping sites, tent-only campgrounds, seasonal/l
 - **Square** (free POS, proprietary) — Camp store, firewood sales, on-site purchases.
 - Many small campgrounds still take reservations by phone and manage sites on a paper grid or spreadsheet. If it works and the volume is manageable, that's fine.
 
+## Review platforms
+
+- **Google Business Profile** — Most campers start their search on Google Maps ("campgrounds near [location]"). Keep the profile up to date with seasonal hours, current photos of sites and amenities, and respond to every review. Negative reviews about cleanliness or facilities have outsized impact.
+- **Hipcamp** — A leading platform for discovering independent campgrounds, glamping sites, and unique outdoor experiences. If the park isn't listed, it's missing a major discovery channel for younger and first-time campers.
+- **The Dyrt** — A campground-specific review and discovery platform with a large community of dedicated campers. Reviews here are detailed and read carefully by research-minded campers.
+- **Campendium** — Popular with RV travelers. Reviews focus on hookups, cell signal, Wi-Fi, and practical details. Full-hookup and RV parks especially benefit from being active here.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Health department**: Campgrounds with public facilities (showers, restrooms, pools, water systems) are regulated by state and local health departments. Display your license. Inspections are routine. Water system testing (for campgrounds on well water) is often required.

--- a/docs/smb/car-wash.md
+++ b/docs/smb/car-wash.md
@@ -38,6 +38,16 @@ Covers: automatic car washes (tunnel and in-bay), self-serve car washes, hand wa
 - **Google Business Profile** — Essential. People search "car wash near me" and "auto detailing [town]." Keep hours current, especially holiday hours.
 - **Yelp** — Active for car washes and detailing in most markets.
 
+## Review platforms
+
+- **Google Business Profile** — Essential. "Car wash near me" and "auto detailing [town]" are high-volume searches that resolve through Google Maps. Keep hours current (especially holiday hours and weather-related closures), upload photos of finished results, and respond to all reviews. A car wash with 100+ reviews and a 4.7+ rating captures significantly more drive-by and search traffic than one with sparse reviews.
+- **Yelp** — Active for car washes and detailing shops. Used frequently when someone is deciding between a few options nearby. A well-maintained Yelp listing with before/after photos and owner responses to reviews is worth the effort.
+- **Facebook** — Detailing before/after photos shared on Facebook generate organic referrals. A business page with customer photos (with permission), positive reviews, and active engagement builds trust in the local community. Customers who tag you in their "look at my clean car!" posts are free advertising.
+
+For membership-based washes, a steady stream of reviews matters: a prospective member is committing to a monthly charge, so reputation signals carry more weight than for a one-time wash purchase. Prompt members at the 30-day mark, when they're most satisfied with their decision.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Environmental regulations**: Car washes must manage wastewater. In most jurisdictions, wash water cannot flow into storm drains — it must go to a sanitary sewer or be captured and treated. Many states require a wastewater discharge permit. Note environmentally responsible practices on the website: "We reclaim and recycle our water" or "Our wastewater goes to the sanitary sewer, not storm drains."

--- a/docs/smb/childcare.md
+++ b/docs/smb/childcare.md
@@ -37,6 +37,17 @@ Covers: daycare centers, preschools, in-home daycare, after-school programs, Mon
 - **Cal.com** (open source, free tier) — Tour scheduling.
 - For small in-home daycares, a simple website + phone may be all that's needed. Don't overcomplicate.
 
+## Review platforms
+
+- **Google Business Profile** — Primary discovery channel for parents searching "daycare near me" or "preschool [neighborhood]." A childcare center with 40+ reviews and a 4.8+ rating is significantly more likely to get a tour request than one with no reviews. Parents reading reviews look for specifics: "They know my daughter's name, they tell me about her day, they handle meltdowns with patience." Respond to every review to show the center is attentive.
+- **Yelp** — Parents in many markets use Yelp specifically when researching childcare. A strong Yelp profile with recent reviews is worth maintaining. Some parents trust Yelp's filter model because they believe it catches fake reviews.
+- **Winnie** — A childcare-specific platform that parents use to find, compare, and review daycares and preschools. Claim the profile at winnie.com. Winnie lets parents browse by neighborhood, age, curriculum, and schedule — a complete profile with reviews drives qualified inquiries.
+- **Facebook** — Parent communities are intensely active on Facebook. A positive mention in a neighborhood parenting group is worth more than any advertising. A business page with visible reviews and photos of the facility reinforces word-of-mouth. Ask happy parents to post a recommendation.
+
+Never ask parents to review before enrollment or in exchange for anything — this creates pressure and violates platform terms. After a positive interaction (first month went well, a parent thanks you at pickup), a simple ask: "We'd love it if you have time to leave us a Google or Winnie review — it helps other families find us."
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **State licensing**: Every state regulates childcare. Display your license number, licensed capacity, and age range. Link to your state's childcare licensing agency. License must be current and posted at the facility — mention this on the website.

--- a/docs/smb/cleaning.md
+++ b/docs/smb/cleaning.md
@@ -37,6 +37,17 @@ Covers: residential cleaning (housekeeping, maid service), commercial/janitorial
 - **Cal.com** (open source, free tier) — Estimate scheduling.
 - Many cleaning businesses run on a phone, a calendar, and a payment app. If volume is under 10 clients/week, that's fine.
 
+## Review platforms
+
+- **Google Business Profile** — The primary channel. People search "house cleaning service [city]" or "maid service near me" and choose based on reviews. A cleaning service with 40+ reviews and a consistent 4.8–5.0 rating looks trustworthy enough to invite into someone's home. Reviews that mention consistency ("they clean it the same way every time"), trust ("I leave them my key"), and specific cleaners by name are especially persuasive.
+- **Yelp** — Active for cleaning services in most markets. Clients who are comparison-shopping often check both Google and Yelp. Claim the listing, add photos of before/after work, and respond to reviews.
+- **Nextdoor** — Hyperlocal and high-trust. A recommendation on Nextdoor from a neighbor is more persuasive than a generic Google review for cleaning services — it's a neighbor vouching for someone who was inside their home. Claim the Nextdoor Business Page and ask satisfied clients to recommend you on the platform.
+- **HomeAdvisor / Angi** — If the business generates leads from these platforms, keep the review profiles current. Clients who found the service through Angi may leave reviews there that new leads will see.
+
+After each cleaning, send a brief follow-up: "Thanks for having us today! If everything looked great, a quick Google review helps other homeowners find us." Include the direct review link. Services with scheduling software (Jobber, ZenMaid) can automate this follow-up.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Bonding and insurance**: General liability insurance and a surety bond protect the client and the business. Display "Licensed, bonded, and insured" prominently — it's the #1 trust signal.

--- a/docs/smb/community-theater.md
+++ b/docs/smb/community-theater.md
@@ -35,6 +35,13 @@ See [nonprofit.md](nonprofit.md) for shared nonprofit traits (donate page, trans
 - For orchestras/choral: concert program management may be handled in-house. Focus the website on the season schedule and tickets.
 - **GiveButter** (free, tips-based) — For fundraising campaigns and galas.
 
+## Review platforms
+
+- **Google Business Profile** — "Community theater [city]" and "theater near me" searches often land on Google. Keep the profile updated with the current season's showtimes — potential ticket buyers will check here before visiting the website.
+- **Facebook** — Community theater audiences are often older and highly engaged on Facebook. The Facebook page functions as both a discovery tool and a place where patrons leave recommendations. Monitor and respond to recommendations.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Licensing and royalties**: If performing copyrighted works (musicals, plays), licensing is handled by the company (MTI, Samuel French/Concord, etc.), not the website. But do NOT publish full scripts, lyrics, or copyrighted music on the website.

--- a/docs/smb/creator.md
+++ b/docs/smb/creator.md
@@ -37,6 +37,17 @@ Covers: bloggers, social media influencers, newsletter writers, online educators
 
 For podcast-specific tools, see [podcaster.md](podcaster.md). For video-specific tools, see [video-creator.md](video-creator.md). For musician-specific tools, see [musician.md](musician.md).
 
+## Review platforms
+
+Review platforms in the traditional sense don't apply to most content creators — audiences don't leave Yelp reviews for bloggers. Reputation is built through platform presence, audience engagement, and the creator's own website as a portfolio.
+
+- **Social platforms** — Follower counts, comments, and engagement rates on the creator's primary platforms (Instagram, YouTube, TikTok) function as public social proof for potential brand partners.
+- **Google Business Profile** — Only relevant if the creator operates as a business with a physical presence (e.g., a studio open for brand shoots, workshops, or events). If not, skip.
+
+For creators monetizing through brand deals, the media kit on the website IS the reputation asset — not review platform ratings.
+
+See `docs/smb/reviews.md` for general review management guidance.
+
 ## Compliance
 
 - **FTC endorsement guidelines**: Sponsored content and affiliate links must be disclosed. "#ad" or "sponsored" must be clear and conspicuous — not buried in hashtags. Applies to website content, not just social.

--- a/docs/smb/credit-union.md
+++ b/docs/smb/credit-union.md
@@ -49,6 +49,15 @@ Covers: credit unions, community development financial institutions (CDFIs), len
 - **NMLS**: If listing loan officers, include NMLS numbers where required.
 - **Field of membership**: Clearly state who is eligible to join. This is a regulatory requirement.
 
+## Review platforms
+
+- **Google Business Profile** — Members and prospective members search for branch locations, hours, and services on Google. Reviews here often reflect the member experience (loan process, staff helpfulness, wait times). Respond to all reviews — especially negative ones — to demonstrate member-first values.
+- **Yelp** — Less dominant for financial institutions than Google, but some markets have active Yelp communities that include banks and credit unions. Worth claiming and monitoring.
+
+Credit unions are not heavily rated on financial comparison sites (like Bankrate or NerdWallet) at the branch level, but the institution may appear in "best credit unions in [state]" editorial lists — ensure the website is current so those links look credible when people click through.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Content ideas
 
 Rate change announcements, financial literacy tips (budgeting, credit building, home buying), community event sponsorships and recaps, member spotlights (with consent), new product or service announcements, scholarship recipient features, fraud and scam alerts, holiday closures, annual meeting announcements, "why credit unions are different" explainers, youth savings program updates, partnership announcements with local organizations.

--- a/docs/smb/dance-studio.md
+++ b/docs/smb/dance-studio.md
@@ -42,6 +42,16 @@ Covers: ballet studios, hip-hop dance, ballroom and social dance, contemporary/m
 - **Instagram** — Visual platform ideal for dance. Class clips, recital highlights, student spotlights.
 - **Mailchimp** (free up to 500 contacts) or **Buttondown** (~$9/mo, indie) — For registration reminders, recital info, studio news.
 
+## Review platforms
+
+- **Google Business Profile** — Parents searching "ballet classes near me" or "dance studio [neighborhood]" rely heavily on Google. A studio with 30+ reviews and photos of recitals, classes, and the facility looks established and safe to enroll with. Reviews that mention specific instructors and teaching quality ("Miss Sarah is so patient with the 3-year-olds") are especially persuasive. Respond to all reviews.
+- **Yelp** — Active for dance studios in many markets, particularly for adult classes. Claim the profile, upload photos, and respond to reviews. Some parents specifically check Yelp because they trust its filter.
+- **Facebook** — Dance studio families are highly active on Facebook. Parents share recital photos, tag the studio, and recommend it in local parent groups. A business page with active engagement, class highlights, and visible reviews turns satisfied parents into vocal advocates. Ask parents to leave a Facebook recommendation at the end of recital season — when they're already posting photos and feeling great about the studio.
+
+The annual recital is the best time to build review volume. Right after the performance, when parents and students are still buzzing: "Thank you for a wonderful season — if you have a moment, a Google review helps other families find us." A card at the recital with a QR code to the review form makes it easy in the moment.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Background checks**: Staff and instructors who work with minors should have background checks. Many states require this for businesses working with children. Note on the website: "All instructors undergo background checks." Parents expect this.

--- a/docs/smb/education.md
+++ b/docs/smb/education.md
@@ -37,6 +37,17 @@ Covers: private tutors, music teachers, driving schools, test prep, language sch
 - **Monica CRM** (open source, free) — Track students and parents.
 - For driving schools: look into **ScheduleOnce** or similar for multi-instructor, multi-vehicle scheduling.
 
+## Review platforms
+
+- **Google Business Profile** — The primary channel for parents searching "tutor near me" or "music lessons [city]." Reviews that describe specific results ("my daughter went from a C to an A in math," "my son finally enjoys piano") are enormously persuasive. Respond to every review — parents see that the educator is engaged and communicative.
+- **Yelp** — Used for tutors and enrichment centers in some markets. Claim the profile if it exists and keep it updated.
+- **Care.com** (if applicable) — For in-home tutors and some after-school programs, parents search Care.com as part of their vetting. Reviews there carry weight because the platform requires background check verification.
+- **Facebook** — Parent communities are active on Facebook and word-of-mouth referrals dominate this category. A business page where parents can leave recommendations, and where the educator shares tips and achievements (with permission), builds a visible reputation.
+
+For tutors and private instructors, the best time to ask for a review is after a noticeable achievement — a test score improvement, a competition result, a grade turnaround. The parent is already pleased; a brief email with a direct Google review link is almost always welcomed.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Background checks**: Mention if instructors have passed background checks. Parents expect this. Not always legally required, but it builds trust.

--- a/docs/smb/entertainment.md
+++ b/docs/smb/entertainment.md
@@ -40,6 +40,17 @@ Covers: bowling alleys, escape rooms, mini golf, arcades, go-kart tracks, trampo
 - **Yelp** — Active for entertainment venues in many markets. Claim the listing.
 - **TripAdvisor** — If the venue attracts tourists (especially escape rooms, unique attractions). Claim and manage the listing.
 
+## Review platforms
+
+- **Google Business Profile** — Primary discovery channel for "things to do near me" and "[activity] near me" searches. Families planning an outing check Google first. A venue with 200+ reviews and a 4.5+ rating looks like a sure bet for an afternoon out. Photos of real people having fun in the space are as important as the reviews themselves. Respond to all reviews, including complaints about wait times or equipment — it shows you take experience quality seriously.
+- **Yelp** — Active for entertainment venues in most markets. Families and groups comparison-shopping will check both Google and Yelp. A strong Yelp presence with event-specific categories (birthday party reviews, group visit reviews) builds credibility for the party booking side of the business.
+- **TripAdvisor** — Worth maintaining if the venue attracts tourists or if it's a distinctive enough attraction that out-of-town visitors might seek it out (escape rooms, unusual entertainment, attractions in tourist areas). A TripAdvisor listing gives the venue another discovery channel beyond local search.
+- **Facebook** — Party photos and event recaps shared on Facebook generate organic referrals. Families share photos from birthdays, kids tag friends. A business page with visible engagement, event posts, and reviews turns customers into advocates. Ask party organizers to tag the venue in their post-party photos.
+
+Post-birthday-party is the highest-leverage moment: the organizer was just a hero to a dozen kids, and they're happy. A follow-up message: "We hope [child's name] had an amazing birthday! If you have a minute to leave us a Google review, it helps other parents find us for their celebrations." Simple, personal, well-timed.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Amusement ride safety**: If the venue has mechanical rides, inflatables, or trampolines, state amusement ride regulations may apply. Many states require annual inspections, incident reporting, and operator training. Check with the state's amusement ride safety office.

--- a/docs/smb/equipment-rental.md
+++ b/docs/smb/equipment-rental.md
@@ -37,6 +37,17 @@ Covers: tool and equipment rental (construction, landscaping, moving), party and
 - **Yelp** — Active for party rental in many markets.
 - **The Knot / WeddingWire** — If the business does wedding rentals, listing here reaches brides and planners. theknot.com / weddingwire.com
 
+## Review platforms
+
+- **Google Business Profile** — The first stop for "tent rental near me" or "bounce house rental [town]." Reviews for rental businesses are particularly valuable because potential customers are trusting that equipment will show up on time, in good condition, and be set up correctly. Reviews that mention reliability ("delivered and set up perfectly, arrived exactly on time") and condition ("everything was clean and worked great") directly address customer anxieties. Respond to all reviews.
+- **Yelp** — Active for party rental in most markets. Families planning events comparison-shop, and Yelp is a common second check after Google. A strong Yelp presence with event setup photos is worth maintaining.
+- **The Knot / WeddingWire** (if the business does wedding rentals) — Couples researching vendors for weddings use these platforms extensively. A rental company with a profile and reviews on The Knot reaches brides and planners who are actively planning. This is especially relevant for tent and linen rental businesses that serve weddings regularly.
+- **Facebook** — Event photos shared by clients (tents set up in backyards, bounce houses at birthday parties) generate organic referrals. A business page with real setup photos and visible reviews is worth maintaining. Ask clients to tag the rental company in their event photos.
+
+After a successful delivery and event, a follow-up text or email: "Glad the party was a success! If you have a moment, a Google review would help other families find us." Include the direct link. Timing right — within 24 hours of the event — gets the best response rate.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Liability and insurance**: Rental businesses carry significant liability. Inflatable and bounce house rentals require commercial general liability insurance and often specific rider policies. Require signed rental agreements before every rental. Note on the website: "All rentals require a signed rental agreement."

--- a/docs/smb/event-venue.md
+++ b/docs/smb/event-venue.md
@@ -39,6 +39,29 @@ The business model: the property IS the product. Customers rent the space for th
 - **Cal.com** (open source, free tier) — For scheduling venue tours. cal.com
 - **The Knot / WeddingWire** — Wedding marketplace for discovery. Charges for listing but brings leads. The website should be the primary presence; these are supplemental.
 
+## Review platforms
+
+- **Google Business Profile** — Most couples and event planners search Google first. A venue with 100+ reviews and a 4.8+ average shows up in more searches and earns more tour requests. Respond to every review — prospective clients read how the venue handles feedback almost as carefully as they read the reviews themselves.
+- **The Knot** — Couples on The Knot are actively planning weddings, often with a specific budget and date in mind. A complete, review-rich profile on The Knot drives qualified leads. Getting to 25+ reviews makes a significant difference in The Knot's internal ranking.
+- **WeddingWire** — The Knot's sister platform, with substantial audience overlap. A good WeddingWire rating is a trust signal that reinforces the Google profile. If the venue is listed, keep the profile current and encourage newlyweds to leave reviews.
+- **Yelp** — Used for event venues in some markets, particularly for corporate and non-wedding events. A complete Yelp profile with photos and recent reviews is worth maintaining, even if it's not the primary channel.
+- **Wedding Map** (weddingmapper.com) and **Zola** — Emerging wedding planning platforms that include venue reviews. If the business gets inquiries from these platforms, claim and maintain those profiles too.
+
+The best time to ask for a review is 2–4 weeks after the event, when the couple has settled into married life and the memories are fresh but the stress of the day is gone. A personal note from the venue owner or coordinator goes a long way.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
+## Review platforms
+
+- **Google Business Profile** — First stop for couples and event planners searching for venues. A venue with 50+ reviews and a 4.9 average appears trustworthy and established. Respond to every review — couples who are still considering venues will read your responses and draw conclusions about how you treat clients.
+- **The Knot / WeddingWire** — The dominant wedding vendor marketplaces. Couples actively browsing for venues spend significant time on these platforms comparing listings, photos, and reviews. Paid listings give more visibility, but even free profiles allow reviews. Getting 30+ reviews on The Knot is a major trust signal for wedding bookings.
+- **Yelp** — Used for corporate event and party venue searches in some markets. Less dominant than The Knot for weddings but worth maintaining for non-wedding event business.
+- **Facebook** — Couples and event planners often ask for venue recommendations in local Facebook groups. A business page with visible reviews and real event photos gives you something to point to. Ask couples to leave a Facebook recommendation after their event.
+
+The best time to ask for a review is right after the event when emotions are high. A personal note from the venue owner, emailed a week after the event: "We loved hosting your [wedding/event]. If you have a moment to share your experience on Google or The Knot, it would mean so much to our team." Include direct links.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Zoning**: The #1 compliance issue for rural event venues. Agricultural and residential zoning may not permit commercial events. Check with the town/county planning office. Some jurisdictions require a special use permit, conditional use permit, or variance. This can take months — start early.

--- a/docs/smb/farm.md
+++ b/docs/smb/farm.md
@@ -39,6 +39,14 @@ Covers: small farms, CSA (community-supported agriculture) programs, market gard
 - **Mailchimp** (free up to 500 contacts) or **Buttondown** (~$9/mo, indie) — For weekly "what's in the box" or "what's at market" emails. Buttondown is indie-run and respects privacy.
 - Many small farms manage CSA with just a spreadsheet and email. If that's working and the operation is small (<30 members), don't overcomplicate it.
 
+## Review platforms
+
+- **Google Business Profile** — Useful for farms with a farm stand, u-pick operation, or physical location. Customers searching "farms near me," "u-pick strawberries," or "Christmas trees [town]" will find you here. Seasonal hour accuracy is especially important — nothing frustrates a family more than driving to find the stand closed.
+- **LocalHarvest** (localharvest.org) — A farm-specific directory where CSA-seekers actively search for local producers. A well-maintained listing here reaches the exact audience most likely to sign up for a share.
+- **Word of mouth and email** — For many small farms, especially CSAs, the most important reviews happen in the farmer's market community, neighborhood groups, and email forwards. Encourage happy members to tell friends and post in local neighborhood groups.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Organic certification**: Only use the word "organic" if USDA certified. Display the certification and certifier name. Farms grossing under $5,000/year are exempt from certification but must still follow organic practices to use the term.

--- a/docs/smb/fitness.md
+++ b/docs/smb/fitness.md
@@ -35,6 +35,17 @@ Covers: gyms, yoga studios, Pilates, martial arts schools, dance studios, CrossF
 - **Square** (free POS, proprietary) — Good for drop-in payments and retail (merchandise, water, etc.).
 - Many studios already use MindBody or ClassPass. If it's working, integrate with it rather than replacing it.
 
+## Review platforms
+
+- **Google Business Profile** — The primary channel. People search "yoga studio near me" or "CrossFit [neighborhood]" and decide based on star ratings, photo quality, and responses. A studio with 50+ reviews looks established and safe to try. Respond to all reviews, including negative ones — showing you care about feedback builds trust with prospective members.
+- **Yelp** — Active for fitness and wellness businesses. Used especially when someone is comparing multiple studios in an area. A complete Yelp profile with photos of the space and real member reviews is worth maintaining.
+- **ClassPass** — If the studio offers drop-in classes through ClassPass, the in-app reviews are the primary signal for new ClassPass members trying the studio for the first time. A high ClassPass rating drives bookings.
+- **Facebook** — Fitness communities are active on Facebook. A business page with visible reviews, event posts, and community interaction signals an active, engaged studio. Many members will leave a recommendation on Facebook if asked.
+
+After a member's first month or a milestone class (e.g., "you've completed 10 classes!"), ask: "We'd love a Google review if you've been enjoying your time here." Members who feel part of the community are the most willing to write substantive, persuasive reviews.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Waivers**: Most fitness businesses require liability waivers. Link to a digital waiver form (many scheduling tools include this). Don't collect health information on the website itself.

--- a/docs/smb/florist.md
+++ b/docs/smb/florist.md
@@ -43,6 +43,14 @@ Covers: flower shops, floral design studios, wedding/event florists, plant shops
 - **Pesticide/chemical**: If selling plants, note any treatment disclosures required in your state.
 - **ADA**: Online ordering must be accessible — form labels, alt text on arrangement photos.
 
+## Review platforms
+
+- **Google Business Profile** — The primary discovery channel for "florist near me," "same-day flower delivery [city]," and "wedding florist [area]." Reviews here are read by people placing time-sensitive orders — keep the profile current and respond to every review. Positive reviews specifically mentioning delivery reliability or sympathy orders are especially valuable.
+- **Yelp** — Used by customers comparing florists, especially for everyday and gift purchases. Yelp reviewers tend to describe the arrangement quality, value, and delivery experience in detail.
+- **The Knot / WeddingWire** — For florists doing wedding work, these platforms are where couples actively search. Reviews from past brides carry significant weight in the wedding market.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Content ideas
 
 Seasonal arrangement spotlights, flower care tips ("how to make your bouquet last"), behind-the-scenes of event setups, "flower of the month," sourcing stories (local farm partnerships), wedding trend recaps, sympathy etiquette guides, houseplant care, DIY arrangement tutorials, holiday ordering deadlines.

--- a/docs/smb/food-bank.md
+++ b/docs/smb/food-bank.md
@@ -40,6 +40,14 @@ See [nonprofit.md](nonprofit.md) for shared nonprofit traits (donate page, trans
 - **Allergen info**: If distributing prepared meals, note common allergens.
 - **Good Samaritan Act**: Food donors are protected from liability. Mention this on the "donate food" page to encourage donations.
 
+## Review platforms
+
+Review platforms are less relevant for food banks — people seeking help don't rely on Yelp stars, and donors are driven by trust and mission alignment rather than review scores.
+
+If the organization has a Google Business Profile (many food banks do, since they have a physical location), keep it accurate — especially hours and holiday closures. Volunteers and donors sometimes find the pantry via Google Maps, and reviews there occasionally reflect donor or volunteer experiences.
+
+See `docs/smb/reviews.md` for general review management guidance.
+
 ## Content ideas
 
 Impact numbers ("this month we served X families"), food drive announcements and results, volunteer spotlights, partner agency features, seasonal needs ("holiday meal program"), recipes using common pantry items, SNAP/benefits enrollment info, community garden updates, donor recognition (with permission), behind-the-scenes of operations.

--- a/docs/smb/food-truck.md
+++ b/docs/smb/food-truck.md
@@ -38,6 +38,17 @@ The key difference from a fixed-location restaurant: **customers need to know wh
 - **HoneyBook** or **Dubsado** (~$19–$35/mo) — For managing event/catering bookings, contracts, invoices. Only if they do enough events to justify the cost. Otherwise Square invoicing works.
 - **Roaming Hunger** — Food truck marketplace for event booking. Charges a commission but brings leads. roaminghunger.com
 
+## Review platforms
+
+- **Google Business Profile** — Critical even for mobile businesses. Customers who had a great experience will search the truck by name to find it again — and to leave a review. A food truck with 50+ Google reviews and a 4.7+ rating shows up in "food trucks near me" and builds credibility for event booking clients who are deciding whether to hire you. Keep the profile updated with photos and respond to reviews.
+- **Yelp** — Active for food trucks in most urban markets. Yelp users specifically seek out local and independent food options, making it a natural audience for trucks. Claim the listing, keep it current with the schedule, and respond to reviews.
+- **TripAdvisor** (for trucks in tourist areas) — If the truck regularly operates in a tourist area, farmers market, or has a consistent spot, TripAdvisor is worth maintaining. Travelers actively look for interesting local food options.
+- **Instagram** — While not a traditional review platform, food truck customers share their meals and tag the truck. These tagged posts function as public endorsements. Feature customer posts on your own account (with permission). A high volume of tagged posts signals a beloved truck to potential customers.
+
+The best time to ask for a review is at the window while the customer is happy with their food: "If you loved it, a Google review helps us book more events." A sticker on your takeout bag or container with a QR code to the review page works with no additional friction.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Mobile food vendor permit**: Required in most jurisdictions. Different from a restaurant health permit — covers the vehicle, not a building. Display the permit number if required. Some cities require separate permits for each location.

--- a/docs/smb/funeral-home.md
+++ b/docs/smb/funeral-home.md
@@ -46,6 +46,14 @@ Covers: funeral homes, mortuaries, cremation services, memorial chapels, cemeter
 - **Green burial**: If offered, note certifications (Green Burial Council) and explain what it means.
 - **Pre-need trusting/insurance**: Pre-planned funeral funds are regulated by state. Explain how funds are held.
 
+## Review platforms
+
+- **Google Business Profile** — Many families search for funeral homes in their area immediately after a loss. Reviews on Google are read carefully and carry enormous weight — families are making a high-stakes, emotional decision in a short time. Compassionate, professional responses to all reviews (positive and negative) signal the home's character.
+- **Yelp** — Families in some markets use Yelp to compare funeral homes. Reviews tend to focus on staff compassion, communication, and the facility. Worth claiming and maintaining.
+- **Funeral Home Review sites** (FuneralWise, Funeralocity) — Industry-specific directories where families compare homes by price transparency, services, and ratings. Claim and update listings on these platforms.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Content ideas
 
 Grief resources, "what to do when someone dies" guides, pre-planning benefits, veteran honor stories (with family permission), community memorial events (Memorial Day, Day of the Dead), staff spotlights, historical obituary archives, funeral tradition explainers, green burial information, estate planning basics, holiday grief support.

--- a/docs/smb/government.md
+++ b/docs/smb/government.md
@@ -53,6 +53,14 @@ For special districts, focus on the district's specific function:
 - **FOIA/state equivalent**: Link to the public records request process and name the records custodian.
 - **Posted document formats**: Avoid posting scanned image PDFs — they're not accessible. Use text-based PDFs or HTML. If scanning is unavoidable, OCR the document.
 
+## Review platforms
+
+Review platforms are not relevant for municipal government — residents don't "rate" their town government. Focus on transparency, accessibility, and community engagement instead.
+
+That said, if the municipality has a Google Business Profile (some towns do, especially for town halls, libraries, or parks), monitor it for accuracy and respond to any questions posted there. Residents sometimes use it to report concerns or ask questions.
+
+See `docs/smb/reviews.md` for general review management context.
+
 ## Content ideas
 
 Meeting summaries in plain language (not just posting raw minutes), road and infrastructure project updates, seasonal reminders (leaf pickup, snow plowing, water conservation), community event announcements, new ordinance explainers, budget breakdowns in simple terms, "meet your officials" profiles, public hearing notices, park and recreation program announcements, emergency preparedness tips, water quality reports with plain-language summaries.

--- a/docs/smb/grocery.md
+++ b/docs/smb/grocery.md
@@ -43,6 +43,13 @@ Covers: independent grocery stores, co-op markets, specialty food shops (cheese,
 - **WIC/SNAP/EBT**: If accepted, mention prominently — it's important for community access.
 - **Co-op membership**: Clearly explain membership vs. non-member pricing if applicable.
 
+## Review platforms
+
+- **Google Business Profile** — "Grocery stores near me" and "natural food store [city]" searches resolve through Google. Reviews here often focus on the shopping experience, selection, staff knowledge, and freshness. Keep the profile updated with current hours and reply to reviews — especially those mentioning specific staff or products.
+- **Yelp** — Yelp is actively used for specialty food shops, co-ops, and ethnic grocers. Detailed reviews about specialty products and sourcing help differentiate from chain grocers.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Content ideas
 
 Weekly specials and seasonal highlights, recipes using products from the shop, local producer spotlights with photos, seasonal eating guides ("what's fresh this month"), cooking tips and techniques, event announcements (tastings, classes), community stories, holiday gift guides, co-op membership benefits and updates, food preservation tips.

--- a/docs/smb/hardware.md
+++ b/docs/smb/hardware.md
@@ -41,6 +41,13 @@ Covers: independent hardware stores, lumber yards, garden centers, paint stores,
 - **Contractor licensing**: The store doesn't need a contractor license, but if they recommend contractors, note that recommendations are informational (not endorsements).
 - **ADA**: Note physical accessibility — important for a store with heavy products and wide aisles.
 
+## Review platforms
+
+- **Google Business Profile** — "Hardware store near me" is one of the most common local searches for this category. Reviews here often praise knowledgeable staff — that's the indie hardware store's core differentiator. Encourage staff to mention their name in good-service encounters so reviewers can call them out by name.
+- **Yelp** — Some hardware stores have strong Yelp presences, especially in urban markets. Reviews tend to highlight whether staff actually helped solve the problem, which is the key reason people choose an indie store over a big-box.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Content ideas
 
 Seasonal project guides ("winterize your home," "spring garden prep"), how-to articles for common repairs, product comparisons and recommendations, new product spotlights, staff expertise highlights ("meet our paint expert"), workshop and event announcements, local contractor tips, holiday gift guides for DIYers, community project spotlights.

--- a/docs/smb/healthcare.md
+++ b/docs/smb/healthcare.md
@@ -34,6 +34,20 @@ Covers: chiropractors, dentists, therapists (physical, occupational, mental heal
 - **SimplePractice** (~$29/mo, proprietary) — Popular with therapists and counselors. Includes telehealth, billing, client portal.
 - For patient forms: link to their existing EHR/portal. Don't build patient intake into the website.
 
+## Review platforms
+
+- **Google Business Profile** — The primary channel. Patients search "dentist near me" or "chiropractor [city]" and choose largely on star rating and number of reviews. A practice with 100+ reviews and a 4.7 average gets significantly more new patient calls than one with 10. Respond to all reviews professionally — even brief "Thank you, we look forward to seeing you again" responses show the practice is attentive.
+- **Healthgrades** — Heavily used for physicians, dentists, and specialists. Patients check Healthgrades specifically when researching providers. Claim the profile and encourage patients to leave reviews here.
+- **Zocdoc** — If the practice accepts Zocdoc bookings, patients leave reviews through the platform after appointments. These are verified patient reviews and carry weight. Keep the profile complete.
+- **Yelp** — Relevant for dentists, chiropractors, and alternative health practices. Less used for physicians in most markets but worth monitoring.
+- **Psychology Today** (mental health only) — The dominant directory for therapists and counselors. Reviews aren't the focus here but profile completeness matters enormously.
+
+For practices that use patient communication platforms (Solutionreach, Weave, etc.), set up automated post-visit review requests. These integrations make consistent review generation essentially automatic.
+
+**Note:** Some jurisdictions restrict healthcare testimonials. Review state licensing board rules before prominently featuring reviews. See the Compliance section below.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **HIPAA (US)**: The website itself isn't a HIPAA concern — it's public information. But do NOT collect patient health information through website forms. Contact forms should only collect name, phone, and reason for visit (not symptoms or diagnoses). Link to a HIPAA-compliant patient portal for intake forms.

--- a/docs/smb/hospitality.md
+++ b/docs/smb/hospitality.md
@@ -36,6 +36,18 @@ Covers: bed & breakfasts, boutique hotels, small independent hotels, vacation re
 - **Cal.com** (open source, free tier) — For scheduling tours, tastings, or activity bookings.
 - **Square** (free POS, proprietary) — For on-site purchases, gift shop, or event deposits.
 
+## Review platforms
+
+- **Google Business Profile** — Essential for local visibility. Many guests check Google first, especially for B&Bs and boutique hotels they found through local search. Respond to every review — prospective guests read the responses as much as the reviews themselves.
+- **TripAdvisor** — The dominant travel review platform for hospitality. B&Bs and small hotels live or die on TripAdvisor reputation. Getting a Certificate of Excellence (based on review volume and rating) is worth actively pursuing. Respond professionally to all reviews, including critical ones.
+- **Booking.com** — If the property lists on Booking.com, guests leave reviews through the platform after checkout. Booking.com reviews are verified (only guests who booked through the platform can review). These carry significant weight for travelers.
+- **Airbnb / VRBO** — For vacation rentals and short-term rental properties, platform reviews are the primary trust signal. Guest ratings directly affect search ranking within the platform. Respond to every review promptly.
+- **Expedia / Hotels.com** — Relevant for properties listed on these OTA platforms. Maintaining reviews across all listing platforms you're on is important — a guest might find you on one platform but check reviews on another.
+
+Ask guests at checkout: "We'd love it if you had a moment to leave us a review on TripAdvisor or Google — it helps other travelers find us." Include a thank-you card with QR codes for both.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Occupancy tax / tourism tax**: Many jurisdictions require hospitality businesses to collect and remit occupancy or lodging taxes. Note if the pricing includes or excludes taxes.

--- a/docs/smb/house-of-worship.md
+++ b/docs/smb/house-of-worship.md
@@ -35,6 +35,15 @@ See [nonprofit.md](nonprofit.md) for shared nonprofit traits (donate page, trans
 - **YouTube** or **Facebook Live** — For livestreaming services. Link from the website.
 - Most congregations already have a management tool. Integrate rather than replace.
 
+## Review platforms
+
+Traditional review platforms are an awkward fit for congregations — faith communities aren't restaurants. However, a few platforms matter for discovery.
+
+- **Google Business Profile** — The single most useful platform. People searching for "churches near me," "mosque in [city]," or "[denomination] [city]" will find the listing. Reviews here are often left by visitors after a first-visit experience. Keep the listing accurate with current service times — this is the #1 reason people search.
+- **Facebook** — Congregation members and the broader community often recommend their house of worship on Facebook. The page's recommendations section (formerly ratings) is visible to anyone looking at the page.
+
+See `docs/smb/reviews.md` for general review management guidance.
+
 ## Compliance
 
 - **Tax-exempt status**: Churches are automatically tax-exempt under IRC 501(c)(3) without filing for recognition. Still display this status for donor confidence.

--- a/docs/smb/insurance.md
+++ b/docs/smb/insurance.md
@@ -35,6 +35,16 @@ Covers: independent insurance agents, captive agents (State Farm, Allstate, Farm
 - **Map listings** — Critical for local insurance agents. Claim the business on Google Business Profile, Apple Business Connect, and OpenStreetMap. Most clients find agents through local search. See `docs/webmaster.md` → Map listings.
 - Most agencies have a carrier-provided or vendor website. Independent agents may want something better — that's the Anglesite opportunity.
 
+## Review platforms
+
+- **Google Business Profile** — The primary channel for local insurance agents. "Insurance agent near me" or "State Farm agent [city]" goes to Google. Clients researching an agent before their policy review or after getting a referral will check Google. Reviews that mention responsiveness and help at claim time ("when our basement flooded, they were there immediately") are the most persuasive.
+- **Yelp** — Used for insurance agencies in some markets, particularly for independent agents. Claim the listing and respond to reviews. Yelp is more relevant in urban markets.
+- **Facebook** — Insurance clients often stay with an agent for years and refer friends and family. A Facebook business page where satisfied clients can leave recommendations and share their experience is a natural fit for a referral-based business. Ask long-term clients to leave a Facebook recommendation.
+
+**Note:** State insurance department advertising regulations may restrict certain kinds of testimonials (no guarantees of outcomes, no misleading claims). Review your state's advertising rules before featuring specific client quotes or outcome claims. In general, reviews describing service quality and responsiveness are safe; reviews that sound like they promise savings or specific outcomes need more care.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **State licensing**: Insurance agents and agencies must be licensed in every state where they sell. Display license numbers. Individual agent licenses are public record.

--- a/docs/smb/laundry.md
+++ b/docs/smb/laundry.md
@@ -44,6 +44,13 @@ Covers: dry cleaners, laundromats (self-service), wash-and-fold services, laundr
 - **Sales tax**: Laundry services are taxable in some states, exempt in others. Varies by service type (self-service vs. drop-off).
 - **Lost/damaged garments**: Have a clear policy for handling lost or damaged items. Display or link to your terms of service.
 
+## Review platforms
+
+- **Google Business Profile** — "Laundromat near me" and "dry cleaner [neighborhood]" are high-intent local searches. Reviews here frequently mention cleanliness of machines, wait times, and whether staff was helpful for special items. Prompt, professional responses to reviews signal that management is engaged.
+- **Yelp** — Used in many markets for dry cleaners and laundromats. Reviews often compare turnaround time, pricing, and how a shop handles delicate or special items.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Content ideas
 
 Garment care tips, stain removal guides, "what those laundry symbols mean," seasonal wardrobe care (winter coat cleaning, summer whites), eco-friendly cleaning explainers, behind-the-scenes of the cleaning process, alterations tips, wedding dress preservation guide, "what to do before you donate clothes."

--- a/docs/smb/legal.md
+++ b/docs/smb/legal.md
@@ -33,6 +33,17 @@ Covers: law firms, solo attorneys, immigration consultants, notaries, mediators.
 - **Cal.com** (open source, free tier) — For scheduling consultations. Self-hostable alternative to Calendly.
 - **LawPay** (proprietary, ~$20/mo + processing) — Trust-account compliant payment processing for attorneys. Required in many jurisdictions when accepting client payments online.
 
+## Review platforms
+
+- **Google Business Profile** — The starting point for anyone searching for an attorney by specialty or city. Solo attorneys and small firms compete with larger practices through Google reviews. A firm with 50+ reviews and a 4.8 rating ranks higher in local search and gets more calls than one with 5 reviews.
+- **Avvo** — An attorney-specific directory that many clients check before calling. Claim the profile, complete the bio, and encourage past clients to leave Avvo reviews. Avvo has its own rating system (based on profile completeness and peer endorsements) separate from client reviews.
+- **Yelp** — Used for attorneys in some markets, particularly family law, immigration, and general practice. Less dominant than for consumer businesses, but worth maintaining a presence.
+- **Martindale-Hubbell** — Peer-reviewed ratings (AV, BV) and client reviews. More relevant for higher-ticket practice areas and business clients. Long-established credibility signal.
+
+**Important:** Every state regulates attorney advertising, including testimonials and reviews. Some states prohibit certain types of endorsements or require disclaimers. Check the state bar's advertising rules before prominently featuring client reviews on the website. Always get written consent from clients before displaying their names or quotes.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **State bar advertising rules**: Every state regulates attorney advertising. Common requirements: disclaimers ("This is an advertisement"), no guarantees of outcomes, no misleading specialization claims. Check the state bar's rules before publishing.

--- a/docs/smb/marina.md
+++ b/docs/smb/marina.md
@@ -39,6 +39,16 @@ Covers: marinas, boat dealers (new and used), boat repair and service, charter f
 - **FishBrain** (free to list) — Fishing app where anglers share catches and spots. Charter captains can build a profile. fishbrain.com
 - **Google Business Profile** — Essential. Boaters search "marina near [lake/bay]" and "boat rental [area]." Claim and keep hours/photos current.
 
+## Review platforms
+
+- **Google Business Profile** — Essential. Boaters search "marina near [lake/bay]" and "boat rental [area]" through Google Maps. A marina with 50+ reviews and a strong rating looks like a reliable place to leave your boat or spend a day on the water. Keep photos current (aerial shots of the marina layout, facility photos, launch ramp), respond to reviews, and post seasonal updates (spring opening, fall closing, fuel price updates).
+- **Yelp** — Used for marinas and boat rentals in some markets, particularly for casual customers rather than seasonal slip holders. Worth claiming and monitoring.
+- **Facebook** — Boating communities are active on Facebook. A marina's Facebook page with fishing reports, event posts, and community engagement is often where regulars interact. Reviews and recommendations on Facebook carry weight for local boaters who trust their community network. Post regularly during season.
+
+For charter fishing operations specifically, reviews on Google and TripAdvisor (see [tour-guide.md](tour-guide.md)) matter significantly. Anglers share trip reports online and direct recommendations to fishing forums and Facebook groups — those community endorsements drive charter bookings as much as formal review platforms.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **USCG regulations**: Charter boats carrying passengers for hire must comply with US Coast Guard regulations. The captain needs an Operator of Uninspected Passenger Vessels (OUPV/"Six-Pack") license for up to 6 passengers, or a Master license for larger vessels. Display the license number on the website.

--- a/docs/smb/museum.md
+++ b/docs/smb/museum.md
@@ -42,6 +42,14 @@ See [nonprofit.md](nonprofit.md) for shared nonprofit traits (donate page, trans
 - **Deaccessioning**: If the museum sells collection items, this is controversial. Not a website concern, but be aware.
 - **Repatriation (NAGPRA)**: For history/anthropology museums with indigenous collections. Not directly a website concern, but transparency pages should acknowledge this if applicable.
 
+## Review platforms
+
+- **Google Business Profile** — "Museums near me" and "[type] museum [city]" are common visitor searches. Reviews often describe the visitor experience: accessibility, staff knowledge, exhibit quality, and value. Keep the profile updated with current exhibitions and special event hours.
+- **TripAdvisor** — A dominant platform for cultural attractions, especially museums. TripAdvisor is heavily used by tourists and out-of-town visitors planning itineraries. For science centers, children's museums, and history museums, TripAdvisor reviews are widely read and directly influence attendance decisions.
+- **Yelp** — Used in many markets for local museum discovery. Particularly relevant for smaller museums, galleries, and botanical gardens.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Content ideas
 
 Exhibition previews and reviews, "object of the month" deep dives, curator Q&As, artist interviews, behind-the-scenes of exhibition installation, education program recaps, conservation and restoration stories, collection acquisition announcements, community event recaps, seasonal programming highlights, "what's on this weekend" roundups.

--- a/docs/smb/musician.md
+++ b/docs/smb/musician.md
@@ -42,6 +42,16 @@ Covers: bands, solo artists, singer-songwriters, DJs, cover bands, tribute acts,
 - **Mailchimp** (free up to 500 contacts) or **Buttondown** (~$9/mo, indie) — For mailing list management. Buttondown is simpler and respects privacy.
 - **SoundCloud** (free tier) — Good for demos, unreleased tracks, DJ mixes, and discovery. Less relevant for finished releases than Bandcamp/streaming. soundcloud.com
 
+## Review platforms
+
+Traditional review platforms aren't the primary reputation channel for musicians — audiences don't leave Yelp reviews for bands. Reputation is built through music platforms, live performance, and the artist's own website.
+
+- **Spotify / Apple Music / Bandcamp** — Follower counts, save rates, and playlist adds are the de facto social proof signals for streaming listeners. Bandcamp specifically allows fans to leave comments on purchases, which function as public testimonials.
+- **Google Business Profile** — Relevant for musicians with a physical presence: a recording studio, a rehearsal space open for booking, or regular residencies at a venue. If there's no physical location, skip it.
+- **Venue-adjacent reviews** — Fans often leave reviews on the venues where a band plays, specifically mentioning the performance. Monitor venue Google and Yelp listings — a mentioned performance in a positive venue review is worthwhile to screenshot and share.
+
+See `docs/smb/reviews.md` for general review management guidance.
+
 ## Compliance
 
 - **Performance rights organizations (PROs)**: If the artist writes original music, they should register with a PRO — **ASCAP**, **BMI**, or **SESAC** in the US. PROs collect royalties when songs are played on radio, in venues, on TV, or streamed. The website should note the artist's PRO affiliation if relevant to licensing.

--- a/docs/smb/nonprofit.md
+++ b/docs/smb/nonprofit.md
@@ -39,6 +39,18 @@ Every nonprofit website needs these regardless of sub-type:
 - **Photography style:** Impact photography — real people, real community, real work. Avoid stock photos. 4:3 for general use, 16:9 for hero banners. Warm and authentic treatment.
 - **Key component:** Impact stat cards — a large number with a brief description (e.g., "1,200 meals served this month"). These build donor confidence and make the mission tangible.
 
+## Review platforms
+
+Review platforms matter less for general nonprofits than for for-profit businesses, but Google Business Profile is worth claiming for any nonprofit with a physical location.
+
+- **Google Business Profile** — Donors, volunteers, and people seeking services may find the organization via Google. Reviews here sometimes reflect volunteer or donor experiences. Keep the profile accurate (especially hours) and respond to any reviews.
+- **Charity Navigator / GuideStar (Candid)** — These nonprofit-specific platforms rate organizations on financial health and transparency. A strong Charity Navigator rating builds donor confidence far more than Yelp stars. Make sure the nonprofit's financials are current on both platforms.
+- **GreatNonprofits** — A review platform specifically for nonprofits where volunteers, donors, and clients can leave testimonials. Often integrated with Charity Navigator.
+
+For nonprofit sub-types, see the specific vertical file for more targeted guidance.
+
+See `docs/smb/reviews.md` for general review management guidance.
+
 ## Shared tools
 
 - **Donorbox** (free up to $1000/mo) — Embeddable donation forms. donorbox.org

--- a/docs/smb/pet-services.md
+++ b/docs/smb/pet-services.md
@@ -35,6 +35,17 @@ Covers: dog grooming, pet boarding/kennels, dog walking, pet sitting, dog traini
 - **Cal.com** (open source, free tier) — For booking grooming appointments or training sessions.
 - Many pet businesses manage bookings via phone/text. If that works and the volume is manageable, don't fix what isn't broken.
 
+## Review platforms
+
+- **Google Business Profile** — Pet owners search "dog groomer near me" or "dog boarding [city]" and choose heavily on reviews. Reviews that mention a specific pet's name or a funny story ("they even sent us a photo of Max during his bath") are especially persuasive. Respond to every review personally — pet parents appreciate the warmth.
+- **Yelp** — Active for pet services in most markets. Pet owners use Yelp specifically when searching for grooming and boarding options. Features like photos and check-ins give it depth. Claim the listing and keep it updated with current photos.
+- **Rover** (if applicable) — For dog walkers and pet sitters who use the Rover platform, the in-app review system is the primary credibility signal. A high Rover rating and review count significantly affects booking rates within the platform.
+- **Facebook** — Many pet owners ask for recommendations in neighborhood Facebook Groups. A business page with visible reviews and active posts gives you something to point to when someone mentions your name in a group. Respond to recommendations and tags.
+
+Ask pet parents at pickup: "If [pet's name] had a great time, a Google or Yelp review would mean the world to us!" Including the pet's name in the ask makes it personal and almost always gets a yes.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Vaccination records**: Boarding and daycare facilities typically require proof of vaccination. Note requirements on the policies page (rabies, DHPP, bordetella are common).

--- a/docs/smb/pharmacy.md
+++ b/docs/smb/pharmacy.md
@@ -49,6 +49,13 @@ Covers: independent pharmacies, compounding pharmacies, specialty pharmacies, ap
 - **FDA and FTC**: The pharmacy cannot make health claims about products or services beyond what's FDA-approved. "Our compound cures [condition]" is not allowed. "Our compounding pharmacy prepares custom medications as prescribed by your doctor" is fine.
 - **Accessibility**: Pharmacy websites must be accessible. Many pharmacy customers are elderly and may use screen readers, have low vision, or have difficulty with small text. See `docs/accessibility.md`.
 
+## Review platforms
+
+- **Google Business Profile** — "Pharmacy near me" and "compounding pharmacy [city]" are common searches. Reviews here directly drive new patient acquisition. Reviews often mention staff knowledge, wait times, and whether the pharmacist called back — the differentiators from chain pharmacies. Respond to every review to reinforce the personal-service message.
+- **Yelp** — Used in some markets for pharmacy discovery, especially for specialty pharmacies and those with strong retail or compounding reputations.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Content ideas
 
 Flu season vaccine reminders, medication safety tips ("how to store medications properly"), drug disposal events and permanent disposal locations, seasonal health topics (allergies, sun protection, cold and flu, holiday stress), new service announcements, pharmacist spotlights, compounding FAQs, Medicare Part D enrollment reminders (Oct 15–Dec 7), community health screening events, travel health tips, pet medication awareness, medication synchronization benefits explained, "ask your pharmacist" Q&A posts, partnership announcements with local doctors and clinics.

--- a/docs/smb/photography.md
+++ b/docs/smb/photography.md
@@ -34,6 +34,17 @@ Covers: wedding photographers, portrait photographers, commercial photographers,
 - **Cal.com** (open source, free tier) — For booking consultations or mini-sessions.
 - **Ko-fi** (free, no fees) — For selling prints, presets, or digital products.
 
+## Review platforms
+
+- **Google Business Profile** — The baseline for any photography business. People searching "wedding photographer [city]" or "portrait photographer near me" check Google first. A photographer with 40+ reviews and a 4.9 rating gets booked more frequently than an equally talented one with 5 reviews. Respond to every review — future clients are reading.
+- **The Knot / WeddingWire** (if weddings are a primary service) — Wedding photographers live on these platforms. Couples shortlist photographers based on The Knot and WeddingWire reviews before ever visiting a website. Paying for a listing is an investment in this business model; even the free profiles allow reviews. Getting 20+ reviews on The Knot is more impactful for wedding bookings than almost any other marketing.
+- **Facebook** — Clients who love a photographer often tag them in wedding recap posts or write recommendations on the business page. A photographer with active engagement and visible client appreciation on Facebook signals a trusted, personable vendor.
+- **Yelp** — Used for portrait and commercial photographers in some markets, less so for weddings. Worth monitoring and maintaining a profile if the business appears there.
+
+After delivering a gallery, include a personal note: "It was such a pleasure photographing your [wedding/family/team]. If you have a moment, a Google review helps me find more clients like you — here's a direct link." Personalized, timed right (when the client is still in the glow of their photos), this request lands well.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Model releases**: If featuring clients or subjects on the website (especially children), have a model release. Mention this during the design interview when discussing gallery photos.

--- a/docs/smb/podcaster.md
+++ b/docs/smb/podcaster.md
@@ -67,6 +67,16 @@ Every podcast needs a hosting platform that stores the audio files and generates
 - **Memberful** (~$25/mo, proprietary) — Private podcast feeds for paying members. memberful.com
 - **Buttondown** (free tier, indie) — Newsletter for episode announcements and listener engagement. buttondown.email
 
+## Review platforms
+
+Traditional review platforms don't apply to podcasts in the way they do to local businesses. Podcast reputation is built through platform presence, episode quality, and word-of-mouth sharing.
+
+- **Apple Podcasts** — Listener ratings and reviews on Apple Podcasts are the most visible credibility signal in the podcasting ecosystem. A show with many positive reviews ranks better in search and appears more credible to first-time listeners. Ask listeners to rate and review after a strong episode.
+- **Spotify** — Spotify allows listener ratings and shows aggregate scores. As Spotify becomes the primary podcast platform for many audiences, the rating there increasingly matters.
+- **Podcast Index / community** — Podchaser (podchaser.com) is a podcast-specific review platform where enthusiasts leave detailed reviews. Less volume than Apple but respected in the podcasting community.
+
+See `docs/smb/reviews.md` for general review management guidance.
+
 ## Compliance
 
 - **Music and audio licensing**: Background music, sound effects, and intro/outro music must be licensed. Options: royalty-free music libraries (Epidemic Sound, Artlist, Free Music Archive), Creative Commons music (credit required), or original music. Using copyrighted music without a license can get episodes pulled from platforms.

--- a/docs/smb/printing.md
+++ b/docs/smb/printing.md
@@ -45,6 +45,13 @@ Covers: print shops, sign makers, screen printers, embroidery shops, custom appa
 - **OSHA and chemical safety**: Screen printing involves chemicals (inks, solvents, emulsions). OSHA compliance for ventilation, PPE, and chemical storage. Not a website concern, but worth knowing.
 - **Sales tax**: Custom printing may or may not be taxable depending on the state and the type of product. Some states tax finished goods but exempt services. Consult a tax advisor.
 
+## Review platforms
+
+- **Google Business Profile** — "Print shop near me," "sign shop [city]," and "custom t-shirts [town]" are high-intent searches that resolve through Google Maps. Reviews here often describe turnaround time, communication, and print quality — the things that matter most to business customers. Respond to reviews, especially those mentioning specific jobs, to show attentiveness.
+- **Yelp** — Used in some markets for print shops. Reviews tend to describe reliability and quality more than price — the qualities that win repeat business clients.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Content ideas
 
 Project spotlights with photos (with client permission), material comparisons (vinyl vs. coroplast, screen print vs. DTG, matte vs. glossy), file preparation tips, design trends, seasonal product promotions (graduation banners, election yard signs, holiday cards, team uniforms), customer success stories ("how a new sign increased foot traffic"), equipment and process behind-the-scenes, tips for choosing colors and fonts, community event sponsorships, trade show recaps, staff spotlights.

--- a/docs/smb/real-estate.md
+++ b/docs/smb/real-estate.md
@@ -33,6 +33,17 @@ Covers: real estate agents, brokerages, property management companies.
 - For listings: link to the agent's MLS profile or brokerage listing page. Don't try to replicate MLS on the website — the data changes too frequently and requires IDX compliance.
 - **Canva** (free tier) — For social media graphics, just-listed flyers, open house announcements.
 
+## Review platforms
+
+- **Google Business Profile** — Most sellers and buyers search for agents by name or by "real estate agent [city]" before making contact. A strong Google presence with 20+ reviews signals an active agent. Reviews that describe specific outcomes ("helped us sell in 11 days over asking," "found exactly the right house for our family") are the most persuasive.
+- **Zillow** — Buyers and sellers spend significant time on Zillow. Agent profiles on Zillow include client reviews, and clients often check a specific agent's Zillow profile after being referred. Claim and maintain the profile. Encourage past clients to leave Zillow reviews specifically.
+- **Realtor.com** — Similar to Zillow. Many buyers use both platforms. A complete Realtor.com profile with reviews reinforces credibility.
+- **Facebook** — Real estate clients frequently post about their home purchase or sale, tagging their agent. A business page with visible client posts, reviews, and regular neighborhood content builds a local presence. Ask clients to leave a recommendation on Facebook after closing.
+
+The best time to ask for a review is right at closing — emotions are high, gratitude is fresh. "It was such a pleasure working with you. A Google or Zillow review would be incredibly helpful and would only take a minute." Hand them a card with direct links.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Fair Housing Act (US)**: Website content must not express preference or limitation based on race, color, religion, sex, familial status, national origin, or disability. Avoid language like "perfect for young couples" or "family neighborhood." Use inclusive descriptions.

--- a/docs/smb/repair.md
+++ b/docs/smb/repair.md
@@ -39,6 +39,18 @@ Covers: auto repair, auto body/collision, computer/phone/electronics repair, app
 - **Cal.com** (open source, free tier) — Appointment booking for drop-offs or estimates.
 - Many small repair shops run on paper tickets or a simple spreadsheet. If volume is low (<10 jobs/week), that's fine — don't overcomplicate it.
 
+## Review platforms
+
+- **Google Business Profile** — The first place people turn when something breaks. "Phone repair near me" or "appliance repair [town]" goes straight to Google Maps results. Reviews that say "they were honest about whether to repair or replace" and "fast turnaround, kept me updated" are the most persuasive for repair businesses. Respond to every review, including complaints — showing you address problems professionally is as important as the good reviews.
+- **Yelp** — Active for auto repair, phone repair, and electronics repair shops. Some customers specifically use Yelp because they believe its filter catches fake reviews and provides more authentic signal. A strong Yelp presence with recent reviews and owner responses is worth building.
+- **RepairShopr / RepairDesk reviews** (if using these platforms) — If the shop uses job management software with customer portals, some platforms have review prompts built in. Enable them.
+- **Better Business Bureau** — For auto repair specifically, an accredited BBB profile with positive reviews is a meaningful trust signal, especially for first-time customers who are nervous about being overcharged.
+- **Facebook** — Neighborhood groups are where people ask "anyone have a good mechanic?" A business page with visible reviews and quick responses to comments positions the shop to be recommended when those questions come up.
+
+Timing matters: ask for the review when the customer picks up their item and says they're happy — not a week later by email when the moment has passed. A receipt or pickup notice with a direct review link makes it easy.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Right to Repair laws**: Landscape is changing fast. As of 2025, several US states and the EU have enacted repair legislation requiring manufacturers to provide parts, tools, and documentation. If the business advocates for Right to Repair, feature this on the about page — it's a differentiator and a values statement.

--- a/docs/smb/restaurant.md
+++ b/docs/smb/restaurant.md
@@ -34,6 +34,17 @@ Covers: restaurants, cafés, coffee shops, bakeries, catering, delis, ice cream 
 - For reservations: consider whether the owner actually needs reservation software, or if a phone number and email work fine. Most small restaurants don't need Resy or OpenTable.
 - **Map listings** — Essential for "restaurants near me" searches. Claim the business on Google Business Profile, Apple Business Connect, and OpenStreetMap. Post menu updates and photos regularly. See `docs/webmaster.md` → Map listings.
 
+## Review platforms
+
+- **Google Business Profile** — The dominant discovery channel. "Restaurants near me" searches resolve almost entirely through Google. Keep the profile complete with photos, menu link, and current hours. Respond to reviews within a day or two — it's visible to every future customer who reads that review.
+- **Yelp** — Heavily used for restaurants in most urban markets. Some cities (San Francisco, NYC, Chicago) have denser Yelp cultures than others. Claim the listing, keep it current, and respond to reviews. Yelp's filter may hide some genuine reviews — it's a feature, not a bug on your end.
+- **TripAdvisor** — Relevant if the business is in a tourist area or destination city. Even in non-tourist markets, some customers check TripAdvisor. Worth claiming.
+- **OpenTable / Resy** — If using either for reservations, guests leave reviews directly on the platform. These matter because they appear right where people are booking.
+
+Encourage reviews by placing a small card at the table or printing a QR code on the receipt. "We're a local business — a Google review means a lot." Don't ask for a specific rating.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Health department permits**: Required for commercial kitchens. Display permit number if required by jurisdiction. Link to latest inspection report if publicly available (builds trust).

--- a/docs/smb/retail.md
+++ b/docs/smb/retail.md
@@ -33,6 +33,13 @@ Covers: gift shops, boutiques, clothing stores, toy stores, antique shops, thrif
 - **Shopify** ($39/mo, proprietary) — Polished but expensive. Only recommend if WooCommerce is too complex and they need a full e-commerce platform.
 - **Big Cartel** (free for 5 products, proprietary) — Lightweight option for shops with a small product line.
 
+## Review platforms
+
+- **Google Business Profile** — "Gift shops near me," "boutiques in [city]," and "antique stores [town]" all resolve through Google Maps. The profile photo, hours accuracy, and review responses are what turn a discovery into a visit.
+- **Yelp** — Browseable by category in most markets. Shoppers use Yelp to compare boutiques and specialty stores before deciding where to spend an afternoon. Detailed reviews about selection, staff, and atmosphere carry weight.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Sales tax collection**: Must collect and remit state/local sales tax. If selling online, nexus rules may require collecting tax in multiple states.

--- a/docs/smb/roadside-attraction.md
+++ b/docs/smb/roadside-attraction.md
@@ -39,6 +39,18 @@ The business model: people stop because it's worth the detour. Discovery is road
 - **Shopify Lite** or **Square Online** — For online gift shop if they sell merchandise.
 - **Social media** — Instagram and TikTok are primary discovery channels. Visitors create content — encourage it with photo spots, hashtags, and signs. The attraction IS the content.
 
+## Review platforms
+
+- **Google Business Profile** — Critical. Travelers searching "things to do near [highway/town]" find roadside attractions primarily through Google Maps. Keep photos current (show the attraction at its best), respond to all reviews, and post updates before peak travel season. A high Google rating and review count is the single biggest factor in whether a road tripper adds the stop to their route.
+- **TripAdvisor** — The dominant review platform for tourist attractions. Families and road trippers cross-check Google with TripAdvisor. A TripAdvisor Certificate of Excellence signals legitimacy. Respond to reviews, especially critical ones — a measured, friendly response to a mixed review demonstrates character. Claim the listing and upload photos.
+- **Atlas Obscura** — Not a traditional review platform, but comments and saves on Atlas Obscura entries function as social proof for the "weird and wonderful" crowd. A well-maintained Atlas Obscura entry with many saves signals the attraction is worth the detour for road trip enthusiasts and travel bloggers.
+- **Roadtrippers** — User reviews and saves on Roadtrippers influence road trip planning decisions. The app is used heavily by the demographic that visits roadside attractions — submit and keep the listing current.
+- **Yelp** — Relevant in some markets. Worth monitoring and responding, but less dominant for attractions than for food and services.
+
+Feature the best visitor quotes prominently on the home page and the Reviews page — "is it worth the stop?" is the exact question reviews answer for a potential visitor sitting in a car 20 miles away deciding whether to turn off.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Liability and insurance**: Visitors on the property need general liability coverage. If there are physical activities (climbing, mazes, rides), additional coverage and safety inspections apply. Consult an insurance agent specializing in attractions or tourism.

--- a/docs/smb/salon.md
+++ b/docs/smb/salon.md
@@ -36,7 +36,16 @@ Covers: hair salons, barbershops, nail salons, spas, aestheticians, lash/brow st
 - **Vagaro** (~$25/mo, proprietary) — Booking, payments, marketing. Popular with salons and spas. vagaro.com
 - If they already use Booksy, GlossGenius, or Boulevard — keep it. Link from the website.
 - **Instagram** is the primary portfolio for most beauty professionals — often more important than the website gallery. Embed or link the feed prominently on the home page and gallery. Keep `rel="me"` for verification. During `/anglesite:start`, ask for the Instagram handle early and feature it in the site design.
-- **Reviews** — Clients choose beauty providers based on reviews. Encourage and link to reviews on Google, Yelp, and the booking platform (Booksy, Fresha, etc.). Add a "Reviews" section to the home page or a dedicated page with a link to leave a review.
+## Review platforms
+
+- **Google Business Profile** — Primary discovery channel. Most clients search "salon near me" and pick based on stars and photos. Respond to every review — clients notice whether a salon engages.
+- **Yelp** — Heavily used for beauty services, especially in urban areas. Yelp's filter is aggressive — don't panic if reviews disappear. Filtered reviews are still visible to users who click through.
+- **Booking platform** (Fresha, Vagaro, Booksy) — Reviews here appear at the moment of booking decision. A provider with 50 reviews converts better than one with 5. Ask clients to review after each visit.
+- **Instagram** — Not traditional reviews, but DM testimonials and comment praise are social proof. Ask permission to screenshot and feature them on the website or in Stories.
+
+Add a "Leave us a review" link on the contact page and a short reviews section on the home page. Ask clients at checkout.
+
+See `docs/smb/reviews.md` for full review management guidance.
 
 ## Compliance
 

--- a/docs/smb/service.md
+++ b/docs/smb/service.md
@@ -35,6 +35,18 @@ Covers: consultants, coaches (business, life, executive), freelancers, virtual a
 - **Dubsado** (~$20/mo, proprietary) — Similar to HoneyBook. Workflows, forms, contracts, invoicing. dubsado.com
 - **Wave** (free, proprietary) — Invoicing and accounting. Good for solo service providers who don't need a full practice management tool. waveapps.com
 
+## Review platforms
+
+- **Google Business Profile** — The baseline for all service businesses. When a referral checks out a consultant or coach, Google is the first stop. A service business with 15+ reviews and a strong rating looks legitimate and established. Reviews that describe specific outcomes ("helped me increase revenue by 40%," "completely transformed how I run my calendar") convert better than generic praise. Respond to every review.
+- **Yelp** — Relevant for some service categories (event planners, bookkeepers, coaches) in urban markets. Claim the profile if the business appears there.
+- **LinkedIn** (recommendations, not traditional reviews) — For B2B service businesses — consultants, coaches, fractional CFOs — LinkedIn recommendations are often more credible than Google reviews. Encourage clients to write a recommendation on LinkedIn. These feed directly into the profile that business clients will check.
+- **Clutch.co** (for agencies and B2B services) — A review platform specifically for agencies, software companies, and B2B service providers. If the business serves other businesses, Clutch is worth claiming and building reviews on.
+- **Facebook** — For consumer-facing service businesses (event planners, life coaches, virtual assistants), a Facebook business page with visible recommendations provides social proof for clients who found the business through social referrals.
+
+Testimonials displayed on the website (case studies, client quotes) are often more persuasive than platform reviews for high-ticket service businesses — a detailed case study outweighs 50 one-sentence Google reviews for a six-month consulting engagement. Both matter; they serve different audiences at different points in the decision process.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Contracts**: Always use a written agreement. Scope of work, payment terms, cancellation policy, intellectual property ownership. Templates from SCORE or SBA are a starting point.

--- a/docs/smb/social-services.md
+++ b/docs/smb/social-services.md
@@ -44,6 +44,14 @@ See [nonprofit.md](nonprofit.md) for shared nonprofit traits (donate page, trans
 - **Nondiscrimination**: Display a nondiscrimination policy. Many funders (HUD, FEMA, etc.) require this.
 - **Language access**: If serving a multilingual community, key pages (especially "get help" and "crisis resources") should be available in the primary languages of the community served.
 
+## Review platforms
+
+Review platforms are not a primary concern for social service organizations — clients seeking help don't browse Yelp stars, and many clients are in crisis and value confidentiality over public visibility.
+
+If the organization has a Google Business Profile (common for organizations with a physical office), keep the hours and contact information accurate. Some volunteers, donors, and partner agencies use Google to find the organization. Respond to any questions or reviews professionally to build community trust.
+
+See `docs/smb/reviews.md` for general review management guidance.
+
 ## Content ideas
 
 Impact stories (anonymized or with explicit consent — never pressure clients), program milestone announcements ("we housed 50 families this year"), volunteer spotlights, donor recognition, awareness month features (Hunger and Homelessness Awareness Week, DV Awareness Month), policy and advocacy updates, community resource roundups, staff spotlights, fundraiser announcements and recaps.

--- a/docs/smb/storage.md
+++ b/docs/smb/storage.md
@@ -44,6 +44,13 @@ Covers: self-storage units, climate-controlled storage, vehicle/boat/RV storage,
 - **Privacy**: Access logs contain personally identifiable information. Gate access systems must be secure.
 - **Vehicle/RV/boat storage**: If offering outdoor or covered vehicle storage, check local ordinances and note any size or height restrictions.
 
+## Review platforms
+
+- **Google Business Profile** — "Storage units near me" is a high-volume local search. Reviews here influence whether a customer chooses this facility over the next one. Reviews often focus on security, cleanliness, access hours, and staff helpfulness. Respond to all reviews — prospective customers read those responses before deciding.
+- **Yelp** — Used in some markets for storage facility discovery. Reviews tend to describe the rental process, gate access reliability, and whether the facility feels safe.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Content ideas
 
 Packing and organization tips, "what size storage unit do I need?" guides, moving checklists, seasonal storage tips (holiday decorations, winter gear), business storage use cases, climate control explainers, security feature spotlights, local moving guides, decluttering advice, "how to prepare items for long-term storage."

--- a/docs/smb/tattoo.md
+++ b/docs/smb/tattoo.md
@@ -36,6 +36,14 @@ Covers: tattoo shops, piercing studios, permanent makeup/microblading, body art 
 - **Cal.com** (open source, free tier) — Consultation booking.
 - Many studios manage booking through Instagram DMs or a simple form. If that works, don't overcomplicate it.
 
+## Review platforms
+
+- **Google Business Profile** — "Tattoo shops near me" is a high-volume search. Reviews on Google determine which shops appear in the map pack. Keep the profile current with photos of the shop and portfolio examples — the visual impression matters here as much as the star rating.
+- **Yelp** — Many people use Yelp specifically for tattoo shops before booking. Yelp reviews tend to be detailed and describe the whole experience: cleanliness, artist communication, pain management, aftercare instructions. Claim the listing and respond to feedback.
+- **Instagram** — Not a traditional review platform, but the de facto portfolio and reputation channel for tattoo artists. Followers, comments, and DMs function as public social proof. Keep the Instagram profile linked from the website.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Health department licensing**: Tattoo and piercing studios are regulated by local or state health departments. Display your license. Inspections are routine.

--- a/docs/smb/tour-guide.md
+++ b/docs/smb/tour-guide.md
@@ -43,6 +43,18 @@ Covers: fishing guides, hunting outfitters, adventure tours (zip lines, rafting,
 - **Square** (free POS, 2.6% per transaction) — For on-site payments, tips, and merchandise.
 - **Mailchimp** (free up to 500 contacts) or **Buttondown** (~$9/mo, indie) — For trip announcements, seasonal updates, and fishing/conditions reports.
 
+## Review platforms
+
+- **Google Business Profile** — The starting point for "fishing guide [lake]," "kayak tour [city]," or "ghost tour [city]" searches. Guides with 50+ reviews and a 4.8+ rating rank higher in local search and get more organic bookings. Reviews that describe the guide specifically ("Jake knew every good hole on the river," "she kept the kids engaged the whole time") convert better than generic five-star ratings. Respond to every review.
+- **TripAdvisor** — The dominant platform for tour discovery among leisure travelers. For tours in tourist markets, TripAdvisor is often where travelers make their final booking decision. Claim the listing, upload photos from real trips, respond to all reviews, and pursue the Certificate of Excellence once you have enough reviews. A high TripAdvisor ranking in the "activities" category for your area drives consistent organic traffic.
+- **Viator** — TripAdvisor's OTA booking marketplace. If using FareHarbor, it can distribute automatically to Viator. Viator reviews feed into the TripAdvisor ecosystem and reach international travelers. Reviews here matter for OTA-sourced bookings.
+- **Yelp** — Relevant for urban tours (food tours, walking tours, city-based experiences) and some outdoor activities. Worth monitoring and maintaining a profile.
+- **GetYourGuide** — An alternative OTA for tour distribution. Reviews on GetYourGuide reach European and international markets where it's strong. If distributing there, keep the listing and reviews managed.
+
+The best time to ask for a review is at trip end, in person: "If you had a great time today, a TripAdvisor or Google review would be incredibly helpful — they're how other people find us." Trip guests who just had a great experience are the most willing to write substantive, enthusiastic reviews. Don't wait until a follow-up email — the moment is now.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Licensing and permits**: Most guide activities require specific licenses or permits:

--- a/docs/smb/trades.md
+++ b/docs/smb/trades.md
@@ -35,6 +35,18 @@ Covers: general contractors, plumbers, electricians, HVAC, roofers, painters, la
 - **Square Invoices** (free, 2.9% + 30¢ on card payments) — Simple invoicing if they don't need full job management.
 - **Monica CRM** (open source, free) — If they just need to track clients and jobs.
 
+## Review platforms
+
+- **Google Business Profile** — The primary review channel for trades. Customers search "plumber near me" or "electrician [town]" and choose based on stars and responses. Getting to 20+ reviews significantly improves conversion from search. Respond to every review, including negative ones — a professional response to a bad review demonstrates how you handle problems.
+- **Nextdoor** — Very active for home services. Neighbors ask for recommendations, and a business recommended by a neighbor has built-in trust. Claim the Nextdoor Business Page and ask happy customers to recommend you there.
+- **Angi (formerly Angie's List)** — Still checked by homeowners researching contractors. Paid leads are optional; the profile with reviews is free to maintain.
+- **HomeAdvisor** — Similar audience to Angi. If the business gets leads from either platform, keep the profile and reviews current.
+- **Better Business Bureau** — Less used by younger customers but still checked. An accredited, A-rated BBB profile is a trust signal for high-ticket work.
+
+After a successful job, text the customer a direct Google review link. "Glad everything looks good — if you have a minute, a Google review helps us find more neighbors to help." One message, once, no pressure.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Licensing display**: Most jurisdictions require contractors to display their license number on advertising, including websites. Add to the footer on every page.

--- a/docs/smb/video-creator.md
+++ b/docs/smb/video-creator.md
@@ -58,6 +58,16 @@ Covers: YouTubers, video essayists, educational video creators, streamers (Twitc
 - **VidIQ** (free tier, proprietary) or **TubeBuddy** (free tier, proprietary) — YouTube analytics and SEO tools. Help with titles, tags, thumbnails, best upload times. Use one, not both.
 - **SponsorBlock** data / SocialBlade — Public analytics for understanding channel performance trends. Not tools to install, but useful references.
 
+## Review platforms
+
+Traditional review platforms don't apply to video creators — viewers don't leave Yelp reviews for YouTubers. Reputation is established through platform presence, view counts, and community engagement.
+
+- **YouTube** — The like/dislike ratio, subscriber count, and comment quality are the public trust signals for YouTube-based creators. A comments section that shows engaged, appreciative viewers is itself a form of social proof.
+- **Twitch** — For streamers, follower count, subscription count, and channel reviews (where available) signal community standing.
+- **Google Business Profile** — Only relevant if the creator operates a physical studio available for hire, teaches in-person workshops, or hosts live events with a fixed venue. If there's no physical location, skip it.
+
+See `docs/smb/reviews.md` for general review management guidance.
+
 ## Compliance
 
 - **Copyright and fair use**: Video creators frequently use clips, images, music, and other copyrighted material. Fair use is a legal defense, not a right — it's determined case by case. Guidelines: transformative use is stronger than reproductive use; commentary and criticism have more protection than compilation; using less of the original is better than more. YouTube's Content ID system can claim or block videos regardless of fair use. The website is not subject to Content ID — another reason to host content there.

--- a/docs/smb/youth-org.md
+++ b/docs/smb/youth-org.md
@@ -35,6 +35,13 @@ See [nonprofit.md](nonprofit.md) for shared nonprofit traits (donate page, trans
 - **GiveButter** (free, tips-based) — Fundraising for equipment, scholarships, facility needs.
 - For summer camps: **CampMinder** or **UltraCamp** — Camp-specific registration and management.
 
+## Review platforms
+
+- **Google Business Profile** — Parents searching for youth sports leagues, after-school programs, or scouting groups use Google Maps. Reviews here focus on safety, communication, and whether children thrived in the program — the trust signals that matter most to parents.
+- **Facebook** — Many youth organizations have active Facebook communities where parent recommendations are especially common. Monitor and respond to recommendations on the Facebook page.
+
+See `docs/smb/reviews.md` for full review management guidance.
+
 ## Compliance
 
 - **Child safety**: This is the #1 compliance concern. Display:

--- a/docs/superpowers/plans/2026-03-26-reputation-coaching.md
+++ b/docs/superpowers/plans/2026-03-26-reputation-coaching.md
@@ -1,0 +1,415 @@
+# Reputation Coaching Enhancements — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enhance the existing reputation skill with multi-platform review coaching and connect it to the start/check workflows.
+
+**Architecture:** Modify three existing skill files (reputation, start, check) to add platform awareness. Add `## Review platforms` sections to ~50 vertical docs in `docs/smb/`. Create one new workflow doc for non-plugin agents. No new infrastructure, APIs, or dependencies.
+
+**Tech Stack:** Markdown (skill files, docs). No code changes — this is entirely skill/doc content.
+
+**Spec:** `docs/superpowers/specs/2026-03-26-reputation-coaching-design.md`
+
+---
+
+### Task 1: Add `REVIEW_PLATFORMS` question to start skill
+
+**Files:**
+- Modify: `skills/start/SKILL.md:74` (after question 7 in business branch)
+
+- [ ] **Step 1: Read the current start skill Step 0 business branch**
+
+Read `skills/start/SKILL.md` lines 70-81. The new question goes after question 7 (tools/apps) and before question 8 (physical location).
+
+- [ ] **Step 2: Add the review platforms question**
+
+Insert after line 74 (the question 7 block), before question 8:
+
+```markdown
+7b. **Business and organization sites only:** "Where do your customers leave reviews? Google, Yelp, your booking platform?" — Save as `REVIEW_PLATFORMS=google,yelp,fresha` (comma-separated slugs) in `.site-config`. If they mention Google Business Profile and `GOOGLE_REVIEW_URL` is not already set, ask for their business name to construct the direct review link: `https://search.google.com/local/writereview?placeid=PLACE_ID`. Find the Place ID via [Google's Place ID Finder](https://developers.google.com/maps/documentation/places/web-service/place-id) and save as `GOOGLE_REVIEW_URL` in `.site-config`. Skip this question for personal, blog, and portfolio site types.
+```
+
+- [ ] **Step 3: Verify the edit doesn't break the flow**
+
+Read the surrounding lines (65-110) to confirm the question fits naturally between Q7 and Q8, and that the numbering/flow reads correctly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/start/SKILL.md
+git commit -m "feat(start): collect review platforms during onboarding
+
+Adds question 7b to the business/org branch of Step 0 asking which
+platforms the owner's customers use for reviews. Stores as
+REVIEW_PLATFORMS in .site-config. Skipped for personal/blog/portfolio.
+
+Refs #61"
+```
+
+---
+
+### Task 2: Add per-platform walk-through to reputation skill
+
+**Files:**
+- Modify: `skills/reputation/SKILL.md:44-52` (Step 2)
+
+- [ ] **Step 1: Read the current Step 2**
+
+Read `skills/reputation/SKILL.md` lines 28-52. Understand the existing context-reading (Step 1) and review monitoring coaching (Step 2).
+
+- [ ] **Step 2: Replace Step 2 with platform-aware version**
+
+Replace lines 44-52 (the current Step 2) with:
+
+```markdown
+## Step 2 — Review monitoring coaching
+
+Read `REVIEW_PLATFORMS` from `.site-config` if available.
+
+### If `REVIEW_PLATFORMS` is set (structured walk-through)
+
+Walk through each platform in order. For each:
+
+1. Direct the owner to open their review page:
+   - **Google:** Use `GOOGLE_REVIEW_URL` from `.site-config` if available. Otherwise: "Open Google Maps and search for your business name, then click Reviews."
+   - **Yelp:** "Open yelp.com and search for your business name, then click the Reviews tab."
+   - **Booking platform** (Fresha, Vagaro, Booksy, etc.): "Open [platform] and check your reviews dashboard."
+   - **Other platforms:** Direct the owner to the review section of that platform.
+
+2. Ask: "Any new reviews on [platform] since last time?"
+   - If yes: "Read me the review (or paste it) and I'll help you draft a response." → proceed to Step 3.
+   - If no: "Great — you're caught up on [platform]." → move to next platform.
+
+3. After all platforms: proceed to Step 4 (getting more reviews).
+
+### If `REVIEW_PLATFORMS` is not set but `BUSINESS_TYPE` is (generic coaching)
+
+Fall back to general questions:
+
+1. **"Have you checked your Google reviews recently?"** — Most owners forget. A gentle nudge is the most valuable thing this skill does.
+2. **"Any new reviews since we last talked?"** — If yes, offer to help draft a response (Step 3).
+3. **"Are you getting reviews from customers?"** — If not, suggest a simple ask strategy (Step 4).
+
+Also ask: "Which platforms do your customers use for reviews? I can save that so next time we go through them one by one." If the owner answers, save to `.site-config` as `REVIEW_PLATFORMS`.
+
+### Non-interactive context (e.g., part of `/anglesite:check`)
+
+Skip the questions. Present 1-3 platform-specific coaching tips based on `REVIEW_PLATFORMS` (or generic tips if not set). Example: "Reminder: check your Google and Yelp reviews this week. Responding within a few days shows customers you care."
+```
+
+- [ ] **Step 3: Add QR code suggestion to Step 4**
+
+In Step 4 (getting more reviews), after the existing bullet 3 about adding a review link to the website (around line 90-94), insert a new bullet:
+
+```markdown
+6. **QR code** — Invoke the `qr` skill to generate a QR code for the Google review link. The owner can print it on receipts, table tents, or business cards. (The `qr` skill is model-only — invoke it directly, do not present it as a slash command to the owner.)
+```
+
+This is an unconditional addition — the current file does not mention the qr skill at all.
+
+- [ ] **Step 4: Add `REVIEW_PLATFORMS` to Step 1 context reading**
+
+In Step 1, insert two new bullets into the existing `.site-config` read list (lines 30-33). Insert after the `SITE_URL` bullet (line 33). **Do not modify or remove lines 37-42** (the "Read the business type guide" and "Read competitive positioning guidance" paragraphs — those must stay).
+
+Insert after line 33:
+
+```markdown
+- `REVIEW_PLATFORMS` — comma-separated platform slugs (google, yelp, fresha, etc.)
+- `GOOGLE_REVIEW_URL` — direct link to Google review form (if available)
+```
+
+- [ ] **Step 5: Verify the full skill reads coherently**
+
+Read the entire `skills/reputation/SKILL.md` to confirm the new Step 2 flows naturally into the unchanged Steps 3-6, and that the Step 1 updates are consistent.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/reputation/SKILL.md
+git commit -m "feat(reputation): add per-platform review walk-through
+
+Step 2 now iterates through REVIEW_PLATFORMS from .site-config, guiding
+the owner to each platform individually. Falls back to generic Google
+coaching when REVIEW_PLATFORMS is not set. Non-interactive context
+(check skill) gets platform-specific tips instead of questions.
+
+Refs #61"
+```
+
+---
+
+### Task 3: Refine check skill Reputation section
+
+**Files:**
+- Modify: `skills/check/SKILL.md:122-127` (Reputation section through trailing blank line)
+
+- [ ] **Step 1: Read the current Reputation section**
+
+Read `skills/check/SKILL.md` lines 118-132.
+
+- [ ] **Step 2: Replace the Reputation section**
+
+Replace lines 122-127 (the `## Reputation` header through the trailing blank line before `## Results`) with:
+
+```markdown
+## Reputation
+
+If `BUSINESS_TYPE` is set in `.site-config`, invoke the reputation skill for review coaching and competitive awareness.
+
+Read `REVIEW_PLATFORMS` from `.site-config` if available. When invoking the reputation skill, note that this is a non-interactive check context so it should present tips, not questions.
+
+If `REVIEW_PLATFORMS` is set, include the platform names in the nudge: "Reminder: check your [Google, Yelp] reviews — responding within a few days helps your reputation." If not set, use the generic nudge.
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/reputation/SKILL.md` and follow it. Include the output as a "Reputation" section in the health report. Keep it brief — 1-3 action items max. If `BUSINESS_TYPE` is not set, skip this section.
+```
+
+- [ ] **Step 3: Verify surrounding context**
+
+Read lines 112-135 to confirm the section fits between "Social preview" and "Results."
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/check/SKILL.md
+git commit -m "feat(check): name specific review platforms in reputation nudge
+
+The Reputation section now reads REVIEW_PLATFORMS from .site-config and
+names specific platforms in the coaching nudge instead of defaulting to
+generic Google-only messaging.
+
+Refs #61"
+```
+
+---
+
+### Task 4: Create workflow doc for non-plugin agents
+
+**Files:**
+- Create: `template/docs/workflows/reputation.md`
+- Modify: `template/AGENTS.md:42-57` (workflows table)
+
+- [ ] **Step 1: Write the workflow doc**
+
+Create `template/docs/workflows/reputation.md`:
+
+```markdown
+# Review reputation coaching
+
+Help the site owner manage their online reviews across third-party platforms.
+
+## When to use
+
+- The owner asks about reviews, reputation, or "how do I respond to this review?"
+- During a quarterly check-in
+- After a seasonal peak (holidays, events) when review volume increases
+
+## Before you start
+
+Read `.site-config` for:
+- `REVIEW_PLATFORMS` — which platforms the owner uses (e.g., `google,yelp,fresha`)
+- `GOOGLE_REVIEW_URL` — direct link to their Google review form
+- `BUSINESS_TYPE` — determines tone and platform relevance
+
+If `REVIEW_PLATFORMS` is not set, ask the owner which platforms their customers use and save it.
+
+## Steps
+
+### 1. Walk through each platform
+
+For each platform in `REVIEW_PLATFORMS`:
+
+1. Direct the owner to open their review page
+   - **Google:** Search for their business on Google Maps → Reviews tab
+   - **Yelp:** Search on yelp.com → Reviews tab
+   - **Booking platforms:** Check the reviews dashboard in their booking tool
+2. Ask: "Any new reviews since last time?"
+3. If yes: help draft a response (see below)
+4. If no: move to the next platform
+
+### 2. Draft review responses
+
+**Positive reviews (4-5 stars):**
+- Thank the reviewer by name
+- Reference something specific they mentioned
+- Keep it warm and brief (2-3 sentences)
+- Match the business's tone (casual for cafes, professional for legal)
+
+**Negative reviews (1-3 stars):**
+- Acknowledge the problem — never dismiss or argue
+- Apologize for the specific issue
+- Take it offline: "Please call us at [phone] so we can make this right"
+- Stay professional — future customers read the response more than the review
+
+**Fake or malicious reviews:**
+- Coach the owner through the platform's reporting process
+- Draft a calm, factual public response
+
+### 3. Encourage more reviews
+
+If the owner has few reviews:
+- Add a "Leave us a review" link to the contact page
+- Suggest asking customers right after a positive experience
+- Consider a QR code for the Google review link on printed materials
+
+### 4. Wrap up
+
+Summarize what was addressed: how many reviews responded to, on which platforms, and any site changes made. Suggest checking again in 2-4 weeks.
+
+## Reference
+
+Full review management guidance: `docs/smb/reviews.md`
+```
+
+- [ ] **Step 2: Add to the AGENTS.md workflows table**
+
+In `template/AGENTS.md`, insert a new row after line 61 (the `testimonials.md` row):
+
+```markdown
+| Review reputation coaching | `docs/workflows/reputation.md` |
+```
+
+- [ ] **Step 3: Verify the table renders correctly**
+
+Read `template/AGENTS.md` lines 38-65 to confirm the new row is present, aligned, and the table is well-formed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add template/docs/workflows/reputation.md template/AGENTS.md
+git commit -m "docs: add reputation coaching workflow for non-plugin agents
+
+Step-by-step guide for any AI agent to coach site owners through
+third-party review management. Added to the AGENTS.md workflows table.
+
+Refs #61"
+```
+
+---
+
+### Task 5: Add `## Review platforms` to vertical docs (batch 1 — verticals with existing review content)
+
+**Files:**
+- Modify: ~15 vertical docs in `docs/smb/` that already mention reviews
+
+These verticals already reference reviews somewhere in their content. Consolidate into a standardized `## Review platforms` section.
+
+- [ ] **Step 1: Identify verticals with existing review mentions**
+
+Search `docs/smb/` for files mentioning "review", "Yelp", "Google Business Profile", or "testimonial" (excluding `reviews.md`, `competitor-awareness.md`, `legal-checklist.md`, `README.md`, `pre-launch.md`, `info-changes.md`, `multi-mode.md`, and the `seasonal-calendar/` directory — these are reference docs, not verticals).
+
+- [ ] **Step 2: Cross-reference with the platform table in reviews.md**
+
+Read `docs/smb/reviews.md` lines 19-40 for the platform-by-business-type table. This is the source of truth for which platforms matter per vertical.
+
+- [ ] **Step 3: For each vertical with existing review content, add `## Review platforms`**
+
+For each file, add a `## Review platforms` section after the `## Tools` section (or after `## Design` if no Tools section). If the file already mentions reviews inline (e.g., salon.md line 39), move that content into the new section and expand it.
+
+Pattern per vertical:
+
+```markdown
+## Review platforms
+
+- **[Platform 1]** — [Why it matters for this vertical]. [What to watch for.]
+- **[Platform 2]** — [Why it matters]. [Platform-specific note.]
+
+See `docs/smb/reviews.md` for full review management guidance.
+```
+
+Use the `reviews.md` platform table for the platform list. Add vertical-specific context from the vertical doc's existing content and the design spec's examples.
+
+- [ ] **Step 4: Verify no duplicate review content**
+
+For each modified file, search for remaining review mentions outside the new section. If any exist, either move them into the section or confirm they serve a different purpose (e.g., "Testimonials page" in a Pages section is about site structure, not review platforms).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/smb/
+git commit -m "docs(smb): add Review platforms section to verticals with existing review content
+
+Consolidates scattered review mentions into a standardized section
+per vertical. Platforms sourced from reviews.md table, expanded with
+vertical-specific context.
+
+Refs #61"
+```
+
+---
+
+### Task 6: Add `## Review platforms` to vertical docs (batch 2 — verticals without review content)
+
+**Files:**
+- Modify: remaining vertical docs in `docs/smb/` (~35 files)
+
+- [ ] **Step 1: Identify remaining verticals**
+
+List all `docs/smb/*.md` files that are actual business verticals (not reference docs) and don't yet have a `## Review platforms` section after Task 5.
+
+- [ ] **Step 2: For each, add `## Review platforms` based on business type**
+
+Use the `reviews.md` platform table. If the vertical isn't in the table, default to:
+
+```markdown
+## Review platforms
+
+- **Google Business Profile** — Primary discovery channel for local search. Claim the listing, keep hours current, and respond to every review.
+
+See `docs/smb/reviews.md` for full review management guidance.
+```
+
+For verticals that have a clear match in the table (e.g., `hospitality.md` → TripAdvisor), add the relevant platforms. For verticals where review platforms are less obvious (e.g., `government.md`, `food-bank.md`), use only Google or skip the section entirely with a note: "Review platforms are less relevant for [type] — focus on community engagement instead."
+
+Place the section after `## Tools` (or `## Design` if no Tools section), consistent with Task 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/smb/
+git commit -m "docs(smb): add Review platforms section to remaining verticals
+
+Adds standardized review platform guidance to verticals that didn't
+previously mention reviews. Defaults to Google Business Profile for
+verticals without industry-specific platforms.
+
+Refs #61"
+```
+
+---
+
+### Task 7: Final verification and cleanup
+
+**Files:**
+- Read: all modified files
+
+- [ ] **Step 1: Verify reputation skill reads coherently end-to-end**
+
+Read the full `skills/reputation/SKILL.md` and confirm the flow from Step 1 through Step 6 is logical and consistent.
+
+- [ ] **Step 2: Verify start skill question flow**
+
+Read `skills/start/SKILL.md` Step 0 and confirm question 7b fits naturally.
+
+- [ ] **Step 3: Verify check skill Reputation section**
+
+Read `skills/check/SKILL.md` lines 118-135 and confirm the section works.
+
+- [ ] **Step 4: Verify workflow doc is discoverable**
+
+Read `template/AGENTS.md` workflows table and confirm the new row is present and the path is correct.
+
+- [ ] **Step 5: Spot-check 3-5 vertical docs**
+
+Read `docs/smb/salon.md`, `docs/smb/restaurant.md`, `docs/smb/trades.md`, `docs/smb/accounting.md`, and one vertical that previously had no review content. Confirm the `## Review platforms` section is present, well-placed, and accurate.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+npm test
+```
+
+No new tests needed — this is all doc/skill content. But verify existing tests still pass since some tests validate skill structure. Note: if `tests/themes.test.ts` (an untracked file from parallel work) causes a failure, assess it separately — it is not a regression from this plan's changes.
+
+- [ ] **Step 7: Final commit if any cleanup was needed**
+
+Only if Steps 1-6 revealed issues that needed fixing.

--- a/docs/superpowers/specs/2026-03-26-reputation-coaching-design.md
+++ b/docs/superpowers/specs/2026-03-26-reputation-coaching-design.md
@@ -1,87 +1,95 @@
-# Reputation coaching skill — design spec
+# Reputation coaching enhancements — design spec
 
 **Issue:** [#61 — Add competitor awareness and review monitoring skill](https://github.com/Anglesite/anglesite/issues/61)
-**Scope:** V1 — guide-based coaching for third-party review management (no OAuth, no API integrations)
+**Scope:** V1 — enhance existing reputation skill with multi-platform coaching and better onboarding
 **Date:** 2026-03-26
 
 ## Problem
 
-Online reputation management is critical for local businesses, but owners don't know when to check reviews, how to respond well, or which platforms matter for their business type. The existing `docs/smb/reviews.md` has comprehensive guidance, but it's passive reference material — the owner has to seek it out. Meanwhile, unanswered reviews pile up and hurt reputation.
+The `skills/reputation/SKILL.md` skill already exists and provides review coaching, response drafting, and competitive context. However, it has two gaps:
 
-## Solution
+1. **Platform awareness** — The skill assumes Google is the only review platform. It doesn't know which platforms the owner uses (Yelp, booking platforms, industry-specific sites) and can't coach per-platform.
+2. **Onboarding** — The `/anglesite:start` skill doesn't collect review platform information, so the reputation skill lacks context about where the owner's reviews live.
 
-A model-only skill (`reputation`) that coaches owners through their third-party reviews in a structured conversation, paired with integration into `start` (collect platform profiles) and `check` (periodic nudge).
+The `docs/smb/reviews.md` reference doc already has comprehensive platform-by-vertical guidance (lines 19-40), but this knowledge isn't connected to the skill or the vertical docs where the Webmaster looks for business-specific advice.
 
-The Webmaster is a writing coach, not an integration. No API calls, no OAuth, no scraping, no storing review content. The owner reads their own reviews and posts their own responses. The Webmaster helps them do it well.
+## Existing state
 
-## Components
+**`skills/reputation/SKILL.md`** — Already has:
+- Review coaching flow (Steps 2-4)
+- Response drafting with tone-by-vertical templates (Step 3)
+- Review solicitation coaching (Step 4)
+- Competitive context with `COMPETITORS` in `.site-config` (Step 5)
+- Action item summary (Step 6)
+- Integration with check, testimonials, seasonal, and business-info skills
+- Privacy rule: never store review content locally
+- Guard: skips if `BUSINESS_TYPE` is not set
 
-### 1. `.site-config` integration during `/anglesite:start`
+**`skills/check/SKILL.md`** — Already has a "Reputation" section (line 122-126) that invokes the reputation skill when `BUSINESS_TYPE` is set.
 
-During Step 4 (content discovery), after the design interview, add these questions:
+**`docs/smb/reviews.md`** — Comprehensive reference covering platforms by vertical, solicitation strategies, response templates, and monitoring cadence. Already directs the start and design-interview skills to ask about review platforms.
 
-- "Do you have a Google Business Profile?" — If yes, find their Place ID and store `GOOGLE_PLACE_ID` and `GOOGLE_REVIEW_URL=https://search.google.com/local/writereview?placeid=...` in `.site-config`.
-- "Where else do your customers leave reviews?" — Store as `REVIEW_PLATFORMS=google,yelp,fresha` (comma-separated slugs) in `.site-config`.
-- "How often do you check your reviews?" — Informs nudge tone (encouragement vs. reminder).
+## Changes
 
-This wires up guidance already in `docs/smb/reviews.md` (lines 40-41) that says to ask during start but wasn't connected to the skill.
+### 1. Add `REVIEW_PLATFORMS` to `.site-config` during `/anglesite:start`
 
-### 2. Check-in nudge in `/anglesite:check`
+**Where:** In `/anglesite:start` Step 0, question 7 ("Are you already using any tools or apps for your business?") in the `SITE_TYPE=business` branch. Add to this existing question flow. **Only for business and organization site types** — personal, blog, and portfolio sites don't have review platforms.
 
-After automated diagnostics complete, if `REVIEW_PLATFORMS` is set in `.site-config`, the Webmaster adds one question:
+- "Where do your customers leave reviews? Google, Yelp, your booking platform?" — Store as `REVIEW_PLATFORMS=google,yelp,fresha` (comma-separated slugs) in `.site-config`.
+- If they mention Google Business Profile and `GOOGLE_REVIEW_URL` isn't already set, construct the direct review link (`https://search.google.com/local/writereview?placeid=PLACE_ID`) and store it. Don't store `GOOGLE_PLACE_ID` separately — it's embedded in the URL and a redundant key adds confusion.
 
-> "Quick question — have you checked your [Google/Yelp/etc.] reviews recently? If there are any you haven't responded to, I can help you draft responses."
+This connects the guidance in `docs/smb/reviews.md` (line 41: "ask: Where have your customers left reviews?") to the actual start flow.
 
-Rules:
-- One question, not a diagnostic step. Doesn't block the check workflow.
-- If `REVIEW_PLATFORMS` is not set, don't mention reviews — no nagging about setup they haven't opted into.
-- Point the owner to the reputation skill for the full walk-through.
+### 2. Enhance the reputation skill with per-platform walk-through
 
-### 3. The `reputation` skill
+**File:** `skills/reputation/SKILL.md`
+**Nature:** Modify existing Step 2 (review monitoring coaching), not replace the skill.
 
-**Location:** `skills/reputation/SKILL.md`
-**Type:** Model-only (`user-invokable: false`)
-**Invoked when:** Owner asks about reviews, responds to the check nudge, or says "help me with my reviews."
+Current Step 2 asks three generic questions. Replace with a structured per-platform flow:
 
-**Flow:**
+**If `REVIEW_PLATFORMS` is set in `.site-config`:**
+- Walk through each platform in order
+- For each: direct the owner to open their review page (provide `GOOGLE_REVIEW_URL` if available for Google)
+- "Any new reviews on [platform] since last time?"
+- If yes: proceed to existing Step 3 (response drafting) for each review
+- If no: "You're caught up on [platform]."
 
-1. **Read context** — Pull `REVIEW_PLATFORMS`, `GOOGLE_REVIEW_URL`, `BUSINESS_TYPE` from `.site-config`. Read the matching `docs/smb/<type>.md` for platform-specific guidance and `docs/smb/reviews.md` for universal guidance.
+**If `REVIEW_PLATFORMS` is not set but `BUSINESS_TYPE` is:**
+- Fall back to current behavior (generic "Have you checked your Google reviews?")
+- Additionally ask which platforms they use and offer to save to `.site-config` for next time
 
-2. **Platform-by-platform walk-through** — For each platform in `REVIEW_PLATFORMS`:
-   - Direct the owner to open their review page (provide the URL if known, e.g., `GOOGLE_REVIEW_URL`).
-   - "Any new reviews since last time?"
-   - If yes: "Read me the review (or paste it) and I'll help you draft a response."
-   - If no: "Great — you're caught up on [platform]."
+This preserves the existing guard (`BUSINESS_TYPE` required) and adds `REVIEW_PLATFORMS` as an enhancement, not a replacement.
 
-3. **Response drafting** — When the owner shares a review:
-   - **Positive reviews:** Draft a short, genuine, specific response. Reference something from the review. Avoid generic templates repeated verbatim.
-   - **Negative reviews:** Draft a professional, empathetic response that acknowledges the problem and takes the conversation offline. Follow the template pattern in `reviews.md`.
-   - **Fake/malicious reviews:** Coach the owner through the reporting process for that platform. Draft a calm, factual public response.
-   - Match the business's tone — casual for cafes, professional for legal. Read tone guidance from the vertical's `docs/smb/<type>.md`.
+Also add to Step 4 (getting more reviews): when suggesting a QR code for the review link, invoke the `qr` skill directly (it's model-only, not user-invokable — don't present it as `/anglesite:qr`).
 
-4. **Solicitation coaching** — After the review walk-through, if the owner has few reviews relative to their business age:
-   - Suggest adding a "Leave us a review" link to the contact page (with direct URL to Google review form).
-   - Offer to generate a QR code for the review link via `/anglesite:qr`.
-   - Suggest printed review cards, follow-up email language, or in-person scripts from `reviews.md`.
+### 3. Refine the check nudge
 
-5. **Wrap up** — Summarize: how many reviews were addressed, on which platforms, and any site changes made. Suggest when to check again.
+**File:** `skills/check/SKILL.md`
+**Nature:** Modify existing "Reputation" section (lines 122-126).
 
-**What it does not do:**
-- No API calls to any review platform
-- No OAuth or authentication to any external service
-- No scraping or crawling review sites
-- No storing review content in the project or git
-- Never posts responses on behalf of the owner — only drafts them
-- No automated monitoring or alerting
+Current behavior: invokes the full reputation skill when `BUSINESS_TYPE` is set.
 
-### 4. Updates to `docs/smb/<type>.md` files
+Change to: the check skill still invokes the reputation skill (same `Read ... and follow it` pattern), but passes context that this is a check-in. The reputation skill handles the lighter touch internally — its Step 2 already distinguishes interactive vs. non-interactive contexts. The change in the check skill is to pass `REVIEW_PLATFORMS` context so the reputation skill can name specific platforms:
 
-Each vertical doc gets a standardized `## Review platforms` section listing:
-- Which platforms matter most for that business type
-- Why each platform matters (discovery vs. booking vs. reputation)
-- What to watch for on each platform (e.g., Yelp's aggressive filter, booking platform reviews appearing at moment of purchase)
+- If `REVIEW_PLATFORMS` is set: the check skill's Reputation section notes the specific platforms before invoking the reputation skill, so it can say "Have you checked your Google and Yelp reviews recently?" instead of generic "Google reviews"
+- If only `BUSINESS_TYPE` is set: current behavior (invoke reputation skill with generic context)
+- Keep it to 1-3 action items max (already specified in the reputation skill's Step 6)
 
-Content is redistributed from the existing table in `docs/smb/reviews.md` (lines 19-40) but expanded with vertical-specific context. The canonical reference remains `reviews.md` — vertical docs point to it for the full picture.
+### 4. Add `## Review platforms` sections to `docs/smb/<type>.md` files
+
+Each vertical doc gets a standardized section listing which platforms matter and why. Content sourced from the existing table in `docs/smb/reviews.md` (lines 19-40) but expanded with vertical-specific context.
+
+**For verticals that already mention reviews** (e.g., `salon.md` line 39 mentions reviews on Google, Yelp, and booking platforms): consolidate existing review mentions into the new `## Review platforms` section. Don't duplicate — move and expand.
+
+**For verticals that don't mention reviews yet:** Add the section based on the `reviews.md` platform table and the vertical's characteristics.
+
+**Structure per vertical:**
+
+```markdown
+## Review platforms
+
+- **[Platform]** — [Why it matters for this vertical]. [What to watch for.]
+```
 
 Example for salon:
 
@@ -92,17 +100,28 @@ Example for salon:
 - **Yelp** — Heavily used for beauty services, especially urban areas. Yelp's filter is aggressive — don't panic if reviews disappear; filtered reviews are still visible to users who click through.
 - **Booking platform** (Fresha, Vagaro, Booksy) — Reviews here appear at the moment of booking. A provider with 50 reviews converts better than one with 5.
 - **Instagram** — Not traditional reviews, but DM testimonials and comment praise are social proof. Ask permission to screenshot and feature them.
+
+See `docs/smb/reviews.md` for full review management guidance.
 ```
+
+### 5. Add workflow doc for non-plugin agents
+
+**File:** `template/docs/workflows/reputation.md`
+
+A step-by-step guide for agents that don't have access to the plugin skill system. Covers:
+- Which platforms to check (read from `.site-config` or ask the owner)
+- How to coach the owner through reviewing and responding
+- Response drafting guidelines (reference `docs/smb/reviews.md`)
+- When to suggest this workflow (quarterly, after seasonal peaks)
 
 ## Files changed
 
 | File | Change |
 |---|---|
-| `skills/reputation/SKILL.md` | New model-only skill |
-| `skills/start/SKILL.md` | Add review platform questions to Step 4 |
-| `skills/check/SKILL.md` | Add review nudge after diagnostics |
-| `docs/smb/<type>.md` (all verticals) | Add `## Review platforms` section |
-| `CLAUDE.md` | Add `reputation` to model-only skills table |
+| `skills/reputation/SKILL.md` | Add per-platform walk-through to Step 2; reference `REVIEW_PLATFORMS` config key |
+| `skills/start/SKILL.md` | Add review platform question to tool/service discovery |
+| `skills/check/SKILL.md` | Refine Reputation section to name specific platforms when known |
+| `docs/smb/<type>.md` (all verticals) | Add or consolidate `## Review platforms` section |
 | `template/docs/workflows/reputation.md` | New workflow doc for non-plugin agents |
 
 ## Files not changed
@@ -110,8 +129,8 @@ Example for salon:
 | File | Why |
 |---|---|
 | `docs/smb/reviews.md` | Already comprehensive — remains canonical reference |
-| `skills/testimonials/SKILL.md` | First-party review collection is separate from third-party coaching |
-| `template/worker/review-worker.js` | No backend changes needed |
+| `skills/testimonials/SKILL.md` | First-party review collection stays separate |
+| `CLAUDE.md` | `reputation` skill already listed in model-only skills table |
 
 ## Out of scope (future versions)
 

--- a/docs/superpowers/specs/2026-03-26-reputation-coaching-design.md
+++ b/docs/superpowers/specs/2026-03-26-reputation-coaching-design.md
@@ -1,0 +1,122 @@
+# Reputation coaching skill — design spec
+
+**Issue:** [#61 — Add competitor awareness and review monitoring skill](https://github.com/Anglesite/anglesite/issues/61)
+**Scope:** V1 — guide-based coaching for third-party review management (no OAuth, no API integrations)
+**Date:** 2026-03-26
+
+## Problem
+
+Online reputation management is critical for local businesses, but owners don't know when to check reviews, how to respond well, or which platforms matter for their business type. The existing `docs/smb/reviews.md` has comprehensive guidance, but it's passive reference material — the owner has to seek it out. Meanwhile, unanswered reviews pile up and hurt reputation.
+
+## Solution
+
+A model-only skill (`reputation`) that coaches owners through their third-party reviews in a structured conversation, paired with integration into `start` (collect platform profiles) and `check` (periodic nudge).
+
+The Webmaster is a writing coach, not an integration. No API calls, no OAuth, no scraping, no storing review content. The owner reads their own reviews and posts their own responses. The Webmaster helps them do it well.
+
+## Components
+
+### 1. `.site-config` integration during `/anglesite:start`
+
+During Step 4 (content discovery), after the design interview, add these questions:
+
+- "Do you have a Google Business Profile?" — If yes, find their Place ID and store `GOOGLE_PLACE_ID` and `GOOGLE_REVIEW_URL=https://search.google.com/local/writereview?placeid=...` in `.site-config`.
+- "Where else do your customers leave reviews?" — Store as `REVIEW_PLATFORMS=google,yelp,fresha` (comma-separated slugs) in `.site-config`.
+- "How often do you check your reviews?" — Informs nudge tone (encouragement vs. reminder).
+
+This wires up guidance already in `docs/smb/reviews.md` (lines 40-41) that says to ask during start but wasn't connected to the skill.
+
+### 2. Check-in nudge in `/anglesite:check`
+
+After automated diagnostics complete, if `REVIEW_PLATFORMS` is set in `.site-config`, the Webmaster adds one question:
+
+> "Quick question — have you checked your [Google/Yelp/etc.] reviews recently? If there are any you haven't responded to, I can help you draft responses."
+
+Rules:
+- One question, not a diagnostic step. Doesn't block the check workflow.
+- If `REVIEW_PLATFORMS` is not set, don't mention reviews — no nagging about setup they haven't opted into.
+- Point the owner to the reputation skill for the full walk-through.
+
+### 3. The `reputation` skill
+
+**Location:** `skills/reputation/SKILL.md`
+**Type:** Model-only (`user-invokable: false`)
+**Invoked when:** Owner asks about reviews, responds to the check nudge, or says "help me with my reviews."
+
+**Flow:**
+
+1. **Read context** — Pull `REVIEW_PLATFORMS`, `GOOGLE_REVIEW_URL`, `BUSINESS_TYPE` from `.site-config`. Read the matching `docs/smb/<type>.md` for platform-specific guidance and `docs/smb/reviews.md` for universal guidance.
+
+2. **Platform-by-platform walk-through** — For each platform in `REVIEW_PLATFORMS`:
+   - Direct the owner to open their review page (provide the URL if known, e.g., `GOOGLE_REVIEW_URL`).
+   - "Any new reviews since last time?"
+   - If yes: "Read me the review (or paste it) and I'll help you draft a response."
+   - If no: "Great — you're caught up on [platform]."
+
+3. **Response drafting** — When the owner shares a review:
+   - **Positive reviews:** Draft a short, genuine, specific response. Reference something from the review. Avoid generic templates repeated verbatim.
+   - **Negative reviews:** Draft a professional, empathetic response that acknowledges the problem and takes the conversation offline. Follow the template pattern in `reviews.md`.
+   - **Fake/malicious reviews:** Coach the owner through the reporting process for that platform. Draft a calm, factual public response.
+   - Match the business's tone — casual for cafes, professional for legal. Read tone guidance from the vertical's `docs/smb/<type>.md`.
+
+4. **Solicitation coaching** — After the review walk-through, if the owner has few reviews relative to their business age:
+   - Suggest adding a "Leave us a review" link to the contact page (with direct URL to Google review form).
+   - Offer to generate a QR code for the review link via `/anglesite:qr`.
+   - Suggest printed review cards, follow-up email language, or in-person scripts from `reviews.md`.
+
+5. **Wrap up** — Summarize: how many reviews were addressed, on which platforms, and any site changes made. Suggest when to check again.
+
+**What it does not do:**
+- No API calls to any review platform
+- No OAuth or authentication to any external service
+- No scraping or crawling review sites
+- No storing review content in the project or git
+- Never posts responses on behalf of the owner — only drafts them
+- No automated monitoring or alerting
+
+### 4. Updates to `docs/smb/<type>.md` files
+
+Each vertical doc gets a standardized `## Review platforms` section listing:
+- Which platforms matter most for that business type
+- Why each platform matters (discovery vs. booking vs. reputation)
+- What to watch for on each platform (e.g., Yelp's aggressive filter, booking platform reviews appearing at moment of purchase)
+
+Content is redistributed from the existing table in `docs/smb/reviews.md` (lines 19-40) but expanded with vertical-specific context. The canonical reference remains `reviews.md` — vertical docs point to it for the full picture.
+
+Example for salon:
+
+```markdown
+## Review platforms
+
+- **Google Business Profile** — Primary discovery channel. Most clients search "salon near me" and pick based on stars and photos. Respond to every review.
+- **Yelp** — Heavily used for beauty services, especially urban areas. Yelp's filter is aggressive — don't panic if reviews disappear; filtered reviews are still visible to users who click through.
+- **Booking platform** (Fresha, Vagaro, Booksy) — Reviews here appear at the moment of booking. A provider with 50 reviews converts better than one with 5.
+- **Instagram** — Not traditional reviews, but DM testimonials and comment praise are social proof. Ask permission to screenshot and feature them.
+```
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `skills/reputation/SKILL.md` | New model-only skill |
+| `skills/start/SKILL.md` | Add review platform questions to Step 4 |
+| `skills/check/SKILL.md` | Add review nudge after diagnostics |
+| `docs/smb/<type>.md` (all verticals) | Add `## Review platforms` section |
+| `CLAUDE.md` | Add `reputation` to model-only skills table |
+| `template/docs/workflows/reputation.md` | New workflow doc for non-plugin agents |
+
+## Files not changed
+
+| File | Why |
+|---|---|
+| `docs/smb/reviews.md` | Already comprehensive — remains canonical reference |
+| `skills/testimonials/SKILL.md` | First-party review collection is separate from third-party coaching |
+| `template/worker/review-worker.js` | No backend changes needed |
+
+## Out of scope (future versions)
+
+- API integration with Google Business Profile or other platforms
+- Automated review monitoring or alerts
+- Sentiment analysis of reviews
+- Competitive review comparison
+- Review data storage or analytics

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -119,6 +119,12 @@ Have the owner paste their site URL. Explain the scores: green (90+) is great, o
 - [ ] Test by pasting the site URL into a group chat or social media draft — the preview card should show the site title, description, and image
 - [ ] Each page has its own `og:title` and `og:description` (not all the same)
 
+## Reputation
+
+If `BUSINESS_TYPE` is set in `.site-config`, invoke the reputation skill for review coaching and competitive awareness:
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/reputation/SKILL.md` and follow it. Include the output as a "Reputation" section in the health report. Keep it brief — 1-3 action items max. If `BUSINESS_TYPE` is not set, skip this section.
+
 ## Results
 
 **The owner is not technical.** Do not report raw checklist items. Translate every finding into one plain-English sentence that answers: what's wrong, why it matters, and what happens next. Group by severity using these everyday labels:

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -121,7 +121,11 @@ Have the owner paste their site URL. Explain the scores: green (90+) is great, o
 
 ## Reputation
 
-If `BUSINESS_TYPE` is set in `.site-config`, invoke the reputation skill for review coaching and competitive awareness:
+If `BUSINESS_TYPE` is set in `.site-config`, invoke the reputation skill for review coaching and competitive awareness.
+
+Read `REVIEW_PLATFORMS` from `.site-config` if available. When invoking the reputation skill, note that this is a non-interactive check context so it should present tips, not questions.
+
+If `REVIEW_PLATFORMS` is set, include the platform names in the nudge: "Reminder: check your [Google, Yelp] reviews — responding within a few days helps your reputation." If not set, use the generic nudge.
 
 Read `${CLAUDE_PLUGIN_ROOT}/skills/reputation/SKILL.md` and follow it. Include the output as a "Reputation" section in the health report. Keep it brief — 1-3 action items max. If `BUSINESS_TYPE` is not set, skip this section.
 

--- a/skills/reputation/SKILL.md
+++ b/skills/reputation/SKILL.md
@@ -31,6 +31,8 @@ Read `.site-config` for:
 - `BUSINESS_TYPE` — determines which review platforms and competitive factors matter
 - `SITE_NAME` — for personalized suggestions
 - `SITE_URL` — to check if Google Business Profile link exists on the site
+- `REVIEW_PLATFORMS` — comma-separated platform slugs (google, yelp, fresha, etc.)
+- `GOOGLE_REVIEW_URL` — direct link to Google review form (if available)
 
 If `BUSINESS_TYPE` is not set, skip this skill entirely. Generic review advice is not useful without business context.
 
@@ -43,13 +45,37 @@ Read competitive positioning guidance from `${CLAUDE_PLUGIN_ROOT}/docs/smb/compe
 
 ## Step 2 — Review monitoring coaching
 
-Ask the owner (if this is an interactive session, not a scheduled check):
+Read `REVIEW_PLATFORMS` from `.site-config` if available.
+
+### If `REVIEW_PLATFORMS` is set (structured walk-through)
+
+Walk through each platform in order. For each:
+
+1. Direct the owner to open their review page:
+   - **Google:** Use `GOOGLE_REVIEW_URL` from `.site-config` if available. Otherwise: "Open Google Maps and search for your business name, then click Reviews."
+   - **Yelp:** "Open yelp.com and search for your business name, then click the Reviews tab."
+   - **Booking platform** (Fresha, Vagaro, Booksy, etc.): "Open [platform] and check your reviews dashboard."
+   - **Other platforms:** Direct the owner to the review section of that platform.
+
+2. Ask: "Any new reviews on [platform] since last time?"
+   - If yes: "Read me the review (or paste it) and I'll help you draft a response." → proceed to Step 3.
+   - If no: "Great — you're caught up on [platform]." → move to next platform.
+
+3. After all platforms: proceed to Step 4 (getting more reviews).
+
+### If `REVIEW_PLATFORMS` is not set but `BUSINESS_TYPE` is (generic coaching)
+
+Fall back to general questions:
 
 1. **"Have you checked your Google reviews recently?"** — Most owners forget. A gentle nudge is the most valuable thing this skill does.
 2. **"Any new reviews since we last talked?"** — If yes, offer to help draft a response (Step 3).
 3. **"Are you getting reviews from customers?"** — If not, suggest a simple ask strategy (Step 4).
 
-If this is a non-interactive context (e.g., part of `/anglesite:check`), skip the questions and present the coaching tips directly.
+Also ask: "Which platforms do your customers use for reviews? I can save that so next time we go through them one by one." If the owner answers, save to `.site-config` as `REVIEW_PLATFORMS`.
+
+### Non-interactive context (e.g., part of `/anglesite:check`)
+
+Skip the questions. Present 1-3 platform-specific coaching tips based on `REVIEW_PLATFORMS` (or generic tips if not set). Example: "Reminder: check your Google and Yelp reviews this week. Responding within a few days shows customers you care."
 
 ## Step 3 — Review response drafting
 
@@ -90,6 +116,7 @@ If the owner has few reviews, suggest these low-effort strategies:
 3. **Add a review link to the website** — a simple "Leave us a review" link in the footer or contact page. Check if this already exists.
 4. **Follow up** — for service businesses, a thank-you email a day after service with a review link converts well.
 5. **Never incentivize** — offering discounts for reviews violates Google's policies and erodes trust.
+6. **QR code** — Invoke the `qr` skill to generate a QR code for the Google review link. The owner can print it on receipts, table tents, or business cards. (The `qr` skill is model-only — invoke it directly, do not present it as a slash command to the owner.)
 
 Check if the site already has a Google review link by scanning `src/` for review-related URLs or text. If not, suggest adding one.
 

--- a/skills/reputation/SKILL.md
+++ b/skills/reputation/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: reputation
+description: "Surface review response suggestions and competitive insights based on business type"
+user-invokable: false
+allowed-tools: Bash(date *), Read, Glob
+---
+
+Coach the owner on online reputation — Google reviews, competitor activity, and review response. Called during `/anglesite:check`, quarterly reviews, or when the owner asks about reviews, reputation, or competitors. Not invoked directly by the owner.
+
+## Architecture decisions
+
+- [ADR-0009 Industry tools](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0009-industry-tools-over-custom-code.md) — recommend Google Business Profile, not custom review infrastructure
+- [ADR-0011 Owner ownership](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0011-owner-controls-everything.md) — never store customer data locally; coaching only
+
+## Privacy rule
+
+**Never store review content, customer names, or reviewer information locally.** This skill is advisory — it coaches the owner on what to do, not a data pipeline. All review data stays on the platform where it was posted (Google, Yelp, etc.).
+
+## When to invoke this skill
+
+- During `/anglesite:check` — add a "Reputation" section to the health report
+- When the owner asks "how are my reviews?" or "what are competitors doing?"
+- During quarterly reviews (aligned with `/anglesite:update`)
+- After `/anglesite:testimonials` setup — remind the owner to also monitor platform reviews
+
+Present suggestions as coaching, not commands. The owner should feel supported, not overwhelmed.
+
+## Step 1 — Read context
+
+Read `.site-config` for:
+- `BUSINESS_TYPE` — determines which review platforms and competitive factors matter
+- `SITE_NAME` — for personalized suggestions
+- `SITE_URL` — to check if Google Business Profile link exists on the site
+
+If `BUSINESS_TYPE` is not set, skip this skill entirely. Generic review advice is not useful without business context.
+
+Read the business type guide from `${CLAUDE_PLUGIN_ROOT}/docs/smb/BUSINESS_TYPE.md` for:
+- Tone and communication style (casual for cafes, professional for legal)
+- Key differentiators and customer expectations
+- Industry-specific review platforms (Yelp for restaurants, Houzz for contractors, Avvo for lawyers, etc.)
+
+Read competitive positioning guidance from `${CLAUDE_PLUGIN_ROOT}/docs/smb/competitor-awareness.md`.
+
+## Step 2 — Review monitoring coaching
+
+Ask the owner (if this is an interactive session, not a scheduled check):
+
+1. **"Have you checked your Google reviews recently?"** — Most owners forget. A gentle nudge is the most valuable thing this skill does.
+2. **"Any new reviews since we last talked?"** — If yes, offer to help draft a response (Step 3).
+3. **"Are you getting reviews from customers?"** — If not, suggest a simple ask strategy (Step 4).
+
+If this is a non-interactive context (e.g., part of `/anglesite:check`), skip the questions and present the coaching tips directly.
+
+## Step 3 — Review response drafting
+
+When the owner shares a review (reads it aloud or pastes it), draft a response that:
+
+### For positive reviews (4-5 stars)
+- Thank the reviewer by name
+- Reference something specific they mentioned (shows the response isn't generic)
+- Keep it warm and brief (2-3 sentences)
+- Match the business's tone from the SMB guide
+
+### For negative reviews (1-3 stars)
+- Acknowledge the experience — never dismiss or argue
+- Apologize for the specific issue (not a generic "sorry for the inconvenience")
+- Offer to make it right offline ("Please call us at [phone] so we can fix this")
+- Keep it professional — future customers read the response more than the review
+- Never reveal private details about the transaction
+
+### Response templates by tone
+
+**Casual** (cafes, shops, salons):
+> Thanks [Name]! So glad you enjoyed [specific thing]. See you next time!
+
+**Professional** (legal, medical, financial):
+> Thank you for your kind words, [Name]. We're pleased we could help with [general reference]. We appreciate your trust.
+
+**Warm** (childcare, pet care, community orgs):
+> [Name], this made our day! [Specific reference]. Thank you for being part of our community.
+
+Adapt the tone using the `BUSINESS_TYPE` guide. Never use emojis in professional contexts. Never fabricate details the reviewer didn't mention.
+
+## Step 4 — Getting more reviews
+
+If the owner has few reviews, suggest these low-effort strategies:
+
+1. **Ask at the point of success** — right after a positive interaction, say "Would you mind leaving us a Google review? It really helps." Timing matters more than the ask.
+2. **Make it easy** — add a direct review link to the website, email signature, and receipts. The Google review link format is: `https://search.google.com/local/writereview?placeid=PLACE_ID`
+3. **Add a review link to the website** — a simple "Leave us a review" link in the footer or contact page. Check if this already exists.
+4. **Follow up** — for service businesses, a thank-you email a day after service with a review link converts well.
+5. **Never incentivize** — offering discounts for reviews violates Google's policies and erodes trust.
+
+Check if the site already has a Google review link by scanning `src/` for review-related URLs or text. If not, suggest adding one.
+
+## Step 5 — Competitive context
+
+Reference the guidance in `${CLAUDE_PLUGIN_ROOT}/docs/smb/competitor-awareness.md`. This is a light check, not a deep analysis.
+
+If the owner named competitors during `/anglesite:design-interview` (check `.site-config` for `COMPETITORS`), briefly note:
+- "Last time you mentioned [competitor]. Have they changed anything on their site?"
+- "Are customers mentioning other businesses when they come to you?"
+
+If no competitors are recorded, ask: "Who are the other [business type] businesses in your area?" and save the answer to `.site-config` as `COMPETITORS` (comma-separated names) for future sessions.
+
+**Do not visit competitor websites during this skill.** That's a separate, intentional activity for quarterly reviews. Just surface the awareness.
+
+## Step 6 — Action items
+
+Summarize 1-3 concrete, low-effort actions. Never more than three — the owner is busy. Prioritize by impact:
+
+1. **Respond to unanswered reviews** (highest impact — shows customers the owner cares)
+2. **Add a review link to the website** (one-time setup, ongoing benefit)
+3. **Ask one happy customer for a review this week** (small habit, compounds over time)
+
+Present actions in plain English. No jargon, no marketing terminology. Frame each action as something that takes less than 5 minutes.
+
+## Integration with other skills
+
+- **`/anglesite:check`** — include a "Reputation" section with review coaching tips
+- **`/anglesite:testimonials`** — if the testimonials system is set up, remind the owner that platform reviews (Google, Yelp) and on-site testimonials serve different purposes: platform reviews help new customers find the business; on-site testimonials help visitors who already found it
+- **`/anglesite:seasonal`** — holiday seasons often bring more reviews; suggest monitoring more actively during peak periods
+- **`/anglesite:business-info`** — ensure Google Business Profile hours, phone, and address match the website
+
+## Keep docs in sync
+
+After first run, update:
+- `.site-config` — `COMPETITORS` value if learned
+- `docs/architecture.md` — note review link if added to the site

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -72,6 +72,9 @@ Then branch based on site type:
 5. "What do you want your website to do for your business?" Listen for concrete goals — get phone calls, book appointments, sell products online, build credibility, share news. These goals shape every design decision.
 6. "How do customers find you today?" — word of mouth, Google, social media, events, referrals. This tells you which pages and content matter most.
 7. "Are you already using any tools or apps for your business?" — anything counts: Etsy, Square, Venmo, Instagram for sales, a booking app, a spreadsheet. If they already have tools, don't replace them — integrate with the website. Recognize informal tools (Venmo, PayPal, Cash App, Zelle) as valid starting points — suggest professional invoicing (Square, Stripe) when they're ready, not as an immediate replacement.
+
+7b. **Business and organization sites only:** "Where do your customers leave reviews? Google, Yelp, your booking platform?" — Save as `REVIEW_PLATFORMS=google,yelp,fresha` (comma-separated slugs) in `.site-config`. If they mention Google Business Profile and `GOOGLE_REVIEW_URL` is not already set, ask for their business name to construct the direct review link: `https://search.google.com/local/writereview?placeid=PLACE_ID`. Find the Place ID via [Google's Place ID Finder](https://developers.google.com/maps/documentation/places/web-service/place-id) and save as `GOOGLE_REVIEW_URL` in `.site-config`. Skip this question for personal, blog, and portfolio site types.
+
 8. If the business has a physical location, ask:
    - "What's your business address?" (for maps and local search)
    - "What's your business phone number?" (for the website and local search)

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -59,6 +59,7 @@ Step-by-step guides for common operations:
 | QR codes and campaign tracking | `docs/workflows/qr.md` |
 | Customer testimonials | `docs/workflows/testimonials.md` |
 | Multi-language (i18n) | `docs/workflows/i18n.md` |
+| Review reputation coaching | `docs/workflows/reputation.md` |
 
 ## Key files
 

--- a/template/docs/workflows/reputation.md
+++ b/template/docs/workflows/reputation.md
@@ -1,0 +1,65 @@
+# Review reputation coaching
+
+Help the site owner manage their online reviews across third-party platforms.
+
+## When to use
+
+- The owner asks about reviews, reputation, or "how do I respond to this review?"
+- During a quarterly check-in
+- After a seasonal peak (holidays, events) when review volume increases
+
+## Before you start
+
+Read `.site-config` for:
+- `REVIEW_PLATFORMS` — which platforms the owner uses (e.g., `google,yelp,fresha`)
+- `GOOGLE_REVIEW_URL` — direct link to their Google review form
+- `BUSINESS_TYPE` — determines tone and platform relevance
+
+If `REVIEW_PLATFORMS` is not set, ask the owner which platforms their customers use and save it.
+
+## Steps
+
+### 1. Walk through each platform
+
+For each platform in `REVIEW_PLATFORMS`:
+
+1. Direct the owner to open their review page
+   - **Google:** Search for their business on Google Maps → Reviews tab
+   - **Yelp:** Search on yelp.com → Reviews tab
+   - **Booking platforms:** Check the reviews dashboard in their booking tool
+2. Ask: "Any new reviews since last time?"
+3. If yes: help draft a response (see below)
+4. If no: move to the next platform
+
+### 2. Draft review responses
+
+**Positive reviews (4-5 stars):**
+- Thank the reviewer by name
+- Reference something specific they mentioned
+- Keep it warm and brief (2-3 sentences)
+- Match the business's tone (casual for cafes, professional for legal)
+
+**Negative reviews (1-3 stars):**
+- Acknowledge the problem — never dismiss or argue
+- Apologize for the specific issue
+- Take it offline: "Please call us at [phone] so we can make this right"
+- Stay professional — future customers read the response more than the review
+
+**Fake or malicious reviews:**
+- Coach the owner through the platform's reporting process
+- Draft a calm, factual public response
+
+### 3. Encourage more reviews
+
+If the owner has few reviews:
+- Add a "Leave us a review" link to the contact page
+- Suggest asking customers right after a positive experience
+- Consider a QR code for the Google review link on printed materials
+
+### 4. Wrap up
+
+Summarize what was addressed: how many reviews responded to, on which platforms, and any site changes made. Suggest checking again in 2-4 weeks.
+
+## Reference
+
+Full review management guidance: `docs/smb/reviews.md`


### PR DESCRIPTION
## Summary

Closes #61. Enhances the existing reputation skill with multi-platform review coaching — no OAuth, no API integrations, just structured coaching conversations.

- **Start skill**: Collects `REVIEW_PLATFORMS` during onboarding (business/org sites only)
- **Reputation skill**: Per-platform walk-through when `REVIEW_PLATFORMS` is set, falls back to generic Google coaching when not, tips-only mode for non-interactive check context. Added QR code suggestion via `qr` skill.
- **Check skill**: Reputation nudge now names specific platforms instead of generic messaging
- **Workflow doc**: `template/docs/workflows/reputation.md` for non-plugin agents (Codex, Cursor, etc.)
- **56 vertical docs**: Every `docs/smb/<type>.md` now has a `## Review platforms` section with platform-specific guidance

## Design

The Webmaster is a writing coach, not an integration. The owner reads their own reviews on each platform and posts their own responses. The Webmaster helps them respond well, ask for reviews effectively, and stay on top of their reputation.

Two contexts, different rules:
- **In-conversation**: Full coaching — walk through each platform, draft responses, suggest solicitation strategies
- **Non-interactive** (check skill): Light nudge naming specific platforms, 1-3 action items max

## Test plan

- [ ] Verify `npm test` passes (579 tests, all green)
- [ ] Spot-check `skills/reputation/SKILL.md` flow (Steps 1→6 coherent)
- [ ] Spot-check `skills/start/SKILL.md` Q7b placement (between Q7 and Q8, business branch only)
- [ ] Spot-check `skills/check/SKILL.md` Reputation section (between Social preview and Results)
- [ ] Spot-check 3-5 vertical docs for `## Review platforms` section placement and content
- [ ] Verify `template/AGENTS.md` workflows table includes reputation row
- [ ] Verify `template/docs/workflows/reputation.md` exists with complete content

🤖 Generated with [Claude Code](https://claude.com/claude-code)