### PR TITLE
feat(phase-7): KeychainStore for Cloudflare API token (#23)

### DIFF
--- a/Sources/AnglesiteApp/CloudflareTokenPromptView.swift
+++ b/Sources/AnglesiteApp/CloudflareTokenPromptView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import AnglesiteCore
+
+/// First-deploy modal: ask the user to paste their Cloudflare API token, store it in the
+/// Keychain, and let the parked deploy proceed. Surfaced by `DeployModel` when both the env var
+/// and the Keychain are empty at the moment the user clicks Deploy.
+///
+/// The view is intentionally narrow — it only captures the token. Long-term management
+/// (replacing, clearing) happens in Settings → Advanced → Credentials. Surfacing the same
+/// `KeychainStore` slot here means a token saved from either entry point is immediately usable
+/// by `wrangler deploy`.
+struct CloudflareTokenPromptView: View {
+    let model: DeployModel
+    let onCancel: () -> Void
+
+    @State private var token: String = ""
+    @State private var errorMessage: String?
+    @FocusState private var fieldFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Cloudflare API token required")
+                    .font(.headline)
+                Text("Anglesite needs an API token to run `wrangler deploy`. Paste one below — it'll be stored in your Mac's Keychain and re-used for future deploys.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            SecureField("API token", text: $token, prompt: Text("paste token"))
+                .textFieldStyle(.roundedBorder)
+                .focused($fieldFocused)
+                .onSubmit(save)
+
+            Link(
+                "Create an API token at Cloudflare →",
+                destination: URL(string: "https://dash.cloudflare.com/profile/api-tokens")!
+            )
+            .font(.footnote)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    onCancel()
+                }
+                .keyboardShortcut(.cancelAction)
+                Button("Save & deploy") {
+                    save()
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .disabled(token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+        .task { fieldFocused = true }
+    }
+
+    private func save() {
+        if let message = model.saveTokenAndRetry(token) {
+            errorMessage = message
+        }
+    }
+}
+
+#Preview {
+    CloudflareTokenPromptView(model: DeployModel(), onCancel: {})
+}

--- a/Sources/AnglesiteApp/ContentView.swift
+++ b/Sources/AnglesiteApp/ContentView.swift
@@ -72,6 +72,11 @@ struct ContentView: View {
                 }
             }
         }
+        .sheet(isPresented: $deploy.tokenPromptPresented) {
+            CloudflareTokenPromptView(model: deploy) {
+                deploy.cancelTokenPrompt()
+            }
+        }
     }
 
     // MARK: Header

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -29,14 +29,26 @@ final class DeployModel {
     /// Bound to a `.sheet` in `ContentView` for the `.blocked` outcome. The sheet has no
     /// override button — per CLAUDE.md, the app cannot bypass plugin security hooks.
     var blockedPresented: Bool = false
+    /// Bound to a `.sheet` in `ContentView` for the first-deploy "paste your Cloudflare token"
+    /// flow. Set when `deploy(...)` is invoked without a token in either the env or the
+    /// Keychain; cleared when the user saves a token (which then retries the deploy) or cancels.
+    var tokenPromptPresented: Bool = false
 
     private let command: DeployCommand
     private let logCenter: LogCenter
+    private let keychain: KeychainStore
     private var inFlight: Task<Void, Never>?
+    /// Site to retry once the user pastes a token. `nil` outside the prompt flow.
+    private var pendingDeploy: (siteID: String, siteDirectory: URL)?
 
-    init(command: DeployCommand = DeployCommand(), logCenter: LogCenter = .shared) {
+    init(
+        command: DeployCommand = DeployCommand(),
+        logCenter: LogCenter = .shared,
+        keychain: KeychainStore = KeychainStore()
+    ) {
         self.command = command
         self.logCenter = logCenter
+        self.keychain = keychain
     }
 
     var isRunning: Bool {
@@ -50,11 +62,46 @@ final class DeployModel {
     }
 
     /// Kicks off a deploy. No-op if one is already running.
+    ///
+    /// First checks whether a Cloudflare token is available (env > Keychain). If neither has one,
+    /// the token-prompt sheet is presented and the deploy is parked until the user saves a token
+    /// via `saveTokenAndRetry(_:)` — at which point the parked site is dispatched without the
+    /// user having to click Deploy again.
     func deploy(siteID: String, siteDirectory: URL) {
         guard !isRunning else { return }
+        if !hasUsableToken() {
+            pendingDeploy = (siteID, siteDirectory)
+            tokenPromptPresented = true
+            return
+        }
         inFlight = Task { @MainActor [weak self] in
             await self?.runDeploy(siteID: siteID, siteDirectory: siteDirectory)
         }
+    }
+
+    /// Called by the token-prompt sheet's "Save" button. Persists the token to the Keychain and
+    /// — if a deploy was parked on the prompt — kicks it off. Returns `nil` on success or an
+    /// error message on failure (the sheet stays presented so the user can correct it).
+    @discardableResult
+    func saveTokenAndRetry(_ token: String) -> String? {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "Token is empty." }
+        do {
+            try keychain.writeCloudflareToken(trimmed)
+        } catch {
+            return "Couldn't save to Keychain: \(error)"
+        }
+        tokenPromptPresented = false
+        if let pending = pendingDeploy {
+            pendingDeploy = nil
+            deploy(siteID: pending.siteID, siteDirectory: pending.siteDirectory)
+        }
+        return nil
+    }
+
+    func cancelTokenPrompt() {
+        pendingDeploy = nil
+        tokenPromptPresented = false
     }
 
     func dismissDrawer() {
@@ -63,6 +110,18 @@ final class DeployModel {
 
     func dismissBlocked() {
         blockedPresented = false
+    }
+
+    /// True if either the env var or the Keychain currently holds a non-empty Cloudflare token.
+    /// Keychain errors are treated as "no token" — the user can recover by pasting fresh.
+    private func hasUsableToken() -> Bool {
+        if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
+            return true
+        }
+        if let stored = (try? keychain.readCloudflareToken()) ?? nil, !stored.isEmpty {
+            return true
+        }
+        return false
     }
 
     private func runDeploy(siteID: String, siteDirectory: URL) async {

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -43,6 +43,13 @@ private struct AdvancedSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Credentials") {
+                CloudflareTokenRow()
+                Text("Stored in the macOS Keychain under `dev.anglesite.app`. The token is passed to `wrangler deploy` as `CLOUDFLARE_API_TOKEN` and never written to logs. An exported `CLOUDFLARE_API_TOKEN` in the shell that launched Anglesite takes precedence over this entry.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Diagnostics") {
                 Toggle("Show Debug Pane menu item", isOn: $debugPaneEnabled)
                 #if DEBUG
@@ -58,6 +65,92 @@ private struct AdvancedSettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+    }
+}
+
+/// Cloudflare API token row. Reads the current state from the Keychain on appear; saves a new
+/// value on commit; clears the slot on "Clear". The field stays a `SecureField` so the token
+/// doesn't appear in a screen share, but the actual secret bytes only round-trip when the user
+/// edits the field — appearing only redacts.
+private struct CloudflareTokenRow: View {
+    @State private var token: String = ""
+    @State private var status: Status = .unknown
+    @State private var savedMessage: String?
+
+    private enum Status: Equatable {
+        case unknown
+        case present
+        case absent
+        case error(String)
+    }
+
+    private let store = KeychainStore()
+
+    var body: some View {
+        LabeledContent("Cloudflare API token") {
+            VStack(alignment: .trailing, spacing: 6) {
+                HStack(spacing: 8) {
+                    SecureField("paste token", text: $token, prompt: Text(promptText))
+                        .textFieldStyle(.roundedBorder)
+                        .frame(minWidth: 240)
+                    Button("Save") { save() }
+                        .disabled(token.isEmpty)
+                    Button("Clear") { clear() }
+                        .disabled(status != .present)
+                }
+                if let savedMessage {
+                    Text(savedMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if case .error(let message) = status {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .task { refreshStatus() }
+    }
+
+    private var promptText: String {
+        switch status {
+        case .present: return "•••••••• (stored)"
+        case .absent:  return "paste token"
+        case .unknown: return ""
+        case .error:   return "paste token"
+        }
+    }
+
+    private func refreshStatus() {
+        do {
+            status = (try store.readCloudflareToken() != nil) ? .present : .absent
+        } catch {
+            status = .error("couldn't read keychain: \(error)")
+        }
+    }
+
+    private func save() {
+        do {
+            try store.writeCloudflareToken(token)
+            token = ""
+            status = .present
+            savedMessage = "Saved."
+        } catch {
+            status = .error("couldn't save: \(error)")
+            savedMessage = nil
+        }
+    }
+
+    private func clear() {
+        do {
+            try store.clearCloudflareToken()
+            token = ""
+            status = .absent
+            savedMessage = "Cleared."
+        } catch {
+            status = .error("couldn't clear: \(error)")
+            savedMessage = nil
+        }
     }
 }
 

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -37,8 +37,9 @@ public actor DeployCommand {
     }
 
     public typealias CommandResolver = @Sendable (_ siteDirectory: URL) -> LaunchPlan
-    /// Returns the Cloudflare API token, or `nil` if none is configured. Phase 7's
-    /// `KeychainStore` will replace the default `envTokenSource` in production callers.
+    /// Returns the Cloudflare API token, or `nil` if none is configured. Production callers use
+    /// `DeployCommand.keychainTokenSource` (Keychain with an env-var fallback for development);
+    /// tests typically inject a closure returning a literal.
     public typealias TokenSource = @Sendable () async throws -> String?
     /// Runs the bundled plugin's pre-deploy scan against a site and returns the outcome.
     /// Real callers use `DeployCommand.defaultPreflight`; tests inject a fake.
@@ -56,7 +57,7 @@ public actor DeployCommand {
         logCenter: LogCenter = .shared,
         resolveCommand: @escaping CommandResolver = DeployCommand.resolveWranglerCommand,
         resolveBuildCommand: @escaping CommandResolver = DeployCommand.resolveBuildCommand,
-        tokenSource: @escaping TokenSource = DeployCommand.envTokenSource,
+        tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
         preflight: @escaping PreflightChecker = DeployCommand.defaultPreflight
     ) {
         self.supervisor = supervisor
@@ -80,7 +81,7 @@ public actor DeployCommand {
             return .failed(reason: "couldn't read Cloudflare API token: \(error)", exitCode: nil)
         }
         guard let token, !token.isEmpty else {
-            return .failed(reason: "no CLOUDFLARE_API_TOKEN — set in env or Settings (Phase 7)", exitCode: nil)
+            return .failed(reason: "no CLOUDFLARE_API_TOKEN — add it in Settings → Advanced → Credentials, or set the env var", exitCode: nil)
         }
 
         // Build dist/ before the scan needs it. Streams to LogCenter via launch().
@@ -241,9 +242,22 @@ public actor DeployCommand {
 
     // MARK: Default seams
 
-    /// Default `TokenSource`: read `CLOUDFLARE_API_TOKEN` from the environment.
+    /// Reads `CLOUDFLARE_API_TOKEN` from the process environment. Useful in development (the env
+    /// var dominates the Keychain entry when both are set, so a shell with `CLOUDFLARE_API_TOKEN`
+    /// exported behaves the way a wrangler user expects).
     public static let envTokenSource: TokenSource = {
         ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"]
+    }
+
+    /// Default `TokenSource` for production: env var first (so a developer's shell still wins),
+    /// then the user's Keychain. A Keychain error is surfaced to the caller — we'd rather show
+    /// the user "couldn't read token" than silently fall through to `nil` and prompt for a
+    /// re-paste of a token that's actually stored fine.
+    public static let keychainTokenSource: TokenSource = {
+        if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
+            return env
+        }
+        return try KeychainStore().readCloudflareToken()
     }
 
     /// Default `PreflightChecker`: invokes the site's own `scripts/pre-deploy-check.ts

--- a/Sources/AnglesiteCore/KeychainStore.swift
+++ b/Sources/AnglesiteCore/KeychainStore.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Security
+
+/// Stores secrets in the user's login keychain via `SecItem` (generic-password class).
+///
+/// One instance per service name; the service identifies the app to the keychain UI ("Anglesite
+/// wants to use 'Anglesite Cloudflare API token'…"). Production uses the default service
+/// `dev.anglesite.app` to match the app's bundle id; tests pass a scratch service per case so
+/// they don't collide with the real user's keychain entries.
+///
+/// All operations are synchronous — `SecItemCopyMatching` / `SecItemAdd` block while the keychain
+/// resolves access. Callers from actor-isolated code should treat reads/writes as fast (no I/O
+/// beyond an in-process system call) but should not hold a non-cancellable lock around them; the
+/// first write after a fresh login may surface a Keychain Access prompt.
+///
+/// Security notes:
+/// - `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` keeps the token off iCloud Keychain and
+///   inaccessible while the Mac is locked.
+/// - The token must never be logged. `DeployCommand` passes it via `environment` (which is opaque
+///   to the supervisor's stdout/stderr pump), so it does not end up in `LogCenter`.
+public struct KeychainStore: Sendable {
+    public enum Error: Swift.Error, Equatable {
+        /// `SecItemCopyMatching` / `SecItemAdd` / `SecItemUpdate` / `SecItemDelete` returned a
+        /// non-success `OSStatus`. The raw value is carried so test assertions can pin it down.
+        case unhandled(OSStatus)
+        /// A read returned data that didn't decode as UTF-8. Should never happen for tokens we
+        /// wrote ourselves, but guards against a foreign actor having scribbled in our slot.
+        case invalidUTF8
+    }
+
+    /// Default service identifier. Matches the app's bundle id.
+    public static let defaultService = "dev.anglesite.app"
+
+    /// Account key under the default service for the Cloudflare API token used by
+    /// `wrangler deploy`. Centralized here so the Settings UI and `DeployCommand` refer to the
+    /// same slot.
+    public static let cloudflareTokenAccount = "cloudflare-api-token"
+
+    public let service: String
+
+    public init(service: String = KeychainStore.defaultService) {
+        self.service = service
+    }
+
+    // MARK: Reads
+
+    /// Returns the stored secret for `account`, or `nil` if no entry exists.
+    public func read(account: String) throws -> String? {
+        var query = baseQuery(account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data else { return nil }
+            guard let string = String(data: data, encoding: .utf8) else { throw Error.invalidUTF8 }
+            return string
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw Error.unhandled(status)
+        }
+    }
+
+    // MARK: Writes
+
+    /// Writes `value` for `account`, replacing any existing entry. An empty `value` deletes
+    /// the entry — keychain entries for "" are nonsensical and would round-trip differently
+    /// from `read → nil`.
+    public func write(_ value: String, account: String) throws {
+        if value.isEmpty {
+            try delete(account: account)
+            return
+        }
+        guard let data = value.data(using: .utf8) else { throw Error.invalidUTF8 }
+
+        let existing = baseQuery(account: account)
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        let updateStatus = SecItemUpdate(existing as CFDictionary, attributes as CFDictionary)
+        switch updateStatus {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            var addQuery = baseQuery(account: account)
+            for (k, v) in attributes { addQuery[k] = v }
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else { throw Error.unhandled(addStatus) }
+        default:
+            throw Error.unhandled(updateStatus)
+        }
+    }
+
+    /// Removes the stored entry for `account`. No-op if no entry exists.
+    public func delete(account: String) throws {
+        let status = SecItemDelete(baseQuery(account: account) as CFDictionary)
+        switch status {
+        case errSecSuccess, errSecItemNotFound:
+            return
+        default:
+            throw Error.unhandled(status)
+        }
+    }
+
+    // MARK: Cloudflare convenience
+
+    /// Read the Cloudflare API token under the default account.
+    public func readCloudflareToken() throws -> String? {
+        try read(account: Self.cloudflareTokenAccount)
+    }
+
+    /// Store the Cloudflare API token under the default account. Empty string clears.
+    public func writeCloudflareToken(_ token: String) throws {
+        try write(token, account: Self.cloudflareTokenAccount)
+    }
+
+    /// Clear the Cloudflare API token slot.
+    public func clearCloudflareToken() throws {
+        try delete(account: Self.cloudflareTokenAccount)
+    }
+
+    // MARK: Internals
+
+    private func baseQuery(account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: false
+        ]
+    }
+}

--- a/Tests/AnglesiteCoreTests/KeychainStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/KeychainStoreTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import AnglesiteCore
+
+/// Each test uses a unique service name so it can't collide with the user's real Keychain entries
+/// or with other tests running in parallel. Tests `XCTSkip` cleanly when the keychain isn't
+/// reachable (some CI environments and unsigned test binaries reject `SecItemAdd` with
+/// `errSecMissingEntitlement` (-34018) or similar). Locally, the first run may surface a one-time
+/// Keychain Access prompt — that's the system asking the user to authorize the test binary.
+final class KeychainStoreTests: XCTestCase {
+    private var service: String = ""
+    private var store: KeychainStore!
+
+    override func setUp() async throws {
+        service = "dev.anglesite.tests." + UUID().uuidString
+        store = KeychainStore(service: service)
+        try await probeKeychainOrSkip()
+    }
+
+    override func tearDown() async throws {
+        // Best effort — if the keychain refused us in setUp, this won't matter.
+        try? store.delete(account: "alpha")
+        try? store.delete(account: "beta")
+        try? store.delete(account: KeychainStore.cloudflareTokenAccount)
+    }
+
+    /// Confirm the test process can talk to the keychain at all. Avoids opaque failures in CI by
+    /// converting "no keychain access" into a clean skip.
+    private func probeKeychainOrSkip() async throws {
+        do {
+            try store.write("probe", account: "__probe__")
+            try store.delete(account: "__probe__")
+        } catch KeychainStore.Error.unhandled(let status) {
+            throw XCTSkip("keychain not reachable in this environment (OSStatus \(status))")
+        }
+    }
+
+    // MARK: Round trips
+
+    func testReadReturnsNilWhenNoEntryExists() throws {
+        XCTAssertNil(try store.read(account: "alpha"))
+    }
+
+    func testWriteThenReadRoundTrips() throws {
+        try store.write("super-secret", account: "alpha")
+        XCTAssertEqual(try store.read(account: "alpha"), "super-secret")
+    }
+
+    func testSecondWriteReplacesTheFirst() throws {
+        try store.write("first", account: "alpha")
+        try store.write("second", account: "alpha")
+        XCTAssertEqual(try store.read(account: "alpha"), "second")
+    }
+
+    func testDeleteRemovesEntry() throws {
+        try store.write("temp", account: "alpha")
+        try store.delete(account: "alpha")
+        XCTAssertNil(try store.read(account: "alpha"))
+    }
+
+    func testDeleteIsNoOpWhenEntryAbsent() throws {
+        XCTAssertNoThrow(try store.delete(account: "never-existed"))
+    }
+
+    func testEmptyValueWriteDeletesTheEntry() throws {
+        try store.write("present", account: "alpha")
+        try store.write("", account: "alpha")
+        XCTAssertNil(try store.read(account: "alpha"))
+    }
+
+    func testAccountsAreIndependentUnderTheSameService() throws {
+        try store.write("A", account: "alpha")
+        try store.write("B", account: "beta")
+        XCTAssertEqual(try store.read(account: "alpha"), "A")
+        XCTAssertEqual(try store.read(account: "beta"), "B")
+        try store.delete(account: "alpha")
+        XCTAssertNil(try store.read(account: "alpha"))
+        XCTAssertEqual(try store.read(account: "beta"), "B")
+    }
+
+    func testServicesAreIndependent() throws {
+        let other = KeychainStore(service: service + ".other")
+        do {
+            try store.write("here", account: "alpha")
+            try other.write("there", account: "alpha")
+            XCTAssertEqual(try store.read(account: "alpha"), "here")
+            XCTAssertEqual(try other.read(account: "alpha"), "there")
+        }
+        try? other.delete(account: "alpha")
+    }
+
+    // MARK: Cloudflare convenience
+
+    func testCloudflareConvenienceRoundTrips() throws {
+        XCTAssertNil(try store.readCloudflareToken())
+        try store.writeCloudflareToken("cf-token-xyz")
+        XCTAssertEqual(try store.readCloudflareToken(), "cf-token-xyz")
+        try store.clearCloudflareToken()
+        XCTAssertNil(try store.readCloudflareToken())
+    }
+}

--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -75,7 +75,7 @@ This work lands in `anglesite/server/` — the app repo just calls it.
 
 ## Phase 7 — Keychain + secrets
 
-1. `KeychainStore` for the Cloudflare API token. First-launch deploy prompts; subsequent deploys read silently.
+1. ✅ `KeychainStore` (AnglesiteCore) wraps `SecItem` generic-password APIs under service `dev.anglesite.app`, account `cloudflare-api-token`, accessibility `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. `DeployCommand.keychainTokenSource` is the new default `TokenSource` — env var wins (so a developer shell with `CLOUDFLARE_API_TOKEN` exported still dominates), then the Keychain. `DeployModel.deploy(...)` does the same pre-check and parks the deploy behind a `CloudflareTokenPromptView` sheet when neither slot has a token; saving the token writes it to the Keychain and immediately fires the parked deploy. Settings → Advanced → Credentials gets a `CloudflareTokenRow` that surfaces "stored / absent" status and provides paste/save/clear without leaking the token through `@AppStorage`. The token never enters `LogCenter` — it's passed via `Process.environment` (opaque to the supervisor's stdout/stderr pipe pumps). Tests cover `KeychainStore` round-trips against per-test scratch services (the `XCTSkip` path handles CI environments where the keychain refuses access).
 2. `gh` device-code flow stays in `gh` — the app just spawns it and surfaces the URL/code in a sheet.
 
 ## Phase 8 — v0.5 chat panel


### PR DESCRIPTION
Closes #23.

## Summary
- New `KeychainStore` in `AnglesiteCore` wraps `SecItem` generic-password APIs (service `dev.anglesite.app`, account `cloudflare-api-token`, accessibility `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` — keeps the token off iCloud Keychain and inaccessible while the Mac is locked).
- `DeployCommand.keychainTokenSource` is the new default `TokenSource`: env var first (so a developer shell with `CLOUDFLARE_API_TOKEN` still wins), then the Keychain.
- `DeployModel` does the same pre-check and parks the deploy behind a new `CloudflareTokenPromptView` sheet when neither slot has a token. Saving the token writes to the Keychain and fires the parked deploy — no second click needed.
- Settings → Advanced → Credentials gets a `CloudflareTokenRow` (stored/absent status, paste/save/clear) so the user can manage the slot independent of the first-deploy flow.

## Security / logging
- The token never enters `LogCenter`. It's passed via `Process.environment`, which is opaque to the supervisor's stdout/stderr pipe pumps.
- `SecureField` is used everywhere the token is captured.

## Tests
- `KeychainStoreTests` covers read/write/delete, replace, empty-write-deletes, per-account / per-service isolation, and the Cloudflare convenience helpers. Each test uses a UUID-based scratch service so it can't collide with the user's real keychain entries or other tests.
- `XCTSkip` path handles CI environments where unsigned test binaries can't reach the keychain.
- Existing `DeployCommandTests` already cover the `TokenSource` contract (nil → refusal, value → propagated as env var); no changes needed there.

## Test plan
- [x] `swift test --filter "DeployCommandTests|KeychainStoreTests"` — 22 passed
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeded
- [ ] Manual: launch app, click Deploy with no token → token sheet appears; paste fake token, click Save & deploy → deploy proceeds (will fail on wrangler with the fake token, but the parking flow works); reopen Deploy → no prompt (token now in Keychain)
- [ ] Manual: Settings → Advanced → Credentials → Clear → next Deploy re-prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)