### PR TITLE
test(e2e): discover nvm-managed Node in AppliesEditEndToEndTests

### DIFF
--- a/Tests/AnglesiteBridgeTests/AppliesEditEndToEndTests.swift
+++ b/Tests/AnglesiteBridgeTests/AppliesEditEndToEndTests.swift
@@ -128,17 +128,29 @@ final class AppliesEditEndToEndTests {
 
     @discardableResult
     private static func requireNode() throws -> URL {
-        let candidates = [
+        // Explicit override (CI / nvm shells) wins.
+        if let override = ProcessInfo.processInfo.environment["NODE_BINARY"], !override.isEmpty,
+           FileManager.default.isExecutableFile(atPath: override) {
+            return URL(fileURLWithPath: override)
+        }
+        var candidates = [
             "/opt/homebrew/bin/node",
             "/usr/local/bin/node",
             "/usr/bin/node",
         ]
-        for p in candidates {
-            if FileManager.default.isExecutableFile(atPath: p) {
-                return URL(fileURLWithPath: p)
-            }
+        // nvm-managed installs live under ~/.nvm/versions/node/<version>/bin/node and aren't on
+        // any of the common paths; add whatever versions are present.
+        let nvmDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".nvm/versions/node")
+        if let versions = try? FileManager.default.contentsOfDirectory(at: nvmDir, includingPropertiesForKeys: nil) {
+            candidates.append(contentsOf: versions
+                .map { $0.appendingPathComponent("bin/node").path }
+                .filter { FileManager.default.isExecutableFile(atPath: $0) }
+                .sorted())
         }
-        throw SkipReason("node not found in common paths; install Node ≥22")
+        for p in candidates where FileManager.default.isExecutableFile(atPath: p) {
+            return URL(fileURLWithPath: p)
+        }
+        throw SkipReason("node not found; set NODE_BINARY, install Node ≥22 in a common path, or via nvm")
     }
 }
 


### PR DESCRIPTION
`AppliesEditEndToEndTests.requireNode()` only probed `/opt/homebrew/bin`, `/usr/local/bin`, and `/usr/bin`, so the apply-edit end-to-end test fail-skipped on dev machines whose Node is **nvm-managed** (the path CLAUDE.md notes as the documented skip).

Adds a `NODE_BINARY` env override plus `~/.nvm/versions/node/*/bin/node` discovery — the same helper the new `MCPClientHTTPEndToEndTests` uses. The test now **runs and passes locally** (0.44s, real apply-edit round-trip against the sibling plugin) instead of skipping. CI is unaffected (it sets `ANGLESITE_PLUGIN_PATH` and installs Node on a common path).

Independent of #98; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)