### PR TITLE
feat(template): compose @dwk/* indieweb handlers into site-entry.js

### DIFF
--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -23,6 +23,11 @@
  *   ASSETS                       — Static assets fetcher (always present)
  *   EXPERIMENTS (KV, optional)   — Active A/B experiment config
  *   ANALYTICS   (AED, optional)  — Impression event stream
+ *   AUTH_DB     (D1, optional)   — IndieAuth codes + tokens
+ *   MICROPUB_DB (D1, optional)   — Micropub post records + DPoP jti replay
+ *   WEBMENTION_DB (D1, optional) — Verified webmention inbox
+ *   MEDIA       (R2, optional)   — Micropub media-endpoint blob storage
+ *   WEBMENTION_QUEUE (Queue, optional) — Async webmention verification
  *
  * Vars / secrets:
  *   MEMBERSHIP_SIGNING_KEY (optional) — hex HMAC key, set as a wrangler
@@ -33,13 +38,22 @@
  *                                         the gate, for owner preview.
  *   CONSENT_GEO (optional)            — "true" to enable cf-country meta
  *                                       injection.
+ *   INDIEAUTH_SIGNING_KEY (secret, optional) — Token signing material.
+ *   GITHUB_TOKEN (secret, optional)   — Fine-grained PAT for Micropub bridge.
  */
 
 import premiumRoutes from "./_premium-routes.json";
+import { createHandler as createIndieAuth } from "@dwk/indieauth";
+import { createHandler as createMicropub } from "@dwk/micropub";
+import { createHandler as createWebmention } from "@dwk/webmention";
 
 const COOKIE_NAME = "__anglesite_member";
 
-export default {
+const indieauth = createIndieAuth();
+const micropub = createMicropub();
+const webmention = createWebmention();
+
+const worker = {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
     const accept = request.headers.get("Accept") ?? "";
@@ -107,6 +121,15 @@ export default {
       }
     }
 
+    // 4. IndieWeb endpoints — each gated on its D1 binding being present.
+    const p = url.pathname;
+    if (env.AUTH_DB && p.startsWith("/auth"))
+      return indieauth(request, env, ctx);
+    if (env.MICROPUB_DB && (p === "/micropub" || p === "/media"))
+      return micropub(request, env, ctx);
+    if (env.WEBMENTION_DB && p === "/webmention")
+      return webmention(request, env, ctx);
+
     if (!response) {
       response = await env.ASSETS.fetch(request);
     }
@@ -138,7 +161,20 @@ export default {
 
     return response;
   },
+
+  async queue(batch, env, ctx) {
+    if (!env.WEBMENTION_DB) return;
+    await webmention.queue(batch, env, ctx);
+  },
+
+  async scheduled(event, env, ctx) {
+    if (env.WEBMENTION_DB) {
+      await webmention.scheduled(event, env, ctx);
+    }
+  },
 };
+
+export default worker;
 
 class CountryInjector {
   constructor(country) {

--- a/template/wrangler.jsonc
+++ b/template/wrangler.jsonc
@@ -14,5 +14,28 @@
   },
   "observability": {
     "enabled": true
+  },
+
+  // IndieWeb bindings — provisioned by /anglesite:indieweb.
+  // Each is optional; site-entry.js gates on binding presence.
+  // Database IDs are written by the skill after D1/R2 creation.
+  "d1_databases": [
+    { "binding": "AUTH_DB",       "database_name": "indieauth",   "database_id": "" },
+    { "binding": "MICROPUB_DB",   "database_name": "micropub",    "database_id": "" },
+    { "binding": "WEBMENTION_DB", "database_name": "webmention",  "database_id": "" }
+  ],
+  "r2_buckets": [
+    { "binding": "MEDIA", "bucket_name": "" }
+  ],
+  "queues": {
+    "consumers": [
+      { "queue": "webmention-queue", "max_batch_size": 10, "max_retries": 3 }
+    ],
+    "producers": [
+      { "binding": "WEBMENTION_QUEUE", "queue": "webmention-queue" }
+    ]
+  },
+  "triggers": {
+    "crons": ["0 */6 * * *"]
   }
 }


### PR DESCRIPTION
## Summary

- Compose `@dwk/indieauth`, `@dwk/micropub`, and `@dwk/webmention` factory handlers into `template/worker/site-entry.js`, gated on D1 binding presence (`AUTH_DB`, `MICROPUB_DB`, `WEBMENTION_DB`) — follows the same per-binding guard pattern used by membership/experiment/consent
- Add `queue` export (drains `WEBMENTION_QUEUE` for async link verification) and `scheduled` export (cron retry for webmention re-verification)
- Wire the full binding union into `template/wrangler.jsonc`: three D1 databases, one R2 bucket (`MEDIA`), queue producer/consumer (`WEBMENTION_QUEUE`), and a cron trigger (`0 */6 * * *`) — all with empty IDs that `/anglesite:indieweb` fills after provisioning

## Design

Per `docs/superpowers/specs/2026-06-09-active-indieweb-design.md` §3.1 and §3.2.

## Notes

**Blocked** for merge until `@dwk/*` packages are published to npm (imports will fail at build time). The structure is safely gated — a site without the bindings serves identically to today.

Closes #330

## Test plan

- [ ] Verify existing tests pass (97/97 test files — 3 failures are pre-existing git-signing infra issues)
- [ ] Confirm a site without IndieWeb bindings still serves ASSETS-only (guards are all false)
- [ ] After `@dwk/*` publish: scaffold a test site, run `/anglesite:indieweb`, verify dispatch routes each prefix to its handler
- [ ] Verify `wrangler.jsonc` validates with the binding union after skill fills in database IDs

https://claude.ai/code/session_01BTRXxg4R47JJyNMJRC8o7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTRXxg4R47JJyNMJRC8o7e)_