### PR TITLE
fix(stats): don't route Cloudflare API token through chat

### DIFF
--- a/skills/stats/SKILL.md
+++ b/skills/stats/SKILL.md
@@ -83,9 +83,9 @@ If `CF_API_TOKEN` is missing, guide the owner through creating one:
 6. Account Resources: Include → (their Cloudflare account)
 7. Zone Resources: Include → All zones from the same account (or the specific zone if known)
 8. Click "Continue to summary" → "Create Token"
-9. Copy the token and share it
+9. Copy the token, then open `.env` in your editor and add the line `CF_API_TOKEN=<paste-token-here>`. Save the file and tell me when done. **Do not paste the token into chat** — it would end up in the conversation transcript. `.env` is gitignored and stays local.
 
-Save to `.env` as `CF_API_TOKEN=token-value` using the Write tool (update or create the file). **Never save API tokens to `.site-config`** — that file is committed to git. `.env` is gitignored and stays local.
+If `.env` doesn't exist yet, the owner can copy it from `.env.example` first. **Never save API tokens to `.site-config`** — that file is committed to git. Read the file with the Read tool on the next turn to pick up the token; never write the token value yourself.
 
 If the owner created an older token with only **Zone → Analytics → Read** (the original version of this skill recommended that), they may see "Account → Analytics" errors below. If the token is missing **Account → Analytics Engine → Read**, the conversions section will return an `authz` error — surface a one-line note ("Add Account → Analytics Engine → Read to your token to see conversion numbers") and skip the section. Have them either edit the existing token to add the missing permissions, or create a new one.
 


### PR DESCRIPTION
## Summary

Step 9 of the "Token creation" section in `skills/stats/SKILL.md` told the owner to paste their Cloudflare API token into chat so Claude could write it to `.env`. That puts the token in the conversation transcript before it ever reaches disk.

Replace the chat-paste flow with the pattern from the issue: the owner edits `.env` themselves, then tells Claude when done. Claude reads the file on the next turn — the token never passes through chat.

## Audit of other secret-handling skills

Per the issue's request to audit. Checked every skill that touches secrets:

- `deploy`, `contact`, `forms`, `newsletter` — all use `npx wrangler secret put`, which prompts in the terminal. Wrangler reads stdin directly; Claude doesn't see the input. Safe as-is.
- `membership` "paste the same hex value" refers to a `wrangler secret put` prompt too. Safe.

`stats` was the only skill routing a secret through chat.

## Test plan

- [ ] Run `/anglesite:stats` on a fresh site with no `CF_API_TOKEN`
- [ ] Confirm Claude asks the owner to edit `.env` themselves rather than asking for the token
- [ ] Confirm Claude reads `.env` after the owner says they've saved it, and proceeds with the analytics flow

Fixes #290

---
_Generated by [Claude Code](https://claude.ai/code/session_014boiH863FuCqh5SPkTmD5N)_