### PR TITLE
skills(inbox,membership): prefer Cloudflare MCP for KV provisioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ Two levels of agent instructions exist — do not confuse them:
 - **Reference docs** go in `docs/` at the plugin root — skills read them via `${CLAUDE_PLUGIN_ROOT}/docs/`.
 - **Site-specific docs** go in `template/docs/` — these are scaffolded to the user's project and updated per-site.
 - **Documentation must stay in sync.** Update docs when you change behavior.
+- **MCP-first for Cloudflare provisioning.** When a skill provisions Cloudflare resources (KV namespaces, R2 buckets, D1 databases, Hyperdrive configs, Workers), prefer the Cloudflare MCP tools (`mcp__cloudflare__kv_namespace_create`, `mcp__cloudflare__kv_namespace_get`, `mcp__cloudflare__kv_namespaces_list`, etc.) over shelling out to `npx wrangler …`. The MCP path returns the resource id directly, so the skill can write the binding into the relevant `worker/*-wrangler.toml` itself — no copy-paste, no terminal-output parsing, and no human-readable prompt the owner has to interpret. Always document a `wrangler` CLI fallback for offline / no-MCP environments, and add the relevant `mcp__cloudflare__*` tools to the skill's `allowed-tools` frontmatter.
 
 ## Key decisions
 

--- a/skills/inbox/SKILL.md
+++ b/skills/inbox/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: inbox
 description: "Browse, triage, and export form submissions from Keystatic instead of digging through email"
-allowed-tools: Bash(npm run *), Bash(npx wrangler *), Bash(grep *), Write, Read, Glob
+allowed-tools: Bash(npm run *), Bash(npx wrangler *), Bash(grep *), Write, Read, Edit, Glob, mcp__cloudflare__kv_namespace_create, mcp__cloudflare__kv_namespace_get, mcp__cloudflare__kv_namespaces_list, mcp__cloudflare__accounts_list
 disable-model-invocation: true
 ---
 
@@ -29,6 +29,14 @@ If `INBOX_KV_ID` is already set in `.site-config`, the inbox is already configur
 
 Tell the owner: "I'm creating a Cloudflare Workers KV namespace to store your form submissions. It's free up to 100k reads and 1k writes per day, more than enough for a small business."
 
+**Preferred — Cloudflare MCP (no copy-paste):**
+
+1. Call `mcp__cloudflare__accounts_list` if the active account hasn't been resolved yet, then `mcp__cloudflare__set_active_account` with the matching `account_id`.
+2. Call `mcp__cloudflare__kv_namespace_create` with `title: "form_submissions"`. Read the `id` from the response.
+3. Save the `id` to `.site-config` as `INBOX_KV_ID=<id>` using the Write tool.
+
+**Fallback — wrangler CLI** (use only if the Cloudflare MCP server isn't connected):
+
 ```sh
 npx wrangler kv namespace create form_submissions
 ```
@@ -46,7 +54,7 @@ Copy the `id` value. Save it to `.site-config` as `INBOX_KV_ID=abc123def456...` 
 
 ## Step 2 — Wire the binding into each worker
 
-For every deployed worker (`worker/wrangler.toml` for the contact form, `worker/forms-wrangler.toml` for the forms handler), uncomment the `[[kv_namespaces]]` block and replace `REPLACE_WITH_KV_NAMESPACE_ID` with the saved `INBOX_KV_ID`. The binding name must remain `SUBMISSIONS`.
+For every deployed worker (`worker/wrangler.toml` for the contact form, `worker/forms-wrangler.toml` for the forms handler), uncomment the `[[kv_namespaces]]` block and replace `REPLACE_WITH_KV_NAMESPACE_ID` with the saved `INBOX_KV_ID`. The binding name must remain `SUBMISSIONS`. Use the Edit tool — do not Write the whole file.
 
 Example (after edit):
 

--- a/skills/membership/SKILL.md
+++ b/skills/membership/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: membership
 description: "Gate premium content with newsletter (free) or Stripe (paid) — signed-cookie unlocks at the edge"
-allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Bash(node *), Write, Read, Edit, Glob
+allowed-tools: Bash(npm run build), Bash(npx wrangler *), Bash(npx astro check), Bash(grep *), Bash(node *), Write, Read, Edit, Glob, mcp__cloudflare__kv_namespace_create, mcp__cloudflare__kv_namespace_get, mcp__cloudflare__kv_namespaces_list, mcp__cloudflare__accounts_list
 disable-model-invocation: true
 ---
 
@@ -176,13 +176,27 @@ Webhooks are how the Worker knows when a subscription becomes active. The Worker
 
 ### 4e — KV namespace
 
-Create the KV namespace and bind it to the Worker:
+Create the KV namespace and bind it to the Worker.
+
+**Preferred — Cloudflare MCP (no copy-paste):**
+
+1. Call `mcp__cloudflare__accounts_list` / `mcp__cloudflare__set_active_account` if the active account isn't already resolved.
+2. Call `mcp__cloudflare__kv_namespace_create` with `title: "MEMBERSHIPS"`. Read the `id` from the response.
+3. Use Edit to write `id = "<id>"` into the `[[kv_namespaces]]` block in `worker/membership-wrangler.toml` (binding name `MEMBERSHIPS`). Save the value to `.site-config` as `MEMBERSHIP_KV_ID=<id>` for future reference.
+
+**Fallback — wrangler CLI:**
 
 ```sh
 npx wrangler kv namespace create MEMBERSHIPS
 ```
 
-Copy the `id` value from the output and paste it into `worker/membership-wrangler.toml` under `[[kv_namespaces]]`. Re-deploy.
+Copy the `id` value from the output and paste it into `worker/membership-wrangler.toml` under `[[kv_namespaces]]`.
+
+Re-deploy after the binding is wired:
+
+```sh
+npx wrangler deploy --config worker/membership-wrangler.toml
+```
 
 ## Step 5 — Mark pages as `tier: premium`
 


### PR DESCRIPTION
## Summary

Closes #249.

- `skills/inbox/SKILL.md` and `skills/membership/SKILL.md` — the only two skills that actually provision a KV namespace — now call the Cloudflare MCP `kv_namespace_create` tool first, read the returned `id` from the tool response, and write the binding into the relevant `worker/*-wrangler.toml`. The `npx wrangler kv namespace create` path remains documented as an offline / no-MCP fallback.
- Adds `mcp__cloudflare__kv_namespace_create`, `kv_namespace_get`, `kv_namespaces_list`, and `accounts_list` to each skill's `allowed-tools` frontmatter. The inbox skill also gains `Edit` (the binding is now edited into existing wrangler.toml files rather than rewritten).
- Documents the MCP-first / CLI-fallback pattern in the root `CLAUDE.md` editing guidelines so future skills (R2, D1, Hyperdrive, Workers) follow the same shape.

The other skills listed in the issue scope (`newsletter`, `contact`, `forms`, `testimonials`) don't directly create KV namespaces today — they either only use Worker secrets, or defer KV provisioning to `/anglesite:inbox` — so they were left unchanged per the issue's "if it provisions KV" qualifier.

## Test plan

- [ ] Run `/anglesite:inbox` end-to-end on a site with the Cloudflare MCP server connected and confirm no `wrangler kv namespace create` prompt appears
- [ ] Run `/anglesite:inbox` with the Cloudflare MCP server disconnected and confirm the documented `wrangler` fallback still works
- [ ] Run `/anglesite:membership` end-to-end with Cloudflare MCP and confirm `worker/membership-wrangler.toml` is edited automatically with the returned KV id
- [ ] Verify the `MEMBERSHIP_KV_ID` / `INBOX_KV_ID` values land in `.site-config`

https://claude.ai/code/session_016nFHU8Mm8GD1ZzAVEobRei

---
_Generated by [Claude Code](https://claude.ai/code/session_016nFHU8Mm8GD1ZzAVEobRei)_