### PR TITLE
fix(vendor-node): re-vendor when existing node is a pre-#106 universal binary

### DIFF
--- a/scripts/vendor-node.sh
+++ b/scripts/vendor-node.sh
@@ -28,8 +28,12 @@ ARM64_TARBALL="node-v${NODE_VERSION}-darwin-arm64.tar.xz"
 if [[ -x "$DEST/bin/node" ]]; then
     current=$("$DEST/bin/node" --version 2>/dev/null || echo "")
     if [[ "$current" == "v${NODE_VERSION}" ]]; then
-        echo "Node ${current} already vendored at $DEST. Skipping."
-        exit 0
+        if file "$DEST/bin/node" | grep -q "universal binary"; then
+            echo "Existing $DEST/bin/node is a pre-#106 universal binary. Re-vendoring as arm64-only."
+        else
+            echo "Node ${current} already vendored at $DEST. Skipping."
+            exit 0
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary

- The idempotency short-circuit in `scripts/vendor-node.sh` only compared `node --version`, so checkouts that vendored before #106 kept their lipo'd x86_64+arm64 binary indefinitely. The build kept working but shipped dead x64 code — the exact payload #106 was meant to delete.
- Add a `file | grep -q "universal binary"` check inside the version match: stale universal → fall through to download+extract; arm64-only → skip as before. Post-vendor arm64 assertion is unchanged.

## Test plan

Verified on macOS 27 / Apple Silicon. Three paths drove end-to-end:

- [x] Happy path (arm64-only, correct version) → `Node v24.15.0 already vendored… Skipping.`
- [x] Stale path (faked universal via `lipo -create $arm64_node /bin/ls's x86_64 slice` — arm64 slice still self-reports `v24.15.0`) → `Existing … is a pre-#106 universal binary. Re-vendoring as arm64-only.` → ends `Mach-O 64-bit executable arm64`
- [x] Third run after re-vendor → idempotent skip restored (one-shot, not a loop)
- [x] `bash -n scripts/vendor-node.sh` passes

Follow-up to #109 (which dropped the x64 slice itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)