### PR TITLE
Skip HTTPS preview setup when sudo isn't available

### DIFF
--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -231,28 +231,33 @@ If the owner wants to skip this ("I already have photos" / "I'll figure it out l
 
 ## Step 3 — Install tools
 
-Your design is saved. Before running setup, present the wizard summary so the owner knows exactly what's coming:
+Your design is saved. Before running setup, present the wizard summary so the owner knows exactly what's coming.
 
-"Your website design is ready! Now I need to install the tools to run it on your computer and set up a secure local preview."
+The setup script auto-detects whether the environment supports admin/sudo access. If it doesn't (typical for Claude Cowork, web-based shells, or sandboxed containers), HTTPS preview setup is skipped entirely and the dev server runs on `http://localhost:4321` instead. No password prompts, no certificate trust dialogs — the site still works, just without a padlock locally.
 
-On **macOS**, tell the owner what to expect:
-"Here's what will happen — I'll walk you through each step:
-1. **Developer tools** — If this is your first time, macOS will pop up a window asking to install developer tools. Click **Install** and wait about a minute.
-2. **Password** — Your Mac password is needed to set up secure local preview. Type your password — nothing will appear as you type. Press Enter.
-3. **Certificate trust** — A system dialog asks to trust a local security certificate so your browser shows a padlock. Click **Allow** (or enter your password again).
-That's it — three things, and I'll tell you when each one is coming. Ready?"
+Tailor your wizard summary to the environment:
 
-On **Linux**, tell the owner:
-"Here's what will happen:
-1. **Password** — Your password is needed to set up secure local preview.
-2. **Certificate trust** — I'll install a local certificate so your browser shows a padlock.
-That's it — I'll walk you through each step. Ready?"
+- If the owner is in **Claude Cowork** (or any non-admin environment), tell them:
+  "Your website design is ready! I'll install the tools to run it on your computer. Your preview will run at http://localhost:4321 — fully functional, just without the padlock icon. Ready?"
 
-On **Windows**, tell the owner:
-"Here's what will happen:
-1. **Certificate trust** — A Windows dialog may ask to trust a security certificate. Click **Yes**.
-2. Some steps may need Administrator access — I'll let you know.
-Ready?"
+- On **macOS** (with admin access), tell the owner:
+  "Here's what will happen — I'll walk you through each step:
+  1. **Developer tools** — If this is your first time, macOS will pop up a window asking to install developer tools. Click **Install** and wait about a minute.
+  2. **Password** — Your Mac password is needed to set up secure local preview. Type your password — nothing will appear as you type. Press Enter.
+  3. **Certificate trust** — A system dialog asks to trust a local security certificate so your browser shows a padlock. Click **Allow** (or enter your password again).
+  That's it — three things, and I'll tell you when each one is coming. Ready?"
+
+- On **Linux** (with admin access), tell the owner:
+  "Here's what will happen:
+  1. **Password** — Your password is needed to set up secure local preview.
+  2. **Certificate trust** — I'll install a local certificate so your browser shows a padlock.
+  That's it — I'll walk you through each step. Ready?"
+
+- On **Windows**, tell the owner:
+  "Here's what will happen:
+  1. **Certificate trust** — A Windows dialog may ask to trust a security certificate. Click **Yes**.
+  2. Some steps may need Administrator access — I'll let you know.
+  Ready?"
 
 First install project dependencies (needed to run the setup script):
 
@@ -266,9 +271,12 @@ Then run the setup script:
 npm run ai-setup
 ```
 
-The setup script installs Xcode CLI tools, fnm, Node.js LTS, mkcert, a locally-trusted HTTPS certificate, hostname resolution, port forwarding, npm dependencies, and initializes git. It skips anything already present.
+The setup script installs Xcode CLI tools, fnm, Node.js LTS, npm dependencies, the GitHub CLI, and initializes git. When admin/sudo access is available, it also installs mkcert, generates a locally-trusted HTTPS certificate, and configures hostname resolution and port forwarding. It writes `HTTPS_AVAILABLE=true|false` to `.site-config` and skips anything already present.
 
-If the script succeeds, read `DEV_HOSTNAME` from `.site-config` and tell the owner: "Everything is installed! Your website now runs securely at https://DEV_HOSTNAME — just like a real website, but only visible on your computer."
+After setup finishes, read `HTTPS_AVAILABLE` from `.site-config`:
+
+- If `HTTPS_AVAILABLE=true` (admin access was available), read `DEV_HOSTNAME` and tell the owner: "Everything is installed! Your website now runs securely at https://DEV_HOSTNAME — just like a real website, but only visible on your computer."
+- If `HTTPS_AVAILABLE=false` (no admin access — e.g., Claude Cowork), tell the owner: "Everything is installed! Your website previews at http://localhost:4321. The local padlock isn't available in this environment, but the site is fully functional and the live version on your real domain will be HTTPS once you deploy."
 
 If it fails, read the log:
 

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -273,7 +273,12 @@ The owner uses commands provided by the Anglesite plugin, invoked as slash comma
 
 For everything else — adding a page, changing the design, adding animations, updating dependencies — the owner just asks in plain English. You handle it.
 
-To write and edit blog posts, they navigate to `https://DEV_HOSTNAME/keystatic` in the preview panel (while the dev server is running). Read `DEV_HOSTNAME` from `.site-config`.
+To write and edit blog posts, they navigate to the Keystatic editor in the preview panel (while the dev server is running). The URL depends on `HTTPS_AVAILABLE` in `.site-config`:
+
+- `HTTPS_AVAILABLE=true` → `https://DEV_HOSTNAME/keystatic`
+- `HTTPS_AVAILABLE=false` (e.g., Claude Cowork — no sudo for HTTPS setup) → `http://localhost:4321/keystatic`
+
+If `HTTPS_AVAILABLE` is missing (older sites set up before this flag), assume `true` and use `https://DEV_HOSTNAME`.
 
 ## Reference docs
 

--- a/template/docs/local-https.md
+++ b/template/docs/local-https.md
@@ -53,6 +53,12 @@ On Linux and Windows, `.local` may also be used by mDNS/Avahi, but the hosts fil
 
 When the project is moved to a new machine (handoff, new laptop), run `npm run ai-setup`. It installs mkcert, trusts the CA, generates new certs, updates the hosts file, and configures port forwarding (auto on macOS, manual instructions on Linux/Windows). Certificates are machine-specific and never committed to git.
 
+## Environments without admin/sudo
+
+Some environments — Claude Cowork, web-based shells, and minimal containers — don't expose `sudo` or a TTY for password prompts. The setup script auto-detects this (`canRunPrivileged()` in `setup.ts`) and skips HTTPS setup entirely: no mkcert install, no CA trust, no hosts file edit, no port forwarding. The dev server falls back to `http://localhost:4321`, and the script writes `HTTPS_AVAILABLE=false` to `.site-config`. Re-running setup on a machine with admin access enables HTTPS later.
+
+`check-prereqs.ts` reports `https=available` or `https=unavailable (no admin/sudo — preview at http://localhost:4321)` so skills can adapt their messaging.
+
 ## Cleanup
 
 To remove all system modifications without deleting the project:

--- a/template/scripts/check-prereqs.ts
+++ b/template/scripts/check-prereqs.ts
@@ -14,16 +14,34 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { execaCommand } from "execa";
+import { execa, execaCommand } from "execa";
 import consola from "consola";
 import {
   platform,
+  isWindows,
   HOSTS_FILE,
   hasPfctl,
   mkcertBin as mkcertBinPath,
   needsXcodeTools,
 } from "./platform.js";
 import { readConfig } from "./config.js";
+
+/** Whether sudo can be used in this environment (interactive or cached). */
+async function canRunPrivileged(): Promise<boolean> {
+  if (!isWindows && process.getuid?.() === 0) return true;
+  if (isWindows) return true;
+  try {
+    await execaCommand("command -v sudo", { shell: true });
+  } catch {
+    return false;
+  }
+  try {
+    await execa("sudo", ["-n", "true"], { stdio: "pipe" });
+    return true;
+  } catch {
+    return process.stdin.isTTY === true;
+  }
+}
 
 /** Directory this script lives in (`scripts/`). */
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -116,6 +134,15 @@ async function main(): Promise<void> {
   console.log(`git_branch=${branch ?? "unknown"}`);
 
   // --- HTTPS ---
+
+  // HTTPS environment availability (sudo / admin access)
+  const httpsConfigured = readConfig("HTTPS_AVAILABLE");
+  const httpsEnv = await canRunPrivileged();
+  if (httpsConfigured === "false" || (httpsConfigured === undefined && !httpsEnv)) {
+    console.log("https=unavailable (no admin/sudo — preview at http://localhost:4321)");
+  } else {
+    console.log("https=available");
+  }
 
   // mkcert
   const mkcertPath = mkcertBinPath();

--- a/template/scripts/cleanup.ts
+++ b/template/scripts/cleanup.ts
@@ -15,7 +15,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { execa } from "execa";
+import { execa, execaCommand } from "execa";
 import consola from "consola";
 import {
   isMacos,
@@ -25,6 +25,23 @@ import {
   mkcertBin as mkcertBinPath,
 } from "./platform.js";
 import { readConfig } from "./config.js";
+
+/** Whether sudo can be used in this environment (interactive or cached). */
+async function canRunPrivileged(): Promise<boolean> {
+  if (!isWindows && process.getuid?.() === 0) return true;
+  if (isWindows) return true;
+  try {
+    await execaCommand("command -v sudo", { shell: true });
+  } catch {
+    return false;
+  }
+  try {
+    await execa("sudo", ["-n", "true"], { stdio: "pipe" });
+    return true;
+  } catch {
+    return process.stdin.isTTY === true;
+  }
+}
 
 /** Directory this script lives in (`scripts/`). */
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -79,6 +96,20 @@ async function main(): Promise<void> {
   }
 
   // macOS / Linux: use sudo
+  if (!(await canRunPrivileged())) {
+    consola.warn("Cannot remove system modifications: this environment doesn't support sudo.");
+    if (hasHostsEntry) {
+      consola.info(
+        `To remove the hosts entry, edit ${HOSTS_FILE} on a machine with admin access`,
+      );
+      consola.info(`and delete the line containing "${devHostname}".`);
+    }
+    if (hasPfctlRules) {
+      consola.info("To remove pfctl rules, run cleanup on a machine with admin access.");
+    }
+    return;
+  }
+
   consola.warn("Your password is needed for this.");
   await execa("sudo", ["-v"], { stdio: "inherit" });
 

--- a/template/scripts/setup.ts
+++ b/template/scripts/setup.ts
@@ -134,6 +134,39 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+/**
+ * Detect whether this environment can perform privileged operations
+ * (sudo on macOS/Linux, admin on Windows). Returns false in environments
+ * like Claude Cowork where there's no sudo binary or no TTY for a
+ * password prompt — in which case HTTPS preview setup is skipped.
+ */
+async function canRunPrivileged(): Promise<boolean> {
+  // Running as root — no sudo needed
+  if (!isWindows && process.getuid?.() === 0) return true;
+
+  if (isWindows) {
+    // Windows uses GUI dialogs for elevation; we already provide manual
+    // fallbacks for non-elevated runs, so don't gate the whole flow here.
+    return true;
+  }
+
+  // sudo binary present?
+  try {
+    await execaCommand("command -v sudo", { shell: true });
+  } catch {
+    return false;
+  }
+
+  // Cached sudo session or NOPASSWD?
+  try {
+    await execa("sudo", ["-n", "true"], { stdio: "pipe" });
+    return true;
+  } catch {
+    // Password required — only OK if we have a TTY to prompt on
+    return process.stdin.isTTY === true;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Setup steps
 // ---------------------------------------------------------------------------
@@ -595,28 +628,39 @@ async function initGit(): Promise<void> {
   log("Git initialized.");
 }
 
+/** Write or update a single key=value pair in `.site-config`. */
+function setConfigValue(key: string, value: string): void {
+  if (existsSync(CONFIG_FILE)) {
+    const content = readFileSync(CONFIG_FILE, "utf-8");
+    const re = new RegExp(`^${key}=.*$`, "m");
+    if (re.test(content)) {
+      writeFileSync(CONFIG_FILE, content.replace(re, `${key}=${value}`));
+    } else {
+      const sep = content.endsWith("\n") || content === "" ? "" : "\n";
+      appendFileSync(CONFIG_FILE, `${sep}${key}=${value}\n`);
+    }
+  } else {
+    writeFileSync(CONFIG_FILE, `${key}=${value}\n`);
+  }
+}
+
 /** Write PROJECT_DIR to `.site-config`. */
 function saveProjectDir(): void {
   if (DRY_RUN) {
     log("[dry-run] would write PROJECT_DIR to .site-config");
     return;
   }
-
-  if (existsSync(CONFIG_FILE)) {
-    const content = readFileSync(CONFIG_FILE, "utf-8");
-    if (content.includes("PROJECT_DIR=")) {
-      writeFileSync(
-        CONFIG_FILE,
-        content.replace(/^PROJECT_DIR=.*$/m, `PROJECT_DIR=${PROJECT_DIR}`),
-      );
-    } else {
-      appendFileSync(CONFIG_FILE, `\nPROJECT_DIR=${PROJECT_DIR}\n`);
-    }
-  } else {
-    writeFileSync(CONFIG_FILE, `PROJECT_DIR=${PROJECT_DIR}\n`);
-  }
-
+  setConfigValue("PROJECT_DIR", PROJECT_DIR);
   log("Project directory saved to .site-config");
+}
+
+/** Persist whether HTTPS preview is available in this environment. */
+function saveHttpsAvailability(available: boolean): void {
+  if (DRY_RUN) {
+    log(`[dry-run] would write HTTPS_AVAILABLE=${available} to .site-config`);
+    return;
+  }
+  setConfigValue("HTTPS_AVAILABLE", available ? "true" : "false");
 }
 
 /** Show a desktop notification (best-effort, cross-platform). */
@@ -647,11 +691,24 @@ async function main(): Promise<void> {
   await installNode();
   await ensureShellProfile();
   await installDependencies();
-  await installMkcert();
   await installGhCli();
-  await trustLocalCA();
-  await generateCert();
-  await configureSystemHttps();
+
+  const httpsAvailable = await canRunPrivileged();
+  if (httpsAvailable) {
+    await installMkcert();
+    await trustLocalCA();
+    await generateCert();
+    await configureSystemHttps();
+  } else {
+    log("Skipping HTTPS preview setup — this environment doesn't support admin/sudo access.");
+    log("The dev server will run at http://localhost:4321 (no padlock, but fully functional).");
+    log("To enable HTTPS later, run `npm run ai-setup` on a machine where you can grant admin access.");
+    skipped.push(
+      "HTTPS preview (no admin access available — site will preview at http://localhost:4321)",
+    );
+  }
+  saveHttpsAvailability(httpsAvailable);
+
   await initGit();
   saveProjectDir();
 


### PR DESCRIPTION
## Summary

Anglesite's local HTTPS preview (mkcert + hosts file + pfctl) requires sudo/admin access. In Claude Cowork and other web-based or sandboxed environments, sudo isn't available, which currently causes confusing prompts or hangs during `npm run ai-setup`.

This PR detects the environment and skips HTTPS setup entirely when admin access isn't available. The dev server falls back to `http://localhost:4321`.

## Changes

- **`template/scripts/setup.ts`** — New `canRunPrivileged()` helper checks for root, sudo binary, cached/NOPASSWD sudo, and TTY availability. The HTTPS-related steps (`installMkcert`, `trustLocalCA`, `generateCert`, `configureSystemHttps`) are gated behind it. Persists `HTTPS_AVAILABLE=true|false` to `.site-config` so other code can adapt.
- **`template/scripts/cleanup.ts`** — Same detection; falls back to printing manual cleanup instructions instead of attempting sudo.
- **`template/scripts/check-prereqs.ts`** — Reports `https=available` or `https=unavailable (no admin/sudo — preview at http://localhost:4321)` based on `.site-config` and live environment check.
- **`skills/start/SKILL.md`** — Adds Claude Cowork wizard summary and post-setup messaging based on `HTTPS_AVAILABLE`.
- **`template/CLAUDE.md`** — Webmaster guide explains how to choose the right preview URL (`https://DEV_HOSTNAME` vs `http://localhost:4321`) based on `HTTPS_AVAILABLE`.
- **`template/docs/local-https.md`** — Documents the no-admin fallback and `HTTPS_AVAILABLE` flag.

## Detection logic

```ts
async function canRunPrivileged(): Promise<boolean> {
  if (!isWindows && process.getuid?.() === 0) return true;   // root
  if (isWindows) return true;                                // GUI elevation
  if (sudo binary missing) return false;                     // Cowork-like env
  if (sudo -n true succeeds) return true;                    // cached/NOPASSWD
  return process.stdin.isTTY === true;                       // can prompt
}
```

## Test plan

- [ ] Run `npm test` (passes — 2184 tests)
- [ ] Run `npm run ai-setup` in a sudo-less environment (e.g., container without sudo binary) and confirm HTTPS steps are skipped, `HTTPS_AVAILABLE=false` is written, dev server starts on `http://localhost:4321`
- [ ] Run `npm run ai-setup` on macOS with sudo and confirm existing flow still works, `HTTPS_AVAILABLE=true` is written
- [ ] Run `npm run ai-check` in both environments and confirm `https=available|unavailable` is reported correctly
- [ ] Verify the `start` skill picks the correct post-setup message based on `HTTPS_AVAILABLE`


---
_Generated by [Claude Code](https://claude.ai/code/session_01YHbxLC2xCxdgkmMqcpFATd)_