### PR TITLE
feat: on-device alt text for imported images (ai-alt pass)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ Two levels of agent instructions exist — do not confuse them:
 | Industry tools first | Recommend purpose-built solutions (Square, Shopify, Clio, etc.) over generic databases |
 | Edge A/B testing (not client-side) | Build-time variants + Worker-entry edge assignment = zero flicker, static-site compatible |
 | Pagefind (not Algolia/Orama) | Build-time index, ~6 KB JS, no external service, first-class Astro integration |
-| On-device `fm` as optional authoring accelerator | Free/private/offline drafts — alt text and inbox triage; never in the deployed site, always falls back to Claude (ADR-0021) |
+| On-device `fm` as optional authoring accelerator | Free/private/offline drafts — alt text (incl. imported images via `ai-alt`) and inbox triage; never in the deployed site, always falls back to Claude (ADR-0021) |
 
 Full ADRs are in `docs/decisions/` (ADR-0001 through ADR-0021).
 

--- a/docs/superpowers/plans/2026-06-11-fm-import-alt.md
+++ b/docs/superpowers/plans/2026-06-11-fm-import-alt.md
@@ -1,0 +1,541 @@
+# On-device Alt Text for Imported Images (`ai-alt` pass) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a standalone `npm run ai-alt` pass that drafts on-device alt text for any image (including `.webp`) into `image-alt.json`, and wire `/anglesite:import` + `/anglesite:convert` to use it so imported images that lack alt get drafts — reusing slice 1's `fm.ts` + catalog.
+
+**Architecture:** Extract slice 1's per-image alt block into a shared `draftAltForImage` helper in `fm.ts`; `optimize-images.ts` calls it (behavior-preserving DRY refactor); a new `draft-alt.ts` script walks `public/images/` including `.webp` and drafts via the same helper. Import/convert run `ai-alt` after downloading images and read drafts from the catalog when source alt is missing. Authoring-time only; falls back to today's behavior when `fm` is absent. Reuses ADR-0021 — no new ADR.
+
+**Tech Stack:** TypeScript (strict, ESM), Node `node:fs`/`node:path`, Vitest 3, the existing `template/scripts/fm.ts` (`generateAltText`, catalog helpers, `isFmAvailable`, `shouldRunAltPass`, `FM_MODEL_ID`) and `template/scripts/config.ts` (`readConfig`).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-fm-import-alt-design.md`
+
+---
+
+## File Structure
+
+- **Modify:** `template/scripts/fm.ts` — add `draftAltForImage` (extract the per-image alt block, in one place for both callers).
+- **Modify:** `tests/fm.test.ts` — tests for `draftAltForImage`.
+- **Modify:** `template/scripts/optimize-images.ts` — call `draftAltForImage`; trim now-unused imports.
+- **Create:** `template/scripts/draft-alt.ts` — `getAltCandidateFiles` + `isAltCandidate` + `main()` for `npm run ai-alt`.
+- **Create:** `tests/draft-alt.test.ts` — tests for `getAltCandidateFiles`/`isAltCandidate`.
+- **Modify:** `template/package.json` — add the `ai-alt` script.
+- **Modify:** `skills/import/SKILL.md`, `skills/convert/SKILL.md`, `skills/optimize-images/SKILL.md`, `template/docs/workflows/optimize-images.md`, `CLAUDE.md` (root) — documentation.
+
+---
+
+## Task 1: `draftAltForImage` shared helper
+
+**Files:**
+- Modify: `template/scripts/fm.ts`
+- Test: `tests/fm.test.ts`
+
+`fm.ts` already exports `generateAltText`, `catalogKeyFor`, `needsAltDraft`, `mergeAltEntry`, `FM_MODEL_ID`, `type AltCatalog`, `type CommandRunner`. This helper composes them. READ the end of `fm.ts` first to confirm those names.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/fm.test.ts`, add `draftAltForImage` and `type AltCatalog` (if not already) to the top import from `../template/scripts/fm.js`. Append:
+
+```ts
+describe("draftAltForImage", () => {
+  it("drafts and merges a draft entry for a missing key", async () => {
+    const catalog: AltCatalog = {};
+    const run: CommandRunner = async () => ({ stdout: "A red barn", exitCode: 0 });
+    const alt = await draftAltForImage(catalog, "/site/public", "/site/public/images/x.webp", run);
+    expect(alt).toBe("A red barn");
+    expect(catalog["/images/x.webp"]).toMatchObject({
+      alt: "A red barn",
+      model: "apple-fm-system",
+      status: "draft",
+    });
+    expect(catalog["/images/x.webp"].generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+  it("returns null and does not overwrite a reviewed entry", async () => {
+    const catalog: AltCatalog = {
+      "/images/x.webp": { alt: "kept", model: "m", generatedAt: "2026-01-01", status: "reviewed" },
+    };
+    const run: CommandRunner = async () => ({ stdout: "new", exitCode: 0 });
+    const alt = await draftAltForImage(catalog, "/site/public", "/site/public/images/x.webp", run);
+    expect(alt).toBeNull();
+    expect(catalog["/images/x.webp"].alt).toBe("kept");
+  });
+  it("re-drafts when the existing entry is a draft", async () => {
+    const catalog: AltCatalog = {
+      "/images/x.webp": { alt: "old", model: "m", generatedAt: "2026-01-01", status: "draft" },
+    };
+    const run: CommandRunner = async () => ({ stdout: "fresh", exitCode: 0 });
+    const alt = await draftAltForImage(catalog, "/site/public", "/site/public/images/x.webp", run);
+    expect(alt).toBe("fresh");
+    expect(catalog["/images/x.webp"].alt).toBe("fresh");
+  });
+  it("returns null when generateAltText yields nothing (non-zero exit)", async () => {
+    const catalog: AltCatalog = {};
+    const run: CommandRunner = async () => ({ stdout: "", exitCode: 1 });
+    const alt = await draftAltForImage(catalog, "/site/public", "/site/public/images/x.webp", run);
+    expect(alt).toBeNull();
+    expect(catalog["/images/x.webp"]).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/fm.test.ts -t "draftAltForImage"`
+Expected: FAIL — `draftAltForImage` is not exported.
+
+- [ ] **Step 3: Implement the helper**
+
+In `template/scripts/fm.ts`, append after `generateAltText` (at the end of the file):
+
+```ts
+/**
+ * Draft alt text for one image and merge it into the catalog as a `draft`,
+ * unless the image already has a usable entry (draft or reviewed-protected).
+ * Shared by `ai-optimize` (source images) and `ai-alt` (all images incl. webp).
+ * Returns the drafted alt, or null if skipped or generation failed.
+ */
+export async function draftAltForImage(
+  catalog: AltCatalog,
+  publicDir: string,
+  absImagePath: string,
+  run?: CommandRunner,
+): Promise<string | null> {
+  const key = catalogKeyFor(publicDir, absImagePath);
+  if (!needsAltDraft(catalog, key)) return null;
+  const alt = await generateAltText(absImagePath, run);
+  if (!alt) return null;
+  mergeAltEntry(catalog, key, {
+    alt,
+    model: FM_MODEL_ID,
+    generatedAt: new Date().toISOString().slice(0, 10),
+    status: "draft",
+  });
+  return alt;
+}
+```
+
+Note: passing `run` through to `generateAltText(absImagePath, run)` works even when `run` is `undefined` — `generateAltText`'s default parameter (`defaultRunner`) applies. `new Date()` is fine here (normal template script).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/fm.test.ts`
+Expected: PASS — all prior `fm.test.ts` tests plus the 4 new `draftAltForImage` cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add template/scripts/fm.ts tests/fm.test.ts
+git commit -m "feat(template): draftAltForImage shared alt-drafting helper"
+```
+
+---
+
+## Task 2: refactor `optimize-images.ts` to use the helper
+
+**Files:**
+- Modify: `template/scripts/optimize-images.ts`
+
+Behavior-preserving DRY refactor. No new unit test (the helper is tested in Task 1; `optimize-images`'s own tests cover the pure helpers and stay green). READ the file's current fm import block (around line 13) and the alt block in `main()` first.
+
+- [ ] **Step 1: Trim the fm import to what's still used**
+
+Replace the existing `import { ... } from "./fm.js";` block (currently importing `isFmAvailable`, `generateAltText`, `catalogKeyFor`, `readCatalog`, `writeCatalog`, `needsAltDraft`, `mergeAltEntry`, `shouldRunAltPass`, `FM_MODEL_ID`, `type AltCatalog`) with:
+
+```ts
+import {
+  isFmAvailable,
+  readCatalog,
+  writeCatalog,
+  shouldRunAltPass,
+  draftAltForImage,
+  type AltCatalog,
+} from "./fm.js";
+```
+
+(Removed `generateAltText`, `catalogKeyFor`, `needsAltDraft`, `mergeAltEntry`, `FM_MODEL_ID` — they're now only used inside `draftAltForImage`.)
+
+- [ ] **Step 2: Replace the inline alt block in the loop**
+
+In `main()`, find the per-image alt block inside the `for (const file of files)` loop. It currently reads:
+
+```ts
+    // Draft alt sequentially: `fm` drives a single on-device model, so
+    // concurrent calls would contend on the same hardware, not speed up.
+    if (fmReady) {
+      const primaryAbs = join(dirname(file), result.primary);
+      const key = catalogKeyFor(publicDir, primaryAbs);
+      if (needsAltDraft(catalog, key)) {
+        const alt = await generateAltText(primaryAbs);
+        if (alt) {
+          mergeAltEntry(catalog, key, {
+            alt,
+            model: FM_MODEL_ID,
+            generatedAt: new Date().toISOString().slice(0, 10),
+            status: "draft",
+          });
+          altDrafted++;
+          console.log(`    alt draft: ${alt}`);
+        }
+      }
+    }
+```
+
+Replace it with:
+
+```ts
+    // Draft alt sequentially: `fm` drives a single on-device model, so
+    // concurrent calls would contend on the same hardware, not speed up.
+    if (fmReady) {
+      const primaryAbs = join(dirname(file), result.primary);
+      const alt = await draftAltForImage(catalog, publicDir, primaryAbs);
+      if (alt) {
+        altDrafted++;
+        console.log(`    alt draft: ${alt}`);
+      }
+    }
+```
+
+If the existing block differs slightly, preserve the real structure and make the equivalent substitution (replace the `catalogKeyFor`/`needsAltDraft`/`generateAltText`/`mergeAltEntry` sequence with the single `draftAltForImage` call, keeping the `altDrafted++` and log).
+
+- [ ] **Step 3: Verify no behavior change and types check**
+
+Run: `npx vitest run`
+Expected: same 5 pre-existing `sharp`/mcp failures as baseline; `tests/optimize-images.test.ts` and `tests/fm.test.ts` green. No NEW failures.
+
+Run: `npx tsc --noEmit -p template/tsconfig.json` (best-effort — if `template/node_modules` is absent and tsc can't run, note it and rely on vitest). Expected: no NEW errors in `optimize-images.ts` (no unused-import errors from the trimmed list).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add template/scripts/optimize-images.ts
+git commit -m "refactor(template): optimize-images uses draftAltForImage helper"
+```
+
+---
+
+## Task 3: standalone `draft-alt.ts` + `ai-alt` script
+
+**Files:**
+- Create: `template/scripts/draft-alt.ts`
+- Test: `tests/draft-alt.test.ts`
+- Modify: `template/package.json`
+
+- [ ] **Step 1: Write the failing tests for the file walk**
+
+Create `tests/draft-alt.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { isAltCandidate, getAltCandidateFiles } from "../template/scripts/draft-alt.js";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("isAltCandidate", () => {
+  it("accepts raster and webp/avif", () => {
+    expect(isAltCandidate("/x/photo.jpg")).toBe(true);
+    expect(isAltCandidate("/x/photo.PNG")).toBe(true);
+    expect(isAltCandidate("/x/photo.webp")).toBe(true);
+    expect(isAltCandidate("/x/photo.avif")).toBe(true);
+    expect(isAltCandidate("/x/photo.heic")).toBe(true);
+  });
+  it("rejects svg and generated filenames", () => {
+    expect(isAltCandidate("/x/logo.svg")).toBe(false);
+    expect(isAltCandidate("/x/favicon.svg")).toBe(false);
+    expect(isAltCandidate("/x/og-image.png")).toBe(false);
+    expect(isAltCandidate("/x/apple-touch-icon.png")).toBe(false);
+  });
+  it("rejects non-images", () => {
+    expect(isAltCandidate("/x/readme.md")).toBe(false);
+  });
+});
+
+describe("getAltCandidateFiles", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "alt-cand-"));
+    mkdirSync(join(dir, "sub"), { recursive: true });
+    mkdirSync(join(dir, "originals"), { recursive: true });
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("includes webp and recurses subdirs, excludes svg/generated/originals", () => {
+    writeFileSync(join(dir, "a.webp"), "");
+    writeFileSync(join(dir, "b.png"), "");
+    writeFileSync(join(dir, "logo.svg"), "");
+    writeFileSync(join(dir, "og-image.png"), "");
+    writeFileSync(join(dir, "sub", "c.jpg"), "");
+    writeFileSync(join(dir, "originals", "d.jpg"), "");
+    const files = getAltCandidateFiles(dir).map((f) => f.replace(dir + "/", "")).sort();
+    expect(files).toEqual(["a.webp", "b.png", "sub/c.jpg"]);
+  });
+  it("returns [] for a missing directory", () => {
+    expect(getAltCandidateFiles(join(dir, "nope"))).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/draft-alt.test.ts`
+Expected: FAIL — `Cannot find module '../template/scripts/draft-alt.js'`.
+
+- [ ] **Step 3: Create `template/scripts/draft-alt.ts`**
+
+```ts
+/**
+ * Standalone on-device alt-text pass. Walks public/images/ — INCLUDING already
+ * optimized .webp — and drafts alt text into image-alt.json for any image
+ * lacking a catalog entry. Complements `ai-optimize` (which only drafts for
+ * freshly-optimized source images), and serves imported images + backfill.
+ * Run via `npm run ai-alt`. Authoring-time only; falls back silently when `fm`
+ * is unavailable. See docs/decisions/0021-on-device-ai-accelerator.md.
+ *
+ * @module
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { join, extname, basename } from "node:path";
+import { readConfig } from "./config.js";
+import {
+  isFmAvailable,
+  readCatalog,
+  writeCatalog,
+  shouldRunAltPass,
+  draftAltForImage,
+} from "./fm.js";
+
+const ALT_CANDIDATE_EXTENSIONS = new Set([
+  ".jpg", ".jpeg", ".png", ".gif", ".tiff", ".tif", ".heif", ".heic", ".webp", ".avif",
+]);
+const SKIP_FILENAMES = new Set([
+  "apple-touch-icon.png",
+  "og-image.png",
+  "favicon.svg",
+]);
+
+export function isAltCandidate(filePath: string): boolean {
+  const ext = extname(filePath).toLowerCase();
+  if (!ALT_CANDIDATE_EXTENSIONS.has(ext)) return false;
+  if (SKIP_FILENAMES.has(basename(filePath))) return false;
+  return true;
+}
+
+export function getAltCandidateFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "originals") continue;
+      out.push(...getAltCandidateFiles(full));
+    } else if (entry.isFile() && isAltCandidate(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const cwd = process.cwd();
+  const publicDir = join(cwd, "public");
+  const imagesDir = join(publicDir, "images");
+  if (!existsSync(imagesDir)) {
+    console.log("No public/images/ — nothing to draft alt for.");
+    return;
+  }
+  const noAltFlag = process.argv.includes("--no-alt");
+  if (!shouldRunAltPass({ noAltFlag, altTextAiConfig: readConfig("ALT_TEXT_AI") })) {
+    console.log("Alt-text drafting is disabled (ALT_TEXT_AI=off or --no-alt).");
+    return;
+  }
+  if (!(await isFmAvailable())) {
+    console.log("On-device alt drafting unavailable (fm not present). Skipping.");
+    return;
+  }
+  const files = getAltCandidateFiles(imagesDir);
+  const catalogPath = join(cwd, "image-alt.json");
+  const catalog = readCatalog(catalogPath);
+  let drafted = 0;
+  for (const file of files) {
+    const alt = await draftAltForImage(catalog, publicDir, file);
+    if (alt) {
+      drafted++;
+      console.log(`  ${file.replace(cwd + "/", "")}: ${alt}`);
+    }
+  }
+  if (drafted > 0) {
+    writeCatalog(catalogPath, catalog);
+    console.log(
+      `Drafted alt text for ${drafted} image(s) → image-alt.json (review before publishing).`,
+    );
+  } else {
+    console.log("No new images needed alt text.");
+  }
+}
+
+if (process.argv[1]?.endsWith("draft-alt.ts")) {
+  await main();
+}
+```
+
+- [ ] **Step 4: Add the npm script**
+
+In `template/package.json`, add to `scripts` (next to `"ai-optimize"`):
+
+```json
+    "ai-alt": "tsx scripts/draft-alt.ts",
+```
+
+(Ensure valid JSON — trailing comma only if another entry follows.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run tests/draft-alt.test.ts`
+Expected: PASS — `isAltCandidate` and `getAltCandidateFiles` cases green.
+
+Run: `npx vitest run`
+Expected: only the 5 pre-existing `sharp`/mcp failures, no new ones.
+
+- [ ] **Step 6: Manual real-`fm` smoke (Mac only, best-effort)**
+
+```bash
+rm -rf /tmp/alt-smoke && mkdir -p /tmp/alt-smoke/public/images
+# write a small real webp via sharp from the repo, or a precomputed one:
+node --input-type=module -e "
+import { writeFileSync } from 'node:fs';
+const b64='UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAARBxAR/Q9ERP8DAABWUDggGAAAABQBAJ0BKgEAAQAAAP4AAA3AAP7mtQAAAA==';
+writeFileSync('/tmp/alt-smoke/public/images/x.webp', Buffer.from(b64,'base64'));
+"
+cd /tmp/alt-smoke && npx tsx /Users/dwk/Developer/github.com/Anglesite/anglesite/template/scripts/draft-alt.ts
+echo '--- catalog ---'; cat /tmp/alt-smoke/image-alt.json 2>/dev/null || echo '(none written)'
+rm -rf /tmp/alt-smoke
+```
+Expected on a capable Mac: `image-alt.json` has an entry keyed `/images/x.webp` with `"status": "draft"` and a non-empty alt — proving the `.webp` path drafts (which `ai-optimize` would have skipped). Report the actual output. On non-Mac: the script prints the "fm not present" notice and writes nothing — note it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add template/scripts/draft-alt.ts tests/draft-alt.test.ts template/package.json
+git commit -m "feat(template): ai-alt standalone on-device alt pass (incl. webp)"
+```
+
+---
+
+## Task 4: documentation — import/convert/optimize skills + CLAUDE.md
+
+**Files:**
+- Modify: `skills/import/SKILL.md`
+- Modify: `skills/convert/SKILL.md`
+- Modify: `skills/optimize-images/SKILL.md`
+- Modify: `template/docs/workflows/optimize-images.md`
+- Modify: `CLAUDE.md` (root)
+
+READ each file before editing.
+
+- [ ] **Step 1: Wire `ai-alt` into the import skill**
+
+First, grant the permission to run it. In `skills/import/SKILL.md`, the `allowed-tools` frontmatter lists specific Bash commands (e.g. `"Bash(npm run build)"`, `"Bash(npm install)"`) with no `npm run *` wildcard. Add `"Bash(npm run ai-alt)"` to that array (next to the other `npm run` entries). Do the same in Task 4 Step 2 for the convert skill.
+
+Then, in `skills/import/SKILL.md`, find "### 2c — Download and optimize images". At the END of that section (after the inline-images paragraph, before "### 2d"), add:
+
+```markdown
+**Draft missing alt text (on-device).** After the images for this import are
+downloaded, run `npm run ai-alt` once. On an Apple-Silicon Mac with Apple
+Intelligence enabled, it drafts alt text **on-device** (nothing is uploaded)
+for every image lacking one — including the `.webp` files just created — into
+`image-alt.json`. On any other machine it's a no-op and nothing breaks.
+```
+
+Then in "### 2d — Assemble frontmatter and write the .mdoc file", add a bullet to the "Additionally, set:" list:
+
+```markdown
+- Image alt text: where the **source HTML provides alt** (`<img alt="...">`),
+  keep it. Where alt is **missing or empty**, look up the image's draft in
+  `image-alt.json` (keyed by its `/images/...` path) and use it for the Markdown
+  `![alt](path)` and the blog `imageAlt` frontmatter, then set that catalog
+  entry's `status` to `reviewed`. Never override real authored alt with a draft.
+  If there's no draft (no `fm`), leave alt as the source provided (or empty).
+```
+
+- [ ] **Step 2: Wire `ai-alt` into the convert skill**
+
+First, add `"Bash(npm run ai-alt)"` to the `allowed-tools` frontmatter array in `skills/convert/SKILL.md` (it has specific `Bash(npm run build)` / `Bash(npm install)` entries, no wildcard — same as import).
+
+Then, in `skills/convert/SKILL.md`, find the image step (step 3 in the conversion procedure: "Copy and optimize images per the shared procedures", around line 497). Immediately after that item, add:
+
+```markdown
+   After copying the images, run `npm run ai-alt` once. On a capable Mac it
+   drafts on-device alt text for any image lacking it (including `.webp`) into
+   `image-alt.json`; elsewhere it's a no-op. When writing each post, where the
+   source frontmatter/Markdown has **no alt** for an image, use the draft from
+   `image-alt.json` for the `![alt](path)` / `imageAlt` and flip that entry to
+   `reviewed`. Keep any alt the source already provided.
+```
+
+- [ ] **Step 3: Note the standalone pass in the optimize-images skill + workflow**
+
+In `skills/optimize-images/SKILL.md`, in the "## Step 4 — AI-drafted alt text (when available)" section, add a short paragraph (after the existing catalog explanation):
+
+```markdown
+Images that arrived **already optimized** (`.webp`) — e.g. from `/anglesite:import`
+— are skipped by `npm run ai-optimize`. To draft alt for those, run
+`npm run ai-alt`, the standalone pass that walks every image in `public/images/`
+(including `.webp`) and drafts alt for anything missing from `image-alt.json`.
+Same catalog, same review flow.
+```
+
+In `template/docs/workflows/optimize-images.md`, add a short owner-facing note after the AI-alt section:
+
+```markdown
+If you imported a site or already have web-ready images, run `npm run ai-alt` to
+draft alt text for those too (the regular optimize step only covers images it
+converts). It works the same way — drafts you review before publishing.
+```
+
+- [ ] **Step 4: Update root CLAUDE.md**
+
+In `CLAUDE.md` (root), find the on-device `fm` key-decisions row (it currently mentions "alt text and inbox triage"). Update its "Why" cell to add imported images:
+
+```
+| On-device `fm` as optional authoring accelerator | Free/private/offline drafts — alt text (incl. imported images via `ai-alt`) and inbox triage; never in the deployed site, always falls back to Claude (ADR-0021) |
+```
+
+If the exact wording differs, preserve the rest of the cell and add the `ai-alt`/imported-images mention alongside the existing alt-text reference. Report what you found.
+
+- [ ] **Step 5: Verify no regression**
+
+Run: `npx vitest run`
+Expected: only the 5 pre-existing `sharp`/mcp failures, no new ones.
+
+Manually confirm the docs reference `npm run ai-alt`, `image-alt.json`, and the "keep authored alt / fill only missing" rule consistently with `template/scripts/draft-alt.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/import/SKILL.md skills/convert/SKILL.md skills/optimize-images/SKILL.md template/docs/workflows/optimize-images.md CLAUDE.md
+git commit -m "docs: wire ai-alt into import/convert + note webp backfill"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `draftAltForImage` shared helper → Task 1.
+- `optimize-images.ts` calls the helper (behavior-preserving) → Task 2.
+- Standalone `draft-alt.ts` / `ai-alt` over all images incl. `.webp`, gated on `shouldRunAltPass` + `isFmAvailable`, reports a count → Task 3.
+- `getAltCandidateFiles` includes `.webp`/`.avif`, excludes `.svg`/generated/`originals/` → Task 3.
+- `ai-alt` npm script → Task 3.
+- Import/convert run `ai-alt` + consult the catalog for missing alt, keep authored alt, flip to reviewed → Task 4 Steps 1-2.
+- `.webp` backfill documented in optimize skill/workflow → Task 4 Step 3.
+- Root CLAUDE.md ADR-0021 row updated → Task 4 Step 4.
+- Fallback (no fm → no-op, alt as today) → Task 3 `main()` gate + Task 4 doc wording.
+- Reuse ADR-0021, no new ADR → Task 4 (CLAUDE.md row); spec states it.
+- Testing split (pure helpers in CI + manual fm smoke) → Tasks 1, 3.
+
+No gaps found.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every command shows expected output.
+
+**Type consistency:** `draftAltForImage(catalog, publicDir, absImagePath, run?)` defined in Task 1, called identically in Task 2 (`optimize-images.ts`) and Task 3 (`draft-alt.ts`). `getAltCandidateFiles`/`isAltCandidate` defined and tested in Task 3. `AltCatalog`/`CommandRunner`/`FM_MODEL_ID`/`shouldRunAltPass`/`readCatalog`/`writeCatalog`/`isFmAvailable`/`generateAltText` are existing `fm.ts` exports (slice 1), used consistently. The catalog key format (`/images/...`) produced by `catalogKeyFor` inside `draftAltForImage` matches the `/images/...` lookup the import/convert docs describe.

--- a/docs/superpowers/specs/2026-06-11-fm-import-alt-design.md
+++ b/docs/superpowers/specs/2026-06-11-fm-import-alt-design.md
@@ -1,0 +1,98 @@
+# Design — On-device alt text for imported images (standalone `ai-alt` pass)
+
+**Date:** 2026-06-11
+**Status:** Approved for planning
+**Scope:** Third slice of the "use `fm` where it makes sense" effort. Adds a standalone on-device alt-drafting pass that works on any image (including `.webp`), and wires `/anglesite:import` and `/anglesite:convert` to use it so imported images that lack alt text get on-device drafts. Reuses slice 1's `fm.ts` + `image-alt.json` catalog and ADR-0021's pattern.
+
+## Background
+
+`/anglesite:import` (from a website URL) and `/anglesite:convert` (from an SSG project) are **agent-driven** skills: Claude reads the source HTML/Markdown, converts it, downloads images into `public/images/blog/`, and writes `.mdoc` files. They map `<img src alt="text">` → `![text](url)` and set blog `imageAlt` from source alt where present. Old sites frequently have empty or missing alt, so imported images often become `![](url)` / empty `imageAlt` — a real accessibility gap.
+
+Slice 1 (ADR-0021) already drafts on-device alt text into a project-root `image-alt.json` catalog (`draft` → `reviewed` status), but **only for freshly-optimized source images** during `npm run ai-optimize` — its file walk skips `.webp` (`SKIP_EXTENSIONS`). Import converts images to `.webp` on download, so slice 1's pass would skip every imported image and draft nothing. The same `.webp` limitation is the deferred "backfill" enhancement noted in slice 1's review.
+
+Therefore import-alt and the `.webp` backfill need the same missing capability: **draft alt for images already in `.webp`, decoupled from the optimize pass.** This slice builds that once.
+
+Constraints inherited from ADR-0021: `fm` is Mac-only and authoring-time; every integration gates on `isFmAvailable()` and falls back to Claude/manual when absent; machine output is a reviewable draft that never clobbers a `reviewed` entry.
+
+## Decisions (from brainstorming)
+
+- **Alt only.** `fm` summaries are out — import principle #3 already generates descriptions via Claude (first 1–2 sentences, in-context), so Claude is already in the loop with the content; offloading summaries to the on-device model saves little and lowers quality. The image-vision pass is the genuine offload win.
+- **Approach A — standalone pass.** Add `npm run ai-alt` over all images incl. `.webp`, reused by import/convert. Least invasive to import's tested, platform-specific image handling; also delivers the `.webp` backfill capability.
+- **Reuse, no new ADR.** Third consumer of ADR-0021's pattern; reuses `generateAltText`, the catalog helpers, and the `ALT_TEXT_AI`/`--no-alt` controls.
+
+## Architecture
+
+```
+import/convert downloads images → public/images/blog/ → npm run ai-alt (drafts → image-alt.json)
+                                                              │
+            writing ![alt](path) / imageAlt, source alt empty → catalog draft → flip to reviewed
+```
+
+Slice 1's optimize-coupled pass (source images only) and this standalone pass share ONE per-image helper, so the two never diverge. The deployed site has no dependency on `fm` or the catalog (authoring-time only); published alt lives in the Markdown/frontmatter exactly as today.
+
+### Component 1 — `fm.ts`: extract `draftAltForImage`
+
+Pull the per-image alt block currently inline in `optimize-images.ts` `main()` into a shared helper:
+
+```ts
+export async function draftAltForImage(
+  catalog: AltCatalog,
+  publicDir: string,
+  absImagePath: string,
+  run?: CommandRunner,
+): Promise<string | null>;
+```
+
+Behavior: compute `catalogKeyFor(publicDir, absImagePath)`; if `needsAltDraft(catalog, key)` is false, return `null` (skip — already drafted or reviewed); else `generateAltText(absImagePath, run)`; on a non-null result, `mergeAltEntry(catalog, key, { alt, model: FM_MODEL_ID, generatedAt: <today>, status: "draft" })` and return the alt; on failure return `null`. The entry construction (model id, date stamp, `draft` status) lives here, in one place.
+
+Slice 1's review explicitly deferred this extraction as "one caller / YAGNI." There are now two callers (`ai-optimize` and `ai-alt`), so the extraction is justified.
+
+### Component 2 — `optimize-images.ts`: call the shared helper
+
+Replace the inline alt block in `main()` with a `draftAltForImage(catalog, publicDir, join(dirname(file), result.primary))` call, preserving the `altDrafted` tally and the per-image log. Behavior is unchanged — still gated on `isFmAvailable()` + `shouldRunAltPass`, still source-images-only (its `getImageFiles` walk is untouched). This is a behavior-preserving DRY refactor; existing `optimize-images` tests must stay green.
+
+### Component 3 — new `template/scripts/draft-alt.ts` (`npm run ai-alt`)
+
+- `getAltCandidateFiles(dir: string): string[]` (pure) — recursively walk `public/images/`, INCLUDING `.webp`, returning raster + webp images. Excludes: `.svg` (vector, nothing to caption), the generated filenames (`favicon.svg`, `og-image.png`, `apple-touch-icon.png`), and the `originals/` directory. Alt-candidate extensions: `.jpg .jpeg .png .gif .tiff .tif .heif .heic .webp .avif`.
+- `main()` — gate once on `shouldRunAltPass({ noAltFlag: process.argv.includes("--no-alt"), altTextAiConfig: readConfig("ALT_TEXT_AI") })` AND `isFmAvailable()`; if disabled/unavailable, print a short notice and exit 0 (no error). Otherwise: `publicDir = join(cwd, "public")`, `imagesDir = join(publicDir, "images")`, read `image-alt.json`, loop `getAltCandidateFiles(imagesDir)` calling `draftAltForImage` (sequential — single on-device model), tally drafts, write the catalog if any drafted, and report a count (`Drafted alt text for N image(s) → image-alt.json (review before publishing).`).
+- `package.json`: add `"ai-alt": "tsx scripts/draft-alt.ts"`.
+
+This standalone pass IS the `.webp` backfill: run it any time to draft alt for images the optimize pass skipped.
+
+### Component 4 — import / convert wiring (skill docs)
+
+- **After image download** (import Step 2c "Download and optimize images"; the analogous convert image step): run `npm run ai-alt` once, after all images for the import are on disk. Tell the owner plainly ("drafting alt text for your images on-device").
+- **When writing content** (import Step 2d / convert): for each image reference whose **source alt is empty or missing**, look up the `image-alt.json` draft by its public-relative key and use it for the Markdown `![alt](path)` and the blog `imageAlt` frontmatter; then flip that catalog entry's `status` to `reviewed`. Where the source provided real alt, KEEP it — never override authored alt with a machine draft.
+- **Fallback:** no `fm` (non-Mac / AI off / `ALT_TEXT_AI=off`) → `ai-alt` writes nothing → alt stays preserved-or-empty exactly as today; Claude may still draft from context. Identical end state; `fm` only fills the gaps for free.
+
+### Component 5 — docs
+
+- `skills/import/SKILL.md` and `skills/convert/SKILL.md` — the wiring above (run `ai-alt`, consult the catalog for missing alt, keep authored alt, fallback).
+- `skills/optimize-images/SKILL.md` and `template/docs/workflows/optimize-images.md` — note the standalone `npm run ai-alt` / `.webp` backfill (draft alt for images the optimize pass skipped or that arrived already optimized).
+- `CLAUDE.md` (root) — extend the ADR-0021 key-decisions row to add "imported images" alongside alt text and inbox triage.
+
+## Fallback contract
+
+| Environment | Behavior |
+|---|---|
+| Mac + Apple Intelligence on | `ai-alt` drafts alt for images lacking a catalog entry (incl. `.webp`); import/convert fill missing alt from the catalog. |
+| No `fm`, or `ALT_TEXT_AI=off` | `ai-alt` is a no-op; imported alt stays preserved-or-empty as today. |
+
+## Testing
+
+- **Unit (CI, no `fm`):** `getAltCandidateFiles` (includes `.webp`/`.avif`, excludes `.svg`, the generated filenames, and `originals/`; recurses subdirs); `draftAltForImage` with a fake `CommandRunner` (drafts when `needsAltDraft`, returns null + skips when entry is `reviewed`, merges a `draft` entry with the right shape, returns null when `generateAltText` yields null).
+- **Regression:** existing `tests/optimize-images.test.ts` and `tests/fm.test.ts` stay green (the `draftAltForImage` extraction is behavior-preserving for `ai-optimize`).
+- **Integration (manual, Mac):** `npm run ai-alt` over a folder with a `.webp` drafts an entry; verified real `fm` already proven in slice 1.
+- Import/convert changes are skill-doc (agent-driven; no unit tests).
+
+## Out of scope
+
+- `fm` summaries / descriptions (Claude generates these in-context).
+- Rerouting import through `ai-optimize` (Approach B — invasive to import's image handling).
+- Non-English alt (system model is English-centric).
+- Captioning `.svg` (vector; no raster to read).
+- Auto-detecting decorative images (owner/Claude decides `alt=""`).
+
+## Open questions
+
+None blocking.

--- a/skills/convert/SKILL.md
+++ b/skills/convert/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: convert
 description: "Convert an existing static site generator project (Hugo, Jekyll, Next.js, Gatsby, Nuxt, Docusaurus, VuePress, MkDocs, Eleventy, Hexo) to Anglesite/Astro"
-allowed-tools: ["Bash(npm run build)", "Bash(npm install)", "Bash(zsh *)", "Bash(node *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(git add *)", "Bash(git commit *)", "Bash(ls *)", "Bash(wc *)", "Bash(cp *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(find */layouts *)", "Bash(find */templates *)", "Bash(find */_includes *)", "Write", "Read", "Glob", "Edit"]
+allowed-tools: ["Bash(npm run build)", "Bash(npm install)", "Bash(npm run ai-alt)", "Bash(zsh *)", "Bash(node *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(git add *)", "Bash(git commit *)", "Bash(ls *)", "Bash(wc *)", "Bash(cp *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(find */layouts *)", "Bash(find */templates *)", "Bash(find */_includes *)", "Write", "Read", "Glob", "Edit"]
 disable-model-invocation: true
 ---
 
@@ -498,6 +498,14 @@ For each post in BLOG_POSTS:
    "Image handling" section specifies where images are stored (e.g.,
    `static/img/` for Docusaurus, `source/images/` for Hexo, `content/` for
    Hugo page bundles)
+
+   After copying the images, run `npm run ai-alt` once. On a capable Mac it
+   drafts on-device alt text for any image lacking it (including `.webp`) into
+   `image-alt.json`; elsewhere it's a no-op. When writing each post, where the
+   source frontmatter/Markdown has **no alt** for an image, use the draft from
+   `image-alt.json` for the `![alt](path)` / `imageAlt` and flip that entry to
+   `reviewed`. Keep any alt the source already provided.
+
 4. Write the `.mdoc` file per the shared procedures. Use `-converted` suffix
    for slug conflicts
 

--- a/skills/import/SKILL.md
+++ b/skills/import/SKILL.md
@@ -2,7 +2,7 @@
 name: import
 description: "Import content from a website URL (WordPress, Squarespace, Wix, Webflow, GoDaddy, Ghost, Medium, Substack, Blogger, Shopify, Weebly, Tumblr, Micro.blog, WriteFreely, Carrd) or static site generator project"
 argument-hint: "[website URL or local path]"
-allowed-tools: ["WebFetch", "Bash(curl *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(npm run build)", "Bash(npm install)", "Bash(zsh *)", "Bash(node *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", "Bash(ls *)", "Bash(wc *)", "Bash(grep *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(cp *)", "Write", "Read", "Glob", "Edit"]
+allowed-tools: ["WebFetch", "Bash(curl *)", "Bash(npx sharp-cli *)", "Bash(mkdir *)", "Bash(npm run build)", "Bash(npm install)", "Bash(npm run ai-alt)", "Bash(zsh *)", "Bash(node *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", "Bash(ls *)", "Bash(wc *)", "Bash(grep *)", "Bash(find src/content/posts *)", "Bash(find public/images *)", "Bash(find */images *)", "Bash(find */public *)", "Bash(find */static *)", "Bash(find */source *)", "Bash(find */content *)", "Bash(find */docs *)", "Bash(find */_posts *)", "Bash(cp *)", "Write", "Read", "Glob", "Edit"]
 disable-model-invocation: true
 ---
 
@@ -468,12 +468,24 @@ If the download fails, add to FAILED_IMAGES and omit `image` from frontmatter.
 **Inline images:** Download with `SLUG-body-N.webp` naming and replace inline
 URLs with local paths.
 
+**Draft missing alt text (on-device).** After the images for this import are
+downloaded, run `npm run ai-alt` once. On an Apple-Silicon Mac with Apple
+Intelligence enabled, it drafts alt text **on-device** (nothing is uploaded)
+for every image lacking one — including the `.webp` files just created — into
+`image-alt.json`. On any other machine it's a no-op and nothing breaks.
+
 ### 2d — Assemble frontmatter and write the .mdoc file
 
 Follow the `.mdoc` writing procedure in
 `${CLAUDE_PLUGIN_ROOT}/docs/content-conversion.md`. Use `-imported`
 suffix for slug conflicts. Additionally, set:
 - `syndication`: `["ORIGINAL_POST_URL"]` — the URL on the old platform, preserving provenance per ADR-0006
+- Image alt text: where the **source HTML provides alt** (`<img alt="...">`),
+  keep it. Where alt is **missing or empty**, look up the image's draft in
+  `image-alt.json` (keyed by its `/images/...` path) and use it for the Markdown
+  `![alt](path)` and the blog `imageAlt` frontmatter, then set that catalog
+  entry's `status` to `reviewed`. Never override real authored alt with a draft.
+  If there's no draft (no `fm`), leave alt as the source provided (or empty).
 
 ### 2e — Progress updates
 

--- a/skills/import/SKILL.md
+++ b/skills/import/SKILL.md
@@ -667,11 +667,20 @@ curl -L -s -o "public/images/gallery/PAGE-SLUG-NN.jpg" "IMAGE_URL"
 
 Check file size and convert with `sharp-cli` if over 500KB (same as Step 2c).
 
+After the gallery images are downloaded and converted, run `npm run ai-alt`
+again (it's idempotent — it only drafts images that have no entry yet, so this
+just covers the new gallery images). On a capable Mac it drafts on-device alt
+text for any gallery image lacking it into `image-alt.json`; elsewhere it's a
+no-op.
+
 Create a gallery `.astro` page in `src/pages/` with:
 - The page title and meta description
 - `BaseLayout` wrapper
 - A responsive CSS grid layout displaying all downloaded images
-- Each image using Astro's `<img>` tag with the local path and alt text
+- Each image using Astro's `<img>` tag with the local path and alt text — where
+  the source had no alt, use the draft from `image-alt.json` (keyed by the
+  image's `/images/gallery/...` path) and treat that entry as `reviewed`; keep
+  any alt the source provided
 - A note that the owner can rearrange or edit in the source file
 
 ## Step 5 — Generate redirect mappings

--- a/skills/optimize-images/SKILL.md
+++ b/skills/optimize-images/SKILL.md
@@ -70,6 +70,13 @@ When you place an image (new page, blog post, menu, gallery) or remediate an
 Always present drafted alt text to the owner as something to review before
 publishing.
 
+Images that arrived **already optimized** (`.webp`) — e.g. from `/anglesite:import`
+— are skipped by `npm run ai-optimize`. To draft alt for those, run
+`npm run ai-alt`, the standalone pass that walks every image in `public/images/`
+(including `.webp`) and drafts alt for anything missing from `image-alt.json`.
+Same catalog, same review flow. It's idempotent — re-running only drafts images
+that have no entry yet.
+
 ### When `fm` is not available
 
 On any other machine, no catalog is written and nothing breaks — draft alt text

--- a/template/docs/workflows/optimize-images.md
+++ b/template/docs/workflows/optimize-images.md
@@ -44,6 +44,10 @@ directly — the end result is the same.
 
 To turn the feature off, add `ALT_TEXT_AI=off` to `.site-config`.
 
+If you imported a site or already have web-ready images, run `npm run ai-alt` to
+draft alt text for those too (the regular optimize step only covers images it
+converts). It works the same way — drafts you review before publishing.
+
 ## Why this matters
 
 A single unoptimized phone photo (3–5 MB) can make a page load 10x slower. WebP images are typically 25–35% smaller than JPEG at equivalent quality. Responsive variants ensure mobile visitors don't download desktop-sized images.

--- a/template/package.json
+++ b/template/package.json
@@ -16,6 +16,7 @@
     "ai-images": "tsx scripts/generate-images.ts",
     "ai-og": "tsx scripts/generate-og-pages.ts",
     "ai-optimize": "tsx scripts/optimize-images.ts",
+    "ai-alt": "tsx scripts/draft-alt.ts",
     "ai-qr": "tsx scripts/qr-generate.ts",
     "ai-linkcheck": "tsx scripts/link-check.ts",
     "ai-forms-build": "tsx scripts/build-forms-catalog.ts",

--- a/template/scripts/draft-alt.ts
+++ b/template/scripts/draft-alt.ts
@@ -18,6 +18,8 @@ import {
   writeCatalog,
   shouldRunAltPass,
   draftAltForImage,
+  catalogKeyFor,
+  type AltCatalog,
 } from "./fm.js";
 
 const ALT_CANDIDATE_EXTENSIONS = new Set([
@@ -34,6 +36,19 @@ export function isAltCandidate(filePath: string): boolean {
   if (!ALT_CANDIDATE_EXTENSIONS.has(ext)) return false;
   if (SKIP_FILENAMES.has(basename(filePath))) return false;
   return true;
+}
+
+/**
+ * Images with no catalog entry yet. `ai-alt` is a backfill pass: it never
+ * re-drafts an image that already has an entry (draft or reviewed), so
+ * re-running it is idempotent and won't re-hammer the on-device model.
+ */
+export function uncataloguedImages(
+  files: string[],
+  publicDir: string,
+  catalog: AltCatalog,
+): string[] {
+  return files.filter((f) => !catalog[catalogKeyFor(publicDir, f)]);
 }
 
 export function getAltCandidateFiles(dir: string): string[] {
@@ -68,9 +83,9 @@ async function main(): Promise<void> {
     console.log("On-device alt drafting unavailable (fm not present). Skipping.");
     return;
   }
-  const files = getAltCandidateFiles(imagesDir);
   const catalogPath = join(cwd, "image-alt.json");
   const catalog = readCatalog(catalogPath);
+  const files = uncataloguedImages(getAltCandidateFiles(imagesDir), publicDir, catalog);
   let drafted = 0;
   for (const file of files) {
     const alt = await draftAltForImage(catalog, publicDir, file);

--- a/template/scripts/draft-alt.ts
+++ b/template/scripts/draft-alt.ts
@@ -1,0 +1,94 @@
+/**
+ * Standalone on-device alt-text pass. Walks public/images/ — INCLUDING already
+ * optimized .webp — and drafts alt text into image-alt.json for any image
+ * lacking a catalog entry. Complements `ai-optimize` (which only drafts for
+ * freshly-optimized source images), and serves imported images + backfill.
+ * Run via `npm run ai-alt`. Authoring-time only; falls back silently when `fm`
+ * is unavailable. See docs/decisions/0021-on-device-ai-accelerator.md.
+ *
+ * @module
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { join, extname, basename } from "node:path";
+import { readConfig } from "./config.js";
+import {
+  isFmAvailable,
+  readCatalog,
+  writeCatalog,
+  shouldRunAltPass,
+  draftAltForImage,
+} from "./fm.js";
+
+const ALT_CANDIDATE_EXTENSIONS = new Set([
+  ".jpg", ".jpeg", ".png", ".gif", ".tiff", ".tif", ".heif", ".heic", ".webp", ".avif",
+]);
+const SKIP_FILENAMES = new Set([
+  "apple-touch-icon.png",
+  "og-image.png",
+  "favicon.svg",
+]);
+
+export function isAltCandidate(filePath: string): boolean {
+  const ext = extname(filePath).toLowerCase();
+  if (!ALT_CANDIDATE_EXTENSIONS.has(ext)) return false;
+  if (SKIP_FILENAMES.has(basename(filePath))) return false;
+  return true;
+}
+
+export function getAltCandidateFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "originals") continue;
+      out.push(...getAltCandidateFiles(full));
+    } else if (entry.isFile() && isAltCandidate(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const cwd = process.cwd();
+  const publicDir = join(cwd, "public");
+  const imagesDir = join(publicDir, "images");
+  if (!existsSync(imagesDir)) {
+    console.log("No public/images/ — nothing to draft alt for.");
+    return;
+  }
+  const noAltFlag = process.argv.includes("--no-alt");
+  if (!shouldRunAltPass({ noAltFlag, altTextAiConfig: readConfig("ALT_TEXT_AI") })) {
+    console.log("Alt-text drafting is disabled (ALT_TEXT_AI=off or --no-alt).");
+    return;
+  }
+  if (!(await isFmAvailable())) {
+    console.log("On-device alt drafting unavailable (fm not present). Skipping.");
+    return;
+  }
+  const files = getAltCandidateFiles(imagesDir);
+  const catalogPath = join(cwd, "image-alt.json");
+  const catalog = readCatalog(catalogPath);
+  let drafted = 0;
+  for (const file of files) {
+    const alt = await draftAltForImage(catalog, publicDir, file);
+    if (alt) {
+      drafted++;
+      console.log(`  ${file.replace(cwd + "/", "")}: ${alt}`);
+    }
+  }
+  if (drafted > 0) {
+    writeCatalog(catalogPath, catalog);
+    console.log(
+      `Drafted alt text for ${drafted} image(s) → image-alt.json (review before publishing).`,
+    );
+  } else {
+    console.log("No new images needed alt text.");
+  }
+}
+
+if (process.argv[1]?.endsWith("draft-alt.ts")) {
+  await main();
+}

--- a/template/scripts/draft-alt.ts
+++ b/template/scripts/draft-alt.ts
@@ -25,10 +25,12 @@ import {
 const ALT_CANDIDATE_EXTENSIONS = new Set([
   ".jpg", ".jpeg", ".png", ".gif", ".tiff", ".tif", ".heif", ".heic", ".webp", ".avif",
 ]);
+// Generated raster files that ARE candidate extensions but should never be
+// captioned. (`.svg` files are already excluded by the extension check above,
+// so no `.svg` filename belongs here.)
 const SKIP_FILENAMES = new Set([
   "apple-touch-icon.png",
   "og-image.png",
-  "favicon.svg",
 ]);
 
 export function isAltCandidate(filePath: string): boolean {
@@ -85,6 +87,11 @@ async function main(): Promise<void> {
   }
   const catalogPath = join(cwd, "image-alt.json");
   const catalog = readCatalog(catalogPath);
+  // This pre-filter makes `ai-alt` deliberately MORE conservative than
+  // `ai-optimize`: it skips images with any entry (draft or reviewed), whereas
+  // `ai-optimize` calls `draftAltForImage` directly and so re-drafts existing
+  // `draft` entries (the source was just re-optimized). A backfill pass must
+  // not re-hammer the on-device model on every run.
   const files = uncataloguedImages(getAltCandidateFiles(imagesDir), publicDir, catalog);
   let drafted = 0;
   for (const file of files) {

--- a/template/scripts/fm.ts
+++ b/template/scripts/fm.ts
@@ -285,3 +285,28 @@ export async function generateAltText(
     return null;
   }
 }
+
+/**
+ * Draft alt text for one image and merge it into the catalog as a `draft`,
+ * unless the image already has a usable entry (draft or reviewed-protected).
+ * Shared by `ai-optimize` (source images) and `ai-alt` (all images incl. webp).
+ * Returns the drafted alt, or null if skipped or generation failed.
+ */
+export async function draftAltForImage(
+  catalog: AltCatalog,
+  publicDir: string,
+  absImagePath: string,
+  run?: CommandRunner,
+): Promise<string | null> {
+  const key = catalogKeyFor(publicDir, absImagePath);
+  if (!needsAltDraft(catalog, key)) return null;
+  const alt = await generateAltText(absImagePath, run);
+  if (!alt) return null;
+  mergeAltEntry(catalog, key, {
+    alt,
+    model: FM_MODEL_ID,
+    generatedAt: new Date().toISOString().slice(0, 10),
+    status: "draft",
+  });
+  return alt;
+}

--- a/template/scripts/fm.ts
+++ b/template/scripts/fm.ts
@@ -287,9 +287,10 @@ export async function generateAltText(
 }
 
 /**
- * Draft alt text for one image and merge it into the catalog as a `draft`,
- * unless the image already has a usable entry (draft or reviewed-protected).
- * Shared by `ai-optimize` (source images) and `ai-alt` (all images incl. webp).
+ * Draft alt text for one image and merge it into the catalog as a `draft`.
+ * Skips images that already have a `reviewed` entry (never overwritten);
+ * a missing key or an existing `draft` entry is (re)drafted. Shared by
+ * `ai-optimize` (source images) and `ai-alt` (all images incl. webp).
  * Returns the drafted alt, or null if skipped or generation failed.
  */
 export async function draftAltForImage(

--- a/template/scripts/optimize-images.ts
+++ b/template/scripts/optimize-images.ts
@@ -12,14 +12,10 @@ import { join, extname, basename, dirname } from "node:path";
 import { readConfig } from "./config.js";
 import {
   isFmAvailable,
-  generateAltText,
-  catalogKeyFor,
   readCatalog,
   writeCatalog,
-  needsAltDraft,
-  mergeAltEntry,
   shouldRunAltPass,
-  FM_MODEL_ID,
+  draftAltForImage,
   type AltCatalog,
 } from "./fm.js";
 
@@ -160,19 +156,10 @@ async function main() {
     // concurrent calls would contend on the same hardware, not speed up.
     if (fmReady) {
       const primaryAbs = join(dirname(file), result.primary);
-      const key = catalogKeyFor(publicDir, primaryAbs);
-      if (needsAltDraft(catalog, key)) {
-        const alt = await generateAltText(primaryAbs);
-        if (alt) {
-          mergeAltEntry(catalog, key, {
-            alt,
-            model: FM_MODEL_ID,
-            generatedAt: new Date().toISOString().slice(0, 10),
-            status: "draft",
-          });
-          altDrafted++;
-          console.log(`    alt draft: ${alt}`);
-        }
+      const alt = await draftAltForImage(catalog, publicDir, primaryAbs);
+      if (alt) {
+        altDrafted++;
+        console.log(`    alt draft: ${alt}`);
       }
     }
   }

--- a/tests/draft-alt.test.ts
+++ b/tests/draft-alt.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { isAltCandidate, getAltCandidateFiles } from "../template/scripts/draft-alt.js";
+import { isAltCandidate, getAltCandidateFiles, uncataloguedImages } from "../template/scripts/draft-alt.js";
+import type { AltCatalog } from "../template/scripts/fm.js";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -11,6 +12,10 @@ describe("isAltCandidate", () => {
     expect(isAltCandidate("/x/photo.webp")).toBe(true);
     expect(isAltCandidate("/x/photo.avif")).toBe(true);
     expect(isAltCandidate("/x/photo.heic")).toBe(true);
+    expect(isAltCandidate("/x/photo.gif")).toBe(true);
+    expect(isAltCandidate("/x/scan.tiff")).toBe(true);
+    expect(isAltCandidate("/x/scan.tif")).toBe(true);
+    expect(isAltCandidate("/x/photo.heif")).toBe(true);
   });
   it("rejects svg and generated filenames", () => {
     expect(isAltCandidate("/x/logo.svg")).toBe(false);
@@ -44,5 +49,16 @@ describe("getAltCandidateFiles", () => {
   });
   it("returns [] for a missing directory", () => {
     expect(getAltCandidateFiles(join(dir, "nope"))).toEqual([]);
+  });
+});
+
+describe("uncataloguedImages", () => {
+  it("keeps only images with no catalog entry (idempotent backfill)", () => {
+    const files = ["/p/images/a.webp", "/p/images/b.webp", "/p/images/c.webp"];
+    const catalog: AltCatalog = {
+      "/images/a.webp": { alt: "x", model: "m", generatedAt: "d", status: "draft" },
+      "/images/b.webp": { alt: "y", model: "m", generatedAt: "d", status: "reviewed" },
+    };
+    expect(uncataloguedImages(files, "/p", catalog)).toEqual(["/p/images/c.webp"]);
   });
 });

--- a/tests/draft-alt.test.ts
+++ b/tests/draft-alt.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { isAltCandidate, getAltCandidateFiles } from "../template/scripts/draft-alt.js";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("isAltCandidate", () => {
+  it("accepts raster and webp/avif", () => {
+    expect(isAltCandidate("/x/photo.jpg")).toBe(true);
+    expect(isAltCandidate("/x/photo.PNG")).toBe(true);
+    expect(isAltCandidate("/x/photo.webp")).toBe(true);
+    expect(isAltCandidate("/x/photo.avif")).toBe(true);
+    expect(isAltCandidate("/x/photo.heic")).toBe(true);
+  });
+  it("rejects svg and generated filenames", () => {
+    expect(isAltCandidate("/x/logo.svg")).toBe(false);
+    expect(isAltCandidate("/x/favicon.svg")).toBe(false);
+    expect(isAltCandidate("/x/og-image.png")).toBe(false);
+    expect(isAltCandidate("/x/apple-touch-icon.png")).toBe(false);
+  });
+  it("rejects non-images", () => {
+    expect(isAltCandidate("/x/readme.md")).toBe(false);
+  });
+});
+
+describe("getAltCandidateFiles", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "alt-cand-"));
+    mkdirSync(join(dir, "sub"), { recursive: true });
+    mkdirSync(join(dir, "originals"), { recursive: true });
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("includes webp and recurses subdirs, excludes svg/generated/originals", () => {
+    writeFileSync(join(dir, "a.webp"), "");
+    writeFileSync(join(dir, "b.png"), "");
+    writeFileSync(join(dir, "logo.svg"), "");
+    writeFileSync(join(dir, "og-image.png"), "");
+    writeFileSync(join(dir, "sub", "c.jpg"), "");
+    writeFileSync(join(dir, "originals", "d.jpg"), "");
+    const files = getAltCandidateFiles(dir).map((f) => f.replace(dir + "/", "")).sort();
+    expect(files).toEqual(["a.webp", "b.png", "sub/c.jpg"]);
+  });
+  it("returns [] for a missing directory", () => {
+    expect(getAltCandidateFiles(join(dir, "nope"))).toEqual([]);
+  });
+});

--- a/tests/draft-alt.test.ts
+++ b/tests/draft-alt.test.ts
@@ -17,11 +17,14 @@ describe("isAltCandidate", () => {
     expect(isAltCandidate("/x/scan.tif")).toBe(true);
     expect(isAltCandidate("/x/photo.heif")).toBe(true);
   });
-  it("rejects svg and generated filenames", () => {
+  it("rejects svg by extension, regardless of filename", () => {
     expect(isAltCandidate("/x/logo.svg")).toBe(false);
     expect(isAltCandidate("/x/favicon.svg")).toBe(false);
+  });
+  it("rejects generated png filenames by name (a normal png is a candidate)", () => {
     expect(isAltCandidate("/x/og-image.png")).toBe(false);
     expect(isAltCandidate("/x/apple-touch-icon.png")).toBe(false);
+    expect(isAltCandidate("/x/photo.png")).toBe(true);
   });
   it("rejects non-images", () => {
     expect(isAltCandidate("/x/readme.md")).toBe(false);

--- a/tests/fm.test.ts
+++ b/tests/fm.test.ts
@@ -9,6 +9,7 @@ import {
   writeCatalog,
   parseClassification,
   classifySubmission,
+  draftAltForImage,
   type AltCatalog,
   type SubmissionClassification,
 } from "../template/scripts/fm.js";
@@ -277,5 +278,45 @@ describe("classifySubmission", () => {
   it("returns null when the runner throws", async () => {
     const run: CommandRunner = async () => { throw new Error("boom"); };
     expect(await classifySubmission("x", run)).toBeNull();
+  });
+});
+
+describe("draftAltForImage", () => {
+  it("drafts and merges a draft entry for a missing key", async () => {
+    const catalog: AltCatalog = {};
+    const run: CommandRunner = async () => ({ stdout: "A red barn", exitCode: 0 });
+    const alt = await draftAltForImage(catalog, "/site/public", "/site/public/images/x.webp", run);
+    expect(alt).toBe("A red barn");
+    expect(catalog["/images/x.webp"]).toMatchObject({
+      alt: "A red barn",
+      model: "apple-fm-system",
+      status: "draft",
+    });
+    expect(catalog["/images/x.webp"].generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+  it("returns null and does not overwrite a reviewed entry", async () => {
+    const catalog: AltCatalog = {
+      "/images/x.webp": { alt: "kept", model: "m", generatedAt: "2026-01-01", status: "reviewed" },
+    };
+    const run: CommandRunner = async () => ({ stdout: "new", exitCode: 0 });
+    const alt = await draftAltForImage(catalog, "/site/public", "/site/public/images/x.webp", run);
+    expect(alt).toBeNull();
+    expect(catalog["/images/x.webp"].alt).toBe("kept");
+  });
+  it("re-drafts when the existing entry is a draft", async () => {
+    const catalog: AltCatalog = {
+      "/images/x.webp": { alt: "old", model: "m", generatedAt: "2026-01-01", status: "draft" },
+    };
+    const run: CommandRunner = async () => ({ stdout: "fresh", exitCode: 0 });
+    const alt = await draftAltForImage(catalog, "/site/public", "/site/public/images/x.webp", run);
+    expect(alt).toBe("fresh");
+    expect(catalog["/images/x.webp"].alt).toBe("fresh");
+  });
+  it("returns null when generateAltText yields nothing (non-zero exit)", async () => {
+    const catalog: AltCatalog = {};
+    const run: CommandRunner = async () => ({ stdout: "", exitCode: 1 });
+    const alt = await draftAltForImage(catalog, "/site/public", "/site/public/images/x.webp", run);
+    expect(alt).toBeNull();
+    expect(catalog["/images/x.webp"]).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Third slice of the on-device `fm` effort (after #353 alt text, #354 inbox triage). Adds a standalone `npm run ai-alt` pass that drafts on-device alt text for **any** image in `public/images/` — including `.webp` — and wires `/anglesite:import` + `/anglesite:convert` to use it so imported images that lack alt get drafts.

- **Why a new pass:** slice 1's `ai-optimize` only drafts alt for freshly-optimized *source* images (it skips `.webp`). Import converts images to `.webp`, so those would get no alt. `ai-alt` closes that gap — and is the deferred `.webp` **backfill** capability.
- **`draftAltForImage`** — slice 1's per-image alt block (`catalogKeyFor → needsAltDraft → generateAltText → mergeAltEntry`) extracted into one shared `fm.ts` helper now that there are two callers (`ai-optimize` + `ai-alt`). `optimize-images.ts` refactored to call it (behavior-preserving, loop body 12→4 lines).
- **`draft-alt.ts` / `npm run ai-alt`** — no sharp dependency; walks `public/images/` incl. `.webp` (excludes `.svg`, generated filenames, `originals/`); gated identically to slice 1 (`shouldRunAltPass` + `isFmAvailable`). **Idempotent** — `uncataloguedImages` filters to images with no catalog entry, so re-runs never re-hammer the on-device model.
- **import/convert wiring** (skill docs + `allowed-tools`): run `ai-alt` after downloading images (blog posts *and* galleries), then consult `image-alt.json` for any image whose source alt is missing — **keeping authored alt, never overriding it**, flipping filled entries to `reviewed`.
- **Fallback:** no `fm` / `ALT_TEXT_AI=off` → `ai-alt` is a clean no-op (exit 0); imported alt stays preserved-or-empty as today.
- Reuses ADR-0021's pattern — no new ADR. `fm` summaries deliberately dropped (Claude already generates descriptions in-context).

Spec: `docs/superpowers/specs/2026-06-11-fm-import-alt-design.md` · Plan: `docs/superpowers/plans/2026-06-11-fm-import-alt.md`

## Test Plan

- [x] `tests/fm.test.ts` — `draftAltForImage` (drafts on missing key, never overwrites `reviewed`, re-drafts `draft`, null on generation failure).
- [x] `tests/draft-alt.test.ts` — `isAltCandidate` (webp/avif/heic/tif included, svg + generated names excluded), `getAltCandidateFiles` (recurses, skips `originals/`), `uncataloguedImages` (idempotent filter).
- [x] Existing `tests/optimize-images.test.ts` green (refactor is behavior-preserving).
- [x] Full suite: 2581 passing (the 5 `sharp`/mcp failures pre-exist this branch — verified at base).
- [x] **Real `fm` `.webp` smoke** on Apple Silicon: `ai-alt` drafted an entry for a `.webp` image (`"blank, empty"` for a 1×1) — proving the path `ai-optimize` skips.
- [x] Gallery wiring gap (caught in holistic review) closed — import Step 4 now runs `ai-alt` + consults the catalog for gallery images too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)