### PR TITLE
fix(stats): ship .env.example, drop dead CF_PROJECT_NAME read

### DIFF
--- a/skills/stats/SKILL.md
+++ b/skills/stats/SKILL.md
@@ -16,7 +16,7 @@ Read `EXPLAIN_STEPS` from `.site-config`. If `true` or not set, explain before e
 
 ## Step 0 — Check prerequisites
 
-Read `.env` for `CF_API_TOKEN` and `CF_ZONE_ID`.
+Read `.env` for `CF_API_TOKEN` and `CF_ZONE_ID`. The scaffolded project ships a `.env.example` that lists these keys with comments — copy or create `.env` from it on first run if it doesn't exist yet.
 
 If `CF_API_TOKEN` is missing, guide the owner through creating one:
 
@@ -166,9 +166,8 @@ If a top page hasn't been updated in more than 30 days, suggest: "Your /services
 
 After showing the summary, remind the owner they can see more detail in the Cloudflare dashboard:
 
-"For more detailed charts, visit your analytics dashboard:"
+"For more detailed charts, visit your analytics dashboard: `https://dash.cloudflare.com/?to=/:account/web-analytics`"
 
-Read `CF_PROJECT_NAME` from `.site-config` if available, and provide:
-`https://dash.cloudflare.com/?to=/:account/web-analytics`
+The Web Analytics URL is account-scoped (Cloudflare resolves `:account` from the logged-in session) and doesn't need a project identifier.
 
 Tell them: "The dashboard shows trends over time, geographic data, and more. But for a quick check-in, just run this command anytime."

--- a/template/.env.example
+++ b/template/.env.example
@@ -1,0 +1,15 @@
+# Local-only secrets. Copy this file to `.env` and fill in the values.
+# `.env` is gitignored — never commit real tokens. `.site-config` IS committed,
+# so secrets must live here, not there.
+#
+# Skills that need these values (stats, domain, email, experiment) will guide
+# you through creating them on first run. You usually don't need to fill this
+# in by hand — but having the keys listed here makes it obvious where they go.
+
+# Cloudflare API token — Zone → Analytics → Read (plus DNS Edit if using /anglesite:domain).
+# Create at https://dash.cloudflare.com/profile/api-tokens
+CF_API_TOKEN=
+
+# Cloudflare zone identifier for your domain. Auto-discovered from SITE_DOMAIN
+# on first run if not set. Find it on the Cloudflare dashboard's zone overview.
+CF_ZONE_ID=

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -8,6 +8,7 @@ node_modules
 # env
 .env
 .env.*
+!.env.example
 
 # OS
 .DS_Store


### PR DESCRIPTION
Closes #220

## Summary

Two small ergonomics fixes for the `stats` skill flagged in the issue:

- **Ship `.env.example` in the template.** The skill expects `CF_API_TOKEN` and `CF_ZONE_ID` in `.env`, but on a fresh checkout the file simply didn't exist — leaving the agent (or owner) to guess. The new `template/.env.example` lists both keys with inline comments explaining where each value comes from. The existing `.env.*` ignore rule would have hidden it, so a `!.env.example` exception was added to `template/.gitignore`. Other Cloudflare-using skills (`domain`, `email`, `experiment`) reuse the same `.env`, so they all benefit.
- **Remove the dead `CF_PROJECT_NAME` lookup from Step 4.** The Web Analytics dashboard URL (`https://dash.cloudflare.com/?to=/:account/web-analytics`) is account-scoped — Cloudflare resolves `:account` from the logged-in session and never used the project name. Reading the key did nothing.
- Step 0 now points the owner at the example file on first run.

`CF_PROJECT_NAME` itself stays in `.site-config` (where it's set during `/anglesite:deploy` and used by `domain`, `contact`, `add-store`, etc.) — the issue's suggestion to put it in `.env.example` would have been the wrong file, since it's not a secret and other skills already read it from `.site-config`.

## Test plan

- [x] `npm test` — all 2193 tests pass (12 skipped)
- [ ] Manual: `zsh scripts/scaffold.sh /tmp/test-site` produces a `.env.example` in the destination
- [ ] Manual: `git status` in the scaffolded project shows `.env.example` as tracked, `.env` as ignored

https://claude.ai/code/session_01Q37c35huKGL9h57jVks6Sj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q37c35huKGL9h57jVks6Sj)_