### PR TITLE
fix: rename skill frontmatter `user-invokable` to canonical `user-invocable`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ Two levels of agent instructions exist — do not confuse them:
 | `menu` | Restaurant menu import (PDF/photo), creation, and editing |
 | `design-import` | Import design tokens and page layouts from Canva or Figma |
 
-**Model-only** (called programmatically by other skills, `user-invokable: false`):
+**Model-only** (called programmatically by other skills, `user-invocable: false`):
 
 | Skill | Purpose |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Anglesite works with [Claude Cowork](https://support.claude.com/en/articles/1334
 
 ### Claude Cowork (recommended for site owners)
 
+Plugins in Cowork require a paid plan (Pro, Max, Team, or Enterprise).
+
 1. Open [Claude](https://claude.ai) and start a Cowork session
 2. Open the **Code** tab
 3. Press **+** > **Plugins** > **Add Plugin**

--- a/bin/generate-skill-registry.ts
+++ b/bin/generate-skill-registry.ts
@@ -15,7 +15,7 @@ export interface SkillMeta {
   name: string;
   description: string;
   disableModelInvocation?: boolean;
-  userInvokable?: boolean;
+  userInvocable?: boolean;
 }
 
 export type SkillClassification = "user-facing" | "model-only" | "both";
@@ -38,8 +38,8 @@ export function parseSkillFrontmatter(content: string): SkillMeta {
     meta.disableModelInvocation = true;
   }
 
-  if (/^user-invokable:\s*false$/m.test(fm)) {
-    meta.userInvokable = false;
+  if (/^user-invocable:\s*false$/m.test(fm)) {
+    meta.userInvocable = false;
   }
 
   return meta;
@@ -52,7 +52,7 @@ export function parseSkillFrontmatter(content: string): SkillMeta {
 const VALID_FRONTMATTER_KEYS = new Set([
   "name",
   "description",
-  "user-invokable",
+  "user-invocable",
   "disable-model-invocation",
   "allowed-tools",
   "argument-hint",
@@ -72,10 +72,10 @@ export function validateSkillFrontmatter(content: string): string[] {
     if (keyMatch) keys.push(keyMatch[1]);
   }
 
-  // Check for unknown keys (catches typos like user-invocable)
+  // Check for unknown keys (catches typos like user-invokable)
   for (const key of keys) {
     if (!VALID_FRONTMATTER_KEYS.has(key)) {
-      const suggestion = key === "user-invocable" ? " (did you mean user-invokable?)" : "";
+      const suggestion = key === "user-invokable" ? " (did you mean user-invocable?)" : "";
       errors.push(`unknown frontmatter key "${key}"${suggestion}`);
     }
   }
@@ -93,7 +93,7 @@ export function validateSkillFrontmatter(content: string): string[] {
 // ---------------------------------------------------------------------------
 
 export function classifySkill(meta: SkillMeta): SkillClassification {
-  if (meta.userInvokable === false) return "model-only";
+  if (meta.userInvocable === false) return "model-only";
   if (meta.disableModelInvocation === true) return "user-facing";
   return "both";
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anglesite",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anglesite",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0"

--- a/skills/animate/SKILL.md
+++ b/skills/animate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: animate
 description: "Design CSS animations: hover effects, scroll reveals, page transitions"
-user-invokable: false
+user-invocable: false
 allowed-tools: Write, Read, Glob
 ---
 

--- a/skills/business-info/SKILL.md
+++ b/skills/business-info/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: business-info
 description: "Collect and display business hours, address, phone, and LocalBusiness JSON-LD"
-user-invokable: false
+user-invocable: false
 allowed-tools: Write, Read, Glob
 ---
 

--- a/skills/buy-button/SKILL.md
+++ b/skills/buy-button/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: buy-button
 description: "Add a buy button to sell a product, service, or digital good (Stripe or Polar)"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 ---
 

--- a/skills/copy-edit/SKILL.md
+++ b/skills/copy-edit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: copy-edit
 description: "Audit and coach website copy for clarity, tone, and brand voice"
-user-invokable: false
+user-invocable: false
 allowed-tools: Write, Read, Edit, Glob
 ---
 

--- a/skills/creative-canvas/SKILL.md
+++ b/skills/creative-canvas/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: creative-canvas
 description: "Add interactive visual effects and creative coding to any page"
-user-invokable: false
+user-invocable: false
 argument-hint: "[effect description or library name]"
 allowed-tools: Bash(npm install *), Bash(npm run dev), Bash(npm run build), Write, Read, Glob
 ---

--- a/skills/design-interview/SKILL.md
+++ b/skills/design-interview/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design-interview
 description: "Redo the visual identity and branding"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(npm run *), WebFetch, Write, Read, Edit, Glob
 ---
 

--- a/skills/email/SKILL.md
+++ b/skills/email/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: email
 description: "Set up business email: Apple-first provider recommendation, DNS pre-fill, tier routing"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(curl *), Write, Read
 ---
 

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment
 description: "Propose, run, and analyze A/B tests to improve conversions"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Write, Read, Edit, Glob
 ---
 

--- a/skills/freedesignmd/SKILL.md
+++ b/skills/freedesignmd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: freedesignmd
 description: "Browse, fetch, and apply a design system from freedesignmd.com to the project"
-user-invokable: false
+user-invocable: false
 allowed-tools: WebFetch, Write, Read, Edit, Glob
 ---
 

--- a/skills/i18n/SKILL.md
+++ b/skills/i18n/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: i18n
 description: "Set up multi-language support with localized routes, hreflang, and language switcher"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(npm run build), Bash(npx astro check), Write, Read, Glob
 ---
 

--- a/skills/lemon-squeezy/SKILL.md
+++ b/skills/lemon-squeezy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lemon-squeezy
 description: "Add a Lemon Squeezy checkout overlay for digital product sales (alternative to Polar)"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(npm run build), Write, Read, Edit, Glob
 ---
 

--- a/skills/new-page/SKILL.md
+++ b/skills/new-page/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: new-page
 description: "Create a new page with SEO and accessibility"
-user-invokable: false
+user-invocable: false
 argument-hint: "[page name or purpose]"
 allowed-tools: Write, Read, Glob
 ---

--- a/skills/og-images/SKILL.md
+++ b/skills/og-images/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: og-images
 description: "Generate branded OG images for social sharing: per-page and site-wide, using Satori"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(npm run ai-images), Bash(npm run ai-og), Read, Glob, Write
 ---
 

--- a/skills/optimize-images/SKILL.md
+++ b/skills/optimize-images/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: optimize-images
 description: "Optimize images: resize, convert to WebP, strip EXIF, generate srcset variants"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(npm run ai-optimize), Write, Read, Edit, Glob
 ---
 

--- a/skills/paddle/SKILL.md
+++ b/skills/paddle/SKILL.md
@@ -2,7 +2,7 @@
 name: paddle
 description: "Set up Paddle checkout for software licensing, SaaS subscriptions, or metered billing"
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
-user-invokable: false
+user-invocable: false
 ---
 
 Set up Paddle checkout for selling software, plugins, SaaS subscriptions, or metered-billing products. Paddle acts as Merchant of Record — it handles global tax compliance, subscription management, license keys, and payouts. Claude embeds a checkout overlay on the site using Paddle.js.

--- a/skills/print/SKILL.md
+++ b/skills/print/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: print
 description: "Generate print-ready materials (business cards, flyers, door hangers, social cards) from site branding"
-user-invokable: false
+user-invocable: false
 allowed-tools: Write, Read, Glob, Bash(npm run ai-qr)
 ---
 

--- a/skills/qr/SKILL.md
+++ b/skills/qr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qr
 description: "Generate QR codes with UTM tracking, shortlink redirects, and campaign-tagged URLs"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(npm run ai-qr), Write, Read, Glob
 ---
 

--- a/skills/reputation/SKILL.md
+++ b/skills/reputation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reputation
 description: "Surface review response suggestions and competitive insights based on business type"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(date *), Read, Glob
 ---
 

--- a/skills/seasonal/SKILL.md
+++ b/skills/seasonal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: seasonal
 description: "Surface seasonal content suggestions based on business type and current date"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(date *), Read, Glob
 ---
 

--- a/skills/shopify-buy-button/SKILL.md
+++ b/skills/shopify-buy-button/SKILL.md
@@ -2,7 +2,7 @@
 name: shopify-buy-button
 description: "Set up Shopify Buy Button for a full physical product catalog with dashboard"
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
-user-invokable: false
+user-invocable: false
 ---
 
 Set up Shopify Buy Button for selling physical goods with a full catalog (10+ products) that needs inventory management, order tracking, and shipping configuration. The owner manages products in Shopify's admin dashboard; Claude embeds Buy Buttons on the site.

--- a/skills/snipcart/SKILL.md
+++ b/skills/snipcart/SKILL.md
@@ -2,7 +2,7 @@
 name: snipcart
 description: "Set up Snipcart ecommerce for a small physical product catalog"
 allowed-tools: Write, Read, Edit, Glob, Bash(npm run build), Bash(npx astro check)
-user-invokable: false
+user-invocable: false
 ---
 
 Set up Snipcart ecommerce for selling physical goods with a small catalog (under ~10 products). Snipcart adds a full shopping cart with no monthly fees (2% per transaction + Stripe fees). Products are managed as content files via Keystatic; Snipcart handles cart, checkout, and payment.

--- a/skills/social-media/SKILL.md
+++ b/skills/social-media/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: social-media
 description: "Proactive social media strategy, content calendars, and profile optimization"
-user-invokable: false
+user-invocable: false
 allowed-tools: Write, Read, Glob
 ---
 

--- a/skills/syndicate/SKILL.md
+++ b/skills/syndicate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: syndicate
 description: "Generate social media posts from a blog post for POSSE syndication"
-user-invokable: false
+user-invocable: false
 allowed-tools: Write, Read, Glob
 ---
 

--- a/skills/testimonials/SKILL.md
+++ b/skills/testimonials/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: testimonials
 description: "Set up customer review collection, moderation, and display with star ratings"
-user-invokable: false
+user-invocable: false
 allowed-tools: Bash(npm run build), Bash(npx wrangler *), Write, Read, Glob
 ---
 

--- a/skills/themes/SKILL.md
+++ b/skills/themes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: themes
 description: "Present pre-built visual themes from freedesignmd plus built-in quick-picks, then apply the owner's choice"
-user-invokable: false
+user-invocable: false
 allowed-tools: WebFetch, Write, Read, Edit, Glob
 ---
 

--- a/tests/skill-registry.test.ts
+++ b/tests/skill-registry.test.ts
@@ -40,14 +40,14 @@ disable-model-invocation: true
     expect(meta.disableModelInvocation).toBe(true);
   });
 
-  it("extracts user-invokable flag", () => {
+  it("extracts user-invocable flag", () => {
     const content = `---
 name: animate
 description: "CSS animations"
-user-invokable: false
+user-invocable: false
 ---`;
     const meta = parseSkillFrontmatter(content);
-    expect(meta.userInvokable).toBe(false);
+    expect(meta.userInvocable).toBe(false);
   });
 
   it("defaults flags to undefined when absent", () => {
@@ -57,7 +57,7 @@ description: "Health audit"
 ---`;
     const meta = parseSkillFrontmatter(content);
     expect(meta.disableModelInvocation).toBeUndefined();
-    expect(meta.userInvokable).toBeUndefined();
+    expect(meta.userInvocable).toBeUndefined();
   });
 
   it("handles description without quotes", () => {
@@ -81,8 +81,8 @@ describe("classifySkill", () => {
     ).toBe("user-facing");
   });
 
-  it("classifies user-invokable: false as model-only", () => {
-    expect(classifySkill({ userInvokable: false } as SkillMeta)).toBe(
+  it("classifies user-invocable: false as model-only", () => {
+    expect(classifySkill({ userInvocable: false } as SkillMeta)).toBe(
       "model-only",
     );
   });
@@ -111,7 +111,7 @@ describe("generateRegistry", () => {
     {
       name: "animate",
       description: "CSS animations",
-      userInvokable: false,
+      userInvocable: false,
     },
     {
       name: "check",
@@ -182,7 +182,7 @@ describe("validateSkillFrontmatter", () => {
     const content = `---
 name: animate
 description: "CSS animations"
-user-invokable: false
+user-invocable: false
 allowed-tools: Write, Read, Glob
 ---`;
     expect(validateSkillFrontmatter(content)).toEqual([]);
@@ -198,24 +198,24 @@ allowed-tools: Bash(npm run build), Write, Read
     expect(validateSkillFrontmatter(content)).toEqual([]);
   });
 
-  it("flags user-invocable as a typo of user-invokable", () => {
+  it("flags user-invokable as a typo of user-invocable", () => {
     const content = `---
 name: experiment
 description: "A/B tests"
-user-invocable: false
+user-invokable: false
 allowed-tools: Write, Read
 ---`;
     const errors = validateSkillFrontmatter(content);
     expect(errors.length).toBeGreaterThan(0);
-    expect(errors[0]).toContain("user-invocable");
     expect(errors[0]).toContain("user-invokable");
+    expect(errors[0]).toContain("user-invocable");
   });
 
   it("flags missing allowed-tools", () => {
     const content = `---
 name: experiment
 description: "A/B tests"
-user-invokable: false
+user-invocable: false
 ---`;
     const errors = validateSkillFrontmatter(content);
     expect(errors.length).toBeGreaterThan(0);
@@ -249,7 +249,7 @@ disable-model-invocation: true
     const content = `---
 name: bad-skill
 description: "Broken"
-user-invocable: false
+user-invokable: false
 ---`;
     const errors = validateSkillFrontmatter(content);
     // Should flag both the typo and missing allowed-tools


### PR DESCRIPTION
## Summary

The official Claude Code skill frontmatter field is [`user-invocable`](https://code.claude.com/docs/en/skills#frontmatter-reference), not `user-invokable`. Claude Code silently ignores unknown frontmatter keys, so the 25 "model-only" skills in this plugin were actually appearing in the `/` slash menu and could be invoked directly by users — the opposite of the intended design.

The misspelling was institutional: the project's own validator (`bin/generate-skill-registry.ts`) enforced the wrong spelling and flagged the correct spelling as a typo. An earlier internal audit (`docs/superpowers/specs/2026-03-30-comprehensive-audit-design.md`, item C11) inverted the typo direction when "fixing" the `experiment` skill, then standardized the rest of the codebase on the wrong spelling.

## Changes

- Rename `user-invokable: false` → `user-invocable: false` in all 25 model-only `SKILL.md` files
- Update `bin/generate-skill-registry.ts` so the correct spelling is canonical, and `user-invokable` is now flagged as the typo (suggestion direction inverted)
- Update `tests/skill-registry.test.ts` to match (test names, fixtures, and assertions)
- Regenerate `docs/dev/skill-registry.md` (output unchanged — same 18 user-facing + 25 model-only classification)
- Update reference in root `CLAUDE.md`
- Add note to `README.md` that Cowork plugins require a paid plan (Pro/Max/Team/Enterprise), since plugin install is one of the first things a Cowork visitor sees

Historical specs/plans under `docs/superpowers/` are intentionally **not** edited — they are dated records of past decisions.

## Verification

- `npm test` → 2184 passed, 12 skipped, 0 failed
- `npx tsx bin/generate-skill-registry.ts` → `43 skills: 18 user-facing, 25 model-only, 0 both`
- `grep -rl 'user-invokable' skills/` → no results
- The 25 affected skills (`animate`, `business-info`, `buy-button`, `copy-edit`, `creative-canvas`, `design-interview`, `email`, `experiment`, `freedesignmd`, `i18n`, `lemon-squeezy`, `new-page`, `og-images`, `optimize-images`, `paddle`, `print`, `qr`, `reputation`, `seasonal`, `shopify-buy-button`, `snipcart`, `social-media`, `syndicate`, `testimonials`, `themes`) will no longer appear in the `/anglesite:*` slash menu after this lands

## Test plan

- [ ] Install the plugin locally (`claude --plugin-dir .`) and confirm only the 18 user-facing skills appear in the `/` menu
- [ ] Confirm `start` still triggers `design-interview`, `business-info`, etc. programmatically
- [ ] Confirm `add-store` still routes to `buy-button`, `lemon-squeezy`, `snipcart`, `shopify-buy-button`, `paddle` programmatically
- [ ] `npm test` passes in CI

https://claude.ai/code/session_01CdwoR1fmvnMHgzuCT3yaC1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdwoR1fmvnMHgzuCT3yaC1)_