### PR TITLE
fix(seo): resolve four /anglesite:seo audit bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anglesite",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anglesite",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0"

--- a/template/scripts/seo.ts
+++ b/template/scripts/seo.ts
@@ -115,13 +115,18 @@ function getMetaContent(
   attr: string,
   value: string,
 ): string | undefined {
-  // Match both name="x" and property="x" meta tags
+  // Each capture is anchored to the same quote that opened it, so a value
+  // like `What's new` (with a stray apostrophe inside a double-quoted attr)
+  // isn't truncated at the first inner quote.
+  const attrPart = `${attr}=(?:"${value}"|'${value}')`;
+  const contentPart = `content=(?:"([^"]*)"|'([^']*)')`;
   const re = new RegExp(
-    `<meta\\s+[^>]*${attr}=["']${value}["'][^>]*content=["']([^"']*)["'][^>]*/?>|<meta\\s+[^>]*content=["']([^"']*)["'][^>]*${attr}=["']${value}["'][^>]*/?>`,
+    `<meta\\s+[^>]*${attrPart}[^>]*${contentPart}[^>]*/?>|<meta\\s+[^>]*${contentPart}[^>]*${attrPart}[^>]*/?>`,
     "i",
   );
   const m = html.match(re);
-  return m ? (m[1] ?? m[2]) : undefined;
+  if (!m) return undefined;
+  return m[1] ?? m[2] ?? m[3] ?? m[4];
 }
 
 function getLinkHref(
@@ -140,7 +145,24 @@ function getLinkHref(
 // auditPage — single-page SEO checks
 // ---------------------------------------------------------------------------
 
+/**
+ * Detect whether a page opts out of search indexing via `<meta name="robots">`
+ * (or `googlebot`). Pages with `noindex` won't appear in search results, so
+ * the SEO checks aren't actionable for them.
+ */
+function isNoindex(html: string): boolean {
+  const robots = getMetaContent(html, "name", "robots");
+  if (robots && /\bnoindex\b/i.test(robots)) return true;
+  const googlebot = getMetaContent(html, "name", "googlebot");
+  if (googlebot && /\bnoindex\b/i.test(googlebot)) return true;
+  return false;
+}
+
 export function auditPage(html: string, url: string): SeoIssue[] {
+  // Pages explicitly marked noindex (e.g. KioskLayout) won't be indexed by
+  // search engines, so warning about missing meta/og tags isn't actionable.
+  if (isNoindex(html)) return [];
+
   const issues: SeoIssue[] = [];
 
   // Title
@@ -420,15 +442,23 @@ export function validateSitemap(
     sitemapUrls.push(sm[1].trim());
   }
 
-  // Normalize sitemap URLs to paths
+  // Normalize sitemap URLs to paths (strip trailing slash so `/about/` and
+  // `/about` compare equal). We apply the same rule to `builtPages` because
+  // Astro's default `trailingSlash: 'ignore'` produces directory-style URLs.
   const normalizedBase = siteUrl.replace(/\/$/, "");
-  const sitemapPaths = sitemapUrls.map((url) => {
-    const path = url.replace(normalizedBase, "");
-    return path === "" ? "/" : path.replace(/\/$/, "") || "/";
-  });
+  const normalizePath = (p: string): string => {
+    if (p === "" || p === "/") return "/";
+    return p.replace(/\/$/, "") || "/";
+  };
+  const sitemapPaths = sitemapUrls.map((url) =>
+    normalizePath(url.replace(normalizedBase, "")),
+  );
+  const normalizedBuiltPages = builtPages.map(normalizePath);
 
   // Check which built pages are missing from sitemap
-  const missing = builtPages.filter((p) => !sitemapPaths.includes(p));
+  const missing = normalizedBuiltPages.filter(
+    (p) => !sitemapPaths.includes(p),
+  );
   if (missing.length > 0) {
     issues.push({
       code: "sitemap-missing-page",
@@ -635,8 +665,24 @@ export function generateLlmsTxt(input: LlmsTxtInput): string | null {
 export function auditChunkability(html: string, url: string): SeoIssue[] {
   const issues: SeoIssue[] = [];
 
+  // Scope to <main> if present, otherwise <article>, otherwise the full page
+  // with global chrome (header/footer/nav/aside) stripped out — those would
+  // otherwise lump into the trailing chunk after the last heading and falsely
+  // inflate word counts.
+  const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+  const articleMatch = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+  const scope = mainMatch
+    ? mainMatch[1]
+    : articleMatch
+    ? articleMatch[1]
+    : html
+        .replace(/<header[\s\S]*?<\/header>/gi, " ")
+        .replace(/<footer[\s\S]*?<\/footer>/gi, " ")
+        .replace(/<nav[\s\S]*?<\/nav>/gi, " ")
+        .replace(/<aside[\s\S]*?<\/aside>/gi, " ");
+
   // Split content by headings (h1-h6) to get sections
-  const sections = html.split(/<h[1-6][^>]*>/i);
+  const sections = scope.split(/<h[1-6][^>]*>/i);
 
   for (const section of sections) {
     // Strip HTML tags to get raw text

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -165,6 +165,38 @@ describe("auditPage", () => {
     expect(issues.length).toBeGreaterThan(0);
     expect(issues.every((i) => i.page === "/broken")).toBe(true);
   });
+
+  it("does not truncate meta description at apostrophes (#280)", () => {
+    const description =
+      "I'm a regular sentence with apostrophes — what's new is fine here.";
+    const html = minimal.replace(
+      /<meta name="description"[^>]*>/,
+      `<meta name="description" content="${description}">`,
+    );
+    const issues = auditPage(html, "/");
+    // Should not flag length issues — the full description is well within range
+    expect(issues.some((i) => i.code === "description-length")).toBe(false);
+  });
+
+  it("returns no issues for noindex pages (#280)", () => {
+    const html = `<!DOCTYPE html>
+<html><head>
+  <meta name="robots" content="noindex">
+  <title>Hi</title>
+</head><body></body></html>`;
+    const issues = auditPage(html, "/kiosk");
+    expect(issues).toEqual([]);
+  });
+
+  it("respects googlebot noindex too (#280)", () => {
+    const html = `<!DOCTYPE html>
+<html><head>
+  <meta name="googlebot" content="noindex,nofollow">
+  <title>Hi</title>
+</head><body></body></html>`;
+    const issues = auditPage(html, "/internal");
+    expect(issues).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -405,6 +437,23 @@ describe("validateSitemap", () => {
     const issues = validateSitemap(xml, ["/"], "https://example.com");
     expect(issues.some((i) => i.code === "sitemap-no-lastmod")).toBe(false);
   });
+
+  it("matches built pages with trailing slashes against sitemap entries (#280)", () => {
+    // Astro's default `trailingSlash: 'ignore'` produces directory-style URLs
+    // like `/about/`, while sitemap entries are typically stripped to `/about`.
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/</loc><lastmod>2025-01-01</lastmod></url>
+  <url><loc>https://example.com/about</loc><lastmod>2025-01-01</lastmod></url>
+  <url><loc>https://example.com/contact</loc><lastmod>2025-01-01</lastmod></url>
+</urlset>`;
+    const issues = validateSitemap(
+      xml,
+      ["/", "/about/", "/contact/"],
+      "https://example.com",
+    );
+    expect(issues.some((i) => i.code === "sitemap-missing-page")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -623,6 +672,24 @@ describe("auditChunkability", () => {
     const words = Array(100).fill("word").join(" ");
     const html = `<p>${words}</p><h2>Break</h2><p>${words}</p>`;
     const issues = auditChunkability(html, "/");
+    expect(issues).toEqual([]);
+  });
+
+  it("ignores global header/footer/nav when scoring sections (#280)", () => {
+    // The visible article is well-structured (short paragraphs split by
+    // headings), but the page wraps it in a long footer/nav. The trailing
+    // chunk after the last heading shouldn't lump in the chrome.
+    const para = Array(100).fill("word").join(" ");
+    const footerWords = Array(250).fill("foot").join(" ");
+    const html = `
+      <header><nav>${Array(80).fill("nav").join(" ")}</nav></header>
+      <main>
+        <h2>Section A</h2><p>${para}</p>
+        <h2>Section B</h2><p>${para}</p>
+      </main>
+      <footer>${footerWords}</footer>
+    `;
+    const issues = auditChunkability(html, "/long");
     expect(issues).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the four bugs reported in #280 that made `/anglesite:seo` reports noisy and incorrect.

1. **`getMetaContent` apostrophe truncation** — the captured group `[^"']*` stopped at the first apostrophe inside the value, so `content="What's new"` was returned as `"What"` (4 chars) and then flagged as a too-short description. The capture is now anchored to the same quote that opened it: `content=(?:"([^"]*)"|'([^']*)')`.

2. **`validateSitemap` trailing-slash mismatch** — sitemap entries were normalized to strip trailing slashes (`/about/` → `/about`) but `builtPages` weren't, so Astro's default `trailingSlash: 'ignore'` produced `/about/` and every page read as missing. `builtPages` is now run through the same `normalizePath` helper before the comparison.

3. **`auditPage` ignored `noindex`** — pages with `<meta name="robots" content="noindex">` (e.g. `KioskLayout`) generated unactionable warnings. `auditPage` now short-circuits and returns `[]` for noindex pages (also respects `googlebot` noindex).

4. **`auditChunkability` heading split too coarse** — the trailing chunk after the last heading absorbed the global footer/CTA, blowing past 225 words on long pages. The audit now scopes to `<main>` (preferred) or `<article>`, falling back to the full HTML with header/footer/nav/aside stripped.

## Test plan

- [x] All 64 `tests/seo.test.ts` tests pass (5 new regression cases — apostrophe-safe meta, noindex skipping, trailing-slash sitemap match, chunkability ignoring chrome)
- [x] Full suite: 2317 tests pass
- [ ] Manual smoke: run `/anglesite:seo` against a site with apostrophe-bearing descriptions, noindex kiosk pages, and trailing-slash URLs

https://claude.ai/code/session_01GiMJTb2T47TFkT1Tb344Mx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiMJTb2T47TFkT1Tb344Mx)_