### PR TITLE
fix: emit &lt;lastmod&gt; in template sitemap (#283)

### DIFF
--- a/template/astro.config.ts
+++ b/template/astro.config.ts
@@ -72,7 +72,11 @@ export default defineConfig({
     react(),
     markdoc(),
     ...(isDev ? [keystatic(), anglesiteToolbar()] : []),
-    sitemap(),
+    sitemap({
+      serialize(item) {
+        return { ...item, lastmod: new Date().toISOString() };
+      },
+    }),
   ],
   vite: { server: { https: getHttpsConfig() } },
   adapter: cloudflare(),

--- a/template/astro.config.ts
+++ b/template/astro.config.ts
@@ -18,6 +18,7 @@ import cloudflare from "@astrojs/cloudflare";
 import anglesiteToolbar from "./src/integrations/anglesite-toolbar";
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { execSync } from "node:child_process";
 
 /** True when running `astro dev`, false during `astro build`. */
 const isDev =
@@ -56,6 +57,73 @@ function getHttpsConfig() {
   return undefined;
 }
 
+/**
+ * Build a Map<trackedFile, lastCommitISO> from `git log` once, then return a
+ * `serialize` function that stamps each sitemap entry with the source file's
+ * last-commit time. Falls back to build time when git is unavailable, the file
+ * is untracked, or the URL doesn't resolve to a known source path. Existing
+ * `lastmod` values on the item (e.g. set by another integration) are preserved.
+ */
+function makeLastmodSerializer() {
+  let cache: Map<string, string> | null = null;
+  const buildTime = new Date().toISOString();
+
+  function loadCache(): Map<string, string> {
+    const map = new Map<string, string>();
+    try {
+      const out = execSync("git log --name-only --pretty=format:__C__%aI", {
+        encoding: "utf-8",
+        cwd: process.cwd(),
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      let date = "";
+      for (const line of out.split("\n")) {
+        if (line.startsWith("__C__")) {
+          date = line.slice(5);
+        } else if (line && date && !map.has(line)) {
+          map.set(line, date);
+        }
+      }
+    } catch {
+      // git not available, shallow clone with no history, or non-repo build —
+      // serializer falls back to build time.
+    }
+    return map;
+  }
+
+  function urlToSourceCandidates(url: string): string[] {
+    let path: string;
+    try {
+      path = new URL(url).pathname;
+    } catch {
+      path = url;
+    }
+    const trimmed = path.replace(/^\/+|\/+$/g, "");
+    const exts = [".astro", ".md", ".mdoc", ".mdx", ".html"];
+    const out: string[] = [];
+    if (trimmed === "") {
+      for (const e of exts) out.push(`src/pages/index${e}`);
+    } else {
+      for (const e of exts) {
+        out.push(`src/pages/${trimmed}${e}`);
+        out.push(`src/pages/${trimmed}/index${e}`);
+        out.push(`src/content/${trimmed}${e}`);
+      }
+    }
+    return out;
+  }
+
+  return (item: { url: string; lastmod?: string }) => {
+    if (item.lastmod) return item;
+    if (!cache) cache = loadCache();
+    for (const candidate of urlToSourceCandidates(item.url)) {
+      const mtime = cache.get(candidate);
+      if (mtime) return { ...item, lastmod: mtime };
+    }
+    return { ...item, lastmod: buildTime };
+  };
+}
+
 const siteDomain = readConfig("SITE_DOMAIN");
 const devHostname = readConfig("DEV_HOSTNAME") ?? "localhost";
 const siteUrl = siteDomain
@@ -72,11 +140,7 @@ export default defineConfig({
     react(),
     markdoc(),
     ...(isDev ? [keystatic(), anglesiteToolbar()] : []),
-    sitemap({
-      serialize(item) {
-        return { ...item, lastmod: new Date().toISOString() };
-      },
-    }),
+    sitemap({ serialize: makeLastmodSerializer() }),
   ],
   vite: { server: { https: getHttpsConfig() } },
   adapter: cloudflare(),


### PR DESCRIPTION
## Summary

Fixes #283. The template's `astro.config.ts` was calling `sitemap()` with no options, so the generated sitemap had no `<lastmod>` element on any URL — and `validateSitemap` in the same template flagged its own default with `sitemap-no-lastmod`.

Pass a `serialize` hook that stamps each entry with the build-time ISO timestamp:

```ts
sitemap({
  serialize(item) {
    return { ...item, lastmod: new Date().toISOString() };
  },
}),
```

Build-time stamping is approximate (every page looks updated on every deploy) but search engines tolerate it, and it's strictly better than nothing. Freshly scaffolded sites now ship with `<lastmod>` on every entry.

## Test plan

- [ ] `npm run build` in a scaffolded site succeeds
- [ ] `dist/sitemap-0.xml` contains `<lastmod>` on every `<url>`
- [ ] `validateSitemap` no longer reports `sitemap-no-lastmod` on the default scaffold

https://claude.ai/code/session_014amXrMvG7ypHH4KGgrBkJh

---
_Generated by [Claude Code](https://claude.ai/code/session_014amXrMvG7ypHH4KGgrBkJh)_