### PR TITLE
feat: prefer Wix MCP server for blog content imports (#212)

### DIFF
--- a/docs/import/wix.md
+++ b/docs/import/wix.md
@@ -1,6 +1,8 @@
 # Importing from Wix
 
-Wix has the most restrictive content export of any major platform. There is no content API, no full export feature, and pages are JavaScript-rendered (Wix Thunderbolt). The import skill uses a combination of sitemaps, RSS metadata, and two extraction backends: **Playwright** (preferred — extracts content + design tokens in one pass) and **curl + regex** (fallback — content only).
+Wix has the most restrictive content export of any major platform — but the [Wix MCP server](https://dev.wix.com/docs/wix-cli/mcp) substantially closes the gap for blog content. When the owner is signed into the Wix account that owns the site, the MCP server exposes a posts query and a Ricos→HTML converter that produce noticeably cleaner output than scraping rendered pages.
+
+The import skill prefers the MCP path for blog posts and metadata, and falls back to **Playwright** (extracts content + design tokens in one pass) or **curl + regex** (content only) for everything the MCP doesn't cover. Static pages, design tokens, and JS-rendered widgets always require Playwright — the Wix API does not expose editor pages.
 
 See [hosted-platforms.md](hosted-platforms.md) for standard HTML-to-Markdown conversion rules, image optimization pipeline, pagination patterns, and missing field fallbacks. This doc covers only what's specific to Wix.
 
@@ -9,6 +11,81 @@ See [hosted-platforms.md](hosted-platforms.md) for standard HTML-to-Markdown con
 The import skill uses WebFetch on the homepage and checks for `wix` or `Thunderbolt` in the page source, or `static.wixstatic.com` in asset URLs.
 
 ## Extraction methods
+
+### Wix MCP server (preferred for blog content)
+
+When the [Wix MCP server](https://dev.wix.com/docs/wix-cli/mcp) is installed
+and the owner is authenticated to the Wix account that owns the site, two
+tools dramatically simplify blog extraction:
+
+- `ListWixSites` — enumerates the owner's Wix sites (active and archived).
+  Useful for confirming which site to import from up front instead of
+  re-running with a different URL.
+- `ExecuteWixAPI` — calls Wix REST endpoints with the owner's auth.
+
+**Detection:** Look for tools matching `*__ListWixSites` and
+`*__ExecuteWixAPI` (the namespace prefix varies per MCP install). The
+`/anglesite:import` skill checks for these in Step 1a.1.
+
+**Owner authentication is required.** The Wix MCP only works when the owner
+is logged into the Wix account being migrated from. It is not usable by
+anyone visiting another person's Wix site.
+
+#### Posts query
+
+One call returns titles, slugs, dates, excerpts, cover image URLs, language,
+SEO data, and the full Ricos document for every published post:
+
+```
+ExecuteWixAPI POST https://www.wixapis.com/v3/posts/query
+body: {
+  "fieldsets": ["URL", "CONTENT_TEXT", "SEO", "RICH_CONTENT"],
+  "paging": { "limit": 100 }
+}
+```
+
+Paginate with `paging.cursor` when `pagingMetadata.cursors.next` is returned.
+This bypasses the 20-post RSS limit and the API's metadata-only default
+that requires `fieldsets` to include `RICH_CONTENT`.
+
+#### Ricos → HTML conversion
+
+Convert each post's `richContent` to HTML (not Markdown — see below):
+
+```
+ExecuteWixAPI POST https://www.wixapis.com/ricos/v1/ricos-document/convert/from-ricos
+body: {
+  "ricosDocument": <richContent>,
+  "targetFormat": "HTML"
+}
+```
+
+The converter handles whitespace, link unwrapping, and heading levels
+correctly — none of the HTML cleanup the Playwright/regex path needs is
+required. From there, the standard HTML-to-Markdown rules in
+[`content-conversion.md`](../content-conversion.md) take over.
+
+**Why HTML, not Markdown:** the converter accepts `targetFormat: "MARKDOWN"`
+too, but Markdown output strips inline image nodes (it only preserves
+captions as bare text). HTML preserves `<img>` tags so the standard image
+pipeline can rewrite `static.wixstatic.com` URLs to local paths during
+conversion.
+
+#### Operational notes
+
+- **Token budget:** `ExecuteWixAPI` responses are capped at ~6,000 tokens.
+  Convert at most 4 posts per call. Fetch one at a time for long posts. If a
+  response is truncated, retry with a smaller batch.
+- **Cover images:** `coverMedia.image.url` returns a direct
+  `static.wixstatic.com` URL — ready for `curl` (apply the standard
+  parameter stripping below).
+- **What it does NOT cover:**
+  - Static (editor) pages — About, FAQ, Get Involved, etc. still require
+    Playwright or curl + regex.
+  - Design tokens (colors, fonts) — extract from the homepage with
+    Playwright.
+  - JS-rendered widgets (FAQ accordions, custom embeds) — neither the MCP
+    nor WebFetch sees these. Playwright is the only option.
 
 ### Sitemap for content discovery
 
@@ -56,6 +133,12 @@ The RSS feed does NOT contain full post content — only excerpts. It also has n
 
 ### Wix Blog REST API (if owner has API access)
 
+Prefer the Wix MCP server path above when available — it uses the same
+underlying API but handles auth automatically and gives you the Ricos
+converter for clean output. Only use the raw API key path below when the
+owner can't or won't install the MCP server but is willing to mint an API
+key.
+
 If the owner has a Wix API key (from the Wix Developers dashboard), the Blog
 REST API can extract all posts with pagination — bypassing the 20-post RSS limit:
 
@@ -73,11 +156,13 @@ the owner to create an API key. Don't ask for it unless the site has more than
 20 blog posts (where RSS falls short). The API does **not** cover static pages —
 those still require WebFetch.
 
-### Playwright extraction (preferred — content + styling)
+### Playwright extraction (when Wix MCP is unavailable, or for static pages and design tokens)
 
 When Playwright is available, a single browser session extracts both content
-and computed CSS styles from the rendered page. This is the preferred method
-because it:
+and computed CSS styles from the rendered page. This is the path the import
+skill uses when the Wix MCP server is not installed, and it remains the
+required path for static (editor) pages and design-token extraction even
+when the MCP is available. It:
 - Gets complete content via TreeWalker on the rendered DOM (not regex)
 - Extracts computed colors, fonts, and spacing via `getComputedStyle()`
 - Captures all JS-rendered navigation links (including dynamic sub-navs)

--- a/skills/import/SKILL.md
+++ b/skills/import/SKILL.md
@@ -190,7 +190,7 @@ For each detected platform, read the corresponding doc from `${CLAUDE_PLUGIN_ROO
 | Platform | Detection signals | Doc reference |
 | --- | --- | --- |
 | Squarespace | `squarespace` in scripts/meta, `squarespace-cdn.com` | `${CLAUDE_PLUGIN_ROOT}/docs/import/squarespace.md` |
-| Wix | `wix` or `Thunderbolt` in source, `wixstatic.com` | `${CLAUDE_PLUGIN_ROOT}/docs/import/wix.md` |
+| Wix | `wix` or `Thunderbolt` in source, `wixstatic.com` | `${CLAUDE_PLUGIN_ROOT}/docs/import/wix.md` (also see Wix MCP path in Step 1a.1) |
 | Shopify | `cdn.shopify.com`, `/collections/`, `/products/` | `${CLAUDE_PLUGIN_ROOT}/docs/import/shopify.md` |
 | Medium | `miro.medium.com`, `.medium.com` domain | `${CLAUDE_PLUGIN_ROOT}/docs/import/medium.md` |
 | Substack | `substackcdn.com`, `.substack.com` domain | `${CLAUDE_PLUGIN_ROOT}/docs/import/substack.md` |
@@ -208,6 +208,39 @@ extraction instructions. For unknown platforms, tell the owner:
 > by reading each page. It just takes a bit longer."
 
 Store the detected platform as PLATFORM.
+
+### 1a.1 — Wix MCP server detection (Wix only)
+
+If PLATFORM is `wix`, check whether the [Wix MCP server](https://dev.wix.com/docs/wix-cli/mcp)
+is installed by looking for tools whose names end in `__ListWixSites` and
+`__ExecuteWixAPI` (the prefix is the MCP server's namespaced ID, which varies
+per install). If both are available, set USE_WIX_MCP=true.
+
+If the tools are not available, surface a one-line install hint:
+
+> "Your Wix site has a much cleaner import path if you enable the Wix MCP
+> server — it gives me direct access to your blog posts and metadata via
+> Wix's API instead of scraping rendered pages. It only works if you're
+> signed in to the Wix account that owns this site. Want to install it
+> before we continue? Otherwise I'll fall through to the slower extraction
+> method."
+
+If the owner installs it, ask them to restart the session so the new tools
+load, then re-run `/anglesite:import`. If they decline (or aren't the site
+owner — the MCP only works for the authenticated Wix account), set
+USE_WIX_MCP=false and continue with Playwright + curl extraction.
+
+When USE_WIX_MCP=true:
+
+1. Call `ListWixSites` to enumerate the owner's Wix sites. If more than one
+   matches (e.g., active site plus an archived copy), present the list and
+   ask which one to import from. Store the chosen site ID as WIX_SITE_ID.
+2. The Wix MCP path covers blog posts and their metadata. **Static pages and
+   design tokens are not exposed via the API** — Playwright (Step 2a / 3b)
+   is still required for those, so don't skip the Playwright install prompt.
+
+Read `${CLAUDE_PLUGIN_ROOT}/docs/import/wix.md` ("Wix MCP server" section)
+for the full extraction workflow and operational notes.
 
 ### 1b — Platform-specific content discovery
 
@@ -301,8 +334,61 @@ the RSS feed, use the `<description>` or `<content:encoded>` field. For posts
 NOT in the RSS feed (older than the most recent 10–20), use WebFetch on the
 post URL with the extraction prompt below.
 
-**Wix:** Use Playwright to extract content and design tokens. WebFetch does
-not work on Wix pages.
+**Wix (MCP path, USE_WIX_MCP=true):** Use the Wix MCP server's `ExecuteWixAPI`
+tool — the Ricos document converter returns clean output and eliminates
+almost all of the HTML post-processing the Playwright/regex path needs.
+
+1. Query all published posts in one call (paginate with `paging.cursor` if
+   `pagingMetadata.cursors.next` is returned):
+
+   ```
+   ExecuteWixAPI POST https://www.wixapis.com/v3/posts/query
+   body: {
+     "fieldsets": ["URL", "CONTENT_TEXT", "SEO", "RICH_CONTENT"],
+     "paging": { "limit": 100 }
+   }
+   ```
+
+   Each result includes `title`, `slug`, `firstPublishedDate`, `excerpt`,
+   `coverMedia` (with a direct `static.wixstatic.com` URL), `language`,
+   `seoData`, and a `richContent` Ricos document.
+
+2. For each post, convert the Ricos document to **HTML** (not Markdown — the
+   Markdown target strips inline image nodes and only preserves captions).
+   HTML lets the standard image pipeline swap CDN URLs to local paths during
+   conversion:
+
+   ```
+   ExecuteWixAPI POST https://www.wixapis.com/ricos/v1/ricos-document/convert/from-ricos
+   body: {
+     "ricosDocument": <richContent>,
+     "targetFormat": "HTML"
+   }
+   ```
+
+3. **Token budget:** `ExecuteWixAPI` responses are capped at ~6,000 tokens.
+   Convert at most 4 posts per call, and fall back to one post at a time for
+   long posts. If a response is truncated, retry with a smaller batch.
+
+4. Convert the returned HTML to Markdown using the rules in
+   `${CLAUDE_PLUGIN_ROOT}/docs/content-conversion.md` (Step 2b). Map fields:
+   - `title` → `title`
+   - `slug` → file slug
+   - `firstPublishedDate` → `publishDate` (truncate to YYYY-MM-DD)
+   - `excerpt` → `description` (or generate from body if empty)
+   - `coverMedia.image.url` → `image` (download in Step 2c)
+   - `seoData.tags` → tag/keyword frontmatter where applicable
+   - `url.url` (or constructed `/post/<slug>`) → `syndication`
+
+5. **Static pages and design tokens still need Playwright** — see Step 3b for
+   pages and Step 5.5 for tokens. The Wix API does not expose editor pages.
+
+If `ExecuteWixAPI` fails on a specific post, fall back to the Playwright path
+below for that post only. Add the post to FAILED_POSTS only if both methods
+fail.
+
+**Wix (USE_WIX_MCP=false):** Use Playwright to extract content and design
+tokens. WebFetch does not work on Wix pages.
 
 Before the first extraction, check if Playwright is installed and offer to
 install it if not:

--- a/skills/import/content-discovery.md
+++ b/skills/import/content-discovery.md
@@ -90,6 +90,29 @@ will be fetched via WebFetch in Step 2.
 
 ## Wix
 
+If USE_WIX_MCP=true (set in Step 1a.1), discover blog posts via the Wix MCP
+server's `ExecuteWixAPI` tool first — it returns the complete post list with
+metadata in one call:
+
+```
+ExecuteWixAPI POST https://www.wixapis.com/v3/posts/query
+body: {
+  "fieldsets": ["URL", "CONTENT_TEXT", "SEO", "RICH_CONTENT"],
+  "paging": { "limit": 100 }
+}
+```
+
+Build BLOG_POSTS from the response (each entry includes `title`, `slug`,
+`firstPublishedDate`, `excerpt`, `coverMedia`, `seoData`, and `richContent`).
+Paginate with `paging.cursor` if `pagingMetadata.cursors.next` is returned.
+The `richContent` field is the Ricos document — convert it in Step 2a.
+
+The MCP path covers blog posts only. Static pages still come from the
+sitemap and homepage navigation crawl below.
+
+If USE_WIX_MCP=false (no MCP installed, or owner declined), discover both
+blog posts and pages via the sitemap:
+
 ```sh
 curl -s SITE_URL/sitemap.xml
 ```
@@ -138,12 +161,14 @@ BLOG_POSTS by `<link>` URL.
   empty or links-only, skip it and rely on sitemap + extraction scripts
 - Never contains static pages — those always need extraction in Step 3
 
-**Blog REST API (20+ posts):** If the blog has more than 20 posts, ask the
-owner if they have a Wix API key. The Blog REST API at
+**Blog REST API (20+ posts, USE_WIX_MCP=false):** If the blog has more than
+20 posts and the Wix MCP server isn't installed, ask the owner if they have a
+Wix API key. The Blog REST API at
 `https://www.wixapis.com/blog/v3/posts?fieldsToInclude=CONTENT` returns full
 post content with pagination — much faster than WebFetch for large blogs. See
 `${CLAUDE_PLUGIN_ROOT}/docs/import/wix.md` for details. Don't ask for an API
-key if the blog has 20 or fewer posts (RSS + WebFetch is sufficient).
+key if the blog has 20 or fewer posts (RSS + WebFetch is sufficient), or if
+USE_WIX_MCP=true (the MCP path already covers this).
 
 **Metadata extraction:** When extracting each post, use the bundled extraction
 script to get structured metadata (JSON-LD and OG tags):


### PR DESCRIPTION
## Summary

When `/anglesite:import` detects a Wix site, prefer the [Wix MCP server](https://dev.wix.com/docs/wix-cli/mcp) for blog content extraction:

- New **Step 1a.1** detects whether the Wix MCP is installed (`*__ListWixSites`, `*__ExecuteWixAPI`). If not, surface a one-line install hint; if yes, set `USE_WIX_MCP=true` and call `ListWixSites` to confirm which site to import from (catches the active-vs-archived case).
- **Step 2a Wix path** uses `ExecuteWixAPI` to call `POST /v3/posts/query` with `fieldsets: [URL, CONTENT_TEXT, SEO, RICH_CONTENT]`, then converts each post's Ricos document via the `from-ricos` endpoint with `targetFormat: HTML`. HTML (not Markdown) is used so inline image nodes survive and the standard image pipeline can rewrite `static.wixstatic.com` URLs. Falls back to the Playwright path on per-post failure.
- **Static pages and design tokens** still flow through Playwright — the Wix API doesn't expose editor pages or computed CSS.
- Operational notes captured: ~6,000-token cap on `ExecuteWixAPI` responses (≤4 posts per conversion call), MCP-only-works-when-owner-is-authenticated.

`docs/import/wix.md` gains a "Wix MCP server (preferred for blog content)" section; the existing Playwright/curl/RSS/REST API methods are now framed as fallbacks.

`skills/import/content-discovery.md` is updated so blog-post discovery uses the MCP query when `USE_WIX_MCP=true` and the manual API-key path is skipped (the MCP already covers it).

Closes #212.

## Test plan

- [x] `npx vitest run tests/skill-registry.test.ts tests/build-instructions.test.ts tests/markdownlint.test.ts` — 50 passed
- [x] `npx vitest run test/wix-extract.test.js test/wix-playwright.test.js test/wix-color-utils.test.js` — 104 passed (no regressions in fallback extraction)
- [ ] Live import run on a Wix site with the Wix MCP server installed, confirming the MCP path is taken and posts come back clean
- [ ] Live import run on a Wix site without the Wix MCP server, confirming the install-hint surfaces and Playwright fallback still works

https://claude.ai/code/session_01PNWZZgNDPTyKzk1PdW27Ny

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNWZZgNDPTyKzk1PdW27Ny)_