### PR TITLE
feat(server): hidden-branch edit history for per-edit undo (#298)

### DIFF
--- a/server/edit-history.mjs
+++ b/server/edit-history.mjs
@@ -1,0 +1,95 @@
+/**
+ * Hidden-branch edit history for the Anglesite-app edit pipeline (#298).
+ *
+ * Every successful patch from `apply-edit-dispatcher.mjs` calls `recordEdit` here, which
+ * commits the post-patch file content onto `refs/heads/anglesite/edits` without touching the
+ * user's HEAD, current branch, index, or working tree. The trick is git's plumbing:
+ *
+ *   - Initialize `anglesite/edits` from `HEAD` on first call.
+ *   - Use a *temporary* `GIT_INDEX_FILE` so the real index is untouched.
+ *   - `read-tree anglesite/edits` into the temp index, `hash-object -w` the post-patch file,
+ *     `update-index --cacheinfo` to stage it, `write-tree`, `commit-tree`, `update-ref`
+ *     with CAS (OLDVALUE) so concurrent calls can't lose commits.
+ *
+ * Returns the new commit SHA, or `undefined` on any failure — that includes "projectRoot
+ * isn't a git repo", "no commits yet on HEAD", "git binary missing", etc. The dispatcher
+ * treats `undefined` as "history not recorded; the on-disk patch still landed" and omits
+ * `commit` from the `edit-applied` response. Honest about partial success.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const EDITS_REF = "refs/heads/anglesite/edits";
+
+function runGit(projectRoot, args, env = {}) {
+  return execFileSync("git", args, {
+    cwd: projectRoot,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...env },
+  }).trim();
+}
+
+function tryRunGit(projectRoot, args, env = {}) {
+  try { return runGit(projectRoot, args, env); } catch { return undefined; }
+}
+
+function isGitRepo(projectRoot) {
+  return tryRunGit(projectRoot, ["rev-parse", "--git-dir"]) !== undefined;
+}
+
+function formatMessage({ file, range, message }) {
+  const headline = message && message.trim() ? message.trim() : `anglesite: edit ${file}`;
+  return `${headline}\n\nfile: ${file}\nrange: ${range.start}-${range.end}\n`;
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {{ file: string, range: {start:number,end:number}, message?: string }} info
+ * @returns {Promise<string | undefined>} commit SHA, or undefined on any failure
+ */
+export async function recordEdit(projectRoot, { file, range, message }) {
+  if (!isGitRepo(projectRoot)) return undefined;
+
+  try {
+    // 1. Ensure refs/heads/anglesite/edits exists, initializing from HEAD on first edit.
+    const existing = tryRunGit(projectRoot, ["show-ref", "--verify", "--hash", EDITS_REF]);
+    if (!existing) {
+      const head = tryRunGit(projectRoot, ["rev-parse", "HEAD"]);
+      if (!head) return undefined; // empty repo with no commits yet
+      runGit(projectRoot, ["update-ref", EDITS_REF, head]);
+    }
+
+    // 2. Build the new tree on top of anglesite/edits using a *temporary* index, so the
+    //    user's real index stays untouched even if they had staged changes.
+    const tmpDir = mkdtempSync(join(tmpdir(), "anglesite-edit-idx-"));
+    const tmpIndex = join(tmpDir, "index");
+    const env = { GIT_INDEX_FILE: tmpIndex };
+    try {
+      runGit(projectRoot, ["read-tree", EDITS_REF], env);
+      // hash-object -w writes a blob from the on-disk file content into the object DB,
+      // regardless of whether `file` is tracked or .gitignored.
+      const blob = runGit(projectRoot, ["hash-object", "-w", "--", file]);
+      // --cacheinfo lets us add/replace by blob SHA without consulting the working index.
+      runGit(
+        projectRoot,
+        ["update-index", "--add", "--cacheinfo", `100644,${blob},${file}`],
+        env,
+      );
+      const tree = runGit(projectRoot, ["write-tree"], env);
+      const parent = runGit(projectRoot, ["rev-parse", EDITS_REF]);
+      const commit = runGit(projectRoot, [
+        "commit-tree", tree, "-p", parent, "-m", formatMessage({ file, range, message }),
+      ]);
+      // CAS update with OLDVALUE so two concurrent recordEdits can't silently clobber each other.
+      runGit(projectRoot, ["update-ref", EDITS_REF, commit, parent]);
+      return commit;
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  } catch {
+    return undefined;
+  }
+}

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -8,6 +8,7 @@ import {
 } from "./annotations.mjs";
 import { applyEditInputShape } from "./apply-edit-schema.mjs";
 import { applyEdit } from "./apply-edit-dispatcher.mjs";
+import { recordEdit } from "./edit-history.mjs";
 
 const projectRoot = process.env.ANGLESITE_PROJECT_ROOT || process.cwd();
 
@@ -71,13 +72,20 @@ server.tool(
 );
 
 // Phase 5 edit pipeline. The schema lives in `apply-edit-schema.mjs` (#296); the resolver in
-// `patcher.mjs` (#295); the apply/refusal logic in `apply-edit-dispatcher.mjs` (#297). The
-// commit-to-hidden-branch undo is #298, which will inject an `onApplied` hook here once it lands.
+// `patcher.mjs` (#295); the apply/refusal logic in `apply-edit-dispatcher.mjs` (#297); the
+// hidden-branch history that backs per-edit undo in `edit-history.mjs` (#298). The dispatcher
+// invokes `onApplied` after a successful patch — `recordEdit` commits onto refs/heads/anglesite/edits
+// without touching HEAD/index/working-tree and returns the SHA, which the dispatcher threads
+// back as `commit` on the edit-applied response.
 server.tool(
   "apply_edit",
-  "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file.",
+  "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file. Successful edits are also committed onto the hidden anglesite/edits branch for per-edit undo.",
   applyEditInputShape,
-  async (input) => applyEdit(projectRoot, input),
+  async (input) =>
+    applyEdit(projectRoot, input, {
+      onApplied: ({ file, range }) =>
+        recordEdit(projectRoot, { file, range, message: `anglesite: edit ${file}` }),
+    }),
 );
 
 const transport = new StdioServerTransport();

--- a/test/edit-history.test.js
+++ b/test/edit-history.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { recordEdit } from "../server/edit-history.mjs";
+
+let repo;
+
+function git(args, opts = {}) {
+  return execFileSync("git", args, {
+    cwd: repo,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...opts,
+  }).trim();
+}
+
+function initRepo() {
+  repo = mkdtempSync(join(tmpdir(), "edit-history-"));
+  execFileSync("git", ["init", "--initial-branch=main", repo], { stdio: "ignore" });
+  git(["config", "user.email", "test@example.com"]);
+  git(["config", "user.name", "Test"]);
+  writeFileSync(join(repo, "README.md"), "initial\n");
+  git(["add", "README.md"]);
+  git(["commit", "-m", "initial"]);
+}
+
+beforeEach(initRepo);
+afterEach(() => repo && rmSync(repo, { recursive: true, force: true }));
+
+describe("recordEdit", () => {
+  it("creates anglesite/edits on first call and commits the post-edit file content", async () => {
+    expect(() => git(["show-ref", "--verify", "refs/heads/anglesite/edits"])).toThrow();
+
+    writeFileSync(join(repo, "README.md"), "edited\n");
+    const sha = await recordEdit(repo, {
+      file: "README.md",
+      range: { start: 0, end: 7 },
+      message: "anglesite: edit README.md",
+    });
+
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(git(["rev-parse", "refs/heads/anglesite/edits"])).toBe(sha);
+    expect(git(["show", `${sha}:README.md`])).toBe("edited");
+  });
+
+  it("leaves the user's HEAD, current branch, and working tree untouched", async () => {
+    const headBefore = git(["rev-parse", "HEAD"]);
+    const branchBefore = git(["symbolic-ref", "--short", "HEAD"]);
+
+    writeFileSync(join(repo, "README.md"), "edited\n");
+    await recordEdit(repo, { file: "README.md", range: { start: 0, end: 7 }, message: "edit" });
+
+    expect(git(["rev-parse", "HEAD"])).toBe(headBefore);
+    expect(git(["symbolic-ref", "--short", "HEAD"])).toBe(branchBefore);
+    // Working-tree file content is whatever the dispatcher wrote (we mutated it; recordEdit
+    // must not have undone that mutation).
+    expect(readFileSync(join(repo, "README.md"), "utf-8")).toBe("edited\n");
+    // The user's main branch tip is unchanged (no edit commits sneak onto it).
+    expect(git(["rev-parse", "main"])).toBe(headBefore);
+  });
+
+  it("accumulates: a second recordEdit commits on top of the first", async () => {
+    writeFileSync(join(repo, "README.md"), "one\n");
+    const a = await recordEdit(repo, { file: "README.md", range: { start: 0, end: 4 }, message: "a" });
+
+    writeFileSync(join(repo, "README.md"), "two\n");
+    const b = await recordEdit(repo, { file: "README.md", range: { start: 0, end: 4 }, message: "b" });
+
+    expect(a).not.toBe(b);
+    const parents = git(["rev-list", "--parents", "-n", "1", b]).split(/\s+/);
+    expect(parents[0]).toBe(b);
+    expect(parents[1]).toBe(a);
+    expect(git(["show", `${b}:README.md`])).toBe("two");
+  });
+
+  it("captures an untracked new file too (not just files already tracked)", async () => {
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "src/new.txt"), "fresh content\n");
+    const sha = await recordEdit(repo, { file: "src/new.txt", range: { start: 0, end: 0 }, message: "add" });
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(git(["show", `${sha}:src/new.txt`])).toBe("fresh content");
+  });
+
+  it("returns undefined when projectRoot is not a git repository", async () => {
+    const notRepo = mkdtempSync(join(tmpdir(), "not-a-repo-"));
+    try {
+      writeFileSync(join(notRepo, "x.txt"), "y\n");
+      const sha = await recordEdit(notRepo, { file: "x.txt", range: { start: 0, end: 0 }, message: "x" });
+      expect(sha).toBeUndefined();
+    } finally {
+      rmSync(notRepo, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Every successful `apply_edit` now also commits the post-patch file content onto a hidden `refs/heads/anglesite/edits` branch, without touching the user's HEAD, current branch, index, or working tree. That branch is the substrate for per-edit undo in the Anglesite-app v0.5 chat panel. Closes #298.

> _Was originally stacked on #315; that merged while this branch was being prepared. Rebased onto `main` — single commit, mergeable as-is._

## Why "hidden" matters

Edits arrive at any time during a preview session. If history-keeping moved the user's HEAD or modified their index, we'd be writing changes through their actively-used branch — both confusing and dangerous (what if they had unstaged work? what if they were on a feature branch?). The hidden-branch pattern lets `anglesite/edits` accumulate commits independently while the user keeps doing whatever they're doing.

## How (plumbing, not porcelain)

1. **Initialize** `refs/heads/anglesite/edits` from current `HEAD` on the first call. Subsequent calls find it and continue.
2. **Temp index.** Set `GIT_INDEX_FILE` to a fresh `mktemp` path so the user's real `.git/index` is untouched even if they had staged changes.
3. **Read tree:** `git read-tree anglesite/edits` into the temp index — gives the new commit its base state.
4. **Hash the post-patch file:** `git hash-object -w -- <file>` writes a blob from on-disk content into the object DB. Works for tracked, untracked, and even `.gitignored` files (it bypasses the working-index ignore policy because we're not staging from a working-index lookup — we're staging a blob SHA directly).
5. **Stage by SHA:** `git update-index --add --cacheinfo 100644,<blob>,<path>` updates the temp index without consulting the real working tree.
6. **Write tree + commit-tree + update-ref:** standard plumbing. The `update-ref` form is the CAS variant — `update-ref REF NEW OLD` — so two concurrent `recordEdit` calls can't silently lose commits.

## API

```js
recordEdit(projectRoot, { file, range, message? }) → Promise<string | undefined>
```

Returns the new commit SHA on success, `undefined` on any failure: not-a-git-repo, no commits on HEAD yet, `git` binary missing, malformed file path, etc. Per the dispatcher's existing policy (#297), `undefined` is interpreted as "history not recorded; the on-disk patch still landed" and `commit` is omitted from the `edit-applied` response. Honest about partial success.

## Wire in `server/index.mjs`

```js
async (input) =>
  applyEdit(projectRoot, input, {
    onApplied: ({ file, range }) =>
      recordEdit(projectRoot, { file, range, message: `anglesite: edit ${file}` }),
  })
```

## Tests (`test/edit-history.test.js`, 5)

Real-git integration via `execFileSync` on per-test tmp `git init` repos.

- **Branch created from HEAD on first call**, and the commit captures the post-edit file content (`git show <sha>:<file>` matches what's on disk).
- **User state byte-identical before/after:** `HEAD`, `symbolic-ref --short HEAD`, `main`'s tip, the working-tree file content — none of them move.
- **Accumulation:** a second `recordEdit` produces a different SHA whose parent is the first.
- **Untracked new files captured** (the `hash-object` path bypasses the working-index ignore policy).
- **Not-a-git-repo returns `undefined`** without throwing.

## Verification

- `npx vitest run` → all plugin tests pass (5 new in `test/edit-history.test.js`).
- `node --check server/index.mjs` → ok.
- `node --check server/edit-history.mjs` → ok.

## Phase 5 status after this PR lands

- ✅ #296 schema (PR #313, merged)
- ✅ #295 patcher (PR #314, merged)
- ✅ #299 patcher tests (on main from PR #314 — deliverable in place)
- ✅ #297 dispatcher (PR #315, merged)
- 🟡 #298 hidden-branch history (this PR)
- 🟡 [tracking] #294 closes once a plugin release ships with `apply_edit` end-to-end and the Anglesite-app pointer bumps

After this merges, Phase 5 server-side is **complete** and ready for an Anglesite-app paired PR (overlay `op` literals → `replace-text` / `replace-image-src`, `MCPApplyEditRouter` tool name → `apply_edit`, bundled-plugin pointer bump).
