### PR TITLE
feat(server): apply_edit MCP tool schema + edit-pipeline message types (#296)

### DIFF
--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -1,0 +1,87 @@
+/**
+ * Zod schema for the `apply_edit` MCP tool — the wire format the Anglesite-app WKWebView edit
+ * overlay sends. Decided in Anglesite/Anglesite-app#18 (selector strategy = server-side
+ * resolution via this `ElementInfo` payload) and finalized here. Mirrors the `ElementInfo`
+ * typedef in `selector.mjs` so `buildSelector(info)` can consume the payload directly.
+ *
+ * Reconciled vs. the original #296 proposal:
+ *   - `selector: ElementInfo` (drops `element/tagName/textFingerprint/domPath`; matches
+ *     selector.mjs's existing typedef).
+ *   - `path` (drops `url`; the app already uses `path` on its side).
+ *   - `op` is the closed enum {replace-text, replace-attr, replace-image-src}.
+ *   - No `site` field — the MCP server already knows its `projectRoot`.
+ *   - `type` is accepted-and-ignored — the app uses it as a WKWebView-side boundary tag.
+ */
+import { z } from "zod";
+
+const ancestorInfoSchema = z.object({
+  tag: z.string(),
+  id: z.string().optional(),
+  classes: z.array(z.string()).optional(),
+  nthChild: z.number().int().optional(),
+  role: z.string().optional(),
+  ariaLabel: z.string().optional(),
+});
+
+export const elementInfoSchema = z.object({
+  tag: z.string(),
+  id: z.string().optional(),
+  classes: z.array(z.string()),
+  nthChild: z.number().int(),
+  ancestors: z.array(ancestorInfoSchema).optional(),
+  dataAnglesiteId: z.string().optional(),
+  dataTestId: z.string().optional(),
+  role: z.string().optional(),
+  ariaLabel: z.string().optional(),
+  textContent: z.string().optional(),
+});
+
+/** Edit operations the patcher knows how to apply. Phase 5's patcher (#295) implements these;
+ *  new ops require an explicit enum addition + a resolver update. */
+export const editOps = ["replace-text", "replace-attr", "replace-image-src"];
+
+/** The MCP tool's input shape, as passed to `server.tool(name, description, shape, handler)`. */
+export const applyEditInputShape = {
+  id: z
+    .string()
+    .describe("Correlation ID echoed back in edit-applied/edit-failed"),
+  type: z
+    .string()
+    .optional()
+    .describe(
+      "Boundary tag from the WKWebView side (e.g. 'anglesite:apply-edit') — accepted and ignored; the MCP tool name is authoritative",
+    ),
+  path: z
+    .string()
+    .describe("Page path where the edit happened, e.g. /about/"),
+  selector: elementInfoSchema.describe(
+    "Structured element metadata; resolved server-side via selector.mjs.buildSelector",
+  ),
+  op: z
+    .enum(editOps)
+    .describe(
+      "Edit operation: replace-text (innerText), replace-attr (op needs value to be {name, value}), replace-image-src (value is {filename, mimeType, dataURL})",
+    ),
+  value: z
+    .unknown()
+    .describe(
+      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src)",
+    ),
+};
+
+/** Build the MCP `content` entry for an edit-failed response. The handler wraps this in
+ *  `{content: [...], isError: true}`. */
+export function createEditFailedContent(id, reason, detail) {
+  const body = { type: "anglesite:edit-failed", id, reason };
+  if (detail !== undefined) body.detail = detail;
+  return { type: "text", text: JSON.stringify(body) };
+}
+
+/** Build the MCP `content` entry for an edit-applied response. `range` is `{start, end}` byte
+ *  offsets in `file`; `commit` is the SHA the patch was committed to on the hidden
+ *  `anglesite/edits` branch (added by #298). */
+export function createEditAppliedContent(id, file, range, commit) {
+  const body = { type: "anglesite:edit-applied", id, file, range };
+  if (commit !== undefined) body.commit = commit;
+  return { type: "text", text: JSON.stringify(body) };
+}

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -6,6 +6,10 @@ import {
   listAnnotations,
   resolveAnnotation,
 } from "./annotations.mjs";
+import {
+  applyEditInputShape,
+  createEditFailedContent,
+} from "./apply-edit-schema.mjs";
 
 const projectRoot = process.env.ANGLESITE_PROJECT_ROOT || process.cwd();
 
@@ -65,6 +69,24 @@ server.tool(
         isError: true,
       };
     }
+  },
+);
+
+// Phase 5 edit pipeline (#294). The schema is settled here; the patcher (#295), dispatcher
+// (#297), and edit-history (#298) land in follow-up PRs. Until then the handler stubs out
+// with `edit-failed: not-implemented`, which is enough for the app to exercise the wire
+// format end-to-end and surface the reply in the Debug pane.
+server.tool(
+  "apply_edit",
+  "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file.",
+  applyEditInputShape,
+  ({ id }) => {
+    return {
+      content: [
+        createEditFailedContent(id, "not-implemented", "Phase 5 patcher (Anglesite/anglesite#295) hasn't landed yet — schema-only stub."),
+      ],
+      isError: true,
+    };
   },
 );
 

--- a/server/messages.mjs
+++ b/server/messages.mjs
@@ -6,8 +6,26 @@ export const MESSAGE_TYPES = Object.freeze({
   ANNOTATIONS_RESPONSE: "anglesite:annotations-response",
   ANNOTATION_RESPONSE: "anglesite:annotation-response",
   ANNOTATION_RESOLVED: "anglesite:annotation-resolved",
+  // Edit pipeline (Phase 5). The active MCP surface is the `apply_edit` tool registered in
+  // `server/index.mjs`; these constants mirror that so consumers using `messages.mjs` see a
+  // complete catalog. `EDIT_APPLIED` / `EDIT_FAILED` describe the response payload that the
+  // tool's text content carries (JSON-encoded).
+  APPLY_EDIT: "anglesite:apply-edit",
+  EDIT_APPLIED: "anglesite:edit-applied",
+  EDIT_FAILED: "anglesite:edit-failed",
   ERROR: "anglesite:error",
 });
+
+/** Reasons an apply-edit can refuse. The patcher (#295) emits these as the first non-refusal
+ *  resolver's `reason`; the dispatcher (#297) routes them into `EDIT_FAILED` responses. */
+export const EDIT_FAILED_REASONS = Object.freeze([
+  "no-match",
+  "ambiguous",
+  "dynamic-expression",
+  "patch-conflict",
+  "write-failed",
+  "not-implemented",
+]);
 
 const KNOWN_TYPES = new Set(Object.values(MESSAGE_TYPES));
 
@@ -48,6 +66,19 @@ export function createErrorMessage(message) {
   return { type: MESSAGE_TYPES.ERROR, message };
 }
 
+/** Build an edit-applied response (server → client). `range` is `{start, end}` byte offsets in
+ *  `file`; `commit` is the SHA on the hidden `anglesite/edits` branch (#298). */
+export function createEditAppliedMessage(id, file, range, commit) {
+  return { type: MESSAGE_TYPES.EDIT_APPLIED, id, file, range, commit };
+}
+
+/** Build an edit-failed response (server → client). `reason` must be one of `EDIT_FAILED_REASONS`. */
+export function createEditFailedMessage(id, reason, detail) {
+  const msg = { type: MESSAGE_TYPES.EDIT_FAILED, id, reason };
+  if (detail !== undefined) msg.detail = detail;
+  return msg;
+}
+
 /** Required-field rules per message type. */
 const REQUIRED_FIELDS = Object.freeze({
   [MESSAGE_TYPES.ADD_ANNOTATION]: ["path", "selector", "text"],
@@ -56,6 +87,9 @@ const REQUIRED_FIELDS = Object.freeze({
   [MESSAGE_TYPES.ANNOTATIONS_RESPONSE]: ["annotations"],
   [MESSAGE_TYPES.ANNOTATION_RESPONSE]: ["annotation"],
   [MESSAGE_TYPES.ANNOTATION_RESOLVED]: ["id"],
+  [MESSAGE_TYPES.APPLY_EDIT]: ["id", "path", "selector", "op"],
+  [MESSAGE_TYPES.EDIT_APPLIED]: ["id", "file", "range"],
+  [MESSAGE_TYPES.EDIT_FAILED]: ["id", "reason"],
   [MESSAGE_TYPES.ERROR]: ["message"],
 });
 

--- a/test/apply-edit-schema.test.js
+++ b/test/apply-edit-schema.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  applyEditInputShape,
+  elementInfoSchema,
+  editOps,
+  createEditFailedContent,
+  createEditAppliedContent,
+} from "../server/apply-edit-schema.mjs";
+
+// `server.tool(name, description, shape, handler)` validates against `z.object(shape)` internally;
+// reconstruct the same composition here so we can drive the validator directly.
+const applyEditSchema = z.object(applyEditInputShape);
+
+const validSelector = {
+  tag: "P",
+  classes: [],
+  nthChild: 2,
+  ancestors: [
+    { tag: "BODY", nthChild: 2 },
+    { tag: "MAIN", nthChild: 1 },
+  ],
+};
+
+const validPayload = {
+  id: "e-1",
+  type: "anglesite:apply-edit",
+  path: "/about/",
+  selector: validSelector,
+  op: "replace-text",
+  value: "Hello, world.",
+};
+
+describe("applyEditInputShape", () => {
+  it("accepts the agreed-upon wire format", () => {
+    const result = applyEditSchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+  });
+
+  it("treats `type` as optional and accepts the namespaced WKWebView tag", () => {
+    const { type: _t, ...sansType } = validPayload;
+    expect(applyEditSchema.safeParse(sansType).success).toBe(true);
+    expect(
+      applyEditSchema.safeParse({ ...validPayload, type: "anything-the-app-sends" }).success,
+    ).toBe(true);
+  });
+
+  it("requires id, path, selector, and op", () => {
+    for (const field of ["id", "path", "selector", "op"]) {
+      const { [field]: _omitted, ...rest } = validPayload;
+      expect(
+        applyEditSchema.safeParse(rest).success,
+        `${field} should be required`,
+      ).toBe(false);
+    }
+  });
+
+  it("rejects op values outside the enum", () => {
+    expect(applyEditSchema.safeParse({ ...validPayload, op: "set-text" }).success).toBe(false);
+    expect(applyEditSchema.safeParse({ ...validPayload, op: "delete" }).success).toBe(false);
+  });
+
+  it("accepts every enum op", () => {
+    for (const op of editOps) {
+      expect(applyEditSchema.safeParse({ ...validPayload, op }).success).toBe(true);
+    }
+  });
+});
+
+describe("elementInfoSchema", () => {
+  it("requires tag, classes, and nthChild", () => {
+    expect(elementInfoSchema.safeParse(validSelector).success).toBe(true);
+    expect(elementInfoSchema.safeParse({ classes: [], nthChild: 1 }).success).toBe(false);
+    expect(elementInfoSchema.safeParse({ tag: "P", nthChild: 1 }).success).toBe(false);
+    expect(elementInfoSchema.safeParse({ tag: "P", classes: [] }).success).toBe(false);
+  });
+
+  it("accepts the optional id / data-* / role / aria-label / textContent fields", () => {
+    const richer = {
+      tag: "DIV",
+      id: "hero",
+      classes: ["card", "primary", "astro-abc123"],
+      nthChild: 1,
+      dataAnglesiteId: "home:hero",
+      dataTestId: "hero-card",
+      role: "region",
+      ariaLabel: "Hero section",
+      textContent: "Welcome to our shop",
+      ancestors: [],
+    };
+    expect(elementInfoSchema.safeParse(richer).success).toBe(true);
+  });
+
+  it("rejects nthChild that isn't an integer", () => {
+    expect(elementInfoSchema.safeParse({ ...validSelector, nthChild: 1.5 }).success).toBe(false);
+    expect(elementInfoSchema.safeParse({ ...validSelector, nthChild: "2" }).success).toBe(false);
+  });
+
+  it("rejects ancestor entries missing the required tag", () => {
+    const bad = { ...validSelector, ancestors: [{ nthChild: 1 }] };
+    expect(elementInfoSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe("createEditFailedContent", () => {
+  it("produces an MCP text content entry with type/id/reason in the JSON body", () => {
+    const content = createEditFailedContent("e-9", "no-match", "selector did not resolve");
+    expect(content.type).toBe("text");
+    const body = JSON.parse(content.text);
+    expect(body).toEqual({
+      type: "anglesite:edit-failed",
+      id: "e-9",
+      reason: "no-match",
+      detail: "selector did not resolve",
+    });
+  });
+
+  it("omits `detail` when not provided", () => {
+    const content = createEditFailedContent("e-9", "ambiguous");
+    const body = JSON.parse(content.text);
+    expect(body.detail).toBeUndefined();
+  });
+});
+
+describe("createEditAppliedContent", () => {
+  it("produces an MCP text content entry with file/range/commit in the JSON body", () => {
+    const content = createEditAppliedContent(
+      "e-1",
+      "src/pages/about.astro",
+      { start: 120, end: 145 },
+      "abc1234",
+    );
+    const body = JSON.parse(content.text);
+    expect(body).toEqual({
+      type: "anglesite:edit-applied",
+      id: "e-1",
+      file: "src/pages/about.astro",
+      range: { start: 120, end: 145 },
+      commit: "abc1234",
+    });
+  });
+
+  it("omits `commit` when not provided (edit-history hasn't landed yet)", () => {
+    const content = createEditAppliedContent("e-1", "src/pages/about.astro", { start: 0, end: 1 });
+    const body = JSON.parse(content.text);
+    expect(body.commit).toBeUndefined();
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -152,7 +152,7 @@ describe("MCP annotation server", () => {
     }
   });
 
-  it("lists three annotation tools", async () => {
+  it("lists the annotation tools plus the apply_edit edit-pipeline tool", async () => {
     const proc = startServer(tmpDir);
     try {
       await sendMessage(proc, {
@@ -180,6 +180,7 @@ describe("MCP annotation server", () => {
       const names = result.tools.map((t) => t.name).sort();
       expect(names).toEqual([
         "add_annotation",
+        "apply_edit",
         "list_annotations",
         "resolve_annotation",
       ]);


### PR DESCRIPTION
## Summary

Schema-only PR for Phase 5 (#294). Settles the wire format for the Anglesite-app edit pipeline so the patcher (#295), dispatcher (#297), edit-history (#298), and tests (#299) can land against a stable contract. The `apply_edit` MCP tool handler stubs out with `edit-failed: not-implemented` until #295 arrives.

## Why a separate spec PR

The original #296 proposal predated the cross-repo selector decision (Anglesite/Anglesite-app#18) and contradicted `selector.mjs`'s own `ElementInfo` typedef. Rather than baking a stale shape into the patcher, this PR reconciles the wire format first, on a small surface, with no behavior changes — making the follow-up PRs a straight read against the contract.

## Reconciled wire format

```js
// app → server (as `apply_edit` tool arguments)
{
  id: string,                    // correlation ID; echoed back
  type?: "anglesite:apply-edit", // boundary tag from WKWebView side; accepted-and-ignored
  path: string,                  // page path, e.g. "/about/"
  selector: ElementInfo,         // matches server/selector.mjs's typedef
  op: "replace-text" | "replace-attr" | "replace-image-src",
  value?: unknown,               // op-specific payload
}

// server → app (as MCP tool `content`, JSON-encoded)
{ type: "anglesite:edit-applied", id, file, range: {start, end}, commit? }
{ type: "anglesite:edit-failed",  id, reason, detail? }
```

Where `reason ∈ {no-match | ambiguous | dynamic-expression | patch-conflict | write-failed | not-implemented}`.

## Changes vs. #296's original proposal

| Field | Was proposed | Settled | Why |
|---|---|---|---|
| Element metadata | `element: {tagName, attributes, textFingerprint, domPath}` | `selector: ElementInfo` | The plugin's own `selector.mjs` already defines `ElementInfo` (`{tag, id?, classes, nthChild, ancestors, dataAnglesiteId?, dataTestId?, role?, ariaLabel?, textContent?}`). One source of truth for the selector strategy — no fork-prone duplicated JS in the overlay. |
| Page identifier | `url` | `path` | Matches what Anglesite-app already sends. |
| `op` | string union (proposed) | closed `z.enum` | Closed set at the boundary, extendable by an explicit enum change. New ops require a resolver update — that's the point. |
| `site` | string | _omitted_ | The MCP server already knows its `projectRoot` (`process.env.ANGLESITE_PROJECT_ROOT \|\| process.cwd()`). Adding a `site` channel would be redundant and easy to misuse. |
| `type` | required | optional, accepted-and-ignored | The app uses it as a WKWebView-side boundary tag (closed-set check before the bridge forwards anything). The MCP tool name (`apply_edit`) is authoritative server-side, so the field is informational only. |
| MCP tool name | not specified | `apply_edit` (snake_case, unnamespaced) | Matches `add_annotation` / `list_annotations` / `resolve_annotation` convention. |

## Files

- `server/apply-edit-schema.mjs` (new) — zod schemas (`elementInfoSchema`, `applyEditInputShape`, `editOps`) + `createEditFailedContent` / `createEditAppliedContent` helpers. New module so #295's patcher can import without circular deps.
- `server/index.mjs` — registers the `apply_edit` MCP tool. Stub handler returns `edit-failed: not-implemented` pointing at #295.
- `server/messages.mjs` — adds `APPLY_EDIT` / `EDIT_APPLIED` / `EDIT_FAILED` constants, `EDIT_FAILED_REASONS` frozen list, message builders, and required-field rules. (Kept the parallel `messages.mjs` channel consistent even though the active surface is the MCP tool.)
- `test/apply-edit-schema.test.js` (new) — 13 tests: zod acceptance/rejection of the agreed shape, every op enum value, optional-field handling, `edit-applied` / `edit-failed` content helpers.
- `tests/mcp-server.test.ts` — `tools/list` now expects 4 entries (was 3), with `apply_edit` between `add_annotation` and `list_annotations`.

## Test plan

- [x] `npx vitest run test/apply-edit-schema.test.js` — 13/13 pass
- [x] `npx vitest run tests/mcp-server.test.ts` — 5/5 pass (4-tool listing)
- [x] Full suite: 2369/2369 pass
- [x] `node --check` on all three server modules
- [x] `node -e "import('./server/apply-edit-schema.mjs').then(...)"` — exports load cleanly

## Follow-up PRs (this repo)

- #295 — `server/patcher.mjs` (the meat: three resolvers `.mdoc` → Keystatic → `.astro`)
- #297 — wire the `apply_edit` handler in `server/index.mjs` to dispatch through the patcher
- #298 — `server/edit-history.mjs` (hidden `anglesite/edits` branch for undo)
- #299 — `test/patcher.test.js` (per-resolver coverage + ambiguous-match refusal)

## Paired app-side PR

Once this merges and a plugin release ships, the Anglesite-app side needs:

- Overlay `op` literals: `set-text` → `replace-text`, `set-image` → `replace-image-src`
- `MCPApplyEditRouter` tool name: `"anglesite:apply-edit"` → `"apply_edit"`
- Bundled-plugin pointer bump

Tracking: Anglesite/Anglesite-app#19.
