### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Pages.",
   "author": {
     "name": "David W. Keith"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.0] — 2026-04-23
+
+Stable release. All beta blockers resolved, 42 skills, 2018 passing tests.
+
+### Added
+- `/anglesite:design-import` skill — import design tokens and layouts from Canva published sites (#183)
+- `/anglesite:email` skill — business email setup with Apple-first provider recommendations
+- Canva Playwright extraction: colors, fonts, text hierarchy, layout heuristics, design axis inference
+- PII phone number allowlist (`PII_PHONE_ALLOW` in `.site-config`)
+- Content collection pruning by site type — only scaffold collections the site actually needs
+- Serena language server integration for plugin development
+- Style guide and CSS/markdown linting (stylelint + markdownlint)
+- Bug filing workflow for plugin-level issues
+
+### Fixed
+- Import/convert skills now protect existing pages from overwrite (#173)
+- Import skill preserves scaffolded page features instead of overwriting
+- Pagefind CSS variables scoped to `#search` instead of `:root` (#169)
+- Blog post URLs no longer include `.mdoc` extension (#168)
+- Wix Playwright extraction: header logos, footer content, fullPage mode (#166)
+- Playwright resolved from project cwd, not plugin cache (#167)
+- Flat sitemap image extraction warning in import skill (#172)
+- Import scripts renamed from `.js` to `.mjs` for ESM compatibility
+- Empty content collection glob-loader warnings suppressed
+
 ## [1.0.0-beta.1] — 2026-03-31
 
 First beta for the 1.0 release. All 0.16.x blockers resolved — entering QA.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Anglesite is a Claude plugin that scaffolds and manages websites for small businesses. It works with Claude Cowork (non-technical site owners, GUI) and Claude Code (developers, CLI). It generates Astro + Keystatic sites deployed to Cloudflare Pages.
 
-**Version:** 1.0.0-beta.4 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
+**Version:** 1.0.0 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
 
 ## Plugin structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 
 ```
 ├── .claude-plugin/plugin.json    Plugin manifest (name, version, metadata)
-├── skills/                       Skills (41 total: 18 user-facing, 23 model-only)
+├── skills/                       Skills (42 total: 18 user-facing, 24 model-only)
 │   ├── start/SKILL.md            First-time setup + scaffolding
 │   ├── deploy/SKILL.md           Build, scan, deploy to Cloudflare Pages
 │   ├── check/SKILL.md            Health audit + troubleshooting
@@ -22,6 +22,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 │   ├── newsletter/SKILL.md       Email newsletter setup + subscribe form
 │   ├── add-store/SKILL.md        Ecommerce intake (user-facing)
 │   ├── design-interview/SKILL.md Visual identity (model-only)
+│   ├── email/SKILL.md            Business email setup, Apple-first (model-only)
 │   ├── animate/SKILL.md          CSS animations (model-only)
 │   ├── new-page/SKILL.md         Page creation (model-only)
 │   ├── syndicate/SKILL.md        Social media post generation (model-only)
@@ -146,6 +147,7 @@ Two levels of agent instructions exist — do not confuse them:
 | Skill | Purpose |
 |---|---|
 | `design-interview` | Visual identity and branding questionnaire |
+| `email` | Business email setup: Apple-first provider recommendation, DNS pre-fill |
 | `animate` | CSS animations (hover, scroll reveals, transitions) |
 | `creative-canvas` | Interactive visual effects and creative coding (p5.js, Three.js, GSAP, Tone.js, D3.js) |
 | `new-page` | Create new page with SEO and accessibility |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Pages.",
   "scripts": {

--- a/template/package.json
+++ b/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dwk/anglesite",
   "type": "module",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary

- Bumps version from `1.0.0-beta.4` to `1.0.0` across all three manifests (`package.json`, `.claude-plugin/plugin.json`, `template/package.json`) and `CLAUDE.md`
- Adds `[1.0.0]` changelog entry summarizing all changes since beta.1 (design-import skill, email skill, 9 bug fixes, tooling additions)
- All 8 prerequisite issues (#145–#155) are resolved

Closes #156

## Release steps after merge

After merging this PR, run `bin/release.ts` to create the `v1.0.0` tag and push it, which triggers the CI release workflow:

```sh
git tag v1.0.0
git push --tags
```

## Test plan

- [x] All 2018 tests pass (4 pre-existing stylelint failures unrelated to this change)
- [ ] Verify version is `1.0.0` in all three manifests after merge
- [ ] After tagging, verify GitHub Release artifact is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)