### PR TITLE
fix: stop shipping placeholder favicon.svg in template (#222)

### DIFF
--- a/skills/convert/SKILL.md
+++ b/skills/convert/SKILL.md
@@ -374,7 +374,7 @@ Copy found assets to `public/`:
 cp SOURCE_LOGO public/logo.EXT
 ```
 
-If a `favicon.svg` or `favicon.ico` is found, copy it to replace the scaffold default.
+If a `favicon.svg` or `favicon.ico` is found, copy it to `public/`. The Anglesite template ships without a default favicon, so this populates the missing icon.
 
 ### 1.5e — Apply extracted design to Anglesite
 

--- a/skills/design-interview/SKILL.md
+++ b/skills/design-interview/SKILL.md
@@ -171,7 +171,7 @@ Ensure `src/layouts/BaseLayout.astro` imports `src/design/tokens.css`. Add this 
 5. Save the interview results to `docs/brand.md` with all answers and design decisions
 6. Update CSS custom properties in `src/styles/global.css` — replace old color/font/spacing vars with references to the tokens, or remove duplicates
 7. Verify color contrast meets WCAG AA (4.5:1 for body text, 3:1 for large text) — the generation functions handle this, but double-check
-8. Update the favicon (`public/favicon.svg`) to match the identity
+8. Create the favicon (`public/favicon.svg`) to match the identity (no placeholder ships in the template — write a brand-aligned SVG so the `<link rel="icon">` tag activates)
 9. Update `public/manifest.webmanifest` with brand colors (`theme_color` from `--color-primary`, `background_color` from `--color-bg`)
 10. Run `npm run ai-images` to regenerate `apple-touch-icon.png` and `og-image.png`
 11. Build a styled home page that reflects the brand and site type

--- a/skills/print/SKILL.md
+++ b/skills/print/SKILL.md
@@ -41,7 +41,7 @@ Read these files to extract the design system and business details:
    - `--color-primary`, `--color-accent`, `--color-bg`, `--color-text`
    - `--font-heading`, `--font-body`
    - `--radius-sm`, `--radius-md`
-4. **`public/favicon.svg`** — the site's logo/icon for placement on materials
+4. **`public/favicon.svg`** — the site's logo/icon for placement on materials (may not exist yet — generate fallbacks from brand colors when missing)
 5. **`public/images/qr/`** — check for existing QR codes to include
 
 If `BUSINESS_TYPE` is set, read `${CLAUDE_PLUGIN_ROOT}/docs/smb/<type>.md` for industry-specific guidance on what materials work best.

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -210,7 +210,7 @@ Branch based on the choice:
 
 Post-design tasks (run for any of the three paths):
 
-- Update `public/favicon.svg` to match the identity
+- Create `public/favicon.svg` to match the identity (the template no longer ships a placeholder — write a brand-aligned SVG here so the `<link rel="icon">` tag in `BaseLayout.astro` activates)
 - Update `public/manifest.webmanifest` with brand colors (`theme_color` from `--color-primary`, `background_color` from `--color-bg`)
 - Run `npm run ai-images` to regenerate `apple-touch-icon.png` and `og-image.png`
 - Add JSON-LD structured data to the home page (`LocalBusiness` for physical businesses, `Organization` for online-only, `Person` for personal sites)

--- a/template/public/favicon.svg
+++ b/template/public/favicon.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <text x="2" y="26" font-size="28">🌱</text>
-</svg>

--- a/template/src/layouts/BaseLayout.astro
+++ b/template/src/layouts/BaseLayout.astro
@@ -37,6 +37,8 @@ const aiModel =
 const siteName =
   configContent.match(/^SITE_NAME=(.+)$/m)?.[1]?.trim() ?? "My Website";
 const generator = `Anglesite ${version} (${aiModel}, ${Astro.generator})`;
+
+const hasFavicon = existsSync(resolve(process.cwd(), "public/favicon.svg"));
 ---
 
 <!doctype html>
@@ -48,7 +50,7 @@ const generator = `Anglesite ${version} (${aiModel}, ${Astro.generator})`;
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    {hasFavicon && <link rel="icon" type="image/svg+xml" href="/favicon.svg" />}
     <link rel="sitemap" href="/sitemap-index.xml" />
 
     <!-- Open Graph -->

--- a/template/src/layouts/ImmersiveLayout.astro
+++ b/template/src/layouts/ImmersiveLayout.astro
@@ -1,4 +1,7 @@
 ---
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
 /**
  * ImmersiveLayout — full-viewport layout for creative experiments.
  * No header/footer chrome. Dark background. Canvas fills the viewport.
@@ -16,6 +19,7 @@ const { title, description, image, labUrl = '/lab', siteName } = Astro.props;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
 const ogImage = image ? new URL(image, Astro.site).href : undefined;
 const displayName = siteName || title;
+const hasFavicon = existsSync(resolve(process.cwd(), "public/favicon.svg"));
 ---
 
 <!doctype html>
@@ -40,7 +44,7 @@ const displayName = siteName || title;
     <meta name="twitter:description" content={description} />
     {ogImage && <meta name="twitter:image" content={ogImage} />}
 
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    {hasFavicon && <link rel="icon" href="/favicon.svg" type="image/svg+xml" />}
 
     <style>
       @import '../styles/immersive.css';

--- a/template/src/layouts/KioskLayout.astro
+++ b/template/src/layouts/KioskLayout.astro
@@ -34,6 +34,8 @@ const siteName =
   propSiteName ?? configContent.match(/^SITE_NAME=(.+)$/m)?.[1]?.trim() ?? "Menu";
 
 const resolvedThemeColor = themeColor ?? "#0f0f0f";
+
+const hasFavicon = existsSync(resolve(process.cwd(), "public/favicon.svg"));
 ---
 
 <!doctype html>
@@ -50,7 +52,7 @@ const resolvedThemeColor = themeColor ?? "#0f0f0f";
     <meta name="robots" content="noindex, nofollow" />
 
     <!-- Icons -->
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    {hasFavicon && <link rel="icon" href="/favicon.svg" type="image/svg+xml" />}
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 
     <!-- Open Graph -->


### PR DESCRIPTION
Fixes #222.

## Summary

The template shipped a sprout-emoji `public/favicon.svg` that lingered after owners customized their branding — visiting `/favicon.svg` directly returned the placeholder even when their configured favicon lived elsewhere. Adopt option 1 from the issue: don't ship a default.

## Changes

- Delete `template/public/favicon.svg`.
- Make `<link rel="icon">` conditional in `BaseLayout.astro`, `ImmersiveLayout.astro`, and `KioskLayout.astro` so the tag only renders when the file actually exists (uses the same `existsSync` pattern `BaseLayout` already employs for `package.json` and `.site-config`).
- Update `start`, `design-interview`, `convert`, and `print` skill docs to reflect that the favicon is *created* (not updated) and that downstream flows must handle its absence.

The og-image and apple-touch-icon generators (`scripts/generate-images.ts`, `scripts/generate-og-pages.ts`) already use `existsSync` fallbacks, and `og-images/SKILL.md` documents the `text-only` template for the missing-favicon case, so no script changes are needed.

## Test plan

- [x] `npm test` — all 2184 tests pass (12 skipped, unrelated)
- [ ] Manual: scaffold a fresh site → confirm `public/favicon.svg` is absent and dev server renders pages without a 404 for `/favicon.svg` in DevTools
- [ ] Manual: run `/anglesite:design-interview` → confirm it creates `public/favicon.svg` and the icon link reactivates after a rebuild

---
_Generated by [Claude Code](https://claude.ai/code/session_011o1R63bFvuWxQMQ3Wq8SaC)_