### PR TITLE
fix: add ai-seo audit script to template (#282)

### DIFF
--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -38,8 +38,10 @@ These checks are not optional. Accessibility failures are as serious as security
 Build the site first, then run the unified accessibility audit:
 
 ```sh
-npm run ai-a11y -- --report a11y-report.md
+npm run ai-a11y
 ```
+
+The report is written to `reports/a11y-report.md` (the `reports/` directory is gitignored — regenerated on demand, never committed).
 
 This script (`scripts/a11y-audit.ts`) walks every HTML file in `dist/` and produces a per-page WCAG 2.1 AA report with suggested fixes. It runs three checkers and aggregates the results:
 

--- a/skills/copy-edit/SKILL.md
+++ b/skills/copy-edit/SKILL.md
@@ -112,7 +112,7 @@ Example format for the check report:
 
 If no issues are found, say: "Copy quality looks good — clear headlines, consistent tone, and every page has a next step for visitors."
 
-For deploy context, write findings to `copy-edit-report.md` in the project root and mention it briefly: "I found a few copy improvements you can make later — they're saved in copy-edit-report.md."
+For deploy context, write findings to `reports/copy-edit-report.md` (the `reports/` directory is gitignored — regenerated on demand) and mention it briefly: "I found a few copy improvements you can make later — they're saved in reports/copy-edit-report.md."
 
 ### Interactive context (direct invocation or after page creation)
 
@@ -136,7 +136,7 @@ If the owner asks for rewrites, edit content files directly but always show the 
 ## Integration with other skills
 
 - **`/anglesite:check`** — include a "Copy quality" section in the health report (non-interactive)
-- **`/anglesite:deploy`** — non-blocking content scan; write findings to `copy-edit-report.md`
+- **`/anglesite:deploy`** — non-blocking content scan; write findings to `reports/copy-edit-report.md`
 - **`/anglesite:new-page`** — after page creation, review the new page's copy interactively
 - **`/anglesite:syndicate`** — shares `docs/brand-voice.md` for consistent tone across platforms
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -94,9 +94,9 @@ Run the SEO audit from `scripts/seo.ts` against the built output in `dist/`. Thi
 
 **Critical issues** (missing titles, missing descriptions) pause the deploy. Present them to the owner with one-shot fix options. After fixes, rebuild and re-scan.
 
-**Warnings and Nice-to-haves** are non-blocking. Log them to `seo-report.md` in the project root and briefly mention to the owner: "I found a few SEO improvements you can make later — they're saved in seo-report.md."
+**Warnings and Nice-to-haves** are non-blocking. Log them to `reports/seo-report.md` (the `reports/` directory is gitignored — regenerated on demand, never committed) and briefly mention to the owner: "I found a few SEO improvements you can make later — they're saved in reports/seo-report.md."
 
-If the owner passes `--skip-seo`, skip this step and log a timestamped note to `seo-report.md`: `SEO audit skipped on YYYY-MM-DD HH:MM`.
+If the owner passes `--skip-seo`, skip this step and log a timestamped note to `reports/seo-report.md`: `SEO audit skipped on YYYY-MM-DD HH:MM`.
 
 ## Step 2a½ — Link check (opt-in gate)
 
@@ -123,13 +123,13 @@ If the owner passes `--skip-linkcheck`, skip this step.
 Read `A11Y_GATE` from `.site-config`. If unset or `false`, skip this step (the full accessibility audit still runs in `/anglesite:check`). If set to `true`, run the unified accessibility audit against the built site:
 
 ```sh
-npm run ai-a11y -- --report a11y-report.md
+npm run ai-a11y
 ```
 
-The script exits with severity-aware codes (`1` for WCAG 2.1 AA errors, `2` for warnings, `0` for clean). When the gate is on:
+The script writes the report to `reports/a11y-report.md` (the `reports/` directory is gitignored — regenerated on demand) and exits with severity-aware codes (`1` for WCAG 2.1 AA errors, `2` for warnings, `0` for clean). When the gate is on:
 
 - **Errors (exit 1)** pause the deploy. Present each violation with its suggested fix, offer to apply the fixes, then rebuild and re-run.
-- **Warnings (exit 2)** are mentioned to the owner but do not block: "I found a few accessibility improvements you can make later — they're saved in a11y-report.md."
+- **Warnings (exit 2)** are mentioned to the owner but do not block: "I found a few accessibility improvements you can make later — they're saved in reports/a11y-report.md."
 
 **Warn-only mode for sites mid-remediation.** If `A11Y_WARN_ONLY=true` is set in `.site-config` (or the owner passes `--warn-only`), the audit always exits `0` regardless of findings, but the report is still written. Use this when a legacy site is being brought up to standard so deploys aren't blocked while the backlog clears.
 
@@ -189,7 +189,7 @@ If the owner passes `--skip-a14y`, skip this step.
 
 Read `${CLAUDE_PLUGIN_ROOT}/skills/copy-edit/SKILL.md` and follow it in non-interactive deploy context. This scans all content pages for clarity, tone consistency, and missing CTAs.
 
-**No issues block the deploy.** Write findings to `copy-edit-report.md` in the project root and briefly mention to the owner: "I found a few copy improvements you can make later — they're saved in copy-edit-report.md."
+**No issues block the deploy.** Write findings to `reports/copy-edit-report.md` (the `reports/` directory is gitignored — regenerated on demand) and briefly mention to the owner: "I found a few copy improvements you can make later — they're saved in reports/copy-edit-report.md."
 
 If the owner passes `--skip-copy`, skip this step.
 
@@ -198,7 +198,7 @@ If the owner passes `--skip-copy`, skip this step.
 Run the performance budget audit against the built site:
 
 ```sh
-npm run ai-perf -- --report perf-report.md --trend perf-trend.json --warn-only
+npm run ai-perf -- --warn-only
 ```
 
 This walks `dist/` and computes the JS + CSS weight referenced by each HTML page, comparing against budgets in `.site-config`:
@@ -215,12 +215,12 @@ PERF_BUDGET_JS_LAB=512000
 PERF_BUDGET_CSS_LAB=102400
 ```
 
-The script writes:
+The script writes both files into the gitignored `reports/` directory (regenerated on demand, never committed):
 
-- `perf-report.md` — human-readable per-page table (committed alongside `seo-report.md`, `a11y-report.md`)
-- `perf-trend.json` — rolling history (last 30 runs) used by `/anglesite:stats` to surface regressions
+- `reports/perf-report.md` — human-readable per-page table (alongside `reports/seo-report.md`, `reports/a11y-report.md`)
+- `reports/perf-trend.json` — rolling history (last 30 runs) used by `/anglesite:stats` to surface regressions
 
-**1.1 ships warn-only.** Findings never block the deploy. Mention the result to the owner in plain language ("All pages within budget" or "Two pages over the JS budget — saved to perf-report.md"), then continue. Once defaults are tuned (1.2), `PERF_WARN_ONLY=false` will let owners opt into a hard gate.
+**1.1 ships warn-only.** Findings never block the deploy. Mention the result to the owner in plain language ("All pages within budget" or "Two pages over the JS budget — saved to reports/perf-report.md"), then continue. Once defaults are tuned (1.2), `PERF_WARN_ONLY=false` will let owners opt into a hard gate.
 
 ### Optional: LCP and CLS via Lighthouse
 
@@ -233,7 +233,7 @@ npm run preview -- --port 4321 &
 Wait a couple of seconds for it to come up, then run the audit:
 
 ```sh
-npm run ai-perf -- --report perf-report.md --trend perf-trend.json --lighthouse --url http://localhost:4321 --warn-only
+npm run ai-perf -- --lighthouse --url http://localhost:4321 --warn-only
 ```
 
 Then kill the background preview process.

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -2,7 +2,7 @@
 name: seo
 description: "SEO audit, metadata editing, Schema.org, sitemap, and LLM/GEO optimization"
 argument-hint: "[page /about | schema | sitemap | og-images]"
-allowed-tools: Bash(npm run build), Bash(npx astro check), Bash(grep *), Bash(find dist/ *), Bash(git log *), Write, Read, Glob
+allowed-tools: Bash(npm run build), Bash(npm run ai-seo*), Bash(npx astro check), Bash(grep *), Bash(find dist/ *), Bash(git log *), Write, Read, Glob
 disable-model-invocation: true
 ---
 
@@ -44,7 +44,15 @@ If the build fails, fix it before proceeding.
 
 ## Step 2 — Full site audit
 
-Crawl all HTML files in `dist/` and run the SEO audit functions from `scripts/seo.ts`:
+Run the audit script, which walks `dist/` and applies every audit function from `scripts/seo.ts`:
+
+```sh
+npm run ai-seo
+```
+
+The script writes the formatted report to `seo-report.md`, prints a one-line summary to stderr, and exits 0 unless there are critical issues. Pages with `<meta name="robots" content="noindex">` are skipped. Pass `--warn-only` to always exit 0 (used during the predeploy non-blocking call) or `--json` to get the machine-readable form on stdout.
+
+The audit covers:
 
 1. **Per-page audit** — For each HTML file, call `auditPage(html, url)` to check:
    - Title present and 30–60 characters
@@ -156,11 +164,11 @@ Confirm all Critical issues are resolved. Present the updated report.
 
 ## Pre-deploy integration
 
-When called from `/anglesite:deploy`, the SEO audit runs as a non-blocking step:
+`scripts/pre-deploy-check.ts` invokes `runAudit` from `scripts/seo-audit.ts` as a non-blocking step on every deploy. It writes `seo-report.md` and surfaces a one-line summary in the predeploy warnings:
 
-- **Critical issues** pause the deploy. Claude presents them with fix options.
-- **Warnings and Nice-to-haves** are logged to `seo-report.md` but don't block.
-- The owner can skip with `/anglesite:deploy --skip-seo`, which logs the skip with a timestamp.
+- **Critical issues** are surfaced as a `WARN:` line pointing at `seo-report.md`. The deploy is not blocked — `/anglesite:deploy` reads the report and walks the owner through fixes.
+- **Warnings and Nice-to-haves** are summarized in the same line.
+- Pass `--skip-seo` to `npm run predeploy` (or `/anglesite:deploy --skip-seo`) to skip the audit entirely.
 
 ## Keep docs in sync
 

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -50,7 +50,7 @@ Run the audit script, which walks `dist/` and applies every audit function from 
 npm run ai-seo
 ```
 
-The script writes the formatted report to `seo-report.md`, prints a one-line summary to stderr, and exits 0 unless there are critical issues. Pages with `<meta name="robots" content="noindex">` are skipped. Pass `--warn-only` to always exit 0 (used during the predeploy non-blocking call) or `--json` to get the machine-readable form on stdout.
+The script writes the formatted report to `reports/seo-report.md` (the `reports/` directory is gitignored — regenerated on demand, never committed), prints a one-line summary to stderr, and exits 0 unless there are critical issues. Pages with `<meta name="robots" content="noindex">` are skipped. Pass `--warn-only` to always exit 0 (used during the predeploy non-blocking call) or `--json` to get the machine-readable form on stdout.
 
 The audit covers:
 
@@ -87,7 +87,7 @@ Call `formatSeoReport(allIssues)` to generate the ranked report. Present it to t
 - **Warnings** — "These would improve how your site appears in search results." Explain each.
 - **Nice-to-have** — "Bonus improvements for even better visibility." Brief mention.
 
-Write the full report to `seo-report.md` in the project root.
+Write the full report to `reports/seo-report.md` (the `reports/` directory is gitignored).
 
 ## Step 4 — Fix issues (if owner approves)
 
@@ -164,9 +164,9 @@ Confirm all Critical issues are resolved. Present the updated report.
 
 ## Pre-deploy integration
 
-`scripts/pre-deploy-check.ts` invokes `runAudit` from `scripts/seo-audit.ts` as a non-blocking step on every deploy. It writes `seo-report.md` and surfaces a one-line summary in the predeploy warnings:
+`scripts/pre-deploy-check.ts` invokes `runAudit` from `scripts/seo-audit.ts` as a non-blocking step on every deploy. It writes `reports/seo-report.md` and surfaces a one-line summary in the predeploy warnings:
 
-- **Critical issues** are surfaced as a `WARN:` line pointing at `seo-report.md`. The deploy is not blocked — `/anglesite:deploy` reads the report and walks the owner through fixes.
+- **Critical issues** are surfaced as a `WARN:` line pointing at `reports/seo-report.md`. The deploy is not blocked — `/anglesite:deploy` reads the report and walks the owner through fixes.
 - **Warnings and Nice-to-haves** are summarized in the same line.
 - Pass `--skip-seo` to `npm run predeploy` (or `/anglesite:deploy --skip-seo`) to skip the audit entirely.
 

--- a/skills/stats/SKILL.md
+++ b/skills/stats/SKILL.md
@@ -424,13 +424,13 @@ If a top page hasn't been updated in more than 30 days, suggest: "Your /services
 
 ## Step 4.5 — Performance trends (if available)
 
-If `perf-trend.json` exists in the project root, the deploy skill has been recording performance budget snapshots. Each entry has `generatedAt`, `totalJs`, `totalCss`, `pageCount`, `findingCount`, and (when Lighthouse ran) `worstLcpMs` / `worstCls`.
+If `reports/perf-trend.json` exists, the deploy skill has been recording performance budget snapshots. Each entry has `generatedAt`, `totalJs`, `totalCss`, `pageCount`, `findingCount`, and (when Lighthouse ran) `worstLcpMs` / `worstCls`.
 
 Read the file with `Read`, then surface the trend in plain language. Show the most recent run alongside the run from ~30 days ago (or the oldest available) so the owner can see drift:
 
-> **Performance:** Across {pageCount} pages your site ships {totalJs / 1024 KB} of JavaScript and {totalCss / 1024 KB} of CSS — about the same as last month. {findingCount} pages were over budget on this deploy ({listed in perf-report.md}).
+> **Performance:** Across {pageCount} pages your site ships {totalJs / 1024 KB} of JavaScript and {totalCss / 1024 KB} of CSS — about the same as last month. {findingCount} pages were over budget on this deploy ({listed in reports/perf-report.md}).
 
-If `totalJs` or `totalCss` has grown by more than 25% since the oldest entry, surface that as a heads-up: "Your JavaScript bundle has grown from 32 KB to 71 KB over the last month — worth checking what was added." The deploy skill writes the granular per-page report to `perf-report.md`; point the owner there for specifics.
+If `totalJs` or `totalCss` has grown by more than 25% since the oldest entry, surface that as a heads-up: "Your JavaScript bundle has grown from 32 KB to 71 KB over the last month — worth checking what was added." The deploy skill writes the granular per-page report to `reports/perf-report.md`; point the owner there for specifics.
 
 If the file doesn't exist, skip this section — performance trends only appear after the owner has run `/anglesite:deploy` at least once on a build with the perf budget step active.
 

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -32,3 +32,6 @@ annotations.json
 
 # Anglesite skill audit trails (local-only)
 .anglesite/
+
+# Audit / scan reports (regenerated on demand; never committed)
+/reports/

--- a/template/package.json
+++ b/template/package.json
@@ -24,6 +24,7 @@
     "ai-a11y": "tsx scripts/a11y-audit.ts",
     "ai-a14y": "tsx scripts/a14y-audit.ts",
     "ai-perf": "tsx scripts/perf-budget.ts",
+    "ai-seo": "tsx scripts/seo-audit.ts",
     "ai-premium-build": "node scripts/build-premium-routes.mjs",
     "predeploy": "tsx scripts/pre-deploy-check.ts",
     "lint:css": "stylelint 'src/**/*.css'",

--- a/template/package.json
+++ b/template/package.json
@@ -55,6 +55,7 @@
     "@resvg/resvg-js": "^2.6.0",
     "satori": "^0.12.0",
     "sharp": "^0.33.0",
+    "schema-dts": "^2.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "markdownlint-cli2": "^0.22.0",

--- a/template/scripts/a11y-audit.ts
+++ b/template/scripts/a11y-audit.ts
@@ -24,11 +24,11 @@
  *   tsx scripts/a11y-audit.ts             # human-readable report
  *   tsx scripts/a11y-audit.ts --json      # machine-readable report
  *   tsx scripts/a11y-audit.ts --warn-only # always exit 0 (mid-remediation)
- *   tsx scripts/a11y-audit.ts --report a11y-report.md  # write markdown
+ *   tsx scripts/a11y-audit.ts --report reports/a11y-report.md  # write markdown (default path)
  */
 
-import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { extname, join, relative } from "node:path";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, extname, join, relative } from "node:path";
 import { validateHtml, type A11yIssue } from "./a11y-validate.js";
 import { readConfig } from "./config.js";
 
@@ -500,7 +500,7 @@ if (process.argv[1]?.endsWith("a11y-audit.ts")) {
   const args = process.argv.slice(2);
   const wantJson = args.includes("--json");
   const reportIdx = args.indexOf("--report");
-  const reportPath = reportIdx >= 0 ? args[reportIdx + 1] : undefined;
+  const reportPath = reportIdx >= 0 ? args[reportIdx + 1] : "reports/a11y-report.md";
   const cliWarnOnly = args.includes("--warn-only");
   const configWarnOnly = (readConfig("A11Y_WARN_ONLY") ?? "").toLowerCase() === "true";
   const warnOnly = cliWarnOnly || configWarnOnly;
@@ -513,6 +513,7 @@ if (process.argv[1]?.endsWith("a11y-audit.ts")) {
   runAudit("dist")
     .then((report) => {
       if (reportPath) {
+        mkdirSync(dirname(reportPath), { recursive: true });
         writeFileSync(reportPath, formatReport(report), "utf-8");
         console.log(`Wrote accessibility report to ${reportPath}`);
       }

--- a/template/scripts/perf-budget.ts
+++ b/template/scripts/perf-budget.ts
@@ -18,7 +18,7 @@
  * Usage:
  *   tsx scripts/perf-budget.ts                    # static audit, text report
  *   tsx scripts/perf-budget.ts --json             # machine-readable
- *   tsx scripts/perf-budget.ts --report perf-report.md
+ *   tsx scripts/perf-budget.ts --report reports/perf-report.md
  *   tsx scripts/perf-budget.ts --lighthouse --url http://localhost:4321
  *   tsx scripts/perf-budget.ts --warn-only        # never exit non-zero
  *
@@ -28,8 +28,8 @@
  *   2 — Lighthouse not installed but --lighthouse requested
  */
 
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { extname, join, posix, resolve } from "node:path";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, extname, join, posix, resolve } from "node:path";
 import { readConfig } from "./config.js";
 
 // ---------------------------------------------------------------------------
@@ -520,9 +520,9 @@ if (process.argv[1]?.endsWith("perf-budget.ts")) {
   const args = process.argv.slice(2);
   const wantJson = args.includes("--json");
   const reportIdx = args.indexOf("--report");
-  const reportPath = reportIdx >= 0 ? args[reportIdx + 1] : undefined;
+  const reportPath = reportIdx >= 0 ? args[reportIdx + 1] : "reports/perf-report.md";
   const trendIdx = args.indexOf("--trend");
-  const trendPath = trendIdx >= 0 ? args[trendIdx + 1] : "perf-trend.json";
+  const trendPath = trendIdx >= 0 ? args[trendIdx + 1] : "reports/perf-trend.json";
   const lighthouse = args.includes("--lighthouse");
   const urlIdx = args.indexOf("--url");
   const url = urlIdx >= 0 ? args[urlIdx + 1] : undefined;
@@ -543,11 +543,13 @@ if (process.argv[1]?.endsWith("perf-budget.ts")) {
   runAudit({ lighthouse, url, warnOnly })
     .then((report) => {
       if (reportPath) {
+        mkdirSync(dirname(reportPath), { recursive: true });
         writeFileSync(reportPath, formatReport(report), "utf-8");
         console.log(`Wrote performance report to ${reportPath}`);
       }
 
       const history = appendTrend(trendPath, summarizeForTrend(report));
+      mkdirSync(dirname(trendPath), { recursive: true });
       writeFileSync(trendPath, JSON.stringify(history, null, 2), "utf-8");
 
       if (wantJson) {

--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -15,8 +15,8 @@
  * Also runs on Cloudflare's build system via the build command.
  */
 
-import { readdirSync, readFileSync, statSync, existsSync, writeFileSync } from "node:fs";
-import { join, extname, resolve } from "node:path";
+import { readdirSync, readFileSync, statSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, extname, resolve, dirname } from "node:path";
 import { readConfig } from "./config.js";
 import { parseProviders, buildAllowedScripts } from "./csp.js";
 import { runAudit as runSeoAudit } from "./seo-audit.js";
@@ -317,14 +317,16 @@ if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
       const agenticCrawlers =
         (readConfig("AGENTIC_CRAWLERS") as AgenticCrawlersPolicy | undefined) ?? "allow";
       const seoReport = runSeoAudit({ distDir: DIST, siteUrl, agenticCrawlers });
-      writeFileSync("seo-report.md", formatSeoReport(seoReport.issues), "utf-8");
+      const seoReportPath = "reports/seo-report.md";
+      mkdirSync(dirname(seoReportPath), { recursive: true });
+      writeFileSync(seoReportPath, formatSeoReport(seoReport.issues), "utf-8");
       if (seoReport.totals.critical > 0) {
         warnings.push(
-          `SEO: ${seoReport.totals.critical} critical issue(s) — see seo-report.md. Run \`/anglesite:seo\` to review.`,
+          `SEO: ${seoReport.totals.critical} critical issue(s) — see ${seoReportPath}. Run \`/anglesite:seo\` to review.`,
         );
       } else if (seoReport.totals.warning > 0 || seoReport.totals.niceToHave > 0) {
         warnings.push(
-          `SEO: ${seoReport.totals.warning} warning(s), ${seoReport.totals.niceToHave} nice-to-have — see seo-report.md.`,
+          `SEO: ${seoReport.totals.warning} warning(s), ${seoReport.totals.niceToHave} nice-to-have — see ${seoReportPath}.`,
         );
       }
     } catch (err) {

--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -15,10 +15,12 @@
  * Also runs on Cloudflare's build system via the build command.
  */
 
-import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
+import { readdirSync, readFileSync, statSync, existsSync, writeFileSync } from "node:fs";
 import { join, extname, resolve } from "node:path";
 import { readConfig } from "./config.js";
 import { parseProviders, buildAllowedScripts } from "./csp.js";
+import { runAudit as runSeoAudit } from "./seo-audit.js";
+import { formatSeoReport, type AgenticCrawlersPolicy } from "./seo.js";
 
 // ---------------------------------------------------------------------------
 // Exported patterns and constants
@@ -303,6 +305,31 @@ if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
   // 6. Maintenance log (warn only)
   for (const w of scanMaintenance(readConfig)) {
     warnings.push(formatMaintenanceWarning(w));
+  }
+
+  // 7. SEO audit (warn only; critical issues surface as warnings here so they
+  //    don't block deploy — the deploy skill walks the owner through fixes)
+  const skipSeo = process.argv.includes("--skip-seo");
+  if (!skipSeo) {
+    try {
+      const siteDomain = readConfig("SITE_DOMAIN");
+      const siteUrl = siteDomain ? `https://${siteDomain}` : "";
+      const agenticCrawlers =
+        (readConfig("AGENTIC_CRAWLERS") as AgenticCrawlersPolicy | undefined) ?? "allow";
+      const seoReport = runSeoAudit({ distDir: DIST, siteUrl, agenticCrawlers });
+      writeFileSync("seo-report.md", formatSeoReport(seoReport.issues), "utf-8");
+      if (seoReport.totals.critical > 0) {
+        warnings.push(
+          `SEO: ${seoReport.totals.critical} critical issue(s) — see seo-report.md. Run \`/anglesite:seo\` to review.`,
+        );
+      } else if (seoReport.totals.warning > 0 || seoReport.totals.niceToHave > 0) {
+        warnings.push(
+          `SEO: ${seoReport.totals.warning} warning(s), ${seoReport.totals.niceToHave} nice-to-have — see seo-report.md.`,
+        );
+      }
+    } catch (err) {
+      warnings.push(`SEO audit failed: ${(err as Error).message}`);
+    }
   }
 
   // Report

--- a/template/scripts/seo-audit.ts
+++ b/template/scripts/seo-audit.ts
@@ -16,21 +16,23 @@
  * Sitemap URLs are normalized before comparison so a built page like
  * `/blog/index.html` matches a sitemap entry of `/blog/`.
  *
- * Writes the formatted report to `seo-report.md` and prints a one-line summary
- * to stderr. Exit codes are severity-aware so the script is usable in CI:
+ * Writes the formatted report to `reports/seo-report.md` (the `reports/`
+ * directory is gitignored — regenerated on demand) and prints a one-line
+ * summary to stderr. Exit codes are severity-aware so the script is usable
+ * in CI:
  *
  *   0  — no critical issues (warnings or nice-to-have are OK, or `--warn-only`)
  *   1  — at least one critical issue
  *
  * Usage:
- *   tsx scripts/seo-audit.ts                       # write seo-report.md, log summary
+ *   tsx scripts/seo-audit.ts                       # write reports/seo-report.md, log summary
  *   tsx scripts/seo-audit.ts --json                # machine-readable report on stdout
  *   tsx scripts/seo-audit.ts --warn-only           # always exit 0 (non-blocking mode)
  *   tsx scripts/seo-audit.ts --report path.md      # write the report to a custom path
  */
 
-import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { extname, join, relative } from "node:path";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, extname, join, relative } from "node:path";
 import { readConfig } from "./config.js";
 import {
   auditChunkability,
@@ -245,7 +247,7 @@ if (process.argv[1]?.endsWith("seo-audit.ts")) {
   const args = process.argv.slice(2);
   const wantJson = args.includes("--json");
   const reportIdx = args.indexOf("--report");
-  const reportPath = reportIdx >= 0 ? args[reportIdx + 1] : "seo-report.md";
+  const reportPath = reportIdx >= 0 ? args[reportIdx + 1] : "reports/seo-report.md";
   const warnOnly = args.includes("--warn-only");
 
   if (!existsSync("dist")) {
@@ -261,6 +263,7 @@ if (process.argv[1]?.endsWith("seo-audit.ts")) {
   const report = runAudit({ distDir: "dist", siteUrl, agenticCrawlers });
 
   if (reportPath) {
+    mkdirSync(dirname(reportPath), { recursive: true });
     writeFileSync(reportPath, formatSeoReport(report.issues), "utf-8");
   }
 

--- a/template/scripts/seo-audit.ts
+++ b/template/scripts/seo-audit.ts
@@ -1,0 +1,280 @@
+/**
+ * SEO audit orchestrator.
+ *
+ * Walks `dist/` and runs the audit functions exported from `seo.ts`:
+ *
+ * 1. `auditPage` per HTML file (title, description, canonical, OG, Twitter)
+ * 2. `auditSite` across collected pages (duplicate titles/descriptions)
+ * 3. Schema.org JSON-LD presence per page
+ * 4. `validateSitemap` against `dist/sitemap-index.xml` or `dist/sitemap-0.xml`
+ * 5. `auditRobotsTxt` against the `AGENTIC_CRAWLERS` policy
+ * 6. `auditChunkability` per content-heavy HTML page
+ *
+ * Pages with `<meta name="robots" content="...noindex...">` are skipped — they
+ * are intentionally excluded from search and don't need title/description tuning.
+ *
+ * Sitemap URLs are normalized before comparison so a built page like
+ * `/blog/index.html` matches a sitemap entry of `/blog/`.
+ *
+ * Writes the formatted report to `seo-report.md` and prints a one-line summary
+ * to stderr. Exit codes are severity-aware so the script is usable in CI:
+ *
+ *   0  — no critical issues (warnings or nice-to-have are OK, or `--warn-only`)
+ *   1  — at least one critical issue
+ *
+ * Usage:
+ *   tsx scripts/seo-audit.ts                       # write seo-report.md, log summary
+ *   tsx scripts/seo-audit.ts --json                # machine-readable report on stdout
+ *   tsx scripts/seo-audit.ts --warn-only           # always exit 0 (non-blocking mode)
+ *   tsx scripts/seo-audit.ts --report path.md      # write the report to a custom path
+ */
+
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+import { readConfig } from "./config.js";
+import {
+  auditChunkability,
+  auditPage,
+  auditRobotsTxt,
+  auditSite,
+  formatSeoReport,
+  validateSitemap,
+  type AgenticCrawlersPolicy,
+  type PageSeoData,
+  type SeoIssue,
+} from "./seo.js";
+
+// ---------------------------------------------------------------------------
+// HTML walking
+// ---------------------------------------------------------------------------
+
+export function walkHtml(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkHtml(full));
+    } else if (extname(entry.name) === ".html") {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Per-file extraction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a built HTML path under `dist/` to a public URL path.
+ *   dist/blog/index.html      -> /blog/
+ *   dist/blog/post/index.html -> /blog/post/
+ *   dist/about.html           -> /about
+ *   dist/index.html           -> /
+ */
+export function htmlPathToUrlPath(file: string, distDir: string): string {
+  const rel = relative(distDir, file).replace(/\\/g, "/");
+  if (rel === "index.html") return "/";
+  if (rel.endsWith("/index.html")) {
+    return "/" + rel.slice(0, -"index.html".length);
+  }
+  return "/" + rel.replace(/\.html$/, "");
+}
+
+export function isNoindex(html: string): boolean {
+  const m = html.match(
+    /<meta\s+[^>]*name=["']robots["'][^>]*content=["']([^"']*)["'][^>]*\/?>|<meta\s+[^>]*content=["']([^"']*)["'][^>]*name=["']robots["'][^>]*\/?>/i,
+  );
+  const content = m ? (m[1] ?? m[2] ?? "") : "";
+  return /\bnoindex\b/i.test(content);
+}
+
+export function extractTitle(html: string): string {
+  const m = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  return m ? m[1].trim() : "";
+}
+
+export function extractDescription(html: string): string {
+  const m = html.match(
+    /<meta\s+[^>]*name=["']description["'][^>]*content=["']([^"']*)["'][^>]*\/?>|<meta\s+[^>]*content=["']([^"']*)["'][^>]*name=["']description["'][^>]*\/?>/i,
+  );
+  return m ? (m[1] ?? m[2] ?? "").trim() : "";
+}
+
+export function hasJsonLd(html: string): boolean {
+  return /<script[^>]+type=["']application\/ld\+json["'][^>]*>[\s\S]*?<\/script>/i.test(html);
+}
+
+// ---------------------------------------------------------------------------
+// Sitemap discovery
+// ---------------------------------------------------------------------------
+
+export function findSitemapFile(distDir: string): string | null {
+  const candidates = ["sitemap-index.xml", "sitemap-0.xml", "sitemap.xml"];
+  for (const name of candidates) {
+    const full = join(distDir, name);
+    if (existsSync(full)) return full;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Audit
+// ---------------------------------------------------------------------------
+
+export interface SeoAuditReport {
+  issues: SeoIssue[];
+  totals: { critical: number; warning: number; niceToHave: number };
+  pagesAudited: number;
+  pagesSkipped: number;
+}
+
+export interface RunAuditOptions {
+  distDir?: string;
+  siteUrl?: string;
+  agenticCrawlers?: AgenticCrawlersPolicy;
+}
+
+export function runAudit(opts: RunAuditOptions = {}): SeoAuditReport {
+  const distDir = opts.distDir ?? "dist";
+  const siteUrl = opts.siteUrl ?? "";
+  const agenticCrawlers = opts.agenticCrawlers ?? "allow";
+
+  const issues: SeoIssue[] = [];
+  let pagesAudited = 0;
+  let pagesSkipped = 0;
+
+  if (!existsSync(distDir)) {
+    return {
+      issues,
+      totals: { critical: 0, warning: 0, niceToHave: 0 },
+      pagesAudited: 0,
+      pagesSkipped: 0,
+    };
+  }
+
+  const htmlFiles = walkHtml(distDir);
+  const pageData: PageSeoData[] = [];
+  const indexedPagePaths: string[] = [];
+
+  for (const file of htmlFiles) {
+    const html = readFileSync(file, "utf-8");
+    const urlPath = htmlPathToUrlPath(file, distDir);
+
+    if (isNoindex(html)) {
+      pagesSkipped += 1;
+      continue;
+    }
+
+    pagesAudited += 1;
+    indexedPagePaths.push(urlPath);
+
+    // Per-page audit
+    issues.push(...auditPage(html, urlPath));
+
+    // Schema.org presence
+    if (!hasJsonLd(html)) {
+      issues.push({
+        code: "missing-jsonld",
+        severity: "warning",
+        message: "Page is missing Schema.org JSON-LD structured data",
+        page: urlPath,
+      });
+    }
+
+    // Chunkability
+    issues.push(...auditChunkability(html, urlPath));
+
+    pageData.push({
+      url: urlPath,
+      title: extractTitle(html),
+      description: extractDescription(html),
+    });
+  }
+
+  // Cross-page audit
+  issues.push(...auditSite(pageData));
+
+  // Sitemap validation — only when we have a site URL to normalize against
+  const sitemapPath = findSitemapFile(distDir);
+  if (sitemapPath && siteUrl) {
+    const xml = readFileSync(sitemapPath, "utf-8");
+    issues.push(...validateSitemap(xml, indexedPagePaths, siteUrl));
+  } else if (!sitemapPath) {
+    issues.push({
+      code: "missing-sitemap",
+      severity: "warning",
+      message: "No sitemap.xml / sitemap-index.xml found in dist/",
+      page: "sitemap.xml",
+    });
+  }
+
+  // robots.txt audit
+  const robotsPath = join(distDir, "robots.txt");
+  if (existsSync(robotsPath)) {
+    const content = readFileSync(robotsPath, "utf-8");
+    issues.push(...auditRobotsTxt(content, siteUrl, agenticCrawlers));
+  } else {
+    issues.push({
+      code: "missing-robots",
+      severity: "warning",
+      message: "No robots.txt found in dist/",
+      page: "robots.txt",
+    });
+  }
+
+  const totals = {
+    critical: issues.filter((i) => i.severity === "critical").length,
+    warning: issues.filter((i) => i.severity === "warning").length,
+    niceToHave: issues.filter((i) => i.severity === "nice-to-have").length,
+  };
+
+  return { issues, totals, pagesAudited, pagesSkipped };
+}
+
+export function exitCodeFor(report: SeoAuditReport, warnOnly: boolean): number {
+  if (warnOnly) return 0;
+  return report.totals.critical > 0 ? 1 : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Script entry — executed when run directly
+// ---------------------------------------------------------------------------
+
+if (process.argv[1]?.endsWith("seo-audit.ts")) {
+  const args = process.argv.slice(2);
+  const wantJson = args.includes("--json");
+  const reportIdx = args.indexOf("--report");
+  const reportPath = reportIdx >= 0 ? args[reportIdx + 1] : "seo-report.md";
+  const warnOnly = args.includes("--warn-only");
+
+  if (!existsSync("dist")) {
+    console.error("dist/ not found — run `npm run build` first.");
+    process.exit(warnOnly ? 0 : 1);
+  }
+
+  const siteDomain = readConfig("SITE_DOMAIN");
+  const siteUrl = siteDomain ? `https://${siteDomain}` : "";
+  const agenticCrawlers =
+    (readConfig("AGENTIC_CRAWLERS") as AgenticCrawlersPolicy | undefined) ?? "allow";
+
+  const report = runAudit({ distDir: "dist", siteUrl, agenticCrawlers });
+
+  if (reportPath) {
+    writeFileSync(reportPath, formatSeoReport(report.issues), "utf-8");
+  }
+
+  if (wantJson) {
+    console.log(JSON.stringify(report, null, 2));
+  } else if (reportPath) {
+    console.log(`Wrote SEO report to ${reportPath}`);
+  } else {
+    console.log(formatSeoReport(report.issues));
+  }
+
+  console.error(
+    `SEO audit: ${report.totals.critical} critical, ${report.totals.warning} warning, ${report.totals.niceToHave} nice-to-have across ${report.pagesAudited} page(s) (skipped ${report.pagesSkipped} noindex).`,
+  );
+
+  process.exit(exitCodeFor(report, warnOnly));
+}

--- a/template/scripts/seo.ts
+++ b/template/scripts/seo.ts
@@ -9,7 +9,26 @@
  * - generateLlmsTxt: generate /llms.txt for AI crawlers (skipped when blocked)
  * - auditChunkability: flag pages with long unbroken prose
  * - formatSeoReport: produce ranked issues table as markdown
+ *
+ * Schema.org JSON-LD construction is validated at compile time against the
+ * `schema-dts` types. The exported return type stays as a plain `Record` so
+ * Astro layouts can keep their current `jsonLd` prop typing without churn —
+ * the `satisfies WithContext<T>` checks inside each branch are what enforce
+ * Schema.org correctness.
  */
+
+import type {
+  AboutPage,
+  Article,
+  BlogPosting,
+  BreadcrumbList,
+  ContactPage,
+  Event,
+  FAQPage,
+  Product,
+  WebPage,
+  WithContext,
+} from "schema-dts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -320,59 +339,130 @@ export function inferPageSchemaType(pageType: string): string {
 // generatePageJsonLd — produce JSON-LD for any page type
 // ---------------------------------------------------------------------------
 
+type PrimaryPageSchema =
+  | WithContext<WebPage>
+  | WithContext<BlogPosting>
+  | WithContext<Article>
+  | WithContext<FAQPage>
+  | WithContext<Event>
+  | WithContext<Product>
+  | WithContext<AboutPage>
+  | WithContext<ContactPage>;
+
+function buildBlogPosting(input: PageSchemaInput): WithContext<BlogPosting> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    name: input.title,
+    url: input.url,
+    description: input.description,
+    headline: input.title,
+    publisher: { "@type": "Organization", name: input.siteName },
+    ...(input.datePublished && { datePublished: input.datePublished }),
+    ...(input.dateModified && { dateModified: input.dateModified }),
+    ...(input.author && { author: { "@type": "Person", name: input.author } }),
+    ...(input.image && { image: input.image }),
+  };
+}
+
+function buildArticle(input: PageSchemaInput): WithContext<Article> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    name: input.title,
+    url: input.url,
+    description: input.description,
+    headline: input.title,
+    publisher: { "@type": "Organization", name: input.siteName },
+    ...(input.datePublished && { datePublished: input.datePublished }),
+    ...(input.dateModified && { dateModified: input.dateModified }),
+    ...(input.author && { author: { "@type": "Person", name: input.author } }),
+    ...(input.image && { image: input.image }),
+  };
+}
+
+function buildFaqPage(input: PageSchemaInput): WithContext<FAQPage> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    name: input.title,
+    url: input.url,
+    description: input.description,
+    ...(input.faqItems?.length && {
+      mainEntity: input.faqItems.map((faq) => ({
+        "@type": "Question" as const,
+        name: faq.question,
+        acceptedAnswer: {
+          "@type": "Answer" as const,
+          text: faq.answer,
+        },
+      })),
+    }),
+  };
+}
+
+function buildSimplePage<T extends "WebPage" | "Event" | "Product" | "AboutPage" | "ContactPage">(
+  type: T,
+  input: PageSchemaInput,
+): WithContext<WebPage | Event | Product | AboutPage | ContactPage> {
+  return {
+    "@context": "https://schema.org",
+    "@type": type,
+    name: input.title,
+    url: input.url,
+    description: input.description,
+  };
+}
+
+function buildBreadcrumbList(
+  breadcrumbs: BreadcrumbItem[],
+): WithContext<BreadcrumbList> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: breadcrumbs.map((bc, i) => ({
+      "@type": "ListItem" as const,
+      position: i + 1,
+      name: bc.name,
+      item: bc.url,
+    })),
+  };
+}
+
 export function generatePageJsonLd(
   input: PageSchemaInput,
 ): Record<string, unknown> | Record<string, unknown>[] {
   const schemaType = inferPageSchemaType(input.pageType);
 
-  const basePage: Record<string, unknown> = {
-    "@context": "https://schema.org",
-    "@type": schemaType,
-    name: input.title,
-    url: input.url,
-    description: input.description,
-  };
-
-  // BlogPosting / Article specifics
-  if (schemaType === "BlogPosting" || schemaType === "Article") {
-    basePage.headline = input.title;
-    if (input.datePublished) basePage.datePublished = input.datePublished;
-    if (input.dateModified) basePage.dateModified = input.dateModified;
-    if (input.author) {
-      basePage.author = { "@type": "Person", name: input.author };
-    }
-    if (input.image) basePage.image = input.image;
-    basePage.publisher = { "@type": "Organization", name: input.siteName };
+  let basePage: PrimaryPageSchema;
+  switch (schemaType) {
+    case "BlogPosting":
+      basePage = buildBlogPosting(input);
+      break;
+    case "Article":
+      basePage = buildArticle(input);
+      break;
+    case "FAQPage":
+      basePage = buildFaqPage(input);
+      break;
+    case "Event":
+    case "Product":
+    case "AboutPage":
+    case "ContactPage":
+      basePage = buildSimplePage(schemaType, input);
+      break;
+    default:
+      basePage = buildSimplePage("WebPage", input);
   }
 
-  // FAQPage specifics
-  if (schemaType === "FAQPage" && input.faqItems?.length) {
-    basePage.mainEntity = input.faqItems.map((faq) => ({
-      "@type": "Question",
-      name: faq.question,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: faq.answer,
-      },
-    }));
-  }
-
-  // BreadcrumbList for interior pages
   if (input.breadcrumbs?.length) {
-    const breadcrumb: Record<string, unknown> = {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      itemListElement: input.breadcrumbs.map((bc, i) => ({
-        "@type": "ListItem",
-        position: i + 1,
-        name: bc.name,
-        item: bc.url,
-      })),
-    };
-    return [basePage, breadcrumb];
+    return [
+      basePage as unknown as Record<string, unknown>,
+      buildBreadcrumbList(input.breadcrumbs) as unknown as Record<string, unknown>,
+    ];
   }
 
-  return basePage;
+  return basePage as unknown as Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/seo-audit.test.ts
+++ b/tests/seo-audit.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  htmlPathToUrlPath,
+  isNoindex,
+  extractTitle,
+  extractDescription,
+  hasJsonLd,
+  exitCodeFor,
+  type SeoAuditReport,
+} from "../template/scripts/seo-audit.js";
+
+describe("htmlPathToUrlPath", () => {
+  it("maps dist/index.html to /", () => {
+    expect(htmlPathToUrlPath("dist/index.html", "dist")).toBe("/");
+  });
+
+  it("maps dist/blog/index.html to /blog/", () => {
+    expect(htmlPathToUrlPath("dist/blog/index.html", "dist")).toBe("/blog/");
+  });
+
+  it("maps dist/blog/post/index.html to /blog/post/", () => {
+    expect(htmlPathToUrlPath("dist/blog/post/index.html", "dist")).toBe("/blog/post/");
+  });
+
+  it("maps dist/about.html to /about", () => {
+    expect(htmlPathToUrlPath("dist/about.html", "dist")).toBe("/about");
+  });
+});
+
+describe("isNoindex", () => {
+  it("returns true for noindex meta", () => {
+    expect(
+      isNoindex(`<html><head><meta name="robots" content="noindex,follow"></head></html>`),
+    ).toBe(true);
+  });
+
+  it("handles content-then-name attribute order", () => {
+    expect(
+      isNoindex(`<html><head><meta content="noindex" name="robots"></head></html>`),
+    ).toBe(true);
+  });
+
+  it("returns false when robots meta is index", () => {
+    expect(
+      isNoindex(`<html><head><meta name="robots" content="index,follow"></head></html>`),
+    ).toBe(false);
+  });
+
+  it("returns false when robots meta is missing", () => {
+    expect(isNoindex(`<html><head><title>Hi</title></head></html>`)).toBe(false);
+  });
+});
+
+describe("extractTitle and extractDescription", () => {
+  it("extracts title content", () => {
+    expect(extractTitle(`<title>  Hello  </title>`)).toBe("Hello");
+  });
+
+  it("returns empty string when title is missing", () => {
+    expect(extractTitle(`<head></head>`)).toBe("");
+  });
+
+  it("extracts description content", () => {
+    expect(
+      extractDescription(`<meta name="description" content="A description">`),
+    ).toBe("A description");
+  });
+});
+
+describe("hasJsonLd", () => {
+  it("detects JSON-LD script tag", () => {
+    expect(
+      hasJsonLd(`<script type="application/ld+json">{"@type":"WebPage"}</script>`),
+    ).toBe(true);
+  });
+
+  it("returns false when no JSON-LD is present", () => {
+    expect(hasJsonLd(`<script>console.log("hi")</script>`)).toBe(false);
+  });
+});
+
+describe("exitCodeFor", () => {
+  const base: SeoAuditReport = {
+    issues: [],
+    totals: { critical: 0, warning: 0, niceToHave: 0 },
+    pagesAudited: 0,
+    pagesSkipped: 0,
+  };
+
+  it("returns 0 when there are no critical issues", () => {
+    expect(exitCodeFor({ ...base, totals: { critical: 0, warning: 5, niceToHave: 2 } }, false)).toBe(0);
+  });
+
+  it("returns 1 when there is at least one critical issue", () => {
+    expect(exitCodeFor({ ...base, totals: { critical: 1, warning: 0, niceToHave: 0 } }, false)).toBe(1);
+  });
+
+  it("returns 0 in warn-only mode regardless of critical count", () => {
+    expect(exitCodeFor({ ...base, totals: { critical: 9, warning: 0, niceToHave: 0 } }, true)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `template/scripts/seo-audit.ts` that walks `dist/`, runs every audit function from `seo.ts` (`auditPage`, `auditSite`, `auditChunkability`, `validateSitemap`, `auditRobotsTxt`), skips `noindex` pages, normalizes built paths before sitemap comparison, writes `seo-report.md`, and exits non-zero only on critical issues.
- Wire `npm run ai-seo` in `template/package.json`.
- Call the audit from `pre-deploy-check.ts` as a non-blocking step — surfaces a one-line warning and a path to `seo-report.md`; `--skip-seo` opts out. Matches the documented deploy behavior in the SEO skill.
- Update `skills/seo/SKILL.md` Step 2 to invoke `npm run ai-seo` and add it to `allowed-tools`.

Closes #282

## Test plan

- [x] `npx vitest run` — all 2,328 tests pass, including new `tests/seo-audit.test.ts` (16 tests covering path normalization, noindex detection, JSON-LD detection, exit-code logic).
- [ ] Manual smoke against a scaffolded site: `npm run build && npm run ai-seo` writes `seo-report.md`.

https://claude.ai/code/session_016YnAG9PBCDaHPgc4fww1F4

---
_Generated by [Claude Code](https://claude.ai/code/session_016YnAG9PBCDaHPgc4fww1F4)_