### PR TITLE
deploy: add maintenance log + pre-deploy freshness warning

### DIFF
--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -341,6 +341,12 @@ If any must-fix issues are found, explain and offer to fix them. If everything p
 
 After the check, tell the owner: "This is the same kind of checkup a good web developer would do regularly. Your site should get one of these at least once a month — just type `/anglesite:check` anytime."
 
+## Stamp the maintenance log
+
+After completing a full health audit (regardless of whether issues were found — running the check is the maintenance event), update `MAINTENANCE_MONTHLY_LAST` in `.site-config` to today's date in `YYYY-MM-DD` format. Use the **Read** tool to load the file, then the **Write** tool to replace or append the line. This is what `/anglesite:deploy`'s pre-deploy scan reads when surfacing overdue-maintenance warnings (see `docs/webmaster.md` → Maintenance schedule).
+
+Don't stamp the log if the audit was aborted early (e.g., the build failed before any checks ran) — only when the owner has actually been through the checkup.
+
 ## File bugs for persistent issues
 
 After the audit, if any must-fix issues were found that couldn't be resolved in the current session, file a GitHub issue for each one. Read `GITHUB_REPO` from `.site-config`. If not set, skip this step.

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -55,7 +55,9 @@ Run the automated security scan:
 npm run predeploy
 ```
 
-This checks PII (emails, phone numbers), API tokens, third-party scripts, Keystatic admin routes, and OG images. If any blocking check fails, it exits with code 1 and prints what went wrong. Fix the issues before proceeding.
+This checks PII (emails, phone numbers), API tokens, third-party scripts, Keystatic admin routes, OG images, and the maintenance log. If any blocking check fails, it exits with code 1 and prints what went wrong. Fix the issues before proceeding.
+
+The maintenance log is **warn-only** — it never blocks a deploy. The script reads `MAINTENANCE_MONTHLY_LAST`, `MAINTENANCE_QUARTERLY_LAST`, and `MAINTENANCE_ANNUAL_LAST` from `.site-config` and warns once any stamp is older than its grace window (35, 100, or 380 days). If any warning fires, surface it to the owner in plain language after the build — for example: "It's been about three months since your last health check — want me to run `/anglesite:check` before we publish?" — and let them decide whether to pause or continue. See `docs/webmaster.md` → Maintenance schedule.
 
 If the site intentionally publishes a contact email (e.g., a `mailto:` link in the footer), tell the owner you'll add it to the allowlist so it doesn't block future deploys. Add to `.site-config`:
 

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -142,6 +142,8 @@ Update `ANGLESITE_VERSION` in `.site-config` to the current plugin version. Read
 
 Use the **Write tool** to update `.site-config` — read the current contents, replace or add the `ANGLESITE_VERSION` line, and write it back.
 
+In the same edit, update the maintenance log: set `MAINTENANCE_QUARTERLY_LAST` to today's date in `YYYY-MM-DD` format, and also refresh `MAINTENANCE_MONTHLY_LAST` (running `/anglesite:update` exercises the build and dependency checks that the monthly health pass would cover). If today is on or after the existing `MAINTENANCE_ANNUAL_LAST` plus 365 days — or if `MAINTENANCE_ANNUAL_LAST` is missing — also stamp `MAINTENANCE_ANNUAL_LAST` and tell the owner: "It's been a year since your last full review — I'll set the annual stamp now. Take a few minutes to skim `docs/webmaster.md` → 'Annually' and let me know if anything needs attention." See `docs/webmaster.md` → Maintenance schedule for what each stamp covers.
+
 ## Step 6 — Save a snapshot
 
 ```sh

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -142,7 +142,14 @@ Update `ANGLESITE_VERSION` in `.site-config` to the current plugin version. Read
 
 Use the **Write tool** to update `.site-config` — read the current contents, replace or add the `ANGLESITE_VERSION` line, and write it back.
 
-In the same edit, update the maintenance log: set `MAINTENANCE_QUARTERLY_LAST` to today's date in `YYYY-MM-DD` format, and also refresh `MAINTENANCE_MONTHLY_LAST` (running `/anglesite:update` exercises the build and dependency checks that the monthly health pass would cover). If today is on or after the existing `MAINTENANCE_ANNUAL_LAST` plus 365 days — or if `MAINTENANCE_ANNUAL_LAST` is missing — also stamp `MAINTENANCE_ANNUAL_LAST` and tell the owner: "It's been a year since your last full review — I'll set the annual stamp now. Take a few minutes to skim `docs/webmaster.md` → 'Annually' and let me know if anything needs attention." See `docs/webmaster.md` → Maintenance schedule for what each stamp covers.
+In the same edit, update the maintenance log: set `MAINTENANCE_QUARTERLY_LAST` to today's date in `YYYY-MM-DD` format, and also refresh `MAINTENANCE_MONTHLY_LAST` (running `/anglesite:update` exercises the build and dependency checks that the monthly health pass would cover). If today is on or after the existing `MAINTENANCE_ANNUAL_LAST` plus 365 days — or if `MAINTENANCE_ANNUAL_LAST` is missing — also stamp `MAINTENANCE_ANNUAL_LAST` and walk the owner through the annual checklist yourself (see `docs/webmaster.md` → "Annually"). The owner should never be asked to read a doc; you read it and surface concrete recommendations:
+
+- **Domain renewal** — read `DOMAIN` from `.site-config`. Tell the owner roughly when the registration expires (Cloudflare emails reminders, but flag it now). If you can check via Cloudflare MCP, do so.
+- **Design refresh** — ask: "It's been a year since the site went up. Has the business changed in any way that should be reflected on the site — new services, new audience, new brand colors?"
+- **Costs** — list the paid tools currently configured in `.site-config` (e.g., `BOOKING_PROVIDER`, `ECOMMERCE_PROVIDER`, `NEWSLETTER_PROVIDER`) and ask: "Are you still using each of these? I can wire down anything you've stopped using."
+- **Map listings** — ask: "Quick check — are your Google, Apple, and OpenStreetMap business listings still claimed and accurate? If anything's changed (hours, address, phone), I can help update them."
+
+Frame it as a short conversation, not homework. See `docs/webmaster.md` → Maintenance schedule for what each stamp covers.
 
 ## Step 6 — Save a snapshot
 

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -248,7 +248,8 @@ When the owner asks to update their site:
 5. If something breaks, revert and explain
 6. For `npm audit` vulnerabilities: try `npm audit fix` first, then evaluate severity
 7. Save a snapshot: `git add -A` then `git commit -m "Update dependencies: YYYY-MM-DD"`
-8. Ask if they want to deploy
+8. Stamp the maintenance log: write today's date to `MAINTENANCE_MONTHLY_LAST` and `MAINTENANCE_QUARTERLY_LAST` in `.site-config` (and `MAINTENANCE_ANNUAL_LAST` if it has been a year). The pre-deploy scan reads these stamps and warns when a cadence is overdue. See `docs/webmaster.md` → Maintenance schedule.
+9. Ask if they want to deploy
 
 ## Commands
 

--- a/template/docs/webmaster.md
+++ b/template/docs/webmaster.md
@@ -40,6 +40,18 @@ The site must be usable by people with disabilities. This is legally required in
 - Review all costs — any unused paid tools? (see `docs/cost-of-ownership.md`)
 - Verify map listings are still claimed and accurate
 
+### Maintenance log
+
+The site tracks when each cadence was last performed in `.site-config`:
+
+| Key | Stamped by | Grace window |
+|---|---|---|
+| `MAINTENANCE_MONTHLY_LAST` | `/anglesite:check` (and `/anglesite:update`, since updating exercises the same build + dependency checks) | 35 days |
+| `MAINTENANCE_QUARTERLY_LAST` | `/anglesite:update` | 100 days |
+| `MAINTENANCE_ANNUAL_LAST` | `/anglesite:update` (when it has been a year) | 380 days |
+
+Each stamp is an ISO date (`YYYY-MM-DD`). Every `/anglesite:deploy` runs `npm run predeploy`, which reads these stamps and prints a non-blocking warning when any cadence is overdue. Deploys never fail because of an overdue stamp — the warning is a nudge, not a gate. To clear a warning, run the matching command. To replay a stamp manually (e.g., the owner did the maintenance offline), edit the date in `.site-config`.
+
 ## Local SEO
 
 For businesses with a physical location:

--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -7,6 +7,9 @@
  * 3. Unauthorized third-party scripts
  * 4. Keystatic admin routes in production build
  * 5. OG image presence (warn only)
+ * 6. Maintenance log freshness (warn only) — checks the monthly,
+ *    quarterly, and annual stamps recorded by /anglesite:check and
+ *    /anglesite:update. Never blocks deploy.
  *
  * Usage: tsx scripts/pre-deploy-check.ts
  * Also runs on Cloudflare's build system via the build command.
@@ -124,6 +127,89 @@ export function scanScripts(content: string, scriptAllowlist?: string[]): string
 }
 
 // ---------------------------------------------------------------------------
+// Maintenance log
+// ---------------------------------------------------------------------------
+
+/**
+ * Maintenance categories tracked in `.site-config`.
+ * Each entry pairs the config key with a grace period in days — the scan
+ * warns once the recorded date is older than that many days. Grace periods
+ * include a small buffer over the nominal cadence so a one-week slip does
+ * not nag the owner.
+ */
+export const maintenanceCategories: ReadonlyArray<{
+  key: string;
+  label: string;
+  graceDays: number;
+  command: string;
+}> = [
+  { key: "MAINTENANCE_MONTHLY_LAST",   label: "monthly health check",   graceDays: 35,  command: "/anglesite:check"  },
+  { key: "MAINTENANCE_QUARTERLY_LAST", label: "quarterly update",       graceDays: 100, command: "/anglesite:update" },
+  { key: "MAINTENANCE_ANNUAL_LAST",    label: "annual review",          graceDays: 380, command: "/anglesite:check"  },
+];
+
+/**
+ * Compute days between two ISO calendar dates (YYYY-MM-DD).
+ * Returns null if `iso` cannot be parsed. Uses UTC midnight to avoid
+ * timezone drift turning "today" into a one-day stale warning.
+ */
+export function daysSince(iso: string, now: Date = new Date()): number | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso.trim());
+  if (!match) return null;
+  const [, y, m, d] = match;
+  const then = Date.UTC(Number(y), Number(m) - 1, Number(d));
+  if (Number.isNaN(then)) return null;
+  const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return Math.floor((today - then) / 86_400_000);
+}
+
+export interface MaintenanceWarning {
+  key: string;
+  label: string;
+  command: string;
+  /** Days since the last recorded run, or null if no record exists. */
+  age: number | null;
+  graceDays: number;
+}
+
+/**
+ * Inspect the maintenance log and return a warning for each category that
+ * is overdue or has never been recorded. Pure function — pass the config
+ * value lookup as `read` so callers can stub it in tests.
+ */
+export function scanMaintenance(
+  read: (key: string) => string | undefined,
+  now: Date = new Date(),
+  categories: ReadonlyArray<{ key: string; label: string; graceDays: number; command: string }> = maintenanceCategories,
+): MaintenanceWarning[] {
+  const warnings: MaintenanceWarning[] = [];
+  for (const cat of categories) {
+    const value = read(cat.key);
+    if (!value) {
+      warnings.push({ key: cat.key, label: cat.label, command: cat.command, age: null, graceDays: cat.graceDays });
+      continue;
+    }
+    const age = daysSince(value, now);
+    if (age === null) {
+      warnings.push({ key: cat.key, label: cat.label, command: cat.command, age: null, graceDays: cat.graceDays });
+      continue;
+    }
+    if (age > cat.graceDays) {
+      warnings.push({ key: cat.key, label: cat.label, command: cat.command, age, graceDays: cat.graceDays });
+    }
+  }
+  return warnings;
+}
+
+/** Format a maintenance warning into a single-line, owner-facing message. */
+export function formatMaintenanceWarning(w: MaintenanceWarning): string {
+  if (w.age === null) {
+    return `Maintenance: no record of a ${w.label}. Run \`${w.command}\` to log one.`;
+  }
+  return `Maintenance: ${w.label} last logged ${w.age} days ago (over the ${w.graceDays}-day window). Run \`${w.command}\`.`;
+}
+
+// ---------------------------------------------------------------------------
 // Main script (only runs when executed directly)
 // ---------------------------------------------------------------------------
 
@@ -212,6 +298,11 @@ if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
   const hasOgImage = htmlFiles.some(f => readFileSync(f, "utf-8").includes("og:image"));
   if (!hasOgImage) {
     warnings.push("No og:image meta tag found. Social shares won't show a preview image. Run `npm run ai-images` to generate one.");
+  }
+
+  // 6. Maintenance log (warn only)
+  for (const w of scanMaintenance(readConfig)) {
+    warnings.push(formatMaintenanceWarning(w));
   }
 
   // Report

--- a/tests/pre-deploy-check.test.ts
+++ b/tests/pre-deploy-check.test.ts
@@ -9,6 +9,10 @@ import {
   scanScripts,
   walkHtml,
   walkAll,
+  daysSince,
+  scanMaintenance,
+  formatMaintenanceWarning,
+  maintenanceCategories,
 } from "../template/scripts/pre-deploy-check.js";
 
 // ---------------------------------------------------------------------------
@@ -243,5 +247,114 @@ describe("walkAll", () => {
 
   it("returns empty array for non-existent directory", () => {
     expect(walkAll(join(tmpDir, "nonexistent"))).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Maintenance log
+// ---------------------------------------------------------------------------
+
+describe("daysSince", () => {
+  it("returns 0 for today", () => {
+    const now = new Date("2026-05-07T12:00:00Z");
+    expect(daysSince("2026-05-07", now)).toBe(0);
+  });
+
+  it("returns positive day count for past dates", () => {
+    const now = new Date("2026-05-07T12:00:00Z");
+    expect(daysSince("2026-04-07", now)).toBe(30);
+  });
+
+  it("returns null for malformed dates", () => {
+    expect(daysSince("yesterday")).toBeNull();
+    expect(daysSince("2026/05/07")).toBeNull();
+    expect(daysSince("")).toBeNull();
+  });
+
+  it("ignores time-of-day and timezone drift", () => {
+    // Stamp written at the end of a day; "now" is early next morning UTC.
+    const now = new Date("2026-05-08T01:00:00Z");
+    expect(daysSince("2026-05-07", now)).toBe(1);
+  });
+});
+
+describe("scanMaintenance", () => {
+  const now = new Date("2026-05-07T12:00:00Z");
+
+  it("warns when a category has never been recorded", () => {
+    const result = scanMaintenance(() => undefined, now);
+    expect(result).toHaveLength(maintenanceCategories.length);
+    expect(result.every(w => w.age === null)).toBe(true);
+  });
+
+  it("does not warn when stamps are within their grace period", () => {
+    const stamps: Record<string, string> = {
+      MAINTENANCE_MONTHLY_LAST: "2026-05-01",   // 6 days ago
+      MAINTENANCE_QUARTERLY_LAST: "2026-03-01", // 67 days ago
+      MAINTENANCE_ANNUAL_LAST: "2025-08-01",    // 279 days ago
+    };
+    const result = scanMaintenance(k => stamps[k], now);
+    expect(result).toEqual([]);
+  });
+
+  it("warns when monthly check is overdue", () => {
+    const stamps: Record<string, string> = {
+      MAINTENANCE_MONTHLY_LAST: "2026-03-01",   // 67 days ago — over 35-day window
+      MAINTENANCE_QUARTERLY_LAST: "2026-03-01",
+      MAINTENANCE_ANNUAL_LAST: "2025-08-01",
+    };
+    const result = scanMaintenance(k => stamps[k], now);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("MAINTENANCE_MONTHLY_LAST");
+    expect(result[0].age).toBe(67);
+  });
+
+  it("warns when quarterly update is overdue", () => {
+    const stamps: Record<string, string> = {
+      MAINTENANCE_MONTHLY_LAST: "2026-05-01",
+      MAINTENANCE_QUARTERLY_LAST: "2026-01-01", // 126 days ago — over 100-day window
+      MAINTENANCE_ANNUAL_LAST: "2025-08-01",
+    };
+    const result = scanMaintenance(k => stamps[k], now);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("MAINTENANCE_QUARTERLY_LAST");
+  });
+
+  it("treats malformed stamps as missing", () => {
+    const stamps: Record<string, string> = {
+      MAINTENANCE_MONTHLY_LAST: "garbage",
+      MAINTENANCE_QUARTERLY_LAST: "2026-03-01",
+      MAINTENANCE_ANNUAL_LAST: "2025-08-01",
+    };
+    const result = scanMaintenance(k => stamps[k], now);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("MAINTENANCE_MONTHLY_LAST");
+    expect(result[0].age).toBeNull();
+  });
+});
+
+describe("formatMaintenanceWarning", () => {
+  it("formats a missing-stamp warning", () => {
+    const msg = formatMaintenanceWarning({
+      key: "MAINTENANCE_MONTHLY_LAST",
+      label: "monthly health check",
+      command: "/anglesite:check",
+      age: null,
+      graceDays: 35,
+    });
+    expect(msg).toContain("no record");
+    expect(msg).toContain("/anglesite:check");
+  });
+
+  it("formats an overdue warning with age and command", () => {
+    const msg = formatMaintenanceWarning({
+      key: "MAINTENANCE_QUARTERLY_LAST",
+      label: "quarterly update",
+      command: "/anglesite:update",
+      age: 120,
+      graceDays: 100,
+    });
+    expect(msg).toContain("120 days");
+    expect(msg).toContain("/anglesite:update");
   });
 });


### PR DESCRIPTION
## Summary

The webmaster guide already defines a Monthly / Quarterly / Annual maintenance schedule (`template/docs/webmaster.md`), but nothing was tracking when each cadence was last performed — so the schedule was aspirational. This PR adds a maintenance log and surfaces overdue cadences as a warn-only pre-deploy step.

## What changed

- **Three new ISO-date stamps** in `.site-config`:
  - `MAINTENANCE_MONTHLY_LAST` — stamped by `/anglesite:check` (and `/anglesite:update`, since updating exercises the same build + dependency checks)
  - `MAINTENANCE_QUARTERLY_LAST` — stamped by `/anglesite:update`
  - `MAINTENANCE_ANNUAL_LAST` — stamped by `/anglesite:update` once it has been a year
- **Pre-deploy scan** (`template/scripts/pre-deploy-check.ts`) reads the stamps and emits a warn-only message for any cadence past its grace window (35 / 100 / 380 days). Deploys are never blocked — the warning is a nudge.
- **Skills updated** so the check / update / deploy commands read and write the log:
  - `skills/check/SKILL.md` — stamp `MAINTENANCE_MONTHLY_LAST` after a successful audit
  - `skills/update/SKILL.md` — stamp monthly + quarterly (and annual when due)
  - `skills/deploy/SKILL.md` — surface the warning to the owner in plain language
- **Docs updated**: `template/docs/webmaster.md` (new "Maintenance log" subsection with the table of stamps and grace windows) and `template/CLAUDE.md` (Maintenance step 8 now stamps the log).

## Design notes

- **Warn-only, never blocking.** Maintenance is the owner's call; the script just makes overdue cadences visible.
- **Grace windows** include a small buffer over the nominal cadence (35 / 100 / 380 days vs. 30 / 90 / 365) so a one-week slip does not nag the owner.
- **`scanMaintenance` is pure** — accepts a `read(key)` callback so unit tests can stub config without touching the filesystem.
- **`daysSince` uses UTC midnight**, so a stamp written late in the day does not show as "1 day old" by the next morning.

## Test plan

- [x] `npx vitest run` — full suite, 2322 passed (12 skipped, none touched)
- [x] New unit tests for `daysSince`, `scanMaintenance`, `formatMaintenanceWarning` covering missing / fresh / overdue / malformed stamps
- [ ] Manual: scaffold a fresh test site, run `/anglesite:deploy`, confirm warning appears for an unstamped log
- [ ] Manual: backdate a stamp in `.site-config` and confirm the matching warning fires with the right age

https://claude.ai/code/session_01MqmN5pamFa5CqtJ4m2sxaC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqmN5pamFa5CqtJ4m2sxaC)_