### PR TITLE
feat(phase-5): align edit-pipeline wire format with plugin's apply_edit tool

### DIFF
--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -81,7 +81,7 @@ function attachClickToEdit(awaitReply: (id: string, handler: (r: { status: strin
         type: "anglesite:apply-edit",
         path: location.pathname,
         selector: elementInfoFor(target),
-        op: "set-text",
+        op: "replace-text",
         value: newText,
       };
       postEdit(msg);
@@ -114,7 +114,7 @@ function attachImageDrop(): void {
         type: "anglesite:apply-edit",
         path: location.pathname,
         selector: elementInfoFor(target),
-        op: "set-image",
+        op: "replace-image-src",
         value: { filename: file.name, mimeType: file.type, dataURL },
       };
       postEdit(msg);

--- a/JS/edit-overlay/test/messages.test.ts
+++ b/JS/edit-overlay/test/messages.test.ts
@@ -12,7 +12,7 @@ const sampleMessage: EditMessage = {
   type: "anglesite:apply-edit",
   path: "/about/",
   selector: { tag: "P", classes: [], nthChild: 1, ancestors: [] },
-  op: "set-text",
+  op: "replace-text",
   value: "Hello",
 };
 

--- a/JS/edit-overlay/test/overlay.test.ts
+++ b/JS/edit-overlay/test/overlay.test.ts
@@ -89,7 +89,7 @@ describe("click-to-edit", () => {
     expect(sent.length).toBe(1);
     const msg = sent[0] as { type: string; op: string; selector: { tag: string; ancestors?: Array<{ tag: string }> }; value: unknown };
     expect(msg.type).toBe("anglesite:apply-edit");
-    expect(msg.op).toBe("set-text");
+    expect(msg.op).toBe("replace-text");
     expect(msg.value).toBe("new");
     expect(msg.selector.tag).toBe("P");
     expect(msg.selector.ancestors?.map((a) => a.tag)).toEqual(["BODY", "MAIN"]);

--- a/Sources/AnglesiteBridge/EditMessage.swift
+++ b/Sources/AnglesiteBridge/EditMessage.swift
@@ -22,7 +22,7 @@ public struct EditMessage: Sendable, Equatable {
     /// Structured element metadata (`ElementInfo`) — the plugin's `server/selector.mjs` resolves
     /// this to a CSS selector server-side. The bridge is a relay; #18 records the decision.
     public let selector: JSONValue
-    /// Edit operation — `"set-text"`, `"set-attribute"`, etc. Phase 5 finalizes the taxonomy.
+    /// Edit operation — `"replace-text"`, `"replace-attr"`, etc. Phase 5 finalizes the taxonomy.
     public let op: String
     /// Operation payload — varies by `op`. Optional because some ops (e.g. `"delete"`) won't carry one.
     public let value: JSONValue?
@@ -37,7 +37,9 @@ public struct EditMessage: Sendable, Equatable {
     }
 
     /// Round-trippable `JSONValue` representation — used as the `arguments` payload when the
-    /// router forwards an edit to the plugin's `anglesite:apply-edit` MCP tool.
+    /// router forwards an edit to the plugin's `apply_edit` MCP tool (the `type` field stays as
+    /// the WKWebView-side boundary tag `"anglesite:apply-edit"`; the plugin's schema accepts and
+    /// ignores it since the tool name is authoritative server-side).
     public var jsonValue: JSONValue {
         var obj: [String: JSONValue] = [
             "id": .string(id),

--- a/Sources/AnglesiteBridge/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteBridge/MCPApplyEditRouter.swift
@@ -1,13 +1,13 @@
 import Foundation
 import AnglesiteCore
 
-/// `EditRouter` backed by an `MCPClient` `tools/call` to the plugin's `anglesite:apply-edit` tool.
+/// `EditRouter` backed by an `MCPClient` `tools/call` to the plugin's `apply_edit` tool.
 ///
-/// Scaffolding for Phase 5: today nothing in the app instantiates an `MCPClient` running against
-/// the plugin server, and the plugin server doesn't speak `anglesite:apply-edit` yet — so the
-/// `PreviewView` wiring uses `LoggingEditRouter` instead. When Phase 5 lands, the wiring swaps to
-/// this router (the test-shaped `init(toolCaller:)` is the seam; the convenience `init(mcpClient:)`
-/// is the production hookup).
+/// Phase 5's `apply_edit` MCP tool is live in the plugin server (anglesite/anglesite#296 + #297
+/// + #298). Nothing in the app instantiates an `MCPClient` against that server yet, so the
+/// `PreviewView` wiring stays on `LoggingEditRouter`; this is the router the wiring will swap
+/// to once an MCP client is launched (the test-shaped `init(toolCaller:)` is the seam; the
+/// convenience `init(mcpClient:)` is the production hookup).
 public struct MCPApplyEditRouter: EditRouter {
     public typealias ToolCaller = @Sendable (_ name: String, _ arguments: JSONValue) async throws -> MCPClient.ToolCallResult
 
@@ -31,7 +31,7 @@ public struct MCPApplyEditRouter: EditRouter {
     public func apply(_ message: EditMessage) async -> EditReply {
         let args = message.jsonValue
         do {
-            let result = try await toolCaller("anglesite:apply-edit", args)
+            let result = try await toolCaller("apply_edit", args)
             let text = result.content.compactMap(\.text).joined(separator: "\n")
             let trimmed = text.isEmpty ? nil : text
             if result.isError {

--- a/Tests/AnglesiteBridgeTests/AnglesiteScriptHandlerTests.swift
+++ b/Tests/AnglesiteBridgeTests/AnglesiteScriptHandlerTests.swift
@@ -13,7 +13,7 @@ final class AnglesiteScriptHandlerTests: XCTestCase {
                 "classes": [] as [String],
                 "nthChild": 1,
             ] as [String: Any],
-            "op": "set-text",
+            "op": "replace-text",
             "value": "New heading",
         ]
     }
@@ -29,7 +29,7 @@ final class AnglesiteScriptHandlerTests: XCTestCase {
         let received = await router.received
         XCTAssertEqual(received.count, 1)
         XCTAssertEqual(received.first?.id, "e-99")
-        XCTAssertEqual(received.first?.op, "set-text")
+        XCTAssertEqual(received.first?.op, "replace-text")
     }
 
     func testHandleInvalidBodyReturnsDecodeErrorAndDoesNotRoute() async {

--- a/Tests/AnglesiteBridgeTests/EditMessageTests.swift
+++ b/Tests/AnglesiteBridgeTests/EditMessageTests.swift
@@ -20,7 +20,7 @@ final class EditMessageTests: XCTestCase {
             "type": "anglesite:apply-edit",
             "path": "/about/",
             "selector": validSelector(),
-            "op": "set-text",
+            "op": "replace-text",
             "value": "Hello, world.",
         ]
         for (k, v) in overrides { body[k] = v }
@@ -41,7 +41,7 @@ final class EditMessageTests: XCTestCase {
         }
         XCTAssertEqual(dict["tag"], .string("P"))
         XCTAssertEqual(dict["nthChild"], .int(2))
-        XCTAssertEqual(msg.op, "set-text")
+        XCTAssertEqual(msg.op, "replace-text")
         XCTAssertEqual(msg.value, .string("Hello, world."))
     }
 

--- a/Tests/AnglesiteBridgeTests/EditReplyAndRouterTests.swift
+++ b/Tests/AnglesiteBridgeTests/EditReplyAndRouterTests.swift
@@ -33,7 +33,7 @@ final class EditReplyAndRouterTests: XCTestCase {
         let msg = EditMessage(
             id: "e-42", type: .applyEdit, path: "/",
             selector: .object(["tag": .string("H1"), "classes": .array([]), "nthChild": .int(1)]),
-            op: "set-text", value: .string("Hi")
+            op: "replace-text", value: .string("Hi")
         )
         let reply = await router.apply(msg)
         XCTAssertEqual(reply.id, "e-42")
@@ -49,13 +49,13 @@ final class EditReplyAndRouterTests: XCTestCase {
         let msg = EditMessage(
             id: "e-1", type: .applyEdit, path: "/about/",
             selector: .object(["tag": .string("P"), "classes": .array([]), "nthChild": .int(1)]),
-            op: "set-text", value: .string("x")
+            op: "replace-text", value: .string("x")
         )
         _ = await router.apply(msg)
         let lines = await center.snapshot().filter { $0.source == "bridge" }
         XCTAssertFalse(lines.isEmpty, "expected at least one bridge log line")
         let text = lines.last?.text ?? ""
-        XCTAssertTrue(text.contains("set-text") && text.contains("/about/"),
+        XCTAssertTrue(text.contains("replace-text") && text.contains("/about/"),
                       "log line should reflect the op + path — got: \(text)")
     }
 }

--- a/Tests/AnglesiteBridgeTests/MCPApplyEditRouterTests.swift
+++ b/Tests/AnglesiteBridgeTests/MCPApplyEditRouterTests.swift
@@ -14,7 +14,7 @@ final class MCPApplyEditRouterTests: XCTestCase {
         type: .applyEdit,
         path: "/about/",
         selector: MCPApplyEditRouterTests.sampleSelector,
-        op: "set-text",
+        op: "replace-text",
         value: .string("Hello, world.")
     )
 
@@ -25,7 +25,7 @@ final class MCPApplyEditRouterTests: XCTestCase {
 
         let calls = await recorder.calls
         XCTAssertEqual(calls.count, 1)
-        XCTAssertEqual(calls.first?.name, "anglesite:apply-edit")
+        XCTAssertEqual(calls.first?.name, "apply_edit")
         XCTAssertEqual(
             calls.first?.arguments,
             .object([
@@ -33,7 +33,7 @@ final class MCPApplyEditRouterTests: XCTestCase {
                 "type": .string("anglesite:apply-edit"),
                 "path": .string("/about/"),
                 "selector": MCPApplyEditRouterTests.sampleSelector,
-                "op": .string("set-text"),
+                "op": .string("replace-text"),
                 "value": .string("Hello, world."),
             ])
         )


### PR DESCRIPTION
## Summary

Phase 5 server-side ([Anglesite/anglesite#296](https://github.com/Anglesite/anglesite/issues/296), [#297](https://github.com/Anglesite/anglesite/issues/297), [#298](https://github.com/Anglesite/anglesite/issues/298)) settled the apply-edit contract:

- **MCP tool name:** `apply_edit` (snake_case, unnamespaced — matches the existing `add_annotation` / `list_annotations` / `resolve_annotation` convention).
- **`op` is a closed `z.enum`:** `replace-text | replace-attr | replace-image-src`.
- **The `type` field at the MCP boundary** is accepted-and-ignored; the plugin's tool name is authoritative.

This PR aligns the app's two outbound boundaries with that contract. Implements the paired-PR commitment from `Anglesite/anglesite/server/apply-edit-schema.mjs` (the "When Phase 5 lands, the paired Anglesite-app PR…" note).

References [#19](https://github.com/Anglesite/Anglesite-app/issues/19) (Phase 5 tracking).

## Changes

**JS overlay** (`JS/edit-overlay/src/overlay.ts`):
- `op: "set-text"` → `"replace-text"` (click → blur path)
- `op: "set-image"` → `"replace-image-src"` (image-drop path)

**Swift router** (`Sources/AnglesiteBridge/MCPApplyEditRouter.swift`):
- `toolCaller("anglesite:apply-edit", …)` → `toolCaller("apply_edit", …)`
- Module docstring updated to reflect that Phase 5 server-side is live.

**What deliberately stays the same:**
- `EditMessage.MessageType.applyEdit = "anglesite:apply-edit"` — that's the **WKWebView-side boundary tag** (the closed-set validator at the JS → native bridge), not the MCP tool name. `AnglesiteScriptHandler` rejects messages whose `type` isn't this exact string.
- `EditMessage.jsonValue` still emits `type` as `"anglesite:apply-edit"` in the args sent to MCP. The plugin's `apply-edit-schema.mjs` accepts that field and ignores it — the tool name is authoritative server-side. Docstring on `jsonValue` clarifies the relationship.

## Verification

| Layer | Result |
|---|---|
| vitest (`JS/edit-overlay`) | **21 / 21** pass |
| `swift test --filter "AnglesiteBridgeTests.*"` | **21 / 21** pass across 5 classes (`EditMessageTests` 8, `EditReplyAndRouterTests` 4, `MCPApplyEditRouterTests` 4, `AnglesiteScriptHandlerTests` 2, `WebViewBridgeTests` 3) |
| `xcodebuild -scheme Anglesite -configuration Debug build` | **BUILD SUCCEEDED** |
| Overlay bundle | regenerated, 6960 bytes (+12B vs. before — `replace-image-src` is longer than `set-image`) |

## What's left for #19

After this merges, the only thing standing between Anglesite-app and a live round-trip is **wiring an `MCPClient` instance against a per-site plugin server and swapping `PreviewView`'s `LoggingEditRouter` → `MCPApplyEditRouter`**. That's its own piece — the router is built, fully tested, and points at the right tool name. Once the MCP client is launched (and a plugin release ships with `apply_edit` end-to-end), the round-trip goes live with no further changes to the wire format.
