### PR TITLE
fix: add PII_PHONE_ALLOW config for phone number scan allowlist

### DIFF
--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -29,6 +29,12 @@ if [[ -f ".site-config" ]]; then
   PII_ALLOW=$(grep '^PII_EMAIL_ALLOW=' .site-config 2>/dev/null | cut -d= -f2- | tr -d ' ' || true)
 fi
 
+# Read PII_PHONE_ALLOW from .site-config (comma-separated list of allowed phone numbers)
+PHONE_ALLOW=""
+if [[ -f ".site-config" ]]; then
+  PHONE_ALLOW=$(grep '^PII_PHONE_ALLOW=' .site-config 2>/dev/null | cut -d= -f2- | tr -d ' ' || true)
+fi
+
 # 1. PII scan — email addresses and phone numbers in built HTML
 EMAIL_HITS=$(grep -rE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' "$DIST/" --include='*.html' 2>/dev/null \
   | grep -v 'charset' | grep -v 'viewport' | grep -v '@astro' \
@@ -47,7 +53,21 @@ if [[ -n "$EMAIL_HITS" ]]; then
   REASONS+=("Possible email address found in built HTML")
 fi
 
-if grep -rE '\(?\d{3}\)?[-.[[:space:]]]?\d{3}[-.[[:space:]]]?\d{4}' "$DIST/" --include='*.html' 2>/dev/null | grep -q .; then
+PHONE_HITS=$(grep -rE '\(?\d{3}\)?[-.[[:space:]]]?\d{3}[-.[[:space:]]]?\d{4}' "$DIST/" --include='*.html' 2>/dev/null || true)
+
+# Filter out allowlisted phone numbers (normalize to digits-only for comparison)
+if [[ -n "$PHONE_HITS" && -n "$PHONE_ALLOW" ]]; then
+  IFS=',' read -ra ALLOWED_PHONES <<< "$PHONE_ALLOW"
+  for phone in "${ALLOWED_PHONES[@]}"; do
+    # Strip non-digit characters for matching
+    digits=$(echo "$phone" | tr -cd '0-9')
+    if [[ -n "$digits" ]]; then
+      PHONE_HITS=$(echo "$PHONE_HITS" | grep -v "$digits" || true)
+    fi
+  done
+fi
+
+if [[ -n "$PHONE_HITS" ]]; then
   REASONS+=("Possible phone number found in built HTML")
 fi
 

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -166,6 +166,7 @@ If you changed it, document it. Same session. No exceptions.
 - On Cloudflare's build system, the build command `npm run build && npm run predeploy` ensures scans also run remotely.
 - Scans: PII (emails, phone numbers), API tokens, third-party scripts, Keystatic admin routes, OG images (warn only)
 - If the site intentionally publishes a contact email (e.g., `mailto:` link), add it to `.site-config`: `PII_EMAIL_ALLOW=me@example.com`
+- If the site intentionally publishes a phone number (e.g., business hotline), add it to `.site-config`: `PII_PHONE_ALLOW=1-800-662-4357`
 - Failed check exits with code 1 and blocks deployment. No exceptions, even if the owner asks.
 
 ### Third-party code

--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -94,10 +94,15 @@ export function scanEmails(content: string, allowlist: string[]): string[] {
   });
 }
 
-export function scanPhones(content: string): boolean {
-  // Reset lastIndex since phonePattern has the global flag
+export function scanPhones(content: string, allowlist: string[] = []): string[] {
   phonePattern.lastIndex = 0;
-  return phonePattern.test(content);
+  const matches = content.match(phonePattern) || [];
+  if (allowlist.length === 0) return matches;
+  // Normalize to digits-only, using last 10 digits for comparison
+  // (handles 1-800 vs 800 country-code prefix differences)
+  const last10 = (s: string) => s.replace(/\D/g, "").slice(-10);
+  const normalizedAllow = allowlist.map(last10);
+  return matches.filter(m => !normalizedAllow.includes(last10(m)));
 }
 
 export function scanTokens(content: string): boolean {
@@ -140,6 +145,15 @@ if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
     .map(e => e.trim().toLowerCase())
     .filter(Boolean);
 
+  /**
+   * Phone numbers the site owner has explicitly approved for publication.
+   * Set in .site-config as: PII_PHONE_ALLOW=1-800-662-4357,555-123-4567
+   */
+  const phoneAllowlist: string[] = (readConfig("PII_PHONE_ALLOW") ?? "")
+    .split(",")
+    .map(p => p.trim())
+    .filter(Boolean);
+
   const failures: string[] = [];
   const warnings: string[] = [];
 
@@ -157,8 +171,9 @@ if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
   // 1b. PII scan — phone numbers
   for (const file of htmlFiles) {
     const content = readFileSync(file, "utf-8");
-    if (scanPhones(content)) {
-      failures.push(`PII: possible phone number in ${file}`);
+    const phoneHits = scanPhones(content, phoneAllowlist);
+    if (phoneHits.length > 0) {
+      failures.push(`PII: possible phone number in ${file}: ${phoneHits.join(", ")}`);
     }
   }
 
@@ -202,7 +217,10 @@ if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
 
   // Report
   if (emailAllowlist.length > 0) {
-    console.log(`PII allowlist: ${emailAllowlist.join(", ")}`);
+    console.log(`PII email allowlist: ${emailAllowlist.join(", ")}`);
+  }
+  if (phoneAllowlist.length > 0) {
+    console.log(`PII phone allowlist: ${phoneAllowlist.join(", ")}`);
   }
 
   if (warnings.length > 0) {

--- a/tests/pre-deploy-check.test.ts
+++ b/tests/pre-deploy-check.test.ts
@@ -80,19 +80,33 @@ describe("scanEmails", () => {
 
 describe("scanPhones", () => {
   it("detects (555) 123-4567", () => {
-    expect(scanPhones("Call us at (555) 123-4567")).toBe(true);
+    expect(scanPhones("Call us at (555) 123-4567")).toEqual(["(555) 123-4567"]);
   });
 
   it("detects 555.123.4567", () => {
-    expect(scanPhones("Phone: 555.123.4567")).toBe(true);
+    expect(scanPhones("Phone: 555.123.4567")).toEqual(["555.123.4567"]);
   });
 
   it("detects 555-123-4567", () => {
-    expect(scanPhones("Phone: 555-123-4567")).toBe(true);
+    expect(scanPhones("Phone: 555-123-4567")).toEqual(["555-123-4567"]);
   });
 
-  it("returns false for content without phone numbers", () => {
-    expect(scanPhones("No phone numbers here.")).toBe(false);
+  it("returns empty array for content without phone numbers", () => {
+    expect(scanPhones("No phone numbers here.")).toEqual([]);
+  });
+
+  it("respects allowlist with exact format match", () => {
+    expect(scanPhones("Call 1-800-662-4357 for help", ["1-800-662-4357"])).toEqual([]);
+  });
+
+  it("respects allowlist with different formatting", () => {
+    // Allowlist uses dashes, content uses dots — should still match via digit normalization
+    expect(scanPhones("Call 800.662.4357 for help", ["1-800-662-4357"])).toEqual([]);
+  });
+
+  it("only filters allowlisted numbers, keeps others", () => {
+    const content = "Call 800-662-4357 or 555-123-4567";
+    expect(scanPhones(content, ["800-662-4357"])).toEqual(["555-123-4567"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `PII_PHONE_ALLOW` config key to `.site-config`, mirroring the existing `PII_EMAIL_ALLOW` mechanism for the pre-deploy phone number scan
- Changes `scanPhones()` from returning `boolean` to returning matched phone strings, enabling allowlist filtering
- Normalizes phone numbers to last 10 digits for comparison, handling `1-800` vs `800` prefix differences
- Updates both TypeScript (`template/scripts/pre-deploy-check.ts`) and shell script (`scripts/pre-deploy-check.sh`) implementations

Closes #174

## Test plan

- [x] Existing phone detection tests updated to match new `string[]` return type
- [x] New tests: exact format match, cross-format matching (dashes vs dots), partial allowlist filtering
- [x] All 34 pre-deploy-check tests pass
- [x] Full test suite passes (1867/1867, excluding pre-existing stylelint failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)