### PR TITLE
fix(template): bump deps to clear npm audit findings (#301)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "author": {
     "name": "David W. Keith"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Anglesite is a Claude plugin that scaffolds and manages websites for small businesses. It works with Claude Cowork (non-technical site owners, GUI) and Claude Code (developers, CLI). It generates Astro + Keystatic sites deployed to Cloudflare Workers (Static Assets, via the `@astrojs/cloudflare` adapter).
 
-**Version:** 1.0.1 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
+**Version:** 1.0.2 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
 
 ## Plugin structure
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "scripts": {

--- a/template/astro.config.ts
+++ b/template/astro.config.ts
@@ -143,5 +143,8 @@ export default defineConfig({
     sitemap({ serialize: makeLastmodSerializer() }),
   ],
   vite: { server: { https: getHttpsConfig() } },
-  adapter: cloudflare(),
+  // prerenderEnvironment: "node" keeps the prerender step in Node so the
+  // adapter doesn't spin up a workerd-based preview server that conflicts
+  // with the custom worker entry in worker/site-entry.js.
+  adapter: cloudflare({ prerenderEnvironment: "node" }),
 });

--- a/template/package.json
+++ b/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dwk/anglesite",
   "type": "module",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "dev": "astro dev",
@@ -31,19 +31,28 @@
     "lint:md": "markdownlint-cli2 'docs/**/*.md' '*.md'"
   },
   "dependencies": {
-    "@astrojs/cloudflare": "^12.6.13",
-    "@astrojs/markdoc": "0.14.0",
-    "@astrojs/react": "4.2.1",
-    "@astrojs/rss": "^4.0.0",
-    "@astrojs/sitemap": "3.3.1",
+    "@astrojs/cloudflare": "13.5.0",
+    "@astrojs/markdoc": "1.0.4",
+    "@astrojs/react": "5.0.4",
+    "@astrojs/rss": "^4.0.18",
+    "@astrojs/sitemap": "3.7.2",
     "@keystatic/astro": "5.0.6",
-    "@keystatic/core": "0.5.49",
-    "astro": "5.18.1",
+    "@keystatic/core": "0.5.50",
+    "astro": "6.3.1",
     "astro-pagefind": "^1.6.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },
-  "overrides": {},
+  "overrides": {
+    "@keystatic/astro": {
+      "astro": "$astro"
+    },
+    "volar-service-yaml": "^0.0.71",
+    "fast-uri": "^3.1.2",
+    "fast-xml-builder": "^1.2.0",
+    "fast-xml-parser": "^5.7.3",
+    "lodash": "^4.18.1"
+  },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",
     "html-validate": "^10.11.2",


### PR DESCRIPTION
## Summary

- Fresh scaffolds were failing `npm audit` with 18 vulnerabilities (12 moderate, 6 high) because the template pinned older majors of `@astrojs/cloudflare`, `@astrojs/markdoc`, and `astro`. This PR bumps the direct deps to current secure majors and adds targeted npm `overrides` for transitive advisories that the direct bumps don't reach. `npm audit` on a fresh scaffold now reports `0 vulnerabilities`.
- The new `@astrojs/cloudflare` 13 spins up a workerd-based prerender preview server that conflicts with Anglesite's custom `worker/site-entry.js`. The adapter exposes `prerenderEnvironment: "node"` to keep prerendering in Node — added to `template/astro.config.ts` with a comment explaining why.
- Plugin manifests bumped to 1.0.2 across `package.json`, `.claude-plugin/plugin.json`, `template/package.json`, and the **Version:** line in root `CLAUDE.md`.

## Direct dep bumps

| Package | Before | After | Notes |
|---|---|---|---|
| `@astrojs/cloudflare` | `^12.6.13` | `13.5.0` | Fixes SSRF (GHSA-88gm-j2wx-58h6); pulls fixed `wrangler`/`miniflare`/`undici` |
| `@astrojs/markdoc` | `0.14.0` | `1.0.4` | Required by astro 6 |
| `astro` | `5.18.1` | `6.3.1` | Fixes XSS in `define:vars` (CVE-2026-41067) |
| `@astrojs/react` | `4.2.1` | `5.0.4` | Brings vite 7 instead of vulnerable vite 6 |
| `@astrojs/rss` | `^4.0.0` | `^4.0.18` | Earlier 4.0.15 declared zod v4 but called the removed `z.function().returns()` API |
| `@astrojs/sitemap` | `3.3.1` | `3.7.2` | Routine bump |
| `@keystatic/core` | `0.5.49` | `0.5.50` | Routine bump |

`@keystatic/astro` stays at 5.0.6 (latest); its peer range hasn't been refreshed for astro 6, so an `overrides.@keystatic/astro.astro = $astro` entry silences the resolution mismatch — the integration runs fine on astro 6 in practice.

## Overrides added

| Package | Pinned to | Reason |
|---|---|---|
| `volar-service-yaml` | `^0.0.71` | Pulls fixed `yaml-language-server@~1.23.0` → `yaml@2.8.3+` (GHSA-48c2-rrv3-qjmp) |
| `fast-uri` | `^3.1.2` | GHSA-q3j6-qgpj-74h6 / GHSA-v39h-62p7-jpjc (via `ajv` ← `html-validate`) |
| `fast-xml-builder` | `^1.2.0` | GHSA-5wm8-gmm8-39j9 (via `fast-xml-parser` ← `@astrojs/rss`) |
| `fast-xml-parser` | `^5.7.3` | GHSA-gh4j-gqv2-49f6 |
| `lodash` | `^4.18.1` | GHSA-r5fr-rjxr-66jc / GHSA-f23m-r3pf-42rh (via `slate-react` ← `@keystatic/core`) |

## Verification

- Fresh scaffold to `/tmp/test-anglesite-301-v7`, `npm install`, `npm audit`: **0 vulnerabilities**
- `npm run build`: clean (warnings are pre-existing "missing content collection" notices for a bare scaffold)
- `npm run predeploy`: runs and behaves identically (only blocks on template placeholder `you@example.com`)
- Plugin tests: 2345 / 2345 passing

## Test plan

- [ ] Scaffold a fresh project: `mkdir /tmp/site && zsh scripts/scaffold.sh -y /tmp/site && cd /tmp/site && npm install && npm audit`
- [ ] Confirm `npm audit` reports 0 vulnerabilities
- [ ] Run `npm run build` and confirm it produces `dist/client/index.html` and `dist/server/entry.mjs`
- [ ] Existing owners can pull via `/anglesite:update` (no migration steps required)

Fixes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)