### PR TITLE
feat(phase-a): drop deploy from chat quick-actions (#84)

### DIFF
--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -171,12 +171,10 @@ struct ChatView: View {
         inputFocused = true
     }
 
-    /// Maps the curated v0.5 quick-action names to SF Symbols. Keeps icons consistent
-    /// with the rest of the app (e.g. Deploy uses the same paperplane the toolbar Deploy
-    /// button uses). Unmapped names fall back to a generic command icon.
+    /// Maps the curated quick-action names to SF Symbols. Unmapped names fall back to a
+    /// generic command icon.
     private static func iconName(for skillName: String) -> String {
         switch skillName {
-        case "deploy": return "paperplane.fill"
         case "backup": return "externaldrive.fill.badge.icloud"
         case "check":  return "checkmark.shield.fill"
         case "import": return "tray.and.arrow.down.fill"

--- a/Sources/AnglesiteCore/SkillRegistry.swift
+++ b/Sources/AnglesiteCore/SkillRegistry.swift
@@ -28,7 +28,13 @@ public enum SkillRegistry {
 
     /// Curated v0.5 quick-action set, in display order. Hard-coded here because exposing all
     /// owner-triggered skills (28 today, more coming) would overwhelm the chat toolbar.
-    public static let quickActionNames: [String] = ["deploy", "backup", "check", "import"]
+    ///
+    /// `deploy` is intentionally absent: #84 moved it to the toolbar Deploy button, which
+    /// calls `DeployCommand` directly. Surfacing a chat pill for the same action would just
+    /// burn LLM tokens to invoke a tool Claude always invokes. The chat path still works for
+    /// natural-language phrasings ("deploy my site"); only the dedicated button is gone.
+    /// Phase A is dissolving the rest of this list the same way (#85 backup, #86 check).
+    public static let quickActionNames: [String] = ["backup", "check", "import"]
 
     /// Discover skills under `<pluginDirectory>/skills/`. Returns all readable skills in
     /// directory order; the caller filters down (e.g. by `quickActionNames`) for display.

--- a/Tests/AnglesiteCoreTests/SkillRegistryTests.swift
+++ b/Tests/AnglesiteCoreTests/SkillRegistryTests.swift
@@ -133,18 +133,32 @@ final class SkillRegistryTests: XCTestCase {
             "skills/backup/SKILL.md": "---\nname: backup\ndescription: \"snapshot\"\n---\n"
         ])
         let quick = SkillRegistry.quickActions(in: root)
-        XCTAssertEqual(quick.map(\.name), ["deploy", "backup", "check", "import"],
-                       "must be in curated order, must exclude non-curated skills")
-        XCTAssertEqual(quick.first?.description, "deploy")
+        // `deploy` is intentionally absent: the toolbar Deploy button invokes
+        // DeployCommand directly (#84), so surfacing a redundant LLM-routed Deploy
+        // pill in chat would just burn tokens for an action that already has a
+        // structured entry point.
+        XCTAssertEqual(quick.map(\.name), ["backup", "check", "import"],
+                       "must be in curated order, must exclude non-curated skills, must exclude deploy")
+        XCTAssertEqual(quick.first?.description, "snapshot")
+    }
+
+    func testQuickActionsExcludesDeployEvenWhenSkillExists() throws {
+        // Regression guard for #84: even with a deploy/SKILL.md on disk, the chat
+        // quick-actions must not surface it — the toolbar owns Deploy.
+        let root = try makeFixturePlugin([
+            "skills/deploy/SKILL.md": "---\nname: deploy\ndescription: \"deploy\"\n---\n",
+            "skills/backup/SKILL.md": "---\nname: backup\ndescription: \"snapshot\"\n---\n"
+        ])
+        XCTAssertEqual(SkillRegistry.quickActions(in: root).map(\.name), ["backup"])
     }
 
     func testQuickActionsTolerantOfMissingCuratedSkills() throws {
         // A plugin that's missing some of the curated names just returns whatever it has.
         let root = try makeFixturePlugin([
-            "skills/deploy/SKILL.md": "---\nname: deploy\n---\n",
+            "skills/backup/SKILL.md": "---\nname: backup\n---\n",
             "skills/check/SKILL.md": "---\nname: check\n---\n"
         ])
-        XCTAssertEqual(SkillRegistry.quickActions(in: root).map(\.name), ["deploy", "check"])
+        XCTAssertEqual(SkillRegistry.quickActions(in: root).map(\.name), ["backup", "check"])
     }
 
     // MARK: Test helpers


### PR DESCRIPTION
## Summary

- Removes `"deploy"` from `SkillRegistry.quickActionNames` so the chat panel no longer surfaces a Deploy pill. The toolbar Deploy button (already direct since Phase 6) is now the sole one-click deploy entry point.
- Drops the now-dead `case "deploy": return "paperplane.fill"` from `ChatView.iconName(for:)` and updates the surrounding docstring.
- Adds a regression test (`testQuickActionsExcludesDeployEvenWhenSkillExists`) so a future change can't silently re-add Deploy to the chat's curated set.

Closes #84.

## Why

The toolbar Deploy button has invoked `DeployCommand.deploy()` directly since Phase 6 — full `DeployDrawerView` streaming, `BlockedDeploySheetView` for scan failures, `CloudflareTokenPromptView` for first-deploy, and URL extraction on success. The chat-panel Deploy pill, by contrast, called `model.send("/anglesite:deploy")` → Claude CLI → tool call → wrangler, spending LLM tokens to narrate an action Claude always runs the same way and surfacing a worse UX than the toolbar sibling.

The natural-language path ("deploy my site" typed in chat) is preserved per the issue's explicit requirement — only the dedicated pill is removed. Phase A is dissolving the rest of this list the same way (#85 backup, #86 check, #87 swipe-to-resolve), trending toward the chat-panel scope #94 calls for.

## Acceptance criteria from #84

| Criterion | Status |
|---|---|
| Clicking the deploy button does not spawn `claude` | Toolbar Deploy was already direct (Phase 6); the chat pill that did spawn Claude is gone. |
| Deploy progress visible in UI | `DeployDrawerView` streams build → scan → wrangler from `LogCenter`. |
| Pre-deploy scan failures render in `BlockedDeploySheetView` (no override) | Wired via `DeployModel.blockedPresented` in `SiteWindow`. |
| Successful deploys show deployed URL | `DeployDrawerView` surfaces it with Copy URL / Open in browser. |
| Zero LLM token usage for direct deploys | Toolbar Deploy goes straight to `DeployCommand.deploy()`. |

## Test plan

- [x] `swift test --package-path . --filter SkillRegistryTests` → 15/15 green (3 modified + 1 new + 11 untouched).
- [x] `swift test --package-path .` full run → XCTest layer "All tests passed". Pre-existing Swift-Testing failures (`AppliesEditEndToEndTests`, `MCPClientHTTPEndToEndTests`) confirmed independent of this change via `git stash` baseline on `main` — both need a fresh sibling-plugin `node_modules`.
- [x] `xcodebuild -scheme Anglesite -configuration Debug build` → BUILD SUCCEEDED.
- [x] `xcodebuild -scheme AnglesiteMAS -configuration Debug build` → BUILD SUCCEEDED.
- [ ] Manual smoke: open a site, confirm the chat panel shows only Backup / Check / Import pills (no Deploy), and confirm the toolbar Deploy button still streams build + scan + wrangler into the drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)