### PR TITLE
feat(server): list_content, create_page, create_post MCP tools (#140)

### DIFF
--- a/server/content-frontmatter.mjs
+++ b/server/content-frontmatter.mjs
@@ -1,0 +1,73 @@
+/**
+ * Minimal YAML frontmatter reader for the content tools (#140 / A.6).
+ *
+ * The plugin has no YAML dependency, and `list_content` only needs a handful of scalar/array
+ * fields (`title`, `slug`, `draft`, `publishDate`, `date`, `tags`) off article-like collection
+ * entries. This parses exactly that subset — quoted/unquoted scalars, booleans, and string
+ * arrays in both inline (`[a, b]`) and block (`- a`) form. It is deliberately NOT a general
+ * YAML parser; anything it doesn't recognize is left out of the returned object rather than
+ * guessed at.
+ *
+ * @param {string} source full file contents (frontmatter + body)
+ * @returns {Record<string, string | boolean | string[]>} parsed scalar/array fields
+ */
+export function parseFrontmatter(source) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source);
+  if (!match) return {};
+
+  const out = {};
+  const lines = match[1].split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    // Only top-level keys (no indentation) start a new field.
+    if (/^\s/.test(line)) continue;
+
+    const kv = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(line);
+    if (!kv) continue;
+    const key = kv[1];
+    const rawValue = kv[2].trim();
+
+    if (rawValue === "") {
+      // Possible block array on the following indented `- item` lines.
+      const items = [];
+      let j = i + 1;
+      while (j < lines.length && /^\s*-\s+/.test(lines[j])) {
+        items.push(unquote(lines[j].replace(/^\s*-\s+/, "").trim()));
+        j++;
+      }
+      if (items.length) {
+        out[key] = items;
+        i = j - 1;
+      } else {
+        out[key] = "";
+      }
+      continue;
+    }
+
+    out[key] = parseScalarOrArray(rawValue);
+  }
+  return out;
+}
+
+function parseScalarOrArray(raw) {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  // Inline array: [a, b, c]
+  if (raw.startsWith("[") && raw.endsWith("]")) {
+    const inner = raw.slice(1, -1).trim();
+    if (!inner) return [];
+    return inner.split(",").map((s) => unquote(s.trim()));
+  }
+  return unquote(raw);
+}
+
+function unquote(s) {
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}

--- a/server/create-content.mjs
+++ b/server/create-content.mjs
@@ -1,0 +1,166 @@
+/**
+ * `create_page` / `create_post` MCP tool backends (#140 / A.6).
+ *
+ * Both scaffold a minimal, valid source file from a fixed template and commit it onto the
+ * project's current branch (best-effort — the filesystem is the source of truth, so a missing
+ * git repo or a rejecting hook leaves the file on disk and reports `commit: null` rather than
+ * failing). Neither overwrites an existing file. These back the App Intents Add-Page / Add-Post
+ * flows (A.5) and feed the same content graph `list_content` reports.
+ *
+ * @module
+ */
+import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { execFileSync } from "node:child_process";
+
+/**
+ * Scaffold a new Astro page under `src/pages/`.
+ *
+ * @param {string} projectRoot
+ * @param {{ name: string, route?: string }} input
+ * @returns {{ filePath: string, route: string, commit: string | null }}
+ */
+export function createPage(projectRoot, { name, route }) {
+  const title = (name ?? "").trim();
+  if (!title) throw new Error("create_page requires a non-empty name");
+
+  const normalizedRoute = normalizeRoute(route ?? slugify(title));
+  if (normalizedRoute === "/") {
+    throw new Error("create_page can't scaffold the site root; give the page a name or route");
+  }
+  const relPath = "src/pages" + normalizedRoute + ".astro";
+  const abs = join(projectRoot, relPath);
+  if (existsSync(abs)) throw new Error(`A page already exists at ${relPath}`);
+
+  // Depth below src/pages/ decides how many `../` the layout import needs.
+  const depth = normalizedRoute.replace(/^\//, "").split("/").length; // 1 for "/about"
+  const layoutImport = "../".repeat(depth) + "layouts/BaseLayout.astro";
+
+  writeFile(abs, pageTemplate({ title, layoutImport }));
+  return { filePath: relPath, route: normalizedRoute, commit: commitFile(projectRoot, relPath, `anglesite: add page ${normalizedRoute}`) };
+}
+
+/**
+ * Scaffold a new content-collection entry. Defaults to the `posts` collection (the on-disk
+ * Astro collection name; the issue's colloquial "blog" maps here). New posts are created as
+ * drafts so they stay out of the production build until the owner publishes.
+ *
+ * @param {string} projectRoot
+ * @param {{ title: string, collection?: string, slug?: string }} input
+ * @returns {{ filePath: string, slug: string, collection: string, commit: string | null }}
+ */
+export function createPost(projectRoot, { title, collection, slug }) {
+  const cleanTitle = (title ?? "").trim();
+  if (!cleanTitle) throw new Error("create_post requires a non-empty title");
+
+  const coll = (collection ?? "posts").trim() || "posts";
+  // `collection` becomes a path segment under src/content/, so it must not escape it. `slug`
+  // is neutralized by slugify below, but `collection` is used verbatim — restrict it to a
+  // single safe segment (no separators, dots, or traversal) rather than silently retargeting.
+  if (!/^[A-Za-z0-9_-]+$/.test(coll)) {
+    throw new Error(`Invalid collection name: ${coll}`);
+  }
+  const finalSlug = slugify(slug ?? cleanTitle);
+  if (!finalSlug) throw new Error("create_post could not derive a slug from the title");
+
+  const relPath = `src/content/${coll}/${finalSlug}.md`;
+  const abs = join(projectRoot, relPath);
+  if (existsSync(abs)) throw new Error(`A ${coll} entry already exists at ${relPath}`);
+
+  writeFile(abs, postTemplate({ title: cleanTitle }));
+  return {
+    filePath: relPath,
+    slug: finalSlug,
+    collection: coll,
+    commit: commitFile(projectRoot, relPath, `anglesite: add ${coll} ${finalSlug}`),
+  };
+}
+
+// MARK: - Templates
+
+function pageTemplate({ title, layoutImport }) {
+  const description = `${title}.`;
+  return `---
+import BaseLayout from "${layoutImport}";
+---
+
+<BaseLayout title="${escapeAttr(title)}" description="${escapeAttr(description)}">
+  <main>
+    <h1>${escapeHtml(title)}</h1>
+    <p>Add your content here.</p>
+  </main>
+</BaseLayout>
+`;
+}
+
+function postTemplate({ title }) {
+  const publishDate = new Date().toISOString();
+  return `---
+title: "${escapeYaml(title)}"
+description: ""
+publishDate: ${publishDate}
+draft: true
+tags: []
+---
+
+Write your post here.
+`;
+}
+
+// MARK: - Git (best-effort, commits to HEAD on the current branch)
+
+/**
+ * Stage and commit exactly `relPath` on the current branch. Returns the new HEAD SHA, or null
+ * on any failure (not a git repo, no prior commit, a pre-commit hook rejecting, git missing).
+ * Commits a single pathspec so unrelated staged/working changes are left untouched.
+ */
+function commitFile(projectRoot, relPath, message) {
+  const run = (args) =>
+    execFileSync("git", args, { cwd: projectRoot, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+  try {
+    run(["rev-parse", "--git-dir"]);
+    run(["add", "--", relPath]);
+    run(["commit", "-m", message, "--", relPath]);
+    return run(["rev-parse", "HEAD"]);
+  } catch {
+    return null;
+  }
+}
+
+// MARK: - Helpers
+
+function writeFile(abs, contents) {
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, contents);
+}
+
+/** `/About//Us/` → `/about-us`; bare name → `/name`. Always leading-slash, no trailing slash. */
+function normalizeRoute(route) {
+  const segments = String(route)
+    .split("/")
+    .map((s) => slugify(s))
+    .filter(Boolean);
+  return "/" + segments.join("/");
+}
+
+function slugify(value) {
+  return String(value)
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "") // strip combining diacritical marks
+    .replace(/['"]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function escapeAttr(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeYaml(s) {
+  return String(s).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}

--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -10,6 +10,8 @@ import { applyEditInputShape } from "./apply-edit-schema.mjs";
 import { applyEdit } from "./apply-edit-dispatcher.mjs";
 import { recordEdit } from "./edit-history.mjs";
 import { undoEdit } from "./undo-edit.mjs";
+import { listContent } from "./list-content.mjs";
+import { createPage, createPost } from "./create-content.mjs";
 
 /**
  * Build the Anglesite MCP server with every tool registered against `projectRoot`.
@@ -105,6 +107,59 @@ export function buildServer(projectRoot) {
         content: [{ type: "text", text: JSON.stringify(result) }],
         isError: result.status === "refused",
       };
+    },
+  );
+
+  // Siri AI Phase A content tools (#140 / A.6). `list_content` feeds the Anglesite-app's
+  // SiteContentGraph (#142); `create_page`/`create_post` back the Add-Page/Add-Post intents (A.5).
+  server.tool(
+    "list_content",
+    "List the site's pages, article-like content-collection entries (posts, notes, episodes, experiments), and images under public/images, as structured JSON. Read-only; the filesystem is the source of truth.",
+    {},
+    () => {
+      const listing = listContent(projectRoot);
+      return { content: [{ type: "text", text: JSON.stringify(listing) }] };
+    },
+  );
+
+  server.tool(
+    "create_page",
+    "Scaffold a new Astro page under src/pages/ from a BaseLayout template and commit it. Does not overwrite an existing page.",
+    {
+      name: z.string().describe("Human-readable page name, e.g. 'About Us'. Used as the title."),
+      route: z
+        .string()
+        .optional()
+        .describe("URL route, e.g. /about or /services/web. Derived from name when omitted."),
+    },
+    ({ name, route }) => {
+      try {
+        const result = createPage(projectRoot, { name, route });
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      } catch (error) {
+        return { content: [{ type: "text", text: error.message }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "create_post",
+    "Scaffold a new content-collection entry (default collection: posts) as a draft from a template and commit it. Does not overwrite an existing entry.",
+    {
+      title: z.string().describe("Post title. Used as the slug source when slug is omitted."),
+      collection: z
+        .string()
+        .optional()
+        .describe("Content collection name, e.g. posts (default) or notes."),
+      slug: z.string().optional().describe("URL slug. Derived from title when omitted."),
+    },
+    ({ title, collection, slug }) => {
+      try {
+        const result = createPost(projectRoot, { title, collection, slug });
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      } catch (error) {
+        return { content: [{ type: "text", text: error.message }], isError: true };
+      }
     },
   );
 

--- a/server/list-content.mjs
+++ b/server/list-content.mjs
@@ -1,0 +1,191 @@
+/**
+ * `list_content` MCP tool backend (#140 / A.6).
+ *
+ * Scans a project's `src/pages/`, the article-like content collections under `src/content/`,
+ * and `public/images/`, returning a site-agnostic JSON projection. The Anglesite-app consumes
+ * this via `ContentListing.parse(jsonText:siteID:)` (A.8, #142) to populate `SiteContentGraph`,
+ * which backs the App Intents `PageEntity`/`PostEntity`/`ImageEntity` (A.2, #137) and the
+ * Spotlight indexer (A.3). The payload carries NO siteID and NO entity ids — the app stamps
+ * those, so the plugin never needs to know which on-disk site it's serving.
+ *
+ * The filesystem is the source of truth; this is a read-only scan with no side effects.
+ *
+ * @module
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep, basename, extname } from "node:path";
+import { parseFrontmatter } from "./content-frontmatter.mjs";
+
+/** Page source extensions that map to a navigable route. */
+const PAGE_EXTENSIONS = new Set([".astro", ".md", ".mdx", ".markdown", ".html"]);
+/** Content-collection entry extensions (Astro content layer glob: mdoc, mdx, md). */
+const ENTRY_EXTENSIONS = new Set([".md", ".mdx", ".mdoc", ".markdown"]);
+/** Raster/vector image extensions surfaced from `public/images/`. */
+const IMAGE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp", ".gif", ".svg", ".avif"]);
+/**
+ * Collections whose entries are "posts" in the graph's sense — they carry title / publishDate /
+ * draft / tags. Other collections (gallery, team, menus, submissions, …) don't fit the Post
+ * shape and would pollute Siri's "show my drafts", so they're intentionally excluded (#140).
+ */
+const ARTICLE_COLLECTIONS = new Set(["posts", "notes", "episodes", "experiments"]);
+
+/**
+ * @param {string} projectRoot absolute path to the site root
+ * @returns {{ pages: object[], posts: object[], images: object[] }}
+ */
+export function listContent(projectRoot) {
+  return {
+    pages: scanPages(projectRoot),
+    posts: scanPosts(projectRoot),
+    images: scanImages(projectRoot),
+  };
+}
+
+// MARK: - Pages
+
+function scanPages(projectRoot) {
+  const pagesDir = join(projectRoot, "src", "pages");
+  const out = [];
+  for (const abs of walk(pagesDir)) {
+    const rel = relative(projectRoot, abs);
+    const relPosix = toPosix(rel);
+    // Skip dynamic routes (`[slug]`, `[...rest]`) — they're templates, not concrete pages.
+    if (relPosix.includes("[")) continue;
+    if (!PAGE_EXTENSIONS.has(extname(abs).toLowerCase())) continue;
+
+    out.push({
+      route: routeFromPagePath(relPosix),
+      filePath: relPosix,
+      title: pageTitle(abs),
+      lastModified: mtimeISO(abs),
+    });
+  }
+  return out;
+}
+
+/** `src/pages/index.astro` → `/`, `src/pages/blog/index.astro` → `/blog`, `…/about.astro` → `/about`. */
+function routeFromPagePath(relPosix) {
+  let r = relPosix.replace(/^src\/pages\//, "").replace(/\.[^.]+$/, "");
+  r = r.replace(/(^|\/)index$/, "$1");
+  r = r.replace(/\/$/, "");
+  return "/" + r;
+}
+
+/**
+ * Best-effort page title: the `title="…"` (or `title='…'`) prop passed to a layout component,
+ * else the first markdown frontmatter `title`, else null. `.astro` files have no standard
+ * title field, so this is heuristic by design — the app treats Page.title as optional.
+ */
+function pageTitle(abs) {
+  let text;
+  try {
+    text = readFileSync(abs, "utf-8");
+  } catch {
+    return null;
+  }
+  const fm = parseFrontmatter(text);
+  if (typeof fm.title === "string" && fm.title) return fm.title;
+  const m = /\btitle\s*=\s*(?:"([^"]*)"|'([^']*)')/.exec(text);
+  const found = m && (m[1] ?? m[2]);
+  return found ? found : null;
+}
+
+// MARK: - Posts
+
+function scanPosts(projectRoot) {
+  const contentDir = join(projectRoot, "src", "content");
+  const out = [];
+  for (const collection of ARTICLE_COLLECTIONS) {
+    const dir = join(contentDir, collection);
+    for (const abs of walk(dir)) {
+      if (!ENTRY_EXTENSIONS.has(extname(abs).toLowerCase())) continue;
+      const relPosix = toPosix(relative(projectRoot, abs));
+      const fm = readFrontmatter(abs);
+      const slug = (typeof fm.slug === "string" && fm.slug) ? fm.slug : basename(abs, extname(abs));
+      const title = (typeof fm.title === "string" && fm.title) ? fm.title : slug;
+      out.push({
+        collection,
+        slug,
+        title,
+        draft: fm.draft === true,
+        publishDate: dateISO(fm.publishDate ?? fm.date),
+        tags: Array.isArray(fm.tags) ? fm.tags : [],
+        filePath: relPosix,
+        lastModified: mtimeISO(abs),
+      });
+    }
+  }
+  return out;
+}
+
+function readFrontmatter(abs) {
+  try {
+    return parseFrontmatter(readFileSync(abs, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+// MARK: - Images
+
+function scanImages(projectRoot) {
+  const imagesDir = join(projectRoot, "public", "images");
+  const out = [];
+  for (const abs of walk(imagesDir)) {
+    if (!IMAGE_EXTENSIONS.has(extname(abs).toLowerCase())) continue;
+    let size = null;
+    try {
+      size = statSync(abs).size;
+    } catch {
+      // leave byteSize null
+    }
+    out.push({
+      relativePath: toPosix(relative(projectRoot, abs)),
+      fileName: basename(abs),
+      byteSize: size,
+      // Reverse "which pages use this image" is an expensive cross-scan; deferred (#140).
+      usedOnPages: [],
+      lastModified: mtimeISO(abs),
+    });
+  }
+  return out;
+}
+
+// MARK: - Helpers
+
+/** Recursively yield absolute file paths under `dir`. Missing dir → nothing. */
+function* walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(abs);
+    } else if (entry.isFile()) {
+      yield abs;
+    }
+  }
+}
+
+function mtimeISO(abs) {
+  try {
+    return statSync(abs).mtime.toISOString();
+  } catch {
+    return new Date(0).toISOString();
+  }
+}
+
+/** Normalize a frontmatter date value to an ISO string, or null if unparseable/absent. */
+function dateISO(value) {
+  if (typeof value !== "string" || !value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+function toPosix(p) {
+  return sep === "/" ? p : p.split(sep).join("/");
+}

--- a/test/create-content.test.js
+++ b/test/create-content.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { createPage, createPost } from "../server/create-content.mjs";
+import { parseFrontmatter } from "../server/content-frontmatter.mjs";
+
+let repo;
+
+function git(args) {
+  return execFileSync("git", args, { cwd: repo, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function initRepo() {
+  repo = mkdtempSync(join(tmpdir(), "create-content-"));
+  execFileSync("git", ["init", "--initial-branch=main", repo], { stdio: "ignore" });
+  git(["config", "user.email", "test@example.com"]);
+  git(["config", "user.name", "Test"]);
+  // BaseLayout target so the scaffolded import resolves against a real file.
+  mkdirSync(join(repo, "src", "layouts"), { recursive: true });
+  writeFileSync(join(repo, "src", "layouts", "BaseLayout.astro"), "layout");
+  writeFileSync(join(repo, "README.md"), "seed\n");
+  git(["add", "."]);
+  git(["commit", "-m", "initial"]);
+}
+
+beforeEach(initRepo);
+afterEach(() => repo && rmSync(repo, { recursive: true, force: true }));
+
+describe("createPage", () => {
+  it("scaffolds a top-level page, derives the route from the name, and commits", () => {
+    const result = createPage(repo, { name: "About Us" });
+
+    expect(result.route).toBe("/about-us");
+    expect(result.filePath).toBe("src/pages/about-us.astro");
+    expect(result.commit).toMatch(/^[0-9a-f]{40}$/);
+
+    const body = readFileSync(join(repo, result.filePath), "utf-8");
+    expect(body).toContain("../layouts/BaseLayout.astro");
+    expect(body).toContain('title="About Us"');
+
+    // The file is committed at HEAD with nothing left staged.
+    expect(git(["status", "--porcelain"])).toBe("");
+    expect(git(["log", "-1", "--name-only", "--format="]).trim()).toContain("src/pages/about-us.astro");
+  });
+
+  it("honors an explicit nested route with the correct relative import depth", () => {
+    const result = createPage(repo, { name: "Web Design", route: "/services/web" });
+    expect(result.filePath).toBe("src/pages/services/web.astro");
+    const body = readFileSync(join(repo, result.filePath), "utf-8");
+    expect(body).toContain("../../layouts/BaseLayout.astro");
+  });
+
+  it("refuses to overwrite an existing page", () => {
+    createPage(repo, { name: "About" });
+    expect(() => createPage(repo, { name: "About" })).toThrow(/exists/i);
+  });
+
+  it("refuses to scaffold the site root", () => {
+    expect(() => createPage(repo, { name: "Home", route: "/" })).toThrow(/root/i);
+  });
+
+  it("still writes the file when the project is not a git repo (commit is null)", () => {
+    const plain = mkdtempSync(join(tmpdir(), "create-content-nogit-"));
+    try {
+      const result = createPage(plain, { name: "Solo" });
+      expect(existsSync(join(plain, result.filePath))).toBe(true);
+      expect(result.commit).toBeNull();
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("createPost", () => {
+  it("scaffolds a draft post in the posts collection, derives the slug, and commits", () => {
+    const result = createPost(repo, { title: "Hello, World!" });
+
+    expect(result.collection).toBe("posts");
+    expect(result.slug).toBe("hello-world");
+    expect(result.filePath).toBe("src/content/posts/hello-world.md");
+    expect(result.commit).toMatch(/^[0-9a-f]{40}$/);
+
+    const fm = parseFrontmatter(readFileSync(join(repo, result.filePath), "utf-8"));
+    expect(fm.title).toBe("Hello, World!");
+    expect(fm.draft).toBe(true);
+    expect(typeof fm.publishDate).toBe("string");
+    expect(() => new Date(fm.publishDate).toISOString()).not.toThrow();
+    expect(git(["status", "--porcelain"])).toBe("");
+  });
+
+  it("honors explicit collection and slug", () => {
+    const result = createPost(repo, { title: "A Note", collection: "notes", slug: "my-note" });
+    expect(result.collection).toBe("notes");
+    expect(result.slug).toBe("my-note");
+    expect(result.filePath).toBe("src/content/notes/my-note.md");
+  });
+
+  it("refuses to overwrite an existing entry", () => {
+    createPost(repo, { title: "Dup" });
+    expect(() => createPost(repo, { title: "Dup" })).toThrow(/exists/i);
+  });
+
+  it("rejects a collection that would escape src/content (path traversal)", () => {
+    expect(() => createPost(repo, { title: "Evil", collection: "../../../etc" })).toThrow(/invalid collection/i);
+    // Nothing was written outside the project.
+    expect(existsSync(join(repo, "..", "..", "..", "etc", "evil.md"))).toBe(false);
+  });
+});

--- a/test/list-content.test.js
+++ b/test/list-content.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listContent } from "../server/list-content.mjs";
+
+let root;
+
+function write(rel, content) {
+  const abs = join(root, rel);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, content);
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "list-content-"));
+});
+afterEach(() => root && rmSync(root, { recursive: true, force: true }));
+
+describe("listContent — pages", () => {
+  it("derives routes from src/pages, including index → parent", () => {
+    write("src/pages/index.astro", `<BaseLayout title="Home" description="x">hi</BaseLayout>`);
+    write("src/pages/about.astro", `<BaseLayout title="About Us" description="x" />`);
+    write("src/pages/blog/index.astro", `<h1>Blog</h1>`);
+    write("src/pages/blog/archive.astro", `<h1>Archive</h1>`);
+
+    const { pages } = listContent(root);
+    const byRoute = Object.fromEntries(pages.map((p) => [p.route, p]));
+
+    expect(Object.keys(byRoute).sort()).toEqual(["/", "/about", "/blog", "/blog/archive"]);
+    expect(byRoute["/about"].filePath).toBe("src/pages/about.astro");
+    expect(typeof byRoute["/about"].lastModified).toBe("string");
+    expect(() => new Date(byRoute["/about"].lastModified).toISOString()).not.toThrow();
+  });
+
+  it("extracts a best-effort title from BaseLayout, else null", () => {
+    write("src/pages/about.astro", `<BaseLayout title="About Us" description="x" />`);
+    write("src/pages/raw.astro", `<h1>No layout title here</h1>`);
+
+    const { pages } = listContent(root);
+    const byRoute = Object.fromEntries(pages.map((p) => [p.route, p]));
+    expect(byRoute["/about"].title).toBe("About Us");
+    expect(byRoute["/raw"].title).toBeNull();
+  });
+
+  it("skips dynamic routes and non-page endpoint files", () => {
+    write("src/pages/blog/[slug].astro", `dynamic`);
+    write("src/pages/rss.xml.ts", `export const GET = () => {}`);
+    write("src/pages/real.astro", `<BaseLayout title="Real" description="x" />`);
+
+    const { pages } = listContent(root);
+    expect(pages.map((p) => p.route)).toEqual(["/real"]);
+  });
+});
+
+describe("listContent — posts", () => {
+  it("reads article-like collections with frontmatter fields", () => {
+    write(
+      "src/content/posts/hello-world.md",
+      `---\ntitle: Hello World\ndescription: A greeting\npublishDate: 2026-06-01\ndraft: false\ntags: [intro, news]\n---\nBody`,
+    );
+    write(
+      "src/content/posts/wip.md",
+      `---\ntitle: Work in Progress\ndescription: d\npublishDate: 2026-06-10\ndraft: true\ntags: []\n---\nBody`,
+    );
+
+    const { posts } = listContent(root);
+    const bySlug = Object.fromEntries(posts.map((p) => [p.slug, p]));
+
+    expect(bySlug["hello-world"].collection).toBe("posts");
+    expect(bySlug["hello-world"].title).toBe("Hello World");
+    expect(bySlug["hello-world"].draft).toBe(false);
+    expect(bySlug["hello-world"].tags).toEqual(["intro", "news"]);
+    expect(bySlug["hello-world"].publishDate).toMatch(/^2026-06-01/);
+    expect(bySlug["hello-world"].filePath).toBe("src/content/posts/hello-world.md");
+    expect(bySlug["wip"].draft).toBe(true);
+    expect(bySlug["wip"].tags).toEqual([]);
+  });
+
+  it("uses an explicit frontmatter slug when present, else the filename", () => {
+    write(
+      "src/content/notes/2026-06-05-quick.md",
+      `---\nslug: quick-note\npublishDate: 2026-06-05\ndraft: false\n---\njust a note`,
+    );
+    const { posts } = listContent(root);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].slug).toBe("quick-note");
+    expect(posts[0].collection).toBe("notes");
+    // notes can be titleless — fall back to the slug so the graph's non-optional title is satisfied
+    expect(posts[0].title).toBe("quick-note");
+  });
+
+  it("ignores non-article collections (gallery, team, …)", () => {
+    write("src/content/gallery/photo.md", `---\nimage: /x.jpg\nalt: a\n---`);
+    write("src/content/team/jane.md", `---\nname: Jane\n---`);
+    write("src/content/posts/real.md", `---\ntitle: Real\ndescription: d\npublishDate: 2026-06-01\n---\nx`);
+
+    const { posts } = listContent(root);
+    expect(posts.map((p) => p.collection)).toEqual(["posts"]);
+  });
+
+  it("defaults draft to false and tags to [] when absent", () => {
+    write("src/content/posts/min.md", `---\ntitle: Minimal\ndescription: d\npublishDate: 2026-06-01\n---\nx`);
+    const { posts } = listContent(root);
+    expect(posts[0].draft).toBe(false);
+    expect(posts[0].tags).toEqual([]);
+    expect(posts[0].publishDate).toMatch(/^2026-06-01/);
+  });
+});
+
+describe("listContent — images", () => {
+  it("scans public/images recursively with size and relative path", () => {
+    write("public/images/hero.jpg", "fakejpgbytes");
+    write("public/images/blog/cover.webp", "fakewebp");
+    write("public/images/notes.txt", "not an image");
+
+    const { images } = listContent(root);
+    const byPath = Object.fromEntries(images.map((i) => [i.relativePath, i]));
+
+    expect(Object.keys(byPath).sort()).toEqual(["public/images/blog/cover.webp", "public/images/hero.jpg"]);
+    expect(byPath["public/images/hero.jpg"].fileName).toBe("hero.jpg");
+    expect(byPath["public/images/hero.jpg"].byteSize).toBe("fakejpgbytes".length);
+    expect(byPath["public/images/hero.jpg"].usedOnPages).toEqual([]);
+    expect(typeof byPath["public/images/hero.jpg"].lastModified).toBe("string");
+  });
+});
+
+describe("listContent — empty / missing dirs", () => {
+  it("returns empty arrays for a site with no content dirs", () => {
+    const result = listContent(root);
+    expect(result).toEqual({ pages: [], posts: [], images: [] });
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { spawn } from "node:child_process";
@@ -181,7 +181,10 @@ describe("MCP annotation server", () => {
       expect(names).toEqual([
         "add_annotation",
         "apply_edit",
+        "create_page",
+        "create_post",
         "list_annotations",
+        "list_content",
         "resolve_annotation",
         "undo_edit",
       ]);
@@ -355,6 +358,90 @@ describe("MCP annotation server", () => {
       };
       const remaining = JSON.parse(listResult.content[0].text);
       expect(remaining).toHaveLength(0);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("list_content returns structured pages, posts, and images over stdio", async () => {
+    mkdirSync(join(tmpDir, "src", "pages"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "src", "pages", "about.astro"),
+      `<BaseLayout title="About" description="x" />`,
+    );
+    mkdirSync(join(tmpDir, "src", "content", "posts"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "src", "content", "posts", "hello.md"),
+      `---\ntitle: Hello\ndescription: d\npublishDate: 2026-06-01\ndraft: false\ntags: [intro]\n---\nBody`,
+    );
+
+    const proc = startServer(tmpDir);
+    try {
+      await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+      sendNotification(proc, {
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      });
+
+      const response = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "list_content", arguments: {} },
+      });
+      const result = response.result as { content: { text: string }[] };
+      const listing = JSON.parse(result.content[0].text);
+      expect(listing.pages).toEqual([
+        expect.objectContaining({ route: "/about", filePath: "src/pages/about.astro", title: "About" }),
+      ]);
+      expect(listing.posts).toEqual([
+        expect.objectContaining({ collection: "posts", slug: "hello", title: "Hello", draft: false, tags: ["intro"] }),
+      ]);
+      expect(listing.images).toEqual([]);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("create_page scaffolds a page and reports its route over stdio", async () => {
+    const proc = startServer(tmpDir);
+    try {
+      await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+      sendNotification(proc, {
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      });
+
+      const response = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "create_page", arguments: { name: "Contact Us" } },
+      });
+      const result = response.result as { content: { text: string }[]; isError?: boolean };
+      expect(result.isError).toBeFalsy();
+      const created = JSON.parse(result.content[0].text);
+      expect(created.route).toBe("/contact-us");
+      expect(created.filePath).toBe("src/pages/contact-us.astro");
+      expect(readFileSync(join(tmpDir, created.filePath), "utf-8")).toContain('title="Contact Us"');
     } finally {
       proc.kill();
     }


### PR DESCRIPTION
Implements **Anglesite-app#140** (Siri AI Phase A — A.6): the three plugin-side MCP tools the app's Phase A work depends on. Paired with Anglesite-app#171 (A.8), which consumes `list_content`.

## Tools

- **`list_content`** (read-only) — scans `src/pages/`, the article-like content collections (`posts`, `notes`, `episodes`, `experiments`) under `src/content/`, and `public/images/`, returning a **site-agnostic** JSON projection. No siteID, no entity ids — those are the app's to stamp.
- **`create_page`** — scaffolds a `BaseLayout` `.astro` page under `src/pages/`. Route and the relative layout-import depth are derived from the name (or an explicit `route`). Refuses to overwrite; won't scaffold the site root.
- **`create_post`** — scaffolds a **draft** content entry (default collection `posts` — the on-disk Astro collection name; the issue's colloquial "blog" maps here). Slug derived from the title. Refuses to overwrite.

## Contract with the app

`list_content`'s output matches the app's Swift `ContentListing.parse` (A.8) field-for-field, so it populates `SiteContentGraph` with no remapping:

| array | fields |
|---|---|
| `pages` | `route, filePath, title\|null, lastModified` |
| `posts` | `collection, slug, title, draft, publishDate\|null, tags, filePath, lastModified` |
| `images` | `relativePath, fileName, byteSize\|null, usedOnPages, lastModified` |

All dates are ISO strings (covered by the app's fractional-second decoder). `usedOnPages` is `[]` for now (reverse image→page lookup is an expensive cross-scan, deferred).

### Collection scope

Only article-like collections (`posts`/`notes`/`episodes`/`experiments`) map to `posts` — they carry title/publishDate/draft/tags. Gallery, team, menus, submissions, etc. don't fit the Post shape and would pollute Siri's "show my drafts", so they're excluded by design.

## Safety / honesty

- **Path traversal:** `create_post`'s `collection` is validated as a single safe segment (`^[A-Za-z0-9_-]+$`) so it can't escape `src/content/`; `create_page`'s `route` is fully slugified per segment.
- **Best-effort commit:** both create tools commit a single pathspec to HEAD and return the SHA, or `null` when there's no git repo / a hook rejects — the file still lands on disk (the source of truth). Unrelated staged/working changes are left untouched.
- Overwrite attempts throw → `{isError:true}` through the handler.

## Frontmatter

A minimal, dependency-free reader (`server/content-frontmatter.mjs`) parses the scalar/boolean/string-array subset the article collections actually use (quoted/unquoted scalars, booleans, inline `[a,b]` and block `- a` arrays). Deliberately not a general YAML parser.

## Tests

- `test/list-content.test.js` (10) — route derivation, title heuristic, dynamic-route/endpoint skipping, frontmatter fields, slug fallback, non-article exclusion, image scan, empty site.
- `test/create-content.test.js` (8) — scaffold + commit, nested import depth, no-overwrite, non-git fallback, slug/collection handling, **path-traversal rejection**.
- `tests/mcp-server.test.ts` — updated `tools/list` assertion + stdio e2e for `list_content` and `create_page`.

Full suite green apart from a **pre-existing** `optimize-images-packaging` failure (tsx sandbox path resolution; reproduces on `main`, unrelated to this change).

## Release coordination

Per the two-repo workflow, this ships in a tagged plugin release; the app PR then bumps the bundled-plugin pointer. CHANGELOG/version bump deferred to that release tagging (the CHANGELOG is backfilled per release, not per PR). The app degrades gracefully against older plugins without `list_content` (Anglesite-app#171), so ordering is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)