### PR TITLE
fix(template): add @astrojs/check and typescript to devDependencies

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -31,12 +31,14 @@
     "brace-expansion": "^5.0.5"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.0",
     "@types/node": "22.13.10",
     "consola": "^3.4.0",
     "execa": "^9.5.0",
     "qrcode": "^1.5.0",
     "sharp": "^0.33.0",
     "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
     "wrangler": "^4.77.0"
   }
 }

--- a/tests/template-deps.test.ts
+++ b/tests/template-deps.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const templatePkg = JSON.parse(
+  readFileSync(resolve(__dirname, "../template/package.json"), "utf-8"),
+);
+
+describe("template/package.json", () => {
+  it("has @astrojs/check in devDependencies so astro check runs non-interactively", () => {
+    expect(templatePkg.devDependencies).toHaveProperty("@astrojs/check");
+  });
+
+  it("has typescript in devDependencies (required by @astrojs/check)", () => {
+    expect(templatePkg.devDependencies).toHaveProperty("typescript");
+  });
+
+  it("has a check script that runs astro check", () => {
+    expect(templatePkg.scripts.check).toBe("astro check");
+  });
+});


### PR DESCRIPTION
## Changes

- Added `@astrojs/check` (^0.9.0) to template devDependencies for non-interactive type checking
- Added `typescript` (^5.6.0) to template devDependencies (required by @astrojs/check)
- Added test suite (`template-deps.test.ts`) to verify required dependencies are present

This ensures the template has all necessary dependencies for running Astro's type checking functionality.