### PR TITLE
fix: suppress glob-loader warnings for empty content collections

### DIFF
--- a/template/src/content.config.ts
+++ b/template/src/content.config.ts
@@ -5,16 +5,17 @@
  * `src/content/`. The Zod schema here must stay in sync with the
  * Keystatic field definitions in `keystatic.config.ts`.
  *
- * Only collections whose `src/content/<name>/` directory exists are
- * exported. This avoids glob-loader warnings for collections that
- * aren't relevant to the site type. Directories are created or removed
- * by `scripts/prune-collections.mjs` during setup.
+ * Only collections whose `src/content/<name>/` directory contains at
+ * least one content file (.mdoc, .mdx, .md) are exported. This avoids
+ * Astro glob-loader warnings for empty or unused collection directories.
+ * Directories are created or removed by `scripts/prune-collections.mjs`
+ * during setup; this file-presence check is a second safety net.
  *
  * @see https://docs.astro.build/en/guides/content-collections/
  * @module
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { defineCollection, z } from "astro:content";
 
 /** Blog posts stored in `src/content/posts/` as `.mdx` / `.mdoc` files. */
@@ -275,14 +276,29 @@ const experiments = defineCollection({
 });
 
 /**
+ * Check whether a content directory has actual content files (.mdoc, .mdx,
+ * .md), not just a `.gitkeep` placeholder. This prevents Astro's glob-loader
+ * from warning about empty collection directories.
+ */
+function hasContentFiles(name: string): boolean {
+  const dir = new URL(`./content/${name}`, import.meta.url);
+  if (!existsSync(dir)) return false;
+  try {
+    return readdirSync(dir).some((f) => /\.(mdoc|mdx|md)$/.test(f));
+  } catch {
+    return false;
+  }
+}
+
+/**
  * All content collections exported for Astro's build pipeline.
- * Only collections with an existing content directory are registered,
- * preventing glob-loader warnings for unused collection types.
+ * Only collections that contain at least one content file are registered,
+ * preventing glob-loader warnings for empty or unused collection directories.
+ * Directories are created or removed by `scripts/prune-collections.mjs`
+ * during setup; this filter provides a second safety net.
  */
 const allCollections = { posts, services, team, testimonials, gallery, events, menus, menuSections, menuItems, faq, products, experiments };
 
 export const collections = Object.fromEntries(
-  Object.entries(allCollections).filter(([name]) =>
-    existsSync(new URL(`./content/${name}`, import.meta.url)),
-  ),
+  Object.entries(allCollections).filter(([name]) => hasContentFiles(name)),
 );

--- a/test/content-collections.test.js
+++ b/test/content-collections.test.js
@@ -27,10 +27,12 @@ describe('content collections', () => {
     }
   });
 
-  it('filters collections by existing directories', () => {
-    // The export should use existsSync to conditionally register collections
+  it('filters collections by actual content files, not just directory existence', () => {
+    // The export should check for .mdoc/.mdx/.md files, not just existsSync on directory
     expect(contentConfig).toContain('existsSync');
+    expect(contentConfig).toContain('readdirSync');
     expect(contentConfig).toContain('Object.fromEntries');
+    expect(contentConfig).toContain('hasContentFiles');
   });
 
   it('defines all collections in keystatic.config.ts', () => {


### PR DESCRIPTION
## Summary

- Changes `content.config.ts` to check for actual content files (`.mdoc`/`.mdx`/`.md`) instead of just directory existence before registering Astro collections
- Empty directories with only `.gitkeep` files no longer trigger `[WARN] [glob-loader] No files found matching` warnings
- Acts as a second safety net alongside `prune-collections.mjs` — even if pruning doesn't run, empty collections stay silent

## Test plan

- [x] All existing tests pass (1869/1869, 4 pre-existing stylelint failures unrelated)
- [x] Updated `content-collections.test.js` to verify `readdirSync` and `hasContentFiles` are used
- [ ] Manual: scaffold a portfolio site, run `npx astro dev`, confirm no glob-loader warnings
- [ ] Manual: add a `.mdoc` file to a collection, confirm it registers and builds correctly

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)