### PR TITLE
chore: auto-regenerate Anglesite.xcodeproj via git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ scripts/vendor-node.sh
 # Generate the Xcode project
 xcodegen generate
 
+# (Recommended) Enable git hooks that auto-regenerate the .xcodeproj after
+# `git pull` / branch switches / rebases — keeps Xcode in sync with project.yml
+# and Sources/ without manual `xcodegen generate` calls.
+git config core.hooksPath scripts/git-hooks
+
 # Build via CLI (ad-hoc signed; no Apple account required)
 xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
 

--- a/scripts/git-hooks/post-checkout
+++ b/scripts/git-hooks/post-checkout
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Fires on branch checkouts. $1=prev HEAD, $2=new HEAD, $3=1 for branch checkout, 0 for file checkout.
+set -euo pipefail
+prev_head="${1:-}"
+new_head="${2:-}"
+branch_checkout="${3:-0}"
+# Skip per-file checkouts (`git checkout -- path`) — they can't change project shape.
+if [[ "$branch_checkout" != "1" ]]; then
+  exit 0
+fi
+exec "$(dirname "$0")/regenerate-xcodeproj.sh" "$prev_head" "$new_head"

--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Fires after `git pull` / `git merge`. ORIG_HEAD is the pre-merge tip; HEAD is the new tip.
+set -euo pipefail
+exec "$(dirname "$0")/regenerate-xcodeproj.sh" "ORIG_HEAD" "HEAD"

--- a/scripts/git-hooks/post-rewrite
+++ b/scripts/git-hooks/post-rewrite
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Fires after `git rebase` / `git commit --amend`. No simple old/new pair — regenerate
+# unconditionally; xcodegen is cheap and idempotent.
+set -euo pipefail
+exec "$(dirname "$0")/regenerate-xcodeproj.sh"

--- a/scripts/git-hooks/regenerate-xcodeproj.sh
+++ b/scripts/git-hooks/regenerate-xcodeproj.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Shared logic for the post-merge / post-checkout / post-rewrite hooks.
+# Regenerates Anglesite.xcodeproj via xcodegen when project.yml or a source tree
+# Xcode cares about has changed between $1 and $2 (old/new ref).
+#
+# Args: $1 = old ref, $2 = new ref. If either is missing, regenerate unconditionally.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+old_ref="${1:-}"
+new_ref="${2:-}"
+
+# Paths whose changes warrant a project regeneration. Keep this list aligned with
+# the `sources:` globs in project.yml.
+watched=(project.yml Sources Resources/Info.plist Resources/Assets.xcassets)
+
+if [[ -n "$old_ref" && -n "$new_ref" && "$old_ref" != "0000000000000000000000000000000000000000" ]]; then
+  if git diff --quiet "$old_ref" "$new_ref" -- "${watched[@]}" 2>/dev/null; then
+    exit 0
+  fi
+fi
+
+if ! command -v xcodegen >/dev/null 2>&1; then
+  echo "[git-hook] xcodegen not found on PATH — skipping project regeneration." >&2
+  echo "[git-hook] Install with: brew install xcodegen" >&2
+  exit 0
+fi
+
+echo "[git-hook] Regenerating Anglesite.xcodeproj via xcodegen…"
+xcodegen generate --quiet


### PR DESCRIPTION
## Summary
- Adds tracked hooks (`post-merge`, `post-checkout`, `post-rewrite`) under `scripts/git-hooks/` that run `xcodegen generate` whenever `project.yml`, `Sources/`, or watched `Resources/` paths change between the old and new ref.
- Shared `regenerate-xcodeproj.sh` does the diff + xcodegen call; skips gracefully (with an install hint) when xcodegen isn't on PATH.
- README updated with the one-liner contributors run after cloning:
  ```
  git config core.hooksPath scripts/git-hooks
  ```

## Why
`Anglesite.xcodeproj/` is gitignored and regenerated from `project.yml`, but nothing was automating that locally. After a `git pull` that brought in new sources or a Sparkle package dep, Xcode would fail with "Cannot find 'Updater' in scope" until the user remembered to re-run `xcodegen generate`.

## Test plan
- [x] `regenerate-xcodeproj.sh HEAD HEAD` is a no-op (exit 0, no output).
- [x] `regenerate-xcodeproj.sh` with no args regenerates the project.
- [x] After `git config core.hooksPath scripts/git-hooks`, the hooks are picked up (verified locally).
- [ ] Reviewer: try `git pull` on a branch that touches `project.yml` or `Sources/` and confirm `Anglesite.xcodeproj` updates automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)