### PR TITLE
chore: release v1.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Pages.",
   "author": {
     "name": "David W. Keith"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Anglesite is a Claude plugin that scaffolds and manages websites for small businesses. It works with Claude Cowork (non-technical site owners, GUI) and Claude Code (developers, CLI). It generates Astro + Keystatic sites deployed to Cloudflare Pages.
 
-**Version:** 1.0.0-beta.4 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
+**Version:** 1.0.0 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
 
 ## Plugin structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 
 ```
 ├── .claude-plugin/plugin.json    Plugin manifest (name, version, metadata)
-├── skills/                       Skills (41 total: 18 user-facing, 23 model-only)
+├── skills/                       Skills (42 total: 18 user-facing, 24 model-only)
 │   ├── start/SKILL.md            First-time setup + scaffolding
 │   ├── deploy/SKILL.md           Build, scan, deploy to Cloudflare Pages
 │   ├── check/SKILL.md            Health audit + troubleshooting
@@ -22,6 +22,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 │   ├── newsletter/SKILL.md       Email newsletter setup + subscribe form
 │   ├── add-store/SKILL.md        Ecommerce intake (user-facing)
 │   ├── design-interview/SKILL.md Visual identity (model-only)
+│   ├── email/SKILL.md            Business email setup, Apple-first (model-only)
 │   ├── animate/SKILL.md          CSS animations (model-only)
 │   ├── new-page/SKILL.md         Page creation (model-only)
 │   ├── syndicate/SKILL.md        Social media post generation (model-only)
@@ -146,6 +147,7 @@ Two levels of agent instructions exist — do not confuse them:
 | Skill | Purpose |
 |---|---|
 | `design-interview` | Visual identity and branding questionnaire |
+| `email` | Business email setup: Apple-first provider recommendation, DNS pre-fill |
 | `animate` | CSS animations (hover, scroll reveals, transitions) |
 | `creative-canvas` | Interactive visual effects and creative coding (p5.js, Three.js, GSAP, Tone.js, D3.js) |
 | `new-page` | Create new page with SEO and accessibility |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Pages.",
   "scripts": {

--- a/template/package.json
+++ b/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dwk/anglesite",
   "type": "module",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary

- Bumps version from `1.0.0-beta.4` to `1.0.0` across all three manifests (`package.json`, `.claude-plugin/plugin.json`, `template/package.json`) and `CLAUDE.md`
- All 8 prerequisite issues (#145, #146, #147, #148, #149, #150, #151, #155) are resolved

Closes #156

## Post-merge steps

After merging, run `bin/release.ts` to create the `v1.0.0` tag, which triggers the CI release workflow:

```sh
git tag v1.0.0
git push --tags
```

## Test plan

- [x] All 2018 non-stylelint tests pass (4 pre-existing stylelint failures due to missing dev dependency)
- [ ] Verify version consistency: `jq '.version' package.json .claude-plugin/plugin.json template/package.json` all return `1.0.0`
- [ ] After merge: tag `v1.0.0` and verify GitHub Release artifact is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)