### PR TITLE
feat(server): add patcher.mjs with three source-file resolvers (#295)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 │   ├── annotations.mjs           Annotation store (CRUD + persistence)
 │   ├── selector.mjs              CSS selector generation from element metadata
 │   ├── messages.mjs              WebSocket message schema (overlay ↔ server)
+│   ├── apply-edit-schema.mjs     Zod schema for apply_edit MCP tool
+│   ├── patcher.mjs               Source-file resolver (mdoc → Keystatic → .astro)
 │   └── index.mjs                 MCP stdio server entry point
 ├── bin/
 │   ├── average-tokens.ts         Token cost calculator for start skill

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -1,0 +1,526 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, extname, basename, dirname } from "node:path";
+
+/**
+ * @typedef {import('./apply-edit-schema.mjs').default} _unused
+ * @typedef {{ file: string, range: { start: number, end: number }, replacement: string }} ResolveResult
+ * @typedef {{ refused: true, reason: string, detail?: string }} ResolveRefusal
+ */
+
+/**
+ * Resolve an edit payload to a source-file patch.
+ *
+ * Tries resolvers in priority order: .mdoc → Keystatic YAML/JSON → .astro.
+ * Returns the first non-refusal. If all refuse, returns the most informative
+ * refusal (from the highest-priority resolver that had an opinion).
+ *
+ * @param {string} projectRoot
+ * @param {{ path: string, selector: object, op: string, value?: unknown }} edit
+ * @returns {ResolveResult | ResolveRefusal}
+ */
+export function resolve(projectRoot, edit) {
+  const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];
+  let bestRefusal = /** @type {ResolveRefusal | null} */ (null);
+
+  for (const resolver of resolvers) {
+    const result = resolver(projectRoot, edit);
+    if (!result.refused) return result;
+    if (!bestRefusal || refusalPriority(result.reason) > refusalPriority(bestRefusal.reason)) {
+      bestRefusal = result;
+    }
+  }
+
+  return bestRefusal || refuse("no-match", "no resolver found candidate files");
+}
+
+const REASON_PRIORITY = {
+  "dynamic-expression": 4,
+  "ambiguous": 3,
+  "patch-conflict": 2,
+  "no-match": 1,
+  "not-implemented": 0,
+  "write-failed": 0,
+};
+
+function refusalPriority(reason) {
+  return REASON_PRIORITY[reason] ?? 0;
+}
+
+/** Build a refusal object. */
+function refuse(reason, detail) {
+  const r = { refused: true, reason };
+  if (detail !== undefined) r.detail = detail;
+  return r;
+}
+
+// ── Shared helpers ────────────────────────────────────────────────
+
+/**
+ * Recursively collect files matching `predicate` under `dir`.
+ * Skips node_modules, .git, dist, .astro.
+ */
+function walkFiles(dir, predicate) {
+  const results = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    if (["node_modules", ".git", "dist", ".astro"].includes(entry.name)) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkFiles(full, predicate));
+    } else if (predicate(entry.name)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Find all occurrences of `needle` in `haystack`, returning byte-offset ranges.
+ * Returns [] if not found.
+ */
+function findAllOccurrences(haystack, needle) {
+  if (!needle || needle.length === 0) return [];
+  const matches = [];
+  let idx = 0;
+  while ((idx = haystack.indexOf(needle, idx)) !== -1) {
+    matches.push({ start: idx, end: idx + needle.length });
+    idx += 1;
+  }
+  return matches;
+}
+
+/**
+ * Normalize text for fuzzy matching: collapse whitespace and trim.
+ */
+function normalizeText(text) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Derive the replacement string for a given op + value + matched source text.
+ */
+function buildReplacement(op, value, _matchedSource) {
+  if (op === "replace-text") {
+    return typeof value === "string" ? value : String(value ?? "");
+  }
+  if (op === "replace-attr" && value && typeof value === "object") {
+    return value.value != null ? String(value.value) : "";
+  }
+  if (op === "replace-image-src" && value && typeof value === "object") {
+    return value.filename || "";
+  }
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Map a page path to candidate .astro files in src/pages/.
+ * /about/ → [src/pages/about.astro, src/pages/about/index.astro]
+ */
+function pathToAstroCandidates(projectRoot, pagePath) {
+  const normalized = pagePath.replace(/^\/|\/$/g, "") || "index";
+  const pagesDir = join(projectRoot, "src", "pages");
+  const candidates = [];
+
+  if (normalized === "index") {
+    candidates.push(join(pagesDir, "index.astro"));
+  } else {
+    candidates.push(join(pagesDir, `${normalized}.astro`));
+    candidates.push(join(pagesDir, normalized, "index.astro"));
+  }
+
+  return candidates.filter((f) => {
+    try {
+      return statSync(f).isFile();
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Extract the slug from a page path by stripping any collection prefix.
+ * /blog/my-post/ → my-post
+ * /about/ → about
+ */
+function extractSlug(pagePath) {
+  const segments = pagePath.replace(/^\/|\/$/g, "").split("/");
+  return segments[segments.length - 1] || "";
+}
+
+// ── .mdoc resolver ────────────────────────────────────────────────
+
+function resolveMdoc(projectRoot, edit) {
+  const { path: pagePath, selector, op, value } = edit;
+  const contentDir = join(projectRoot, "src", "content");
+  const mdocFiles = walkFiles(contentDir, (name) => extname(name) === ".mdoc");
+
+  if (mdocFiles.length === 0) {
+    return refuse("no-match", "no .mdoc files found");
+  }
+
+  const textContent = selector.textContent;
+  if (!textContent && op === "replace-text") {
+    return refuse("no-match", "no textContent in selector for replace-text");
+  }
+
+  const slug = extractSlug(pagePath);
+  const needle = op === "replace-text" ? textContent : getAttrSearchValue(op, selector, value);
+  if (!needle) {
+    return refuse("no-match", "nothing to search for in .mdoc files");
+  }
+
+  const normalizedNeedle = normalizeText(needle);
+  const allMatches = [];
+
+  for (const file of mdocFiles) {
+    const fileSlug = basename(dirname(file)) === basename(file, ".mdoc")
+      ? basename(dirname(file))
+      : basename(file, ".mdoc");
+
+    if (slug && fileSlug !== slug && fileSlug !== "index") {
+      const parentDir = basename(dirname(file));
+      if (parentDir !== slug) continue;
+    }
+
+    let source;
+    try {
+      source = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const bodyStart = findFrontmatterEnd(source);
+
+    if (op === "replace-text") {
+      const occurrences = findTextInMdoc(source, normalizedNeedle, bodyStart);
+      for (const range of occurrences) {
+        allMatches.push({ file: relative(projectRoot, file), range });
+      }
+    }
+  }
+
+  if (allMatches.length === 0) {
+    return refuse("no-match", "textContent not found in any .mdoc file");
+  }
+  if (allMatches.length > 1) {
+    return refuse("ambiguous", `${allMatches.length} matches in .mdoc files: ${allMatches.map((m) => m.file).join(", ")}`);
+  }
+
+  return {
+    file: allMatches[0].file,
+    range: allMatches[0].range,
+    replacement: buildReplacement(op, value),
+  };
+}
+
+/**
+ * Find the byte offset where frontmatter ends (after the closing ---).
+ * Returns 0 if no frontmatter.
+ */
+function findFrontmatterEnd(source) {
+  if (!source.startsWith("---")) return 0;
+  const closeIdx = source.indexOf("\n---", 3);
+  if (closeIdx === -1) return 0;
+  const afterClose = source.indexOf("\n", closeIdx + 4);
+  return afterClose === -1 ? closeIdx + 4 : afterClose + 1;
+}
+
+/**
+ * Find exact occurrences of normalized text in the body of a .mdoc file.
+ * Handles the fact that .mdoc text may have different whitespace than rendered HTML.
+ */
+function findTextInMdoc(source, normalizedNeedle, bodyStart) {
+  const body = source.slice(bodyStart);
+  const matches = [];
+
+  // Try exact match first
+  const exactMatches = findAllOccurrences(body, normalizedNeedle);
+  if (exactMatches.length > 0) {
+    return exactMatches.map((m) => ({
+      start: bodyStart + m.start,
+      end: bodyStart + m.end,
+    }));
+  }
+
+  // Try normalized match: collapse whitespace in source and find spans
+  const normalizedBody = normalizeText(body);
+  const normalizedMatches = findAllOccurrences(normalizedBody, normalizedNeedle);
+  if (normalizedMatches.length === 0) return matches;
+
+  // Map normalized positions back to original source positions
+  for (const nm of normalizedMatches) {
+    const range = mapNormalizedRangeToSource(body, normalizedNeedle, nm.start);
+    if (range) {
+      matches.push({ start: bodyStart + range.start, end: bodyStart + range.end });
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Given a normalized-space position, map back to the original source range.
+ * Walks the original string tracking how many non-collapsed characters we've seen.
+ */
+function mapNormalizedRangeToSource(original, needle, normalizedStart) {
+  let normalizedIdx = 0;
+  let sourceStart = -1;
+  let inWhitespace = false;
+  const trimmedStart = original.length - original.trimStart().length;
+
+  for (let i = trimmedStart; i < original.length && normalizedIdx <= normalizedStart + needle.length; i++) {
+    const ch = original[i];
+    const isWs = /\s/.test(ch);
+
+    if (isWs) {
+      if (!inWhitespace) {
+        if (normalizedIdx === normalizedStart) sourceStart = i;
+        normalizedIdx++; // collapsed space
+        inWhitespace = true;
+      }
+    } else {
+      if (normalizedIdx === normalizedStart) sourceStart = i;
+      normalizedIdx++;
+      inWhitespace = false;
+    }
+
+    if (normalizedIdx === normalizedStart + needle.length && sourceStart !== -1) {
+      return { start: sourceStart, end: i + 1 };
+    }
+  }
+
+  return null;
+}
+
+// ── Keystatic resolver ────────────────────────────────────────────
+
+function resolveKeystatic(projectRoot, edit) {
+  const { path: pagePath, selector, op, value } = edit;
+  const contentDir = join(projectRoot, "src", "content");
+
+  const dataFiles = walkFiles(contentDir, (name) => {
+    const ext = extname(name);
+    return ext === ".yaml" || ext === ".yml" || ext === ".json";
+  });
+
+  if (dataFiles.length === 0) {
+    return refuse("no-match", "no YAML/JSON content files found");
+  }
+
+  const textContent = selector.textContent;
+  const needle = op === "replace-text" ? textContent : getAttrSearchValue(op, selector, value);
+  if (!needle) {
+    return refuse("no-match", "nothing to search for in Keystatic data files");
+  }
+
+  const slug = extractSlug(pagePath);
+  const allMatches = [];
+
+  for (const file of dataFiles) {
+    const fileSlug = basename(file, extname(file));
+    if (slug && fileSlug !== slug && fileSlug !== "index") {
+      const parentDir = basename(dirname(file));
+      if (parentDir !== slug) continue;
+    }
+
+    let source;
+    try {
+      source = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const occurrences = findValueInDataFile(source, needle, extname(file));
+    for (const range of occurrences) {
+      allMatches.push({ file: relative(projectRoot, file), range });
+    }
+  }
+
+  if (allMatches.length === 0) {
+    return refuse("no-match", "value not found in Keystatic data files");
+  }
+  if (allMatches.length > 1) {
+    return refuse("ambiguous", `${allMatches.length} matches in Keystatic data files`);
+  }
+
+  return {
+    file: allMatches[0].file,
+    range: allMatches[0].range,
+    replacement: buildReplacement(op, value),
+  };
+}
+
+/**
+ * Find occurrences of a value in a YAML or JSON data file.
+ * For YAML, searches for lines like `key: "value"` or `key: value`.
+ * For JSON, searches for `"key": "value"`.
+ */
+function findValueInDataFile(source, needle, ext) {
+  if (ext === ".json") {
+    return findAllOccurrences(source, needle);
+  }
+  // YAML: search for the value as a string (possibly quoted)
+  const matches = [];
+  const quoted = findAllOccurrences(source, `"${needle}"`);
+  for (const q of quoted) {
+    // Include only the inner value, not the quotes
+    matches.push({ start: q.start + 1, end: q.end - 1 });
+  }
+  const singleQuoted = findAllOccurrences(source, `'${needle}'`);
+  for (const q of singleQuoted) {
+    matches.push({ start: q.start + 1, end: q.end - 1 });
+  }
+  if (matches.length === 0) {
+    return findAllOccurrences(source, needle);
+  }
+  return matches;
+}
+
+// ── .astro resolver ───────────────────────────────────────────────
+
+function resolveAstro(projectRoot, edit) {
+  const { path: pagePath, selector, op, value } = edit;
+  const candidates = pathToAstroCandidates(projectRoot, pagePath);
+
+  if (candidates.length === 0) {
+    return refuse("no-match", `no .astro file found for path ${pagePath}`);
+  }
+
+  const textContent = selector.textContent;
+  const needle = op === "replace-text" ? textContent : getAttrSearchValue(op, selector, value);
+  if (!needle) {
+    return refuse("no-match", "nothing to search for in .astro files");
+  }
+
+  const allMatches = [];
+
+  for (const file of candidates) {
+    let source;
+    try {
+      source = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const templateStart = findAstroTemplateStart(source);
+    const template = source.slice(templateStart);
+
+    const occurrences = findTextInAstroTemplate(source, needle, templateStart, selector);
+    if (occurrences.length === 0 && hasDynamicExpressionEvidence(template, needle, selector)) {
+      return refuse("dynamic-expression", `"${truncate(needle, 40)}" is rendered via a dynamic expression in ${relative(projectRoot, file)}`);
+    }
+    for (const range of occurrences) {
+      allMatches.push({ file: relative(projectRoot, file), range });
+    }
+  }
+
+  if (allMatches.length === 0) {
+    return refuse("no-match", `textContent not found as static text in .astro template`);
+  }
+  if (allMatches.length > 1) {
+    return refuse("ambiguous", `${allMatches.length} matches in .astro files`);
+  }
+
+  return {
+    file: allMatches[0].file,
+    range: allMatches[0].range,
+    replacement: buildReplacement(op, value),
+  };
+}
+
+/**
+ * Find the start of the Astro template (after the closing --- of frontmatter).
+ * Returns 0 if no frontmatter.
+ */
+function findAstroTemplateStart(source) {
+  return findFrontmatterEnd(source);
+}
+
+/**
+ * Check if there's positive evidence that the needle text is rendered via a
+ * dynamic expression in the template. Only returns true when the template
+ * contains `{...}` interpolation inside a tag context matching the selector.
+ * Returns false when the text simply doesn't exist (that's a no-match, not
+ * a dynamic-expression).
+ */
+function hasDynamicExpressionEvidence(template, needle, selector) {
+  const tag = selector.tag?.toLowerCase();
+  if (!tag) return false;
+
+  const tagBlockRe = new RegExp(
+    `<${tag}[^>]*>([\\s\\S]*?)</${tag}>`,
+    "gi",
+  );
+  let m;
+  while ((m = tagBlockRe.exec(template)) !== null) {
+    const innerContent = m[1];
+    if (/\{[^}]+\}/.test(innerContent)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Find occurrences of text in the Astro template section.
+ * Uses the selector's tag to narrow down matches when possible.
+ */
+function findTextInAstroTemplate(source, needle, templateStart, selector) {
+  const template = source.slice(templateStart);
+  const tag = selector.tag?.toLowerCase();
+
+  // Try exact match in the template
+  let matches = findAllOccurrences(template, needle);
+
+  if (matches.length === 0) {
+    // Try with normalized whitespace
+    const normalizedNeedle = normalizeText(needle);
+    const exactTrimmed = findAllOccurrences(template, normalizedNeedle);
+    matches = exactTrimmed;
+  }
+
+  if (matches.length === 0) return [];
+
+  // If we have the tag context, try to narrow to matches inside that tag
+  if (tag && matches.length > 1) {
+    const tagFiltered = matches.filter((m) => {
+      const before = template.slice(Math.max(0, m.start - 200), m.start);
+      const openTagRe = new RegExp(`<${tag}[^>]*>\\s*$`, "i");
+      return openTagRe.test(before);
+    });
+    if (tagFiltered.length > 0) {
+      matches = tagFiltered;
+    }
+  }
+
+  return matches.map((m) => ({
+    start: templateStart + m.start,
+    end: templateStart + m.end,
+  }));
+}
+
+/**
+ * For non-replace-text ops, extract the search value from the selector/value.
+ */
+function getAttrSearchValue(op, selector, value) {
+  if (op === "replace-attr" && value && typeof value === "object") {
+    // We don't know the current attribute value from the edit payload alone;
+    // the selector's textContent or other metadata is the best hint.
+    return selector.textContent || null;
+  }
+  if (op === "replace-image-src") {
+    return selector.textContent || null;
+  }
+  return null;
+}
+
+function truncate(str, maxLen) {
+  if (!str || str.length <= maxLen) return str;
+  return str.slice(0, maxLen) + "…";
+}

--- a/test/fixtures/patcher/src/content/posts/duplicate-text/index.mdoc
+++ b/test/fixtures/patcher/src/content/posts/duplicate-text/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Duplicate Text Post
+description: A post that has text appearing twice
+publishDate: "2026-02-01"
+---
+
+Welcome to our bakery! We bake fresh bread every morning.
+
+Welcome to our bakery! We bake fresh bread every morning.

--- a/test/fixtures/patcher/src/content/posts/hello-world/index.mdoc
+++ b/test/fixtures/patcher/src/content/posts/hello-world/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Hello World
+description: Our very first blog post
+publishDate: "2026-01-15"
+---
+
+Welcome to our new website! We are excited to share our journey with you.
+
+This is the second paragraph with some **bold text** and a [link](https://example.com).

--- a/test/fixtures/patcher/src/content/site/settings.yaml
+++ b/test/fixtures/patcher/src/content/site/settings.yaml
@@ -1,0 +1,4 @@
+name: "Sunrise Bakery"
+tagline: "Fresh bread since 1985"
+phone: "555-0123"
+address: "123 Main Street, Springfield"

--- a/test/fixtures/patcher/src/pages/about.astro
+++ b/test/fixtures/patcher/src/pages/about.astro
@@ -1,0 +1,10 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+const teamSize = 12;
+---
+
+<BaseLayout title="About Us">
+  <h1>About Our Company</h1>
+  <p>We have been serving the community since 2010.</p>
+  <p>Our team of {teamSize} experts is here to help you.</p>
+</BaseLayout>

--- a/test/fixtures/patcher/src/pages/about/index.astro
+++ b/test/fixtures/patcher/src/pages/about/index.astro
@@ -1,0 +1,8 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="About (index)">
+  <h1>About Our Team</h1>
+  <p>We are a small team of dedicated professionals.</p>
+</BaseLayout>

--- a/test/fixtures/patcher/src/pages/blog/[slug].astro
+++ b/test/fixtures/patcher/src/pages/blog/[slug].astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+const { post } = Astro.props;
+---
+
+<BaseLayout title={post.data.title}>
+  <article>
+    <h1>{post.data.title}</h1>
+    <Content />
+  </article>
+</BaseLayout>

--- a/test/fixtures/patcher/src/pages/index.astro
+++ b/test/fixtures/patcher/src/pages/index.astro
@@ -1,0 +1,9 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Home">
+  <h1>Welcome to Our Shop</h1>
+  <p>We sell the finest goods in town. Come visit us today!</p>
+  <p>Open Monday through Friday, 9am to 5pm.</p>
+</BaseLayout>

--- a/test/patcher.test.js
+++ b/test/patcher.test.js
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "../server/patcher.mjs";
+import { resolve as resolvePath } from "node:path";
+import { readFileSync } from "node:fs";
+
+const FIXTURE_ROOT = resolvePath(import.meta.dirname, "fixtures/patcher");
+
+function makeSelector(overrides = {}) {
+  return {
+    tag: "P",
+    classes: [],
+    nthChild: 1,
+    ...overrides,
+  };
+}
+
+function makeEdit(overrides = {}) {
+  return {
+    path: "/",
+    selector: makeSelector(),
+    op: "replace-text",
+    value: "New text",
+    ...overrides,
+  };
+}
+
+// ── .mdoc resolver ────────────────────────────────────────────────
+
+describe("mdoc resolver", () => {
+  it("unique match → returns correct {file, range, replacement}", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/blog/hello-world/",
+      selector: makeSelector({ textContent: "Welcome to our new website! We are excited to share our journey with you." }),
+      value: "Welcome to our redesigned website!",
+    }));
+    expect(result.refused).toBeUndefined();
+    expect(result.file).toBe("src/content/posts/hello-world/index.mdoc");
+    expect(result.replacement).toBe("Welcome to our redesigned website!");
+
+    const source = readFileSync(resolvePath(FIXTURE_ROOT, result.file), "utf-8");
+    const matched = source.slice(result.range.start, result.range.end);
+    expect(matched).toBe("Welcome to our new website! We are excited to share our journey with you.");
+  });
+
+  it("no match → refuses with reason: no-match", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/blog/hello-world/",
+      selector: makeSelector({ textContent: "This text does not exist anywhere" }),
+    }));
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+
+  it("multiple matches → refuses with reason: ambiguous", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/blog/duplicate-text/",
+      selector: makeSelector({ textContent: "Welcome to our bakery! We bake fresh bread every morning." }),
+    }));
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("ambiguous");
+  });
+
+  it("finds text in the body, not in the frontmatter", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/blog/hello-world/",
+      selector: makeSelector({ textContent: "This is the second paragraph with some bold text and a link." }),
+      value: "Updated second paragraph.",
+    }));
+    // The .mdoc has markdown formatting (**bold text** and [link](url))
+    // so an exact match of the rendered text won't be found — this should refuse
+    expect(result.refused).toBe(true);
+  });
+});
+
+// ── Keystatic (YAML/JSON) resolver ────────────────────────────────
+
+describe("keystatic resolver", () => {
+  it("unique match in YAML → returns correct {file, range, replacement}", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/",
+      selector: makeSelector({ textContent: "Fresh bread since 1985" }),
+      value: "Fresh bread since 1980",
+    }));
+    // The mdoc resolver won't match (no mdoc has this text).
+    // The keystatic resolver should find it in the YAML.
+    if (!result.refused) {
+      expect(result.file).toBe("src/content/site/settings.yaml");
+      expect(result.replacement).toBe("Fresh bread since 1980");
+      const source = readFileSync(resolvePath(FIXTURE_ROOT, result.file), "utf-8");
+      const matched = source.slice(result.range.start, result.range.end);
+      expect(matched).toBe("Fresh bread since 1985");
+    }
+  });
+
+  it("no match in data files → falls through to astro resolver", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/",
+      selector: makeSelector({ textContent: "We sell the finest goods in town. Come visit us today!" }),
+      value: "Updated shop description",
+    }));
+    // Should fall through to the astro resolver and match in index.astro
+    expect(result.refused).toBeUndefined();
+    expect(result.file).toBe("src/pages/index.astro");
+  });
+});
+
+// ── .astro resolver ───────────────────────────────────────────────
+
+describe("astro resolver", () => {
+  it("unique match → returns correct {file, range, replacement}", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/",
+      selector: makeSelector({ tag: "H1", textContent: "Welcome to Our Shop" }),
+      value: "Welcome to Our New Shop",
+    }));
+    expect(result.refused).toBeUndefined();
+    expect(result.file).toBe("src/pages/index.astro");
+    expect(result.replacement).toBe("Welcome to Our New Shop");
+
+    const source = readFileSync(resolvePath(FIXTURE_ROOT, result.file), "utf-8");
+    const matched = source.slice(result.range.start, result.range.end);
+    expect(matched).toBe("Welcome to Our Shop");
+  });
+
+  it("no match → refuses with reason: no-match", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/",
+      selector: makeSelector({ textContent: "This sentence does not appear anywhere in the project" }),
+    }));
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("no-match");
+  });
+
+  it("dynamic expression → refuses with reason: dynamic-expression", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/about/",
+      // "12" rendered by {teamSize} in about.astro — not static text
+      selector: makeSelector({ textContent: "Our team of 12 experts is here to help you." }),
+      value: "Our team of 15 experts is here to help you.",
+    }));
+    // The text "Our team of 12 experts..." doesn't appear literally in the source
+    // (the source has {teamSize}), so the astro resolver should flag it
+    expect(result.refused).toBe(true);
+    expect(result.reason).toBe("dynamic-expression");
+  });
+
+  it("resolves static text from index.astro for / path", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/",
+      selector: makeSelector({ tag: "P", textContent: "Open Monday through Friday, 9am to 5pm." }),
+      value: "Open every day, 8am to 6pm.",
+    }));
+    expect(result.refused).toBeUndefined();
+    expect(result.file).toBe("src/pages/index.astro");
+    expect(result.replacement).toBe("Open every day, 8am to 6pm.");
+  });
+});
+
+// ── Cross-resolver priority ───────────────────────────────────────
+
+describe("cross-resolver priority", () => {
+  it("mdoc wins over astro when both could match", () => {
+    // The mdoc fixture has "Welcome to our new website!" which a greedy astro
+    // resolver might also match if there were an astro file with the same text.
+    // By design, mdoc is tried first.
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/blog/hello-world/",
+      selector: makeSelector({ textContent: "Welcome to our new website! We are excited to share our journey with you." }),
+      value: "Updated content",
+    }));
+    if (!result.refused) {
+      expect(result.file).toContain(".mdoc");
+    }
+  });
+
+  it("all three refuse → returns the most informative reason", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/nonexistent/",
+      selector: makeSelector({ textContent: "Text that does not exist in any file" }),
+    }));
+    expect(result.refused).toBe(true);
+    // Should get the most informative refusal, not just the last one
+    expect(["no-match", "ambiguous", "dynamic-expression"]).toContain(result.reason);
+  });
+});
+
+// ── Resolver contract ─────────────────────────────────────────────
+
+describe("resolver contract", () => {
+  it("successful resolve returns file, range, and replacement", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/",
+      selector: makeSelector({ tag: "H1", textContent: "Welcome to Our Shop" }),
+      value: "Updated Title",
+    }));
+    expect(result).toHaveProperty("file");
+    expect(result).toHaveProperty("range");
+    expect(result).toHaveProperty("replacement");
+    expect(result.range).toHaveProperty("start");
+    expect(result.range).toHaveProperty("end");
+    expect(typeof result.range.start).toBe("number");
+    expect(typeof result.range.end).toBe("number");
+    expect(result.range.start).toBeLessThan(result.range.end);
+  });
+
+  it("refusal returns refused: true and a reason string", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/",
+      selector: makeSelector({ textContent: "No such text" }),
+    }));
+    expect(result.refused).toBe(true);
+    expect(typeof result.reason).toBe("string");
+  });
+
+  it("range bytes correctly slice the original file", () => {
+    const result = resolve(FIXTURE_ROOT, makeEdit({
+      path: "/",
+      selector: makeSelector({ tag: "P", textContent: "Open Monday through Friday, 9am to 5pm." }),
+      value: "Replacement",
+    }));
+    expect(result.refused).toBeUndefined();
+    const source = readFileSync(resolvePath(FIXTURE_ROOT, result.file), "utf-8");
+    const sliced = source.slice(result.range.start, result.range.end);
+    expect(sliced).toBe("Open Monday through Friday, 9am to 5pm.");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `server/patcher.mjs` with three resolvers in priority order: `.mdoc` → Keystatic YAML/JSON → `.astro` static text
- Each resolver returns `{file, range, replacement}` on a unique match or `{refused: true, reason}` on failure
- Covers all refusal reasons: `no-match`, `ambiguous`, `dynamic-expression`
- Includes 15 tests across all three resolvers plus cross-resolver priority and contract validation
- Adds minimal site fixtures in `test/fixtures/patcher/` (no filesystem mocking)

**Tracking:** #294
**Closes:** #295

## Test plan
- [x] All 15 patcher tests pass (`npx vitest run test/patcher.test.js`)
- [x] Full test suite passes (95 files, 2387 tests)
- [ ] Verify resolver priority: `.mdoc` wins over `.astro` when both could match
- [ ] Verify `dynamic-expression` detection for `{variable}` interpolation in `.astro`
- [ ] Verify `ambiguous` refusal when text appears multiple times in `.mdoc`
- [ ] Verify correct byte-range slicing against original source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)