### PR TITLE
Simplify dev-only vite ternary in astro.config.ts

### DIFF
--- a/template/astro.config.ts
+++ b/template/astro.config.ts
@@ -74,12 +74,6 @@ export default defineConfig({
     ...(isDev ? [keystatic(), anglesiteToolbar()] : []),
     sitemap(),
   ],
-  vite: isDev
-    ? {
-        server: {
-          https: getHttpsConfig(),
-        },
-      }
-    : {},
+  vite: { server: { https: getHttpsConfig() } },
   adapter: cloudflare(),
 });


### PR DESCRIPTION
## Summary

Collapses the `isDev` ternary around `vite.server.https` in `template/astro.config.ts` to an unconditional assignment. `vite.server` is ignored at build time, and `getHttpsConfig()` already returns `undefined` when certs are missing, so this is a pure cosmetic cleanup with zero behavior change.

Fixes #271

## Test plan

- [ ] `npm run build` in a scaffolded site still succeeds
- [ ] `npm run dev` still serves over HTTPS when local certs are present
- [ ] `npm run dev` falls back to HTTP when certs are missing


---
_Generated by [Claude Code](https://claude.ai/code/session_01VPRFqXFAWh4ACURYb3QGo7)_