### PR TITLE
feat(phase-6): DeployCommand actor for `wrangler deploy`

### DIFF
--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+/// One-shot orchestrator for `wrangler deploy`.
+///
+/// Unlike `AstroDevServer` and `MCPClient` (long-running supervisees), a deploy is a single
+/// foreground action: spawn wrangler, wait for exit, parse the deployed URL out of the success
+/// line, return a `Result`. The process goes through `ProcessSupervisor.run(...)` (synchronous
+/// capture) rather than `.launch(...)`, because the `.launch(...)` path's LogCenter pump is
+/// async-and-untracked — `waitForExit` returns before late `Task { logCenter.append(...) }`
+/// calls have settled, and the URL line we need can be one of those late lines. The captured
+/// stdout/stderr are *also* fed to LogCenter line-by-line after exit so the Debug pane sees
+/// the run; for now that lands at the end of the deploy rather than in real time. Real-time
+/// streaming would require tracking the supervisor's pump Tasks — left as a follow-up.
+///
+/// Pre-spawn refusals (no Cloudflare token, no wrangler) return `.failed` without launching
+/// anything. After spawn, only the exit code + collected stdout matter: a zero exit with a
+/// matched `Published <name> (…)\n  <url>` block becomes `.succeeded`; a non-zero exit, or zero
+/// exit with no matched URL, becomes `.failed` with a reason.
+public actor DeployCommand {
+    public enum Result: Sendable, Equatable {
+        case succeeded(url: URL, duration: TimeInterval)
+        /// `exitCode` is `nil` for pre-spawn refusals (no token, no wrangler) and for spawn
+        /// failures; otherwise it's wrangler's exit code (including `0` for the
+        /// "exited cleanly but we couldn't find a URL" case).
+        case failed(reason: String, exitCode: Int32?)
+    }
+
+    /// How to run wrangler for a site directory — or why it can't be run.
+    public enum LaunchPlan: Sendable, Equatable {
+        case run(executable: URL, arguments: [String])
+        case unavailable(reason: String)
+    }
+
+    public typealias CommandResolver = @Sendable (_ siteDirectory: URL) -> LaunchPlan
+    /// Returns the Cloudflare API token, or `nil` if none is configured. Phase 7's
+    /// `KeychainStore` will replace the default `envTokenSource` in production callers.
+    public typealias TokenSource = @Sendable () async throws -> String?
+
+    private let supervisor: ProcessSupervisor
+    private let logCenter: LogCenter
+    private let resolveCommand: CommandResolver
+    private let tokenSource: TokenSource
+
+    public init(
+        supervisor: ProcessSupervisor = .shared,
+        logCenter: LogCenter = .shared,
+        resolveCommand: @escaping CommandResolver = DeployCommand.resolveWranglerCommand,
+        tokenSource: @escaping TokenSource = DeployCommand.envTokenSource
+    ) {
+        self.supervisor = supervisor
+        self.logCenter = logCenter
+        self.resolveCommand = resolveCommand
+        self.tokenSource = tokenSource
+    }
+
+    /// Run a deploy for `siteID`. Returns once wrangler has exited (or before, if pre-spawn
+    /// refusal applies). The subprocess streams to `logCenter` under source `deploy:<siteID>`
+    /// for the whole supervisor / Debug-pane / deploy-drawer pipeline.
+    public func deploy(siteID: String, siteDirectory: URL) async -> Result {
+        // Pre-spawn checks. The token comes first so we never spend time resolving an
+        // executable we won't end up running.
+        let token: String?
+        do {
+            token = try await tokenSource()
+        } catch {
+            return .failed(reason: "couldn't read Cloudflare API token: \(error)", exitCode: nil)
+        }
+        guard let token, !token.isEmpty else {
+            return .failed(reason: "no CLOUDFLARE_API_TOKEN — set in env or Settings (Phase 7)", exitCode: nil)
+        }
+
+        let plan = resolveCommand(siteDirectory)
+        let executable: URL
+        let arguments: [String]
+        switch plan {
+        case .unavailable(let reason):
+            return .failed(reason: reason, exitCode: nil)
+        case .run(let exe, let args):
+            executable = exe
+            arguments = args
+        }
+
+        let source = "deploy:\(siteID)"
+        var environment = ProcessInfo.processInfo.environment
+        environment["CLOUDFLARE_API_TOKEN"] = token
+
+        let started = Date()
+        let result: ProcessSupervisor.RunResult
+        do {
+            result = try await supervisor.run(
+                executable: executable,
+                arguments: arguments,
+                environment: environment
+            )
+        } catch {
+            return .failed(reason: "couldn't spawn wrangler: \(error)", exitCode: nil)
+        }
+        let duration = Date().timeIntervalSince(started)
+
+        // Mirror the captured output into LogCenter line-by-line so the Debug pane shows the
+        // run. This lands after exit rather than in real time — see the doc-comment header for
+        // why; the deploy drawer (#22) will show a spinner during the run so the user knows
+        // something is happening.
+        for line in result.stdout.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
+            await logCenter.append(source: source, stream: .stdout, text: String(line))
+        }
+        for line in result.stderr.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
+            await logCenter.append(source: source, stream: .stderr, text: String(line))
+        }
+
+        let code = result.exitCode
+        if code == 0 {
+            if let url = Self.extractDeployedURL(from: result.stdout) {
+                return .succeeded(url: url, duration: duration)
+            }
+            return .failed(reason: "wrangler exited cleanly but no deployed URL was found in its output", exitCode: 0)
+        }
+        return .failed(reason: "wrangler exited with code \(code)", exitCode: code)
+    }
+
+    // MARK: URL extraction
+
+    /// Scans for the wrangler "Published" anchor and the first URL after it. The line shape is
+    ///
+    ///     Published <name> (1.23 sec)
+    ///       https://<name>.<acct>.workers.dev
+    ///
+    /// Anchoring on `Published` (start-of-line, case-sensitive) prevents help-text URLs from
+    /// being mistaken for the deploy result. We accept the URL on the same line or any
+    /// subsequent line — wrangler has shipped multiple layouts of this block over the years.
+    public static func extractDeployedURL(from output: String) -> URL? {
+        let lines = output.split(separator: "\n", omittingEmptySubsequences: false)
+        guard let publishedIdx = lines.firstIndex(where: { $0.hasPrefix("Published") || $0.hasPrefix("Published ") }) else {
+            return nil
+        }
+        // Search the Published line itself, then subsequent lines, for the first URL.
+        for line in lines[publishedIdx...] {
+            if let urlRange = line.range(of: #"https?://[^\s]+"#, options: [.regularExpression]) {
+                // Strip trailing punctuation a terminal might tack on (commas, periods, closing parens).
+                var raw = String(line[urlRange])
+                while let last = raw.last, ",.)]}>".contains(last) {
+                    raw.removeLast()
+                }
+                return URL(string: raw)
+            }
+        }
+        return nil
+    }
+
+    // MARK: Default seams
+
+    /// Default `TokenSource`: read `CLOUDFLARE_API_TOKEN` from the environment.
+    public static let envTokenSource: TokenSource = {
+        ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"]
+    }
+
+    /// Default `CommandResolver`: run the site's own `wrangler` (`node_modules/.bin/wrangler
+    /// deploy`) with the vendored Node. Reports `.unavailable` when prerequisites are missing.
+    public static let resolveWranglerCommand: CommandResolver = { siteDirectory in
+        let wranglerBin = siteDirectory
+            .appendingPathComponent("node_modules", isDirectory: true)
+            .appendingPathComponent(".bin", isDirectory: true)
+            .appendingPathComponent("wrangler")
+        guard FileManager.default.isExecutableFile(atPath: wranglerBin.path) else {
+            return .unavailable(reason: "wrangler not installed — run `npm install` in this site")
+        }
+        guard let node = NodeRuntime.bundledExecutableURL else {
+            return .unavailable(reason: "the embedded Node runtime isn't bundled (rebuild the app)")
+        }
+        return .run(executable: node, arguments: [wranglerBin.path, "deploy"])
+    }
+}

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import AnglesiteCore
+
+final class DeployCommandTests: XCTestCase {
+    /// A real, existing directory — the supervisor `cd`s into the site dir before spawning, so a
+    /// nonexistent path would fail `process.run()` before our fixture script even runs.
+    private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+    private func makeCommand(
+        resolve: @escaping DeployCommand.CommandResolver,
+        token: @escaping DeployCommand.TokenSource
+    ) -> (DeployCommand, ProcessSupervisor, LogCenter) {
+        let supervisor = ProcessSupervisor()
+        let center = LogCenter()
+        let cmd = DeployCommand(
+            supervisor: supervisor,
+            logCenter: center,
+            resolveCommand: resolve,
+            tokenSource: token
+        )
+        return (cmd, supervisor, center)
+    }
+
+    private func shFixture(_ script: String, _ args: String...) -> DeployCommand.LaunchPlan {
+        .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", script] + args)
+    }
+
+    // MARK: Pre-spawn refusal (no work wasted)
+
+    func testRefusesBeforeSpawnWhenTokenSourceReturnsNil() async {
+        var spawned = false
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in
+                spawned = true
+                return self.shFixture("exit 0")
+            },
+            token: { nil }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        XCTAssertFalse(spawned, "resolver should not be consulted when token is missing")
+        guard case .failed(let reason, let exit) = result else { return XCTFail("expected .failed, got \(result)") }
+        XCTAssertTrue(reason.contains("CLOUDFLARE_API_TOKEN"), "reason should name the env var the caller should set: \(reason)")
+        XCTAssertNil(exit)
+    }
+
+    func testRefusesBeforeSpawnWhenTokenSourceReturnsEmptyString() async {
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in self.shFixture("exit 0") },
+            token: { "" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, _) = result else { return XCTFail("expected .failed, got \(result)") }
+        XCTAssertTrue(reason.contains("CLOUDFLARE_API_TOKEN"), reason)
+    }
+
+    func testFailsWhenResolverReportsUnavailable() async {
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in .unavailable(reason: "wrangler not installed — run `npm install`") },
+            token: { "fake-token" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else { return XCTFail("expected .failed, got \(result)") }
+        XCTAssertEqual(reason, "wrangler not installed — run `npm install`")
+        XCTAssertNil(exit)
+    }
+
+    // MARK: Happy path — URL extraction
+
+    func testSucceedsAndExtractsURLFromPublishedLine() async {
+        // Synthetic wrangler output: a blank line, the `Published ...` summary, indented URL, exit 0.
+        let script = """
+        echo ''
+        echo '⛅️ wrangler 3.50.0'
+        echo 'Total Upload: 4.20 KiB'
+        echo 'Published angle-app (1.23 sec)'
+        echo '  https://angle-app.example.workers.dev'
+        echo '  Current Deployment ID: abc-123'
+        exit 0
+        """
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in self.shFixture(script) },
+            token: { "fake-token" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .succeeded(let url, let duration) = result else { return XCTFail("expected .succeeded, got \(result)") }
+        XCTAssertEqual(url, URL(string: "https://angle-app.example.workers.dev")!)
+        XCTAssertGreaterThanOrEqual(duration, 0)
+    }
+
+    func testIgnoresURLsThatAppearBeforeThePublishedAnchor() async {
+        // A help-text URL in wrangler's output must NOT be reported as the deployed URL.
+        let script = """
+        echo 'See https://developers.cloudflare.com/workers for help.'
+        echo 'Published angle-app (1.23 sec)'
+        echo '  https://angle-app.example.workers.dev'
+        exit 0
+        """
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in self.shFixture(script) },
+            token: { "fake-token" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .succeeded(let url, _) = result else { return XCTFail("expected .succeeded, got \(result)") }
+        XCTAssertEqual(url.host, "angle-app.example.workers.dev")
+    }
+
+    // MARK: Failure surfacing
+
+    func testFailsWhenWranglerExitsNonZero() async {
+        let script = """
+        echo 'Error: authentication failed' 1>&2
+        exit 10
+        """
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in self.shFixture(script) },
+            token: { "fake-token" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else { return XCTFail("expected .failed, got \(result)") }
+        XCTAssertEqual(exit, 10)
+        XCTAssertTrue(reason.contains("10"), "reason should mention the exit code: \(reason)")
+    }
+
+    func testFailsSemanticallyWhenZeroExitButNoPublishedURL() async {
+        // A wrangler bug or unexpected output shape: process exits 0 but our anchor never matched.
+        // We surface this as a clear failure rather than silently returning a bogus URL.
+        let script = """
+        echo 'Did some thing.'
+        echo 'No anchor here.'
+        exit 0
+        """
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in self.shFixture(script) },
+            token: { "fake-token" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else { return XCTFail("expected .failed, got \(result)") }
+        XCTAssertEqual(exit, 0)
+        XCTAssertTrue(reason.lowercased().contains("url"), "reason should explain the URL was missing: \(reason)")
+    }
+
+    // MARK: Token propagation
+
+    func testPassesCloudflareTokenAsEnvironmentVariableToSubprocess() async {
+        // Fixture echoes the value of $CLOUDFLARE_API_TOKEN, then prints a fake Published URL so
+        // the deploy reaches `.succeeded`. We can then read what was echoed via the LogCenter.
+        let script = """
+        echo "TOKEN_SEEN_BY_WRANGLER=$CLOUDFLARE_API_TOKEN"
+        echo 'Published angle-app (0.42 sec)'
+        echo '  https://t.example.workers.dev'
+        exit 0
+        """
+        let (cmd, _, center) = makeCommand(
+            resolve: { _ in self.shFixture(script) },
+            token: { "secret-token-abc" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .succeeded = result else { return XCTFail("expected .succeeded, got \(result)") }
+        let lines = await center.snapshot()
+        let tokenLine = lines.first(where: { $0.text.contains("TOKEN_SEEN_BY_WRANGLER=") })
+        XCTAssertEqual(tokenLine?.text, "TOKEN_SEEN_BY_WRANGLER=secret-token-abc")
+    }
+}

--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -54,16 +54,18 @@ This is the riskiest piece, so do it first.
 4. ✅ **Selector strategy: server-side resolution (#18, decided 2026-05-13).** The overlay sends a structured `ElementInfo` payload — `{tag, id?, classes, nthChild, ancestors?, dataAnglesiteId?, dataTestId?, role?, ariaLabel?, textContent?}` matching the typedef in `anglesite/server/selector.mjs` — and the plugin invokes `buildSelector(info)` server-side. One source of truth for the priority order (`data-anglesite-id` > `data-testid` > `#id` > role/aria > stable classes > `tag:nth-child`), no fork-prone duplicated JS. `JS/edit-overlay/src/selector.ts` exposes `elementInfoFor(element)`; ancestors are root-first and stop at `<body>`. The bridge stays a relay: `EditMessage.selector` is `JSONValue` (validated as an object at decode), forwarded as-is by `MCPApplyEditRouter` to the `anglesite:apply-edit` tool when Phase 5 wires it up.
 5. ✅ MCP client lifecycle + apply-edit round-trip wired (2026-05-22). `PreviewSession` (AnglesiteCore) now owns one `MCPClient` per site alongside its `AstroDevServer` — spawned together in `start(siteID:siteDirectory:)`, drained together in `stop()`, both tracked by `ProcessSupervisor.shared` so app-quit drains every child. Spawn defaults: vendored Node + bundled plugin's `server/index.mjs` resolved via `PluginRuntime`, `ANGLESITE_PROJECT_ROOT` set to the site path, source tag `mcp:<siteName>`. Graceful failure — if MCP can't spawn the session still reaches `.ready(url)`; only edit attempts fail (with the existing `EditReply.failed("MCP not running")` shape). `PreviewModel` builds an `MCPApplyEditRouter` wrapping a weak getter to `session.mcpClient` and exposes it as `editRouter`; `PreviewView`/`ContentView` thread it into `AnglesiteScriptHandler` (was `LoggingEditRouter`). End-to-end test in `AnglesiteBridgeTests/AppliesEditEndToEndTests` spawns the real bundled plugin against a tmp Astro-shaped fixture, drives `apply_edit` through a real `MCPClient`, asserts the file's bytes change — `XCTSkip`s cleanly when the sibling plugin checkout or its `node_modules` aren't present (CI provides both via `actions/checkout` + `npm ci` + `ANGLESITE_PLUGIN_PATH`). Cost: +1 Node process per open site (~80–150 MB on top of the existing `astro dev` process).
 
-## Phase 5 — Source patcher (in the plugin repo, not the app)
+## Phase 5 — Source patcher (in the plugin repo, not the app) ✅
 
 This work lands in `anglesite/server/` — the app repo just calls it.
 
-1. Add `server/patcher.mjs` with three resolvers in priority order: `.mdoc` → Keystatic schema → `.astro` static text. Each resolver returns `{file, range, replacement}` or refuses with a reason.
-2. Extend `server/messages.mjs` with `apply-edit`, `edit-applied`, `edit-failed`.
-3. Wire `server/index.mjs` to dispatch the new message types.
-4. Implement the **hidden git branch** undo: every successful patch commits to `anglesite/edits` branch. Add `server/edit-history.mjs`.
-5. Tests in `anglesite/test/patcher.test.js` covering each resolver + ambiguous-match refusal.
-6. **Bounce-to-Claude path** is deferred to v0.5 — for v0, ambiguous edits surface a "Can't edit this directly — try chat (coming soon)" sheet.
+1. ✅ `server/patcher.mjs` — three resolvers in priority order (`.mdoc` → Keystatic schema → `.astro` static text). Each returns `{file, range, replacement}` or `{refused, reason, detail?}`. Landed in `Anglesite/anglesite#295` → merged via #314.
+2. ✅ `server/apply-edit-schema.mjs` — zod schemas for `apply_edit`, `edit-applied`, `edit-failed` (replaces the `messages.mjs` extension; tool name is `apply_edit` snake-case server-side, the WKWebView-side `type:` tag stays `"anglesite:apply-edit"`). Landed in `#296` → merged via #313.
+3. ✅ `server/index.mjs` dispatch — wires the `apply_edit` MCP tool to the dispatcher. Landed in `#297` → merged via #315.
+4. ✅ Hidden git branch undo — `server/edit-history.mjs` commits each successful patch to `anglesite/edits` via git plumbing (no working-tree-dirtying). Landed in `#298` → merged via #316.
+5. ✅ Tests in `anglesite/test/patcher.test.js` + `apply-edit-dispatcher.test.js` + `edit-history.test.js` covering each resolver, ambiguous-match refusal, write-failed mapping, and the onApplied hook contract.
+6. Bounce-to-Claude path remains deferred to v0.5 — for v0, ambiguous edits surface as `edit-failed` reasons (`no-match`, `dynamic-expression`, `ambiguous-match`); the app's plan is to render a "Can't edit this directly — try chat (coming soon)" sheet once the chat panel arrives in Phase 8.
+
+**End-to-end verification (2026-05-22):** typed h1 edit in `~/Sites/smoke/src/pages/index.astro` flowed through the WKWebView overlay → `AnglesiteScriptHandler.decode` → `MCPApplyEditRouter` → bundled MCP server → dispatcher → atomic file write. Tracking issues `Anglesite/anglesite#294` and `Anglesite/Anglesite-app#19` closed. The `AppliesEditEndToEndTests` xctest gives this round-trip ongoing CI coverage.
 
 ## Phase 6 — Deploy button (v0 finishing)
 


### PR DESCRIPTION
## Summary
- Lands Phase 6 item 1 from `docs/build-plan.md`: a `DeployCommand` actor in `AnglesiteCore` that shells out to `wrangler deploy` from a site directory, with the Cloudflare token sourced from env (Keychain integration lands with Phase 7 / #23).
- Ticks the Phase 5 header `✅` in the build plan now that the apply-edit round-trip is verified end-to-end (per the 2026-05-22 verification note at the bottom of Phase 5).

Phase 6 items still open after this lands:
- #21 — honor `pre-deploy-check.sh` before deploy
- #22 — deploy output drawer with Copy/Open URL

## Test plan
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` succeeds
- [ ] Unit tests for `DeployCommand` pass (`xcodebuild test`)
- [ ] Manual: with `CLOUDFLARE_API_TOKEN` set in env, invoking `DeployCommand` against a real site streams `wrangler deploy` output to the Debug pane and reports the deployed URL on success
- [ ] Manual: with no token / invalid token, the failure path surfaces a useful error rather than hanging
- [ ] `ProcessSupervisor` drains the `wrangler` child on app quit (no orphaned processes)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)