### PR TITLE
fix(update): resolve SITE_DIR to absolute path before cd

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -18,6 +18,7 @@ if [ -z "${ZSH_VERSION-}" ]; then exec /bin/zsh "$0" "$@"; fi
 set -euo pipefail
 
 SITE_DIR="${1:-.}"
+SITE_DIR="${SITE_DIR:A}"
 PLUGIN_ROOT="${ANGLESITE_PLUGIN_ROOT:-${0:A:h:h}}"
 TEMPLATE="${PLUGIN_ROOT}/template"
 


### PR DESCRIPTION
## Summary

- Fixes update.sh comparing template files against themselves when given a relative path (`.`)
- Resolves `SITE_DIR` to absolute path using zsh `:A` modifier before the `cd "$TEMPLATE"` that changes working directory

Fixes #68

## Test plan

- [x] Existing 9 update tests pass
- [x] Manual test: `cd /tmp/test-site && zsh update.sh .` now correctly reports `A`/`M`/`=` status instead of all `=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)