### PR TITLE
fix(deploy): wire up Cloudflare Web Analytics on first deploy

### DIFF
--- a/docs/decisions/0003-cloudflare-workers-hosting.md
+++ b/docs/decisions/0003-cloudflare-workers-hosting.md
@@ -44,7 +44,7 @@ Chosen option: **Cloudflare Workers Static Assets**, because it is the platform 
 * Good, because hosting is genuinely free with no bandwidth caps for static sites
 * Good, because `wrangler deploy` works from any machine with a Cloudflare API token — no Git-integration dance
 * Good, because domain registration through Cloudflare is at ICANN cost with no markup
-* Good, because Web Analytics is privacy-first (no cookies); the Anglesite layouts inject the beacon when `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config` (one-time setup via `/anglesite:stats`)
+* Good, because Web Analytics is privacy-first (no cookies); the Anglesite layouts inject the beacon when `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config` (one-time setup during the first `/anglesite:deploy`)
 * Good, because Email Routing provides free email forwarding without an external email service
 * Good, because Workers run on every request — A/B test variant assignment, membership gates, and edge logic do not require a separate Worker project (same `wrangler.jsonc` deploys everything)
 * Good, because the Cloudflare API allows the agent to manage DNS records programmatically

--- a/docs/decisions/0008-no-third-party-javascript.md
+++ b/docs/decisions/0008-no-third-party-javascript.md
@@ -31,7 +31,7 @@ Third-party JavaScript (analytics, social embeds, chat widgets, ad networks) is 
 
 Chosen option: "No third-party JavaScript", with eight exceptions:
 
-1. **Cloudflare Web Analytics** — `static.cloudflareinsights.com/beacon.min.js`, injected by the Anglesite layouts (`BaseLayout.astro`, `KioskLayout.astro`, `ImmersiveLayout.astro`) when `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config`. Uses no cookies, collects no personal data. Wired up by `/anglesite:stats` on first run.
+1. **Cloudflare Web Analytics** — `static.cloudflareinsights.com/beacon.min.js`, injected by the Anglesite layouts (`BaseLayout.astro`, `KioskLayout.astro`, `ImmersiveLayout.astro`) when `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config`. Uses no cookies, collects no personal data. Wired up by `/anglesite:deploy` on the first deploy so launch traffic is captured.
 2. **Cloudflare Turnstile** — privacy-respecting CAPTCHA alternative used by the contact form (`/anglesite:contact`). Same vendor as the hosting platform, no cookies, no tracking. Only loaded on the `/contact` page.
 3. **Polar checkout overlay** (`cdn.polar.sh`) — open-source, indie-web-aligned checkout overlay for digital product sales. Acts as Merchant of Record (handles global VAT/sales tax). Only loaded on pages with a `PolarCheckout` component. No cookies or visitor tracking beyond the checkout transaction.
 4. **Snipcart** (`cdn.snipcart.com`) — shopping cart for small physical product catalogs. No monthly fee (2% per transaction + Stripe fees). Only loaded on pages with product components and the Snipcart container. No visitor tracking beyond the checkout transaction.

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -446,13 +446,47 @@ Tell the owner: "Your website is now live at your custom domain! SSL is handled 
 
 Tell the owner: "Try pasting your website URL into a text message or social media post draft — you should see a nice preview card with your site name and description. If it doesn't look right, we can adjust the preview image and description."
 
-## Step 6 — First deploy: Show analytics
+## Step 6 — First deploy: Wire up Web Analytics
 
-Tell the owner: "Cloudflare automatically tracks how many people visit your site — no cookies, completely private. You can check anytime."
+The site is live, but the Cloudflare Web Analytics beacon won't fire until `CF_WEB_ANALYTICS_TOKEN` is written into `.site-config` and a build picks it up. **Doing this now means launch-week traffic (usually the most interesting traffic) actually gets recorded** — if we wait until the owner asks for `/anglesite:stats`, the beacon misses days or weeks of real visitors.
 
-Open the analytics dashboard: `https://dash.cloudflare.com/?to=/:account/web-analytics`
+Read `CF_WEB_ANALYTICS_TOKEN` from `.site-config`. If it's already set, skip this step entirely — the beacon is wired up.
 
-Explain what they'll see: page views, visitor count, where visitors come from (Google, social media, direct links), and which pages get the most traffic. Suggest checking monthly.
+Tell the owner: "Now let's turn on Cloudflare's privacy-friendly analytics so visitors get counted from day one. It's free, cookieless, no GDPR banner needed. The beacon is already in your site code — we just need to enable it on the Cloudflare side and copy a public site tag back."
+
+Open the Web Analytics dashboard: `https://dash.cloudflare.com/?to=/:account/web-analytics`
+
+Walk them through:
+1. Click **Add a site**
+2. **Hostname** — enter the site's live hostname:
+   - If `SITE_DOMAIN` is in `.site-config`, use that (e.g., `www.example.com`)
+   - Otherwise, use the `CF_PROJECT_NAME.<account>.workers.dev` URL Wrangler printed in Step 3
+3. Leave the "Enable on this site" toggle off (the beacon is injected by the layouts, not by Cloudflare's auto-injector — leaving it off prevents a double beacon)
+4. Click **Done**
+5. Cloudflare shows a JS snippet that looks like `<script ... data-cf-beacon='{"token":"abc123..."}'></script>`. Copy the **token value only** — the 32-character hex string between `"token":"` and `"}'`
+
+Tell the owner: "Paste the token here. It's safe to share — every visitor sees it in your site's HTML anyway. It's not an API key."
+
+Once they paste it, validate the shape (32 hex characters) and save it to `.site-config` with the Write tool by adding `CF_WEB_ANALYTICS_TOKEN=<value>`. Do not paste the token into chat from your side and do not write it anywhere outside `.site-config`.
+
+If the owner declines or wants to skip, tell them: "No problem — you can wire it up later by running `/anglesite:stats` and it'll walk you through the same steps. Just know that any traffic before then won't be counted."
+
+### Rebuild and redeploy so the beacon goes live
+
+The layouts inject the beacon at build time, so the site needs one more deploy with the token in place. Reuse the publish flow:
+
+```sh
+npm run deploy
+```
+
+Tell the owner: "Your site is now reporting real-browser pageviews to Cloudflare Web Analytics. The first numbers usually show up within a few minutes."
+
+### Where to read the numbers
+
+"You can check anytime two ways:"
+
+- `/anglesite:stats` — plain-language summary right here in chat (page views, top pages, busiest day, referrers)
+- Dashboard for richer charts: `https://dash.cloudflare.com/?to=/:account/web-analytics`
 
 Remind them of the goals they shared during `/anglesite:start`: "You said you wanted [goal]. Once you've been live for a few weeks, check analytics to see if visitors are finding the pages that matter — like your [menu/services/portfolio] page."
 

--- a/skills/stats/SKILL.md
+++ b/skills/stats/SKILL.md
@@ -31,7 +31,7 @@ Cloudflare exposes three unrelated analytics datasets and the skill must pick th
 
 | Source | Dataset | Beacon? | Permission | Filter | Available when |
 |---|---|---|---|---|---|
-| **Web Analytics RUM** | `rumPageloadEventsAdaptiveGroups` | Yes (`static.cloudflareinsights.com/beacon.min.js`, injected by `BaseLayout`/`KioskLayout`/`ImmersiveLayout` when `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config`) | **Account → Analytics → Read** | `siteTag` + `accountTag` | After the owner enables Web Analytics for the site and the token is written to `.site-config` (this skill walks them through it on first run) |
+| **Web Analytics RUM** | `rumPageloadEventsAdaptiveGroups` | Yes (`static.cloudflareinsights.com/beacon.min.js`, injected by `BaseLayout`/`KioskLayout`/`ImmersiveLayout` when `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config`) | **Account → Analytics → Read** | `siteTag` + `accountTag` | After Web Analytics is enabled and the token is written to `.site-config`. `/anglesite:deploy` wires this up on the first deploy; this skill has a fallback for sites that were deployed before that step existed |
 | **Zone HTTP analytics** | `httpRequests1dGroups` / `httpRequestsAdaptiveGroups` | No — derived from edge logs | **Zone → Analytics → Read** | `zoneTag` | Only when the custom domain runs through Cloudflare DNS proxied (orange cloud) |
 | **Anglesite events (Analytics Engine)** | `anglesite_events` | No — written from helper Workers | **Account → Analytics Engine → Read** | `dataset='anglesite_events'`, optionally `index1=<site domain>` | When at least one helper Worker (contact, forms, membership, review, subscribe, ecommerce) is deployed |
 
@@ -66,7 +66,9 @@ Free Cloudflare accounts include 10M Analytics Engine writes per month and a 30-
 
 Read `.env` for `CF_API_TOKEN`, `CF_ACCOUNT_ID`, `CF_WEB_ANALYTICS_SITE_TAG`, and (optional) `CF_ZONE_ID`. The scaffolded project ships a `.env.example` that lists these keys with comments — copy or create `.env` from it on first run if it doesn't exist yet.
 
-Also read `.site-config` for `CF_WEB_ANALYTICS_TOKEN`. This is the public beacon token (the same value as `CF_WEB_ANALYTICS_SITE_TAG`, just stored in the committed config so the layouts can inject the beacon at build time). It is safe to commit — every visitor sees it in the page HTML anyway. If it is missing, the site is currently not reporting any beacon hits and this skill will guide the owner through enabling Web Analytics before falling back to zone HTTP.
+Also read `.site-config` for `CF_WEB_ANALYTICS_TOKEN`. This is the public beacon token (the same value as `CF_WEB_ANALYTICS_SITE_TAG`, just stored in the committed config so the layouts can inject the beacon at build time). It is safe to commit — every visitor sees it in the page HTML anyway.
+
+`/anglesite:deploy` wires this up on the first deploy, so on a freshly deployed site the value should already be present. If it is missing — typically on sites deployed before the deploy skill handled this, or if the owner skipped that step — the site is currently not reporting any beacon hits. This skill will walk the owner through enabling Web Analytics below as a fallback, then fall back to zone HTTP if that isn't possible either. If `CF_WEB_ANALYTICS_TOKEN` is in `.site-config` but `CF_WEB_ANALYTICS_SITE_TAG` is missing from `.env`, just copy the value across — they're the same token, split across two files only because `.site-config` is committed and `.env` isn't.
 
 ### Token creation (one-time)
 
@@ -108,7 +110,9 @@ Save to `.env` as `CF_ACCOUNT_ID=account-id`.
 
 ### Web Analytics site tag
 
-If `CF_WEB_ANALYTICS_SITE_TAG` is missing, list the account's Web Analytics sites and pick the one whose host matches `SITE_DOMAIN` (or, if no custom domain is set yet, the `*.workers.dev` preview hostname).
+If `CF_WEB_ANALYTICS_SITE_TAG` is missing from `.env` but `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config`, copy the value over (they're the same token) and move on — no API lookup needed.
+
+Otherwise (both missing), Web Analytics hasn't been wired up yet. The fast path is `/anglesite:deploy`, which wires this up automatically on the first deploy. If the owner would rather wire it up right here without redeploying, list the account's Web Analytics sites and pick the one whose host matches `SITE_DOMAIN` (or, if no custom domain is set yet, the `*.workers.dev` preview hostname).
 
 ```sh
 CF_API_TOKEN=$(grep CF_API_TOKEN .env | cut -d= -f2)

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -176,7 +176,7 @@ If you changed it, document it. Same session. No exceptions.
 
 ### Third-party code
 
-- Site loads zero third-party JavaScript. The Anglesite layouts inject the Cloudflare Web Analytics beacon when `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config` (run `/anglesite:stats` to wire it up).
+- Site loads zero third-party JavaScript. The Anglesite layouts inject the Cloudflare Web Analytics beacon when `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config` (wired up automatically by `/anglesite:deploy` on the first deploy).
 - Never add analytics, tracking, social embeds, or ad scripts without explicit approval
 - Prefer self-hosted alternatives (local fonts over Google Fonts)
 

--- a/template/src/layouts/BaseLayout.astro
+++ b/template/src/layouts/BaseLayout.astro
@@ -51,7 +51,7 @@ const generator = `Anglesite ${version} (${aiModel}, ${Astro.generator})`;
 
 // Cloudflare Web Analytics beacon. Injected at build time when
 // `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config` — populated by
-// `/anglesite:stats` once Web Analytics is enabled for the site.
+// `/anglesite:deploy` on the first deploy once Web Analytics is enabled.
 const webAnalyticsToken = configContent
   .match(/^CF_WEB_ANALYTICS_TOKEN=(.+)$/m)?.[1]
   ?.trim();

--- a/template/src/layouts/ImmersiveLayout.astro
+++ b/template/src/layouts/ImmersiveLayout.astro
@@ -23,7 +23,7 @@ const hasFavicon = existsSync(resolve(process.cwd(), "public/favicon.svg"));
 
 // Cloudflare Web Analytics beacon. Injected at build time when
 // `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config` — populated by
-// `/anglesite:stats` once Web Analytics is enabled for the site.
+// `/anglesite:deploy` on the first deploy once Web Analytics is enabled.
 const configPath = resolve(process.cwd(), ".site-config");
 const webAnalyticsToken = existsSync(configPath)
   ? readFileSync(configPath, "utf-8")

--- a/template/src/layouts/KioskLayout.astro
+++ b/template/src/layouts/KioskLayout.astro
@@ -43,7 +43,7 @@ const siteName =
 
 // Cloudflare Web Analytics beacon. Injected at build time when
 // `CF_WEB_ANALYTICS_TOKEN` is set in `.site-config` — populated by
-// `/anglesite:stats` once Web Analytics is enabled for the site.
+// `/anglesite:deploy` on the first deploy once Web Analytics is enabled.
 const webAnalyticsToken = configContent
   .match(/^CF_WEB_ANALYTICS_TOKEN=(.+)$/m)?.[1]
   ?.trim();


### PR DESCRIPTION
## Summary

- `/anglesite:deploy` now writes `CF_WEB_ANALYTICS_TOKEN` to `.site-config` and triggers a rebuild on the first deploy, so the beacon ships with the site from day one
- `/anglesite:stats` keeps the enable flow as a fallback for sites deployed before this change, and auto-copies the token between `.site-config` and `.env` when only one is set
- ADR-0003, ADR-0008, template `CLAUDE.md`, and the three layout comments updated to say "wired up by /anglesite:deploy" instead of "/anglesite:stats"

## Why

Previously, Web Analytics was enabled lazily on first `/anglesite:stats` — which usually happens weeks or months after launch. That meant freshly deployed sites collected zero analytics during their most interesting window (launch week traffic from announcements, link shares, etc.). Wiring this up at deploy time means launch traffic is captured.

Closes #292

## Test plan

- [ ] All 2333 existing tests still pass (`npm test`) ✅
- [ ] Manual verification of new Step 6 flow on a fresh scaffolded site
- [ ] Verify `/anglesite:stats` still works on a site that already has `CF_WEB_ANALYTICS_TOKEN` in `.site-config`
- [ ] Verify the `.site-config` → `.env` token copy path works when `CF_WEB_ANALYTICS_SITE_TAG` is missing

https://claude.ai/code/session_017nZeZ9Cm45qufDGY59pCri

---
_Generated by [Claude Code](https://claude.ai/code/session_017nZeZ9Cm45qufDGY59pCri)_