### PR TITLE
chore(release): wire up release.sh + appcast generator

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -1,52 +1,98 @@
 # Release pipeline
 
 The app ships auto-updates via [Sparkle 2.x](https://sparkle-project.org/). This document
-walks the one-time setup and the per-release steps.
+walks the one-time setup and the per-release flow.
 
 ## One-time setup (do once, ever)
 
-1. **Generate the Ed25519 keypair.** Sparkle ships a `generate_keys` binary in its SPM
-   product's bundled tools. After the first `swift build`:
+1. **Generate the Ed25519 keypair.** Sparkle ships `generate_keys` in its SPM product's
+   bundled tools. After building the Anglesite scheme at least once:
 
    ```sh
-   # Locate the binary (path varies by Swift toolchain)
-   find ~/Library/Developer/Xcode/DerivedData -name generate_keys -path '*Sparkle*' | head -1
-
-   # Run it
-   /path/to/generate_keys
+   find ~/Library/Developer/Xcode/DerivedData -name generate_keys -path '*Sparkle*/bin/generate_keys' | head -1
+   # then run that path; or to print an already-generated public key without creating new keys:
+   /path/to/generate_keys -p
    ```
 
-   The tool stores the **private** key in your login keychain (label
-   `https://sparkle-project.org`). Do not export it; do not commit it.
+   The tool stores the **private** key in your login keychain under label
+   `https://sparkle-project.org`. Do not export it; do not commit it.
 
-2. **Paste the public key into `Resources/Info.plist`.** Replace the placeholder string
-   under `SUPublicEDKey`. This is the key Sparkle uses on every user's machine to verify
-   downloaded updates.
+2. **Paste the public key into `Resources/Info.plist`.** Replace the `SUPublicEDKey`
+   placeholder with the base64 string printed by `generate_keys`. This is the key Sparkle
+   uses on every user's machine to verify downloaded updates.
 
-3. **Stand up the appcast URL.** `https://anglesite.dev/appcast.xml` is the configured
-   feed (see `SUFeedURL` in `Info.plist`). Two reasonable hosting paths:
-   - Static file on a CDN/CF Pages, manually updated each release
-   - GitHub Releases + a script that regenerates `appcast.xml` from the `gh release list`
-     output
+3. **Set up appcast hosting.** `SUFeedURL` in `Info.plist` points at
+   `https://anglesite.dev/appcast.xml`. The plan is to serve it from a `gh-pages` branch
+   of this repo with `anglesite.dev` configured as a GitHub Pages custom domain. Until that
+   DNS work is done, the in-app "Check for Updates…" will fail with a network error.
 
-## Per-release steps
+   Steps when ready:
+   - Create the `gh-pages` branch (orphan) and push a `CNAME` file containing `anglesite.dev`.
+   - In repo Settings → Pages: set source to `gh-pages` / root.
+   - At your DNS provider, point `anglesite.dev` (and `www.anglesite.dev`) at GitHub Pages'
+     A records (185.199.108.153, .109.153, .110.153, .111.153) and an AAAA record set.
+   - Wait for Pages to issue the cert (a few minutes).
 
-The build-plan calls for a `scripts/release.sh` that performs the full pipeline. Today
-that script is a stub — `scripts/release.sh` exists but only prints the checklist below.
-Wire it up to a CI workflow once the steady state is settled.
+4. **Set up `notarytool` credentials** (one-time, per machine):
 
-The manual checklist (until the script is finished):
+   ```sh
+   xcrun notarytool store-credentials AC_PASSWORD \
+     --apple-id you@example.com \
+     --team-id YOUR_TEAM_ID \
+     --password <app-specific-password>
+   ```
 
-1. Bump `MARKETING_VERSION` (and optionally `CURRENT_PROJECT_VERSION`) in `project.yml`,
-   then `xcodegen generate`.
-2. `xcodebuild archive -project Anglesite.xcodeproj -scheme Anglesite -configuration Release -archivePath build/Anglesite.xcarchive`
-3. Export the .app with Developer ID signing: `xcodebuild -exportArchive`
-4. Notarize: `xcrun notarytool submit Anglesite.zip --keychain-profile <profile> --wait`
-5. Staple: `xcrun stapler staple Anglesite.app`
-6. Sign the update package with Sparkle's `sign_update` (uses the private key from the
-   keychain) — produces an `ed25519` signature string.
-7. Update `appcast.xml` with the new `<item>` block (version, URL, signature, length).
-8. Upload the .app (zipped or .dmg) + `appcast.xml` to the hosting destination.
+## Per-release flow
 
-Sparkle's documentation has reference scripts for steps 6–8:
-<https://sparkle-project.org/documentation/publishing/>.
+Once the one-time setup is done:
+
+```sh
+TEAM_ID=YOUR_TEAM_ID scripts/release.sh 0.2.0
+```
+
+The script:
+
+1. Bumps `MARKETING_VERSION` (from the arg) and increments `CURRENT_PROJECT_VERSION` in
+   `project.yml`.
+2. Runs `scripts/notarize-dry-run.sh` (archive → exportArchive → notarytool → stapler → spctl).
+3. Zips the resulting `.app` with `ditto`.
+4. Signs the zip with Sparkle's `sign_update` (reads private key from your Keychain) and
+   captures `edSignature` + `length`.
+5. Commits the version bump and tags `vX.Y.Z`.
+6. Pushes to `origin/main`.
+7. Creates the GitHub Release, uploads the zip, and embeds `<!-- sparkle-* -->` markers in
+   the release body so the appcast generator can read them later.
+8. Regenerates `build/appcast.xml` by walking every published GitHub Release and parsing
+   its sparkle-* markers.
+
+### After the script finishes
+
+The appcast.xml isn't pushed automatically — copy it to the `gh-pages` branch:
+
+```sh
+git worktree add ../Anglesite-app-pages gh-pages
+cp build/appcast.xml ../Anglesite-app-pages/appcast.xml
+(cd ../Anglesite-app-pages && git add appcast.xml \
+  && git commit -m "appcast: 0.2.0" && git push)
+```
+
+Then test the in-app "Check for Updates…" against the new release.
+
+## Regenerating just the appcast
+
+If you need to rebuild the feed (e.g. after manually editing a release's body):
+
+```sh
+scripts/generate-appcast.sh build/appcast.xml
+```
+
+Drafts and prereleases are skipped. Releases missing the sparkle-* markers are skipped
+with a warning.
+
+## Why a `release.sh` and not CI?
+
+Today releases are driven from a developer machine because the signing keys (Apple
+Developer ID, Sparkle Ed25519) live in the macOS Keychain. Moving to CI requires either
+GitHub Actions secrets for the signing identity + Sparkle private key (and a hardened
+self-hosted macOS runner), or a third-party signing service. That's deferred; the script
+documents the steady-state so the move is mechanical when we're ready.

--- a/scripts/generate-appcast.sh
+++ b/scripts/generate-appcast.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Generate Sparkle appcast.xml from GitHub Releases.
+#
+# Each release's body is expected to contain machine-readable markers added by
+# `scripts/release.sh`:
+#
+#   <!-- sparkle-version: 1 -->
+#   <!-- sparkle-shortVersionString: 0.2.0 -->
+#   <!-- sparkle-edSignature: ABC123... -->
+#   <!-- sparkle-length: 12345678 -->
+#   <!-- sparkle-minimumSystemVersion: 14.0 -->
+#
+# Drafts and prereleases are skipped. The enclosure URL points at the .zip asset
+# uploaded to the GitHub Release.
+#
+# Usage:
+#   scripts/generate-appcast.sh > build/appcast.xml
+#   scripts/generate-appcast.sh build/appcast.xml
+set -euo pipefail
+
+out_path="${1:-/dev/stdout}"
+
+command -v gh >/dev/null \
+  || { echo "error: gh CLI not installed" >&2; exit 1; }
+command -v jq >/dev/null \
+  || { echo "error: jq not installed (brew install jq)" >&2; exit 1; }
+
+repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+feed_url="https://anglesite.dev/appcast.xml"
+
+# Pull every non-draft, non-prerelease release in descending publish order.
+releases_json="$(gh release list --limit 100 --json tagName,name,createdAt,isDraft,isPrerelease,publishedAt 2>/dev/null)"
+
+# Extract a marker value from a release body. Returns empty string if absent.
+marker() {
+  local body="$1" key="$2"
+  printf '%s\n' "$body" | sed -n "s|.*<!-- sparkle-${key}: \\([^>]*\\) -->.*|\\1|p" | head -1 | sed 's/[[:space:]]*$//'
+}
+
+# Convert ISO 8601 to RFC 822 (Sparkle requires RFC 822 in pubDate).
+iso_to_rfc822() {
+  local iso="$1"
+  # macOS date: ISO 8601 input with -j -f
+  date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$iso" "+%a, %d %b %Y %H:%M:%S +0000" 2>/dev/null \
+    || echo "$iso"
+}
+
+emit_header() {
+  cat <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Anglesite</title>
+    <link>${feed_url}</link>
+    <description>Most recent updates to Anglesite.</description>
+    <language>en</language>
+EOF
+}
+
+emit_footer() {
+  cat <<'EOF'
+  </channel>
+</rss>
+EOF
+}
+
+emit_item() {
+  local tag="$1"
+  local name="$2"
+  local pub_date="$3"
+  local version="$4"
+  local short_version="$5"
+  local signature="$6"
+  local length="$7"
+  local min_system="$8"
+  local zip_url="https://github.com/${repo}/releases/download/${tag}/Anglesite-${short_version}.zip"
+  local title_text="${name:-$tag}"
+  cat <<EOF
+    <item>
+      <title>${title_text}</title>
+      <pubDate>${pub_date}</pubDate>
+      <sparkle:version>${version}</sparkle:version>
+      <sparkle:shortVersionString>${short_version}</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>${min_system}</sparkle:minimumSystemVersion>
+      <sparkle:releaseNotesLink>https://github.com/${repo}/releases/tag/${tag}</sparkle:releaseNotesLink>
+      <enclosure
+        url="${zip_url}"
+        sparkle:edSignature="${signature}"
+        length="${length}"
+        type="application/octet-stream" />
+    </item>
+EOF
+}
+
+{
+  emit_header
+
+  # Iterate releases newest-first; for each, fetch body and parse markers.
+  echo "$releases_json" | jq -c '.[] | select(.isDraft == false and .isPrerelease == false)' \
+    | while read -r entry; do
+      tag="$(echo "$entry" | jq -r '.tagName')"
+      name="$(echo "$entry" | jq -r '.name')"
+      published="$(echo "$entry" | jq -r '.publishedAt // .createdAt')"
+      body="$(gh release view "$tag" --json body -q .body)"
+
+      version="$(marker "$body" version)"
+      short_version="$(marker "$body" shortVersionString)"
+      signature="$(marker "$body" edSignature)"
+      length="$(marker "$body" length)"
+      min_system="$(marker "$body" minimumSystemVersion)"
+      min_system="${min_system:-14.0}"
+
+      if [[ -z "$version" || -z "$short_version" || -z "$signature" || -z "$length" ]]; then
+        echo "warning: skipping release $tag — missing sparkle-* markers in body" >&2
+        continue
+      fi
+
+      pub_date="$(iso_to_rfc822 "$published")"
+      emit_item "$tag" "$name" "$pub_date" "$version" "$short_version" "$signature" "$length" "$min_system"
+    done
+
+  emit_footer
+} > "$out_path"
+
+if [[ "$out_path" != "/dev/stdout" ]]; then
+  echo "wrote appcast → $out_path" >&2
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,30 +1,131 @@
 #!/usr/bin/env bash
-# Release pipeline driver. Stubbed until the steady state is settled — for now this script
-# prints the checklist documented in docs/release.md and exits non-zero so it can't be
-# mistaken for a real automation hook.
+# End-to-end release pipeline for Anglesite.
 #
-# See `docs/release.md` for the full background. The intended end state is:
+# Bumps MARKETING_VERSION + CURRENT_PROJECT_VERSION, archives + notarizes via
+# scripts/notarize-dry-run.sh, signs the resulting .zip with Sparkle's
+# sign_update, publishes a GitHub Release with sparkle-* markers in the body,
+# and regenerates build/appcast.xml via scripts/generate-appcast.sh.
 #
-#   ./scripts/release.sh 0.2.0
-#     1. Bump MARKETING_VERSION
-#     2. xcodegen generate
-#     3. xcodebuild archive -> exportArchive (Developer ID signed)
-#     4. xcrun notarytool submit … --wait
-#     5. xcrun stapler staple
-#     6. sign_update (Sparkle) -> signature + length
-#     7. Regenerate appcast.xml entry
-#     8. Upload artifacts to anglesite.dev (or GitHub Releases)
+# The appcast.xml is *not* pushed anywhere — that step is manual until the
+# gh-pages branch + anglesite.dev custom domain are wired up (see docs/release.md).
+#
+# Usage:
+#   scripts/release.sh 0.2.0
+#
+# Env:
+#   TEAM_ID            (required) 10-char Apple Developer Team ID.
+#   KEYCHAIN_PROFILE   (default AC_PASSWORD) notarytool keychain profile.
 
 set -euo pipefail
 
-cat <<'EOF'
-🚧  scripts/release.sh is a stub.
+VERSION="${1:-}"
+[[ -n "$VERSION" ]] \
+  || { echo "usage: scripts/release.sh <version>   e.g. 0.2.0" >&2; exit 64; }
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+  || { echo "error: version must be MAJOR.MINOR.PATCH (got '$VERSION')" >&2; exit 64; }
+[[ -n "${TEAM_ID:-}" ]] \
+  || { echo "error: TEAM_ID is unset. Export your 10-char Apple Developer Team ID." >&2; exit 64; }
 
-Until this is wired up to CI, follow the per-release checklist in
-docs/release.md. The one-time Sparkle key-generation step lives in
-the same doc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$REPO_ROOT/build"
+APP_PATH="$BUILD_DIR/export/Anglesite.app"
+ZIP_PATH="$BUILD_DIR/Anglesite-${VERSION}.zip"
+APPCAST_PATH="$BUILD_DIR/appcast.xml"
+TAG="v${VERSION}"
+MIN_SYSTEM_VERSION="14.0"
 
-This stub exits non-zero so CI can't silently no-op a release.
+cd "$REPO_ROOT"
+
+bail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+step() { printf '\n=== %s ===\n' "$*"; }
+
+for cmd in gh jq xcodegen ditto; do
+  command -v "$cmd" >/dev/null || bail "$cmd not on PATH"
+done
+
+git diff --quiet && git diff --cached --quiet \
+  || bail "working tree has uncommitted changes — commit or stash before releasing"
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+[[ "$branch" == "main" ]] \
+  || bail "releases must run from main (current: $branch)"
+
+if gh release view "$TAG" >/dev/null 2>&1; then
+  bail "release $TAG already exists on GitHub — bump the version"
+fi
+
+# Locate Sparkle's sign_update. The SourcePackages path is deterministic once
+# the Anglesite scheme has been built at least once.
+SIGN_UPDATE="$(find ~/Library/Developer/Xcode/DerivedData -name sign_update -path '*Sparkle*/bin/sign_update' 2>/dev/null | head -1)"
+[[ -n "$SIGN_UPDATE" && -x "$SIGN_UPDATE" ]] \
+  || bail "sign_update not found. Build the Anglesite scheme once so Sparkle is resolved, then re-run."
+
+step "1/8 bump versions"
+prev_build="$(grep -E '^\s*CURRENT_PROJECT_VERSION:' project.yml | awk '{print $2}')"
+[[ "$prev_build" =~ ^[0-9]+$ ]] || bail "CURRENT_PROJECT_VERSION in project.yml is not a bare integer"
+new_build=$((prev_build + 1))
+echo "  MARKETING_VERSION:      → ${VERSION}"
+echo "  CURRENT_PROJECT_VERSION: ${prev_build} → ${new_build}"
+# macOS sed needs -i ''
+sed -i '' "s|^\(\s*MARKETING_VERSION:\) .*|\1 \"${VERSION}\"|" project.yml
+sed -i '' "s|^\(\s*CURRENT_PROJECT_VERSION:\) .*|\1 ${new_build}|" project.yml
+
+step "2/8 archive + notarize + staple"
+"${SCRIPT_DIR}/notarize-dry-run.sh"
+[[ -d "$APP_PATH" ]] || bail "notarize-dry-run.sh did not produce $APP_PATH"
+
+step "3/8 zip"
+rm -f "$ZIP_PATH"
+ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_PATH"
+zip_length="$(stat -f%z "$ZIP_PATH")"
+echo "  → $ZIP_PATH ($zip_length bytes)"
+
+step "4/8 sign_update"
+# sign_update emits e.g.   sparkle:edSignature="ABC..." length="12345"
+sig_line="$("$SIGN_UPDATE" "$ZIP_PATH")"
+ed_signature="$(echo "$sig_line" | sed -n 's|.*sparkle:edSignature="\([^"]*\)".*|\1|p')"
+[[ -n "$ed_signature" ]] || bail "could not parse edSignature from sign_update output: $sig_line"
+echo "  edSignature: ${ed_signature:0:16}…"
+echo "  length:      $zip_length"
+
+step "5/8 commit version bump"
+git add project.yml
+git commit -m "release: ${VERSION}"
+
+step "6/8 tag + push"
+git tag -a "$TAG" -m "Anglesite ${VERSION}"
+git push origin main "$TAG"
+
+step "7/8 gh release create"
+notes_file="$(mktemp)"
+trap 'rm -f "$notes_file"' EXIT
+cat >"$notes_file" <<EOF
+Anglesite ${VERSION}
+
+<!-- Machine-readable markers consumed by scripts/generate-appcast.sh. Do not edit. -->
+<!-- sparkle-version: ${new_build} -->
+<!-- sparkle-shortVersionString: ${VERSION} -->
+<!-- sparkle-edSignature: ${ed_signature} -->
+<!-- sparkle-length: ${zip_length} -->
+<!-- sparkle-minimumSystemVersion: ${MIN_SYSTEM_VERSION} -->
 EOF
+gh release create "$TAG" "$ZIP_PATH" \
+  --title "Anglesite ${VERSION}" \
+  --notes-file "$notes_file"
 
-exit 1
+step "8/8 regenerate appcast.xml"
+"${SCRIPT_DIR}/generate-appcast.sh" "$APPCAST_PATH"
+
+cat <<EOF
+
+✅ Released ${TAG}.
+
+Next steps (manual until gh-pages automation lands):
+  1. Commit ${APPCAST_PATH} to the gh-pages branch:
+       git worktree add ../Anglesite-app-pages gh-pages
+       cp ${APPCAST_PATH} ../Anglesite-app-pages/appcast.xml
+       (cd ../Anglesite-app-pages && git add appcast.xml && git commit -m "appcast: ${VERSION}" && git push)
+  2. Confirm https://anglesite.dev/appcast.xml serves the updated feed.
+  3. Test in-app "Check for Updates…" against the new release.
+EOF


### PR DESCRIPTION
## Summary
- `scripts/release.sh` now drives the full pipeline: version bump → notarize-dry-run.sh (archive/notarize/staple) → ditto zip → Sparkle `sign_update` → tag/push → `gh release create` with sparkle-* markers in the body → regenerate `build/appcast.xml`.
- New `scripts/generate-appcast.sh` walks `gh release list`, parses the sparkle-* markers out of each release body, and emits a Sparkle-compliant feed.
- `docs/release.md` rewritten: one-time setup (Ed25519 keypair, `SUPublicEDKey`, gh-pages + anglesite.dev DNS, `notarytool store-credentials`) and the new per-release one-liner.

## What's still manual
- **Keypair** — only the owner can run Sparkle's `generate_keys` (private key lands in their login Keychain). After they do, the public key gets pasted into `Resources/Info.plist`'s `SUPublicEDKey` (placeholder today).
- **Appcast hosting** — the script regenerates `build/appcast.xml` but does not push it. The plan is a `gh-pages` branch with `anglesite.dev` as a Pages custom domain; that DNS work + branch creation is a follow-up.
- **CI** — releases run from a developer machine because signing keys live in the macOS Keychain. Moving to GitHub Actions is documented as deferred.

## Test plan
- [x] `bash -n` syntax check passes on both scripts.
- [x] `scripts/generate-appcast.sh /tmp/out.xml` against this repo (zero releases) emits a valid empty feed.
- [ ] First real release (`scripts/release.sh 0.2.0`) — gated on the keypair + custom-domain follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)