### PR TITLE
Backup/audit hardening: non-repo guard, push stderr, audit log (review follow-ups)

### DIFF
--- a/Sources/AnglesiteCore/AuditCommand.swift
+++ b/Sources/AnglesiteCore/AuditCommand.swift
@@ -93,6 +93,13 @@ public actor AuditCommand {
                 findings.append(contentsOf: runnerFindings)
                 executed.append(runner.category)
             } catch {
+                // Record the skip AND log it — a runner that throws before it can emit anything
+                // itself (e.g. a spawn failure) would otherwise be invisible in the drawer.
+                await logCenter.append(
+                    source: source,
+                    stream: .stderr,
+                    text: "\(runner.category.rawValue) audit skipped — \(error)"
+                )
                 skipped.append(.init(category: runner.category, reason: "\(error)"))
             }
         }

--- a/Sources/AnglesiteCore/BackupCommand.swift
+++ b/Sources/AnglesiteCore/BackupCommand.swift
@@ -35,8 +35,11 @@ public actor BackupCommand {
 
     /// Runs a streaming git command (logs flow to `LogCenter` under `source`).
     /// Used for action steps whose output the drawer renders live (`add`, `commit`,
-    /// `push`). Returns the git exit code; throws only on spawn failure.
-    public typealias GitStreamer = @Sendable (_ siteDirectory: URL, _ arguments: [String], _ source: String) async throws -> Int32
+    /// `push`). Returns the git exit code **and** the stderr it emitted (also streamed
+    /// live), so a failing step can surface git's own message — e.g. the
+    /// `! [rejected] ... (fetch first)` of a push rejection — in the `.failed` reason
+    /// rather than only in the drawer log. Throws only on spawn failure.
+    public typealias GitStreamer = @Sendable (_ siteDirectory: URL, _ arguments: [String], _ source: String) async throws -> (exitCode: Int32, stderr: String)
 
     private let runner: GitRunner
     private let streamer: GitStreamer
@@ -54,6 +57,23 @@ public actor BackupCommand {
 
     public func backup(siteID: String, siteDirectory: URL) async -> Result {
         let source = "backup:\(siteID)"
+
+        // 0. Repository — refuse outside a git work tree with a clear, actionable message.
+        // `git rev-parse --is-inside-work-tree` exits 0 inside any repo (including a fresh
+        // one with no commits) and non-zero outside one, so it distinguishes "not a repo"
+        // from the later "couldn't read branch"/"no remote" cases that would otherwise
+        // produce a confusing diagnosis on a plain directory.
+        do {
+            let result = try await runner(siteDirectory, ["rev-parse", "--is-inside-work-tree"])
+            guard result.exitCode == 0 else {
+                return .failed(
+                    reason: "this site isn't a git repository — run `git init` and add an `origin` remote, or use `/anglesite:backup` in chat to set it up.",
+                    exitCode: nil
+                )
+            }
+        } catch {
+            return .failed(reason: "couldn't check the git repository: \(error)", exitCode: nil)
+        }
 
         // 1. Branch — refuse on main. Done first so a user who's on main isn't
         // surprised by a "no changes" message that would mask the real issue
@@ -145,9 +165,13 @@ public actor BackupCommand {
         label: String
     ) async -> Result? {
         do {
-            let exit = try await streamer(siteDirectory, arguments, source)
+            let (exit, stderr) = try await streamer(siteDirectory, arguments, source)
             if exit == 0 { return nil }
-            return .failed(reason: "`\(label)` failed (exit \(exit))", exitCode: exit)
+            let detail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return .failed(
+                reason: "`\(label)` failed (exit \(exit))" + (detail.isEmpty ? "" : ": \(detail)"),
+                exitCode: exit
+            )
         } catch {
             return .failed(reason: "couldn't spawn `\(label)`: \(error)", exitCode: nil)
         }
@@ -179,7 +203,20 @@ public actor BackupCommand {
     /// stdout/stderr flow into `LogCenter` line-by-line under `source`. Waits for exit and
     /// returns the code; `git push`'s auth-prompt back-and-forth is therefore visible in
     /// the drawer in real time.
+    ///
+    /// It also subscribes to `LogCenter` *before* launching and collects this run's stderr
+    /// lines, so a non-zero exit can carry git's own message back to the caller. Subscribing
+    /// before launch (rather than reading a snapshot afterward) scopes the capture to exactly
+    /// this invocation — a snapshot would also include earlier runs under the same `source`.
     public static let defaultStreamer: GitStreamer = { siteDirectory, arguments, source in
+        let subscription = await LogCenter.shared.subscribe()
+        let collector = StderrCollector()
+        let collectTask = Task {
+            for await line in subscription.stream where line.source == source && line.stream == .stderr {
+                await collector.append(line.text)
+            }
+        }
+
         let handle = try await ProcessSupervisor.shared.launch(
             source: source,
             executable: URL(fileURLWithPath: "/usr/bin/env"),
@@ -187,10 +224,26 @@ public actor BackupCommand {
             currentDirectoryURL: siteDirectory
         )
         let reason = await ProcessSupervisor.shared.waitForExit(handle)
+
+        // `waitForExit` only resumes once the supervisor's pipe-drain Tasks have finished, so
+        // every stderr line is already in LogCenter; cancelling ends the stream and the await
+        // drains any still-buffered lines into the collector before we read it.
+        subscription.cancel()
+        _ = await collectTask.value
+        let stderr = await collector.joined()
+
         switch reason {
-        case .exited(let code):                return code
-        case .terminated:                       return -1
-        case .retriesExhausted(let lastCode):   return lastCode
+        case .exited(let code):                return (code, stderr)
+        case .terminated:                       return (-1, stderr)
+        case .retriesExhausted(let lastCode):   return (lastCode, stderr)
         }
     }
+}
+
+/// Accumulates streamed stderr lines for `BackupCommand.defaultStreamer`. An actor so the
+/// `@Sendable` collect Task can append without a lock.
+private actor StderrCollector {
+    private var lines: [String] = []
+    func append(_ line: String) { lines.append(line) }
+    func joined() -> String { lines.joined(separator: "\n") }
 }

--- a/Tests/AnglesiteCoreTests/BackupCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/BackupCommandTests.swift
@@ -26,6 +26,11 @@ struct BackupCommandTests {
 
     /// Fake runner that dispatches on the first git argument so each test can script multiple
     /// subcommands (`status`, `rev-parse`, `remote`) in one closure without nested switches.
+    ///
+    /// Note: the `"rev-parse"` entry answers BOTH `rev-parse --is-inside-work-tree` (step 0,
+    /// where only `exitCode == 0` matters — it means "is a repo") and `rev-parse --abbrev-ref
+    /// HEAD` (step 1, whose stdout is the branch name). Tests that want to reach the branch/
+    /// remote/status steps therefore give `"rev-parse"` an exit-0 entry.
     private func runner(
         _ table: [String: (stdout: String, exitCode: Int32)]
     ) -> BackupCommand.GitRunner {

--- a/Tests/AnglesiteCoreTests/BackupCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/BackupCommandTests.swift
@@ -19,7 +19,7 @@ struct BackupCommandTests {
 
     private func makeCommand(
         runner: @escaping BackupCommand.GitRunner,
-        streamer: @escaping BackupCommand.GitStreamer = { _, _, _ in 0 }
+        streamer: @escaping BackupCommand.GitStreamer = { _, _, _ in (0, "") }
     ) -> BackupCommand {
         BackupCommand(runner: runner, streamer: streamer, clock: fixedClock)
     }
@@ -36,6 +36,28 @@ struct BackupCommandTests {
             }
             return ProcessSupervisor.RunResult(stdout: entry.stdout, stderr: "", exitCode: entry.exitCode)
         }
+    }
+
+    // MARK: Non-repo refusal
+
+    @Test("Refuses outside a git repository with a clear, actionable message")
+    func refusesOutsideGitRepo() async {
+        // `git rev-parse --is-inside-work-tree` exits non-zero on a plain directory. The
+        // command must stop here — before branch/remote/status — with a git-init remediation.
+        let cmd = makeCommand(runner: { _, args in
+            if args.contains("--is-inside-work-tree") {
+                return .init(stdout: "", stderr: "fatal: not a git repository", exitCode: 128)
+            }
+            Issue.record("no git command should run after the work-tree check fails: \(args)")
+            return .init(stdout: "", stderr: "unexpected", exitCode: 1)
+        })
+        let result = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else {
+            Issue.record("expected .failed, got \(result)")
+            return
+        }
+        #expect(reason.lowercased().contains("git repository"), "reason should name the missing repo: \(reason)")
+        #expect(exit == nil, "non-repo refusal is pre-spawn — no exit code")
     }
 
     // MARK: noChanges
@@ -109,7 +131,7 @@ struct BackupCommandTests {
                 return .init(stdout: "", stderr: "unmocked", exitCode: 1)
             }
         }
-        let cmd = makeCommand(runner: runner, streamer: { _, _, _ in 0 })
+        let cmd = makeCommand(runner: runner, streamer: { _, _, _ in (0, "") })
 
         let result = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
         guard case .succeeded(let sha, let branch, let remote) = result else {
@@ -123,7 +145,7 @@ struct BackupCommandTests {
 
     // MARK: Push failure
 
-    @Test("Surfaces push failure with exit code")
+    @Test("Surfaces push failure with exit code and git's stderr")
     func surfacesPushFailureWithExitCode() async {
         let runner: BackupCommand.GitRunner = { _, args in
             switch args.first {
@@ -139,8 +161,10 @@ struct BackupCommandTests {
             }
         }
         let streamer: BackupCommand.GitStreamer = { _, args, _ in
-            // Fail only on `git push`; add/commit succeed.
-            args.first == "push" ? 128 : 0
+            // Fail only on `git push` (with a realistic rejection on stderr); add/commit succeed.
+            args.first == "push"
+                ? (128, "! [rejected] draft -> draft (fetch first)\nerror: failed to push some refs")
+                : (0, "")
         }
         let cmd = makeCommand(runner: runner, streamer: streamer)
 
@@ -150,6 +174,7 @@ struct BackupCommandTests {
             return
         }
         #expect(reason.lowercased().contains("push"), "reason should mention which step failed: \(reason)")
+        #expect(reason.contains("rejected"), "reason should embed git's stderr so the user sees why: \(reason)")
         #expect(exit == 128)
     }
 
@@ -176,7 +201,7 @@ struct BackupCommandTests {
             if args.first == "commit" {
                 captured.set(args)
             }
-            return 0
+            return (0, "")
         }
         let cmd = makeCommand(runner: runner, streamer: streamer)
 
@@ -213,7 +238,7 @@ struct BackupCommandTests {
         }
         let streamer: BackupCommand.GitStreamer = { _, _, source in
             sources.add(source)
-            return 0
+            return (0, "")
         }
         let cmd = makeCommand(runner: runner, streamer: streamer)
         _ = await cmd.backup(siteID: "mysite", siteDirectory: tmpDir)


### PR DESCRIPTION
## Summary

Three small robustness follow-ups identified when comparing the two parallel #85/#86 implementations (during #117 review). All are improvements to code already on `main`.

### 1. Backup: explicit non-repo guard (`BackupCommand`)
A plain (non-git) directory previously failed at the branch check with a confusing *"couldn't read current branch"*. Added a `git rev-parse --is-inside-work-tree` pre-flight that fails with an actionable *"this site isn't a git repository — run `git init`…"* message. New test `refusesOutsideGitRepo` (also asserts no further git runs after the failed check).

### 2. Backup: surface git's stderr in streamed-step failures (`BackupCommand`)
`GitStreamer` now returns `(exitCode, stderr)`. The default streamer captures *this run's* stderr via a `LogCenter` subscription opened before launch (scoped to the invocation, unlike a post-hoc snapshot), and `streamGit` embeds it in the `.failed` reason. A push rejection now reads `` `git push` failed (exit 128): ! [rejected] … (fetch first) `` in the model's failure string, not only the live drawer log. Test updated to assert the stderr reaches the reason.

### 3. Audit: log skipped-runner failures (`AuditCommand`)
A runner that threw before emitting anything itself was recorded in `runnersSkipped` but invisible in the drawer log. The catch now also appends to `LogCenter` under the runner's source tag — no swallowed failures.

## Notes
- The streamer's subscribe→launch→waitForExit→cancel→await ordering matches the established `DeployModel` pattern and relies on `waitForExit`'s drain-before-resume guarantee (reviewed for races — none found).
- The 4th gap from the comparison (a clearer non-repo *message*) is folded into #1.

## Test Plan
- [x] `swift test` — full suite green (144 Core + 27 Bridge = 171 tests, 0 failures; +1 new backup test)
- [x] DevID scheme (`Anglesite`) builds: `BUILD SUCCEEDED`
- [x] MAS scheme (`AnglesiteMAS`) builds: `BUILD SUCCEEDED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)