### PR TITLE
fix(update): merge [observability] block into existing worker/*.toml

### DIFF
--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -80,6 +80,7 @@ To tell the difference:
 | `package.json` | **Merge dependencies.** Don't replace the whole file — update `dependencies` and `devDependencies` versions to match the template. Preserve any packages the owner added. |
 | `astro.config.ts` | **Merge carefully.** The owner may have added integrations. Update template portions, preserve additions. |
 | `keystatic.config.ts` | **Merge carefully.** The owner may have added or modified content collections. Update template portions, preserve additions. |
+| `worker/*.toml` | **Merge carefully.** The owner has pasted real ids into these (KV namespace ids, D1 `database_id`, account names, `SITE_DOMAIN`, etc.) — never overwrite. Read both versions, preserve every owner-supplied value, and apply only the additive template changes. The current required addition is an `[observability]` block (`enabled = true`, `head_sampling_rate = 1.0`) right after `compatibility_date` — add it if missing. If the file is otherwise identical to the template apart from owner-supplied ids, that's expected; don't flag it. Tell the owner the worker needs a redeploy for changes to take effect. |
 | `.gitignore` | **Append only.** Add new entries from the template without removing existing ones. |
 | Config files (`tsconfig.json`, etc.) | **Safe to update** unless customized. |
 


### PR DESCRIPTION
## Summary

Closes the remaining gap from #302.

The plugin's six helper-Worker templates already ship `[observability] enabled = true` (added in #261), so any site scaffolded on 1.0.1+ is already correct. The remaining gap is sites scaffolded **before** #261 — their local `worker/*.toml` files predate the block, and `/anglesite:update` had no explicit guidance on how to merge it in without clobbering owner-supplied values (KV namespace ids, D1 `database_id`, `SITE_DOMAIN`, etc.).

This PR adds a `worker/*.toml` row to the modified-files merge table in `skills/update/SKILL.md`:

- Preserve every owner-supplied id — never overwrite the file wholesale.
- Add the `[observability]` block (`enabled = true`, `head_sampling_rate = 1.0`) right after `compatibility_date` if missing.
- Don't flag the file as drift just because owner-supplied ids differ from the template placeholders.
- Tell the owner a redeploy is needed for the change to take effect.

## Test plan

- [ ] Run `/anglesite:update` against a site whose `worker/wrangler.toml` lacks `[observability]` and confirm the block is added without disturbing owner ids.
- [ ] Run `/anglesite:update` against a site whose `worker/wrangler.toml` already has `[observability]` and confirm nothing changes.
- [ ] Run `/anglesite:check` after the update and confirm Step 4 (Workers Logs) no longer flags a finding.

Refs #302

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bh4FD5d6bWoMvJGzhCKkzV)_