### PR TITLE
feat(template): add notes collection + h-entry/h-feed pages

### DIFF
--- a/template/anglesite.config.json
+++ b/template/anglesite.config.json
@@ -2,6 +2,7 @@
   "keystatic": {
     "collections": [
       "posts",
+      "notes",
       "services",
       "team",
       "testimonials",

--- a/template/keystatic.config.ts
+++ b/template/keystatic.config.ts
@@ -84,6 +84,63 @@ const allCollections: Record<string, ReturnType<typeof collection>> = {
         content: fields.markdoc({ label: "Content" }),
       },
     }),
+    notes: collection({
+      label: "Notes",
+      slugField: "slug",
+      path: "src/content/notes/*",
+      format: { contentField: "content" },
+      schema: {
+        slug: fields.slug({
+          name: {
+            label: "ID",
+            description: "Timestamp or short identifier (auto-filled by Micropub)",
+          },
+        }),
+        publishDate: fields.date({
+          label: "Publish Date",
+          validation: { isRequired: true },
+        }),
+        title: fields.text({
+          label: "Title",
+          description: "Optional — notes are often titleless",
+        }),
+        image: fields.text({
+          label: "Image",
+          description: "Path relative to public/ (e.g., /images/notes/photo.webp)",
+        }),
+        imageAlt: fields.text({
+          label: "Image Alt Text",
+          description: "Required if image is set",
+        }),
+        inReplyTo: fields.url({
+          label: "In Reply To",
+          description: "URL of the post this note is replying to",
+        }),
+        bookmarkOf: fields.url({
+          label: "Bookmark Of",
+          description: "URL being bookmarked",
+        }),
+        likeOf: fields.url({
+          label: "Like Of",
+          description: "URL being liked",
+        }),
+        repostOf: fields.url({
+          label: "Repost Of",
+          description: "URL being reposted",
+        }),
+        syndication: fields.array(fields.url({ label: "URL" }), {
+          label: "Syndication Links",
+          description: "URLs where this note was shared",
+          itemLabel: (props) => props.value || "Add URL",
+        }),
+        draft: fields.checkbox({
+          label: "Draft",
+          description: "Drafts are not published to the live site",
+          defaultValue: false,
+        }),
+        content: fields.markdoc({ label: "Content" }),
+      },
+    }),
     services: collection({
       label: "Services",
       slugField: "name",

--- a/template/src/content.config.ts
+++ b/template/src/content.config.ts
@@ -53,6 +53,24 @@ const posts = defineCollection({
   }),
 });
 
+/** IndieWeb notes (short, often titleless posts) stored in `src/content/notes/`. */
+const notes = defineCollection({
+  loader: contentLoader("notes"),
+  schema: z.object({
+    slug: z.string(),
+    publishDate: z.string().transform((str) => new Date(str)),
+    title: z.string().optional(),
+    image: z.string().optional(),
+    imageAlt: z.string().optional(),
+    inReplyTo: z.string().url().optional(),
+    bookmarkOf: z.string().url().optional(),
+    likeOf: z.string().url().optional(),
+    repostOf: z.string().url().optional(),
+    syndication: z.array(z.string().url()).default([]),
+    draft: z.boolean().default(false),
+  }),
+});
+
 /** Services or menu items stored in `src/content/services/`. */
 const services = defineCollection({
   loader: contentLoader("services"),
@@ -418,6 +436,7 @@ const submissions = defineCollection({
 
 export const collections = {
   posts,
+  notes,
   services,
   team,
   testimonials,

--- a/template/src/pages/notes/[slug].astro
+++ b/template/src/pages/notes/[slug].astro
@@ -1,0 +1,115 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCollection, render } from "astro:content";
+
+export const prerender = true;
+
+export async function getStaticPaths() {
+  const notes = await getCollection("notes", ({ data }) => {
+    return import.meta.env.PROD ? !data.draft : true;
+  });
+  return notes.map((note) => ({
+    params: { slug: note.id },
+    props: { note },
+  }));
+}
+
+const { note } = Astro.props;
+const { Content } = await render(note);
+
+const pageTitle = note.data.title
+  || `Note — ${note.data.publishDate.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}`;
+---
+
+<BaseLayout
+  title={pageTitle}
+  description={note.data.title || "A short note."}
+>
+  <article class="h-entry">
+    {note.data.title && <h1 class="p-name">{note.data.title}</h1>}
+    <time
+      class="dt-published"
+      datetime={note.data.publishDate.toISOString()}
+    >
+      {note.data.publishDate.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      })}
+    </time>
+
+    {
+      note.data.inReplyTo && (
+        <p>
+          In reply to{" "}
+          <a href={note.data.inReplyTo} class="u-in-reply-to">
+            {note.data.inReplyTo}
+          </a>
+        </p>
+      )
+    }
+
+    {
+      note.data.repostOf && (
+        <p>
+          Repost of{" "}
+          <a href={note.data.repostOf} class="u-repost-of">
+            {note.data.repostOf}
+          </a>
+        </p>
+      )
+    }
+
+    {
+      note.data.likeOf && (
+        <p>
+          Liked{" "}
+          <a href={note.data.likeOf} class="u-like-of">
+            {note.data.likeOf}
+          </a>
+        </p>
+      )
+    }
+
+    {
+      note.data.bookmarkOf && (
+        <p>
+          Bookmarked{" "}
+          <a href={note.data.bookmarkOf} class="u-bookmark-of">
+            {note.data.bookmarkOf}
+          </a>
+        </p>
+      )
+    }
+
+    {
+      note.data.image && (
+        <img
+          src={note.data.image}
+          alt={note.data.imageAlt || ""}
+          class="u-photo"
+        />
+      )
+    }
+
+    <div class="e-content">
+      <Content />
+    </div>
+
+    {
+      note.data.syndication.length > 0 && (
+        <ul class="syndication">
+          {note.data.syndication.map((url) => (
+            <li>
+              <a href={url} class="u-syndication" rel="syndication">
+                {new URL(url).hostname}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )
+    }
+  </article>
+</BaseLayout>

--- a/template/src/pages/notes/index.astro
+++ b/template/src/pages/notes/index.astro
@@ -1,0 +1,53 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
+
+const allNotes = await getCollection("notes", ({ data }) => {
+  return import.meta.env.PROD ? !data.draft : true;
+});
+
+const notes = allNotes.sort(
+  (a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime(),
+);
+---
+
+<BaseLayout
+  title="Notes"
+  description="Short notes, replies, and links."
+>
+  <div class="h-feed">
+    <h1 class="p-name">Notes</h1>
+
+    {notes.length === 0 && <p>No notes yet.</p>}
+
+    {
+      notes.map((note) => (
+        <article class="h-entry">
+          <a href={`/notes/${note.id}/`} class="u-url">
+            <time
+              class="dt-published"
+              datetime={note.data.publishDate.toISOString()}
+            >
+              {note.data.publishDate.toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+                hour: "numeric",
+                minute: "2-digit",
+              })}
+            </time>
+          </a>
+          {note.data.title && <p class="p-name">{note.data.title}</p>}
+          {note.data.inReplyTo && (
+            <p>
+              In reply to{" "}
+              <a href={note.data.inReplyTo} class="u-in-reply-to">
+                {new URL(note.data.inReplyTo).hostname}
+              </a>
+            </p>
+          )}
+        </article>
+      ))
+    }
+  </div>
+</BaseLayout>

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -50,7 +50,9 @@ import { createHandler as createWebmention } from "@dwk/webmention";
 const COOKIE_NAME = "__anglesite_member";
 
 const indieauth = createIndieAuth();
-const micropub = createMicropub();
+const micropub = createMicropub({
+  generatePostUrl: (slug) => `/notes/${slug}/`,
+});
 const webmention = createWebmention();
 
 const worker = {

--- a/test/content-collections.test.js
+++ b/test/content-collections.test.js
@@ -16,7 +16,7 @@ const keystatic = readFileSync(
   'utf-8',
 );
 
-const COLLECTIONS = ['posts', 'services', 'team', 'testimonials', 'gallery', 'events', 'menus', 'menuSections', 'menuItems', 'faq', 'products', 'experiments'];
+const COLLECTIONS = ['posts', 'notes', 'services', 'team', 'testimonials', 'gallery', 'events', 'menus', 'menuSections', 'menuItems', 'faq', 'products', 'experiments'];
 
 describe('content collections', () => {
   it('defines all collections with defineCollection', () => {
@@ -75,6 +75,7 @@ describe('content collections', () => {
 describe('collection schema fields', () => {
   // Verify key fields exist in both configs for each collection
   const fieldChecks = {
+    notes: ['slug', 'publishDate', 'inReplyTo', 'syndication', 'draft'],
     services: ['name', 'description', 'price', 'order'],
     team: ['name', 'role', 'bio', 'photo', 'order'],
     testimonials: ['author', 'quote', 'attribution', 'rating'],


### PR DESCRIPTION
## Summary\n\nCloses #332.\n\n- **`template/keystatic.config.ts`** — new `notes` collection at `src/content/notes/*` with timestamp slug, optional title, and mf2-friendly fields (`inReplyTo`, `bookmarkOf`, `likeOf`, `repostOf`, `syndication`)\n- **`template/src/content.config.ts`** — matching Zod schema for the `notes` collection\n- **`template/src/pages/notes/index.astro`** — `h-feed` listing page, sorted reverse-chronological\n- **`template/src/pages/notes/[slug].astro`** — single note `h-entry` page with full mf2 markup (`u-in-reply-to`, `u-repost-of`, `u-like-of`, `u-bookmark-of`, `u-photo`, `u-syndication`, `dt-published`, `e-content`)\n- **`template/worker/site-entry.js`** — pass `generatePostUrl` to `createMicropub()` so the Micropub `201 Location` header points to `/notes/<slug>/`\n- **`template/anglesite.config.json`** — register `notes` in the manifest\n- **`test/content-collections.test.js`** — add `notes` to the `COLLECTIONS` array and field checks\n\n## Test plan\n\n- [x] `npx vitest run test/content-collections.test.js tests/schema.test.ts` — 40 tests pass\n- [ ] Scaffold a test site, create a sample `.mdoc` in `src/content/notes/`, verify it renders as a valid h-entry at `/notes/<slug>/` and appears in the h-feed at `/notes/`\n\nhttps://claude.ai/code/session_015JvHGCNAbLzq59a8RLFEZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_015JvHGCNAbLzq59a8RLFEZ1)_