### PR TITLE
fix(stats): caveat unique-visitor inflation and surface country breakdown

### DIFF
--- a/skills/stats/SKILL.md
+++ b/skills/stats/SKILL.md
@@ -84,6 +84,17 @@ curl -s "https://api.cloudflare.com/client/v4/graphql" \
   --data '{"query":"{ viewer { zones(filter: {zoneTag: \"'$CF_ZONE_ID'\"}) { httpRequestsAdaptiveGroups(filter: {date: \"DATE_TODAY\", edgeResponseContentTypeName: \"html\", edgeResponseStatus_lt: 400}, limit: 100, orderBy: [count_DESC]) { count dimensions { clientRequestPath } } } } }"}'
 ```
 
+### Query C — country breakdown (most recent day)
+
+Replace `DATE_TODAY` with today's ISO date. Same single-day window as Query B. The country breakdown lets the owner self-diagnose datacenter/bot inflation in the unique-visitor count — small sites often see Hetzner Frankfurt (DE), AWS/Hetzner Dublin (IE), OVH, Vultr Singapore (SG), and Tor (T1) dominate the geography.
+
+```sh
+curl -s "https://api.cloudflare.com/client/v4/graphql" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"query":"{ viewer { zones(filter: {zoneTag: \"'$CF_ZONE_ID'\"}) { httpRequestsAdaptiveGroups(filter: {date: \"DATE_TODAY\", edgeResponseContentTypeName: \"html\", edgeResponseStatus_lt: 400}, limit: 25, orderBy: [count_DESC]) { count dimensions { clientCountryName } } } } }"}'
+```
+
 ### Graceful degradation
 
 Inspect the JSON response for an `errors[]` array before parsing. If any error message contains `authz`, `does not have access`, or `time range wider than`, drop that section from the output and continue with the data you do have. Don't surface the raw error to the owner — note in the summary that the section requires a paid Cloudflare plan (for referrer/device) or a longer history (for the adaptive window).
@@ -96,8 +107,8 @@ Only attempt these if the owner has confirmed a paid Cloudflare plan. Add `clien
 
 These three numbers measure different things and must not be substituted for one another:
 
-- **Unique visitors** — `uniq.uniques` from `httpRequests1dGroups`. The number of distinct people.
-- **Page views** — `sum.pageViews` from `httpRequests1dGroups`, or `count` from `httpRequestsAdaptiveGroups` *when filtered to HTML responses* (Query B). One person can generate many page views.
+- **Unique visitors** — `uniq.uniques` from `httpRequests1dGroups`. The number of distinct IP+UA pairs Cloudflare saw. **This includes datacenter ranges (Hetzner, AWS, OVH, Vultr) and bots that did not get blocked at the edge**, so on small personal sites it can overstate human readers by 50–100%. Always present it with the caveat in the summary, and lead with page views when both are available.
+- **Page views** — `sum.pageViews` from `httpRequests1dGroups`, or `count` from `httpRequestsAdaptiveGroups` *when filtered to HTML responses* (Query B). One person can generate many page views. Less inflated by bots than uniques because most non-rendering scrapers don't request many distinct HTML pages.
 - **Requests** — raw `count` from `httpRequestsAdaptiveGroups` with no content-type filter. Includes every asset, redirect, bot hit, and error response. Don't surface this as "visitors" or "views"; only mention it explicitly as "requests" when relevant.
 
 From the responses, extract:
@@ -107,17 +118,27 @@ From the responses, extract:
 3. **Busiest day** — from Query A, map each `dimensions.date` (ISO date) to its weekday name, take the day with the highest `sum.pageViews` in the current week. Label the figure as "page views" (not "visits" or "visitors").
 4. **Top pages** — from Query B (HTML-filtered), group rows by `clientRequestPath`, sum `count`, sort descending, take top 5. Label the figure as "page views". Note in the summary that this reflects the most recent 24 hours (free-plan limitation).
 5. **Campaign breakdown** — from Query B's `clientRequestPath` values, extract URL query strings containing `utm_source`, `utm_medium`, `utm_campaign`. Group by `utm_source`/`utm_campaign`, label each entry as `{source} "{campaign}"`, and sort by page-view count descending.
-6. **Referral sources** *(paid plans only)* — group by `clientRefererHost`, rename common ones (e.g., `google.com` → "Google Search", empty → "Direct"). Skip entirely on free plans.
-7. **Device breakdown** *(paid plans only)* — group by `userAgentBrowser` or device class. Skip entirely on free plans.
+6. **Country breakdown** — from Query C, take top 8 countries by `count`. Mark the following as `(datacenter-heavy)` so the owner can spot bot inflation: `IE` (Dublin — Hetzner/AWS), `DE` (Frankfurt — Hetzner), `NL` (Amsterdam — OVH/Hetzner), `SG` (Vultr/DigitalOcean), `FI` (Hetzner Helsinki), `T1` or `XX` (Tor exit nodes), and any country whose share looks disproportionate to the site's audience (e.g., `CN` on an English-language local-business site). Use the country code as returned by Cloudflare; map common ones to readable names (`US` → "United States", etc.) when presenting.
+7. **Referral sources** *(paid plans only)* — group by `clientRefererHost`, rename common ones (e.g., `google.com` → "Google Search", empty → "Direct"). Skip entirely on free plans.
+8. **Device breakdown** *(paid plans only)* — group by `userAgentBrowser` or device class. Skip entirely on free plans.
 
 Present the summary in plain language. Example output (free plan):
 
-> Your site had **142 unique visitors** and **318 page views** this week (visitors up 23%, page views up 31% from last week).
+> Your site drew **318 page views** this week (up 31% from last week), from **142 unique IPs** (up 23%).
+>
+> *Heads up — Cloudflare counts every distinct IP as a "unique visitor", which sweeps in datacenter traffic (Hetzner, AWS, OVH) and bots that don't get blocked at the edge. On small sites the real human-reader count is usually 50–60% of the unique number. Use page views as the more reliable signal and check the country breakdown below.*
 >
 > **Top pages** (last 24 hours, HTML page views):
 > 1. /services — 58 page views
 > 2. / — 45 page views
 > 3. /about — 30 page views
+>
+> **Top countries** (last 24 hours, HTML page views):
+> 1. United States — 1,248
+> 2. Ireland — 358 *(datacenter-heavy)*
+> 3. Germany — 349 *(datacenter-heavy)*
+> 4. China — 190
+> 5. Tor — 124 *(datacenter-heavy)*
 >
 > **Busiest day:** Tuesday with 65 page views. Consider posting new content on Monday to catch the wave.
 >
@@ -133,8 +154,10 @@ Present the summary in plain language. Example output (free plan):
 After collecting the data, present results as a clean markdown summary:
 
 - **Top pages** — markdown table with page path and page-view count (and optional bar made of `█` characters proportional to page views, e.g. `████████ 240`). Header the count column "Page views", not "Visits".
-- **Campaign performance** — second markdown table if campaign data exists, also in page views
-- **Plain-language summary** — 2–3 sentences explaining what the numbers mean. When you cite a headline figure, say which one (visitors vs page views) — they tell different stories.
+- **Top countries** — markdown table with country name and page-view count. Append `(datacenter-heavy)` to known datacenter-dominant origins (see Step 2 item 6).
+- **Campaign performance** — markdown table if campaign data exists, also in page views.
+- **Bot/datacenter caveat** — always include the one-line heads-up about unique-visitor inflation when reporting `uniq.uniques` on a free plan. Don't skip it on the assumption that the site is large; the owner is rarely in a position to know.
+- **Plain-language summary** — 2–3 sentences explaining what the numbers mean. When you cite a headline figure, say which one (visitors vs page views) — they tell different stories. Lead with page views when both are available.
 
 Lead with the table, follow with the summary and actionable suggestions.
 


### PR DESCRIPTION
## Summary

- Adds a `Query C` for country breakdown (HTML-filtered, last 24 hours) so the owner can self-diagnose datacenter/bot inflation in Cloudflare's `uniq.uniques`.
- Always emits a one-line caveat next to the unique-visitor count, and recommends leading with page views when both are available.
- Annotates known datacenter-heavy origins (IE, DE, NL, SG, FI, Tor) in the country table so e.g. 358 visits from Dublin reads as Hetzner/AWS rather than a real surge.

## Why

On small personal sites, datacenter ranges and unblocked bots dominate `uniq.uniques`. Concrete example from the issue (pulletsforever.com, 2026-05-05): IE 358, DE 349, NL 101, SG 84 — the naive ~3,800 unique number was probably 1.5–2k humans. The skill was reporting the headline figure with no caveat.

## Test plan

- [ ] Re-run `/anglesite:stats` on a small site and confirm the caveat appears and the country table flags datacenter origins.
- [ ] Confirm the new Query C degrades gracefully on a free plan when adaptive falls outside the 1-day window (existing graceful-degradation block already covers it).
- [ ] Eyeball the example output for tone/length.

Closes #219

https://claude.ai/code/session_0196Pn61TubGH4c1z4mXjnMD

---
_Generated by [Claude Code](https://claude.ai/code/session_0196Pn61TubGH4c1z4mXjnMD)_