### PR TITLE
fix(audit): dedupe exit code and wire build log into failure sheet

### DIFF
--- a/Sources/AnglesiteApp/AuditModel.swift
+++ b/Sources/AnglesiteApp/AuditModel.swift
@@ -15,7 +15,7 @@ final class AuditModel {
         case idle
         case running(siteID: String, since: Date)
         case succeeded(report: AuditReport, duration: TimeInterval)
-        case failed(reason: String, exitCode: Int32?)
+        case failed(reason: String, exitCode: Int32?, logTail: [LogCenter.LogLine])
     }
 
     private(set) var phase: Phase = .idle
@@ -35,6 +35,14 @@ final class AuditModel {
     var isRunning: Bool {
         if case .running = phase { return true }
         return false
+    }
+
+    /// Renders the captured build log as plain text for the "Copy log" affordance on the
+    /// failure sheet. Empty for non-failure phases or for failures that produced no output
+    /// (e.g. spawn refusal before the build process started).
+    var logText: String {
+        guard case .failed(_, _, let tail) = phase else { return "" }
+        return tail.map(\.text).joined(separator: "\n")
     }
 
     /// Kicks off an audit. No-op if one is already running.
@@ -60,8 +68,8 @@ final class AuditModel {
         switch result {
         case .succeeded(let report, let duration):
             phase = .succeeded(report: report, duration: duration)
-        case .failed(let reason, let exit):
-            phase = .failed(reason: reason, exitCode: exit)
+        case .failed(let reason, let exit, let logTail):
+            phase = .failed(reason: reason, exitCode: exit, logTail: logTail)
         }
         sheetPresented = true
     }

--- a/Sources/AnglesiteApp/AuditSheetView.swift
+++ b/Sources/AnglesiteApp/AuditSheetView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import AnglesiteCore
 
 /// Modal sheet that renders an `AuditCommand` result. Groups findings by category,
@@ -86,11 +87,18 @@ struct AuditSheetView: View {
             }
             parts.append(String(format: "%.1f s", duration))
             return parts.joined(separator: " · ")
-        case .failed(let reason, let exit):
-            return exit.map { "\(reason) (exit \($0))" } ?? reason
+        case .failed(let reason, let exit, _):
+            return Self.formatFailure(reason: reason, exitCode: exit)
         default:
             return nil
         }
+    }
+
+    /// Compose `reason` and `exitCode` for display. Kept as the single formatter so
+    /// the header subtitle and the body render the same string — when the exit was
+    /// also encoded into `reason`, both layers appended it and produced "(exit N) (exit N)".
+    static func formatFailure(reason: String, exitCode: Int32?) -> String {
+        exitCode.map { "\(reason) (exit \($0))" } ?? reason
     }
 
     // MARK: Body
@@ -100,11 +108,12 @@ struct AuditSheetView: View {
         switch model.phase {
         case .succeeded(let report, _):
             findingsList(report)
-        case .failed(let reason, _):
+        case .failed(let reason, let exit, let tail):
             VStack(alignment: .leading, spacing: 12) {
-                Text(reason).font(.callout).foregroundStyle(.secondary)
+                Text(Self.formatFailure(reason: reason, exitCode: exit))
+                    .font(.callout).foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Spacer()
+                failureLog(tail)
             }
             .padding(16)
         case .idle, .running:
@@ -242,6 +251,45 @@ struct AuditSheetView: View {
         }
     }
 
+    // MARK: Failure log
+
+    /// Monospaced scroller of the captured `audit:<siteID>:build` output. Mirrors the deploy
+    /// drawer's log presentation (stderr in red) so a failed audit shows the same diagnostic
+    /// surface owners already know from deploys, without making them open the Debug pane.
+    @ViewBuilder
+    private func failureLog(_ tail: [LogCenter.LogLine]) -> some View {
+        if tail.isEmpty {
+            Text("The build produced no output.")
+                .font(.caption).foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Spacer()
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 1) {
+                        ForEach(tail) { line in
+                            Text(line.text)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(line.stream == .stderr ? Color.red : Color.primary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                                .id(line.id)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+                .background(Color(NSColor.textBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .onAppear {
+                    if let last = tail.last {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
     // MARK: Footer
 
     private var footer: some View {
@@ -250,9 +298,15 @@ struct AuditSheetView: View {
                 Button("Run again") {
                     onRunAgain()
                 }
-            } else if !model.isRunning, case .failed = model.phase {
+            } else if !model.isRunning, case .failed(_, _, let tail) = model.phase {
                 Button("Try again") {
                     onRunAgain()
+                }
+                if !tail.isEmpty {
+                    Button("Copy log") {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(model.logText, forType: .string)
+                    }
                 }
             }
             Spacer()

--- a/Sources/AnglesiteCore/AuditCommand.swift
+++ b/Sources/AnglesiteCore/AuditCommand.swift
@@ -36,7 +36,11 @@ public protocol AuditRunner: Sendable {
 public actor AuditCommand {
     public enum Result: Sendable, Equatable {
         case succeeded(report: AuditReport, duration: TimeInterval)
-        case failed(reason: String, exitCode: Int32?)
+        /// `logTail` carries the captured `audit:<siteID>:build` lines so the failure
+        /// sheet can show *why* the build failed without the owner having to open the
+        /// Debug pane. Empty for pre-spawn refusals (`.unavailable`, spawn errors) where
+        /// no subprocess produced output.
+        case failed(reason: String, exitCode: Int32?, logTail: [LogCenter.LogLine])
     }
 
     /// How to run a subprocess for a site directory — or why it can't be run.
@@ -118,7 +122,7 @@ public actor AuditCommand {
         let arguments: [String]
         switch plan {
         case .unavailable(let reason):
-            return .failure(.failed(reason: reason, exitCode: nil))
+            return .failure(.failed(reason: reason, exitCode: nil, logTail: []))
         case .run(let exe, let args):
             executable = exe
             arguments = args
@@ -135,19 +139,23 @@ public actor AuditCommand {
                 logCenter: logCenter
             )
         } catch {
-            return .failure(.failed(reason: "couldn't spawn build: \(error)", exitCode: nil))
+            return .failure(.failed(reason: "couldn't spawn build: \(error)", exitCode: nil, logTail: []))
         }
 
         let reason = await supervisor.waitForExit(handle)
+        // `waitForExit` only returns after the supervisor's per-pipe drain Tasks have finished,
+        // so every byte the build wrote is already in `LogCenter` — filtering the snapshot by
+        // source gives us the complete captured output for this build run.
+        let tail = await logCenter.snapshot().filter { $0.source == source }
         switch reason {
         case .exited(let code) where code == 0:
             return .success
         case .exited(let code):
-            return .failure(.failed(reason: "build failed (exit \(code))", exitCode: code))
+            return .failure(.failed(reason: "build failed", exitCode: code, logTail: tail))
         case .terminated:
-            return .failure(.failed(reason: "build was terminated", exitCode: nil))
+            return .failure(.failed(reason: "build was terminated", exitCode: nil, logTail: tail))
         case .retriesExhausted(let lastCode):
-            return .failure(.failed(reason: "build retries exhausted (exit \(lastCode))", exitCode: lastCode))
+            return .failure(.failed(reason: "build retries exhausted", exitCode: lastCode, logTail: tail))
         }
     }
 

--- a/Tests/AnglesiteCoreTests/AuditCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/AuditCommandTests.swift
@@ -43,12 +43,33 @@ struct AuditCommandTests {
             build: { _ in self.shFixture("exit 1") }
         )
         let result = await cmd.audit(siteID: "site", siteDirectory: tmpDir)
-        guard case .failed(let reason, let exit) = result else {
+        guard case .failed(let reason, let exit, _) = result else {
             Issue.record("expected .failed, got \(result)")
             return
         }
         #expect(reason.lowercased().contains("build"), "reason should name the failing step: \(reason)")
+        #expect(!reason.lowercased().contains("exit"), "exit code lives in the exitCode field; encoding it into reason caused the view to render '(exit N) (exit N)'")
         #expect(exit == 1)
+    }
+
+    @Test("Failed build carries its captured stdout+stderr as logTail so the failure sheet can show why")
+    func failedBuildCapturesLogTail() async {
+        let (cmd, _, _) = makeCommand(
+            runners: [FakeAuditRunner(category: .accessibility, result: .success([]))],
+            build: { _ in self.shFixture("echo build-started; echo build-broke >&2; exit 1") }
+        )
+        let result = await cmd.audit(siteID: "site", siteDirectory: tmpDir)
+        guard case .failed(_, _, let tail) = result else {
+            Issue.record("expected .failed, got \(result)")
+            return
+        }
+        let texts = tail.map(\.text)
+        #expect(texts.contains("build-started"), "stdout line missing from logTail: \(texts)")
+        #expect(texts.contains("build-broke"), "stderr line missing from logTail: \(texts)")
+        #expect(tail.allSatisfy { $0.source == "audit:site:build" },
+                "logTail must only contain this build's output, not unrelated LogCenter sources")
+        #expect(tail.contains { $0.stream == .stderr },
+                "stderr stream metadata must be preserved so the sheet can color it red")
     }
 
     @Test("Fails when the build resolver reports unavailable")
@@ -58,12 +79,13 @@ struct AuditCommandTests {
             build: { _ in .unavailable(reason: "vendored npm not found — rebuild the app") }
         )
         let result = await cmd.audit(siteID: "site", siteDirectory: tmpDir)
-        guard case .failed(let reason, let exit) = result else {
+        guard case .failed(let reason, let exit, let tail) = result else {
             Issue.record("expected .failed, got \(result)")
             return
         }
         #expect(reason == "vendored npm not found — rebuild the app")
         #expect(exit == nil)
+        #expect(tail.isEmpty, "pre-spawn refusals have no build output to show")
     }
 
     // MARK: Empty runner list


### PR DESCRIPTION
## Summary

- Fix `build failed (exit 1) (exit 1)` doubling in the audit failure subtitle by dropping the exit-code substring from `AuditCommand`'s `reason` (the `exitCode:` field is the single source of truth) and sharing one formatter between subtitle and body.
- Wire the captured `audit:<siteID>:build` LogCenter tail into the failure sheet body so owners can see *why* the build failed without opening the Debug pane. Renders as a monospaced scroll view with stderr in red, text-selectable, auto-scrolled to the last line, and a "Copy log" footer button.
- `AuditCommand.Result.failed` gains `logTail: [LogCenter.LogLine]`; `AuditModel.Phase.failed` mirrors it.

## Test plan

- [x] `swift test --package-path . --filter AuditCommandTests` — 7/7 pass, including new `failedBuildCapturesLogTail` (asserts stdout, stderr, source filtering, and `.stderr` stream-flag preservation) and a regression assertion that `reason` no longer contains "exit"
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds
- [ ] Manual: trigger a failing audit and verify the sheet shows the build's stderr in red, the subtitle is single `(exit N)`, "Copy log" copies the joined log text, and `textSelection` works
- [ ] Manual: trigger a `.unavailable` failure (e.g. delete the vendored npm symlink) and verify the body falls back to "The build produced no output." with no "Copy log" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)