### PR TITLE
feat(phase-a): BackupCommand + toolbar Backup button (#85)

### DIFF
--- a/Sources/AnglesiteApp/BackupDrawerView.swift
+++ b/Sources/AnglesiteApp/BackupDrawerView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+import AppKit
+import AnglesiteCore
+
+/// Slide-up drawer for a backup in progress and its terminal result. Mirrors
+/// `DeployDrawerView`: spinner + streaming log during `.running`, structured result on
+/// `.succeeded` / `.failed`. The `.noChanges` outcome is rendered by a separate banner —
+/// the drawer never opens for it.
+struct BackupDrawerView: View {
+    @Bindable var model: BackupModel
+    let siteName: String
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            logScroller
+            Divider()
+            footer
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 320)
+        .background(.regularMaterial)
+    }
+
+    // MARK: Sections
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            statusIcon
+            VStack(alignment: .leading, spacing: 1) {
+                Text(headerTitle).font(.headline)
+                if let subtitle = headerSubtitle {
+                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            if case .succeeded(let sha, _, _, _) = model.phase {
+                Button("Copy SHA") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(sha, forType: .string)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch model.phase {
+        case .running:
+            ProgressView().controlSize(.small)
+        case .succeeded:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green).font(.title3)
+        case .noChanges:
+            Image(systemName: "checkmark.seal.fill")
+                .foregroundStyle(.secondary).font(.title3)
+        case .failed:
+            Image(systemName: "exclamationmark.octagon.fill")
+                .foregroundStyle(.red).font(.title3)
+        case .idle:
+            Image(systemName: "externaldrive").font(.title3)
+        }
+    }
+
+    private var headerTitle: String {
+        switch model.phase {
+        case .running: return "Backing up \(siteName)…"
+        case .succeeded(_, let branch, _, _): return "Backed up to \(branch)"
+        case .noChanges: return "Already backed up"
+        case .failed: return "Backup failed"
+        case .idle: return siteName
+        }
+    }
+
+    private var headerSubtitle: String? {
+        switch model.phase {
+        case .succeeded(let sha, _, let remote, let duration):
+            return "\(String(sha.prefix(7))) · \(remote) · \(String(format: "%.1f s", duration))"
+        case .noChanges:
+            return "No new changes to save."
+        case .failed(let reason, let exit):
+            return exit.map { "\(reason) (exit \($0))" } ?? reason
+        default:
+            return nil
+        }
+    }
+
+    private var logScroller: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 1) {
+                    ForEach(model.logLines) { line in
+                        Text(line.text)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(line.stream == .stderr ? Color.red : Color.primary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .id(line.id)
+                    }
+                    if model.logLines.isEmpty {
+                        Text("Waiting for output…")
+                            .font(.caption).foregroundStyle(.tertiary)
+                            .padding(.top, 4)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+            }
+            .background(Color(NSColor.textBackgroundColor))
+            .onChange(of: model.logLines.count) { _, _ in
+                if let last = model.logLines.last {
+                    withAnimation(.linear(duration: 0.1)) {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            if case .failed = model.phase {
+                Button("Copy log") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(model.logText, forType: .string)
+                }
+            }
+            Spacer()
+            Button(model.isRunning ? "Hide" : "Dismiss") {
+                model.dismissDrawer()
+            }
+            .keyboardShortcut(.cancelAction)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+}

--- a/Sources/AnglesiteApp/BackupModel.swift
+++ b/Sources/AnglesiteApp/BackupModel.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+import AnglesiteCore
+
+/// SwiftUI-facing wrapper around `BackupCommand`. Mirrors `DeployModel` — drives one backup
+/// at a time, exposes the live log stream, the terminal `Phase`, and a single drawer flag.
+@MainActor
+@Observable
+final class BackupModel {
+    enum Phase: Equatable {
+        case idle
+        case running(siteID: String, since: Date)
+        case succeeded(commitSHA: String, branch: String, remote: String, duration: TimeInterval)
+        case noChanges
+        case failed(reason: String, exitCode: Int32?)
+    }
+
+    private(set) var phase: Phase = .idle
+    /// Captured backup log lines for the current/most-recent run.
+    private(set) var logLines: [LogCenter.LogLine] = []
+
+    /// Bound to a slide-up drawer in `SiteWindow`. The view sets this back to false when the
+    /// user clicks "Dismiss" — we never auto-close on success because the commit SHA is
+    /// worth letting the user see + copy, and on `.noChanges` the user explicitly asked.
+    var drawerPresented: Bool = false
+
+    private let command: BackupCommand
+    private let logCenter: LogCenter
+    private var inFlight: Task<Void, Never>?
+
+    init(
+        command: BackupCommand = BackupCommand(),
+        logCenter: LogCenter = .shared
+    ) {
+        self.command = command
+        self.logCenter = logCenter
+    }
+
+    var isRunning: Bool {
+        if case .running = phase { return true }
+        return false
+    }
+
+    var logText: String {
+        logLines.map(\.text).joined(separator: "\n")
+    }
+
+    /// Kicks off a backup. No-op if one is already running.
+    func backup(siteID: String, siteDirectory: URL) {
+        guard !isRunning else { return }
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runBackup(siteID: siteID, siteDirectory: siteDirectory)
+        }
+    }
+
+    func dismissDrawer() {
+        drawerPresented = false
+    }
+
+    private func runBackup(siteID: String, siteDirectory: URL) async {
+        let started = Date()
+        phase = .running(siteID: siteID, since: started)
+        logLines = []
+        drawerPresented = true
+
+        let source = "backup:\(siteID)"
+        let subscription = await logCenter.subscribe()
+        let logTask = Task { @MainActor [weak self] in
+            for await line in subscription.stream where line.source == source {
+                self?.logLines.append(line)
+            }
+        }
+
+        let result = await command.backup(siteID: siteID, siteDirectory: siteDirectory)
+
+        subscription.cancel()
+        _ = await logTask.value
+
+        let duration = Date().timeIntervalSince(started)
+        switch result {
+        case .succeeded(let sha, let branch, let remote):
+            phase = .succeeded(commitSHA: sha, branch: branch, remote: remote, duration: duration)
+        case .noChanges:
+            phase = .noChanges
+        case .failed(let reason, let exit):
+            phase = .failed(reason: reason, exitCode: exit)
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -25,6 +25,7 @@ struct SiteWindow: View {
 
     @State private var preview = PreviewModel()
     @State private var deploy = DeployModel()
+    @State private var backup = BackupModel()
     @State private var audit = AuditModel()
     #if !ANGLESITE_MAS
     @State private var chat: ChatModel?
@@ -93,9 +94,20 @@ struct SiteWindow: View {
                         ? .opacity
                         : .move(edge: .bottom).combined(with: .opacity))
                     .shadow(radius: 8, y: -2)
+            } else if backup.drawerPresented {
+                // Backup and deploy can't both run at once (each disables the other's
+                // button while running), but a stale completed-deploy drawer might still
+                // be on screen when a backup finishes. Deploy wins the z-order — its
+                // drawer carries the more critical "your deploy URL" payload.
+                BackupDrawerView(model: backup, siteName: site.name)
+                    .transition(reduceMotion
+                        ? .opacity
+                        : .move(edge: .bottom).combined(with: .opacity))
+                    .shadow(radius: 8, y: -2)
             }
         }
         .animation(.easeInOut(duration: 0.18), value: deploy.drawerPresented)
+        .animation(.easeInOut(duration: 0.18), value: backup.drawerPresented)
         .navigationTitle(site.name)
         .sheet(isPresented: $deploy.blockedPresented) {
             if case .blocked(let failures, let warnings) = deploy.phase {
@@ -159,6 +171,18 @@ struct SiteWindow: View {
                 #endif
 
                 Button {
+                    backup.backup(siteID: site.id, siteDirectory: site.path)
+                } label: {
+                    Label("Backup", systemImage: "externaldrive.fill.badge.icloud")
+                }
+                .controlSize(.small)
+                .buttonStyle(.bordered)
+                .disabled(backup.isRunning || audit.isRunning || deploy.isRunning || !site.isValid)
+                .help(site.isValid
+                      ? "Commit and push working-tree changes to your current branch"
+                      : "Site is missing required files")
+
+                Button {
                     audit.audit(siteID: site.id, siteDirectory: site.path)
                 } label: {
                     if audit.isRunning {
@@ -169,7 +193,7 @@ struct SiteWindow: View {
                 }
                 .controlSize(.small)
                 .buttonStyle(.bordered)
-                .disabled(audit.isRunning || deploy.isRunning || !site.isValid)
+                .disabled(audit.isRunning || backup.isRunning || deploy.isRunning || !site.isValid)
                 .help(site.isValid
                       ? "Run the structured accessibility audit against this site"
                       : "Site is missing required files")
@@ -181,7 +205,7 @@ struct SiteWindow: View {
                 }
                 .controlSize(.small)
                 .buttonStyle(.borderedProminent)
-                .disabled(deploy.isRunning || audit.isRunning || !site.isValid)
+                .disabled(deploy.isRunning || backup.isRunning || audit.isRunning || !site.isValid)
                 .help(site.isValid
                       ? "Build, scan, and run wrangler deploy on this site"
                       : "Site is missing required files")

--- a/Sources/AnglesiteCore/BackupCommand.swift
+++ b/Sources/AnglesiteCore/BackupCommand.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+/// One-shot orchestrator for the deterministic backup path: `git add -A` →
+/// `git commit -m "Backup <ISO timestamp>"` → `git push origin <branch>`.
+///
+/// Pairs with the LLM-routed `/anglesite:backup` skill, which retains the broader
+/// surface (restore flow, descriptive commit summaries, branch-switching, gh-auth
+/// recovery). The direct path is the optimistic case the chat panel wired through
+/// Claude for no reason — Claude was just calling the same git tools every time.
+///
+/// Pre-flight checks before any working-tree mutation:
+///   1. Branch: refuse on `main`. The plugin's backup skill is explicit that backup
+///      pushes go to feature/draft branches; `main` is reserved for the deploy
+///      pipeline. We surface a `.failed` with no override and let the user switch
+///      branches (or use the chat-routed path, which can auto-switch to `draft`).
+///   2. Remote: refuse if `origin` isn't configured. There's nowhere to push to.
+///   3. Status: bail with `.noChanges` if the working tree is clean — no point
+///      generating a no-op commit.
+///
+/// Then the action steps stream their output to `LogCenter` under
+/// `backup:<siteID>`, so the drawer UI can show progress in real time.
+public actor BackupCommand {
+    public enum Result: Sendable, Equatable {
+        case succeeded(commitSHA: String, branch: String, remote: String)
+        case noChanges
+        /// `exitCode` is `nil` for pre-spawn refusals (on `main`, no remote) and for
+        /// spawn failures; otherwise it's the failing git subprocess's exit code.
+        case failed(reason: String, exitCode: Int32?)
+    }
+
+    /// Runs a one-shot git command in the site directory, returns captured output.
+    /// Used for introspection steps whose output we parse (`status`, `rev-parse`,
+    /// `remote get-url`). Production uses `ProcessSupervisor.run(...)`; tests fake.
+    public typealias GitRunner = @Sendable (_ siteDirectory: URL, _ arguments: [String]) async throws -> ProcessSupervisor.RunResult
+
+    /// Runs a streaming git command (logs flow to `LogCenter` under `source`).
+    /// Used for action steps whose output the drawer renders live (`add`, `commit`,
+    /// `push`). Returns the git exit code; throws only on spawn failure.
+    public typealias GitStreamer = @Sendable (_ siteDirectory: URL, _ arguments: [String], _ source: String) async throws -> Int32
+
+    private let runner: GitRunner
+    private let streamer: GitStreamer
+    private let clock: @Sendable () -> Date
+
+    public init(
+        runner: @escaping GitRunner = BackupCommand.defaultRunner,
+        streamer: @escaping GitStreamer = BackupCommand.defaultStreamer,
+        clock: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.runner = runner
+        self.streamer = streamer
+        self.clock = clock
+    }
+
+    public func backup(siteID: String, siteDirectory: URL) async -> Result {
+        let source = "backup:\(siteID)"
+
+        // 1. Branch — refuse on main. Done first so a user who's on main isn't
+        // surprised by a "no changes" message that would mask the real issue
+        // when they later try to back up actual work.
+        let branch: String
+        do {
+            let result = try await runner(siteDirectory, ["rev-parse", "--abbrev-ref", "HEAD"])
+            guard result.exitCode == 0 else {
+                return .failed(reason: "couldn't read current branch (`git rev-parse` exit \(result.exitCode))", exitCode: result.exitCode)
+            }
+            branch = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return .failed(reason: "couldn't run `git rev-parse`: \(error)", exitCode: nil)
+        }
+        if branch == "main" {
+            return .failed(
+                reason: "backup refuses to push to `main` — that's the deploy branch. Switch to `draft` (or another working branch) and try again.",
+                exitCode: nil
+            )
+        }
+
+        // 2. Remote — refuse when `origin` isn't configured. `git remote get-url`
+        // exits non-zero with an empty stdout when the remote doesn't exist.
+        let remote: String
+        do {
+            let result = try await runner(siteDirectory, ["remote", "get-url", "origin"])
+            guard result.exitCode == 0 else {
+                return .failed(
+                    reason: "no `origin` remote configured — run `/anglesite:backup` in chat to set one up, or add one with `git remote add origin <url>`.",
+                    exitCode: nil
+                )
+            }
+            remote = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !remote.isEmpty else {
+                return .failed(reason: "the `origin` remote is configured but empty.", exitCode: nil)
+            }
+        } catch {
+            return .failed(reason: "couldn't read `origin` remote: \(error)", exitCode: nil)
+        }
+
+        // 3. Status — bail early on a clean working tree.
+        do {
+            let result = try await runner(siteDirectory, ["status", "--porcelain"])
+            guard result.exitCode == 0 else {
+                return .failed(reason: "`git status` exited \(result.exitCode)", exitCode: result.exitCode)
+            }
+            if result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return .noChanges
+            }
+        } catch {
+            return .failed(reason: "couldn't run `git status`: \(error)", exitCode: nil)
+        }
+
+        // 4. add → 5. commit → 6. read HEAD SHA → 7. push.
+        // Each streamed action goes through the streamer so the drawer can render
+        // live output (auth prompts on push are the obvious case).
+        if let failure = await streamGit(["add", "-A"], in: siteDirectory, source: source, label: "git add") {
+            return failure
+        }
+        let commitMessage = "Backup \(Self.iso8601Formatter.string(from: clock()))"
+        if let failure = await streamGit(["commit", "-m", commitMessage], in: siteDirectory, source: source, label: "git commit") {
+            return failure
+        }
+        let sha: String
+        do {
+            let result = try await runner(siteDirectory, ["rev-parse", "HEAD"])
+            guard result.exitCode == 0 else {
+                return .failed(reason: "couldn't read commit SHA (`git rev-parse HEAD` exit \(result.exitCode))", exitCode: result.exitCode)
+            }
+            sha = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return .failed(reason: "couldn't read commit SHA: \(error)", exitCode: nil)
+        }
+        if let failure = await streamGit(["push", "origin", branch], in: siteDirectory, source: source, label: "git push") {
+            return failure
+        }
+
+        return .succeeded(commitSHA: sha, branch: branch, remote: remote)
+    }
+
+    // MARK: - Helpers
+
+    /// Streams a single git action and maps the exit reason into a terminal `Result`.
+    /// Returns `nil` on success — the caller can keep going.
+    private func streamGit(
+        _ arguments: [String],
+        in siteDirectory: URL,
+        source: String,
+        label: String
+    ) async -> Result? {
+        do {
+            let exit = try await streamer(siteDirectory, arguments, source)
+            if exit == 0 { return nil }
+            return .failed(reason: "`\(label)` failed (exit \(exit))", exitCode: exit)
+        } catch {
+            return .failed(reason: "couldn't spawn `\(label)`: \(error)", exitCode: nil)
+        }
+    }
+
+    /// ISO-8601 timestamps in commit messages so they sort correctly under `git log` and
+    /// stay locale-agnostic. `Backup 2026-06-10T14:13:20Z` — unambiguous, machine-friendly.
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    // MARK: - Default production seams
+
+    /// Default `GitRunner`: shells out to `git` via `ProcessSupervisor.shared.run(...)`.
+    /// Uses `/usr/bin/env` so the user's shell-resolved `git` is used (matches what they'd
+    /// run in Terminal). Under the MAS sandbox this still spawns directly from the app, so
+    /// the per-site security-scoped grant is inherited.
+    public static let defaultRunner: GitRunner = { siteDirectory, arguments in
+        try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["git"] + arguments,
+            currentDirectoryURL: siteDirectory
+        )
+    }
+
+    /// Default `GitStreamer`: launches `git` via `ProcessSupervisor.shared.launch(...)` so
+    /// stdout/stderr flow into `LogCenter` line-by-line under `source`. Waits for exit and
+    /// returns the code; `git push`'s auth-prompt back-and-forth is therefore visible in
+    /// the drawer in real time.
+    public static let defaultStreamer: GitStreamer = { siteDirectory, arguments, source in
+        let handle = try await ProcessSupervisor.shared.launch(
+            source: source,
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["git"] + arguments,
+            currentDirectoryURL: siteDirectory
+        )
+        let reason = await ProcessSupervisor.shared.waitForExit(handle)
+        switch reason {
+        case .exited(let code):                return code
+        case .terminated:                       return -1
+        case .retriesExhausted(let lastCode):   return lastCode
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/BackupCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/BackupCommandTests.swift
@@ -1,0 +1,244 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for `BackupCommand` — the deterministic add/commit/push path that replaces
+/// the chat-routed `/anglesite:backup` for one-click backups (#85).
+///
+/// Style matches `DeployCommandTests`: real `ProcessSupervisor` + `LogCenter` instances,
+/// shell-fixture closures injected via the `runner`/`streamer` seams. The `clock` seam
+/// makes commit-message timestamps deterministic.
+struct BackupCommandTests {
+
+    private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    private let fixedClock: @Sendable () -> Date = {
+        Date(timeIntervalSince1970: 1_780_000_000)  // 2026-06-08 ~14:13 UTC
+    }
+
+    // MARK: Builder
+
+    private func makeCommand(
+        runner: @escaping BackupCommand.GitRunner,
+        streamer: @escaping BackupCommand.GitStreamer = { _, _, _ in 0 }
+    ) -> BackupCommand {
+        BackupCommand(runner: runner, streamer: streamer, clock: fixedClock)
+    }
+
+    /// Fake runner that dispatches on the first git argument so each test can script multiple
+    /// subcommands (`status`, `rev-parse`, `remote`) in one closure without nested switches.
+    private func runner(
+        _ table: [String: (stdout: String, exitCode: Int32)]
+    ) -> BackupCommand.GitRunner {
+        return { _, args in
+            let key = args.first ?? ""
+            guard let entry = table[key] else {
+                return ProcessSupervisor.RunResult(stdout: "", stderr: "unmocked git \(args.joined(separator: " "))", exitCode: 1)
+            }
+            return ProcessSupervisor.RunResult(stdout: entry.stdout, stderr: "", exitCode: entry.exitCode)
+        }
+    }
+
+    // MARK: noChanges
+
+    @Test("Returns .noChanges when git status is empty")
+    func returnsNoChangesWhenStatusEmpty() async {
+        let cmd = makeCommand(runner: runner([
+            "status": ("", 0),
+            "rev-parse": ("draft\n", 0),
+            "remote": ("git@github.com:owner/site.git\n", 0)
+        ]))
+        let result = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
+        #expect(result == .noChanges)
+    }
+
+    // MARK: Main-branch refusal
+
+    @Test("Refuses when current branch is main")
+    func refusesOnMain() async {
+        let cmd = makeCommand(runner: runner([
+            "status": (" M src/pages/index.astro\n", 0),
+            "rev-parse": ("main\n", 0),
+            "remote": ("git@github.com:owner/site.git\n", 0)
+        ]))
+        let result = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else {
+            Issue.record("expected .failed, got \(result)")
+            return
+        }
+        #expect(reason.contains("main"), "reason should explain the main-branch rule: \(reason)")
+        #expect(exit == nil, "main-branch refusal is pre-spawn — no exit code")
+    }
+
+    // MARK: Missing-remote refusal
+
+    @Test("Refuses when origin remote is not configured")
+    func refusesWhenNoRemote() async {
+        // git emits an empty stdout and non-zero exit when the remote doesn't exist.
+        let cmd = makeCommand(runner: runner([
+            "status": (" M src/pages/index.astro\n", 0),
+            "rev-parse": ("draft\n", 0),
+            "remote": ("", 2)
+        ]))
+        let result = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
+        guard case .failed(let reason, _) = result else {
+            Issue.record("expected .failed, got \(result)")
+            return
+        }
+        #expect(reason.lowercased().contains("remote"), "reason should mention the missing remote: \(reason)")
+    }
+
+    // MARK: Happy path
+
+    @Test("Succeeds and returns commit SHA + branch + remote")
+    func succeedsAndReturnsStructuredResult() async {
+        // status/rev-parse/remote answer up-front; after commit, rev-parse HEAD returns the SHA.
+        // The dispatcher returns whatever's at the keyed first arg, so HEAD is dispatched via "rev-parse"
+        // — that's fine because we run branch-detection (rev-parse --abbrev-ref HEAD) before the
+        // commit, and HEAD-SHA (rev-parse HEAD) after. The fake distinguishes them by args length.
+        let runner: BackupCommand.GitRunner = { _, args in
+            switch args.first {
+            case "status":   return .init(stdout: " M src/pages/index.astro\n", stderr: "", exitCode: 0)
+            case "remote":   return .init(stdout: "git@github.com:owner/site.git\n", stderr: "", exitCode: 0)
+            case "rev-parse":
+                // `git rev-parse --abbrev-ref HEAD` for branch detection, `git rev-parse HEAD` for SHA.
+                if args.contains("--abbrev-ref") {
+                    return .init(stdout: "draft\n", stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "abc1234deadbeef0000000000000000000000000\n", stderr: "", exitCode: 0)
+            default:
+                return .init(stdout: "", stderr: "unmocked", exitCode: 1)
+            }
+        }
+        let cmd = makeCommand(runner: runner, streamer: { _, _, _ in 0 })
+
+        let result = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
+        guard case .succeeded(let sha, let branch, let remote) = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        #expect(sha == "abc1234deadbeef0000000000000000000000000")
+        #expect(branch == "draft")
+        #expect(remote == "git@github.com:owner/site.git")
+    }
+
+    // MARK: Push failure
+
+    @Test("Surfaces push failure with exit code")
+    func surfacesPushFailureWithExitCode() async {
+        let runner: BackupCommand.GitRunner = { _, args in
+            switch args.first {
+            case "status":   return .init(stdout: " M src/pages/index.astro\n", stderr: "", exitCode: 0)
+            case "remote":   return .init(stdout: "git@github.com:owner/site.git\n", stderr: "", exitCode: 0)
+            case "rev-parse":
+                if args.contains("--abbrev-ref") {
+                    return .init(stdout: "draft\n", stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "abc1234\n", stderr: "", exitCode: 0)
+            default:
+                return .init(stdout: "", stderr: "unmocked", exitCode: 1)
+            }
+        }
+        let streamer: BackupCommand.GitStreamer = { _, args, _ in
+            // Fail only on `git push`; add/commit succeed.
+            args.first == "push" ? 128 : 0
+        }
+        let cmd = makeCommand(runner: runner, streamer: streamer)
+
+        let result = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else {
+            Issue.record("expected .failed, got \(result)")
+            return
+        }
+        #expect(reason.lowercased().contains("push"), "reason should mention which step failed: \(reason)")
+        #expect(exit == 128)
+    }
+
+    // MARK: Commit message format
+
+    @Test("Commit message uses ISO-8601 timestamp from injected clock")
+    func commitMessageUsesISO8601Timestamp() async {
+        // Capture the commit message by intercepting the streamer's args.
+        let captured = LockedCapture()
+        let runner: BackupCommand.GitRunner = { _, args in
+            switch args.first {
+            case "status":   return .init(stdout: " M file\n", stderr: "", exitCode: 0)
+            case "remote":   return .init(stdout: "origin-url\n", stderr: "", exitCode: 0)
+            case "rev-parse":
+                if args.contains("--abbrev-ref") {
+                    return .init(stdout: "draft\n", stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "abc\n", stderr: "", exitCode: 0)
+            default:
+                return .init(stdout: "", stderr: "unmocked", exitCode: 1)
+            }
+        }
+        let streamer: BackupCommand.GitStreamer = { _, args, _ in
+            if args.first == "commit" {
+                captured.set(args)
+            }
+            return 0
+        }
+        let cmd = makeCommand(runner: runner, streamer: streamer)
+
+        _ = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
+        let committed = captured.get()
+        // `git commit -m "Backup <ISO timestamp>"` — find the message after -m.
+        guard let mIdx = committed.firstIndex(of: "-m"), mIdx + 1 < committed.count else {
+            Issue.record("expected -m flag in commit args, got \(committed)")
+            return
+        }
+        let message = committed[mIdx + 1]
+        #expect(message.hasPrefix("Backup "), "message should start with 'Backup ': \(message)")
+        // The fixed clock is 2026-06-08T~14:13Z; check the year/month land in the message.
+        #expect(message.contains("2026"), "message should contain ISO year: \(message)")
+    }
+
+    // MARK: Source tagging
+
+    @Test("Streams every action step under backup:<siteID>")
+    func streamsActionsUnderBackupSiteIDSource() async {
+        let sources = LockedSourceList()
+        let runner: BackupCommand.GitRunner = { _, args in
+            switch args.first {
+            case "status":   return .init(stdout: " M file\n", stderr: "", exitCode: 0)
+            case "remote":   return .init(stdout: "origin-url\n", stderr: "", exitCode: 0)
+            case "rev-parse":
+                if args.contains("--abbrev-ref") {
+                    return .init(stdout: "draft\n", stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "abc\n", stderr: "", exitCode: 0)
+            default:
+                return .init(stdout: "", stderr: "unmocked", exitCode: 1)
+            }
+        }
+        let streamer: BackupCommand.GitStreamer = { _, _, source in
+            sources.add(source)
+            return 0
+        }
+        let cmd = makeCommand(runner: runner, streamer: streamer)
+        _ = await cmd.backup(siteID: "mysite", siteDirectory: tmpDir)
+
+        let seen = sources.snapshot()
+        #expect(seen.allSatisfy { $0 == "backup:mysite" }, "every streamed step must carry the site-specific source tag, got \(seen)")
+        #expect(seen.count == 3, "expected add + commit + push, got \(seen.count): \(seen)")
+    }
+}
+
+// MARK: - Sendable capture helpers
+//
+// Swift Testing closures are @Sendable so plain `var` doesn't work for cross-closure capture.
+// These thin wrappers use NSLock for the small mutation the tests need.
+
+private final class LockedCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: [String] = []
+    func set(_ v: [String]) { lock.lock(); value = v; lock.unlock() }
+    func get() -> [String] { lock.lock(); defer { lock.unlock() }; return value }
+}
+
+private final class LockedSourceList: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String] = []
+    func add(_ v: String) { lock.lock(); values.append(v); lock.unlock() }
+    func snapshot() -> [String] { lock.lock(); defer { lock.unlock() }; return values }
+}


### PR DESCRIPTION
## Summary

- New `BackupCommand` actor in `AnglesiteCore` — deterministic `git add → commit (ISO timestamp) → push` path with pre-flight checks (refuses on `main`, requires `origin` remote, bails on clean working tree).
- New `BackupModel` + `BackupDrawerView` in `AnglesiteApp` — mirrors the `DeployModel` / `DeployDrawerView` shape, streams git output live to a slide-up drawer.
- Toolbar Backup button in `SiteWindow` between Chat and Deploy; Backup and Deploy mutually disable each other while running.
- Drops `"backup"` from `SkillRegistry.quickActionNames` so the chat pill that used to spawn Claude just to invoke `/anglesite:backup` is gone.

Closes #85.

> **Overlap with #114 / #84:** this branch also drops `"deploy"` (and its `case "deploy"` icon line) because #114 hadn't merged into `main` when this branch was cut. Whichever of #114 / this PR merges first, the other will need a one-line `quickActionNames` rebase. The other changes don't overlap.

## Why

The chat-panel Backup pill was a redundant LLM-routed entry point — Claude was just running the same `git status`/`git add`/`git commit`/`git push` sequence every time. `BackupCommand` makes that path deterministic so one-click backups skip the model entirely. The chat path stays available for everything the LLM-routed skill actually adds value for (descriptive commit messages, restore, auto-switching to `draft`, gh-auth recovery).

## Architecture choices

**Two seams, not one.** `GitRunner = (cwd, args) -> RunResult` for capture-only steps (`status`, `rev-parse`, `remote get-url`); `GitStreamer = (cwd, args, source) -> ExitCode` for action steps whose output the drawer renders. Production uses `ProcessSupervisor.shared.run(...)` and `.launch(...)` respectively; tests inject closures. The split lets `git push`'s live auth-prompt back-and-forth flow to the drawer while keeping `git rev-parse HEAD` (parsing for SHA) trivially testable.

**Refuses on `main` rather than auto-switching to `draft`.** The plugin's backup skill auto-creates and switches to `draft` if needed. The direct path doesn't — it surfaces a `.failed` with remediation ("switch to `draft`, or use chat") and lets the owner choose. Auto-mutating branches behind a one-click button felt too magical; chat is the place for that interaction.

**`"Backup <ISO-8601 timestamp>"` commit messages.** Deterministic, locale-agnostic, sorts correctly under `git log`. Descriptive summaries ("Add 2 blog posts and update About page") stay in the LLM-routed skill — they need a categorization step the toolbar button shouldn't take a position on.

**`.noChanges` shown via the drawer, not a banner.** Considered a transient toast but the drawer was already the right shape — same dismissal pattern, same place owners look for the result, one less UI surface to maintain.

## Acceptance criteria from #85

| Criterion | Status |
|---|---|
| `BackupCommand` actor with injectable seams | ✅ `GitRunner`, `GitStreamer`, `clock` |
| Backup button triggers direct git, no `claude` spawn | ✅ |
| UI shows progress and result (success+SHA / no-changes / error) | ✅ `BackupDrawerView` renders all four `Phase`s |
| All git operations routed through `ProcessSupervisor` | ✅ default seams use `.run` / `.launch` |
| Unit tests cover success, no-changes, and failure paths | ✅ 7 tests |

## Scope vs the plugin's `backup` skill

| Step | LLM-routed `/anglesite:backup` | Direct `BackupCommand` (#85) |
|---|---|---|
| Detect changes via `git status --porcelain` | ✅ | ✅ |
| Categorize changed files semantically | ✅ | ❌ |
| Descriptive commit message ("Add 2 blog posts") | ✅ | ❌ — ISO timestamp |
| Refuse on `main` | ✅ (offers to switch to `draft`) | ✅ (surfaces failure, owner switches) |
| Push to `origin` | ✅ | ✅ |
| Re-run `gh auth login` on auth failure | ✅ | ❌ |
| Restore flow (snapshots, recovery branches, diffs) | ✅ full | ❌ (LLM-only) |

## Test plan

- [x] `swift test --package-path . --filter BackupCommandTests` → 7/7 green.
- [x] `swift test --package-path . --filter SkillRegistryTests` → 15/15 green.
- [x] Full `swift test --package-path .` → AnglesiteCoreTests.xctest layer "All tests passed"; pre-existing Swift Testing integration failures (`AppliesEditEndToEndTests`, `MCPClientHTTPEndToEndTests`) unchanged from main, both stash-baselined as independent of this PR.
- [x] `xcodegen generate && xcodebuild -scheme Anglesite -configuration Debug build` → BUILD SUCCEEDED.
- [x] `xcodebuild -scheme AnglesiteMAS -configuration Debug build` → BUILD SUCCEEDED.
- [ ] Manual smoke on a real site: dirty working tree → click Backup → drawer streams git output → succeed with SHA + remote. Clean working tree → `.noChanges`. On `main` → refusal banner.
- [ ] Manual smoke on the `.failed` push path (e.g. unauthenticated remote): drawer shows the git stderr, Copy log works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)