### PR TITLE
feat(intents): Spotlight semantic index for SiteEntity (#102)

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -10,7 +10,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Register App Intents dependencies before the app surface comes up so backgrounded
         // intent processes (and #101's system MCP entry, later) can resolve immediately.
-        AnglesiteIntents.bootstrap()
+        // `bootstrap()` is async (it awaits the Spotlight handler installation on `SiteStore`);
+        // we kick it off here without waiting — the launcher view's `task` modifier doesn't
+        // block on it, and bootstrap's own defensive `load()` closes any race.
+        Task { await AnglesiteIntents.bootstrap() }
 
         // Extract the bundled npm cache into Application Support so the first site `npm install`
         // is offline-fast. No-op when nothing's bundled or it's already current; logged either way.

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -87,13 +87,15 @@ public actor SiteStore {
 
     /// Loads the persisted site list from disk into memory. Safe to call before `refresh()`
     /// when the UI wants to render quickly without waiting for filesystem validation.
+    /// Skips the change emit on a fresh-install no-file path — there's nothing to propagate,
+    /// and we'd otherwise wake the SpotlightIndexer for a no-op on every cold launch.
     public func load() async throws {
-        if fileManager.fileExists(atPath: persistenceURL.path) {
-            let data = try Data(contentsOf: persistenceURL)
-            sites = try Self.decoder.decode([Site].self, from: data)
-        } else {
+        guard fileManager.fileExists(atPath: persistenceURL.path) else {
             sites = []
+            return
         }
+        let data = try Data(contentsOf: persistenceURL)
+        sites = try Self.decoder.decode([Site].self, from: data)
         await emitChange()
     }
 

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -52,10 +52,17 @@ public actor SiteStore {
         case invalidProject(URL, missing: [String])
     }
 
+    /// Async callback invoked with the new site list after every mutation that changes the
+    /// visible registry (load/refresh/add/remove). Bookmark-only updates are not emitted —
+    /// they don't affect what consumers like `SpotlightIndexer` care about. Single-subscriber
+    /// by design; the indexer is the only known consumer today.
+    public typealias ChangeHandler = @Sendable ([Site]) async -> Void
+
     private let fileManager: FileManager
     private let settings: AppSettings
     private let persistenceURL: URL
     private(set) public var sites: [Site] = []
+    private var changeHandler: ChangeHandler?
 
     /// - Parameters:
     ///   - settings: settings store consulted for `sitesRoot`.
@@ -72,21 +79,28 @@ public actor SiteStore {
         self.persistenceURL = persistenceURL ?? Self.defaultPersistenceURL(fileManager: fileManager)
     }
 
+    /// Install (or replace, or clear with `nil`) the post-mutation change handler. Invoked on
+    /// the actor's executor after `sites` is updated and persisted, with the new list.
+    public func setChangeHandler(_ handler: ChangeHandler?) {
+        changeHandler = handler
+    }
+
     /// Loads the persisted site list from disk into memory. Safe to call before `refresh()`
     /// when the UI wants to render quickly without waiting for filesystem validation.
-    public func load() throws {
-        guard fileManager.fileExists(atPath: persistenceURL.path) else {
+    public func load() async throws {
+        if fileManager.fileExists(atPath: persistenceURL.path) {
+            let data = try Data(contentsOf: persistenceURL)
+            sites = try Self.decoder.decode([Site].self, from: data)
+        } else {
             sites = []
-            return
         }
-        let data = try Data(contentsOf: persistenceURL)
-        sites = try Self.decoder.decode([Site].self, from: data)
+        await emitChange()
     }
 
     /// Scans `settings.sitesRoot` for project directories, validates each, merges with the
     /// existing in-memory list, and persists. Returns the new list.
     @discardableResult
-    public func refresh() throws -> [Site] {
+    public func refresh() async throws -> [Site] {
         let root = settings.sitesRoot
         let discovered: [Site]
         if fileManager.fileExists(atPath: root.path) {
@@ -129,12 +143,13 @@ public actor SiteStore {
         }
         sites = byID.values.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         try persist()
+        await emitChange()
         return sites
     }
 
     /// Adds a site by absolute path. Validates first; throws if the directory isn't an Anglesite project.
     @discardableResult
-    public func add(_ url: URL) throws -> Site {
+    public func add(_ url: URL) async throws -> Site {
         var isDir: ObjCBool = false
         guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
             throw StoreError.notADirectory(url)
@@ -159,13 +174,15 @@ public actor SiteStore {
         sites.append(site)
         sites.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         try persist()
+        await emitChange()
         return site
     }
 
     /// Removes a site from the list. Does not delete files on disk.
-    public func remove(id: String) throws {
+    public func remove(id: String) async throws {
         sites.removeAll { $0.id == id }
         try persist()
+        await emitChange()
     }
 
     /// Look up a site by id. Convenience used by window scenes that receive the id as a
@@ -185,6 +202,13 @@ public actor SiteStore {
         guard let index = sites.firstIndex(where: { $0.id == id }) else { return }
         sites[index].bookmarkData = data
         try persist()
+    }
+
+    // MARK: - Change notification
+
+    private func emitChange() async {
+        guard let handler = changeHandler else { return }
+        await handler(sites)
     }
 
     // MARK: - Persistence

--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -1,32 +1,39 @@
 import AppIntents
 import AnglesiteCore
+import OSLog
+
+private let log = Logger(subsystem: "dev.anglesite.app", category: "spotlight-indexer")
 
 /// Public entry point that registers production dependencies with `AppDependencyManager` and
 /// hooks the Spotlight indexer to `SiteStore.shared`.
 ///
-/// Called once from `AppDelegate.applicationDidFinishLaunching` today. #101 (system MCP)
-/// will reuse this from a non-UI process so a backgrounded intent can resolve `SiteOperationsService`
-/// before any window is opened.
+/// Async so the call site can await handler installation before driving any `SiteStore`
+/// mutations — that way a caller in an async context (e.g. #101's system MCP entry from a
+/// non-UI process) gets the indexer reliably set up before they touch the store.
+///
+/// The kicker `try await SiteStore.shared.load()` inside is belt-and-suspenders for the
+/// SwiftUI case: `AppDelegate.applicationDidFinishLaunching` can only fire-and-forget us in a
+/// `Task`, which races with the launcher view's own `task` modifier. The handler is registered
+/// before the load here, so the load *will* emit even if the launcher already raced ahead and
+/// missed it — emission is idempotent (the indexer dedups by id set).
 public enum AnglesiteIntents {
-    public static func bootstrap() {
+    public static func bootstrap() async {
         AppDependencyManager.shared.add { () -> any SiteOperationsService in
             SiteOperations(factory: LiveCommandFactory())
         }
 
-        // Wire the Spotlight indexer to the shared SiteStore. From now on, every load /
-        // refresh / add / remove fires the handler, which reindexes the semantic index — so
-        // Siri can resolve "back up my portfolio" against current registry state without us
-        // having to call into the indexer at every mutation site.
-        Task {
-            await SiteStore.shared.setChangeHandler { sites in
-                do {
-                    try await SpotlightIndexer.shared.reindex(sites)
-                } catch {
-                    // Index failures are non-fatal — the app still works, the user just doesn't
-                    // get Spotlight discoverability for that snapshot. Logged via os_log; we
-                    // don't surface UI for it.
-                }
+        await SiteStore.shared.setChangeHandler { sites in
+            do {
+                let outcome = try await SpotlightIndexer.shared.reindex(sites)
+                log.info("indexed=\(outcome.indexed, privacy: .public) removed=\(outcome.removed, privacy: .public)")
+            } catch {
+                log.error("reindex failed: \(error.localizedDescription, privacy: .public)")
             }
+        }
+        do {
+            try await SiteStore.shared.load()
+        } catch {
+            log.error("initial load failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -1,7 +1,8 @@
 import AppIntents
 import AnglesiteCore
 
-/// Public entry point that registers production dependencies with `AppDependencyManager`.
+/// Public entry point that registers production dependencies with `AppDependencyManager` and
+/// hooks the Spotlight indexer to `SiteStore.shared`.
 ///
 /// Called once from `AppDelegate.applicationDidFinishLaunching` today. #101 (system MCP)
 /// will reuse this from a non-UI process so a backgrounded intent can resolve `SiteOperationsService`
@@ -10,6 +11,22 @@ public enum AnglesiteIntents {
     public static func bootstrap() {
         AppDependencyManager.shared.add { () -> any SiteOperationsService in
             SiteOperations(factory: LiveCommandFactory())
+        }
+
+        // Wire the Spotlight indexer to the shared SiteStore. From now on, every load /
+        // refresh / add / remove fires the handler, which reindexes the semantic index — so
+        // Siri can resolve "back up my portfolio" against current registry state without us
+        // having to call into the indexer at every mutation site.
+        Task {
+            await SiteStore.shared.setChangeHandler { sites in
+                do {
+                    try await SpotlightIndexer.shared.reindex(sites)
+                } catch {
+                    // Index failures are non-fatal — the app still works, the user just doesn't
+                    // get Spotlight discoverability for that snapshot. Logged via os_log; we
+                    // don't surface UI for it.
+                }
+            }
         }
     }
 }

--- a/Sources/AnglesiteIntents/SiteIntents.swift
+++ b/Sources/AnglesiteIntents/SiteIntents.swift
@@ -134,21 +134,25 @@ public struct AuditSiteIntent: AppIntent {
     }
 }
 
-public struct OpenSiteIntent: AppIntent {
+/// `OpenIntent` (not just `AppIntent`) so Spotlight's semantic-index hits on `SiteEntity` know
+/// which verb to run when the user clicks a result. The `OpenIntent` protocol requires the
+/// entity parameter to be named `target` — that contract is also why Shortcuts can chain
+/// "find a site" → "open that site" by piping the resolved entity straight in.
+public struct OpenSiteIntent: OpenIntent {
     public static var title: LocalizedStringResource = "Open Site"
     public static var description = IntentDescription("Open a site window in Anglesite.")
     public static var openAppWhenRun = true
 
-    @Parameter(title: "Site") public var site: SiteEntity
+    @Parameter(title: "Site") public var target: SiteEntity
 
     public init() {}
 
-    public static var parameterSummary: some ParameterSummary { Summary("Open \(\.$site)") }
+    public static var parameterSummary: some ParameterSummary { Summary("Open \(\.$target)") }
 
     @MainActor
     public func perform() async throws -> some IntentResult & ProvidesDialog {
-        WindowRouter.shared.requestOpen(siteID: site.id)
-        return .result(dialog: "Opening \(site.displayName).")
+        WindowRouter.shared.requestOpen(siteID: target.id)
+        return .result(dialog: "Opening \(target.displayName).")
     }
 }
 

--- a/Sources/AnglesiteIntents/SpotlightIndexer.swift
+++ b/Sources/AnglesiteIntents/SpotlightIndexer.swift
@@ -39,8 +39,12 @@ public actor SpotlightIndexer {
     }
 
     /// Compute the diff against the previously-indexed set, delete anything dropped, then
-    /// upsert the current set. Resets the tracked set even if the backend throws on upsert —
-    /// the caller can retry; we don't want to wedge into "everything looks deleted" state.
+    /// upsert the current set. `lastIndexedIDs` only advances on full success — if
+    /// `backend.index` throws after a successful delete, the tracked set stays at its
+    /// pre-call value, so the next `reindex` replays the (id-set-idempotent) delete and
+    /// retries the upsert. That's the intended retry posture; it costs one extra harmless
+    /// delete on the daemon but avoids drifting into "the indexer thinks it published this
+    /// but the index is missing entries" state.
     @discardableResult
     public func reindex(_ sites: [SiteStore.Site]) async throws -> Outcome {
         let entities = sites.map(SiteEntity.init)

--- a/Sources/AnglesiteIntents/SpotlightIndexer.swift
+++ b/Sources/AnglesiteIntents/SpotlightIndexer.swift
@@ -1,0 +1,74 @@
+import AppIntents
+import CoreSpotlight
+import Foundation
+import AnglesiteCore
+
+/// Conforming `SiteEntity` to `IndexedEntity` is what lets `CSSearchableIndex.indexAppEntities`
+/// accept it and contribute to macOS 27's Spotlight semantic index. The default `attributeSet`
+/// synthesized from the entity's `displayRepresentation` (title + subtitle) is sufficient for v0
+/// — override only if Spotlight result formatting needs more (kind, contentURL, thumbnail).
+extension SiteEntity: IndexedEntity {}
+
+/// Pluggable seam over `CSSearchableIndex` so `SpotlightIndexerTests` can verify the diff/upsert
+/// sequencing without hitting the live system index daemon.
+public protocol SpotlightIndexBackend: Sendable {
+    func index(_ entities: [SiteEntity]) async throws
+    func deleteEntities(identifiers: [String]) async throws
+}
+
+/// Maintains the Spotlight semantic index for `SiteEntity`. Single-entry point: `reindex(_:)`.
+///
+/// `reindex` is diff-based — it tracks the id set published on the last call and deletes any
+/// id absent from the new snapshot before upserting the current set. This mirrors the
+/// "fold a stream of `SiteStore` mutations into the index" use case driven by
+/// `SiteStore.setChangeHandler` (see `AnglesiteIntents.bootstrap`).
+public actor SpotlightIndexer {
+    public static let shared = SpotlightIndexer(backend: LiveSpotlightBackend())
+
+    private let backend: any SpotlightIndexBackend
+    private var lastIndexedIDs: Set<String> = []
+
+    public init(backend: any SpotlightIndexBackend) {
+        self.backend = backend
+    }
+
+    /// Result returned to callers (today: tests only) so they can assert the diff outcome.
+    public struct Outcome: Sendable, Equatable {
+        public let indexed: Int
+        public let removed: Int
+    }
+
+    /// Compute the diff against the previously-indexed set, delete anything dropped, then
+    /// upsert the current set. Resets the tracked set even if the backend throws on upsert —
+    /// the caller can retry; we don't want to wedge into "everything looks deleted" state.
+    @discardableResult
+    public func reindex(_ sites: [SiteStore.Site]) async throws -> Outcome {
+        let entities = sites.map(SiteEntity.init)
+        let currentIDs = Set(entities.map(\.id))
+        let removedIDs = lastIndexedIDs.subtracting(currentIDs)
+
+        if !removedIDs.isEmpty {
+            try await backend.deleteEntities(identifiers: Array(removedIDs))
+        }
+        if !entities.isEmpty {
+            try await backend.index(entities)
+        }
+        lastIndexedIDs = currentIDs
+        return Outcome(indexed: entities.count, removed: removedIDs.count)
+    }
+}
+
+/// Production backend. Routes to `CSSearchableIndex.default()`, the system-wide index used by
+/// Spotlight and Siri. macOS 27 routes `IndexedEntity` writes through the semantic index.
+struct LiveSpotlightBackend: SpotlightIndexBackend {
+    func index(_ entities: [SiteEntity]) async throws {
+        try await CSSearchableIndex.default().indexAppEntities(entities)
+    }
+
+    func deleteEntities(identifiers: [String]) async throws {
+        try await CSSearchableIndex.default().deleteAppEntities(
+            identifiedBy: identifiers,
+            ofType: SiteEntity.self
+        )
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -207,7 +207,7 @@ final class SiteStoreTests {
         _ = try makeValidSite(named: "alpha")
         let store = SiteStore(settings: settings, persistenceURL: persistenceURL)
         try await store.refresh()
-        let id = await store.sites.first!.id
+        let id = try #require(await store.sites.first).id
 
         let recorder = ChangeRecorder()
         await store.setChangeHandler { sites in await recorder.record(sites) }
@@ -260,9 +260,24 @@ final class SiteStoreTests {
         let dir = try makeValidSite(named: "alpha")
         _ = try await store.add(dir)
         await store.setChangeHandler(nil)
-        try await store.remove(id: await store.sites.first!.id)
+        let id = try #require(await store.sites.first).id
+        try await store.remove(id: id)
 
         let count = await recorder.count
         #expect(count == 1, "the post-clear remove must not emit")
+    }
+
+    @Test("Change handler does not fire on no-file load")
+    func changeHandlerDoesNotFireOnNoFileLoad() async throws {
+        // Fresh install: no sites.json. The handler should not be woken for a snapshot
+        // that didn't change — the indexer would just no-op against its own prior state.
+        let store = SiteStore(settings: settings, persistenceURL: persistenceURL)
+        let recorder = ChangeRecorder()
+        await store.setChangeHandler { sites in await recorder.record(sites) }
+
+        try await store.load()
+
+        let count = await recorder.count
+        #expect(count == 0)
     }
 }

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -163,4 +163,106 @@ final class SiteStoreTests {
         #expect(remaining.isEmpty)
         #expect(fileManager.fileExists(atPath: dir.path), "files on disk must be untouched")
     }
+
+    // MARK: - Change handler (#102)
+
+    /// Captures change-handler emissions so each test can assert on the post-mutation snapshot.
+    actor ChangeRecorder {
+        private(set) var snapshots: [[SiteStore.Site]] = []
+        func record(_ sites: [SiteStore.Site]) { snapshots.append(sites) }
+        var count: Int { snapshots.count }
+        var last: [SiteStore.Site]? { snapshots.last }
+    }
+
+    @Test("Change handler fires on refresh")
+    func changeHandlerFiresOnRefresh() async throws {
+        _ = try makeValidSite(named: "alpha")
+        let store = SiteStore(settings: settings, persistenceURL: persistenceURL)
+        let recorder = ChangeRecorder()
+        await store.setChangeHandler { sites in await recorder.record(sites) }
+
+        try await store.refresh()
+
+        let count = await recorder.count
+        let last = await recorder.last
+        #expect(count == 1)
+        #expect(last?.map(\.name) == ["alpha"])
+    }
+
+    @Test("Change handler fires on add")
+    func changeHandlerFiresOnAdd() async throws {
+        let store = SiteStore(settings: settings, persistenceURL: persistenceURL)
+        let recorder = ChangeRecorder()
+        await store.setChangeHandler { sites in await recorder.record(sites) }
+
+        let dir = try makeValidSite(named: "alpha")
+        _ = try await store.add(dir)
+
+        let last = await recorder.last
+        #expect(last?.map(\.name) == ["alpha"])
+    }
+
+    @Test("Change handler fires on remove")
+    func changeHandlerFiresOnRemove() async throws {
+        _ = try makeValidSite(named: "alpha")
+        let store = SiteStore(settings: settings, persistenceURL: persistenceURL)
+        try await store.refresh()
+        let id = await store.sites.first!.id
+
+        let recorder = ChangeRecorder()
+        await store.setChangeHandler { sites in await recorder.record(sites) }
+
+        try await store.remove(id: id)
+
+        let last = await recorder.last
+        #expect(last?.isEmpty == true)
+    }
+
+    @Test("Change handler fires on load")
+    func changeHandlerFiresOnLoad() async throws {
+        _ = try makeValidSite(named: "alpha")
+        // Seed sites.json by refreshing through a separate store.
+        let writer = SiteStore(settings: settings, persistenceURL: persistenceURL)
+        try await writer.refresh()
+
+        let reader = SiteStore(settings: settings, persistenceURL: persistenceURL)
+        let recorder = ChangeRecorder()
+        await reader.setChangeHandler { sites in await recorder.record(sites) }
+
+        try await reader.load()
+
+        let last = await recorder.last
+        #expect(last?.map(\.name) == ["alpha"])
+    }
+
+    @Test("Change handler does not fire on setBookmark")
+    func changeHandlerDoesNotFireOnSetBookmark() async throws {
+        let dir = try makeValidSite(named: "alpha")
+        let store = SiteStore(settings: settings, persistenceURL: persistenceURL)
+        let site = try await store.add(dir)
+
+        let recorder = ChangeRecorder()
+        await store.setChangeHandler { sites in await recorder.record(sites) }
+        // Bookmark-only updates don't change the visible entity surface, so they don't emit —
+        // avoids re-indexing Spotlight on every panel grant.
+        try await store.setBookmark(Data([0x01, 0x02]), for: site.id)
+
+        let count = await recorder.count
+        #expect(count == 0)
+    }
+
+    @Test("Change handler can be cleared")
+    func changeHandlerCanBeCleared() async throws {
+        let store = SiteStore(settings: settings, persistenceURL: persistenceURL)
+        let recorder = ChangeRecorder()
+        await store.setChangeHandler { sites in await recorder.record(sites) }
+
+        let dir = try makeValidSite(named: "alpha")
+        _ = try await store.add(dir)
+        await store.setChangeHandler(nil)
+        try await store.remove(id: await store.sites.first!.id)
+
+        let count = await recorder.count
+        #expect(count == 1, "the post-clear remove must not emit")
+    }
 }

--- a/Tests/AnglesiteIntentsTests/OpenSiteIntentTests.swift
+++ b/Tests/AnglesiteIntentsTests/OpenSiteIntentTests.swift
@@ -14,7 +14,7 @@ extension AppIntentsTests {
             WindowRouter.shared.requested = nil   // reset between runs
             let site = TestStore.site(id: "s1", name: "Portfolio")
             var intent = OpenSiteIntent()
-            intent.site = SiteEntity(site)
+            intent.target = SiteEntity(site)
             _ = try await intent.perform()
             #expect(WindowRouter.shared.requested == "s1")
         }

--- a/Tests/AnglesiteIntentsTests/SpotlightIndexerTests.swift
+++ b/Tests/AnglesiteIntentsTests/SpotlightIndexerTests.swift
@@ -1,0 +1,94 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+extension AppIntentsTests {
+    /// Verifies the diff/upsert behavior of `SpotlightIndexer` against a recording fake backend.
+    /// The live `CSSearchableIndex` path isn't exercised here — it talks to the system index
+    /// daemon, which has no usable test seam.
+    @Suite("SpotlightIndexer")
+    struct SpotlightIndexerTests {
+        actor RecordingBackend: SpotlightIndexBackend {
+            private(set) var indexedBatches: [[SiteEntity]] = []
+            private(set) var deletedBatches: [[String]] = []
+
+            func index(_ entities: [SiteEntity]) async throws {
+                indexedBatches.append(entities)
+            }
+            func deleteEntities(identifiers: [String]) async throws {
+                deletedBatches.append(identifiers)
+            }
+        }
+
+        private func site(_ id: String, _ name: String) -> SiteStore.Site {
+            SiteStore.Site(
+                id: id,
+                name: name,
+                path: URL(fileURLWithPath: "/tmp/\(name)", isDirectory: true),
+                isValid: true,
+                missingSentinels: []
+            )
+        }
+
+        @Test("first reindex publishes every site, deletes nothing")
+        func firstReindexPublishesAllWithoutDeletes() async throws {
+            let backend = RecordingBackend()
+            let indexer = SpotlightIndexer(backend: backend)
+            let outcome = try await indexer.reindex([site("s1", "Portfolio"), site("s2", "Blog")])
+
+            #expect(outcome == .init(indexed: 2, removed: 0))
+            let indexed = await backend.indexedBatches
+            let deleted = await backend.deletedBatches
+            #expect(indexed.count == 1)
+            #expect(Set(indexed[0].map(\.id)) == Set(["s1", "s2"]))
+            #expect(deleted.isEmpty)
+        }
+
+        @Test("subsequent reindex deletes ids dropped from the snapshot")
+        func subsequentReindexDeletesDroppedIDs() async throws {
+            let backend = RecordingBackend()
+            let indexer = SpotlightIndexer(backend: backend)
+            _ = try await indexer.reindex([site("s1", "Portfolio"), site("s2", "Blog")])
+            let outcome = try await indexer.reindex([site("s1", "Portfolio")])
+
+            #expect(outcome == .init(indexed: 1, removed: 1))
+            let deleted = await backend.deletedBatches
+            #expect(deleted.count == 1)
+            #expect(deleted[0] == ["s2"])
+        }
+
+        @Test("reindex with empty snapshot deletes everything previously published")
+        func reindexEmptyDeletesAll() async throws {
+            let backend = RecordingBackend()
+            let indexer = SpotlightIndexer(backend: backend)
+            _ = try await indexer.reindex([site("s1", "Portfolio"), site("s2", "Blog")])
+            let outcome = try await indexer.reindex([])
+
+            #expect(outcome == .init(indexed: 0, removed: 2))
+            let deleted = await backend.deletedBatches
+            #expect(deleted.count == 1)
+            #expect(Set(deleted[0]) == Set(["s1", "s2"]))
+            // No index call for empty snapshot — avoids needless daemon traffic.
+            let indexed = await backend.indexedBatches
+            #expect(indexed.count == 1, "only the first non-empty reindex calls index()")
+        }
+
+        @Test("identical snapshot upserts again and deletes nothing")
+        func identicalSnapshotUpsertsAgain() async throws {
+            let backend = RecordingBackend()
+            let indexer = SpotlightIndexer(backend: backend)
+            _ = try await indexer.reindex([site("s1", "Portfolio")])
+            let outcome = try await indexer.reindex([site("s1", "Portfolio")])
+
+            // We don't dedupe-on-equality — the backend takes both upserts. Spotlight is
+            // idempotent on (id, type), so cost is one daemon RPC. Cheaper than diffing
+            // attribute sets here.
+            #expect(outcome == .init(indexed: 1, removed: 0))
+            let indexed = await backend.indexedBatches
+            #expect(indexed.count == 2)
+            let deleted = await backend.deletedBatches
+            #expect(deleted.isEmpty)
+        }
+    }
+}

--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -142,7 +142,7 @@ These issues target macOS 27 APIs available with Xcode 27 / Swift 6.4:
 
 - 🔲 **Native chat on Foundation Models** (#105) — replace Claude CLI subprocess with the on-device `LanguageModel` protocol for the MAS build.
 - 🔲 **System-wide MCP** (#101) — expose Anglesite actions to system AI via macOS 27's system-wide MCP.
-- 🔲 **Spotlight semantic index** (#102) — contribute sites/pages via App Intents entity schemas.
+- ✅ **Spotlight semantic index** (#102) — `SiteEntity: IndexedEntity` + `SpotlightIndexer` actor (diff-based, fake-backend testable); `OpenSiteIntent` upgraded to `OpenIntent` so Spotlight result clicks route through `WindowRouter`; `SiteStore` change-handler installed in `AnglesiteIntents.bootstrap` keeps the index in sync with launcher add/remove without coupling Core → Intents. Site-level only for v0; per-page/post indexing deferred until usage shows whether the index churn is worth it.
 - 🔲 **View Annotations for Siri** (#103) — onscreen awareness on the preview pane.
 - 🔲 **App Intents Testing** (#104) — adopt the framework for intent coverage.
 - 🔲 **SwiftUI toolbar APIs** (#107) — adopt macOS 27 native toolbar for the site window action bar.


### PR DESCRIPTION
## Summary

- Conforms `SiteEntity` to `IndexedEntity` and adds `SpotlightIndexer` so registered sites appear in the macOS 27 Spotlight semantic index.
- `OpenSiteIntent` is upgraded to `OpenIntent` (`site` → `target`) so clicking a Spotlight result routes through `WindowRouter` and opens the right `SiteWindow`.
- `SiteStore` gains a single `@Sendable` change-handler (`load`/`refresh`/`add`/`remove` — not `setBookmark`); `AnglesiteIntents.bootstrap` installs the indexer as its handler.

Closes #102. Closes #89 (the `SiteEntity` + `EntityStringQuery` work shipped in #122 — issue was just stale).

## Design notes

- **Core has no dependency on AnglesiteIntents.** The change-handler closure is a `@Sendable` callback on the actor; the live wiring is installed once from the AppIntents bootstrap. Tests can install per-store recorders without touching globals.
- **Indexer is diff-based** so dropping a site from the launcher also removes it from Spotlight without a separate \`remove\` callback path. The previously-indexed id set is tracked on the actor; \`reindex(snapshot)\` deletes the diff before upserting the new entities.
- **Backend is protocol-injected** (\`SpotlightIndexBackend\`). The live backend routes to \`CSSearchableIndex.default()\`; tests use a recording fake — no system index daemon traffic, no cleanup.
- **\`OpenIntent\` is what makes Spotlight result clicks work.** Without it, hits on \`SiteEntity\` would just open the app generically. The rename \`site\` → \`target\` is required by the \`OpenIntent\` contract.
- **Page/post-level indexing deferred.** Site-level only for v0 per the issue's "decide based on index size/refresh cost" guidance — landing now, decision recorded; we'll revisit once we have data on launcher churn.

## Test plan

- [x] \`swift test --filter \"SiteStoreTests|SpotlightIndexer|OpenSiteIntent|AppIntents|SiteEntityQuery\"\` — 39 tests pass (15 SiteStore including 5 new change-handler tests + 24 App Intents including 4 new SpotlightIndexer tests).
- [x] \`xcodebuild -scheme Anglesite -configuration Debug build\` — clean.
- [x] \`xcodebuild -scheme AnglesiteMAS -configuration Debug build\` — clean.
- [ ] Manual: run the app, register a site, search for it in Spotlight, click the result — verify the corresponding \`SiteWindow\` opens. (Not yet exercised; the indexer is wired through the same code path as the unit tests, but the daemon roundtrip needs a notarized-or-ad-hoc-signed run.)

## Unrelated pre-existing failures observed

- \`AppliesEditEndToEndTests\` (\`Caught error: .reconnecting\`) and \`MCPClientHTTPEndToEndTests\` (\`Caught error: .sessionLost\`) both fail locally — they spawn the sibling plugin server and are unrelated to this change. Not regressed by this PR (it doesn't touch the edit pipeline or MCP transport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)