### PR TITLE
feat: add WordPress import support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 
 ```
 ├── .claude-plugin/plugin.json    Plugin manifest (name, version, metadata)
-├── skills/                       Skills (41 total: 18 user-facing, 23 model-only)
+├── skills/                       Skills (42 total: 18 user-facing, 24 model-only)
 │   ├── start/SKILL.md            First-time setup + scaffolding
 │   ├── deploy/SKILL.md           Build, scan, deploy to Cloudflare Pages
 │   ├── check/SKILL.md            Health audit + troubleshooting
@@ -22,6 +22,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 │   ├── newsletter/SKILL.md       Email newsletter setup + subscribe form
 │   ├── add-store/SKILL.md        Ecommerce intake (user-facing)
 │   ├── design-interview/SKILL.md Visual identity (model-only)
+│   ├── email/SKILL.md            Business email setup, Apple-first (model-only)
 │   ├── animate/SKILL.md          CSS animations (model-only)
 │   ├── new-page/SKILL.md         Page creation (model-only)
 │   ├── syndicate/SKILL.md        Social media post generation (model-only)
@@ -146,6 +147,7 @@ Two levels of agent instructions exist — do not confuse them:
 | Skill | Purpose |
 |---|---|
 | `design-interview` | Visual identity and branding questionnaire |
+| `email` | Business email setup: Apple-first provider recommendation, DNS pre-fill |
 | `animate` | CSS animations (hover, scroll reveals, transitions) |
 | `creative-canvas` | Interactive visual effects and creative coding (p5.js, Three.js, GSAP, Tone.js, D3.js) |
 | `new-page` | Create new page with SEO and accessibility |

--- a/scripts/import/wordpress/wp-content-clean.mjs
+++ b/scripts/import/wordpress/wp-content-clean.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+// WordPress content cleaning utilities.
+//
+// Converts WordPress post/page HTML (from content.rendered or
+// content:encoded) into clean Markdown suitable for .mdoc files.
+//
+// Handles WordPress-specific patterns: Gutenberg block comments,
+// shortcodes, wp-block-* classes, and HTML entity encoding.
+//
+// Usage (CLI):
+//   node wp-content-clean.mjs html <file.html>   # Clean HTML → Markdown
+//   node wp-content-clean.mjs images <file.html>  # Extract image URLs
+//
+// All commands output JSON to stdout.
+
+import { readFileSync } from 'node:fs';
+import { decodeEntities } from './wp-xml-parse.mjs';
+
+// ---------------------------------------------------------------------------
+// Strip WordPress block comments (Gutenberg)
+// ---------------------------------------------------------------------------
+
+export function stripBlockComments(html) {
+  if (!html) return '';
+  return html.replace(/<!--\s*\/?wp:[a-z][a-z0-9-/]*(?:\s+\{[^}]*\})?\s*-->/g, '');
+}
+
+// ---------------------------------------------------------------------------
+// Strip WordPress shortcodes
+// ---------------------------------------------------------------------------
+
+const SHORTCODE_WITH_CONTENT = /\[(gallery|caption|embed|audio|video|playlist)\b[^\]]*\]([\s\S]*?)\[\/\1\]/gi;
+const SHORTCODE_SELF_CLOSING = /\[(gallery|caption|embed|audio|video|playlist|wp_caption|jetpack[_-]\w+|contact-form|gravityform|woocommerce_[a-z_]+|vc_\w+|fusion_\w+|et_pb_\w+)\b[^\]]*\/?]/gi;
+
+export function stripShortcodes(html) {
+  if (!html) return '';
+  let result = html.replace(SHORTCODE_WITH_CONTENT, (_, tag, inner) => {
+    const cleaned = inner.replace(/<[^>]*>/g, '').trim();
+    return cleaned || '';
+  });
+  result = result.replace(SHORTCODE_SELF_CLOSING, '');
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Strip wp-block-* class attributes and other WordPress-specific attributes
+// ---------------------------------------------------------------------------
+
+export function stripWpClasses(html) {
+  if (!html) return '';
+  return html
+    .replace(/\s+class="[^"]*wp-block-[^"]*"/gi, '')
+    .replace(/\s+class="[^"]*wp-image-[^"]*"/gi, '')
+    .replace(/\s+class="[^"]*aligncenter[^"]*"/gi, '')
+    .replace(/\s+class="[^"]*alignleft[^"]*"/gi, '')
+    .replace(/\s+class="[^"]*alignright[^"]*"/gi, '')
+    .replace(/\s+class="[^"]*alignnone[^"]*"/gi, '')
+    .replace(/\s+class="[^"]*size-[a-z]+[^"]*"/gi, '')
+    .replace(/\s+class="[^"]*has-[a-z]+-[a-z]+-color[^"]*"/gi, '')
+    .replace(/\s+id="[^"]*"/gi, '')
+    .replace(/\s+style="[^"]*"/gi, '')
+    .replace(/\s+data-[a-z-]+="[^"]*"/gi, '');
+}
+
+// ---------------------------------------------------------------------------
+// Extract image URLs from WordPress HTML content
+// ---------------------------------------------------------------------------
+
+export function extractImages(html) {
+  if (!html) return [];
+  const images = [];
+  const re = /<img\s[^>]*>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const tag = m[0];
+    const srcMatch = tag.match(/src=["']([^"']+)["']/);
+    const altMatch = tag.match(/alt=["']([^"']*?)["']/);
+    if (srcMatch) {
+      images.push({
+        src: decodeEntities(srcMatch[1]),
+        alt: altMatch ? decodeEntities(altMatch[1]) : '',
+      });
+    }
+  }
+  return images;
+}
+
+// ---------------------------------------------------------------------------
+// HTML-to-Markdown conversion
+// ---------------------------------------------------------------------------
+
+export function htmlToMarkdown(html) {
+  if (!html) return '';
+
+  let md = html;
+
+  md = stripBlockComments(md);
+  md = stripShortcodes(md);
+  md = stripWpClasses(md);
+
+  md = md.replace(/<script[\s\S]*?<\/script>/gi, '');
+  md = md.replace(/<style[\s\S]*?<\/style>/gi, '');
+  md = md.replace(/<nav[\s\S]*?<\/nav>/gi, '');
+
+  md = md.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_, level, content) => {
+    const text = content.replace(/<[^>]*>/g, '').trim();
+    return `\n${'#'.repeat(Number(level))} ${text}\n`;
+  });
+
+  md = md.replace(/<blockquote[^>]*>([\s\S]*?)<\/blockquote>/gi, (_, content) => {
+    const text = content.replace(/<[^>]*>/g, '').trim();
+    return text.split('\n').map((line) => `> ${line}`).join('\n');
+  });
+
+  md = md.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (_, content) => {
+    const text = content.replace(/<[^>]*>/g, '').trim();
+    return `- ${text}`;
+  });
+  md = md.replace(/<\/?[ou]l[^>]*>/gi, '\n');
+
+  md = md.replace(/<a\s[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi, (_, href, inner) => {
+    const text = inner.replace(/<[^>]*>/g, '').trim();
+    return text ? `[${text}](${href})` : '';
+  });
+
+  md = md.replace(/<img\s[^>]*src=["']([^"']+)["'][^>]*alt=["']([^"']*?)["'][^>]*\/?>/gi,
+    (_, src, alt) => `![${alt}](${src})`);
+  md = md.replace(/<img\s[^>]*alt=["']([^"']*?)["'][^>]*src=["']([^"']+)["'][^>]*\/?>/gi,
+    (_, alt, src) => `![${alt}](${src})`);
+  md = md.replace(/<img\s[^>]*src=["']([^"']+)["'][^>]*\/?>/gi,
+    (_, src) => `![](${src})`);
+
+  md = md.replace(/<strong[^>]*>([\s\S]*?)<\/strong>/gi, (_, t) => `**${t.replace(/<[^>]*>/g, '').trim()}**`);
+  md = md.replace(/<b[^>]*>([\s\S]*?)<\/b>/gi, (_, t) => `**${t.replace(/<[^>]*>/g, '').trim()}**`);
+  md = md.replace(/<em[^>]*>([\s\S]*?)<\/em>/gi, (_, t) => `*${t.replace(/<[^>]*>/g, '').trim()}*`);
+  md = md.replace(/<i[^>]*>([\s\S]*?)<\/i>/gi, (_, t) => `*${t.replace(/<[^>]*>/g, '').trim()}*`);
+  md = md.replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, (_, t) => `\`${t.replace(/<[^>]*>/g, '').trim()}\``);
+
+  md = md.replace(/<pre[^>]*>([\s\S]*?)<\/pre>/gi, (_, content) => {
+    const code = content.replace(/<[^>]*>/g, '').trim();
+    return `\n\`\`\`\n${code}\n\`\`\`\n`;
+  });
+
+  md = md.replace(/<hr\s*\/?>/gi, '\n---\n');
+
+  md = md.replace(/<br\s*\/?>/gi, '\n');
+
+  md = md.replace(/<\/p>/gi, '\n\n');
+  md = md.replace(/<p[^>]*>/gi, '');
+
+  md = md.replace(/<\/div>/gi, '\n');
+  md = md.replace(/<div[^>]*>/gi, '');
+
+  md = md.replace(/<figure[^>]*>([\s\S]*?)<\/figure>/gi, (_, content) => {
+    const imgMatch = content.match(/!\[[^\]]*\]\([^)]+\)/);
+    const captionMatch = content.match(/<figcaption[^>]*>([\s\S]*?)<\/figcaption>/i);
+    if (imgMatch) {
+      const caption = captionMatch ? captionMatch[1].replace(/<[^>]*>/g, '').trim() : '';
+      return caption ? `${imgMatch[0]}\n*${caption}*` : imgMatch[0];
+    }
+    return content.replace(/<[^>]*>/g, '').trim();
+  });
+
+  md = md.replace(/<[^>]+>/g, '');
+
+  md = decodeEntities(md);
+
+  md = md.replace(/\n{3,}/g, '\n\n');
+  md = md.trim();
+
+  return md;
+}
+
+// ---------------------------------------------------------------------------
+// Full content pipeline: WXR content → clean Markdown + images
+// ---------------------------------------------------------------------------
+
+export function cleanContent(rawHtml) {
+  const images = extractImages(rawHtml);
+  const markdown = htmlToMarkdown(rawHtml);
+  return { markdown, images };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+const [,, command, arg] = process.argv;
+
+if (command && arg) {
+  const html = readFileSync(arg, 'utf-8');
+  let output;
+  switch (command) {
+    case 'html':
+      output = cleanContent(html);
+      break;
+    case 'images':
+      output = extractImages(html);
+      break;
+    default:
+      console.error(`Unknown command: ${command}. Use: html, images`);
+      process.exitCode = 1;
+  }
+  if (output) {
+    console.log(JSON.stringify(output, null, 2));
+  }
+}

--- a/scripts/import/wordpress/wp-xml-parse.mjs
+++ b/scripts/import/wordpress/wp-xml-parse.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+
+// WordPress WXR (WordPress eXtended RSS) XML parser.
+//
+// Parses a WXR export file and extracts posts, pages, media attachments,
+// categories, tags, navigation menus, and authors into structured JSON.
+//
+// Usage (CLI):
+//   node wp-xml-parse.mjs <wxr-file.xml>              # Parse everything
+//   node wp-xml-parse.mjs <wxr-file.xml> --posts       # Posts only
+//   node wp-xml-parse.mjs <wxr-file.xml> --pages       # Pages only
+//   node wp-xml-parse.mjs <wxr-file.xml> --media       # Media attachments only
+//   node wp-xml-parse.mjs <wxr-file.xml> --taxonomies  # Categories + tags only
+//
+// All commands output JSON to stdout.
+
+import { readFileSync } from 'node:fs';
+
+// ---------------------------------------------------------------------------
+// XML helpers — lightweight tag extraction without a full DOM parser.
+// WXR files are well-formed RSS 2.0 with WordPress namespaces, so regex
+// extraction on the known tag set is reliable and avoids a dependency.
+// ---------------------------------------------------------------------------
+
+function getTagContent(xml, tag) {
+  const re = new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</${tag}>`, 'i');
+  const m = xml.match(re);
+  return m ? m[1].trim() : '';
+}
+
+function getCdataContent(xml, tag) {
+  const re = new RegExp(`<${tag}(?:\\s[^>]*)?>\\s*<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>\\s*</${tag}>`, 'i');
+  const m = xml.match(re);
+  return m ? m[1] : '';
+}
+
+function getAllItems(xml) {
+  const items = [];
+  const re = /<item>([\s\S]*?)<\/item>/gi;
+  let m;
+  while ((m = re.exec(xml)) !== null) {
+    items.push(m[1]);
+  }
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// HTML entity decoding
+// ---------------------------------------------------------------------------
+
+const HTML_ENTITIES = {
+  '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#039;': "'",
+  '&apos;': "'", '&#8217;': '’', '&#8216;': '‘', '&#8220;': '“',
+  '&#8221;': '”', '&#8211;': '–', '&#8212;': '—',
+  '&#8230;': '…', '&nbsp;': ' ', '&#160;': ' ',
+};
+
+export function decodeEntities(text) {
+  if (!text) return '';
+  let result = text.replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)));
+  result = result.replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+  for (const [entity, char] of Object.entries(HTML_ENTITIES)) {
+    result = result.replaceAll(entity, char);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Parse categories and tags from <wp:category> and <wp:tag> channel elements
+// ---------------------------------------------------------------------------
+
+export function parseTaxonomies(xml) {
+  const categories = [];
+  const tags = [];
+
+  const catRe = /<wp:category>([\s\S]*?)<\/wp:category>/gi;
+  let m;
+  while ((m = catRe.exec(xml)) !== null) {
+    const block = m[1];
+    const slug = getTagContent(block, 'wp:category_nicename');
+    const name = getCdataContent(block, 'wp:cat_name') || slug;
+    const parent = getTagContent(block, 'wp:category_parent') || null;
+    categories.push({ slug, name: decodeEntities(name), parent });
+  }
+
+  const tagRe = /<wp:tag>([\s\S]*?)<\/wp:tag>/gi;
+  while ((m = tagRe.exec(xml)) !== null) {
+    const block = m[1];
+    const slug = getTagContent(block, 'wp:tag_slug');
+    const name = getCdataContent(block, 'wp:tag_name') || slug;
+    tags.push({ slug, name: decodeEntities(name) });
+  }
+
+  return { categories, tags };
+}
+
+// ---------------------------------------------------------------------------
+// Parse authors from <wp:author> channel elements
+// ---------------------------------------------------------------------------
+
+export function parseAuthors(xml) {
+  const authors = [];
+  const re = /<wp:author>([\s\S]*?)<\/wp:author>/gi;
+  let m;
+  while ((m = re.exec(xml)) !== null) {
+    const block = m[1];
+    authors.push({
+      login: getCdataContent(block, 'wp:author_login') || getTagContent(block, 'wp:author_login'),
+      email: getCdataContent(block, 'wp:author_email') || getTagContent(block, 'wp:author_email'),
+      displayName: getCdataContent(block, 'wp:author_display_name') || getTagContent(block, 'wp:author_display_name'),
+    });
+  }
+  return authors;
+}
+
+// ---------------------------------------------------------------------------
+// Parse a single <item> into a structured object
+// ---------------------------------------------------------------------------
+
+export function parseItem(itemXml) {
+  const postType = getTagContent(itemXml, 'wp:post_type') || 'post';
+  const status = getTagContent(itemXml, 'wp:status') || 'publish';
+  const title = decodeEntities(getTagContent(itemXml, 'title'));
+  const link = getTagContent(itemXml, 'link');
+  const slug = getTagContent(itemXml, 'wp:post_name');
+  const content = getCdataContent(itemXml, 'content:encoded');
+  const excerpt = getCdataContent(itemXml, 'excerpt:encoded');
+  const dateRaw = getTagContent(itemXml, 'wp:post_date');
+  const publishDate = dateRaw ? dateRaw.slice(0, 10) : '';
+  const postId = getTagContent(itemXml, 'wp:post_id');
+
+  const categories = [];
+  const tags = [];
+  const catRe = /<category\s+domain="([^"]+)"[^>]*><!\[CDATA\[([\s\S]*?)\]\]><\/category>/gi;
+  let m;
+  while ((m = catRe.exec(itemXml)) !== null) {
+    const domain = m[1];
+    const name = m[2].trim();
+    if (domain === 'category') categories.push(name);
+    else if (domain === 'post_tag') tags.push(name);
+  }
+
+  const attachmentUrl = getTagContent(itemXml, 'wp:attachment_url');
+
+  const metaEntries = [];
+  const metaRe = /<wp:postmeta>([\s\S]*?)<\/wp:postmeta>/gi;
+  while ((m = metaRe.exec(itemXml)) !== null) {
+    const key = getTagContent(m[1], 'wp:meta_key') || getCdataContent(m[1], 'wp:meta_key');
+    const value = getTagContent(m[1], 'wp:meta_value') || getCdataContent(m[1], 'wp:meta_value');
+    if (key) metaEntries.push({ key, value });
+  }
+  const featuredImageId = metaEntries.find((e) => e.key === '_thumbnail_id')?.value || '';
+
+  return {
+    postType,
+    status,
+    postId,
+    title,
+    link,
+    slug,
+    content,
+    excerpt: excerpt.replace(/<[^>]*>/g, '').trim(),
+    publishDate,
+    categories,
+    tags,
+    attachmentUrl,
+    featuredImageId,
+    meta: metaEntries,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Full WXR parse — returns posts, pages, media, taxonomies, authors, nav
+// ---------------------------------------------------------------------------
+
+export function parseWxr(xml) {
+  const items = getAllItems(xml);
+  const parsed = items.map(parseItem);
+
+  const posts = parsed.filter((i) => i.postType === 'post' && i.status === 'publish');
+  const pages = parsed.filter((i) => i.postType === 'page' && i.status === 'publish');
+  const attachments = parsed.filter((i) => i.postType === 'attachment');
+  const navItems = parsed.filter((i) => i.postType === 'nav_menu_item');
+  const drafts = parsed.filter((i) => i.status === 'draft');
+
+  const mediaMap = new Map();
+  for (const att of attachments) {
+    if (att.postId && att.attachmentUrl) {
+      mediaMap.set(att.postId, {
+        id: att.postId,
+        url: att.attachmentUrl,
+        title: att.title,
+        slug: att.slug,
+      });
+    }
+  }
+
+  for (const item of [...posts, ...pages]) {
+    if (item.featuredImageId && mediaMap.has(item.featuredImageId)) {
+      item.featuredImage = mediaMap.get(item.featuredImageId).url;
+    }
+  }
+
+  const taxonomies = parseTaxonomies(xml);
+  const authors = parseAuthors(xml);
+
+  const navigation = navItems
+    .map((n) => {
+      const urlMeta = n.meta.find((m) => m.key === '_menu_item_url');
+      const objectIdMeta = n.meta.find((m) => m.key === '_menu_item_object_id');
+      const typeMeta = n.meta.find((m) => m.key === '_menu_item_type');
+      return {
+        title: n.title,
+        url: urlMeta?.value || '',
+        objectId: objectIdMeta?.value || '',
+        type: typeMeta?.value || '',
+        order: n.meta.find((m) => m.key === '_menu_item_menu_item_parent')?.value || '0',
+      };
+    })
+    .filter((n) => n.title || n.url);
+
+  const skipped = [];
+  const customTypes = new Set();
+  for (const item of parsed) {
+    if (!['post', 'page', 'attachment', 'nav_menu_item'].includes(item.postType)) {
+      customTypes.add(item.postType);
+      skipped.push({ postType: item.postType, title: item.title, slug: item.slug });
+    }
+  }
+  if (drafts.length > 0) {
+    for (const d of drafts) {
+      skipped.push({ postType: d.postType, title: d.title, slug: d.slug, reason: 'draft' });
+    }
+  }
+
+  return {
+    posts,
+    pages,
+    media: [...mediaMap.values()],
+    taxonomies,
+    authors,
+    navigation,
+    skipped,
+    customTypes: [...customTypes],
+    stats: {
+      posts: posts.length,
+      pages: pages.length,
+      media: mediaMap.size,
+      navigation: navigation.length,
+      drafts: drafts.length,
+      customTypeItems: skipped.filter((s) => !s.reason).length,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Redirect generation from WordPress URLs to Anglesite paths
+// ---------------------------------------------------------------------------
+
+export function generateRedirects(items, pathPrefix = '/blog') {
+  const redirects = [];
+  for (const item of items) {
+    if (!item.link) continue;
+    try {
+      const url = new URL(item.link);
+      const oldPath = url.pathname.replace(/\/$/, '') || '/';
+      const newPath = item.postType === 'page'
+        ? `/${item.slug}`
+        : `${pathPrefix}/${item.slug}`;
+      if (oldPath !== newPath) {
+        redirects.push(`${oldPath} ${newPath} 301`);
+      }
+    } catch {
+      // malformed URL, skip
+    }
+  }
+  return redirects;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+const cliArgs = process.argv.slice(2);
+const cliFile = cliArgs.find((a) => !a.startsWith('--'));
+
+if (cliFile) {
+  const xml = readFileSync(cliFile, 'utf-8');
+  const flag = cliArgs.find((a) => a.startsWith('--'));
+
+  let output;
+  const result = parseWxr(xml);
+
+  switch (flag) {
+    case '--posts':
+      output = result.posts;
+      break;
+    case '--pages':
+      output = result.pages;
+      break;
+    case '--media':
+      output = result.media;
+      break;
+    case '--taxonomies':
+      output = result.taxonomies;
+      break;
+    default:
+      output = result;
+  }
+
+  console.log(JSON.stringify(output, null, 2));
+}

--- a/test/fixtures/wordpress/wp-post-content.html
+++ b/test/fixtures/wordpress/wp-post-content.html
@@ -1,0 +1,54 @@
+<!-- wp:paragraph -->
+<p>Making sourdough bread at home is one of the most rewarding baking experiences. In this guide, we&#8217;ll walk you through every step.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Getting Started with Your Starter</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>A sourdough starter is a living culture of <strong>wild yeast</strong> and <em>beneficial bacteria</em>. It takes about 7 days to create one from scratch.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":101,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://greenvalleybakery.com/wp-content/uploads/2024/03/sourdough-starter.jpg" alt="A bubbling sourdough starter in a glass jar" class="wp-image-101"/><figcaption class="wp-element-caption">Our 3-year-old starter, nicknamed &#8220;Bubbles&#8221;</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading -->
+<h2>The Basic Recipe</h2>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul class="wp-block-list"><li>500g bread flour</li><li>350g water</li><li>100g active starter</li><li>10g salt</li></ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p>Mix the flour and water, let it rest for 30 minutes (<strong>autolyse</strong>), then add the starter and salt. For more details, visit <a href="https://greenvalleybakery.com/classes">our baking classes</a>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3>Pro Tips</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Use a <code>Dutch oven</code> for the best crust. Preheat it to 250&deg;C (482&deg;F) for at least 30 minutes.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+[gallery ids="101,102,103"]
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote"><p>The secret to great bread is time and patience.</p></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:code -->
+<pre class="wp-block-code"><code>Temperature: 250°C
+Time: 25 min covered + 20 min uncovered</code></pre>
+<!-- /wp:code -->
+
+<!-- wp:paragraph -->
+<p>Happy baking! &#8212; Maria</p>
+<!-- /wp:paragraph -->

--- a/test/fixtures/wordpress/wxr-export.xml
+++ b/test/fixtures/wordpress/wxr-export.xml
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+  xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:wp="http://wordpress.org/export/1.2/"
+>
+<channel>
+  <title>Green Valley Bakery</title>
+  <link>https://greenvalleybakery.com</link>
+  <description>Artisan breads and pastries since 2018</description>
+  <wp:wxr_version>1.2</wp:wxr_version>
+  <wp:base_site_url>https://greenvalleybakery.com</wp:base_site_url>
+  <wp:base_blog_url>https://greenvalleybakery.com</wp:base_blog_url>
+
+  <wp:author>
+    <wp:author_id>1</wp:author_id>
+    <wp:author_login><![CDATA[maria]]></wp:author_login>
+    <wp:author_email><![CDATA[maria@greenvalleybakery.com]]></wp:author_email>
+    <wp:author_display_name><![CDATA[Maria Santos]]></wp:author_display_name>
+  </wp:author>
+  <wp:author>
+    <wp:author_id>2</wp:author_id>
+    <wp:author_login><![CDATA[james]]></wp:author_login>
+    <wp:author_email><![CDATA[james@greenvalleybakery.com]]></wp:author_email>
+    <wp:author_display_name><![CDATA[James Chen]]></wp:author_display_name>
+  </wp:author>
+
+  <wp:category>
+    <wp:category_nicename>recipes</wp:category_nicename>
+    <wp:category_parent></wp:category_parent>
+    <wp:cat_name><![CDATA[Recipes]]></wp:cat_name>
+  </wp:category>
+  <wp:category>
+    <wp:category_nicename>sourdough</wp:category_nicename>
+    <wp:category_parent>recipes</wp:category_parent>
+    <wp:cat_name><![CDATA[Sourdough]]></wp:cat_name>
+  </wp:category>
+  <wp:category>
+    <wp:category_nicename>news</wp:category_nicename>
+    <wp:category_parent></wp:category_parent>
+    <wp:cat_name><![CDATA[Bakery News]]></wp:cat_name>
+  </wp:category>
+
+  <wp:tag>
+    <wp:tag_slug>gluten-free</wp:tag_slug>
+    <wp:tag_name><![CDATA[Gluten Free]]></wp:tag_name>
+  </wp:tag>
+  <wp:tag>
+    <wp:tag_slug>seasonal</wp:tag_slug>
+    <wp:tag_name><![CDATA[Seasonal]]></wp:tag_name>
+  </wp:tag>
+  <wp:tag>
+    <wp:tag_slug>beginner</wp:tag_slug>
+    <wp:tag_name><![CDATA[Beginner]]></wp:tag_name>
+  </wp:tag>
+
+  <item>
+    <title>The Art of Sourdough: A Beginner&#8217;s Guide</title>
+    <link>https://greenvalleybakery.com/2024/03/15/sourdough-beginners-guide/</link>
+    <dc:creator><![CDATA[maria]]></dc:creator>
+    <category domain="category" nicename="recipes"><![CDATA[Recipes]]></category>
+    <category domain="category" nicename="sourdough"><![CDATA[Sourdough]]></category>
+    <category domain="post_tag" nicename="beginner"><![CDATA[Beginner]]></category>
+    <wp:post_id>42</wp:post_id>
+    <wp:post_date>2024-03-15 10:30:00</wp:post_date>
+    <wp:post_name>sourdough-beginners-guide</wp:post_name>
+    <wp:status>publish</wp:status>
+    <wp:post_type>post</wp:post_type>
+    <content:encoded><![CDATA[<!-- wp:paragraph -->
+<p>Making sourdough bread at home is one of the most rewarding baking experiences. In this guide, we&#8217;ll walk you through every step.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2>Getting Started with Your Starter</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>A sourdough starter is a living culture of <strong>wild yeast</strong> and <em>beneficial bacteria</em>. It takes about 7 days to create one from scratch.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":101,"sizeSlug":"large"} -->
+<figure class="wp-block-image size-large"><img src="https://greenvalleybakery.com/wp-content/uploads/2024/03/sourdough-starter.jpg" alt="A bubbling sourdough starter in a glass jar" class="wp-image-101"/><figcaption>Our 3-year-old starter, affectionately named &quot;Bubbles&quot;</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading -->
+<h2>The Basic Recipe</h2>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul><li>500g bread flour</li><li>350g water</li><li>100g active starter</li><li>10g salt</li></ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p>Mix the flour and water, let it rest for 30 minutes (<strong>autolyse</strong>), then add the starter and salt. For more details, visit <a href="https://greenvalleybakery.com/classes">our baking classes</a> or read the <a href="https://example.com/sourdough-science">science behind sourdough</a>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3>Pro Tips</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Use a <code>Dutch oven</code> for the best crust. Preheat it to 250&deg;C (482&deg;F) for at least 30 minutes.</p>
+<!-- /wp:paragraph -->
+
+[gallery ids="101,102,103"]
+
+<!-- wp:paragraph -->
+<p>Happy baking! &#8212; Maria</p>
+<!-- /wp:paragraph -->]]></content:encoded>
+    <excerpt:encoded><![CDATA[<p>Making sourdough bread at home is one of the most rewarding baking experiences.</p>]]></excerpt:encoded>
+    <wp:postmeta>
+      <wp:meta_key>_thumbnail_id</wp:meta_key>
+      <wp:meta_value>101</wp:meta_value>
+    </wp:postmeta>
+  </item>
+
+  <item>
+    <title>Holiday Hours &amp; Special Menu</title>
+    <link>https://greenvalleybakery.com/2024/12/20/holiday-hours/</link>
+    <dc:creator><![CDATA[james]]></dc:creator>
+    <category domain="category" nicename="news"><![CDATA[Bakery News]]></category>
+    <category domain="post_tag" nicename="seasonal"><![CDATA[Seasonal]]></category>
+    <wp:post_id>85</wp:post_id>
+    <wp:post_date>2024-12-20 08:00:00</wp:post_date>
+    <wp:post_name>holiday-hours</wp:post_name>
+    <wp:status>publish</wp:status>
+    <wp:post_type>post</wp:post_type>
+    <content:encoded><![CDATA[<!-- wp:paragraph -->
+<p>We&#8217;re adjusting our hours for the holiday season. Here&#8217;s what you need to know:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2>Updated Hours</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><strong>December 24th:</strong> 6am &#8211; 2pm<br/><strong>December 25th:</strong> Closed<br/><strong>December 31st:</strong> 6am &#8211; 4pm<br/><strong>January 1st:</strong> 10am &#8211; 3pm</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Pre-order your holiday bread by December 22nd!</p>
+<!-- /wp:paragraph -->]]></content:encoded>
+    <excerpt:encoded><![CDATA[<p>We're adjusting our hours for the holiday season.</p>]]></excerpt:encoded>
+  </item>
+
+  <item>
+    <title>Unpublished Recipe Draft</title>
+    <link>https://greenvalleybakery.com/?p=90</link>
+    <dc:creator><![CDATA[maria]]></dc:creator>
+    <wp:post_id>90</wp:post_id>
+    <wp:post_date>2024-11-01 12:00:00</wp:post_date>
+    <wp:post_name>unpublished-recipe</wp:post_name>
+    <wp:status>draft</wp:status>
+    <wp:post_type>post</wp:post_type>
+    <content:encoded><![CDATA[<p>This is a draft post that should not be imported.</p>]]></content:encoded>
+    <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+  </item>
+
+  <item>
+    <title>About Us</title>
+    <link>https://greenvalleybakery.com/about/</link>
+    <dc:creator><![CDATA[maria]]></dc:creator>
+    <wp:post_id>10</wp:post_id>
+    <wp:post_date>2023-01-15 09:00:00</wp:post_date>
+    <wp:post_name>about</wp:post_name>
+    <wp:status>publish</wp:status>
+    <wp:post_type>page</wp:post_type>
+    <content:encoded><![CDATA[<!-- wp:heading -->
+<h2>Our Story</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Green Valley Bakery was founded in 2018 by <strong>Maria Santos</strong> and <strong>James Chen</strong>. What started as a weekend farmers market stall has grown into a beloved neighborhood bakery.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":102} -->
+<figure class="wp-block-image"><img src="https://greenvalleybakery.com/wp-content/uploads/2023/01/bakery-storefront.jpg" alt="Green Valley Bakery storefront" class="wp-image-102"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>We believe in using <em>locally sourced</em>, organic ingredients. Every loaf is made by hand with care and patience.</p>
+<!-- /wp:paragraph -->]]></content:encoded>
+    <excerpt:encoded><![CDATA[<p>Learn about Green Valley Bakery's story, our team, and our commitment to artisan baking.</p>]]></excerpt:encoded>
+  </item>
+
+  <item>
+    <title>Contact</title>
+    <link>https://greenvalleybakery.com/contact/</link>
+    <dc:creator><![CDATA[james]]></dc:creator>
+    <wp:post_id>12</wp:post_id>
+    <wp:post_date>2023-01-15 09:30:00</wp:post_date>
+    <wp:post_name>contact</wp:post_name>
+    <wp:status>publish</wp:status>
+    <wp:post_type>page</wp:post_type>
+    <content:encoded><![CDATA[<!-- wp:paragraph -->
+<p>We&#8217;d love to hear from you!</p>
+<!-- /wp:paragraph -->
+
+[contact-form to="hello@greenvalleybakery.com" subject="Website Inquiry"]
+
+<!-- wp:paragraph -->
+<p>Or visit us at <strong>123 Main Street, Green Valley, CA 94000</strong>.</p>
+<!-- /wp:paragraph -->]]></content:encoded>
+    <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+  </item>
+
+  <item>
+    <title>sourdough-starter</title>
+    <link>https://greenvalleybakery.com/wp-content/uploads/2024/03/sourdough-starter.jpg</link>
+    <wp:post_id>101</wp:post_id>
+    <wp:post_date>2024-03-15 10:00:00</wp:post_date>
+    <wp:post_name>sourdough-starter</wp:post_name>
+    <wp:status>inherit</wp:status>
+    <wp:post_type>attachment</wp:post_type>
+    <wp:attachment_url>https://greenvalleybakery.com/wp-content/uploads/2024/03/sourdough-starter.jpg</wp:attachment_url>
+    <content:encoded><![CDATA[]]></content:encoded>
+    <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+  </item>
+
+  <item>
+    <title>bakery-storefront</title>
+    <link>https://greenvalleybakery.com/wp-content/uploads/2023/01/bakery-storefront.jpg</link>
+    <wp:post_id>102</wp:post_id>
+    <wp:post_date>2023-01-15 08:00:00</wp:post_date>
+    <wp:post_name>bakery-storefront</wp:post_name>
+    <wp:status>inherit</wp:status>
+    <wp:post_type>attachment</wp:post_type>
+    <wp:attachment_url>https://greenvalleybakery.com/wp-content/uploads/2023/01/bakery-storefront.jpg</wp:attachment_url>
+    <content:encoded><![CDATA[]]></content:encoded>
+    <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+  </item>
+
+  <item>
+    <title>Home</title>
+    <link>https://greenvalleybakery.com/</link>
+    <wp:post_id>201</wp:post_id>
+    <wp:post_date>2023-01-01 00:00:00</wp:post_date>
+    <wp:post_name></wp:post_name>
+    <wp:status>publish</wp:status>
+    <wp:post_type>nav_menu_item</wp:post_type>
+    <content:encoded><![CDATA[]]></content:encoded>
+    <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+    <wp:postmeta>
+      <wp:meta_key>_menu_item_type</wp:meta_key>
+      <wp:meta_value>custom</wp:meta_value>
+    </wp:postmeta>
+    <wp:postmeta>
+      <wp:meta_key>_menu_item_url</wp:meta_key>
+      <wp:meta_value>https://greenvalleybakery.com/</wp:meta_value>
+    </wp:postmeta>
+    <wp:postmeta>
+      <wp:meta_key>_menu_item_menu_item_parent</wp:meta_key>
+      <wp:meta_value>0</wp:meta_value>
+    </wp:postmeta>
+  </item>
+
+  <item>
+    <title>About</title>
+    <link>https://greenvalleybakery.com/about/</link>
+    <wp:post_id>202</wp:post_id>
+    <wp:post_date>2023-01-01 00:00:00</wp:post_date>
+    <wp:post_name></wp:post_name>
+    <wp:status>publish</wp:status>
+    <wp:post_type>nav_menu_item</wp:post_type>
+    <content:encoded><![CDATA[]]></content:encoded>
+    <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+    <wp:postmeta>
+      <wp:meta_key>_menu_item_type</wp:meta_key>
+      <wp:meta_value>post_type</wp:meta_value>
+    </wp:postmeta>
+    <wp:postmeta>
+      <wp:meta_key>_menu_item_object_id</wp:meta_key>
+      <wp:meta_value>10</wp:meta_value>
+    </wp:postmeta>
+    <wp:postmeta>
+      <wp:meta_key>_menu_item_url</wp:meta_key>
+      <wp:meta_value></wp:meta_value>
+    </wp:postmeta>
+    <wp:postmeta>
+      <wp:meta_key>_menu_item_menu_item_parent</wp:meta_key>
+      <wp:meta_value>0</wp:meta_value>
+    </wp:postmeta>
+  </item>
+
+  <item>
+    <title>Spring Tasting Menu</title>
+    <link>https://greenvalleybakery.com/portfolio/spring-tasting/</link>
+    <dc:creator><![CDATA[maria]]></dc:creator>
+    <wp:post_id>150</wp:post_id>
+    <wp:post_date>2024-04-01 12:00:00</wp:post_date>
+    <wp:post_name>spring-tasting</wp:post_name>
+    <wp:status>publish</wp:status>
+    <wp:post_type>portfolio</wp:post_type>
+    <content:encoded><![CDATA[<p>Our seasonal tasting menu for spring 2024.</p>]]></content:encoded>
+    <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+  </item>
+
+</channel>
+</rss>

--- a/test/wordpress-extract.test.js
+++ b/test/wordpress-extract.test.js
@@ -1,0 +1,580 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  decodeEntities,
+  parseTaxonomies,
+  parseAuthors,
+  parseItem,
+  parseWxr,
+  generateRedirects,
+} from '../scripts/import/wordpress/wp-xml-parse.mjs';
+
+import {
+  stripBlockComments,
+  stripShortcodes,
+  stripWpClasses,
+  extractImages,
+  htmlToMarkdown,
+  cleanContent,
+} from '../scripts/import/wordpress/wp-content-clean.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = (name) => readFileSync(join(__dirname, 'fixtures', 'wordpress', name), 'utf-8');
+
+// ---------------------------------------------------------------------------
+// wp-xml-parse.mjs
+// ---------------------------------------------------------------------------
+
+describe('decodeEntities', () => {
+  it('decodes numeric HTML entities', () => {
+    expect(decodeEntities('&#8217;')).toBe('’');
+    expect(decodeEntities('&#8220;')).toBe('“');
+  });
+
+  it('decodes hex HTML entities', () => {
+    expect(decodeEntities('&#x2019;')).toBe('’');
+  });
+
+  it('decodes named HTML entities', () => {
+    expect(decodeEntities('&amp;')).toBe('&');
+    expect(decodeEntities('&lt;')).toBe('<');
+    expect(decodeEntities('&gt;')).toBe('>');
+    expect(decodeEntities('&quot;')).toBe('"');
+  });
+
+  it('decodes mixed entities in a string', () => {
+    expect(decodeEntities('A Beginner&#8217;s Guide &amp; More'))
+      .toBe('A Beginner’s Guide & More');
+  });
+
+  it('returns empty string for falsy input', () => {
+    expect(decodeEntities('')).toBe('');
+    expect(decodeEntities(null)).toBe('');
+    expect(decodeEntities(undefined)).toBe('');
+  });
+});
+
+describe('parseTaxonomies', () => {
+  const xml = fixture('wxr-export.xml');
+  const { categories, tags } = parseTaxonomies(xml);
+
+  it('extracts all categories', () => {
+    expect(categories).toHaveLength(3);
+    expect(categories.map((c) => c.name)).toEqual(['Recipes', 'Sourdough', 'Bakery News']);
+  });
+
+  it('extracts category slugs', () => {
+    expect(categories.map((c) => c.slug)).toEqual(['recipes', 'sourdough', 'news']);
+  });
+
+  it('tracks parent-child category relationships', () => {
+    const sourdough = categories.find((c) => c.slug === 'sourdough');
+    expect(sourdough.parent).toBe('recipes');
+    const recipes = categories.find((c) => c.slug === 'recipes');
+    expect(recipes.parent).toBeNull();
+  });
+
+  it('extracts all tags', () => {
+    expect(tags).toHaveLength(3);
+    expect(tags.map((t) => t.name)).toEqual(['Gluten Free', 'Seasonal', 'Beginner']);
+  });
+
+  it('extracts tag slugs', () => {
+    expect(tags.map((t) => t.slug)).toEqual(['gluten-free', 'seasonal', 'beginner']);
+  });
+});
+
+describe('parseAuthors', () => {
+  const xml = fixture('wxr-export.xml');
+  const authors = parseAuthors(xml);
+
+  it('extracts all authors', () => {
+    expect(authors).toHaveLength(2);
+  });
+
+  it('extracts author display names', () => {
+    expect(authors[0].displayName).toBe('Maria Santos');
+    expect(authors[1].displayName).toBe('James Chen');
+  });
+
+  it('extracts author logins', () => {
+    expect(authors[0].login).toBe('maria');
+    expect(authors[1].login).toBe('james');
+  });
+
+  it('extracts author emails', () => {
+    expect(authors[0].email).toBe('maria@greenvalleybakery.com');
+  });
+});
+
+describe('parseItem', () => {
+  const xml = fixture('wxr-export.xml');
+  const items = [];
+  const re = /<item>([\s\S]*?)<\/item>/gi;
+  let m;
+  while ((m = re.exec(xml)) !== null) items.push(m[1]);
+  const postItem = parseItem(items[0]);
+
+  it('extracts post type', () => {
+    expect(postItem.postType).toBe('post');
+  });
+
+  it('decodes HTML entities in title', () => {
+    expect(postItem.title).toBe('The Art of Sourdough: A Beginner’s Guide');
+  });
+
+  it('extracts the slug', () => {
+    expect(postItem.slug).toBe('sourdough-beginners-guide');
+  });
+
+  it('extracts the publish date as YYYY-MM-DD', () => {
+    expect(postItem.publishDate).toBe('2024-03-15');
+  });
+
+  it('extracts the original link', () => {
+    expect(postItem.link).toBe('https://greenvalleybakery.com/2024/03/15/sourdough-beginners-guide/');
+  });
+
+  it('extracts categories from item', () => {
+    expect(postItem.categories).toEqual(['Recipes', 'Sourdough']);
+  });
+
+  it('extracts tags from item', () => {
+    expect(postItem.tags).toEqual(['Beginner']);
+  });
+
+  it('extracts content:encoded as raw HTML', () => {
+    expect(postItem.content).toContain('sourdough bread at home');
+    expect(postItem.content).toContain('<!-- wp:paragraph -->');
+  });
+
+  it('strips HTML from excerpt', () => {
+    expect(postItem.excerpt).toBe('Making sourdough bread at home is one of the most rewarding baking experiences.');
+  });
+
+  it('extracts featured image ID from postmeta', () => {
+    expect(postItem.featuredImageId).toBe('101');
+  });
+});
+
+describe('parseWxr', () => {
+  const xml = fixture('wxr-export.xml');
+  const result = parseWxr(xml);
+
+  it('separates posts from pages', () => {
+    expect(result.posts).toHaveLength(2);
+    expect(result.pages).toHaveLength(2);
+  });
+
+  it('filters out draft posts', () => {
+    const titles = result.posts.map((p) => p.title);
+    expect(titles).not.toContain('Unpublished Recipe Draft');
+  });
+
+  it('extracts media attachments', () => {
+    expect(result.media).toHaveLength(2);
+    expect(result.media[0].url).toContain('wp-content/uploads');
+  });
+
+  it('resolves featured images from media map', () => {
+    const sourdoughPost = result.posts.find((p) => p.slug === 'sourdough-beginners-guide');
+    expect(sourdoughPost.featuredImage).toBe(
+      'https://greenvalleybakery.com/wp-content/uploads/2024/03/sourdough-starter.jpg'
+    );
+  });
+
+  it('does not add featuredImage when no _thumbnail_id exists', () => {
+    const holidayPost = result.posts.find((p) => p.slug === 'holiday-hours');
+    expect(holidayPost.featuredImage).toBeUndefined();
+  });
+
+  it('extracts navigation items', () => {
+    expect(result.navigation.length).toBeGreaterThanOrEqual(2);
+    const homeNav = result.navigation.find((n) => n.title === 'Home');
+    expect(homeNav.url).toBe('https://greenvalleybakery.com/');
+  });
+
+  it('reports custom post types in skipped', () => {
+    expect(result.customTypes).toContain('portfolio');
+    const portfolioSkipped = result.skipped.find((s) => s.postType === 'portfolio');
+    expect(portfolioSkipped.title).toBe('Spring Tasting Menu');
+  });
+
+  it('reports draft posts in skipped', () => {
+    const draftSkipped = result.skipped.find((s) => s.reason === 'draft');
+    expect(draftSkipped.title).toBe('Unpublished Recipe Draft');
+  });
+
+  it('provides accurate stats', () => {
+    expect(result.stats.posts).toBe(2);
+    expect(result.stats.pages).toBe(2);
+    expect(result.stats.media).toBe(2);
+    expect(result.stats.drafts).toBe(1);
+    expect(result.stats.customTypeItems).toBe(1);
+  });
+
+  it('includes taxonomies and authors', () => {
+    expect(result.taxonomies.categories).toHaveLength(3);
+    expect(result.taxonomies.tags).toHaveLength(3);
+    expect(result.authors).toHaveLength(2);
+  });
+});
+
+describe('generateRedirects', () => {
+  const xml = fixture('wxr-export.xml');
+  const result = parseWxr(xml);
+
+  it('generates 301 redirects from old WordPress URLs', () => {
+    const redirects = generateRedirects(result.posts);
+    expect(redirects).toContain('/2024/03/15/sourdough-beginners-guide /blog/sourdough-beginners-guide 301');
+    expect(redirects).toContain('/2024/12/20/holiday-hours /blog/holiday-hours 301');
+  });
+
+  it('generates page redirects without /blog prefix', () => {
+    const redirects = generateRedirects(result.pages);
+    const aboutRedirect = redirects.find((r) => r.includes('/about'));
+    expect(aboutRedirect).toBeUndefined();
+  });
+
+  it('skips items without a link', () => {
+    const redirects = generateRedirects([{ slug: 'test', postType: 'post' }]);
+    expect(redirects).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wp-content-clean.mjs
+// ---------------------------------------------------------------------------
+
+describe('stripBlockComments', () => {
+  it('removes simple block comments', () => {
+    expect(stripBlockComments('<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->'))
+      .toBe('<p>Hello</p>');
+  });
+
+  it('removes block comments with JSON attributes', () => {
+    expect(stripBlockComments('<!-- wp:image {"id":101,"sizeSlug":"large"} --><img/><!-- /wp:image -->'))
+      .toBe('<img/>');
+  });
+
+  it('removes nested namespace blocks', () => {
+    expect(stripBlockComments('<!-- wp:heading {"level":3} -->'))
+      .toBe('');
+  });
+
+  it('preserves non-WordPress comments', () => {
+    expect(stripBlockComments('<!-- This is a regular comment -->'))
+      .toBe('<!-- This is a regular comment -->');
+  });
+
+  it('handles empty input', () => {
+    expect(stripBlockComments('')).toBe('');
+    expect(stripBlockComments(null)).toBe('');
+  });
+});
+
+describe('stripShortcodes', () => {
+  it('removes self-closing gallery shortcodes', () => {
+    expect(stripShortcodes('[gallery ids="1,2,3"]')).toBe('');
+  });
+
+  it('removes shortcodes with content, preserving inner text', () => {
+    expect(stripShortcodes('[caption id="att_1"]A nice photo[/caption]'))
+      .toBe('A nice photo');
+  });
+
+  it('removes contact-form shortcodes', () => {
+    expect(stripShortcodes('[contact-form to="a@b.com" subject="Hi"]')).toBe('');
+  });
+
+  it('removes embed shortcodes with content, preserving URL', () => {
+    expect(stripShortcodes('[embed]https://youtube.com/watch?v=abc[/embed]'))
+      .toBe('https://youtube.com/watch?v=abc');
+  });
+
+  it('removes page builder shortcodes', () => {
+    expect(stripShortcodes('[vc_column width="1/2"]')).toBe('');
+    expect(stripShortcodes('[fusion_text]')).toBe('');
+    expect(stripShortcodes('[et_pb_section]')).toBe('');
+  });
+
+  it('preserves text around shortcodes', () => {
+    expect(stripShortcodes('Before [gallery ids="1"] After')).toBe('Before  After');
+  });
+});
+
+describe('stripWpClasses', () => {
+  it('removes wp-block-* classes', () => {
+    expect(stripWpClasses('<h2 class="wp-block-heading">Title</h2>'))
+      .toBe('<h2>Title</h2>');
+  });
+
+  it('removes wp-image-* classes', () => {
+    expect(stripWpClasses('<img class="wp-image-101" src="test.jpg"/>'))
+      .toBe('<img src="test.jpg"/>');
+  });
+
+  it('removes alignment classes', () => {
+    expect(stripWpClasses('<div class="aligncenter">Content</div>'))
+      .toBe('<div>Content</div>');
+  });
+
+  it('removes inline styles', () => {
+    expect(stripWpClasses('<p style="color: red;">Text</p>'))
+      .toBe('<p>Text</p>');
+  });
+
+  it('removes data attributes', () => {
+    expect(stripWpClasses('<div data-id="123" data-type="block">Text</div>'))
+      .toBe('<div>Text</div>');
+  });
+});
+
+describe('extractImages', () => {
+  it('extracts image src and alt from HTML', () => {
+    const images = extractImages('<img src="https://example.com/photo.jpg" alt="A photo"/>');
+    expect(images).toHaveLength(1);
+    expect(images[0].src).toBe('https://example.com/photo.jpg');
+    expect(images[0].alt).toBe('A photo');
+  });
+
+  it('handles images without alt text', () => {
+    const images = extractImages('<img src="https://example.com/photo.jpg"/>');
+    expect(images).toHaveLength(1);
+    expect(images[0].alt).toBe('');
+  });
+
+  it('extracts multiple images', () => {
+    const html = '<img src="a.jpg" alt="A"/><p>text</p><img src="b.jpg" alt="B"/>';
+    const images = extractImages(html);
+    expect(images).toHaveLength(2);
+  });
+
+  it('decodes HTML entities in URLs', () => {
+    const images = extractImages('<img src="https://example.com/photo.jpg?w=100&amp;h=200" alt="Test"/>');
+    expect(images[0].src).toBe('https://example.com/photo.jpg?w=100&h=200');
+  });
+
+  it('returns empty array for no images', () => {
+    expect(extractImages('<p>No images here</p>')).toEqual([]);
+    expect(extractImages('')).toEqual([]);
+  });
+});
+
+describe('htmlToMarkdown', () => {
+  it('converts headings', () => {
+    expect(htmlToMarkdown('<h2>Title</h2>')).toContain('## Title');
+    expect(htmlToMarkdown('<h3>Subtitle</h3>')).toContain('### Subtitle');
+  });
+
+  it('converts paragraphs to separated text', () => {
+    const md = htmlToMarkdown('<p>First paragraph.</p><p>Second paragraph.</p>');
+    expect(md).toContain('First paragraph.');
+    expect(md).toContain('Second paragraph.');
+  });
+
+  it('converts links to markdown links', () => {
+    expect(htmlToMarkdown('<a href="https://example.com">Click here</a>'))
+      .toContain('[Click here](https://example.com)');
+  });
+
+  it('converts images to markdown images', () => {
+    expect(htmlToMarkdown('<img src="photo.jpg" alt="A photo"/>'))
+      .toContain('![A photo](photo.jpg)');
+  });
+
+  it('converts bold and italic', () => {
+    expect(htmlToMarkdown('<strong>bold</strong>')).toContain('**bold**');
+    expect(htmlToMarkdown('<em>italic</em>')).toContain('*italic*');
+    expect(htmlToMarkdown('<b>bold</b>')).toContain('**bold**');
+    expect(htmlToMarkdown('<i>italic</i>')).toContain('*italic*');
+  });
+
+  it('converts inline code', () => {
+    expect(htmlToMarkdown('<code>npm install</code>')).toContain('`npm install`');
+  });
+
+  it('converts code blocks', () => {
+    const md = htmlToMarkdown('<pre><code>const x = 1;</code></pre>');
+    expect(md).toContain('```');
+    expect(md).toContain('const x = 1;');
+  });
+
+  it('converts lists', () => {
+    const md = htmlToMarkdown('<ul><li>Item 1</li><li>Item 2</li></ul>');
+    expect(md).toContain('- Item 1');
+    expect(md).toContain('- Item 2');
+  });
+
+  it('converts blockquotes', () => {
+    expect(htmlToMarkdown('<blockquote><p>A quote</p></blockquote>'))
+      .toContain('> A quote');
+  });
+
+  it('converts horizontal rules', () => {
+    expect(htmlToMarkdown('<hr/>')).toContain('---');
+  });
+
+  it('strips all block comments', () => {
+    const md = htmlToMarkdown('<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->');
+    expect(md).not.toContain('wp:paragraph');
+    expect(md).toContain('Hello');
+  });
+
+  it('strips shortcodes', () => {
+    const md = htmlToMarkdown('<p>Before</p>[gallery ids="1,2"]<p>After</p>');
+    expect(md).not.toContain('[gallery');
+    expect(md).toContain('Before');
+    expect(md).toContain('After');
+  });
+
+  it('strips wp-block-* classes', () => {
+    const md = htmlToMarkdown('<h2 class="wp-block-heading">Title</h2>');
+    expect(md).not.toContain('wp-block');
+    expect(md).toContain('## Title');
+  });
+
+  it('decodes HTML entities in output', () => {
+    const md = htmlToMarkdown('<p>It&#8217;s great &amp; wonderful</p>');
+    expect(md).toContain('’s great & wonderful');
+  });
+
+  it('handles figure elements with captions', () => {
+    const md = htmlToMarkdown(
+      '<figure><img src="photo.jpg" alt="test"/><figcaption>Caption text</figcaption></figure>'
+    );
+    expect(md).toContain('![test](photo.jpg)');
+    expect(md).toContain('*Caption text*');
+  });
+
+  it('removes script and style elements', () => {
+    const md = htmlToMarkdown('<script>alert("x")</script><style>.x{}</style><p>Keep</p>');
+    expect(md).not.toContain('alert');
+    expect(md).not.toContain('.x{}');
+    expect(md).toContain('Keep');
+  });
+
+  it('collapses excessive newlines', () => {
+    const md = htmlToMarkdown('<p>A</p>\n\n\n\n<p>B</p>');
+    expect(md).not.toMatch(/\n{3,}/);
+  });
+
+  it('handles empty input', () => {
+    expect(htmlToMarkdown('')).toBe('');
+    expect(htmlToMarkdown(null)).toBe('');
+  });
+});
+
+describe('cleanContent', () => {
+  const html = fixture('wp-post-content.html');
+
+  it('returns both markdown and images', () => {
+    const result = cleanContent(html);
+    expect(result).toHaveProperty('markdown');
+    expect(result).toHaveProperty('images');
+  });
+
+  it('extracts images from the content', () => {
+    const { images } = cleanContent(html);
+    expect(images).toHaveLength(1);
+    expect(images[0].src).toContain('sourdough-starter.jpg');
+    expect(images[0].alt).toBe('A bubbling sourdough starter in a glass jar');
+  });
+
+  it('produces clean markdown without block comments', () => {
+    const { markdown } = cleanContent(html);
+    expect(markdown).not.toContain('<!-- wp:');
+    expect(markdown).not.toContain('wp:paragraph');
+  });
+
+  it('produces markdown without shortcodes', () => {
+    const { markdown } = cleanContent(html);
+    expect(markdown).not.toContain('[gallery');
+  });
+
+  it('preserves heading structure', () => {
+    const { markdown } = cleanContent(html);
+    expect(markdown).toContain('## Getting Started with Your Starter');
+    expect(markdown).toContain('## The Basic Recipe');
+    expect(markdown).toContain('### Pro Tips');
+  });
+
+  it('preserves inline formatting', () => {
+    const { markdown } = cleanContent(html);
+    expect(markdown).toContain('**wild yeast**');
+    expect(markdown).toContain('*beneficial bacteria*');
+    expect(markdown).toContain('`Dutch oven`');
+  });
+
+  it('preserves links', () => {
+    const { markdown } = cleanContent(html);
+    expect(markdown).toContain('[our baking classes](https://greenvalleybakery.com/classes)');
+  });
+
+  it('preserves list items', () => {
+    const { markdown } = cleanContent(html);
+    expect(markdown).toContain('- 500g bread flour');
+    expect(markdown).toContain('- 10g salt');
+  });
+
+  it('converts blockquotes', () => {
+    const { markdown } = cleanContent(html);
+    expect(markdown).toContain('> The secret to great bread is time and patience.');
+  });
+
+  it('decodes HTML entities throughout', () => {
+    const { markdown } = cleanContent(html);
+    expect(markdown).not.toContain('&#8217;');
+    expect(markdown).not.toContain('&#8220;');
+    expect(markdown).toContain('— Maria');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: full WXR parse + content cleaning pipeline
+// ---------------------------------------------------------------------------
+
+describe('integration: WXR parse + content clean', () => {
+  const xml = fixture('wxr-export.xml');
+  const result = parseWxr(xml);
+
+  it('cleans each post content into markdown', () => {
+    for (const post of result.posts) {
+      const { markdown } = cleanContent(post.content);
+      expect(markdown).not.toContain('<!-- wp:');
+    }
+  });
+
+  it('produces a complete "what didn\'t import" report', () => {
+    const report = [];
+    if (result.customTypes.length > 0) {
+      report.push(`Custom post types not imported: ${result.customTypes.join(', ')}`);
+    }
+    for (const s of result.skipped) {
+      const reason = s.reason === 'draft' ? ' (draft)' : ` (custom type: ${s.postType})`;
+      report.push(`  - ${s.title}${reason}`);
+    }
+    expect(report.length).toBeGreaterThan(0);
+    expect(report[0]).toContain('portfolio');
+    expect(report.some((r) => r.includes('draft'))).toBe(true);
+  });
+
+  it('maps posts with categories and tags to Anglesite format', () => {
+    const sourdough = result.posts.find((p) => p.slug === 'sourdough-beginners-guide');
+    const angleTags = [...sourdough.categories, ...sourdough.tags];
+    expect(angleTags).toContain('Recipes');
+    expect(angleTags).toContain('Sourdough');
+    expect(angleTags).toContain('Beginner');
+  });
+
+  it('generates redirect map for all imported content', () => {
+    const postRedirects = generateRedirects(result.posts);
+    const pageRedirects = generateRedirects(result.pages);
+    const allRedirects = [...postRedirects, ...pageRedirects];
+    expect(allRedirects.length).toBeGreaterThan(0);
+    expect(allRedirects.every((r) => r.endsWith('301'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds WXR (WordPress eXtended RSS) XML parser (`scripts/import/wordpress/wp-xml-parse.mjs`) that extracts posts, pages, media attachments, categories, tags, navigation menus, and authors from WordPress export files
- Adds content cleaning utilities (`scripts/import/wordpress/wp-content-clean.mjs`) for converting WordPress HTML to clean Markdown — strips Gutenberg block comments, shortcodes, `wp-block-*` classes, and decodes HTML entities
- Includes redirect generation from WordPress permalink structures to Anglesite paths
- Reports "what didn't import" (drafts, custom post types like portfolios)
- 90 tests across WXR parsing, content cleaning, entity decoding, and full integration pipeline
- Realistic test fixtures modeled after a bakery site with mixed content types

## Test plan

- [x] All 90 new tests pass (`npx vitest run test/wordpress-extract.test.js`)
- [x] All existing tests pass — no regressions (4 pre-existing stylelint failures unrelated)
- [ ] Manual verification: run parser against a real WordPress WXR export

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)