### PR TITLE
fix(og): decompress WOFF2 → TTF so Satori can render OG images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anglesite",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anglesite",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0"

--- a/template/package.json
+++ b/template/package.json
@@ -64,6 +64,7 @@
     "@resvg/resvg-js": "^2.6.0",
     "satori": "^0.12.0",
     "sharp": "^0.33.0",
+    "wawoff2": "^2.0.1",
     "schema-dts": "^2.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",

--- a/template/scripts/generate-og-pages.ts
+++ b/template/scripts/generate-og-pages.ts
@@ -85,15 +85,14 @@ async function main() {
     : "";
   const template = logoSvg ? "text-logo" : "text-only";
 
-  // Load font
-  const fontPath = resolve(
-    import.meta.dirname ?? ".",
-    "fonts",
-    "Inter-Regular.woff",
-  );
-  const fontData = existsSync(fontPath)
-    ? readFileSync(fontPath)
-    : undefined;
+  // Optional font override: drop a Satori-compatible font (TTF, OTF, or WOFF —
+  // not WOFF2) at scripts/fonts/Inter-Regular.{ttf,otf,woff} to bypass the
+  // default @fontsource decompression path.
+  const fontsDir = resolve(import.meta.dirname ?? ".", "fonts");
+  const overridePath = ["ttf", "otf", "woff"]
+    .map((ext) => join(fontsDir, `Inter-Regular.${ext}`))
+    .find((p) => existsSync(p));
+  const fontData = overridePath ? readFileSync(overridePath) : undefined;
 
   // Discover pages from content collections
   const pages: PageInfo[] = [];

--- a/template/scripts/satori-og.ts
+++ b/template/scripts/satori-og.ts
@@ -27,20 +27,32 @@ export interface RenderOgOptions {
   colors: OgColors;
   template: "text-only" | "text-logo";
   logoSvg?: string;
-  /** Override font data (useful for testing without a font file on disk). */
+  /**
+   * Override font data (useful for testing without a font file on disk).
+   * Must be TTF, OTF, or WOFF — Satori does not support WOFF2.
+   */
   fontData?: Buffer;
 }
 
-/** Font data — loaded once from @fontsource/inter, cached in memory. */
+/** TTF font data, decompressed from @fontsource/inter's WOFF2 once and cached. */
 let fontCache: Buffer | undefined;
 
-/** Load Inter latin-400 woff2 from the @fontsource/inter npm package. */
-export function loadFont(): Buffer {
+/**
+ * Load Inter latin-400 as TTF for Satori.
+ *
+ * Satori only accepts TTF, OTF, or WOFF — not WOFF2 — so we decompress the
+ * @fontsource/inter WOFF2 file in-process via wawoff2. WOFF2 → TTF is the only
+ * direction this conversion needs to run; the original file stays untouched.
+ */
+export async function loadFont(): Promise<Buffer> {
   if (fontCache) return fontCache;
   const fontPath = _require.resolve(
     "@fontsource/inter/files/inter-latin-400-normal.woff2",
   );
-  fontCache = readFileSync(fontPath);
+  const woff2 = readFileSync(fontPath);
+  const { default: wawoff } = await import("wawoff2");
+  const ttf = await wawoff.decompress(woff2);
+  fontCache = Buffer.from(ttf);
   return fontCache;
 }
 
@@ -57,7 +69,7 @@ export async function renderOgImage(options: RenderOgOptions): Promise<Buffer> {
       : textOnlyTemplate(title, siteName, colors);
 
   // Render to SVG via Satori
-  const font = fontData ?? loadFont();
+  const font = fontData ?? (await loadFont());
   const svg = await satori(element as never, {
     width: OG_WIDTH,
     height: OG_HEIGHT,

--- a/tests/__stubs__/wawoff2.ts
+++ b/tests/__stubs__/wawoff2.ts
@@ -1,0 +1,10 @@
+// Stub wawoff2 for tests. The real package is a template devDependency; aliasing
+// to this stub means "wawoff2" resolves to the same module ID regardless of
+// whether `template/node_modules/wawoff2` is installed locally. Tests use
+// `vi.mock("wawoff2")` to substitute behavior — this stub only needs to satisfy
+// the import shape (default export with a `decompress` function).
+export default {
+  decompress(_input: Uint8Array): Promise<Uint8Array> {
+    throw new Error("wawoff2 stub — vi.mock should intercept this in tests");
+  },
+};

--- a/tests/satori-og.test.ts
+++ b/tests/satori-og.test.ts
@@ -1,18 +1,52 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Use vi.hoisted so mock references are available inside vi.mock factories
-const { mockSatori, mockRender, MockResvg } = vi.hoisted(() => {
-  const mockRender = vi.fn();
-  return {
-    mockSatori: vi.fn(),
-    mockRender,
-    MockResvg: vi.fn().mockImplementation(() => ({ render: mockRender })),
-  };
-});
+const { mockSatori, mockRender, MockResvg, mockDecompress, FAKE_FONT_PATH } =
+  vi.hoisted(() => {
+    const mockRender = vi.fn();
+    return {
+      mockSatori: vi.fn(),
+      mockRender,
+      MockResvg: vi.fn().mockImplementation(() => ({ render: mockRender })),
+      mockDecompress: vi.fn(),
+      FAKE_FONT_PATH: "/__mocked__/inter-latin-400-normal.woff2",
+    };
+  });
 
 vi.mock("satori", () => ({ default: mockSatori }));
 vi.mock("@resvg/resvg-js", () => ({ Resvg: MockResvg }));
 vi.mock("sharp", () => ({ default: vi.fn() }));
+vi.mock("wawoff2", () => ({ default: { decompress: mockDecompress } }));
+
+// Intercept the @fontsource/inter require.resolve + readFileSync chain so the
+// loadFont code path runs without needing the npm package installed locally.
+vi.mock("node:module", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:module")>();
+  return {
+    ...actual,
+    createRequire: () => ({
+      resolve: (id: string) => {
+        if (id.includes("inter-latin-400-normal.woff2")) return FAKE_FONT_PATH;
+        throw new Error(`createRequire mock: unhandled id ${id}`);
+      },
+    }),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn((path: unknown, ...rest: unknown[]) => {
+      if (path === FAKE_FONT_PATH) {
+        // Fake WOFF2 bytes — wawoff2.decompress is mocked, so contents don't matter
+        return Buffer.from([0x77, 0x4f, 0x46, 0x32]);
+      }
+      // @ts-expect-error — pass through to the real implementation
+      return actual.readFileSync(path, ...rest);
+    }),
+  };
+});
 
 import { renderOgImage } from "../template/scripts/satori-og.js";
 import { OG_WIDTH, OG_HEIGHT, type OgColors } from "../template/scripts/og-templates.js";
@@ -25,6 +59,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockSatori.mockResolvedValue(fakeSvg);
   mockRender.mockReturnValue({ asPng: () => new Uint8Array(fakePng) });
+  mockDecompress.mockResolvedValue(new Uint8Array([0x00, 0x01, 0x00, 0x00]));
 });
 
 // ---------------------------------------------------------------------------
@@ -109,5 +144,47 @@ describe("renderOgImage", () => {
     expect(options.fonts).toBeDefined();
     expect(options.fonts.length).toBeGreaterThanOrEqual(1);
     expect(options.fonts[0].name).toBe("Inter");
+  });
+
+  it("decompresses WOFF2 to TTF when no fontData is provided", async () => {
+    // Hand satori the bundled font path — must go through wawoff2 so that the
+    // bytes it sees are TTF, never WOFF2. Regression guard for #305.
+    await renderOgImage({
+      title: "Bundled",
+      siteName: "Site",
+      colors,
+      template: "text-only",
+    });
+
+    expect(mockDecompress).toHaveBeenCalledTimes(1);
+    const [, options] = mockSatori.mock.calls[0];
+    // Decompressed TTF starts with 0x00010000 (TrueType magic)
+    expect(options.fonts[0].data[0]).toBe(0x00);
+    expect(options.fonts[0].data[1]).toBe(0x01);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadFont
+// ---------------------------------------------------------------------------
+
+describe("loadFont", () => {
+  it("returns TTF bytes after decompressing the bundled WOFF2", async () => {
+    // Reset so the module-level cache doesn't hide the decompress call when
+    // this test runs after renderOgImage tests that already warmed the cache.
+    vi.resetModules();
+    const fresh = await import("../template/scripts/satori-og.js");
+    const font = await fresh.loadFont();
+    expect(Buffer.isBuffer(font)).toBe(true);
+    expect(mockDecompress).toHaveBeenCalled();
+  });
+
+  it("caches the decompressed font across calls", async () => {
+    vi.resetModules();
+    mockDecompress.mockClear();
+    const fresh = await import("../template/scripts/satori-og.js");
+    await fresh.loadFont();
+    await fresh.loadFont();
+    expect(mockDecompress).toHaveBeenCalledTimes(1);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       satori: resolve(__dirname, "tests/__stubs__/satori.ts"),
       "@resvg/resvg-js": resolve(__dirname, "tests/__stubs__/resvg.ts"),
       sharp: resolve(__dirname, "tests/__stubs__/sharp.ts"),
+      wawoff2: resolve(__dirname, "tests/__stubs__/wawoff2.ts"),
     },
   },
   esbuild: {


### PR DESCRIPTION
## Summary

- Fixes #305: `npm run ai-og` and `npm run ai-images` were both crashing with `Unsupported OpenType signature wOF2`, leaving every page's `og:image` as a 404 in production.
- Root cause: Satori only accepts TTF, OTF, or WOFF — but `loadFont()` was handing it the `@fontsource/inter` WOFF2 file directly.
- Fix: pipe the WOFF2 bytes through `wawoff2` to produce TTF, cache the result. No binary font shipped in the repo.

## Changes

- `template/scripts/satori-og.ts` — `loadFont()` is now async, decompresses WOFF2 → TTF via `wawoff2`, caches the buffer.
- `template/scripts/generate-og-pages.ts` — optional font override now accepts `.ttf`/`.otf`/`.woff` at `scripts/fonts/Inter-Regular.*` (Satori-compatible formats only, not WOFF2).
- `template/package.json` — adds `wawoff2` as a devDependency.
- `tests/satori-og.test.ts` — adds regression coverage: renderOgImage without explicit `fontData` must round-trip through wawoff so Satori never sees WOFF2 bytes; loadFont caches across calls.
- `tests/__stubs__/wawoff2.ts` + `vitest.config.ts` — stub alias so tests pass without `template/node_modules` populated.

## Test plan

- [x] `npm test` (2347 passed, 12 skipped — no regressions)
- [ ] On a real Anglesite site: `npm run ai-og` produces PNGs under `public/images/og/` instead of crashing
- [ ] On a real Anglesite site: `npm run ai-images` produces both `apple-touch-icon.png` and `og-image.png`

https://claude.ai/code/session_01CFanvLuj4QDvuanBka2C5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFanvLuj4QDvuanBka2C5G)_