### PR TITLE
fix(template): astro dev returns 404 for all routes (#322)

### DIFF
--- a/template/astro.config.ts
+++ b/template/astro.config.ts
@@ -2,8 +2,11 @@
  * Astro configuration for an Anglesite-managed website.
  *
  * Reads site identity from `.site-config` (written by `/anglesite:start`).
- * In dev mode, enables Keystatic CMS, local HTTPS via mkcert, and server
- * output. In production, builds static HTML with no client JavaScript.
+ * In dev mode, enables local HTTPS via mkcert and the Anglesite annotations
+ * toolbar; in both dev and production, builds static HTML with no client
+ * JavaScript. The Cloudflare adapter is wired only for production builds —
+ * its dev-mode behavior conflicts with Astro 6.3.x's SSR routing (see the
+ * `adapter` block below for the full justification).
  *
  * @see https://docs.astro.build/en/reference/configuration-reference/
  * @module
@@ -135,16 +138,41 @@ const siteUrl = siteDomain
 export default defineConfig({
   site: siteUrl,
   devToolbar: { enabled: isDev },
-  output: isDev ? "server" : "static",
+  // Was: `isDev ? "server" : "static"`. The server-mode dev option requires
+  // the Cloudflare adapter to be loaded too, but @astrojs/cloudflare 13.5.0
+  // + Astro 6.3.1 intercepts dev-mode routing through the workerd shim and
+  // 404s every SSR request. Static + hot-reload gives a working preview
+  // without the adapter. Trade-off: Keystatic's `/keystatic` admin UI is
+  // SSR-only and isn't reachable in dev under this config. For owners who
+  // need the Keystatic admin locally, run a separate `astro dev` invocation
+  // with `output: "server"` + `adapter: cloudflare(...)` re-added.
+  output: "static",
   integrations: [
     react(),
     markdoc(),
     ...(isDev ? [keystatic(), anglesiteToolbar()] : []),
     sitemap({ serialize: makeLastmodSerializer() }),
   ],
-  vite: { server: { https: getHttpsConfig() } },
+  vite: {
+    server: { https: getHttpsConfig() },
+    // Exclude Keystatic packages from optimizeDeps so esbuild's pre-bundler
+    // doesn't try to resolve `virtual:keystatic-config` (a virtual module
+    // the Keystatic Astro integration only registers at serve time via a
+    // vite resolveId plugin). Without this, dev startup logs a non-fatal:
+    //   "Could not resolve 'virtual:keystatic-config'" from
+    //   @keystatic/astro/internal/keystatic-api.js
+    // Known issue with @keystatic/astro 5.x on recent Astro + Vite.
+    optimizeDeps: {
+      exclude: ["@keystatic/core", "@keystatic/astro"],
+    },
+  },
   // prerenderEnvironment: "node" keeps the prerender step in Node so the
   // adapter doesn't spin up a workerd-based preview server that conflicts
   // with the custom worker entry in worker/site-entry.js.
-  adapter: cloudflare({ prerenderEnvironment: "node" }),
+  //
+  // Skipped in dev — @astrojs/cloudflare 13.5.0 + Astro 6.3.1 intercepts SSR
+  // routing during `astro dev` and 404s every request. The adapter is only
+  // needed at build/deploy time. Pair this with `output: "static"` in dev
+  // (set above) since `output: "server"` requires an adapter.
+  adapter: isDev ? undefined : cloudflare({ prerenderEnvironment: "node" }),
 });


### PR DESCRIPTION
Closes #322. Unbreaks `npm run dev` for all freshly-scaffolded Anglesite sites.

## What was broken

In `template/astro.config.ts`, the combo of:
- `output: isDev ? "server" : "static"`
- `adapter: cloudflare({ prerenderEnvironment: "node" })`
- `@astrojs/cloudflare` 13.5.0 + Astro 6.3.1

caused the adapter to intercept SSR routing during `astro dev` and 404 every request that wasn't a static asset (`public/` files served fine, but every Astro page returned 404 with `content-length: 0`).

Independently, `@keystatic/astro` 5.x logged a non-fatal `Could not resolve "virtual:keystatic-config"` error from esbuild's pre-bundler on every startup.

Issue #322 has the full root-cause analysis.

## The fix

Three changes to `template/astro.config.ts`:

1. **`output: "static"`** (was `isDev ? "server" : "static"`). Server-mode dev required the Cloudflare adapter, which is the actual culprit. Static + hot-reload gives a working dev preview.
2. **`adapter: isDev ? undefined : cloudflare({...})`**. Adapter is only needed for the production build/deploy. Skipping it in dev sidesteps the routing interception entirely.
3. **`vite.optimizeDeps.exclude: ["@keystatic/core", "@keystatic/astro"]`**. Tells esbuild's pre-bundler to skip the keystatic packages so it doesn't trip on `virtual:keystatic-config` (only resolvable via the integration's vite plugin at serve time).

## Trade-off

Keystatic's `/keystatic` admin UI is SSR-only and isn't reachable in dev under this config. Owners who actively use the Keystatic admin locally can re-enable `output: "server"` + the adapter for a separate dev run; the v1 preview/edit-overlay flow Anglesite-app drives doesn't need it.

## Verification

- Copied the updated `template/astro.config.ts` into a freshly-scaffolded site (`~/Sites/anglesite-smoke`).
- Ran `npm run dev` → `astro ready in 2043ms`, no errors.
- `curl http://127.0.0.1:4328/` → `200`, full HTML rendered (11821 bytes).
- Plugin test suite: **2417/2417 pass**.

## Side effects

None on the rest of the template. `output: "static"` was already the production setting; the change only relaxes dev-mode behavior. The Cloudflare adapter still drives the production worker build identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)