### PR TITLE
indieweb: webmention edge-render known-target gate + display styles (#335)

### DIFF
--- a/template/docs/indieweb.md
+++ b/template/docs/indieweb.md
@@ -213,6 +213,8 @@ Don't recommend it during `/anglesite:start`. It adds complexity that most SMB o
 
 Run the owner's own Webmention endpoint on their domain instead of delegating to webmention.io. `/anglesite:indieweb` deploys `@dwk/webmention` into the site's Worker: it receives mentions, verifies the source link asynchronously, stores them in a D1 inbox, and edge-renders them onto the target page (no client JS). No third-party dependency; the mention data lives only on the owner's Cloudflare account. See the "Active IndieWeb" section above and `docs/platforms/dwk-workers.md`.
 
+Display details: the note and blog post templates ship an empty `<div id="webmentions">` after the article; the Worker fills it per-request (h-cite list with author, avatar, content, permalink) only for pages that actually have verified mentions — mention-free pages serve unchanged, and new mentions appear within about a minute. Styling lives under the `.webmentions-*` rules in `src/styles/global.css` (it must stay global — scoped Astro styles can't reach edge-injected markup).
+
 **Option 3: Static webmentions (build-time)**
 
 Fetch webmentions during `npm run build` and bake them into the HTML. No client-side JavaScript needed. Use the webmention.io API or a self-hosted endpoint. This fits Anglesite's zero-JS philosophy.

--- a/template/src/styles/global.css
+++ b/template/src/styles/global.css
@@ -159,6 +159,50 @@ footer {
   color: var(--color-muted);
 }
 
+/* Webmentions — markup is injected into <div id="webmentions"> at the edge
+   by worker/site-entry.js, so these rules must live in a global stylesheet
+   (scoped Astro styles never see it). Empty on sites without mentions. */
+.webmentions-title {
+  font-size: var(--font-size-lg);
+}
+
+.webmentions-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.webmentions-list .h-cite {
+  overflow: auto;
+  padding: var(--space-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.webmentions-list .u-photo {
+  float: left;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  margin-right: var(--space-sm);
+}
+
+.webmentions-list .p-author {
+  font-weight: 600;
+}
+
+.webmentions-list .p-content {
+  margin-top: var(--space-xs);
+}
+
+.webmentions-list a.u-url:not(.p-author) {
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+}
+
 /* Contact form */
 .contact-form {
   display: flex;

--- a/template/worker/site-entry.js
+++ b/template/worker/site-entry.js
@@ -20,7 +20,9 @@
  *   5. Webmention edge-render — on note/post HTML responses, injects any
  *      stored mentions of that page into a <div id="webmentions"> container
  *      via HTMLRewriter. Gated to note/post target paths that actually have
- *      mentions — no WEBMENTION_DB query or rewrite is paid otherwise.
+ *      mentions: a per-isolate cache of known target URLs (refreshed at most
+ *      once per minute) means mention-free pages pay no per-request D1 query
+ *      and no rewrite.
  *
  * Every feature is gated on its binding/var being present, so a site that
  * hasn't run any of these skills serves identically to a bare ASSETS-only
@@ -160,10 +162,11 @@ const worker = {
 
     // 5. Webmention edge-render — inject stored mentions into note/post pages.
     //    Gating order keeps the cost off pages that can't have mentions:
-    //    HTML request → WEBMENTION_DB bound → known target path → HTML
-    //    response → only then query D1. The rewrite is skipped entirely when
-    //    the page has no stored mentions, so a mention-free site pays nothing
-    //    beyond the guard checks.
+    //    HTML request → WEBMENTION_DB bound → note/post path → HTML response
+    //    → page is a known mention target (cached set, refreshed at most once
+    //    a minute per isolate) → only then query D1 for the mentions and
+    //    rewrite. Pages with no stored mentions pay no per-request query and
+    //    no rewrite.
     if (
       isHtmlRequest &&
       env.WEBMENTION_DB &&
@@ -172,11 +175,14 @@ const worker = {
       const contentType = response.headers.get("content-type") ?? "";
       if (contentType.includes("text/html")) {
         const target = `${url.origin}${url.pathname}`;
-        const mentions = await loadWebmentions(env.WEBMENTION_DB, target);
-        if (mentions.length > 0) {
-          response = new HTMLRewriter()
-            .on("#webmentions", new WebmentionInjector(mentions))
-            .transform(response);
+        const targets = await loadWebmentionTargets(env.WEBMENTION_DB);
+        if (targets.has(target)) {
+          const mentions = await loadWebmentions(env.WEBMENTION_DB, target);
+          if (mentions.length > 0) {
+            response = new HTMLRewriter()
+              .on("#webmentions", new WebmentionInjector(mentions))
+              .transform(response);
+          }
         }
       }
     }
@@ -231,6 +237,36 @@ class CountryInjector {
 function isWebmentionTarget(pathname) {
   const p = pathname.replace(/\/+$/, "");
   return p.startsWith("/notes/") || p.startsWith("/blog/");
+}
+
+// The set of target URLs that have at least one verified mention, cached per
+// WEBMENTION_DB binding so each isolate runs the distinct-targets query at
+// most once per TTL — every other note/post request is an in-memory set
+// lookup. New mentions therefore appear within a minute, which is fine for
+// content that's already verified asynchronously. A query failure serves the
+// stale set (or an empty one) rather than breaking the page render.
+const WEBMENTION_TARGETS_TTL_MS = 60_000;
+const webmentionTargetsCache = new WeakMap();
+
+async function loadWebmentionTargets(db) {
+  const cached = webmentionTargetsCache.get(db);
+  if (cached && cached.expires > Date.now()) return cached.targets;
+  try {
+    const rows = await db
+      .prepare(
+        `SELECT DISTINCT target FROM webmentions WHERE status = 'verified'`,
+      )
+      .all();
+    const targets = new Set((rows?.results ?? []).map((row) => row.target));
+    webmentionTargetsCache.set(db, {
+      targets,
+      expires: Date.now() + WEBMENTION_TARGETS_TTL_MS,
+    });
+    return targets;
+  } catch (err) {
+    console.error("Webmention target-set query failed:", err?.message);
+    return cached?.targets ?? new Set();
+  }
 }
 
 // Query WEBMENTION_DB for verified mentions of a target URL. The table/columns

--- a/tests/indieweb-dispatch.test.ts
+++ b/tests/indieweb-dispatch.test.ts
@@ -188,37 +188,55 @@ describe("Webmention edge-render gating", () => {
     delete (globalThis as any).HTMLRewriter;
   });
 
-  function webmentionDb(results: unknown[]) {
-    const all = vi.fn(async () => ({ results }));
-    const bind = vi.fn(() => ({ all }));
-    const prepare = vi.fn(() => ({ bind }));
-    return { db: { prepare }, prepare, bind, all };
+  // Serves both edge-render queries: the distinct-targets set (keys of
+  // mentionsByTarget) and the per-target mention rows. The worker caches the
+  // target set per binding object, so each test's fresh mock starts cold.
+  function webmentionDb(mentionsByTarget: Record<string, unknown[]>) {
+    const targetsAll = vi.fn(async () => ({
+      results: Object.keys(mentionsByTarget).map((target) => ({ target })),
+    }));
+    let boundTarget: string;
+    const mentionsAll = vi.fn(async () => ({
+      results: mentionsByTarget[boundTarget] ?? [],
+    }));
+    const bind = vi.fn((target: string) => {
+      boundTarget = target;
+      return { all: mentionsAll };
+    });
+    const prepare = vi.fn((sql: string) =>
+      sql.includes("DISTINCT") ? { all: targetsAll } : { bind },
+    );
+    return { db: { prepare }, prepare, bind, targetsAll, mentionsAll };
   }
 
   it("queries D1 and rewrites a note/blog page that has stored mentions", async () => {
     for (const path of ["/notes/abc/", "/blog/my-post/"]) {
       rewriteUsed = false;
-      const { db, prepare, bind } = webmentionDb([
-        {
-          author_name: "Alice",
-          author_url: "https://alice.example",
-          content: "Great post!",
-          url: "https://alice.example/reply/1",
-          type: "in-reply-to",
-          published: "2026-06-01T00:00:00Z",
-        },
-      ]);
+      const target = `https://example.com${path}`;
+      const { db, bind } = webmentionDb({
+        [target]: [
+          {
+            author_name: "Alice",
+            author_url: "https://alice.example",
+            content: "Great post!",
+            url: "https://alice.example/reply/1",
+            type: "in-reply-to",
+            published: "2026-06-01T00:00:00Z",
+          },
+        ],
+      });
       const env = makeEnv({ WEBMENTION_DB: db });
       await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
 
-      expect(prepare, path).toHaveBeenCalledOnce();
-      expect(bind, path).toHaveBeenCalledWith(`https://example.com${path}`);
+      expect(bind, path).toHaveBeenCalledWith(target);
       expect(rewriteUsed, path).toBe(true);
     }
   });
 
-  it("queries but does NOT rewrite when the target page has no mentions", async () => {
-    const { db, prepare } = webmentionDb([]);
+  it("does NOT query mentions or rewrite when the page has no stored mentions", async () => {
+    const { db, bind } = webmentionDb({
+      "https://example.com/notes/other/": [{ author_name: "Alice" }],
+    });
     const env = makeEnv({ WEBMENTION_DB: db });
     const res = await worker.fetch(
       req("/notes/abc/", { accept: "text/html" }),
@@ -226,15 +244,26 @@ describe("Webmention edge-render gating", () => {
       makeCtx(),
     );
 
-    expect(prepare).toHaveBeenCalledOnce();
+    // The page isn't in the known-target set, so no per-target query runs.
+    expect(bind).not.toHaveBeenCalled();
     expect(rewriteUsed).toBe(false);
     // Response passes through untouched.
     expect(res.headers.get("x-asset")).toBe("1");
   });
 
+  it("caches the known-target set — one distinct query across requests", async () => {
+    const { db, targetsAll } = webmentionDb({});
+    const env = makeEnv({ WEBMENTION_DB: db });
+    await worker.fetch(req("/notes/a/", { accept: "text/html" }), env, makeCtx());
+    await worker.fetch(req("/notes/b/", { accept: "text/html" }), env, makeCtx());
+    expect(targetsAll).toHaveBeenCalledOnce();
+  });
+
   it("does NOT query for non-target paths (home, about)", async () => {
     for (const path of ["/", "/about/", "/contact/"]) {
-      const { db, prepare } = webmentionDb([{ author_name: "Bob" }]);
+      const { db, prepare } = webmentionDb({
+        "https://example.com/notes/abc/": [{ author_name: "Bob" }],
+      });
       const env = makeEnv({ WEBMENTION_DB: db });
       await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
       expect(prepare, path).not.toHaveBeenCalled();
@@ -244,7 +273,9 @@ describe("Webmention edge-render gating", () => {
 
   it("does NOT query the collection index — only permalinks are targets", async () => {
     for (const path of ["/notes", "/notes/", "/blog", "/blog/"]) {
-      const { db, prepare } = webmentionDb([{ author_name: "Bob" }]);
+      const { db, prepare } = webmentionDb({
+        "https://example.com/notes/abc/": [{ author_name: "Bob" }],
+      });
       const env = makeEnv({ WEBMENTION_DB: db });
       await worker.fetch(req(path, { accept: "text/html" }), env, makeCtx());
       expect(prepare, path).not.toHaveBeenCalled();
@@ -263,7 +294,9 @@ describe("Webmention edge-render gating", () => {
   });
 
   it("does NOT query non-HTML responses even on a target path", async () => {
-    const { db, prepare } = webmentionDb([{ author_name: "Bob" }]);
+    const { db, prepare } = webmentionDb({
+      "https://example.com/notes/abc/": [{ author_name: "Bob" }],
+    });
     const env = makeEnv({
       WEBMENTION_DB: db,
       ASSETS: {
@@ -276,7 +309,9 @@ describe("Webmention edge-render gating", () => {
   });
 
   it("does NOT query for non-HTML requests (no Accept: text/html)", async () => {
-    const { db, prepare } = webmentionDb([{ author_name: "Bob" }]);
+    const { db, prepare } = webmentionDb({
+      "https://example.com/notes/abc/": [{ author_name: "Bob" }],
+    });
     const env = makeEnv({ WEBMENTION_DB: db });
     await worker.fetch(req("/notes/abc/"), env, makeCtx());
     expect(prepare).not.toHaveBeenCalled();


### PR DESCRIPTION
Completes #335 (webmention edge-render into target pages via HTMLRewriter, design §3.5).

Most of the edge-render landed with the test PR (#348): the `HTMLRewriter` injection in `worker/site-entry.js` and the `<div id="webmentions">` container in the note/blog templates. Two gaps remained against the issue's scope and acceptance criteria, fixed here:

## Known-target gate (the acceptance criterion)

> A page with stored mentions shows them server-rendered; **a page with none does no extra query/rewrite.**

Previously every note/blog HTML request paid a `WEBMENTION_DB` query even when the page had no mentions. Now `site-entry.js` keeps a per-binding cached `Set` of known target URLs (`SELECT DISTINCT target … WHERE status = 'verified'`, refreshed at most once per minute per isolate, stale-on-error):

- Page not in the set → no per-target query, no rewrite — the response passes through untouched.
- Page in the set → one targeted query + rewrite, as before.
- New mentions appear within ~a minute, consistent with the already-async verification pipeline.

## Display styles

The injected markup (`.webmentions-title`, `.webmentions-list`, `.h-cite`, avatar, author, content, permalink) had no CSS anywhere. Added a `.webmentions-*` block to `template/src/styles/global.css` — it has to be global because scoped Astro styles can't reach edge-injected HTML.

## Also

- `tests/indieweb-dispatch.test.ts` — mock now serves both queries (target set + per-target rows); the no-mentions test asserts **no** per-target query; new test that the target set is fetched once across requests.
- `template/docs/indieweb.md` — documented the container, gating behavior, and where the styles live.

## Testing

- `tests/indieweb-dispatch.test.ts` + `tests/indieweb-wiring.test.ts`: 37/37 pass.
- Full suite: same 18 pre-existing failures as on a clean `main` checkout in this sandbox (git/fs-permission-dependent tests in `test/undo-edit`, `test/edit-history`, `test/apply-edit-dispatcher`), unrelated to this change.

Closes #335

https://claude.ai/code/session_01Y6NCqfjoovAK3QRd3P7Pss

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6NCqfjoovAK3QRd3P7Pss)_