### PR TITLE
Add legal compliance guidance and free policy templates

### DIFF
--- a/docs/smb/legal-checklist.md
+++ b/docs/smb/legal-checklist.md
@@ -28,7 +28,7 @@ What to include: what data is collected, how it's used, who it's shared with (if
 
 **Ask the owner:** "Your site will have a contact form [and a mailing list signup], so we need a privacy policy page. I'll draft one — it's straightforward since your site doesn't use third-party tracking."
 
-Don't recommend privacy policy generators that inject their own tracking or affiliate links. A simple, honest, plain-language page is better than a 10-page legal template.
+Don't recommend privacy policy generators that inject their own tracking or affiliate links. A simple, honest, plain-language page is better than a 10-page legal template. See [legal-templates.md](legal-templates.md) for vetted free template sources.
 
 ---
 
@@ -58,7 +58,7 @@ Keep it short. The most useful thing is a contact method for people who encounte
 
 **Ask the owner:** Nothing for the basic statement — just add it. During `/anglesite:design-interview` (Step 9, accessibility), ask about audience-specific accessibility needs.
 
-Note: WCAG AA compliance is already enforced by `/anglesite:check` and `/anglesite:deploy`. The statement is about communication, not a substitute for actual accessibility.
+Note: WCAG AA compliance is already enforced by `/anglesite:check` and `/anglesite:deploy`. The statement is about communication, not a substitute for actual accessibility. See [legal-templates.md](legal-templates.md) for the W3C WAI template.
 
 ---
 
@@ -104,7 +104,7 @@ Many owners already have terms from their booking or payment platform (Square, H
 
 **Ask the owner:** "Do you take payments, bookings, or deposits through the website? We'll need a terms of service page." If they already have terms from their platform, use those as a starting point.
 
-Keep it plain language. A clear 1-page terms document is better than a 20-page one nobody reads.
+Keep it plain language. A clear 1-page terms document is better than a 20-page one nobody reads. See [legal-templates.md](legal-templates.md) for free template sources.
 
 ---
 
@@ -147,6 +147,102 @@ This applies to website content (blog posts, reviews), not just social media. A 
 **Where to add:** Inline with each sponsored post or affiliate link. Not buried in a separate page. Example: "This post contains affiliate links — I earn a small commission if you purchase through them, at no extra cost to you."
 
 **Ask the owner:** "Do you use affiliate links or accept sponsored content on your site?" If yes, plan disclosure placement for each post type.
+
+---
+
+### 10. Return/refund policy
+
+**types:** businesses with ecommerce (buy-button, snipcart, shopify-buy-button, lemon-squeezy)
+
+Required by most payment processors and builds buyer trust. Clearly states what happens if a customer wants a return, exchange, or refund. For service businesses using booking, a cancellation policy serves the same purpose.
+
+**Where to add:** Dedicated page (`/returns/` or `/refund-policy/`) linked from the footer and referenced near checkout buttons.
+
+**Ask the owner:** "Since you're selling through your website, we need a return/refund policy. Do you already have one? If not, I'll draft one as a starting point." See [legal-templates.md](legal-templates.md) for free template sources.
+
+---
+
+### 11. Shipping policy
+
+**types:** businesses selling physical goods (snipcart, shopify-buy-button)
+
+Sets delivery expectations: processing time, shipping methods, estimated delivery windows, and who pays for return shipping. Reduces disputes and support requests.
+
+**Where to add:** Dedicated page (`/shipping/`) or a section within the returns/refund page. Link from the footer and from product pages.
+
+**Ask the owner:** "What are your typical shipping times? Do you ship everywhere or just within certain areas?" Draft the policy from their answers.
+
+---
+
+### 12. Age verification notice
+
+**types:** alcohol, cannabis, firearms, tobacco, vape, adult-content businesses
+
+Legal requirement in most jurisdictions for businesses selling age-restricted products or services. The website must include a notice or gate before users can access product content.
+
+**Where to add:** A brief notice on the homepage or a lightweight age gate before product pages. Don't build a complex verification system — a simple "You must be 21+ to purchase" notice with acknowledgment is sufficient for a website. The actual age verification happens at point of sale.
+
+**Ask the owner:** "Your business sells age-restricted products. I'll add a notice that visitors must be of legal age. Does your state require a specific minimum age?"
+
+---
+
+### 13. Professional license display
+
+**types:** contractor, electrician, plumber, cosmetologist, barber, real-estate, insurance
+
+Many state licensing boards require the license number to be displayed on advertising — which includes websites. Even when not legally required, displaying a license number builds credibility.
+
+**Where to add:** Footer (brief) and About page (with issuing authority). Example: "Licensed General Contractor #12345 — California CSLB"
+
+**Ask the owner:** "Do you have a professional license or contractor license number? Many states require it to be displayed on your website."
+
+---
+
+### 14. GDPR data processing disclosure
+
+**types:** all (if the site has any EU visitors and collects data via forms or newsletter)
+
+GDPR requires explicit disclosure of what data is collected, the legal basis for processing, and the right to request deletion. For most Anglesite sites, the privacy policy covers this — but it must specifically mention GDPR rights (access, rectification, erasure, portability) if EU visitors are expected.
+
+**Where to add:** A "For European visitors" section in the privacy policy page. Not a separate page.
+
+**Ask the owner:** "Do you expect visitors from Europe? If so, I'll add a section to your privacy policy about their data rights under GDPR." If unsure, add it anyway — it's free insurance.
+
+---
+
+### 15. CCPA "Do Not Sell" notice
+
+**types:** all (if the site has California visitors and collects any data)
+
+CCPA requires businesses meeting certain thresholds to include a "Do Not Sell My Personal Information" notice. Most Anglesite SMB sites fall below CCPA thresholds ($25M+ revenue, 50K+ consumers' data), but a simple statement in the privacy policy builds trust regardless.
+
+**Where to add:** A sentence in the privacy policy: "We do not sell your personal information." No separate page needed for sites below CCPA thresholds.
+
+**Ask the owner:** Nothing — just include the statement in the privacy policy by default. Anglesite's no-third-party-JS architecture means there's genuinely nothing being sold.
+
+---
+
+### 16. Service cancellation/refund policy
+
+**types:** businesses with appointment booking (booking skill configured)
+
+Reduces no-shows and disputes. States how far in advance a booking can be cancelled, whether deposits are refundable, and what happens for late cancellations.
+
+**Where to add:** Dedicated section on the booking page and referenced in terms of service. Link from the footer if booking is a primary feature.
+
+**Ask the owner:** "What's your cancellation policy? For example, do you require 24-hour notice? Are deposits refundable?" Draft the policy from their answers.
+
+---
+
+### 17. Testimonial and endorsement disclosure
+
+**types:** all businesses displaying testimonials, reviews, or endorsements
+
+The FTC requires disclosure of material connections — paid testimonials, incentivized reviews, or affiliate relationships. Updated 2023 FTC endorsement guides apply to website content, not just social media.
+
+**Where to add:** Inline with each testimonial or review. If all testimonials are genuine unpaid reviews, a brief note is still good practice: "These are reviews from real customers. We did not pay for or incentivize these reviews."
+
+**Ask the owner:** "Did you offer any discount or incentive for these reviews? The FTC requires disclosure if so." This expands on item 9 (FTC disclosure for affiliate/sponsored content) to cover testimonials specifically.
 
 ---
 

--- a/docs/smb/legal-templates.md
+++ b/docs/smb/legal-templates.md
@@ -1,0 +1,96 @@
+# Free Legal Template Sources for SMB Websites
+
+Curated, well-regarded sources for legal page templates. These are **starting points** — every template should be reviewed by a lawyer before publishing. A basic legal review runs $300–$500 and is worth it.
+
+The agent reads this file when creating legal pages during `/anglesite:start` or when the owner asks about privacy policies, terms, or disclaimers. Use templates as a starting framework, then customize for the owner's specific business.
+
+---
+
+## Privacy policy
+
+| Source | What it covers | Limitations |
+|---|---|---|
+| [Termly](https://termly.io/products/privacy-policy-generator/) | Free generator, comprehensive, no tracking injected | Requires account; generated policy can be verbose |
+| [FreePrivacyPolicy.com](https://www.freeprivacypolicy.com/) | Free generator with GDPR and CCPA options | Free tier is basic; upsells premium features |
+
+**For default Anglesite sites**, a privacy policy is straightforward because the architecture is privacy-first: no third-party cookies, no tracking scripts, no data sold. The policy should cover:
+
+- Contact form submissions (name, email, message) — stored by the owner only
+- Newsletter signups (email) — managed by the email platform (Buttondown, Mailchimp)
+- Cloudflare Web Analytics — cookieless, aggregate-only, no individual tracking
+- No data shared with or sold to third parties
+
+**Don't use generators that:** inject their own tracking pixels, require linking back to the generator, or add affiliate code to the generated policy.
+
+---
+
+## Terms of service
+
+| Source | What it covers | Limitations |
+|---|---|---|
+| [Termly](https://termly.io/products/terms-and-conditions-generator/) | Free generator for basic terms | Account required; generated terms can be generic |
+
+**When needed:** Any site that takes payments, bookings, deposits, or user-submitted content. See legal-checklist.md item 6.
+
+**Key sections to customize:** Refund/cancellation policy, liability limits, governing jurisdiction, acceptable use. If the owner already has terms from their booking or payment platform, use those as the baseline — the website terms should be consistent, not contradictory.
+
+---
+
+## Return and refund policy
+
+| Source | What it covers | Limitations |
+|---|---|---|
+| [Termly](https://termly.io/products/refund-policy-generator/) | Free generator for return/refund terms | Basic; may not cover service-based businesses well |
+| [Shopify free generator](https://www.shopify.com/tools/policy-generator/refund) | Retail-focused return policy | Tailored to physical goods; needs adaptation for services |
+
+**When needed:** Any site with ecommerce (buy-button, snipcart, shopify-buy-button, lemon-squeezy). Payment processors often require a visible return policy.
+
+---
+
+## Accessibility statement
+
+| Source | What it covers | Limitations |
+|---|---|---|
+| [W3C WAI template](https://www.w3.org/WAI/planning/statements/generator/) | International standard, well-established | Can be overly formal; simplify the language |
+
+**Always include.** Anglesite sites get an accessibility statement by default. The most useful content is a contact method for people who encounter barriers. Keep it short and honest.
+
+---
+
+## Professional disclaimers
+
+No generator needed — these are short, profession-specific statements. See legal-checklist.md item 5 for standard language by profession (legal, healthcare, accounting, insurance, fitness).
+
+**Additional professions that need disclaimers:**
+
+| Profession | Disclaimer focus |
+|---|---|
+| Real estate | "Not a substitute for professional appraisal or inspection" |
+| Financial planning | "Past performance does not guarantee future results" |
+| Nutrition/dietetics | "Not a substitute for medical nutrition therapy from a licensed dietitian" |
+| Mental health/therapy | "This site is not a crisis service. If you are in crisis, call 988" |
+| Veterinary | "This information does not replace a veterinary examination" |
+
+---
+
+## Cookie consent / GDPR notice
+
+**Most Anglesite sites don't need a cookie banner.** The privacy-first architecture (no third-party JS, cookieless analytics) means there are no tracking cookies to consent to. A cookie banner where none is needed annoys users and implies tracking that isn't happening.
+
+**When a banner IS needed:** If the owner embeds YouTube videos, Instagram feeds, Google Maps, or other third-party content that sets cookies. In that case, disclose the specific third-party cookies in the privacy policy.
+
+---
+
+## CCPA "Do Not Sell" notice
+
+**When needed:** Sites that collect personal information from California residents AND meet CCPA thresholds (>$25M revenue, >50K consumers' data, or >50% revenue from selling data). Most Anglesite SMB sites fall below these thresholds — but including a "We do not sell your personal information" statement in the privacy policy is free insurance and builds trust.
+
+---
+
+## Important reminders
+
+1. **Templates are starting points, not legal advice.** Always recommend the owner consult a lawyer for customization — especially for licensed professions, ecommerce, and healthcare.
+2. **Plain language wins.** A clear 1-page policy that people actually read beats a 20-page document nobody opens.
+3. **Keep policies consistent.** Terms on the website should match terms from the booking platform, payment processor, and any signed contracts.
+4. **Update annually.** Legal pages should be reviewed at least once a year or whenever the site adds new features (ecommerce, newsletter, booking).
+5. **Don't copy competitors' policies.** Their business, jurisdiction, and data practices differ. Use templates designed for customization.

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -96,6 +96,30 @@ Check that the site works on small screens. Start the dev server if not already 
 - [ ] Blog posts have valid frontmatter (title, description, publishDate)
 - [ ] Business name, address, and contact info are easy to find (not buried)
 
+## Legal compliance
+
+Check that the site has the legal pages appropriate for its features and business type. Read `BUSINESS_TYPE` and `ECOMMERCE_PROVIDER` from `.site-config`. Refer to `${CLAUDE_PLUGIN_ROOT}/docs/smb/legal-checklist.md` for the full checklist and `${CLAUDE_PLUGIN_ROOT}/docs/smb/legal-templates.md` for free template sources.
+
+- [ ] Privacy policy page exists at `/privacy/` and is linked from the footer
+- [ ] Copyright notice in the footer with the current year
+- [ ] Accessibility statement exists at `/accessibility/` (or as a section on another page) and is linked from the footer
+- [ ] If ecommerce is configured (`ECOMMERCE_PROVIDER` set): terms of service exists at `/terms/`
+- [ ] If ecommerce is configured: return/refund policy exists at `/returns/` or `/refund-policy/`
+- [ ] If physical goods ecommerce (snipcart, shopify-buy-button): shipping policy exists
+- [ ] If `BUSINESS_TYPE` is a licensed profession (legal, healthcare, accounting, insurance, fitness, contractor, real-estate): professional disclaimer present in footer or on a dedicated page
+- [ ] If booking is configured: cancellation policy is visible on the booking page
+- [ ] Newsletter signup forms include a clear description of what subscribers will receive
+
+Report legal compliance findings as **"Worth fixing soon"** severity, not deploy blockers. Frame findings as helpful next steps:
+
+| Missing item | What to tell the owner |
+|---|---|
+| No privacy policy | "Your site collects contact info through the form, so it needs a privacy policy page. I can draft one for you — it's straightforward since your site doesn't track visitors." |
+| No terms of service (with ecommerce) | "Since you're selling through your website, you'll want a terms of service page. I can create one as a starting point." |
+| No return policy (with ecommerce) | "Customers will want to know your return policy before buying. I'll add a page for that." |
+| Missing professional disclaimer | "Most [profession] websites include a disclaimer. I'll add a brief one to your footer." |
+| Missing copyright notice | "I'll add a copyright line to your footer — it's a small thing that signals ownership." |
+
 ## IndieWeb (see `docs/indieweb.md`)
 - [ ] `h-card` in site header with `p-name` and `u-url`
 - [ ] `h-entry` on blog posts with `p-name`, `dt-published`, `e-content`


### PR DESCRIPTION
## Summary
- Create `docs/smb/legal-templates.md` with curated free template sources (Termly, W3C WAI, Shopify generators) — each with clear caveats about consulting a lawyer
- Add 8 new compliance items to `docs/smb/legal-checklist.md`: return/refund policy, shipping policy, age verification, professional license display, GDPR disclosure, CCPA notice, service cancellation policy, and testimonial/endorsement disclosure
- Add legal compliance audit section to `/anglesite:check` skill with plain-English finding templates

Closes #133

## Test plan
- [ ] Verify `legal-templates.md` links are valid and descriptions are accurate
- [ ] Verify new checklist items 10–17 follow the same format as items 1–9
- [ ] Verify check skill legal compliance section references correct `.site-config` keys
- [ ] Verify cross-references between `legal-checklist.md` and `legal-templates.md` are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)