### PR TITLE
Add inline visual communication with tldraw helpers

### DIFF
--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -2,7 +2,7 @@
 name: check
 description: "Health audit and troubleshooting"
 argument-hint: "[optional: describe the problem]"
-allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(grep *), Bash(find dist/ *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(dscacheutil *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), Write, Read, Glob
+allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(grep *), Bash(find dist/ *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(dscacheutil *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), mcp__claude_ai_tldraw__create_shapes, mcp__claude_ai_tldraw__diagram_drawing_read_me, Write, Read, Glob
 ---
 
 Run a full health check on the site — and fix what you find. If the owner described a specific problem, diagnose that first; otherwise run the full audit below. The checklists are for you (the agent) — **do not show raw checklist items, technical terms, or jargon to the owner.** Translate every finding into plain English. See the Results section at the bottom for how to present findings.
@@ -150,6 +150,8 @@ Examples of how to translate findings:
 | EXIF GPS data in images | "Some of your photos have location information embedded in them. I'll strip that out so visitors can't see where the photos were taken." |
 
 Never show the owner: CSS selectors, HTML tag names, HTTP headers, schema.org terms, WCAG levels, npm package names, or code snippets. If you need to explain *why* something matters, use an analogy or a concrete consequence ("visitors on phones will have to scroll sideways").
+
+**Visual summary:** After the audit, use tldraw to draw a visual scorecard using `progressChecklist()` from `scripts/tldraw-helpers.ts`. Show each check category as a checklist item (green check for passing, grey box for issues found). The owner sees at a glance what's working and what needs attention.
 
 If any must-fix issues are found, explain and offer to fix them. If everything passes, keep it short: "Your site looks good — it builds correctly, works on phones, is secure, and is easy for search engines to find. No issues."
 

--- a/skills/design-interview/SKILL.md
+++ b/skills/design-interview/SKILL.md
@@ -2,7 +2,7 @@
 name: design-interview
 description: "Redo the visual identity and branding"
 user-invokable: false
-allowed-tools: Write, Read, Glob
+allowed-tools: mcp__claude_ai_tldraw__create_shapes, mcp__claude_ai_tldraw__diagram_drawing_read_me, Write, Read, Glob
 ---
 
 You're a professional web designer conducting a visual identity intake. Read `.site-config` for `SITE_TYPE`, `SITE_NAME`, `BUSINESS_TYPE`, `OWNER_NAME`, and `EXISTING_TOOLS`.
@@ -39,6 +39,17 @@ Tailor your questions to the site type. Cover these topics naturally (not necess
 Ask one topic at a time. Listen, reflect back what you heard, then move on. After each answer, briefly describe what you're thinking design-wise so the owner feels like they're designing *with* you, not filling out a form.
 
 **"Design it for me" escape hatch:** If the owner says something like "you pick," "I trust you," "just make it look good," or otherwise defers on multiple topics, don't keep asking one-by-one. Instead, design the whole identity yourself based on what you already know — site type, business type, any preferences they *did* share — and present the complete design in one shot: colors, typography feel, page structure, and vibe. Ask: "Here's what I'd do — does this feel right?" Let them approve, tweak, or start over.
+
+## Visual communication
+
+Use tldraw to show the owner what you're proposing throughout the interview:
+
+- **Theme selection** — invoke the `themes` skill to render color swatch cards as a visual grid (see `skills/themes/SKILL.md`)
+- **Page structure** — use `sitemapTree()` from `scripts/tldraw-helpers.ts` to show the proposed site navigation as a tree diagram
+- **Tool comparisons** — if recommending SaaS tools, use `comparisonTable()` to show options side by side
+- **Design summary** — after the interview, show a visual card with the chosen colors (rectangles), font names, and page list before applying
+
+The owner should see their design before it goes live. Visual previews build confidence and reduce revision cycles.
 
 ## After the interview
 

--- a/skills/new-page/SKILL.md
+++ b/skills/new-page/SKILL.md
@@ -3,10 +3,14 @@ name: new-page
 description: "Create a new page with SEO and accessibility"
 user-invokable: false
 argument-hint: "[page name or purpose]"
-allowed-tools: Write, Read, Glob
+allowed-tools: mcp__claude_ai_tldraw__create_shapes, mcp__claude_ai_tldraw__diagram_drawing_read_me, Write, Read, Glob
 ---
 
 Create a new page on the site.
+
+## Visual planning
+
+Before creating the page, use tldraw to show the owner where it fits in the site structure. Use `sitemapTree()` from `scripts/tldraw-helpers.ts` to draw the current page tree with the proposed new page highlighted. This helps the owner understand navigation impact and approve the placement.
 
 ## Architecture decisions
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start
 description: "First-time setup: discovery, design, tools, preview"
-allowed-tools: Bash(zsh *), Bash(npm install), Bash(npm run *), Bash(gh *), Bash(git remote *), Bash(git push *), Bash(git branch *), Write, Read, Glob
+allowed-tools: Bash(zsh *), Bash(npm install), Bash(npm run *), Bash(gh *), Bash(git remote *), Bash(git push *), Bash(git branch *), mcp__claude_ai_tldraw__create_shapes, mcp__claude_ai_tldraw__diagram_drawing_read_me, Write, Read, Glob
 disable-model-invocation: true
 ---
 
@@ -279,6 +279,19 @@ gh label create build --description "Build or deploy failure" --color fbca04
 ```
 
 Tell the owner: "Your website is backed up to GitHub! Every time we make changes, they'll be saved there automatically. If anything ever happens to your computer, your website is safe."
+
+## Visual progress
+
+Throughout the setup process, use tldraw to show the owner a visual progress checklist using `progressChecklist()` from `scripts/tldraw-helpers.ts`. Update it as each step completes:
+
+- Scaffolding
+- Discovery interview
+- Design interview
+- Tool installation
+- GitHub backup
+- Preview
+
+This gives the owner a clear sense of where they are and what's left. Draw it once early and update it after major milestones.
 
 ## Step 6 — Preview
 

--- a/skills/stats/SKILL.md
+++ b/skills/stats/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: stats
 description: "Show site analytics in plain language"
-allowed-tools: Bash(curl *), Bash(grep *), Bash(git log *), Read, Glob
+allowed-tools: Bash(curl *), Bash(grep *), Bash(git log *), mcp__claude_ai_tldraw__create_shapes, mcp__claude_ai_tldraw__diagram_drawing_read_me, Read, Glob
 disable-model-invocation: true
 ---
 
@@ -99,6 +99,16 @@ Present the summary in plain language. Example output:
 > - QR code "table-tent": 23 visits
 > - facebook ad "march-promo": 45 visits
 > - Email "weekly-update" via newsletter: 12 visits
+
+## Visual presentation
+
+After collecting the data, **draw the results** using tldraw before presenting text:
+
+- Use `barChart()` from `scripts/tldraw-helpers.ts` to show top pages as a horizontal bar chart
+- If campaign data exists, draw a second bar chart for campaign performance
+- The owner sees their numbers as a visual dashboard, not a wall of text
+
+Show the visual first, then follow up with the plain-language summary and actionable suggestions.
 
 ## Step 3 — Actionable suggestions
 

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -61,6 +61,25 @@ Step-by-step guides for common operations:
 | Multi-language (i18n) | `docs/workflows/i18n.md` |
 | Review reputation coaching | `docs/workflows/reputation.md` |
 
+## Visual communication
+
+When discussing the site with the owner, **show don't tell**. Use tldraw (or equivalent visual tools) to draw diagrams instead of describing things in text. Visual communication is faster and more accessible for non-technical owners.
+
+**When to draw:**
+- **Design proposals** — show color palettes, page layouts, navigation structure as visual cards/trees
+- **Analytics** — show bar charts of page views, traffic sources, campaign performance
+- **Progress tracking** — show visual checklists during setup and deployment
+- **Site structure** — show sitemap trees when proposing new pages or reorganizing
+- **Tool comparisons** — show side-by-side comparison tables when recommending services
+- **Timelines** — show project milestones, content calendars, seasonal planning
+
+**When NOT to draw:**
+- Simple yes/no questions
+- Single-step instructions
+- When the owner has asked to skip visuals
+
+Helper functions for common patterns are in `scripts/tldraw-helpers.ts`: `progressChecklist()`, `barChart()`, `comparisonTable()`, `sitemapTree()`, `timeline()`.
+
 ## Key files
 
 Reference docs live in `docs/`. Read the relevant file when you need context on architecture, brand, content, hosting, IndieWeb, or best practices.

--- a/template/scripts/tldraw-helpers.ts
+++ b/template/scripts/tldraw-helpers.ts
@@ -1,0 +1,474 @@
+/**
+ * Tldraw visualization helpers.
+ *
+ * Generates tldraw shape arrays for common in-conversation visualizations:
+ * progress checklists, bar charts, comparison tables, sitemap trees, and timelines.
+ *
+ * Used by skills to communicate visually with the site owner during
+ * design, analytics, and planning conversations.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TldrawShape {
+  _type: string;
+  shapeId: string;
+  x: number;
+  y: number;
+  w?: number;
+  h?: number;
+  text?: string;
+  color?: string;
+  fill?: string;
+  size?: string;
+  font?: string;
+  anchor?: string;
+  maxWidth?: number | null;
+  fromId?: string;
+  toId?: string;
+  [key: string]: unknown;
+}
+
+export interface ChecklistItem {
+  label: string;
+  done: boolean;
+}
+
+export interface BarDatum {
+  label: string;
+  value: number;
+}
+
+export interface ComparisonCriterion {
+  name: string;
+  values: string[];
+}
+
+export interface SitemapPage {
+  name: string;
+  path: string;
+  children?: string[];
+}
+
+export interface TimelineEvent {
+  label: string;
+  date: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _id = 0;
+function uid(prefix: string): string {
+  return `${prefix}-${++_id}`;
+}
+
+/** Reset ID counter (for deterministic tests if needed). */
+export function resetIds(): void {
+  _id = 0;
+}
+
+// ---------------------------------------------------------------------------
+// progressChecklist
+// ---------------------------------------------------------------------------
+
+/**
+ * Visual checklist with check-box shapes for done items.
+ */
+export function progressChecklist(
+  items: ChecklistItem[],
+  title?: string,
+): TldrawShape[] {
+  if (items.length === 0) return [];
+
+  const shapes: TldrawShape[] = [];
+  let yOffset = 0;
+
+  if (title) {
+    shapes.push({
+      _type: "text",
+      shapeId: uid("title"),
+      x: 0,
+      y: 0,
+      text: title,
+      color: "black",
+      size: "l",
+      font: "sans",
+      anchor: "top-left",
+    });
+    yOffset = 60;
+  }
+
+  for (const item of items) {
+    const boxId = uid("box");
+    const labelId = uid("label");
+
+    shapes.push({
+      _type: item.done ? "check-box" : "rectangle",
+      shapeId: boxId,
+      x: 0,
+      y: yOffset,
+      w: 40,
+      h: 40,
+      color: item.done ? "green" : "grey",
+      fill: item.done ? "tint" : "none",
+    });
+
+    shapes.push({
+      _type: "text",
+      shapeId: labelId,
+      x: 60,
+      y: yOffset + 8,
+      text: item.label,
+      color: item.done ? "black" : "grey",
+      size: "m",
+      font: "sans",
+      anchor: "top-left",
+    });
+
+    yOffset += 60;
+  }
+
+  return shapes;
+}
+
+// ---------------------------------------------------------------------------
+// barChart
+// ---------------------------------------------------------------------------
+
+/**
+ * Horizontal bar chart. Bar widths are proportional to values.
+ */
+export function barChart(
+  data: BarDatum[],
+  title: string,
+): TldrawShape[] {
+  const shapes: TldrawShape[] = [];
+
+  shapes.push({
+    _type: "text",
+    shapeId: uid("title"),
+    x: 0,
+    y: 0,
+    text: title,
+    color: "black",
+    size: "l",
+    font: "sans",
+    anchor: "top-left",
+  });
+
+  if (data.length === 0) return shapes;
+
+  const maxValue = Math.max(...data.map((d) => d.value));
+  const maxBarWidth = 400;
+  const barHeight = 36;
+  const gap = 16;
+  const labelWidth = 140;
+  let yOffset = 60;
+
+  for (const datum of data) {
+    const barWidth =
+      maxValue > 0 ? Math.max(4, (datum.value / maxValue) * maxBarWidth) : 4;
+
+    shapes.push({
+      _type: "text",
+      shapeId: uid("label"),
+      x: labelWidth - 8,
+      y: yOffset + 6,
+      text: datum.label,
+      color: "black",
+      size: "s",
+      font: "sans",
+      anchor: "top-right",
+    });
+
+    shapes.push({
+      _type: "rectangle",
+      shapeId: uid("bar"),
+      x: labelWidth,
+      y: yOffset,
+      w: barWidth,
+      h: barHeight,
+      color: "blue",
+      fill: "solid",
+    });
+
+    shapes.push({
+      _type: "text",
+      shapeId: uid("val"),
+      x: labelWidth + barWidth + 8,
+      y: yOffset + 6,
+      text: String(datum.value),
+      color: "grey",
+      size: "s",
+      font: "mono",
+      anchor: "top-left",
+    });
+
+    yOffset += barHeight + gap;
+  }
+
+  return shapes;
+}
+
+// ---------------------------------------------------------------------------
+// comparisonTable
+// ---------------------------------------------------------------------------
+
+/**
+ * Side-by-side comparison table with headers and criteria rows.
+ */
+export function comparisonTable(
+  options: string[],
+  criteria: ComparisonCriterion[],
+): TldrawShape[] {
+  const shapes: TldrawShape[] = [];
+  const colWidth = 200;
+  const rowHeight = 50;
+  const headerX = 0;
+  const dataStartX = 160;
+
+  // Column headers (option names)
+  for (let i = 0; i < options.length; i++) {
+    shapes.push({
+      _type: "text",
+      shapeId: uid("hdr"),
+      x: dataStartX + i * colWidth + colWidth / 2,
+      y: 0,
+      text: options[i],
+      color: "blue",
+      size: "m",
+      font: "sans",
+      anchor: "top-center",
+    });
+  }
+
+  // Criteria rows
+  for (let r = 0; r < criteria.length; r++) {
+    const y = (r + 1) * rowHeight;
+    const criterion = criteria[r];
+
+    // Row label
+    shapes.push({
+      _type: "text",
+      shapeId: uid("row"),
+      x: headerX,
+      y,
+      text: criterion.name,
+      color: "black",
+      size: "s",
+      font: "sans",
+      anchor: "top-left",
+    });
+
+    // Cell values
+    for (let c = 0; c < criterion.values.length; c++) {
+      shapes.push({
+        _type: "text",
+        shapeId: uid("cell"),
+        x: dataStartX + c * colWidth + colWidth / 2,
+        y,
+        text: criterion.values[c],
+        color: "grey",
+        size: "s",
+        font: "sans",
+        anchor: "top-center",
+      });
+    }
+  }
+
+  return shapes;
+}
+
+// ---------------------------------------------------------------------------
+// sitemapTree
+// ---------------------------------------------------------------------------
+
+/**
+ * Site navigation tree with boxes for pages and arrows for hierarchy.
+ */
+export function sitemapTree(pages: SitemapPage[]): TldrawShape[] {
+  const shapes: TldrawShape[] = [];
+  const pageMap = new Map<string, { id: string; x: number; y: number }>();
+
+  const boxW = 160;
+  const boxH = 60;
+  const gapX = 40;
+  const gapY = 100;
+
+  // Find root pages (those with children or the first page)
+  const roots = pages.filter((p) => p.children && p.children.length > 0);
+  const rootPage = roots.length > 0 ? roots[0] : pages[0];
+  if (!rootPage) return shapes;
+
+  // Place root
+  const rootId = uid("page");
+  const rootX = 0;
+  const rootY = 0;
+  shapes.push({
+    _type: "rectangle",
+    shapeId: rootId,
+    x: rootX,
+    y: rootY,
+    w: boxW,
+    h: boxH,
+    color: "blue",
+    fill: "tint",
+    text: rootPage.name,
+    font: "sans",
+    size: "s",
+  });
+  pageMap.set(rootPage.name, { id: rootId, x: rootX, y: rootY });
+
+  // Place children
+  if (rootPage.children) {
+    const totalWidth =
+      rootPage.children.length * boxW +
+      (rootPage.children.length - 1) * gapX;
+    const startX = rootX + boxW / 2 - totalWidth / 2;
+
+    for (let i = 0; i < rootPage.children.length; i++) {
+      const childName = rootPage.children[i];
+      const childId = uid("page");
+      const childX = startX + i * (boxW + gapX);
+      const childY = rootY + boxH + gapY;
+
+      shapes.push({
+        _type: "rectangle",
+        shapeId: childId,
+        x: childX,
+        y: childY,
+        w: boxW,
+        h: boxH,
+        color: "light-blue",
+        fill: "tint",
+        text: childName,
+        font: "sans",
+        size: "s",
+      });
+      pageMap.set(childName, { id: childId, x: childX, y: childY });
+
+      // Arrow from root to child
+      shapes.push({
+        _type: "arrow",
+        shapeId: uid("arrow"),
+        x: rootX + boxW / 2,
+        y: rootY + boxH,
+        x1: rootX + boxW / 2,
+        y1: rootY + boxH,
+        x2: childX + boxW / 2,
+        y2: childY,
+        color: "grey",
+        fromId: rootId,
+        toId: childId,
+      });
+    }
+  }
+
+  // Place remaining pages that aren't already placed
+  let nextY =
+    (pageMap.size > 1 ? rootY + boxH + gapY + boxH + gapY : rootY + boxH + gapY);
+  for (const page of pages) {
+    if (pageMap.has(page.name)) continue;
+    const pageId = uid("page");
+    shapes.push({
+      _type: "rectangle",
+      shapeId: pageId,
+      x: 0,
+      y: nextY,
+      w: boxW,
+      h: boxH,
+      color: "light-blue",
+      fill: "tint",
+      text: page.name,
+      font: "sans",
+      size: "s",
+    });
+    pageMap.set(page.name, { id: pageId, x: 0, y: nextY });
+    nextY += boxH + gapY;
+  }
+
+  return shapes;
+}
+
+// ---------------------------------------------------------------------------
+// timeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Horizontal timeline with circles for events and labels above/below.
+ */
+export function timeline(events: TimelineEvent[]): TldrawShape[] {
+  if (events.length === 0) return [];
+
+  const shapes: TldrawShape[] = [];
+  const spacing = 240;
+  const lineY = 100;
+  const dotSize = 20;
+
+  // Connecting line
+  if (events.length > 1) {
+    shapes.push({
+      _type: "line",
+      shapeId: uid("line"),
+      x: 0,
+      y: lineY + dotSize / 2,
+      x1: 0,
+      y1: lineY + dotSize / 2,
+      x2: (events.length - 1) * spacing,
+      y2: lineY + dotSize / 2,
+      color: "grey",
+      dash: "solid",
+      size: "m",
+    });
+  }
+
+  for (let i = 0; i < events.length; i++) {
+    const x = i * spacing;
+    const event = events[i];
+
+    // Dot
+    shapes.push({
+      _type: "ellipse",
+      shapeId: uid("dot"),
+      x: x - dotSize / 2,
+      y: lineY,
+      w: dotSize,
+      h: dotSize,
+      color: "blue",
+      fill: "solid",
+    });
+
+    // Date label (below)
+    shapes.push({
+      _type: "text",
+      shapeId: uid("date"),
+      x,
+      y: lineY + dotSize + 16,
+      text: event.date,
+      color: "grey",
+      size: "s",
+      font: "mono",
+      anchor: "top-center",
+    });
+
+    // Event label (above)
+    shapes.push({
+      _type: "text",
+      shapeId: uid("event"),
+      x,
+      y: lineY - 12,
+      text: event.label,
+      color: "black",
+      size: "s",
+      font: "sans",
+      anchor: "bottom-center",
+      maxWidth: spacing - 20,
+    });
+  }
+
+  return shapes;
+}

--- a/tests/tldraw-helpers.test.ts
+++ b/tests/tldraw-helpers.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+import {
+  progressChecklist,
+  barChart,
+  comparisonTable,
+  sitemapTree,
+  timeline,
+  type TldrawShape,
+} from "../template/scripts/tldraw-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Shared validation
+// ---------------------------------------------------------------------------
+
+function validateShapes(shapes: TldrawShape[]) {
+  for (const shape of shapes) {
+    expect(shape.shapeId, "missing shapeId").toBeDefined();
+    expect(shape._type, "missing _type").toBeDefined();
+    expect(typeof shape.x).toBe("number");
+    expect(typeof shape.y).toBe("number");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// progressChecklist
+// ---------------------------------------------------------------------------
+
+describe("progressChecklist", () => {
+  const items = [
+    { label: "Create GitHub repo", done: true },
+    { label: "Set up Cloudflare", done: true },
+    { label: "Design interview", done: false },
+    { label: "Deploy", done: false },
+  ];
+
+  it("returns shapes for all items", () => {
+    const shapes = progressChecklist(items);
+    // Each item needs at least a checkbox shape + label text
+    expect(shapes.length).toBeGreaterThanOrEqual(items.length * 2);
+  });
+
+  it("returns valid tldraw shapes", () => {
+    validateShapes(progressChecklist(items));
+  });
+
+  it("uses check-box for completed items", () => {
+    const shapes = progressChecklist(items);
+    const checkboxes = shapes.filter((s) => s._type === "check-box");
+    expect(checkboxes.length).toBeGreaterThan(0);
+  });
+
+  it("uses rectangle or x-box for incomplete items", () => {
+    const shapes = progressChecklist(items);
+    const incomplete = shapes.filter(
+      (s) => s._type === "rectangle" || s._type === "x-box",
+    );
+    expect(incomplete.length).toBeGreaterThan(0);
+  });
+
+  it("includes title shape", () => {
+    const shapes = progressChecklist(items, "Setup Progress");
+    const title = shapes.find(
+      (s) => s._type === "text" && s.text === "Setup Progress",
+    );
+    expect(title).toBeDefined();
+  });
+
+  it("handles empty list", () => {
+    const shapes = progressChecklist([]);
+    expect(shapes.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// barChart
+// ---------------------------------------------------------------------------
+
+describe("barChart", () => {
+  const data = [
+    { label: "/services", value: 58 },
+    { label: "/", value: 45 },
+    { label: "/about", value: 30 },
+  ];
+
+  it("returns shapes for all bars + labels", () => {
+    const shapes = barChart(data, "Top Pages");
+    expect(shapes.length).toBeGreaterThanOrEqual(data.length * 2);
+  });
+
+  it("returns valid tldraw shapes", () => {
+    validateShapes(barChart(data, "Top Pages"));
+  });
+
+  it("includes a title", () => {
+    const shapes = barChart(data, "Top Pages");
+    const title = shapes.find(
+      (s) => s._type === "text" && s.text === "Top Pages",
+    );
+    expect(title).toBeDefined();
+  });
+
+  it("bar widths are proportional to values", () => {
+    const shapes = barChart(data, "Chart");
+    const bars = shapes.filter(
+      (s) => s._type === "rectangle" && s.w !== undefined && s.w > 0,
+    );
+    // First bar (58) should be wider than last bar (30)
+    if (bars.length >= 2) {
+      expect(bars[0].w).toBeGreaterThan(bars[bars.length - 1].w!);
+    }
+  });
+
+  it("handles empty data", () => {
+    const shapes = barChart([], "Empty");
+    expect(shapes.length).toBeLessThanOrEqual(1); // just title or nothing
+  });
+
+  it("handles single item", () => {
+    const shapes = barChart([{ label: "Home", value: 100 }], "One");
+    validateShapes(shapes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// comparisonTable
+// ---------------------------------------------------------------------------
+
+describe("comparisonTable", () => {
+  const options = ["Buttondown", "Mailchimp"];
+  const criteria = [
+    { name: "Free tier", values: ["100 subscribers", "500 contacts"] },
+    { name: "Privacy", values: ["Excellent", "Good"] },
+    { name: "Ease of use", values: ["Simple", "Complex"] },
+  ];
+
+  it("returns valid tldraw shapes", () => {
+    validateShapes(comparisonTable(options, criteria));
+  });
+
+  it("includes option names as text", () => {
+    const shapes = comparisonTable(options, criteria);
+    const texts = shapes.filter((s) => s._type === "text").map((s) => s.text);
+    expect(texts.some((t) => t?.includes("Buttondown"))).toBe(true);
+    expect(texts.some((t) => t?.includes("Mailchimp"))).toBe(true);
+  });
+
+  it("includes criteria names", () => {
+    const shapes = comparisonTable(options, criteria);
+    const texts = shapes.filter((s) => s._type === "text").map((s) => s.text);
+    expect(texts.some((t) => t?.includes("Free tier"))).toBe(true);
+  });
+
+  it("includes cell values", () => {
+    const shapes = comparisonTable(options, criteria);
+    const texts = shapes.filter((s) => s._type === "text").map((s) => s.text);
+    expect(texts.some((t) => t?.includes("100 subscribers"))).toBe(true);
+  });
+
+  it("handles empty criteria", () => {
+    const shapes = comparisonTable(["A", "B"], []);
+    validateShapes(shapes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sitemapTree
+// ---------------------------------------------------------------------------
+
+describe("sitemapTree", () => {
+  const pages = [
+    { name: "Home", path: "/", children: ["Blog", "Services", "About"] },
+    { name: "Blog", path: "/blog" },
+    { name: "Services", path: "/services" },
+    { name: "About", path: "/about" },
+  ];
+
+  it("returns valid tldraw shapes", () => {
+    validateShapes(sitemapTree(pages));
+  });
+
+  it("includes shapes for all pages", () => {
+    const shapes = sitemapTree(pages);
+    const texts = shapes.filter((s) => s._type === "text" || s.text).map((s) => s.text);
+    expect(texts.some((t) => t?.includes("Home"))).toBe(true);
+    expect(texts.some((t) => t?.includes("Blog"))).toBe(true);
+  });
+
+  it("includes arrows for parent-child relationships", () => {
+    const shapes = sitemapTree(pages);
+    const arrows = shapes.filter((s) => s._type === "arrow");
+    expect(arrows.length).toBeGreaterThan(0);
+  });
+
+  it("handles single page", () => {
+    const shapes = sitemapTree([{ name: "Home", path: "/" }]);
+    validateShapes(shapes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// timeline
+// ---------------------------------------------------------------------------
+
+describe("timeline", () => {
+  const events = [
+    { label: "Site created", date: "Jan 2026" },
+    { label: "First deploy", date: "Feb 2026" },
+    { label: "100 visitors", date: "Mar 2026" },
+  ];
+
+  it("returns valid tldraw shapes", () => {
+    validateShapes(timeline(events));
+  });
+
+  it("includes event labels", () => {
+    const shapes = timeline(events);
+    const texts = shapes.filter((s) => s._type === "text").map((s) => s.text);
+    expect(texts.some((t) => t?.includes("Site created"))).toBe(true);
+    expect(texts.some((t) => t?.includes("100 visitors"))).toBe(true);
+  });
+
+  it("includes date labels", () => {
+    const shapes = timeline(events);
+    const texts = shapes.filter((s) => s._type === "text").map((s) => s.text);
+    expect(texts.some((t) => t?.includes("Jan 2026"))).toBe(true);
+  });
+
+  it("events are positioned left to right", () => {
+    const shapes = timeline(events);
+    const textShapes = shapes.filter((s) => s._type === "text");
+    // Check that x values generally increase
+    const xs = textShapes.map((s) => s.x);
+    expect(xs[xs.length - 1]).toBeGreaterThan(xs[0]);
+  });
+
+  it("handles empty events", () => {
+    const shapes = timeline([]);
+    expect(shapes.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds tldraw visualization helper library (`template/scripts/tldraw-helpers.ts`) with 5 reusable shape generators: `progressChecklist()`, `barChart()`, `comparisonTable()`, `sitemapTree()`, `timeline()`
- Updates 5 existing skills (design-interview, stats, check, start, new-page) with tldraw MCP tool permissions and guidance on when to draw visuals for the site owner
- Adds "Visual communication" section to AGENTS.md establishing show-don't-tell as a core principle

Closes #67

## Test plan

- [ ] 26 new tests pass validating all shape generators produce valid tldraw shape arrays with required fields (`shapeId`, `_type`, `x`, `y`)
- [ ] Full test suite passes (605 tests)
- [ ] Verify tldraw shapes render correctly in Claude app by invoking `/anglesite:check` and confirming the visual scorecard appears
- [ ] Verify `/anglesite:stats` draws bar charts when presenting analytics data

🤖 Generated with [Claude Code](https://claude.com/claude-code)