### PR TITLE
feat(server): image-drop pipeline for the WKWebView edit overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.28.0"
+        "@modelcontextprotocol/sdk": "^1.28.0",
+        "sharp": "^0.33.0"
       },
       "devDependencies": {
         "@types/semver": "^7.7.1",
@@ -246,6 +247,16 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -713,6 +724,403 @@
       },
       "engines": {
         "node": "^20.11 || >= 22.16"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1675,11 +2083,23 @@
         "node": ">= 16"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1692,8 +2112,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -1905,6 +2334,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/devlop": {
@@ -4541,7 +4979,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4600,6 +5037,45 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4713,6 +5189,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -5091,6 +5582,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "playwright": "^1.52.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.28.0"
+    "@modelcontextprotocol/sdk": "^1.28.0",
+    "sharp": "^0.33.0"
   }
 }

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -2,22 +2,36 @@
  * Edit-pipeline dispatcher — the bridge between the `apply_edit` MCP tool and `patcher.mjs`.
  *
  * Flow:
- *   1. `resolve(projectRoot, edit)` (patcher.mjs) returns either `{file, range, replacement}`
+ *   1. For `replace-image-src` with a raw `{filename, mimeType, dataURL}` value: pre-process
+ *      via `processImageDrop` — write the bytes under `public/images/`, run optimize, build the
+ *      `{src, srcset}` value the patcher's resolver expects. Throws map to `image-optimize-failed`.
+ *   2. `resolve(projectRoot, edit)` (patcher.mjs) returns either `{file, range, replacement}`
  *      or `{refused: true, reason, detail?}`.
- *   2. On refusal: forward as an `edit-failed` MCP response.
- *   3. On success: read the source, splice in the replacement, atomically write back (write to
+ *   3. On refusal: forward as an `edit-failed` MCP response.
+ *   4. On success: read the source, splice in the replacement, atomically write back (write to
  *      a sibling temp file then `rename`), invoke an optional `onApplied` hook so #298's
  *      `edit-history.mjs` can commit to the hidden `anglesite/edits` branch and thread its SHA
- *      back as `commit`, then return `edit-applied`.
- *   4. On any filesystem error: return `edit-failed` with reason `write-failed`.
+ *      back as `commit`, then return `edit-applied` — with `result: {src, srcset}` for the
+ *      image-drop path.
+ *   5. On any filesystem error: return `edit-failed` with reason `write-failed`.
  *
  * The handler stays a pure async function so it's unit-testable independent of the MCP
  * `server.tool` plumbing; `server/index.mjs` is a one-line wire.
  */
-import { readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
-import { join, dirname, basename } from "node:path";
+import {
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+  mkdirSync,
+  existsSync,
+  readdirSync,
+} from "node:fs";
+import { join, dirname, basename, extname } from "node:path";
+import { Buffer } from "node:buffer";
 import { randomBytes } from "node:crypto";
 import { resolve as resolveEdit } from "./patcher.mjs";
+import { optimizeImage } from "./optimize-images.mjs";
 import {
   createEditAppliedContent,
   createEditFailedContent,
@@ -27,8 +41,8 @@ function failed(id, reason, detail) {
   return { content: [createEditFailedContent(id, reason, detail)], isError: true };
 }
 
-function applied(id, file, range, commit) {
-  return { content: [createEditAppliedContent(id, file, range, commit)] };
+function applied(id, file, range, commit, result) {
+  return { content: [createEditAppliedContent(id, file, range, commit, result)] };
 }
 
 /** Splice `replacement` into `source` at the resolved byte range. */
@@ -51,6 +65,93 @@ function atomicWrite(absPath, content) {
   }
 }
 
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function mimeToExt(mime) {
+  return {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+    "image/tiff": ".tiff",
+    "image/webp": ".webp",
+  }[mime];
+}
+
+/**
+ * Decode the dropped image's data URL, write it to public/images/<basename>.<ext>,
+ * move any pre-existing same-stem files to public/images/originals/, then run
+ * optimizeImage and build the srcset string from the variants.
+ *
+ * Basename: stem of the target <img>'s current src (e.g. /images/hero.jpg → "hero").
+ * Falls back to the dropped filename's stem when the target src is external
+ * (http(s)://…) or otherwise can't be parsed to a /images/ path.
+ *
+ * @returns {Promise<{ src: string, srcset: string }>}
+ */
+async function processImageDrop(projectRoot, edit) {
+  const { selector, value } = edit;
+  if (!value || typeof value !== "object" || !value.dataURL) {
+    throw new Error("image drop missing dataURL");
+  }
+
+  const currentSrc = selector.textContent ?? "";
+  let stem;
+  const localMatch = currentSrc.match(/\/images\/([^/?#]+?)(?:\.[a-z0-9]+)?$/i);
+  if (localMatch) {
+    stem = localMatch[1];
+  } else {
+    stem = basename(value.filename, extname(value.filename));
+  }
+
+  const imagesDir = join(projectRoot, "public/images");
+  const originalsDir = join(imagesDir, "originals");
+  mkdirSync(imagesDir, { recursive: true });
+
+  // Move any pre-existing <stem>.* and <stem>-<width>w.* files into originals/.
+  if (existsSync(imagesDir)) {
+    mkdirSync(originalsDir, { recursive: true });
+    const re = new RegExp(`^${escapeRegex(stem)}(-\\d+w)?\\.[a-z0-9]+$`, "i");
+    for (const entry of readdirSync(imagesDir)) {
+      if (entry === "originals") continue;
+      if (re.test(entry)) {
+        try {
+          renameSync(join(imagesDir, entry), join(originalsDir, entry));
+        } catch {
+          // best-effort; collisions in originals/ shadow the older copy
+        }
+      }
+    }
+  }
+
+  // Decode the dataURL.
+  const m = value.dataURL.match(/^data:([^;]+);base64,(.+)$/);
+  if (!m) throw new Error("dataURL is not base64-encoded");
+  const ext = extname(value.filename) || mimeToExt(m[1]);
+  if (!ext) {
+    throw new Error(`can't infer extension from mimeType ${m[1]} / filename ${value.filename}`);
+  }
+  const bytes = Buffer.from(m[2], "base64");
+  const droppedPath = join(imagesDir, `${stem}${ext}`);
+  writeFileSync(droppedPath, bytes);
+
+  // Optimize.
+  const optimized = await optimizeImage(droppedPath, {
+    outputDir: imagesDir,
+    widths: [480, 768, 1024, 1920],
+    preserveOriginalsDir: originalsDir,
+  });
+
+  const src = `/images/${optimized.primary}`;
+  const srcset = optimized.variants
+    .map((v) => `/images/${v.file} ${v.width}w`)
+    .join(", ");
+  return { src, srcset };
+}
+
 /**
  * Apply an edit. Returns an MCP tool response (`{content, isError?}`) whose first content entry
  * is the JSON-encoded `edit-applied` / `edit-failed` body.
@@ -60,7 +161,22 @@ function atomicWrite(absPath, content) {
  * @param {{ onApplied?: (info: {file:string, range:{start:number,end:number}, projectRoot:string}) => Promise<string|undefined> | string | undefined }} [opts]
  */
 export async function applyEdit(projectRoot, edit, opts = {}) {
-  const resolution = resolveEdit(projectRoot, edit);
+  let effectiveEdit = edit;
+  let imageResult;
+
+  if (edit.op === "replace-image-src") {
+    try {
+      imageResult = await processImageDrop(projectRoot, edit);
+    } catch (err) {
+      return failed(edit.id, "image-optimize-failed", String(err.message || err));
+    }
+    effectiveEdit = {
+      ...edit,
+      value: { src: imageResult.src, srcset: imageResult.srcset },
+    };
+  }
+
+  const resolution = resolveEdit(projectRoot, effectiveEdit);
   if (resolution.refused) {
     return failed(edit.id, resolution.reason, resolution.detail);
   }
@@ -94,5 +210,5 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
     }
   }
 
-  return applied(edit.id, file, range, commit);
+  return applied(edit.id, file, range, commit, imageResult ? { src: imageResult.src, srcset: imageResult.srcset } : undefined);
 }

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -139,10 +139,13 @@ async function processImageDrop(projectRoot, edit) {
   writeFileSync(droppedPath, bytes);
 
   // Optimize.
+  // Don't pass preserveOriginalsDir: the sweep above already moved any
+  // pre-existing <stem>.* and <stem>-*w.* files into originalsDir. If we
+  // passed it here, optimizeImage would copyFileSync the freshly-written
+  // (new) bytes over the preserved original, destroying it.
   const optimized = await optimizeImage(droppedPath, {
     outputDir: imagesDir,
     widths: [480, 768, 1024, 1920],
-    preserveOriginalsDir: originalsDir,
   });
 
   const src = `/images/${optimized.primary}`;

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -79,9 +79,12 @@ export function createEditFailedContent(id, reason, detail) {
 
 /** Build the MCP `content` entry for an edit-applied response. `range` is `{start, end}` byte
  *  offsets in `file`; `commit` is the SHA the patch was committed to on the hidden
- *  `anglesite/edits` branch (added by #298). */
-export function createEditAppliedContent(id, file, range, commit) {
+ *  `anglesite/edits` branch (added by #298). `result` is optional, op-scoped metadata that the
+ *  overlay can apply directly: e.g. `replace-image-src` returns `{ src, srcset? }` so the
+ *  overlay swaps both attributes on success without re-deriving them from the patch text. */
+export function createEditAppliedContent(id, file, range, commit, result) {
   const body = { type: "anglesite:edit-applied", id, file, range };
   if (commit !== undefined) body.commit = commit;
+  if (result !== undefined) body.result = result;
   return { type: "text", text: JSON.stringify(body) };
 }

--- a/server/messages.mjs
+++ b/server/messages.mjs
@@ -68,9 +68,15 @@ export function createErrorMessage(message) {
 }
 
 /** Build an edit-applied response (server → client). `range` is `{start, end}` byte offsets in
- *  `file`; `commit` is the SHA on the hidden `anglesite/edits` branch (#298). */
-export function createEditAppliedMessage(id, file, range, commit) {
-  return { type: MESSAGE_TYPES.EDIT_APPLIED, id, file, range, commit };
+ *  `file`; `commit` is the SHA on the hidden `anglesite/edits` branch (#298). `result` is
+ *  optional, op-scoped metadata that the overlay can apply directly: e.g. `replace-image-src`
+ *  returns `{ src, srcset? }` so the overlay swaps both attributes on success without
+ *  re-deriving them from the patch text. Mirrors `createEditAppliedContent` in
+ *  `apply-edit-schema.mjs` — keep them in lockstep when the wire format changes. */
+export function createEditAppliedMessage(id, file, range, commit, result) {
+  const msg = { type: MESSAGE_TYPES.EDIT_APPLIED, id, file, range, commit };
+  if (result !== undefined) msg.result = result;
+  return msg;
 }
 
 /** Build an edit-failed response (server → client). `reason` must be one of `EDIT_FAILED_REASONS`. */

--- a/server/messages.mjs
+++ b/server/messages.mjs
@@ -25,6 +25,7 @@ export const EDIT_FAILED_REASONS = Object.freeze([
   "patch-conflict",
   "write-failed",
   "not-implemented",
+  "image-optimize-failed",
 ]);
 
 const KNOWN_TYPES = new Set(Object.values(MESSAGE_TYPES));

--- a/server/optimize-images.mjs
+++ b/server/optimize-images.mjs
@@ -1,0 +1,63 @@
+import { mkdirSync, copyFileSync, existsSync } from "node:fs";
+import { join, basename, extname } from "node:path";
+import sharp from "sharp";
+
+/**
+ * Optimize a single image: write a primary WebP plus responsive variants,
+ * stripping EXIF metadata. Idempotent on re-run.
+ *
+ * @param {string} inputFile - absolute path to a source image (.jpg/.png/.heic/etc)
+ * @param {{
+ *   outputDir: string,
+ *   widths?: number[],
+ *   preserveOriginalsDir?: string,
+ * }} options
+ * @returns {Promise<{
+ *   primary: string,
+ *   variants: Array<{ width: number, file: string, bytes: number }>,
+ * }>}
+ */
+export async function optimizeImage(inputFile, options) {
+  const widths = options.widths ?? [480, 768, 1024, 1920];
+  const outputDir = options.outputDir;
+  if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
+
+  const stem = basename(inputFile, extname(inputFile));
+
+  if (options.preserveOriginalsDir) {
+    if (!existsSync(options.preserveOriginalsDir)) {
+      mkdirSync(options.preserveOriginalsDir, { recursive: true });
+    }
+    copyFileSync(inputFile, join(options.preserveOriginalsDir, basename(inputFile)));
+  }
+
+  const meta = await sharp(inputFile).metadata();
+  const inputWidth = meta.width ?? 0;
+  const usableWidths = widths.filter((w) => w <= inputWidth).sort((a, b) => a - b);
+  if (usableWidths.length === 0) {
+    usableWidths.push(Math.min(widths[0] ?? inputWidth, inputWidth));
+  }
+
+  const variants = [];
+  for (const width of usableWidths) {
+    const file = `${stem}-${width}w.webp`;
+    const out = join(outputDir, file);
+    await sharp(inputFile)
+      .rotate()
+      .resize({ width, withoutEnlargement: true })
+      .webp({ quality: 80 })
+      .toFile(out);
+    const stats = await sharp(out).metadata();
+    variants.push({ width, file, bytes: stats.size ?? 0 });
+  }
+
+  const primaryWidth = usableWidths[usableWidths.length - 1];
+  const primary = `${stem}.webp`;
+  await sharp(inputFile)
+    .rotate()
+    .resize({ width: primaryWidth, withoutEnlargement: true })
+    .webp({ quality: 80 })
+    .toFile(join(outputDir, primary));
+
+  return { primary, variants };
+}

--- a/server/optimize-images.mjs
+++ b/server/optimize-images.mjs
@@ -42,13 +42,12 @@ export async function optimizeImage(inputFile, options) {
   for (const width of usableWidths) {
     const file = `${stem}-${width}w.webp`;
     const out = join(outputDir, file);
-    await sharp(inputFile)
+    const info = await sharp(inputFile)
       .rotate()
       .resize({ width, withoutEnlargement: true })
       .webp({ quality: 80 })
       .toFile(out);
-    const stats = await sharp(out).metadata();
-    variants.push({ width, file, bytes: stats.size ?? 0 });
+    variants.push({ width, file, bytes: info.size });
   }
 
   const primaryWidth = usableWidths[usableWidths.length - 1];

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -104,7 +104,7 @@ function normalizeText(text) {
 /**
  * Derive the replacement string for a given op + value + matched source text.
  */
-function buildReplacement(op, value, _matchedSource) {
+function buildReplacement(op, value, matchedSource) {
   if (op === "replace-text") {
     return typeof value === "string" ? value : String(value ?? "");
   }
@@ -112,9 +112,55 @@ function buildReplacement(op, value, _matchedSource) {
     return value.value != null ? String(value.value) : "";
   }
   if (op === "replace-image-src" && value && typeof value === "object") {
-    return value.filename || "";
+    // matchedSource is the entire opening <img …> tag. Rewrite its src and
+    // srcset attributes while preserving everything else (alt, width, class,
+    // data-*, etc). Existing src/srcset are replaced; missing srcset is added.
+    return rewriteImgTag(matchedSource, value.src, value.srcset);
   }
   return typeof value === "string" ? value : "";
+}
+
+/**
+ * Rewrite the src and srcset attributes inside an <img …> opening tag.
+ * Preserves all other attributes. If srcset is absent in the source tag,
+ * it's inserted right after src.
+ *
+ * @param {string} tagSource - e.g. '<img src="/foo.jpg" alt="x" />'
+ * @param {string} newSrc
+ * @param {string} newSrcset - empty string means "don't emit srcset"
+ */
+function rewriteImgTag(tagSource, newSrc, newSrcset) {
+  let out = tagSource;
+  if (/\ssrc=("[^"]*"|'[^']*')/i.test(out)) {
+    out = out.replace(/(\ssrc=)("[^"]*"|'[^']*')/i, `$1"${newSrc}"`);
+  } else {
+    out = out.replace(/(\s*\/?>)$/, ` src="${newSrc}"$1`);
+  }
+  if (newSrcset) {
+    if (/\ssrcset=("[^"]*"|'[^']*')/i.test(out)) {
+      out = out.replace(/(\ssrcset=)("[^"]*"|'[^']*')/i, `$1"${newSrcset}"`);
+    } else {
+      out = out.replace(/(\ssrc="[^"]*")/i, `$1 srcset="${newSrcset}"`);
+    }
+  }
+  return out;
+}
+
+/**
+ * Given a src URL needle (e.g. "/images/hero.jpg"), find the full
+ * opening tag that contains it. Returns an array of
+ * {start, end, source} objects — or [] if not found.
+ */
+function findImgTagBySrc(source, srcNeedle) {
+  const tagRe = /<img\b[^>]*\/?>/gi;
+  let m;
+  const matches = [];
+  while ((m = tagRe.exec(source)) !== null) {
+    if (m[0].includes(`src="${srcNeedle}"`) || m[0].includes(`src='${srcNeedle}'`)) {
+      matches.push({ start: m.index, end: m.index + m[0].length, source: m[0] });
+    }
+  }
+  return matches;
 }
 
 /**
@@ -389,6 +435,38 @@ function resolveAstro(projectRoot, edit) {
 
   if (candidates.length === 0) {
     return refuse("no-match", `no .astro file found for path ${pagePath}`);
+  }
+
+  if (op === "replace-image-src") {
+    const currentSrc = selector.textContent;
+    if (!currentSrc) {
+      return refuse("no-match", "no current src to find in .astro files");
+    }
+    const allTagMatches = [];
+    for (const file of candidates) {
+      let source;
+      try {
+        source = readFileSync(file, "utf-8");
+      } catch {
+        continue;
+      }
+      const matches = findImgTagBySrc(source, currentSrc);
+      for (const tag of matches) {
+        allTagMatches.push({ file: relative(projectRoot, file), tag });
+      }
+    }
+    if (allTagMatches.length === 0) {
+      return refuse("no-match", `no <img src="${currentSrc}"> found in .astro files`);
+    }
+    if (allTagMatches.length > 1) {
+      return refuse("ambiguous", `${allTagMatches.length} <img> tags match src="${currentSrc}"`);
+    }
+    const only = allTagMatches[0];
+    return {
+      file: only.file,
+      range: { start: only.tag.start, end: only.tag.end },
+      replacement: buildReplacement(op, value, only.tag.source),
+    };
   }
 
   const textContent = selector.textContent;

--- a/template/scripts/optimize-images.ts
+++ b/template/scripts/optimize-images.ts
@@ -1,24 +1,17 @@
 /**
- * Image optimization pipeline.
+ * CLI wrapper around server/optimize-images.mjs. Walks public/images/,
+ * preserves originals in public/images/originals/, and emits responsive
+ * WebP variants. Run via `npm run ai-optimize`.
  *
- * Processes images in public/images/:
- * - Resizes to max width (default 1920px)
- * - Converts to WebP
- * - Generates responsive srcset variants (480, 768, 1024, 1920)
- * - Strips EXIF metadata (privacy: removes GPS, camera info)
- * - Preserves originals in public/images/originals/
- *
- * Supports: jpg, jpeg, png, gif, tiff, heif, heic
- * Skips: svg, webp, avif, favicon files, og-image
- *
- * Run: npm run ai-optimize
+ * The actual sharp pipeline lives in the plugin's server/optimize-images.mjs
+ * so the apply-edit dispatcher can reuse it for drop-on-<img> optimization.
  */
 
-import { readdirSync, existsSync, statSync, mkdirSync, copyFileSync } from "node:fs";
-import { join, extname, basename, relative } from "node:path";
+import { readdirSync, existsSync } from "node:fs";
+import { join, extname, basename, dirname } from "node:path";
 
 // ---------------------------------------------------------------------------
-// Types
+// Types (kept here so template-side tests can import them)
 // ---------------------------------------------------------------------------
 
 export interface OptimizeResult {
@@ -35,65 +28,41 @@ export interface OptimizeResult {
 const IMAGE_EXTENSIONS = new Set([
   ".jpg", ".jpeg", ".png", ".gif", ".tiff", ".tif", ".heif", ".heic",
 ]);
-
 const SKIP_EXTENSIONS = new Set([".svg", ".webp", ".avif"]);
-
 const SKIP_FILENAMES = new Set([
   "apple-touch-icon.png",
   "og-image.png",
   "favicon.svg",
 ]);
 
-export const DEFAULT_WIDTHS = [480, 768, 1024, 1920];
-export const DEFAULT_MAX_WIDTH = 1920;
-
 // ---------------------------------------------------------------------------
-// Pure logic functions (tested without sharp)
+// Pure helpers (tested without sharp)
 // ---------------------------------------------------------------------------
 
-/**
- * Recursively find image files in a directory.
- * @param dir - Absolute or relative path to the directory to search.
- * @returns Array of absolute file paths for supported image types.
- */
+export function shouldOptimize(filePath: string): boolean {
+  const ext = extname(filePath).toLowerCase();
+  if (!IMAGE_EXTENSIONS.has(ext)) return false;
+  if (SKIP_EXTENSIONS.has(ext)) return false;
+  const name = basename(filePath);
+  if (SKIP_FILENAMES.has(name)) return false;
+  return true;
+}
+
 export function getImageFiles(dir: string): string[] {
   if (!existsSync(dir)) return [];
-
-  const results: string[] = [];
+  const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
-      results.push(...getImageFiles(full));
-    } else if (entry.isFile()) {
-      const ext = extname(entry.name).toLowerCase();
-      if (IMAGE_EXTENSIONS.has(ext)) {
-        results.push(full);
-      }
+      if (entry.name === "originals") continue;
+      out.push(...getImageFiles(full));
+    } else if (entry.isFile() && shouldOptimize(full)) {
+      out.push(full);
     }
   }
-  return results;
+  return out;
 }
 
-/**
- * Determine whether an image file should be optimized.
- * Skips SVGs, already-optimized formats, and generated files.
- * @param filePath - Path to the image file to evaluate.
- * @returns `true` if the file is a supported format that should be optimized.
- */
-export function shouldOptimize(filePath: string): boolean {
-  const ext = extname(filePath).toLowerCase();
-  const name = basename(filePath);
-
-  if (SKIP_EXTENSIONS.has(ext)) return false;
-  if (SKIP_FILENAMES.has(name)) return false;
-  return IMAGE_EXTENSIONS.has(ext);
-}
-
-/**
- * Format optimization results as a plain-language report.
- * @param results - Array of per-file optimization outcomes.
- * @returns Human-readable summary with total savings and variant count.
- */
 export function formatReport(results: OptimizeResult[]): string {
   if (results.length === 0) {
     return "No images to optimize.";
@@ -117,9 +86,6 @@ export function formatReport(results: OptimizeResult[]): string {
   );
 }
 
-/**
- * Format bytes as human-readable string.
- */
 function formatBytes(bytes: number): string {
   if (bytes === 0) return "0 KB";
   if (bytes < 1024 * 1024) {
@@ -129,101 +95,35 @@ function formatBytes(bytes: number): string {
 }
 
 // ---------------------------------------------------------------------------
-// Sharp pipeline (only runs when executed directly)
+// CLI entry point — dynamic import deferred so helpers can be imported
+// without triggering the sharp pipeline load.
 // ---------------------------------------------------------------------------
 
-async function optimizeImage(
-  inputPath: string,
-  outputDir: string,
-  widths: number[] = DEFAULT_WIDTHS,
-): Promise<OptimizeResult> {
-  // Dynamic import so tests don't require sharp
-  const sharp = (await import("sharp")).default;
-
-  const originalBytes = statSync(inputPath).size;
-  const name = basename(inputPath, extname(inputPath));
-
-  // Preserve original
-  const originalsDir = join(outputDir, "originals");
-  mkdirSync(originalsDir, { recursive: true });
-  copyFileSync(inputPath, join(originalsDir, basename(inputPath)));
-
-  let totalOptimizedBytes = 0;
-  let variantCount = 0;
-
-  const image = sharp(inputPath).rotate(); // auto-rotate from EXIF, then strip
-
-  const metadata = await image.metadata();
-  const originalWidth = metadata.width || DEFAULT_MAX_WIDTH;
-
-  for (const width of widths) {
-    if (width > originalWidth) continue;
-
-    const outputPath = join(outputDir, `${name}-${width}w.webp`);
-    const result = await sharp(inputPath)
-      .rotate()
-      .resize(width, undefined, { withoutEnlargement: true })
-      .webp({ quality: 80 })
-      .toFile(outputPath);
-
-    totalOptimizedBytes += result.size;
-    variantCount++;
-  }
-
-  // Generate default WebP (at original size or max width)
-  const defaultWidth = Math.min(originalWidth, DEFAULT_MAX_WIDTH);
-  const defaultPath = join(outputDir, `${name}.webp`);
-  const defaultResult = await sharp(inputPath)
-    .rotate()
-    .resize(defaultWidth, undefined, { withoutEnlargement: true })
-    .webp({ quality: 80 })
-    .toFile(defaultPath);
-
-  totalOptimizedBytes += defaultResult.size;
-  variantCount++;
-
-  return {
-    file: basename(inputPath),
-    originalBytes,
-    optimizedBytes: totalOptimizedBytes,
-    variants: variantCount,
-  };
-}
-
 async function main() {
-  const imagesDir = "public/images";
+  const { optimizeImage } = await import("@dwk/anglesite/server/optimize-images.mjs");
 
+  const cwd = process.cwd();
+  const imagesDir = join(cwd, "public/images");
   if (!existsSync(imagesDir)) {
-    console.log("No public/images/ directory found.");
+    console.log("No public/images/ — nothing to optimize.");
     return;
   }
-
-  const files = getImageFiles(imagesDir).filter(shouldOptimize);
-
+  const files = getImageFiles(imagesDir);
   if (files.length === 0) {
-    console.log("No images to optimize.");
+    console.log("All images already optimized.");
     return;
   }
-
-  console.log(`Found ${files.length} image${files.length !== 1 ? "s" : ""} to optimize...`);
-
-  const results: OptimizeResult[] = [];
+  console.log(`Optimizing ${files.length} image(s)…`);
   for (const file of files) {
-    try {
-      const result = await optimizeImage(file, imagesDir);
-      results.push(result);
-      console.log(`  ✓ ${result.file}`);
-    } catch (err: any) {
-      console.error(`  ✗ ${basename(file)}: ${err.message}`);
-    }
+    const result = await optimizeImage(file, {
+      outputDir: dirname(file),
+      preserveOriginalsDir: join(imagesDir, "originals"),
+    });
+    console.log(`  ${file.replace(cwd + "/", "")} → ${result.primary} (+${result.variants.length} variants)`);
   }
-
-  console.log(`\n${formatReport(results)}`);
+  console.log("Done.");
 }
 
 if (process.argv[1]?.endsWith("optimize-images.ts")) {
-  main().catch((err) => {
-    console.error("Image optimization failed:", err.message);
-    process.exit(1);
-  });
+  await main();
 }

--- a/test/apply-edit-dispatcher.test.js
+++ b/test/apply-edit-dispatcher.test.js
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, cpSync, readFileSync, rmSync, chmodSync, statSync } from "node:fs";
+import { mkdtempSync, cpSync, readFileSync, rmSync, chmodSync, statSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
+import { execSync } from "node:child_process";
+import sharp from "sharp";
 import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
 
 const FIXTURE = resolvePath(import.meta.dirname, "fixtures/patcher");
@@ -135,5 +137,114 @@ describe("applyEdit — write-failed surface", () => {
     } finally {
       chmodSync(pagesDir, originalMode);
     }
+  });
+});
+
+describe("replace-image-src", () => {
+  let projectRoot;
+
+  beforeEach(() => {
+    // Set up a tmpdir as a git repo so applyEdit's onApplied (recordEdit) hook can commit.
+    projectRoot = mkdtempSync(join(tmpdir(), "anglesite-img-drop-"));
+    execSync("git init -q -b main", { cwd: projectRoot });
+    execSync("git config user.email test@example.com", { cwd: projectRoot });
+    execSync("git config user.name Test", { cwd: projectRoot });
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it("writes bytes, optimizes, patches <img>, and returns result.src+srcset", async () => {
+    mkdirSync(join(projectRoot, "src/pages"), { recursive: true });
+    mkdirSync(join(projectRoot, "public/images"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, "src/pages/about.astro"),
+      `<img src="/images/hero.jpg" alt="Hero" />`,
+    );
+    await sharp({ create: { width: 100, height: 100, channels: 3, background: { r: 0, g: 0, b: 255 } } })
+      .jpeg()
+      .toFile(join(projectRoot, "public/images/hero.jpg"));
+    execSync("git add .", { cwd: projectRoot });
+    execSync("git commit -q -m fixture", { cwd: projectRoot });
+
+    const dropped = await sharp({ create: { width: 2000, height: 1500, channels: 3, background: { r: 255, g: 128, b: 0 } } })
+      .jpeg()
+      .toBuffer();
+    const dataURL = `data:image/jpeg;base64,${dropped.toString("base64")}`;
+
+    const result = await applyEdit(projectRoot, {
+      id: "e-img-1",
+      path: "/about/",
+      selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "/images/hero.jpg" },
+      op: "replace-image-src",
+      value: { filename: "vacation.jpg", mimeType: "image/jpeg", dataURL },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const reply = JSON.parse(result.content[0].text);
+    expect(reply.type).toBe("anglesite:edit-applied");
+    expect(reply.result.src).toBe("/images/hero.webp");
+    expect(reply.result.srcset).toContain("/images/hero-480w.webp 480w");
+
+    const astro = readFileSync(join(projectRoot, "src/pages/about.astro"), "utf-8");
+    expect(astro).toContain('src="/images/hero.webp"');
+    expect(astro).toContain('srcset="/images/hero-480w.webp');
+
+    expect(existsSync(join(projectRoot, "public/images/hero.webp"))).toBe(true);
+    expect(existsSync(join(projectRoot, "public/images/hero-480w.webp"))).toBe(true);
+    expect(existsSync(join(projectRoot, "public/images/originals/hero.jpg"))).toBe(true);
+  });
+
+  it("falls back to dropped filename when target src is external", async () => {
+    mkdirSync(join(projectRoot, "src/pages"), { recursive: true });
+    mkdirSync(join(projectRoot, "public/images"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, "src/pages/about.astro"),
+      `<img src="https://cdn.example.com/photo.jpg" alt="External" />`,
+    );
+    execSync("git add .", { cwd: projectRoot });
+    execSync("git commit -q -m fixture", { cwd: projectRoot });
+
+    const dropped = await sharp({ create: { width: 1500, height: 1000, channels: 3, background: { r: 0, g: 200, b: 50 } } })
+      .jpeg()
+      .toBuffer();
+    const dataURL = `data:image/jpeg;base64,${dropped.toString("base64")}`;
+
+    const result = await applyEdit(projectRoot, {
+      id: "e-img-ext",
+      path: "/about/",
+      selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "https://cdn.example.com/photo.jpg" },
+      op: "replace-image-src",
+      value: { filename: "trip-sunset.jpg", mimeType: "image/jpeg", dataURL },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const reply = JSON.parse(result.content[0].text);
+    expect(reply.result.src).toBe("/images/trip-sunset.webp");
+  });
+
+  it("returns image-optimize-failed when the dataURL bytes are corrupt", async () => {
+    mkdirSync(join(projectRoot, "src/pages"), { recursive: true });
+    mkdirSync(join(projectRoot, "public/images"), { recursive: true });
+    writeFileSync(join(projectRoot, "src/pages/about.astro"), `<img src="/images/hero.jpg" />`);
+    execSync("git add .", { cwd: projectRoot });
+    execSync("git commit -q -m fixture", { cwd: projectRoot });
+
+    const result = await applyEdit(projectRoot, {
+      id: "e-img-bad",
+      path: "/about/",
+      selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "/images/hero.jpg" },
+      op: "replace-image-src",
+      value: {
+        filename: "broken.jpg",
+        mimeType: "image/jpeg",
+        dataURL: "data:image/jpeg;base64,bm90LWFuLWltYWdl",
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    const reply = JSON.parse(result.content[0].text);
+    expect(reply.reason).toBe("image-optimize-failed");
   });
 });

--- a/test/apply-edit-dispatcher.test.js
+++ b/test/apply-edit-dispatcher.test.js
@@ -194,6 +194,12 @@ describe("replace-image-src", () => {
     expect(existsSync(join(projectRoot, "public/images/hero.webp"))).toBe(true);
     expect(existsSync(join(projectRoot, "public/images/hero-480w.webp"))).toBe(true);
     expect(existsSync(join(projectRoot, "public/images/originals/hero.jpg"))).toBe(true);
+
+    // Verify originals/hero.jpg contains the OLD (blue 100x100) bytes, not the
+    // new (orange 2000x1500) bytes. This guards against a regression where
+    // the optimize call's preserveOriginalsDir overwrites the preserved file.
+    const preserved = await sharp(join(projectRoot, "public/images/originals/hero.jpg")).metadata();
+    expect(preserved.width).toBe(100);
   });
 
   it("falls back to dropped filename when target src is external", async () => {

--- a/test/fixtures/patcher/src/pages/photo.astro
+++ b/test/fixtures/patcher/src/pages/photo.astro
@@ -1,0 +1,7 @@
+---
+const title = "Photo";
+---
+<p>Before image.</p>
+<img src="/images/hero.jpg" srcset="/images/hero-480w.jpg 480w, /images/hero-768w.jpg 768w" alt="Hero" />
+<img src="/images/loose.jpg" alt="No srcset" />
+<p>After image.</p>

--- a/test/optimize-images.test.js
+++ b/test/optimize-images.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import sharp from "sharp";
+import { optimizeImage } from "../server/optimize-images.mjs";
+
+let dir;
+
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), "anglesite-optimize-"));
+  await sharp({ create: { width: 2400, height: 1600, channels: 3, background: { r: 255, g: 0, b: 0 } } })
+    .withMetadata({ exif: { IFD0: { Make: "Anglesite Test" } } })
+    .jpeg()
+    .toFile(join(dir, "photo.jpg"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("optimizeImage", () => {
+  it("emits a WebP primary at the largest width and width-suffixed variants", async () => {
+    const result = await optimizeImage(join(dir, "photo.jpg"), {
+      outputDir: dir,
+      widths: [480, 768, 1024, 1920],
+    });
+
+    expect(result.primary).toBe("photo.webp");
+    expect(result.variants).toHaveLength(4);
+    expect(result.variants.map((v) => v.width)).toEqual([480, 768, 1024, 1920]);
+    expect(result.variants.map((v) => v.file)).toEqual([
+      "photo-480w.webp",
+      "photo-768w.webp",
+      "photo-1024w.webp",
+      "photo-1920w.webp",
+    ]);
+
+    for (const v of result.variants) {
+      expect(existsSync(join(dir, v.file))).toBe(true);
+    }
+    expect(existsSync(join(dir, result.primary))).toBe(true);
+  });
+
+  it("strips EXIF metadata from the output", async () => {
+    const result = await optimizeImage(join(dir, "photo.jpg"), {
+      outputDir: dir,
+      widths: [480],
+    });
+    const meta = await sharp(join(dir, result.primary)).metadata();
+    expect(meta.exif).toBeUndefined();
+  });
+
+  it("preserves the original under originals/ before overwriting", async () => {
+    const result = await optimizeImage(join(dir, "photo.jpg"), {
+      outputDir: dir,
+      widths: [480],
+      preserveOriginalsDir: join(dir, "originals"),
+    });
+    expect(existsSync(join(dir, "originals", "photo.jpg"))).toBe(true);
+  });
+
+  it("does not upscale: if input is narrower than a requested width, that variant is skipped", async () => {
+    await sharp({ create: { width: 600, height: 400, channels: 3, background: { r: 0, g: 255, b: 0 } } })
+      .jpeg()
+      .toFile(join(dir, "small.jpg"));
+
+    const result = await optimizeImage(join(dir, "small.jpg"), {
+      outputDir: dir,
+      widths: [480, 768, 1024, 1920],
+    });
+    expect(result.variants.map((v) => v.width)).toEqual([480]);
+  });
+});

--- a/test/patcher.test.js
+++ b/test/patcher.test.js
@@ -154,6 +154,57 @@ describe("astro resolver", () => {
     expect(result.file).toBe("src/pages/index.astro");
     expect(result.replacement).toBe("Open every day, 8am to 6pm.");
   });
+
+  describe("replace-image-src", () => {
+    it("rewrites the entire <img> opening tag with new src + srcset", () => {
+      const result = resolve(FIXTURE_ROOT, {
+        path: "/photo/",
+        selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "/images/hero.jpg" },
+        op: "replace-image-src",
+        value: {
+          src: "/images/hero.webp",
+          srcset: "/images/hero-480w.webp 480w, /images/hero-768w.webp 768w, /images/hero-1024w.webp 1024w, /images/hero-1920w.webp 1920w",
+        },
+      });
+      expect(result.refused).toBeUndefined();
+      expect(result.file).toBe("src/pages/photo.astro");
+      expect(result.replacement).toMatch(/^<img/);
+      expect(result.replacement).toContain('src="/images/hero.webp"');
+      expect(result.replacement).toContain('srcset="/images/hero-480w.webp 480w');
+      expect(result.replacement).toContain('alt="Hero"');
+      const src = readFileSync(resolvePath(FIXTURE_ROOT, result.file), "utf-8");
+      const matched = src.slice(result.range.start, result.range.end);
+      expect(matched.startsWith("<img")).toBe(true);
+      expect(matched.endsWith("/>") || matched.endsWith(">")).toBe(true);
+    });
+
+    it("adds srcset when the original <img> had none", () => {
+      const result = resolve(FIXTURE_ROOT, {
+        path: "/photo/",
+        selector: { tag: "IMG", classes: [], nthChild: 2, textContent: "/images/loose.jpg" },
+        op: "replace-image-src",
+        value: {
+          src: "/images/loose.webp",
+          srcset: "/images/loose-480w.webp 480w, /images/loose-768w.webp 768w",
+        },
+      });
+      expect(result.refused).toBeUndefined();
+      expect(result.replacement).toContain('src="/images/loose.webp"');
+      expect(result.replacement).toContain('srcset="/images/loose-480w.webp 480w');
+      expect(result.replacement).toContain('alt="No srcset"');
+    });
+
+    it("refuses with no-match when no <img> with the current src is found", () => {
+      const result = resolve(FIXTURE_ROOT, {
+        path: "/photo/",
+        selector: { tag: "IMG", classes: [], nthChild: 1, textContent: "/images/missing.jpg" },
+        op: "replace-image-src",
+        value: { src: "/images/whatever.webp", srcset: "" },
+      });
+      expect(result.refused).toBe(true);
+      expect(result.reason).toBe("no-match");
+    });
+  });
 });
 
 // ── Cross-resolver priority ───────────────────────────────────────

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,8 @@ export default defineConfig({
       // mock registry (keyed by the test file's resolved path) wouldn't match.
       satori: resolve(__dirname, "tests/__stubs__/satori.ts"),
       "@resvg/resvg-js": resolve(__dirname, "tests/__stubs__/resvg.ts"),
-      sharp: resolve(__dirname, "tests/__stubs__/sharp.ts"),
+      // sharp is now a root dependency (required by server/optimize-images.mjs);
+      // tests that need it mocked call vi.mock("sharp") themselves.
       wawoff2: resolve(__dirname, "tests/__stubs__/wawoff2.ts"),
     },
   },


### PR DESCRIPTION
## Summary

Paired PR with [Anglesite/Anglesite-app#32](https://github.com/Anglesite/Anglesite-app/issues/32). Delivers Phase 9 step 3 — dropping an image onto an `<img>` in the live preview optimizes it and patches the source `<img>` tag end-to-end.

## What's new

- **`server/optimize-images.mjs`** — hoisted from `template/scripts/optimize-images.ts`. ESM function `optimizeImage(file, { outputDir, widths, preserveOriginalsDir })` returning `{ primary, variants }`. Sharp pipeline with EXIF strip + width variants (default 480/768/1024/1920). The template script is now a thin CLI wrapper around it for `npm run ai-optimize`.
- **`server/patcher.mjs` `replace-image-src` resolver** — finds the matching `<img>` by current `src` attribute and returns a range covering the entire opening tag; replacement is the rewritten tag with new `src` + `srcset`, preserving alt / class / data-* etc. The resolver is pure — consumes `value: { src, srcset }` as pre-computed strings.
- **`server/apply-edit-dispatcher.mjs`** — extended `applyEdit` to handle `replace-image-src`. Derives a basename from the target's current src (stem of `/images/<name>.<ext>`, falling back to dropped filename for external URLs); moves any pre-existing `<stem>.*` files to `public/images/originals/`; decodes the dataURL → bytes → `public/images/<stem>.<ext>`; runs `optimizeImage`; builds the `srcset` string; transforms the value before calling the resolver. Returns `edit-applied` with `result: { src, srcset }` so the overlay can apply both attributes on swap.
- **`server/messages.mjs`** — new `image-optimize-failed` reason in `EDIT_FAILED_REASONS`; optional `result` parameter on `createEditAppliedMessage` (kept in lockstep with `createEditAppliedContent` in `apply-edit-schema.mjs`).

Design doc lives in the app repo: [`docs/specs/2026-05-26-image-drop-design.md`](https://github.com/Anglesite/Anglesite-app/blob/main/docs/specs/2026-05-26-image-drop-design.md).

## Test plan

- [x] `npx vitest run` — all 2409+ tests pass (existing + new): edit-history (96), apply-edit-dispatcher (10, +3 new), patcher (18, +3 new), optimize-images (4 new)
- [ ] Manual: launch Anglesite-app's debug build against `~/Sites/anglesite-smoke`, drag a JPEG onto an `<img>` in the preview, observe:
  - Blob URL appears immediately in the preview
  - 2–10 seconds later the URL swaps to `/images/<stem>.webp` + populated srcset
  - `~/Sites/anglesite-smoke/public/images/` contains the new `.webp` + 4 width variants
  - `~/Sites/anglesite-smoke/public/images/originals/` contains the previous file (with original bytes intact)
  - The `<img>` tag in the source `.astro` file is patched with `src` + `srcset`
  - A new commit appears on `refs/heads/anglesite/edits` in the smoke site

🤖 Generated with [Claude Code](https://claude.com/claude-code)