### PR TITLE
feat: on-device inbox triage via Apple Foundation Models (fm)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ Two levels of agent instructions exist — do not confuse them:
 | Industry tools first | Recommend purpose-built solutions (Square, Shopify, Clio, etc.) over generic databases |
 | Edge A/B testing (not client-side) | Build-time variants + Worker-entry edge assignment = zero flicker, static-site compatible |
 | Pagefind (not Algolia/Orama) | Build-time index, ~6 KB JS, no external service, first-class Astro integration |
-| On-device `fm` as optional authoring accelerator | Free/private/offline drafts (alt text first); never in the deployed site, always falls back to Claude (ADR-0021) |
+| On-device `fm` as optional authoring accelerator | Free/private/offline drafts — alt text and inbox triage; never in the deployed site, always falls back to Claude (ADR-0021) |
 
 Full ADRs are in `docs/decisions/` (ADR-0001 through ADR-0021).
 

--- a/docs/superpowers/plans/2026-06-10-fm-inbox-triage.md
+++ b/docs/superpowers/plans/2026-06-10-fm-inbox-triage.md
@@ -1,0 +1,786 @@
+# On-device Inbox Triage via Apple Foundation Models — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** During `npm run ai-inbox-fetch`, classify each new form submission on-device (spam likelihood + lead/support/question/other category) and write advisory `aiCategory`/`aiSpam`/`aiReason` fields, with a Claude-relayed triage summary — falling back cleanly to manual triage when `fm` is absent.
+
+**Architecture:** Extends the existing `template/scripts/fm.ts` module with a stdin-capable command runner, a structured-output classifier (`classifySubmission`) using `fm`'s `--schema`, and a defensive parser. `fetch-submissions.ts` calls the classifier for each new submission, renders advisory frontmatter, and reports a triage tally. Keystatic surfaces three read-mostly fields beside the existing `status`. Advisory only — `status` is never auto-changed. Reuses ADR-0021's pattern (no new ADR).
+
+**Tech Stack:** TypeScript (strict, ESM), Node `node:child_process` (`execFile` + stdin), `node:os`/`node:fs` for the temp schema file, Vitest 3, the existing `.site-config` reader, Keystatic.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-fm-inbox-triage-design.md`
+
+---
+
+## File Structure
+
+- **Modify:** `template/scripts/fm.ts` — add `input?` to `CommandRunner`/`defaultRunner`; add `SubmissionCategory`/`SubmissionClassification` types, the embedded `TRIAGE_SCHEMA`, `parseClassification`, and `classifySubmission`.
+- **Modify:** `tests/fm.test.ts` — tests for stdin passing, `parseClassification`, and `classifySubmission`.
+- **Modify:** `template/scripts/fetch-submissions.ts` — add `buildSubmissionText`, extend `renderSubmission` with optional classification, wire classification into the new-submission path, add the `TriageTally` + `formatTriageSummary`, and report the summary.
+- **Create:** `tests/fetch-submissions.test.ts` — tests for `buildSubmissionText`, `renderSubmission`, and `formatTriageSummary`.
+- **Modify:** `template/keystatic.config.ts` — add `aiCategory`/`aiSpam`/`aiReason` to the `submissions` collection.
+- **Modify:** `skills/inbox/SKILL.md`, `template/docs/workflows/inbox.md`, `CLAUDE.md` (root) — documentation.
+
+Boundary note: `fm.ts` stays domain-agnostic about the inbox — it classifies a **string**. `fetch-submissions.ts` owns turning a `Submission` into that string (`buildSubmissionText`). The `SubmissionClassification` type lives in `fm.ts` because it is bound to `TRIAGE_SCHEMA` and `parseClassification`.
+
+---
+
+## Task 1: stdin support in the command runner
+
+**Files:**
+- Modify: `template/scripts/fm.ts` (the `CommandRunner` type and `defaultRunner`)
+- Test: `tests/fm.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/fm.test.ts` (the `defaultRunner` describe block already exists — add this case inside it, or as a new `it` in that block):
+
+```ts
+  it("passes opts.input to the child's stdin", async () => {
+    const r = await defaultRunner(
+      process.execPath,
+      ["-e", "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>process.stdout.write(d.toUpperCase()))"],
+      { input: "hello" },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("HELLO");
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/fm.test.ts -t "passes opts.input"`
+Expected: FAIL — `input` is not in the opts type / not written, so stdout is empty (`""`), not `"HELLO"`. (TypeScript may also error that `input` is not assignable; that still counts as red.)
+
+- [ ] **Step 3: Add `input` to the runner type and write it to stdin**
+
+In `template/scripts/fm.ts`, change the `CommandRunner` type:
+
+```ts
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  opts?: { timeoutMs?: number; input?: string },
+) => Promise<CommandResult>;
+```
+
+And change `defaultRunner` to capture the child process and write stdin (note the `child` binding and the trailing `if (opts.input != null)` block):
+
+```ts
+export const defaultRunner: CommandRunner = (command, args, opts = {}) =>
+  new Promise((resolve) => {
+    const child = execFile(
+      command,
+      args,
+      { timeout: opts.timeoutMs ?? 60_000, maxBuffer: 4 * 1024 * 1024 },
+      (error, stdout) => {
+        if (!error) {
+          resolve({ stdout: stdout ?? "", exitCode: 0 });
+          return;
+        }
+        // Numeric `code` = process exit status; string `code` (ENOENT) or a
+        // kill signal (timeout) = spawn failure → treat as unavailable (-1).
+        const code = (error as NodeJS.ErrnoException & { code?: string | number }).code;
+        const exitCode = typeof code === "number" ? code : -1;
+        resolve({ stdout: stdout ?? "", exitCode });
+      },
+    );
+    if (opts.input != null) {
+      // Guard against EPIPE if the child exits without reading stdin.
+      child.stdin?.on("error", () => {});
+      child.stdin?.end(opts.input);
+    }
+  });
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run tests/fm.test.ts`
+Expected: PASS — all prior `fm.test.ts` tests plus the new stdin case.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add template/scripts/fm.ts tests/fm.test.ts
+git commit -m "feat(template): stdin support in fm.ts command runner"
+```
+
+---
+
+## Task 2: `parseClassification` + classification types
+
+**Files:**
+- Modify: `template/scripts/fm.ts`
+- Test: `tests/fm.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the top `../template/scripts/fm.js` import in `tests/fm.test.ts`: `parseClassification`, `type SubmissionClassification`. Append:
+
+```ts
+describe("parseClassification", () => {
+  it("parses a valid object", () => {
+    const r = parseClassification('{"isSpam": true, "category": "lead", "reason": "wants a quote"}');
+    expect(r).toEqual({ isSpam: true, category: "lead", reason: "wants a quote" });
+  });
+  it("is order-independent", () => {
+    const r = parseClassification('{"reason": "x", "category": "support", "isSpam": false}');
+    expect(r).toEqual({ isSpam: false, category: "support", reason: "x" });
+  });
+  it("falls back to 'other' for an unknown category", () => {
+    expect(parseClassification('{"isSpam": false, "category": "marketing", "reason": "ad"}')!.category).toBe("other");
+  });
+  it("coerces non-boolean isSpam", () => {
+    expect(parseClassification('{"isSpam": "yes", "category": "other", "reason": ""}')!.isSpam).toBe(true);
+    expect(parseClassification('{"isSpam": "no", "category": "other", "reason": ""}')!.isSpam).toBe(false);
+  });
+  it("defaults a missing reason to empty string", () => {
+    expect(parseClassification('{"isSpam": false, "category": "question"}')!.reason).toBe("");
+  });
+  it("strips ANSI and whitespace before parsing", () => {
+    expect(parseClassification('\x1b[32m {"isSpam": false, "category": "lead", "reason": "x"} \x1b[0m')!.category).toBe("lead");
+  });
+  it("returns null for malformed JSON", () => {
+    expect(parseClassification("{ not json")).toBeNull();
+  });
+  it("returns null for a JSON array", () => {
+    expect(parseClassification("[1,2,3]")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/fm.test.ts -t "parseClassification"`
+Expected: FAIL — `parseClassification` is not exported.
+
+- [ ] **Step 3: Implement the types + parser**
+
+In `template/scripts/fm.ts`, after the `AltCatalog` type (or near the other types), add:
+
+```ts
+export type SubmissionCategory = "lead" | "support" | "question" | "other";
+
+export interface SubmissionClassification {
+  category: SubmissionCategory;
+  isSpam: boolean;
+  reason: string;
+}
+
+const SUBMISSION_CATEGORIES: SubmissionCategory[] = ["lead", "support", "question", "other"];
+
+/**
+ * Parse `fm`'s structured-output JSON into a classification. Defensive:
+ * validates the category against the allowed set (else "other"), coerces
+ * isSpam to a boolean, and returns null only when the input is not a usable
+ * JSON object. `fm` field order is not guaranteed, so this never relies on it.
+ */
+export function parseClassification(raw: string): SubmissionClassification | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.replace(ANSI, "").trim());
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const o = parsed as Record<string, unknown>;
+  const category =
+    typeof o.category === "string" && (SUBMISSION_CATEGORIES as string[]).includes(o.category)
+      ? (o.category as SubmissionCategory)
+      : "other";
+  const isSpam = o.isSpam === true || o.isSpam === "true" || o.isSpam === "yes";
+  const reason = typeof o.reason === "string" ? o.reason.trim() : "";
+  return { category, isSpam, reason };
+}
+```
+
+Note: `ANSI` is the existing module-level regex in `fm.ts` (used by `normalizeAltOutput`). Reuse it; do not redeclare.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/fm.test.ts`
+Expected: PASS — all cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add template/scripts/fm.ts tests/fm.test.ts
+git commit -m "feat(template): parseClassification for fm structured triage output"
+```
+
+---
+
+## Task 3: `classifySubmission` shell-out
+
+**Files:**
+- Modify: `template/scripts/fm.ts`
+- Test: `tests/fm.test.ts`
+
+- [ ] **Step 1: Write the failing tests (fake runner)**
+
+Add to the top `../template/scripts/fm.js` import: `classifySubmission`, `type CommandRunner` (already imported). Append:
+
+```ts
+describe("classifySubmission", () => {
+  it("returns the parsed classification on success and forwards text via stdin", async () => {
+    let seenInput: string | undefined;
+    let seenArgs: string[] = [];
+    const run: CommandRunner = async (_cmd, args, opts) => {
+      seenInput = opts?.input;
+      seenArgs = args;
+      return { stdout: '{"isSpam": false, "category": "lead", "reason": "quote request"}', exitCode: 0 };
+    };
+    const r = await classifySubmission("Form: contact\nMessage: please send a quote", run);
+    expect(r).toEqual({ isSpam: false, category: "lead", reason: "quote request" });
+    expect(seenInput).toContain("please send a quote");
+    expect(seenArgs).toContain("--schema");
+  });
+  it("returns null on non-zero exit", async () => {
+    const run: CommandRunner = async () => ({ stdout: "{}", exitCode: 1 });
+    expect(await classifySubmission("x", run)).toBeNull();
+  });
+  it("returns null on unparseable output", async () => {
+    const run: CommandRunner = async () => ({ stdout: "not json", exitCode: 0 });
+    expect(await classifySubmission("x", run)).toBeNull();
+  });
+  it("returns null when the runner throws", async () => {
+    const run: CommandRunner = async () => { throw new Error("boom"); };
+    expect(await classifySubmission("x", run)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/fm.test.ts -t "classifySubmission"`
+Expected: FAIL — `classifySubmission` is not exported.
+
+- [ ] **Step 3: Implement the classifier**
+
+Add imports to the top of `template/scripts/fm.ts`: extend the `node:path` import to include `join`, and add `node:os`:
+
+```ts
+import { relative, join } from "node:path";
+import { tmpdir } from "node:os";
+```
+
+Then append (after `generateAltText`):
+
+```ts
+// The schema fm expects is NOT generic JSON Schema — it requires fm's own
+// shape (note `x-order`). `enum` IS honored inside that shape. Verified against
+// the real CLI during design.
+const TRIAGE_SCHEMA = {
+  required: ["isSpam", "category", "reason"],
+  "x-order": ["isSpam", "category", "reason"],
+  additionalProperties: false,
+  title: "Triage",
+  type: "object",
+  properties: {
+    isSpam: {
+      type: "boolean",
+      description: "true if the message is spam, advertising, or abuse",
+    },
+    category: {
+      type: "string",
+      enum: ["lead", "support", "question", "other"],
+      description:
+        "lead=potential new customer; support=existing-customer help; question=general inquiry; other=anything else",
+    },
+    reason: { type: "string", description: "short rationale, max 12 words" },
+  },
+};
+
+const TRIAGE_INSTRUCTIONS =
+  "Classify this form submission. A pricing, booking, or service inquiry from a " +
+  "potential new customer is a 'lead'. Help from an existing customer is 'support'.";
+
+/**
+ * Classify a form submission on-device. Writes fm's schema to a temp file,
+ * runs `fm respond --schema` with the submission text on stdin, and parses
+ * the structured JSON. Returns null on any failure (caller falls back).
+ */
+export async function classifySubmission(
+  submissionText: string,
+  run: CommandRunner = defaultRunner,
+): Promise<SubmissionClassification | null> {
+  try {
+    const schemaPath = join(tmpdir(), "anglesite-fm-triage-schema.json");
+    writeFileSync(schemaPath, JSON.stringify(TRIAGE_SCHEMA));
+    const { stdout, exitCode } = await run(
+      "fm",
+      [
+        "respond",
+        "--schema", schemaPath,
+        "--use-case", "content-tagging",
+        "-g",
+        "--no-stream",
+        "-i", TRIAGE_INSTRUCTIONS,
+      ],
+      { timeoutMs: 60_000, input: submissionText },
+    );
+    if (exitCode !== 0) return null;
+    return parseClassification(stdout);
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/fm.test.ts`
+Expected: PASS — all `fm.test.ts` tests green.
+
+- [ ] **Step 5: Manual real-`fm` smoke (Mac only, best-effort)**
+
+```bash
+cat > /tmp/fm-triage-smoke.ts <<'EOF'
+import { classifySubmission, isFmAvailable } from "/Users/dwk/Developer/github.com/Anglesite/anglesite/template/scripts/fm.ts";
+async function run() {
+  console.log("available:", await isFmAvailable());
+  console.log("spam:", JSON.stringify(await classifySubmission("Form: contact\nFrom: deals@cheap-seo.biz\nMessage: Buy 5000 backlinks now!!! Rank #1 guaranteed")));
+  console.log("lead:", JSON.stringify(await classifySubmission("Form: contact\nFrom: maria@gmail.com\nMessage: Do you have availability for a kitchen remodel consult next month? What are rates?")));
+}
+run();
+EOF
+npx tsx /tmp/fm-triage-smoke.ts ; rm -f /tmp/fm-triage-smoke.ts /tmp/anglesite-fm-triage-schema.json
+```
+Expected on a capable Mac: the spam line shows `"isSpam":true`; the lead line shows `"isSpam":false` with category `lead` or `question`. Report the actual output. On non-Mac, `available:false` and both classifications `null` — that's the fallback path; note it and move on.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add template/scripts/fm.ts tests/fm.test.ts
+git commit -m "feat(template): classifySubmission via fm structured output"
+```
+
+---
+
+## Task 4: wire classification into the inbox sync
+
+**Files:**
+- Modify: `template/scripts/fetch-submissions.ts`
+- Test: `tests/fetch-submissions.test.ts` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/fetch-submissions.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  buildSubmissionText,
+  renderSubmission,
+  formatTriageSummary,
+  type Submission,
+  type TriageTally,
+} from "../template/scripts/fetch-submissions.js";
+
+const sample: Submission = {
+  id: "abc123",
+  formSlug: "contact",
+  formTitle: "Contact Form",
+  submittedAt: "2026-06-10T12:00:00Z",
+  senderName: "Maria",
+  senderEmail: "maria@example.com",
+  entries: [
+    { key: "message", label: "Message", type: "textarea", value: "Do you have availability?" },
+  ],
+};
+
+describe("buildSubmissionText", () => {
+  it("includes form title, sender, and entry label:value", () => {
+    const text = buildSubmissionText(sample);
+    expect(text).toContain("Contact Form");
+    expect(text).toContain("Maria");
+    expect(text).toContain("maria@example.com");
+    expect(text).toContain("Message: Do you have availability?");
+  });
+  it("truncates very long values", () => {
+    const big: Submission = { ...sample, entries: [{ key: "m", value: "x".repeat(5000) }] };
+    const line = buildSubmissionText(big).split("\n").find((l) => l.startsWith("m:"))!;
+    expect(line.length).toBeLessThan(1100);
+  });
+});
+
+describe("renderSubmission", () => {
+  it("omits ai fields when no classification is given", () => {
+    const out = renderSubmission(sample);
+    expect(out).not.toContain("aiCategory");
+    expect(out).toContain("status: new");
+  });
+  it("emits advisory ai fields when a classification is given", () => {
+    const out = renderSubmission(sample, { category: "lead", isSpam: false, reason: "wants a quote" });
+    expect(out).toContain("aiCategory: lead");
+    expect(out).toContain("aiSpam: no");
+    expect(out).toContain("aiReason:");
+    expect(out).toContain("aiModel: apple-fm-system");
+    // status is still the owner's field, untouched
+    expect(out).toContain("status: new");
+  });
+});
+
+describe("formatTriageSummary", () => {
+  it("returns empty string when nothing was classified", () => {
+    const t: TriageTally = { classified: 0, spam: 0, lead: 0, support: 0, question: 0, other: 0 };
+    expect(formatTriageSummary(t)).toBe("");
+  });
+  it("summarizes nonzero buckets", () => {
+    const t: TriageTally = { classified: 3, spam: 1, lead: 2, support: 0, question: 0, other: 0 };
+    expect(formatTriageSummary(t)).toBe("Triaged 3 new: 1 likely spam, 2 leads");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/fetch-submissions.test.ts`
+Expected: FAIL — the symbols are not exported from `fetch-submissions.ts`.
+
+- [ ] **Step 3: Export types and add the new helpers**
+
+In `template/scripts/fetch-submissions.ts`:
+
+a) Export the existing interfaces (add `export` to the existing `SubmissionEntry` and `Submission` declarations):
+
+```ts
+export interface SubmissionEntry {
+  key: string;
+  label?: string;
+  type?: string;
+  value: string;
+}
+
+export interface Submission {
+  id: string;
+  formSlug: string;
+  formTitle?: string;
+  submittedAt: string;
+  status?: "new" | "archived" | "spam";
+  senderName?: string;
+  senderEmail?: string;
+  ip?: string;
+  entries?: SubmissionEntry[];
+}
+```
+
+b) Add the fm imports near the existing `import { readConfig } from "./config.js";`:
+
+```ts
+import { isFmAvailable, classifySubmission, FM_MODEL_ID, type SubmissionClassification } from "./fm.js";
+```
+
+c) Add `buildSubmissionText` and the triage tally + summary (place near the other helpers):
+
+```ts
+export function buildSubmissionText(s: Submission): string {
+  const lines: string[] = [`Form: ${s.formTitle ?? s.formSlug}`];
+  if (s.senderName) lines.push(`From: ${s.senderName}`);
+  if (s.senderEmail) lines.push(`Email: ${s.senderEmail}`);
+  for (const e of s.entries ?? []) {
+    const label = e.label ?? e.key;
+    lines.push(`${label}: ${(e.value ?? "").slice(0, 1000)}`);
+  }
+  return lines.join("\n");
+}
+
+export interface TriageTally {
+  classified: number;
+  spam: number;
+  lead: number;
+  support: number;
+  question: number;
+  other: number;
+}
+
+export function formatTriageSummary(t: TriageTally): string {
+  if (t.classified === 0) return "";
+  const parts: string[] = [];
+  if (t.spam) parts.push(`${t.spam} likely spam`);
+  if (t.lead) parts.push(`${t.lead} lead${t.lead === 1 ? "" : "s"}`);
+  if (t.support) parts.push(`${t.support} support`);
+  if (t.question) parts.push(`${t.question} question${t.question === 1 ? "" : "s"}`);
+  if (t.other) parts.push(`${t.other} other`);
+  return `Triaged ${t.classified} new: ${parts.join(", ")}`;
+}
+```
+
+- [ ] **Step 4: Extend `renderSubmission` and export it**
+
+Replace the existing `renderSubmission` with (adds the optional `classification` param + `aiLines`, and `export`):
+
+```ts
+export function renderSubmission(
+  s: Submission,
+  classification?: SubmissionClassification | null,
+): string {
+  const status = s.status ?? "new";
+  const entries = (s.entries ?? []).map(renderEntry).join("\n");
+  const aiLines = classification
+    ? [
+        `aiCategory: ${escapeYaml(classification.category)}`,
+        `aiSpam: ${classification.isSpam ? "yes" : "no"}`,
+        `aiReason: ${escapeYaml(classification.reason)}`,
+        `aiModel: ${escapeYaml(FM_MODEL_ID)}`,
+      ]
+    : [];
+  return [
+    "---",
+    `id: ${escapeYaml(s.id)}`,
+    `formSlug: ${escapeYaml(s.formSlug)}`,
+    `formTitle: ${escapeYaml(s.formTitle ?? s.formSlug)}`,
+    `submittedAt: ${escapeYaml(s.submittedAt)}`,
+    `status: ${escapeYaml(status)}`,
+    `senderName: ${escapeYaml(s.senderName ?? "")}`,
+    `senderEmail: ${escapeYaml(s.senderEmail ?? "")}`,
+    `ip: ${escapeYaml(s.ip ?? "")}`,
+    ...aiLines,
+    "entries:",
+    entries,
+    "---",
+    "",
+  ].join("\n");
+}
+```
+
+- [ ] **Step 5: Wire classification into `fetchSubmissions` and report the summary**
+
+In `fetchSubmissions`, change the return type and add the triage gate + tally. Specifically:
+
+1. Change the function signature's return type from `Promise<{ added: number; skipped: number }>` to:
+```ts
+export async function fetchSubmissions(): Promise<{ added: number; skipped: number; triage: TriageTally }> {
+```
+
+2. After the `secret` check and before the `for (const url of urls)` loop, add:
+```ts
+  const triageEnabled =
+    readConfig("INBOX_TRIAGE_AI") !== "off" && (await isFmAvailable());
+  const triage: TriageTally = { classified: 0, spam: 0, lead: 0, support: 0, question: 0, other: 0 };
+```
+
+3. Replace the existing add block:
+```ts
+      const path = join(SUBMISSIONS_DIR, `${item.id}.mdoc`);
+      writeFileSync(path, renderSubmission(item));
+      added++;
+```
+with:
+```ts
+      let classification: SubmissionClassification | null = null;
+      if (triageEnabled) {
+        classification = await classifySubmission(buildSubmissionText(item));
+        if (classification) {
+          triage.classified++;
+          if (classification.isSpam) triage.spam++;
+          else triage[classification.category]++;
+        }
+      }
+      const path = join(SUBMISSIONS_DIR, `${item.id}.mdoc`);
+      writeFileSync(path, renderSubmission(item, classification));
+      added++;
+```
+
+4. Change the final `return { added, skipped };` to:
+```ts
+  return { added, skipped, triage };
+```
+
+5. Update `main()` to print the triage summary when present:
+```ts
+async function main(): Promise<void> {
+  const result = await fetchSubmissions();
+  console.log(
+    `fetch-submissions: ${result.added} new, ${result.skipped} already on disk`,
+  );
+  const summary = formatTriageSummary(result.triage);
+  if (summary) console.log(summary);
+}
+```
+
+- [ ] **Step 6: Run tests + full suite**
+
+Run: `npx vitest run tests/fetch-submissions.test.ts`
+Expected: PASS — all new tests green.
+
+Run: `npx vitest run`
+Expected: same 5 pre-existing `sharp`/mcp-server failures as before, everything else green. No NEW failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add template/scripts/fetch-submissions.ts tests/fetch-submissions.test.ts
+git commit -m "feat(template): classify new submissions during ai-inbox-fetch"
+```
+
+---
+
+## Task 5: Keystatic advisory fields
+
+**Files:**
+- Modify: `template/keystatic.config.ts` (the `submissions` collection schema, around lines 631-665)
+
+No new unit test (Keystatic config is declarative). Verification is reading the diff and a no-regression suite run.
+
+- [ ] **Step 1: Add the three advisory fields**
+
+In `template/keystatic.config.ts`, inside the `submissions` collection `schema`, immediately AFTER the `status` field (the `fields.select` with New/Archived/Spam) and BEFORE `senderName`, insert:
+
+```ts
+        aiCategory: fields.select({
+          label: "AI Category",
+          description: "On-device suggestion (advisory). The Status field above is what you triage.",
+          options: [
+            { label: "—", value: "" },
+            { label: "Lead", value: "lead" },
+            { label: "Support", value: "support" },
+            { label: "Question", value: "question" },
+            { label: "Other", value: "other" },
+          ],
+          defaultValue: "",
+        }),
+        aiSpam: fields.select({
+          label: "AI Spam?",
+          description: "On-device suggestion (advisory).",
+          options: [
+            { label: "—", value: "" },
+            { label: "Yes", value: "yes" },
+            { label: "No", value: "no" },
+          ],
+          defaultValue: "",
+        }),
+        aiReason: fields.text({
+          label: "AI Reason",
+          description: "Why the model suggested the above. Advisory — safe to ignore or edit.",
+          multiline: true,
+        }),
+```
+
+- [ ] **Step 2: Verify no regression**
+
+Run: `npx vitest run`
+Expected: no NEW failures vs. the known 5 pre-existing ones.
+
+Manually confirm the inserted block is valid TS and the field keys (`aiCategory`, `aiSpam`, `aiReason`) exactly match the frontmatter keys written by `renderSubmission` in Task 4. Note: `renderSubmission` writes `aiSpam: yes|no` and `aiCategory: <enum>`, which line up with these `select` option values; `aiModel` is written to frontmatter but intentionally has no Keystatic field (internal provenance, not owner-facing).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add template/keystatic.config.ts
+git commit -m "feat(template): advisory AI triage fields on the submissions collection"
+```
+
+---
+
+## Task 6: Documentation
+
+**Files:**
+- Modify: `skills/inbox/SKILL.md`
+- Modify: `template/docs/workflows/inbox.md`
+- Modify: `CLAUDE.md` (root)
+
+READ each file before editing.
+
+- [ ] **Step 1: Update the inbox skill**
+
+In `skills/inbox/SKILL.md`, after "## Step 6 — Sync the inbox" (and before "## Step 7 — Export to CSV"), insert:
+
+```markdown
+## Step 6b — AI triage (when available)
+
+On an Apple-Silicon Mac with Apple Intelligence enabled, `npm run ai-inbox-fetch`
+also classifies each **new** submission **on-device** — nothing is uploaded.
+Each new submission gets three advisory fields: `aiCategory`
+(lead / support / question / other), `aiSpam` (yes / no), and `aiReason` (the
+model's short rationale).
+
+These are **suggestions only**. The owner's `status` field is never changed
+automatically — a misclassified message is never hidden. Surface the suggestion
+and let the owner decide.
+
+After a sync, the script prints a one-line summary like
+`Triaged 3 new: 1 likely spam, 2 leads`. **Relay this to the owner in chat** so
+they get the overview before opening Keystatic — e.g. "3 new submissions: 1
+looks like spam, 2 look like leads. Open the inbox to confirm and triage."
+
+### When `fm` is not available
+
+On any other machine, no AI fields are written and nothing breaks — the owner
+triages `status` manually exactly as before. To disable AI triage even on a
+capable Mac, set `INBOX_TRIAGE_AI=off` in `.site-config`.
+```
+
+- [ ] **Step 2: Update the owner-facing workflow doc**
+
+In `template/docs/workflows/inbox.md`, add a short section (place it after the sync description):
+
+```markdown
+## AI triage (Mac only)
+
+If you're on a Mac with Apple Intelligence turned on, syncing your inbox also
+adds a quick on-device read on each new submission: whether it looks like spam,
+and a rough category (lead, support, question, or other). This happens entirely
+on your Mac — no submissions are uploaded anywhere.
+
+These are suggestions, not decisions. Your webmaster shows you the summary
+("3 new: 1 likely spam, 2 leads") and you stay in control of how each one is
+filed — the AI never marks anything as spam for you. On computers without this
+feature, you just triage as usual.
+
+To turn it off, add `INBOX_TRIAGE_AI=off` to `.site-config`.
+```
+
+- [ ] **Step 3: Update root CLAUDE.md**
+
+In `CLAUDE.md` (root), find the Key-decisions table row added for on-device `fm` (it mentions "alt text first"). Update its "Why" cell to note inbox triage as the second consumer. Change:
+
+```
+| On-device `fm` as optional authoring accelerator | Free/private/offline drafts (alt text first); never in the deployed site, always falls back to Claude (ADR-0021) |
+```
+
+to:
+
+```
+| On-device `fm` as optional authoring accelerator | Free/private/offline drafts — alt text and inbox triage; never in the deployed site, always falls back to Claude (ADR-0021) |
+```
+
+If the exact wording differs, preserve the rest of the cell and just add ", inbox triage" alongside the alt-text mention. Report what you found.
+
+- [ ] **Step 4: Verify no regression**
+
+Run: `npx vitest run`
+Expected: no NEW failures vs. the known 5 pre-existing ones.
+
+Manually confirm the docs reference `INBOX_TRIAGE_AI`, `aiCategory`/`aiSpam`/`aiReason`, and the summary string consistently with `fetch-submissions.ts` and `keystatic.config.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/inbox/SKILL.md template/docs/workflows/inbox.md CLAUDE.md
+git commit -m "docs: document on-device inbox triage + advisory review flow"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `classifySubmission` (fm `--schema`, temp schema file, stdin) → Task 3 (+ Task 1 stdin runner).
+- `parseClassification` (validate enum→other, coerce boolean, null on garbage) → Task 2.
+- `buildSubmissionText` (sender + entries, truncation) → Task 4.
+- `renderSubmission` advisory `aiCategory`/`aiSpam`/`aiReason`/`aiModel`, omitted when absent → Task 4.
+- Gate on `isFmAvailable()` + `INBOX_TRIAGE_AI` once per run; classify only new submissions → Task 4.
+- Triage tally + Claude-relayed summary → Task 4 (`formatTriageSummary`) + Task 6 (skill relays it).
+- Keystatic advisory fields beside `status` → Task 5.
+- Fallback (no fm → no fields, manual triage) → Task 4 gate + Task 6 docs.
+- Privacy (on-device, no new data leaves) → documented in Task 6.
+- Reuse ADR-0021, no new ADR → Task 6 CLAUDE.md row.
+- Testing split (pure helpers + fake-runner shell-out in CI; real fm manual) → Tasks 1-4 + Task 3 Step 5.
+
+No gaps found.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every command shows expected output.
+
+**Type consistency:** `SubmissionClassification` / `SubmissionCategory` defined in Task 2, consumed identically in Tasks 3-4. `classifySubmission(text, run?)`, `parseClassification(raw)`, `buildSubmissionText(s)`, `renderSubmission(s, classification?)`, `formatTriageSummary(t)`, and `TriageTally` are named and signed consistently across tasks and tests. Frontmatter keys (`aiCategory`/`aiSpam` values `yes|no`/`aiReason`) written in Task 4 match the Keystatic field keys/options in Task 5. `CommandRunner` `input?` (Task 1) is the field `classifySubmission` passes (Task 3) and the stdin test asserts (Task 1). `FM_MODEL_ID` (existing export) is imported into `fetch-submissions.ts` in Task 4.
+```

--- a/docs/superpowers/specs/2026-06-10-fm-inbox-triage-design.md
+++ b/docs/superpowers/specs/2026-06-10-fm-inbox-triage-design.md
@@ -1,0 +1,119 @@
+# Design — On-device inbox triage via Apple Foundation Models (`fm`)
+
+**Date:** 2026-06-10
+**Status:** Approved for planning
+**Scope:** Second slice of the "use `fm` where it makes sense" effort. Adds on-device classification (spam likelihood + category) of new form submissions during `npm run ai-inbox-fetch`. Reuses the `fm.ts` module and ADR-0021 pattern established by the alt-text slice.
+
+## Background
+
+`/anglesite:inbox` persists form submissions to Cloudflare D1 (written by the contact/forms Workers). `npm run ai-inbox-fetch` (`template/scripts/fetch-submissions.ts`) pulls **new** submissions onto the owner's machine into `src/content/submissions/*.mdoc`, which Keystatic surfaces as a `Form Submissions` collection. Triage today is the owner manually editing a `status` field (`new` / `archived` / `spam`) in Keystatic. There is no automation.
+
+Key existing behaviors this design relies on:
+
+- `fetch-submissions.ts` **only ever writes new files** — existing submission files are skipped so owner triage edits (`status`, `notes`) are never overwritten. Classification therefore runs exactly once per submission, with no merge/catalog bookkeeping.
+- Submissions carry PII (sender name/email, message bodies) and already live locally, committed to the owner's **private** repo. They are never rendered on the public site, so the pre-deploy PII scan (which walks `dist/`) is unaffected.
+
+Constraints inherited from ADR-0021:
+
+1. **Authoring-time, Mac-only.** `fm` runs the on-device system model on a capable Mac; it cannot run in a Worker. Classification happens locally during sync, never server-side.
+2. **Always optional, always falls back.** Gates on `isFmAvailable()`. Without `fm`, no AI fields are written and the owner triages manually exactly as today.
+
+## Decisions (from brainstorming)
+
+- **Taxonomy:** spam likelihood **and** category (`lead` / `support` / `question` / `other`).
+- **Action model:** **advisory only.** Suggestions are written to separate fields; the owner's `status` is never auto-changed. Auto-marking spam could hide a misclassified real inquiry from the default view — unacceptable. Mirrors ADR-0021 draft→reviewed.
+- **Structure:** **inline at sync time** (Approach A). Classify during `ai-inbox-fetch`; defer any backfill pass as a future enhancement.
+
+## De-risking result (verified against real `fm`)
+
+`fm respond --schema <file>` was tested on real submissions:
+
+- It requires **fm's own schema format** (the shape `fm schema object` emits, including an `x-order` key). A hand-authored generic JSON Schema is rejected (`Invalid schema … missing`).
+- `enum` **is** honored when embedded in that format. The `category` enum constrained outputs correctly.
+- Output is JSON on stdout but **field order varies** between calls, and the model can still emit an unexpected value when unconstrained. Therefore the module must parse as an object (never positionally), validate `category` against the allowed set (fallback `other`), and coerce `isSpam` to a boolean.
+
+Verified outputs: spam ad → `isSpam: true`; pricing inquiry → `{category: question, isSpam: false}`; invoice problem → `{category: support, isSpam: false}`.
+
+## Architecture
+
+```
+ai-inbox-fetch ─► (new submission) ─► fm.ts classifySubmission(text) ─► aiCategory/aiSpam/aiReason/aiModel in frontmatter
+                                          │ (fm --schema, on-device)        │
+                                   isFmAvailable()? no ─► no AI fields       └─► Keystatic (advisory) ─► owner triages `status`
+```
+
+The deployed site has no dependency on `fm` or the AI fields. Classification is authoring-time only. The owner's `status` field remains the single source of triage truth.
+
+### Component 1 — `fm.ts` additions
+
+Extends the existing module (`template/scripts/fm.ts`); reuses `isFmAvailable`, `CommandRunner`, `defaultRunner`, and `FM_MODEL_ID`.
+
+- **Type:**
+  ```ts
+  export type SubmissionCategory = "lead" | "support" | "question" | "other";
+  export interface SubmissionClassification {
+    category: SubmissionCategory;
+    isSpam: boolean;
+    reason: string;
+  }
+  ```
+- **Embedded schema constant** — the fm-format JSON (with `x-order`, `additionalProperties:false`, `required`, and the `category` `enum`). Stored as a module constant and written to a temp file (`os.tmpdir()`) at call time, so there is no scaffolded asset to manage and no bare-path resolution risk (cf. issue #320).
+- **`buildSubmissionText(submission): string`** (pure) — assembles a compact, model-friendly block from `formTitle`, `senderName`, `senderEmail`, and each entry rendered as `label: value`. Truncates very long values to keep the prompt bounded.
+- **`parseClassification(raw: string): SubmissionClassification | null`** (pure) — `JSON.parse` inside try/catch; validate `category` ∈ the four values (else `other`); coerce `isSpam` to boolean; trim `reason` (default `""`); return `null` only when the input is not a usable object.
+- **`classifySubmission(submissionText, run = defaultRunner): Promise<SubmissionClassification | null>`** — writes the schema temp file, runs `fm respond --schema <tmp> --use-case content-tagging -g --no-stream` with `submissionText` on stdin, then `parseClassification`. Returns `null` on non-zero exit, unparseable output, or any throw (caller falls back).
+  - The `CommandRunner` interface gains an optional `input?: string` so the runner can pass stdin; `defaultRunner` writes it to the child's stdin. (Alt-text calls omit `input`, unaffected.)
+
+### Component 2 — sync integration (`fetch-submissions.ts`)
+
+- Once per run: `triageEnabled = isFmAvailable()` AND `readConfig("INBOX_TRIAGE_AI") !== "off"`.
+- For each **new** submission (the existing add path), when `triageEnabled`: `classifySubmission(buildSubmissionText(item))`. On a non-null result, include in the rendered frontmatter:
+  - `aiCategory: lead|support|question|other`
+  - `aiSpam: yes|no`
+  - `aiReason: "<short rationale>"`
+  - `aiModel: apple-fm-system`
+- `renderSubmission` is extended to emit those fields when present (omitted entirely when classification was skipped or failed — old submissions and the fallback path render exactly as today).
+- Tally classified submissions and print a per-run **triage summary** (e.g. `Triaged 3 new: 1 likely spam, 2 leads`). The `fetchSubmissions` return type gains a small triage breakdown so the skill/test can consume it.
+
+### Component 3 — Keystatic schema (`keystatic.config.ts`)
+
+Add three advisory fields to the `submissions` collection, beside `status`:
+
+- `aiCategory` — `fields.select` (`Lead` / `Support` / `Question` / `Other` / `—` unset), default unset.
+- `aiSpam` — `fields.select` (`Yes` / `No` / `—` unset), default unset.
+- `aiReason` — `fields.text` (multiline), described as the model's rationale (advisory; safe to ignore or edit).
+
+These are read-mostly hints. The owner continues to triage via `status`.
+
+### Component 4 — skill + docs
+
+- `skills/inbox/SKILL.md`: a new section documenting advisory triage — what the fields mean, that `status` is never auto-changed, the `INBOX_TRIAGE_AI=off` opt-out, and an instruction for Claude to **relay the sync triage summary in chat** ("3 new: 1 likely spam, 2 leads — open Keystatic to confirm") so the owner gets the overview before opening the CMS.
+- `template/docs/workflows/inbox.md` (owner-facing, if present): a short plain-language note that on a Mac, new submissions get an on-device spam/category hint, nothing is uploaded, and the hints are suggestions the owner confirms.
+- Root `CLAUDE.md`: extend the existing ADR-0021 key-decisions row to mention inbox triage as the second `fm` consumer (no new ADR).
+
+## Fallback contract
+
+| Environment | Behavior |
+|---|---|
+| Mac + Apple Intelligence on, `INBOX_TRIAGE_AI` unset/on | New submissions get `aiCategory`/`aiSpam`/`aiReason`; summary reported. |
+| No `fm`, or `INBOX_TRIAGE_AI=off` | No AI fields written; owner triages `status` manually as today. |
+
+Identical end state — the owner can always triage. `fm` only adds an advisory first pass.
+
+## Testing
+
+- **Unit (no `fm`, CI):** `buildSubmissionText` (sender + entries assembly, truncation); `parseClassification` (valid object; non-enum `category` → `other`; non-boolean `isSpam` coerced; malformed JSON → `null`; missing keys → defaults); `renderSubmission` emits AI fields when present and omits them when absent.
+- **Shell-out (fake runner):** `classifySubmission` — valid JSON → object; non-zero exit → `null`; unparseable → `null`; throw → `null`; confirms stdin `input` is passed.
+- **Integration (manual, Mac):** real `fm` classification — already verified during design (spam / lead / support cases).
+- Mirrors the alt-text split: pure helpers importable without invoking `fm`.
+
+## Out of scope (this slice)
+
+- Backfill pass for submissions synced on a non-Mac (future enhancement, like the alt-text backfill).
+- Auto-acting on `status` (explicitly rejected — advisory only).
+- Server-side / Worker classification (impossible — `fm` is Mac-only).
+- Non-English submissions: the system model is English-centric; non-English messages get a best-effort classification. Noted, not solved.
+- Re-classifying already-synced submissions (existing files are never rewritten).
+
+## Open questions
+
+None blocking. Backfill and language handling are explicitly deferred.

--- a/skills/inbox/SKILL.md
+++ b/skills/inbox/SKILL.md
@@ -134,6 +134,29 @@ Open Keystatic and route them to the **Form Submissions** collection so they can
 
 Triage actions are just edits to the `status` field — no special tooling. Encourage the owner to bulk-process: archive what's resolved, mark spam as spam.
 
+## Step 6b — AI triage (when available)
+
+On an Apple-Silicon Mac with Apple Intelligence enabled, `npm run ai-inbox-fetch`
+also classifies each **new** submission **on-device** — nothing is uploaded.
+Each new submission gets three advisory fields: `aiCategory`
+(lead / support / question / other), `aiSpam` (yes / no), and `aiReason` (the
+model's short rationale).
+
+These are **suggestions only**. The owner's `status` field is never changed
+automatically — a misclassified message is never hidden. Surface the suggestion
+and let the owner decide.
+
+After a sync, the script prints a one-line summary like
+`Triaged 3 new: 1 likely spam, 2 leads`. **Relay this to the owner in chat** so
+they get the overview before opening Keystatic — e.g. "3 new submissions: 1
+looks like spam, 2 look like leads. Open the inbox to confirm and triage."
+
+### When `fm` is not available
+
+On any other machine, no AI fields are written and nothing breaks — the owner
+triages `status` manually exactly as before. To disable AI triage even on a
+capable Mac, set `INBOX_TRIAGE_AI=off` in `.site-config`.
+
 ## Step 7 — Export to CSV (optional)
 
 Lead-capture and survey responses are easier to work with in a spreadsheet. The export script reads the same files Keystatic shows:

--- a/template/docs/workflows/inbox.md
+++ b/template/docs/workflows/inbox.md
@@ -48,6 +48,20 @@ Open Keystatic → **Form Submissions**. Each entry shows the form it came from,
 
 Add private commentary in the **Notes** field — it's never published.
 
+## AI triage (Mac only)
+
+If you're on a Mac with Apple Intelligence turned on, syncing your inbox also
+adds a quick on-device read on each new submission: whether it looks like spam,
+and a rough category (lead, support, question, or other). This happens entirely
+on your Mac — no submissions are uploaded anywhere.
+
+These are suggestions, not decisions. Your webmaster shows you the summary
+("3 new: 1 likely spam, 2 leads") and you stay in control of how each one is
+filed — the AI never marks anything as spam for you. On computers without this
+feature, you just triage as usual.
+
+To turn it off, add `INBOX_TRIAGE_AI=off` to `.site-config`.
+
 ## CSV export
 
 ```sh

--- a/template/keystatic.config.ts
+++ b/template/keystatic.config.ts
@@ -637,6 +637,33 @@ const allCollections: Record<string, ReturnType<typeof collection>> = {
           ],
           defaultValue: "new",
         }),
+        aiCategory: fields.select({
+          label: "AI Category",
+          description: "On-device suggestion (advisory). The Status field above is what you triage.",
+          options: [
+            { label: "—", value: "" },
+            { label: "Lead", value: "lead" },
+            { label: "Support", value: "support" },
+            { label: "Question", value: "question" },
+            { label: "Other", value: "other" },
+          ],
+          defaultValue: "",
+        }),
+        aiSpam: fields.select({
+          label: "AI Spam?",
+          description: "On-device suggestion (advisory).",
+          options: [
+            { label: "—", value: "" },
+            { label: "Yes", value: "yes" },
+            { label: "No", value: "no" },
+          ],
+          defaultValue: "",
+        }),
+        aiReason: fields.text({
+          label: "AI Reason",
+          description: "Why the model suggested the above. Advisory — safe to ignore or edit.",
+          multiline: true,
+        }),
         senderName: fields.text({ label: "Sender Name" }),
         senderEmail: fields.text({ label: "Sender Email" }),
         ip: fields.text({

--- a/template/scripts/fetch-submissions.ts
+++ b/template/scripts/fetch-submissions.ts
@@ -20,15 +20,16 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { readConfig } from "./config.js";
+import { isFmAvailable, classifySubmission, FM_MODEL_ID, type SubmissionClassification } from "./fm.js";
 
-interface SubmissionEntry {
+export interface SubmissionEntry {
   key: string;
   label?: string;
   type?: string;
   value: string;
 }
 
-interface Submission {
+export interface Submission {
   id: string;
   formSlug: string;
   formTitle?: string;
@@ -90,9 +91,20 @@ function renderEntry(entry: SubmissionEntry): string {
   return lines.join("\n");
 }
 
-function renderSubmission(s: Submission): string {
+export function renderSubmission(
+  s: Submission,
+  classification?: SubmissionClassification | null,
+): string {
   const status = s.status ?? "new";
   const entries = (s.entries ?? []).map(renderEntry).join("\n");
+  const aiLines = classification
+    ? [
+        `aiCategory: ${escapeYaml(classification.category)}`,
+        `aiSpam: ${classification.isSpam ? "yes" : "no"}`,
+        `aiReason: ${escapeYaml(classification.reason)}`,
+        `aiModel: ${escapeYaml(FM_MODEL_ID)}`,
+      ]
+    : [];
   return [
     "---",
     `id: ${escapeYaml(s.id)}`,
@@ -103,11 +115,43 @@ function renderSubmission(s: Submission): string {
     `senderName: ${escapeYaml(s.senderName ?? "")}`,
     `senderEmail: ${escapeYaml(s.senderEmail ?? "")}`,
     `ip: ${escapeYaml(s.ip ?? "")}`,
+    ...aiLines,
     "entries:",
     entries,
     "---",
     "",
   ].join("\n");
+}
+
+export function buildSubmissionText(s: Submission): string {
+  const lines: string[] = [`Form: ${s.formTitle ?? s.formSlug}`];
+  if (s.senderName) lines.push(`From: ${s.senderName}`);
+  if (s.senderEmail) lines.push(`Email: ${s.senderEmail}`);
+  for (const e of s.entries ?? []) {
+    const label = e.label ?? e.key;
+    lines.push(`${label}: ${(e.value ?? "").slice(0, 1000)}`);
+  }
+  return lines.join("\n");
+}
+
+export interface TriageTally {
+  classified: number;
+  spam: number;
+  lead: number;
+  support: number;
+  question: number;
+  other: number;
+}
+
+export function formatTriageSummary(t: TriageTally): string {
+  if (t.classified === 0) return "";
+  const parts: string[] = [];
+  if (t.spam) parts.push(`${t.spam} likely spam`);
+  if (t.lead) parts.push(`${t.lead} lead${t.lead === 1 ? "" : "s"}`);
+  if (t.support) parts.push(`${t.support} support`);
+  if (t.question) parts.push(`${t.question} question${t.question === 1 ? "" : "s"}`);
+  if (t.other) parts.push(`${t.other} other`);
+  return `Triaged ${t.classified} new: ${parts.join(", ")}`;
 }
 
 function workerUrls(): string[] {
@@ -119,7 +163,7 @@ function workerUrls(): string[] {
   return [...urls];
 }
 
-export async function fetchSubmissions(): Promise<{ added: number; skipped: number }> {
+export async function fetchSubmissions(): Promise<{ added: number; skipped: number; triage: TriageTally }> {
   const urls = workerUrls();
   if (urls.length === 0) {
     throw new Error(
@@ -132,6 +176,10 @@ export async function fetchSubmissions(): Promise<{ added: number; skipped: numb
       "INBOX_SECRET not set in .env.local. Run /anglesite:inbox to set it up.",
     );
   }
+
+  const triageEnabled =
+    readConfig("INBOX_TRIAGE_AI") !== "off" && (await isFmAvailable());
+  const triage: TriageTally = { classified: 0, spam: 0, lead: 0, support: 0, question: 0, other: 0 };
 
   if (!existsSync(SUBMISSIONS_DIR)) {
     mkdirSync(SUBMISSIONS_DIR, { recursive: true });
@@ -158,13 +206,22 @@ export async function fetchSubmissions(): Promise<{ added: number; skipped: numb
         skipped++;
         continue;
       }
+      let classification: SubmissionClassification | null = null;
+      if (triageEnabled) {
+        classification = await classifySubmission(buildSubmissionText(item));
+        if (classification) {
+          triage.classified++;
+          if (classification.isSpam) triage.spam++;
+          else triage[classification.category]++;
+        }
+      }
       const path = join(SUBMISSIONS_DIR, `${item.id}.mdoc`);
-      writeFileSync(path, renderSubmission(item));
+      writeFileSync(path, renderSubmission(item, classification));
       added++;
     }
   }
 
-  return { added, skipped };
+  return { added, skipped, triage };
 }
 
 async function main(): Promise<void> {
@@ -172,6 +229,8 @@ async function main(): Promise<void> {
   console.log(
     `fetch-submissions: ${result.added} new, ${result.skipped} already on disk`,
   );
+  const summary = formatTriageSummary(result.triage);
+  if (summary) console.log(summary);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/template/scripts/fetch-submissions.ts
+++ b/template/scripts/fetch-submissions.ts
@@ -77,7 +77,14 @@ function listExistingIds(): Set<string> {
 
 function escapeYaml(value: string): string {
   if (value === "") return '""';
-  if (/^[\w\-/.@:+ ]+$/.test(value) && !/^[\d-]/.test(value)) return value;
+  if (
+    /^[\w\-/.@:+ ]+$/.test(value) &&
+    !/^[\d-]/.test(value) &&
+    !/:\s/.test(value) && // colon followed by whitespace is a YAML mapping indicator
+    !/:$/.test(value) // trailing colon
+  ) {
+    return value;
+  }
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`;
 }
 

--- a/template/scripts/fm.ts
+++ b/template/scripts/fm.ts
@@ -10,7 +10,8 @@
 
 import { execFile } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { relative } from "node:path";
+import { relative, join } from "node:path";
+import { tmpdir } from "node:os";
 
 // ---------------------------------------------------------------------------
 // Catalog types
@@ -188,6 +189,58 @@ export async function isFmAvailable(run: CommandRunner = defaultRunner): Promise
 
 /** Identifier recorded in catalog entries for drafts produced by `fm`'s system model. */
 export const FM_MODEL_ID = "apple-fm-system";
+
+// The schema fm expects is NOT generic JSON Schema — it requires fm's own
+// shape (note `x-order`). `enum` IS honored inside that shape. Verified against
+// the real CLI during design. Property descriptions are intentionally terse to
+// stay within the on-device system model's context window.
+const TRIAGE_SCHEMA = {
+  required: ["isSpam", "category", "reason"],
+  "x-order": ["isSpam", "category", "reason"],
+  additionalProperties: false,
+  title: "Triage",
+  type: "object",
+  properties: {
+    isSpam: { type: "boolean" },
+    category: { type: "string", enum: ["lead", "support", "question", "other"] },
+    reason: { type: "string" },
+  },
+};
+
+const TRIAGE_INSTRUCTIONS =
+  "Classify this form submission. A pricing, booking, or service inquiry from a " +
+  "potential new customer is a 'lead'. Help from an existing customer is 'support'.";
+
+/**
+ * Classify a form submission on-device. Writes fm's schema to a temp file,
+ * runs `fm respond --schema` with the submission text on stdin, and parses
+ * the structured JSON. Returns null on any failure (caller falls back).
+ */
+export async function classifySubmission(
+  submissionText: string,
+  run: CommandRunner = defaultRunner,
+): Promise<SubmissionClassification | null> {
+  try {
+    const schemaPath = join(tmpdir(), "anglesite-fm-triage-schema.json");
+    writeFileSync(schemaPath, JSON.stringify(TRIAGE_SCHEMA));
+    const { stdout, exitCode } = await run(
+      "fm",
+      [
+        "respond",
+        "--schema", schemaPath,
+        "--use-case", "content-tagging",
+        "-g",
+        "--no-stream",
+        "-i", TRIAGE_INSTRUCTIONS,
+      ],
+      { timeoutMs: 60_000, input: submissionText },
+    );
+    if (exitCode !== 0) return null;
+    return parseClassification(stdout);
+  } catch {
+    return null;
+  }
+}
 
 const ALT_INSTRUCTIONS =
   "Write concise alt text for this image, suitable for a screen reader. " +

--- a/template/scripts/fm.ts
+++ b/template/scripts/fm.ts
@@ -26,6 +26,20 @@ export interface AltEntry {
 export type AltCatalog = Record<string, AltEntry>;
 
 // ---------------------------------------------------------------------------
+// Inbox triage classification types
+// ---------------------------------------------------------------------------
+
+export type SubmissionCategory = "lead" | "support" | "question" | "other";
+
+export interface SubmissionClassification {
+  category: SubmissionCategory;
+  isSpam: boolean;
+  reason: string;
+}
+
+const SUBMISSION_CATEGORIES: SubmissionCategory[] = ["lead", "support", "question", "other"];
+
+// ---------------------------------------------------------------------------
 // Pure helpers (no I/O, no shell — unit-tested directly)
 // ---------------------------------------------------------------------------
 
@@ -65,6 +79,30 @@ export function shouldRunAltPass(opts: { noAltFlag: boolean; altTextAiConfig?: s
   if (opts.noAltFlag) return false;
   if ((opts.altTextAiConfig ?? "").toLowerCase() === "off") return false;
   return true;
+}
+
+/**
+ * Parse `fm`'s structured-output JSON into a classification. Defensive:
+ * validates the category against the allowed set (else "other"), coerces
+ * isSpam to a boolean, and returns null only when the input is not a usable
+ * JSON object. `fm` field order is not guaranteed, so this never relies on it.
+ */
+export function parseClassification(raw: string): SubmissionClassification | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.replace(ANSI, "").trim());
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const o = parsed as Record<string, unknown>;
+  const category =
+    typeof o.category === "string" && (SUBMISSION_CATEGORIES as string[]).includes(o.category)
+      ? (o.category as SubmissionCategory)
+      : "other";
+  const isSpam = o.isSpam === true || o.isSpam === "true" || o.isSpam === "yes";
+  const reason = typeof o.reason === "string" ? o.reason.trim() : "";
+  return { category, isSpam, reason };
 }
 
 // ---------------------------------------------------------------------------

--- a/template/scripts/fm.ts
+++ b/template/scripts/fm.ts
@@ -229,6 +229,8 @@ export async function classifySubmission(
   run: CommandRunner = defaultRunner,
 ): Promise<SubmissionClassification | null> {
   try {
+    // Fixed temp path is safe because callers classify sequentially (the inbox
+    // sync awaits each call); revisit if classification is ever parallelized.
     const schemaPath = join(tmpdir(), "anglesite-fm-triage-schema.json");
     writeFileSync(schemaPath, JSON.stringify(TRIAGE_SCHEMA));
     const { stdout, exitCode } = await run(

--- a/template/scripts/fm.ts
+++ b/template/scripts/fm.ts
@@ -201,9 +201,17 @@ const TRIAGE_SCHEMA = {
   title: "Triage",
   type: "object",
   properties: {
-    isSpam: { type: "boolean" },
-    category: { type: "string", enum: ["lead", "support", "question", "other"] },
-    reason: { type: "string" },
+    isSpam: {
+      type: "boolean",
+      description: "true if the message is spam, advertising, or abuse",
+    },
+    category: {
+      type: "string",
+      enum: ["lead", "support", "question", "other"],
+      description:
+        "lead=potential new customer; support=existing-customer help; question=general inquiry; other=anything else",
+    },
+    reason: { type: "string", description: "short rationale, max 12 words" },
   },
 };
 

--- a/template/scripts/fm.ts
+++ b/template/scripts/fm.ts
@@ -101,12 +101,12 @@ export interface CommandResult {
 export type CommandRunner = (
   command: string,
   args: string[],
-  opts?: { timeoutMs?: number },
+  opts?: { timeoutMs?: number; input?: string },
 ) => Promise<CommandResult>;
 
 export const defaultRunner: CommandRunner = (command, args, opts = {}) =>
   new Promise((resolve) => {
-    execFile(
+    const child = execFile(
       command,
       args,
       { timeout: opts.timeoutMs ?? 60_000, maxBuffer: 4 * 1024 * 1024 },
@@ -122,6 +122,11 @@ export const defaultRunner: CommandRunner = (command, args, opts = {}) =>
         resolve({ stdout: stdout ?? "", exitCode });
       },
     );
+    if (opts.input != null) {
+      // Guard against EPIPE if the child exits without reading stdin.
+      child.stdin?.on("error", () => {});
+      child.stdin?.end(opts.input);
+    }
   });
 
 // ---------------------------------------------------------------------------

--- a/template/scripts/fm.ts
+++ b/template/scripts/fm.ts
@@ -96,11 +96,12 @@ export function parseClassification(raw: string): SubmissionClassification | nul
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
   const o = parsed as Record<string, unknown>;
-  const category =
-    typeof o.category === "string" && (SUBMISSION_CATEGORIES as string[]).includes(o.category)
-      ? (o.category as SubmissionCategory)
-      : "other";
-  const isSpam = o.isSpam === true || o.isSpam === "true" || o.isSpam === "yes";
+  const categoryRaw = typeof o.category === "string" ? o.category.toLowerCase() : "";
+  const category = (SUBMISSION_CATEGORIES as string[]).includes(categoryRaw)
+    ? (categoryRaw as SubmissionCategory)
+    : "other";
+  const isSpam =
+    o.isSpam === true || (typeof o.isSpam === "string" && /^(true|yes)$/i.test(o.isSpam));
   const reason = typeof o.reason === "string" ? o.reason.trim() : "";
   return { category, isSpam, reason };
 }

--- a/tests/fetch-submissions.test.ts
+++ b/tests/fetch-submissions.test.ts
@@ -48,6 +48,16 @@ describe("renderSubmission", () => {
     expect(out).toContain("aiModel: apple-fm-system");
     expect(out).toContain("status: new");
   });
+  it("quotes an aiReason containing colon-space (valid YAML)", () => {
+    const out = renderSubmission(sample, { category: "question", isSpam: false, reason: "re: pricing question" });
+    expect(out).toContain('aiReason: "re: pricing question"');
+  });
+  it("still emits an ISO timestamp without escaping internal colons", () => {
+    // Timestamps start with a digit so escapeYaml quotes them for YAML safety,
+    // but internal colons (12:00:00Z) must not be double-escaped.
+    const out = renderSubmission(sample);
+    expect(out).toContain('submittedAt: "2026-06-10T12:00:00Z"');
+  });
 });
 
 describe("formatTriageSummary", () => {

--- a/tests/fetch-submissions.test.ts
+++ b/tests/fetch-submissions.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSubmissionText,
+  renderSubmission,
+  formatTriageSummary,
+  type Submission,
+  type TriageTally,
+} from "../template/scripts/fetch-submissions.js";
+
+const sample: Submission = {
+  id: "abc123",
+  formSlug: "contact",
+  formTitle: "Contact Form",
+  submittedAt: "2026-06-10T12:00:00Z",
+  senderName: "Maria",
+  senderEmail: "maria@example.com",
+  entries: [
+    { key: "message", label: "Message", type: "textarea", value: "Do you have availability?" },
+  ],
+};
+
+describe("buildSubmissionText", () => {
+  it("includes form title, sender, and entry label:value", () => {
+    const text = buildSubmissionText(sample);
+    expect(text).toContain("Contact Form");
+    expect(text).toContain("Maria");
+    expect(text).toContain("maria@example.com");
+    expect(text).toContain("Message: Do you have availability?");
+  });
+  it("truncates very long values", () => {
+    const big: Submission = { ...sample, entries: [{ key: "m", value: "x".repeat(5000) }] };
+    const line = buildSubmissionText(big).split("\n").find((l) => l.startsWith("m:"))!;
+    expect(line.length).toBeLessThan(1100);
+  });
+});
+
+describe("renderSubmission", () => {
+  it("omits ai fields when no classification is given", () => {
+    const out = renderSubmission(sample);
+    expect(out).not.toContain("aiCategory");
+    expect(out).toContain("status: new");
+  });
+  it("emits advisory ai fields when a classification is given", () => {
+    const out = renderSubmission(sample, { category: "lead", isSpam: false, reason: "wants a quote" });
+    expect(out).toContain("aiCategory: lead");
+    expect(out).toContain("aiSpam: no");
+    expect(out).toContain("aiReason:");
+    expect(out).toContain("aiModel: apple-fm-system");
+    expect(out).toContain("status: new");
+  });
+});
+
+describe("formatTriageSummary", () => {
+  it("returns empty string when nothing was classified", () => {
+    const t: TriageTally = { classified: 0, spam: 0, lead: 0, support: 0, question: 0, other: 0 };
+    expect(formatTriageSummary(t)).toBe("");
+  });
+  it("summarizes nonzero buckets", () => {
+    const t: TriageTally = { classified: 3, spam: 1, lead: 2, support: 0, question: 0, other: 0 };
+    expect(formatTriageSummary(t)).toBe("Triaged 3 new: 1 likely spam, 2 leads");
+  });
+});

--- a/tests/fm.test.ts
+++ b/tests/fm.test.ts
@@ -7,7 +7,9 @@ import {
   shouldRunAltPass,
   readCatalog,
   writeCatalog,
+  parseClassification,
   type AltCatalog,
+  type SubmissionClassification,
 } from "../template/scripts/fm.js";
 import { isFmAvailable, generateAltText, defaultRunner, type CommandRunner } from "../template/scripts/fm.js";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
@@ -205,5 +207,35 @@ describe("defaultRunner (real execFile)", () => {
     );
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toBe("HELLO");
+  });
+});
+
+describe("parseClassification", () => {
+  it("parses a valid object", () => {
+    const r = parseClassification('{"isSpam": true, "category": "lead", "reason": "wants a quote"}');
+    expect(r).toEqual({ isSpam: true, category: "lead", reason: "wants a quote" });
+  });
+  it("is order-independent", () => {
+    const r = parseClassification('{"reason": "x", "category": "support", "isSpam": false}');
+    expect(r).toEqual({ isSpam: false, category: "support", reason: "x" });
+  });
+  it("falls back to 'other' for an unknown category", () => {
+    expect(parseClassification('{"isSpam": false, "category": "marketing", "reason": "ad"}')!.category).toBe("other");
+  });
+  it("coerces non-boolean isSpam", () => {
+    expect(parseClassification('{"isSpam": "yes", "category": "other", "reason": ""}')!.isSpam).toBe(true);
+    expect(parseClassification('{"isSpam": "no", "category": "other", "reason": ""}')!.isSpam).toBe(false);
+  });
+  it("defaults a missing reason to empty string", () => {
+    expect(parseClassification('{"isSpam": false, "category": "question"}')!.reason).toBe("");
+  });
+  it("strips ANSI and whitespace before parsing", () => {
+    expect(parseClassification('\x1b[32m {"isSpam": false, "category": "lead", "reason": "x"} \x1b[0m')!.category).toBe("lead");
+  });
+  it("returns null for malformed JSON", () => {
+    expect(parseClassification("{ not json")).toBeNull();
+  });
+  it("returns null for a JSON array", () => {
+    expect(parseClassification("[1,2,3]")).toBeNull();
   });
 });

--- a/tests/fm.test.ts
+++ b/tests/fm.test.ts
@@ -8,6 +8,7 @@ import {
   readCatalog,
   writeCatalog,
   parseClassification,
+  classifySubmission,
   type AltCatalog,
   type SubmissionClassification,
 } from "../template/scripts/fm.js";
@@ -246,5 +247,33 @@ describe("parseClassification", () => {
   it("normalizes category casing", () => {
     expect(parseClassification('{"isSpam": false, "category": "Lead", "reason": ""}')!.category).toBe("lead");
     expect(parseClassification('{"isSpam": false, "category": "SUPPORT", "reason": ""}')!.category).toBe("support");
+  });
+});
+
+describe("classifySubmission", () => {
+  it("returns the parsed classification on success and forwards text via stdin", async () => {
+    let seenInput: string | undefined;
+    let seenArgs: string[] = [];
+    const run: CommandRunner = async (_cmd, args, opts) => {
+      seenInput = opts?.input;
+      seenArgs = args;
+      return { stdout: '{"isSpam": false, "category": "lead", "reason": "quote request"}', exitCode: 0 };
+    };
+    const r = await classifySubmission("Form: contact\nMessage: please send a quote", run);
+    expect(r).toEqual({ isSpam: false, category: "lead", reason: "quote request" });
+    expect(seenInput).toContain("please send a quote");
+    expect(seenArgs).toContain("--schema");
+  });
+  it("returns null on non-zero exit", async () => {
+    const run: CommandRunner = async () => ({ stdout: "{}", exitCode: 1 });
+    expect(await classifySubmission("x", run)).toBeNull();
+  });
+  it("returns null on unparseable output", async () => {
+    const run: CommandRunner = async () => ({ stdout: "not json", exitCode: 0 });
+    expect(await classifySubmission("x", run)).toBeNull();
+  });
+  it("returns null when the runner throws", async () => {
+    const run: CommandRunner = async () => { throw new Error("boom"); };
+    expect(await classifySubmission("x", run)).toBeNull();
   });
 });

--- a/tests/fm.test.ts
+++ b/tests/fm.test.ts
@@ -262,7 +262,9 @@ describe("classifySubmission", () => {
     const r = await classifySubmission("Form: contact\nMessage: please send a quote", run);
     expect(r).toEqual({ isSpam: false, category: "lead", reason: "quote request" });
     expect(seenInput).toContain("please send a quote");
-    expect(seenArgs).toContain("--schema");
+    const schemaIdx = seenArgs.indexOf("--schema");
+    expect(schemaIdx).toBeGreaterThan(-1);
+    expect(seenArgs[schemaIdx + 1]).toMatch(/anglesite-fm-triage-schema\.json$/);
   });
   it("returns null on non-zero exit", async () => {
     const run: CommandRunner = async () => ({ stdout: "{}", exitCode: 1 });

--- a/tests/fm.test.ts
+++ b/tests/fm.test.ts
@@ -238,4 +238,13 @@ describe("parseClassification", () => {
   it("returns null for a JSON array", () => {
     expect(parseClassification("[1,2,3]")).toBeNull();
   });
+  it("coerces case-insensitively for isSpam", () => {
+    expect(parseClassification('{"isSpam": "Yes", "category": "other", "reason": ""}')!.isSpam).toBe(true);
+    expect(parseClassification('{"isSpam": "TRUE", "category": "other", "reason": ""}')!.isSpam).toBe(true);
+    expect(parseClassification('{"isSpam": "true", "category": "other", "reason": ""}')!.isSpam).toBe(true);
+  });
+  it("normalizes category casing", () => {
+    expect(parseClassification('{"isSpam": false, "category": "Lead", "reason": ""}')!.category).toBe("lead");
+    expect(parseClassification('{"isSpam": false, "category": "SUPPORT", "reason": ""}')!.category).toBe("support");
+  });
 });

--- a/tests/fm.test.ts
+++ b/tests/fm.test.ts
@@ -196,4 +196,14 @@ describe("defaultRunner (real execFile)", () => {
     expect(r.exitCode).toBe(2);
     expect(r.stdout).toContain("partial");
   });
+
+  it("passes opts.input to the child's stdin", async () => {
+    const r = await defaultRunner(
+      process.execPath,
+      ["-e", "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>process.stdout.write(d.toUpperCase()))"],
+      { input: "hello" },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("HELLO");
+  });
 });


### PR DESCRIPTION
## Summary

Second slice of using Apple's on-device `fm` CLI as an authoring-time accelerator (after #353, alt text). During `npm run ai-inbox-fetch`, each **new** form submission is classified **on-device** — spam likelihood + a lead/support/question/other category — and written as advisory frontmatter the owner reviews.

- New in `template/scripts/fm.ts`: stdin support on the command runner, `parseClassification` (defensive — validates the category enum → `other`, coerces `isSpam`, case-insensitive, null on garbage), and `classifySubmission` using `fm respond --schema` (fm's own schema format with `x-order` + a category `enum`).
- `fetch-submissions.ts` classifies each new submission (gated once on `INBOX_TRIAGE_AI !== "off"` && `isFmAvailable()`), writes `aiCategory`/`aiSpam`/`aiReason`/`aiModel`, and prints a triage summary (`Triaged 3 new: 1 likely spam, 2 leads`) the inbox skill relays in chat.
- **Advisory only:** three read-mostly Keystatic fields sit beside the owner's `status`, which is **never** auto-changed — a misclassified message is never hidden.
- **Privacy:** submissions are PII; classification reads them on-device, nothing is uploaded, nothing reaches the deployed site.
- **Graceful fallback:** no `fm` (non-Mac / AI off) or `INBOX_TRIAGE_AI=off` → no AI fields, manual triage exactly as before. Per-item classify failures (e.g. fm daemon hiccup) just skip that submission's AI fields; the sync continues.
- Reuses ADR-0021's pattern — no new ADR.
- Also hardens `escapeYaml` to quote values containing colon-space (a latent bug that `aiReason` free text would otherwise trigger; also protects existing `senderName`/`value` fields).

Spec: `docs/superpowers/specs/2026-06-10-fm-inbox-triage-design.md` · Plan: `docs/superpowers/plans/2026-06-10-fm-inbox-triage.md`

## Test Plan

- [x] `tests/fm.test.ts` (55 across the module): stdin round-trip via real `execFile`; `parseClassification` (enum fallback, case-insensitive coercion, order-independence, ANSI strip, null on malformed/array); `classifySubmission` via fake runner (success forwards text on stdin + asserts `--schema` path, null on non-zero/unparseable/throw).
- [x] `tests/fetch-submissions.test.ts`: `buildSubmissionText` (+ truncation), `renderSubmission` (omits AI fields when absent / emits advisory fields when present / never touches `status` / quotes colon-space `aiReason` as valid YAML), `formatTriageSummary` (empty + reconciling buckets).
- [x] Full suite: 2571 passing (the 5 `sharp`/mcp failures pre-exist this branch — verified at base).
- [x] **Real `fm` integration** verified on Apple Silicon: spam ad → `isSpam:true`; pricing inquiry → `category:lead, isSpam:false`; invoice problem → `category:support`.
- [x] Keystatic `aiSpam` select values (`yes`/`no`) confirmed to match what `renderSubmission` writes and to parse back as strings under Keystatic's js-yaml (no `yes`→boolean coercion trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)