### PR TITLE
fix(tests): poll for MCP reconnect instead of fixed sleep

### DIFF
--- a/Tests/AnglesiteCoreTests/MCPClientTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientTests.swift
@@ -177,15 +177,30 @@ struct MCPClientTests {
         let crashResult = try await client.callTool(name: "crash")
         #expect(crashResult.content.first?.text == "crashing")
 
-        // Allow respawn + re-handshake to complete.
-        try? await Task.sleep(nanoseconds: 600_000_000)
-
         // Fresh instance should answer normally — proves the client reconnected and re-initialized.
-        let tools = try await client.listTools()
+        // Poll instead of a fixed sleep: respawn + handshake comfortably fits in a few hundred ms
+        // locally but can take seconds on a loaded CI runner. .notInitialized / .reconnecting are
+        // the documented transient errors during a supervised respawn; anything else is real.
+        let tools = try await Self.listToolsAwaitingReconnect(client, timeout: 10)
         #expect(tools.first?.name == "echo")
 
         let echoed = try await client.callTool(name: "echo", arguments: .object(["text": .string("after-reconnect")]))
         #expect(echoed.content.first?.text == "after-reconnect")
+    }
+
+    private static func listToolsAwaitingReconnect(
+        _ client: MCPClient,
+        timeout: TimeInterval
+    ) async throws -> [MCPClient.ToolDescriptor] {
+        let deadline = Date().addingTimeInterval(timeout)
+        while true {
+            do {
+                return try await client.listTools()
+            } catch MCPClient.MCPError.notInitialized, MCPClient.MCPError.reconnecting {
+                guard Date() < deadline else { throw MCPClient.MCPError.timeout }
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+        }
     }
 
     // MARK: JSONValue round-trip


### PR DESCRIPTION
## Summary
- Replace the fixed `Task.sleep(600 ms)` in `MCPClientTests."Reconnects after server crash"` with a 10 s poll on `listTools()`, retrying only the two documented transient errors (`.notInitialized` / `.reconnecting`).
- Unblocks `main`: CI run [27220330448](https://github.com/Anglesite/Anglesite-app/actions/runs/27220330448) failed at `MCPClientTests.swift:166:6 — Caught error: notInitialized` because supervisor respawn + MCP re-handshake took longer than the fixed budget on the GHA runner.
- Reconnect test now finishes in ~0.24 s vs ~6 s of waiting-then-failing — and still proves the same property (first successful response after the crash means the client reconnected and re-initialized).

The XCTest → Swift Testing migration in #74 didn't introduce the race; it just translated the same body. It was the first CI run after the migration that happened to lose the race.

## Test plan
- [x] `xcrun swift test --filter MCPClientTests` — 7/7 pass, reconnect test in ~0.24 s
- [x] `xcrun swift test` — 147/147 pass (120 Core + 27 Bridge)
- [x] `xcodebuild -scheme Anglesite -configuration Debug build` — clean
- [x] `xcodebuild -scheme AnglesiteMAS -configuration Debug build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)