### PR TITLE
fix(import): warn against flat sitemap image extraction

### DIFF
--- a/docs/import/hosted-platforms.md
+++ b/docs/import/hosted-platforms.md
@@ -130,6 +130,10 @@ Use `.webp` for optimized images. Keep originals only as a fallback.
 | Inline body image (Nth) | `SLUG-body-N.webp` | `my-great-post-body-1.webp` |
 | Gallery image (Nth) | `PAGE-SLUG-NN.webp` | `portfolio-01.webp` |
 
+### Sitemap image extensions
+
+Some platforms (Squarespace, Shopify, Webflow) include `<image:image>` XML extensions in their sitemaps. These are scoped inside each `<url>` block — images listed under one URL belong to that page only. **Never use a flat `grep '<image:loc>'`** to extract image URLs from a sitemap, as this mixes images from every page together. Always extract gallery/page images from the page itself via WebFetch (import skill Step 4).
+
 ### CDN URL normalization
 
 Different platforms use different CDN URL schemes. Strip platform-specific transforms to get the best quality:

--- a/docs/import/squarespace.md
+++ b/docs/import/squarespace.md
@@ -130,6 +130,7 @@ If no tags are found in either RSS or the page HTML, leave `tags: []`.
 
 ## Common issues
 
+- **Sitemap image extraction is per-page, not global**: Squarespace sitemaps include `<image:image>` extensions inside each `<url>` block. Never use a flat `grep '<image:loc>'` to extract image URLs — this mixes images from all pages (e.g., an About page headshot appears in the gallery). Always extract gallery images from the gallery page itself via WebFetch (import skill Step 4), not from the sitemap.
 - **Gallery pages not in export**: Squarespace galleries contain images but the export only includes text content. Gallery images must be scraped from the live page before cancellation. Gallery thumbnails use `?format=100w` — replace with `?format=2500w` to get full-size images.
 - **Blog collection URL varies**: The blog may not be at `/blog`. Check the sitemap or navigation for the actual collection URL before attempting RSS fetch. A 404 on `/blog?format=rss` usually means the collection has a different name.
 - **Custom CSS lost**: Code injection and custom CSS are not exported. The owner should save these manually if they contain brand-specific overrides.

--- a/skills/import/content-discovery.md
+++ b/skills/import/content-discovery.md
@@ -69,6 +69,12 @@ Look for blog post URLs in the sitemap to identify the collection path prefix
 (e.g., `/news/2026/3/slug` means the collection is at `/news`). Also check the
 homepage navigation links for the blog link.
 
+**Do NOT extract images from the sitemap.** Squarespace sitemaps include
+`<image:image>` elements inside each `<url>` block, but a flat grep like
+`grep '<image:loc>'` returns images from ALL pages mixed together — an About
+page headshot ends up in the gallery. Use WebFetch on each gallery page instead
+(Step 4 of the import skill handles this correctly).
+
 Then fetch the RSS feed using the discovered collection URL:
 
 ```sh


### PR DESCRIPTION
## Summary

- Adds warnings in three locations to prevent flat `grep '<image:loc>'` extraction from sitemaps, which mixes images from all pages together
- Squarespace content-discovery section now explicitly says to use WebFetch per gallery page (Step 4) instead of sitemap image extensions
- Added general guidance in hosted-platforms.md about sitemap image scoping
- Added Squarespace-specific common issue entry about this anti-pattern

Closes #172

## Test plan

- [ ] Review the three changed docs files for accuracy
- [ ] Verify the guidance is consistent across content-discovery.md, squarespace.md, and hosted-platforms.md
- [ ] Run a test Squarespace import to confirm gallery image extraction still works via WebFetch (Step 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)