### PR TITLE
fix(supervisor): drain pipe readers before resolving waitForExit

### DIFF
--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -139,13 +139,9 @@ public actor DeployCommand {
         let reason = await supervisor.waitForExit(handle)
         let duration = Date().timeIntervalSince(started)
 
-        // The supervisor's pipe pump dispatches each line via an untracked
-        // `Task { await logCenter.append(...) }`, so a few lines may still be
-        // in flight when waitForExit returns. A small grace period gives them
-        // time to land in LogCenter before we snapshot for URL extraction.
-        // Until the pump is restructured to be fully await-able, this is the
-        // pragmatic fix.
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        // `waitForExit` only resumes after the supervisor's per-pipe drain Tasks have
+        // finished — every byte wrangler wrote to stdout/stderr is in `LogCenter` by
+        // the time we get here, so the snapshot can't miss the `Published` line.
         let snapshot = await logCenter.snapshot()
         let stdout = snapshot
             .filter { $0.source == source && $0.stream == .stdout }

--- a/Sources/AnglesiteCore/ProcessSupervisor.swift
+++ b/Sources/AnglesiteCore/ProcessSupervisor.swift
@@ -266,6 +266,13 @@ public actor ProcessSupervisor {
         var finalReason: ExitReason?
         // Keyed by waiter ID so cancellation handlers can remove their own continuation.
         var exitWaiters: [UUID: CheckedContinuation<ExitReason, Never>] = [:]
+        /// Log-drain Tasks for the current process incarnation (stdout + stderr). Each consumes
+        /// an `AsyncStream<String>` fed by the corresponding `readabilityHandler` and awaits
+        /// `logCenter.append` serially, so once both tasks complete every read byte has landed
+        /// in `LogCenter`. The supervision loop awaits these in `finalize` *before* resuming
+        /// exit waiters — that's what lets callers `snapshot()` immediately after `waitForExit`
+        /// without losing the tail of the output.
+        var logDrainTasks: [Task<Void, Never>] = []
 
         init(
             handle: Handle,
@@ -316,25 +323,29 @@ public actor ProcessSupervisor {
 
         entry.currentProcess = process
 
-        // Kick off pipe readers. They run until EOF on their pipe (which happens when the
-        // process exits or we close the pipes). They don't need to be awaited — they
-        // self-terminate. We use callback-based `readabilityHandler` so the blocking read
-        // happens on libdispatch, never on the Swift cooperative pool — otherwise the test
-        // runner can starve the readers under load and we don't see output until process exit.
+        // Kick off pipe readers. The `readabilityHandler` runs on a libdispatch queue
+        // (blocking reads never compete with the Swift cooperative pool — otherwise the test
+        // runner could starve the readers under load). Each handler yields complete lines
+        // into an `AsyncStream`, and a dedicated drain `Task` per pipe awaits
+        // `logCenter.append(...)` serially. Both drain Tasks are stored on the entry so
+        // `finalize` can await them before resuming exit waiters — guaranteeing every byte
+        // read has landed in `LogCenter` by the time `waitForExit(_:)` returns.
         let source = entry.handle.source
         let logCenter = entry.logCenter
-        Self.attachLineReader(
-            to: stdoutPipe.fileHandleForReading,
-            source: source,
-            stream: .stdout,
-            logCenter: logCenter
-        )
-        Self.attachLineReader(
-            to: stderrPipe.fileHandleForReading,
-            source: source,
-            stream: .stderr,
-            logCenter: logCenter
-        )
+        entry.logDrainTasks = [
+            Self.attachLineReader(
+                to: stdoutPipe.fileHandleForReading,
+                source: source,
+                stream: .stdout,
+                logCenter: logCenter
+            ),
+            Self.attachLineReader(
+                to: stderrPipe.fileHandleForReading,
+                source: source,
+                stream: .stderr,
+                logCenter: logCenter
+            )
+        ]
     }
 
     private func superviseLoop(id: UUID) async {
@@ -393,6 +404,21 @@ public actor ProcessSupervisor {
     }
 
     private func finalize(_ entry: Entry, reason: ExitReason) async {
+        // Drain the pipe readers before resuming exit waiters. Once `process.terminationHandler`
+        // fires, the OS closes our read ends of stdout/stderr and the `readabilityHandler`
+        // sees EOF on its next callback — which finishes the AsyncStream and lets the drain
+        // `Task` exit. Awaiting both drain tasks here means a caller doing
+        //
+        //   await supervisor.waitForExit(handle)
+        //   let lines = await logCenter.snapshot()
+        //
+        // never loses the tail of the output to the dispatch/runtime gap. Drain tasks have
+        // already started (they were spawned in `startProcess`), so we only `await` them —
+        // we don't spawn new work here.
+        for task in entry.logDrainTasks {
+            await task.value
+        }
+        entry.logDrainTasks.removeAll()
         entry.finalReason = reason
         entry.currentProcess = nil
         let waiters = entry.exitWaiters
@@ -410,34 +436,42 @@ public actor ProcessSupervisor {
         }
     }
 
-    /// Attaches a `readabilityHandler` that emits one line at a time to `logCenter`. The handler
-    /// runs on a libdispatch queue so blocking I/O doesn't compete with the Swift cooperative
-    /// thread pool. We accumulate bytes in a `LineBuffer` to handle partial reads / multi-line
-    /// chunks.
+    /// Attaches a `readabilityHandler` and returns the `Task` that drains the lines into
+    /// `logCenter`. The handler (libdispatch) yields complete lines into an `AsyncStream`; the
+    /// returned `Task` awaits each `logCenter.append(...)` in order. When the pipe sees EOF,
+    /// the handler finishes the stream and the drain `Task` ends — so awaiting the returned
+    /// `Task` is equivalent to "every byte read from this pipe has been written to LogCenter".
+    /// That awaitable boundary is what `finalize` uses to fix the prior race where the process
+    /// could exit before its last few log lines landed.
     private static func attachLineReader(
         to handle: FileHandle,
         source: String,
         stream: LogCenter.Stream,
         logCenter: LogCenter
-    ) {
+    ) -> Task<Void, Never> {
         let buffer = LineBuffer()
+        let (lineStream, continuation) = AsyncStream<String>.makeStream(bufferingPolicy: .unbounded)
+
         handle.readabilityHandler = { fh in
             let data = fh.availableData
             if data.isEmpty {
-                // EOF — flush trailing partial line and detach the handler.
+                // EOF — flush trailing partial line and tear down. The stream finish() lets the
+                // drain `Task` below exit naturally.
                 if let trailing = buffer.flush() {
-                    Task { await logCenter.append(source: source, stream: stream, text: trailing) }
+                    continuation.yield(trailing)
                 }
+                continuation.finish()
                 handle.readabilityHandler = nil
                 return
             }
-            let lines = buffer.append(data)
-            if !lines.isEmpty {
-                Task {
-                    for line in lines {
-                        await logCenter.append(source: source, stream: stream, text: line)
-                    }
-                }
+            for line in buffer.append(data) {
+                continuation.yield(line)
+            }
+        }
+
+        return Task {
+            for await line in lineStream {
+                await logCenter.append(source: source, stream: stream, text: line)
             }
         }
     }

--- a/Tests/AnglesiteCoreTests/ProcessSupervisorLaunchTests.swift
+++ b/Tests/AnglesiteCoreTests/ProcessSupervisorLaunchTests.swift
@@ -12,8 +12,6 @@ final class ProcessSupervisorLaunchTests: XCTestCase {
             logCenter: center
         )
         let reason = await supervisor.waitForExit(handle)
-        // Pipe drainage may complete after exit signal; give readers a beat.
-        try? await Task.sleep(nanoseconds: 100_000_000)
 
         XCTAssertEqual(reason, .exited(code: 0))
         let lines = await center.snapshot().filter { $0.source == "stdout-test" && $0.stream == .stdout }
@@ -30,13 +28,44 @@ final class ProcessSupervisorLaunchTests: XCTestCase {
             logCenter: center
         )
         _ = await supervisor.waitForExit(handle)
-        try? await Task.sleep(nanoseconds: 100_000_000)
 
         let snapshot = await center.snapshot().filter { $0.source == "stderr-test" }
         let outs = snapshot.filter { $0.stream == .stdout }.map(\.text)
         let errs = snapshot.filter { $0.stream == .stderr }.map(\.text)
         XCTAssertEqual(outs, ["out"])
         XCTAssertEqual(errs, ["err"])
+    }
+
+    /// Regression: `waitForExit` must not resume until every byte read from the child's
+    /// stdout/stderr is in `LogCenter`. The previous pump fired untracked
+    /// `Task { await logCenter.append }` from the readabilityHandler, so a snapshot taken
+    /// immediately after `waitForExit` could miss the tail of the output — `DeployCommand`
+    /// papered over the gap with a 100ms sleep, and `DeployCommandTests` still flaked under
+    /// CI load. This test runs the burst-then-exit pattern that triggered the flake (lots of
+    /// output crammed into the last few milliseconds before exit) and asserts that the very
+    /// last line is present in the snapshot with zero post-exit sleep.
+    func testSnapshotIncludesLastLineAfterWaitForExitWithoutSleep() async throws {
+        for _ in 0..<25 {
+            let supervisor = ProcessSupervisor()
+            let center = LogCenter()
+            let handle = try await supervisor.launch(
+                source: "drain-race",
+                executable: URL(fileURLWithPath: "/bin/sh"),
+                arguments: [
+                    "-c",
+                    // Burst a few lines, then write a sentinel right before exiting. If the
+                    // pump ever loses the tail, this test will fail on the sentinel.
+                    "for i in 1 2 3 4 5 6 7 8 9 10; do printf 'line %s\\n' $i; done; printf 'SENTINEL\\n'"
+                ],
+                logCenter: center
+            )
+            _ = await supervisor.waitForExit(handle)
+            let lines = await center.snapshot()
+                .filter { $0.source == "drain-race" && $0.stream == .stdout }
+                .map(\.text)
+            XCTAssertEqual(lines.last, "SENTINEL", "last stdout line must be in LogCenter the moment waitForExit returns")
+            XCTAssertEqual(lines.count, 11, "all lines must be present, none lost: \(lines)")
+        }
     }
 
     func testWaitForExitReportsNonZeroCode() async throws {


### PR DESCRIPTION
Closes the race that caused `DeployCommandTests.testSucceedsAndExtractsURLFromPublishedLine` to flake on CI (#44 hit this; a rerun was the workaround).

## Root cause
`ProcessSupervisor`'s pump used to fire untracked Tasks from the dispatch readabilityHandler:

```swift
handle.readabilityHandler = { fh in
    …
    Task {
        for line in lines {
            await logCenter.append(source: source, stream: stream, text: line)
        }
    }
}
```

Meanwhile `process.terminationHandler` resumed `awaitExit → finalize → exit waiters` on a separate dispatch path. Nothing tied the two together, so a caller doing

```swift
await supervisor.waitForExit(handle)
let lines = await logCenter.snapshot()
```

could win the race against the last few `append` Tasks and miss the tail of the output. `DeployCommand` papered over the gap with a 100 ms sleep (see the deleted comment block) and still flaked under CI load.

## Fix
Replace the per-line untracked Tasks with **one structured drain `Task` per pipe** that consumes an `AsyncStream<String>` fed by the readabilityHandler. Each drain awaits `logCenter.append(...)` serially and ends naturally when the handler signals EOF on the stream. `finalize` awaits both drains *before* resuming exit waiters, so when `waitForExit` returns every byte read is in `LogCenter`.

- Drop the 100 ms grace sleep in `DeployCommand`.
- Drop equivalent workaround sleeps in `ProcessSupervisorLaunchTests`.
- Add `testSnapshotIncludesLastLineAfterWaitForExitWithoutSleep` — runs the burst-then-exit pattern 25× and asserts the sentinel last line is present with zero post-exit sleep.

## Test plan
- [x] `swift test` (full suite, sequential and `--parallel`) — green
- [x] `swift test --filter "ProcessSupervisorLaunchTests|DeployCommandTests"` — 23 passed
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeded
- [x] 25× regression loop passes locally; CI will run it once per push

🤖 Generated with [Claude Code](https://claude.com/claude-code)