### PR TITLE
fix(intents): repair main build (#121/#122 semantic conflict) + adopt LongRunningIntent (#124)

### DIFF
--- a/Sources/AnglesiteApp/Intents/SiteIntents.swift
+++ b/Sources/AnglesiteApp/Intents/SiteIntents.swift
@@ -5,7 +5,10 @@ import AnglesiteCore
 /// the testable Result→dialog logic. No Claude/LLM process is involved — the intents drive the
 /// deterministic command actors directly.
 
-struct DeploySiteIntent: AppIntent {
+// `LongRunningIntent` (→ `ProgressReportingIntent` → `AppIntent`) tells the system this work
+// can exceed the default intent execution budget, so a real deploy/audit invoked from Siri or
+// a background Shortcut isn't killed mid-run. The actual work runs inside `performBackgroundTask`.
+struct DeploySiteIntent: LongRunningIntent {
     static var title: LocalizedStringResource = "Deploy Site"
     static var description = IntentDescription("Deploy a site to production with Anglesite.")
 
@@ -18,13 +21,16 @@ struct DeploySiteIntent: AppIntent {
         // pre-deploy security scan still gates inside DeployCommand — confirmation is an
         // additional guard against accidental voice/Shortcut triggers, not a replacement.
         try await requestConfirmation(
-            result: .result(dialog: "Deploy \(site.displayName) to production?")
+            dialog: "Deploy \(site.displayName) to production?"
         )
         let ops = SiteOperations()
         guard let resolved = await ops.site(id: site.id) else {
             return .result(dialog: "Couldn't find \(site.displayName).")
         }
-        let result = await ops.deploy(site: resolved)
+        // Deploys (build + wrangler) routinely exceed the default budget — run as long-running.
+        let result = try await performBackgroundTask {
+            await ops.deploy(site: resolved)
+        }
         return .result(dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forDeploy: result)))
     }
 }
@@ -47,7 +53,7 @@ struct BackupSiteIntent: AppIntent {
     }
 }
 
-struct AuditSiteIntent: AppIntent {
+struct AuditSiteIntent: LongRunningIntent {
     static var title: LocalizedStringResource = "Check Site"
     static var description = IntentDescription("Run an Anglesite audit and report findings.")
 
@@ -61,7 +67,10 @@ struct AuditSiteIntent: AppIntent {
         guard let resolved = await ops.site(id: site.id) else {
             return .result(value: site, dialog: "Couldn't find \(site.displayName).")
         }
-        let result = await ops.audit(site: resolved)
+        // A full audit runs a site build + runners — can exceed the default budget.
+        let result = try await performBackgroundTask {
+            await ops.audit(site: resolved)
+        }
         return .result(value: site, dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forAudit: result)))
     }
 }

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -52,9 +52,9 @@ public struct SiteOperations: Sendable {
                 await factory.audit().audit(siteID: site.id, siteDirectory: url)
             }
         } catch let SiteAccess.AccessError.noGrant(message) {
-            return .failed(reason: message, exitCode: nil)
+            return .failed(reason: message, exitCode: nil, logTail: [])
         } catch {
-            return .failed(reason: error.localizedDescription, exitCode: nil)
+            return .failed(reason: error.localizedDescription, exitCode: nil, logTail: [])
         }
     }
 
@@ -91,7 +91,7 @@ public struct SiteOperations: Sendable {
             let w = report.findings.filter { $0.severity == .warning }.count
             let i = report.findings.filter { $0.severity == .info }.count
             return "Audit complete: \(c) critical, \(w) warning, \(i) info."
-        case .failed(let reason, _):
+        case .failed(let reason, _, _):
             return "Audit failed: \(reason)"
         }
     }


### PR DESCRIPTION
## ⚠️ This also repairs a broken `main`

`main` currently **does not compile**. Squash-merging #122 (Phase B) onto a `main` that already had #121's audit hardening produced a semantic conflict git couldn't detect (different files, no textual conflict): `SiteOperations.swift` constructs/matches the old 2-arg `AuditCommand.Result.failed`, but #121 added a third `logTail:` associated value. The first commit here fixes that (`logTail: []` on the noGrant/error fallbacks, `.failed(_, _, _)` in `dialog(forAudit)`). Deploy/Backup `.failed` are still 2-arg and untouched.

**Recommend merging promptly** — until this lands, `main` and every branch's CI is red. Happy to split the `logTail` commit into a standalone hotfix if you'd rather fast-track it.

## LongRunningIntent adoption (#124)

Intents have a bounded execution budget; real deploys (build + wrangler) and audits (build + runners) exceed it, so a Siri or background-Shortcut invocation could be **killed mid-run**. This conforms `DeploySiteIntent` and `AuditSiteIntent` to `LongRunningIntent` (→ `ProgressReportingIntent` → `AppIntent`) and runs the work inside `performBackgroundTask { … }`.

Also migrates the deploy confirmation off the macOS 27-**deprecated** `requestConfirmation(result:)` to `requestConfirmation(dialog:)`.

API verified against the Xcode 27 / macOS 27 `AppIntents.swiftinterface` (`LongRunningIntent`, `performBackgroundTask(options:operation:)`, `requestConfirmation(conditions:actionName:dialog:)`), not from memory.

## Test Plan
- [x] `swift test` — 151 + 27 across both bundles pass (was failing to **compile** on `main` before the logTail fix).
- [x] `xcodebuild` Debug build of both `Anglesite` and `AnglesiteMAS` succeeds.
- [ ] Manual (needs human): a deploy/audit that runs longer than the default budget completes when invoked from Shortcuts/Siri (not killed).

Refs #124, #88. Follows #122 (merged), #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
