### PR TITLE
feat: add link checker to /anglesite:check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 
 ```
 ├── .claude-plugin/plugin.json    Plugin manifest (name, version, metadata)
-├── skills/                       Skills (41 total: 18 user-facing, 23 model-only)
+├── skills/                       Skills (42 total: 18 user-facing, 24 model-only)
 │   ├── start/SKILL.md            First-time setup + scaffolding
 │   ├── deploy/SKILL.md           Build, scan, deploy to Cloudflare Pages
 │   ├── check/SKILL.md            Health audit + troubleshooting
@@ -22,6 +22,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 │   ├── newsletter/SKILL.md       Email newsletter setup + subscribe form
 │   ├── add-store/SKILL.md        Ecommerce intake (user-facing)
 │   ├── design-interview/SKILL.md Visual identity (model-only)
+│   ├── email/SKILL.md            Business email setup, Apple-first (model-only)
 │   ├── animate/SKILL.md          CSS animations (model-only)
 │   ├── new-page/SKILL.md         Page creation (model-only)
 │   ├── syndicate/SKILL.md        Social media post generation (model-only)
@@ -146,6 +147,7 @@ Two levels of agent instructions exist — do not confuse them:
 | Skill | Purpose |
 |---|---|
 | `design-interview` | Visual identity and branding questionnaire |
+| `email` | Business email setup: Apple-first provider recommendation, DNS pre-fill |
 | `animate` | CSS animations (hover, scroll reveals, transitions) |
 | `creative-canvas` | Interactive visual effects and creative coding (p5.js, Three.js, GSAP, Tone.js, D3.js) |
 | `new-page` | Create new page with SEO and accessibility |

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -2,7 +2,7 @@
 name: check
 description: "Health audit and troubleshooting"
 argument-hint: "[optional: describe the problem]"
-allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(grep *), Bash(find dist/ *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), mcp__claude_ai_tldraw__create_shapes, mcp__claude_ai_tldraw__diagram_drawing_read_me, Write, Read, Glob
+allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(npx tsx scripts/link-check.ts *), Bash(grep *), Bash(find dist/ *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), mcp__claude_ai_tldraw__create_shapes, mcp__claude_ai_tldraw__diagram_drawing_read_me, Write, Read, Glob
 disable-model-invocation: true
 ---
 
@@ -88,12 +88,47 @@ Check that the site works on small screens. Start the dev server if not already 
 - [ ] `npm audit` — check for known vulnerabilities
 - [ ] Images in `public/images/` checked for EXIF GPS data (see `docs/security.md`)
 
+## Link health
+
+Run the automated link checker after a successful build:
+
+```sh
+npm run ai-linkcheck
+```
+
+This scans every page in `dist/` and reports:
+- **Broken internal links** (warn) — hrefs that don't resolve to a file in `dist/`
+- **Orphaned pages** (info) — pages with no inbound link from any other page or sitemap
+
+To also check external links (slower — makes HTTP requests), run:
+
+```sh
+npm run ai-linkcheck -- --external
+```
+
+This additionally reports:
+- **Broken external links** (warn) — URLs that return 4xx/5xx or time out
+- **Redirect chains > 1 hop** (info) — detected from `public/_redirects`
+
+If any links are intentionally broken or external (e.g., internal-only domains, staging URLs), the owner can add them to `.site-config`:
+
+```
+LINK_CHECK_ALLOW=staging.example.com,internal.corp
+```
+
+Multiple patterns are comma-separated. Wildcards are supported: `https://cdn.example.com/*`.
+
+Present link health findings using the same severity mapping as other checks:
+- Broken internal links → **"Worth fixing soon"** with the affected page and target
+- Broken external links → **"Worth fixing soon"** (the linked site may be temporarily down — suggest re-checking)
+- Orphaned pages → **"All good (heads up)"** — mention the page exists but nothing links to it
+- Redirect chains → **"All good (heads up)"** — mention the chain and suggest collapsing it
+
 ## Content and SEO
 - [ ] Every page has a unique `<title>` and `<meta name="description">`
 - [ ] Open Graph tags present (`og:title`, `og:description`, `og:image`)
 - [ ] Sitemap exists at `/sitemap-index.xml`
 - [ ] `robots.txt` exists and includes sitemap URL
-- [ ] No broken internal links — scan `dist/` for hrefs that don't resolve to a file
 - [ ] Blog posts have valid frontmatter (title, description, publishDate)
 - [ ] Business name, address, and contact info are easy to find (not buried)
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deploy
 description: "Build, security scan, and deploy to Cloudflare Pages"
-allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Write, Read
+allowed-tools: Bash(npm run build), Bash(npm run ai-linkcheck *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Write, Read
 disable-model-invocation: true
 ---
 
@@ -78,6 +78,26 @@ Run the SEO audit from `scripts/seo.ts` against the built output in `dist/`. Thi
 **Warnings and Nice-to-haves** are non-blocking. Log them to `seo-report.md` in the project root and briefly mention to the owner: "I found a few SEO improvements you can make later — they're saved in seo-report.md."
 
 If the owner passes `--skip-seo`, skip this step and log a timestamped note to `seo-report.md`: `SEO audit skipped on YYYY-MM-DD HH:MM`.
+
+## Step 2a½ — Link check (opt-in gate)
+
+Read `LINK_CHECK_DEPLOY` from `.site-config`. If set to `true`, run the link checker against the built site:
+
+```sh
+npm run ai-linkcheck
+```
+
+If broken internal links are found, pause the deploy and present them to the owner. Offer to fix or allowlist each one. After fixes, rebuild and re-check.
+
+**This gate is off by default.** Only runs when the owner has opted in via `.site-config`:
+
+```
+LINK_CHECK_DEPLOY=true
+```
+
+Orphaned pages and redirect chains are always non-blocking (info-level). Broken external links are non-blocking even when the gate is enabled — external sites may be temporarily down.
+
+If the owner passes `--skip-linkcheck`, skip this step.
 
 ## Step 2b — Copy quality scan (non-blocking)
 

--- a/template/docs/workflows/check.md
+++ b/template/docs/workflows/check.md
@@ -59,13 +59,28 @@ Manual checks:
 - `npm audit` — check for known vulnerabilities
 - Images in `public/images/` checked for EXIF GPS data
 
+## Link health
+
+Run the automated link checker after a successful build:
+
+```sh
+npm run ai-linkcheck
+```
+
+Reports broken internal links and orphaned pages. Add `--external` to also check external URLs (slower).
+
+If a link is intentionally broken or excluded, add it to `.site-config`:
+
+```
+LINK_CHECK_ALLOW=staging.example.com,internal.corp
+```
+
 ## Content and SEO
 
 - Every page has unique `<title>` and `<meta name="description">`
 - Open Graph tags present (`og:title`, `og:description`, `og:image`)
 - Sitemap at `/sitemap-index.xml`
 - `robots.txt` includes sitemap URL
-- No broken internal links
 
 ## IndieWeb
 

--- a/template/docs/workflows/check.md
+++ b/template/docs/workflows/check.md
@@ -71,7 +71,7 @@ Reports broken internal links and orphaned pages. Add `--external` to also check
 
 If a link is intentionally broken or excluded, add it to `.site-config`:
 
-```
+```text
 LINK_CHECK_ALLOW=staging.example.com,internal.corp
 ```
 

--- a/template/package.json
+++ b/template/package.json
@@ -15,6 +15,7 @@
     "ai-og": "tsx scripts/generate-og-pages.ts",
     "ai-optimize": "tsx scripts/optimize-images.ts",
     "ai-qr": "tsx scripts/qr-generate.ts",
+    "ai-linkcheck": "tsx scripts/link-check.ts",
     "predeploy": "tsx scripts/pre-deploy-check.ts",
     "lint:css": "stylelint 'src/**/*.css'",
     "lint:md": "markdownlint-cli2 'docs/**/*.md' '*.md'"

--- a/template/scripts/link-check.ts
+++ b/template/scripts/link-check.ts
@@ -1,0 +1,512 @@
+/**
+ * Link checker for built Anglesite sites.
+ *
+ * Scans dist/ for broken internal links, broken external links,
+ * orphaned pages, and redirect chains.
+ *
+ * Usage: tsx scripts/link-check.ts [--external] [--json]
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve, extname, dirname, posix } from "node:path";
+import { readConfig } from "./config.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type IssueSeverity = "warn" | "info";
+
+export interface LinkIssue {
+  type: "broken-internal" | "broken-external" | "orphaned-page" | "redirect-chain";
+  severity: IssueSeverity;
+  source: string;
+  target: string;
+  detail: string;
+}
+
+export interface LinkCheckResult {
+  issues: LinkIssue[];
+  stats: {
+    pagesScanned: number;
+    internalLinksChecked: number;
+    externalLinksChecked: number;
+    brokenInternal: number;
+    brokenExternal: number;
+    orphanedPages: number;
+    redirectChains: number;
+  };
+}
+
+export interface RedirectEntry {
+  source: string;
+  destination: string;
+  status: number;
+}
+
+// ---------------------------------------------------------------------------
+// HTML link extraction
+// ---------------------------------------------------------------------------
+
+const hrefPattern = /href\s*=\s*["']([^"']*?)["']/gi;
+
+export function extractLinks(html: string): string[] {
+  const links: string[] = [];
+  let match: RegExpExecArray | null;
+  hrefPattern.lastIndex = 0;
+  while ((match = hrefPattern.exec(html)) !== null) {
+    const href = match[1].trim();
+    if (href) links.push(href);
+  }
+  return links;
+}
+
+export function isInternalLink(href: string): boolean {
+  if (href.startsWith("http://") || href.startsWith("https://") || href.startsWith("//")) {
+    return false;
+  }
+  if (href.startsWith("mailto:") || href.startsWith("tel:") || href.startsWith("javascript:")) {
+    return false;
+  }
+  if (href.startsWith("#") || href.startsWith("data:")) {
+    return false;
+  }
+  return true;
+}
+
+export function isExternalLink(href: string): boolean {
+  return href.startsWith("http://") || href.startsWith("https://") || href.startsWith("//");
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+export function normalizeInternalHref(href: string, sourcePath: string, distDir: string): string {
+  let clean = href.split("#")[0].split("?")[0];
+  if (!clean) return "";
+
+  if (clean.startsWith("/")) {
+    return clean;
+  }
+
+  const sourceRelative = sourcePath.replace(distDir, "").replace(/\\/g, "/");
+  const sourceDir = posix.dirname(sourceRelative);
+  return posix.resolve(sourceDir, clean);
+}
+
+export function resolveInternalLink(normalizedHref: string, distDir: string): boolean {
+  if (!normalizedHref) return true;
+
+  const candidates = [
+    join(distDir, normalizedHref),
+    join(distDir, normalizedHref, "index.html"),
+    join(distDir, normalizedHref + ".html"),
+  ];
+
+  if (normalizedHref.endsWith("/")) {
+    candidates.push(join(distDir, normalizedHref, "index.html"));
+  }
+
+  return candidates.some((c) => existsSync(c) && statSync(c).isFile());
+}
+
+// ---------------------------------------------------------------------------
+// External link checking
+// ---------------------------------------------------------------------------
+
+export async function checkExternalLink(
+  url: string,
+  timeoutMs: number = 10_000,
+  retries: number = 1,
+): Promise<{ ok: boolean; status?: number; error?: string }> {
+  let normalizedUrl = url;
+  if (normalizedUrl.startsWith("//")) {
+    normalizedUrl = "https:" + normalizedUrl;
+  }
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      const response = await fetch(normalizedUrl, {
+        method: "HEAD",
+        signal: controller.signal,
+        redirect: "follow",
+        headers: { "User-Agent": "Anglesite-LinkChecker/1.0" },
+      });
+      clearTimeout(timer);
+
+      if (response.ok || response.status === 405) {
+        if (response.status === 405) {
+          const getController = new AbortController();
+          const getTimer = setTimeout(() => getController.abort(), timeoutMs);
+          const getResponse = await fetch(normalizedUrl, {
+            method: "GET",
+            signal: getController.signal,
+            redirect: "follow",
+            headers: { "User-Agent": "Anglesite-LinkChecker/1.0" },
+          });
+          clearTimeout(getTimer);
+          return { ok: getResponse.ok, status: getResponse.status };
+        }
+        return { ok: true, status: response.status };
+      }
+
+      if (response.status >= 400 && attempt < retries) continue;
+      return { ok: false, status: response.status };
+    } catch (err: unknown) {
+      if (attempt < retries) continue;
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message };
+    }
+  }
+
+  return { ok: false, error: "exhausted retries" };
+}
+
+// ---------------------------------------------------------------------------
+// Redirect chain detection
+// ---------------------------------------------------------------------------
+
+export function parseRedirects(content: string): RedirectEntry[] {
+  const entries: RedirectEntry[] = [];
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const parts = trimmed.split(/\s+/);
+    if (parts.length >= 2) {
+      const source = parts[0];
+      const destination = parts[1];
+      const status = parts[2] ? parseInt(parts[2], 10) : 301;
+      if (source && destination) {
+        entries.push({ source, destination, status });
+      }
+    }
+  }
+  return entries;
+}
+
+export function findRedirectChains(redirects: RedirectEntry[]): LinkIssue[] {
+  const issues: LinkIssue[] = [];
+  const redirectMap = new Map(redirects.map((r) => [r.source, r]));
+
+  for (const redirect of redirects) {
+    const chain: string[] = [redirect.source];
+    let current = redirect.destination;
+    let depth = 0;
+
+    while (redirectMap.has(current) && depth < 10) {
+      chain.push(current);
+      current = redirectMap.get(current)!.destination;
+      depth++;
+    }
+
+    if (chain.length > 2) {
+      issues.push({
+        type: "redirect-chain",
+        severity: "info",
+        source: redirect.source,
+        target: current,
+        detail: `${chain.length}-hop chain: ${chain.join(" → ")} → ${current}`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// Orphaned page detection
+// ---------------------------------------------------------------------------
+
+export function findOrphanedPages(
+  distDir: string,
+  pageFiles: string[],
+  inboundLinks: Map<string, Set<string>>,
+  sitemapPaths: string[],
+): LinkIssue[] {
+  const issues: LinkIssue[] = [];
+
+  for (const page of pageFiles) {
+    const pagePath = page.replace(distDir, "").replace(/\\/g, "/");
+    const normalizedPath = pagePath.replace(/\/index\.html$/, "/").replace(/\.html$/, "/");
+
+    if (normalizedPath === "/" || normalizedPath === "/index.html") continue;
+    if (normalizedPath.includes("/404")) continue;
+
+    const hasInbound = inboundLinks.has(normalizedPath) && inboundLinks.get(normalizedPath)!.size > 0;
+    const altPath = normalizedPath.endsWith("/")
+      ? normalizedPath.slice(0, -1)
+      : normalizedPath + "/";
+    const hasInboundAlt = inboundLinks.has(altPath) && inboundLinks.get(altPath)!.size > 0;
+
+    const inSitemap = sitemapPaths.some(
+      (sp) => sp === normalizedPath || sp === altPath || sp === normalizedPath.replace(/\/$/, ""),
+    );
+
+    if (!hasInbound && !hasInboundAlt && !inSitemap) {
+      issues.push({
+        type: "orphaned-page",
+        severity: "info",
+        source: pagePath,
+        target: "",
+        detail: "No inbound link from any other page or sitemap",
+      });
+    }
+  }
+
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// Sitemap parsing
+// ---------------------------------------------------------------------------
+
+export function extractSitemapUrls(xml: string): string[] {
+  const urls: string[] = [];
+  const locPattern = /<loc>([^<]+)<\/loc>/g;
+  let match: RegExpExecArray | null;
+  while ((match = locPattern.exec(xml)) !== null) {
+    try {
+      const url = new URL(match[1]);
+      urls.push(url.pathname);
+    } catch {
+      urls.push(match[1]);
+    }
+  }
+  return urls;
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist
+// ---------------------------------------------------------------------------
+
+export function parseAllowlist(configValue: string | undefined): string[] {
+  if (!configValue) return [];
+  return configValue
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function isAllowlisted(href: string, allowlist: string[]): boolean {
+  return allowlist.some((pattern) => {
+    if (pattern.includes("*")) {
+      const regex = new RegExp("^" + pattern.replace(/\*/g, ".*") + "$");
+      return regex.test(href);
+    }
+    return href.includes(pattern);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// File walking (reuse pattern from pre-deploy-check.ts)
+// ---------------------------------------------------------------------------
+
+function walkHtml(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkHtml(full));
+    } else if (extname(entry.name) === ".html") {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Main check function
+// ---------------------------------------------------------------------------
+
+export async function checkLinks(
+  distDir: string,
+  options: {
+    checkExternal?: boolean;
+    allowlist?: string[];
+    externalTimeout?: number;
+    externalRetries?: number;
+  } = {},
+): Promise<LinkCheckResult> {
+  const issues: LinkIssue[] = [];
+  const htmlFiles = walkHtml(distDir);
+  const inboundLinks = new Map<string, Set<string>>();
+  let internalLinksChecked = 0;
+  let externalLinksChecked = 0;
+
+  const externalUrls = new Map<string, string[]>();
+
+  for (const file of htmlFiles) {
+    const content = readFileSync(file, "utf-8");
+    const links = extractLinks(content);
+    const sourcePath = file.replace(distDir, "").replace(/\\/g, "/");
+
+    for (const href of links) {
+      if (options.allowlist && isAllowlisted(href, options.allowlist)) continue;
+
+      if (isInternalLink(href)) {
+        internalLinksChecked++;
+        const normalized = normalizeInternalHref(href, file, distDir);
+        if (!normalized) continue;
+
+        const targetPath = normalized.endsWith("/") ? normalized : normalized + "/";
+        const altPath = normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+        for (const p of [targetPath, altPath, normalized]) {
+          if (!inboundLinks.has(p)) inboundLinks.set(p, new Set());
+          inboundLinks.get(p)!.add(sourcePath);
+        }
+
+        if (!resolveInternalLink(normalized, distDir)) {
+          issues.push({
+            type: "broken-internal",
+            severity: "warn",
+            source: sourcePath,
+            target: href,
+            detail: `Link to "${href}" does not resolve to a file in dist/`,
+          });
+        }
+      } else if (isExternalLink(href) && options.checkExternal) {
+        if (!externalUrls.has(href)) externalUrls.set(href, []);
+        externalUrls.get(href)!.push(sourcePath);
+      }
+    }
+  }
+
+  if (options.checkExternal) {
+    for (const [url, sources] of externalUrls) {
+      if (options.allowlist && isAllowlisted(url, options.allowlist)) continue;
+      externalLinksChecked++;
+      const result = await checkExternalLink(
+        url,
+        options.externalTimeout ?? 10_000,
+        options.externalRetries ?? 1,
+      );
+      if (!result.ok) {
+        issues.push({
+          type: "broken-external",
+          severity: "warn",
+          source: sources[0],
+          target: url,
+          detail: result.status
+            ? `HTTP ${result.status}`
+            : `Error: ${result.error}`,
+        });
+      }
+    }
+  }
+
+  // Redirect chains
+  const redirectsPath = join(distDir, "../public/_redirects");
+  const distRedirectsPath = join(distDir, "_redirects");
+  const redirectFile = existsSync(redirectsPath)
+    ? redirectsPath
+    : existsSync(distRedirectsPath)
+      ? distRedirectsPath
+      : null;
+
+  if (redirectFile) {
+    const redirectContent = readFileSync(redirectFile, "utf-8");
+    const redirects = parseRedirects(redirectContent);
+    issues.push(...findRedirectChains(redirects));
+  }
+
+  // Orphaned pages
+  let sitemapPaths: string[] = [];
+  const sitemapFile = join(distDir, "sitemap-index.xml");
+  const sitemapSingle = join(distDir, "sitemap-0.xml");
+  if (existsSync(sitemapSingle)) {
+    sitemapPaths = extractSitemapUrls(readFileSync(sitemapSingle, "utf-8"));
+  } else if (existsSync(sitemapFile)) {
+    sitemapPaths = extractSitemapUrls(readFileSync(sitemapFile, "utf-8"));
+  }
+
+  issues.push(...findOrphanedPages(distDir, htmlFiles, inboundLinks, sitemapPaths));
+
+  return {
+    issues,
+    stats: {
+      pagesScanned: htmlFiles.length,
+      internalLinksChecked,
+      externalLinksChecked,
+      brokenInternal: issues.filter((i) => i.type === "broken-internal").length,
+      brokenExternal: issues.filter((i) => i.type === "broken-external").length,
+      orphanedPages: issues.filter((i) => i.type === "orphaned-page").length,
+      redirectChains: issues.filter((i) => i.type === "redirect-chain").length,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Report formatting
+// ---------------------------------------------------------------------------
+
+export function formatReport(result: LinkCheckResult): string {
+  const lines: string[] = [];
+
+  lines.push(`Link check: ${result.stats.pagesScanned} pages scanned`);
+  lines.push(`  Internal links checked: ${result.stats.internalLinksChecked}`);
+  if (result.stats.externalLinksChecked > 0) {
+    lines.push(`  External links checked: ${result.stats.externalLinksChecked}`);
+  }
+
+  if (result.issues.length === 0) {
+    lines.push("\nNo issues found.");
+    return lines.join("\n");
+  }
+
+  const warnings = result.issues.filter((i) => i.severity === "warn");
+  const infos = result.issues.filter((i) => i.severity === "info");
+
+  if (warnings.length > 0) {
+    lines.push(`\nWarnings (${warnings.length}):`);
+    for (const issue of warnings) {
+      lines.push(`  ${issue.source} → ${issue.target}: ${issue.detail}`);
+    }
+  }
+
+  if (infos.length > 0) {
+    lines.push(`\nInfo (${infos.length}):`);
+    for (const issue of infos) {
+      if (issue.type === "orphaned-page") {
+        lines.push(`  ${issue.source}: ${issue.detail}`);
+      } else {
+        lines.push(`  ${issue.source} → ${issue.target}: ${issue.detail}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (process.argv[1]?.endsWith("link-check.ts")) {
+  const DIST = "dist";
+
+  if (!existsSync(DIST)) {
+    console.error("dist/ not found — run `npm run build` first.");
+    process.exit(1);
+  }
+
+  const checkExternal = process.argv.includes("--external");
+  const jsonOutput = process.argv.includes("--json");
+
+  const allowlist = parseAllowlist(readConfig("LINK_CHECK_ALLOW"));
+
+  checkLinks(DIST, { checkExternal, allowlist }).then((result) => {
+    if (jsonOutput) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(formatReport(result));
+    }
+
+    if (result.stats.brokenInternal > 0 || result.stats.brokenExternal > 0) {
+      process.exit(1);
+    }
+  });
+}

--- a/tests/link-check.test.ts
+++ b/tests/link-check.test.ts
@@ -1,0 +1,496 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  extractLinks,
+  isInternalLink,
+  isExternalLink,
+  normalizeInternalHref,
+  resolveInternalLink,
+  parseRedirects,
+  findRedirectChains,
+  findOrphanedPages,
+  extractSitemapUrls,
+  parseAllowlist,
+  isAllowlisted,
+  checkLinks,
+  formatReport,
+} from "../template/scripts/link-check.js";
+
+// ---------------------------------------------------------------------------
+// extractLinks
+// ---------------------------------------------------------------------------
+
+describe("extractLinks", () => {
+  it("extracts href values from anchor tags", () => {
+    const html = '<a href="/about">About</a><a href="/contact">Contact</a>';
+    expect(extractLinks(html)).toEqual(["/about", "/contact"]);
+  });
+
+  it("handles single and double quotes", () => {
+    const html = `<a href="/one">1</a><a href='/two'>2</a>`;
+    expect(extractLinks(html)).toEqual(["/one", "/two"]);
+  });
+
+  it("extracts href from link tags", () => {
+    const html = '<link href="/styles.css" rel="stylesheet">';
+    expect(extractLinks(html)).toEqual(["/styles.css"]);
+  });
+
+  it("returns empty array for no links", () => {
+    expect(extractLinks("<p>No links here</p>")).toEqual([]);
+  });
+
+  it("skips empty href values", () => {
+    const html = '<a href="">empty</a><a href="/real">real</a>';
+    expect(extractLinks(html)).toEqual(["/real"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isInternalLink / isExternalLink
+// ---------------------------------------------------------------------------
+
+describe("isInternalLink", () => {
+  it("returns true for absolute paths", () => {
+    expect(isInternalLink("/about")).toBe(true);
+  });
+
+  it("returns true for relative paths", () => {
+    expect(isInternalLink("../contact")).toBe(true);
+  });
+
+  it("returns false for http URLs", () => {
+    expect(isInternalLink("http://example.com")).toBe(false);
+  });
+
+  it("returns false for https URLs", () => {
+    expect(isInternalLink("https://example.com")).toBe(false);
+  });
+
+  it("returns false for protocol-relative URLs", () => {
+    expect(isInternalLink("//example.com/path")).toBe(false);
+  });
+
+  it("returns false for mailto links", () => {
+    expect(isInternalLink("mailto:info@example.com")).toBe(false);
+  });
+
+  it("returns false for tel links", () => {
+    expect(isInternalLink("tel:+15551234567")).toBe(false);
+  });
+
+  it("returns false for fragment-only links", () => {
+    expect(isInternalLink("#section")).toBe(false);
+  });
+
+  it("returns false for javascript: links", () => {
+    expect(isInternalLink("javascript:void(0)")).toBe(false);
+  });
+
+  it("returns false for data: URIs", () => {
+    expect(isInternalLink("data:text/html,<h1>hi</h1>")).toBe(false);
+  });
+});
+
+describe("isExternalLink", () => {
+  it("returns true for http URLs", () => {
+    expect(isExternalLink("http://example.com")).toBe(true);
+  });
+
+  it("returns true for https URLs", () => {
+    expect(isExternalLink("https://example.com")).toBe(true);
+  });
+
+  it("returns true for protocol-relative URLs", () => {
+    expect(isExternalLink("//cdn.example.com/script.js")).toBe(true);
+  });
+
+  it("returns false for absolute paths", () => {
+    expect(isExternalLink("/about")).toBe(false);
+  });
+
+  it("returns false for relative paths", () => {
+    expect(isExternalLink("../page")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeInternalHref
+// ---------------------------------------------------------------------------
+
+describe("normalizeInternalHref", () => {
+  it("returns absolute paths unchanged", () => {
+    expect(normalizeInternalHref("/about", "/tmp/dist/index.html", "/tmp/dist")).toBe("/about");
+  });
+
+  it("strips hash fragments", () => {
+    expect(normalizeInternalHref("/about#section", "/tmp/dist/index.html", "/tmp/dist")).toBe("/about");
+  });
+
+  it("strips query parameters", () => {
+    expect(normalizeInternalHref("/search?q=test", "/tmp/dist/index.html", "/tmp/dist")).toBe("/search");
+  });
+
+  it("returns empty string for fragment-only href after stripping", () => {
+    expect(normalizeInternalHref("#top", "/tmp/dist/index.html", "/tmp/dist")).toBe("");
+  });
+
+  it("resolves relative paths against the source directory", () => {
+    const result = normalizeInternalHref("../about", "/tmp/dist/blog/post.html", "/tmp/dist");
+    expect(result).toBe("/about");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveInternalLink
+// ---------------------------------------------------------------------------
+
+describe("resolveInternalLink", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-linkcheck-"));
+    mkdirSync(join(tmpDir, "about"), { recursive: true });
+    writeFileSync(join(tmpDir, "index.html"), "<html></html>");
+    writeFileSync(join(tmpDir, "about", "index.html"), "<html></html>");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("resolves root index", () => {
+    expect(resolveInternalLink("/", tmpDir)).toBe(true);
+  });
+
+  it("resolves directory with index.html", () => {
+    expect(resolveInternalLink("/about", tmpDir)).toBe(true);
+  });
+
+  it("resolves directory with trailing slash", () => {
+    expect(resolveInternalLink("/about/", tmpDir)).toBe(true);
+  });
+
+  it("returns false for non-existent path", () => {
+    expect(resolveInternalLink("/nonexistent", tmpDir)).toBe(false);
+  });
+
+  it("returns true for empty normalized href", () => {
+    expect(resolveInternalLink("", tmpDir)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRedirects
+// ---------------------------------------------------------------------------
+
+describe("parseRedirects", () => {
+  it("parses source destination pairs", () => {
+    const result = parseRedirects("/old /new 301");
+    expect(result).toEqual([{ source: "/old", destination: "/new", status: 301 }]);
+  });
+
+  it("defaults to 301 status", () => {
+    const result = parseRedirects("/old /new");
+    expect(result).toEqual([{ source: "/old", destination: "/new", status: 301 }]);
+  });
+
+  it("skips comments and blank lines", () => {
+    const content = "# comment\n\n/old /new 302\n";
+    const result = parseRedirects(content);
+    expect(result).toEqual([{ source: "/old", destination: "/new", status: 302 }]);
+  });
+
+  it("handles multiple redirects", () => {
+    const content = "/a /b 301\n/c /d 302";
+    const result = parseRedirects(content);
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findRedirectChains
+// ---------------------------------------------------------------------------
+
+describe("findRedirectChains", () => {
+  it("detects a 2-hop chain (3 entries)", () => {
+    const redirects = [
+      { source: "/a", destination: "/b", status: 301 },
+      { source: "/b", destination: "/c", status: 301 },
+      { source: "/c", destination: "/d", status: 301 },
+    ];
+    const issues = findRedirectChains(redirects);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues[0].type).toBe("redirect-chain");
+  });
+
+  it("does not flag single-hop redirects", () => {
+    const redirects = [
+      { source: "/old", destination: "/new", status: 301 },
+    ];
+    const issues = findRedirectChains(redirects);
+    expect(issues).toEqual([]);
+  });
+
+  it("does not flag two independent redirects", () => {
+    const redirects = [
+      { source: "/a", destination: "/x", status: 301 },
+      { source: "/b", destination: "/y", status: 301 },
+    ];
+    const issues = findRedirectChains(redirects);
+    expect(issues).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findOrphanedPages
+// ---------------------------------------------------------------------------
+
+describe("findOrphanedPages", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-orphan-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects orphaned pages with no inbound links", () => {
+    const pages = [
+      join(tmpDir, "index.html"),
+      join(tmpDir, "about/index.html"),
+      join(tmpDir, "orphan/index.html"),
+    ];
+    const inbound = new Map<string, Set<string>>();
+    inbound.set("/about/", new Set(["/"]) );
+
+    const issues = findOrphanedPages(tmpDir, pages, inbound, []);
+    expect(issues.some((i) => i.source.includes("orphan"))).toBe(true);
+  });
+
+  it("skips the homepage", () => {
+    const pages = [join(tmpDir, "index.html")];
+    const issues = findOrphanedPages(tmpDir, pages, new Map(), []);
+    expect(issues).toEqual([]);
+  });
+
+  it("skips 404 pages", () => {
+    const pages = [join(tmpDir, "index.html"), join(tmpDir, "404.html")];
+    const issues = findOrphanedPages(tmpDir, pages, new Map(), []);
+    expect(issues).toEqual([]);
+  });
+
+  it("does not flag pages with inbound links", () => {
+    const pages = [
+      join(tmpDir, "index.html"),
+      join(tmpDir, "about/index.html"),
+    ];
+    const inbound = new Map<string, Set<string>>();
+    inbound.set("/about/", new Set(["/"]));
+
+    const issues = findOrphanedPages(tmpDir, pages, inbound, []);
+    expect(issues).toEqual([]);
+  });
+
+  it("does not flag pages in the sitemap", () => {
+    const pages = [
+      join(tmpDir, "index.html"),
+      join(tmpDir, "hidden/index.html"),
+    ];
+    const issues = findOrphanedPages(tmpDir, pages, new Map(), ["/hidden/"]);
+    expect(issues).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractSitemapUrls
+// ---------------------------------------------------------------------------
+
+describe("extractSitemapUrls", () => {
+  it("extracts paths from sitemap XML", () => {
+    const xml = `<?xml version="1.0"?>
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <url><loc>https://example.com/about</loc></url>
+        <url><loc>https://example.com/blog/</loc></url>
+      </urlset>`;
+    const result = extractSitemapUrls(xml);
+    expect(result).toEqual(["/about", "/blog/"]);
+  });
+
+  it("returns empty array for empty XML", () => {
+    expect(extractSitemapUrls("")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Allowlist
+// ---------------------------------------------------------------------------
+
+describe("parseAllowlist", () => {
+  it("splits comma-separated values", () => {
+    expect(parseAllowlist("example.com,test.org")).toEqual(["example.com", "test.org"]);
+  });
+
+  it("trims whitespace", () => {
+    expect(parseAllowlist(" example.com , test.org ")).toEqual(["example.com", "test.org"]);
+  });
+
+  it("returns empty array for undefined", () => {
+    expect(parseAllowlist(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseAllowlist("")).toEqual([]);
+  });
+});
+
+describe("isAllowlisted", () => {
+  it("matches substring patterns", () => {
+    expect(isAllowlisted("https://example.com/page", ["example.com"])).toBe(true);
+  });
+
+  it("returns false for non-matching patterns", () => {
+    expect(isAllowlisted("https://other.com/page", ["example.com"])).toBe(false);
+  });
+
+  it("supports wildcard patterns", () => {
+    expect(isAllowlisted("https://cdn.example.com/script.js", ["https://cdn.example.com/*"])).toBe(true);
+  });
+
+  it("wildcard does not match without prefix", () => {
+    expect(isAllowlisted("https://other.com/page", ["https://example.com/*"])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkLinks (integration)
+// ---------------------------------------------------------------------------
+
+describe("checkLinks", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anglesite-checklinks-"));
+    mkdirSync(join(tmpDir, "about"), { recursive: true });
+    mkdirSync(join(tmpDir, "blog"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds broken internal links", async () => {
+    writeFileSync(
+      join(tmpDir, "index.html"),
+      '<html><body><a href="/about">About</a><a href="/nonexistent">Broken</a></body></html>',
+    );
+    writeFileSync(join(tmpDir, "about", "index.html"), "<html><body>About page</body></html>");
+
+    const result = await checkLinks(tmpDir);
+    expect(result.stats.brokenInternal).toBe(1);
+    expect(result.issues[0].target).toBe("/nonexistent");
+  });
+
+  it("reports no issues for valid internal links", async () => {
+    writeFileSync(
+      join(tmpDir, "index.html"),
+      '<html><body><a href="/about">About</a><a href="/blog">Blog</a></body></html>',
+    );
+    writeFileSync(join(tmpDir, "about", "index.html"), '<html><body><a href="/">Home</a></body></html>');
+    writeFileSync(join(tmpDir, "blog", "index.html"), '<html><body><a href="/">Home</a></body></html>');
+
+    const result = await checkLinks(tmpDir);
+    expect(result.stats.brokenInternal).toBe(0);
+  });
+
+  it("detects orphaned pages", async () => {
+    writeFileSync(
+      join(tmpDir, "index.html"),
+      '<html><body><a href="/about">About</a></body></html>',
+    );
+    writeFileSync(join(tmpDir, "about", "index.html"), '<html><body><a href="/">Home</a></body></html>');
+    writeFileSync(join(tmpDir, "blog", "index.html"), "<html><body>Orphan</body></html>");
+
+    const result = await checkLinks(tmpDir);
+    expect(result.stats.orphanedPages).toBe(1);
+    expect(result.issues.some((i) => i.type === "orphaned-page" && i.source.includes("blog"))).toBe(true);
+  });
+
+  it("respects allowlist for internal links", async () => {
+    writeFileSync(
+      join(tmpDir, "index.html"),
+      '<html><body><a href="/nonexistent">Broken</a></body></html>',
+    );
+
+    const result = await checkLinks(tmpDir, { allowlist: ["/nonexistent"] });
+    expect(result.stats.brokenInternal).toBe(0);
+  });
+
+  it("counts pages scanned correctly", async () => {
+    writeFileSync(join(tmpDir, "index.html"), "<html></html>");
+    writeFileSync(join(tmpDir, "about", "index.html"), "<html></html>");
+    writeFileSync(join(tmpDir, "blog", "index.html"), "<html></html>");
+
+    const result = await checkLinks(tmpDir);
+    expect(result.stats.pagesScanned).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatReport
+// ---------------------------------------------------------------------------
+
+describe("formatReport", () => {
+  it("shows no-issues message when clean", () => {
+    const report = formatReport({
+      issues: [],
+      stats: {
+        pagesScanned: 5,
+        internalLinksChecked: 10,
+        externalLinksChecked: 0,
+        brokenInternal: 0,
+        brokenExternal: 0,
+        orphanedPages: 0,
+        redirectChains: 0,
+      },
+    });
+    expect(report).toContain("No issues found");
+    expect(report).toContain("5 pages scanned");
+  });
+
+  it("groups warnings and info separately", () => {
+    const report = formatReport({
+      issues: [
+        {
+          type: "broken-internal",
+          severity: "warn",
+          source: "/index.html",
+          target: "/broken",
+          detail: "Not found",
+        },
+        {
+          type: "orphaned-page",
+          severity: "info",
+          source: "/orphan/index.html",
+          target: "",
+          detail: "No inbound link",
+        },
+      ],
+      stats: {
+        pagesScanned: 3,
+        internalLinksChecked: 5,
+        externalLinksChecked: 0,
+        brokenInternal: 1,
+        brokenExternal: 0,
+        orphanedPages: 1,
+        redirectChains: 0,
+      },
+    });
+    expect(report).toContain("Warnings (1)");
+    expect(report).toContain("Info (1)");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `template/scripts/link-check.ts` — a pure TypeScript link checker that scans `dist/` for broken internal links, orphaned pages, redirect chains, and optionally broken external links
- Integrates into the check skill as an automated "Link health" section (replaces the manual broken-link checklist item)
- Adds opt-in deploy gate via `LINK_CHECK_DEPLOY=true` in `.site-config` (off by default, as specified in the issue)
- Supports allowlisting via `LINK_CHECK_ALLOW=pattern1,pattern2` in `.site-config` with wildcard support

Closes #195

## Test plan

- [x] 59 unit tests covering: link extraction, internal/external classification, path normalization, internal link resolution, redirect parsing, chain detection, orphan detection, sitemap parsing, allowlist parsing, integration check, and report formatting
- [x] Full test suite passes with no regressions (5 pre-existing failures unrelated to this change)
- [ ] Manual: scaffold a site, build, run `npm run ai-linkcheck` and verify output
- [ ] Manual: add a broken link, verify it's detected
- [ ] Manual: add `LINK_CHECK_ALLOW=<pattern>` and verify the link is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)