### PR TITLE
docs: mark embedded-Node DevID re-sign verified (#4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ When in doubt, the plugin is the source of truth for skills, hooks, and the MCP 
 - **Swift / SwiftUI** — app shell. Targets macOS 27+.
 - **Plain SwiftUI + actors** for v0. No TCA, no third-party state libraries.
 - **WKWebView** — live preview of the Astro dev server.
-- **Embedded Node** — vendored at build time. The sandboxed MAS target re-signs it with the app's identity + hardened-runtime JIT/sandbox entitlements (`scripts/resign-node.sh`); a Developer-ID re-sign for the DevID notarization track is still deferred (#1/#4).
+- **Embedded Node** — vendored at build time. Both targets re-sign it via a `scripts/resign-node.sh` post-build phase with the app's identity + hardened runtime: the MAS target uses `node-runtime.entitlements` (sandbox/inherit + JIT), the DevID target uses `node-runtime-devid.entitlements` (same minus the sandbox keys). The DevID re-sign + bundle-seal verification is done (#4 — `codesign --verify --deep --strict` passes); only the real Developer-ID-cert notarize run remains deferred (#1, gated on the signing cert + `TEAM_ID`).
 - **MCP** — talks to the plugin's server over stdio.
 
 ## Two build targets


### PR DESCRIPTION
## Summary

Closes out **#4** (re-sign embedded Node with Developer ID). The resign-node build phase was already wired on both targets — this verifies the DevID bundle seal and corrects the stale CLAUDE.md note.

- `scripts/resign-node.sh` runs as a post-build phase on both targets (MAS: `node-runtime.entitlements`; DevID: `node-runtime-devid.entitlements`).
- Verified on a Debug build (Xcode-beta 27.0): `codesign --verify --deep --strict --verbose=2 Anglesite.app` → `valid on disk` / `satisfies its Designated Requirement` (exit 0). Nested node re-signed `adhoc,runtime` with JIT + unsigned-exec-mem + disable-library-validation — the DevID set, not the sandbox keys.
- The app passes no `DYLD_*` to the node child (no `DYLD` refs in `Sources/`), so node needs no `allow-dyld-environment-variables` entitlement.
- Only the real Developer-ID-cert notarize/staple run remains, tracked in #1 (`scripts/notarize-dry-run.sh` ready).

Diff is a single line in CLAUDE.md — the container work (#62) already merged via #95; this branch was rebased onto main to drop the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)