### PR TITLE
Resolve annotations via direct MCP call (#87)

### DIFF
--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -34,8 +34,10 @@ final class ChatModel {
         let timestamp: Date
         /// Only set on `role: .edit` rows. Carries file + commit + undone flag.
         var editMetadata: EditMetadata?
+        /// Only set on `role: .annotation` rows. Carries the backing annotation id.
+        var annotationMetadata: AnnotationMetadata?
 
-        enum Role: Equatable { case user, assistant, system, error, edit }
+        enum Role: Equatable { case user, assistant, system, error, edit, annotation }
 
         init(
             id: UUID = UUID(),
@@ -43,7 +45,8 @@ final class ChatModel {
             content: String,
             toolCalls: [ToolCall] = [],
             timestamp: Date = Date(),
-            editMetadata: EditMetadata? = nil
+            editMetadata: EditMetadata? = nil,
+            annotationMetadata: AnnotationMetadata? = nil
         ) {
             self.id = id
             self.role = role
@@ -51,6 +54,7 @@ final class ChatModel {
             self.toolCalls = toolCalls
             self.timestamp = timestamp
             self.editMetadata = editMetadata
+            self.annotationMetadata = annotationMetadata
         }
     }
 
@@ -58,6 +62,11 @@ final class ChatModel {
         let file: String
         let commit: String
         var undone: Bool
+    }
+
+    /// Identifies the backing annotation so its chat row can be resolved via MCP.
+    struct AnnotationMetadata: Equatable {
+        let annotationID: String
     }
 
     struct ToolCall: Identifiable, Equatable {
@@ -114,6 +123,10 @@ final class ChatModel {
     /// `loadAnnotations()` shows the same annotations the edit overlay added; tests inject a
     /// fixture closure. `nil` disables the feed (returns no annotations, no error).
     private let annotationFeed: AnnotationFeed?
+    /// Resolves an annotation via the plugin's `resolve_annotation` MCP tool. Injected so tests
+    /// can assert the id passed and simulate failures. `nil` disables resolution.
+    typealias AnnotationResolver = @Sendable (_ id: String) async throws -> Void
+    private let annotationResolver: ChatModel.AnnotationResolver?
     /// Optional. Wired to the per-site `MCPClient` in production; nil in tests where the
     /// chat has no MCP backing yet.
     private let undoCommand: UndoCommand?
@@ -125,21 +138,23 @@ final class ChatModel {
     /// don't double-post the same sticky note when the user revisits a site mid-session.
     private var surfacedAnnotationIDs: Set<String> = []
 
-    init(siteID: String, siteDirectory: URL, annotationFeed: AnnotationFeed? = nil, undoCommand: UndoCommand? = nil) {
+    init(siteID: String, siteDirectory: URL, annotationFeed: AnnotationFeed? = nil, annotationResolver: AnnotationResolver? = nil, undoCommand: UndoCommand? = nil) {
         self.siteDirectory = siteDirectory
         self.agent = ClaudeAgent(siteID: siteID, siteDirectory: siteDirectory)
         self.history = ChatHistoryStore(siteDirectory: siteDirectory)
         self.annotationFeed = annotationFeed
+        self.annotationResolver = annotationResolver
         self.undoCommand = undoCommand
     }
 
     /// Test-facing initializer: inject the agent (typically with a fixture launcher) and an
     /// optional override of the history store.
-    init(siteDirectory: URL, agent: ClaudeAgent, history: ChatHistoryStore? = nil, annotationFeed: AnnotationFeed? = nil, undoCommand: UndoCommand? = nil) {
+    init(siteDirectory: URL, agent: ClaudeAgent, history: ChatHistoryStore? = nil, annotationFeed: AnnotationFeed? = nil, annotationResolver: AnnotationResolver? = nil, undoCommand: UndoCommand? = nil) {
         self.siteDirectory = siteDirectory
         self.agent = agent
         self.history = history ?? ChatHistoryStore(siteDirectory: siteDirectory)
         self.annotationFeed = annotationFeed
+        self.annotationResolver = annotationResolver
         self.undoCommand = undoCommand
     }
 
@@ -173,8 +188,12 @@ final class ChatModel {
         for annotation in annotations where !annotation.resolved {
             guard !surfacedAnnotationIDs.contains(annotation.id) else { continue }
             surfacedAnnotationIDs.insert(annotation.id)
-            let content = ChatModel.renderAnnotation(annotation)
-            messages.append(.init(role: .system, content: content, timestamp: annotation.createdAt))
+            messages.append(.init(
+                role: .annotation,
+                content: ChatModel.renderAnnotation(annotation),
+                timestamp: annotation.createdAt,
+                annotationMetadata: .init(annotationID: annotation.id)
+            ))
         }
     }
 
@@ -184,6 +203,28 @@ final class ChatModel {
     static func renderAnnotation(_ a: Annotation) -> String {
         let location = a.sourceFile ?? "\(a.path) → \(a.selector)"
         return "📌 \(a.text) — \(location)"
+    }
+
+    /// Resolves the annotation backing `messageID`: optimistically marks it resolved and drops
+    /// the row, then calls the MCP tool. On error, restores the row and records `lastError`.
+    func resolveAnnotation(messageID: UUID) async {
+        guard let idx = messages.firstIndex(where: { $0.id == messageID }),
+              let meta = messages[idx].annotationMetadata,
+              let resolver = annotationResolver else { return }
+
+        let removed = messages.remove(at: idx)              // optimistic: drop from the feed
+        surfacedAnnotationIDs.remove(meta.annotationID)
+        do {
+            try await resolver(meta.annotationID)
+        } catch {
+            // `idx` was captured before the await; messages may have shifted during the
+            // suspension (concurrent resolve, streaming send, loadAnnotations). Re-locate
+            // the chronological insertion point by timestamp instead of trusting idx.
+            let insertIdx = messages.firstIndex { $0.timestamp > removed.timestamp } ?? messages.count
+            messages.insert(removed, at: insertIdx)
+            surfacedAnnotationIDs.insert(meta.annotationID)
+            lastError = "couldn't resolve annotation: \(error.localizedDescription)"
+        }
     }
 
     /// Sends a user prompt to the agent and consumes the resulting event stream. No-op while
@@ -385,7 +426,11 @@ final class ChatModel {
             switch message.role {
             case .user: return .user
             case .assistant: return .assistant
-            case .system, .error: return .assistant
+            // `.system`/`.error`/`.annotation` are never routed through `persist` — they're
+            // appended directly. Annotations in particular are reloaded fresh from MCP each
+            // session via `loadAnnotations()`, so they're intentionally non-persisted. This
+            // arm only keeps the switch exhaustive.
+            case .system, .error, .annotation: return .assistant
             case .edit: return .edit
             }
         }()

--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -205,15 +205,22 @@ final class ChatModel {
         return "📌 \(a.text) — \(location)"
     }
 
-    /// Resolves the annotation backing `messageID`: optimistically marks it resolved and drops
-    /// the row, then calls the MCP tool. On error, restores the row and records `lastError`.
+    /// Resolves the annotation backing `messageID`: optimistically drops the row, then calls the
+    /// MCP tool. On error, restores the row and records `lastError`.
+    ///
+    /// The annotation id is deliberately **kept** in `surfacedAnnotationIDs` for the whole
+    /// operation — including across the `await`. If it were removed first, a `loadAnnotations()`
+    /// that runs during the suspension (e.g. ⌘K toggles the chat panel, tearing down and
+    /// re-mounting `ChatView` and refiring its `.task`) would see the id missing, fetch the
+    /// still-unresolved annotation from MCP, and append a duplicate row. Leaving the id in the
+    /// set makes that re-surface a no-op. On success the row is simply gone (the resolved
+    /// annotation is filtered out of future feeds anyway); on failure we re-insert the one row.
     func resolveAnnotation(messageID: UUID) async {
         guard let idx = messages.firstIndex(where: { $0.id == messageID }),
               let meta = messages[idx].annotationMetadata,
               let resolver = annotationResolver else { return }
 
         let removed = messages.remove(at: idx)              // optimistic: drop from the feed
-        surfacedAnnotationIDs.remove(meta.annotationID)
         do {
             try await resolver(meta.annotationID)
         } catch {
@@ -222,7 +229,6 @@ final class ChatModel {
             // the chronological insertion point by timestamp instead of trusting idx.
             let insertIdx = messages.firstIndex { $0.timestamp > removed.timestamp } ?? messages.count
             messages.insert(removed, at: insertIdx)
-            surfacedAnnotationIDs.insert(meta.annotationID)
             lastError = "couldn't resolve annotation: \(error.localizedDescription)"
         }
     }

--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -230,6 +230,14 @@ struct ChatView: View {
     }
 }
 
+// MARK: - Shared formatter
+
+private let sharedRelativeTimeFormatter: RelativeDateTimeFormatter = {
+    let f = RelativeDateTimeFormatter()
+    f.unitsStyle = .short
+    return f
+}()
+
 // MARK: - Message row
 
 private struct MessageRow: View {
@@ -239,6 +247,8 @@ private struct MessageRow: View {
     var body: some View {
         if message.role == .edit {
             editRow
+        } else if message.role == .annotation {
+            AnnotationRowView(message: message, model: model)
         } else {
             HStack {
                 if message.role == .user { Spacer(minLength: 32) }
@@ -290,9 +300,7 @@ private struct MessageRow: View {
     }
 
     private var relativeTime: String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .short
-        return formatter.localizedString(for: message.timestamp, relativeTo: Date())
+        sharedRelativeTimeFormatter.localizedString(for: message.timestamp, relativeTo: .now)
     }
 
     @ViewBuilder
@@ -324,6 +332,7 @@ private struct MessageRow: View {
         case .system: return Color.secondary.opacity(0.12)
         case .error: return Color.red.opacity(0.15)
         case .edit: return Color.secondary.opacity(0.06)  // editRow handles .edit rendering; this is unreachable
+        case .annotation: return Color.secondary.opacity(0.12)
         }
     }
 
@@ -332,6 +341,49 @@ private struct MessageRow: View {
         case .error: return .red
         default: return .primary
         }
+    }
+}
+
+// MARK: - Annotation row
+
+private struct AnnotationRowView: View {
+    let message: ChatModel.Message
+    let model: ChatModel
+    @State private var isResolving = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Rectangle()
+                .fill(Color.orange.opacity(0.5))
+                .frame(width: 3)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(message.content)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                Text(relativeTime)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Resolve") {
+                isResolving = true
+                Task {
+                    await model.resolveAnnotation(messageID: message.id)
+                    isResolving = false
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(isResolving)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.orange.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private var relativeTime: String {
+        sharedRelativeTimeFormatter.localizedString(for: message.timestamp, relativeTo: .now)
     }
 }
 

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -281,13 +281,27 @@ struct SiteWindow: View {
         #if !ANGLESITE_MAS
         // The annotation feed, undo command, and edit observer exist only to feed the chat
         // panel, which the MAS build omits. The edit overlay still applies edits via MCP.
-        let feed = AnnotationFeedFactory.viaMCP(mcpClient: { [preview] in
+        let mcpClient: @Sendable () async -> MCPClient? = { [preview] in
             await preview.mcpClient()
-        })
-        let undoCommand = UndoCommand(mcpClient: { [preview] in
-            await preview.mcpClient()
-        })
-        chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.path, annotationFeed: feed, undoCommand: undoCommand)
+        }
+        let feed = AnnotationFeedFactory.viaMCP(mcpClient: mcpClient)
+        let undoCommand = UndoCommand(mcpClient: mcpClient)
+        // Resolve directly via the same per-site MCP client the feed uses — no `claude`
+        // process is spawned for a resolve, only a `resolve_annotation` tool call.
+        let annotationResolver: ChatModel.AnnotationResolver = { id in
+            guard let client = await mcpClient() else {
+                throw NSError(domain: "AnnotationFeed", code: 1, userInfo: [NSLocalizedDescriptionKey: "no MCP client"])
+            }
+            let result = try await client.callTool(
+                name: "resolve_annotation",
+                arguments: .object(["id": .string(id)])
+            )
+            if result.isError {
+                let detail = result.content.compactMap(\.text).joined(separator: "\n")
+                throw NSError(domain: "AnnotationFeed", code: 2, userInfo: [NSLocalizedDescriptionKey: detail])
+            }
+        }
+        chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.path, annotationFeed: feed, annotationResolver: annotationResolver, undoCommand: undoCommand)
         preview.setEditObserver { [weak chat] reply in
             Task { @MainActor in
                 chat?.recordEdit(reply)


### PR DESCRIPTION
## Summary

Adds annotation resolution to the chat panel as a direct MCP call — closing **#87**.

Promotes chat annotations from flattened `.system` text to a first-class `.annotation` `Message.Role` carrying the backing annotation id, and renders an `AnnotationRowView` with a **Resolve** button that calls the plugin's `resolve_annotation` MCP tool directly. No `claude` process is spawned for a resolve — only a tool call. Optimistic remove with timestamp-based rollback on error, and an in-flight guard against double-tap. The resolver reuses the same per-site `MCPClient` getter as the annotation feed. DevID-only (chat is compiled out of the MAS build).

### Scope note
This PR originally bundled parallel implementations of #84/#85/#86, but those shipped independently via #114/#115/#116 while this branch was in review. It has been **rebased onto `main` and reduced to just the annotation-resolve work** (#87) that those PRs did not include — now a single focused, conflict-free commit on top of main.

## Test Plan
- [x] `swift test` — full suite green (143 Core + 27 Bridge = 170 tests, 0 failures)
- [x] DevID scheme (`Anglesite`) builds: `BUILD SUCCEEDED`
- [x] MAS scheme (`AnglesiteMAS`) builds: `BUILD SUCCEEDED`
- [ ] Manual GUI smoke (not run in this environment): pin a sticky note → it appears as an annotation row with a Resolve button → Resolve removes it via MCP with no `claude` spawn; a failed resolve restores the row with an inline error

🤖 Generated with [Claude Code](https://claude.com/claude-code)