### PR TITLE
Wire helper Workers to Analytics Engine + surface conversions in stats

### DIFF
--- a/skills/stats/SKILL.md
+++ b/skills/stats/SKILL.md
@@ -14,18 +14,42 @@ Fetch Cloudflare analytics data and present it as a plain-language summary. No d
 
 Read `EXPLAIN_STEPS` from `.site-config`. If `true` or not set, explain before every tool call that will trigger a permission prompt. If `false`, proceed without pre-announcing.
 
-## Two data sources, one skill
+## Three data sources, one skill
 
-Cloudflare exposes two unrelated analytics datasets and the skill must pick the right one. Mixing them up gives wrong numbers.
+Cloudflare exposes three unrelated analytics datasets and the skill must pick the right one for each section. Mixing them up gives wrong numbers.
 
 | Source | Dataset | Beacon? | Permission | Filter | Available when |
 |---|---|---|---|---|---|
 | **Web Analytics RUM** | `rumPageloadEventsAdaptiveGroups` | Yes (`static.cloudflareinsights.com/beacon.min.js`, auto-injected by Pages) | **Account → Analytics → Read** | `siteTag` + `accountTag` | Always, for any Pages-deployed Anglesite site |
 | **Zone HTTP analytics** | `httpRequests1dGroups` / `httpRequestsAdaptiveGroups` | No — derived from edge logs | **Zone → Analytics → Read** | `zoneTag` | Only when the custom domain runs through Cloudflare DNS proxied (orange cloud) |
+| **Anglesite events (Analytics Engine)** | `anglesite_events` | No — written from helper Workers | **Account → Analytics Engine → Read** | `dataset='anglesite_events'`, optionally `index1=<site domain>` | When at least one helper Worker (contact, forms, membership, review, subscribe, ecommerce) is deployed |
 
-Default to Web Analytics RUM because every Anglesite site has the beacon auto-injected by Pages. Fall back to zone HTTP only when RUM is unreachable and a proxied zone exists.
+Default to Web Analytics RUM for traffic. Fall back to zone HTTP only when RUM is unreachable and a proxied zone exists. The `anglesite_events` dataset is independent of both — it surfaces *conversions* (form submits, signups, unlocks) and is queried alongside the traffic source.
 
-When presenting numbers, always tell the owner which source they're seeing — the two datasets count different things and the totals will not match.
+When presenting numbers, always tell the owner which source they're seeing — the datasets count different things and the totals will not match.
+
+## The `anglesite_events` dataset
+
+The Anglesite helper Workers write a standard data point on every meaningful event:
+
+```js
+env.ANALYTICS.writeDataPoint({
+  blobs: [workerName, eventType, formName, outcome],
+  doubles: [1],
+  indexes: [siteDomain],
+});
+```
+
+| Field | Purpose | Example values |
+|---|---|---|
+| `blob1` (workerName) | Which helper Worker wrote the event | `contact`, `forms`, `membership`, `review`, `subscribe`, `ecommerce` |
+| `blob2` (eventType) | What kind of event | `submit`, `signup`, `unlock`, `webhook`, `error` |
+| `blob3` (formName) | Form/tier identifier | `contact`, `rsvp`, `lead`, `free`, `paid`, `newsletter`, `review`, or `""` |
+| `blob4` (outcome) | Result of the request | `ok`, `rate_limited`, `validation_error`, `upstream_error` |
+| `double1` | Count for SUM aggregation | `1` |
+| `index1` (siteDomain) | Site that produced the event (multi-site accounts) | `example.com` |
+
+Free Cloudflare accounts include 10M Analytics Engine writes per month and a 30-day retention window, which is more than enough for SMB conversion tracking.
 
 ## Step 0 — Check prerequisites
 
@@ -35,12 +59,13 @@ Read `.env` for `CF_API_TOKEN`, `CF_ACCOUNT_ID`, `CF_WEB_ANALYTICS_SITE_TAG`, an
 
 If `CF_API_TOKEN` is missing, guide the owner through creating one:
 
-1. Tell them: "To see your analytics, I need a Cloudflare API token. Let's create one — it takes about a minute. We'll add two permissions so the token works whether your site uses Cloudflare's Web Analytics beacon (the default for Anglesite) or proxied DNS."
+1. Tell them: "To see your analytics, I need a Cloudflare API token. Let's create one — it takes about a minute. We'll add three permissions so the token covers traffic (Web Analytics or proxied DNS) and conversions (form submits, signups)."
 2. Open: `https://dash.cloudflare.com/profile/api-tokens`
 3. Click "Create Token"
 4. Use the "Custom token" template
-5. Add **both** permissions:
+5. Add **all three** permissions:
    - **Account → Analytics → Read** — required for Web Analytics RUM (the default)
+   - **Account → Analytics Engine → Read** — required for the `anglesite_events` conversions dataset
    - **Zone → Analytics → Read** — required only if the site uses proxied DNS on Cloudflare; safe to include either way
 6. Account Resources: Include → (their Cloudflare account)
 7. Zone Resources: Include → All zones from the same account (or the specific zone if known)
@@ -49,7 +74,7 @@ If `CF_API_TOKEN` is missing, guide the owner through creating one:
 
 Save to `.env` as `CF_API_TOKEN=token-value` using the Write tool (update or create the file). **Never save API tokens to `.site-config`** — that file is committed to git. `.env` is gitignored and stays local.
 
-If the owner created an older token with only **Zone → Analytics → Read** (the previous version of this skill recommended that), they may see "Account → Analytics" errors below. Have them either edit the existing token to add the account-level permission, or create a new one.
+If the owner created an older token with only **Zone → Analytics → Read** (the original version of this skill recommended that), they may see "Account → Analytics" errors below. If the token is missing **Account → Analytics Engine → Read**, the conversions section will return an `authz` error — surface a one-line note ("Add Account → Analytics Engine → Read to your token to see conversion numbers") and skip the section. Have them either edit the existing token to add the missing permissions, or create a new one.
 
 ### Account ID
 
@@ -235,6 +260,46 @@ curl -s "https://api.cloudflare.com/client/v4/graphql" \
 
 If the response returns an `authz` error or the field is rejected, the owner's plan tier doesn't expose `clientRequestQuery` — skip the campaign section entirely.
 
+## Step 2C — Fetch conversions from `anglesite_events`
+
+Always run this section in addition to Step 2A or 2B — conversions are an independent signal from traffic. Skip it gracefully if the helper Workers haven't been deployed yet (an empty result set, not an error).
+
+The `anglesite_events` dataset lives in Cloudflare Analytics Engine and is queried via the same GraphQL endpoint used for traffic. The schema is documented at the top of this file under "The `anglesite_events` dataset".
+
+```sh
+CF_API_TOKEN=$(grep CF_API_TOKEN .env | cut -d= -f2)
+CF_ACCOUNT_ID=$(grep CF_ACCOUNT_ID .env | cut -d= -f2)
+SITE_DOMAIN=$(grep SITE_DOMAIN .site-config | cut -d= -f2)
+```
+
+### Query D (events) — conversions by worker and outcome (last 14 days, daily roll-ups)
+
+Replace `DATE_START_PREV` with 14 days ago (ISO `YYYY-MM-DD`) and `DATE_END_CURR` with today.
+
+```sh
+curl -s "https://api.cloudflare.com/client/v4/graphql" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"query":"{ viewer { accounts(filter: {accountTag: \"'$CF_ACCOUNT_ID'\"}) { workersAnalyticsEngineAdaptiveGroups(filter: {datasetId: \"anglesite_events\", index1: \"'$SITE_DOMAIN'\", date_geq: \"DATE_START_PREV\", date_leq: \"DATE_END_CURR\"}, limit: 1000, orderBy: [date_ASC]) { sum { _sample_interval } count dimensions { date blob1 blob2 blob3 blob4 } } } } }"}'
+```
+
+`count` is the number of distinct events in the bucket; `sum._sample_interval` is the count weighted for sampling (use this when extrapolating to a real total). For SMB-scale traffic the two are usually identical.
+
+If the response contains an `authz` or `does not have access` error, the token is missing **Account → Analytics Engine → Read**. Skip the conversions section and surface the one-line remediation note from the token-creation step.
+
+If the response is empty (no rows), the helper Workers either haven't been deployed yet or haven't received any traffic. Skip the section silently — don't surface an empty table.
+
+### Query E (events) — totals by form (last 7 days)
+
+```sh
+curl -s "https://api.cloudflare.com/client/v4/graphql" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"query":"{ viewer { accounts(filter: {accountTag: \"'$CF_ACCOUNT_ID'\"}) { workersAnalyticsEngineAdaptiveGroups(filter: {datasetId: \"anglesite_events\", index1: \"'$SITE_DOMAIN'\", date_geq: \"DATE_START_CURR\", date_leq: \"DATE_END_CURR\"}, limit: 200, orderBy: [count_DESC]) { count dimensions { blob1 blob2 blob3 blob4 } } } } }"}'
+```
+
+Replace `DATE_START_CURR` with 7 days ago and `DATE_END_CURR` with today.
+
 ## Step 3 — Parse and summarize
 
 These three numbers measure different things and must not be substituted for one another:
@@ -253,6 +318,14 @@ From the responses, extract:
 6. **Referral sources** — RUM: from Query C, group by `refererHost`, rename common ones (e.g., `google.com` → "Google Search", empty → "Direct"). Zone *(paid only)*: group by `clientRefererHost`. Skip on zone free plans.
 7. **Device breakdown** — RUM: from Query C, group by `deviceType`. Zone *(paid only)*: group by `userAgentBrowser`. Skip on zone free plans.
 8. **Campaign breakdown** *(zone paid only)* — from the `clientRequestQuery` query above, parse each query string for `utm_source`, `utm_medium`, `utm_campaign`. Group by `utm_source`/`utm_campaign`, label each entry as `{source} "{campaign}"`, and sort by page-view count descending. `clientRequestPath` does not include query strings, so this section is impossible on zone free plans — skip it there. RUM exposes campaign dimensions via the beacon but they are not covered by this skill yet — skip on RUM.
+9. **Conversions** *(events dataset)* — from Query D and Query E:
+   - **Total submits this week** — sum `count` from Query D where `blob4 = "ok"`, scoped to the current 7-day window.
+   - **By worker** — group Query E rows by `blob1` (`contact`, `forms`, `membership`, `review`, `subscribe`, `ecommerce`); for each, report total events and the share with `blob4 = "ok"`. This is the signal an SMB owner cares about: "12 contact submits, 8 newsletter signups, 3 paid unlocks."
+   - **By form** — for `blob1 = "forms"`, sub-group by `blob3` (form slug: `rsvp`, `lead`, etc.) so the owner sees per-form volume. Show only forms with at least one submit in the window.
+   - **Error rate** — within each worker, the share of rows where `blob4 != "ok"`. Surface only when error rate exceeds 25% of total events for that worker — most error rows are routine validation noise (rate-limiting, empty fields) and aren't actionable. Frame the alert as "12 of 38 contact submits failed Turnstile this week — worth checking the form is loading the widget."
+   - **Week-over-week** — split Query D rows by date as in the traffic queries (current 7 days vs prior 7 days) and compute the delta on `blob4 = "ok"` events. Phrase as "newsletter signups up from 4 to 11 this week".
+
+   Skip the section silently if Query D returned an empty result (no helper Workers deployed). Surface the token remediation note if the query returned an `authz` error.
 
 Present the summary in plain language. **Always begin with a one-line note that names the data source.** Example output (Web Analytics RUM, free plan):
 
@@ -268,6 +341,17 @@ Present the summary in plain language. **Always begin with a one-line note that 
 > **Busiest day:** Tuesday with 65 page views. Consider posting new content on Monday to catch the wave.
 >
 > **Top referrers:** Google Search (42), Direct (28), bsky.app (12).
+>
+> *Conversions (last 7 days, helper Worker events):*
+>
+> | Worker | Successful events | Notes |
+> |---|---|---|
+> | contact | 12 | up from 7 last week |
+> | subscribe | 8 newsletter signups | up from 4 last week |
+> | forms (rsvp) | 5 | first event this week |
+> | membership | 2 paid unlocks | new |
+>
+> Conversion rate: 27 form events on 318 page views = **8.5%** — healthy for a small business site.
 
 Example output (zone HTTP analytics, free plan):
 
@@ -301,6 +385,7 @@ After collecting the data, present results as a clean markdown summary:
 - **Top pages** — markdown table with page path and page-view count (and optional bar made of `█` characters proportional to page views, e.g. `████████ 240`). Header the count column "Page views", not "Visits".
 - **Top countries** *(zone only)* — markdown table with country name and page-view count. Append `(datacenter-heavy)` to known datacenter-dominant origins (see Step 3 item 5). Skip on RUM.
 - **Campaign performance** *(zone paid only)* — markdown table if `clientRequestQuery` data is available, also in page views. Skip on zone free plans and on RUM.
+- **Conversions** *(events dataset)* — markdown table grouped by worker (and by form slug for `forms`) with a "Successful events" column. Append a one-line conversion-rate sentence (`successful events / page views`) when traffic data is also available. Skip silently when no helper Workers have been deployed; surface the token remediation note when the query returned an `authz` error.
 - **Bot/datacenter caveat** *(zone only)* — always include the one-line heads-up about unique-visitor inflation when reporting `uniq.uniques`. Don't skip it on the assumption that the site is large; the owner is rarely in a position to know. The RUM beacon doesn't have this problem, so skip the caveat there.
 - **Plain-language summary** — 2–3 sentences explaining what the numbers mean. When you cite a headline figure, say which one (visitors vs page views) — they tell different stories. Lead with page views when both are available.
 

--- a/template/worker/contact-worker.js
+++ b/template/worker/contact-worker.js
@@ -21,6 +21,19 @@
 const RATE_LIMIT_SECONDS = 60;
 const recentSubmissions = new Map();
 
+function recordEvent(env, eventType, formName, outcome) {
+  if (!env || !env.ANALYTICS) return;
+  try {
+    env.ANALYTICS.writeDataPoint({
+      blobs: ["contact", eventType, formName || "", outcome],
+      doubles: [1],
+      indexes: [env.SITE_DOMAIN || ""],
+    });
+  } catch (err) {
+    console.error("Analytics writeDataPoint failed:", err);
+  }
+}
+
 const CONTACT_FORM_DEFINITION = {
   slug: "contact",
   title: "Contact",
@@ -288,6 +301,7 @@ export default {
     const ip = request.headers.get("CF-Connecting-IP") || "unknown";
 
     if (isRateLimited(ip)) {
+      recordEvent(env, "submit", "contact", "rate_limited");
       return new Response("Too many requests. Please wait a minute.", {
         status: 429,
         headers: corsHeaders(origin, env.SITE_DOMAIN),
@@ -329,6 +343,7 @@ export default {
     // Validate input
     const errors = validateInput(name, email, message);
     if (errors.length > 0) {
+      recordEvent(env, "submit", "contact", "validation_error");
       return new Response(JSON.stringify({ errors }), {
         status: 400,
         headers: { ...corsHeaders(origin, env.SITE_DOMAIN), "Content-Type": "application/json" },
@@ -337,6 +352,7 @@ export default {
 
     // Verify Turnstile
     if (!turnstileToken) {
+      recordEvent(env, "submit", "contact", "validation_error");
       return new Response(
         JSON.stringify({ errors: ["Please complete the verification."] }),
         {
@@ -355,6 +371,7 @@ export default {
       ip,
     );
     if (!turnstileValid) {
+      recordEvent(env, "submit", "contact", "validation_error");
       return new Response(
         JSON.stringify({ errors: ["Verification failed. Please try again."] }),
         {
@@ -375,6 +392,7 @@ export default {
     const sent = await sendEmail(env, name, email, message);
 
     if (!sent) {
+      recordEvent(env, "submit", "contact", "upstream_error");
       return new Response(
         JSON.stringify({
           errors: ["Failed to send message. Please try again later."],
@@ -388,6 +406,8 @@ export default {
         },
       );
     }
+
+    recordEvent(env, "submit", "contact", "ok");
 
     // For form submissions, redirect to thank you page
     if (contentType.includes("application/x-www-form-urlencoded") && origin) {

--- a/template/worker/forms-worker.js
+++ b/template/worker/forms-worker.js
@@ -29,6 +29,19 @@ import formsCatalog from "./forms.json";
 
 const recentSubmissions = new Map();
 
+function recordEvent(env, eventType, formName, outcome) {
+  if (!env || !env.ANALYTICS) return;
+  try {
+    env.ANALYTICS.writeDataPoint({
+      blobs: ["forms", eventType, formName || "", outcome],
+      doubles: [1],
+      indexes: [env.SITE_DOMAIN || ""],
+    });
+  } catch (err) {
+    console.error("Analytics writeDataPoint failed:", err);
+  }
+}
+
 function rateLimitKey(slug, ip) {
   return `${slug}:${ip}`;
 }
@@ -486,6 +499,7 @@ export default {
       ? form.rateLimitSeconds
       : 60;
     if (isRateLimited(formSlug, ip, rateLimit)) {
+      recordEvent(env, "submit", formSlug, "rate_limited");
       return new Response("Too many requests. Please wait a minute.", {
         status: 429,
         headers: corsHeaders(origin, siteDomain),
@@ -499,10 +513,12 @@ export default {
       errors.push(...validateField(field, values[field.name]));
     }
     if (errors.length > 0) {
+      recordEvent(env, "submit", formSlug, "validation_error");
       return jsonError(errors, 400, origin, siteDomain);
     }
 
     if (!turnstileToken) {
+      recordEvent(env, "submit", formSlug, "validation_error");
       return jsonError(
         ["Please complete the verification."],
         400,
@@ -517,6 +533,7 @@ export default {
       ip,
     );
     if (!turnstileValid) {
+      recordEvent(env, "submit", formSlug, "validation_error");
       return jsonError(
         ["Verification failed. Please try again."],
         403,
@@ -533,6 +550,7 @@ export default {
 
     const sent = await sendEmail(env, form, values);
     if (!sent) {
+      recordEvent(env, "submit", formSlug, "upstream_error");
       return jsonError(
         ["Failed to send. Please try again later."],
         500,
@@ -540,6 +558,8 @@ export default {
         siteDomain,
       );
     }
+
+    recordEvent(env, "submit", formSlug, "ok");
 
     if (contentType.includes("application/x-www-form-urlencoded") && origin) {
       const target =

--- a/template/worker/forms-wrangler.toml
+++ b/template/worker/forms-wrangler.toml
@@ -16,3 +16,10 @@ compatibility_date = "2024-09-23"
 # binding = "INBOX_DB"
 # database_name = "form_submissions"
 # database_id = "REPLACE_WITH_D1_DATABASE_ID"
+
+# Analytics Engine — conversion events (form submits, errors). The shared
+# `anglesite_events` dataset is queried by /anglesite:stats. Writes are
+# best-effort; the worker still functions if the binding is absent.
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "anglesite_events"

--- a/template/worker/membership-worker.js
+++ b/template/worker/membership-worker.js
@@ -38,6 +38,19 @@ const RATE_LIMIT_SECONDS = 30;
 const RATE_LIMIT_MAX_ENTRIES = 10000;
 const recentSubmissions = new Map();
 
+function recordEvent(env, eventType, formName, outcome) {
+  if (!env || !env.ANALYTICS) return;
+  try {
+    env.ANALYTICS.writeDataPoint({
+      blobs: ["membership", eventType, formName || "", outcome],
+      doubles: [1],
+      indexes: [env.SITE_DOMAIN || ""],
+    });
+  } catch (err) {
+    console.error("Analytics writeDataPoint failed:", err);
+  }
+}
+
 function isRateLimited(ip) {
   const now = Date.now();
   const last = recentSubmissions.get(ip);
@@ -339,9 +352,11 @@ function jsonError(errors, status, origin, siteDomain) {
 async function handleUnlockFree(request, env, origin) {
   const tiers = tiersAllowed(env);
   if (!tiers.has("free")) {
+    recordEvent(env, "unlock", "free", "validation_error");
     return jsonError(["Free tier is not enabled."], 400, origin, env.SITE_DOMAIN);
   }
   if (!env.NEWSLETTER_API_KEY) {
+    recordEvent(env, "unlock", "free", "upstream_error");
     return jsonError(["Newsletter not configured."], 500, origin, env.SITE_DOMAIN);
   }
 
@@ -356,10 +371,12 @@ async function handleUnlockFree(request, env, origin) {
       email = form.get("email");
     }
   } catch {
+    recordEvent(env, "unlock", "free", "validation_error");
     return jsonError(["Invalid request."], 400, origin, env.SITE_DOMAIN);
   }
 
   if (!email || !EMAIL_RE.test(String(email))) {
+    recordEvent(env, "unlock", "free", "validation_error");
     return jsonError(
       ["A valid email address is required."],
       400,
@@ -382,6 +399,7 @@ async function handleUnlockFree(request, env, origin) {
   }
 
   if (!onList) {
+    recordEvent(env, "unlock", "free", "validation_error");
     return jsonError(
       [
         "Email not found on the subscriber list. Please subscribe first, then return to unlock.",
@@ -405,6 +423,8 @@ async function handleUnlockFree(request, env, origin) {
     });
   }
 
+  recordEvent(env, "unlock", "free", "ok");
+
   return new Response(JSON.stringify({ ok: true, tier: "free" }), {
     status: 200,
     headers: {
@@ -418,9 +438,11 @@ async function handleUnlockFree(request, env, origin) {
 async function handleUnlockPaid(request, env, origin) {
   const tiers = tiersAllowed(env);
   if (!tiers.has("paid")) {
+    recordEvent(env, "unlock", "paid", "validation_error");
     return jsonError(["Paid tier is not enabled."], 400, origin, env.SITE_DOMAIN);
   }
   if (!env.STRIPE_SECRET_KEY) {
+    recordEvent(env, "unlock", "paid", "upstream_error");
     return jsonError(["Stripe not configured."], 500, origin, env.SITE_DOMAIN);
   }
 
@@ -428,11 +450,13 @@ async function handleUnlockPaid(request, env, origin) {
   const sessionId =
     url.searchParams.get("session_id") || url.searchParams.get("checkout_session");
   if (!sessionId) {
+    recordEvent(env, "unlock", "paid", "validation_error");
     return jsonError(["Missing session id."], 400, origin, env.SITE_DOMAIN);
   }
 
   const session = await getStripeCheckoutSession(sessionId, env);
   if (!session || session.payment_status !== "paid" || !session.customer) {
+    recordEvent(env, "unlock", "paid", "upstream_error");
     return jsonError(
       ["Could not verify the payment. Please contact support."],
       402,
@@ -459,6 +483,8 @@ async function handleUnlockPaid(request, env, origin) {
   const returnPath = isSafeReturnPath(requestedReturn) ? requestedReturn : "/";
   const redirectTarget = new URL(returnPath, `https://${env.SITE_DOMAIN}`);
 
+  recordEvent(env, "unlock", "paid", "ok");
+
   return new Response(null, {
     status: 303,
     headers: {
@@ -470,7 +496,11 @@ async function handleUnlockPaid(request, env, origin) {
 
 async function handleStripeWebhook(request, env) {
   const event = await verifyStripeWebhook(request, env);
-  if (!event) return new Response("Invalid signature", { status: 400 });
+  if (!event) {
+    recordEvent(env, "webhook", "stripe", "validation_error");
+    return new Response("Invalid signature", { status: 400 });
+  }
+  recordEvent(env, "webhook", event.type || "stripe", "ok");
 
   const customerId =
     event?.data?.object?.customer ||
@@ -613,6 +643,7 @@ export default {
     if (request.method === "POST") {
       const ip = request.headers.get("CF-Connecting-IP") || "unknown";
       if (isRateLimited(ip)) {
+        recordEvent(env, "unlock", "free", "rate_limited");
         return new Response("Too many requests. Please wait a moment.", {
           status: 429,
           headers: corsHeaders(origin, env.SITE_DOMAIN),

--- a/template/worker/membership-wrangler.toml
+++ b/template/worker/membership-wrangler.toml
@@ -23,3 +23,10 @@ compatibility_date = "2024-09-23"
 [[kv_namespaces]]
 binding = "MEMBERSHIPS"
 id = "REPLACE_WITH_KV_NAMESPACE_ID"
+
+# Analytics Engine — membership unlock events (free signups, paid unlocks,
+# webhook outcomes, errors). The shared `anglesite_events` dataset is
+# queried by /anglesite:stats. Writes are best-effort.
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "anglesite_events"

--- a/template/worker/review-worker.js
+++ b/template/worker/review-worker.js
@@ -14,6 +14,19 @@
 const RATE_LIMIT_SECONDS = 300; // 5 minutes between submissions
 const recentSubmissions = new Map();
 
+function recordEvent(env, eventType, formName, outcome) {
+  if (!env || !env.ANALYTICS) return;
+  try {
+    env.ANALYTICS.writeDataPoint({
+      blobs: ["review", eventType, formName || "", outcome],
+      doubles: [1],
+      indexes: [env.SITE_DOMAIN || ""],
+    });
+  } catch (err) {
+    console.error("Analytics writeDataPoint failed:", err);
+  }
+}
+
 function isRateLimited(ip) {
   const now = Date.now();
   const last = recentSubmissions.get(ip);
@@ -136,6 +149,7 @@ export default {
     const ip = request.headers.get("CF-Connecting-IP") || "unknown";
 
     if (isRateLimited(ip)) {
+      recordEvent(env, "submit", "review", "rate_limited");
       return new Response("Too many submissions. Please wait a few minutes.", {
         status: 429,
         headers: corsHeaders(origin, env.SITE_DOMAIN),
@@ -176,6 +190,7 @@ export default {
 
     const errors = validateInput(name, rating, text);
     if (errors.length > 0) {
+      recordEvent(env, "submit", "review", "validation_error");
       return new Response(JSON.stringify({ errors }), {
         status: 400,
         headers: { ...corsHeaders(origin, env.SITE_DOMAIN), "Content-Type": "application/json" },
@@ -183,6 +198,7 @@ export default {
     }
 
     if (!turnstileToken) {
+      recordEvent(env, "submit", "review", "validation_error");
       return new Response(
         JSON.stringify({ errors: ["Please complete the verification."] }),
         {
@@ -198,6 +214,7 @@ export default {
       ip,
     );
     if (!turnstileValid) {
+      recordEvent(env, "submit", "review", "validation_error");
       return new Response(
         JSON.stringify({ errors: ["Verification failed. Please try again."] }),
         {
@@ -210,6 +227,7 @@ export default {
     const sent = await emailReview(env, name, rating, text);
 
     if (!sent) {
+      recordEvent(env, "submit", "review", "upstream_error");
       return new Response(
         JSON.stringify({ errors: ["Failed to submit review. Please try again later."] }),
         {
@@ -218,6 +236,8 @@ export default {
         },
       );
     }
+
+    recordEvent(env, "submit", "review", "ok");
 
     if (contentType.includes("application/x-www-form-urlencoded") && origin) {
       return Response.redirect(`${origin}/review/thanks`, 303);

--- a/template/worker/review-wrangler.toml
+++ b/template/worker/review-wrangler.toml
@@ -8,3 +8,9 @@
 name = "review-form"
 main = "review-worker.js"
 compatibility_date = "2024-01-01"
+
+# Analytics Engine — review submission events. The shared `anglesite_events`
+# dataset is queried by /anglesite:stats. Writes are best-effort.
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "anglesite_events"

--- a/template/worker/subscribe-worker.js
+++ b/template/worker/subscribe-worker.js
@@ -13,6 +13,19 @@
 const RATE_LIMIT_SECONDS = 30;
 const recentSubmissions = new Map();
 
+function recordEvent(env, eventType, formName, outcome) {
+  if (!env || !env.ANALYTICS) return;
+  try {
+    env.ANALYTICS.writeDataPoint({
+      blobs: ["subscribe", eventType, formName || "", outcome],
+      doubles: [1],
+      indexes: [env.SITE_DOMAIN || ""],
+    });
+  } catch (err) {
+    console.error("Analytics writeDataPoint failed:", err);
+  }
+}
+
 function isRateLimited(ip) {
   const now = Date.now();
   const last = recentSubmissions.get(ip);
@@ -111,6 +124,7 @@ export default {
     const ip = request.headers.get("CF-Connecting-IP") || "unknown";
 
     if (isRateLimited(ip)) {
+      recordEvent(env, "signup", "newsletter", "rate_limited");
       return new Response("Too many requests. Please wait a moment.", {
         status: 429,
         headers: corsHeaders(origin, env.SITE_DOMAIN),
@@ -144,6 +158,7 @@ export default {
     }
 
     if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      recordEvent(env, "signup", "newsletter", "validation_error");
       return new Response(
         JSON.stringify({ errors: ["A valid email address is required."] }),
         {
@@ -169,6 +184,7 @@ export default {
     }
 
     if (result.ok) {
+      recordEvent(env, "signup", "newsletter", "ok");
       // For form submissions, redirect to thank you
       if (contentType.includes("application/x-www-form-urlencoded") && origin) {
         return Response.redirect(`${origin}/subscribe/thanks`, 303);
@@ -179,6 +195,15 @@ export default {
       });
     }
 
+    const alreadySubscribed = (result.errors || []).some((e) =>
+      /already subscribed/i.test(String(e)),
+    );
+    recordEvent(
+      env,
+      "signup",
+      "newsletter",
+      alreadySubscribed ? "validation_error" : "upstream_error",
+    );
     return new Response(JSON.stringify({ errors: result.errors }), {
       status: 400,
       headers: { ...corsHeaders(origin, env.SITE_DOMAIN), "Content-Type": "application/json" },

--- a/template/worker/subscribe-wrangler.toml
+++ b/template/worker/subscribe-wrangler.toml
@@ -8,3 +8,9 @@
 name = "newsletter-subscribe"
 main = "subscribe-worker.js"
 compatibility_date = "2024-01-01"
+
+# Analytics Engine — newsletter signup events. The shared `anglesite_events`
+# dataset is queried by /anglesite:stats. Writes are best-effort.
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "anglesite_events"

--- a/template/worker/wrangler.toml
+++ b/template/worker/wrangler.toml
@@ -16,3 +16,10 @@ compatibility_date = "2024-01-01"
 # binding = "INBOX_DB"
 # database_name = "form_submissions"
 # database_id = "REPLACE_WITH_D1_DATABASE_ID"
+
+# Analytics Engine — conversion events (form submits, errors). The shared
+# `anglesite_events` dataset is queried by /anglesite:stats. Writes are
+# best-effort; the worker still functions if the binding is absent.
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "anglesite_events"


### PR DESCRIPTION
Closes #262.

## Summary

- Adds an Analytics Engine binding (`ANALYTICS` → `anglesite_events`) to the contact, forms, membership, review, and subscribe helper Workers — they previously had no telemetry, so the owner had no way to see form submissions, signup conversion, or unlock volume.
- Each Worker now records a standard event (`workerName`, `eventType`, `formName`, `outcome`) on every meaningful path: success, validation failure, rate-limit, upstream error. Writes are best-effort — the Worker still functions if the binding is absent.
- Extends `skills/stats/SKILL.md` with a third data source (`anglesite_events` via Analytics Engine), Query D (daily roll-ups, last 14 days) and Query E (totals by form, last 7 days), a new **Conversions** section in Step 3 with worker/form breakdown and week-over-week deltas, and a sample table in the example output.
- Updates the API-token guidance to require **Account → Analytics Engine → Read** alongside the existing Account/Zone Analytics permissions, with a remediation note for tokens missing the new scope.
- Documents the dataset schema (`blob1`-`blob4` semantics, `index1` site domain, `double1` count) at the top of the stats skill so future query authors don't have to read the worker source.

## Files changed

- 5 wrangler tomls: `template/worker/{wrangler,forms-wrangler,membership-wrangler,review-wrangler,subscribe-wrangler}.toml` — added `[[analytics_engine_datasets]]` block.
- 5 worker scripts: `template/worker/{contact,forms,membership,review,subscribe}-worker.js` — added a small `recordEvent` helper and call sites at every outcome branch.
- `skills/stats/SKILL.md` — Conversions documentation, queries, parsing rules, presentation, and updated token setup.

## Test plan

- [x] `npm test` — all 2,325 tests pass (12 skipped, no failures).
- [ ] Manual: deploy a worker with the new binding and confirm the dataset accepts events (`npx wrangler tail` shows no `writeDataPoint` errors).
- [ ] Manual: run `/anglesite:stats` against a site with at least one helper Worker deployed, confirm the Conversions table renders.
- [ ] Manual: revoke the Analytics Engine token scope, confirm the skill surfaces the remediation note instead of crashing.

https://claude.ai/code/session_01TTyEkQQHUs2YSy3i84d2BB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTyEkQQHUs2YSy3i84d2BB)_