### PR TITLE
feat(phase-6): PreDeployCheck + DeployCommand integration

### DIFF
--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+/// One-shot orchestrator for `wrangler deploy`.
+///
+/// Unlike `AstroDevServer` and `MCPClient` (long-running supervisees), a deploy is a single
+/// foreground action: spawn wrangler, wait for exit, parse the deployed URL out of the success
+/// line, return a `Result`. The process goes through `ProcessSupervisor.run(...)` (synchronous
+/// capture) rather than `.launch(...)`, because the `.launch(...)` path's LogCenter pump is
+/// async-and-untracked — `waitForExit` returns before late `Task { logCenter.append(...) }`
+/// calls have settled, and the URL line we need can be one of those late lines. The captured
+/// stdout/stderr are *also* fed to LogCenter line-by-line after exit so the Debug pane sees
+/// the run; for now that lands at the end of the deploy rather than in real time. Real-time
+/// streaming would require tracking the supervisor's pump Tasks — left as a follow-up.
+///
+/// Pre-spawn refusals (no Cloudflare token, no wrangler) return `.failed` without launching
+/// anything. After spawn, only the exit code + collected stdout matter: a zero exit with a
+/// matched `Published <name> (…)\n  <url>` block becomes `.succeeded`; a non-zero exit, or zero
+/// exit with no matched URL, becomes `.failed` with a reason.
+public actor DeployCommand {
+    public enum Result: Sendable, Equatable {
+        case succeeded(url: URL, duration: TimeInterval)
+        /// `exitCode` is `nil` for pre-spawn refusals (no token, no wrangler) and for spawn
+        /// failures; otherwise it's wrangler's exit code (including `0` for the
+        /// "exited cleanly but we couldn't find a URL" case).
+        case failed(reason: String, exitCode: Int32?)
+    }
+
+    /// How to run wrangler for a site directory — or why it can't be run.
+    public enum LaunchPlan: Sendable, Equatable {
+        case run(executable: URL, arguments: [String])
+        case unavailable(reason: String)
+    }
+
+    public typealias CommandResolver = @Sendable (_ siteDirectory: URL) -> LaunchPlan
+    /// Returns the Cloudflare API token, or `nil` if none is configured. Phase 7's
+    /// `KeychainStore` will replace the default `envTokenSource` in production callers.
+    public typealias TokenSource = @Sendable () async throws -> String?
+
+    private let supervisor: ProcessSupervisor
+    private let logCenter: LogCenter
+    private let resolveCommand: CommandResolver
+    private let tokenSource: TokenSource
+
+    public init(
+        supervisor: ProcessSupervisor = .shared,
+        logCenter: LogCenter = .shared,
+        resolveCommand: @escaping CommandResolver = DeployCommand.resolveWranglerCommand,
+        tokenSource: @escaping TokenSource = DeployCommand.envTokenSource
+    ) {
+        self.supervisor = supervisor
+        self.logCenter = logCenter
+        self.resolveCommand = resolveCommand
+        self.tokenSource = tokenSource
+    }
+
+    /// Run a deploy for `siteID`. Returns once wrangler has exited (or before, if pre-spawn
+    /// refusal applies). The subprocess streams to `logCenter` under source `deploy:<siteID>`
+    /// for the whole supervisor / Debug-pane / deploy-drawer pipeline.
+    public func deploy(siteID: String, siteDirectory: URL) async -> Result {
+        // Pre-spawn checks. The token comes first so we never spend time resolving an
+        // executable we won't end up running.
+        let token: String?
+        do {
+            token = try await tokenSource()
+        } catch {
+            return .failed(reason: "couldn't read Cloudflare API token: \(error)", exitCode: nil)
+        }
+        guard let token, !token.isEmpty else {
+            return .failed(reason: "no CLOUDFLARE_API_TOKEN — set in env or Settings (Phase 7)", exitCode: nil)
+        }
+
+        let plan = resolveCommand(siteDirectory)
+        let executable: URL
+        let arguments: [String]
+        switch plan {
+        case .unavailable(let reason):
+            return .failed(reason: reason, exitCode: nil)
+        case .run(let exe, let args):
+            executable = exe
+            arguments = args
+        }
+
+        let source = "deploy:\(siteID)"
+        var environment = ProcessInfo.processInfo.environment
+        environment["CLOUDFLARE_API_TOKEN"] = token
+
+        let started = Date()
+        let result: ProcessSupervisor.RunResult
+        do {
+            result = try await supervisor.run(
+                executable: executable,
+                arguments: arguments,
+                environment: environment
+            )
+        } catch {
+            return .failed(reason: "couldn't spawn wrangler: \(error)", exitCode: nil)
+        }
+        let duration = Date().timeIntervalSince(started)
+
+        // Mirror the captured output into LogCenter line-by-line so the Debug pane shows the
+        // run. This lands after exit rather than in real time — see the doc-comment header for
+        // why; the deploy drawer (#22) will show a spinner during the run so the user knows
+        // something is happening.
+        for line in result.stdout.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
+            await logCenter.append(source: source, stream: .stdout, text: String(line))
+        }
+        for line in result.stderr.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
+            await logCenter.append(source: source, stream: .stderr, text: String(line))
+        }
+
+        let code = result.exitCode
+        if code == 0 {
+            if let url = Self.extractDeployedURL(from: result.stdout) {
+                return .succeeded(url: url, duration: duration)
+            }
+            return .failed(reason: "wrangler exited cleanly but no deployed URL was found in its output", exitCode: 0)
+        }
+        return .failed(reason: "wrangler exited with code \(code)", exitCode: code)
+    }
+
+    // MARK: URL extraction
+
+    /// Scans for the wrangler "Published" anchor and the first URL after it. The line shape is
+    ///
+    ///     Published <name> (1.23 sec)
+    ///       https://<name>.<acct>.workers.dev
+    ///
+    /// Anchoring on `Published` (start-of-line, case-sensitive) prevents help-text URLs from
+    /// being mistaken for the deploy result. We accept the URL on the same line or any
+    /// subsequent line — wrangler has shipped multiple layouts of this block over the years.
+    public static func extractDeployedURL(from output: String) -> URL? {
+        let lines = output.split(separator: "\n", omittingEmptySubsequences: false)
+        guard let publishedIdx = lines.firstIndex(where: { $0.hasPrefix("Published") || $0.hasPrefix("Published ") }) else {
+            return nil
+        }
+        // Search the Published line itself, then subsequent lines, for the first URL.
+        for line in lines[publishedIdx...] {
+            if let urlRange = line.range(of: #"https?://[^\s]+"#, options: [.regularExpression]) {
+                // Strip trailing punctuation a terminal might tack on (commas, periods, closing parens).
+                var raw = String(line[urlRange])
+                while let last = raw.last, ",.)]}>".contains(last) {
+                    raw.removeLast()
+                }
+                return URL(string: raw)
+            }
+        }
+        return nil
+    }
+
+    // MARK: Default seams
+
+    /// Default `TokenSource`: read `CLOUDFLARE_API_TOKEN` from the environment.
+    public static let envTokenSource: TokenSource = {
+        ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"]
+    }
+
+    /// Default `CommandResolver`: run the site's own `wrangler` (`node_modules/.bin/wrangler
+    /// deploy`) with the vendored Node. Reports `.unavailable` when prerequisites are missing.
+    public static let resolveWranglerCommand: CommandResolver = { siteDirectory in
+        let wranglerBin = siteDirectory
+            .appendingPathComponent("node_modules", isDirectory: true)
+            .appendingPathComponent(".bin", isDirectory: true)
+            .appendingPathComponent("wrangler")
+        guard FileManager.default.isExecutableFile(atPath: wranglerBin.path) else {
+            return .unavailable(reason: "wrangler not installed — run `npm install` in this site")
+        }
+        guard let node = NodeRuntime.bundledExecutableURL else {
+            return .unavailable(reason: "the embedded Node runtime isn't bundled (rebuild the app)")
+        }
+        return .run(executable: node, arguments: [wranglerBin.path, "deploy"])
+    }
+}

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -19,6 +19,9 @@ import Foundation
 public actor DeployCommand {
     public enum Result: Sendable, Equatable {
         case succeeded(url: URL, duration: TimeInterval)
+        /// The pre-deploy security scan refused the deploy. Carries the structured
+        /// failures (and any warnings) so the UI can render a sheet with no override.
+        case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning])
         /// `exitCode` is `nil` for pre-spawn refusals (no token, no wrangler) and for spawn
         /// failures; otherwise it's wrangler's exit code (including `0` for the
         /// "exited cleanly but we couldn't find a URL" case).
@@ -35,22 +38,28 @@ public actor DeployCommand {
     /// Returns the Cloudflare API token, or `nil` if none is configured. Phase 7's
     /// `KeychainStore` will replace the default `envTokenSource` in production callers.
     public typealias TokenSource = @Sendable () async throws -> String?
+    /// Runs the bundled plugin's pre-deploy scan against a site and returns the outcome.
+    /// Real callers use `DeployCommand.defaultPreflight`; tests inject a fake.
+    public typealias PreflightChecker = @Sendable (_ siteDirectory: URL) async -> PreDeployCheck.Outcome
 
     private let supervisor: ProcessSupervisor
     private let logCenter: LogCenter
     private let resolveCommand: CommandResolver
     private let tokenSource: TokenSource
+    private let preflight: PreflightChecker
 
     public init(
         supervisor: ProcessSupervisor = .shared,
         logCenter: LogCenter = .shared,
         resolveCommand: @escaping CommandResolver = DeployCommand.resolveWranglerCommand,
-        tokenSource: @escaping TokenSource = DeployCommand.envTokenSource
+        tokenSource: @escaping TokenSource = DeployCommand.envTokenSource,
+        preflight: @escaping PreflightChecker = DeployCommand.defaultPreflight
     ) {
         self.supervisor = supervisor
         self.logCenter = logCenter
         self.resolveCommand = resolveCommand
         self.tokenSource = tokenSource
+        self.preflight = preflight
     }
 
     /// Run a deploy for `siteID`. Returns once wrangler has exited (or before, if pre-spawn
@@ -67,6 +76,21 @@ public actor DeployCommand {
         }
         guard let token, !token.isEmpty else {
             return .failed(reason: "no CLOUDFLARE_API_TOKEN — set in env or Settings (Phase 7)", exitCode: nil)
+        }
+
+        // Pre-deploy scan runs before wrangler resolution. If the bundled plugin's
+        // checks find PII, exposed tokens, unauthorized third-party scripts, or
+        // Keystatic admin routes in dist/, the deploy is blocked regardless of
+        // whether wrangler is installed — the user needs to fix the scan findings
+        // first either way. Per the durable rule in CLAUDE.md, the app cannot
+        // bypass plugin security hooks; the UI sheet for `.blocked` has no override.
+        switch await preflight(siteDirectory) {
+        case .passed:
+            break
+        case .blocked(let failures, let warnings):
+            return .blocked(failures: failures, warnings: warnings)
+        case .error(let reason):
+            return .failed(reason: "pre-deploy scan could not run: \(reason)", exitCode: nil)
         }
 
         let plan = resolveCommand(siteDirectory)
@@ -152,6 +176,42 @@ public actor DeployCommand {
     /// Default `TokenSource`: read `CLOUDFLARE_API_TOKEN` from the environment.
     public static let envTokenSource: TokenSource = {
         ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"]
+    }
+
+    /// Default `PreflightChecker`: invokes the site's own `scripts/pre-deploy-check.ts
+    /// --json` via `npx tsx` and parses the result. The script is part of the bundled
+    /// plugin's template, so every Anglesite site already has it; outdated sites that
+    /// predate the `--json` mode surface as `.error` outcomes, which `deploy` maps to
+    /// `.failed` with a "run `/anglesite:update`" remediation.
+    public static let defaultPreflight: PreflightChecker = { siteDirectory in
+        let check = PreDeployCheck(invoke: { siteDir in
+            let scriptPath = siteDir.appendingPathComponent("scripts/pre-deploy-check.ts").path
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["npx", "tsx", scriptPath, "--json"]
+            process.currentDirectoryURL = siteDir
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+            try process.run()
+            // Drain pipes off the actor — Process.waitUntilExit() blocks; doing it in a
+            // detached task avoids parking the calling actor's executor for long scans.
+            let result: (String, String, Int32) = await withCheckedContinuation { cont in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let out = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+                    let err = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                    process.waitUntilExit()
+                    cont.resume(returning: (
+                        String(data: out, encoding: .utf8) ?? "",
+                        String(data: err, encoding: .utf8) ?? "",
+                        process.terminationStatus
+                    ))
+                }
+            }
+            return (stdout: result.0, exitCode: result.2)
+        })
+        return await check.check(siteID: "deploy", siteDirectory: siteDirectory)
     }
 
     /// Default `CommandResolver`: run the site's own `wrangler` (`node_modules/.bin/wrangler

--- a/Sources/AnglesiteCore/PreDeployCheck.swift
+++ b/Sources/AnglesiteCore/PreDeployCheck.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Runs the bundled plugin's pre-deploy scans against a site directory and
+/// returns a structured outcome the app can render.
+///
+/// The four mandatory blockers (PII, exposed tokens, third-party scripts,
+/// Keystatic admin routes) come from `template/scripts/pre-deploy-check.ts`
+/// invoked with `--json`. The JSON contract is owned by the plugin — this
+/// actor is just a typed shell around `JSONDecoder` and a script invocation.
+///
+/// `PreDeployCheck` is intentionally minimal: no Cloudflare token resolution,
+/// no `npm run build`, no UI. Callers (today: `DeployCommand`) decide what to
+/// do with the `Outcome`. The build step lands with the deploy-flow polish in
+/// #22; this actor presumes `dist/` already exists and surfaces a `.error`
+/// outcome when it does not.
+public actor PreDeployCheck {
+    public enum Outcome: Sendable, Equatable {
+        case passed(warnings: [ScanWarning])
+        case blocked(failures: [ScanFailure], warnings: [ScanWarning])
+        /// Script error — couldn't run the scan at all (missing tsx, missing
+        /// dist/, malformed JSON). Distinct from `.blocked` so callers can
+        /// surface the right remediation.
+        case error(reason: String)
+    }
+
+    public struct ScanFailure: Sendable, Equatable, Codable {
+        public enum Category: String, Sendable, Codable {
+            case piiEmail = "pii-email"
+            case piiPhone = "pii-phone"
+            case exposedToken = "exposed-token"
+            case thirdPartyScript = "third-party-script"
+            case keystaticRoute = "keystatic-route"
+        }
+        public let category: Category
+        /// Repo-relative path of the file where the issue was found, when known.
+        public let file: String?
+        public let detail: String
+        public let remediation: String
+
+        public init(category: Category, file: String?, detail: String, remediation: String) {
+            self.category = category
+            self.file = file
+            self.detail = detail
+            self.remediation = remediation
+        }
+    }
+
+    public struct ScanWarning: Sendable, Equatable, Codable {
+        public enum Category: String, Sendable, Codable {
+            case missingOgImage = "missing-og-image"
+            case maintenanceOverdue = "maintenance-overdue"
+            case seoCritical = "seo-critical"
+            case seoWarning = "seo-warning"
+        }
+        public let category: Category
+        public let detail: String
+        public let remediation: String
+
+        public init(category: Category, detail: String, remediation: String) {
+            self.category = category
+            self.detail = detail
+            self.remediation = remediation
+        }
+    }
+
+    /// Spawns the scan script and returns its stdout + exit code. Tests inject
+    /// a fake; the default invoker shells out to `npx tsx scripts/pre-deploy-check.ts --json`
+    /// with `siteDirectory` as cwd.
+    public typealias ScriptInvoker = @Sendable (_ siteDirectory: URL) async throws -> (stdout: String, exitCode: Int32)
+
+    private let invoke: ScriptInvoker
+
+    public init(invoke: @escaping ScriptInvoker) {
+        self.invoke = invoke
+    }
+
+    public func check(siteID: String, siteDirectory: URL) async -> Outcome {
+        let result: (stdout: String, exitCode: Int32)
+        do {
+            result = try await invoke(siteDirectory)
+        } catch {
+            return .error(reason: "couldn't run pre-deploy scan: \(error)")
+        }
+
+        struct RawReport: Decodable {
+            let ok: Bool
+            let failures: [ScanFailure]
+            let warnings: [ScanWarning]
+        }
+
+        let stdoutData = Data(result.stdout.utf8)
+        let report: RawReport
+        do {
+            report = try JSONDecoder().decode(RawReport.self, from: stdoutData)
+        } catch {
+            // No parseable JSON — the script most likely errored out. Exit
+            // code 1 with no JSON typically means missing dist/ or missing tsx.
+            return .error(reason: result.exitCode == 0
+                ? "pre-deploy scan emitted no JSON (exit 0) — is the site's scripts/pre-deploy-check.ts up to date?"
+                : "pre-deploy scan failed (exit \(result.exitCode)) — run `npm run build` and try again, or run `/anglesite:update` if the script is outdated")
+        }
+
+        if report.ok {
+            return .passed(warnings: report.warnings)
+        }
+        return .blocked(failures: report.failures, warnings: report.warnings)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -8,7 +8,8 @@ final class DeployCommandTests: XCTestCase {
 
     private func makeCommand(
         resolve: @escaping DeployCommand.CommandResolver,
-        token: @escaping DeployCommand.TokenSource
+        token: @escaping DeployCommand.TokenSource,
+        preflight: @escaping DeployCommand.PreflightChecker = { _ in .passed(warnings: []) }
     ) -> (DeployCommand, ProcessSupervisor, LogCenter) {
         let supervisor = ProcessSupervisor()
         let center = LogCenter()
@@ -16,7 +17,8 @@ final class DeployCommandTests: XCTestCase {
             supervisor: supervisor,
             logCenter: center,
             resolveCommand: resolve,
-            tokenSource: token
+            tokenSource: token,
+            preflight: preflight
         )
         return (cmd, supervisor, center)
     }
@@ -159,5 +161,60 @@ final class DeployCommandTests: XCTestCase {
         let lines = await center.snapshot()
         let tokenLine = lines.first(where: { $0.text.contains("TOKEN_SEEN_BY_WRANGLER=") })
         XCTAssertEqual(tokenLine?.text, "TOKEN_SEEN_BY_WRANGLER=secret-token-abc")
+    }
+
+    // MARK: Pre-deploy preflight
+
+    func testReturnsBlockedAndDoesNotSpawnWranglerWhenPreflightBlocks() async {
+        var wranglerSpawned = false
+        let blockedOutcome = PreDeployCheck.Outcome.blocked(
+            failures: [
+                .init(
+                    category: .piiEmail,
+                    file: "dist/index.html",
+                    detail: "Possible email address: jane@yourbusiness.com",
+                    remediation: "Wrap the address in a `mailto:` link or add it to PII_EMAIL_ALLOW in .site-config."
+                )
+            ],
+            warnings: []
+        )
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in
+                wranglerSpawned = true
+                return self.shFixture("exit 0")
+            },
+            token: { "fake-token" },
+            preflight: { _ in blockedOutcome }
+        )
+
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+
+        XCTAssertFalse(wranglerSpawned, "wrangler must not run when the pre-deploy scan blocks the deploy")
+        guard case .blocked(let failures, _) = result else {
+            return XCTFail("expected .blocked, got \(result)")
+        }
+        XCTAssertEqual(failures.count, 1)
+        XCTAssertEqual(failures[0].category, .piiEmail)
+        XCTAssertEqual(failures[0].file, "dist/index.html")
+    }
+
+    func testFailsWhenPreflightErrors() async {
+        var wranglerSpawned = false
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in
+                wranglerSpawned = true
+                return self.shFixture("exit 0")
+            },
+            token: { "fake-token" },
+            preflight: { _ in .error(reason: "tsx not installed in this site") }
+        )
+
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+
+        XCTAssertFalse(wranglerSpawned, "wrangler must not run when preflight could not run at all")
+        guard case .failed(let reason, _) = result else {
+            return XCTFail("expected .failed, got \(result)")
+        }
+        XCTAssertTrue(reason.contains("tsx"), "reason should surface the preflight error: \(reason)")
     }
 }

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import AnglesiteCore
+
+final class DeployCommandTests: XCTestCase {
+    /// A real, existing directory — the supervisor `cd`s into the site dir before spawning, so a
+    /// nonexistent path would fail `process.run()` before our fixture script even runs.
+    private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+    private func makeCommand(
+        resolve: @escaping DeployCommand.CommandResolver,
+        token: @escaping DeployCommand.TokenSource
+    ) -> (DeployCommand, ProcessSupervisor, LogCenter) {
+        let supervisor = ProcessSupervisor()
+        let center = LogCenter()
+        let cmd = DeployCommand(
+            supervisor: supervisor,
+            logCenter: center,
+            resolveCommand: resolve,
+            tokenSource: token
+        )
+        return (cmd, supervisor, center)
+    }
+
+    private func shFixture(_ script: String, _ args: String...) -> DeployCommand.LaunchPlan {
+        .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", script] + args)
+    }
+
+    // MARK: Pre-spawn refusal (no work wasted)
+
+    func testRefusesBeforeSpawnWhenTokenSourceReturnsNil() async {
+        var spawned = false
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in
+                spawned = true
+                return self.shFixture("exit 0")
+            },
+            token: { nil }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        XCTAssertFalse(spawned, "resolver should not be consulted when token is missing")
+        guard case .failed(let reason, let exit) = result else { return XCTFail("expected .failed, got \(result)") }
+        XCTAssertTrue(reason.contains("CLOUDFLARE_API_TOKEN"), "reason should name the env var the caller should set: \(reason)")
+        XCTAssertNil(exit)
+    }
+
+    func testRefusesBeforeSpawnWhenTokenSourceReturnsEmptyString() async {
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in self.shFixture("exit 0") },
+            token: { "" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, _) = result else { return XCTFail("expected .failed, got \(result)") }
+        XCTAssertTrue(reason.contains("CLOUDFLARE_API_TOKEN"), reason)
+    }
+
+    func testFailsWhenResolverReportsUnavailable() async {
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in .unavailable(reason: "wrangler not installed — run `npm install`") },
+            token: { "fake-token" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else { return XCTFail("expected .failed, got \(result)") }
+        XCTAssertEqual(reason, "wrangler not installed — run `npm install`")
+        XCTAssertNil(exit)
+    }
+
+    // MARK: Happy path — URL extraction
+
+    func testSucceedsAndExtractsURLFromPublishedLine() async {
+        // Synthetic wrangler output: a blank line, the `Published ...` summary, indented URL, exit 0.
+        let script = """
+        echo ''
+        echo '⛅️ wrangler 3.50.0'
+        echo 'Total Upload: 4.20 KiB'
+        echo 'Published angle-app (1.23 sec)'
+        echo '  https://angle-app.example.workers.dev'
+        echo '  Current Deployment ID: abc-123'
+        exit 0
+        """
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in self.shFixture(script) },
+            token: { "fake-token" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .succeeded(let url, let duration) = result else { return XCTFail("expected .succeeded, got \(result)") }
+        XCTAssertEqual(url, URL(string: "https://angle-app.example.workers.dev")!)
+        XCTAssertGreaterThanOrEqual(duration, 0)
+    }
+
+    func testIgnoresURLsThatAppearBeforeThePublishedAnchor() async {
+        // A help-text URL in wrangler's output must NOT be reported as the deployed URL.
+        let script = """
+        echo 'See https://developers.cloudflare.com/workers for help.'
+        echo 'Published angle-app (1.23 sec)'
+        echo '  https://angle-app.example.workers.dev'
+        exit 0
+        """
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in self.shFixture(script) },
+            token: { "fake-token" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .succeeded(let url, _) = result else { return XCTFail("expected .succeeded, got \(result)") }
+        XCTAssertEqual(url.host, "angle-app.example.workers.dev")
+    }
+
+    // MARK: Failure surfacing
+
+    func testFailsWhenWranglerExitsNonZero() async {
+        let script = """
+        echo 'Error: authentication failed' 1>&2
+        exit 10
+        """
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in self.shFixture(script) },
+            token: { "fake-token" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else { return XCTFail("expected .failed, got \(result)") }
+        XCTAssertEqual(exit, 10)
+        XCTAssertTrue(reason.contains("10"), "reason should mention the exit code: \(reason)")
+    }
+
+    func testFailsSemanticallyWhenZeroExitButNoPublishedURL() async {
+        // A wrangler bug or unexpected output shape: process exits 0 but our anchor never matched.
+        // We surface this as a clear failure rather than silently returning a bogus URL.
+        let script = """
+        echo 'Did some thing.'
+        echo 'No anchor here.'
+        exit 0
+        """
+        let (cmd, _, _) = makeCommand(
+            resolve: { _ in self.shFixture(script) },
+            token: { "fake-token" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else { return XCTFail("expected .failed, got \(result)") }
+        XCTAssertEqual(exit, 0)
+        XCTAssertTrue(reason.lowercased().contains("url"), "reason should explain the URL was missing: \(reason)")
+    }
+
+    // MARK: Token propagation
+
+    func testPassesCloudflareTokenAsEnvironmentVariableToSubprocess() async {
+        // Fixture echoes the value of $CLOUDFLARE_API_TOKEN, then prints a fake Published URL so
+        // the deploy reaches `.succeeded`. We can then read what was echoed via the LogCenter.
+        let script = """
+        echo "TOKEN_SEEN_BY_WRANGLER=$CLOUDFLARE_API_TOKEN"
+        echo 'Published angle-app (0.42 sec)'
+        echo '  https://t.example.workers.dev'
+        exit 0
+        """
+        let (cmd, _, center) = makeCommand(
+            resolve: { _ in self.shFixture(script) },
+            token: { "secret-token-abc" }
+        )
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .succeeded = result else { return XCTFail("expected .succeeded, got \(result)") }
+        let lines = await center.snapshot()
+        let tokenLine = lines.first(where: { $0.text.contains("TOKEN_SEEN_BY_WRANGLER=") })
+        XCTAssertEqual(tokenLine?.text, "TOKEN_SEEN_BY_WRANGLER=secret-token-abc")
+    }
+}

--- a/Tests/AnglesiteCoreTests/PreDeployCheckTests.swift
+++ b/Tests/AnglesiteCoreTests/PreDeployCheckTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import AnglesiteCore
+
+final class PreDeployCheckTests: XCTestCase {
+    private let siteDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+    // MARK: Happy path
+
+    func testReturnsPassedWhenScriptEmitsOkTrueJSON() async {
+        let json = #"{"ok": true, "failures": [], "warnings": []}"#
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 0) })
+
+        let outcome = await check.check(siteID: "mysite", siteDirectory: siteDir)
+
+        guard case .passed(let warnings) = outcome else {
+            return XCTFail("expected .passed, got \(outcome)")
+        }
+        XCTAssertEqual(warnings, [])
+    }
+
+    // MARK: Blocked
+
+    func testReturnsBlockedWhenScriptEmitsOkFalseWithFailures() async {
+        let json = """
+        {
+          "ok": false,
+          "failures": [
+            {
+              "category": "pii-email",
+              "file": "dist/index.html",
+              "detail": "Possible email address: jane@yourbusiness.com",
+              "remediation": "Wrap the address in a `mailto:` link if it should be published, or add it to PII_EMAIL_ALLOW in .site-config."
+            }
+          ],
+          "warnings": []
+        }
+        """
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 1) })
+
+        let outcome = await check.check(siteID: "mysite", siteDirectory: siteDir)
+
+        guard case .blocked(let failures, _) = outcome else {
+            return XCTFail("expected .blocked, got \(outcome)")
+        }
+        XCTAssertEqual(failures.count, 1)
+        XCTAssertEqual(failures[0].category, .piiEmail)
+        XCTAssertEqual(failures[0].file, "dist/index.html")
+        XCTAssertTrue(failures[0].detail.contains("jane@yourbusiness.com"))
+        XCTAssertTrue(failures[0].remediation.contains("PII_EMAIL_ALLOW"))
+    }
+
+    func testParsesAllFiveFailureCategories() async {
+        let json = """
+        {
+          "ok": false,
+          "failures": [
+            {"category": "pii-email", "file": "a", "detail": "d", "remediation": "r"},
+            {"category": "pii-phone", "file": "a", "detail": "d", "remediation": "r"},
+            {"category": "exposed-token", "file": "a", "detail": "d", "remediation": "r"},
+            {"category": "third-party-script", "file": "a", "detail": "d", "remediation": "r"},
+            {"category": "keystatic-route", "file": "a", "detail": "d", "remediation": "r"}
+          ],
+          "warnings": []
+        }
+        """
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 1) })
+
+        guard case .blocked(let failures, _) = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            return XCTFail("expected .blocked")
+        }
+        XCTAssertEqual(
+            Set(failures.map(\.category)),
+            Set([.piiEmail, .piiPhone, .exposedToken, .thirdPartyScript, .keystaticRoute])
+        )
+    }
+
+    // MARK: Error paths
+
+    func testReturnsErrorWhenInvokerThrows() async {
+        struct SpawnFailed: Error {}
+        let check = PreDeployCheck(invoke: { _ in throw SpawnFailed() })
+
+        let outcome = await check.check(siteID: "mysite", siteDirectory: siteDir)
+
+        guard case .error(let reason) = outcome else {
+            return XCTFail("expected .error, got \(outcome)")
+        }
+        XCTAssertTrue(reason.contains("couldn't run"), reason)
+    }
+
+    func testReturnsErrorWhenStdoutIsNotParseableJSON() async {
+        // tsx not installed → "command not found" on stderr, no stdout, exit 127
+        let check = PreDeployCheck(invoke: { _ in (stdout: "", exitCode: 127) })
+
+        guard case .error(let reason) = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            return XCTFail("expected .error")
+        }
+        XCTAssertTrue(reason.contains("exit 127") || reason.contains("npm run build") || reason.contains("update"), reason)
+    }
+
+    func testReturnsErrorWhenJSONIsMalformed() async {
+        let check = PreDeployCheck(invoke: { _ in (stdout: "not json at all", exitCode: 0) })
+
+        guard case .error = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            return XCTFail("expected .error")
+        }
+    }
+
+    // MARK: Warnings pass-through
+
+    func testWarningsAreReturnedAlongsidePassedAndBlockedOutcomes() async {
+        let warningJSON = """
+        "warnings": [
+          {"category": "missing-og-image", "detail": "No og:image meta tag.", "remediation": "Run `npm run ai-images`."}
+        ]
+        """
+        let passedJSON = "{ \"ok\": true, \"failures\": [], \(warningJSON) }"
+        let blockedJSON = """
+        { "ok": false,
+          "failures": [{"category": "pii-email", "file": "a", "detail": "d", "remediation": "r"}],
+          \(warningJSON) }
+        """
+
+        let passedCheck = PreDeployCheck(invoke: { _ in (stdout: passedJSON, exitCode: 0) })
+        guard case .passed(let pw) = await passedCheck.check(siteID: "mysite", siteDirectory: siteDir) else {
+            return XCTFail("expected .passed")
+        }
+        XCTAssertEqual(pw.count, 1)
+        XCTAssertEqual(pw[0].category, .missingOgImage)
+
+        let blockedCheck = PreDeployCheck(invoke: { _ in (stdout: blockedJSON, exitCode: 1) })
+        guard case .blocked(_, let bw) = await blockedCheck.check(siteID: "mysite", siteDirectory: siteDir) else {
+            return XCTFail("expected .blocked")
+        }
+        XCTAssertEqual(bw.count, 1)
+        XCTAssertEqual(bw[0].category, .missingOgImage)
+    }
+}

--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -54,16 +54,18 @@ This is the riskiest piece, so do it first.
 4. ✅ **Selector strategy: server-side resolution (#18, decided 2026-05-13).** The overlay sends a structured `ElementInfo` payload — `{tag, id?, classes, nthChild, ancestors?, dataAnglesiteId?, dataTestId?, role?, ariaLabel?, textContent?}` matching the typedef in `anglesite/server/selector.mjs` — and the plugin invokes `buildSelector(info)` server-side. One source of truth for the priority order (`data-anglesite-id` > `data-testid` > `#id` > role/aria > stable classes > `tag:nth-child`), no fork-prone duplicated JS. `JS/edit-overlay/src/selector.ts` exposes `elementInfoFor(element)`; ancestors are root-first and stop at `<body>`. The bridge stays a relay: `EditMessage.selector` is `JSONValue` (validated as an object at decode), forwarded as-is by `MCPApplyEditRouter` to the `anglesite:apply-edit` tool when Phase 5 wires it up.
 5. ✅ MCP client lifecycle + apply-edit round-trip wired (2026-05-22). `PreviewSession` (AnglesiteCore) now owns one `MCPClient` per site alongside its `AstroDevServer` — spawned together in `start(siteID:siteDirectory:)`, drained together in `stop()`, both tracked by `ProcessSupervisor.shared` so app-quit drains every child. Spawn defaults: vendored Node + bundled plugin's `server/index.mjs` resolved via `PluginRuntime`, `ANGLESITE_PROJECT_ROOT` set to the site path, source tag `mcp:<siteName>`. Graceful failure — if MCP can't spawn the session still reaches `.ready(url)`; only edit attempts fail (with the existing `EditReply.failed("MCP not running")` shape). `PreviewModel` builds an `MCPApplyEditRouter` wrapping a weak getter to `session.mcpClient` and exposes it as `editRouter`; `PreviewView`/`ContentView` thread it into `AnglesiteScriptHandler` (was `LoggingEditRouter`). End-to-end test in `AnglesiteBridgeTests/AppliesEditEndToEndTests` spawns the real bundled plugin against a tmp Astro-shaped fixture, drives `apply_edit` through a real `MCPClient`, asserts the file's bytes change — `XCTSkip`s cleanly when the sibling plugin checkout or its `node_modules` aren't present (CI provides both via `actions/checkout` + `npm ci` + `ANGLESITE_PLUGIN_PATH`). Cost: +1 Node process per open site (~80–150 MB on top of the existing `astro dev` process).
 
-## Phase 5 — Source patcher (in the plugin repo, not the app)
+## Phase 5 — Source patcher (in the plugin repo, not the app) ✅
 
 This work lands in `anglesite/server/` — the app repo just calls it.
 
-1. Add `server/patcher.mjs` with three resolvers in priority order: `.mdoc` → Keystatic schema → `.astro` static text. Each resolver returns `{file, range, replacement}` or refuses with a reason.
-2. Extend `server/messages.mjs` with `apply-edit`, `edit-applied`, `edit-failed`.
-3. Wire `server/index.mjs` to dispatch the new message types.
-4. Implement the **hidden git branch** undo: every successful patch commits to `anglesite/edits` branch. Add `server/edit-history.mjs`.
-5. Tests in `anglesite/test/patcher.test.js` covering each resolver + ambiguous-match refusal.
-6. **Bounce-to-Claude path** is deferred to v0.5 — for v0, ambiguous edits surface a "Can't edit this directly — try chat (coming soon)" sheet.
+1. ✅ `server/patcher.mjs` — three resolvers in priority order (`.mdoc` → Keystatic schema → `.astro` static text). Each returns `{file, range, replacement}` or `{refused, reason, detail?}`. Landed in `Anglesite/anglesite#295` → merged via #314.
+2. ✅ `server/apply-edit-schema.mjs` — zod schemas for `apply_edit`, `edit-applied`, `edit-failed` (replaces the `messages.mjs` extension; tool name is `apply_edit` snake-case server-side, the WKWebView-side `type:` tag stays `"anglesite:apply-edit"`). Landed in `#296` → merged via #313.
+3. ✅ `server/index.mjs` dispatch — wires the `apply_edit` MCP tool to the dispatcher. Landed in `#297` → merged via #315.
+4. ✅ Hidden git branch undo — `server/edit-history.mjs` commits each successful patch to `anglesite/edits` via git plumbing (no working-tree-dirtying). Landed in `#298` → merged via #316.
+5. ✅ Tests in `anglesite/test/patcher.test.js` + `apply-edit-dispatcher.test.js` + `edit-history.test.js` covering each resolver, ambiguous-match refusal, write-failed mapping, and the onApplied hook contract.
+6. Bounce-to-Claude path remains deferred to v0.5 — for v0, ambiguous edits surface as `edit-failed` reasons (`no-match`, `dynamic-expression`, `ambiguous-match`); the app's plan is to render a "Can't edit this directly — try chat (coming soon)" sheet once the chat panel arrives in Phase 8.
+
+**End-to-end verification (2026-05-22):** typed h1 edit in `~/Sites/smoke/src/pages/index.astro` flowed through the WKWebView overlay → `AnglesiteScriptHandler.decode` → `MCPApplyEditRouter` → bundled MCP server → dispatcher → atomic file write. Tracking issues `Anglesite/anglesite#294` and `Anglesite/Anglesite-app#19` closed. The `AppliesEditEndToEndTests` xctest gives this round-trip ongoing CI coverage.
 
 ## Phase 6 — Deploy button (v0 finishing)
 

--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -69,8 +69,8 @@ This work lands in `anglesite/server/` — the app repo just calls it.
 
 ## Phase 6 — Deploy button (v0 finishing)
 
-1. `DeployCommand`: shells out to `wrangler deploy` from the site directory. Cloudflare token from Keychain (Phase 7) or env.
-2. **Pre-deploy hook honored**: invoke `scripts/pre-deploy-check.sh` from the bundled plugin. On failure, surface the structured output as a sheet with remediation steps; do not allow override.
+1. ✅ `DeployCommand`: shells out to `wrangler deploy` from the site directory (#20). Cloudflare token from Keychain (Phase 7) or env.
+2. 🟡 **Pre-deploy hook honored**: `PreDeployCheck` (AnglesiteCore) shells out to the site's `scripts/pre-deploy-check.ts --json` and parses the structured `ScanReport` (failures + warnings). The plugin gained a `runScan()` export + `--json` CLI flag in the paired plugin PR; the same `template/scripts/pre-deploy-check.ts` powers both the human-readable mode (existing) and the app-facing JSON mode (new). `DeployCommand` now runs the scan after the token check but before `wrangler` is even resolved — a `.blocked` outcome short-circuits to the new `Result.blocked(failures:, warnings:)` case carrying `[PreDeployCheck.ScanFailure]` / `[PreDeployCheck.ScanWarning]`; `.error` outcomes (missing tsx, missing dist/, outdated scaffold without `--json`) fall through to `.failed` with a "run `/anglesite:update`" remediation. Per CLAUDE.md, *the app cannot bypass plugin security hooks* — no override is exposed. *Remaining for full Phase 6 closure (#22):* the blocked sheet UI (so far the data path is wired and tested; the SwiftUI sheet lands with the deploy drawer). The `npm run build` step that produces `dist/` before scanning is also queued for #22 — today the scan throws if `dist/` is missing and the user sees the remediation message.
 3. Output streamed to a transient drawer; success shows the deployed URL with a "Copy/Open" button.
 
 ## Phase 7 — Keychain + secrets


### PR DESCRIPTION
## Summary
- `PreDeployCheck` actor in `AnglesiteCore` runs the bundled plugin's pre-deploy scan (PII, exposed tokens, third-party scripts, Keystatic admin routes) against a site directory and returns a structured `Outcome`.
- `DeployCommand` invokes it before `wrangler deploy`. A `.blocked` outcome short-circuits to a new `Result.blocked(failures:, warnings:)` case carrying everything the UI sheet needs. **No override path is exposed** — per CLAUDE.md, the app cannot bypass plugin security hooks.
- **Stacks on #39** (DeployCommand from #20). The diff against `main` currently includes #39's commit too; collapses to just #21's work once #39 merges. Paired with **Anglesite/anglesite#317**, which adds the `--json` mode + `runScan()` export the actor consumes.

Closes #21

## Deferred to follow-ups (#22 territory)
- The blocked sheet UI — data path is wired and tested; the SwiftUI sheet lands with the deploy drawer.
- `npm run build` step before scanning — today the scan throws when `dist/` is missing and surfaces the remediation. Adding an explicit build step is the next natural increment.

## Test plan
- [x] \`swift test --filter PreDeployCheckTests\` — 7/7 pass (passed / blocked / error / malformed-JSON / non-zero exit / warnings pass-through / all five failure categories)
- [x] \`swift test --filter DeployCommandTests\` — 10/10 pass (8 existing + 2 new preflight tests)
- [ ] Manual: with #317 merged + a site rebuilt to pick up the \`--json\` flag, invoke \`DeployCommand.deploy(...)\` against a site with intentional PII in \`dist/index.html\` and confirm \`.blocked\` with the right failure
- [ ] Manual: with a clean \`dist/\`, confirm preflight passes and wrangler proceeds
- [ ] Manual: with an outdated scaffold (no \`--json\` support), confirm \`.failed\` surfaces the "run \`/anglesite:update\`" remediation

🤖 Generated with [Claude Code](https://claude.com/claude-code)