### PR TITLE
skills(check,domain,deploy): consult Cloudflare docs MCP before troubleshooting

### DIFF
--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -2,7 +2,7 @@
 name: check
 description: "Health audit and troubleshooting"
 argument-hint: "[optional: describe the problem]"
-allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(npx pa11y-ci *), Bash(npx tsx scripts/link-check.ts *), Bash(npx tsx scripts/a11y-audit.ts *), Bash(npx tsx scripts/a14y-audit.ts *), Bash(npx a14y *), Bash(a14y *), Bash(grep *), Bash(find dist/ *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), Write, Read, Glob, mcp__cloudflare__accounts_list
+allowed-tools: Bash(npm run *), Bash(npx astro check), Bash(npx pa11y *), Bash(npx pa11y-ci *), Bash(npx tsx scripts/link-check.ts *), Bash(npx tsx scripts/a11y-audit.ts *), Bash(npx tsx scripts/a14y-audit.ts *), Bash(npx a14y *), Bash(a14y *), Bash(grep *), Bash(find dist/ *), Bash(npm audit *), Bash(lsof *), Bash(netstat *), Bash(getent *), Bash(nslookup *), Bash(gh issue *), Bash(gh label *), Write, Read, Glob, mcp__cloudflare__accounts_list, mcp__cloudflare__search_cloudflare_documentation
 disable-model-invocation: true
 ---
 
@@ -357,6 +357,12 @@ If the issue is in Anglesite itself (not the owner's site), use the plugin bug f
 ## Troubleshooting
 
 If the owner reported a specific problem (or you found one during the audit), diagnose and fix it.
+
+### Step 0 — Look up current Cloudflare docs first
+
+Cloudflare ships features quickly (Workers Static Assets, the Pages → Workers migration, bot management defaults, error code semantics). Before suggesting a fix for any Cloudflare-adjacent issue — DNS propagation, SPF/DKIM/DMARC, Workers limits, custom domain quirks, `wrangler` errors — call `mcp__cloudflare__search_cloudflare_documentation` with a query that names the symptom (e.g., "wrangler deploy 10021 error", "Workers static assets _headers precedence", "DMARC alignment p=quarantine"). Read the matching result before reasoning from training data. If the search returns nothing useful, say so to the owner rather than guessing.
+
+This applies whenever the issue might involve Cloudflare behavior. Skip it for purely local issues (Node version, port conflicts, Astro build errors).
 
 ### Step 1 — Check prerequisites
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deploy
 description: "Build, security scan, and deploy to Cloudflare Workers"
-allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account
+allowed-tools: Bash(npm run build), Bash(npm run deploy *), Bash(npm run preview *), Bash(npm run ai-linkcheck *), Bash(npm run ai-a11y *), Bash(npm run ai-a14y *), Bash(npm run ai-perf *), Bash(npx wrangler *), Bash(grep *), Bash(find dist/ *), Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git checkout *), Bash(git merge *), Bash(git branch *), Bash(kill *), Write, Read, mcp__cloudflare__accounts_list, mcp__cloudflare__set_active_account, mcp__cloudflare__search_cloudflare_documentation
 disable-model-invocation: true
 ---
 
@@ -22,6 +22,12 @@ The site deploys via Wrangler: `npm run deploy` builds the site (`astro build`) 
 - [ADR-0018 Performance budgets](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0018-performance-budgets.md) — why the perf gate ships warn-only with static asset budgets and an opt-in Lighthouse upgrade path
 
 Read `EXPLAIN_STEPS` from `.site-config`. If `true` or not set, explain before every tool call that will trigger a permission prompt — tell the owner what you're about to do and why in plain English. If `false`, proceed without pre-announcing tool calls.
+
+## Interpreting Cloudflare errors
+
+If any `wrangler` command (build, login, versions upload, deploy) returns an error, or if Cloudflare-side behavior surfaces during a deploy step (custom domain not attaching, SSL stuck, account validation mismatch, Workers limit hit), call `mcp__cloudflare__search_cloudflare_documentation` with the error code, error message, or the symptom in plain words (e.g., "wrangler 10021", "Workers script size limit", "custom domain pending SSL"). Read the result before suggesting a fix — Cloudflare's wrangler error catalog and Workers limits change over time, and stale advice wastes the owner's time. If nothing useful comes back, say so to the owner rather than guessing.
+
+This applies anywhere a Cloudflare-side step fails in this skill — not only the auth-error path in Step 7.
 
 ## Step 0 — First deploy: Cloudflare account
 

--- a/skills/domain/SKILL.md
+++ b/skills/domain/SKILL.md
@@ -2,7 +2,7 @@
 name: domain
 description: "Manage DNS records: email, Bluesky, verification"
 argument-hint: "[email, bluesky, or service name]"
-allowed-tools: Bash(curl *), Write, Read
+allowed-tools: Bash(curl *), Write, Read, mcp__cloudflare__search_cloudflare_documentation
 disable-model-invocation: true
 ---
 
@@ -14,6 +14,12 @@ Manage DNS records for the owner's domain on Cloudflare. All DNS changes are mad
 - [ADR-0011 Owner ownership](${CLAUDE_PLUGIN_ROOT}/docs/decisions/0011-owner-controls-everything.md) — why the domain is in the owner's account
 
 Read `EXPLAIN_STEPS` from `.site-config`. If `true` or not set, tell the owner what you're about to do and why in plain English before making any change, and confirm what was done after. If `false`, proceed without pre-announcing changes (still confirm after).
+
+## Look up current Cloudflare docs first
+
+Before explaining DNS records, verification flows, propagation behavior, or any Cloudflare-specific quirk to the owner, call `mcp__cloudflare__search_cloudflare_documentation` with a query that names what's being set up (e.g., "DMARC record syntax Cloudflare DNS", "Bluesky _atproto TXT verification", "domain verification CAA record", "MX records Cloudflare Email Routing"). Read the matching result before answering — Cloudflare ships changes to defaults and dashboard flows often, and stale advice misroutes the owner. If the search returns nothing useful, say so rather than guessing from training data.
+
+Skip this when the request is mechanical (e.g., the owner pasted the exact records a third party told them to add).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Wires `mcp__cloudflare__search_cloudflare_documentation` into the troubleshooting and Cloudflare-explanation paths of three skills so advice tracks Cloudflare's current behavior instead of training-data snapshots.

- **`check`** — adds a "Step 0 — Look up current Cloudflare docs first" to the Troubleshooting section, scoped to Cloudflare-adjacent issues (DNS, Workers limits, custom domains, `wrangler` errors). Skips for purely local issues.
- **`domain`** — adds a "Look up current Cloudflare docs first" prologue before the Prerequisites section, applied when explaining DNS records, verification flows, propagation, or Cloudflare quirks. Skipped for mechanical record-paste from third parties.
- **`deploy`** — adds an "Interpreting Cloudflare errors" callout near the top, triggered whenever a `wrangler` command errors or Cloudflare-side behavior surfaces (custom domain attach, SSL stuck, account validation, Workers limits) — not only the auth-error path in Step 7.

Each skill's `allowed-tools` frontmatter gains `mcp__cloudflare__search_cloudflare_documentation`. Read-only tool — no provisioning side effects.

Closes #253.

## Test plan

- [ ] Trigger a `/anglesite:check` troubleshoot path on a Cloudflare-adjacent issue and confirm the docs MCP is consulted before the fix is suggested
- [ ] Run `/anglesite:domain` for a DMARC / Bluesky / Google verification flow and confirm the docs MCP is consulted before explaining the records
- [ ] Force a `wrangler deploy` failure and confirm `/anglesite:deploy` looks up the error code via the docs MCP before suggesting a fix
- [ ] Confirm purely local issues (Astro build error, Node version, port conflict) do not unnecessarily invoke the docs MCP

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGkyTnh31gf3RBLmBN1CTW)_