### PR TITLE
feat(server): undo_edit MCP tool for per-edit chat undo

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -9,6 +9,7 @@ import {
 import { applyEditInputShape } from "./apply-edit-schema.mjs";
 import { applyEdit } from "./apply-edit-dispatcher.mjs";
 import { recordEdit } from "./edit-history.mjs";
+import { undoEdit } from "./undo-edit.mjs";
 
 const projectRoot = process.env.ANGLESITE_PROJECT_ROOT || process.cwd();
 
@@ -86,6 +87,22 @@ server.tool(
       onApplied: ({ file, range }) =>
         recordEdit(projectRoot, { file, range, message: `anglesite: edit ${file}` }),
     }),
+);
+
+server.tool(
+  "undo_edit",
+  "Undo the most-recent commit on the hidden anglesite/edits branch by writing the parent commit's blobs back to disk. HEAD-only in v1: an optional `commit` argument must equal current HEAD (or be omitted). `force: true` skips the working-tree-modification check and overwrites any external changes to the touched files.",
+  {
+    commit: z.string().optional().describe("SHA to undo. Must equal current HEAD of refs/heads/anglesite/edits if provided."),
+    force: z.boolean().optional().describe("Skip the working-tree-modification check and overwrite any external changes. Default false."),
+  },
+  async ({ commit, force }) => {
+    const result = await undoEdit(projectRoot, { commit, force });
+    return {
+      content: [{ type: "text", text: JSON.stringify(result) }],
+      isError: result.status === "refused",
+    };
+  },
 );
 
 const transport = new StdioServerTransport();

--- a/server/messages.mjs
+++ b/server/messages.mjs
@@ -26,6 +26,10 @@ export const EDIT_FAILED_REASONS = Object.freeze([
   "write-failed",
   "not-implemented",
   "image-optimize-failed",
+  "no-edits-to-undo",
+  "head-only-mode",
+  "initial-commit",
+  "working-tree-modified",
 ]);
 
 const KNOWN_TYPES = new Set(Object.values(MESSAGE_TYPES));

--- a/server/undo-edit.mjs
+++ b/server/undo-edit.mjs
@@ -1,0 +1,103 @@
+/**
+ * Hidden-branch edit undo (#33). Reverts the most-recent commit on
+ * refs/heads/anglesite/edits by writing the parent commit's blobs back to disk
+ * and advancing the branch with a new linearized commit (`undo: <files>`).
+ *
+ * Same defensive-execFile pattern as edit-history.mjs — no shell, never
+ * mutates the user's HEAD or current branch, every git call passes argv as
+ * an array.
+ *
+ * Refusal reasons match the schema enum in server/messages.mjs:
+ *   - no-edits-to-undo:     hidden branch doesn't exist (or projectRoot isn't a repo)
+ *   - head-only-mode:       caller passed a commit arg that isn't HEAD
+ *   - initial-commit:       HEAD has no parent (only one commit on the branch)
+ *   - working-tree-modified: at least one touched file differs on disk vs. HEAD's blob
+ */
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const EDITS_REF = "refs/heads/anglesite/edits";
+
+function runGit(projectRoot, args, env = {}) {
+  return execFileSync("git", args, {
+    cwd: projectRoot,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...env },
+  }).trim();
+}
+
+function tryRunGit(projectRoot, args, env = {}) {
+  try { return runGit(projectRoot, args, env); } catch { return undefined; }
+}
+
+function runGitBuffer(projectRoot, args) {
+  return execFileSync("git", args, {
+    cwd: projectRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {{ commit?: string, force?: boolean }} opts
+ */
+export async function undoEdit(projectRoot, { commit, force = false } = {}) {
+  // 1. Confirm hidden branch exists.
+  const head = tryRunGit(projectRoot, ["show-ref", "--verify", "--hash", EDITS_REF]);
+  if (!head) return { status: "refused", reason: "no-edits-to-undo" };
+
+  // 2. Head-only mode — caller-supplied commit must match HEAD.
+  if (commit && commit !== head) {
+    return { status: "refused", reason: "head-only-mode" };
+  }
+
+  // 3. Get parent — guard against initial-commit case.
+  const parent = tryRunGit(projectRoot, ["rev-parse", `${head}^`]);
+  if (!parent) return { status: "refused", reason: "initial-commit" };
+
+  // 4. List files that differ between HEAD and parent.
+  const diff = tryRunGit(projectRoot, ["diff", "--name-only", parent, head]);
+  if (diff === undefined) return { status: "refused", reason: "no-edits-to-undo" };
+  const files = diff.split("\n").filter(Boolean);
+
+  // 5. Working-tree drift check (unless force).
+  if (!force) {
+    const drifted = [];
+    for (const file of files) {
+      const onDisk = tryRunGit(projectRoot, ["hash-object", "--", file]);
+      const headBlob = tryRunGit(projectRoot, ["rev-parse", `${head}:${file}`]);
+      // hash-object on a missing file fails (returns undefined); treat as drift.
+      if (!onDisk || onDisk !== headBlob) drifted.push(file);
+    }
+    if (drifted.length) {
+      return { status: "refused", reason: "working-tree-modified", files: drifted };
+    }
+  }
+
+  // 6. Write parent's blob content for each file back to disk.
+  for (const file of files) {
+    const content = runGitBuffer(projectRoot, ["show", `${parent}:${file}`]);
+    writeFileSync(join(projectRoot, file), content);
+  }
+
+  // 7. Advance the hidden branch with a new commit whose tree matches parent's tree.
+  const parentTree = runGit(projectRoot, ["rev-parse", `${parent}^{tree}`]);
+  const message = `undo: ${files.join(", ")}`;
+  const env = {
+    GIT_AUTHOR_NAME: "Anglesite",
+    GIT_AUTHOR_EMAIL: "edits@anglesite.local",
+    GIT_COMMITTER_NAME: "Anglesite",
+    GIT_COMMITTER_EMAIL: "edits@anglesite.local",
+  };
+  const newCommit = runGit(
+    projectRoot,
+    ["commit-tree", parentTree, "-p", head, "-m", message],
+    env,
+  );
+  // CAS update: only advance if HEAD is still what we read in step 1.
+  runGit(projectRoot, ["update-ref", EDITS_REF, newCommit, head]);
+
+  return { status: "undone", newCommit };
+}

--- a/test/undo-edit.test.js
+++ b/test/undo-edit.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { recordEdit } from "../server/edit-history.mjs";
+import { undoEdit } from "../server/undo-edit.mjs";
+
+let repo;
+
+function git(args) {
+  return execFileSync("git", args, {
+    cwd: repo, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function initRepo() {
+  repo = mkdtempSync(join(tmpdir(), "undo-edit-"));
+  execFileSync("git", ["init", "--initial-branch=main", repo], { stdio: "ignore" });
+  git(["config", "user.email", "test@example.com"]);
+  git(["config", "user.name", "Test"]);
+  writeFileSync(join(repo, "about.md"), "original\n");
+  git(["add", "about.md"]);
+  git(["commit", "-m", "initial"]);
+}
+
+beforeEach(initRepo);
+afterEach(() => repo && rmSync(repo, { recursive: true, force: true }));
+
+describe("undoEdit", () => {
+  it("rewinds the most-recent edit and advances the branch with a new commit", async () => {
+    writeFileSync(join(repo, "about.md"), "edited\n");
+    const editSha = await recordEdit(repo, {
+      file: "about.md", range: { start: 0, end: 7 }, message: "edit about.md",
+    });
+    expect(editSha).toMatch(/^[0-9a-f]{40}$/);
+    expect(git(["rev-parse", "refs/heads/anglesite/edits"])).toBe(editSha);
+
+    const result = await undoEdit(repo, {});
+    expect(result.status).toBe("undone");
+    expect(result.newCommit).toMatch(/^[0-9a-f]{40}$/);
+    expect(result.newCommit).not.toBe(editSha);
+
+    expect(readFileSync(join(repo, "about.md"), "utf-8")).toBe("original\n");
+
+    expect(git(["rev-parse", "refs/heads/anglesite/edits"])).toBe(result.newCommit);
+    const newTree = git(["rev-parse", `${result.newCommit}^{tree}`]);
+    const editTree = git(["rev-parse", `${editSha}^^{tree}`]);
+    expect(newTree).toBe(editTree);
+
+    const parent = git(["rev-list", "--parents", "-n", "1", result.newCommit]).split(" ")[1];
+    expect(parent).toBe(editSha);
+  });
+
+  it("refuses with working-tree-modified when the file drifted on disk", async () => {
+    writeFileSync(join(repo, "about.md"), "edited\n");
+    await recordEdit(repo, {
+      file: "about.md", range: { start: 0, end: 7 }, message: "edit",
+    });
+
+    writeFileSync(join(repo, "about.md"), "drift!\n");
+
+    const result = await undoEdit(repo, {});
+    expect(result.status).toBe("refused");
+    expect(result.reason).toBe("working-tree-modified");
+    expect(result.files).toEqual(["about.md"]);
+
+    expect(readFileSync(join(repo, "about.md"), "utf-8")).toBe("drift!\n");
+  });
+
+  it("force: true overwrites a drifted file and completes the undo", async () => {
+    writeFileSync(join(repo, "about.md"), "edited\n");
+    await recordEdit(repo, {
+      file: "about.md", range: { start: 0, end: 7 }, message: "edit",
+    });
+    writeFileSync(join(repo, "about.md"), "drift!\n");
+
+    const result = await undoEdit(repo, { force: true });
+    expect(result.status).toBe("undone");
+    expect(readFileSync(join(repo, "about.md"), "utf-8")).toBe("original\n");
+  });
+
+  it("refuses with no-edits-to-undo when the hidden branch doesn't exist", async () => {
+    const result = await undoEdit(repo, {});
+    expect(result.status).toBe("refused");
+    expect(result.reason).toBe("no-edits-to-undo");
+  });
+
+  it("refuses with head-only-mode when commit arg doesn't match HEAD", async () => {
+    writeFileSync(join(repo, "about.md"), "edited\n");
+    await recordEdit(repo, {
+      file: "about.md", range: { start: 0, end: 7 }, message: "edit",
+    });
+    const result = await undoEdit(repo, { commit: "0000000000000000000000000000000000000000" });
+    expect(result.status).toBe("refused");
+    expect(result.reason).toBe("head-only-mode");
+  });
+
+  it("clean undo when commit arg equals HEAD", async () => {
+    writeFileSync(join(repo, "about.md"), "edited\n");
+    const editSha = await recordEdit(repo, {
+      file: "about.md", range: { start: 0, end: 7 }, message: "edit",
+    });
+    const result = await undoEdit(repo, { commit: editSha });
+    expect(result.status).toBe("undone");
+  });
+
+  it("refuses with no-edits-to-undo when projectRoot is not a git repo", async () => {
+    const notARepo = mkdtempSync(join(tmpdir(), "not-a-repo-"));
+    try {
+      const result = await undoEdit(notARepo, {});
+      expect(result.status).toBe("refused");
+      expect(result.reason).toBe("no-edits-to-undo");
+    } finally {
+      rmSync(notARepo, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/undo-edit.test.js
+++ b/test/undo-edit.test.js
@@ -105,6 +105,30 @@ describe("undoEdit", () => {
     expect(result.status).toBe("undone");
   });
 
+  it("refuses with initial-commit when the hidden branch HEAD has no parent", async () => {
+    // Construct a parentless commit on refs/heads/anglesite/edits via git plumbing.
+    // This shape is unreachable through normal recordEdit usage (which always commits
+    // on top of HEAD); we hand-craft it here so the initial-commit path has coverage.
+    const tree = git(["rev-parse", "HEAD^{tree}"]);
+    const orphanCommit = execFileSync("git", ["commit-tree", tree, "-m", "orphan"], {
+      cwd: repo,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "Test",
+        GIT_AUTHOR_EMAIL: "test@example.com",
+        GIT_COMMITTER_NAME: "Test",
+        GIT_COMMITTER_EMAIL: "test@example.com",
+      },
+    }).trim();
+    git(["update-ref", "refs/heads/anglesite/edits", orphanCommit]);
+
+    const result = await undoEdit(repo, {});
+    expect(result.status).toBe("refused");
+    expect(result.reason).toBe("initial-commit");
+  });
+
   it("refuses with no-edits-to-undo when projectRoot is not a git repo", async () => {
     const notARepo = mkdtempSync(join(tmpdir(), "not-a-repo-"));
     try {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -183,6 +183,7 @@ describe("MCP annotation server", () => {
         "apply_edit",
         "list_annotations",
         "resolve_annotation",
+        "undo_edit",
       ]);
     } finally {
       proc.kill();


### PR DESCRIPTION
Paired PR with [Anglesite/Anglesite-app#33](https://github.com/Anglesite/Anglesite-app/issues/33). Delivers Phase 9 step 4 — every successful edit shows up in the chat panel with an inline Undo button.

## What's new

- **server/undo-edit.mjs** — handler that rewinds the most-recent commit on refs/heads/anglesite/edits by writing the parent commit's blobs back to disk and advancing the branch with a new linearized commit ('undo: <files>'). HEAD-only in v1; an optional commit arg must equal current HEAD. force: true skips the working-tree-drift check.
- **server/index.mjs** — registers the undo_edit MCP tool.
- **server/messages.mjs** — four new entries in EDIT_FAILED_REASONS: no-edits-to-undo, head-only-mode, initial-commit, working-tree-modified.

Same defensive-execFile pattern as recordEdit. CAS update-ref so concurrent undos can't silently clobber. Test coverage: 8 cases (happy path, working-tree drift, force override, empty branch, head-only mismatch, commit-matches-head, non-git-repo, initial-commit edge).

Design doc lives in the app repo: [docs/specs/2026-05-27-edit-undo-design.md](https://github.com/Anglesite/Anglesite-app/blob/main/docs/specs/2026-05-27-edit-undo-design.md).

## Test plan

- [x] npx vitest run — all tests pass (existing + 8 new undo-edit)
- [ ] Manual: launch the app's debug build against a site with at least one edit committed to anglesite/edits, click Undo in the chat panel, verify file reverts on disk + new commit appears on refs/heads/anglesite/edits + Undo button moves to the prior row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)