### PR TITLE
feat(template): add Micropub D1→GitHub bridge (#333)

### DIFF
--- a/template/worker/indieweb-bridge.js
+++ b/template/worker/indieweb-bridge.js
@@ -1,0 +1,283 @@
+/**
+ * Micropub D1→GitHub bridge.
+ *
+ * Materializes unsynced records from MICROPUB_DB into Keystatic .mdoc
+ * files and commits them to the site repo via the GitHub Contents API.
+ * Designed to run from the queue (event-driven) and scheduled (cron
+ * retry) exports in site-entry.js.
+ *
+ * The Micropub handler returns 201 immediately after writing to D1.
+ * This bridge runs asynchronously — a failed commit leaves the record
+ * unsynced for cron retry and never blocks the Micropub response.
+ *
+ * Env bindings:
+ *   MICROPUB_DB  (D1)     — Post records with a `synced` column
+ *   GITHUB_TOKEN (secret) — Fine-grained PAT, contents:write only
+ *
+ * Reads from .site-config (via env vars or wrangler vars):
+ *   GITHUB_REPO           — "owner/repo" for the site repository
+ *   GITHUB_BRANCH         — Target branch (default: "main")
+ */
+
+const BATCH_SIZE = 25;
+const CONTENT_PREFIX = "src/content/notes";
+const GITHUB_API = "https://api.github.com";
+
+/**
+ * Process unsynced Micropub records: render to .mdoc and commit to GitHub.
+ * Called from both queue() and scheduled() in site-entry.js.
+ */
+export async function sync(env) {
+  if (!env.MICROPUB_DB || !env.GITHUB_TOKEN || !env.GITHUB_REPO) return;
+
+  const branch = env.GITHUB_BRANCH || "main";
+  const [owner, repo] = env.GITHUB_REPO.split("/");
+  if (!owner || !repo) return;
+
+  const rows = await env.MICROPUB_DB
+    .prepare(
+      `SELECT id, slug, properties, deleted, created_at, updated_at
+       FROM posts WHERE synced = 0 ORDER BY created_at ASC LIMIT ?`,
+    )
+    .bind(BATCH_SIZE)
+    .all();
+
+  if (!rows.results || rows.results.length === 0) return;
+
+  for (const row of rows.results) {
+    try {
+      if (row.deleted) {
+        await deleteFile(owner, repo, branch, row.slug, env.GITHUB_TOKEN);
+      } else {
+        const mdoc = renderMdoc(row);
+        await commitFile(
+          owner,
+          repo,
+          branch,
+          row.slug,
+          mdoc,
+          row.deleted ? "delete" : row.updated_at ? "update" : "create",
+          env.GITHUB_TOKEN,
+        );
+      }
+      await env.MICROPUB_DB
+        .prepare("UPDATE posts SET synced = 1 WHERE id = ?")
+        .bind(row.id)
+        .run();
+    } catch (err) {
+      console.error(`Bridge sync failed for ${row.slug}:`, err.message);
+    }
+  }
+}
+
+/**
+ * Render a D1 post record to a Keystatic-compatible .mdoc string.
+ * The `properties` column stores the mf2 JSON object.
+ */
+export function renderMdoc(row) {
+  const props = typeof row.properties === "string"
+    ? JSON.parse(row.properties)
+    : row.properties;
+
+  const fm = {};
+
+  fm.slug = row.slug;
+
+  fm.publishDate = extractFirst(props.published)
+    || row.created_at
+    || new Date().toISOString();
+
+  const title = extractFirst(props.name);
+  if (title) fm.title = title;
+
+  const photo = extractFirst(props.photo);
+  if (photo) {
+    fm.image = typeof photo === "object" ? photo.value : photo;
+    const alt = typeof photo === "object" ? photo.alt : extractFirst(props["photo-alt"]);
+    if (alt) fm.imageAlt = alt;
+  }
+
+  const inReplyTo = extractFirst(props["in-reply-to"]);
+  if (inReplyTo) fm.inReplyTo = inReplyTo;
+
+  const bookmarkOf = extractFirst(props["bookmark-of"]);
+  if (bookmarkOf) fm.bookmarkOf = bookmarkOf;
+
+  const likeOf = extractFirst(props["like-of"]);
+  if (likeOf) fm.likeOf = likeOf;
+
+  const repostOf = extractFirst(props["repost-of"]);
+  if (repostOf) fm.repostOf = repostOf;
+
+  if (Array.isArray(props.syndication) && props.syndication.length > 0) {
+    fm.syndication = props.syndication;
+  }
+
+  fm.draft = false;
+
+  const body = extractContent(props.content);
+
+  return serializeFrontmatter(fm) + "\n" + body + "\n";
+}
+
+/**
+ * Commit a .mdoc file to GitHub via the Contents API.
+ * Creates or updates (if the file already exists).
+ */
+async function commitFile(owner, repo, branch, slug, content, action, token) {
+  const path = `${CONTENT_PREFIX}/${slug}.mdoc`;
+  const url = `${GITHUB_API}/repos/${owner}/${repo}/contents/${path}`;
+
+  const existing = await githubGet(url, branch, token);
+  const sha = existing?.sha;
+
+  const body = {
+    message: `Micropub: ${action} note ${slug}`,
+    content: btoa(unescape(encodeURIComponent(content))),
+    branch,
+  };
+  if (sha) body.sha = sha;
+
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: githubHeaders(token),
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub PUT ${path} ${res.status}: ${text}`);
+  }
+}
+
+/**
+ * Delete a .mdoc file from GitHub via the Contents API.
+ */
+async function deleteFile(owner, repo, branch, slug, token) {
+  const path = `${CONTENT_PREFIX}/${slug}.mdoc`;
+  const url = `${GITHUB_API}/repos/${owner}/${repo}/contents/${path}`;
+
+  const existing = await githubGet(url, branch, token);
+  if (!existing?.sha) return;
+
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers: githubHeaders(token),
+    body: JSON.stringify({
+      message: `Micropub: delete note ${slug}`,
+      sha: existing.sha,
+      branch,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub DELETE ${path} ${res.status}: ${text}`);
+  }
+}
+
+/**
+ * GET a file from the GitHub Contents API. Returns { sha } or null.
+ */
+async function githubGet(url, branch, token) {
+  const res = await fetch(`${url}?ref=${encodeURIComponent(branch)}`, {
+    headers: githubHeaders(token),
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub GET ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+function githubHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "anglesite-micropub-bridge",
+    "Content-Type": "application/json",
+  };
+}
+
+/**
+ * Extract the first value from an mf2 property array.
+ * mf2 properties are always arrays: { "name": ["My Title"] }
+ */
+function extractFirst(arr) {
+  if (!Array.isArray(arr) || arr.length === 0) return undefined;
+  return arr[0];
+}
+
+/**
+ * Extract body text from an mf2 content property.
+ * content can be: ["plain text"], [{ html: "...", value: "..." }], or [{ value: "..." }]
+ */
+function extractContent(content) {
+  const first = extractFirst(content);
+  if (!first) return "";
+  if (typeof first === "string") return first;
+  if (first.value) return first.value;
+  if (first.html) return htmlToPlain(first.html);
+  return "";
+}
+
+/**
+ * Minimal HTML-to-plain-text conversion for note content.
+ * Micropub notes are typically short — strip tags, decode entities.
+ */
+function htmlToPlain(html) {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>\s*<p[^>]*>/gi, "\n\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .trim();
+}
+
+/**
+ * Serialize a frontmatter object to YAML.
+ * Handles strings, booleans, and arrays of strings.
+ */
+function serializeFrontmatter(obj) {
+  const lines = ["---"];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      lines.push(`${key}:`);
+      for (const item of value) {
+        lines.push(`  - ${yamlString(item)}`);
+      }
+    } else if (typeof value === "boolean") {
+      lines.push(`${key}: ${value}`);
+    } else {
+      lines.push(`${key}: ${yamlString(value)}`);
+    }
+  }
+  lines.push("---");
+  return lines.join("\n");
+}
+
+function yamlString(val) {
+  const s = String(val);
+  if (
+    s === "" ||
+    s === "true" ||
+    s === "false" ||
+    s === "null" ||
+    /^[\d.]+$/.test(s) ||
+    /[:#{}[\],&*?|>!%@`'"]/.test(s) ||
+    s.startsWith(" ") ||
+    s.endsWith(" ")
+  ) {
+    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return s;
+}

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -46,6 +46,7 @@ import premiumRoutes from "./_premium-routes.json";
 import { createHandler as createIndieAuth } from "@dwk/indieauth";
 import { createHandler as createMicropub } from "@dwk/micropub";
 import { createHandler as createWebmention } from "@dwk/webmention";
+import { sync as syncMicropubBridge } from "./indieweb-bridge.js";
 
 const COOKIE_NAME = "__anglesite_member";
 
@@ -165,14 +166,17 @@ const worker = {
   },
 
   async queue(batch, env, ctx) {
-    if (!env.WEBMENTION_DB) return;
-    await webmention.queue(batch, env, ctx);
+    if (env.WEBMENTION_DB) {
+      await webmention.queue(batch, env, ctx);
+    }
+    ctx.waitUntil(syncMicropubBridge(env));
   },
 
   async scheduled(event, env, ctx) {
     if (env.WEBMENTION_DB) {
       await webmention.scheduled(event, env, ctx);
     }
+    ctx.waitUntil(syncMicropubBridge(env));
   },
 };
 

--- a/test/indieweb-bridge.test.js
+++ b/test/indieweb-bridge.test.js
@@ -1,0 +1,330 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderMdoc, sync } from "../template/worker/indieweb-bridge.js";
+
+describe("indieweb-bridge", () => {
+  describe("renderMdoc", () => {
+    it("renders a minimal note with slug and publishDate", () => {
+      const row = {
+        slug: "2026-06-09-abc123",
+        properties: JSON.stringify({ published: ["2026-06-09T12:00:00Z"] }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain("slug: 2026-06-09-abc123");
+      expect(result).toContain('publishDate: "2026-06-09T12:00:00Z"');
+      expect(result).toContain("draft: false");
+      expect(result).toMatch(/^---\n/);
+      expect(result).toMatch(/\n---\n/);
+    });
+
+    it("includes title when name property is present", () => {
+      const row = {
+        slug: "test-note",
+        properties: JSON.stringify({
+          published: ["2026-06-09T12:00:00Z"],
+          name: ["My Test Note"],
+        }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain("title: My Test Note");
+    });
+
+    it("omits title when name property is absent", () => {
+      const row = {
+        slug: "titleless",
+        properties: JSON.stringify({ published: ["2026-06-09T12:00:00Z"] }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).not.toContain("title:");
+    });
+
+    it("maps mf2 photo to image and imageAlt", () => {
+      const row = {
+        slug: "photo-note",
+        properties: JSON.stringify({
+          published: ["2026-06-09T12:00:00Z"],
+          photo: [{ value: "/images/notes/cat.webp", alt: "A fluffy cat" }],
+        }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain("image: /images/notes/cat.webp");
+      expect(result).toContain("imageAlt: A fluffy cat");
+    });
+
+    it("handles photo as a plain string URL", () => {
+      const row = {
+        slug: "photo-string",
+        properties: JSON.stringify({
+          published: ["2026-06-09T12:00:00Z"],
+          photo: ["/images/notes/dog.webp"],
+        }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain("image: /images/notes/dog.webp");
+    });
+
+    it("maps in-reply-to, bookmark-of, like-of, repost-of", () => {
+      const row = {
+        slug: "interactions",
+        properties: JSON.stringify({
+          published: ["2026-06-09T12:00:00Z"],
+          "in-reply-to": ["https://example.com/post/1"],
+          "bookmark-of": ["https://example.com/article"],
+          "like-of": ["https://example.com/liked"],
+          "repost-of": ["https://example.com/reposted"],
+        }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain('inReplyTo: "https://example.com/post/1"');
+      expect(result).toContain('bookmarkOf: "https://example.com/article"');
+      expect(result).toContain('likeOf: "https://example.com/liked"');
+      expect(result).toContain('repostOf: "https://example.com/reposted"');
+    });
+
+    it("includes syndication links as a YAML array", () => {
+      const row = {
+        slug: "syndicated",
+        properties: JSON.stringify({
+          published: ["2026-06-09T12:00:00Z"],
+          syndication: [
+            "https://twitter.com/user/status/123",
+            "https://mastodon.social/@user/456",
+          ],
+        }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain("syndication:");
+      expect(result).toContain(
+        '  - "https://twitter.com/user/status/123"',
+      );
+      expect(result).toContain(
+        '  - "https://mastodon.social/@user/456"',
+      );
+    });
+
+    it("extracts plain text content as the body", () => {
+      const row = {
+        slug: "plain-content",
+        properties: JSON.stringify({
+          published: ["2026-06-09T12:00:00Z"],
+          content: ["Hello, world!"],
+        }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toMatch(/---\nHello, world!\n$/);
+    });
+
+    it("extracts content from { value } object", () => {
+      const row = {
+        slug: "value-content",
+        properties: JSON.stringify({
+          published: ["2026-06-09T12:00:00Z"],
+          content: [{ value: "Text from value field" }],
+        }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain("Text from value field");
+    });
+
+    it("strips HTML tags from html content", () => {
+      const row = {
+        slug: "html-content",
+        properties: JSON.stringify({
+          published: ["2026-06-09T12:00:00Z"],
+          content: [{ html: "<p>Hello <strong>world</strong></p>" }],
+        }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain("Hello world");
+      expect(result).not.toContain("<p>");
+      expect(result).not.toContain("<strong>");
+    });
+
+    it("falls back to created_at when published is missing", () => {
+      const row = {
+        slug: "no-published",
+        properties: JSON.stringify({}),
+        created_at: "2026-06-09T08:30:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain('publishDate: "2026-06-09T08:30:00Z"');
+    });
+
+    it("handles properties as a pre-parsed object", () => {
+      const row = {
+        slug: "parsed",
+        properties: { published: ["2026-06-09T12:00:00Z"], name: ["Parsed"] },
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain("title: Parsed");
+    });
+
+    it("quotes values that contain YAML-special characters", () => {
+      const row = {
+        slug: "special-chars",
+        properties: JSON.stringify({
+          published: ["2026-06-09T12:00:00Z"],
+          name: ["Title: with colon"],
+        }),
+        created_at: "2026-06-09T12:00:00Z",
+      };
+      const result = renderMdoc(row);
+      expect(result).toContain('title: "Title: with colon"');
+    });
+  });
+
+  describe("sync", () => {
+    let env;
+    let prepareStub;
+
+    beforeEach(() => {
+      prepareStub = vi.fn();
+      env = {
+        MICROPUB_DB: { prepare: prepareStub },
+        GITHUB_TOKEN: "ghp_test123",
+        GITHUB_REPO: "testowner/testrepo",
+        GITHUB_BRANCH: "main",
+      };
+    });
+
+    it("returns early when MICROPUB_DB is missing", async () => {
+      await sync({ GITHUB_TOKEN: "x", GITHUB_REPO: "a/b" });
+      expect(prepareStub).not.toHaveBeenCalled();
+    });
+
+    it("returns early when GITHUB_TOKEN is missing", async () => {
+      await sync({ MICROPUB_DB: {}, GITHUB_REPO: "a/b" });
+      expect(prepareStub).not.toHaveBeenCalled();
+    });
+
+    it("returns early when GITHUB_REPO is missing", async () => {
+      await sync({ MICROPUB_DB: {}, GITHUB_TOKEN: "x" });
+      expect(prepareStub).not.toHaveBeenCalled();
+    });
+
+    it("returns early when no unsynced rows", async () => {
+      prepareStub.mockReturnValue({
+        bind: vi.fn().mockReturnValue({
+          all: vi.fn().mockResolvedValue({ results: [] }),
+        }),
+      });
+      await sync(env);
+      expect(prepareStub).toHaveBeenCalledOnce();
+    });
+
+    it("queries for unsynced posts with BATCH_SIZE limit", async () => {
+      const bindFn = vi.fn().mockReturnValue({
+        all: vi.fn().mockResolvedValue({ results: [] }),
+      });
+      prepareStub.mockReturnValue({ bind: bindFn });
+      await sync(env);
+      expect(prepareStub).toHaveBeenCalledWith(
+        expect.stringContaining("synced = 0"),
+      );
+      expect(bindFn).toHaveBeenCalledWith(25);
+    });
+
+    it("marks row as synced after successful commit", async () => {
+      const updateBind = vi.fn().mockReturnValue({
+        run: vi.fn().mockResolvedValue({}),
+      });
+      const selectBind = vi.fn().mockReturnValue({
+        all: vi.fn().mockResolvedValue({
+          results: [
+            {
+              id: 1,
+              slug: "test-note",
+              properties: JSON.stringify({
+                published: ["2026-06-09T12:00:00Z"],
+                content: ["Test"],
+              }),
+              deleted: 0,
+              created_at: "2026-06-09T12:00:00Z",
+              updated_at: null,
+            },
+          ],
+        }),
+      });
+
+      let callCount = 0;
+      prepareStub.mockImplementation((sql) => {
+        if (sql.includes("SELECT")) return { bind: selectBind };
+        if (sql.includes("UPDATE")) return { bind: updateBind };
+        return { bind: vi.fn() };
+      });
+
+      // Mock global fetch for GitHub API calls
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce({
+          status: 404,
+          ok: false,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ content: { sha: "abc" } }),
+        });
+
+      try {
+        await sync(env);
+        expect(updateBind).toHaveBeenCalledWith(1);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("does not mark row synced on GitHub API failure", async () => {
+      const updateBind = vi.fn().mockReturnValue({
+        run: vi.fn().mockResolvedValue({}),
+      });
+      const selectBind = vi.fn().mockReturnValue({
+        all: vi.fn().mockResolvedValue({
+          results: [
+            {
+              id: 1,
+              slug: "fail-note",
+              properties: JSON.stringify({
+                published: ["2026-06-09T12:00:00Z"],
+              }),
+              deleted: 0,
+              created_at: "2026-06-09T12:00:00Z",
+              updated_at: null,
+            },
+          ],
+        }),
+      });
+
+      prepareStub.mockImplementation((sql) => {
+        if (sql.includes("SELECT")) return { bind: selectBind };
+        if (sql.includes("UPDATE")) return { bind: updateBind };
+        return { bind: vi.fn() };
+      });
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce({ status: 404, ok: false })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve("Internal Server Error"),
+        });
+
+      try {
+        await sync(env);
+        expect(updateBind).not.toHaveBeenCalled();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `template/worker/indieweb-bridge.js` — the D1→GitHub materializer that syncs unsynced Micropub records into Keystatic `.mdoc` files via the GitHub Contents API
- Wires the bridge into `site-entry.js` `queue()` and `scheduled()` exports via `ctx.waitUntil()` so it never blocks the Micropub 201 response
- Adds 20 tests covering mf2→mdoc rendering (title, photo, interactions, syndication, content extraction, YAML quoting) and sync behavior (guard clauses, success marking, failure resilience)

### Bridge design

1. **Queue-first, cron retry backstop** — runs on every queue batch and every scheduled cron tick
2. **Reads** unsynced records (`synced = 0`) from `MICROPUB_DB` in batches of 25
3. **Renders** mf2 properties → YAML frontmatter + markdoc body matching the `notes` collection schema
4. **Commits** via GitHub Contents API (`PUT`/`DELETE`) using the `GITHUB_TOKEN` secret
5. **Marks** `synced = 1` on success; leaves unsynced on failure for cron retry
6. **Deletes** committed `.mdoc` files when the D1 record is soft-deleted

### Eventual consistency model

- `q=source` is instant (reads D1)
- Public page is live after rebuild (~1–2 min, triggered by GitHub Actions deploy workflow on commit)
- D1 is the API-facing source of record; `.mdoc` → page is the eventually-consistent public copy

## Test plan

- [x] `renderMdoc` produces valid frontmatter with slug, publishDate, draft
- [x] mf2 property mapping: name→title, photo→image/imageAlt, in-reply-to, bookmark-of, like-of, repost-of, syndication
- [x] Content extraction: plain text, `{ value }` object, HTML stripping
- [x] Fallback to `created_at` when `published` is missing
- [x] YAML-special characters are properly quoted
- [x] `sync()` guards: returns early when MICROPUB_DB, GITHUB_TOKEN, or GITHUB_REPO is missing
- [x] `sync()` marks row synced after successful GitHub commit
- [x] `sync()` does NOT mark row synced on GitHub API failure
- [x] Existing test suite unaffected (3 pre-existing failures in git-signing-dependent tests)

## Depends on

`@dwk/micropub` npm publish; queue/scheduled composition (#330); GitHub Actions deploy workflow. **Blocked** for end-to-end testing.

Closes #333

https://claude.ai/code/session_01L7G889oyzz7xizd7jqez9G

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7G889oyzz7xizd7jqez9G)_