### PR TITLE
spike(container): Cloudflare Sandbox throwaway + image findings (#61)

### DIFF
--- a/Spikes/CloudflareSandboxSpike/.gitignore
+++ b/Spikes/CloudflareSandboxSpike/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.wrangler/
+dist/
+*.log
+.dev.vars

--- a/Spikes/CloudflareSandboxSpike/Dockerfile
+++ b/Spikes/CloudflareSandboxSpike/Dockerfile
@@ -1,0 +1,37 @@
+# Throwaway spike image (#61): canonical Anglesite dev-server image
+#   + the Cloudflare Sandbox `/sandbox` init binary (so the Worker can drive it)
+#   + cloudflared (for the per-session quick tunnel — design §3.3 / #61).
+#
+# Mirrors container/Dockerfile.cloudflare but adds cloudflared, which the canonical
+# image doesn't carry. The behaviour-defining layers (Node, git, Astro toolchain,
+# baked deps, plugin MCP runtime) come from the canonical image unchanged.
+#
+# Prereq: the canonical image must be pushed to a registry wrangler can pull at
+# deploy time. Build + push it first:
+#     IMAGE_TAG=dev scripts/build-container-image.sh --push   # prints the digest
+# then set CANONICAL_IMAGE below to that digest (pin by digest, not tag).
+#
+# ARCH NOTE (spike finding): Cloudflare Containers run linux/amd64; the canonical
+# image is built linux/arm64 for Apple Silicon. Build the canonical image
+# multi-arch (or amd64) for the Cloudflare substrate, or this FROM will fail to
+# run on CF. Confirm + record during the live run.
+
+ARG CANONICAL_IMAGE=ghcr.io/anglesite/anglesite-devserver:dev
+ARG SANDBOX_IMAGE=docker.io/cloudflare/sandbox:0.12.1
+
+FROM ${SANDBOX_IMAGE} AS sandbox
+
+FROM ${CANONICAL_IMAGE}
+
+# Cloudflare Sandbox init lives at /container-server/sandbox (NOT /sandbox — validated
+# by inspecting cloudflare/sandbox:0.12.1 during this spike). It starts the Sandbox HTTP
+# API then spawns CMD as a child. Copy the whole dir in case the binary has siblings.
+COPY --from=sandbox /container-server /container-server
+
+# cloudflared (for the per-session quick tunnel) is already bundled in the sandbox image —
+# reuse it instead of downloading, which also keeps the arch consistent with /sandbox.
+COPY --from=sandbox /usr/local/bin/cloudflared /usr/local/bin/cloudflared
+
+EXPOSE 4321
+ENTRYPOINT ["/container-server/sandbox"]
+CMD ["start-dev-server.sh"]

--- a/Spikes/CloudflareSandboxSpike/README.md
+++ b/Spikes/CloudflareSandboxSpike/README.md
@@ -1,0 +1,120 @@
+# Cloudflare Sandbox spike (#61)
+
+Throwaway Worker that runs the **shared Anglesite dev-server image** (#62) inside a
+[Cloudflare Sandbox](https://developers.cloudflare.com/sandbox/) to prove the *remote*
+substrate end-to-end and produce real numbers for the design doc. **No app changes**;
+this lives under `Spikes/` and is deleted once its findings land in
+[`docs/specs/2026-06-10-cloudflare-sandbox-spike-notes.md`](../../docs/specs/2026-06-10-cloudflare-sandbox-spike-notes.md).
+
+The real consumer is `RemoteSandboxSiteRuntime` (#66); this only validates the substrate.
+
+## What it does
+
+`src/index.ts` exposes routes that drive one sandbox:
+
+| Route | Does |
+|---|---|
+| `POST /start?repo=&ref=` | clone the site → `hydrate.sh` (baked-deps fast path) → `astro dev` → poll ready → `exposePort`. Returns **per-phase timings**. |
+| `POST /tunnel` | start a `cloudflared` quick tunnel to the dev port → `*.trycloudflare.com` URL (no wildcard DNS, WS/HMR works). |
+| `POST /deploy` | run `pre-deploy-check` + `wrangler deploy` **in-container** (the security hook must run where the files are). |
+| `GET /status` · `GET /logs?id=` · `POST /destroy` | inspect / tear down. |
+
+## Prerequisites (yours — this is a live exercise)
+
+1. **Cloudflare account with Workers Paid + Containers/Sandbox** enabled. Confirm with
+   `npx wrangler whoami` and that Containers are available on the account.
+2. **Docker** (to build the image locally; `docker info` must succeed).
+3. A **registry wrangler can pull** the canonical image from (GHCR by default).
+4. For `exposePort` preview URLs: a **custom domain with wildcard DNS** on the account
+   (`.workers.dev` does NOT support the `*-sandbox-<id>.<domain>` subdomains). If you
+   don't have one, use `POST /tunnel` instead — that's the path #61 actually calls for.
+
+## Run it
+
+```sh
+# 0. Build + push the canonical image.
+#    ⚠️ scripts/build-container-image.sh is HARDCODED to linux/arm64 today. Cloudflare
+#    Containers run linux/amd64, so the script needs an amd64 / multi-arch build before
+#    this deploys to CF (see ARCH NOTE below — this is a spike finding/follow-up). For now,
+#    to get an amd64 image, edit PLATFORM in the script (or `docker buildx build --platform
+#    linux/amd64 ...` by hand against the staged context).
+IMAGE_TAG=spike scripts/build-container-image.sh --push   # arm64 today; prints the digest
+#    → note the printed digest; set CANONICAL_IMAGE in ./Dockerfile to pin it.
+
+# 1. Install + deploy the spike Worker (builds ./Dockerfile = canonical + /sandbox + cloudflared).
+cd Spikes/CloudflareSandboxSpike
+npm install
+npx wrangler deploy
+
+# 1b. Set the shared secret that gates every code-execution route (REQUIRED — the routes
+#     run arbitrary commands in the container; a deployed Worker is public).
+export SPIKE_SECRET=$(openssl rand -hex 24)
+echo "$SPIKE_SECRET" | npx wrangler secret put SPIKE_SECRET
+AUTH=(-H "Authorization: Bearer $SPIKE_SECRET")
+BASE="https://anglesite-sandbox-spike.<your-subdomain>.workers.dev"
+
+# 2. Cold start: clone + hydrate + astro dev. Records phase timings.
+curl "${AUTH[@]}" -X POST "$BASE/start?repo=https://github.com/Anglesite/<a-real-site>.git&ref=main"
+
+# 3a. Preview via tunnel (no DNS needed):
+curl "${AUTH[@]}" -X POST "$BASE/tunnel"
+#    → open the returned *.trycloudflare.com URL in a desktop browser.
+
+# 3b. OR preview via exposePort (needs the custom domain): the URL is in /start's response.
+
+# 4. HMR check: with the preview open, edit a file in-container and watch the browser update:
+curl "${AUTH[@]}" "$BASE/logs?id=<devProcessId>"   # confirm astro is watching
+#    (edit via a follow-up exec route, or git push + re-clone; see the findings doc)
+
+# 5. In-container deploy (CF token for the deploy passed separately from the auth secret):
+curl "${AUTH[@]}" -H "x-cf-token: <cf-deploy-token>" -X POST "$BASE/deploy"
+
+# 6. Tear down:
+curl "${AUTH[@]}" -X POST "$BASE/destroy"
+```
+
+> **Security:** every route except `/` runs code in the container, so all are gated behind
+> `Authorization: Bearer $SPIKE_SECRET` (fail-closed if the secret is unset) and `repo`/`ref`
+> are allowlist-validated before they touch a shell. Don't remove these even for a throwaway —
+> a deployed Worker is reachable by anyone who learns the URL.
+
+`npx wrangler tail` streams Worker logs while you poke the routes.
+
+## Local validation (no Cloudflare account)
+
+You can confirm the **image assembles** without deploying — this is what the spike
+author ran first:
+
+```sh
+# Build the canonical image locally (arm64 on Apple Silicon):
+IMAGE_TAG=spike scripts/build-container-image.sh
+# Build the spike image on top (adds /container-server/sandbox + cloudflared from the
+# sandbox image). NOTE: cloudflare/sandbox is amd64-only, so an arm64 build warns
+# "InvalidBaseImagePlatform" and the copied binaries won't *run* on arm64 — but it
+# proves the layers assemble. For a runnable image, build the canonical image amd64 first.
+docker build -t anglesite-sandbox-spike:local \
+  --build-arg CANONICAL_IMAGE=ghcr.io/anglesite/anglesite-devserver:spike \
+  Spikes/CloudflareSandboxSpike
+# Smoke the canonical image's dev server locally (clone + hydrate + astro dev):
+docker run --rm -p 4321:4321 \
+  -e ANGLESITE_GIT_URL=https://github.com/Anglesite/<a-real-site>.git \
+  ghcr.io/anglesite/anglesite-devserver:spike
+# → open http://localhost:4321
+```
+
+## ⚠️ ARCH NOTE — likely the spike's first real finding
+
+Cloudflare Containers run **linux/amd64**; `scripts/build-container-image.sh` builds
+**linux/arm64** (Apple Silicon / Apple Containerization). The "one image, two substrates"
+goal (container/README.md) needs the canonical image built **multi-arch** (`linux/amd64,linux/arm64`)
+or a per-substrate arch. Build the canonical image for amd64 before deploying here, and
+record the multi-arch decision in the findings doc (feeds Q-D image distribution).
+
+## Notes / gotchas baked into the scaffold
+
+- The Sandbox init entrypoint (`/container-server/sandbox`) **bypasses** the image's
+  `entrypoint.sh`, so the Worker drives `git clone` + `hydrate.sh` explicitly (this is also how
+  #66 will work).
+- `@cloudflare/sandbox` (npm) and `docker.io/cloudflare/sandbox` (image) **must be the same
+  version** — pinned to `0.12.1` here and in `container/Dockerfile.cloudflare`.
+- `instance_type` is `"standard"`; if cold start OOMs or is slow, that's a finding — record it.

--- a/Spikes/CloudflareSandboxSpike/package.json
+++ b/Spikes/CloudflareSandboxSpike/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cloudflare-sandbox-spike",
+  "private": true,
+  "type": "module",
+  "description": "Throwaway spike (#61): run the shared Anglesite OCI image in a Cloudflare Sandbox to validate the remote dev-server substrate (cold start, HMR over tunnel, in-container deploy, snapshots).",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail"
+  },
+  "dependencies": {
+    "@cloudflare/sandbox": "0.12.1"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4",
+    "wrangler": "^4",
+    "typescript": "^5.6.0"
+  }
+}

--- a/Spikes/CloudflareSandboxSpike/src/index.ts
+++ b/Spikes/CloudflareSandboxSpike/src/index.ts
@@ -1,0 +1,218 @@
+// Throwaway spike (#61): drive the shared Anglesite dev-server image inside a
+// Cloudflare Sandbox and measure the things the design doc needs real numbers for
+// (cold start, HMR over the tunnel, in-container deploy, snapshots).
+//
+// NOT production code. The real consumer is RemoteSandboxSiteRuntime (#66); this
+// Worker just proves the substrate end-to-end and feeds the findings doc
+// (docs/specs/2026-06-10-cloudflare-sandbox-spike-notes.md).
+//
+// API per https://developers.cloudflare.com/sandbox/ (SDK 0.12.x):
+//   getSandbox, proxyToSandbox, sandbox.exec/startProcess/exposePort/getProcessLogs/destroy
+
+import { getSandbox, proxyToSandbox } from "@cloudflare/sandbox";
+
+// Required: the Worker must re-export the Sandbox Durable Object class.
+export { Sandbox } from "@cloudflare/sandbox";
+
+interface Env {
+  Sandbox: DurableObjectNamespace;
+  DEFAULT_GIT_URL: string;
+  DEFAULT_GIT_REF: string;
+  SITE_DIR: string;
+  DEV_PORT: string;
+  // Shared secret gating every code-execution route. Set as a Worker secret:
+  //   npx wrangler secret put SPIKE_SECRET
+  // Unset → all privileged routes fail closed (503).
+  SPIKE_SECRET?: string;
+}
+
+// One session for the spike. (#66 scopes the id to user+site.)
+const SANDBOX_ID = "anglesite-spike";
+
+// These routes run code / clone / deploy / tear down inside the container — every one
+// is behind the bearer-secret gate. Only `/` (help) is public.
+const PUBLIC_ROUTES = new Set(["/"]);
+
+// Strict allowlists for user-supplied values that reach a shell. Anything with shell
+// metacharacters (;, &, |, $, backtick, spaces, …) is rejected before interpolation.
+const REPO_RE = /^https:\/\/github\.com\/[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+(?:\.git)?$/;
+const REF_RE = /^[A-Za-z0-9._\-/]+$/;
+
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const now = () => Date.now();
+
+/** Constant-time-ish string compare (length leak is acceptable for a spike secret). */
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/** Require `Authorization: Bearer <SPIKE_SECRET>` on privileged routes. */
+function authorized(request: Request, env: Env): boolean {
+  if (!env.SPIKE_SECRET) return false; // fail closed when no secret is configured
+  const header = request.headers.get("authorization") ?? "";
+  const token = header.startsWith("Bearer ") ? header.slice(7) : "";
+  return token.length > 0 && safeEqual(token, env.SPIKE_SECRET);
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // Route requests to any exposed port FIRST (this is what serves the preview
+    // when using exposePort() — including the HMR WebSocket upgrade).
+    const proxied = await proxyToSandbox(request, env);
+    if (proxied) return proxied;
+
+    const url = new URL(request.url);
+
+    // Auth gate: every route except `/` runs code in the container, so require the
+    // bearer secret. A deployed Worker is public — without this it's an open RCE.
+    if (!PUBLIC_ROUTES.has(url.pathname) && !authorized(request, env)) {
+      return json(
+        { error: env.SPIKE_SECRET ? "unauthorized" : "SPIKE_SECRET not configured (wrangler secret put SPIKE_SECRET)" },
+        env.SPIKE_SECRET ? 401 : 503,
+      );
+    }
+
+    const sandbox = getSandbox(env.Sandbox, SANDBOX_ID);
+    const SITE_DIR = env.SITE_DIR || "/workspace";
+    const PORT = env.DEV_PORT || "4321";
+
+    try {
+      switch (url.pathname) {
+        case "/":
+          return json({
+            spike: "cloudflare-sandbox (#61)",
+            routes: {
+              "POST /start?repo=&ref=": "clone + hydrate + astro dev; returns phase timings + exposePort URL",
+              "POST /tunnel": "start a cloudflared quick tunnel to the dev port; returns the *.trycloudflare.com URL",
+              "POST /deploy": "run pre-deploy-check + `wrangler deploy` inside the container",
+              "GET  /status": "list processes + exposed ports",
+              "GET  /logs?id=": "accumulated logs for a process id (default: the dev server)",
+              "POST /destroy": "tear the sandbox down",
+            },
+          });
+
+        // ── Cold-start path: clone → hydrate → astro dev → ready → expose ──
+        case "/start": {
+          const repo = url.searchParams.get("repo") || env.DEFAULT_GIT_URL;
+          const ref = url.searchParams.get("ref") || env.DEFAULT_GIT_REF;
+          // Validate before these reach a shell (defense in depth alongside the auth gate).
+          if (!REPO_RE.test(repo)) return json({ error: "invalid repo (must be https://github.com/owner/name[.git])" }, 400);
+          if (!REF_RE.test(ref)) return json({ error: "invalid ref (alphanumerics, . _ - / only)" }, 400);
+          const hostname = url.hostname; // for exposePort preview URL (needs custom domain)
+          const t: Record<string, number> = {};
+          const t0 = now();
+
+          // 1. Clone the site (Git is the source of truth — design §3.1).
+          //    The /sandbox entrypoint bypasses the image's entrypoint.sh hydrate,
+          //    so we drive clone + hydrate explicitly (the #66 model).
+          const clone = await sandbox.exec(
+            `rm -rf ${SITE_DIR}/* ${SITE_DIR}/.[!.]* 2>/dev/null; git clone --branch ${ref} --depth 1 ${repo} ${SITE_DIR}`,
+          );
+          t.clone_ms = now() - t0;
+          if (!clone.success) return json({ phase: "clone", ...clone, timings: t }, 500);
+
+          // 2. Hydrate deps using the image's pre-baked toolchain (design #5b):
+          //    hardlink baked node_modules if the lockfile matches, else npm ci warm.
+          const tHydrate = now();
+          const hydrate = await sandbox.exec(`hydrate.sh ${SITE_DIR}`, { cwd: SITE_DIR });
+          t.hydrate_ms = now() - tHydrate;
+          if (!hydrate.success) return json({ phase: "hydrate", ...hydrate, timings: t }, 500);
+
+          // 3. Start astro dev in the background.
+          const tDev = now();
+          const proc = await sandbox.startProcess(`start-dev-server.sh`, {
+            cwd: SITE_DIR,
+            env: { SITE_DIR, PORT },
+          });
+
+          // 4. Poll readiness with an in-container HTTP probe (mirrors AstroDevServer).
+          let ready = false;
+          for (let i = 0; i < 60; i++) {
+            const probe = await sandbox.exec(`curl -sf -o /dev/null http://localhost:${PORT}/`);
+            if (probe.success) { ready = true; break; }
+            await new Promise((r) => setTimeout(r, 500));
+          }
+          t.dev_ready_ms = now() - tDev;
+          t.total_ms = now() - t0;
+          if (!ready) {
+            const logs = await sandbox.getProcessLogs(proc.id).catch(() => null);
+            return json({ phase: "dev-ready-timeout", process: proc, logs, timings: t }, 504);
+          }
+
+          // 5. Expose the dev port → preview URL (needs a custom domain w/ wildcard
+          //    DNS; on .workers.dev use POST /tunnel instead).
+          let exposed: { url: string } | { error: string };
+          try {
+            exposed = await sandbox.exposePort(Number(PORT), { hostname, name: "astro" });
+          } catch (e) {
+            exposed = { error: `exposePort failed (expected on .workers.dev): ${String(e)}. Use POST /tunnel.` };
+          }
+
+          return json({ ok: true, repo, ref, process: proc, exposed, timings: t,
+            hint: "Open the exposed URL (or POST /tunnel), edit a file in-container, and watch HMR." });
+        }
+
+        // ── Per-session quick tunnel (no wildcard DNS): *.trycloudflare.com ──
+        case "/tunnel": {
+          // cloudflared prints the tunnel URL to stderr; capture it from the logs.
+          const proc = await sandbox.startProcess(
+            `cloudflared tunnel --no-autoupdate --url http://localhost:${PORT}`,
+          );
+          let tunnelUrl: string | null = null;
+          for (let i = 0; i < 30; i++) {
+            const logs = await sandbox.getProcessLogs(proc.id).catch(() => null);
+            const text = `${logs?.stdout ?? ""}\n${logs?.stderr ?? ""}`;
+            const m = text.match(/https:\/\/[a-z0-9-]+\.trycloudflare\.com/);
+            if (m) { tunnelUrl = m[0]; break; }
+            await new Promise((r) => setTimeout(r, 1000));
+          }
+          return json({ process: proc, tunnelUrl,
+            hint: tunnelUrl ? "Open it; HMR rides the tunnel WebSocket." : "No URL yet — GET /logs?id=" + proc.id });
+        }
+
+        // ── In-container deploy: the plugin security hook must run here too ──
+        case "/deploy": {
+          // pre-deploy-check is part of the bundled plugin/site; wrangler deploys.
+          const check = await sandbox.exec(`npm run -s pre-deploy-check || true`, { cwd: SITE_DIR });
+          const build = await sandbox.exec(`npm run -s build`, { cwd: SITE_DIR });
+          const deploy = build.success
+            ? await sandbox.exec(`npx --yes wrangler deploy`, {
+                cwd: SITE_DIR,
+                env: { CLOUDFLARE_API_TOKEN: request.headers.get("x-cf-token") || "" },
+              })
+            : { skipped: "build failed" };
+          return json({ check, build, deploy });
+        }
+
+        case "/status": {
+          const processes = await sandbox.listProcesses().catch((e) => ({ error: String(e) }));
+          const ports = await sandbox.getExposedPorts(url.hostname).catch((e) => ({ error: String(e) }));
+          return json({ processes, ports });
+        }
+
+        case "/logs": {
+          const id = url.searchParams.get("id");
+          if (!id) return json({ error: "pass ?id=<processId>" }, 400);
+          return json(await sandbox.getProcessLogs(id));
+        }
+
+        case "/destroy":
+          await sandbox.destroy();
+          return json({ destroyed: true });
+
+        default:
+          return json({ error: "not found", try: "/" }, 404);
+      }
+    } catch (e) {
+      return json({ error: String(e), stack: e instanceof Error ? e.stack : undefined }, 500);
+    }
+  },
+};

--- a/Spikes/CloudflareSandboxSpike/tsconfig.json
+++ b/Spikes/CloudflareSandboxSpike/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/Spikes/CloudflareSandboxSpike/wrangler.jsonc
+++ b/Spikes/CloudflareSandboxSpike/wrangler.jsonc
@@ -1,0 +1,45 @@
+{
+  // Throwaway spike (#61): a minimal Worker that drives the Anglesite dev-server
+  // image inside a Cloudflare Sandbox. NOT shipped — lives under Spikes/.
+  //
+  // The container image is built from ./Dockerfile, which FROMs the canonical
+  // Anglesite image (pushed to a registry by scripts/build-container-image.sh)
+  // and adds the Cloudflare `/sandbox` init binary + cloudflared. See README.md.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "anglesite-sandbox-spike",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-06-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": { "enabled": true },
+
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./Dockerfile",
+      // Astro + npm + git want more than the "lite" type; "standard" gives more
+      // RAM/CPU. Adjust during the spike and record what cold start needs.
+      "instance_type": "standard",
+      "max_instances": 1
+    }
+  ],
+
+  "durable_objects": {
+    "bindings": [{ "class_name": "Sandbox", "name": "Sandbox" }]
+  },
+
+  "migrations": [{ "new_sqlite_classes": ["Sandbox"], "tag": "v1" }],
+
+  // The site to clone + serve. Override per-run with `wrangler deploy --var` or
+  // the ?repo= / ?ref= query params on /start.
+  "vars": {
+    "DEFAULT_GIT_URL": "https://github.com/Anglesite/anglesite-example.git",
+    "DEFAULT_GIT_REF": "main",
+    "SITE_DIR": "/workspace",
+    "DEV_PORT": "4321"
+  }
+
+  // To use exposePort() preview URLs (instead of the cloudflared tunnel), add a
+  // custom domain with wildcard DNS and set its hostname — `.workers.dev` does
+  // NOT support the `*-sandbox-<id>.<domain>` preview subdomains. See README.md.
+  // "routes": [{ "pattern": "sandbox-spike.example.com", "custom_domain": true }]
+}

--- a/container/Dockerfile.cloudflare
+++ b/container/Dockerfile.cloudflare
@@ -3,26 +3,32 @@
 # Cloudflare Sandbox substrate wrapper — issue #62, consumed by #61 / #66.
 #
 # Both substrates run the SAME canonical image (container/Dockerfile). The
-# Cloudflare Sandbox SDK needs its standalone `/sandbox` init binary present so
-# the Worker can drive the container over the Sandbox HTTP API. This thin layer
-# adds only that binary on top of the canonical image — the toolchain layers
-# underneath stay byte-identical to what Apple Containerization pulls.
+# Cloudflare Sandbox SDK needs its init binary present so the Worker can drive the
+# container over the Sandbox HTTP API. This thin layer copies the sandbox init
+# (the `/container-server` dir from cloudflare/sandbox) on top of the canonical
+# image — the toolchain layers underneath stay byte-identical to what Apple
+# Containerization pulls.
 #
-# Per Cloudflare's docs, the standalone binary lets you "add sandbox capabilities
-# to any Docker image" without depending on their base image, and you must NOT
-# override the ENTRYPOINT — `/sandbox` is the entrypoint; it starts the HTTP API
-# then spawns CMD as a child with signal forwarding.
+# The init binary is the ENTRYPOINT (`/container-server/sandbox`); it starts the
+# Sandbox HTTP API then spawns CMD as a child with signal forwarding.
 #
-# NOTE: the exact source path/tag of the standalone binary is pinned and
-# validated by the Cloudflare spike (#61); treat the COPY below as the integration
-# point, not a finalized version.
+# ⚠️ ARCH: cloudflare/sandbox is linux/amd64-only, so the canonical image must be
+# built amd64 (or multi-arch) for this substrate. See the #61 spike notes.
+#
+# The standalone-binary version MUST match the `@cloudflare/sandbox` npm package the
+# Worker imports (the SDK and the in-container init speak a versioned protocol). Pinned
+# to 0.12.1 by the Cloudflare spike (#61); bump both together. See
+# Spikes/CloudflareSandboxSpike/ for the throwaway Worker that validated this.
 
 ARG CANONICAL_IMAGE=ghcr.io/anglesite/anglesite-devserver:dev
-ARG SANDBOX_IMAGE=docker.io/cloudflare/sandbox:latest
+ARG SANDBOX_IMAGE=docker.io/cloudflare/sandbox:0.12.1
 
 FROM ${SANDBOX_IMAGE} AS sandbox
 
 FROM ${CANONICAL_IMAGE}
-COPY --from=sandbox /sandbox /sandbox
-ENTRYPOINT ["/sandbox"]
+# The init binary lives at /container-server/sandbox (validated by the #61 spike — it is
+# NOT at /sandbox). Copy the whole dir so any sibling files come along. It starts the
+# Sandbox HTTP API, then spawns CMD as a child with signal forwarding.
+COPY --from=sandbox /container-server /container-server
+ENTRYPOINT ["/container-server/sandbox"]
 CMD ["start-dev-server.sh"]

--- a/docs/specs/2026-06-10-cloudflare-sandbox-spike-notes.md
+++ b/docs/specs/2026-06-10-cloudflare-sandbox-spike-notes.md
@@ -1,0 +1,82 @@
+# Cloudflare Sandbox spike (#61) — findings
+
+> **Status:** in progress. Scaffold + local image validation done; live Cloudflare
+> measurements pending (need the account's Containers/Sandbox + a browser for HMR).
+> Spike code: [`Spikes/CloudflareSandboxSpike/`](../../Spikes/CloudflareSandboxSpike/).
+> Part of #59 · feeds **Q-D** (image distribution) and **#5b** (cold-start strategy).
+
+Throwaway spike to prove the **remote substrate** end-to-end: run the shared OCI image
+(#62) in a Cloudflare Sandbox, clone a real Anglesite site, `astro dev`, reach it from a
+desktop browser, and measure. No app changes.
+
+## Setup as built
+
+- **Worker + `@cloudflare/sandbox` 0.12.1** drives one sandbox (`Spikes/CloudflareSandboxSpike/`).
+- **Image** = canonical Anglesite image (#62) + the Cloudflare `/sandbox` init binary
+  (`docker.io/cloudflare/sandbox:0.12.1`) + `cloudflared`. Pinned the sandbox version in
+  `container/Dockerfile.cloudflare` (was the `:latest` TODO #61 owned).
+- **Exposure:** two paths wired — `exposePort()` preview URL (needs a custom domain with
+  wildcard DNS) and a `cloudflared` quick tunnel (`*.trycloudflare.com`, no DNS). #61/design
+  §3.3 call for the tunnel.
+
+## Confirm (the load-bearing measurements)
+
+| # | Question | Result | Notes |
+|---|---|---|---|
+| 1 | **Cold-start time** — clone + hydrate + `astro dev` ready | ⬜ TBD | `/start` returns `clone_ms` / `hydrate_ms` / `dev_ready_ms` / `total_ms`. Run warm vs cold. |
+| 1a | hydrate fast-path (baked `node_modules` hardlink, #5b) actually hit? | ⬜ TBD | Check hydrate log: "reusing baked node_modules (zero install)" vs "npm ci". Depends on the site's lockfile matching the template. |
+| 2 | **HMR works over the tunnel WebSocket** (edit in-container → browser updates) | ⬜ TBD | The acceptance test. Confirm WS upgrade survives the tunnel/proxy. |
+| 3 | `pre-deploy-check` + `wrangler deploy` run cleanly **in-container** | ⬜ TBD | `/deploy`. Confirm the security hook runs where the files live. |
+| 4 | **Snapshot** availability — does re-entry skip `npm ci`? | ⬜ TBD | Is container snapshotting GA on the account yet? If not, every cold start re-hydrates. |
+
+## Findings confirmed during scaffolding (local Docker, no CF account)
+
+- **✅ Init binary path corrected.** The Cloudflare Sandbox init is at **`/container-server/sandbox`**,
+  **not** `/sandbox` — `container/Dockerfile.cloudflare` (and the spike Dockerfile) had the wrong path
+  (it was the explicit TODO #61 owned). Inspecting `cloudflare/sandbox:0.12.1` also shows it bundles
+  `node`, `bun`, `npm`, and **`cloudflared`** in `/usr/local/bin` — so we copy cloudflared from there
+  instead of downloading it. Both Dockerfiles now `COPY --from=sandbox /container-server /container-server`
+  with `ENTRYPOINT ["/container-server/sandbox"]`. Fix verified: the assembled image carries the
+  init binary (99 MB), cloudflared, `git`, the baked deps (`/opt/anglesite/baked`), and the scripts.
+- **⚠️ ARCH MISMATCH (the headline finding for Q-D).** `cloudflare/sandbox:0.12.1` is **linux/amd64-only**
+  (`docker build` warns `InvalidBaseImagePlatform` on arm64). Cloudflare Containers run **amd64**;
+  `scripts/build-container-image.sh` is **hardcoded `linux/arm64`** (for Apple Silicon / Apple
+  Containerization). So "one image, two substrates" can't be literally one arch — the canonical image
+  must be built **multi-arch** (`linux/amd64,linux/arm64`) or per-substrate, and the build script needs
+  a `PLATFORM`/multi-arch option. Cost (build time, registry size) → **Q-D**.
+- **Image strategy is a real fork for #66.** Two ways to combine the toolchains, to decide:
+  - **A (current design):** canonical Anglesite image (multi-arch) as base + `COPY /container-server`
+    from the sandbox image. Keeps toolchain layers byte-identical to what Apple Containerization runs,
+    but pins the CF image to amd64 (sandbox binary's arch) and couples to the sandbox image's internal
+    layout (`/container-server`).
+  - **B (CF-documented):** `FROM cloudflare/sandbox:0.12.1` + add the Anglesite toolchain on top. The
+    supported pattern; gets node/bun/cloudflared for free; amd64-only; layers diverge from the local
+    substrate. Recommendation pending the live run.
+- **Preview-URL strategy.** `exposePort()` requires a custom domain w/ wildcard DNS; `.workers.dev`
+  can't do the `*-sandbox-<id>` subdomains. The tunnel sidesteps it but adds `cloudflared` to the
+  image + a per-session process. Which does #66 ship? ⬜ decide.
+- **MCP-over-HTTP now unblocked.** #63 (plugin HTTP transport) + #64 (`MCPClient` HTTP transport)
+  **landed** since this image was designed — `start-dev-server.sh`'s "until then... stdio" comment is
+  now stale. The container can start the plugin's MCP server in HTTP mode
+  (`ANGLESITE_MCP_TRANSPORT=http`) alongside `astro dev`, and the app reaches it via
+  `MCPClient.connect(httpEndpoint:)`. #66 should expose a *second* port for it. ⬜ validate the
+  edit pipeline over the tunnel too.
+- **`instance_type`** — started at `"standard"`. Does `astro dev` + `npm` fit? Record RAM/CPU need.
+- **`sleepAfter` / cost** — containers sleep after ~10m idle and lose disk; re-entry re-clones +
+  re-hydrates unless snapshots are available (#5b). Measure the re-entry penalty.
+
+## Local validation (done — no CF account)
+
+- **Canonical image build** (`IMAGE_TAG=spike scripts/build-container-image.sh`): ✅ builds clean,
+  `linux/arm64`, Node 24.15.0. Digest `sha256:057ae307…`. So #62's image assembles.
+- **Spike image build** (canonical + `/container-server/sandbox` + cloudflared): ✅ assembles after the
+  path fix (arm64 base + amd64 sandbox → cosmetic `InvalidBaseImagePlatform` warning; layers export
+  cleanly). Verified contents: init binary, cloudflared, git, baked deps, `start-dev-server.sh`/`hydrate.sh`.
+- **Runnable `docker run` smoke** (clone + hydrate + `astro dev` on :4321): ⬜ pending an **amd64**
+  canonical build — the arm64 spike image can't execute the amd64 init binary. Do this with the
+  amd64/multi-arch canonical image alongside the live CF run.
+
+## Output / recommendation
+
+_(to fill once measured)_ — real cold-start numbers, the arch decision for Q-D, the
+preview-URL strategy for #66, and whether snapshots change the #5b plan.


### PR DESCRIPTION
Throwaway spike (#61) to prove the **remote dev-server substrate**: run the shared Anglesite OCI image (#62) in a [Cloudflare Sandbox](https://developers.cloudflare.com/sandbox/), clone a real site, `astro dev`, reach it from a browser, and measure. Part of #59. **No app changes** — lives under `Spikes/`.

## What's here
- **`Spikes/CloudflareSandboxSpike/`** — a minimal Worker + `@cloudflare/sandbox@0.12.1` with routes: `/start` (clone + `hydrate.sh` + `astro dev`, **per-phase timings**), `/tunnel` (cloudflared quick tunnel — no wildcard DNS), `/deploy` (`pre-deploy-check` + `wrangler deploy` in-container), `/status`, `/logs`, `/destroy`. Plus `wrangler.jsonc`, `Dockerfile`, and a **runbook**.
- **`docs/specs/2026-06-10-cloudflare-sandbox-spike-notes.md`** — findings doc (confirm-table + open questions).

## Real findings already (from local Docker validation — no CF account needed)
1. **Init binary path fixed.** The Sandbox init is at **`/container-server/sandbox`**, not `/sandbox` — the explicit TODO #61 owned in `container/Dockerfile.cloudflare`. Also pinned the sandbox image to `0.12.1` (must match the SDK) and reuse the image's bundled `cloudflared`. *(Real fix to a shipped artifact, beyond the throwaway.)*
2. **Arch mismatch (Q-D).** `cloudflare/sandbox` is **amd64-only**; `scripts/build-container-image.sh` is hardcoded **arm64**. "One image, two substrates" needs **multi-arch**. Documented; build-script change is a follow-up.
3. **`exposePort` needs a custom domain w/ wildcard DNS** (not `.workers.dev`) — confirms the design's per-session tunnel choice. Scaffolded both paths.
4. **MCP-over-HTTP now unblocked** by #63/#64 (merged this session) — the container can run the plugin MCP server in HTTP mode alongside `astro dev`; `start-dev-server.sh`'s "until then… stdio" note is now stale.

## Validated locally
- Canonical image (#62) builds clean (arm64, Node 24.15.0).
- Spike image assembles with the corrected `/container-server` path (init binary + cloudflared + git + baked deps present).

## Security
All code-execution routes are gated behind `Authorization: Bearer $SPIKE_SECRET` (fail-closed) and `repo`/`ref` are allowlist-validated before reaching a shell — a deployed Worker is publicly reachable. (Flagged by the automated security review; addressed.)

## Pending (needs your CF account)
Cold-start numbers, **HMR over the tunnel WebSocket**, in-container deploy, and snapshot behavior — the live half. Runbook in the spike README. Findings doc gets filled in from that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)