### PR TITLE
fix(predeploy): stop matching framework identifiers as Airtable PATs

### DIFF
--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -29,7 +29,18 @@ import { formatSeoReport, type AgenticCrawlersPolicy } from "./seo.js";
 export const emailPattern = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
 export const emailExcludes = ["charset", "viewport", "@astro", "@import", "@keyframes", "@media", "@font-face", "@layer", "@property"];
 export const phonePattern = /\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/g;
-export const tokenPattern = /(?:pat[A-Za-z0-9]{14,}|sk-[A-Za-z0-9]{20,})/;
+/**
+ * Airtable Personal Access Token: `pat` + 14 alphanumerics + `.` + 32+ alphanumerics.
+ * The literal dot and second segment are mandatory in real PATs and eliminate
+ * false positives against framework identifiers like `pathnameContainsDefaultLocale`.
+ */
+export const airtablePatPattern = /\bpat[A-Za-z0-9]{14}\.[A-Za-z0-9]{32,}\b/;
+
+/** OpenAI secret key: `sk-` + 20+ alphanumerics. */
+export const openaiKeyPattern = /\bsk-[A-Za-z0-9]{20,}\b/;
+
+/** @deprecated Use airtablePatPattern or openaiKeyPattern. Kept for backwards-compatible imports. */
+export const tokenPattern = new RegExp(`${airtablePatPattern.source}|${openaiKeyPattern.source}`);
 export const scriptSrcPattern = /<script[^>]*src=/gi;
 
 /**
@@ -109,9 +120,19 @@ export function scanPhones(content: string, allowlist: string[] = []): string[] 
   return matches.filter(m => !allowed.has(norm(m)));
 }
 
-export function scanTokens(content: string): boolean {
-  return tokenPattern.test(content);
+export type TokenKind = "airtable-pat" | "openai-key";
+
+export function scanTokens(content: string): TokenKind[] {
+  const found: TokenKind[] = [];
+  if (airtablePatPattern.test(content)) found.push("airtable-pat");
+  if (openaiKeyPattern.test(content)) found.push("openai-key");
+  return found;
 }
+
+const tokenLabels: Record<TokenKind, string> = {
+  "airtable-pat": "Airtable Personal Access Token",
+  "openai-key": "OpenAI secret key",
+};
 
 export function scanScripts(content: string, scriptAllowlist?: string[]): string[] {
   const allowed = scriptAllowlist ?? allowedScripts;
@@ -271,8 +292,8 @@ if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
     for (const file of walkAll(dir)) {
       try {
         const content = readFileSync(file, "utf-8");
-        if (scanTokens(content)) {
-          failures.push(`TOKEN: API token pattern found in ${file}`);
+        for (const kind of scanTokens(content)) {
+          failures.push(`TOKEN: ${tokenLabels[kind]} found in ${file} — rotate this credential immediately`);
         }
       } catch {
         // Binary file, skip

--- a/tests/pre-deploy-check.test.ts
+++ b/tests/pre-deploy-check.test.ts
@@ -124,24 +124,44 @@ describe("scanPhones", () => {
 // ---------------------------------------------------------------------------
 
 describe("scanTokens", () => {
-  it("detects pat prefix tokens (14+ alphanumeric chars)", () => {
-    expect(scanTokens("token: patAbcDefGhiJklMn")).toBe(true);
+  it("detects real-shaped Airtable PATs (pat + 14 chars + . + 32+ chars)", () => {
+    // pat + 14 alphanumerics + . + 64 alphanumerics
+    const pat = "pat" + "A".repeat(14) + "." + "B".repeat(64);
+    expect(scanTokens(`token: ${pat}`)).toEqual(["airtable-pat"]);
   });
 
   it("detects sk- prefix tokens (20+ alphanumeric chars)", () => {
-    expect(scanTokens("key: sk-AbcDefGhiJklMnOpQrStUv")).toBe(true);
+    expect(scanTokens("key: sk-AbcDefGhiJklMnOpQrStUv")).toEqual(["openai-key"]);
   });
 
-  it("returns false for short pat string", () => {
-    expect(scanTokens("pat123")).toBe(false);
+  it("ignores 'pat' followed by alphanumerics without the dot+second segment", () => {
+    // Real false positives from Astro SSR adapter
+    expect(scanTokens("pathnameContainsDefaultLocale")).toEqual([]);
+    expect(scanTokens("patibleDescriptorOptions")).toEqual([]);
+    expect(scanTokens("pathFallbackLocale")).toEqual([]);
   });
 
-  it("returns false for short sk- string", () => {
-    expect(scanTokens("sk-abc")).toBe(false);
+  it("ignores 'pat' as a substring of larger identifiers", () => {
+    // Word boundary keeps `compatibleX` and similar from matching
+    expect(scanTokens("compatibleDescriptorXXXXXXXXXX")).toEqual([]);
   });
 
-  it("returns false for normal content", () => {
-    expect(scanTokens("Just some regular text about patterns.")).toBe(false);
+  it("returns empty for short pat string", () => {
+    expect(scanTokens("pat123")).toEqual([]);
+  });
+
+  it("returns empty for short sk- string", () => {
+    expect(scanTokens("sk-abc")).toEqual([]);
+  });
+
+  it("returns empty for normal content", () => {
+    expect(scanTokens("Just some regular text about patterns.")).toEqual([]);
+  });
+
+  it("detects both kinds when both are present", () => {
+    const pat = "pat" + "A".repeat(14) + "." + "B".repeat(64);
+    const sk = "sk-" + "C".repeat(40);
+    expect(scanTokens(`${pat} and ${sk}`).sort()).toEqual(["airtable-pat", "openai-key"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Tighten `tokenPattern` to require the literal dot + second segment that real Airtable PATs have (`pat` + 14 alphanums + `.` + 32+ alphanums), and add `\b` word boundaries to both PAT and `sk-` halves.
- Split `scanTokens` into two named credential kinds (`airtable-pat`, `openai-key`) so the blocked-deploy message names the credential the owner needs to rotate, instead of a generic "API token pattern found."

The old regex matched any English word starting with `pat` followed by 14+ alphanumerics. On any Anglesite build using the Cloudflare adapter (the default), this fired on Astro's compiled SSR chunks — `pathnameContainsDefaultLocale`, `patibleDescriptorOptions`, `pathFallbackLocale` — blocking every deploy.

Fixes #303.

## Test plan

- [x] `npx vitest run tests/pre-deploy-check.test.ts` — 49 passed, including new cases for the three real-world false positives (`pathnameContainsDefaultLocale`, `patibleDescriptorOptions`, `pathFallbackLocale`) and a real-shaped Airtable PAT
- [x] Full suite: `npx vitest run` — 2336 passed, 12 skipped, 0 failing
- [ ] Manual: build a fresh Anglesite site and confirm `npm run predeploy` no longer flags the Astro SSR adapter chunks

https://claude.ai/code/session_01KXLSrREXSHtwkZav5e9YW5

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXLSrREXSHtwkZav5e9YW5)_