### PR TITLE
feat(scripts): deploy-scan integration for IndieWeb routes + secrets (#336)

### DIFF
--- a/docs/decisions/0007-mandatory-pre-deploy-scans.md
+++ b/docs/decisions/0007-mandatory-pre-deploy-scans.md
@@ -54,9 +54,11 @@ The `scripts/pre-deploy-check.ts` script runs before every deploy. The `/anglesi
 Four checks, all required:
 
 1. **PII scan** — greps `dist/` for email patterns (`@`) and phone patterns
-2. **Token scan** — greps `dist/`, `src/`, `public/` for API key patterns (`pat[A-Za-z0-9]{14,}`, `sk-[A-Za-z0-9]{20,}`)
+2. **Token scan** — greps `dist/`, `src/`, `public/`, `worker/`, and the wrangler configs for API key patterns (Airtable PATs, OpenAI `sk-` keys, GitHub `ghp_`/`github_pat_` tokens) and for the IndieWeb secret bindings (`INDIEAUTH_SIGNING_KEY`, `GITHUB_TOKEN`) committed as literals — name-only references (`env.GITHUB_TOKEN`, `${{ secrets.GITHUB_TOKEN }}`) never match
 3. **Third-party script check** — greps `dist/` for `<script src=` tags not from `cloudflareinsights` or `_astro`
 4. **Keystatic admin check** — finds any Keystatic routes in `dist/`
+
+The IndieWeb endpoints set up by `/anglesite:indieweb` (`/auth`, `/micropub`, `/media`, `/webmention`) are intentional public routes served by the site Worker — the route-shaped scans treat them as expected and never flag them (see ADR-0020).
 
 * Good, because automated, consistent, and non-bypassable
 * Good, because catches issues at the last possible moment before production

--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # PreToolUse hook: block deploys that fail security scans.
 # Reads tool input JSON from stdin. If the command pushes to main
-# (production deploy), runs 5 mandatory checks against dist/.
+# (production deploy), runs 6 mandatory checks against dist/ and source.
 # Returns JSON with permissionDecision "deny" to block, or exits 0 to allow.
 
 set -euo pipefail
@@ -66,9 +66,27 @@ if [[ -n "$PHONE_HITS" ]]; then
   REASONS+=("Possible phone number found in built HTML")
 fi
 
-# 2. Token scan — API tokens in dist/, src/, or public/
-if grep -rE '(pat[A-Za-z0-9]{14,}|sk-[A-Za-z0-9]{20,})' "$DIST/" src/ public/ 2>/dev/null | grep -q .; then
+# 2. Token scan — API tokens in dist/, src/, public/, worker/, and the
+# wrangler configs (worker/ and the configs are where the IndieWeb secret
+# bindings would land if committed instead of stored via `wrangler secret put`)
+TOKEN_SCAN_PATHS=("$DIST/")
+[[ -d src ]] && TOKEN_SCAN_PATHS+=(src/)
+[[ -d public ]] && TOKEN_SCAN_PATHS+=(public/)
+[[ -d worker ]] && TOKEN_SCAN_PATHS+=(worker/)
+[[ -f wrangler.jsonc ]] && TOKEN_SCAN_PATHS+=(wrangler.jsonc)
+[[ -f wrangler.toml ]] && TOKEN_SCAN_PATHS+=(wrangler.toml)
+
+# Airtable PATs, OpenAI sk- keys, GitHub classic (gh?_) and fine-grained PATs
+if grep -rE 'pat[A-Za-z0-9]{14}\.[A-Za-z0-9]{32,}|sk-[A-Za-z0-9]{20,}|gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{22,}' "${TOKEN_SCAN_PATHS[@]}" 2>/dev/null | grep -q .; then
   REASONS+=("API token pattern found in source or build output")
+fi
+
+# 2b. IndieWeb secret bindings (INDIEAUTH_SIGNING_KEY, GITHUB_TOKEN) committed
+# as literals. Name-only references never match — env.GITHUB_TOKEN,
+# ${{ secrets.GITHUB_TOKEN }}, and `wrangler secret put INDIEAUTH_SIGNING_KEY`
+# all lack a credential-shaped value after = or :
+if grep -rE '(INDIEAUTH_SIGNING_KEY|GITHUB_TOKEN)["'\'']?[[:space:]]*[:=][[:space:]]*["'\'']?[A-Za-z0-9+/_-]{16,}' "${TOKEN_SCAN_PATHS[@]}" 2>/dev/null | grep -q .; then
+  REASONS+=("INDIEAUTH_SIGNING_KEY or GITHUB_TOKEN committed in source — rotate it and store it with 'wrangler secret put'")
 fi
 
 # 3. Third-party scripts — unauthorized external JS (allowlist driven by .site-config)
@@ -107,7 +125,10 @@ check_third_party_scripts() {
 }
 check_third_party_scripts
 
-# 4. Keystatic admin routes — should never be in production
+# 4. Keystatic admin routes — should never be in production.
+# Note: the IndieWeb endpoints (/auth, /micropub, /media, /webmention) set up
+# by /anglesite:indieweb are Worker-served and intentionally public — they
+# never appear in dist/ and must not be added to this scan.
 if find "$DIST/" -path '*keystatic*' -type f 2>/dev/null | grep -q .; then
   REASONS+=("Keystatic admin routes found in build output")
 fi

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -247,6 +247,8 @@ LINK_CHECK_ALLOW=staging.example.com,internal.corp
 
 Multiple patterns are comma-separated. Wildcards are supported: `https://cdn.example.com/*`.
 
+IndieWeb endpoint routes (`/auth` and its subpaths, `/.well-known/oauth-authorization-server`, `/micropub`, `/media`, `/webmention`) are recognized automatically when the matching `INDIEWEB_*` flags are set in `.site-config` — they're served by the site Worker, not by files in `dist/`, so the link checker never reports them as broken. No allowlist entry needed.
+
 Present link health findings using the same severity mapping as other checks:
 - Broken internal links → **"Worth fixing soon"** with the affected page and target
 - Broken external links → **"Worth fixing soon"** (the linked site may be temporarily down — suggest re-checking)

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -83,6 +83,13 @@ Numbers are matched by digits, so formatting differences don't matter.
 
 Then re-run `npm run predeploy` to confirm it passes.
 
+### IndieWeb endpoints (if `/anglesite:indieweb` is set up)
+
+`/auth`, `/micropub`, `/media`, and `/webmention` are **intentional public routes** served by the site Worker — the scans expect them and never flag them. Two things the scan does enforce on an IndieWeb site:
+
+- **Secrets stay secret.** `INDIEAUTH_SIGNING_KEY` and `GITHUB_TOKEN` must be secret bindings (`npx wrangler secret put …` on the Worker, `gh secret set …` for the Actions workflow) — never literals in source, `worker/`, or the wrangler configs. The token scan blocks the deploy if either appears committed; rotate the leaked value first, then move it to the secret store.
+- **DPoP-only is by design.** The Micropub endpoint requires a DPoP proof on every request and binds the token subject to the configured `me` (`INDIEWEB_ME`). Bearer-only Micropub clients — including micropub.rocks' default flow — won't authenticate. That's intentional security posture, not a deploy regression: never "fix" 401s from bearer clients by weakening the endpoint. See `${CLAUDE_PLUGIN_ROOT}/docs/platforms/dwk-workers.md`.
+
 ## Step 2a — SEO audit (non-blocking)
 
 Run the SEO audit from `scripts/seo.ts` against the built output in `dist/`. This uses the same functions as `/anglesite:seo`:

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -169,7 +169,8 @@ If you changed it, document it. Same session. No exceptions.
 
 - `npm run predeploy` runs the security scan standalone. Use this to check before deploying.
 - On Cloudflare's build system, the build command `npm run build && npm run predeploy` ensures scans also run remotely.
-- Scans: PII (emails, phone numbers), API tokens, third-party scripts, Keystatic admin routes, OG images (warn only)
+- Scans: PII (emails, phone numbers), API tokens and committed secrets (including `INDIEAUTH_SIGNING_KEY` / `GITHUB_TOKEN` in `worker/` and the wrangler configs), third-party scripts, Keystatic admin routes, OG images (warn only)
+- The IndieWeb endpoints (`/auth`, `/micropub`, `/media`, `/webmention`) set up by `/anglesite:indieweb` are intentional public routes served by the Worker — the scans never flag them
 - If the site intentionally publishes a contact email (e.g., `mailto:` link), add it to `.site-config`: `PII_EMAIL_ALLOW=me@example.com`
 - If the site publishes phone numbers (business line, hotlines), add them to `.site-config`: `PII_PHONE_ALLOW=555-123-4567,1-800-662-4357`
 - Failed check exits with code 1 and blocks deployment. No exceptions, even if the owner asks.

--- a/template/scripts/link-check.ts
+++ b/template/scripts/link-check.ts
@@ -10,6 +10,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve, extname, dirname, posix } from "node:path";
 import { readConfig } from "./config.js";
+import { indiewebWorkerRoutes } from "./pre-deploy-check.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -93,6 +94,25 @@ export function normalizeInternalHref(href: string, sourcePath: string, distDir:
   const sourceRelative = sourcePath.replace(distDir, "").replace(/\\/g, "/");
   const sourceDir = posix.dirname(sourceRelative);
   return posix.resolve(sourceDir, clean);
+}
+
+/**
+ * Routes served by the site Worker rather than by files in dist/. Built from
+ * `.site-config`: each enabled IndieWeb endpoint flag contributes its route(s)
+ * (see `indiewebWorkerRoutes` in pre-deploy-check.ts). These are intentional
+ * public endpoints — the internal-link check must not report them as broken.
+ */
+export function getWorkerRoutes(read: (key: string) => string | undefined): string[] {
+  const routes: string[] = [];
+  for (const [flag, flagRoutes] of Object.entries(indiewebWorkerRoutes)) {
+    if (read(flag) === "true") routes.push(...flagRoutes);
+  }
+  return routes;
+}
+
+/** True when the href is a worker route or lives under one (e.g. /auth/token). */
+export function isWorkerRoute(normalizedHref: string, workerRoutes: string[]): boolean {
+  return workerRoutes.some(r => normalizedHref === r || normalizedHref.startsWith(r + "/"));
 }
 
 export function resolveInternalLink(normalizedHref: string, distDir: string): boolean {
@@ -329,6 +349,8 @@ export async function checkLinks(
     allowlist?: string[];
     externalTimeout?: number;
     externalRetries?: number;
+    /** Worker-served routes (from getWorkerRoutes) that resolve without a dist/ file. */
+    workerRoutes?: string[];
   } = {},
 ): Promise<LinkCheckResult> {
   const issues: LinkIssue[] = [];
@@ -351,6 +373,8 @@ export async function checkLinks(
         internalLinksChecked++;
         const normalized = normalizeInternalHref(href, file, distDir);
         if (!normalized) continue;
+
+        if (options.workerRoutes && isWorkerRoute(normalized, options.workerRoutes)) continue;
 
         const targetPath = normalized.endsWith("/") ? normalized : normalized + "/";
         const altPath = normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
@@ -497,8 +521,9 @@ if (process.argv[1]?.endsWith("link-check.ts")) {
   const jsonOutput = process.argv.includes("--json");
 
   const allowlist = parseAllowlist(readConfig("LINK_CHECK_ALLOW"));
+  const workerRoutes = getWorkerRoutes(readConfig);
 
-  checkLinks(DIST, { checkExternal, allowlist }).then((result) => {
+  checkLinks(DIST, { checkExternal, allowlist, workerRoutes }).then((result) => {
     if (jsonOutput) {
       console.log(JSON.stringify(result, null, 2));
     } else {

--- a/template/scripts/pre-deploy-check.ts
+++ b/template/scripts/pre-deploy-check.ts
@@ -3,7 +3,8 @@
  *
  * Scans:
  * 1. PII (emails, phone numbers in dist/)
- * 2. API tokens in dist/, src/, public/
+ * 2. API tokens and committed secret bindings in dist/, src/, public/,
+ *    worker/, and the wrangler configs
  * 3. Unauthorized third-party scripts
  * 4. Keystatic admin routes in production build
  * 5. OG image presence (warn only)
@@ -63,6 +64,40 @@ export const airtablePatPattern = /\bpat[A-Za-z0-9]{14}\.[A-Za-z0-9]{32,}\b/;
 
 /** OpenAI secret key: `sk-` + 20+ alphanumerics. */
 export const openaiKeyPattern = /\bsk-[A-Za-z0-9]{20,}\b/;
+
+/**
+ * GitHub tokens: classic prefixes (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`)
+ * and fine-grained PATs (`github_pat_`). The Micropub→GitHub bridge set up by
+ * /anglesite:indieweb uses a fine-grained PAT that must live in Cloudflare's
+ * secret store (`wrangler secret put GITHUB_TOKEN`), never in source.
+ */
+export const githubTokenPattern = /\bgh[pousr]_[A-Za-z0-9]{36,}\b|\bgithub_pat_[A-Za-z0-9_]{22,}\b/;
+
+/**
+ * IndieWeb secret bindings committed as literals. `INDIEAUTH_SIGNING_KEY` and
+ * `GITHUB_TOKEN` are wrangler / GitHub secrets — referencing the *name* is
+ * fine (`env.GITHUB_TOKEN`, `${{ secrets.GITHUB_TOKEN }}`, `wrangler secret
+ * put INDIEAUTH_SIGNING_KEY`), but a credential-shaped literal assigned to
+ * either name means the secret was committed. The value class excludes `$`,
+ * `<`, and `.` so env interpolations, doc placeholders, and property accesses
+ * never match.
+ */
+export const committedSecretPattern = /\b(?:INDIEAUTH_SIGNING_KEY|GITHUB_TOKEN)["']?\s*[:=]\s*["']?[A-Za-z0-9+/_-]{16,}/;
+
+/**
+ * IndieWeb endpoints served by the site Worker (`worker/site-entry.js`), set
+ * up by /anglesite:indieweb and keyed by their `.site-config` feature flag.
+ * These are intentional public routes — route-shaped scans (the Keystatic
+ * admin-route scan here, the internal-link check in link-check.ts) must never
+ * flag them. They have no files in dist/: the Worker answers these paths
+ * before falling through to static assets. `/auth` covers everything under it
+ * (e.g. `/auth/token`).
+ */
+export const indiewebWorkerRoutes: Readonly<Record<string, readonly string[]>> = {
+  INDIEWEB_INDIEAUTH: ["/auth", "/.well-known/oauth-authorization-server"],
+  INDIEWEB_MICROPUB: ["/micropub", "/media"],
+  INDIEWEB_WEBMENTION: ["/webmention"],
+};
 
 /** @deprecated Use airtablePatPattern or openaiKeyPattern. Kept for backwards-compatible imports. */
 export const tokenPattern = new RegExp(`${airtablePatPattern.source}|${openaiKeyPattern.source}`);
@@ -147,18 +182,31 @@ export function scanPhones(content: string, allowlist: string[] = []): string[] 
   return matches.filter(m => !allowed.has(norm(m)));
 }
 
-export type TokenKind = "airtable-pat" | "openai-key";
+export type TokenKind = "airtable-pat" | "openai-key" | "github-token" | "committed-secret-binding";
 
 export function scanTokens(content: string): TokenKind[] {
   const found: TokenKind[] = [];
   if (airtablePatPattern.test(content)) found.push("airtable-pat");
   if (openaiKeyPattern.test(content)) found.push("openai-key");
+  if (githubTokenPattern.test(content)) found.push("github-token");
+  if (committedSecretPattern.test(content)) found.push("committed-secret-binding");
   return found;
 }
 
 const tokenLabels: Record<TokenKind, string> = {
   "airtable-pat": "Airtable Personal Access Token",
   "openai-key": "OpenAI secret key",
+  "github-token": "GitHub token",
+  "committed-secret-binding": "Committed secret binding (INDIEAUTH_SIGNING_KEY / GITHUB_TOKEN)",
+};
+
+const tokenRemediations: Record<TokenKind, string> = {
+  "airtable-pat": "Rotate this credential immediately and move it to a runtime environment variable.",
+  "openai-key": "Rotate this credential immediately and move it to a runtime environment variable.",
+  "github-token":
+    "Rotate this token immediately, then store it with `npx wrangler secret put GITHUB_TOKEN` (and `gh secret set` for the Actions workflow).",
+  "committed-secret-binding":
+    "This is a secret binding — rotate the leaked value, then store it with `npx wrangler secret put <NAME>`. It must never appear in source or wrangler config.",
 };
 
 export function scanScripts(content: string, scriptAllowlist?: string[]): string[] {
@@ -358,28 +406,41 @@ export function runScan(input: { siteDir: string }): ScanReport {
     }
   }
 
-  // 2. Exposed tokens in dist/, src/, public/
-  for (const dir of [distDir, resolve(input.siteDir, "src"), resolve(input.siteDir, "public")]) {
-    if (!existsSync(dir)) continue;
-    for (const file of walkAll(dir)) {
-      let content: string;
-      try {
-        content = readFileSync(file, "utf-8");
-      } catch {
-        continue; // binary file
-      }
-      for (const kind of scanTokens(content)) {
-        failures.push({
-          category: "exposed-token",
-          file: relativeToSite(file),
-          detail: `${tokenLabels[kind]} pattern detected`,
-          remediation: `Rotate this credential immediately and move it to a runtime environment variable.`,
-        });
-      }
+  // 2. Exposed tokens in dist/, src/, public/, worker/, and the wrangler
+  //    configs. worker/ and the configs are where the IndieWeb secret
+  //    bindings (INDIEAUTH_SIGNING_KEY, GITHUB_TOKEN) would land if someone
+  //    committed them instead of using `wrangler secret put`.
+  const tokenScanFiles = [
+    distDir,
+    resolve(input.siteDir, "src"),
+    resolve(input.siteDir, "public"),
+    resolve(input.siteDir, "worker"),
+  ].flatMap(dir => walkAll(dir));
+  for (const name of ["wrangler.jsonc", "wrangler.toml"]) {
+    const full = resolve(input.siteDir, name);
+    if (existsSync(full)) tokenScanFiles.push(full);
+  }
+  for (const file of tokenScanFiles) {
+    let content: string;
+    try {
+      content = readFileSync(file, "utf-8");
+    } catch {
+      continue; // binary file
+    }
+    for (const kind of scanTokens(content)) {
+      failures.push({
+        category: "exposed-token",
+        file: relativeToSite(file),
+        detail: `${tokenLabels[kind]} pattern detected`,
+        remediation: tokenRemediations[kind],
+      });
     }
   }
 
-  // 4. Keystatic admin routes leaking into dist/
+  // 4. Keystatic admin routes leaking into dist/. The IndieWeb endpoints
+  //    (/auth, /micropub, /media, /webmention — see indiewebWorkerRoutes) are
+  //    Worker-served, intentionally public, and never appear in dist/; do not
+  //    extend this scan to flag them.
   for (const file of walkAll(distDir).filter(f => f.includes("keystatic"))) {
     failures.push({
       category: "keystatic-route",
@@ -517,19 +578,21 @@ if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
     }
   }
 
-  // 2. Token scan — API keys in dist/, src/, public/
-  const scanDirs = [DIST, "src", "public"].filter(existsSync);
+  // 2. Token scan — API keys and committed secret bindings in dist/, src/,
+  //    public/, worker/, and the wrangler configs
+  const tokenScanFiles = [
+    ...[DIST, "src", "public", "worker"].flatMap(dir => walkAll(dir)),
+    ...["wrangler.jsonc", "wrangler.toml"].filter(f => existsSync(f)),
+  ];
 
-  for (const dir of scanDirs) {
-    for (const file of walkAll(dir)) {
-      try {
-        const content = readFileSync(file, "utf-8");
-        for (const kind of scanTokens(content)) {
-          failures.push(`TOKEN: ${tokenLabels[kind]} found in ${file} — rotate this credential immediately`);
-        }
-      } catch {
-        // Binary file, skip
+  for (const file of tokenScanFiles) {
+    try {
+      const content = readFileSync(file, "utf-8");
+      for (const kind of scanTokens(content)) {
+        failures.push(`TOKEN: ${tokenLabels[kind]} found in ${file} — ${tokenRemediations[kind]}`);
       }
+    } catch {
+      // Binary file, skip
     }
   }
 
@@ -543,7 +606,8 @@ if (process.argv[1]?.endsWith("pre-deploy-check.ts")) {
     }
   }
 
-  // 4. Keystatic admin routes
+  // 4. Keystatic admin routes. IndieWeb worker routes (/auth, /micropub,
+  //    /media, /webmention) are intentional public endpoints — never flag them.
   const keystatic = walkAll(DIST).filter(f => f.includes("keystatic"));
   if (keystatic.length > 0) {
     failures.push(`KEYSTATIC: admin routes found in production build: ${keystatic.join(", ")}`);

--- a/tests/link-check.test.ts
+++ b/tests/link-check.test.ts
@@ -16,6 +16,8 @@ import {
   isAllowlisted,
   checkLinks,
   formatReport,
+  getWorkerRoutes,
+  isWorkerRoute,
 } from "../template/scripts/link-check.js";
 
 // ---------------------------------------------------------------------------
@@ -437,6 +439,82 @@ describe("checkLinks", () => {
 
     const result = await checkLinks(tmpDir);
     expect(result.stats.pagesScanned).toBe(3);
+  });
+
+  it("does not flag IndieWeb worker routes when workerRoutes are passed", async () => {
+    writeFileSync(
+      join(tmpDir, "index.html"),
+      `<html><head>
+        <link rel="indieauth-metadata" href="/.well-known/oauth-authorization-server" />
+        <link rel="authorization_endpoint" href="/auth" />
+        <link rel="token_endpoint" href="/auth/token" />
+        <link rel="micropub" href="/micropub" />
+        <link rel="webmention" href="/webmention" />
+      </head><body>Hi</body></html>`,
+    );
+
+    const workerRoutes = getWorkerRoutes((key) =>
+      ["INDIEWEB_INDIEAUTH", "INDIEWEB_MICROPUB", "INDIEWEB_WEBMENTION"].includes(key)
+        ? "true"
+        : undefined,
+    );
+    const result = await checkLinks(tmpDir, { workerRoutes });
+    expect(result.stats.brokenInternal).toBe(0);
+  });
+
+  it("still flags worker-route paths when IndieWeb is not configured", async () => {
+    writeFileSync(
+      join(tmpDir, "index.html"),
+      '<html><head><link rel="webmention" href="/webmention" /></head><body>Hi</body></html>',
+    );
+
+    const result = await checkLinks(tmpDir, { workerRoutes: [] });
+    expect(result.stats.brokenInternal).toBe(1);
+    expect(result.issues[0].target).toBe("/webmention");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getWorkerRoutes / isWorkerRoute — IndieWeb endpoints (issue #336)
+// ---------------------------------------------------------------------------
+
+describe("getWorkerRoutes", () => {
+  it("returns no routes when no IndieWeb flags are set", () => {
+    expect(getWorkerRoutes(() => undefined)).toEqual([]);
+  });
+
+  it("maps each enabled endpoint flag to its routes", () => {
+    const config: Record<string, string> = {
+      INDIEWEB_INDIEAUTH: "true",
+      INDIEWEB_MICROPUB: "true",
+      INDIEWEB_WEBMENTION: "true",
+    };
+    const routes = getWorkerRoutes((key) => config[key]);
+    expect(routes).toContain("/auth");
+    expect(routes).toContain("/.well-known/oauth-authorization-server");
+    expect(routes).toContain("/micropub");
+    expect(routes).toContain("/media");
+    expect(routes).toContain("/webmention");
+  });
+
+  it("omits routes for disabled endpoints", () => {
+    const routes = getWorkerRoutes((key) =>
+      key === "INDIEWEB_WEBMENTION" ? "true" : undefined,
+    );
+    expect(routes).toEqual(["/webmention"]);
+  });
+});
+
+describe("isWorkerRoute", () => {
+  it("matches exact routes and subpaths", () => {
+    expect(isWorkerRoute("/auth", ["/auth"])).toBe(true);
+    expect(isWorkerRoute("/auth/token", ["/auth"])).toBe(true);
+    expect(isWorkerRoute("/webmention", ["/webmention"])).toBe(true);
+  });
+
+  it("does not match sibling paths sharing a prefix", () => {
+    expect(isWorkerRoute("/authors", ["/auth"])).toBe(false);
+    expect(isWorkerRoute("/authors/jane", ["/auth"])).toBe(false);
   });
 });
 

--- a/tests/pre-deploy-check.test.ts
+++ b/tests/pre-deploy-check.test.ts
@@ -14,6 +14,7 @@ import {
   formatMaintenanceWarning,
   maintenanceCategories,
   isReservedExampleEmail,
+  indiewebWorkerRoutes,
 } from "../template/scripts/pre-deploy-check.js";
 
 // ---------------------------------------------------------------------------
@@ -21,12 +22,31 @@ import {
 // ---------------------------------------------------------------------------
 
 describe("pre-deploy-check.sh safety", () => {
+  const src = readFileSync(
+    resolve(__dirname, "../scripts/pre-deploy-check.sh"),
+    "utf-8",
+  );
+
   it("does not use eval for script grep", () => {
-    const src = readFileSync(
-      resolve(__dirname, "../scripts/pre-deploy-check.sh"),
-      "utf-8",
-    );
     expect(src).not.toContain("eval ");
+  });
+
+  it("scans worker/ and the wrangler configs for tokens", () => {
+    expect(src).toContain("worker/");
+    expect(src).toContain("wrangler.jsonc");
+    expect(src).toContain("wrangler.toml");
+  });
+
+  it("greps for GitHub token shapes and committed IndieWeb secret bindings", () => {
+    expect(src).toContain("github_pat_");
+    expect(src).toContain("INDIEAUTH_SIGNING_KEY");
+    expect(src).toContain("GITHUB_TOKEN");
+  });
+
+  it("documents the IndieWeb worker routes as intentional public endpoints", () => {
+    for (const route of ["/auth", "/micropub", "/media", "/webmention"]) {
+      expect(src).toContain(route);
+    }
   });
 });
 
@@ -209,6 +229,95 @@ describe("scanTokens", () => {
     const sk = "sk-" + "C".repeat(40);
     expect(scanTokens(`${pat} and ${sk}`).sort()).toEqual(["airtable-pat", "openai-key"]);
   });
+
+  it("detects classic GitHub PATs (ghp_ + 36 chars)", () => {
+    expect(scanTokens("token: ghp_" + "A".repeat(36))).toEqual(["github-token"]);
+  });
+
+  it("detects other classic GitHub token prefixes (gho_, ghu_, ghs_, ghr_)", () => {
+    for (const prefix of ["gho_", "ghu_", "ghs_", "ghr_"]) {
+      expect(scanTokens(`${prefix}${"B".repeat(36)}`)).toEqual(["github-token"]);
+    }
+  });
+
+  it("detects fine-grained GitHub PATs (github_pat_…)", () => {
+    const token = "github_pat_" + "A".repeat(22) + "_" + "B".repeat(59);
+    expect(scanTokens(token)).toEqual(["github-token"]);
+  });
+
+  it("ignores short gh-prefixed strings", () => {
+    expect(scanTokens("ghp_tooshort")).toEqual([]);
+  });
+
+  it("flags a committed INDIEAUTH_SIGNING_KEY literal (wrangler vars, .env, source)", () => {
+    const key = "a1b2c3d4".repeat(8); // openssl rand -hex 32 shape
+    expect(scanTokens(`INDIEAUTH_SIGNING_KEY=${key}`)).toEqual(["committed-secret-binding"]);
+    expect(scanTokens(`"INDIEAUTH_SIGNING_KEY": "${key}"`)).toEqual(["committed-secret-binding"]);
+    expect(scanTokens(`INDIEAUTH_SIGNING_KEY = "${key}"`)).toEqual(["committed-secret-binding"]);
+  });
+
+  it("flags a committed GITHUB_TOKEN literal (both as binding and token shape)", () => {
+    const result = scanTokens(`GITHUB_TOKEN="ghp_${"A".repeat(36)}"`).sort();
+    expect(result).toEqual(["committed-secret-binding", "github-token"]);
+  });
+
+  it("ignores secret *name* references — env access, Actions secrets, wrangler put, docs", () => {
+    expect(scanTokens("if (!env.MICROPUB_DB || !env.GITHUB_TOKEN || !env.GITHUB_REPO) return;")).toEqual([]);
+    expect(scanTokens("GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}")).toEqual([]);
+    expect(scanTokens("npx wrangler secret put INDIEAUTH_SIGNING_KEY --name my-site")).toEqual([]);
+    expect(scanTokens("gh secret set GITHUB_TOKEN --repo owner/site")).toEqual([]);
+    expect(scanTokens("*   GITHUB_TOKEN (secret) — Fine-grained PAT, contents:write only")).toEqual([]);
+    expect(scanTokens("INDIEAUTH_SIGNING_KEY: string;")).toEqual([]);
+    expect(scanTokens('GITHUB_TOKEN="$GITHUB_TOKEN"')).toEqual([]);
+    expect(scanTokens("GITHUB_TOKEN=<paste-your-token-here>")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// indiewebWorkerRoutes — intentional public endpoints (issue #336)
+// ---------------------------------------------------------------------------
+
+describe("indiewebWorkerRoutes", () => {
+  it("covers the four intentional public endpoints", () => {
+    const all = Object.values(indiewebWorkerRoutes).flat();
+    for (const route of ["/auth", "/micropub", "/media", "/webmention"]) {
+      expect(all).toContain(route);
+    }
+  });
+
+  it("keys each route group by its .site-config feature flag", () => {
+    expect(Object.keys(indiewebWorkerRoutes).sort()).toEqual([
+      "INDIEWEB_INDIEAUTH",
+      "INDIEWEB_MICROPUB",
+      "INDIEWEB_WEBMENTION",
+    ]);
+  });
+
+  it("includes the IndieAuth metadata discovery path", () => {
+    expect(indiewebWorkerRoutes.INDIEWEB_INDIEAUTH).toContain(
+      "/.well-known/oauth-authorization-server",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Template files must never trip the token scan (false-positive regression)
+// ---------------------------------------------------------------------------
+
+describe("template IndieWeb files never trip the token scan", () => {
+  const templateFiles = [
+    "../template/worker/site-entry.js",
+    "../template/worker/indieweb-bridge.js",
+    "../template/wrangler.jsonc",
+    "../template/.github/workflows/deploy.yml",
+  ];
+
+  for (const rel of templateFiles) {
+    it(`${rel.replace("../template/", "")} is clean`, () => {
+      const content = readFileSync(resolve(__dirname, rel), "utf-8");
+      expect(scanTokens(content)).toEqual([]);
+    });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/pre-deploy-scan.test.ts
+++ b/tests/pre-deploy-scan.test.ts
@@ -96,6 +96,67 @@ describe("runScan", () => {
     expect(tokenFailure.remediation).toMatch(/rotate/i);
   });
 
+  it("flags a committed GITHUB_TOKEN in worker/ as an exposed-token failure", () => {
+    writeFile("dist/index.html", "<!doctype html><p>hi</p>");
+    writeFile("worker/site-entry.js", `const GITHUB_TOKEN = "ghp_${"A".repeat(36)}";`);
+
+    const report = runScan({ siteDir: site });
+
+    expect(report.ok).toBe(false);
+    const tokenFailures = report.failures.filter(f => f.category === "exposed-token");
+    expect(tokenFailures.length).toBeGreaterThan(0);
+    expect(tokenFailures[0].file).toBe("worker/site-entry.js");
+  });
+
+  it("flags a committed INDIEAUTH_SIGNING_KEY in wrangler.jsonc with a secret-store remediation", () => {
+    writeFile("dist/index.html", "<!doctype html><p>hi</p>");
+    writeFile(
+      "wrangler.jsonc",
+      `{ "vars": { "INDIEAUTH_SIGNING_KEY": "${"ab01cd23".repeat(8)}" } }`,
+    );
+
+    const report = runScan({ siteDir: site });
+
+    expect(report.ok).toBe(false);
+    const failure = report.failures.find(f => f.category === "exposed-token");
+    expect(failure).toBeDefined();
+    expect(failure!.file).toBe("wrangler.jsonc");
+    expect(failure!.remediation).toContain("wrangler secret put");
+  });
+
+  it("passes on a correctly-configured IndieWeb site (intentional routes, secrets as bindings)", () => {
+    writeFile(
+      "dist/index.html",
+      `<!doctype html><html><head>
+        <meta property="og:image" content="/og.png">
+        <link rel="indieauth-metadata" href="/.well-known/oauth-authorization-server" />
+        <link rel="authorization_endpoint" href="/auth" />
+        <link rel="token_endpoint" href="/auth/token" />
+        <link rel="micropub" href="/micropub" />
+        <link rel="webmention" href="/webmention" />
+      </head><body><h1>Hi</h1></body></html>`,
+    );
+    writeFile("dist/notes/index.html", "<!doctype html><h1>Notes</h1>");
+    // Worker references the secrets by *name* only — the correct posture.
+    writeFile(
+      "worker/site-entry.js",
+      "export default { fetch(request, env) { if (!env.INDIEAUTH_SIGNING_KEY || !env.GITHUB_TOKEN) {} } };\n",
+    );
+    writeFile(
+      "wrangler.jsonc",
+      '{ "d1_databases": [{ "binding": "AUTH_DB", "database_name": "indieauth", "database_id": "abc" }] }',
+    );
+    writeFile(
+      ".site-config",
+      "INDIEWEB_ENABLED=true\nINDIEWEB_INDIEAUTH=true\nINDIEWEB_MICROPUB=true\nINDIEWEB_WEBMENTION=true\n",
+    );
+
+    const report = runScan({ siteDir: site });
+
+    expect(report.ok).toBe(true);
+    expect(report.failures).toEqual([]);
+  });
+
   it("flags an unauthorized third-party script as a third-party-script failure", () => {
     writeFile(
       "dist/index.html",


### PR DESCRIPTION
Closes #336.

Implements the deploy-scan integration promised by ADR-0020 §6 / the active-IndieWeb design (`docs/superpowers/specs/2026-06-09-active-indieweb-design.md` §6).

## Intentional public routes

- New `indiewebWorkerRoutes` export in `template/scripts/pre-deploy-check.ts` — the canonical map of `.site-config` flag → Worker-served routes (`/auth` + `/.well-known/oauth-authorization-server`, `/micropub` + `/media`, `/webmention`).
- `link-check.ts` no longer reports the discovery `<link>` hrefs as broken internal links: `getWorkerRoutes()` builds the allow-set from the `INDIEWEB_*` flags and `isWorkerRoute()` matches exact routes and subpaths (`/auth/token` resolves; `/authors` does not). Wired into the CLI automatically.
- The Keystatic-admin route scans (shell hook + TS, both modes) now document that the IndieWeb endpoints are intentionally public and must never be flagged — they have no `dist/` files, so a regression test locks in that a correctly-configured IndieWeb site passes `runScan` clean.

## Token scan: secrets must be bindings

- New patterns: GitHub tokens (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_` classic, `github_pat_` fine-grained) and `INDIEAUTH_SIGNING_KEY` / `GITHUB_TOKEN` committed as credential-shaped literals.
- Scan coverage extended to `worker/` and the root wrangler configs (`wrangler.jsonc`, `wrangler.toml`) — exactly where those bindings would land if someone committed them instead of `wrangler secret put`. Applied in `runScan` (app JSON mode), the per-site CLI, and the plugin's PreToolUse shell hook.
- No false positives on name-only references: `env.GITHUB_TOKEN`, `${{ secrets.GITHUB_TOKEN }}`, `wrangler secret put INDIEAUTH_SIGNING_KEY`, JSDoc mentions, and TS type declarations all stay clean (tested, including a regression suite over the shipped template worker files and Actions workflow).
- Remediation text for these kinds points at `wrangler secret put` + rotation rather than the generic env-var advice.

## DPoP posture documented as intentional

- `skills/deploy/SKILL.md` Step 2 gains an "IndieWeb endpoints" note: routes are expected, secrets are enforced as bindings, and DPoP-everywhere + `me`-subject binding is deliberate — bearer-only Micropub clients (incl. micropub.rocks' default flow) won't authenticate, and 401s from them are not a deploy regression.
- ADR-0007, `skills/check/SKILL.md` (link-health section), and `template/CLAUDE.md` updated to match.

## Verification

- `tests/pre-deploy-check.test.ts`, `tests/pre-deploy-scan.test.ts`, `tests/link-check.test.ts`: 157/157 pass (38 new cases).
- Shell hook exercised end-to-end in a temp site: clean IndieWeb site (discovery links + `env.*` secret references + D1 bindings) passes; a committed `GITHUB_TOKEN` literal blocks the push with both the token-pattern and secret-binding reasons.
- Full suite: 2470 pass; the 18 failures (`test/edit-history`, `test/undo-edit`, `test/apply-edit-dispatcher`) are pre-existing sandbox issues (git commit signing unavailable; root bypasses chmod) and reproduce on the unmodified tree.

https://claude.ai/code/session_01PwZ8EtfmTGnsvbjR6xu5wL

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwZ8EtfmTGnsvbjR6xu5wL)_