### PR TITLE
fix(import): import everything by default, don't prompt for scope

### DIFF
--- a/skills/import/SKILL.md
+++ b/skills/import/SKILL.md
@@ -224,18 +224,12 @@ Tell the owner what was found. Example:
 > **Blog posts:** 23 posts (July 2024 – February 2026)
 > **Pages:** 6 pages (About, FAQ, Services, Contact, Gallery, Get Involved)
 >
-> I'll import all the blog posts and extract the content from each page.
-> The import will take about 5–10 minutes for a blog this size."
+> I'll import all the blog posts, extract the content from each page, and
+> set up redirects so your search rankings carry over. The import will take
+> about 5–10 minutes for a blog this size."
 
 If BLOG_POSTS is empty, tell the owner — skip to Step 3 for pages only, or
 Step 4 if image galleries were detected.
-
-Ask:
-> "Would you like to import all of it, or just the blog posts?"
-> - **Everything** — import posts + page stubs + redirects (recommended)
-> - **Blog posts only** — skip static pages
-
-Wait for their answer before continuing.
 
 ## Step 2 — Import blog posts
 
@@ -383,7 +377,7 @@ instructions to offer newsletter migration.
 
 ## Step 3 — Handle static pages
 
-If the owner chose "Everything" in Step 1, process STATIC_PAGES.
+Process STATIC_PAGES.
 
 ### 3a — Extract homepage branding
 


### PR DESCRIPTION
## Summary

- Remove the "Everything vs Blog posts only" prompt from Step 1d of the import skill
- Import all discovered content (posts, pages, redirects) by default without asking
- Update Step 3 to remove the conditional check on the owner's (now removed) choice

Closes #66

## Test plan

- [ ] Run `/anglesite:import` against a test site and verify it no longer pauses to ask about import scope
- [ ] Verify static pages are still imported (Step 3 no longer gated behind "Everything" choice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)