### PR TITLE
feat(server): HTTP/Streamable MCP transport (#63)

### DIFF
--- a/server/http-server.mjs
+++ b/server/http-server.mjs
@@ -1,0 +1,95 @@
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { buildServer } from "./index-tools.mjs";
+
+/** Read and JSON-parse a request body. Returns `undefined` for an empty body. */
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => { chunks.push(chunk); });
+    req.on("end", () => {
+      if (chunks.length === 0) return resolve(undefined);
+      try { resolve(JSON.parse(Buffer.concat(chunks).toString("utf8"))); } catch (e) { reject(e); }
+    });
+    req.on("error", reject);
+  });
+}
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+/**
+ * Start the Anglesite MCP server over Streamable HTTP on a single `/mcp` endpoint.
+ * Session-managed: an `initialize` POST mints a session + per-session transport;
+ * subsequent requests carry `Mcp-Session-Id`.
+ *
+ * Returns `{ url, close }` where `url` is the full endpoint (`http://host:port/mcp`).
+ */
+export async function startHttpServer({ projectRoot, host = "127.0.0.1", port = 4399 }) {
+  /** @type {Map<string, StreamableHTTPServerTransport>} */
+  const transports = new Map();
+
+  const httpServer = createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      if (url.pathname !== "/mcp") { res.writeHead(404).end(); return; }
+
+      const sid = req.headers["mcp-session-id"];
+
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        let transport = typeof sid === "string" ? transports.get(sid) : undefined;
+
+        if (!transport) {
+          if (!isInitializeRequest(body)) {
+            sendJson(res, 400, {
+              jsonrpc: "2.0",
+              error: { code: -32000, message: "Bad Request: no valid session ID provided" },
+              id: null,
+            });
+            return;
+          }
+          transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
+          transport.onclose = () => {
+            if (transport.sessionId) transports.delete(transport.sessionId);
+          };
+          const server = buildServer(projectRoot);
+          await server.connect(transport);
+        }
+
+        await transport.handleRequest(req, res, body);
+        if (transport.sessionId) transports.set(transport.sessionId, transport);
+        return;
+      }
+
+      if (req.method === "GET" || req.method === "DELETE") {
+        const transport = typeof sid === "string" ? transports.get(sid) : undefined;
+        if (!transport) { res.writeHead(400).end("Invalid or missing session ID"); return; }
+        await transport.handleRequest(req, res);
+        return;
+      }
+
+      res.writeHead(405).end();
+    } catch (err) {
+      if (!res.headersSent) sendJson(res, 500, { jsonrpc: "2.0", error: { code: -32603, message: String(err) }, id: null });
+    }
+  });
+
+  await new Promise((resolve) => httpServer.listen(port, host, resolve));
+  const actualPort = httpServer.address().port;
+  const endpoint = `http://${host}:${actualPort}/mcp`;
+  console.log(`Anglesite MCP listening on ${endpoint}`);
+
+  return {
+    url: endpoint,
+    close: async () => {
+      await Promise.all([...transports.values()].map((t) => t.close?.()));
+      transports.clear();
+      await new Promise((resolve) => httpServer.close(() => resolve()));
+    },
+  };
+}

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -1,0 +1,118 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import {
+  addAnnotation,
+  listAnnotations,
+  resolveAnnotation,
+} from "./annotations.mjs";
+import { applyEditInputShape } from "./apply-edit-schema.mjs";
+import { applyEdit } from "./apply-edit-dispatcher.mjs";
+import { recordEdit } from "./edit-history.mjs";
+import { undoEdit } from "./undo-edit.mjs";
+
+/**
+ * Build the Anglesite MCP server with every tool registered against `projectRoot`.
+ * Transport-agnostic — the caller connects it to stdio or HTTP.
+ */
+export function buildServer(projectRoot) {
+  const server = new McpServer({
+    name: "anglesite-annotations",
+    version: "0.16.4",
+  });
+
+  server.tool(
+    "add_annotation",
+    "Pin a feedback note to a page element",
+    {
+      path: z.string().describe("Page path, e.g. /about"),
+      selector: z.string().describe("CSS selector of the target element"),
+      text: z.string().describe("The feedback note text"),
+      sourceFile: z
+        .string()
+        .optional()
+        .describe("Source file path, e.g. src/pages/about.astro"),
+    },
+    ({ path, selector, text, sourceFile }) => {
+      const annotation = addAnnotation(projectRoot, {
+        path,
+        selector,
+        text,
+        sourceFile,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(annotation) }] };
+    },
+  );
+
+  server.tool(
+    "list_annotations",
+    "List unresolved feedback annotations",
+    {
+      path: z.string().optional().describe("Filter by page path"),
+    },
+    ({ path }) => {
+      const annotations = listAnnotations(projectRoot, path);
+      return { content: [{ type: "text", text: JSON.stringify(annotations) }] };
+    },
+  );
+
+  server.tool(
+    "resolve_annotation",
+    "Mark a feedback annotation as resolved",
+    {
+      id: z.string().describe("Annotation ID to resolve"),
+    },
+    ({ id }) => {
+      try {
+        const annotation = resolveAnnotation(projectRoot, id);
+        return { content: [{ type: "text", text: JSON.stringify(annotation) }] };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: error.message }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // Phase 5 edit pipeline. The schema lives in `apply-edit-schema.mjs` (#296); the resolver in
+  // `patcher.mjs` (#295); the apply/refusal logic in `apply-edit-dispatcher.mjs` (#297); the
+  // hidden-branch history that backs per-edit undo in `edit-history.mjs` (#298). The dispatcher
+  // invokes `onApplied` after a successful patch — `recordEdit` commits onto refs/heads/anglesite/edits
+  // without touching HEAD/index/working-tree and returns the SHA, which the dispatcher threads
+  // back as `commit` on the edit-applied response.
+  server.tool(
+    "apply_edit",
+    "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file. Successful edits are also committed onto the hidden anglesite/edits branch for per-edit undo.",
+    applyEditInputShape,
+    async (input) =>
+      applyEdit(projectRoot, input, {
+        onApplied: ({ file, range }) =>
+          recordEdit(projectRoot, { file, range, message: `anglesite: edit ${file}` }),
+      }),
+  );
+
+  server.tool(
+    "undo_edit",
+    "Undo the most-recent commit on the hidden anglesite/edits branch by writing the parent commit's blobs back to disk. HEAD-only in v1: an optional `commit` argument must equal current HEAD (or be omitted). `force: true` skips the working-tree-modification check and overwrites any external changes to the touched files.",
+    {
+      commit: z.string().optional().describe("SHA to undo. Must equal current HEAD of refs/heads/anglesite/edits if provided."),
+      force: z.boolean().optional().describe("Skip the working-tree-modification check and overwrite any external changes. Default false."),
+    },
+    async ({ commit, force }) => {
+      const result = await undoEdit(projectRoot, { commit, force });
+      return {
+        content: [{ type: "text", text: JSON.stringify(result) }],
+        isError: result.status === "refused",
+      };
+    },
+  );
+
+  return server;
+}
+
+/** Connect a freshly built server to stdio. The default transport. */
+export async function startStdioServer({ projectRoot }) {
+  const server = buildServer(projectRoot);
+  await server.connect(new StdioServerTransport());
+}

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -11,99 +11,111 @@ import { applyEdit } from "./apply-edit-dispatcher.mjs";
 import { recordEdit } from "./edit-history.mjs";
 import { undoEdit } from "./undo-edit.mjs";
 
-const projectRoot = process.env.ANGLESITE_PROJECT_ROOT || process.cwd();
+/**
+ * Build the Anglesite MCP server with every tool registered against `projectRoot`.
+ * Transport-agnostic — the caller connects it to stdio or HTTP.
+ */
+export function buildServer(projectRoot) {
+  const server = new McpServer({
+    name: "anglesite-annotations",
+    version: "0.16.4",
+  });
 
-const server = new McpServer({
-  name: "anglesite-annotations",
-  version: "0.16.4",
-});
-
-server.tool(
-  "add_annotation",
-  "Pin a feedback note to a page element",
-  {
-    path: z.string().describe("Page path, e.g. /about"),
-    selector: z.string().describe("CSS selector of the target element"),
-    text: z.string().describe("The feedback note text"),
-    sourceFile: z
-      .string()
-      .optional()
-      .describe("Source file path, e.g. src/pages/about.astro"),
-  },
-  ({ path, selector, text, sourceFile }) => {
-    const annotation = addAnnotation(projectRoot, {
-      path,
-      selector,
-      text,
-      sourceFile,
-    });
-    return { content: [{ type: "text", text: JSON.stringify(annotation) }] };
-  },
-);
-
-server.tool(
-  "list_annotations",
-  "List unresolved feedback annotations",
-  {
-    path: z.string().optional().describe("Filter by page path"),
-  },
-  ({ path }) => {
-    const annotations = listAnnotations(projectRoot, path);
-    return { content: [{ type: "text", text: JSON.stringify(annotations) }] };
-  },
-);
-
-server.tool(
-  "resolve_annotation",
-  "Mark a feedback annotation as resolved",
-  {
-    id: z.string().describe("Annotation ID to resolve"),
-  },
-  ({ id }) => {
-    try {
-      const annotation = resolveAnnotation(projectRoot, id);
+  server.tool(
+    "add_annotation",
+    "Pin a feedback note to a page element",
+    {
+      path: z.string().describe("Page path, e.g. /about"),
+      selector: z.string().describe("CSS selector of the target element"),
+      text: z.string().describe("The feedback note text"),
+      sourceFile: z
+        .string()
+        .optional()
+        .describe("Source file path, e.g. src/pages/about.astro"),
+    },
+    ({ path, selector, text, sourceFile }) => {
+      const annotation = addAnnotation(projectRoot, {
+        path,
+        selector,
+        text,
+        sourceFile,
+      });
       return { content: [{ type: "text", text: JSON.stringify(annotation) }] };
-    } catch (error) {
+    },
+  );
+
+  server.tool(
+    "list_annotations",
+    "List unresolved feedback annotations",
+    {
+      path: z.string().optional().describe("Filter by page path"),
+    },
+    ({ path }) => {
+      const annotations = listAnnotations(projectRoot, path);
+      return { content: [{ type: "text", text: JSON.stringify(annotations) }] };
+    },
+  );
+
+  server.tool(
+    "resolve_annotation",
+    "Mark a feedback annotation as resolved",
+    {
+      id: z.string().describe("Annotation ID to resolve"),
+    },
+    ({ id }) => {
+      try {
+        const annotation = resolveAnnotation(projectRoot, id);
+        return { content: [{ type: "text", text: JSON.stringify(annotation) }] };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: error.message }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // Phase 5 edit pipeline. The schema lives in `apply-edit-schema.mjs` (#296); the resolver in
+  // `patcher.mjs` (#295); the apply/refusal logic in `apply-edit-dispatcher.mjs` (#297); the
+  // hidden-branch history that backs per-edit undo in `edit-history.mjs` (#298). The dispatcher
+  // invokes `onApplied` after a successful patch — `recordEdit` commits onto refs/heads/anglesite/edits
+  // without touching HEAD/index/working-tree and returns the SHA, which the dispatcher threads
+  // back as `commit` on the edit-applied response.
+  server.tool(
+    "apply_edit",
+    "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file. Successful edits are also committed onto the hidden anglesite/edits branch for per-edit undo.",
+    applyEditInputShape,
+    async (input) =>
+      applyEdit(projectRoot, input, {
+        onApplied: ({ file, range }) =>
+          recordEdit(projectRoot, { file, range, message: `anglesite: edit ${file}` }),
+      }),
+  );
+
+  server.tool(
+    "undo_edit",
+    "Undo the most-recent commit on the hidden anglesite/edits branch by writing the parent commit's blobs back to disk. HEAD-only in v1: an optional `commit` argument must equal current HEAD (or be omitted). `force: true` skips the working-tree-modification check and overwrites any external changes to the touched files.",
+    {
+      commit: z.string().optional().describe("SHA to undo. Must equal current HEAD of refs/heads/anglesite/edits if provided."),
+      force: z.boolean().optional().describe("Skip the working-tree-modification check and overwrite any external changes. Default false."),
+    },
+    async ({ commit, force }) => {
+      const result = await undoEdit(projectRoot, { commit, force });
       return {
-        content: [{ type: "text", text: error.message }],
-        isError: true,
+        content: [{ type: "text", text: JSON.stringify(result) }],
+        isError: result.status === "refused",
       };
-    }
-  },
-);
+    },
+  );
 
-// Phase 5 edit pipeline. The schema lives in `apply-edit-schema.mjs` (#296); the resolver in
-// `patcher.mjs` (#295); the apply/refusal logic in `apply-edit-dispatcher.mjs` (#297); the
-// hidden-branch history that backs per-edit undo in `edit-history.mjs` (#298). The dispatcher
-// invokes `onApplied` after a successful patch — `recordEdit` commits onto refs/heads/anglesite/edits
-// without touching HEAD/index/working-tree and returns the SHA, which the dispatcher threads
-// back as `commit` on the edit-applied response.
-server.tool(
-  "apply_edit",
-  "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file. Successful edits are also committed onto the hidden anglesite/edits branch for per-edit undo.",
-  applyEditInputShape,
-  async (input) =>
-    applyEdit(projectRoot, input, {
-      onApplied: ({ file, range }) =>
-        recordEdit(projectRoot, { file, range, message: `anglesite: edit ${file}` }),
-    }),
-);
+  return server;
+}
 
-server.tool(
-  "undo_edit",
-  "Undo the most-recent commit on the hidden anglesite/edits branch by writing the parent commit's blobs back to disk. HEAD-only in v1: an optional `commit` argument must equal current HEAD (or be omitted). `force: true` skips the working-tree-modification check and overwrites any external changes to the touched files.",
-  {
-    commit: z.string().optional().describe("SHA to undo. Must equal current HEAD of refs/heads/anglesite/edits if provided."),
-    force: z.boolean().optional().describe("Skip the working-tree-modification check and overwrite any external changes. Default false."),
-  },
-  async ({ commit, force }) => {
-    const result = await undoEdit(projectRoot, { commit, force });
-    return {
-      content: [{ type: "text", text: JSON.stringify(result) }],
-      isError: result.status === "refused",
-    };
-  },
-);
+/** Connect a freshly built server to stdio. The default transport. */
+export async function startStdioServer({ projectRoot }) {
+  const server = buildServer(projectRoot);
+  await server.connect(new StdioServerTransport());
+}
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
+const projectRoot = process.env.ANGLESITE_PROJECT_ROOT || process.cwd();
+await startStdioServer({ projectRoot });

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,121 +1,13 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
-import {
-  addAnnotation,
-  listAnnotations,
-  resolveAnnotation,
-} from "./annotations.mjs";
-import { applyEditInputShape } from "./apply-edit-schema.mjs";
-import { applyEdit } from "./apply-edit-dispatcher.mjs";
-import { recordEdit } from "./edit-history.mjs";
-import { undoEdit } from "./undo-edit.mjs";
-
-/**
- * Build the Anglesite MCP server with every tool registered against `projectRoot`.
- * Transport-agnostic — the caller connects it to stdio or HTTP.
- */
-export function buildServer(projectRoot) {
-  const server = new McpServer({
-    name: "anglesite-annotations",
-    version: "0.16.4",
-  });
-
-  server.tool(
-    "add_annotation",
-    "Pin a feedback note to a page element",
-    {
-      path: z.string().describe("Page path, e.g. /about"),
-      selector: z.string().describe("CSS selector of the target element"),
-      text: z.string().describe("The feedback note text"),
-      sourceFile: z
-        .string()
-        .optional()
-        .describe("Source file path, e.g. src/pages/about.astro"),
-    },
-    ({ path, selector, text, sourceFile }) => {
-      const annotation = addAnnotation(projectRoot, {
-        path,
-        selector,
-        text,
-        sourceFile,
-      });
-      return { content: [{ type: "text", text: JSON.stringify(annotation) }] };
-    },
-  );
-
-  server.tool(
-    "list_annotations",
-    "List unresolved feedback annotations",
-    {
-      path: z.string().optional().describe("Filter by page path"),
-    },
-    ({ path }) => {
-      const annotations = listAnnotations(projectRoot, path);
-      return { content: [{ type: "text", text: JSON.stringify(annotations) }] };
-    },
-  );
-
-  server.tool(
-    "resolve_annotation",
-    "Mark a feedback annotation as resolved",
-    {
-      id: z.string().describe("Annotation ID to resolve"),
-    },
-    ({ id }) => {
-      try {
-        const annotation = resolveAnnotation(projectRoot, id);
-        return { content: [{ type: "text", text: JSON.stringify(annotation) }] };
-      } catch (error) {
-        return {
-          content: [{ type: "text", text: error.message }],
-          isError: true,
-        };
-      }
-    },
-  );
-
-  // Phase 5 edit pipeline. The schema lives in `apply-edit-schema.mjs` (#296); the resolver in
-  // `patcher.mjs` (#295); the apply/refusal logic in `apply-edit-dispatcher.mjs` (#297); the
-  // hidden-branch history that backs per-edit undo in `edit-history.mjs` (#298). The dispatcher
-  // invokes `onApplied` after a successful patch — `recordEdit` commits onto refs/heads/anglesite/edits
-  // without touching HEAD/index/working-tree and returns the SHA, which the dispatcher threads
-  // back as `commit` on the edit-applied response.
-  server.tool(
-    "apply_edit",
-    "Apply an edit to the underlying source for a previewed page element. The selector is the structured ElementInfo payload built by the WKWebView overlay; the server resolves it via selector.mjs and patches the matching source file. Successful edits are also committed onto the hidden anglesite/edits branch for per-edit undo.",
-    applyEditInputShape,
-    async (input) =>
-      applyEdit(projectRoot, input, {
-        onApplied: ({ file, range }) =>
-          recordEdit(projectRoot, { file, range, message: `anglesite: edit ${file}` }),
-      }),
-  );
-
-  server.tool(
-    "undo_edit",
-    "Undo the most-recent commit on the hidden anglesite/edits branch by writing the parent commit's blobs back to disk. HEAD-only in v1: an optional `commit` argument must equal current HEAD (or be omitted). `force: true` skips the working-tree-modification check and overwrites any external changes to the touched files.",
-    {
-      commit: z.string().optional().describe("SHA to undo. Must equal current HEAD of refs/heads/anglesite/edits if provided."),
-      force: z.boolean().optional().describe("Skip the working-tree-modification check and overwrite any external changes. Default false."),
-    },
-    async ({ commit, force }) => {
-      const result = await undoEdit(projectRoot, { commit, force });
-      return {
-        content: [{ type: "text", text: JSON.stringify(result) }],
-        isError: result.status === "refused",
-      };
-    },
-  );
-
-  return server;
-}
-
-/** Connect a freshly built server to stdio. The default transport. */
-export async function startStdioServer({ projectRoot }) {
-  const server = buildServer(projectRoot);
-  await server.connect(new StdioServerTransport());
-}
+import { startStdioServer } from "./index-tools.mjs";
+import { startHttpServer } from "./http-server.mjs";
 
 const projectRoot = process.env.ANGLESITE_PROJECT_ROOT || process.cwd();
-await startStdioServer({ projectRoot });
+const transport = (process.env.ANGLESITE_MCP_TRANSPORT || "stdio").toLowerCase();
+
+if (transport === "http") {
+  const host = process.env.ANGLESITE_MCP_HOST || "127.0.0.1";
+  const port = Number(process.env.ANGLESITE_MCP_PORT || "4399");
+  await startHttpServer({ projectRoot, host, port });
+} else {
+  await startStdioServer({ projectRoot });
+}

--- a/test/mcp-http-transport.test.js
+++ b/test/mcp-http-transport.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { startHttpServer } from "../server/http-server.mjs";
+
+describe("MCP Streamable HTTP transport", () => {
+  let root;
+  let handle;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "mcp-http-"));
+  });
+
+  afterEach(async () => {
+    if (handle) await handle.close();
+    handle = undefined;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("serves initialize, tools/list and a tool call over HTTP", async () => {
+    handle = await startHttpServer({ projectRoot: root, host: "127.0.0.1", port: 0 });
+    expect(handle.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+
+    const client = new Client({ name: "test", version: "0.0.0" });
+    await client.connect(new StreamableHTTPClientTransport(new URL(handle.url)));
+
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toContain("list_annotations");
+    expect(names).toContain("apply_edit");
+
+    const res = await client.callTool({ name: "list_annotations", arguments: {} });
+    expect(res.isError).toBeFalsy();
+    expect(JSON.parse(res.content[0].text)).toEqual([]);
+
+    await client.close();
+  });
+});


### PR DESCRIPTION
Part of the containerized dev-server epic. Adds a **Streamable HTTP** transport to the MCP server alongside stdio, so the app can reach the server over HTTP when the files + server run inside a container.

Paired with **Anglesite-app #64** (the Swift `MCPClient` HTTP transport). Plugin merges first.

## Changes
- `server/index-tools.mjs` (new) — `buildServer(projectRoot)` + `startStdioServer({projectRoot})`, importable without side effects.
- `server/http-server.mjs` (new) — `startHttpServer({projectRoot, host, port})`: session-managed `StreamableHTTPServerTransport` on a single `POST/GET/DELETE /mcp` endpoint; returns `{url, close}`; logs the listening URL.
- `server/index.mjs` — reduced to an env-driven entry: `ANGLESITE_MCP_TRANSPORT` (`stdio` default), `ANGLESITE_MCP_HOST` (`127.0.0.1`), `ANGLESITE_MCP_PORT` (`4399`).
- `test/mcp-http-transport.test.js` (new) — vitest round-trip with a real MCP client over HTTP.

## Behavior preserved
`node server/index.mjs` with no env still speaks stdio — claude's `--plugin-dir` connection and the app's host-subprocess client are untouched. **No tool schema changes.**

## Verification
- Full suite: **2418/2418** green (new HTTP test + existing 2417).
- Manual: HTTP mode returns `200` + `Mcp-Session-Id` + `text/event-stream` init result; stdio default returns the stdio init result.

Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)