### PR TITLE
feat(server): wire apply_edit handler to patcher via dispatcher (#297)

### DIFF
--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -1,0 +1,98 @@
+/**
+ * Edit-pipeline dispatcher — the bridge between the `apply_edit` MCP tool and `patcher.mjs`.
+ *
+ * Flow:
+ *   1. `resolve(projectRoot, edit)` (patcher.mjs) returns either `{file, range, replacement}`
+ *      or `{refused: true, reason, detail?}`.
+ *   2. On refusal: forward as an `edit-failed` MCP response.
+ *   3. On success: read the source, splice in the replacement, atomically write back (write to
+ *      a sibling temp file then `rename`), invoke an optional `onApplied` hook so #298's
+ *      `edit-history.mjs` can commit to the hidden `anglesite/edits` branch and thread its SHA
+ *      back as `commit`, then return `edit-applied`.
+ *   4. On any filesystem error: return `edit-failed` with reason `write-failed`.
+ *
+ * The handler stays a pure async function so it's unit-testable independent of the MCP
+ * `server.tool` plumbing; `server/index.mjs` is a one-line wire.
+ */
+import { readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
+import { randomBytes } from "node:crypto";
+import { resolve as resolveEdit } from "./patcher.mjs";
+import {
+  createEditAppliedContent,
+  createEditFailedContent,
+} from "./apply-edit-schema.mjs";
+
+function failed(id, reason, detail) {
+  return { content: [createEditFailedContent(id, reason, detail)], isError: true };
+}
+
+function applied(id, file, range, commit) {
+  return { content: [createEditAppliedContent(id, file, range, commit)] };
+}
+
+/** Splice `replacement` into `source` at the resolved byte range. */
+function spliceSource(source, range, replacement) {
+  return source.slice(0, range.start) + replacement + source.slice(range.end);
+}
+
+/** Atomic write via temp-sibling + rename, so a crashed mid-write can't truncate the source. */
+function atomicWrite(absPath, content) {
+  const tmp = join(
+    dirname(absPath),
+    "." + basename(absPath) + ".anglesite-edit-" + randomBytes(4).toString("hex"),
+  );
+  try {
+    writeFileSync(tmp, content, "utf-8");
+    renameSync(tmp, absPath);
+  } catch (err) {
+    try { unlinkSync(tmp); } catch {} // best-effort cleanup
+    throw err;
+  }
+}
+
+/**
+ * Apply an edit. Returns an MCP tool response (`{content, isError?}`) whose first content entry
+ * is the JSON-encoded `edit-applied` / `edit-failed` body.
+ *
+ * @param {string} projectRoot
+ * @param {object} edit  payload from the `apply_edit` tool (already zod-validated)
+ * @param {{ onApplied?: (info: {file:string, range:{start:number,end:number}, projectRoot:string}) => Promise<string|undefined> | string | undefined }} [opts]
+ */
+export async function applyEdit(projectRoot, edit, opts = {}) {
+  const resolution = resolveEdit(projectRoot, edit);
+  if (resolution.refused) {
+    return failed(edit.id, resolution.reason, resolution.detail);
+  }
+
+  const { file, range, replacement } = resolution;
+  const absPath = join(projectRoot, file);
+
+  let source;
+  try {
+    source = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    return failed(edit.id, "write-failed", `read ${file}: ${err.message}`);
+  }
+
+  const next = spliceSource(source, range, replacement);
+
+  try {
+    atomicWrite(absPath, next);
+  } catch (err) {
+    return failed(edit.id, "write-failed", `${file}: ${err.message}`);
+  }
+
+  let commit;
+  if (opts.onApplied) {
+    try {
+      commit = await opts.onApplied({ file, range, projectRoot });
+    } catch (err) {
+      // Patch landed on disk but history-keeping failed. Surface as a successful apply with no
+      // commit SHA — the user-visible source change is real; #298 can decide its own policy.
+      commit = undefined;
+    }
+  }
+
+  return applied(edit.id, file, range, commit);
+}

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -6,10 +6,8 @@ import {
   listAnnotations,
   resolveAnnotation,
 } from "./annotations.mjs";
-import {
-  applyEditInputShape,
-  createEditFailedContent,
-} from "./apply-edit-schema.mjs";
+import { applyEditInputShape } from "./apply-edit-schema.mjs";
+import { applyEdit } from "./apply-edit-dispatcher.mjs";
 
 const projectRoot = process.env.ANGLESITE_PROJECT_ROOT || process.cwd();
 
@@ -72,22 +70,14 @@ server.tool(
   },
 );
 
-// Phase 5 edit pipeline (#294). The schema is settled here; the patcher (#295), dispatcher
-// (#297), and edit-history (#298) land in follow-up PRs. Until then the handler stubs out
-// with `edit-failed: not-implemented`, which is enough for the app to exercise the wire
-// format end-to-end and surface the reply in the Debug pane.
+// Phase 5 edit pipeline. The schema lives in `apply-edit-schema.mjs` (#296); the resolver in
+// `patcher.mjs` (#295); the apply/refusal logic in `apply-edit-dispatcher.mjs` (#297). The
+// commit-to-hidden-branch undo is #298, which will inject an `onApplied` hook here once it lands.
 server.tool(
   "apply_edit",
   "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file.",
   applyEditInputShape,
-  ({ id }) => {
-    return {
-      content: [
-        createEditFailedContent(id, "not-implemented", "Phase 5 patcher (Anglesite/anglesite#295) hasn't landed yet — schema-only stub."),
-      ],
-      isError: true,
-    };
-  },
+  async (input) => applyEdit(projectRoot, input),
 );
 
 const transport = new StdioServerTransport();

--- a/test/apply-edit-dispatcher.test.js
+++ b/test/apply-edit-dispatcher.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, cpSync, readFileSync, rmSync, chmodSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
+
+const FIXTURE = resolvePath(import.meta.dirname, "fixtures/patcher");
+let root;
+
+function makeEdit(overrides = {}) {
+  return {
+    id: "e-1",
+    path: "/",
+    selector: { tag: "H1", classes: [], nthChild: 1, textContent: "Welcome to Our Shop" },
+    op: "replace-text",
+    value: "Welcome to Our New Shop",
+    ...overrides,
+  };
+}
+
+function parseContent(response) {
+  return JSON.parse(response.content[0].text);
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "dispatcher-"));
+  cpSync(FIXTURE, root, { recursive: true });
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("applyEdit — happy path", () => {
+  it("patches the file at the resolved range and returns edit-applied", async () => {
+    const indexPath = join(root, "src/pages/index.astro");
+    const before = readFileSync(indexPath, "utf-8");
+
+    const response = await applyEdit(root, makeEdit());
+    expect(response.isError).toBeFalsy();
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-applied");
+    expect(body.id).toBe("e-1");
+    expect(body.file).toBe("src/pages/index.astro");
+    expect(body.range).toEqual(expect.objectContaining({ start: expect.any(Number), end: expect.any(Number) }));
+
+    const after = readFileSync(indexPath, "utf-8");
+    // Byte-precise splice: prefix + replacement + suffix.
+    const expected = before.slice(0, body.range.start) + "Welcome to Our New Shop" + before.slice(body.range.end);
+    expect(after).toBe(expected);
+    // And it actually contains the new text.
+    expect(after).toContain("Welcome to Our New Shop");
+    expect(after).not.toContain("Welcome to Our Shop</h1>");
+  });
+
+  it("invokes the onApplied hook and threads its return value into commit", async () => {
+    let captured = null;
+    const response = await applyEdit(root, makeEdit(), {
+      onApplied: async ({ file, range }) => {
+        captured = { file, range };
+        return "deadbeef";
+      },
+    });
+    expect(captured?.file).toBe("src/pages/index.astro");
+    expect(captured?.range.start).toBeTypeOf("number");
+    const body = parseContent(response);
+    expect(body.commit).toBe("deadbeef");
+  });
+
+  it("omits commit when no onApplied hook is provided (Phase-5 history not wired yet)", async () => {
+    const response = await applyEdit(root, makeEdit());
+    const body = parseContent(response);
+    expect(body.commit).toBeUndefined();
+  });
+});
+
+describe("applyEdit — refusal mapping", () => {
+  it("returns edit-failed when the resolver refuses (no-match)", async () => {
+    const response = await applyEdit(
+      root,
+      makeEdit({ selector: { tag: "P", classes: [], nthChild: 1, textContent: "no such text anywhere" } }),
+    );
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.type).toBe("anglesite:edit-failed");
+    expect(body.id).toBe("e-1");
+    expect(body.reason).toBe("no-match");
+  });
+
+  it("passes through dynamic-expression refusals from the resolver", async () => {
+    const response = await applyEdit(
+      root,
+      makeEdit({
+        path: "/about/",
+        selector: { tag: "P", classes: [], nthChild: 1, textContent: "Our team of 12 experts is here to help you." },
+      }),
+    );
+    expect(response.isError).toBe(true);
+    const body = parseContent(response);
+    expect(body.reason).toBe("dynamic-expression");
+  });
+});
+
+describe("applyEdit — write-failed surface", () => {
+  // Atomic write goes through write-tmp + rename, which under POSIX only needs write access on
+  // the *parent directory* — chmod'ing the file 0444 isn't enough to fail the write. We chmod
+  // the directory instead, which is what an actually-locked filesystem looks like.
+  it("returns edit-failed reason: write-failed when the target directory isn't writable", async () => {
+    const pagesDir = join(root, "src/pages");
+    const originalMode = statSync(pagesDir).mode;
+    chmodSync(pagesDir, 0o555);
+    try {
+      const response = await applyEdit(root, makeEdit());
+      expect(response.isError).toBe(true);
+      const body = parseContent(response);
+      expect(body.type).toBe("anglesite:edit-failed");
+      expect(body.reason).toBe("write-failed");
+      expect(body.detail).toBeTruthy();
+    } finally {
+      chmodSync(pagesDir, originalMode);
+    }
+  });
+
+  it("does not invoke onApplied when the write fails", async () => {
+    const pagesDir = join(root, "src/pages");
+    const originalMode = statSync(pagesDir).mode;
+    chmodSync(pagesDir, 0o555);
+    let called = false;
+    try {
+      const response = await applyEdit(root, makeEdit(), {
+        onApplied: async () => { called = true; return "should-not-appear"; },
+      });
+      expect(called).toBe(false);
+      const body = parseContent(response);
+      expect(body.reason).toBe("write-failed");
+    } finally {
+      chmodSync(pagesDir, originalMode);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The `apply_edit` MCP tool now actually patches source files. Closes #297.

The handler stays a one-line wire in `server/index.mjs`; the apply/refusal logic lives in a new `server/apply-edit-dispatcher.mjs` so it's unit-testable in isolation — same pattern as `apply-edit-schema.mjs` from #296.

## Flow

1. `patcher.resolve(projectRoot, edit)` (#295) returns `{file, range, replacement}` or `{refused: true, reason, detail?}`.
2. On refusal → forward as MCP `edit-failed` content (`isError: true`).
3. On success → read source, splice the replacement at the resolved byte range, atomically write back (write-to-tmp + `rename` so a crash mid-write can't truncate the source), invoke an optional `onApplied` hook, return `edit-applied`.
4. On any filesystem error → return `edit-failed` with `reason: "write-failed"`.

## Design notes

- **The `onApplied` hook is the seam for #298.** Signature: `({file, range, projectRoot}) => Promise<string|undefined>`. When `edit-history.mjs` lands, `server/index.mjs`'s wire passes an `onApplied` that commits to the hidden `anglesite/edits` branch and returns the SHA — which the dispatcher threads back as the `commit` field on `edit-applied`. Default (no hook) → `commit` is omitted, matching what the schema already permits. Keeping this seam now means #298 plugs in without touching this PR's surface.
- **Atomic write semantics.** Write a sibling temp file (`.<name>.anglesite-edit-<rand>`), `rename` over the original. POSIX `rename(2)` only needs write permission on the *parent directory*, not on the target file — so the "write-failed" test chmods the dir 0555 rather than the file (which would mislead).
- **`onApplied` errors don't fail the edit.** The patch already landed on disk; if history-keeping throws, we surface a successful apply with no `commit` SHA rather than rolling back. Honest about what actually happened. #298 can revisit this policy when it lands.
- The handler matches the existing `add_annotation` / `list_annotations` / `resolve_annotation` conventions and reuses `createEditAppliedContent` / `createEditFailedContent` from `apply-edit-schema.mjs`.

## Tests (`test/apply-edit-dispatcher.test.js`, 7)

- Happy path: byte-precise splice (file content matches `prefix + replacement + suffix`), response is `edit-applied` with correct `file`/`range`.
- `onApplied` invoked with `{file, range, projectRoot}`; its return value threaded into the response's `commit`.
- `commit` omitted when no `onApplied` is provided.
- Refusal pass-through: `no-match` and `dynamic-expression` from the resolver surface as `edit-failed` with the same `reason`.
- `write-failed` surface: chmod the target directory 0555 → write fails → `edit-failed` reason `write-failed` with a non-empty `detail`.
- `onApplied` NOT invoked when the write fails.

All tests copy `test/fixtures/patcher/` to a per-test tmp dir, so they mutate cleanly without polluting the fixture.

## Verification

- `npx vitest run` → **2394 / 2394** pass.
- `node --check server/index.mjs` → ok.
- `node --check server/apply-edit-dispatcher.mjs` → ok.

## Phase 5 status after this lands

- ✅ #296 schema (PR #313, merged)
- ✅ #295 patcher (PR #314, merged)
- ✅ #299 test (already on main from PR #314 — deliverable in place, this PR doesn't claim to close it)
- ✅ #297 dispatcher (this PR)
- 🟡 #298 `edit-history.mjs` — the `onApplied` seam is ready; that's the natural next piece
- 🟡 [tracking] #294 closes once a plugin release ships with `apply_edit` working and the Anglesite-app pointer bumps

## Paired Anglesite-app PR (when this and #298 ship a release)

- Overlay `op` literals: `set-text` → `replace-text`, `set-image` → `replace-image-src`
- `MCPApplyEditRouter` tool name: `"anglesite:apply-edit"` → `"apply_edit"`
- Bundled-plugin pointer bump
