### PR TITLE
fix: stub template devDeps in vitest so vi.mock works consistently

### DIFF
--- a/tests/__stubs__/resvg.ts
+++ b/tests/__stubs__/resvg.ts
@@ -1,0 +1,10 @@
+// See satori.ts — same rationale. Real `@resvg/resvg-js` is a template
+// devDependency; tests intercept via `vi.mock("@resvg/resvg-js")`.
+export class Resvg {
+  constructor(_svg: string) {
+    throw new Error("resvg stub — vi.mock should intercept this in tests");
+  }
+  render() {
+    throw new Error("resvg stub — vi.mock should intercept this in tests");
+  }
+}

--- a/tests/__stubs__/satori.ts
+++ b/tests/__stubs__/satori.ts
@@ -1,0 +1,8 @@
+// Stub satori for tests. The real package is a template devDependency; aliasing
+// to this stub means "satori" resolves to the same module ID regardless of
+// whether `template/node_modules/satori` is installed locally. Tests use
+// `vi.mock("satori")` to substitute behavior — this stub only needs to satisfy
+// the import shape (default export = function).
+export default function satori() {
+  throw new Error("satori stub — vi.mock should intercept this in tests");
+}

--- a/tests/__stubs__/sharp.ts
+++ b/tests/__stubs__/sharp.ts
@@ -1,0 +1,5 @@
+// See satori.ts — same rationale. Real `sharp` is a template devDependency;
+// tests intercept via `vi.mock("sharp")`.
+export default function sharp() {
+  throw new Error("sharp stub — vi.mock should intercept this in tests");
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
       // Map template/scripts imports to the actual source
       "./config.js": resolve(__dirname, "template/scripts/config.ts"),
       "./platform.js": resolve(__dirname, "template/scripts/platform.ts"),
+      // Stub template devDependencies so resolution is consistent whether or
+      // not `template/node_modules` is populated. Tests use `vi.mock` to
+      // substitute behavior; without these aliases, `template/scripts/*.ts`
+      // would resolve the real packages from a nested node_modules and the
+      // mock registry (keyed by the test file's resolved path) wouldn't match.
+      satori: resolve(__dirname, "tests/__stubs__/satori.ts"),
+      "@resvg/resvg-js": resolve(__dirname, "tests/__stubs__/resvg.ts"),
+      sharp: resolve(__dirname, "tests/__stubs__/sharp.ts"),
     },
   },
   esbuild: {


### PR DESCRIPTION
## Summary

Fixes the fourth bug uncovered while shipping `v1.0.0-beta.7`: `tests/satori-og.test.ts` fails when `template/node_modules` is populated (e.g. after running the manual smoke-test from `CLAUDE.md`).

### What was happening

`vi.mock("satori", ...)` in `tests/satori-og.test.ts` wasn't intercepting `import satori from "satori"` in `template/scripts/satori-og.ts`. The real satori loaded, tried to parse the test's `Buffer.from("fake-font")` as OpenType, and threw `Unsupported OpenType signature fake`.

### Root cause

`vi.mock` keys mocks by the resolved module ID, scoped to the test file's location. The test file lives at the plugin root, where neither `satori` nor `@resvg/resvg-js` is installed — so the mock either fails to register or registers under a different ID than the one the source file produces (resolving via `template/node_modules`).

The reason this looked fine in CI: when the real package isn't installed *anywhere*, `vi.mock` works as a virtual replacement. Installing template deps locally (the standard manual smoke-test step) exposed the gap. CI never installs template deps, so the failure stayed dormant.

### Fix

Alias `satori`, `@resvg/resvg-js`, and `sharp` to stub files in `tests/__stubs__/` via `vitest.config.ts`. Vite now resolves these specifiers to the same path regardless of importer, so `vi.mock` intercepts consistently. The stubs throw if invoked — which would only happen if `vi.mock` somehow misses, making any future regression loud rather than silent.

### Test plan

- [x] `npm test` passes with `template/node_modules` absent (2323 tests, CI condition)
- [x] `npm test` passes with `template/node_modules` populated (2323 tests, smoke-test condition)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)