### PR TITLE
Drop redundant output: &quot;static&quot; from astro.config.ts

### DIFF
--- a/template/astro.config.ts
+++ b/template/astro.config.ts
@@ -3,7 +3,8 @@
  *
  * Reads site identity from `.site-config` (written by `/anglesite:start`).
  * In dev mode, enables Keystatic CMS, local HTTPS via mkcert, and server
- * output. In production, builds static HTML with no client JavaScript.
+ * output (required for Keystatic admin routes). In production, builds
+ * static HTML with no client JavaScript (Astro 5's default `output`).
  *
  * @see https://docs.astro.build/en/reference/configuration-reference/
  * @module
@@ -67,7 +68,7 @@ const siteUrl = siteDomain
 export default defineConfig({
   site: siteUrl,
   devToolbar: { enabled: isDev },
-  output: isDev ? "server" : "static",
+  ...(isDev ? { output: "server" as const } : {}),
   integrations: [
     react(),
     markdoc(),


### PR DESCRIPTION
## Summary

`'static'` is the default in Astro 5, so the production half of the ternary in `template/astro.config.ts:67` was a no-op. Collapsed to a conditional spread that only sets `output` in dev mode (still needed for Keystatic admin routes).

Also tightened the file-level docstring to note that production now relies on Astro 5's default `output`.

Closes #270

## Test plan

- [ ] `npm install && npm test` passes
- [ ] `cd template && npm run build` produces a static `dist/` (no SSR artifacts)
- [ ] `cd template && npm run dev` still serves Keystatic admin routes

---
_Generated by [Claude Code](https://claude.ai/code/session_013fZkQUxddTAxdk8G68LRco)_