### PR TITLE
Enable Workers Logs ([observability]) on all helper Workers (#261)

### DIFF
--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -173,7 +173,19 @@ For each Worker that is present, call `mcp__cloudflare__workers_get_worker` to r
 1. **Local source mtime vs. deployed `modified_on`** — if the local `.js` file was edited *after* the last deploy, the deployed version is stale. Use `stat` to get the local mtime.
 2. **Deployed source vs. local source** — call `mcp__cloudflare__workers_get_worker_code` and compare against the local `.js` file. Treat them as a match if the strings are byte-identical after trimming trailing whitespace; otherwise flag as drifted.
 
-### Step 4 — Present findings
+### Step 4 — Verify Workers Logs (observability)
+
+For every helper Worker config that exists locally, grep the `.toml` file for an `[observability]` block with `enabled = true`. Workers Logs is what lets the owner diagnose a failed contact form / subscribe / webhook *after the fact* — without it, errors only surface during a live `wrangler tail` and then disappear.
+
+| State | Severity | Plain-language framing |
+|---|---|---|
+| `[observability]` block missing or `enabled = false` | Worth fixing soon | "Your [feature] worker isn't keeping logs, so if a submission fails we can't see why. Add `[observability]` with `enabled = true` to `worker/[file].toml` and redeploy." |
+| `[observability]` enabled locally but deployed Worker predates it | Worth fixing soon | "Logs are enabled in your project, but the live worker was deployed before that change. Re-run `/anglesite:deploy` to apply." |
+| Enabled and deployed | All good | (include in scorecard, no separate bullet) |
+
+Workers Logs is free on the Workers free plan; there's no reason to leave it off.
+
+### Step 5 — Present findings
 
 Report one bullet per expected Worker, using the existing severity vocabulary. Keep it boolean — owners don't need a diff:
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -517,3 +517,24 @@ If `wrangler deploy` fails with an auth error, run `npx wrangler login` to refre
 If the GitHub push fails (e.g., auth expired), tell the owner: "I couldn't back up to GitHub — let's fix the connection." Run `gh auth login --web` to re-authenticate, then retry.
 
 Tell the owner: "Your changes are live! They'll appear on the site in about a minute."
+
+### Post-deploy summary — where to look if something breaks
+
+Each helper Worker (contact, forms, subscribe, membership, ecommerce, review) ships with `[observability]` enabled, so failed invocations are retained as logs in the Cloudflare dashboard. If a worker was deployed in this run, surface the matching logs URL so the owner has a single click to debug a "the form isn't working" report later.
+
+Read `CLOUDFLARE_ACCOUNT_ID` from `.site-config` and substitute into:
+
+```
+https://dash.cloudflare.com/<account-id>/workers/services/view/<worker-name>/production/observability/logs
+```
+
+For each helper Worker that exists in `worker/` (look up the `name = "..."` field), include one line in the summary:
+
+- contact form → `contact-form`
+- custom forms → `forms-handler`
+- newsletter signup → `newsletter-subscribe`
+- members area → `anglesite-membership`
+- store order tracker → `ecommerce-webhooks`
+- review form → `review-form`
+
+Frame it plainly: "If a [feature] submission ever fails, you can see the error here: <URL>. Logs are kept for a few days." Don't dump all six links if the site only uses one — only list workers actually deployed.

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -310,4 +310,16 @@ To check tool status, run `npm run ai-check` — never write ad-hoc version/exis
 
 If something is broken, run `/anglesite:check`.
 
+### Helper-Worker logs (Workers Logs)
+
+Every helper Worker (`contact-form`, `forms-handler`, `newsletter-subscribe`, `anglesite-membership`, `ecommerce-webhooks`, `review-form`) deploys with `[observability]` enabled, so invocation errors are retained for a few days in the Cloudflare dashboard. When the owner reports "the contact form didn't send" or "subscriptions aren't going through," check the logs first — don't guess.
+
+Build the URL by substituting the Cloudflare account ID (read `CLOUDFLARE_ACCOUNT_ID` from `.site-config`) and the deployed worker name:
+
+```
+https://dash.cloudflare.com/<account-id>/workers/services/view/<worker-name>/production/observability/logs
+```
+
+The deployed worker name is the `name = "..."` field in the matching `worker/*-wrangler.toml`. For owners who prefer the CLI, `npx wrangler tail <worker-name>` streams live logs but only captures invocations *while it's running* — the dashboard URL is what surfaces past failures.
+
 Read `EXPLAIN_STEPS` from `.site-config`. If `true` or not set, explain before every tool call or command that will trigger a permission prompt — tell the owner what you're about to do and why. They should never see a permission dialog without context. If `false`, proceed without pre-announcing tool calls.

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -316,7 +316,7 @@ Every helper Worker (`contact-form`, `forms-handler`, `newsletter-subscribe`, `a
 
 Build the URL by substituting the Cloudflare account ID (read `CLOUDFLARE_ACCOUNT_ID` from `.site-config`) and the deployed worker name:
 
-```
+```text
 https://dash.cloudflare.com/<account-id>/workers/services/view/<worker-name>/production/observability/logs
 ```
 

--- a/template/worker/forms-wrangler.toml
+++ b/template/worker/forms-wrangler.toml
@@ -9,6 +9,13 @@ name = "forms-handler"
 main = "forms-worker.js"
 compatibility_date = "2024-09-23"
 
+# Workers Logs — retain invocation logs so failed submissions can be
+# diagnosed after the fact. Free on the Workers free plan.
+# View at: https://dash.cloudflare.com/?to=/:account/workers/services/view/forms-handler/production/observability/logs
+[observability]
+enabled = true
+head_sampling_rate = 1.0
+
 # Cloudflare D1 — submissions inbox (ADR-0019). The /anglesite:inbox skill
 # creates the database and rewrites database_id below. Without it the
 # worker still delivers email; D1 writes are best-effort.

--- a/template/worker/membership-wrangler.toml
+++ b/template/worker/membership-wrangler.toml
@@ -20,6 +20,14 @@ name = "anglesite-membership"
 main = "membership-worker.js"
 compatibility_date = "2024-09-23"
 
+# Workers Logs — retain invocation logs so failed unlocks / cookie
+# verifications can be diagnosed after the fact. Free on the Workers
+# free plan.
+# View at: https://dash.cloudflare.com/?to=/:account/workers/services/view/anglesite-membership/production/observability/logs
+[observability]
+enabled = true
+head_sampling_rate = 1.0
+
 [[kv_namespaces]]
 binding = "MEMBERSHIPS"
 id = "REPLACE_WITH_KV_NAMESPACE_ID"

--- a/template/worker/review-wrangler.toml
+++ b/template/worker/review-wrangler.toml
@@ -8,3 +8,10 @@
 name = "review-form"
 main = "review-worker.js"
 compatibility_date = "2024-01-01"
+
+# Workers Logs — retain invocation logs so failed submissions can be
+# diagnosed after the fact. Free on the Workers free plan.
+# View at: https://dash.cloudflare.com/?to=/:account/workers/services/view/review-form/production/observability/logs
+[observability]
+enabled = true
+head_sampling_rate = 1.0

--- a/template/worker/subscribe-wrangler.toml
+++ b/template/worker/subscribe-wrangler.toml
@@ -8,3 +8,10 @@
 name = "newsletter-subscribe"
 main = "subscribe-worker.js"
 compatibility_date = "2024-01-01"
+
+# Workers Logs — retain invocation logs so failed subscribes can be
+# diagnosed after the fact. Free on the Workers free plan.
+# View at: https://dash.cloudflare.com/?to=/:account/workers/services/view/newsletter-subscribe/production/observability/logs
+[observability]
+enabled = true
+head_sampling_rate = 1.0

--- a/template/worker/wrangler-ecommerce.toml
+++ b/template/worker/wrangler-ecommerce.toml
@@ -14,6 +14,14 @@ name = "ecommerce-webhooks"
 main = "ecommerce-webhook-worker.js"
 compatibility_date = "2024-01-01"
 
+# Workers Logs — retain invocation logs so failed webhooks (signature
+# mismatch, malformed payloads) can be diagnosed after the fact.
+# Free on the Workers free plan.
+# View at: https://dash.cloudflare.com/?to=/:account/workers/services/view/ecommerce-webhooks/production/observability/logs
+[observability]
+enabled = true
+head_sampling_rate = 1.0
+
 [[analytics_engine_datasets]]
 binding = "ANALYTICS"
 dataset = "anglesite_events"

--- a/template/worker/wrangler.toml
+++ b/template/worker/wrangler.toml
@@ -9,6 +9,13 @@ name = "contact-form"
 main = "contact-worker.js"
 compatibility_date = "2024-01-01"
 
+# Workers Logs — retain invocation logs so failed submissions can be
+# diagnosed after the fact. Free on the Workers free plan.
+# View at: https://dash.cloudflare.com/?to=/:account/workers/services/view/contact-form/production/observability/logs
+[observability]
+enabled = true
+head_sampling_rate = 1.0
+
 # Cloudflare D1 — submissions inbox (ADR-0019). The /anglesite:inbox skill
 # creates the database and rewrites database_id below. Without it the
 # worker still delivers email; D1 writes are best-effort.


### PR DESCRIPTION
Closes #261.

## Summary

Adds `[observability]` with `enabled = true` and `head_sampling_rate = 1.0` to every helper-worker `wrangler.toml`:

- `template/worker/wrangler.toml` (`contact-form`)
- `template/worker/forms-wrangler.toml` (`forms-handler`)
- `template/worker/membership-wrangler.toml` (`anglesite-membership`)
- `template/worker/review-wrangler.toml` (`review-form`)
- `template/worker/subscribe-wrangler.toml` (`newsletter-subscribe`)
- `template/worker/wrangler-ecommerce.toml` (`ecommerce-webhooks`)

Without `[observability]`, helper-Worker errors only surface during a live `wrangler tail`. With it enabled, failed invocations are retained for a few days in the Cloudflare dashboard, so when an owner reports "the contact form isn't sending email" days later we can actually see why. Free on the Workers free plan.

## Skill + docs updates

- **`skills/check/SKILL.md`** — adds a new "Step 4 — Verify Workers Logs (observability)" check that greps each local helper-worker `.toml` for an `[observability]` block with `enabled = true` and flags missing/disabled cases as "Worth fixing soon."
- **`skills/deploy/SKILL.md`** — adds a "Post-deploy summary — where to look if something breaks" section that emits the dashboard logs URL (`https://dash.cloudflare.com/<account-id>/workers/services/view/<worker-name>/production/observability/logs`) for each helper Worker actually deployed.
- **`template/CLAUDE.md`** — adds a "Helper-Worker logs (Workers Logs)" subsection under Diagnostics documenting the URL pattern and the `wrangler tail` fallback.

## Test plan

- [ ] Confirm all 6 helper `*-wrangler.toml` files have `[observability]` with `enabled = true` and `head_sampling_rate = 1.0`
- [ ] After scaffolding a fresh site, run `/anglesite:check` and confirm the new observability assertion runs and reports correctly
- [ ] After a deploy that publishes at least one helper Worker, confirm the post-deploy summary surfaces the matching logs URL
- [ ] Sanity-check that an actual failed Worker invocation appears in the dashboard logs view at the documented URL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2YorfYpRWk96rg22mdjpZ)_