### PR TITLE
fix: align scaffolded templates with the bundled SEO audit (#281)

### DIFF
--- a/template/src/layouts/BaseLayout.astro
+++ b/template/src/layouts/BaseLayout.astro
@@ -12,6 +12,17 @@ interface Props {
 const { title, description, image, jsonLd } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
+// Default JSON-LD: a basic WebPage built from the props the layout already
+// has. Pages that pass their own `jsonLd` (e.g. BlogPosting, Restaurant,
+// CollectionPage) override this — we only fall back when no schema is set.
+const resolvedJsonLd = jsonLd ?? {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: title,
+  description,
+  url: canonicalURL.toString(),
+};
+
 // Auto-resolve OG image: custom image > per-page generated > site-wide default
 function resolveOgImage(pathname: string, customImage?: string): string {
   if (customImage) return customImage;
@@ -81,9 +92,7 @@ const hasFavicon = existsSync(resolve(process.cwd(), "public/favicon.svg"));
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <!-- Structured data -->
-    {jsonLd && (
-      <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
-    )}
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(resolvedJsonLd)} />
 
     <style is:global>
       @import "../styles/global.css";

--- a/template/src/layouts/KioskLayout.astro
+++ b/template/src/layouts/KioskLayout.astro
@@ -24,7 +24,15 @@ interface Props {
 
 const { title, description, image, themeColor, jsonLd, siteName: propSiteName } = Astro.props;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
-const ogImage = image ? new URL(image, Astro.site).href : undefined;
+
+// Mirror BaseLayout's OG resolution: custom image > per-page generated > site-wide default.
+// Per-page images are emitted by `npm run ai-og`; the site-wide fallback by `npm run ai-images`.
+function resolveOgImage(pathname: string, customImage?: string): string {
+  if (customImage) return customImage;
+  const slug = pathname.replace(/^\/+|\/+$/g, "") || "index";
+  return `/images/og/${slug}.png`;
+}
+const ogImage = new URL(resolveOgImage(Astro.url.pathname, image), Astro.site).toString();
 
 const configPath = resolve(process.cwd(), ".site-config");
 const configContent = existsSync(configPath)
@@ -67,13 +75,13 @@ const hasFavicon = existsSync(resolve(process.cwd(), "public/favicon.svg"));
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalUrl} />
-    {ogImage && <meta property="og:image" content={ogImage} />}
+    <meta property="og:image" content={ogImage} />
 
     <!-- Twitter Card -->
-    <meta name="twitter:card" content={ogImage ? "summary_large_image" : "summary"} />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
-    {ogImage && <meta name="twitter:image" content={ogImage} />}
+    <meta name="twitter:image" content={ogImage} />
 
     <!-- Schema.org structured data -->
     {jsonLd && (

--- a/template/src/pages/404.astro
+++ b/template/src/pages/404.astro
@@ -2,7 +2,10 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
-<BaseLayout title="Page not found" description="The page you're looking for doesn't exist.">
+<BaseLayout
+  title="Page Not Found — This Link May Be Broken or Moved"
+  description="The page you're looking for doesn't exist or has been moved. Head back to the home page to keep browsing."
+>
   <h1>Page not found</h1>
   <p>Sorry, the page you're looking for doesn't exist or has been moved.</p>
   <p><a href="/">Go back to the home page</a></p>

--- a/template/src/pages/accessibility.astro
+++ b/template/src/pages/accessibility.astro
@@ -10,7 +10,7 @@ const contactEmail = config.match(/^PII_EMAIL_ALLOW=(.+)$/m)?.[1]?.trim().split(
 ---
 
 <BaseLayout
-  title="Accessibility"
+  title="Accessibility Statement and WCAG Commitment"
   description={`Accessibility statement for ${siteName}. We are committed to making this website accessible to everyone.`}
 >
   <h1>Accessibility</h1>

--- a/template/src/pages/account.astro
+++ b/template/src/pages/account.astro
@@ -9,7 +9,10 @@ const workerUrl = config.match(/^MEMBERSHIP_WORKER_URL=(.+)$/m)?.[1]?.trim() ?? 
 const siteName = config.match(/^SITE_NAME=(.+)$/m)?.[1]?.trim() ?? "us";
 ---
 
-<BaseLayout title="Your account" description={`Manage your ${siteName} membership.`}>
+<BaseLayout
+  title="Your Account — Manage Your Membership"
+  description={`Manage your ${siteName} membership — update your payment method, download invoices, or cancel anytime.`}
+>
   <h1>Your account</h1>
   <p>
     Manage your membership: update your payment method, download

--- a/template/src/pages/blog/archive.astro
+++ b/template/src/pages/blog/archive.astro
@@ -17,7 +17,10 @@ const olderPosts = (
   );
 ---
 
-<BaseLayout title="Blog Archive" description="All past posts.">
+<BaseLayout
+  title="Blog Archive — All Past Posts and Articles"
+  description="Browse the complete archive of older blog posts, news, and updates."
+>
   <h1>Blog Archive</h1>
 
   <p><a href="/blog/">&larr; Back to recent posts</a></p>

--- a/template/src/pages/blog/index.astro
+++ b/template/src/pages/blog/index.astro
@@ -21,7 +21,10 @@ const hasOlderPosts = allPosts.some(
 );
 ---
 
-<BaseLayout title="Blog" description="Latest news and updates.">
+<BaseLayout
+  title="Blog — Latest News, Updates, and Announcements"
+  description="Recent posts from the blog with news, updates, and announcements from us."
+>
   <h1>Blog</h1>
 
   {recentPosts.length === 0 && <p>No recent posts. Check back soon!</p>}

--- a/template/src/pages/contact.astro
+++ b/template/src/pages/contact.astro
@@ -10,7 +10,10 @@ const turnstileSiteKey = config.match(/^TURNSTILE_SITE_KEY=(.+)$/m)?.[1]?.trim()
 const siteName = config.match(/^SITE_NAME=(.+)$/m)?.[1]?.trim() ?? "us";
 ---
 
-<BaseLayout title="Contact" description={`Get in touch with ${siteName}.`}>
+<BaseLayout
+  title="Contact Us — Send a Message and Get in Touch"
+  description={`Get in touch with ${siteName} — send us a message and we'll get back to you soon.`}
+>
   <h1>Contact</h1>
   <p>Send us a message and we'll get back to you.</p>
 

--- a/template/src/pages/contact/thanks.astro
+++ b/template/src/pages/contact/thanks.astro
@@ -2,7 +2,10 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 ---
 
-<BaseLayout title="Message sent" description="Your message has been sent successfully.">
+<BaseLayout
+  title="Message Sent — Thank You for Getting in Touch"
+  description="Your message has been sent successfully. We'll review it and get back to you as soon as we can."
+>
   <h1>Thank you</h1>
   <p>Your message has been sent. We'll get back to you soon.</p>
   <p><a href="/">Back to home</a></p>

--- a/template/src/pages/forms/[slug]/thanks.astro
+++ b/template/src/pages/forms/[slug]/thanks.astro
@@ -17,8 +17,8 @@ const message =
 ---
 
 <BaseLayout
-  title={`${form?.title ?? "Submitted"} — thanks`}
-  description="Your submission has been received."
+  title={`${form?.title ?? "Submitted"} — Thank You for Submitting`}
+  description="Your submission has been received. We'll review it and get back to you as soon as we can."
 >
   <h1>Thank you</h1>
   <p>{message}</p>

--- a/template/src/pages/index.astro
+++ b/template/src/pages/index.astro
@@ -2,7 +2,10 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
-<BaseLayout title="Welcome" description="Your business website. Run /start to set up.">
+<BaseLayout
+  title="Welcome — Your New Anglesite Business Website"
+  description="Your business website is ready to set up. Run /start in Claude to begin the guided setup."
+>
   <h1>Welcome</h1>
   <p>This site is ready to set up. Type <code>/start</code> in Claude Desktop to get started.</p>
 </BaseLayout>

--- a/template/src/pages/lab/index.astro
+++ b/template/src/pages/lab/index.astro
@@ -11,11 +11,14 @@ const experiments = (await getCollection('experiments'))
   .filter((e) => !e.data.draft)
   .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
 
+const pageTitle = 'Lab — Interactive Experiments and Creative Coding';
+const pageDescription = 'Interactive experiments and creative coding projects exploring visuals, sound, and the web.';
+
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'CollectionPage',
-  name: 'Lab',
-  description: 'Interactive experiments and creative coding projects.',
+  name: pageTitle,
+  description: pageDescription,
   hasPart: experiments.map((e) => ({
     '@type': 'CreativeWork',
     name: e.data.title,
@@ -26,7 +29,7 @@ const jsonLd = {
 };
 ---
 
-<BaseLayout title="Lab" description="Interactive experiments and creative coding projects." jsonLd={jsonLd}>
+<BaseLayout title={pageTitle} description={pageDescription} jsonLd={jsonLd}>
   <section class="lab">
     <h1>Lab</h1>
 

--- a/template/src/pages/location.astro
+++ b/template/src/pages/location.astro
@@ -13,7 +13,10 @@ const hours = config.match(/^SITE_HOURS=(.+)$/m)?.[1]?.trim() ?? "";
 const osmEmbedUrl = config.match(/^OSM_EMBED_URL=(.+)$/m)?.[1]?.trim() ?? "";
 ---
 
-<BaseLayout title="Location & Hours" description={`Find ${siteName} — address, hours, and directions.`}>
+<BaseLayout
+  title="Location & Hours — Address, Map, and Directions"
+  description={`Find ${siteName} — address, hours, phone, and directions to visit us in person.`}
+>
   <h1>Location & Hours</h1>
 
   {address && (

--- a/template/src/pages/menu.astro
+++ b/template/src/pages/menu.astro
@@ -102,8 +102,8 @@ const dietaryLabels: Record<string, string> = {
 ---
 
 <BaseLayout
-  title="Menu"
-  description="Browse our full menu."
+  title="Menu — Browse Our Full Selection"
+  description="Browse our full menu and explore everything we offer, from starters and mains to drinks and desserts."
   jsonLd={menuJsonLd ?? undefined}
 >
   <style>

--- a/template/src/pages/podcast/index.astro
+++ b/template/src/pages/podcast/index.astro
@@ -22,8 +22,8 @@ const podcastJsonLd = {
 ---
 
 <BaseLayout
-  title="Podcast"
-  description="Latest episodes"
+  title="Podcast — Latest Episodes and Show Notes"
+  description="Listen to the latest podcast episodes with show notes, transcripts, and links to subscribe."
   jsonLd={podcastJsonLd}
 >
   <h1>Podcast</h1>

--- a/template/src/pages/podcast/subscribe.astro
+++ b/template/src/pages/podcast/subscribe.astro
@@ -43,8 +43,8 @@ const platforms: Array<{ name: string; url: string; fallback: string }> = [
 ---
 
 <BaseLayout
-  title="Subscribe"
-  description="Listen to the podcast on your favorite app"
+  title="Subscribe to the Podcast in Your Favorite App"
+  description="Listen to the podcast on your favorite app — Apple Podcasts, Spotify, Pocket Casts, Overcast, and more."
 >
   <h1>Subscribe</h1>
   <p>

--- a/template/src/pages/privacy.astro
+++ b/template/src/pages/privacy.astro
@@ -21,7 +21,7 @@ const has = (cat: string) => categories.includes(cat);
 ---
 
 <BaseLayout
-  title="Privacy policy"
+  title="Privacy Policy — What We Collect and Why"
   description={`Privacy policy for ${siteName} — what we collect, why, and how to control it.`}
 >
   <h1>Privacy policy</h1>

--- a/template/src/pages/review.astro
+++ b/template/src/pages/review.astro
@@ -10,7 +10,10 @@ const turnstileSiteKey = config.match(/^TURNSTILE_SITE_KEY=(.+)$/m)?.[1]?.trim()
 const siteName = config.match(/^SITE_NAME=(.+)$/m)?.[1]?.trim() ?? "us";
 ---
 
-<BaseLayout title="Leave a Review" description={`Share your experience with ${siteName}.`}>
+<BaseLayout
+  title="Leave a Review and Share Your Experience"
+  description={`Share your experience with ${siteName} — your feedback helps us improve and helps others choose with confidence.`}
+>
   <h1>Leave a Review</h1>
   <p>We'd love to hear about your experience.</p>
 

--- a/template/src/pages/review/thanks.astro
+++ b/template/src/pages/review/thanks.astro
@@ -2,7 +2,10 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 ---
 
-<BaseLayout title="Review Submitted" description="Thank you for your review.">
+<BaseLayout
+  title="Review Submitted — Thank You for Your Feedback"
+  description="Thank you for your review. We'll read every word and may feature it on our website to help others."
+>
   <h1>Thank you!</h1>
   <p>Your review has been submitted. We'll read it and may feature it on our website.</p>
   <p><a href="/">Back to home</a></p>

--- a/template/src/pages/search.astro
+++ b/template/src/pages/search.astro
@@ -8,7 +8,10 @@ const config = existsSync(configPath) ? readFileSync(configPath, "utf-8") : "";
 const siteName = config.match(/^SITE_NAME=(.+)$/m)?.[1]?.trim() ?? "this site";
 ---
 
-<BaseLayout title="Search" description={`Search ${siteName} for pages, posts, and more.`}>
+<BaseLayout
+  title="Search This Site for Pages, Posts, and More"
+  description={`Search ${siteName} for pages, posts, and more — find what you're looking for across the entire site.`}
+>
   <h1>Search</h1>
   <div id="search" data-pagefind-ignore></div>
 

--- a/template/src/pages/subscribe.astro
+++ b/template/src/pages/subscribe.astro
@@ -9,7 +9,10 @@ const workerUrl = config.match(/^SUBSCRIBE_WORKER_URL=(.+)$/m)?.[1]?.trim() ?? "
 const siteName = config.match(/^SITE_NAME=(.+)$/m)?.[1]?.trim() ?? "us";
 ---
 
-<BaseLayout title="Subscribe" description={`Subscribe to updates from ${siteName}.`}>
+<BaseLayout
+  title="Subscribe to Our Newsletter for Updates"
+  description={`Subscribe to updates from ${siteName} delivered straight to your inbox. No spam — unsubscribe anytime.`}
+>
   <h1>Subscribe</h1>
   <p>Get updates from {siteName} delivered to your inbox.</p>
 

--- a/template/src/pages/subscribe/thanks.astro
+++ b/template/src/pages/subscribe/thanks.astro
@@ -2,7 +2,10 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 ---
 
-<BaseLayout title="Subscribed" description="You've been subscribed to our newsletter.">
+<BaseLayout
+  title="Subscribed — Welcome to Our Newsletter"
+  description="You've been subscribed to our newsletter. Check your inbox for a confirmation email to finish signing up."
+>
   <h1>You're subscribed!</h1>
   <p>Check your inbox for a confirmation email. Once confirmed, you'll receive updates from us.</p>
   <p><a href="/">Back to home</a></p>

--- a/template/src/pages/testimonials.astro
+++ b/template/src/pages/testimonials.astro
@@ -23,8 +23,8 @@ const aggregateJsonLd = rated.length > 0 ? {
 ---
 
 <BaseLayout
-  title="Testimonials"
-  description="What our customers say about us."
+  title="Testimonials — What Our Customers Say About Us"
+  description="Read testimonials and reviews from our customers about their experience working with us."
   jsonLd={aggregateJsonLd}
 >
   <h1>Testimonials</h1>

--- a/template/src/pages/unlock.astro
+++ b/template/src/pages/unlock.astro
@@ -19,7 +19,10 @@ const showFree = tiers.includes("free");
 const showPaid = tiers.includes("paid") && stripeLink.length > 0;
 ---
 
-<BaseLayout title="Unlock" description={`Unlock premium content from ${siteName}.`}>
+<BaseLayout
+  title="Unlock — Access Members-Only Content"
+  description={`Unlock premium content from ${siteName} — choose between newsletter access or a paid membership.`}
+>
   <h1>Unlock</h1>
   <p>This page is for members. Choose how you'd like to unlock it.</p>
 


### PR DESCRIPTION
Closes #281.

## Summary

Default templates shipped titles and descriptions that fell below `auditPage`'s own thresholds (title 30–60, description 50–160), so a fresh scaffold reported ~25 SEO warnings before any owner edits. Two related issues compounded it: `BaseLayout` only emitted JSON-LD when a page passed the prop, and `KioskLayout` was missing the OG image fallback `BaseLayout` had.

## Changes

- **Tighten default titles/descriptions** on every template page that fell below threshold — including the ones listed in #281 (`/blog/`, `/blog/archive/`, `/contact/`, `/contact/thanks/`, `/lab/`, `/menu/`, `/review/`, `/review/thanks/`, `/search/`, `/subscribe/`, `/subscribe/thanks/`, `/testimonials/`) plus several other below-threshold pages caught while sweeping (`/`, `/404`, `/accessibility`, `/account`, `/location`, `/podcast/`, `/podcast/subscribe`, `/privacy`, `/unlock`, `/forms/[slug]/thanks`).
- **Add a default `WebPage` JSON-LD in `BaseLayout`**, built from the `title` / `description` / canonical URL the layout already has. Pages that pass their own `jsonLd` prop (BlogPosting, Restaurant, CollectionPage, etc.) still override it.
- **Mirror BaseLayout's OG image resolver in `KioskLayout`** so the kiosk page no longer ships without `og:image` / `twitter:image`.

## Test plan

- [x] `npm test` — all 2312 tests pass (90 files, 12 skipped), including `base-layout.test.js` and `page-contracts.test.js`.
- [ ] After merge, scaffold a fresh site and run `/anglesite:seo` — out-of-the-box warnings should drop from ~25 to 0 for the title/description and Schema.org buckets.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JesUReCUGNgqCCx46xZ8hi)_