### PR TITLE
fix(template): ai-optimize broken by bare @dwk/anglesite import (#320)

### DIFF
--- a/template/scripts/optimize-images.ts
+++ b/template/scripts/optimize-images.ts
@@ -100,7 +100,14 @@ function formatBytes(bytes: number): string {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const { optimizeImage } = await import("@dwk/anglesite/server/optimize-images.mjs");
+  // Resolve the sharp pipeline relative to this script rather than via a bare
+  // package specifier. A scaffolded site IS the plugin package (its name is set
+  // in template/package.json), so the package is not present in its own
+  // node_modules/ and a bare import would fail with ERR_MODULE_NOT_FOUND
+  // (issue #320). The optimize core is scaffolded alongside this script at
+  // ../server/.
+  const optimizeModule = new URL("../server/optimize-images.mjs", import.meta.url).href;
+  const { optimizeImage } = await import(optimizeModule);
 
   const cwd = process.cwd();
   const imagesDir = join(cwd, "public/images");

--- a/template/server/optimize-images.mjs
+++ b/template/server/optimize-images.mjs
@@ -1,0 +1,62 @@
+import { mkdirSync, copyFileSync, existsSync } from "node:fs";
+import { join, basename, extname } from "node:path";
+import sharp from "sharp";
+
+/**
+ * Optimize a single image: write a primary WebP plus responsive variants,
+ * stripping EXIF metadata. Idempotent on re-run.
+ *
+ * @param {string} inputFile - absolute path to a source image (.jpg/.png/.heic/etc)
+ * @param {{
+ *   outputDir: string,
+ *   widths?: number[],
+ *   preserveOriginalsDir?: string,
+ * }} options
+ * @returns {Promise<{
+ *   primary: string,
+ *   variants: Array<{ width: number, file: string, bytes: number }>,
+ * }>}
+ */
+export async function optimizeImage(inputFile, options) {
+  const widths = options.widths ?? [480, 768, 1024, 1920];
+  const outputDir = options.outputDir;
+  if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
+
+  const stem = basename(inputFile, extname(inputFile));
+
+  if (options.preserveOriginalsDir) {
+    if (!existsSync(options.preserveOriginalsDir)) {
+      mkdirSync(options.preserveOriginalsDir, { recursive: true });
+    }
+    copyFileSync(inputFile, join(options.preserveOriginalsDir, basename(inputFile)));
+  }
+
+  const meta = await sharp(inputFile).metadata();
+  const inputWidth = meta.width ?? 0;
+  const usableWidths = widths.filter((w) => w <= inputWidth).sort((a, b) => a - b);
+  if (usableWidths.length === 0) {
+    usableWidths.push(Math.min(widths[0] ?? inputWidth, inputWidth));
+  }
+
+  const variants = [];
+  for (const width of usableWidths) {
+    const file = `${stem}-${width}w.webp`;
+    const out = join(outputDir, file);
+    const info = await sharp(inputFile)
+      .rotate()
+      .resize({ width, withoutEnlargement: true })
+      .webp({ quality: 80 })
+      .toFile(out);
+    variants.push({ width, file, bytes: info.size });
+  }
+
+  const primaryWidth = usableWidths[usableWidths.length - 1];
+  const primary = `${stem}.webp`;
+  await sharp(inputFile)
+    .rotate()
+    .resize({ width: primaryWidth, withoutEnlargement: true })
+    .webp({ quality: 80 })
+    .toFile(join(outputDir, primary));
+
+  return { primary, variants };
+}

--- a/test/optimize-images-packaging.test.js
+++ b/test/optimize-images-packaging.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import sharp from 'sharp';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const PLUGIN_OPTIMIZE = join(REPO_ROOT, 'server', 'optimize-images.mjs');
+const TEMPLATE_OPTIMIZE = join(REPO_ROOT, 'template', 'server', 'optimize-images.mjs');
+const SCAFFOLD_SCRIPT = join(REPO_ROOT, 'scripts', 'scaffold.sh');
+
+// ---------------------------------------------------------------------------
+// Single-source-of-truth guard (regression for #320)
+//
+// The optimize core runs from two install locations that share no filesystem
+// path at runtime: the plugin's MCP server (server/optimize-images.mjs) and a
+// scaffolded site's CLI (template/server/optimize-images.mjs, copied in by
+// scaffold.sh). The module must therefore physically ship in both, but the two
+// copies must stay byte-identical. This guard makes drift a CI failure instead
+// of a silent divergence.
+// ---------------------------------------------------------------------------
+
+describe('optimize-images packaging (#320)', () => {
+  it('ships the optimize core inside template/server/', () => {
+    expect(existsSync(TEMPLATE_OPTIMIZE)).toBe(true);
+  });
+
+  it('keeps template/server/optimize-images.mjs byte-identical to the plugin-root copy', () => {
+    const plugin = readFileSync(PLUGIN_OPTIMIZE, 'utf-8');
+    const template = readFileSync(TEMPLATE_OPTIMIZE, 'utf-8');
+    expect(template).toBe(plugin);
+  });
+
+  it('the CLI wrapper imports the colocated module, not the bare @dwk/anglesite specifier', () => {
+    const cli = readFileSync(
+      join(REPO_ROOT, 'template', 'scripts', 'optimize-images.ts'),
+      'utf-8',
+    );
+    // The bare specifier is what broke in #320 — a scaffolded site IS the
+    // package, so it can't resolve "@dwk/anglesite" from its own node_modules.
+    // Assert on the import target specifically (a mention in a comment is fine).
+    expect(cli).not.toMatch(/import\([^)]*["']@dwk\/anglesite/);
+    expect(cli).not.toMatch(/from\s+["']@dwk\/anglesite/);
+    expect(cli).toContain('../server/optimize-images.mjs');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end regression: scaffold a site and run `npm run ai-optimize`.
+//
+// Requires zsh (scaffold.sh) and tsx. Skipped where zsh is unavailable, like
+// the existing scaffold-gitignore suite.
+// ---------------------------------------------------------------------------
+
+const hasZsh = (() => {
+  try {
+    execFileSync('/bin/zsh', ['--version'], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe.skipIf(!hasZsh)('ai-optimize in a scaffolded site (#320)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'anglesite-optimize-e2e-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('scaffolds server/optimize-images.mjs alongside the CLI script', () => {
+    execFileSync('/bin/zsh', [SCAFFOLD_SCRIPT, '--yes', tmpDir], { stdio: 'pipe' });
+    expect(existsSync(join(tmpDir, 'server', 'optimize-images.mjs'))).toBe(true);
+    expect(existsSync(join(tmpDir, 'scripts', 'optimize-images.ts'))).toBe(true);
+  });
+
+  it('runs the optimize script against a fixture JPEG without ERR_MODULE_NOT_FOUND', async () => {
+    execFileSync('/bin/zsh', [SCAFFOLD_SCRIPT, '--yes', tmpDir], { stdio: 'pipe' });
+
+    // Drop one unoptimized JPEG into public/images/.
+    const imagesDir = join(tmpDir, 'public', 'images');
+    execFileSync('mkdir', ['-p', imagesDir]);
+    const jpeg = await sharp({
+      create: { width: 64, height: 64, channels: 3, background: { r: 200, g: 100, b: 50 } },
+    })
+      .jpeg()
+      .toBuffer();
+    writeFileSync(join(imagesDir, 'sample.jpg'), jpeg);
+
+    // Run the CLI exactly as `npm run ai-optimize` would, resolving tsx from
+    // the plugin's own node_modules (the scaffolded site isn't `npm install`ed
+    // in this sandbox, but the script + module are what we're exercising).
+    const tsx = join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
+    const out = execFileSync(tsx, ['scripts/optimize-images.ts'], {
+      cwd: tmpDir,
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    });
+
+    expect(out).not.toContain('ERR_MODULE_NOT_FOUND');
+    // A WebP variant should now exist next to the original.
+    expect(existsSync(join(imagesDir, 'sample.webp'))).toBe(true);
+    // The original should be preserved.
+    expect(existsSync(join(imagesDir, 'originals', 'sample.jpg'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #320

## The bug

`#319` thinned `template/scripts/optimize-images.ts` into a CLI wrapper that imports the sharp pipeline with a **bare package specifier**:

```ts
await import("@dwk/anglesite/server/optimize-images.mjs");
```

But a scaffolded site **is** `@dwk/anglesite` — `template/package.json` sets that `name`, and sites inherit it (a site *is* the package, not a consumer of it). So the package is never present in its own `node_modules/`, and `npm run ai-optimize` dies with `ERR_MODULE_NOT_FOUND` on every scaffolded site. The MCP image-drop pipeline (`apply_edit` `replace-image-src`) was unaffected because the dispatcher imports the module by a relative path within `server/`.

## The fix (issue option 3: colocate in the template)

After tracing the packaging scripts, I picked the option that **preserves the invariant both `scaffold.sh` and `update.sh` rely on** — that `template/` is the complete definition of a scaffolded site:

- **`template/server/optimize-images.mjs`** — ship the optimize core inside `template/`. `scaffold.sh` already copies all of `template/`, so scaffolded sites now get their own copy. `update.sh` (which walks `template/`) refreshes it on update. **No changes needed to either script.**
- **`template/scripts/optimize-images.ts`** — import `../server/optimize-images.mjs` resolved from `import.meta.url`, instead of the bare specifier.
- **`test/optimize-images-packaging.test.js`** — new tests:
  - **Single-source guard:** asserts `template/server/optimize-images.mjs` is byte-identical to the plugin-root `server/optimize-images.mjs`, so the two copies can't silently drift (CI failure if they do).
  - **No-regression guard:** asserts the CLI no longer imports the bare `@dwk/anglesite` specifier.
  - **End-to-end (zsh-gated):** scaffolds a site into a tmp dir, drops a fixture JPEG, runs the optimize script, and asserts no `ERR_MODULE_NOT_FOUND` + a WebP variant + preserved original.

### Why not the other options

- *Relative path alone* — insufficient; there was no `server/` module in the site to point at.
- *`exports` self-reference in `package.json`* — also needs the file shipped, and re-introduces bare-specifier indirection (the thing that broke).
- *Single source + copy step in scaffold/update* — removes the committed duplicate but adds cross-install-boundary coupling in both shell scripts plus the update skill's mental model — the same class of problem that caused #320.

## Acceptance criteria

- [x] `npm run ai-optimize` runs cleanly in a freshly-scaffolded site, exits 0, optimizes images in `public/images/`
- [x] The image-drop pipeline (`apply_edit` `replace-image-src`) continues to work unchanged (untouched — still imports `./optimize-images.mjs` relatively)
- [x] A regression test exists that runs `ai-optimize` against a fixture site with one unoptimized JPEG

## Testing

Verified end-to-end manually (this sandbox has no `zsh`, so the e2e test self-skips here, like the existing `scaffold-gitignore` suite): simulated a scaffolded site, ran the CLI, confirmed the `ERR_MODULE_NOT_FOUND` is gone and `sample.webp` + `sample-80w.webp` are produced with the original preserved in `originals/`. Full suite: the 3 new guard tests pass; the 2 e2e tests skip without zsh. (18 unrelated `edit-history`/`undo-edit`/`apply-edit-dispatcher` failures are pre-existing on `main` — caused by this container's git commit-signing wrapper.)

> **Note:** This is unrelated to PR #326, which was mislabeled "Closes #320" but actually adds Microsoft Clarity to the tracking skill. That PR should drop the `#320` reference; this PR is the real fix for the issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hcCYaunBJrnqfbLpB9mVU)_