### PR TITLE
docs: close out §13 open questions (paired with Anglesite-app#77)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- 1–3 bullets. What changed, and why. -->
+
+## Paired PR check
+
+- [ ] This change is **self-contained** to the plugin (skills / hooks / template / docs / MCP server with no consumer-visible contract change).
+- [ ] This change **needs a paired PR** in [`Anglesite/Anglesite-app`](https://github.com/Anglesite/Anglesite-app) (MCP message schema, template fields the app reads, hook surface, anything the native app embeds or shells out to). Link it here: <!-- e.g. Anglesite/Anglesite-app#123 -->
+
+> Cross-cutting changes land as paired PRs: the plugin ships first in a tagged release, then the app bumps its bundled-plugin pointer. The plugin is the source of truth for skills, hooks, and the MCP message schema. See `Anglesite-app/CLAUDE.md` ▸ "Two-repo coordination".
+
+## Test plan
+
+- [ ] Plugin self-checks pass (`scripts/pre-deploy-check.sh`, lint, any relevant audits)
+- [ ] If touching the template: `scripts/scaffold.sh` produces a buildable site
+- [ ] If touching the MCP server: paired app PR exercises the new/changed messages

--- a/docs/dev/mac-app-design.md
+++ b/docs/dev/mac-app-design.md
@@ -206,10 +206,10 @@ Bundle size target: under 200 MB including Node, Astro, and a primed `node_modul
 
 ## 13. What this design explicitly does not commit to
 
-- A specific Swift architecture pattern (MVVM vs TCA vs plain SwiftUI). v0 should pick the simplest path that works.
 - A specific Markdoc/Astro AST library. The patcher is a single module; it can be rewritten if the first choice doesn't hold up.
-- Whether the bundled Node is `node` or `bun`. Whichever notarizes cleanly and runs Astro fastest.
 - Cross-platform parity. Linux/Windows ports are welcome from the community; the maintainers commit to keeping the plugin and MCP server portable, but not the app.
+
+> **Previously open, now decided** (see `Anglesite-app/docs/build-plan.md` ▸ "Cross-cutting decisions to lock in early"): Swift architecture is plain SwiftUI + actors (no TCA for v0); the bundled runtime is Node (vendored universal binary).
 
 ## 14. Relationship to existing ADRs
 


### PR DESCRIPTION
## Summary

Paired with **Anglesite/Anglesite-app#77** (which closes Anglesite-app issue #35).

`docs/dev/mac-app-design.md` §13 lists "what this design explicitly does not commit to." Two of those bullets are now decided on the app side:

- **Swift architecture** → plain SwiftUI + actors (no TCA for v0).
- **Bundled runtime** → Node (not Bun); vendored universal binary ships in Phase 1.

This PR removes both bullets and adds a forward pointer to the app's `docs/build-plan.md` "Cross-cutting decisions to lock in early" block as the authoritative log going forward. The other two §13 bullets (Markdoc/Astro AST library, cross-platform parity) are intentionally retained — both are still genuinely open.

Also adds `.github/PULL_REQUEST_TEMPLATE.md` with the matching paired-PR check pointing at `Anglesite/Anglesite-app`. The plugin remains the source of truth for the MCP schema, hooks, and site template, so changes to those should ship here first and then get consumed by a paired app PR.

## Paired PR check

- [ ] This change is **self-contained** to the plugin.
- [x] This change **needs a paired PR** in `Anglesite/Anglesite-app` — see **Anglesite/Anglesite-app#77**.

## Test plan

- [x] Docs-only change.
- [x] No template, hook, or MCP-schema impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)