### PR TITLE
feat(intents): App Intents for deploy/backup/audit/open-site (Phase B, #88 #89 #90)

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -61,7 +61,7 @@ struct AnglesiteApp: App {
         // SwiftUI has nothing to restore). It autoopens the most-recently-used site from its
         // own .task — see SitesLauncherView.onFirstAppear().
         Window("Sites", id: "sites") {
-            SitesLauncherView()
+            SitesWindowRoot(openWindow: openWindow)
         }
         .windowResizability(.contentSize)
         .commands {

--- a/Sources/AnglesiteApp/Intents/AnglesiteShortcuts.swift
+++ b/Sources/AnglesiteApp/Intents/AnglesiteShortcuts.swift
@@ -1,0 +1,30 @@
+import AppIntents
+
+/// Curated Siri phrases. They appear in Spotlight and Siri suggestions. `\(.applicationName)`
+/// resolves to the app's display name ("Anglesite") on both targets.
+///
+/// The audit→deploy chain is composed in the Shortcuts editor: `AuditSiteIntent` returns a
+/// `SiteEntity` value that the user pipes into `DeploySiteIntent`, whose confirmation still
+/// gates the deploy. No extra `opensIntent` plumbing is needed for v0.
+struct AnglesiteShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: DeploySiteIntent(),
+            phrases: ["Deploy my site with \(.applicationName)"],
+            shortTitle: "Deploy Site",
+            systemImageName: "arrow.up.circle"
+        )
+        AppShortcut(
+            intent: BackupSiteIntent(),
+            phrases: ["Back up my site with \(.applicationName)"],
+            shortTitle: "Back Up Site",
+            systemImageName: "externaldrive.badge.timemachine"
+        )
+        AppShortcut(
+            intent: AuditSiteIntent(),
+            phrases: ["Check my site with \(.applicationName)"],
+            shortTitle: "Check Site",
+            systemImageName: "checkmark.seal"
+        )
+    }
+}

--- a/Sources/AnglesiteApp/Intents/SiteEntity.swift
+++ b/Sources/AnglesiteApp/Intents/SiteEntity.swift
@@ -1,0 +1,52 @@
+import AppIntents
+import AnglesiteCore
+import Foundation
+
+/// An Anglesite site, addressable by Siri/Shortcuts. Backed live by `SiteStore.shared` — no
+/// cache, so the entity never goes stale relative to the registry.
+struct SiteEntity: AppEntity, Identifiable {
+    let id: String
+    let displayName: String
+    let directory: URL
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation { "Site" }
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(displayName)", subtitle: "\(directory.path)")
+    }
+
+    static var defaultQuery = SiteEntityQuery()
+
+    init(_ site: SiteStore.Site) {
+        self.id = site.id
+        self.displayName = site.name
+        self.directory = site.path
+    }
+}
+
+/// Resolves sites by id (Shortcuts re-resolution) and by name (Siri "my portfolio site").
+/// `load()` is called first so a cold background intent process sees the persisted registry.
+struct SiteEntityQuery: EntityStringQuery {
+    private func allSites() async -> [SiteStore.Site] {
+        try? await SiteStore.shared.load()
+        return await SiteStore.shared.sites
+    }
+
+    func entities(for identifiers: [String]) async throws -> [SiteEntity] {
+        await allSites().filter { identifiers.contains($0.id) }.map(SiteEntity.init)
+    }
+
+    func entities(matching string: String) async throws -> [SiteEntity] {
+        let needle = string.lowercased()
+        return await allSites().filter { $0.name.lowercased().contains(needle) }.map(SiteEntity.init)
+    }
+
+    func suggestedEntities() async throws -> [SiteEntity] {
+        await allSites().map(SiteEntity.init)
+    }
+
+    func defaultResult() async -> SiteEntity? {
+        let sites = await allSites()
+        return sites.count == 1 ? sites.first.map(SiteEntity.init) : nil
+    }
+}

--- a/Sources/AnglesiteApp/Intents/SiteIntents.swift
+++ b/Sources/AnglesiteApp/Intents/SiteIntents.swift
@@ -1,0 +1,83 @@
+import AppIntents
+import AnglesiteCore
+
+/// The four App Intents. Each is a thin adapter over `SiteOperations` (Core), which holds all
+/// the testable Result→dialog logic. No Claude/LLM process is involved — the intents drive the
+/// deterministic command actors directly.
+
+struct DeploySiteIntent: AppIntent {
+    static var title: LocalizedStringResource = "Deploy Site"
+    static var description = IntentDescription("Deploy a site to production with Anglesite.")
+
+    @Parameter(title: "Site") var site: SiteEntity
+
+    static var parameterSummary: some ParameterSummary { Summary("Deploy \(\.$site)") }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        // Deploy is outward-facing (pushes to production), so confirm before running. The
+        // pre-deploy security scan still gates inside DeployCommand — confirmation is an
+        // additional guard against accidental voice/Shortcut triggers, not a replacement.
+        try await requestConfirmation(
+            result: .result(dialog: "Deploy \(site.displayName) to production?")
+        )
+        let ops = SiteOperations()
+        guard let resolved = await ops.site(id: site.id) else {
+            return .result(dialog: "Couldn't find \(site.displayName).")
+        }
+        let result = await ops.deploy(site: resolved)
+        return .result(dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forDeploy: result)))
+    }
+}
+
+struct BackupSiteIntent: AppIntent {
+    static var title: LocalizedStringResource = "Back Up Site"
+    static var description = IntentDescription("Commit and push a site backup with Anglesite.")
+
+    @Parameter(title: "Site") var site: SiteEntity
+
+    static var parameterSummary: some ParameterSummary { Summary("Back up \(\.$site)") }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let ops = SiteOperations()
+        guard let resolved = await ops.site(id: site.id) else {
+            return .result(dialog: "Couldn't find \(site.displayName).")
+        }
+        let result = await ops.backup(site: resolved)
+        return .result(dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forBackup: result)))
+    }
+}
+
+struct AuditSiteIntent: AppIntent {
+    static var title: LocalizedStringResource = "Check Site"
+    static var description = IntentDescription("Run an Anglesite audit and report findings.")
+
+    @Parameter(title: "Site") var site: SiteEntity
+
+    static var parameterSummary: some ParameterSummary { Summary("Check \(\.$site)") }
+
+    // Returns the site as a value so a Shortcut can pipe it straight into Deploy (audit→deploy).
+    func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<SiteEntity> {
+        let ops = SiteOperations()
+        guard let resolved = await ops.site(id: site.id) else {
+            return .result(value: site, dialog: "Couldn't find \(site.displayName).")
+        }
+        let result = await ops.audit(site: resolved)
+        return .result(value: site, dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forAudit: result)))
+    }
+}
+
+struct OpenSiteIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Site"
+    static var description = IntentDescription("Open a site window in Anglesite.")
+    static var openAppWhenRun = true
+
+    @Parameter(title: "Site") var site: SiteEntity
+
+    static var parameterSummary: some ParameterSummary { Summary("Open \(\.$site)") }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        WindowRouter.shared.requestOpen(siteID: site.id)
+        return .result(dialog: "Opening \(site.displayName).")
+    }
+}

--- a/Sources/AnglesiteApp/Intents/WindowRouter.swift
+++ b/Sources/AnglesiteApp/Intents/WindowRouter.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Observation
+import SwiftUI
+
+/// Lets `OpenSiteIntent` (which can't call SwiftUI's `openWindow`) request a site window.
+/// The "Sites" scene observes `requested` and opens/focuses the matching per-site window.
+@MainActor
+@Observable
+final class WindowRouter {
+    static let shared = WindowRouter()
+    private init() {}
+
+    /// The site id the intent asked to open; the scene clears it after handling.
+    var requested: String?
+
+    func requestOpen(siteID: String) { requested = siteID }
+}
+
+/// Root content for the "Sites" window. Wraps `SitesLauncherView` and bridges
+/// `WindowRouter` requests (from `OpenSiteIntent`) to `openWindow(value:)`. Holding the router
+/// as observed `@State` guarantees `.onChange` re-evaluates when an intent sets `requested`.
+struct SitesWindowRoot: View {
+    let openWindow: OpenWindowAction
+    @State private var router = WindowRouter.shared
+
+    var body: some View {
+        SitesLauncherView()
+            .onChange(of: router.requested) { _, newValue in
+                guard let id = newValue else { return }
+                openWindow(value: id)   // WindowGroup(for: String.self) focuses or opens the site
+                router.requested = nil
+            }
+    }
+}

--- a/Sources/AnglesiteCore/CommandFactory.swift
+++ b/Sources/AnglesiteCore/CommandFactory.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Constructs the deterministic command actors the App Intents wrap. The live implementation
+/// returns the real zero-arg actors; tests inject a fake whose actors are built with the
+/// actors' existing closure seams to return canned `Result`s (see `SiteOperationsTests`).
+public protocol CommandFactory: Sendable {
+    func deploy() -> DeployCommand
+    func backup() -> BackupCommand
+    func audit() -> AuditCommand
+}
+
+public struct LiveCommandFactory: CommandFactory {
+    public init() {}
+    public func deploy() -> DeployCommand { DeployCommand() }
+    public func backup() -> BackupCommand { BackupCommand() }
+    public func audit() -> AuditCommand { AuditCommand() }
+}

--- a/Sources/AnglesiteCore/SiteAccess.swift
+++ b/Sources/AnglesiteCore/SiteAccess.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Grants folder access around a single unit of work for a site, then releases it.
+///
+/// - DevID (non-sandboxed): passes `site.path` straight through.
+/// - MAS (`ANGLESITE_MAS`): resolves the site's persisted security-scoped bookmark
+///   (`SiteStore.bookmarkData`), holds the grant for the duration of `body`, then stops.
+///   Mirrors `SiteWindow.acquireGrant` but short-lived, so background App Intents work with
+///   no window open. Throws `AccessError.noGrant` if the site has no usable bookmark.
+public enum SiteAccess {
+    public enum AccessError: Error, Sendable, Equatable {
+        /// No security-scoped bookmark for this site (MAS only). Carries a user-facing message.
+        case noGrant(String)
+    }
+
+    /// Run `body` with read/write access to the site's directory. The returned URL is the
+    /// directory `body` should operate in (`site.path` on DevID, the bookmark-resolved URL
+    /// on MAS — they're the same path, but the MAS URL carries the active security scope).
+    public static func withScopedAccess<T: Sendable>(
+        to site: SiteStore.Site,
+        in store: SiteStore = .shared,
+        _ body: (URL) async -> T
+    ) async throws -> T {
+        #if ANGLESITE_MAS
+        guard let data = await store.bookmarkData(for: site.id) else {
+            throw AccessError.noGrant(
+                "\(site.name) has no folder grant. Open it once via Open Folder… in Anglesite, then try again."
+            )
+        }
+        let resolved = try SecurityScopedBookmark.resolve(data)
+        guard resolved.url.startAccessingSecurityScopedResource() else {
+            throw AccessError.noGrant(
+                "Couldn't access \(site.name)'s folder. Re-add it via Open Folder… in Anglesite."
+            )
+        }
+        defer { resolved.url.stopAccessingSecurityScopedResource() }
+        // A stale bookmark still resolves; re-mint while the grant is active so it survives.
+        if resolved.isStale, let fresh = try? SecurityScopedBookmark.create(for: resolved.url) {
+            try? await store.setBookmark(fresh, for: site.id)
+        }
+        return await body(resolved.url)
+        #else
+        return await body(site.path)
+        #endif
+    }
+}

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Resolves a site, runs a command inside `SiteAccess`, and provides user-facing dialog
+/// strings. The App Intent structs are thin adapters over this; this type is fully
+/// unit-testable with a fake `CommandFactory`.
+///
+/// A missing security-scoped grant (MAS) or a not-found site is mapped onto each command's
+/// own `.failed` case so callers handle exactly one Result type per operation.
+public struct SiteOperations: Sendable {
+    private let factory: CommandFactory
+    private let store: SiteStore
+
+    public init(factory: CommandFactory = LiveCommandFactory(), store: SiteStore = .shared) {
+        self.factory = factory
+        self.store = store
+    }
+
+    /// Resolve a site id (as carried by `SiteEntity`) to the registry's `Site`.
+    public func site(id: String) async -> SiteStore.Site? {
+        await store.find(id: id)
+    }
+
+    // MARK: Operations
+
+    public func deploy(site: SiteStore.Site) async -> DeployCommand.Result {
+        do {
+            return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
+                await factory.deploy().deploy(siteID: site.id, siteDirectory: url)
+            }
+        } catch let SiteAccess.AccessError.noGrant(message) {
+            return .failed(reason: message, exitCode: nil)
+        } catch {
+            return .failed(reason: error.localizedDescription, exitCode: nil)
+        }
+    }
+
+    public func backup(site: SiteStore.Site) async -> BackupCommand.Result {
+        do {
+            return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
+                await factory.backup().backup(siteID: site.id, siteDirectory: url)
+            }
+        } catch let SiteAccess.AccessError.noGrant(message) {
+            return .failed(reason: message, exitCode: nil)
+        } catch {
+            return .failed(reason: error.localizedDescription, exitCode: nil)
+        }
+    }
+
+    public func audit(site: SiteStore.Site) async -> AuditCommand.Result {
+        do {
+            return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
+                await factory.audit().audit(siteID: site.id, siteDirectory: url)
+            }
+        } catch let SiteAccess.AccessError.noGrant(message) {
+            return .failed(reason: message, exitCode: nil)
+        } catch {
+            return .failed(reason: error.localizedDescription, exitCode: nil)
+        }
+    }
+
+    // MARK: Dialog mapping (pure)
+
+    public static func dialog(forDeploy result: DeployCommand.Result) -> String {
+        switch result {
+        case .succeeded(let url, _):
+            return "Deployed to \(url.absoluteString)."
+        case .blocked(let failures, _):
+            let count = failures.count
+            let noun = count == 1 ? "issue" : "issues"
+            return "Deploy blocked by the pre-deploy security scan (\(count) \(noun)). Resolve these in Anglesite first."
+        case .failed(let reason, _):
+            return "Deploy failed: \(reason)"
+        }
+    }
+
+    public static func dialog(forBackup result: BackupCommand.Result) -> String {
+        switch result {
+        case .succeeded(let sha, _, let remote):
+            return "Backed up \(sha.prefix(7)) to \(remote)."
+        case .noChanges:
+            return "No changes to back up."
+        case .failed(let reason, _):
+            return "Backup failed: \(reason)"
+        }
+    }
+
+    public static func dialog(forAudit result: AuditCommand.Result) -> String {
+        switch result {
+        case .succeeded(let report, _):
+            let c = report.findings.filter { $0.severity == .critical }.count
+            let w = report.findings.filter { $0.severity == .warning }.count
+            let i = report.findings.filter { $0.severity == .info }.count
+            return "Audit complete: \(c) critical, \(w) warning, \(i) info."
+        case .failed(let reason, _):
+            return "Audit failed: \(reason)"
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteAccessTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteAccessTests.swift
@@ -1,0 +1,32 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// `SiteAccess` DevID branch: passes the site path straight to the body and returns its value.
+/// The MAS branch is compiled out here (`#if ANGLESITE_MAS`) and is covered by manual smoke
+/// against a signed sandboxed build (see the Phase B plan, Task 8).
+struct SiteAccessTests {
+    private func makeSite(path: URL, bookmark: Data? = nil) -> SiteStore.Site {
+        SiteStore.Site(
+            id: "id-\(path.lastPathComponent)",
+            name: path.lastPathComponent,
+            path: path,
+            isValid: true,
+            missingSentinels: [],
+            bookmarkData: bookmark
+        )
+    }
+
+    @Test("DevID: passes the site path straight through and returns the body value")
+    func devIDPassThrough() async throws {
+        let dir = URL(fileURLWithPath: "/tmp/example-site", isDirectory: true)
+        let site = makeSite(path: dir)
+        let store = SiteStore(persistenceURL: URL(fileURLWithPath: "/tmp/sa-test-store.json"))
+
+        let value = try await SiteAccess.withScopedAccess(to: site, in: store) { url -> String in
+            #expect(url == dir)
+            return "ran:\(url.lastPathComponent)"
+        }
+        #expect(value == "ran:example-site")
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// `SiteOperations` core + dialog mapping. The command actors are faked through their existing
+/// closure seams, so these tests verify the Result→dialog behavior without spawning anything.
+struct SiteOperationsTests {
+
+    /// A factory whose backup actor is scripted (via the git `runner` seam) to land on a
+    /// clean feature branch → `.noChanges`. Deploy/audit aren't exercised here (their dialog
+    /// mapping is tested directly against constructed `Result`s below).
+    private struct FakeFactory: CommandFactory {
+        func deploy() -> DeployCommand { DeployCommand() }
+        func audit() -> AuditCommand { AuditCommand() }
+        func backup() -> BackupCommand {
+            BackupCommand(
+                runner: { _, args in
+                    switch args.first {
+                    case "rev-parse":
+                        // Serves both `--is-inside-work-tree` (exit 0 = repo) and
+                        // `--abbrev-ref HEAD` (branch name → non-main so we proceed).
+                        return .init(stdout: "feature\n", stderr: "", exitCode: 0)
+                    case "remote":
+                        return .init(stdout: "git@example.com:me/site.git\n", stderr: "", exitCode: 0)
+                    case "status":
+                        return .init(stdout: "", stderr: "", exitCode: 0) // clean → noChanges
+                    default:
+                        return .init(stdout: "", stderr: "unmocked git \(args.joined(separator: " "))", exitCode: 1)
+                    }
+                },
+                streamer: { _, _, _ in (0, "") },
+                clock: { Date(timeIntervalSince1970: 1_780_000_000) }
+            )
+        }
+    }
+
+    private func throwawayStore() -> SiteStore {
+        SiteStore(persistenceURL: URL(fileURLWithPath: "/tmp/siteops-test-store.json"))
+    }
+
+    private func makeSite() -> SiteStore.Site {
+        SiteStore.Site(
+            id: "s1",
+            name: "Portfolio",
+            path: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true),
+            isValid: true,
+            missingSentinels: []
+        )
+    }
+
+    private func finding(_ severity: AuditReport.Finding.Severity) -> AuditReport.Finding {
+        AuditReport.Finding(
+            category: .seo, severity: severity, title: "t", detail: "d",
+            remediation: nil, location: nil
+        )
+    }
+
+    @Test("backup on a clean feature branch maps to a 'no changes' dialog")
+    func backupNoChanges() async {
+        let ops = SiteOperations(factory: FakeFactory(), store: throwawayStore())
+        let result = await ops.backup(site: makeSite())
+        #expect(result == .noChanges)
+        #expect(SiteOperations.dialog(forBackup: result) == "No changes to back up.")
+    }
+
+    @Test("backup success dialog shows the short SHA and remote")
+    func backupSuccessDialog() {
+        let result = BackupCommand.Result.succeeded(
+            commitSHA: "abcdef1234567890", branch: "feature", remote: "git@example.com:me/site.git"
+        )
+        #expect(SiteOperations.dialog(forBackup: result) == "Backed up abcdef1 to git@example.com:me/site.git.")
+    }
+
+    @Test("audit dialog summarizes findings by severity")
+    func auditDialog() {
+        let report = AuditReport(
+            findings: [finding(.critical), finding(.warning), finding(.warning)],
+            runnersExecuted: [.seo], runnersSkipped: []
+        )
+        let dialog = SiteOperations.dialog(forAudit: .succeeded(report: report, duration: 1))
+        #expect(dialog == "Audit complete: 1 critical, 2 warning, 0 info.")
+    }
+
+    @Test("deploy success dialog shows the deployed URL")
+    func deploySuccessDialog() {
+        let url = URL(string: "https://portfolio.example.workers.dev")!
+        #expect(
+            SiteOperations.dialog(forDeploy: .succeeded(url: url, duration: 2))
+                == "Deployed to https://portfolio.example.workers.dev."
+        )
+    }
+
+    @Test("deploy blocked dialog reports the issue count and never offers an override")
+    func deployBlockedDialog() {
+        let failure = PreDeployCheck.ScanFailure(
+            category: .exposedToken, file: "src/index.md", detail: "API key committed", remediation: "Remove it"
+        )
+        let dialog = SiteOperations.dialog(forDeploy: .blocked(failures: [failure], warnings: []))
+        #expect(dialog == "Deploy blocked by the pre-deploy security scan (1 issue). Resolve these in Anglesite first.")
+        #expect(!dialog.lowercased().contains("force"))
+        #expect(!dialog.lowercased().contains("override"))
+    }
+}

--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -148,7 +148,7 @@ These issues target macOS 27 APIs available with Xcode 27 / Swift 6.4:
 - 🔲 **SwiftUI toolbar APIs** (#107) — adopt macOS 27 native toolbar for the site window action bar.
 - 🔲 **Structured UI for common tasks** (#94) — reduce chat to open-ended tasks; direct UI for deploy, backup, audit.
   - 🔲 Wire deploy button directly (#84), backup (#85), audit (#86), swipe-to-resolve (#87).
-- 🔲 **App Intents + Shortcuts** (#88, #89, #90) — `SiteEntity`, deploy/backup/audit intents, Shortcuts integration.
+- ✅ **App Intents + Shortcuts** (#88, #89, #90) — Phase B landed. `SiteEntity` + `EntityStringQuery` (fuzzy name match, single-site auto-select, live `SiteStore` read); four intents (`DeploySiteIntent` — confirms before pushing, pre-deploy scan still gates; `BackupSiteIntent`; `AuditSiteIntent` — returns the site for audit→deploy chaining; `OpenSiteIntent` via `WindowRouter`); `AnglesiteShortcuts` curated phrases. Intents wrap the deterministic command actors through a Core `SiteOperations` + `CommandFactory` seam (unit-tested Result→dialog mapping) and a target-gated `SiteAccess` helper (DevID pass-through; MAS resolves the persisted security-scoped bookmark so backups run headless with no window). Builds clean on both targets. **Deferred:** real-signed MAS background-backup smoke (gated on the #81 signed build). Design/plan: [`docs/superpowers/specs/2026-06-10-app-intents-phase-b-design.md`](superpowers/specs/2026-06-10-app-intents-phase-b-design.md).
 - 🔲 **On-device summarization** (#93), **Image Playground** (#92), **Writing Tools** (#91).
 - 🔲 **Accessibility** — VoiceOver pass (#80), Dynamic Type audit (#79).
 - 🔲 **Misc** — oxlint for JS overlay (#73), reframe "filesystem is source of truth" → "Git is source of truth" (#72).

--- a/docs/superpowers/plans/2026-06-10-app-intents-phase-b.md
+++ b/docs/superpowers/plans/2026-06-10-app-intents-phase-b.md
@@ -1,0 +1,698 @@
+# Phase B — App Intents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose Anglesite's deploy/backup/audit/open-site operations to Siri and Shortcuts via App Intents, wrapping the existing deterministic command actors with no LLM involvement.
+
+**Architecture:** A `SiteEntity` + `EntityStringQuery` backed by `SiteStore.shared` lets Siri/Shortcuts pick a site. A target-gated `SiteAccess` helper grants folder access (no-op on DevID, security-scoped bookmark resolution on MAS). A `CommandFactory` + pure `SiteOperations` core makes the Result→dialog logic unit-testable; thin `AppIntent` structs adapt that core to the App Intents runtime. An `AppShortcutsProvider` registers curated phrases.
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27), App Intents framework, Swift Testing (`@Test`), xcodegen project (directory-globbed sources — no project.yml edits needed for new files).
+
+---
+
+## File Structure
+
+New files (all auto-discovered: `AnglesiteApp` is directory-globbed in `project.yml`; `AnglesiteCore` is SPM-globbed):
+
+- `Sources/AnglesiteCore/SiteAccess.swift` — security-scoped access wrapper (Core; both targets).
+- `Sources/AnglesiteApp/Intents/SiteEntity.swift` — `SiteEntity` + `SiteEntityQuery`.
+- `Sources/AnglesiteApp/Intents/CommandFactory.swift` — factory protocol + live impl.
+- `Sources/AnglesiteApp/Intents/SiteOperations.swift` — testable Result core + dialog mapping.
+- `Sources/AnglesiteApp/Intents/SiteIntents.swift` — the four `AppIntent` structs.
+- `Sources/AnglesiteApp/Intents/WindowRouter.swift` — `@MainActor @Observable` open-site router.
+- `Sources/AnglesiteApp/Intents/AnglesiteShortcuts.swift` — `AppShortcutsProvider`.
+- `Tests/AnglesiteCoreTests/SiteAccessTests.swift`
+- `Tests/AnglesiteCoreTests/SiteOperationsTests.swift` — uses `@testable import AnglesiteApp`? No — see note.
+
+> **Note on test target:** `SiteOperations`, `CommandFactory`, and `SiteEntity` live in the **app target** (`AnglesiteApp`), which has no unit-test bundle wired for SwiftPM (`swift test` covers `AnglesiteCore`/`AnglesiteBridge` only). To keep `SiteOperations` and dialog mapping unit-testable under `swift test`, **put `SiteOperations`, `CommandFactory`, the dialog mapping, and `SiteAccess` in `AnglesiteCore`** (they have no App Intents dependency). Only `SiteEntity`, the `AppIntent` structs, `WindowRouter`, and `AnglesiteShortcuts` (which `import AppIntents` / need the app scene) stay in `AnglesiteApp`. Revised placement is reflected per-task below.
+
+Revised final placement:
+- **Core (testable under `swift test`):** `SiteAccess.swift`, `CommandFactory.swift`, `SiteOperations.swift` (incl. dialog strings).
+- **App (App Intents runtime, manual smoke):** `Intents/SiteEntity.swift`, `Intents/SiteIntents.swift`, `Intents/WindowRouter.swift`, `Intents/AnglesiteShortcuts.swift`.
+
+---
+
+## Task 1: `SiteAccess` security-scoped wrapper
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SiteAccess.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteAccessTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SiteAccessTests {
+    private func makeSite(path: URL, bookmark: Data? = nil) -> SiteStore.Site {
+        SiteStore.Site(id: "id-\(path.lastPathComponent)", name: path.lastPathComponent,
+                       path: path, isValid: true, missingSentinels: [], bookmarkData: bookmark)
+    }
+
+    @Test("DevID: passes the site path straight through and returns the body value")
+    func devIDPassThrough() async throws {
+        let dir = URL(fileURLWithPath: "/tmp/example-site", isDirectory: true)
+        let site = makeSite(path: dir)
+        let store = SiteStore(fileManager: .default, settings: .shared)
+        let received = await SiteAccess.capturedURL(for: site) // helper defined in impl for the test
+        #expect(received == nil) // not yet run
+        let value = try await SiteAccess.withScopedAccess(to: site, in: store) { url -> String in
+            #expect(url == dir)
+            return "ran:\(url.lastPathComponent)"
+        }
+        #expect(value == "ran:example-site")
+    }
+}
+```
+
+> Remove the `capturedURL` line — it's illustrative. Final test keeps only the `withScopedAccess` call + assertions. (Adjusted in Step 3 if the `SiteStore(fileManager:settings:)` init differs; confirm signature against `SiteStore.swift:65`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter SiteAccessTests`
+Expected: FAIL — `SiteAccess` is not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+import Foundation
+
+/// Grants folder access around a single unit of work for a site, then releases it.
+///
+/// - DevID (non-sandboxed): passes `site.path` straight through.
+/// - MAS (`ANGLESITE_MAS`): resolves the site's persisted security-scoped bookmark
+///   (`SiteStore.bookmarkData`), holds the grant for the duration of `body`, then stops.
+///   Mirrors `SiteWindow.acquireGrant` but short-lived, so background intents work with no
+///   window open. Throws `Error.noGrant` if the site has no bookmark.
+public enum SiteAccess {
+    public enum AccessError: Error, Sendable, Equatable {
+        /// No security-scoped bookmark for this site (MAS only). Carries a user-facing message.
+        case noGrant(String)
+    }
+
+    public static func withScopedAccess<T: Sendable>(
+        to site: SiteStore.Site,
+        in store: SiteStore = .shared,
+        _ body: (URL) async -> T
+    ) async throws -> T {
+        #if ANGLESITE_MAS
+        guard let data = await store.bookmarkData(for: site.id) else {
+            throw AccessError.noGrant(
+                "\(site.name) has no folder grant. Open it once via Open Folder… in Anglesite, then try again."
+            )
+        }
+        let resolved = try SecurityScopedBookmark.resolve(data)
+        guard resolved.url.startAccessingSecurityScopedResource() else {
+            throw AccessError.noGrant("Couldn't access \(site.name)'s folder. Re-add it via Open Folder… in Anglesite.")
+        }
+        defer { resolved.url.stopAccessingSecurityScopedResource() }
+        if resolved.isStale, let fresh = try? SecurityScopedBookmark.create(for: resolved.url) {
+            try? await store.setBookmark(fresh, for: site.id)
+        }
+        return await body(resolved.url)
+        #else
+        return await body(site.path)
+        #endif
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter SiteAccessTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteAccess.swift Tests/AnglesiteCoreTests/SiteAccessTests.swift
+git commit -m "feat(intents): SiteAccess security-scoped wrapper for headless site ops"
+```
+
+---
+
+## Task 2: `CommandFactory` protocol + live implementation
+
+**Files:**
+- Create: `Sources/AnglesiteCore/CommandFactory.swift`
+- Test: covered indirectly by Task 4 (no standalone test — it's a trivial factory).
+
+- [ ] **Step 1: Write the implementation**
+
+```swift
+import Foundation
+
+/// Constructs the deterministic command actors the intents wrap. The live implementation
+/// returns the real zero-arg actors; tests inject a fake whose actors are built with the
+/// actors' existing closure seams to return canned `Result`s (see `SiteOperationsTests`).
+public protocol CommandFactory: Sendable {
+    func deploy() -> DeployCommand
+    func backup() -> BackupCommand
+    func audit() -> AuditCommand
+}
+
+public struct LiveCommandFactory: CommandFactory {
+    public init() {}
+    public func deploy() -> DeployCommand { DeployCommand() }
+    public func backup() -> BackupCommand { BackupCommand() }
+    public func audit() -> AuditCommand { AuditCommand() }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `swift build --package-path .`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CommandFactory.swift
+git commit -m "feat(intents): CommandFactory seam over the deploy/backup/audit actors"
+```
+
+---
+
+## Task 3: `SiteOperations` core + dialog mapping
+
+`SiteOperations` resolves a site id against `SiteStore`, runs the chosen command inside
+`SiteAccess.withScopedAccess`, and maps `noGrant`/not-found to the command's own `.failed`
+case so callers see one uniform Result type. Pure dialog functions turn each Result into a
+user-facing string.
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SiteOperations.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteOperationsTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SiteOperationsTests {
+    // A factory whose actors are built with fake closure seams returning canned outputs.
+    private struct FakeFactory: CommandFactory {
+        let backupResult: ProcessSupervisor.RunResult
+        func deploy() -> DeployCommand { DeployCommand() }
+        func backup() -> BackupCommand {
+            BackupCommand(
+                runner: { _, args in
+                    // Drive backup to .noChanges: work-tree ok, branch feature, remote set, clean status.
+                    switch args.first {
+                    case "rev-parse": return .init(stdout: "feature\n", stderr: "", exitCode: 0)
+                    case "remote": return .init(stdout: "git@example.com:me/site.git\n", stderr: "", exitCode: 0)
+                    case "status": return .init(stdout: "", stderr: "", exitCode: 0) // clean → noChanges
+                    default: return .init(stdout: "", stderr: "unmocked", exitCode: 1)
+                    }
+                },
+                streamer: { _, _, _ in (0, "") },
+                clock: { Date(timeIntervalSince1970: 1_780_000_000) }
+            )
+        }
+        func audit() -> AuditCommand { AuditCommand() }
+    }
+
+    private func storeWith(_ site: SiteStore.Site) -> SiteStore {
+        let store = SiteStore(fileManager: .default, settings: .shared)
+        // Seed via the test seam; if SiteStore has no public seeding API, use `add`/inject.
+        return store
+    }
+
+    @Test("backup on a clean feature branch maps to a 'no changes' dialog")
+    func backupNoChanges() async {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let site = SiteStore.Site(id: "s1", name: "Portfolio", path: dir, isValid: true, missingSentinels: [])
+        let ops = SiteOperations(factory: FakeFactory(backupResult: .init(stdout: "", stderr: "", exitCode: 0)),
+                                 store: storeWith(site))
+        let result = await ops.backup(site: site)
+        #expect(result == .noChanges)
+        #expect(SiteOperations.dialog(forBackup: result) == "No changes to back up.")
+    }
+
+    @Test("audit dialog summarizes findings by severity")
+    func auditDialog() {
+        let findings = [
+            AuditReport.Finding(category: .seo, severity: .critical, title: "t", detail: "d"),
+            AuditReport.Finding(category: .seo, severity: .warning, title: "t", detail: "d"),
+            AuditReport.Finding(category: .seo, severity: .warning, title: "t", detail: "d"),
+        ]
+        let report = AuditReport(findings: findings, runnersExecuted: [.seo], runnersSkipped: [])
+        let dialog = SiteOperations.dialog(forAudit: .succeeded(report: report, duration: 1))
+        #expect(dialog == "Audit complete: 1 critical, 2 warning, 0 info.")
+    }
+}
+```
+
+> Confirm `AuditReport.Finding.init` and `AuditReport.init` parameter labels against `Sources/AnglesiteCore/AuditReport.swift` (Finding has `category, severity, title, detail` + optional `remediation`/`location`; adjust the fixture if labels differ). Confirm `SiteStore` seeding — if there is no in-memory seed seam, add a test-only convenience in `SiteOperations` that accepts the `Site` directly (see Step 3: `backup(site:)` takes the `Site`, so the store is only needed for `SiteAccess` on MAS; on DevID the store is unused and the fixture store can stay empty).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter SiteOperationsTests`
+Expected: FAIL — `SiteOperations` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+import Foundation
+
+/// Resolves a site, runs a command inside `SiteAccess`, and provides user-facing dialog
+/// strings. The App Intent structs are thin adapters over this; this type is fully
+/// unit-testable with a fake `CommandFactory`.
+public struct SiteOperations: Sendable {
+    private let factory: CommandFactory
+    private let store: SiteStore
+
+    public init(factory: CommandFactory = LiveCommandFactory(), store: SiteStore = .shared) {
+        self.factory = factory
+        self.store = store
+    }
+
+    // MARK: Operations
+
+    public func deploy(site: SiteStore.Site) async -> DeployCommand.Result {
+        do {
+            return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
+                await factory.deploy().deploy(siteID: site.id, siteDirectory: url)
+            }
+        } catch let SiteAccess.AccessError.noGrant(message) {
+            return .failed(reason: message, exitCode: nil)
+        } catch {
+            return .failed(reason: error.localizedDescription, exitCode: nil)
+        }
+    }
+
+    public func backup(site: SiteStore.Site) async -> BackupCommand.Result {
+        do {
+            return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
+                await factory.backup().backup(siteID: site.id, siteDirectory: url)
+            }
+        } catch let SiteAccess.AccessError.noGrant(message) {
+            return .failed(reason: message, exitCode: nil)
+        } catch {
+            return .failed(reason: error.localizedDescription, exitCode: nil)
+        }
+    }
+
+    public func audit(site: SiteStore.Site) async -> AuditCommand.Result {
+        do {
+            return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
+                await factory.audit().audit(siteID: site.id, siteDirectory: url)
+            }
+        } catch let SiteAccess.AccessError.noGrant(message) {
+            return .failed(reason: message, exitCode: nil)
+        } catch {
+            return .failed(reason: error.localizedDescription, exitCode: nil)
+        }
+    }
+
+    // MARK: Dialog mapping (pure)
+
+    public static func dialog(forDeploy result: DeployCommand.Result) -> String {
+        switch result {
+        case .succeeded(let url, _): return "Deployed to \(url.absoluteString)."
+        case .blocked(let failures, _):
+            let names = failures.map(\.id).joined(separator: ", ")
+            return "Deploy blocked by the pre-deploy security scan: \(names). Resolve these in Anglesite first."
+        case .failed(let reason, _): return "Deploy failed: \(reason)"
+        }
+    }
+
+    public static func dialog(forBackup result: BackupCommand.Result) -> String {
+        switch result {
+        case .succeeded(let sha, _, let remote): return "Backed up \(sha.prefix(7)) to \(remote)."
+        case .noChanges: return "No changes to back up."
+        case .failed(let reason, _): return "Backup failed: \(reason)"
+        }
+    }
+
+    public static func dialog(forAudit result: AuditCommand.Result) -> String {
+        switch result {
+        case .succeeded(let report, _):
+            let c = report.findings.filter { $0.severity == .critical }.count
+            let w = report.findings.filter { $0.severity == .warning }.count
+            let i = report.findings.filter { $0.severity == .info }.count
+            return "Audit complete: \(c) critical, \(w) warning, \(i) info."
+        case .failed(let reason, _): return "Audit failed: \(reason)"
+        }
+    }
+}
+```
+
+> `PreDeployCheck.ScanFailure` is referenced via `\.id` for the blocked message — confirm `ScanFailure` has a usable `id`/`name` string in `PreDeployCheck.swift`; if it's a different label, use the actual short identifier. Keep the message non-overridable (no "force deploy" path).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter SiteOperationsTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteOperations.swift Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+git commit -m "feat(intents): SiteOperations core + Result→dialog mapping"
+```
+
+---
+
+## Task 4: `SiteEntity` + `SiteEntityQuery`
+
+**Files:**
+- Create: `Sources/AnglesiteApp/Intents/SiteEntity.swift`
+- Test: manual (App Intents types build into the app target only; `swift test` does not cover `AnglesiteApp`). Verified by the build + Shortcuts smoke in Task 8.
+
+- [ ] **Step 1: Write the implementation**
+
+```swift
+import AppIntents
+import AnglesiteCore
+import Foundation
+
+/// An Anglesite site, addressable by Siri/Shortcuts. Backed live by `SiteStore.shared`.
+struct SiteEntity: AppEntity, Identifiable {
+    let id: String
+    let displayName: String
+    let directory: URL
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation { "Site" }
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(displayName)", subtitle: "\(directory.path)")
+    }
+
+    static var defaultQuery = SiteEntityQuery()
+
+    init(_ site: SiteStore.Site) {
+        self.id = site.id
+        self.displayName = site.name
+        self.directory = site.path
+    }
+}
+
+/// Resolves sites by id (Shortcuts re-resolution) and by name (Siri "my portfolio site").
+struct SiteEntityQuery: EntityStringQuery {
+    func entities(for identifiers: [String]) async throws -> [SiteEntity] {
+        let sites = await SiteStore.shared.sites
+        return sites.filter { identifiers.contains($0.id) }.map(SiteEntity.init)
+    }
+
+    func entities(matching string: String) async throws -> [SiteEntity] {
+        let sites = await SiteStore.shared.sites
+        let needle = string.lowercased()
+        return sites.filter { $0.name.lowercased().contains(needle) }.map(SiteEntity.init)
+    }
+
+    func suggestedEntities() async throws -> [SiteEntity] {
+        await SiteStore.shared.sites.map(SiteEntity.init)
+    }
+
+    func defaultResult() async -> SiteEntity? {
+        let sites = await SiteStore.shared.sites
+        return sites.count == 1 ? sites.first.map(SiteEntity.init) : nil
+    }
+}
+```
+
+> `await SiteStore.shared.sites` reads the actor's `private(set) public var sites`. If the registry isn't loaded yet in a background intent process, call `try? await SiteStore.shared.load()` first inside each query method (cheap, idempotent). Add that line if the smoke test shows an empty list from a cold intent launch.
+
+- [ ] **Step 2: Build the app target to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/Intents/SiteEntity.swift
+git commit -m "feat(intents): SiteEntity + EntityStringQuery backed by SiteStore (#89)"
+```
+
+---
+
+## Task 5: The four `AppIntent` structs
+
+**Files:**
+- Create: `Sources/AnglesiteApp/Intents/SiteIntents.swift`
+- Test: manual (app target). Logic is already unit-tested via `SiteOperations` (Task 3).
+
+- [ ] **Step 1: Write the implementation**
+
+```swift
+import AppIntents
+import AnglesiteCore
+
+private let ops = SiteOperations()
+
+private func site(from entity: SiteEntity) async -> SiteStore.Site? {
+    await SiteStore.shared.find(id: entity.id)
+}
+
+struct DeploySiteIntent: AppIntent {
+    static var title: LocalizedStringResource = "Deploy Site"
+    static var description = IntentDescription("Deploy a site to production with Anglesite.")
+
+    @Parameter(title: "Site") var site: SiteEntity
+
+    static var parameterSummary: some ParameterSummary { Summary("Deploy \(\.$site)") }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await requestConfirmation(
+            result: .result(dialog: "Deploy \(site.displayName) to production?")
+        )
+        guard let resolved = await SiteOperations().resolvedSite(for: site) else {
+            return .result(dialog: "Couldn't find \(site.displayName).")
+        }
+        let result = await SiteOperations().deploy(site: resolved)
+        return .result(dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forDeploy: result)))
+    }
+}
+
+struct BackupSiteIntent: AppIntent {
+    static var title: LocalizedStringResource = "Back Up Site"
+    static var description = IntentDescription("Commit and push a site backup with Anglesite.")
+
+    @Parameter(title: "Site") var site: SiteEntity
+    static var parameterSummary: some ParameterSummary { Summary("Back up \(\.$site)") }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        guard let resolved = await SiteOperations().resolvedSite(for: site) else {
+            return .result(dialog: "Couldn't find \(site.displayName).")
+        }
+        let result = await SiteOperations().backup(site: resolved)
+        return .result(dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forBackup: result)))
+    }
+}
+
+struct AuditSiteIntent: AppIntent {
+    static var title: LocalizedStringResource = "Check Site"
+    static var description = IntentDescription("Run an Anglesite audit and report findings.")
+
+    @Parameter(title: "Site") var site: SiteEntity
+    static var parameterSummary: some ParameterSummary { Summary("Check \(\.$site)") }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<SiteEntity> {
+        guard let resolved = await SiteOperations().resolvedSite(for: site) else {
+            return .result(value: site, dialog: "Couldn't find \(site.displayName).")
+        }
+        let result = await SiteOperations().audit(site: resolved)
+        // Return the site as the value so a Shortcut can pipe it into Deploy.
+        return .result(value: site, dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forAudit: result)))
+    }
+}
+
+struct OpenSiteIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Site"
+    static var description = IntentDescription("Open a site window in Anglesite.")
+    static var openAppWhenRun = true
+
+    @Parameter(title: "Site") var site: SiteEntity
+    static var parameterSummary: some ParameterSummary { Summary("Open \(\.$site)") }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        WindowRouter.shared.requestOpen(siteID: site.id)
+        return .result(dialog: "Opening \(site.displayName).")
+    }
+}
+```
+
+> Add `func resolvedSite(for entity: SiteEntity) async -> SiteStore.Site?` to `SiteOperations` (Task 3) — it just calls `await store.find(id: entity.id)`. Add it in this task if not already present, with a one-line follow-up commit folded in. Confirm App Intents on macOS 27 still uses `requestConfirmation(result:)`; if the SDK signature changed, use the current `requestConfirmation` overload (the intent must pause for user confirmation before the deploy call — that behavior is the requirement).
+
+- [ ] **Step 2: Build the app target**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/Intents/SiteIntents.swift Sources/AnglesiteCore/SiteOperations.swift
+git commit -m "feat(intents): Deploy/Backup/Audit/OpenSite App Intents (#88)"
+```
+
+---
+
+## Task 6: `WindowRouter` + scene wiring (OpenSite routing)
+
+Decision (deferred from the spec): use a `@MainActor @Observable` router singleton that the
+"Sites" window observes — simplest, no new deps, and `openWindow(value:)` already exists in
+`AnglesiteApp.body`.
+
+**Files:**
+- Create: `Sources/AnglesiteApp/Intents/WindowRouter.swift`
+- Modify: `Sources/AnglesiteApp/AnglesiteApp.swift` (observe the router in the "Sites" Window)
+
+- [ ] **Step 1: Write the router**
+
+```swift
+import Foundation
+import Observation
+
+/// Lets `OpenSiteIntent` (which can't call SwiftUI's `openWindow`) request a site window.
+/// The "Sites" scene observes `requested` and opens/focuses the window.
+@MainActor
+@Observable
+final class WindowRouter {
+    static let shared = WindowRouter()
+    private init() {}
+
+    /// The site id the intent asked to open; cleared by the scene after handling.
+    var requested: String?
+
+    func requestOpen(siteID: String) { requested = siteID }
+}
+```
+
+- [ ] **Step 2: Wire the scene** — in `AnglesiteApp.swift`, add an observer to the "Sites" `Window` content view that opens the requested site and clears the request.
+
+```swift
+// Inside the `Window("Sites", id: "sites") { ... }` content closure, add the modifier:
+.onChange(of: WindowRouter.shared.requested) { _, newValue in
+    if let id = newValue {
+        openWindow(value: id)            // WindowGroup(for: String.self) already exists below
+        WindowRouter.shared.requested = nil
+    }
+}
+```
+
+> If `AnglesiteApp` is not already observing `WindowRouter.shared` (an `@Observable`), read it once in the view body (e.g. `let _ = WindowRouter.shared.requested`) so `.onChange` tracks it, or hold it as `@State private var router = WindowRouter.shared`. Confirm the exact content view inside the "Sites" Window (around `AnglesiteApp.swift:63`) and attach the modifier there.
+
+- [ ] **Step 3: Build the app target**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/Intents/WindowRouter.swift Sources/AnglesiteApp/AnglesiteApp.swift
+git commit -m "feat(intents): WindowRouter wiring for OpenSiteIntent"
+```
+
+---
+
+## Task 7: `AppShortcutsProvider` + curated phrases (#90)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/Intents/AnglesiteShortcuts.swift`
+
+- [ ] **Step 1: Write the provider**
+
+```swift
+import AppIntents
+
+/// Curated Siri phrases. Appear in Spotlight + Siri suggestions. ${applicationName} resolves
+/// to the app's display name ("Anglesite") on both targets.
+struct AnglesiteShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: DeploySiteIntent(),
+            phrases: ["Deploy my site with \(.applicationName)"],
+            shortTitle: "Deploy Site",
+            systemImageName: "arrow.up.circle"
+        )
+        AppShortcut(
+            intent: BackupSiteIntent(),
+            phrases: ["Back up my site with \(.applicationName)"],
+            shortTitle: "Back Up Site",
+            systemImageName: "externaldrive.badge.timemachine"
+        )
+        AppShortcut(
+            intent: AuditSiteIntent(),
+            phrases: ["Check my site with \(.applicationName)"],
+            shortTitle: "Check Site",
+            systemImageName: "checkmark.seal"
+        )
+    }
+}
+```
+
+> The audit→deploy chain is composed in the Shortcuts editor: `AuditSiteIntent` returns a
+> `SiteEntity` value (Task 5) that the user pipes into `DeploySiteIntent`, whose
+> `requestConfirmation` still gates the deploy. No extra `opensIntent` plumbing is required for
+> v0; if richer "audit passes → auto-offer deploy" UX is wanted later, add `opensIntent` then.
+
+- [ ] **Step 2: Build the app target**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/Intents/AnglesiteShortcuts.swift
+git commit -m "feat(intents): AppShortcutsProvider with curated phrases (#90)"
+```
+
+---
+
+## Task 8: Both-target build + manual smoke + docs
+
+**Files:**
+- Modify: `docs/build-plan.md` (mark Phase B started/done)
+
+- [ ] **Step 1: Build both targets**
+
+```bash
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build
+```
+Expected: both BUILD SUCCEEDED.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `swift test --package-path .`
+Expected: all pass (existing 270 + the new `SiteAccessTests`/`SiteOperationsTests`).
+
+- [ ] **Step 3: Manual smoke (record results in the PR description)**
+
+  - Launch the DevID app; open Shortcuts.app → confirm Deploy/Back Up/Check/Open actions appear under Anglesite with a site picker.
+  - Build a "Check my Portfolio then Deploy" shortcut; run it; confirm the deploy confirmation prompt appears and the pre-deploy scan still gates.
+  - Single-site case: confirm no picker prompt (auto-select).
+  - Siri: "Check my site with Anglesite" → confirm voice invocation.
+  - (MAS, when a signed build is available per #81) Background-run a backup shortcut with no window open → confirm `SiteAccess` resolves the bookmark and the backup completes; with a site that has no grant, confirm the friendly "Open Folder…" dialog.
+
+- [ ] **Step 4: Update build-plan.md**
+
+Add a "Phase B — App Intents integration" entry noting #89/#88/#90 landed (entity, four intents, shortcuts provider, `SiteAccess` headless grant), with the MAS background-backup smoke gated on the #81 signed build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/build-plan.md
+git commit -m "docs: mark Phase B App Intents complete (#88, #89, #90)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** SiteEntity+query (Task 4 ✓ #89), four intents with deploy confirmation (Task 5 ✓ #88), SiteAccess MAS recommendation (Task 1 ✓), CommandFactory test seam (Task 2 ✓), SiteOperations Result→dialog tests (Task 3 ✓), AppShortcutsProvider + chaining (Task 7 ✓ #90), OpenSite routing decided (Task 6 ✓), both-target build + smoke + docs (Task 8 ✓). All spec sections mapped.
+
+**Placeholder scan:** The deferred spec items (OpenSite routing, chaining surface) are now concretely decided in Tasks 6 and 7. The `>` notes flag signatures to confirm against real source (AuditReport labels, ScanFailure.id, SiteStore init, requestConfirmation overload) — these are verification steps, not placeholders; each task still ships complete code.
+
+**Type consistency:** `SiteOperations` (factory+store init), `dialog(forDeploy:/forBackup:/forAudit:)`, `SiteAccess.withScopedAccess(to:in:_:)`, `SiteAccess.AccessError.noGrant`, `WindowRouter.shared.requestOpen(siteID:)`/`requested`, `CommandFactory.deploy()/backup()/audit()` are used consistently across tasks. `SiteEntity.id == SiteStore.Site.id` (String) threads through query → intent → `find(id:)`.

--- a/docs/superpowers/specs/2026-06-10-app-intents-phase-b-design.md
+++ b/docs/superpowers/specs/2026-06-10-app-intents-phase-b-design.md
@@ -1,0 +1,197 @@
+# Phase B — App Intents for Anglesite (#88, #89, #90)
+
+**Status:** Design — approved for planning
+**Date:** 2026-06-10
+**Issues:** #88 (intents), #89 (SiteEntity), #90 (AppShortcutsProvider)
+**Tracking:** macOS 27 platform features; foundation for #101 (system MCP), #102 (Spotlight)
+
+## Goal
+
+Expose Anglesite's deterministic site operations — deploy, backup, audit, open — to
+Siri and Shortcuts.app via App Intents, with **no Claude/LLM process involved**. Users
+can say "Deploy my portfolio site with Anglesite" or build a Shortcuts automation that
+audits then deploys.
+
+The command actors (`DeployCommand`, `BackupCommand`, `AuditCommand`) already do all
+orchestration and construct with sensible zero-arg defaults; `SiteStore.shared` already
+maintains the site registry (including the per-site security-scoped bookmark). The intents
+are thin, deterministic wrappers over those.
+
+## Non-goals
+
+- No new business logic in intents — they wrap existing command actors only.
+- No App Intents for chat or any LLM-backed flow (those are `#if !ANGLESITE_MAS` and
+  out of scope here).
+- No Spotlight entity indexing (#102) or system-wide MCP (#101) — this spec is the
+  entity/intent foundation they will build on, not those features.
+
+## Approach
+
+Entity, intents, and the shortcuts provider live in a new **`Sources/AnglesiteApp/Intents/`**
+group (the app target — `OpenSiteIntent` needs the app's window scene and the intents run
+in the app runtime). One shared **`SiteAccess`** helper lives in `AnglesiteCore` so the
+security-scoped wrapping is testable and target-gated in one place.
+
+*Alternatives considered:* (a) intents in `AnglesiteCore` — rejected: `OpenSiteIntent`
+needs the app window scene and `AppShortcutsProvider` is app-level; (b) a separate
+AppIntents framework target — rejected: unnecessary build complexity for v0.
+
+Both build targets compile the intents (App Intents are auto-discovered from the app
+bundle — no `Info.plist` registration needed). MAS-specific behavior is gated with
+`#if ANGLESITE_MAS`, consistent with the rest of the codebase.
+
+## Components
+
+### 1. `SiteEntity` + `SiteEntityQuery` (#89)
+
+`struct SiteEntity: AppEntity`:
+- `id: String` — the `SiteStore.Site.id` (path-derived, stable across launches).
+- `displayName: String`, `siteType: String`, `directory: URL` — surfaced properties.
+- `displayRepresentation` → site name + type subtitle; `typeDisplayRepresentation` = "Site".
+
+`SiteEntityQuery: EntityStringQuery`, backed by `SiteStore.shared` (read live every call,
+no cache, so it never goes stale):
+- `entities(for ids:)` — resolve specific ids.
+- `suggestedEntities()` — all registered sites.
+- `entities(matching string:)` — case-insensitive substring/fuzzy match on `displayName`
+  so Siri resolves "my portfolio site" to the right entity.
+- `defaultResult()` — returns the sole site when exactly one exists (no picker prompt for
+  single-site users).
+
+### 2. `SiteAccess` helper (`AnglesiteCore`)
+
+A single async wrapper that grants folder access around a unit of work, returning the
+closure's value:
+
+```
+enum SiteAccess {
+    static func withScopedAccess<T>(
+        to site: SiteStore.Site,
+        in store: SiteStore = .shared,
+        _ body: (URL) async -> T
+    ) async throws -> T
+}
+```
+
+- **DevID (non-sandboxed):** pass `site.path` straight to `body` — no security scope needed.
+- **MAS (`#if ANGLESITE_MAS`):** look up `store.bookmarkData(for: site.id)` →
+  `SecurityScopedBookmark.resolve` → `startAccessingSecurityScopedResource()`; run `body`;
+  `defer` `stopAccessingSecurityScopedResource()`. On a stale bookmark, re-mint and persist
+  (mirrors `SiteWindow.acquireGrant`). If the site has **no** bookmark, throw
+  `SiteAccess.Error.noGrant` carrying a friendly "re-add the folder via Open Folder…"
+  message, which the intent surfaces as its result dialog.
+
+This reuses the existing, proven `SecurityScopedBookmark` API. Unlike the window path
+(which holds the grant for the window's lifetime), `withScopedAccess` is short-lived and
+balanced per command — safe even if a window already holds the same grant (start/stop are
+balanced).
+
+### 3. The four intents (#88)
+
+Each declares `@Parameter var site: SiteEntity`, a `parameterSummary`, and returns
+`some IntentResult & ProvidesDialog`. The three spawning intents run their command actor
+inside `SiteAccess.withScopedAccess`; `noGrant`/actor-failure paths map to a dialog.
+
+- **`DeploySiteIntent`** — calls `requestConfirmation` first
+  ("Deploy <site> to production?"), then `DeployCommand.deploy(siteID:siteDirectory:)`.
+  Result mapping: `.succeeded(url)` → "Deployed to <url>"; `.blocked(failures, warnings)` →
+  "Deploy blocked by the pre-deploy security scan: …" (no override — the scan still gates,
+  matching the app rule that the app cannot bypass plugin security hooks);
+  `.failed(reason, _)` → the reason.
+- **`BackupSiteIntent`** — `BackupCommand.backup(...)`. No confirmation (non-destructive
+  git commit/push). `.succeeded(sha, branch, remote)` → "Backed up <sha> to <remote>";
+  `.noChanges` → "No changes to back up"; `.failed` → reason.
+- **`AuditSiteIntent`** — `AuditCommand.audit(...)`. No confirmation. `.succeeded(report)` →
+  finding counts by severity; returns that summary as a value so a downstream intent can
+  consume it. `.failed` → reason.
+- **`OpenSiteIntent`** — no spawn, works on both targets. `openAppWhenRun = true`; requests
+  the app focus/open the `SiteWindow` for `site.id`. **Routing mechanism (router singleton
+  vs. `OpenIntent` conformance) is chosen during writing-plans**; the requirement is: from
+  the intent, open or focus the existing `WindowGroup(for: String.self)` site window for
+  the selected id. Returns a confirmation dialog.
+
+#### Test seam — `CommandFactory`
+
+The three spawning intents depend on a small factory rather than constructing actors
+inline, so `Result → dialog` behavior is unit-testable without spawning:
+
+```
+protocol CommandFactory: Sendable {
+    func deploy() -> DeployCommand
+    func backup() -> BackupCommand
+    func audit() -> AuditCommand
+}
+```
+
+Default implementation returns the real zero-arg actors. Tests inject a fake factory whose
+actors are built with the existing closure seams (resolver/token/git stubs) to return
+canned `Result`s, then assert the intent's dialog.
+
+### 4. `AppShortcutsProvider` + chaining (#90)
+
+`AnglesiteShortcuts: AppShortcutsProvider` registers curated phrases (so they appear in
+Spotlight and Siri suggestions):
+- "Deploy my site with ${applicationName}"
+- "Back up my site with ${applicationName}"
+- "Check my site with ${applicationName}"
+
+Audit→deploy chain: `AuditSiteIntent`'s returned value/dialog lets the Shortcuts editor
+feed the audited site into `DeploySiteIntent` (which still runs its `requestConfirmation`
+gate when chained). The exact chaining surface (`opensIntent` vs. a returned `SiteEntity`
+the user pipes into the next action) is finalized during planning; the requirement is that
+"audit then deploy" composes in Shortcuts and that scheduled backups run reliably with no
+window open (covered by `SiteAccess`).
+
+## Error handling
+
+- **No security-scoped grant (MAS):** `SiteAccess` throws `noGrant`; intent returns a dialog
+  telling the user to re-add the folder via Open Folder. No crash, no silent failure.
+- **Pre-deploy scan refusal:** surfaced verbatim as the deploy dialog; never overridden.
+- **Command actor `.failed`:** the actor's `reason` string becomes the dialog.
+- **Site not found / stale id:** `SiteEntityQuery` returns no entity; Shortcuts/Siri report
+  the unresolved parameter through the system UI.
+
+## Testing
+
+- **Unit (new `Tests/.../IntentsTests` or in `AnglesiteCoreTests`):**
+  - `SiteAccess` DevID pass-through (the MAS branch is compile-gated; covered by manual
+    smoke since it needs a real sandboxed signed run).
+  - Each intent's `Result → dialog` mapping via a fake `CommandFactory`.
+  - `SiteEntityQuery` resolution: `entities(for:)`, `entities(matching:)` fuzzy match,
+    `defaultResult()` single-site auto-select — against a `SiteStore` seeded with fixtures.
+- **Manual smoke (documented, like the existing MAS smoke tasks):**
+  - Intents discoverable in Shortcuts.app on both targets.
+  - Siri voice invocation of each phrase.
+  - "Audit then deploy" Shortcuts automation.
+  - Scheduled background backup on MAS (exercises headless `SiteAccess` bookmark path).
+
+## Target gating
+
+- All intents, `SiteEntity`, `SiteEntityQuery`, `AnglesiteShortcuts`, `SiteAccess`,
+  `CommandFactory`, and the window router compile into **both** `Anglesite` (DevID) and
+  `AnglesiteMAS`.
+- Only the `SiteAccess` MAS branch and (if used) any MAS-specific routing detail sit behind
+  `#if ANGLESITE_MAS`.
+- No chat/LLM/Sparkle coupling — nothing here is excluded from MAS.
+
+## Acceptance criteria (rolled up from #88/#89/#90)
+
+- [ ] `SiteEntity` is an `AppEntity` with a working `EntityStringQuery`; fuzzy name
+      resolution; single-site auto-select; stays in sync with `SiteStore`.
+- [ ] Four intents discoverable in Shortcuts.app; Siri can invoke each by voice.
+- [ ] Intents use the deterministic command actors — no Claude process spawned.
+- [ ] `DeploySiteIntent` confirms before deploying; pre-deploy scan still gates.
+- [ ] Each intent returns a meaningful result dialog.
+- [ ] `AppShortcutsProvider` registered with curated phrases appearing in Spotlight/Siri.
+- [ ] "Audit then deploy" workflow composes; scheduled backup runs reliably (incl. MAS
+      headless via `SiteAccess`).
+- [ ] Builds clean and works on both `Anglesite` and `AnglesiteMAS` targets.
+
+## Build sequence (for the plan)
+
+1. `SiteAccess` helper + tests (DevID branch).
+2. `SiteEntity` + `SiteEntityQuery` + tests.
+3. `CommandFactory` + the four intents + `Result→dialog` tests.
+4. `OpenSiteIntent` window routing (mechanism decided here).
+5. `AnglesiteShortcuts` provider + chaining.
+6. Wire both targets; manual smoke pass; update `docs/build-plan.md` Phase B status.


### PR DESCRIPTION
## Summary

Phase B — exposes Anglesite's deterministic site operations to Siri and Shortcuts via App Intents, with **no Claude/LLM process involved**. Closes #88, #89, #90.

- **`SiteEntity` + `SiteEntityQuery`** (#89) — `EntityStringQuery` backed live by `SiteStore.shared`: fuzzy name resolution ("my portfolio site"), single-site auto-select, `load()` first so cold background intent processes see the registry. No cache.
- **Four App Intents** (#88) — thin adapters over the existing command actors:
  - `DeploySiteIntent` — `requestConfirmation` before pushing (outward-facing); the pre-deploy security scan still gates inside `DeployCommand` (no override).
  - `BackupSiteIntent` — commit/push; no confirmation (non-destructive).
  - `AuditSiteIntent` — finding counts by severity; returns the `SiteEntity` so a Shortcut can pipe it into Deploy.
  - `OpenSiteIntent` — opens/focuses the site window via a `WindowRouter` the Sites scene observes (`openAppWhenRun`, no spawn).
- **`AnglesiteShortcuts`** (#90) — curated Siri phrases ("Deploy/Back up/Check my site with Anglesite") for Spotlight + Siri suggestions; audit→deploy composes in the Shortcuts editor.

### Architecture

- `SiteOperations` + `CommandFactory` (in `AnglesiteCore`) hold the resolve→run→map logic so the **Result→dialog mapping is unit-tested under `swift test`**; only the `import AppIntents` types live in the app target (manual smoke).
- **`SiteAccess`** helper (target-gated): DevID passes `site.path` through; MAS (`#if ANGLESITE_MAS`) resolves the per-site security-scoped bookmark `SiteStore` already persists and holds the grant for one command — so backups run **headless with no window open**. Friendly "re-add via Open Folder…" error when a site has no grant.
- All types compile into **both** `Anglesite` (DevID) and `AnglesiteMAS` (App Intents are auto-discovered — no Info.plist entries).

Design + plan: `docs/superpowers/specs/2026-06-10-app-intents-phase-b-design.md`, `docs/superpowers/plans/2026-06-10-app-intents-phase-b.md`.

## Test Plan

Automated (green):
- [x] `swift test` — new `SiteAccessTests` (DevID pass-through) + `SiteOperationsTests` (Result→dialog for deploy/backup/audit, blocked-deploy never offers an override) pass; full suite green.
- [x] `xcodebuild` Debug build of **both** `Anglesite` and `AnglesiteMAS` schemes succeeds (MAS build exercises the `#if ANGLESITE_MAS` `SiteAccess` branch).

Runtime smoke (verified 2026-06-10, DevID Debug build):
- [x] App launches and runs; site window renders with a registered site and the Backup/Audit/Deploy toolbar.
- [x] Compiled `Metadata.appintents` (the manifest the OS ingests to populate Shortcuts/Siri) contains exactly the four actions — **Deploy Site**, **Back Up Site**, **Check Site**, **Open Site** — each with a `SiteEntity` parameter, plus `SiteEntity` + `SiteEntityQuery` (EntityStringQuery → fuzzy name match) and the three auto-shortcut phrases with correct SF Symbols. No missing/extra/stale intents.
- [x] Confirmed deploy's `requestConfirmation` is a runtime `perform()` call (not a declared trait) — correct that it's absent from the manifest; the gate lives in code (unit-tested).

Manual — needs a human (could not be automated; Shortcuts is a Catalyst app with no AX tree, and Siri voice/MAS-signed paths aren't drivable here):
- [ ] In Shortcuts.app: new shortcut → search "Anglesite" → confirm the four actions show with a site picker. *(Registration verified via the manifest above; this confirms Apple's render.)*
- [ ] "Check my Portfolio then Deploy" shortcut: deploy confirmation prompts; pre-deploy scan still gates.
- [ ] Single-site case: no picker (auto-select) — the running build already has one site registered, ideal for this check.
- [ ] Siri: "Check my site with Anglesite" invokes by voice.
- [ ] (MAS, when a signed build is available per #81) background backup with no window open resolves the bookmark and completes; no-grant site shows the friendly Open Folder… dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
