### PR TITLE
refactor(runtime): extract SiteRuntime protocol from PreviewSession (#65)

### DIFF
--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -110,7 +110,7 @@ final class ChatModel {
     private let siteDirectory: URL
     private let agent: ClaudeAgent
     private let history: ChatHistoryStore
-    /// Sticky-note source. Wired to the per-site `PreviewSession.mcpClient` in production so
+    /// Sticky-note source. Wired to the per-site `SiteRuntime.mcpClient` in production so
     /// `loadAnnotations()` shows the same annotations the edit overlay added; tests inject a
     /// fixture closure. `nil` disables the feed (returns no annotations, no error).
     private let annotationFeed: AnnotationFeed?

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -2,37 +2,37 @@ import SwiftUI
 import AnglesiteBridge
 import AnglesiteCore
 
-/// SwiftUI-facing wrapper over a `PreviewSession` actor: mirrors the session's `State` into an
-/// observable property and exposes `open(...)` / `close()` for the view layer.
+/// SwiftUI-facing wrapper over a `SiteRuntime` actor: mirrors the runtime's `SiteRuntimeState` into
+/// an observable property and exposes `open(...)` / `close()` for the view layer.
 ///
-/// Owns one `PreviewSession`; opening a different site reuses it (the session tears down the
-/// previous one first). For v1 multi-site each window will own its own `PreviewModel`.
+/// Owns one `SiteRuntime`; opening a different site reuses it (the runtime tears down the previous
+/// one first). For v1 multi-site each window will own its own `PreviewModel`.
 @MainActor
 @Observable
 final class PreviewModel {
-    private(set) var state: PreviewSession.State = .idle
+    private(set) var state: SiteRuntimeState = .idle
     /// The site this model was last asked to open, so the UI can show "preview of X" even while
-    /// the session is still `.starting`.
+    /// the runtime is still `.starting`.
     private(set) var openSiteID: String?
 
-    private let session: PreviewSession
+    private let runtime: any SiteRuntime
 
     /// The `EditRouter` that the WKWebView's `AnglesiteScriptHandler` forwards overlay edits to.
-    /// Wired to the session's `MCPClient` via a weak getter so the router doesn't outlive the
-    /// model. If the MCP client isn't running (session not started yet, or graceful spawn
+    /// Wired to the runtime's `MCPClient` via a weak getter so the router doesn't outlive the
+    /// model. If the MCP client isn't running (runtime not started yet, or graceful spawn
     /// failure), `MCPApplyEditRouter` returns `.failed("MCP not running")` per its existing shape.
     private(set) var editRouter: EditRouter
 
-    init(session: PreviewSession = PreviewSession()) {
-        self.session = session
-        self.editRouter = MCPApplyEditRouter(mcpClient: { [weak session] in
-            // `session` is the actor instance; reading `mcpClient` is synchronous on the actor.
-            await session?.mcpClient
+    init(runtime: any SiteRuntime = LocalSiteRuntime()) {
+        self.runtime = runtime
+        self.editRouter = MCPApplyEditRouter(mcpClient: { [weak runtime] in
+            // `runtime` is the actor instance; reading `mcpClient` hops onto the actor.
+            await runtime?.mcpClient
         })
-        // Mirror session state into `state`. `[weak self]` so the model can still be freed; the
+        // Mirror runtime state into `state`. `[weak self]` so the model can still be freed; the
         // stream itself outlives a freed model (one PreviewModel per window today, so it's moot).
         Task { @MainActor [weak self] in
-            for await newState in await session.observe() {
+            for await newState in await runtime.observe() {
                 self?.state = newState
             }
         }
@@ -48,7 +48,7 @@ final class PreviewModel {
         self.editRouter = MCPApplyEditRouter(
             mcpClient: { [weak self] in
                 guard let self else { return nil }
-                return await self.session.mcpClient
+                return await self.runtime.mcpClient
             },
             onEdit: onEdit
         )
@@ -56,12 +56,12 @@ final class PreviewModel {
 
     func open(siteID: String, siteDirectory: URL) {
         openSiteID = siteID
-        Task { await session.start(siteID: siteID, siteDirectory: siteDirectory) }
+        Task { await runtime.start(siteID: siteID, siteDirectory: siteDirectory) }
     }
 
     func close() {
         openSiteID = nil
-        Task { await session.stop() }
+        Task { await runtime.stop() }
     }
 
     /// The ready preview URL, if the session is currently `.ready`.
@@ -70,10 +70,10 @@ final class PreviewModel {
         return nil
     }
 
-    /// Exposes the session's `MCPClient` via the same weak-getter pattern `editRouter` uses,
+    /// Exposes the runtime's `MCPClient` via the same weak-getter pattern `editRouter` uses,
     /// so other features (annotation feed for chat, etc.) can reuse the per-site client
     /// without spawning a duplicate MCP server.
     func mcpClient() async -> MCPClient? {
-        await session.mcpClient
+        await runtime.mcpClient
     }
 }

--- a/Sources/AnglesiteApp/PreviewView.swift
+++ b/Sources/AnglesiteApp/PreviewView.swift
@@ -4,7 +4,7 @@ import AnglesiteBridge
 
 /// SwiftUI wrapper around a `WKWebView` showing the live Astro dev server.
 ///
-/// `url` is owned by the caller (a `PreviewModel` driven by `PreviewSession`). When it changes —
+/// `url` is owned by the caller (a `PreviewModel` driven by a `SiteRuntime`). When it changes —
 /// e.g. a supervised dev-server restart rebinds a new port — the web view reloads from the new URL.
 ///
 /// `router` is the `EditRouter` the in-page overlay's `AnglesiteScriptHandler` forwards edits to.

--- a/Sources/AnglesiteCore/LocalSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalSiteRuntime.swift
@@ -1,23 +1,16 @@
 import Foundation
 
-/// Owns the live preview of one site: it figures out how to run `astro dev` for that site,
-/// spawns it through `AstroDevServer`, and exposes a small `State` that a `PreviewView` can drive
-/// off (placeholder while starting / failed; loads the URL once ready; reloads when a supervised
-/// restart picks a new port).
+/// The host-subprocess `SiteRuntime`: it figures out how to run `astro dev` for a site, spawns it
+/// through `AstroDevServer`, and drives a `SiteRuntimeState` that a `PreviewView` can render off
+/// (placeholder while starting / failed; loads the URL once ready; reloads when a supervised
+/// restart picks a new port). It also owns the per-site MCP client for the edit pipeline.
 ///
-/// One session = one site at a time. `start(siteID:siteDirectory:)` tears down any previous site
-/// first. The session is reused across sites (it holds one `AstroDevServer`); for the v1 multi-site
-/// model each window will own its own `PreviewSession`.
-public actor PreviewSession {
-    public enum State: Sendable, Equatable {
-        case idle
-        case starting(siteID: String)
-        case ready(siteID: String, url: URL)
-        /// Couldn't preview this site (deps not installed, dev server crashed, etc.). `message` is
-        /// shown to the owner; the Debug pane has the full subprocess output.
-        case failed(siteID: String, message: String)
-    }
-
+/// One runtime = one site at a time. `start(siteID:siteDirectory:)` tears down any previous site
+/// first. Each window owns its own `LocalSiteRuntime` (per the v1 multi-site model).
+///
+/// This is the transitional implementation that keeps today's behavior; the Cloudflare (#66) and
+/// local-container (#69) runtimes will be alternate `SiteRuntime` conformers.
+public actor LocalSiteRuntime: SiteRuntime {
     /// How to run `astro dev` for a site directory — or why it can't be run.
     public enum LaunchPlan: Sendable, Equatable {
         case run(executable: URL, arguments: [String])
@@ -39,9 +32,11 @@ public actor PreviewSession {
     private let logCenter: LogCenter
     private let resolveCommand: CommandResolver
     private let resolveMCPCommand: MCPCommandResolver
+    private let restartPolicy: ProcessSupervisor.RestartPolicy
+    private let readyTimeout: TimeInterval
 
-    private var current: State = .idle
-    private var observers: [UUID: AsyncStream<State>.Continuation] = [:]
+    private var current: SiteRuntimeState = .idle
+    private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
     /// Bumped on every `start(...)`; lets a slow `devServer.start` await know it was superseded.
     private var generation = 0
 
@@ -50,22 +45,26 @@ public actor PreviewSession {
         mcpClient: MCPClient? = nil,
         supervisor: ProcessSupervisor = .shared,
         logCenter: LogCenter = .shared,
-        resolveCommand: @escaping CommandResolver = PreviewSession.resolveAstroCommand,
-        resolveMCPCommand: @escaping MCPCommandResolver = PreviewSession.resolveBundledMCPCommand
+        resolveCommand: @escaping CommandResolver = LocalSiteRuntime.resolveAstroCommand,
+        resolveMCPCommand: @escaping MCPCommandResolver = LocalSiteRuntime.resolveBundledMCPCommand,
+        restartPolicy: ProcessSupervisor.RestartPolicy = .onCrash(maxAttempts: 3, baseBackoff: 0.5),
+        readyTimeout: TimeInterval = 30
     ) {
         self.devServer = devServer ?? AstroDevServer(supervisor: supervisor, logCenter: logCenter)
         self.mcpClient = mcpClient ?? MCPClient(supervisor: supervisor, logCenter: logCenter)
         self.logCenter = logCenter
         self.resolveCommand = resolveCommand
         self.resolveMCPCommand = resolveMCPCommand
+        self.restartPolicy = restartPolicy
+        self.readyTimeout = readyTimeout
     }
 
-    public var state: State { current }
+    public var state: SiteRuntimeState { current }
 
     /// Stream of state transitions. Yields the current state immediately, then every subsequent
     /// change. Multiple observers are supported; each gets its own stream.
-    public func observe() -> AsyncStream<State> {
-        let (stream, continuation) = AsyncStream<State>.makeStream(bufferingPolicy: .unbounded)
+    public func observe() -> AsyncStream<SiteRuntimeState> {
+        let (stream, continuation) = AsyncStream<SiteRuntimeState>.makeStream(bufferingPolicy: .unbounded)
         let id = UUID()
         observers[id] = continuation
         continuation.onTermination = { [weak self] _ in
@@ -77,12 +76,7 @@ public actor PreviewSession {
 
     /// Start (or switch to) the live preview for `siteID` at `siteDirectory`. Tears down any
     /// previous site first. Returns once the state has settled to `.ready` or `.failed`.
-    public func start(
-        siteID: String,
-        siteDirectory: URL,
-        restartPolicy: ProcessSupervisor.RestartPolicy = .onCrash(maxAttempts: 3, baseBackoff: 0.5),
-        readyTimeout: TimeInterval = 30
-    ) async {
+    public func start(siteID: String, siteDirectory: URL) async {
         await stopSubprocesses()
         generation += 1
         let gen = generation
@@ -107,7 +101,7 @@ public actor PreviewSession {
                     // newer call already stopped this server, so just drop the result.
                     return
                 }
-                // Best-effort MCP spawn — failures are logged and leave the session in .ready
+                // Best-effort MCP spawn — failures are logged and leave the runtime in .ready
                 // anyway (preview is the primary feature; the edit pipeline is an enhancement).
                 await startMCPClient(siteID: siteID, siteDirectory: siteDirectory)
                 guard gen == generation else { return }
@@ -169,7 +163,7 @@ public actor PreviewSession {
         }
     }
 
-    private func setState(_ newState: State) {
+    private func setState(_ newState: SiteRuntimeState) {
         guard newState != current else { return }
         current = newState
         for continuation in observers.values { continuation.yield(newState) }

--- a/Sources/AnglesiteCore/SiteRuntime.swift
+++ b/Sources/AnglesiteCore/SiteRuntime.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// The lifecycle state of one site's live preview, independent of *where* it runs (host subprocess
+/// today via `LocalSiteRuntime`; a Cloudflare Sandbox or local Apple-Containerization VM later).
+public enum SiteRuntimeState: Sendable, Equatable {
+    case idle
+    case starting(siteID: String)
+    case ready(siteID: String, url: URL)
+    /// Couldn't preview this site (deps not installed, dev server crashed, etc.). `message` is
+    /// shown to the owner; the Debug pane has the full subprocess output.
+    case failed(siteID: String, message: String)
+}
+
+/// One runtime = one site's live preview. This is the seam for swapping execution substrates
+/// (see #59 / design doc §4): a container exposes an HTTP/WS URL rather than a pid + pipes, so the
+/// abstraction lives here — at `PreviewSession`'s old level — not at `SupervisorBackend`.
+///
+/// `start(siteID:siteDirectory:)` tears down any previous site first and settles to `.ready` /
+/// `.failed`; `observe()` streams every `SiteRuntimeState` transition; `mcpClient` is the per-site
+/// MCP connection the edit pipeline and annotation feed route through.
+///
+/// Refines `Actor`: every conformer owns mutable lifecycle state (subprocess handles today, a
+/// remote session later), so isolation is intrinsic — and a class-bound existential keeps the
+/// `[weak]` capture `PreviewModel` uses for its edit router valid.
+///
+/// `mcpClient` is the concrete stdio `MCPClient` for now. When #64 lands an HTTP/WS transport this
+/// getter becomes the substrate-agnostic seam (an endpoint-backed client for the container paths).
+public protocol SiteRuntime: Actor {
+    func start(siteID: String, siteDirectory: URL) async
+    func stop() async
+    func observe() -> AsyncStream<SiteRuntimeState>
+    var mcpClient: MCPClient { get }
+}

--- a/Tests/AnglesiteCoreTests/LocalSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalSiteRuntimeTests.swift
@@ -2,61 +2,59 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
-struct PreviewSessionTests {
+struct LocalSiteRuntimeTests {
     private let alwaysReady: AstroDevServer.ReadinessProbe = { _ in true }
     /// A real, existing directory — the supervisor `cd`s into the site dir before spawning, so a
     /// nonexistent path would fail `process.run()` before our fixture script even runs.
     private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
 
-    private func makeSession(
-        resolve: @escaping PreviewSession.CommandResolver,
-        probe: @escaping AstroDevServer.ReadinessProbe
-    ) -> PreviewSession {
+    private func makeRuntime(
+        resolve: @escaping LocalSiteRuntime.CommandResolver,
+        probe: @escaping AstroDevServer.ReadinessProbe,
+        restartPolicy: ProcessSupervisor.RestartPolicy = .onCrash(maxAttempts: 3, baseBackoff: 0.5)
+    ) -> LocalSiteRuntime {
         let supervisor = ProcessSupervisor()
         let center = LogCenter()
         let devServer = AstroDevServer(supervisor: supervisor, logCenter: center, readinessProbe: probe)
-        return PreviewSession(devServer: devServer, logCenter: center, resolveCommand: resolve)
+        return LocalSiteRuntime(devServer: devServer, logCenter: center, resolveCommand: resolve, restartPolicy: restartPolicy)
     }
 
-    private func shFixture(_ script: String, _ args: String...) -> PreviewSession.LaunchPlan {
+    private func shFixture(_ script: String, _ args: String...) -> LocalSiteRuntime.LaunchPlan {
         .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", script] + args)
     }
 
     @Test("Unavailable command lands in failed") func unavailableCommandLandsInFailed() async {
-        let session = makeSession(
+        let runtime = makeRuntime(
             resolve: { _ in .unavailable(reason: "dependencies not installed — run `npm install`") },
             probe: alwaysReady
         )
-        await session.start(siteID: "mysite", siteDirectory: tmpDir)
-        let state = await session.state
+        await runtime.start(siteID: "mysite", siteDirectory: tmpDir)
+        let state = await runtime.state
         #expect(state == .failed(siteID: "mysite", message: "dependencies not installed — run `npm install`"))
     }
 
     @Test("Runnable command reaches ready then stop returns to idle") func runnableCommandReachesReadyThenStopReturnsToIdle() async {
-        let session = makeSession(
+        let runtime = makeRuntime(
             resolve: { _ in self.shFixture("echo '  Local    http://localhost:4321/'; exec sleep 30") },
             probe: alwaysReady
         )
-        await session.start(siteID: "mysite", siteDirectory: tmpDir)
-        let ready = await session.state
+        await runtime.start(siteID: "mysite", siteDirectory: tmpDir)
+        let ready = await runtime.state
         #expect(ready == .ready(siteID: "mysite", url: URL(string: "http://localhost:4321/")!))
 
-        await session.stop()
-        let idle = await session.state
+        await runtime.stop()
+        let idle = await runtime.state
         #expect(idle == .idle)
     }
 
     @Test("Crash before ready lands in failed") func crashBeforeReadyLandsInFailed() async {
-        let session = makeSession(
+        let runtime = makeRuntime(
             resolve: { _ in self.shFixture("echo broken 1>&2; exit 1") },
-            probe: alwaysReady
-        )
-        await session.start(
-            siteID: "mysite",
-            siteDirectory: tmpDir,
+            probe: alwaysReady,
             restartPolicy: .never
         )
-        let state = await session.state
+        await runtime.start(siteID: "mysite", siteDirectory: tmpDir)
+        let state = await runtime.state
         guard case .failed(let siteID, _) = state else {
             Issue.record("expected .failed, got \(state)")
             return
@@ -74,23 +72,20 @@ struct PreviewSessionTests {
         if [ "$n" -lt 2 ]; then sleep 0.2; exit 1; fi
         exec sleep 30
         """
-        let session = makeSession(
+        let runtime = makeRuntime(
             resolve: { _ in self.shFixture(script, counter) },
-            probe: alwaysReady
-        )
-        await session.start(
-            siteID: "mysite",
-            siteDirectory: tmpDir,
+            probe: alwaysReady,
             restartPolicy: .onCrash(maxAttempts: 3, baseBackoff: 0.05)
         )
-        let first = await session.state
+        await runtime.start(siteID: "mysite", siteDirectory: tmpDir)
+        let first = await runtime.state
         #expect(first == .ready(siteID: "mysite", url: URL(string: "http://localhost:9201/")!))
 
         try? await Task.sleep(nanoseconds: 700_000_000)
-        let updated = await session.state
+        let updated = await runtime.state
         #expect(updated == .ready(siteID: "mysite", url: URL(string: "http://localhost:9202/")!))
 
-        await session.stop()
+        await runtime.stop()
     }
 
     // MARK: MCP client lifecycle
@@ -120,112 +115,112 @@ struct PreviewSessionTests {
         return URL(fileURLWithPath: "/usr/bin/python3")
     }()
 
-    private func makeSessionWithMCP(
-        astroResolve: @escaping PreviewSession.CommandResolver,
-        mcpResolve: @escaping PreviewSession.MCPCommandResolver
-    ) -> (PreviewSession, MCPClient) {
+    private func makeRuntimeWithMCP(
+        astroResolve: @escaping LocalSiteRuntime.CommandResolver,
+        mcpResolve: @escaping LocalSiteRuntime.MCPCommandResolver
+    ) -> (LocalSiteRuntime, MCPClient) {
         let supervisor = ProcessSupervisor()
         let center = LogCenter()
         let devServer = AstroDevServer(supervisor: supervisor, logCenter: center, readinessProbe: alwaysReady)
         let mcpClient = MCPClient(supervisor: supervisor, logCenter: center)
-        let session = PreviewSession(
+        let runtime = LocalSiteRuntime(
             devServer: devServer,
             mcpClient: mcpClient,
             logCenter: center,
             resolveCommand: astroResolve,
             resolveMCPCommand: mcpResolve
         )
-        return (session, mcpClient)
+        return (runtime, mcpClient)
     }
 
-    private func runnableMCPFake() -> PreviewSession.LaunchPlan {
+    private func runnableMCPFake() -> LocalSiteRuntime.LaunchPlan {
         .run(executable: Self.pythonURL, arguments: ["-u", "-c", Self.mcpFakeScript])
     }
 
     @Test("MCP client is running after successful start") func mCPClientIsRunningAfterSuccessfulStart() async {
-        let (session, mcp) = makeSessionWithMCP(
+        let (runtime, mcp) = makeRuntimeWithMCP(
             astroResolve: { _ in self.shFixture("echo '  Local    http://localhost:4321/'; exec sleep 30") },
             mcpResolve: { self.runnableMCPFake() }
         )
-        await session.start(siteID: "mysite", siteDirectory: tmpDir)
+        await runtime.start(siteID: "mysite", siteDirectory: tmpDir)
 
         // AstroDevServer succeeded → state is .ready.
-        let state = await session.state
+        let state = await runtime.state
         #expect(state == .ready(siteID: "mysite", url: URL(string: "http://localhost:4321/")!))
 
         // MCP also came up.
         let running = await mcp.isRunning
-        #expect(running, "expected MCPClient.isRunning after a successful session.start")
+        #expect(running, "expected MCPClient.isRunning after a successful runtime.start")
 
-        // The session's exposed reference is the same instance.
-        let exposed = await session.mcpClient
+        // The runtime's exposed reference is the same instance.
+        let exposed = await runtime.mcpClient
         #expect(exposed === mcp)
 
-        await session.stop()
+        await runtime.stop()
     }
 
-    @Test("MCP client stops when session stops") func mCPClientStopsWhenSessionStops() async {
-        let (session, mcp) = makeSessionWithMCP(
+    @Test("MCP client stops when runtime stops") func mCPClientStopsWhenRuntimeStops() async {
+        let (runtime, mcp) = makeRuntimeWithMCP(
             astroResolve: { _ in self.shFixture("echo '  Local    http://localhost:4321/'; exec sleep 30") },
             mcpResolve: { self.runnableMCPFake() }
         )
-        await session.start(siteID: "mysite", siteDirectory: tmpDir)
+        await runtime.start(siteID: "mysite", siteDirectory: tmpDir)
         let runningBefore = await mcp.isRunning
         #expect(runningBefore)
 
-        await session.stop()
+        await runtime.stop()
         let runningAfter = await mcp.isRunning
-        #expect(!runningAfter, "MCPClient should be stopped after session.stop()")
+        #expect(!runningAfter, "MCPClient should be stopped after runtime.stop()")
     }
 
     @Test("State stays ready when MCP command is unavailable") func stateStaysReadyWhenMCPCommandIsUnavailable() async {
-        // MCP can't be located → session still reaches .ready (preview is the primary feature).
-        let (session, mcp) = makeSessionWithMCP(
+        // MCP can't be located → runtime still reaches .ready (preview is the primary feature).
+        let (runtime, mcp) = makeRuntimeWithMCP(
             astroResolve: { _ in self.shFixture("echo '  Local    http://localhost:4321/'; exec sleep 30") },
             mcpResolve: { .unavailable(reason: "test: bundled plugin not present") }
         )
-        await session.start(siteID: "mysite", siteDirectory: tmpDir)
+        await runtime.start(siteID: "mysite", siteDirectory: tmpDir)
 
-        let state = await session.state
+        let state = await runtime.state
         #expect(state == .ready(siteID: "mysite", url: URL(string: "http://localhost:4321/")!))
         let running = await mcp.isRunning
         #expect(!running)
 
-        await session.stop()
+        await runtime.stop()
     }
 
     @Test("State stays ready when MCP launch fails") func stateStaysReadyWhenMCPLaunchFails() async {
-        // MCP launch errors out (bad executable) → session still reaches .ready, mcpClient is not running.
-        let (session, mcp) = makeSessionWithMCP(
+        // MCP launch errors out (bad executable) → runtime still reaches .ready, mcpClient is not running.
+        let (runtime, mcp) = makeRuntimeWithMCP(
             astroResolve: { _ in self.shFixture("echo '  Local    http://localhost:4321/'; exec sleep 30") },
             mcpResolve: { .run(executable: URL(fileURLWithPath: "/nonexistent/mcp/binary"), arguments: []) }
         )
-        await session.start(siteID: "mysite", siteDirectory: tmpDir)
-        let state = await session.state
+        await runtime.start(siteID: "mysite", siteDirectory: tmpDir)
+        let state = await runtime.state
         if case .ready = state { /* ok */ } else {
             Issue.record("expected .ready (graceful MCP failure), got \(state)")
         }
         let running = await mcp.isRunning
         #expect(!running)
-        await session.stop()
+        await runtime.stop()
     }
 
     @Test("Observe stream emits idle starting ready") func observeStreamEmitsIdleStartingReady() async {
-        let session = makeSession(
+        let runtime = makeRuntime(
             resolve: { _ in self.shFixture("echo '  Local    http://localhost:4321/'; exec sleep 30") },
             probe: alwaysReady
         )
-        let stream = await session.observe()
+        let stream = await runtime.observe()
         var iterator = stream.makeAsyncIterator()
 
         // First emission is the current state (idle), before we start.
         let s0 = await iterator.next()
         #expect(s0 == .idle)
 
-        await session.start(siteID: "mysite", siteDirectory: tmpDir)
+        await runtime.start(siteID: "mysite", siteDirectory: tmpDir)
 
         // Collect the remaining transitions until we see .ready.
-        var seen: [PreviewSession.State] = []
+        var seen: [SiteRuntimeState] = []
         while let s = await iterator.next() {
             seen.append(s)
             if case .ready = s { break }
@@ -233,6 +228,6 @@ struct PreviewSessionTests {
         #expect(seen.first == .starting(siteID: "mysite"))
         #expect(seen.last == .ready(siteID: "mysite", url: URL(string: "http://localhost:4321/")!))
 
-        await session.stop()
+        await runtime.stop()
     }
 }


### PR DESCRIPTION
Closes #65 · part of #59 (containerized dev server) · design doc §4.

Extracts the substrate-swapping seam as a protocol so the host-subprocess path, the future Cloudflare path, and the future local-container path are interchangeable. **Pure refactor — no behavior change.**

## What changed
- **New `SiteRuntime.swift`** — `protocol SiteRuntime: Actor` (`start`/`stop`/`observe`/`mcpClient`) plus a top-level `SiteRuntimeState` (hoisted from the old nested `PreviewSession.State`).
- **`PreviewSession` → `LocalSiteRuntime`** (renamed via `git mv`, history preserved), now conforming to `SiteRuntime`. `restartPolicy`/`readyTimeout` moved from `start(...)` params to `init` so the 2-arg `start` matches the protocol with no overload ambiguity.
- **`PreviewModel`** now depends on `any SiteRuntime` (default `LocalSiteRuntime()`), not the concrete session.
- Doc-comment touch-ups in `ChatModel`/`PreviewView`; test file renamed (`PreviewSessionTests` → `LocalSiteRuntimeTests`) with assertions unchanged.

## Design notes
- Refined the protocol to `Actor` rather than the issue's illustrative `Sendable` — keeps the existing actor-isolated members witnessing the requirements directly, and a class-bound existential preserves `PreviewModel`'s `[weak]` capture for its edit router.
- Kept `mcpClient: MCPClient` on the protocol for now. A container exposes an MCP endpoint rather than an stdio client; #64 turns this getter into the HTTP/WS transport seam.

## Enables
- #66 — `RemoteSandboxSiteRuntime` (Cloudflare)
- #69 — `LocalContainerSiteRuntime` (Apple Containerization)

Both now just need to be alternate `SiteRuntime` conformers.

## Verification
- `LocalSiteRuntimeTests`: 9/9 ✅ (unchanged assertions)
- Full `AnglesiteCore` suite: green ✅
- `Anglesite` (DevID) target build: **SUCCEEDED** ✅
- `AnglesiteMAS` (sandboxed) target build: **SUCCEEDED** ✅
- `AppliesEditEndToEndTests` errors locally with `node not found in common paths` — environmental (nvm-installed Node, outside the test's hard-coded paths), pre-existing, untouched by this change. CI provides Node ≥22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)