### PR TITLE
fix(template): populate warnings in pre-deploy-check --json mode (#318)

### DIFF
--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -283,11 +283,13 @@ export interface ScanReport {
 /**
  * Pure scan entry point — used by the macOS app's `PreDeployCheck` actor to get
  * a structured report it can render. Reads `dist/`, `src/`, `public/`, and
- * `.site-config` from `siteDir`; performs the same four mandatory checks the
- * CLI runs (PII, tokens, third-party scripts, Keystatic routes); returns a
- * `ScanReport` instead of printing.
+ * `.site-config` from `siteDir`; performs the same four mandatory blockers the
+ * CLI runs (PII, tokens, third-party scripts, Keystatic routes) plus the
+ * non-blocking warnings (missing OG image, overdue maintenance, SEO audit);
+ * returns a `ScanReport` instead of printing.
  *
- * Throws on script error (missing `dist/`, unreadable files) — call sites
+ * Read-only: unlike the CLI path it does not write a `reports/seo-report.md`
+ * file. Throws on script error (missing `dist/`, unreadable files) — call sites
  * should catch and surface those distinctly from a clean scan failure.
  */
 export function runScan(input: { siteDir: string }): ScanReport {
@@ -325,8 +327,10 @@ export function runScan(input: { siteDir: string }): ScanReport {
   // 1. PII (emails, phones) in dist/ HTML
   const htmlFiles = walkHtml(distDir);
   const scriptAllowlist = getAllowedScripts(configPath);
+  let hasOgImage = false;
   for (const file of htmlFiles) {
     const content = readFileSync(file, "utf-8");
+    if (content.includes("og:image")) hasOgImage = true;
     for (const email of scanEmails(content, emailAllowlist)) {
       failures.push({
         category: "pii-email",
@@ -383,6 +387,54 @@ export function runScan(input: { siteDir: string }): ScanReport {
       detail: `Keystatic admin route in production build: ${relativeToSite(file)}`,
       remediation: `Set \`output: 'static'\` for Keystatic routes or exclude them from the production build.`,
     });
+  }
+
+  // ---- Warnings (non-blocking; surfaced by the app's health badge) ----
+
+  // 5. OG image presence (warn only)
+  if (htmlFiles.length > 0 && !hasOgImage) {
+    warnings.push({
+      category: "missing-og-image",
+      detail: `No og:image meta tag found — social shares won't show a preview image.`,
+      remediation: `Run \`npm run ai-images\` to generate one.`,
+    });
+  }
+
+  // 6. Maintenance log freshness (warn only)
+  for (const w of scanMaintenance(readSiteConfig)) {
+    warnings.push({
+      category: "maintenance-overdue",
+      detail:
+        w.age === null
+          ? `No record of a ${w.label}.`
+          : `${w.label} last logged ${w.age} days ago (over the ${w.graceDays}-day window).`,
+      remediation: `Run \`${w.command}\`.`,
+    });
+  }
+
+  // 7. SEO audit (warn only). Best-effort in scan mode — a failed audit must
+  //    never break the structured report, so errors are swallowed.
+  try {
+    const siteDomain = readSiteConfig("SITE_DOMAIN");
+    const siteUrl = siteDomain ? `https://${siteDomain}` : "";
+    const agenticCrawlers =
+      (readSiteConfig("AGENTIC_CRAWLERS") as AgenticCrawlersPolicy | undefined) ?? "allow";
+    const seoReport = runSeoAudit({ distDir, siteUrl, agenticCrawlers });
+    if (seoReport.totals.critical > 0) {
+      warnings.push({
+        category: "seo-critical",
+        detail: `${seoReport.totals.critical} critical SEO issue(s).`,
+        remediation: `Run \`/anglesite:seo\` to review.`,
+      });
+    } else if (seoReport.totals.warning > 0 || seoReport.totals.niceToHave > 0) {
+      warnings.push({
+        category: "seo-warning",
+        detail: `${seoReport.totals.warning} SEO warning(s), ${seoReport.totals.niceToHave} nice-to-have.`,
+        remediation: `Run \`/anglesite:seo\` to review.`,
+      });
+    }
+  } catch {
+    // SEO audit is best-effort here; never gate the report on it.
   }
 
   return { ok: failures.length === 0, failures, warnings };

--- a/tests/pre-deploy-scan.test.ts
+++ b/tests/pre-deploy-scan.test.ts
@@ -127,6 +127,53 @@ describe("runScan", () => {
     // No dist/ written
     expect(() => runScan({ siteDir: site })).toThrow(/dist\/ not found/);
   });
+
+  it("emits a missing-og-image warning when no page declares og:image", () => {
+    writeFile("dist/index.html", "<!doctype html><html><head></head><body><h1>Hi</h1></body></html>");
+
+    const report = runScan({ siteDir: site });
+
+    expect(report.ok).toBe(true);
+    expect(report.warnings.some(w => w.category === "missing-og-image")).toBe(true);
+  });
+
+  it("does not warn about og:image when at least one page declares it", () => {
+    writeFile(
+      "dist/index.html",
+      '<!doctype html><html><head><meta property="og:image" content="/og.png"></head><body><h1>Hi</h1></body></html>',
+    );
+
+    const report = runScan({ siteDir: site });
+
+    expect(report.warnings.some(w => w.category === "missing-og-image")).toBe(false);
+  });
+
+  it("emits a maintenance-overdue warning when no maintenance has been logged", () => {
+    writeFile(
+      "dist/index.html",
+      '<!doctype html><html><head><meta property="og:image" content="/og.png"></head><body><h1>Hi</h1></body></html>',
+    );
+
+    const report = runScan({ siteDir: site });
+
+    expect(report.warnings.some(w => w.category === "maintenance-overdue")).toBe(true);
+  });
+
+  it("does not warn about maintenance when the log stamps are current", () => {
+    const today = new Date().toISOString().slice(0, 10);
+    writeFile(
+      "dist/index.html",
+      '<!doctype html><html><head><meta property="og:image" content="/og.png"></head><body><h1>Hi</h1></body></html>',
+    );
+    writeFile(
+      ".site-config",
+      `MAINTENANCE_MONTHLY_LAST=${today}\nMAINTENANCE_QUARTERLY_LAST=${today}\nMAINTENANCE_ANNUAL_LAST=${today}\n`,
+    );
+
+    const report = runScan({ siteDir: site });
+
+    expect(report.warnings.some(w => w.category === "maintenance-overdue")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #318.

## Background

The scan-only `--json` mode added in #317 wired up `tsx scripts/pre-deploy-check.ts --json` and decoded the four mandatory blockers (PII email/phone, exposed tokens, third-party scripts, Keystatic routes) into the `ScanReport` the Anglesite-app's `PreDeployCheck` and Phase 9 health badge read.

But `runScan` always returned an **empty `warnings` array**. The app decodes the full schema from #318's "Expected" section, which includes non-blocking warning categories. Without them, the health badge could never surface the soft-health signals (missing OG image, overdue maintenance, SEO issues) it's designed to show.

## Change

`runScan` now populates `warnings` to match the documented contract:

| Category | Trigger |
|---|---|
| `missing-og-image` | No page in `dist/` declares an `og:image` meta tag |
| `maintenance-overdue` | A maintenance stamp in `.site-config` is overdue or never logged |
| `seo-critical` / `seo-warning` | Best-effort SEO audit results (critical → `seo-critical`, otherwise warnings/nice-to-have → `seo-warning`) |

These mirror the warnings the human-readable CLI path already computes (OG image, maintenance log, SEO audit), so the JSON and human outputs stay consistent.

## Behavior preserved

- **Exit code unchanged:** still `1` only when there are `failures`, `0` otherwise. Warnings never affect `ok` or the exit code.
- **Read-only:** unlike the CLI path, the JSON path does **not** write `reports/seo-report.md`. The SEO audit is best-effort — a thrown audit never breaks the structured report.

## Sample output (clean template site, no maintenance stamps)

```json
{
  "ok": true,
  "failures": [],
  "warnings": [
    { "category": "missing-og-image", "detail": "No og:image meta tag found — social shares won't show a preview image.", "remediation": "Run `npm run ai-images` to generate one." },
    { "category": "maintenance-overdue", "detail": "No record of a monthly health check.", "remediation": "Run `/anglesite:check`." },
    { "category": "seo-critical", "detail": "2 critical SEO issue(s).", "remediation": "Run `/anglesite:seo` to review." }
  ]
}
```

## Tests

Added four cases to `tests/pre-deploy-scan.test.ts` covering the OG-image and maintenance warnings (present/absent). All 14 tests in that file pass.

> Note: 18 unrelated failures in `test/undo-edit.test.js`, `test/edit-history.test.js`, and `test/apply-edit-dispatcher.test.js` are environmental — those tests create real git commits, which fail in the sandbox because git commit signing returns HTTP 400. They do not touch this change.

Pairs with Anglesite/Anglesite-app#31.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra775ArXQuNv5qyyKZwdPd)_