### PR TITLE
Fix Keystatic admin UI hydration failure in dev

### DIFF
--- a/template/astro.config.ts
+++ b/template/astro.config.ts
@@ -142,10 +142,10 @@ export default defineConfig({
   // the Cloudflare adapter to be loaded too, but @astrojs/cloudflare 13.5.0
   // + Astro 6.3.1 intercepts dev-mode routing through the workerd shim and
   // 404s every SSR request. Static + hot-reload gives a working preview
-  // without the adapter. Trade-off: Keystatic's `/keystatic` admin UI is
-  // SSR-only and isn't reachable in dev under this config. For owners who
-  // need the Keystatic admin locally, run a separate `astro dev` invocation
-  // with `output: "server"` + `adapter: cloudflare(...)` re-added.
+  // without the adapter. The Keystatic `/keystatic` admin UI still works in
+  // dev: the keystatic() integration (added to `integrations` above only when
+  // isDev) injects its own route that Astro's dev server renders on demand,
+  // independent of this build-time `output` mode.
   output: "static",
   integrations: [
     react(),
@@ -155,16 +155,23 @@ export default defineConfig({
   ],
   vite: {
     server: { https: getHttpsConfig() },
-    // Exclude Keystatic packages from optimizeDeps so esbuild's pre-bundler
-    // doesn't try to resolve `virtual:keystatic-config` (a virtual module
-    // the Keystatic Astro integration only registers at serve time via a
-    // vite resolveId plugin). Without this, dev startup logs a non-fatal:
-    //   "Could not resolve 'virtual:keystatic-config'" from
-    //   @keystatic/astro/internal/keystatic-api.js
-    // Known issue with @keystatic/astro 5.x on recent Astro + Vite.
-    optimizeDeps: {
-      exclude: ["@keystatic/core", "@keystatic/astro"],
-    },
+    // DO NOT add @keystatic/core or @keystatic/astro to optimizeDeps.exclude.
+    //
+    // The /keystatic admin UI is a client-rendered React app whose dependency
+    // tree is largely CommonJS (slate, slate-react, slate-history, is-hotkey,
+    // use-sync-external-store, @markdoc/markdoc, js-yaml, …). Vite must
+    // pre-bundle that tree into ESM, or the browser fails to resolve named
+    // exports and surfaces errors like:
+    //   SyntaxError: Importing binding name 'isKeyHotkey' is not found.
+    //   SyntaxError: Importing binding name 'useSyncExternalStore' is not found.
+    // one at a time, leaving /keystatic a blank white page (seen on
+    // Node 22+/Vite 6). Excluding the Keystatic packages stops Vite from
+    // discovering and pre-bundling that CJS tree, which is exactly what breaks
+    // hydration. The canonical Keystatic + Astro setup needs no optimizeDeps
+    // config at all, so we keep this empty and let Vite's default dependency
+    // discovery do its job. (Excluding them only silenced a cosmetic, non-fatal
+    // "Could not resolve 'virtual:keystatic-config'" scan warning at startup —
+    // not worth a broken CMS.)
   },
   // prerenderEnvironment: "node" keeps the prerender step in Node so the
   // adapter doesn't spin up a workerd-based preview server that conflicts

--- a/tests/astro-config.test.ts
+++ b/tests/astro-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Read the scaffolded astro.config.ts as text. We assert on source rather than
+// importing it because the config pulls in the full Astro/Keystatic/Cloudflare
+// integration stack, which isn't installed in the plugin's own node_modules.
+const astroConfig = readFileSync(
+  resolve(__dirname, "../template/astro.config.ts"),
+  "utf-8",
+);
+
+describe("template/astro.config.ts — Keystatic dev compatibility", () => {
+  // Regression guard for the Keystatic hydration cascade: excluding the
+  // Keystatic packages from optimizeDeps stops Vite from pre-bundling their
+  // CommonJS dependency tree (slate, is-hotkey, use-sync-external-store,
+  // @markdoc/markdoc, …) into ESM, so the browser throws
+  // "Importing binding name '…' is not found" and /keystatic renders blank.
+  // The canonical Keystatic + Astro setup needs no optimizeDeps config at all.
+  it("does not exclude @keystatic packages from Vite optimizeDeps", () => {
+    const excludeMatch = astroConfig.match(/exclude\s*:\s*\[([^\]]*)\]/);
+    const excluded = excludeMatch?.[1] ?? "";
+    expect(excluded).not.toContain("@keystatic/core");
+    expect(excluded).not.toContain("@keystatic/astro");
+  });
+
+  it("still loads the keystatic integration in dev", () => {
+    expect(astroConfig).toContain("keystatic()");
+  });
+});


### PR DESCRIPTION
## Problem

A user (Pairadocs Farm) reported that `/keystatic` renders a **blank white page** in dev, with a cascade of console errors that each require a separate fix:

```
SyntaxError: Importing binding name 'isKeyHotkey' is not found.
SyntaxError: Importing binding name 'default' cannot be resolved by star export entries.
SyntaxError: Importing binding name 'useSyncExternalStore' is not found.
SyntaxError: Importing binding name 'parse' is not found.
```

Environment: macOS arm64, Node v24.16.0, Astro 6.3.1, `@keystatic/astro` 5.0.6, `@keystatic/core` 0.5.50.

## Root cause

The scaffold's `template/astro.config.ts` excluded `@keystatic/core` and `@keystatic/astro` from Vite's `optimizeDeps`:

```ts
optimizeDeps: {
  exclude: ["@keystatic/core", "@keystatic/astro"],
},
```

That exclusion stops Vite from discovering and pre-bundling Keystatic's largely-CommonJS dependency tree (`slate`, `slate-react`, `slate-history`, `is-hotkey`, `use-sync-external-store`, `@markdoc/markdoc`, `js-yaml`) into ESM. The browser then can't resolve their named exports, and the admin UI fails to hydrate one dependency at a time. The reporter's analysis was correct.

The exclude was originally added only to silence a cosmetic, **non-fatal** `Could not resolve 'virtual:keystatic-config'` scan warning at startup — not worth a broken CMS. The [canonical Keystatic + Astro setup](https://keystatic.com/docs/installation-astro) needs no `optimizeDeps` config at all.

## Fix

- **Remove the `optimizeDeps.exclude` block** so Vite's default dependency discovery pre-bundles Keystatic's CJS tree. Replaced it with a prominent comment explaining why it must not be re-added.
- **Correct a stale comment** that claimed the `/keystatic` admin UI was unreachable in dev — the `keystatic()` integration injects its own route that Astro's dev server renders regardless of the `output: "static"` build mode (which is exactly why the reporter reached it and saw hydration errors rather than a 404).
- **Add a regression test** (`tests/astro-config.test.ts`) that fails if the `@keystatic` exclude creeps back in.

Existing affected sites pick this up via `/anglesite:update`, which tracks `astro.config.ts`.

## Testing

```
✓ tests/astro-config.test.ts (2 tests)
✓ tests/template-deps.test.ts (4 tests)
✓ tests/config.test.ts (12 tests)
```

> [!NOTE]
> The browser-side hydration can't be exercised in this repo (the scaffolded Astro/Keystatic/Cloudflare stack isn't installed in the plugin's own `node_modules`), so the regression test guards the config source. A manual `npm run dev` → open `/keystatic` on a scaffolded site is the end-to-end confirmation.

https://claude.ai/code/session_016A8ymmMJjdJ1UQv88nqbGq

---
_Generated by [Claude Code](https://claude.ai/code/session_016A8ymmMJjdJ1UQv88nqbGq)_