### PR TITLE
deploy: lock site to a specific Cloudflare account (#251)

### DIFF
--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -2,7 +2,7 @@
 name: check
 description: "Health audit and troubleshooting"
 argument-hint: "[optional: describe the problem]"
-allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(npx pa11y-ci *), Bash(npx tsx scripts/link-check.ts *), Bash(npx tsx scripts/a11y-audit.ts *), Bash(npx tsx scripts/a14y-audit.ts *), Bash(npx a14y *), Bash(a14y *), Bash(grep *), Bash(find dist/ *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), Write, Read, Glob
+allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(npx pa11y-ci *), Bash(npx tsx scripts/link-check.ts *), Bash(npx tsx scripts/a11y-audit.ts *), Bash(npx tsx scripts/a14y-audit.ts *), Bash(npx a14y *), Bash(a14y *), Bash(grep *), Bash(find dist/ *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), Write, Read, Glob, mcp__cloudflare__accounts_list
 disable-model-invocation: true
 ---
 
@@ -125,6 +125,16 @@ Check that the site works on small screens. Start the dev server if not already 
 - [ ] Navigation is usable on small screens (hamburger menu, collapsible nav, or simple enough to not need one)
 - [ ] Images use responsive sizing (`max-width: 100%` or `srcset`)
 - [ ] No content hidden on mobile that's visible on desktop (all information should be available)
+
+## Cloudflare account alignment
+
+Read `CLOUDFLARE_ACCOUNT_ID` from `.site-config`. If set, call `mcp__cloudflare__accounts_list` and check which account is currently active.
+
+- If the active account matches the configured one, mark this category as **All good**.
+- If they differ, flag it as **Worth fixing soon** with plain-language framing: "Your computer is currently signed into a different Cloudflare account than the one this site lives in. The next deploy would refuse to publish until you switch back. I can switch the active account for you, or you can run `/anglesite:deploy` and let it sort itself out."
+- If `CLOUDFLARE_ACCOUNT_ID` is unset (older sites set up before this check), suggest running `/anglesite:deploy` once so the picker can lock the site to a specific account.
+
+This check is informational — never block the audit on it. Owners often switch accounts intentionally during the workday.
 
 ## Privacy audit
 - [ ] No customer PII in `dist/` (emails, phone numbers, names)

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deploy
 description: "Build, security scan, and deploy to Cloudflare Workers"
-allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read
+allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account
 disable-model-invocation: true
 ---
 
@@ -278,6 +278,25 @@ npx wrangler login
 
 If the environment can't open a browser (e.g., Claude Cowork without a desktop), fall back to an API token: tell the owner to open `https://dash.cloudflare.com/profile/api-tokens`, click **Create Token**, choose the **Edit Cloudflare Workers** template, and paste the token. Save it as `CLOUDFLARE_API_TOKEN` in their shell or in a `.dev.vars` file (gitignored). Wrangler will pick it up automatically.
 
+### Pick the right Cloudflare account
+
+Owners who use Cloudflare for both personal and work projects (agencies, freelancers, side projects) often have access to multiple accounts. Don't rely on whatever `wrangler whoami` happens to return — pick the account explicitly so future deploys can't silently land in the wrong place.
+
+Call `mcp__cloudflare__accounts_list` to enumerate the accounts the owner can deploy to.
+
+- **One account** — use it. No need to ask.
+- **Multiple accounts** — present a numbered picker with each account's name and ID, e.g.:
+
+  ```
+  Which Cloudflare account should this site live in?
+  1. Jane Smith (personal) — abc123…
+  2. Smith Studio LLC (business) — def456…
+  ```
+
+  Wait for the owner to choose, then call `mcp__cloudflare__set_active_account` with the chosen account ID.
+
+Save the chosen account ID to `.site-config` using the **Write tool** (update the existing file, adding `CLOUDFLARE_ACCOUNT_ID=<id>`). All subsequent deploys validate against this value.
+
 If the owner chose **preview first** in Step 2.5, upload a preview version (does not promote to production):
 
 ```sh
@@ -434,6 +453,14 @@ Remind them of the goals they shared during `/anglesite:start`: "You said you wa
 After the first successful deploy, surface the post-publish education from `${CLAUDE_PLUGIN_ROOT}/docs/education-prompts.md` section 6 ("Post-Publish Success Message"). Check `.site-config` for each `EDUCATION_<KEY>=shown` flag before surfacing. Share `SEO_TIMELINE`, `INDEXING_DELAY`, and `DISTRIBUTION` — the owner is most receptive right after launch, and these set realistic expectations. Write the flags to `.site-config` after.
 
 ## Step 7 — Deploy
+
+### Validate the active Cloudflare account
+
+Before running `wrangler deploy`, confirm the active account still matches what was chosen in Step 3. Read `CLOUDFLARE_ACCOUNT_ID` from `.site-config`, then call `mcp__cloudflare__accounts_list` and check which account is currently active.
+
+- **Match** — proceed.
+- **Mismatch** — abort with a clear message. Don't silently re-point the deploy. Tell the owner: "Heads up — your active Cloudflare account is `<active-name>` (`<active-id>`), but this site was set up to deploy to `<configured-name>` (`<configured-id>`). I'll switch the active account back before publishing." Then call `mcp__cloudflare__set_active_account` with the configured ID and continue. If switching fails, stop and surface the error rather than guessing.
+- **`CLOUDFLARE_ACCOUNT_ID` not set** (older sites set up before this check) — call `mcp__cloudflare__accounts_list`. If exactly one account is returned, save it to `.site-config` and continue. If multiple, run the picker from Step 3 once, then continue.
 
 Commit all changes on `draft`:
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -413,7 +413,7 @@ Summarize what the owner now knows:
 
 Tell the owner what they can do now:
 
-- **`/anglesite:deploy`** — when ready to put the site on the internet (walks through Cloudflare account, domain purchase or transfer, and publishing)
+- **`/anglesite:deploy`** — when ready to put the site on the internet (walks through Cloudflare account, domain purchase or transfer, and publishing). On the first deploy, if the owner has access to more than one Cloudflare account (common for agencies and freelancers), `/anglesite:deploy` shows a picker so the site is locked to the right account — no silent deploys to the wrong place later.
 - **Edit posts** — navigate to `https://DEV_HOSTNAME/keystatic` in the preview panel to write blog posts using the visual editor (replace `DEV_HOSTNAME` with the actual value from `.site-config`)
 - **`/anglesite:domain`** — set up email, verify your Bluesky handle, and other domain settings — available after deploying with a custom domain
 

--- a/template/docs/cloudflare.md
+++ b/template/docs/cloudflare.md
@@ -3,6 +3,7 @@
 ## Worker project
 
 - Project name: stored in `.site-config` as `CF_PROJECT_NAME` (set during first `/anglesite:deploy`) and mirrored as the `name` field in `wrangler.jsonc`
+- Account: stored in `.site-config` as `CLOUDFLARE_ACCOUNT_ID` (set during first `/anglesite:deploy`). Owners with access to multiple accounts (agencies, freelancers, side projects) see a picker on first deploy. Every later deploy validates the active account against this value and aborts on mismatch rather than silently deploying somewhere unexpected.
 - Deployed via the `@astrojs/cloudflare` adapter as **Cloudflare Workers Static Assets** (Worker entry + `ASSETS` binding)
 - Production deploys: run `npm run deploy` (which runs `astro build && wrangler deploy`)
 - Preview versions: `npx wrangler versions upload` (does not promote to production)
@@ -139,4 +140,5 @@ Defined in `public/_headers`. Cloudflare Workers Static Assets honors `_headers`
 - **SSL not working:** Cloudflare provisions SSL automatically. If it shows "pending", wait 15 minutes. Check that the domain's DNS is proxied (orange cloud icon in Cloudflare DNS settings).
 - **CSP errors in console:** A script or style is loading from an unapproved domain. Check `_headers`.
 - **`wrangler.jsonc` name mismatch:** The `name` field must match `CF_PROJECT_NAME` in `.site-config`. Update both if you rename the project.
+- **Deploy aborts with "active Cloudflare account doesn't match":** The active account on this machine differs from `CLOUDFLARE_ACCOUNT_ID` in `.site-config`. `/anglesite:deploy` will offer to switch back automatically. To change the locked account intentionally, edit `CLOUDFLARE_ACCOUNT_ID` in `.site-config`.
 - **Pages Functions middleware (`functions/_middleware.ts`) doesn't run:** With Workers Static Assets, the `functions/` directory is no longer invoked. Membership gates and A/B test variant assignment must be ported into the Worker entry. See `/anglesite:membership` and `/anglesite:experiment`.


### PR DESCRIPTION
Closes #251.

## Summary

`wrangler whoami` returns whichever account the machine happens to be signed into. Owners with access to multiple Cloudflare accounts (agencies, freelancers, side projects) could silently deploy to the wrong account with no in-flow confirmation.

This change uses the Cloudflare MCP `accounts_list` and `set_active_account` tools to:

- After `wrangler login` in `/anglesite:deploy`, present a numbered picker when more than one account is available, then call `set_active_account` and save the ID to `.site-config` as `CLOUDFLARE_ACCOUNT_ID`.
- Before every subsequent `wrangler deploy`, validate that the active account still matches `CLOUDFLARE_ACCOUNT_ID`. On mismatch, switch back via `set_active_account` rather than silently deploying somewhere unexpected. Backfill the ID for older sites that don't have it set.
- In `/anglesite:check`, surface drift between the active and configured account as a non-blocking "Worth fixing soon" finding.
- In `/anglesite:start`, mention the picker in the next-steps summary so the owner knows what to expect on first deploy.

## Files changed

- `skills/deploy/SKILL.md` — account picker after `wrangler login`, pre-deploy validation, MCP tools added to `allowed-tools`
- `skills/check/SKILL.md` — Cloudflare account alignment section, MCP tool added to `allowed-tools`
- `skills/start/SKILL.md` — heads-up in Step 10
- `template/docs/cloudflare.md` — `CLOUDFLARE_ACCOUNT_ID` documented; troubleshooting entry for the abort message

## Test plan

- [ ] Run `/anglesite:deploy` with a single Cloudflare account — picker is skipped, ID saved
- [ ] Run `/anglesite:deploy` with multiple Cloudflare accounts — picker appears, chosen ID saved
- [ ] Switch active account out-of-band, then re-run deploy — validation fires, account is switched back
- [ ] Run `/anglesite:check` with a configured account that doesn't match the active one — drift is reported as a non-blocking finding
- [ ] `npm test` (2311 tests pass locally)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJRbPEUcbaoEcfNT98h5BM)_