### PR TITLE
test(indieweb): plugin-side tests for dispatch, discovery links, notes, bindings, edge-render

### DIFF
--- a/template/src/pages/blog/[slug].astro
+++ b/template/src/pages/blog/[slug].astro
@@ -112,6 +112,11 @@ const giscusProps = showComments
     }
   </article>
 
+  {/* Webmentions are injected here at the edge by worker/site-entry.js when
+      WEBMENTION_DB holds verified mentions of this page. Empty in the static
+      build; populated per-request without client JS. See docs/indieweb.md. */}
+  <div id="webmentions"></div>
+
   {giscusProps && giscusProps.repoId && giscusProps.categoryId && (
     <Comments {...giscusProps} />
   )}

--- a/template/src/pages/notes/[slug].astro
+++ b/template/src/pages/notes/[slug].astro
@@ -112,4 +112,9 @@ const pageTitle = note.data.title
       )
     }
   </article>
+
+  {/* Webmentions are injected here at the edge by worker/site-entry.js when
+      WEBMENTION_DB holds verified mentions of this page. Empty in the static
+      build; populated per-request without client JS. See docs/indieweb.md. */}
+  <div id="webmentions"></div>
 </BaseLayout>

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -14,6 +14,13 @@
  *      <meta name="cf-country"> into HTML responses so the consent banner
  *      runtime can apply EU/UK default-deny on first paint. Configured by
  *      /anglesite:consent.
+ *   4. IndieWeb endpoints — IndieAuth (/auth), Micropub (/micropub, /media),
+ *      and Webmention (/webmention) handlers, each gated on its D1 binding.
+ *      Configured by /anglesite:indieweb.
+ *   5. Webmention edge-render — on note/post HTML responses, injects any
+ *      stored mentions of that page into a <div id="webmentions"> container
+ *      via HTMLRewriter. Gated to note/post target paths that actually have
+ *      mentions — no WEBMENTION_DB query or rewrite is paid otherwise.
  *
  * Every feature is gated on its binding/var being present, so a site that
  * hasn't run any of these skills serves identically to a bare ASSETS-only
@@ -151,6 +158,29 @@ const worker = {
       }
     }
 
+    // 5. Webmention edge-render — inject stored mentions into note/post pages.
+    //    Gating order keeps the cost off pages that can't have mentions:
+    //    HTML request → WEBMENTION_DB bound → known target path → HTML
+    //    response → only then query D1. The rewrite is skipped entirely when
+    //    the page has no stored mentions, so a mention-free site pays nothing
+    //    beyond the guard checks.
+    if (
+      isHtmlRequest &&
+      env.WEBMENTION_DB &&
+      isWebmentionTarget(url.pathname)
+    ) {
+      const contentType = response.headers.get("content-type") ?? "";
+      if (contentType.includes("text/html")) {
+        const target = `${url.origin}${url.pathname}`;
+        const mentions = await loadWebmentions(env.WEBMENTION_DB, target);
+        if (mentions.length > 0) {
+          response = new HTMLRewriter()
+            .on("#webmentions", new WebmentionInjector(mentions))
+            .transform(response);
+        }
+      }
+    }
+
     if (setCookieHeader) {
       const headers = new Headers(response.headers);
       headers.append("Set-Cookie", setCookieHeader);
@@ -189,6 +219,84 @@ class CountryInjector {
   element(el) {
     el.append(`<meta name="cf-country" content="${this.country}">`, { html: true });
   }
+}
+
+// ---------------------------------------------------------------------------
+// Webmention edge-render helpers (§3.5 of the active-IndieWeb design)
+// ---------------------------------------------------------------------------
+
+// Only note and blog-post permalinks can be webmention targets. The collection
+// index pages (`/notes`, `/blog`) are excluded — the trailing-slash strip means
+// a bare `/notes` never matches `"/notes/"`.
+function isWebmentionTarget(pathname) {
+  const p = pathname.replace(/\/+$/, "");
+  return p.startsWith("/notes/") || p.startsWith("/blog/");
+}
+
+// Query WEBMENTION_DB for verified mentions of a target URL. The table/columns
+// follow @dwk/webmention's inbox shape; a query failure degrades to "no
+// mentions" so a transient D1 error never breaks the page render.
+async function loadWebmentions(db, target) {
+  try {
+    const rows = await db
+      .prepare(
+        `SELECT author_name, author_url, author_photo, content, url, type, published
+         FROM webmentions
+         WHERE target = ?1 AND status = 'verified'
+         ORDER BY published ASC`,
+      )
+      .bind(target)
+      .all();
+    return rows?.results ?? [];
+  } catch (err) {
+    console.error("Webmention edge-render query failed:", err?.message);
+    return [];
+  }
+}
+
+class WebmentionInjector {
+  constructor(mentions) {
+    this.mentions = mentions;
+  }
+  element(el) {
+    const items = this.mentions.map(renderMention).join("");
+    el.setInnerContent(
+      `<h2 class="webmentions-title">Mentions</h2>` +
+        `<ol class="webmentions-list">${items}</ol>`,
+      { html: true },
+    );
+  }
+}
+
+function renderMention(m) {
+  const name = escapeHtml(m.author_name || m.author_url || "Someone");
+  const photo = m.author_photo
+    ? `<img class="u-photo" src="${escapeHtml(m.author_photo)}" alt="" width="48" height="48" />`
+    : "";
+  const author = m.author_url
+    ? `<a class="p-author h-card u-url" href="${escapeHtml(m.author_url)}">${name}</a>`
+    : `<span class="p-author">${name}</span>`;
+  const content = m.content
+    ? `<div class="p-content">${escapeHtml(m.content)}</div>`
+    : "";
+  const permalink = m.url
+    ? `<a class="u-url" href="${escapeHtml(m.url)}">permalink</a>`
+    : "";
+  return `<li class="h-cite">${photo}${author}${content}${permalink}</li>`;
+}
+
+function escapeHtml(value) {
+  return String(value).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[c],
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/__stubs__/dwk-indieauth.ts
+++ b/tests/__stubs__/dwk-indieauth.ts
@@ -1,0 +1,14 @@
+// Stub for the unpublished @dwk/indieauth package. site-entry.js composes the
+// real handler at module load; in tests we only need a tagged handler so the
+// dispatch assertions can prove which endpoint a request reached. Tests never
+// mock this — the stub IS the substitute (the real package is 0.0.0/unpublished).
+export function createHandler(_config?: unknown) {
+  return Object.assign(
+    (_request: Request, _env: unknown, _ctx: unknown) =>
+      new Response("indieauth", { headers: { "x-handler": "indieauth" } }),
+    {
+      queue: async () => {},
+      scheduled: async () => {},
+    },
+  );
+}

--- a/tests/__stubs__/dwk-micropub.ts
+++ b/tests/__stubs__/dwk-micropub.ts
@@ -1,0 +1,13 @@
+// Stub for the unpublished @dwk/micropub package. See dwk-indieauth.ts for the
+// rationale. site-entry.js calls createHandler({ generatePostUrl }); the stub
+// accepts and ignores config and returns a tagged handler.
+export function createHandler(_config?: unknown) {
+  return Object.assign(
+    (_request: Request, _env: unknown, _ctx: unknown) =>
+      new Response("micropub", { headers: { "x-handler": "micropub" } }),
+    {
+      queue: async () => {},
+      scheduled: async () => {},
+    },
+  );
+}

--- a/tests/__stubs__/dwk-webmention.ts
+++ b/tests/__stubs__/dwk-webmention.ts
@@ -1,0 +1,30 @@
+// Stub for the unpublished @dwk/webmention package. See dwk-indieauth.ts for
+// the rationale. This stub also records queue/scheduled invocations on a shared
+// `webmentionCalls` object so the queue()/scheduled() dispatch tests can assert
+// that the webmention worker hooks run only when WEBMENTION_DB is bound.
+// Because the vitest alias maps "@dwk/webmention" to this same file, the test
+// and site-entry.js share one module instance — and therefore one counter.
+export const webmentionCalls = { fetch: 0, queue: 0, scheduled: 0 };
+
+export function resetWebmentionCalls() {
+  webmentionCalls.fetch = 0;
+  webmentionCalls.queue = 0;
+  webmentionCalls.scheduled = 0;
+}
+
+export function createHandler(_config?: unknown) {
+  return Object.assign(
+    (_request: Request, _env: unknown, _ctx: unknown) => {
+      webmentionCalls.fetch++;
+      return new Response("webmention", { headers: { "x-handler": "webmention" } });
+    },
+    {
+      queue: async () => {
+        webmentionCalls.queue++;
+      },
+      scheduled: async () => {
+        webmentionCalls.scheduled++;
+      },
+    },
+  );
+}

--- a/tests/indieweb-dispatch.test.ts
+++ b/tests/indieweb-dispatch.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Plugin-side tests for the IndieWeb runtime wiring in
+ * `template/worker/site-entry.js` (issue #337, design §7):
+ *
+ *   - Gated endpoint dispatch — each route fires only when its binding is
+ *     present, and falls through to ASSETS otherwise.
+ *   - queue()/scheduled() hooks — webmention drain runs only with
+ *     WEBMENTION_DB; the Micropub bridge sync always runs via waitUntil.
+ *   - Webmention edge-render gating — no WEBMENTION_DB query and no rewrite
+ *     unless the request is for a note/post HTML page that actually has
+ *     stored mentions.
+ *
+ * The @dwk/* handlers are unpublished; vitest aliases them to tagged stubs
+ * (tests/__stubs__/dwk-*.ts) so the real worker imports cleanly and each
+ * dispatch target is identifiable by its `x-handler` response header.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import worker from "../template/worker/site-entry.js";
+import {
+  webmentionCalls,
+  resetWebmentionCalls,
+} from "./__stubs__/dwk-webmention";
+
+function makeCtx() {
+  return { waitUntil: vi.fn(), passThroughOnException: vi.fn() };
+}
+
+function assetsResponse(
+  body = "<html><body>asset</body></html>",
+  contentType = "text/html",
+) {
+  return new Response(body, {
+    headers: { "content-type": contentType, "x-asset": "1" },
+  });
+}
+
+function makeEnv(overrides: Record<string, unknown> = {}) {
+  return {
+    ASSETS: { fetch: vi.fn(async () => assetsResponse()) },
+    ...overrides,
+  } as any;
+}
+
+function req(
+  path: string,
+  { method = "GET", accept }: { method?: string; accept?: string } = {},
+) {
+  const headers: Record<string, string> = {};
+  if (accept) headers.Accept = accept;
+  return new Request(`https://example.com${path}`, { method, headers });
+}
+
+beforeEach(() => {
+  resetWebmentionCalls();
+});
+
+describe("IndieWeb endpoint dispatch (gated on bindings)", () => {
+  it("routes /auth to the IndieAuth handler when AUTH_DB is bound", async () => {
+    const env = makeEnv({ AUTH_DB: {} });
+    const res = await worker.fetch(req("/auth"), env, makeCtx());
+    expect(res.headers.get("x-handler")).toBe("indieauth");
+    expect(env.ASSETS.fetch).not.toHaveBeenCalled();
+  });
+
+  it("routes any /auth subpath (e.g. /auth/token) to IndieAuth", async () => {
+    const env = makeEnv({ AUTH_DB: {} });
+    const res = await worker.fetch(req("/auth/token"), env, makeCtx());
+    expect(res.headers.get("x-handler")).toBe("indieauth");
+  });
+
+  it("falls through /auth to ASSETS when AUTH_DB is absent", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(req("/auth"), env, makeCtx());
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+    expect(res.headers.get("x-asset")).toBe("1");
+    expect(res.headers.get("x-handler")).toBeNull();
+  });
+
+  it("routes /micropub and /media to Micropub when MICROPUB_DB is bound", async () => {
+    for (const path of ["/micropub", "/media"]) {
+      const env = makeEnv({ MICROPUB_DB: {} });
+      const res = await worker.fetch(req(path), env, makeCtx());
+      expect(res.headers.get("x-handler"), path).toBe("micropub");
+      expect(env.ASSETS.fetch).not.toHaveBeenCalled();
+    }
+  });
+
+  it("falls through /micropub to ASSETS when MICROPUB_DB is absent", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(req("/micropub"), env, makeCtx());
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+    expect(res.headers.get("x-handler")).toBeNull();
+  });
+
+  it("routes /webmention to the Webmention handler when WEBMENTION_DB is bound", async () => {
+    const env = makeEnv({ WEBMENTION_DB: {} });
+    const res = await worker.fetch(
+      req("/webmention", { method: "POST" }),
+      env,
+      makeCtx(),
+    );
+    expect(res.headers.get("x-handler")).toBe("webmention");
+    expect(webmentionCalls.fetch).toBe(1);
+    expect(env.ASSETS.fetch).not.toHaveBeenCalled();
+  });
+
+  it("falls through /webmention to ASSETS when WEBMENTION_DB is absent", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(
+      req("/webmention", { method: "POST" }),
+      env,
+      makeCtx(),
+    );
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+    expect(res.headers.get("x-handler")).toBeNull();
+    expect(webmentionCalls.fetch).toBe(0);
+  });
+
+  it("routes are independent: AUTH_DB alone does not enable /micropub", async () => {
+    const env = makeEnv({ AUTH_DB: {} });
+    const res = await worker.fetch(req("/micropub"), env, makeCtx());
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+    expect(res.headers.get("x-handler")).toBeNull();
+  });
+
+  it("unknown paths always fall through to ASSETS even with every binding set", async () => {
+    const env = makeEnv({ AUTH_DB: {}, MICROPUB_DB: {}, WEBMENTION_DB: {} });
+    const res = await worker.fetch(req("/about/"), env, makeCtx());
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+    expect(res.headers.get("x-handler")).toBeNull();
+  });
+});
+
+describe("queue() and scheduled() dispatch", () => {
+  it("queue() drains the webmention queue only when WEBMENTION_DB is bound", async () => {
+    await worker.queue({ messages: [] }, makeEnv({ WEBMENTION_DB: {} }), makeCtx());
+    expect(webmentionCalls.queue).toBe(1);
+
+    resetWebmentionCalls();
+    await worker.queue({ messages: [] }, makeEnv(), makeCtx());
+    expect(webmentionCalls.queue).toBe(0);
+  });
+
+  it("queue() always schedules the Micropub bridge sync via waitUntil", async () => {
+    const ctx = makeCtx();
+    await worker.queue({ messages: [] }, makeEnv(), ctx);
+    expect(ctx.waitUntil).toHaveBeenCalledOnce();
+  });
+
+  it("scheduled() runs the webmention cron only when WEBMENTION_DB is bound", async () => {
+    await worker.scheduled({}, makeEnv({ WEBMENTION_DB: {} }), makeCtx());
+    expect(webmentionCalls.scheduled).toBe(1);
+
+    resetWebmentionCalls();
+    await worker.scheduled({}, makeEnv(), makeCtx());
+    expect(webmentionCalls.scheduled).toBe(0);
+  });
+
+  it("scheduled() always schedules the Micropub bridge sync via waitUntil", async () => {
+    const ctx = makeCtx();
+    await worker.scheduled({}, makeEnv(), ctx);
+    expect(ctx.waitUntil).toHaveBeenCalledOnce();
+  });
+});
+
+describe("Webmention edge-render gating", () => {
+  // site-entry.js calls `new HTMLRewriter()` only when it decides to inject.
+  // The Node test runtime has no HTMLRewriter, so we install a fake that
+  // records whether a rewrite was attempted — that flag is the assertion.
+  let rewriteUsed = false;
+
+  class FakeHTMLRewriter {
+    on() {
+      return this;
+    }
+    transform(response: Response) {
+      rewriteUsed = true;
+      return response;
+    }
+  }
+
+  beforeEach(() => {
+    rewriteUsed = false;
+    (globalThis as any).HTMLRewriter = FakeHTMLRewriter;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).HTMLRewriter;
+  });
+
+  function webmentionDb(results: unknown[]) {
+    const all = vi.fn(async () => ({ results }));
+    const bind = vi.fn(() => ({ all }));
+    const prepare = vi.fn(() => ({ bind }));
+    return { db: { prepare }, prepare, bind, all };
+  }
+
+  it("queries D1 and rewrites a note/blog page that has stored mentions", async () => {
+    for (const path of ["/notes/abc/", "/blog/my-post/"]) {
+      rewriteUsed = false;
+      const { db, prepare, bind } = webmentionDb([
+        {
+          author_name: "Alice",
+          author_url: "https://alice.example",
+          content: "Great post!",
+          url: "https://alice.example/reply/1",
+          type: "in-reply-to",
+          published: "2026-06-01T00:00:00Z",
+        },
+      ]);
+      const env = makeEnv({ WEBMENTION_DB: db });
+      await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
+
+      expect(prepare, path).toHaveBeenCalledOnce();
+      expect(bind, path).toHaveBeenCalledWith(`https://example.com${path}`);
+      expect(rewriteUsed, path).toBe(true);
+    }
+  });
+
+  it("queries but does NOT rewrite when the target page has no mentions", async () => {
+    const { db, prepare } = webmentionDb([]);
+    const env = makeEnv({ WEBMENTION_DB: db });
+    const res = await worker.fetch(
+      req("/notes/abc/", { accept: "text/html" }),
+      env,
+      makeCtx(),
+    );
+
+    expect(prepare).toHaveBeenCalledOnce();
+    expect(rewriteUsed).toBe(false);
+    // Response passes through untouched.
+    expect(res.headers.get("x-asset")).toBe("1");
+  });
+
+  it("does NOT query for non-target paths (home, about)", async () => {
+    for (const path of ["/", "/about/", "/contact/"]) {
+      const { db, prepare } = webmentionDb([{ author_name: "Bob" }]);
+      const env = makeEnv({ WEBMENTION_DB: db });
+      await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
+      expect(prepare, path).not.toHaveBeenCalled();
+      expect(rewriteUsed, path).toBe(false);
+    }
+  });
+
+  it("does NOT query the collection index — only permalinks are targets", async () => {
+    for (const path of ["/notes", "/notes/", "/blog", "/blog/"]) {
+      const { db, prepare } = webmentionDb([{ author_name: "Bob" }]);
+      const env = makeEnv({ WEBMENTION_DB: db });
+      await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
+      expect(prepare, path).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does NOT query when WEBMENTION_DB is unbound", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(
+      req("/notes/abc/", { accept: "text/html" }),
+      env,
+      makeCtx(),
+    );
+    expect(rewriteUsed).toBe(false);
+    expect(res.headers.get("x-asset")).toBe("1");
+  });
+
+  it("does NOT query non-HTML responses even on a target path", async () => {
+    const { db, prepare } = webmentionDb([{ author_name: "Bob" }]);
+    const env = makeEnv({
+      WEBMENTION_DB: db,
+      ASSETS: {
+        fetch: vi.fn(async () => assetsResponse("{}", "application/json")),
+      },
+    });
+    await worker.fetch(req("/notes/abc/", { accept: "text/html" }), env, makeCtx());
+    expect(prepare).not.toHaveBeenCalled();
+    expect(rewriteUsed).toBe(false);
+  });
+
+  it("does NOT query for non-HTML requests (no Accept: text/html)", async () => {
+    const { db, prepare } = webmentionDb([{ author_name: "Bob" }]);
+    const env = makeEnv({ WEBMENTION_DB: db });
+    await worker.fetch(req("/notes/abc/"), env, makeCtx());
+    expect(prepare).not.toHaveBeenCalled();
+    expect(rewriteUsed).toBe(false);
+  });
+});

--- a/tests/indieweb-wiring.test.ts
+++ b/tests/indieweb-wiring.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Plugin-side tests for the IndieWeb static wiring (issue #337, design §7):
+ *
+ *   - Discovery-link injection in BaseLayout.astro is gated per-endpoint on
+ *     the .site-config flags — each <link> renders only when its flag is set.
+ *   - wrangler.jsonc carries the full binding union after the skill wires it.
+ *   - The Keystatic `notes` collection shape, and a .mdoc rendered from a
+ *     sample mf2 record by the bridge, agree with that shape.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { renderMdoc } from "../template/worker/indieweb-bridge.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+
+const baseLayout = readFileSync(
+  join(root, "template", "src", "layouts", "BaseLayout.astro"),
+  "utf-8",
+);
+const wranglerRaw = readFileSync(
+  join(root, "template", "wrangler.jsonc"),
+  "utf-8",
+);
+const contentConfig = readFileSync(
+  join(root, "template", "src", "content.config.ts"),
+  "utf-8",
+);
+const keystatic = readFileSync(
+  join(root, "template", "keystatic.config.ts"),
+  "utf-8",
+);
+
+// The notes collection's full field set — the contract the bridge's .mdoc
+// output must stay within.
+const NOTES_FIELDS = [
+  "slug",
+  "publishDate",
+  "title",
+  "image",
+  "imageAlt",
+  "inReplyTo",
+  "bookmarkOf",
+  "likeOf",
+  "repostOf",
+  "syndication",
+  "draft",
+];
+
+describe("BaseLayout discovery-link gating", () => {
+  it("derives each endpoint flag from .site-config", () => {
+    expect(baseLayout).toMatch(/INDIEWEB_INDIEAUTH=true/);
+    expect(baseLayout).toMatch(/INDIEWEB_MICROPUB=true/);
+    expect(baseLayout).toMatch(/INDIEWEB_WEBMENTION=true/);
+    expect(baseLayout).toMatch(/indieauthEnabled\s*=/);
+    expect(baseLayout).toMatch(/micropubEnabled\s*=/);
+    expect(baseLayout).toMatch(/webmentionEnabled\s*=/);
+  });
+
+  it("gates each IndieAuth discovery link on indieauthEnabled", () => {
+    expect(baseLayout).toContain(
+      '{indieauthEnabled && <link rel="indieauth-metadata"',
+    );
+    expect(baseLayout).toContain(
+      '{indieauthEnabled && <link rel="authorization_endpoint"',
+    );
+    expect(baseLayout).toContain(
+      '{indieauthEnabled && <link rel="token_endpoint"',
+    );
+  });
+
+  it("gates the Micropub discovery link on micropubEnabled", () => {
+    expect(baseLayout).toContain('{micropubEnabled && <link rel="micropub"');
+  });
+
+  it("gates the Webmention discovery link on webmentionEnabled", () => {
+    expect(baseLayout).toContain(
+      '{webmentionEnabled && <link rel="webmention"',
+    );
+  });
+
+  it("never emits an IndieWeb discovery link unconditionally", () => {
+    // Every rel must appear behind a `{flag && <link ...` guard, so a site
+    // that hasn't run the skill ships none of them.
+    const rels = [
+      "indieauth-metadata",
+      "authorization_endpoint",
+      "token_endpoint",
+      "micropub",
+      "webmention",
+    ];
+    for (const rel of rels) {
+      const matches = baseLayout.match(
+        new RegExp(`<link rel="${rel}"`, "g"),
+      ) ?? [];
+      const guarded =
+        baseLayout.match(
+          new RegExp(`Enabled && <link rel="${rel}"`, "g"),
+        ) ?? [];
+      expect(matches.length, rel).toBe(guarded.length);
+    }
+  });
+});
+
+describe("wrangler.jsonc binding union after wiring", () => {
+  // wrangler.jsonc only uses full-line // comments and no trailing commas,
+  // so stripping comment lines yields parseable JSON.
+  const config = JSON.parse(wranglerRaw.replace(/^\s*\/\/.*$/gm, ""));
+
+  it("targets the composed worker entry and the ASSETS binding", () => {
+    expect(config.main).toBe("worker/site-entry.js");
+    expect(config.assets.binding).toBe("ASSETS");
+  });
+
+  it("declares all three IndieWeb D1 databases", () => {
+    const byBinding = Object.fromEntries(
+      config.d1_databases.map((d: any) => [d.binding, d]),
+    );
+    expect(byBinding.AUTH_DB.database_name).toBe("indieauth");
+    expect(byBinding.MICROPUB_DB.database_name).toBe("micropub");
+    expect(byBinding.WEBMENTION_DB.database_name).toBe("webmention");
+  });
+
+  it("declares the Micropub MEDIA R2 bucket", () => {
+    const media = config.r2_buckets.find((b: any) => b.binding === "MEDIA");
+    expect(media).toBeTruthy();
+  });
+
+  it("wires the webmention queue as both producer and consumer", () => {
+    const producer = config.queues.producers.find(
+      (p: any) => p.binding === "WEBMENTION_QUEUE",
+    );
+    expect(producer.queue).toBe("webmention-queue");
+    const consumer = config.queues.consumers.find(
+      (c: any) => c.queue === "webmention-queue",
+    );
+    expect(consumer).toBeTruthy();
+  });
+
+  it("schedules a cron trigger for the bridge/verification retries", () => {
+    expect(Array.isArray(config.triggers.crons)).toBe(true);
+    expect(config.triggers.crons.length).toBeGreaterThan(0);
+  });
+});
+
+describe("notes collection shape", () => {
+  it("defines the notes collection in both config files", () => {
+    expect(contentConfig).toMatch(/const notes = defineCollection\(/);
+    expect(keystatic).toContain("notes: collection({");
+  });
+
+  it("is titleless-friendly: title is optional, slug is the slug field", () => {
+    const schema =
+      contentConfig.match(
+        /const notes = defineCollection\(\{[\s\S]*?\}\);/,
+      )?.[0] ?? "";
+    expect(schema).toMatch(/title:\s*z\.string\(\)\.optional\(\)/);
+    expect(keystatic).toMatch(/slugField:\s*"slug"/);
+    expect(keystatic).toContain('path: "src/content/notes/*"');
+  });
+
+  it("declares every notes field in the Zod schema", () => {
+    const schema =
+      contentConfig.match(
+        /const notes = defineCollection\(\{[\s\S]*?\}\);/,
+      )?.[0] ?? "";
+    for (const field of NOTES_FIELDS) {
+      expect(schema, `content.config missing: ${field}`).toContain(field);
+    }
+  });
+});
+
+describe("bridge renders a .mdoc from a sample mf2 record", () => {
+  // A realistic Micropub h-entry: titled note with a reply target, a photo,
+  // body content, and a syndication link.
+  const row = {
+    slug: "2026-06-09-x7y8",
+    properties: JSON.stringify({
+      published: ["2026-06-09T14:30:00Z"],
+      name: ["Hello IndieWeb"],
+      content: [{ value: "First note via Micropub." }],
+      photo: [{ value: "/images/notes/sky.webp", alt: "A blue sky" }],
+      "in-reply-to": ["https://example.org/post/42"],
+      syndication: ["https://fosstodon.org/@me/123"],
+    }),
+    created_at: "2026-06-09T14:30:00Z",
+    updated_at: null,
+  };
+  const mdoc = renderMdoc(row);
+
+  it("emits frontmatter delimited by --- with a trailing body", () => {
+    expect(mdoc).toMatch(/^---\n[\s\S]*\n---\n/);
+    expect(mdoc).toContain("First note via Micropub.");
+  });
+
+  it("maps mf2 properties onto the notes schema fields", () => {
+    expect(mdoc).toContain("slug: 2026-06-09-x7y8");
+    expect(mdoc).toContain('publishDate: "2026-06-09T14:30:00Z"');
+    expect(mdoc).toContain("title: Hello IndieWeb");
+    expect(mdoc).toContain("image: /images/notes/sky.webp");
+    expect(mdoc).toContain("imageAlt: A blue sky");
+    expect(mdoc).toContain('inReplyTo: "https://example.org/post/42"');
+    expect(mdoc).toContain("syndication:");
+    expect(mdoc).toContain('  - "https://fosstodon.org/@me/123"');
+    expect(mdoc).toContain("draft: false");
+  });
+
+  it("emits no frontmatter key outside the notes collection shape", () => {
+    const fm = mdoc.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? "";
+    const keys = [...fm.matchAll(/^(\w+):/gm)].map((m) => m[1]);
+    expect(keys.length).toBeGreaterThan(0);
+    for (const key of keys) {
+      expect(NOTES_FIELDS, `unexpected frontmatter key: ${key}`).toContain(key);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
       // sharp is now a root dependency (required by server/optimize-images.mjs);
       // tests that need it mocked call vi.mock("sharp") themselves.
       wawoff2: resolve(__dirname, "tests/__stubs__/wawoff2.ts"),
+      // The @dwk/* IndieWeb packages are unpublished (0.0.0); worker/site-entry.js
+      // composes them at module load. Alias to tagged stubs so the dispatch and
+      // edge-render tests can import the real worker without the packages present.
+      "@dwk/indieauth": resolve(__dirname, "tests/__stubs__/dwk-indieauth.ts"),
+      "@dwk/micropub": resolve(__dirname, "tests/__stubs__/dwk-micropub.ts"),
+      "@dwk/webmention": resolve(__dirname, "tests/__stubs__/dwk-webmention.ts"),
     },
   },
   esbuild: {


### PR DESCRIPTION
Closes #337. Also implements the webmention edge-render (#335 / design §3.5), which test item 5 needs in order to be meaningful.

## What

Plugin-side tests for the Anglesite IndieWeb integration, covering all five scope items from #337 (design §7):

| Scope item | Where |
|---|---|
| `site-entry.js` gated dispatch (each route only with its binding; fallthrough to ASSETS) | `tests/indieweb-dispatch.test.ts` |
| Discovery-link injection present only when flags set | `tests/indieweb-wiring.test.ts` |
| `notes` collection shape; `.mdoc` rendered from a sample mf2 record | `tests/indieweb-wiring.test.ts` (+ existing `test/indieweb-bridge.test.js`) |
| `wrangler.jsonc` binding union after wiring | `tests/indieweb-wiring.test.ts` |
| Webmention edge-render gating (no query/rewrite when no mentions) | `tests/indieweb-dispatch.test.ts` |

## Why a code change too

Test item 5 (edge-render gating) had nothing to test: the §3.5 edge-render display was still an open issue (#335). To make the gating test meaningful rather than asserting the absence of code, this PR implements it:

- **`worker/site-entry.js`** — on note/blog HTML responses, query `WEBMENTION_DB` for verified mentions of the page and inject them into a `#webmentions` container via `HTMLRewriter`. Gated in order — HTML request → `WEBMENTION_DB` bound → note/blog permalink path → HTML response → only then query D1 — so a mention-free site pays only the guard checks. A query failure degrades to "no mentions" and never breaks the render.
- **`src/pages/notes/[slug].astro`, `src/pages/blog/[slug].astro`** — add the `#webmentions` container so the injection has a home (empty in the static build; populated per-request, no client JS). `docs/indieweb.md` already documents this edge-render behavior.

## Test harness

`worker/site-entry.js` composes the unpublished `@dwk/*` handlers at module load, so the tests alias them to tagged stubs (`tests/__stubs__/dwk-*.ts`) via `vitest.config.ts`. Each stub returns an `x-handler`-tagged response so dispatch targets are identifiable; the webmention stub also records `queue`/`scheduled` invocations.

## Verification

```
npx vitest run tests/indieweb-dispatch.test.ts tests/indieweb-wiring.test.ts \
  test/indieweb-bridge.test.js test/base-layout.test.js \
  test/content-collections.test.js tests/pre-deploy-check.test.ts
# 171 passed
```

The only failures in the full suite are pre-existing and environment-specific (`test/{undo-edit,edit-history,apply-edit-dispatcher}.test.js` shell out to `git commit`, which the sandbox's signing server rejects) — unrelated to these changes.

https://claude.ai/code/session_01PFYn7BQzPawjFjVN2ybpuS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFYn7BQzPawjFjVN2ybpuS)_