### PR TITLE
feat(core): wire LocalSiteRuntime → SiteContentGraph population (#142)

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -110,7 +110,7 @@ struct AnglesiteApp: App {
             // route to the launcher when restoration hands us a nil or unresolvable
             // id. If we short-circuit with `if let siteID` here the SiteWindow never
             // instantiates and an empty restored window strands the user.
-            SiteWindow(siteID: siteID)
+            SiteWindow(siteID: siteID, contentGraph: appDelegate.contentGraph)
                 .frame(minWidth: 960, minHeight: 600)
         }
         .windowStyle(.titleBar)

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -23,7 +23,11 @@ final class PreviewModel {
     /// failure), `MCPApplyEditRouter` returns `.failed("MCP not running")` per its existing shape.
     private(set) var editRouter: EditRouter
 
-    init(runtime: any SiteRuntime = LocalSiteRuntime()) {
+    /// `contentGraph` is the app-lifetime `SiteContentGraph` (held by `AppDelegate`); it's threaded
+    /// into the default `LocalSiteRuntime` so opening this site populates the shared graph (A.8,
+    /// #142). Tests inject an explicit `runtime` and leave the graph `nil`.
+    init(contentGraph: SiteContentGraph? = nil, runtime: (any SiteRuntime)? = nil) {
+        let runtime = runtime ?? LocalSiteRuntime(contentGraph: contentGraph)
         self.runtime = runtime
         self.editRouter = MCPApplyEditRouter(mcpClient: { [weak runtime] in
             // `runtime` is the actor instance; reading `mcpClient` hops onto the actor.

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -14,6 +14,16 @@ struct SiteWindow: View {
     /// nil payload — see `loadAndStart()` for how that's handled.
     let siteID: String?
 
+    /// The app-lifetime content graph (held by `AppDelegate`), seeded into this window's
+    /// `PreviewModel` so opening the site populates the shared graph (A.8, #142).
+    private let contentGraph: SiteContentGraph
+
+    init(siteID: String?, contentGraph: SiteContentGraph) {
+        self.siteID = siteID
+        self.contentGraph = contentGraph
+        _preview = State(initialValue: PreviewModel(contentGraph: contentGraph))
+    }
+
     @State private var site: SiteStore.Site?
 
     #if ANGLESITE_MAS
@@ -23,7 +33,7 @@ struct SiteWindow: View {
     @State private var scopedURL: URL?
     #endif
 
-    @State private var preview = PreviewModel()
+    @State private var preview: PreviewModel
     @State private var deploy = DeployModel()
     @State private var backup = BackupModel()
     @State private var audit = AuditModel()

--- a/Sources/AnglesiteCore/ContentListing.swift
+++ b/Sources/AnglesiteCore/ContentListing.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Decoded form of the plugin's `list_content` MCP tool response, projected into
+/// `SiteContentGraph` structs (A.8, #142).
+///
+/// The plugin payload is **site-agnostic** — it carries no `siteID` and no entity `id`. This
+/// type stamps the caller-supplied `siteID` onto every entry and builds the site-scoped ids
+/// (`{siteID}:page:{route}`, `:post:{slug}`, `:image:{relativePath}`) that the graph and the
+/// App Intents entities key off. Keeping id construction here (not in the plugin) means the
+/// plugin never has to know which on-disk site it's serving.
+///
+/// Timestamps are ISO-8601 strings; both plain (`…Z`) and fractional-second (`….500Z`) forms
+/// are accepted. `lastModified` is required on every entry; `publishDate` (posts) is optional.
+/// A missing top-level array (`pages`/`posts`/`images`) decodes to empty — an older or partial
+/// plugin that only reports pages doesn't fail the whole parse.
+public struct ContentListing: Sendable, Equatable {
+    public let pages: [SiteContentGraph.Page]
+    public let posts: [SiteContentGraph.Post]
+    public let images: [SiteContentGraph.Image]
+
+    /// Parse the `list_content` JSON text, stamping `siteID` and constructing site-scoped ids.
+    /// Throws `DecodingError` on malformed JSON, a missing required field, or an unparseable date.
+    public static func parse(jsonText: String, siteID: String) throws -> ContentListing {
+        let data = Data(jsonText.utf8)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom(decodeISO8601)
+        let dto = try decoder.decode(Payload.self, from: data)
+        return ContentListing(
+            pages: dto.pages.map { $0.page(siteID: siteID) },
+            posts: dto.posts.map { $0.post(siteID: siteID) },
+            images: dto.images.map { $0.image(siteID: siteID) }
+        )
+    }
+
+    // MARK: - Wire DTOs
+
+    private struct Payload: Decodable {
+        let pages: [PageDTO]
+        let posts: [PostDTO]
+        let images: [ImageDTO]
+
+        enum CodingKeys: String, CodingKey { case pages, posts, images }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            pages = try c.decodeIfPresent([PageDTO].self, forKey: .pages) ?? []
+            posts = try c.decodeIfPresent([PostDTO].self, forKey: .posts) ?? []
+            images = try c.decodeIfPresent([ImageDTO].self, forKey: .images) ?? []
+        }
+    }
+
+    private struct PageDTO: Decodable {
+        let route: String
+        let filePath: String
+        let title: String?
+        let lastModified: Date
+
+        func page(siteID: String) -> SiteContentGraph.Page {
+            SiteContentGraph.Page(
+                id: "\(siteID):page:\(route)",
+                siteID: siteID,
+                route: route,
+                filePath: filePath,
+                title: title,
+                lastModified: lastModified
+            )
+        }
+    }
+
+    private struct PostDTO: Decodable {
+        let collection: String
+        let slug: String
+        let title: String
+        let draft: Bool
+        let publishDate: Date?
+        let tags: [String]
+        let filePath: String
+        let lastModified: Date
+
+        func post(siteID: String) -> SiteContentGraph.Post {
+            SiteContentGraph.Post(
+                id: "\(siteID):post:\(slug)",
+                siteID: siteID,
+                collection: collection,
+                slug: slug,
+                title: title,
+                draft: draft,
+                publishDate: publishDate,
+                tags: tags,
+                filePath: filePath,
+                lastModified: lastModified
+            )
+        }
+    }
+
+    private struct ImageDTO: Decodable {
+        let relativePath: String
+        let fileName: String
+        let byteSize: Int64?
+        let usedOnPages: [String]
+        let lastModified: Date
+
+        func image(siteID: String) -> SiteContentGraph.Image {
+            SiteContentGraph.Image(
+                id: "\(siteID):image:\(relativePath)",
+                siteID: siteID,
+                relativePath: relativePath,
+                fileName: fileName,
+                byteSize: byteSize,
+                usedOnPages: usedOnPages,
+                lastModified: lastModified
+            )
+        }
+    }
+
+    // MARK: - Date parsing
+
+    /// `ISO8601DateFormatter` instances are not cheap to build and are thread-safe once
+    /// configured, so cache one per format variant.
+    private static let plainFormatter = ISO8601DateFormatter()
+    private static let fractionalFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static func decodeISO8601(_ decoder: Decoder) throws -> Date {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        if let date = fractionalFormatter.date(from: raw) ?? plainFormatter.date(from: raw) {
+            return date
+        }
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "Expected an ISO-8601 timestamp, got \"\(raw)\""
+            )
+        )
+    }
+}

--- a/Sources/AnglesiteCore/LocalSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalSiteRuntime.swift
@@ -29,6 +29,11 @@ public actor LocalSiteRuntime: SiteRuntime {
     /// through it. If MCP spawn fails (graceful), `isRunning` stays false and tool calls
     /// throw `.notInitialized` — preview still works without the edit pipeline.
     public let mcpClient: MCPClient
+    /// Shared, app-lifetime projection of every open site's content (A.1 #136). Populated from
+    /// the plugin's `list_content` MCP tool once this site is ready (#142), and evicted on stop.
+    /// `nil` in headless/test contexts that don't care about the graph — population is then a
+    /// no-op. The App Intents entity queries (A.2 #137) and Spotlight indexer (A.3) read from it.
+    private let contentGraph: SiteContentGraph?
     private let logCenter: LogCenter
     private let resolveCommand: CommandResolver
     private let resolveMCPCommand: MCPCommandResolver
@@ -39,10 +44,14 @@ public actor LocalSiteRuntime: SiteRuntime {
     private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
     /// Bumped on every `start(...)`; lets a slow `devServer.start` await know it was superseded.
     private var generation = 0
+    /// The siteID whose content this runtime last loaded into `contentGraph`, so `stop()` /
+    /// a site switch can evict exactly that site. `nil` when nothing is loaded.
+    private var loadedGraphSiteID: String?
 
     public init(
         devServer: AstroDevServer? = nil,
         mcpClient: MCPClient? = nil,
+        contentGraph: SiteContentGraph? = nil,
         supervisor: ProcessSupervisor = .shared,
         logCenter: LogCenter = .shared,
         resolveCommand: @escaping CommandResolver = LocalSiteRuntime.resolveAstroCommand,
@@ -52,6 +61,7 @@ public actor LocalSiteRuntime: SiteRuntime {
     ) {
         self.devServer = devServer ?? AstroDevServer(supervisor: supervisor, logCenter: logCenter)
         self.mcpClient = mcpClient ?? MCPClient(supervisor: supervisor, logCenter: logCenter)
+        self.contentGraph = contentGraph
         self.logCenter = logCenter
         self.resolveCommand = resolveCommand
         self.resolveMCPCommand = resolveMCPCommand
@@ -105,6 +115,10 @@ public actor LocalSiteRuntime: SiteRuntime {
                 // anyway (preview is the primary feature; the edit pipeline is an enhancement).
                 await startMCPClient(siteID: siteID, siteDirectory: siteDirectory)
                 guard gen == generation else { return }
+                // Populate the content graph from the now-initialized MCP server. Best-effort:
+                // a missing/erroring `list_content` (older plugin) just leaves the graph empty.
+                await populateContentGraph(siteID: siteID, generation: gen)
+                guard gen == generation else { return }
                 setState(.ready(siteID: siteID, url: url))
             } catch {
                 guard gen == generation else { return }
@@ -125,6 +139,49 @@ public actor LocalSiteRuntime: SiteRuntime {
     private func stopSubprocesses() async {
         await devServer.stop()
         await mcpClient.stop()
+        if let siteID = loadedGraphSiteID {
+            await contentGraph?.unload(siteID: siteID)
+            loadedGraphSiteID = nil
+        }
+    }
+
+    /// Call the plugin's `list_content` MCP tool and load the result into `contentGraph`. A no-op
+    /// when no graph is attached. The whole path is best-effort: a missing tool (older plugin,
+    /// surfaced as `MCPError.rpcError`), an `isError` result, a malformed payload, or the MCP
+    /// client not running all log a warning and leave the graph empty — preview is unaffected.
+    private func populateContentGraph(siteID: String, generation gen: Int) async {
+        guard let graph = contentGraph else { return }
+        guard await mcpClient.isRunning else { return }
+        do {
+            let result = try await mcpClient.callTool(name: "list_content")
+            // A newer start() may have superseded us during the call — don't pollute the shared
+            // graph with a site this window is no longer showing; that start() loads its own.
+            guard gen == generation else { return }
+            guard !result.isError else {
+                await logCenter.append(
+                    source: "mcp:\(siteID)", stream: .stderr,
+                    text: "list_content returned an error result — content graph left empty"
+                )
+                return
+            }
+            let text = result.content.first(where: { $0.type == "text" })?.text ?? ""
+            let listing = try ContentListing.parse(jsonText: text, siteID: siteID)
+            await graph.load(siteID: siteID, pages: listing.pages, posts: listing.posts, images: listing.images)
+            loadedGraphSiteID = siteID
+        } catch let MCPClient.MCPError.rpcError(code, _) where code == -32601 {
+            // Method-not-found: older plugin without the tool — expected, not worth alarming about.
+            // Any *other* RPC error means `list_content` exists but failed, so it falls through to
+            // the stderr branch below where it stays visible in the Debug pane (logs are sacred).
+            await logCenter.append(
+                source: "mcp:\(siteID)", stream: .stdout,
+                text: "list_content not available (older plugin) — content graph left empty"
+            )
+        } catch {
+            await logCenter.append(
+                source: "mcp:\(siteID)", stream: .stderr,
+                text: "list_content population failed: \(error) — content graph left empty"
+            )
+        }
     }
 
     private func startMCPClient(siteID: String, siteDirectory: URL) async {

--- a/Tests/AnglesiteCoreTests/ContentListingTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentListingTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for `ContentListing.parse(jsonText:siteID:)` — the bridge from the plugin's
+/// `list_content` MCP tool JSON to `SiteContentGraph` structs (A.8, #142). The parser owns
+/// siteID stamping and site-scoped id construction; the plugin payload is site-agnostic.
+struct ContentListingTests {
+    static let siteID = "/Users/x/Sites/alpha"
+
+    /// `2026-06-11T12:00:00Z`
+    static let noon = ISO8601DateFormatter().date(from: "2026-06-11T12:00:00Z")!
+
+    // MARK: - Happy path
+
+    @Test("Parses pages, posts, and images with siteID stamping and id construction")
+    func parsesFullPayload() throws {
+        let json = """
+        {
+          "pages": [
+            {"route": "/about", "filePath": "src/pages/about.astro", "title": "About", "lastModified": "2026-06-11T12:00:00Z"}
+          ],
+          "posts": [
+            {"collection": "blog", "slug": "hello", "title": "Hello", "draft": false,
+             "publishDate": "2026-06-11T12:00:00Z", "tags": ["intro", "news"],
+             "filePath": "src/content/blog/hello.md", "lastModified": "2026-06-11T12:00:00Z"}
+          ],
+          "images": [
+            {"relativePath": "public/images/hero.jpg", "fileName": "hero.jpg", "byteSize": 12345,
+             "usedOnPages": ["/"], "lastModified": "2026-06-11T12:00:00Z"}
+          ]
+        }
+        """
+
+        let listing = try ContentListing.parse(jsonText: json, siteID: Self.siteID)
+
+        #expect(listing.pages == [
+            SiteContentGraph.Page(
+                id: "\(Self.siteID):page:/about",
+                siteID: Self.siteID,
+                route: "/about",
+                filePath: "src/pages/about.astro",
+                title: "About",
+                lastModified: Self.noon
+            )
+        ])
+        #expect(listing.posts == [
+            SiteContentGraph.Post(
+                id: "\(Self.siteID):post:hello",
+                siteID: Self.siteID,
+                collection: "blog",
+                slug: "hello",
+                title: "Hello",
+                draft: false,
+                publishDate: Self.noon,
+                tags: ["intro", "news"],
+                filePath: "src/content/blog/hello.md",
+                lastModified: Self.noon
+            )
+        ])
+        #expect(listing.images == [
+            SiteContentGraph.Image(
+                id: "\(Self.siteID):image:public/images/hero.jpg",
+                siteID: Self.siteID,
+                relativePath: "public/images/hero.jpg",
+                fileName: "hero.jpg",
+                byteSize: 12345,
+                usedOnPages: ["/"],
+                lastModified: Self.noon
+            )
+        ])
+    }
+
+    // MARK: - Optional fields
+
+    @Test("Optional fields decode to nil when absent")
+    func optionalFieldsAbsent() throws {
+        let json = """
+        {
+          "pages": [{"route": "/", "filePath": "src/pages/index.astro", "lastModified": "2026-06-11T12:00:00Z"}],
+          "posts": [{"collection": "blog", "slug": "draft", "title": "Draft", "draft": true,
+                     "tags": [], "filePath": "src/content/blog/draft.md", "lastModified": "2026-06-11T12:00:00Z"}],
+          "images": [{"relativePath": "public/a.png", "fileName": "a.png",
+                      "usedOnPages": [], "lastModified": "2026-06-11T12:00:00Z"}]
+        }
+        """
+
+        let listing = try ContentListing.parse(jsonText: json, siteID: Self.siteID)
+
+        #expect(listing.pages.first?.title == nil)
+        #expect(listing.posts.first?.publishDate == nil)
+        #expect(listing.posts.first?.draft == true)
+        #expect(listing.images.first?.byteSize == nil)
+    }
+
+    @Test("Missing top-level arrays default to empty")
+    func missingArraysDefaultEmpty() throws {
+        let listing = try ContentListing.parse(jsonText: "{}", siteID: Self.siteID)
+        #expect(listing.pages.isEmpty)
+        #expect(listing.posts.isEmpty)
+        #expect(listing.images.isEmpty)
+    }
+
+    // MARK: - Date formats
+
+    @Test("Parses ISO-8601 timestamps with fractional seconds")
+    func parsesFractionalSeconds() throws {
+        let json = """
+        {"pages": [{"route": "/", "filePath": "src/pages/index.astro", "lastModified": "2026-06-11T12:00:00.500Z"}]}
+        """
+        let listing = try ContentListing.parse(jsonText: json, siteID: Self.siteID)
+        let expected = Self.noon.addingTimeInterval(0.5)
+        #expect(abs((listing.pages.first?.lastModified.timeIntervalSince1970 ?? 0) - expected.timeIntervalSince1970) < 0.001)
+    }
+
+    // MARK: - Error paths
+
+    @Test("Malformed JSON throws")
+    func malformedJSONThrows() {
+        #expect(throws: (any Error).self) {
+            try ContentListing.parse(jsonText: "{not json", siteID: Self.siteID)
+        }
+    }
+
+    @Test("Missing a required field throws")
+    func missingRequiredFieldThrows() {
+        // page without `route`
+        let json = """
+        {"pages": [{"filePath": "src/pages/index.astro", "lastModified": "2026-06-11T12:00:00Z"}]}
+        """
+        #expect(throws: (any Error).self) {
+            try ContentListing.parse(jsonText: json, siteID: Self.siteID)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/LocalSiteRuntimeGraphTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalSiteRuntimeGraphTests.swift
@@ -1,0 +1,134 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// A.8 (#142): `LocalSiteRuntime` populates a `SiteContentGraph` from the plugin's `list_content`
+/// MCP tool after the dev server is ready and the MCP client has initialized, and evicts the
+/// site's content from the graph on stop. A missing/erroring `list_content` (older plugin) is a
+/// no-op: the graph stays empty and preview is unaffected.
+struct LocalSiteRuntimeGraphTests {
+    private let alwaysReady: AstroDevServer.ReadinessProbe = { _ in true }
+    private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    private static let siteID = "/Users/x/Sites/alpha"
+    private static let noon = ISO8601DateFormatter().date(from: "2026-06-11T12:00:00Z")!
+
+    private static let pythonURL: URL = {
+        for path in ["/usr/bin/python3", "/opt/homebrew/bin/python3", "/usr/local/bin/python3"] {
+            if FileManager.default.isExecutableFile(atPath: path) { return URL(fileURLWithPath: path) }
+        }
+        return URL(fileURLWithPath: "/usr/bin/python3")
+    }()
+    private static var pythonAvailable: Bool { FileManager.default.isExecutableFile(atPath: pythonURL.path) }
+
+    /// The JSON the fake `list_content` tool returns as its text content. Triple-quoted Python
+    /// string so the inner JSON needs no escaping; `json.dumps` re-escapes it into the response.
+    private static let listingJSON = """
+    {
+      "pages": [{"route":"/about","filePath":"src/pages/about.astro","title":"About","lastModified":"2026-06-11T12:00:00Z"}],
+      "posts": [{"collection":"blog","slug":"hello","title":"Hello","draft":false,"tags":["intro"],
+                 "filePath":"src/content/blog/hello.md","lastModified":"2026-06-11T12:00:00Z"}],
+      "images": [{"relativePath":"public/hero.jpg","fileName":"hero.jpg","byteSize":123,
+                  "usedOnPages":["/about"],"lastModified":"2026-06-11T12:00:00Z"}]
+    }
+    """
+
+    /// Fake MCP server that returns the listing above from `list_content`.
+    private static let populatingScript = """
+    import sys, json
+    LISTING = '''\(listingJSON)'''
+    for line in sys.stdin:
+        line = line.strip()
+        if not line: continue
+        try: msg = json.loads(line)
+        except Exception: continue
+        method = msg.get("method", ""); rid = msg.get("id")
+        if rid is None: continue
+        if method == "initialize":
+            resp = {"jsonrpc":"2.0","id":rid,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"fake","version":"0"}}}
+        elif method == "tools/call" and (msg.get("params") or {}).get("name") == "list_content":
+            resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":LISTING}],"isError":False}}
+        else:
+            resp = {"jsonrpc":"2.0","id":rid,"error":{"code":-32601,"message":"method not found"}}
+        sys.stdout.write(json.dumps(resp) + chr(10)); sys.stdout.flush()
+    """
+
+    /// Fake MCP server that returns a JSON-RPC error for `list_content` (older plugin).
+    private static let noToolScript = """
+    import sys, json
+    for line in sys.stdin:
+        line = line.strip()
+        if not line: continue
+        try: msg = json.loads(line)
+        except Exception: continue
+        method = msg.get("method", ""); rid = msg.get("id")
+        if rid is None: continue
+        if method == "initialize":
+            resp = {"jsonrpc":"2.0","id":rid,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"fake","version":"0"}}}
+        else:
+            resp = {"jsonrpc":"2.0","id":rid,"error":{"code":-32601,"message":"unknown tool"}}
+        sys.stdout.write(json.dumps(resp) + chr(10)); sys.stdout.flush()
+    """
+
+    private func makeRuntime(graph: SiteContentGraph, mcpScript: String) -> LocalSiteRuntime {
+        let supervisor = ProcessSupervisor()
+        let center = LogCenter()
+        let devServer = AstroDevServer(supervisor: supervisor, logCenter: center, readinessProbe: alwaysReady)
+        let mcpClient = MCPClient(supervisor: supervisor, logCenter: center)
+        return LocalSiteRuntime(
+            devServer: devServer,
+            mcpClient: mcpClient,
+            contentGraph: graph,
+            logCenter: center,
+            resolveCommand: { _ in .run(executable: URL(fileURLWithPath: "/bin/sh"),
+                                        arguments: ["-c", "echo '  Local    http://localhost:4321/'; exec sleep 30"]) },
+            resolveMCPCommand: { .run(executable: Self.pythonURL, arguments: ["-u", "-c", mcpScript]) },
+            restartPolicy: .never
+        )
+    }
+
+    @Test("Populates the graph from list_content after start", .enabled(if: pythonAvailable))
+    func populatesGraphAfterStart() async throws {
+        let graph = SiteContentGraph()
+        let runtime = makeRuntime(graph: graph, mcpScript: Self.populatingScript)
+
+        await runtime.start(siteID: Self.siteID, siteDirectory: tmpDir)
+
+        let pages = await graph.pages(for: Self.siteID)
+        let posts = await graph.posts(for: Self.siteID)
+        let images = await graph.images(for: Self.siteID)
+        #expect(pages.map(\.route) == ["/about"])
+        #expect(pages.first?.title == "About")
+        #expect(pages.first?.lastModified == Self.noon)
+        #expect(posts.map(\.slug) == ["hello"])
+        #expect(images.map(\.fileName) == ["hero.jpg"])
+        #expect(images.first?.byteSize == 123)
+
+        await runtime.stop()
+    }
+
+    @Test("Evicts the site's content from the graph on stop", .enabled(if: pythonAvailable))
+    func unloadsGraphOnStop() async throws {
+        let graph = SiteContentGraph()
+        let runtime = makeRuntime(graph: graph, mcpScript: Self.populatingScript)
+
+        await runtime.start(siteID: Self.siteID, siteDirectory: tmpDir)
+        #expect(await !graph.pages(for: Self.siteID).isEmpty)
+
+        await runtime.stop()
+        #expect(await graph.knownSiteIDs().isEmpty)
+    }
+
+    @Test("Missing list_content tool leaves the graph empty and preview ready", .enabled(if: pythonAvailable))
+    func missingToolIsGracefulFallback() async throws {
+        let graph = SiteContentGraph()
+        let runtime = makeRuntime(graph: graph, mcpScript: Self.noToolScript)
+
+        await runtime.start(siteID: Self.siteID, siteDirectory: tmpDir)
+
+        #expect(await graph.knownSiteIDs().isEmpty)
+        let state = await runtime.state
+        #expect(state == .ready(siteID: Self.siteID, url: URL(string: "http://localhost:4321/")!))
+
+        await runtime.stop()
+    }
+}


### PR DESCRIPTION
Closes #142 (Siri AI Phase A — A.8).

After the dev server is ready and the per-site MCP client initializes, `LocalSiteRuntime.start()` calls the plugin's `list_content` tool, parses the response into `SiteContentGraph` structs, and `graph.load()`s them. The shared app-lifetime graph (held by `AppDelegate`) is threaded through `SiteWindow` → `PreviewModel` → `LocalSiteRuntime`, so opening a site populates the same graph the App Intents entity queries (#137) and the Spotlight indexer (#103) read from.

## What's here

- **`ContentListing.parse(jsonText:siteID:)`** (new, `AnglesiteCore`) — projects the `list_content` JSON into `Page/Post/Image`, stamping `siteID` and constructing the site-scoped ids (`{siteID}:page:{route}`, `:post:{slug}`, `:image:{relativePath}`) that match the #137 entity id formats. The plugin payload stays site-agnostic. Lenient on missing top-level arrays; accepts ISO-8601 with/without fractional seconds; required fields fail loudly.
- **`LocalSiteRuntime`** — optional `contentGraph`; populate on ready, **evict on stop** (`graph.unload`). A generation guard prevents a superseded/torn-down `start()` from writing a no-longer-shown site into the shared graph.
- **App wiring** — `AppDelegate.contentGraph` → `SiteWindow(siteID:contentGraph:)` → `PreviewModel(contentGraph:)` → `LocalSiteRuntime(contentGraph:)`.

## Fallback (issue requirement)

- `-32601` (older plugin without the tool) → info log, graph left empty.
- Any **other** `list_content` failure (present-but-erroring tool, malformed payload) → stderr log so it stays visible in the Debug pane (logs are sacred).
- Preview is unaffected in every case.

File-watch incremental updates (`upsert*`/`remove*` on MCP notifications) are deferred until the plugin emits them, per the issue.

## Dependency

Consumes the paired plugin tool **`list_content` (#140 / A.6)**, which isn't in `../anglesite` yet. The contract is defined here by `ContentListing`'s expected schema; the app ships safely ahead of the plugin via the fallback and activates once the bundled-plugin pointer includes the tool.

## Tests

- `ContentListingTests` (6) — field mapping + id construction, optional fields, empty payload, fractional-second dates, malformed JSON, missing-required-field.
- `LocalSiteRuntimeGraphTests` (3) — populate-on-start, evict-on-stop, older-plugin no-op — using a Python fake MCP server (same pattern as `MCPClientTests`).

Full suite green (225 Core/Bridge tests); `Anglesite` (DevID) and `AnglesiteMAS` both build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)