### PR TITLE
feat(intents): CancellableIntent for Deploy/Audit — cancel actually kills the subprocess (#124)

### DIFF
--- a/Sources/AnglesiteApp/Intents/SiteIntents.swift
+++ b/Sources/AnglesiteApp/Intents/SiteIntents.swift
@@ -7,8 +7,10 @@ import AnglesiteCore
 
 // `LongRunningIntent` (→ `ProgressReportingIntent` → `AppIntent`) tells the system this work
 // can exceed the default intent execution budget, so a real deploy/audit invoked from Siri or
-// a background Shortcut isn't killed mid-run. The actual work runs inside `performBackgroundTask`.
-struct DeploySiteIntent: LongRunningIntent {
+// a background Shortcut isn't killed mid-run. `CancellableIntent` lets the system offer a Cancel
+// affordance; cancellation propagates into the operation task, whose command actor SIGTERMs the
+// running build/wrangler so it actually stops (see DeployCommand/AuditCommand).
+struct DeploySiteIntent: LongRunningIntent, CancellableIntent {
     static var title: LocalizedStringResource = "Deploy Site"
     static var description = IntentDescription("Deploy a site to production with Anglesite.")
 
@@ -27,10 +29,12 @@ struct DeploySiteIntent: LongRunningIntent {
         guard let resolved = await ops.site(id: site.id) else {
             return .result(dialog: "Couldn't find \(site.displayName).")
         }
-        // Deploys (build + wrangler) routinely exceed the default budget — run as long-running.
+        // Deploys (build + wrangler) routinely exceed the default budget — run as long-running,
+        // cancellable work. On cancel the operation task is cancelled, which terminates the
+        // subprocess inside DeployCommand; `onCancel` is the system's acknowledgement hook.
         let result = try await performBackgroundTask {
             await ops.deploy(site: resolved)
-        }
+        } onCancel: { _ in }
         return .result(dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forDeploy: result)))
     }
 }
@@ -53,7 +57,7 @@ struct BackupSiteIntent: AppIntent {
     }
 }
 
-struct AuditSiteIntent: LongRunningIntent {
+struct AuditSiteIntent: LongRunningIntent, CancellableIntent {
     static var title: LocalizedStringResource = "Check Site"
     static var description = IntentDescription("Run an Anglesite audit and report findings.")
 
@@ -67,10 +71,11 @@ struct AuditSiteIntent: LongRunningIntent {
         guard let resolved = await ops.site(id: site.id) else {
             return .result(value: site, dialog: "Couldn't find \(site.displayName).")
         }
-        // A full audit runs a site build + runners — can exceed the default budget.
+        // A full audit runs a site build + runners — can exceed the default budget. Cancellable:
+        // on cancel the build subprocess is terminated inside AuditCommand.
         let result = try await performBackgroundTask {
             await ops.audit(site: resolved)
-        }
+        } onCancel: { _ in }
         return .result(value: site, dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forAudit: result)))
     }
 }

--- a/Sources/AnglesiteCore/AuditCommand.swift
+++ b/Sources/AnglesiteCore/AuditCommand.swift
@@ -142,7 +142,14 @@ public actor AuditCommand {
             return .failure(.failed(reason: "couldn't spawn build: \(error)", exitCode: nil, logTail: []))
         }
 
-        let reason = await supervisor.waitForExit(handle)
+        let reason = await withTaskCancellationHandler {
+            await supervisor.waitForExit(handle)
+        } onCancel: {
+            // The audit was cancelled (e.g. a Shortcuts/Siri CancellableIntent). The backend
+            // resumes our wait as `.terminated`, but the OS build process would otherwise keep
+            // running — actually SIGTERM it so it doesn't finish after we've reported cancellation.
+            Task { await supervisor.terminate(handle) }
+        }
         // `waitForExit` only returns after the supervisor's per-pipe drain Tasks have finished,
         // so every byte the build wrote is already in `LogCenter` — filtering the snapshot by
         // source gives us the complete captured output for this build run.

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -148,7 +148,15 @@ public actor DeployCommand {
             return .failed(reason: "couldn't spawn wrangler: \(error)", exitCode: nil)
         }
 
-        let reason = await supervisor.waitForExit(handle)
+        let reason = await withTaskCancellationHandler {
+            await supervisor.waitForExit(handle)
+        } onCancel: {
+            // The deploy was cancelled (e.g. a Shortcuts/Siri CancellableIntent). The backend
+            // resumes our wait as `.terminated`, but the OS process would otherwise keep running —
+            // actually SIGTERM it so the build/wrangler doesn't finish (and, for wrangler, doesn't
+            // keep publishing to production) after we've reported cancellation.
+            Task { await supervisor.terminate(handle) }
+        }
         let duration = Date().timeIntervalSince(started)
 
         // `waitForExit` only resumes after the supervisor's per-pipe drain Tasks have
@@ -206,7 +214,15 @@ public actor DeployCommand {
             return .failure(.failed(reason: "couldn't spawn build: \(error)", exitCode: nil))
         }
 
-        let reason = await supervisor.waitForExit(handle)
+        let reason = await withTaskCancellationHandler {
+            await supervisor.waitForExit(handle)
+        } onCancel: {
+            // The deploy was cancelled (e.g. a Shortcuts/Siri CancellableIntent). The backend
+            // resumes our wait as `.terminated`, but the OS process would otherwise keep running —
+            // actually SIGTERM it so the build/wrangler doesn't finish (and, for wrangler, doesn't
+            // keep publishing to production) after we've reported cancellation.
+            Task { await supervisor.terminate(handle) }
+        }
         switch reason {
         case .exited(let code) where code == 0:
             return .success

--- a/Tests/AnglesiteCoreTests/AuditCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/AuditCommandTests.swift
@@ -34,6 +34,39 @@ struct AuditCommandTests {
         .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", script])
     }
 
+    // MARK: Cancellation
+
+    /// Poll `center` for a marker line up to `timeout`. Returns true once it appears.
+    private func waitForMarker(_ marker: String, in center: LogCenter, timeout: Duration = .seconds(3)) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await center.snapshot().contains(where: { $0.text.contains(marker) }) { return true }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return false
+    }
+
+    @Test("Cancelling the task actually SIGTERMs the in-flight build subprocess")
+    func cancellationTerminatesBuild() async {
+        // The fixture echoes a marker only if it receives SIGTERM; otherwise it sleeps and prints
+        // a different marker. Cancelling the audit task must kill the build (not orphan it), so the
+        // result is `.failed(terminated)` AND the process reports the SIGTERM trap.
+        let (cmd, _, center) = makeCommand(
+            runners: [FakeAuditRunner(category: .accessibility, result: .success([]))],
+            build: { _ in self.shFixture("trap 'echo __SIGTERM__; exit 143' TERM; sleep 20; echo __COMPLETED__") }
+        )
+        let task = Task { await cmd.audit(siteID: "site", siteDirectory: tmpDir) }
+        try? await Task.sleep(for: .milliseconds(300))  // let the supervisor actually spawn it
+        task.cancel()
+        let result = await task.value
+        guard case .failed(let reason, _, _) = result else {
+            Issue.record("expected .failed(terminated), got \(result)")
+            return
+        }
+        #expect(reason.contains("terminated"))
+        #expect(await waitForMarker("__SIGTERM__", in: center), "build subprocess was not actually SIGTERM'd")
+    }
+
     // MARK: Build failure
 
     @Test("Fails when the build step exits non-zero")

--- a/Tests/AnglesiteCoreTests/AuditCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/AuditCommandTests.swift
@@ -48,15 +48,16 @@ struct AuditCommandTests {
 
     @Test("Cancelling the task actually SIGTERMs the in-flight build subprocess")
     func cancellationTerminatesBuild() async {
-        // The fixture echoes a marker only if it receives SIGTERM; otherwise it sleeps and prints
-        // a different marker. Cancelling the audit task must kill the build (not orphan it), so the
-        // result is `.failed(terminated)` AND the process reports the SIGTERM trap.
+        // The fixture sets a SIGTERM trap, echoes __STARTED__, then blocks. We cancel exactly once
+        // the build is running (synchronized on __STARTED__, not a fixed delay), and assert the
+        // result is `.failed(terminated)` AND the process reports the SIGTERM trap — proving it was
+        // actually killed, not orphaned.
         let (cmd, _, center) = makeCommand(
             runners: [FakeAuditRunner(category: .accessibility, result: .success([]))],
-            build: { _ in self.shFixture("trap 'echo __SIGTERM__; exit 143' TERM; sleep 20; echo __COMPLETED__") }
+            build: { _ in self.shFixture("trap 'echo __SIGTERM__; exit 143' TERM; echo __STARTED__; sleep 20; echo __COMPLETED__") }
         )
         let task = Task { await cmd.audit(siteID: "site", siteDirectory: tmpDir) }
-        try? await Task.sleep(for: .milliseconds(300))  // let the supervisor actually spawn it
+        #expect(await waitForMarker("__STARTED__", in: center, timeout: .seconds(10)), "build never started")
         task.cancel()
         let result = await task.value
         guard case .failed(let reason, _, _) = result else {
@@ -64,7 +65,7 @@ struct AuditCommandTests {
             return
         }
         #expect(reason.contains("terminated"))
-        #expect(await waitForMarker("__SIGTERM__", in: center), "build subprocess was not actually SIGTERM'd")
+        #expect(await waitForMarker("__SIGTERM__", in: center, timeout: .seconds(10)), "build subprocess was not actually SIGTERM'd")
     }
 
     // MARK: Build failure

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -30,6 +30,40 @@ struct DeployCommandTests {
         .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", script] + args)
     }
 
+    // MARK: Cancellation
+
+    /// Poll `center` for a marker line up to `timeout`. Returns true once it appears.
+    private func waitForMarker(_ marker: String, in center: LogCenter, timeout: Duration = .seconds(3)) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await center.snapshot().contains(where: { $0.text.contains(marker) }) { return true }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return false
+    }
+
+    @Test("Cancelling the task actually SIGTERMs the in-flight wrangler subprocess")
+    func cancellationTerminatesWrangler() async {
+        // Token + build (/usr/bin/true) + preflight pass quickly, then wrangler blocks. Cancelling
+        // the deploy must kill wrangler (not orphan it mid-publish): `.failed(terminated)` AND the
+        // process reports the SIGTERM trap.
+        let (cmd, _, center) = makeCommand(
+            resolve: { _ in self.shFixture("trap 'echo __SIGTERM__; exit 143' TERM; sleep 20; echo __COMPLETED__") },
+            token: { "tok" }
+        )
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let task = Task { await cmd.deploy(siteID: "site", siteDirectory: dir) }
+        try? await Task.sleep(for: .milliseconds(400))  // past build+preflight, into wrangler
+        task.cancel()
+        let result = await task.value
+        guard case .failed(let reason, _) = result else {
+            Issue.record("expected .failed(terminated), got \(result)")
+            return
+        }
+        #expect(reason.contains("terminated"))
+        #expect(await waitForMarker("__SIGTERM__", in: center), "wrangler subprocess was not actually SIGTERM'd")
+    }
+
     // MARK: Pre-spawn refusal (no work wasted)
 
     @Test("Refuses before spawn when token source returns nil") func refusesBeforeSpawnWhenTokenSourceReturnsNil() async {

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -46,14 +46,16 @@ struct DeployCommandTests {
     func cancellationTerminatesWrangler() async {
         // Token + build (/usr/bin/true) + preflight pass quickly, then wrangler blocks. Cancelling
         // the deploy must kill wrangler (not orphan it mid-publish): `.failed(terminated)` AND the
-        // process reports the SIGTERM trap.
+        // process reports the SIGTERM trap. The fixture sets the trap, then echoes __STARTED__ so
+        // we cancel exactly once wrangler is running (no fixed-delay race — `__STARTED__` is unique
+        // to wrangler since the build step is silent /usr/bin/true).
         let (cmd, _, center) = makeCommand(
-            resolve: { _ in self.shFixture("trap 'echo __SIGTERM__; exit 143' TERM; sleep 20; echo __COMPLETED__") },
+            resolve: { _ in self.shFixture("trap 'echo __SIGTERM__; exit 143' TERM; echo __STARTED__; sleep 20; echo __COMPLETED__") },
             token: { "tok" }
         )
         let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         let task = Task { await cmd.deploy(siteID: "site", siteDirectory: dir) }
-        try? await Task.sleep(for: .milliseconds(400))  // past build+preflight, into wrangler
+        #expect(await waitForMarker("__STARTED__", in: center, timeout: .seconds(10)), "wrangler never started")
         task.cancel()
         let result = await task.value
         guard case .failed(let reason, _) = result else {
@@ -61,7 +63,7 @@ struct DeployCommandTests {
             return
         }
         #expect(reason.contains("terminated"))
-        #expect(await waitForMarker("__SIGTERM__", in: center), "wrangler subprocess was not actually SIGTERM'd")
+        #expect(await waitForMarker("__SIGTERM__", in: center, timeout: .seconds(10)), "wrangler subprocess was not actually SIGTERM'd")
     }
 
     // MARK: Pre-spawn refusal (no work wasted)


### PR DESCRIPTION
## Summary

Adds graceful cancellation to the deploy/audit App Intents (the `CancellableIntent` item of #124).

- **`DeploySiteIntent` / `AuditSiteIntent` conform to `CancellableIntent`** and run via `performBackgroundTask(operation:onCancel:)`, so Siri/Shortcuts surface a Cancel affordance.
- **The real fix is in the command actors.** While implementing this I found that `InProcessBackend.waitForExit` *already* resumes its waiter as `.terminated` on task cancellation — but it only **detaches the waiter**; the OS subprocess kept running. So a "cancelled" deploy would keep `wrangler` publishing to production in the background. `DeployCommand` and `AuditCommand` now wrap their `waitForExit` calls in `withTaskCancellationHandler` that calls `supervisor.terminate(handle)`, so cancellation actually **SIGTERMs** the build/wrangler.
- **Scoped deliberately:** only deploy/audit get "cancel kills the process." The global `waitForExit` "stop waiting ≠ kill" semantics that the dev-server supervision and MCP client rely on are unchanged.

## Why the tests matter

My first-cut tests asserted only that the result was `.terminated` — and they **passed while the subprocess was still orphaned** (the backend returns `.terminated` regardless). The committed tests use a `trap 'echo __SIGTERM__' TERM` fixture and assert the marker appears in `LogCenter`, proving the process is *actually* killed. They were red before the command-level fix, green after.

## Test Plan
- [x] `swift test` — 153 + 27 pass, incl. two new cancellation tests (`DeployCommandTests`, `AuditCommandTests`) that verify the subprocess receives SIGTERM on cancel.
- [x] `xcodebuild` Debug build of both `Anglesite` and `AnglesiteMAS` succeeds (`CancellableIntent` compiles against the Xcode 27 SDK).
- [ ] Manual (needs human + macOS 27 device): cancelling a running Deploy/Audit from Shortcuts/Siri stops it — verifies the system cancels the operation task (which propagates to the command's SIGTERM). The unit tests prove the Swift-task→SIGTERM half; this confirms the system→task half.

API verified against the Xcode 27 `AppIntents.swiftinterface` (`CancellableIntent`, `performBackgroundTask(options:operation:onCancel:)`, `IntentCancellationReason`).

Refs #124. Follows #122, #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
