### PR TITLE
docs(changelog): backfill 1.0.0-beta.2 through 1.0.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,103 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.0-beta.7] — 2026-05-07
+
+Big beta. Nine new user-invocable skills round out the 1.0 commerce, community, and ops surface; analytics gets honest about what it's measuring; deploy learns about agent readability and performance budgets.
+
+### Added
+- `/anglesite:membership` skill — paywall and content gating via Polar or Memberful
+- `/anglesite:podcast` skill — episode collection, Apple/Spotify-ready RSS feed, embeddable player, optional per-episode YouTube video embed
+- `/anglesite:consent` skill — category-based GDPR/CCPA cookie consent banner with granular per-category opt-in
+- `/anglesite:giscus` skill — blog comments backed by GitHub Discussions
+- `/anglesite:inbox` skill — Keystatic-based inbox for form submissions from `/anglesite:contact` and `/anglesite:forms` (#193)
+- `/anglesite:donations` skill — Stripe, Liberapay, and GitHub Sponsors donation flows with optional fundraising goal widget and 501(c)(3) tax-receipt template
+- `/anglesite:redirects` skill — URL redirect manager with CSV bulk import, Cloudflare Pages `_redirects` generation (#192)
+- `/anglesite:export` skill — portable site export for self-host or migration
+- `/anglesite:forms` skill — custom RSVP, lead, survey, and callback forms wired through Cloudflare Workers into the Keystatic inbox
+- Per-page performance budgets in `/anglesite:deploy` — warn-only by default, with a planned `PERF_WARN_ONLY=false` opt-in for hard gating in 1.2
+- Restore flow added to `/anglesite:backup` — roll a site back to any GitHub backup snapshot
+- Wix MCP server preferred for blog content imports, with the Playwright path as fallback
+- Sudo-less HTTPS fallback — `/anglesite:start` skips local HTTPS setup when sudo isn't available (e.g., Claude Cowork) and records `HTTPS_AVAILABLE=false` in `.site-config` so the Keystatic editor URL adapts
+- ADR-0017 — agent readability deploy gate driven by `AGENTIC_CRAWLERS` intent
+
+### Changed
+- `/anglesite:stats` distinguishes unique visitors, page views, and total requests
+- `/anglesite:stats` splits Cloudflare Web Analytics RUM data from zone HTTP logs
+- `/anglesite:stats` supports free Cloudflare zones (#216)
+- `/anglesite:stats` surfaces country breakdown and caveats bot-inflated unique-visitor numbers
+- `AGENTIC_CRAWLERS` in `.site-config` now drives `llms.txt` and `robots.txt` generation as a single source of truth (#210)
+- Skill frontmatter field renamed from `user-invokable` to canonical `user-invocable`
+
+### Fixed
+- Pre-beta.7 review fixes — security, consent, and performance-budget hardening (#244)
+- `/anglesite:stats` no longer extracts UTM data on the free Cloudflare plan (where it isn't reliable)
+- `/anglesite:stats` ships `.env.example` and stops reading the dead `CF_PROJECT_NAME` env var
+- Template no longer ships placeholder `favicon.svg` (#222)
+
+## [1.0.0-beta.6] — 2026-05-04
+
+### Added
+- a14y agent readability audit and opt-in deploy gate, driven by `AGENTIC_CRAWLERS` in `.site-config`
+- Owner name collected on-demand (only when a specific output needs it) instead of being asked upfront during `/anglesite:start`
+
+## [1.0.0-beta.5] — 2026-05-04
+
+The bulk of the 1.0 feature work. WCAG 2.1 AA audit, link checker, WordPress import, design-import for Canva, the email skill, freedesignmd integration, and a wave of import/convert and search/blog fixes.
+
+### Added
+- WCAG 2.1 AA audit in `/anglesite:check` with opt-in deploy gate (`A11Y_GATE=true`) and warn-only escape hatch (`A11Y_WARN_ONLY=true`) (#197)
+- Automated link checker in `/anglesite:check` — internal links by default, `--external` for off-site URL verification (#195)
+- WordPress import — WXR parser plus content cleaner that handles shortcodes and Gutenberg blocks
+- `/anglesite:design-import` skill — extracts colors, typography, spacing, and layout heuristics from a published Canva site and applies them to the project (Figma support stubbed for a future release)
+- Model-only email skill — Apple-first provider flow (iCloud Mail+, Hide My Email) with reference setup for Fastmail, ProtonMail, Google Workspace, and Microsoft 365
+- freedesignmd integration as the design system source of truth, replacing the tldraw experiment
+- Per-skill style guide and CSS/markdown linting (`stylelint`, `markdownlint-cli2`)
+- `PII_PHONE_ALLOW` allowlist in `.site-config` for sites that intentionally publish a phone number (#174)
+- Workflow for filing bugs against the Anglesite plugin repo
+- Serena project configuration for plugin development
+
+### Changed
+- Email setup delegated from the domain skill into a dedicated email skill
+- Install instructions updated for the separate marketplace repo
+
+### Fixed
+- `/anglesite:import` and `/anglesite:convert` protect existing pages from being overwritten during re-import (#173)
+- Content collections only scaffolded when needed for the site type (#171)
+- Glob-loader warnings for empty content collections suppressed
+- Wix import — header logos and footer content extracted in fullPage mode (#166)
+- Wix import — Playwright resolved from the project cwd, not the plugin cache (#167)
+- `/anglesite:import` warns against flat-sitemap image extraction (#172)
+- `/anglesite:search` — Pagefind CSS variables scoped to `#search` instead of `:root` (#169)
+- Blog post URLs strip the `.mdoc` extension (#168)
+- `astro-pagefind/components` import replaced with a runtime dynamic import to fix breakage
+- Import scripts renamed from `.js` to `.mjs` for ESM compatibility
+- `/anglesite:convert` and `/anglesite:import` detect both Astro 5 content config paths (#35)
+- Removed Gemini CLI support to focus on Claude
+
+## [1.0.0-beta.4] — 2026-04-02
+
+### Fixed
+- Plugin uses inline settings marketplace to fix skill loading
+
+### Added
+- Style guide for HTML, CSS, and TypeScript
+
+## [1.0.0-beta.3] — 2026-04-01
+
+### Fixed
+- Stop infinite recursion in marketplace plugin source
+
+## [1.0.0-beta.2] — 2026-04-01
+
+### Fixed
+- Remove dev artifacts that caused `ENAMETOOLONG` on update
+- Support prerelease versions in `bin/release.ts` semver validation
+
+### Changed
+- `bin/release.ts` uses the `semver` package for version bumping
+- 0.16.x and beta.1 release notes backfilled into this changelog
+
 ## [1.0.0-beta.1] — 2026-03-31
 
 First beta for the 1.0 release. All 0.16.x blockers resolved — entering QA.


### PR DESCRIPTION
## Summary

`CHANGELOG.md` stopped at 1.0.0-beta.1, so beta.2 through beta.7 — six
tagged releases including the bulk of the 1.0 feature work — had no
public notes. This backfills entries from git history and PR titles,
matching the existing keep-a-changelog format.

## Highlights now documented

- **beta.5** — WCAG 2.1 AA audit (#197), link checker (#195), WordPress
  import, `/anglesite:design-import` (Canva), email skill, freedesignmd
  integration replacing tldraw, content-collection scaffolding fixes
  (#171, #173)
- **beta.6** — a14y agent readability audit and deploy gate, on-demand
  owner-name collection
- **beta.7** — nine new user-invocable skills (`membership`, `podcast`,
  `consent`, `giscus`, `inbox` (#193), `donations`, `redirects` (#192),
  `export`, `forms`), per-page performance budgets, backup restore,
  `AGENTIC_CRAWLERS`-driven `llms.txt` and `robots.txt` (#210), sudo-less
  HTTPS fallback, honest analytics (#216, plus unique vs page views vs
  requests, RUM vs zone)
- **beta.2-beta.4** — marketplace and release-script fixes that
  unblocked plugin install and update flows

## Why this matters

The marketing site (`anglesite.dwk.io/releases`) is the public-facing
rewrite of the changelog. Without canonical entries to translate from,
the site drifted (see Anglesite/anglesite.dwk.io PR for the corrections).
Keeping CHANGELOG.md as the source of truth makes future release-note
generation mechanical.

## Test plan

- [ ] Visual review against git tags `v1.0.0-beta.2` … `v1.0.0-beta.7`
- [ ] Confirm referenced PR numbers (#171, #173, #192, #193, #195, #197, #210, #216) match the work landed in each beta
- [ ] No code or build changes — docs only