### PR TITLE
podcast: provision Cloudflare R2 audio hosting via MCP tools

### DIFF
--- a/docs/smb/podcaster.md
+++ b/docs/smb/podcaster.md
@@ -39,6 +39,7 @@ Every podcast needs a hosting platform that stores the audio files and generates
 - **Transistor** (~$19/mo, proprietary) — Multiple shows on one account, better analytics, private podcasts for paid content. Good for growing shows. transistor.fm
 - **Captivate** (~$19/mo, proprietary) — Growth-focused features, unlimited team members, built-in calls to action. captivate.fm
 - **Libsyn** (~$5/mo, proprietary) — One of the oldest hosts. Reliable, good for high-volume shows. libsyn.com
+- **Cloudflare R2** ($0.015/GB-month storage, **zero egress**, proprietary but fully open via S3 API) — The cheapest viable host: a 100-episode show typically runs free or under $1/month. `/anglesite:podcast` provisions the bucket, custom subdomain, and per-episode upload command for the owner — no Cloudflare-dashboard work required. Trade-off: no per-episode listener-app analytics (Cloudflare reports only aggregate request counts), so sponsors that want CPM breakdowns may push back. Fine for self-funded or membership-funded shows. cloudflare.com/products/r2
 - **Castopod** (open source, self-hosted) — ActivityPub integration (federated social). The IndieWeb/self-sovereignty option. Requires a server. castopod.org
 - **Anchor/Spotify for Podcasters** (free, proprietary) — Free but Spotify-controlled. Limited portability. Fine for starting out; move to an independent host when the show grows. podcasters.spotify.com
 

--- a/skills/export/SKILL.md
+++ b/skills/export/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: export
 description: "Produce a portable export of the site (built HTML, content, media, MIGRATING.md) so the owner can self-host or move to any other platform"
-allowed-tools: Bash(npm run build), Bash(mkdir *), Bash(cp *), Bash(rsync *), Bash(zip *), Bash(ls *), Bash(find *), Bash(du *), Bash(grep *), Bash(date *), Bash(git rev-parse *), Read, Write
+allowed-tools: Bash(npm run build), Bash(mkdir *), Bash(cp *), Bash(rsync *), Bash(zip *), Bash(ls *), Bash(find *), Bash(du *), Bash(grep *), Bash(date *), Bash(git rev-parse *), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Read, Write
 disable-model-invocation: true
 ---
 

--- a/skills/og-images/SKILL.md
+++ b/skills/og-images/SKILL.md
@@ -2,7 +2,7 @@
 name: og-images
 description: "Generate branded OG images for social sharing: per-page and site-wide, using Satori"
 user-invocable: false
-allowed-tools: Bash(npm run ai-images), Bash(npm run ai-og), Read, Glob, Write
+allowed-tools: Bash(npm run ai-images), Bash(npm run ai-og), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Read, Glob, Write
 ---
 
 Generate branded Open Graph images so every page has a social sharing preview. Called automatically during design, page creation, SEO audits, and deploy — not invoked directly by the owner.

--- a/skills/optimize-images/SKILL.md
+++ b/skills/optimize-images/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize-images
 description: "Optimize images: resize, convert to WebP, strip EXIF, generate srcset variants"
 user-invocable: false
-allowed-tools: Bash(npm run ai-optimize), Write, Read, Edit, Glob
+allowed-tools: Bash(npm run ai-optimize), Bash(npx wrangler r2 *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, Write, Read, Edit, Glob
 ---
 
 Optimize images in `public/images/` for web performance and privacy. Called automatically when images are added during design, page creation, or content editing — not invoked directly by the owner.

--- a/skills/podcast/SKILL.md
+++ b/skills/podcast/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: podcast
 description: "Set up a podcast on the site — episodes, RSS feed with iTunes namespace, transcripts, audio player, and platform submission"
-allowed-tools: Bash(npm run build), Bash(npm run dev), Read, Write, Edit, Glob, Grep
+allowed-tools: Bash(npm run build), Bash(npm run dev), Bash(npx wrangler r2 *), Bash(wc -c *), Bash(stat *), mcp__cloudflare__r2_bucket_create, mcp__cloudflare__r2_bucket_get, mcp__cloudflare__r2_buckets_list, mcp__cloudflare__r2_bucket_delete, Read, Write, Edit, Glob, Grep
 disable-model-invocation: true
 ---
 
@@ -86,20 +86,64 @@ PUBLIC_PODCAST_EXPLICIT=false
 
 ## Step 2 — Audio hosting
 
-Tell the owner: "Audio files are large — most podcasters use a dedicated host that serves the files and provides analytics. I'll embed the player on your site, but the audio itself lives on the host."
+Tell the owner: "Audio files are large — they don't belong in the website's git repo or `public/` directory. They live on a host that serves the audio and (usually) reports download analytics. I'll embed the player on your site, but the file itself sits somewhere else."
 
 Read the audio hosting comparison in `${CLAUDE_PLUGIN_ROOT}/docs/smb/podcaster.md` (Tools → Podcast hosting) and present the options:
 
-- **Buzzsprout** (~$12/mo) — beginner-friendly, transcription included, good first host
-- **Transistor** (~$19/mo) — multi-show, better analytics, private podcasts
-- **Captivate** (~$19/mo) — growth-focused features
-- **Libsyn** (~$5/mo) — reliable, oldest in the space
-- **Castopod** (open source, self-hosted) — IndieWeb / ActivityPub option
-- **Self-hosted on Cloudflare R2** — cheapest if the owner is technical and has low downloads. No analytics, manual file size lookup.
+- **Buzzsprout** (~$12/mo) — beginner-friendly, transcription included, basic download analytics. Good first host.
+- **Transistor** (~$19/mo) — multi-show, better analytics, private podcasts.
+- **Captivate** (~$19/mo) — growth-focused features, built-in calls to action.
+- **Libsyn** (~$5/mo) — reliable, oldest in the space.
+- **Castopod** (open source, self-hosted, requires a server) — IndieWeb / ActivityPub option.
+- **Cloudflare R2** (self-hosted, ~$0.015/GB-month storage, **zero egress fees**) — the cheapest option, and Anglesite can provision the bucket and upload episodes for the owner. No download analytics out of the box (Cloudflare reports requests in aggregate). Recommended for owners already on Cloudflare and not relying on host-side analytics for sponsor reporting.
 
-Ask the owner which they want. Save to `.site-config` as `PODCAST_HOST=buzzsprout` (or the chosen platform).
+Ask the owner which they want. Save to `.site-config` as `PODCAST_HOST=r2` (or `buzzsprout`, `transistor`, `captivate`, `libsyn`, `castopod`).
 
-If the owner picks self-hosted on R2, drop audio files in `public/audio/` and warn them about the `public/` directory size — a typical 30-minute MP3 is 30–60 MB. Cloudflare Pages has a 25 MB per-file limit, so anything larger must move to R2 or another host.
+### 2a. If the owner picked R2
+
+Anglesite can provision an R2 bucket with the Cloudflare MCP tools and upload episodes through `wrangler`. The owner does not need to touch the Cloudflare dashboard.
+
+**Cost expectations for the owner** (prices as of writing — re-check before quoting):
+
+- **Storage**: $0.015 per GB-month. A 30-minute MP3 at ~40 MB ≈ $0.0006/month per episode. 100 episodes ≈ $0.06/month in storage.
+- **Class A operations** (writes/uploads): $4.50 per million. One upload per episode is rounding error.
+- **Class B operations** (reads/downloads): $0.36 per million. 100,000 episode downloads ≈ $0.04.
+- **Egress (bandwidth)**: $0 — this is the reason R2 is cheap for podcasts.
+- **Free tier**: 10 GB storage, 1 million Class A, 10 million Class B ops per month. Most starting podcasts stay under this for the first ~250 episodes.
+
+Tell the owner: "For most starting podcasts, R2 is free or under $1/month. The trade-off vs. Buzzsprout is that you don't get per-episode download charts — Cloudflare gives you total request counts, but not the listener-app breakdown sponsors sometimes ask for."
+
+Then provision:
+
+1. **Confirm the user is logged in to Cloudflare** — run `npx wrangler whoami`. If not logged in, prompt them through `npx wrangler login` (browser OAuth).
+
+2. **Pick a bucket name.** Use `<site-slug>-podcast-audio` (e.g., `acmeshow-podcast-audio`). R2 bucket names are globally unique within an account, lowercase, hyphens allowed. Read `SITE_SLUG` from `.site-config`; if missing, derive from `PODCAST_TITLE` (lowercased, hyphenated).
+
+3. **Check whether the bucket already exists** with the Cloudflare MCP tool `mcp__cloudflare__r2_buckets_list`. If a bucket with the chosen name is present, reuse it; otherwise create it with `mcp__cloudflare__r2_bucket_create` (location: `auto` unless the owner has a strong reason to pin a region).
+
+4. **Save the bucket name** to `.site-config` as `PODCAST_R2_BUCKET=<name>`.
+
+5. **Configure public access.** R2 buckets are private by default — podcast apps need the audio at a public URL.
+   - Recommended: a custom subdomain like `audio.<owner-domain>`. Tell the owner: "I'll set up `audio.<your-domain>` to serve audio files. Cloudflare DNS handles this; no extra setup needed beyond confirming the domain." Bucket → R2 → Settings → Custom Domains → Connect Domain. Save as `PODCAST_R2_PUBLIC_BASE=https://audio.<owner-domain>`.
+   - Fallback: enable the `r2.dev` development URL (`https://pub-<hash>.r2.dev`). Faster to set up, but Cloudflare rate-limits it and discourages production use. Save the URL to `.site-config` as `PODCAST_R2_PUBLIC_BASE=…`.
+
+6. **Emit the upload command** for the owner to run per episode. Tell them: "Drop the MP3 anywhere on your machine, then run this for each episode."
+
+   ```sh
+   npx wrangler r2 object put <bucket>/<slug>.mp3 --file=/path/to/episode.mp3 --content-type=audio/mpeg
+   ```
+
+   The episode's audio URL will be `${PODCAST_R2_PUBLIC_BASE}/<slug>.mp3`.
+
+7. **Auto-fill the Keystatic episode entry** in Step 4: when the host is R2 and the owner gives a local file path, run `wc -c <path>` for `lengthBytes`, set `audioUrl` to `${PODCAST_R2_PUBLIC_BASE}/<slug>.mp3`, and (if `wrangler` is configured) run the `wrangler r2 object put` command on their behalf — only after confirming the bucket and the file path with the owner.
+
+8. **Off-ramp.** R2 isn't a podcast host in the Buzzsprout sense. If the owner later wants per-episode analytics or transcription, they can move to a real podcast host without changing their RSS feed URL: re-host the audio elsewhere, update each episode's `audioUrl`, redeploy. Mention this when offering R2 so the owner doesn't feel locked in.
+
+### 2b. If the owner picked any other host
+
+The owner uploads each episode to the host's dashboard and copies the host's MP3 URL into the Keystatic episode entry. Anglesite does not store audio files on R2 or in `public/audio/` in this case.
+
+**Do not drop audio files in `public/audio/` for production.** Cloudflare's static assets bind has a 25 MB per-file limit, but more importantly, large binaries in git slow every clone, push, and deploy. The legacy `public/audio/` path is preserved only as a last-resort fallback for very small files (e.g., a single 5 MB trailer); the deploy skill warns when files there exceed 10 MB.
 
 ## Step 3 — Activate the episodes collection
 
@@ -120,8 +164,11 @@ Walk the owner through filling in the first episode. Frame the questions plainly
 - **Title** — episode title (e.g., "Ep. 1: Welcome to the Show")
 - **Publish date** — today by default
 - **Description** — 1–3 sentences for listings, RSS, and social sharing
-- **Audio** — either the URL from the hosting platform's RSS-ready download link (Buzzsprout calls it the "MP3 URL") or `/audio/ep-01.mp3` if self-hosting
-- **Audio file size** — bytes. If self-hosted, run `wc -c public/audio/ep-01.mp3`. If hosted, the host shows it in the episode dashboard. Apple's directory listing requires this.
+- **Audio** — depends on the host:
+  - **R2**: ask for the local MP3 path. Upload via `npx wrangler r2 object put $PODCAST_R2_BUCKET/<slug>.mp3 --file=<path> --content-type=audio/mpeg` and set `audioUrl = $PODCAST_R2_PUBLIC_BASE/<slug>.mp3`.
+  - **Hosted (Buzzsprout, Transistor, etc.)**: paste the host's RSS-ready MP3 URL (Buzzsprout labels it "MP3 URL"; Transistor calls it the "audio file URL").
+  - **Legacy `public/audio/`**: only for trailers under 10 MB; set `audioUrl = /audio/<slug>.mp3`.
+- **Audio file size** — bytes. Auto-fill when possible: for R2 or `public/audio/` runs, `wc -c <local-path>` before/after upload and write the result to the episode's `lengthBytes`. For hosted platforms, the host shows the size in the episode dashboard. Apple's directory listing requires this.
 - **Duration** — `MM:SS` or `HH:MM:SS`
 - **Episode number, season** — sequential numbering (optional but recommended; Apple uses these for sorting)
 - **Episode type** — `full`, `trailer`, or `bonus`
@@ -250,7 +297,7 @@ After any change, run `npm run build` and verify the RSS feed still validates.
 - **QR codes** (`/anglesite:qr`) — offer a QR code for each episode page (e.g., for a sticker, a flyer at a live show, or a guest's social bio).
 - **Photography** (`/anglesite:photography`) — show artwork and guest portraits matter more for podcasts than most verticals. The photography shot list for podcasters covers this.
 - **SEO** (`/anglesite:seo`) — the podcast pages get the standard SEO pass. The transcript is the biggest single SEO contribution; remind the owner not to skip it.
-- **Backup** (`/anglesite:backup`) — episode `.mdoc` files commit normally. Audio files in `public/audio/` are large; consider whether they belong in git or only in the host. If the owner self-hosts on R2, audio is in the bucket, not in the repo.
+- **Backup** (`/anglesite:backup`) — episode `.mdoc` files commit normally. Audio files do not belong in git: hosted shows have audio at the host, R2-hosted shows have audio in the bucket, and the legacy `public/audio/` fallback should only hold tiny clips. The backup skill skips `public/audio/` files larger than 10 MB.
 - **Stats** (`/anglesite:stats`) — Cloudflare reports website visits to episode pages. Audio download counts come from the podcast host (Buzzsprout, Transistor, etc.) — the website cannot see them.
 
 ## Re-running the command


### PR DESCRIPTION
## Summary

- Promotes self-hosted-on-R2 from "technical owners only" to a first-class option in `/anglesite:podcast`. The skill now uses the Cloudflare MCP `r2_bucket_*` tools to check/create the bucket, walks the owner through public access (custom subdomain or `r2.dev` fallback), saves `PODCAST_R2_BUCKET` and `PODCAST_R2_PUBLIC_BASE` to `.site-config`, and emits the `npx wrangler r2 object put` command per episode.
- Auto-fills the Keystatic episode entry: `audioUrl` from the public base + slug, `lengthBytes` from `wc -c`. Step 4 covers the three host paths (R2, hosted platform, legacy `public/audio/`) explicitly.
- Documents R2 size and cost expectations for owners (storage, request classes, free tier, $0 egress) and the no-per-episode-analytics trade-off, plus an off-ramp note so the choice doesn't feel locking.
- Updates `docs/smb/podcaster.md` to add R2 to the hosting comparison.
- Adds `mcp__cloudflare__r2_bucket_create|get|list|delete` and `Bash(npx wrangler r2 *)` to `allowed-tools` for `podcast`, `optimize-images`, `og-images`, and `export` per the issue scope.

Closes #250.

## Test plan

- [ ] `/anglesite:podcast` on a fresh site — pick R2, verify bucket creation, custom-domain walkthrough, and per-episode upload command produce a working `audioUrl`.
- [ ] `/anglesite:podcast` on an existing site that previously dropped files in `public/audio/` — verify Step 4 still accepts that path as a fallback.
- [ ] `/anglesite:podcast` with each non-R2 host (Buzzsprout, Transistor, etc.) — confirm Step 2b path is unchanged.
- [ ] Inspect rendered RSS feed for an R2 episode: `<enclosure url>` matches `PODCAST_R2_PUBLIC_BASE/<slug>.mp3` and `length` matches `wc -c`.
- [ ] Confirm `allowed-tools` additions parse correctly in `optimize-images`, `og-images`, `export` (no permission prompts for already-allowed Bash patterns).

https://claude.ai/code/session_01LqHUJ7JG3gE3TYzxJzfCjq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqHUJ7JG3gE3TYzxJzfCjq)_