### PR TITLE
feat: add BuyButton component and Stripe Payment Link skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 ```
 ├── .claude-plugin/plugin.json    Plugin manifest (name, version, metadata)
 ├── marketplace.json              Marketplace distribution config
-├── skills/                       Skills (23 total: 11 user-facing, 12 model-only)
+├── skills/                       Skills (24 total: 11 user-facing, 13 model-only)
 │   ├── start/SKILL.md            First-time setup + scaffolding
 │   ├── deploy/SKILL.md           Build, scan, deploy to Cloudflare Pages
 │   ├── check/SKILL.md            Health audit + troubleshooting
@@ -34,6 +34,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 │   ├── testimonials/SKILL.md    Review collection + display (model-only)
 │   ├── i18n/SKILL.md            Multi-language support (model-only)
 │   ├── print/SKILL.md           Print materials generation (model-only)
+│   ├── buy-button/SKILL.md     Stripe Payment Link buy button (model-only)
 │   └── shared/content-conversion.md  Shared HTML-to-Markdown guidance
 ├── settings.json                 Plugin settings (empty — permissions via allowed-tools)
 ├── hooks/hooks.json              PreToolUse hook for deploy safety scans
@@ -128,6 +129,7 @@ Three levels of agent instructions exist — do not confuse them:
 | `testimonials` | Customer review collection, moderation, display |
 | `i18n` | Multi-language support with hreflang and language switcher |
 | `print` | Print-ready materials (business cards, flyers, door hangers, social cards) |
+| `buy-button` | Stripe Payment Link buy button for single product/service sales |
 
 ## Editing guidelines
 

--- a/skills/buy-button/SKILL.md
+++ b/skills/buy-button/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: buy-button
+description: "Add a Stripe Payment Link buy button to sell a single product or service"
+user-invokable: false
+allowed-tools: Write, Read, Edit, Glob
+---
+
+Add a buy/payment button to a page using Stripe Payment Links. This is the zero-integration ecommerce path — no cart, no catalog, no server-side code, no third-party JavaScript. The button links to a hosted Stripe checkout page.
+
+## Architecture decisions
+
+- [ADR-0008 No third-party JS](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0008-no-third-party-javascript.md) — Stripe Payment Links are external redirects, not embedded scripts. Fully compliant.
+
+## When to invoke this skill
+
+- When the owner wants to sell a single product or service
+- When the owner wants to accept a payment or donation
+- When the owner mentions Stripe, payment links, or "buy button"
+- When `/anglesite:add-store` routes here (single product, no catalog needed)
+
+## Step 1 — Collect product details
+
+Ask the owner for:
+
+1. **What are you selling?** — product name, service, or donation purpose
+2. **Price** — fixed amount (e.g., "$500") or "customer chooses" for donations
+3. **One-line description** — shown on the checkout page
+4. **Which page?** — where the button should appear (e.g., homepage, a service page)
+5. **Button label** — default "Buy Now", but could be "Book Now", "Donate", "Get Started", etc.
+
+## Step 2 — Guide the owner through Stripe Payment Link creation
+
+Tell the owner:
+
+> To accept payments, you'll need a Stripe account and a Payment Link. Here's how:
+>
+> 1. Go to your **Stripe Dashboard** → Payment Links → Create payment link
+> 2. Set the product name, price, and description
+> 3. Click **Create link** and copy the URL (it looks like `https://buy.stripe.com/...`)
+> 4. Paste the URL here
+
+If the owner doesn't have a Stripe account, explain:
+
+> Stripe is free to set up — you only pay when you make a sale (2.9% + 30¢ per transaction). Create an account at stripe.com, then follow the steps above.
+
+Wait for the owner to provide the Payment Link URL before proceeding.
+
+## Step 3 — Add the BuyButton component
+
+The `BuyButton.astro` component already exists at `src/components/BuyButton.astro`.
+
+Import and use it on the target page:
+
+```astro
+---
+import BuyButton from "../components/BuyButton.astro";
+---
+
+<BuyButton href="https://buy.stripe.com/OWNER_LINK" label="Buy Now" />
+```
+
+Adjust the `label` prop to match what the owner requested (e.g., "Book Now", "Donate", "Get Started").
+
+Place the button in context — near the product description, pricing section, or call-to-action area. Don't drop it in isolation.
+
+## Step 4 — Verify
+
+Run `npm run build` to confirm the site builds cleanly with the new component.
+
+## Notes
+
+- Stripe Payment Links handle the entire checkout flow — no server routes, no API keys in the codebase, no PII concerns
+- The button is a plain `<a>` tag with `target="_blank"` — accessible, works without JavaScript, prints cleanly
+- If the owner later needs a full catalog or cart, suggest upgrading to Snipcart or Shopify Buy Button (see issue #96)

--- a/template/src/components/BuyButton.astro
+++ b/template/src/components/BuyButton.astro
@@ -1,0 +1,10 @@
+---
+interface Props {
+  href: string;
+  label?: string;
+}
+const { href, label = "Buy Now" } = Astro.props;
+---
+<a href={href} class="buy-button" target="_blank" rel="noopener">
+  {label}
+</a>

--- a/template/src/styles/global.css
+++ b/template/src/styles/global.css
@@ -301,6 +301,30 @@ footer {
   outline-offset: 2px;
 }
 
+/* Buy button */
+.buy-button {
+  display: inline-block;
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.buy-button:hover {
+  opacity: 0.9;
+  color: #fff;
+}
+
+.buy-button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 /* Print */
 @media print {
   .skip-link,


### PR DESCRIPTION
## Summary

- Add `BuyButton.astro` component for Stripe Payment Link integration
- Add `buy-button` model-only skill that guides Claude through the payment link setup flow
- Add `.buy-button` CSS styles consistent with existing button patterns
- Update CLAUDE.md skill tables and directory tree

## Details

This implements the zero-integration ecommerce path from #97. Stripe Payment Links are external redirects — no third-party JavaScript, no server routes, no API keys in the codebase. Fully compliant with ADR-0008.

The skill walks the owner through creating a Stripe Payment Link, then drops a styled CTA button onto the appropriate page.

## Test plan

- [x] All 628 existing tests pass
- [ ] Manual: scaffold a test site and verify BuyButton renders correctly
- [ ] Manual: verify button styles match existing CTA patterns (primary color, hover, focus)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)