### PR TITLE
build(swift6): step 1 — strict concurrency on (warnings), tree warning-clean

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,14 @@ import PackageDescription
 // The macOS app target itself is owned by Anglesite.xcodeproj (generated from
 // project.yml via XcodeGen). This package exposes the supporting libraries
 // that the app target links against, and drives CI via `swift test`.
+
+// Step 1 of the Swift 6 migration: surface every data-race / isolation issue
+// as a warning under Swift 5 mode. Once the tree is clean, flip these targets
+// to the Swift 6 language mode (errors) by bumping swift-tools-version.
+let strictConcurrency: [SwiftSetting] = [
+    .enableUpcomingFeature("StrictConcurrency")
+]
+
 let package = Package(
     name: "Anglesite",
     platforms: [
@@ -16,22 +24,26 @@ let package = Package(
     targets: [
         .target(
             name: "AnglesiteCore",
-            path: "Sources/AnglesiteCore"
+            path: "Sources/AnglesiteCore",
+            swiftSettings: strictConcurrency
         ),
         .target(
             name: "AnglesiteBridge",
             dependencies: ["AnglesiteCore"],
-            path: "Sources/AnglesiteBridge"
+            path: "Sources/AnglesiteBridge",
+            swiftSettings: strictConcurrency
         ),
         .testTarget(
             name: "AnglesiteCoreTests",
             dependencies: ["AnglesiteCore"],
-            path: "Tests/AnglesiteCoreTests"
+            path: "Tests/AnglesiteCoreTests",
+            swiftSettings: strictConcurrency
         ),
         .testTarget(
             name: "AnglesiteBridgeTests",
             dependencies: ["AnglesiteBridge"],
-            path: "Tests/AnglesiteBridgeTests"
+            path: "Tests/AnglesiteBridgeTests",
+            swiftSettings: strictConcurrency
         )
     ]
 )

--- a/Sources/AnglesiteBridge/WebViewBridge.swift
+++ b/Sources/AnglesiteBridge/WebViewBridge.swift
@@ -16,6 +16,12 @@ public enum WebViewBridge {
     /// for edit messages from the overlay. The overlay bundle (`edit-overlay/overlay.js`) is
     /// injected via `WKUserScript` at `atDocumentEnd` when present; missing bundle is non-fatal —
     /// the preview just loads without edit affordances.
+    ///
+    /// `@MainActor` because every WebKit type touched here (`WKWebViewConfiguration`,
+    /// `WKUserContentController`, `WKWebsiteDataStore`, `WKUserScript`) is main-actor isolated
+    /// in modern SDKs. This matches the existing call sites: SwiftUI view bodies and the
+    /// `WKScriptMessageHandler` delegate, both of which are already on the main actor.
+    @MainActor
     public static func localDevConfiguration(handler: WKScriptMessageHandler? = nil, bundle: Bundle = .main) -> WKWebViewConfiguration {
         let config = WKWebViewConfiguration()
         #if DEBUG
@@ -33,6 +39,7 @@ public enum WebViewBridge {
     /// Loads the bundled edit overlay (built by `scripts/build-overlay.sh`) as a `WKUserScript`,
     /// or returns `nil` when the bundle hasn't been produced (e.g. `swift test`, or a build where
     /// the prebuild script was skipped).
+    @MainActor
     public static func makeOverlayUserScript(in bundle: Bundle = .main) -> WKUserScript? {
         guard let url = bundle.url(forResource: "overlay", withExtension: "js", subdirectory: "edit-overlay")
         else { return nil }
@@ -41,6 +48,7 @@ public enum WebViewBridge {
 
     /// Reads `url` and wraps it as a `WKUserScript` at `atDocumentEnd`. Returns `nil` on read
     /// failure. Public so it's testable with a real file path independent of any `Bundle`.
+    @MainActor
     public static func makeOverlayUserScript(from url: URL) -> WKUserScript? {
         guard let source = try? String(contentsOf: url, encoding: .utf8) else { return nil }
         return WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
@@ -48,6 +56,7 @@ public enum WebViewBridge {
 
     /// Per-instance dev tweaks that aren't expressible on the configuration. In Debug builds this
     /// enables the Web Inspector (right-click → Inspect Element, or ⌥⌘I when the web view is focused).
+    @MainActor
     public static func applyLocalDevDefaults(to webView: WKWebView) {
         #if DEBUG
         webView.isInspectable = true

--- a/Tests/AnglesiteCoreTests/HealthModelTests.swift
+++ b/Tests/AnglesiteCoreTests/HealthModelTests.swift
@@ -198,9 +198,9 @@ final class GateRunner: HealthCheckRunner, @unchecked Sendable {
     /// (the task body hasn't reached `run` yet); fatals if more than one is queued.
     func respond(with result: Result<PreDeployCheck.Outcome, Error>) async {
         let cont = await dequeueOldest()
-        lock.lock()
-        precondition(pending.isEmpty, "expected exactly one pending call, found \(pending.count + 1)")
-        lock.unlock()
+        lock.withLock {
+            precondition(pending.isEmpty, "expected exactly one pending call, found \(pending.count + 1)")
+        }
         deliver(cont, result)
     }
 
@@ -213,13 +213,9 @@ final class GateRunner: HealthCheckRunner, @unchecked Sendable {
 
     private func dequeueOldest() async -> CheckedContinuation<PreDeployCheck.Outcome, Error> {
         while true {
-            lock.lock()
-            if !pending.isEmpty {
-                let cont = pending.removeFirst()
-                lock.unlock()
+            if let cont = lock.withLock({ pending.isEmpty ? nil : pending.removeFirst() }) {
                 return cont
             }
-            lock.unlock()
             try? await Task.sleep(for: .milliseconds(5))
         }
     }

--- a/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import os
 @testable import AnglesiteCore
 
 final class SiteScaffolderTests: XCTestCase {
@@ -78,15 +79,18 @@ final class SiteScaffolderTests: XCTestCase {
 
     func testNpmFailureIsNonFatalAndStillRegisters() async throws {
         let root = tmpDir()
-        var registered = false
+        let registered = OSAllocatedUnfairLock<Bool>(initialState: false)
         let scaffolder = SiteScaffolder(
             sitesRoot: root, pluginURL: URL(fileURLWithPath: "/plugin"), catalog: ThemeCatalog(themes: [theme]),
             run: fakeRunner(npmExit: 1, calls: CallRecorder()),
-            register: { url in registered = true; return SiteStore.Site(id: url.path, name: "x", path: url, isValid: true, missingSentinels: []) }
+            register: { url in
+                registered.withLock { $0 = true }
+                return SiteStore.Site(id: url.path, name: "x", path: url, isValid: true, missingSentinels: [])
+            }
         )
         var steps: [SiteScaffolder.ScaffoldStep] = []
         for await s in scaffolder.scaffold(makeDraft()) { steps.append(s) }
-        XCTAssertTrue(registered, "npm failure should not block registration")
+        XCTAssertTrue(registered.withLock { $0 }, "npm failure should not block registration")
         XCTAssertTrue(steps.contains { if case .warning(let s, _) = $0 { return s == "installing" }; return false })
         guard case .done? = steps.last else { return XCTFail("expected .done despite npm failure") }
     }

--- a/Tests/AnglesiteCoreTests/UndoCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/UndoCommandTests.swift
@@ -7,7 +7,7 @@ final class UndoCommandTests: XCTestCase {
             content: [.init(type: "text", text: #"{"status":"undone","newCommit":"abcd1234"}"#)],
             isError: false
         )))
-        let cmd = UndoCommand(caller: fake.call)
+        let cmd = UndoCommand(caller: fake.asCaller)
         let result = await cmd.undo(commit: "current-head", force: false)
         guard case .success(let newCommit) = result else {
             return XCTFail("expected .success, got \(result)")
@@ -24,7 +24,7 @@ final class UndoCommandTests: XCTestCase {
             content: [.init(type: "text", text: #"{"status":"refused","reason":"working-tree-modified","files":["src/pages/about.astro"]}"#)],
             isError: true
         )))
-        let cmd = UndoCommand(caller: fake.call)
+        let cmd = UndoCommand(caller: fake.asCaller)
         let result = await cmd.undo(commit: "current-head", force: false)
         guard case .workingTreeModified(let files) = result else {
             return XCTFail("expected .workingTreeModified, got \(result)")
@@ -37,7 +37,7 @@ final class UndoCommandTests: XCTestCase {
             content: [.init(type: "text", text: #"{"status":"undone","newCommit":"abcd1234"}"#)],
             isError: false
         )))
-        let cmd = UndoCommand(caller: fake.call)
+        let cmd = UndoCommand(caller: fake.asCaller)
         _ = await cmd.undo(commit: "current-head", force: true)
         guard case .object(let dict) = fake.lastArgs,
               case .bool(let force)? = dict["force"]
@@ -50,7 +50,7 @@ final class UndoCommandTests: XCTestCase {
             content: [.init(type: "text", text: #"{"status":"refused","reason":"initial-commit"}"#)],
             isError: true
         )))
-        let cmd = UndoCommand(caller: fake.call)
+        let cmd = UndoCommand(caller: fake.asCaller)
         let result = await cmd.undo(commit: "current-head", force: false)
         guard case .failed(let reason, _) = result else {
             return XCTFail("expected .failed, got \(result)")
@@ -63,7 +63,7 @@ final class UndoCommandTests: XCTestCase {
             var errorDescription: String? { "oops: something broke" }
         }
         let fake = FakeMCPCaller(result: .failure(OopsError()))
-        let cmd = UndoCommand(caller: fake.call)
+        let cmd = UndoCommand(caller: fake.asCaller)
         let result = await cmd.undo(commit: "current-head", force: false)
         guard case .failed(let reason, let detail) = result else {
             return XCTFail("expected .failed, got \(result)")
@@ -83,10 +83,17 @@ private final class FakeMCPCaller: @unchecked Sendable {
     }
 
     func call(name: String, arguments: JSONValue) async throws -> MCPClient.ToolCallResult {
-        lock.lock(); lastArgs = arguments; lock.unlock()
+        lock.withLock { lastArgs = arguments }
         switch result {
         case .success(let r): return r
         case .failure(let e): throw e
         }
+    }
+
+    /// Bridges the class method to a `@Sendable` closure that matches `UndoCommand`'s
+    /// `caller` parameter. An unbound `fake.call` reference isn't `@Sendable`, so
+    /// each test wraps through this property instead.
+    var asCaller: @Sendable (String, JSONValue) async throws -> MCPClient.ToolCallResult {
+        { name, args in try await self.call(name: name, arguments: args) }
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -78,6 +78,8 @@ targets:
         ENABLE_HARDENED_RUNTIME: YES
         MACOSX_DEPLOYMENT_TARGET: "14.0"
         SWIFT_VERSION: "5.10"
+        # Step 1 of the Swift 6 migration: data-race issues as warnings, not errors.
+        SWIFT_STRICT_CONCURRENCY: complete
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "0.1.0"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon


### PR DESCRIPTION
## Summary

- Enables Swift 6 strict-concurrency checking as **warnings** (Swift 5 mode + `StrictConcurrency` upcoming feature) on both the SPM package and the Xcode/XcodeGen project, so data-race and isolation issues surface without breaking the build.
- Clears all 23 fresh warnings the flag flip surfaces, leaving the tree warning-clean under strict concurrency. 147/147 tests pass on a clean rebuild.
- Step 2 (a follow-up) will bump `swift-tools-version` to `6.0` and `SWIFT_VERSION` to `6.0`, at which point these warnings become enforced errors.

## What changed

**Build infrastructure (commit 1327a3c)**
- `Package.swift`: declare a `strictConcurrency` `SwiftSetting` and apply it to all four targets (`AnglesiteCore`, `AnglesiteBridge`, `AnglesiteCoreTests`, `AnglesiteBridgeTests`).
- `project.yml`: set `SWIFT_STRICT_CONCURRENCY: complete` so XcodeGen regenerates the Xcode build settings to match.

**Test-suite cleanup (commit 1327a3c)** — 13 warnings:
- `UndoCommandTests`: replace the non-Sendable unbound method reference `fake.call` with a new `@Sendable` computed property `asCaller` (5 sites). Swap raw `NSLock` `lock()`/`unlock()` in the async call body for `lock.withLock`.
- `HealthModelTests`: same `NSLock` → `withLock` swap in `GateRunner.respond` and `dequeueOldest` (the two async sites the compiler flags). The synchronous continuation-closure site in `run` stays as-is — no suspension can happen there, so it isn't warned.
- `SiteScaffolderTests`: replace the captured `var registered` with `OSAllocatedUnfairLock<Bool>` so the synchronous `register:` closure can record the flag without mutating a non-Sendable capture.

**Production code (commit 511ac4e)** — 10 warnings:
- `Sources/AnglesiteBridge/WebViewBridge.swift`: annotate the four WebKit factory/mutator methods (`localDevConfiguration`, both `makeOverlayUserScript` overloads, `applyLocalDevDefaults`) with `@MainActor`. WebKit annotates its types as `@MainActor`-isolated in modern SDKs, so the previously non-isolated callers produced 10 strict-concurrency warnings. No runtime behavior change — the existing call sites (SwiftUI view bodies in `PreviewView`, the `WKScriptMessageHandler` delegate, and the already-`@MainActor`-annotated test struct) all already run on the main actor. `scriptMessageNamespace` stays non-isolated because it's a compile-time `String` constant read from a delegate callback.

## Test plan

- [x] `swift package clean && swift test` — 147/147 tests pass
- [x] Clean rebuild produces **zero** strict-concurrency warnings (down from 23)
- [ ] Reviewer: build both `Anglesite` and `AnglesiteMAS` schemes in Xcode-beta to confirm `SWIFT_STRICT_CONCURRENCY: complete` flows through XcodeGen correctly
- [ ] Reviewer: spot-check that nothing in `PreviewView` or the script-message-handler delegate path needs callsite changes (it shouldn't — all callers were already on the main actor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)