### PR TITLE
fix(skills): include [observability] in inline wrangler.toml snippets

### DIFF
--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -88,6 +88,10 @@ Create `worker/subscribe-wrangler.toml` if it doesn't exist:
 name = "newsletter-subscribe"
 main = "subscribe-worker.js"
 compatibility_date = "2024-01-01"
+
+[observability]
+enabled = true
+head_sampling_rate = 1.0
 ```
 
 ## Step 3 — Add the subscribe page

--- a/skills/testimonials/SKILL.md
+++ b/skills/testimonials/SKILL.md
@@ -41,6 +41,10 @@ Create `worker/review-wrangler.toml` if needed:
 name = "review-form"
 main = "review-worker.js"
 compatibility_date = "2024-01-01"
+
+[observability]
+enabled = true
+head_sampling_rate = 1.0
 ```
 
 Deploy:


### PR DESCRIPTION
## Summary

- The six `template/worker/*.toml` files already ship with an `[observability] enabled = true` block, and `skills/update/SKILL.md` already migrates existing sites — so the main path described in #302 is covered.
- However, `skills/newsletter/SKILL.md` and `skills/testimonials/SKILL.md` each contained an inline TOML snippet shown when the skill needs to scaffold `worker/subscribe-wrangler.toml` or `worker/review-wrangler.toml` from scratch. Those inline snippets did not include the `[observability]` block, so when an owner ran the skill before that file existed, the agent would create a wrangler.toml without logging — exactly the gap the issue describes.
- This PR adds the `[observability]` block to both inline snippets so newly-scaffolded helper Workers always ship with Workers Logs enabled.

Closes #302

## Test plan

- [ ] `/anglesite:newsletter` on a fresh site → `worker/subscribe-wrangler.toml` contains `[observability]\nenabled = true`
- [ ] `/anglesite:testimonials` on a fresh site → `worker/review-wrangler.toml` contains `[observability]\nenabled = true`
- [ ] `/anglesite:check` reports no "Worth fixing soon" observability findings for either Worker

https://claude.ai/code/session_01XppC5Jt6wsqvG71RXLiovh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XppC5Jt6wsqvG71RXLiovh)_