### PR TITLE
feat(container): shared OCI image for both substrates (#62)

### DIFF
--- a/container/.dockerignore
+++ b/container/.dockerignore
@@ -1,0 +1,19 @@
+# The build context is staged by scripts/build-container-image.sh, which copies
+# in only what the image needs (plugin runtime + template manifests + helpers).
+# These excludes are a belt-and-suspenders guard in case the Dockerfile is built
+# against an un-staged context.
+**/node_modules
+**/.git
+**/.github
+**/.worktrees
+**/.serena
+**/.playwright-mcp
+**/.claude
+**/dist
+**/build
+**/tests
+**/test
+**/docs
+**/*.log
+**/.DS_Store
+metadata.json

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1
+#
+# Canonical Anglesite dev-server image — issue #62 (design doc Q-D).
+#
+# ONE image, TWO substrates. The Astro dev server and the plugin's MCP server
+# run inside this Linux container, never in the host app process, so the dev
+# server behaves identically everywhere:
+#
+#   • Apple Containerization (local, DevID Macs)  — pulls this image by digest.
+#   • Cloudflare Sandbox     (remote, MAS / iOS)  — see container/Dockerfile.cloudflare.
+#
+# Built for linux/arm64 (local Apple Silicon + Cloudflare). Node is pinned to
+# scripts/node-version.txt and passed in as NODE_VERSION by
+# scripts/build-container-image.sh.
+
+ARG NODE_VERSION=24.15.0
+FROM node:${NODE_VERSION}-bookworm-slim
+
+# git: Git is the source of truth — the container clones the site on start
+#      (design §3.1 option A). No host-share, no embedded Node.
+# tini: PID 1 that reaps the long-lived dev server's children and forwards signals.
+# ca-certificates: HTTPS git clone + npm registry.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates tini \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV ANGLESITE_HOME=/opt/anglesite \
+    NPM_CONFIG_CACHE=/opt/anglesite/npm-cache \
+    NPM_CONFIG_FUND=false \
+    NPM_CONFIG_AUDIT=false \
+    SITE_DIR=/workspace \
+    PORT=4321
+
+# ---- Plugin MCP server runtime ------------------------------------------------
+# The plugin is the source of truth for the MCP server (CLAUDE.md). Bake its
+# runtime — server/*.mjs plus the production dependency closure
+# (@modelcontextprotocol/sdk, sharp, and the SDK's hoisted zod) — so the runtime
+# substrates can start it with no network install. Deps are installed against the
+# committed lockfile before the source is copied so this layer caches well.
+COPY plugin/package.json plugin/package-lock.json ${ANGLESITE_HOME}/plugin/
+RUN cd ${ANGLESITE_HOME}/plugin \
+ && ( npm ci --omit=dev \
+      || { echo "WARN: plugin lockfile out of sync — falling back to npm install" >&2; \
+           npm install --omit=dev; } )
+COPY plugin/ ${ANGLESITE_HOME}/plugin/
+ENV ANGLESITE_MCP_ENTRY=${ANGLESITE_HOME}/plugin/server/index.mjs
+
+# ---- Pre-baked site toolchain (skip npm ci on cold start; design §5b) ---------
+# Install the template's full dependency closure once, at build time. This warms
+# the npm cache for any cloned site AND keeps the resolved node_modules so a site
+# whose lockfile matches the template reuses it with zero install (hydrate.sh).
+# `npm ci` is preferred (reproducible, and it's what hydrate.sh's zero-install
+# fast path compares against). If the template's committed lockfile has drifted
+# out of sync with its package.json, fall back to `npm install` with a loud
+# warning rather than failing the image — sites then take hydrate.sh's
+# warm-cache `npm ci` path instead of the zero-install hardlink.
+COPY template/package.json template/package-lock.json ${ANGLESITE_HOME}/baked/
+RUN cd ${ANGLESITE_HOME}/baked \
+ && ( npm ci \
+      || { echo "WARN: template lockfile out of sync — falling back to npm install" >&2; \
+           npm install; } )
+
+# ---- Hydration + start helpers ------------------------------------------------
+COPY entrypoint.sh hydrate.sh start-dev-server.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+             /usr/local/bin/hydrate.sh \
+             /usr/local/bin/start-dev-server.sh
+
+WORKDIR /workspace
+EXPOSE 4321
+
+# tini as PID 1; entrypoint hydrates the repo + deps, then execs the CMD.
+# Substrates may override CMD or drive their own start sequence — this is a
+# sensible, override-friendly default.
+ENTRYPOINT ["/usr/bin/tini", "--", "entrypoint.sh"]
+CMD ["start-dev-server.sh"]

--- a/container/Dockerfile.cloudflare
+++ b/container/Dockerfile.cloudflare
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+#
+# Cloudflare Sandbox substrate wrapper — issue #62, consumed by #61 / #66.
+#
+# Both substrates run the SAME canonical image (container/Dockerfile). The
+# Cloudflare Sandbox SDK needs its standalone `/sandbox` init binary present so
+# the Worker can drive the container over the Sandbox HTTP API. This thin layer
+# adds only that binary on top of the canonical image — the toolchain layers
+# underneath stay byte-identical to what Apple Containerization pulls.
+#
+# Per Cloudflare's docs, the standalone binary lets you "add sandbox capabilities
+# to any Docker image" without depending on their base image, and you must NOT
+# override the ENTRYPOINT — `/sandbox` is the entrypoint; it starts the HTTP API
+# then spawns CMD as a child with signal forwarding.
+#
+# NOTE: the exact source path/tag of the standalone binary is pinned and
+# validated by the Cloudflare spike (#61); treat the COPY below as the integration
+# point, not a finalized version.
+
+ARG CANONICAL_IMAGE=ghcr.io/anglesite/anglesite-devserver:dev
+ARG SANDBOX_IMAGE=docker.io/cloudflare/sandbox:latest
+
+FROM ${SANDBOX_IMAGE} AS sandbox
+
+FROM ${CANONICAL_IMAGE}
+COPY --from=sandbox /sandbox /sandbox
+ENTRYPOINT ["/sandbox"]
+CMD ["start-dev-server.sh"]

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,70 @@
+# Anglesite dev-server container image
+
+The **one OCI image, two substrates** that issue [#62](https://github.com/Anglesite/Anglesite-app/issues/62) calls for. The Astro dev server and the plugin's MCP server run **inside this Linux container**, never in the host app process, so the dev server behaves identically everywhere:
+
+| Substrate | Platform | How it gets the image |
+|---|---|---|
+| **Apple Containerization** (local) | `Anglesite` DevID build · macOS 26+ · Apple Silicon | pulls the canonical image **by digest** |
+| **Cloudflare Sandbox** (remote) | `AnglesiteMAS` · Intel · macOS < 26 · iOS | extends the canonical image via [`Dockerfile.cloudflare`](Dockerfile.cloudflare) (#61) |
+
+This realizes the [design doc](../docs/specs/2026-05-30-cloudflare-sandbox-dev-server-design.md) §0 ("platform-split, one container image") and answers follow-up **Q-D** (image distribution).
+
+## What's in the image
+
+- **Node**, pinned to [`scripts/node-version.txt`](../scripts/node-version.txt) (passed as `NODE_VERSION` at build).
+- **`git`** — Git is the source of truth (design §3.1 option A); the container clones the site on start, edits commit/push. No host-share, no embedded Node.
+- **The Astro / site toolchain**, pre-installed from the plugin template's lockfile (`@opt/anglesite/baked`).
+- **The plugin's MCP server runtime** — `server/*.mjs` plus its production deps, baked at `/opt/anglesite/plugin` (`ANGLESITE_MCP_ENTRY`). The plugin is the source of truth for the MCP server (`CLAUDE.md`).
+- **`tini`** as PID 1 for signal/zombie reaping.
+
+Built for **`linux/arm64`** (local Apple Silicon + Cloudflare).
+
+## Pre-baked dependencies (skip `npm ci` on cold start)
+
+Design decision **#5b**: cold starts must not pay for `npm ci`. At build time the template's full dependency closure is installed once, which:
+
+1. **warms the npm cache** (`/opt/anglesite/npm-cache`) for any cloned site, and
+2. keeps the resolved **`node_modules`** at `/opt/anglesite/baked`.
+
+On start, [`hydrate.sh`](hydrate.sh) installs the cloned site's deps the fastest way available:
+
+- lockfile **identical** to the baked template → hardlink the baked `node_modules` (**zero install** — the common case for template-derived sites);
+- otherwise → `npm ci --prefer-offline` against the warm cache.
+
+## Build
+
+```sh
+# Build + load locally (arm64). Reads Node version + plugin source automatically.
+scripts/build-container-image.sh
+
+# Build + push to the registry by digest, and print the digest to pin.
+scripts/build-container-image.sh --push
+```
+
+Env overrides: `IMAGE_REPO` (default `ghcr.io/anglesite/anglesite-devserver`), `IMAGE_TAG` (default `dev`), `ANGLESITE_PLUGIN_SRC` (default `../anglesite`, same as `copy-plugin.sh`).
+
+The script stages a clean build context (plugin runtime + template manifests + helper scripts), so the `Dockerfile` is **not** buildable on its own — build through the script.
+
+## Runtime contract
+
+The default `ENTRYPOINT` ([`entrypoint.sh`](entrypoint.sh)) hydrates then execs the CMD; substrates may override either:
+
+| Variable | Purpose |
+|---|---|
+| `ANGLESITE_GIT_URL` | repo to clone into `$SITE_DIR` when it's empty |
+| `ANGLESITE_GIT_REF` | branch/tag/sha to check out after clone |
+| `SITE_DIR` | working tree (default `/workspace`) |
+| `PORT` | Astro dev port (default `4321`) |
+| `ANGLESITE_MCP_ENTRY` | path to the baked MCP server entry |
+
+The default CMD ([`start-dev-server.sh`](start-dev-server.sh)) runs `astro dev` bound to `0.0.0.0`. The **network-reachable MCP server** starts here too once the plugin's HTTP/SSE transport (#63) and `MCPClient`'s HTTP transport (#64) land; until then the MCP runtime is baked in and started over stdio by the runtime layer.
+
+## Distribution decision (Q-D)
+
+**Build once, push by digest; both substrates consume the same digest.**
+
+- The canonical image is built for `linux/arm64` and pushed to a registry (default GHCR). For reproducibility, pin the **base image by digest** and consume the **resulting image by digest** — not by floating tag.
+- **Apple Containerization** pulls that exact digest locally — no second build, no drift.
+- **Cloudflare Sandbox** can't run the canonical image entirely unmodified: the Sandbox SDK needs its standalone `/sandbox` init binary in the image. [`Dockerfile.cloudflare`](Dockerfile.cloudflare) `FROM`s the canonical image (by digest) and adds **only** that binary, so the toolchain layers stay byte-identical to what Apple Containerization runs. Cloudflare builds/pushes this thin wrapper to its own registry at `wrangler deploy`; the exact `/sandbox` source pin is finalized by the Cloudflare spike (#61).
+
+This keeps the *behavior-defining* layers (Node, git, Astro toolchain, plugin MCP runtime, baked deps) identical across substrates while accommodating each substrate's init requirements.

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Default entrypoint for the Anglesite dev-server image (issue #62).
+#
+# Hydrates the site (Git is the source of truth — design §3.1 option A): clones
+# $ANGLESITE_GIT_URL into $SITE_DIR when the dir is empty, installs deps via the
+# pre-baked toolchain (hydrate.sh), then execs the CMD (default: start-dev-server.sh).
+#
+# The runtime substrates (LocalContainerSiteRuntime / RemoteSandboxSiteRuntime,
+# issues #69 / #66) may override the CMD or run their own start sequence; this
+# entrypoint stays an override-friendly default that "just works" when exec'd bare.
+
+set -euo pipefail
+
+SITE_DIR="${SITE_DIR:-/workspace}"
+mkdir -p "$SITE_DIR"
+cd "$SITE_DIR"
+
+if [ -n "${ANGLESITE_GIT_URL:-}" ] && [ -z "$(ls -A "$SITE_DIR" 2>/dev/null)" ]; then
+    echo "==> Cloning ${ANGLESITE_GIT_URL} (ref: ${ANGLESITE_GIT_REF:-default})"
+    git clone "${ANGLESITE_GIT_URL}" "$SITE_DIR"
+    if [ -n "${ANGLESITE_GIT_REF:-}" ]; then
+        git -C "$SITE_DIR" checkout "${ANGLESITE_GIT_REF}"
+    fi
+fi
+
+# Install the site's npm dependencies, reusing the pre-baked toolchain when possible.
+if [ -f "$SITE_DIR/package.json" ]; then
+    hydrate.sh "$SITE_DIR"
+fi
+
+exec "$@"

--- a/container/hydrate.sh
+++ b/container/hydrate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Install a cloned site's npm dependencies as fast as possible by reusing the
+# image's pre-baked toolchain (design decision #5b — skip npm ci on cold start).
+#
+#   • node_modules already present            -> nothing to do.
+#   • lockfile identical to the baked template -> hardlink the baked node_modules
+#                                                 (zero install — the common case
+#                                                 for template-derived sites).
+#   • otherwise                                -> npm ci/install against the warm
+#                                                 npm cache (offline-first).
+
+set -euo pipefail
+
+SITE_DIR="${1:-${SITE_DIR:-/workspace}}"
+BAKED="${ANGLESITE_HOME:-/opt/anglesite}/baked"
+cd "$SITE_DIR"
+
+if [ -d node_modules ]; then
+    echo "==> node_modules already present; skipping install"
+    exit 0
+fi
+
+if [ -f package-lock.json ] && [ -f "$BAKED/package-lock.json" ] \
+   && cmp -s package-lock.json "$BAKED/package-lock.json"; then
+    echo "==> Lockfile matches the pre-baked toolchain; reusing baked node_modules (zero install)"
+    # Hardlink for speed; fall back to a copy if /workspace is a separate device.
+    cp -al "$BAKED/node_modules" ./node_modules 2>/dev/null \
+        || cp -a "$BAKED/node_modules" ./node_modules
+    exit 0
+fi
+
+if [ -f package-lock.json ]; then
+    echo "==> npm ci (warm cache, offline-first)"
+    npm ci --prefer-offline
+else
+    echo "==> npm install (warm cache, offline-first)"
+    npm install --prefer-offline
+fi

--- a/container/start-dev-server.sh
+++ b/container/start-dev-server.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Default CMD: start the Astro dev server bound to all interfaces so the substrate
+# can reach it (local container IP, or a Cloudflare exposed port). HMR rides the
+# same connection (design §2).
+#
+# The network-reachable MCP server starts here too once the plugin grows an
+# HTTP/SSE transport (#63) and MCPClient grows the matching HTTP transport (#64).
+# Until then the MCP runtime is baked in (ANGLESITE_MCP_ENTRY) and started by the
+# runtime layer over stdio. See container/README.md.
+
+set -euo pipefail
+
+SITE_DIR="${SITE_DIR:-/workspace}"
+PORT="${PORT:-4321}"
+cd "$SITE_DIR"
+
+echo "==> astro dev on 0.0.0.0:${PORT}"
+exec npm run dev -- --host 0.0.0.0 --port "${PORT}"

--- a/scripts/build-container-image.sh
+++ b/scripts/build-container-image.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Build the shared Anglesite dev-server OCI image (issue #62).
+#
+# ONE image, TWO substrates: Apple Containerization (local) and Cloudflare Sandbox
+# (remote) run the SAME linux/arm64 image so the dev server behaves identically
+# everywhere. Node is pinned to scripts/node-version.txt; git, the Astro/site
+# toolchain, and the plugin's MCP server runtime are baked in; the template's
+# dependency closure is pre-installed so cold starts skip npm ci (design §5b).
+#
+# Usage:
+#   scripts/build-container-image.sh            # build + load locally (arm64)
+#   scripts/build-container-image.sh --push     # build + push to $IMAGE_REPO, print digest
+#
+# Env overrides:
+#   IMAGE_REPO            registry repo (default: ghcr.io/anglesite/anglesite-devserver)
+#   IMAGE_TAG            human tag    (default: dev)
+#   ANGLESITE_PLUGIN_SRC plugin checkout (default: ../anglesite sibling, like copy-plugin.sh)
+#
+# Distribution (decision Q-D): the image is built once for linux/arm64 and pushed
+# to a registry BY DIGEST. Apple Containerization pulls that exact digest; the
+# Cloudflare substrate layers its sandbox init on top via container/Dockerfile.cloudflare
+# (#61). Pinning by digest is what makes the two substrates reproducibly identical —
+# see container/README.md.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+CONTAINER_DIR="$REPO_ROOT/container"
+VERSION_FILE="$SCRIPT_DIR/node-version.txt"
+
+IMAGE_REPO="${IMAGE_REPO:-ghcr.io/anglesite/anglesite-devserver}"
+IMAGE_TAG="${IMAGE_TAG:-dev}"
+PLATFORM="linux/arm64"
+
+PUSH=0
+[[ "${1:-}" == "--push" ]] && PUSH=1
+
+[[ -f "$VERSION_FILE" ]] || { echo "missing $VERSION_FILE" >&2; exit 1; }
+NODE_VERSION=$(tr -d '[:space:]' < "$VERSION_FILE")
+[[ -n "$NODE_VERSION" ]] || { echo "$VERSION_FILE is empty" >&2; exit 1; }
+
+# Resolve the plugin source the same way copy-plugin.sh does.
+DEFAULT_SRC=$(cd "$REPO_ROOT/.." && pwd)/anglesite
+SRC="${ANGLESITE_PLUGIN_SRC:-$DEFAULT_SRC}"
+[[ -d "$SRC" ]] || { echo "plugin source not found at $SRC (set ANGLESITE_PLUGIN_SRC)" >&2; exit 1; }
+[[ -f "$SRC/.claude-plugin/plugin.json" ]] || { echo "$SRC is not the Anglesite plugin (no .claude-plugin/plugin.json)" >&2; exit 1; }
+[[ -f "$SRC/template/package.json" && -f "$SRC/template/package-lock.json" ]] \
+    || { echo "template manifests missing under $SRC/template" >&2; exit 1; }
+
+command -v docker >/dev/null 2>&1 || { echo "docker not found on PATH" >&2; exit 1; }
+
+# ---- Stage a clean build context ----------------------------------------------
+CTX=$(mktemp -d)
+trap 'rm -rf "$CTX"' EXIT
+
+echo "==> Staging build context"
+cp "$CONTAINER_DIR/Dockerfile" "$CONTAINER_DIR/.dockerignore" "$CTX/"
+cp "$CONTAINER_DIR/entrypoint.sh" "$CONTAINER_DIR/hydrate.sh" "$CONTAINER_DIR/start-dev-server.sh" "$CTX/"
+
+# Plugin runtime: server + manifests + lockfile. node_modules/.git and other
+# heavy/private dirs are excluded — production deps are installed inside the image.
+mkdir -p "$CTX/plugin"
+rsync -a \
+    --exclude='node_modules/' --exclude='.git/' --exclude='.github/' \
+    --exclude='.worktrees/' --exclude='.serena/' --exclude='.playwright-mcp/' \
+    --exclude='.claude/' --exclude='dist/' --exclude='build/' \
+    --exclude='tests/' --exclude='test/' --exclude='docs/' \
+    --exclude='*.log' --exclude='.DS_Store' \
+    "$SRC/" "$CTX/plugin/"
+
+# Template: manifests only. We bake the template's dependency closure, not its source.
+mkdir -p "$CTX/template"
+cp "$SRC/template/package.json" "$SRC/template/package-lock.json" "$CTX/template/"
+
+# ---- Build --------------------------------------------------------------------
+IMAGE_REF="${IMAGE_REPO}:${IMAGE_TAG}"
+META="$CTX/metadata.json"
+OUTPUT="--load"
+[[ $PUSH -eq 1 ]] && OUTPUT="--push"
+
+echo "==> Building $IMAGE_REF for $PLATFORM (Node v$NODE_VERSION)"
+docker buildx build \
+    --platform "$PLATFORM" \
+    --build-arg "NODE_VERSION=$NODE_VERSION" \
+    --tag "$IMAGE_REF" \
+    --metadata-file "$META" \
+    $OUTPUT \
+    "$CTX"
+
+DIGEST=$(awk -F'"' '/containerimage.digest/{print $4}' "$META" 2>/dev/null || true)
+
+echo
+echo "Built $IMAGE_REF (linux/arm64, Node v$NODE_VERSION)"
+if [[ -n "$DIGEST" ]]; then
+    echo "Digest: $DIGEST"
+    echo
+    echo "Pin BOTH substrates to this digest for reproducibility:"
+    echo "  ${IMAGE_REPO}@${DIGEST}"
+fi
+if [[ $PUSH -eq 0 ]]; then
+    echo
+    echo "Loaded into the local Docker image store. Re-run with --push to publish to $IMAGE_REPO."
+fi


### PR DESCRIPTION
Closes #62 · part of #59 · design doc Q-D.

Both runtimes (`LocalContainerSiteRuntime` via Apple Containerization, `RemoteSandboxSiteRuntime` via Cloudflare) run the **same** container image so the dev server behaves identically everywhere.

## What's here
- **`container/Dockerfile`** — one `linux/arm64` image: Node pinned to `scripts/node-version.txt` (24.15.0), `git`, `tini`, the Astro/site toolchain, and the plugin's MCP server runtime baked at `/opt/anglesite/plugin` (`ANGLESITE_MCP_ENTRY`).
- **Pre-baked deps (design §5b)** — the template dependency closure is installed at build time. `hydrate.sh` hardlinks the baked `node_modules` when a cloned site's lockfile matches (zero install), else `npm ci --prefer-offline` against the warm cache.
- **`container/Dockerfile.cloudflare`** — thin wrapper adding the Cloudflare Sandbox `/sandbox` init binary on top of the canonical image; toolchain layers stay byte-identical. Exact binary pin finalized by #61.
- **`scripts/build-container-image.sh`** — stages the build context from the sibling plugin (same resolution as `copy-plugin.sh`), builds `linux/arm64`, optionally `--push`, prints the digest to pin.
- **`container/README.md`** — documents contents, build, runtime contract, and the **distribution decision (Q-D)**: build-once / push-by-digest; Apple Containerization pulls the digest, Cloudflare extends it.

## Scope checklist (#62)
- [x] One `Dockerfile` — Node pinned, Astro/site toolchain, `git`, plugin MCP server runtime
- [x] Build for `linux/arm64`
- [x] Decide distribution — build-once / push-by-digest, both substrates same digest (Q-D)
- [x] Pre-bake site deps so `npm ci` is skipped on cold start (feeds #5b)

## Validation (Docker 29.5, `linux/arm64`)
- Image builds in ~80s; digest emitted.
- `node v24.15.0`, `git 2.39.5`, `tini` present.
- MCP server answers a stdio `initialize` handshake (`anglesite-annotations` v0.16.4).
- `hydrate.sh` zero-install fast path hardlinks the baked toolchain (verified same inode); astro resolves.
- `astro dev` boots and serves HTTP over the exposed `:4321`.

## Note for reviewers
The sibling `../anglesite/template/package-lock.json` is currently **out of sync** with its `package.json`, so strict `npm ci` fails on the baked layer. The build prefers `npm ci` and falls back to `npm install` with a loud `WARN` so the image stays buildable; until the template lock is regenerated upstream, template-derived sites take the warm-cache `npm ci` path instead of the zero-install hardlink. Filing a separate issue against `Anglesite/anglesite` for the lockfile drift.

Not wired into the Xcode build — it's a CI/dev artifact like the spikes it feeds (#60/#61/#66/#69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)