### PR TITLE
feat(template): self-gating GitHub Actions deploy workflow (#334)

### DIFF
--- a/template/.github/workflows/deploy.yml
+++ b/template/.github/workflows/deploy.yml
@@ -1,0 +1,79 @@
+# Deploy to Cloudflare Workers on content/source changes.
+#
+# This workflow is SELF-GATING: it ships with every Anglesite site but does
+# nothing until the two repository secrets below are set. Sites that deploy
+# locally with `/anglesite:deploy` (the default) are unaffected — every run
+# finishes green with its build/deploy steps skipped.
+#
+# To enable git-push deploys (required for the Micropub publish loop set up by
+# `/anglesite:indieweb`, where a created note is committed here and must be
+# rebuilt), set both secrets on the repo:
+#
+#   gh secret set CLOUDFLARE_API_TOKEN   # "Edit Cloudflare Workers" template token
+#   gh secret set CLOUDFLARE_ACCOUNT_ID  # the account id from .site-config
+#
+# `/anglesite:indieweb` sets these for you. To set them by hand, create the
+# token at https://dash.cloudflare.com/profile/api-tokens.
+
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "public/**"
+      - "worker/**"
+      - "astro.config.ts"
+      - "keystatic.config.ts"
+      - "wrangler.jsonc"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+
+# Never let two deploys race; cancel an in-flight run when a newer push lands.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Gate the whole job on the deploy token being present. We can't read a
+      # secret in a job-level `if:`, so surface it as a step output and guard
+      # every subsequent step on it. No token → steps skip, run stays green.
+      - name: Check for Cloudflare credentials
+        id: guard
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "::notice::CLOUDFLARE_API_TOKEN is not set — skipping deploy. This site deploys locally via /anglesite:deploy. To enable git-push deploys, set the CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID repository secrets."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.guard.outputs.configured == 'true'
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.guard.outputs.configured == 'true'
+        run: npm ci
+
+      - name: Build
+        if: steps.guard.outputs.configured == 'true'
+        run: npm run build
+
+      - name: Deploy to Cloudflare Workers
+        if: steps.guard.outputs.configured == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy


### PR DESCRIPTION
Closes #334. Part of the active-IndieWeb work (#339).

## What
Adds `template/.github/workflows/deploy.yml` — a **self-gating** deploy workflow scaffolded into every Anglesite site.

- Triggers on push to `main` (the production branch per `template/CLAUDE.md`) touching `src/`, `public/`, `worker/`, or config, plus manual `workflow_dispatch`.
- A guard step reads `CLOUDFLARE_API_TOKEN` (via `env:`) and sets a step output; the `npm ci → build → wrangler deploy` steps are `if:`-gated on it. **No secrets → steps skip, run stays green.**
- `concurrency` cancels superseded runs. Secrets are only ever passed through `env:`, never interpolated into `run:`.

## Why
The Micropub publish loop (#333) commits a note `.mdoc`; something must rebuild + redeploy on that push. No CI existed in the template (deploy was local `wrangler deploy`), so this is the rebuild trigger. Self-gating keeps it harmless for the default local-deploy flow — only sites that opt in (the `/anglesite:indieweb` skill, or `gh secret set`) get the git-push deploy path.

## Decision
Per the design (ADR-0020 / spec), the chosen option was **template + self-gating** over skill-only or always-on (which would fail noisily on every push for local-deploy sites).

## Notes / follow-ups
- The `gh secret set` automation for `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` belongs to the skill (#329); the workflow header documents the manual commands.
- `template/CLAUDE.md` currently says `main` deploys "automatically by Git integration" — this workflow implements that promise (when secrets are set). Reconciling that doc and avoiding double-deploys (local `npm run deploy` + CI) is deploy-skill/#329 territory, intentionally not touched here.

## Test
`scaffold.sh` (rsync, no `.github` exclude) copies it to user projects; verified `deploy.yml` parses as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)