### PR TITLE
Add Serena plugin development setup documentation

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,9 @@
+# Serena project config — semantic code navigation for plugin development
+# See https://github.com/oraios/serena
+#
+# Setup:
+#   uvx -p 3.13 --from git+https://github.com/oraios/serena serena project index
+#   Then add the Serena MCP server to your Claude Code config.
+
+language: typescript
+index: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,22 @@ npm install
 npm run dev
 ```
 
+## Serena (optional, plugin development)
+
+[Serena](https://github.com/oraios/serena) provides semantic, symbol-level code navigation via language servers. It's useful when working on the plugin itself (tracing cross-skill references, finding symbol usages across 40 skills). Not required — all standard tools work without it.
+
+**Setup:**
+
+```sh
+# Index the project (one-time)
+uvx -p 3.13 --from git+https://github.com/oraios/serena serena project index
+
+# Start the MCP server
+uvx -p 3.13 --from git+https://github.com/oraios/serena serena start-mcp-server --project .
+```
+
+Config lives in `.serena/project.yml`. Requires Python 3.13 and [uv](https://docs.astral.sh/uv/).
+
 ## Security hooks
 
 The `hooks/hooks.json` defines a PreToolUse hook that runs `scripts/pre-deploy-check.sh` before any Bash tool use. It enforces four mandatory scans before deploying to `main`:


### PR DESCRIPTION
## Summary
Added documentation and configuration for Serena, an optional semantic code navigation tool for plugin development. This enables developers to trace cross-skill references and find symbol usages across the 40+ skills in the codebase.

## Changes
- **CLAUDE.md**: Added new "Serena (optional, plugin development)" section with setup instructions, including:
  - Overview of Serena's capabilities and use cases
  - Step-by-step setup commands using `uvx`
  - Configuration file location and system requirements (Python 3.13, uv)
  
- **.serena/project.yml**: Created new Serena project configuration file with:
  - Language set to TypeScript
  - Indexing enabled
  - Setup instructions and reference to Serena repository

## Notes
This is an optional development tool that enhances the development experience but is not required for normal plugin development. All standard tools continue to work without Serena installed.

https://claude.ai/code/session_016zQ1BnV5KXdcYyuKmH1N9L