### PR TITLE
fix(predeploy): exempt RFC 2606 reserved domains from PII email scan

### DIFF
--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -28,6 +28,31 @@ import { formatSeoReport, type AgenticCrawlersPolicy } from "./seo.js";
 
 export const emailPattern = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
 export const emailExcludes = ["charset", "viewport", "@astro", "@import", "@keyframes", "@media", "@font-face", "@layer", "@property"];
+
+/**
+ * RFC 2606 reserved second-level domains. Email addresses on these domains are
+ * documentation placeholders by convention and never represent real PII.
+ */
+export const reservedExampleDomains = ["example.com", "example.net", "example.org"];
+
+/**
+ * RFC 2606 / RFC 6761 reserved top-level domains. Any address whose domain
+ * ends in one of these is a placeholder.
+ */
+export const reservedExampleTlds = [".example", ".test", ".invalid", ".localhost"];
+
+/**
+ * True when an email address sits on a reserved documentation domain. Used by
+ * the PII scan to ignore scaffold-shipped placeholders like `you@example.com`
+ * without forcing owners to enumerate them in `PII_EMAIL_ALLOW`.
+ */
+export function isReservedExampleEmail(email: string): boolean {
+  const at = email.lastIndexOf("@");
+  if (at < 0) return false;
+  const domain = email.slice(at + 1).toLowerCase();
+  if (reservedExampleDomains.includes(domain)) return true;
+  return reservedExampleTlds.some(tld => domain.endsWith(tld));
+}
 export const phonePattern = /\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/g;
 /**
  * Airtable Personal Access Token: `pat` + 14 alphanumerics + `.` + 32+ alphanumerics.
@@ -101,6 +126,8 @@ export function scanEmails(content: string, allowlist: string[]): string[] {
   return matches.filter(m => {
     // Skip CSS at-rules and meta tags
     if (emailExcludes.some(ex => m.includes(ex))) return false;
+    // Skip RFC 2606 / RFC 6761 reserved documentation domains
+    if (isReservedExampleEmail(m)) return false;
     // Skip emails in mailto: links (intentionally published)
     const idx = content.indexOf(m);
     if (idx >= 7 && content.slice(idx - 7, idx).includes("mailto:")) return false;

--- a/tests/pre-deploy-check.test.ts
+++ b/tests/pre-deploy-check.test.ts
@@ -13,6 +13,7 @@ import {
   scanMaintenance,
   formatMaintenanceWarning,
   maintenanceCategories,
+  isReservedExampleEmail,
 } from "../template/scripts/pre-deploy-check.js";
 
 // ---------------------------------------------------------------------------
@@ -35,8 +36,24 @@ describe("pre-deploy-check.sh safety", () => {
 
 describe("scanEmails", () => {
   it("finds real emails", () => {
-    const result = scanEmails("Contact us at user@example.com for info.", []);
-    expect(result).toEqual(["user@example.com"]);
+    const result = scanEmails("Contact us at user@mysite.com for info.", []);
+    expect(result).toEqual(["user@mysite.com"]);
+  });
+
+  it("ignores RFC 2606 reserved example.com placeholders", () => {
+    expect(scanEmails("Try you@example.com to subscribe.", [])).toEqual([]);
+  });
+
+  it("ignores RFC 2606 reserved example.net and example.org placeholders", () => {
+    expect(scanEmails("Reach hello@example.net or info@example.org.", [])).toEqual([]);
+  });
+
+  it("ignores reserved .test / .invalid / .localhost TLDs", () => {
+    expect(scanEmails("Test a@foo.test, b@bar.invalid, c@baz.localhost.", [])).toEqual([]);
+  });
+
+  it("still flags real-looking addresses on non-reserved domains", () => {
+    expect(scanEmails("Reach jane@yourbusiness.com today.", [])).toEqual(["jane@yourbusiness.com"]);
   });
 
   it("ignores CSS at-rules: @import", () => {
@@ -75,6 +92,35 @@ describe("scanEmails", () => {
 
   it("returns empty array for content with no emails", () => {
     expect(scanEmails("No email addresses here.", [])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isReservedExampleEmail
+// ---------------------------------------------------------------------------
+
+describe("isReservedExampleEmail", () => {
+  it("recognizes example.com / example.net / example.org", () => {
+    expect(isReservedExampleEmail("a@example.com")).toBe(true);
+    expect(isReservedExampleEmail("b@EXAMPLE.NET")).toBe(true);
+    expect(isReservedExampleEmail("c@example.org")).toBe(true);
+  });
+
+  it("recognizes reserved TLDs (.test, .invalid, .localhost, .example)", () => {
+    expect(isReservedExampleEmail("a@foo.test")).toBe(true);
+    expect(isReservedExampleEmail("a@foo.invalid")).toBe(true);
+    expect(isReservedExampleEmail("a@foo.localhost")).toBe(true);
+    expect(isReservedExampleEmail("a@foo.example")).toBe(true);
+  });
+
+  it("does not flag normal domains", () => {
+    expect(isReservedExampleEmail("a@mysite.com")).toBe(false);
+    expect(isReservedExampleEmail("a@yourbusiness.com")).toBe(false);
+    expect(isReservedExampleEmail("a@example.com.evil.com")).toBe(false);
+  });
+
+  it("returns false for strings without an @", () => {
+    expect(isReservedExampleEmail("not-an-email")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #304. The pre-deploy PII scanner was flagging placeholder emails on scaffolded template pages (`you@example.com` on `/subscribe/`, `/unlock/`), which blocked deploy on a brand-new site until the owner deleted demo pages or curated `PII_EMAIL_ALLOW` by hand.

This change teaches `scanEmails` to skip addresses on RFC 2606 / RFC 6761 reserved documentation domains:

- `example.com`, `example.net`, `example.org`
- any domain ending in `.test`, `.invalid`, `.localhost`, or `.example`

Real-looking addresses on any other domain still trip the gate.

## Test plan

- [x] `npx vitest run tests/pre-deploy-check.test.ts` — 57/57 pass, including new cases covering each reserved domain/TLD and the negative case (`jane@yourbusiness.com` still flagged).
- [x] `npx vitest run` — full suite (2344 tests) green.


---
_Generated by [Claude Code](https://claude.ai/code/session_012PjZ5k4xXmMUfVZJ4eQEY9)_