### PR TITLE
Add Microsoft Clarity support to the tracking skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Anglesite is a Claude plugin that scaffolds and manages websites for small busin
 │   ├── giscus/SKILL.md          Blog comments via Giscus + GitHub Discussions (user-facing)
 │   ├── consent/SKILL.md         Category-based GDPR/CCPA cookie consent banner (user-facing)
 │   ├── membership/SKILL.md       Paywall + content gating: free (newsletter) and paid (Stripe) tiers (user-facing)
-│   └── tracking/SKILL.md         Meta Pixel, Google Ads, GA4, LinkedIn, TikTok, Pinterest, X via @astrojs/partytown (user-facing)
+│   └── tracking/SKILL.md         Meta Pixel, Google Ads, GA4, LinkedIn, TikTok, Pinterest, X via @astrojs/partytown + Microsoft Clarity (main thread) (user-facing)
 ├── settings.json                 Plugin settings (empty — permissions via allowed-tools)
 ├── hooks/hooks.json              PreToolUse hook for deploy safety scans
 ├── scripts/
@@ -165,7 +165,7 @@ Two levels of agent instructions exist — do not confuse them:
 | `giscus` | Blog comments backed by GitHub Discussions (per-post opt-out via frontmatter) |
 | `consent` | Category-based GDPR/CCPA cookie consent banner; gates third-party scripts/embeds via `data-consent` |
 | `membership` | Paywall and content gating: free tier (newsletter) and paid tier (Stripe), edge-gated via signed cookie |
-| `tracking` | Meta Pixel, Google Ads, GA4, LinkedIn Insight, TikTok, Pinterest, X — wrapped in `@astrojs/partytown` so they run in a worker, not on the main thread |
+| `tracking` | Meta Pixel, Google Ads, GA4, LinkedIn Insight, TikTok, Pinterest, X — wrapped in `@astrojs/partytown` so they run in a worker, not on the main thread; plus Microsoft Clarity (heatmaps + session recording), which runs on the main thread because session replay needs DOM access |
 
 **Model-only** (called programmatically by other skills, `user-invocable: false`):
 

--- a/docs/dev/skill-registry.md
+++ b/docs/dev/skill-registry.md
@@ -34,7 +34,7 @@ Invoked via `/anglesite:<name>` (28 skills):
 | `seo` | SEO audit, metadata editing, Schema.org, sitemap, and LLM/GEO optimization |
 | `start` | First-time setup: discovery, design, tools, preview |
 | `stats` | Show site analytics in plain language |
-| `tracking` | Embed Meta Pixel, Google Ads / GA4, LinkedIn, TikTok, Pinterest, or X tracking pixels via @astrojs/partytown so they don't block the main thread |
+| `tracking` | Embed Meta Pixel, Google Ads / GA4, LinkedIn, TikTok, Pinterest, or X conversion pixels via @astrojs/partytown (off the main thread), plus Microsoft Clarity analytics (heatmaps + session recording) on the main thread. All gated behind cookie consent. |
 | `update` | Update site dependencies and template files to the latest version |
 
 ## Model-only

--- a/docs/platforms/tracking-pixels.md
+++ b/docs/platforms/tracking-pixels.md
@@ -1,8 +1,8 @@
-# Tracking pixel snippets (Partytown-wrapped)
+# Tracking pixel snippets
 
 Reference snippets for `/anglesite:tracking`. Drop these into `src/components/TrackingPixels.astro` — one block per platform — and the layout component will only render the ones whose `TRACKING_*` key is set in `.site-config`.
 
-Each snippet uses `is:inline` so Astro doesn't bundle the script and the `data-partytown-type="text/partytown"` attribute so the consent runtime knows which type to restore when promoting a `text/plain` script after consent.
+Most snippets are **Partytown-wrapped** (the ad pixels): they use `is:inline` so Astro doesn't bundle the script, plus a `data-partytown-type="text/partytown"` attribute so the consent runtime knows which type to restore when promoting a `text/plain` script after consent. The one exception is **Microsoft Clarity**, which runs on the main thread (see its section at the bottom) and therefore carries no `data-partytown-type` hint.
 
 Variables referenced below come from the component frontmatter:
 
@@ -101,6 +101,39 @@ const analyticsType = consentEnabled ? "text/plain" : "text/partytown";
     s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
     a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
     twq('config','${xId}');
+  `} />
+)}
+```
+
+## Microsoft Clarity (main thread — **not** Partytown)
+
+Clarity is the one tracker that does **not** go through Partytown. Its session
+recording observes the live DOM, which Partytown's web worker can't expose, so
+it must run on the main thread. That means:
+
+- It uses `type={clarityType}` (`text/javascript` when consent is off, `text/plain`
+  when consent gating is on) — **never** `text/partytown`.
+- It carries **no** `data-partytown-type` attribute. When the consent runtime
+  promotes a `text/plain` script with no hint, it restores `text/javascript`,
+  which is exactly what Clarity needs.
+- It is still gated behind `data-consent="analytics"` like any other analytics
+  tracker, and its loader domain (`www.clarity.ms`) is still allowlisted by
+  `template/scripts/csp.ts`.
+
+`clarityType` comes from the component frontmatter:
+
+```ts
+const clarityType = consentEnabled ? "text/plain" : "text/javascript";
+```
+
+```astro
+{clarityId && (
+  <script type={clarityType} data-consent="analytics" is:inline set:html={`
+    (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window,document,"clarity","script","${clarityId}");
   `} />
 )}
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -809,9 +809,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -827,9 +824,6 @@
       "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -847,9 +841,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -865,9 +856,6 @@
       "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -885,9 +873,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -904,9 +889,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -922,9 +904,6 @@
       "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -948,9 +927,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -972,9 +948,6 @@
       "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -998,9 +971,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1023,9 +993,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1047,9 +1014,6 @@
       "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/skills/tracking/SKILL.md
+++ b/skills/tracking/SKILL.md
@@ -32,7 +32,12 @@ Do **not** run this skill for:
 - Form-submit or signup conversions inside Anglesite — those are already counted in the `anglesite_events` dataset surfaced by `/anglesite:stats`
 - Hotjar heatmaps / session recording — Partytown can't safely run it (it needs main-thread DOM access) and its free tier (≈35 sessions/day) is too limited to recommend. Refuse and explain.
 
-**Microsoft Clarity is supported** — see "Supported platforms" below. Unlike Hotjar, it's genuinely free with no traffic caps, so this skill installs it as a first-class **analytics** provider. It's the one tracker that runs on the main thread instead of in Partytown (session recording needs direct DOM access).
+**Microsoft Clarity is supported, but opt-in only** — see "Supported platforms" below. Unlike Hotjar, it's genuinely free with no traffic caps, so when an owner wants heatmaps or session recording this skill installs it as a first-class **analytics** provider. It's the one tracker that runs on the main thread instead of in Partytown (session recording needs direct DOM access).
+
+Two things keep Clarity opt-in rather than default:
+
+- **Cloudflare Web Analytics is already the default** traffic analytics for every Anglesite site (cookieless, on the main thread, no extra account, surfaced by `/anglesite:stats`). Clarity is an *additive* behavioral layer — heatmaps + session replay — not a replacement for it.
+- **Clarity requires a separate Microsoft account** (clarity.microsoft.com) that the owner likely doesn't already have. Don't surface it in the default platform checklist below and don't recommend it speculatively. Configure it **only when the owner explicitly asks** for heatmaps, session recording, or Clarity by name — then walk them through creating the project to get the ID.
 
 ## Cost — the only real downside
 
@@ -73,7 +78,9 @@ Read `.site-config`. If any `TRACKING_*` key is already set, this is an update �
 
 Ask: "Which ad platforms are you actually running campaigns on right now? Don't install pixels speculatively — each one is data your visitors don't need to give away."
 
-Surface the table from "Supported platforms" above with checkboxes. Multi-select is normal: a typical SMB is on Meta + Google Ads, a B2B is on Google Ads + LinkedIn.
+Surface the **ad pixels** from "Supported platforms" above (Meta, Google Ads, GA4, LinkedIn, TikTok, Pinterest, X) with checkboxes. Multi-select is normal: a typical SMB is on Meta + Google Ads, a B2B is on Google Ads + LinkedIn.
+
+**Do not put Microsoft Clarity in this checklist.** Clarity is opt-in analytics that needs its own Microsoft account, and the site already has Cloudflare Web Analytics by default — so only add it when the owner explicitly asks for heatmaps or session recording (or names Clarity). If they do, set `TRACKING_CLARITY_PROJECT_ID` from the prompt below and follow the same install steps; otherwise skip it entirely.
 
 For each chosen platform, ask for the tracking ID. Frame the question by what the owner will see in their ad dashboard:
 

--- a/skills/tracking/SKILL.md
+++ b/skills/tracking/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tracking
-description: "Embed Meta Pixel, Google Ads / GA4, LinkedIn, TikTok, Pinterest, or X tracking pixels via @astrojs/partytown so they don't block the main thread"
+description: "Embed Meta Pixel, Google Ads / GA4, LinkedIn, TikTok, Pinterest, or X conversion pixels via @astrojs/partytown (off the main thread), plus Microsoft Clarity analytics (heatmaps + session recording) on the main thread. All gated behind cookie consent."
 allowed-tools: Bash(npm install *), Bash(npm run build), Bash(npx astro check), Bash(grep *), Write, Read, Edit, Glob
 disable-model-invocation: true
 ---
@@ -30,7 +30,9 @@ Do **not** run this skill for:
 
 - Plain traffic analytics — that's `/anglesite:stats` (Cloudflare Web Analytics)
 - Form-submit or signup conversions inside Anglesite — those are already counted in the `anglesite_events` dataset surfaced by `/anglesite:stats`
-- Heatmaps / session recording (Hotjar, Microsoft Clarity) — Partytown can't safely run them; they need DOM access. Refuse and explain.
+- Hotjar heatmaps / session recording — Partytown can't safely run it (it needs main-thread DOM access) and its free tier (≈35 sessions/day) is too limited to recommend. Refuse and explain.
+
+**Microsoft Clarity is supported** — see "Supported platforms" below. Unlike Hotjar, it's genuinely free with no traffic caps, so this skill installs it as a first-class **analytics** provider. It's the one tracker that runs on the main thread instead of in Partytown (session recording needs direct DOM access).
 
 ## Cost — the only real downside
 
@@ -57,8 +59,11 @@ State this plainly to the owner before installing anything:
 | TikTok Pixel | `TRACKING_TIKTOK_PIXEL_ID` | `ttq.track`, `ttq.page`, `ttq.identify` | `analytics.tiktok.com` | `ads` |
 | Pinterest Tag | `TRACKING_PINTEREST_TAG_ID` | `pintrk` | `s.pinimg.com` | `ads` |
 | X / Twitter Pixel | `TRACKING_X_PIXEL_ID` | `twq` | `static.ads-twitter.com` | `ads` |
+| Microsoft Clarity (heatmaps + session recording) | `TRACKING_CLARITY_PROJECT_ID` | — (main thread, **not** Partytown) | `www.clarity.ms` | `analytics` |
 
-Each ID format is platform-specific — Meta uses a 15–16 digit number, GA4 starts with `G-`, Google Ads with `AW-`, LinkedIn with a partner ID number, TikTok with a `C` prefix, Pinterest with a 13-digit number, X with an alphanumeric tag. Don't validate format strictly; the platforms reject bad IDs at fire time and we don't want to block a legitimate format change.
+> **Microsoft Clarity is the one sanctioned main-thread exception.** Unlike the ad pixels above, Clarity is a free, privacy-friendly **analytics** tool (heatmaps + session replay) that auto-masks text and form inputs by default. Its session recording has to observe the live DOM, which Partytown's web worker can't expose — so Clarity **must** load on the main thread. **Do not "fix" this by wrapping it in Partytown**; that would break session replay. It is still gated behind the `analytics` consent category, and its loader domain (`www.clarity.ms`) is still added to the pre-deploy allowlist via `template/scripts/csp.ts`, exactly like every other tracker.
+
+Each ID format is platform-specific — Meta uses a 15–16 digit number, GA4 starts with `G-`, Google Ads with `AW-`, LinkedIn with a partner ID number, TikTok with a `C` prefix, Pinterest with a 13-digit number, X with an alphanumeric tag, and Clarity uses a 10-character lowercase alphanumeric project ID. Don't validate format strictly; the platforms reject bad IDs at fire time and we don't want to block a legitimate format change.
 
 ## Step 0 — Check prerequisites
 
@@ -78,6 +83,7 @@ For each chosen platform, ask for the tracking ID. Frame the question by what th
 - TikTok: "TikTok Ads Manager → Assets → Events → Web. The pixel code starts with `C` followed by alphanumerics."
 - Pinterest: "Pinterest Business → Ads → Conversions. 13-digit numeric ID."
 - X: "X Ads → Tools → Conversion tracking. Alphanumeric pixel code."
+- Microsoft Clarity: "Open clarity.microsoft.com → your project → Settings → Overview. The Project ID is a 10-character code (it's also embedded in the install snippet Clarity gives you)."
 
 Save each one to `.site-config` using the **Write tool** (update the existing file). Multiple keys are fine — owners often run two or three pixels concurrently:
 
@@ -85,6 +91,7 @@ Save each one to `.site-config` using the **Write tool** (update the existing fi
 TRACKING_META_PIXEL_ID=1234567890123456
 TRACKING_GA4_ID=G-ABC1234567
 TRACKING_GOOGLE_ADS_ID=AW-9876543210
+TRACKING_CLARITY_PROJECT_ID=abcde12345
 ```
 
 If the owner only mentions Google Ads (no GA4), set `TRACKING_GOOGLE_ADS_ID` and leave GA4 unset — they share the same loader (`gtag.js`) but represent different conversion goals and are billed separately on the Google side. The skill will detect the shared loader and only emit it once at build time.
@@ -132,6 +139,8 @@ partytown({
 
 Use the **Edit** tool to splice it into the existing `integrations: [...]` array. Don't replace the whole config.
 
+**Do not add a Clarity entry to the `forward` array.** Microsoft Clarity runs on the main thread, not in Partytown, so it has no forwarded global — its inline snippet calls `clarity(...)` directly on the page. The `forward` array is only for Partytown-wrapped pixels.
+
 ## Step 4 — Add the pixel snippets to the layout
 
 The pixels live in `src/components/TrackingPixels.astro` so that `BaseLayout`, `KioskLayout`, and `ImmersiveLayout` can all opt in by importing one component. Create the component (or edit if it exists). The frontmatter reads each `TRACKING_*` key from `.site-config` and a single `consentEnabled` flag, then renders one `<script type="text/partytown">` block per configured pixel.
@@ -154,6 +163,7 @@ const linkedinId  = read("TRACKING_LINKEDIN_PARTNER_ID");
 const tiktokId    = read("TRACKING_TIKTOK_PIXEL_ID");
 const pinterestId = read("TRACKING_PINTEREST_TAG_ID");
 const xId         = read("TRACKING_X_PIXEL_ID");
+const clarityId   = read("TRACKING_CLARITY_PROJECT_ID");
 
 // Both Google Ads and GA4 share gtag.js. Emit the loader once.
 const gtagId = ga4Id ?? googleAdsId;
@@ -165,10 +175,17 @@ const gtagId = ga4Id ?? googleAdsId;
 const consentEnabled = !!read("CONSENT_VERSION");
 const adsType        = consentEnabled ? "text/plain" : "text/partytown";
 const analyticsType  = consentEnabled ? "text/plain" : "text/partytown";
+
+// Microsoft Clarity is the exception: it must run on the MAIN THREAD (its
+// session recording observes the live DOM, which Partytown's worker can't
+// expose). So it promotes to `text/javascript`, not `text/partytown`, and
+// it carries NO `data-partytown-type` hint. It's still gated behind the
+// `analytics` category when consent is enabled.
+const clarityType    = consentEnabled ? "text/plain" : "text/javascript";
 ---
 ```
 
-Then drop in one block per platform from `${CLAUDE_PLUGIN_ROOT}/docs/platforms/tracking-pixels.md`. The reference doc has the inline snippets verbatim (Meta, Google Ads/GA4, LinkedIn, TikTok, Pinterest, X) — copy each block whose ID variable is non-empty. Skip blocks whose key isn't set; the conditional rendering keeps `dist/` clean.
+Then drop in one block per platform from `${CLAUDE_PLUGIN_ROOT}/docs/platforms/tracking-pixels.md`. The reference doc has the inline snippets verbatim (Meta, Google Ads/GA4, LinkedIn, TikTok, Pinterest, X, and Microsoft Clarity) — copy each block whose ID variable is non-empty. Skip blocks whose key isn't set; the conditional rendering keeps `dist/` clean. The Clarity block is the only one that renders with `type={clarityType}` and **no** `data-partytown-type` attribute, because it runs on the main thread.
 
 Import and render the component once in `BaseLayout.astro`, just before `</head>`:
 
@@ -211,7 +228,7 @@ npx astro check
 npm run build
 ```
 
-The pre-deploy script scan reads the `TRACKING_*` keys and adds the corresponding loader domains (`connect.facebook.net`, `www.googletagmanager.com`, `snap.licdn.com`, `analytics.tiktok.com`, `s.pinimg.com`, `static.ads-twitter.com`) to its allowlist via `template/scripts/csp.ts`. If the build succeeds and the scan passes, the install is correct. If the scan fails with "unauthorized third-party script", check that the keys in `.site-config` match the loader actually rendered into the HTML.
+The pre-deploy script scan reads the `TRACKING_*` keys and adds the corresponding loader domains (`connect.facebook.net`, `www.googletagmanager.com`, `snap.licdn.com`, `analytics.tiktok.com`, `s.pinimg.com`, `static.ads-twitter.com`, `www.clarity.ms`) to its allowlist via `template/scripts/csp.ts`. If the build succeeds and the scan passes, the install is correct. If the scan fails with "unauthorized third-party script", check that the keys in `.site-config` match the loader actually rendered into the HTML.
 
 Tell the owner what's now in place:
 
@@ -230,6 +247,7 @@ Each ad platform has its own validator. Surface the relevant URLs and tell the o
 - **TikTok**: TikTok Ads Manager → Events → Web → status panel.
 - **Pinterest**: Pinterest Business → Ads → Conversions → Pixel health.
 - **X**: X Ads → Tools → Conversion tracking → status.
+- **Microsoft Clarity**: clarity.microsoft.com → your project → it flips to "Recording" once it receives the first session (usually within a few minutes). Heatmaps and recordings populate as visitors browse.
 
 Frame it as a one-time check: "Run through these on the live site once — if a platform shows the pixel as 'Active' or 'Receiving events', you're done. If something stays unverified after 24 hours, run `/anglesite:check` and we'll diagnose it."
 

--- a/template/docs/workflows/tracking.md
+++ b/template/docs/workflows/tracking.md
@@ -14,13 +14,15 @@ Do **not** run it for:
 
 - Plain traffic analytics — use `/anglesite:stats` instead. Cloudflare Web Analytics is faster, cookieless, and already wired up.
 - Form-submit and signup conversions inside Anglesite — those are already counted in the `anglesite_events` dataset surfaced by `/anglesite:stats`.
-- Heatmaps and session recording (Hotjar, Microsoft Clarity) — they need DOM access and can't safely run in Partytown.
+- Hotjar heatmaps / session recording — Partytown can't safely run it (it needs main-thread DOM access) and its free tier is too limited to recommend.
+
+**Microsoft Clarity is supported.** It's a free, privacy-friendly heatmap + session-recording tool (auto-masks text and form inputs). Unlike the ad pixels, it runs on the **main thread** — its session recording needs direct DOM access that Partytown's worker can't expose — so it's the one sanctioned exception to the "all tracking goes through Partytown" rule. It's still gated behind `data-consent="analytics"`.
 
 ## How it works
 
 - **Partytown integration.** `@astrojs/partytown` ships a small loader that spawns a web worker on first paint. Each pixel is rendered as `<script type="text/partytown">…</script>`; the worker fetches and executes the script off the main thread.
 - **Per-platform IDs.** Each platform has its own `TRACKING_*` key in `.site-config`. Setting any one of them turns the pixel on; removing the key turns it off.
-- **CSP and pre-deploy scan.** `template/scripts/csp.ts` reads each `TRACKING_*` key and adds the matching loader domain (`connect.facebook.net`, `www.googletagmanager.com`, `snap.licdn.com`, `analytics.tiktok.com`, `s.pinimg.com`, `static.ads-twitter.com`) to both the CSP header and the pre-deploy script allowlist. Owners who run only Meta + GA4 don't widen their CSP to LinkedIn or TikTok.
+- **CSP and pre-deploy scan.** `template/scripts/csp.ts` reads each `TRACKING_*` key and adds the matching loader domain (`connect.facebook.net`, `www.googletagmanager.com`, `snap.licdn.com`, `analytics.tiktok.com`, `s.pinimg.com`, `static.ads-twitter.com`, `www.clarity.ms`) to both the CSP header and the pre-deploy script allowlist. Owners who run only Meta + GA4 don't widen their CSP to LinkedIn or TikTok.
 - **Consent gating.** When `CONSENT_VERSION` is set in `.site-config`, every pixel is gated behind `data-consent="ads"` (or `"analytics"` for GA4) and the consent runtime promotes the script to `text/partytown` once the visitor accepts the matching category.
 
 ## Cost — the only real downside
@@ -45,6 +47,7 @@ Don't install pixels speculatively — fewer pixels means a faster site.
 | `TRACKING_TIKTOK_PIXEL_ID` | TikTok Pixel |
 | `TRACKING_PINTEREST_TAG_ID` | Pinterest Tag |
 | `TRACKING_X_PIXEL_ID` | X / Twitter Pixel |
+| `TRACKING_CLARITY_PROJECT_ID` | Microsoft Clarity (heatmaps + session recording, main thread) |
 
 Multiple keys are normal — owners often run two or three pixels concurrently. GA4 and Google Ads share `gtag.js`; the loader is emitted once even when both keys are set.
 
@@ -60,5 +63,6 @@ Each ad platform has its own validator:
 | TikTok | TikTok Ads Manager → Events → Web |
 | Pinterest | Pinterest Business → Ads → Conversions → Pixel health |
 | X | X Ads → Tools → Conversion tracking |
+| Microsoft Clarity | clarity.microsoft.com → your project (flips to "Recording" after the first session) |
 
 Conversion data shows up in each platform's dashboard within 30–60 minutes of the next deploy.

--- a/template/docs/workflows/tracking.md
+++ b/template/docs/workflows/tracking.md
@@ -16,7 +16,7 @@ Do **not** run it for:
 - Form-submit and signup conversions inside Anglesite — those are already counted in the `anglesite_events` dataset surfaced by `/anglesite:stats`.
 - Hotjar heatmaps / session recording — Partytown can't safely run it (it needs main-thread DOM access) and its free tier is too limited to recommend.
 
-**Microsoft Clarity is supported.** It's a free, privacy-friendly heatmap + session-recording tool (auto-masks text and form inputs). Unlike the ad pixels, it runs on the **main thread** — its session recording needs direct DOM access that Partytown's worker can't expose — so it's the one sanctioned exception to the "all tracking goes through Partytown" rule. It's still gated behind `data-consent="analytics"`.
+**Microsoft Clarity is supported, but opt-in only.** It's a free, privacy-friendly heatmap + session-recording tool (auto-masks text and form inputs). It's configured **only when you ask for it** — your site already has Cloudflare Web Analytics by default (cookieless, no extra account), and Clarity needs its own Microsoft account at clarity.microsoft.com. So it's an optional behavioral add-on, never installed speculatively. Unlike the ad pixels, it runs on the **main thread** — its session recording needs direct DOM access that Partytown's worker can't expose — so it's the one sanctioned exception to the "all tracking goes through Partytown" rule. It's still gated behind `data-consent="analytics"`.
 
 ## How it works
 

--- a/template/scripts/csp.ts
+++ b/template/scripts/csp.ts
@@ -51,6 +51,11 @@ export interface TrackingPixels {
   pinterest: boolean;
   /** TRACKING_X_PIXEL_ID — X / Twitter Pixel. */
   x: boolean;
+  /** TRACKING_CLARITY_PROJECT_ID — Microsoft Clarity (heatmaps + session
+   *  recording). Unlike the ad pixels above, Clarity runs on the MAIN THREAD,
+   *  not in Partytown — its session recording needs direct DOM access. The
+   *  loader domain still has to be allowlisted by the CSP and pre-deploy scan. */
+  clarity: boolean;
 }
 
 /** CSP directives as arrays of domains per directive */
@@ -147,6 +152,13 @@ export function buildTrackingCSP(pixels: TrackingPixels): CSPDirectives {
     connectSrc.push("analytics.twitter.com");
     imgSrc.push("t.co", "analytics.twitter.com");
   }
+  if (pixels.clarity) {
+    // Microsoft Clarity loads on the main thread (not Partytown), but it still
+    // pulls its tag script and beacons telemetry over the network, so both the
+    // loader and the telemetry endpoint must be permitted.
+    scriptSrc.push("www.clarity.ms");
+    connectSrc.push("www.clarity.ms", "c.clarity.ms");
+  }
 
   const directives: CSPDirectives = {};
   if (scriptSrc.length) directives["script-src"] = scriptSrc;
@@ -183,6 +195,7 @@ export function parseProviders(configContent: string): SiteProviders {
     tiktok: !!readConfigFromString(configContent, "TRACKING_TIKTOK_PIXEL_ID"),
     pinterest: !!readConfigFromString(configContent, "TRACKING_PINTEREST_TAG_ID"),
     x: !!readConfigFromString(configContent, "TRACKING_X_PIXEL_ID"),
+    clarity: !!readConfigFromString(configContent, "TRACKING_CLARITY_PROJECT_ID"),
   };
   const anyTracking =
     tracking.meta ||
@@ -191,7 +204,8 @@ export function parseProviders(configContent: string): SiteProviders {
     tracking.linkedin ||
     tracking.tiktok ||
     tracking.pinterest ||
-    tracking.x;
+    tracking.x ||
+    tracking.clarity;
 
   return {
     ecommerce,
@@ -349,6 +363,9 @@ export function buildAllowedScripts(providers: SiteProviders): string[] {
     }
     if (providers.tracking.x) {
       scripts.push("static.ads-twitter.com");
+    }
+    if (providers.tracking.clarity) {
+      scripts.push("www.clarity.ms");
     }
   }
 

--- a/tests/csp.test.ts
+++ b/tests/csp.test.ts
@@ -336,6 +336,7 @@ const noPixels = {
   tiktok: false,
   pinterest: false,
   x: false,
+  clarity: false,
 };
 
 describe("buildTrackingCSP", () => {
@@ -379,6 +380,13 @@ describe("buildTrackingCSP", () => {
     const csp = buildTrackingCSP({ ...noPixels, x: true });
     expect(csp["script-src"]).toContain("static.ads-twitter.com");
   });
+
+  it("adds Clarity loader and telemetry domains when clarity is enabled", () => {
+    const csp = buildTrackingCSP({ ...noPixels, clarity: true });
+    expect(csp["script-src"]).toContain("www.clarity.ms");
+    expect(csp["connect-src"]).toContain("www.clarity.ms");
+    expect(csp["connect-src"]).toContain("c.clarity.ms");
+  });
 });
 
 describe("parseProviders — tracking", () => {
@@ -405,6 +413,12 @@ describe("parseProviders — tracking", () => {
     expect(p.tracking?.googleAds).toBe(true);
     expect(p.tracking?.linkedin).toBe(false);
   });
+
+  it("populates tracking when only TRACKING_CLARITY_PROJECT_ID is set", () => {
+    const p = parseProviders("TRACKING_CLARITY_PROJECT_ID=abcde12345");
+    expect(p.tracking?.clarity).toBe(true);
+    expect(p.tracking?.meta).toBe(false);
+  });
 });
 
 describe("buildCSP — with tracking pixels", () => {
@@ -425,11 +439,20 @@ describe("buildCSP — with tracking pixels", () => {
     expect(csp).toContain("www.google-analytics.com");
   });
 
+  it("adds Clarity domain when clarity is enabled", () => {
+    const csp = buildCSP({
+      turnstile: false,
+      tracking: { ...noPixels, clarity: true },
+    });
+    expect(csp).toContain("www.clarity.ms");
+  });
+
   it("does not include any tracking domains when tracking is undefined", () => {
     const csp = buildCSP({ turnstile: false });
     expect(csp).not.toContain("connect.facebook.net");
     expect(csp).not.toContain("www.googletagmanager.com");
     expect(csp).not.toContain("snap.licdn.com");
+    expect(csp).not.toContain("www.clarity.ms");
   });
 });
 
@@ -461,6 +484,7 @@ describe("buildAllowedScripts — with tracking pixels", () => {
         tiktok: true,
         pinterest: true,
         x: true,
+        clarity: true,
       },
     });
     expect(scripts).toContain("connect.facebook.net");
@@ -469,6 +493,15 @@ describe("buildAllowedScripts — with tracking pixels", () => {
     expect(scripts).toContain("analytics.tiktok.com");
     expect(scripts).toContain("s.pinimg.com");
     expect(scripts).toContain("static.ads-twitter.com");
+    expect(scripts).toContain("www.clarity.ms");
+  });
+
+  it("adds Clarity loader when clarity is enabled", () => {
+    const scripts = buildAllowedScripts({
+      turnstile: false,
+      tracking: { ...noPixels, clarity: true },
+    });
+    expect(scripts).toContain("www.clarity.ms");
   });
 });
 


### PR DESCRIPTION
## Summary

Promotes **Microsoft Clarity** from a refused tracker to a supported, **opt-in** **analytics** provider in the `tracking` skill. Clarity is free with no traffic caps and auto-masks text/form inputs, making it the most-requested missing analytics integration for SMB owners.

**Clarity is opt-in, not a default.** Every Anglesite site already ships Cloudflare Web Analytics as its default traffic analytics (cookieless, main-thread, no extra account, surfaced by `/anglesite:stats`). Clarity is an *additive* behavioral layer (heatmaps + session replay) that requires a **separate Microsoft account** the owner likely doesn't have — so the skill configures it **only when the owner explicitly asks** for heatmaps/session recording or names Clarity. It is deliberately kept out of the Step 1 ad-pixel checklist so it's never surfaced or installed speculatively.

The key architectural point: **Clarity runs on the main thread, not in Partytown.** Its session recording has to observe the live DOM, which Partytown's web worker can't expose — so it's the one sanctioned exception to the "all tracking goes through Partytown" rule. The reasoning is documented inline (in the skill, the snippet doc, `tracking-pixels.md`, the workflow doc, and `CLAUDE.md`) so a future contributor doesn't "fix" it by wrapping it in Partytown.

## Changes

- **`skills/tracking/SKILL.md`**
  - Removed Clarity from the "refuse" list; **kept Hotjar** there (its free tier is too limited to recommend).
  - Added Clarity to the supported-platforms table as `analytics` / `www.clarity.ms`, plus a callout explaining the main-thread exception.
  - Added the ID prompt (10-char project ID from `clarity.microsoft.com → Settings → Overview`), the `.site-config` key `TRACKING_CLARITY_PROJECT_ID`, a `clarityType` frontmatter variable (`text/javascript`, never `text/partytown`), a "don't add it to the `forward` array" caveat, the allowlist domain in the verify step, and a dashboard-verification bullet.
  - **Opt-in gating:** the "supported" note now reads "supported, but opt-in only" and states the Cloudflare default + separate-account reasons; Step 1 surfaces only the seven ad pixels in its checklist with an explicit *"do not put Clarity in this checklist"* — it's added only on an explicit owner request, otherwise skipped.
- **`template/scripts/csp.ts`** — Added `clarity` to the `TrackingPixels` interface, parse `TRACKING_CLARITY_PROJECT_ID`, and allowlist `www.clarity.ms` (+ `c.clarity.ms` telemetry) in both `buildTrackingCSP` (CSP header) and `buildAllowedScripts` (pre-deploy scan).
- **`tests/csp.test.ts`** — New tests covering the Clarity CSP entry, the pre-deploy allowlist, and the parser; `clarity: false` added to the shared `noPixels` fixture.
- **`docs/platforms/tracking-pixels.md`** — Added the main-thread Clarity snippet (no `data-partytown-type`) and rationale.
- **`template/docs/workflows/tracking.md`** — Clarity flipped to ✅ supported (with the opt-in framing); Hotjar stays refused. Config + verify rows and the CSP domain added.
- **`CLAUDE.md`** & **`docs/dev/skill-registry.md`** — Tracking skill description updated (registry is auto-generated via `npm run registry`).

## Acceptance criteria

- [x] Skill documents Clarity as a supported **analytics** provider (not an ad pixel)
- [x] Clarity is **opt-in only** — Cloudflare Web Analytics stays the default; Clarity is configured only on an explicit owner request and excluded from the ad-pixel checklist
- [x] Clarity loads on the **main thread**, NOT in Partytown — with the rationale documented inline
- [x] Gated behind `data-consent="analytics"`
- [x] Project ID stored as `TRACKING_CLARITY_PROJECT_ID`
- [x] CSP / pre-deploy scan allowlists `www.clarity.ms`
- [x] Removed from the "refuse" list; Hotjar kept
- [x] Docs table updated
- [x] Root `CLAUDE.md` skill description updated

## Testing

`npm test` — the CSP suite passes (64 tests, including the new Clarity cases) and the skill-registry + instruction-validation consistency tests pass.

> **Note:** 18 tests in `test/edit-history.test.js`, `test/undo-edit.test.js`, and `test/apply-edit-dispatcher.test.js` fail in the sandboxed dev container due to its git commit-signing wrapper — they fail identically on `main` and are unrelated to this change.

> **Issue linkage:** This PR previously referenced "Closes #320" by mistake — #320 is the unrelated `ai-optimize` `ERR_MODULE_NOT_FOUND` bug, fixed in #327. This Clarity work has no separate tracking issue, so no `Closes` reference is included here.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hcCYaunBJrnqfbLpB9mVU)_