### PR TITLE
feat(intents): ContentSpotlightIndexer for pages/posts/images (#144)

### DIFF
--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -3,6 +3,7 @@ import AnglesiteCore
 import OSLog
 
 private let log = Logger(subsystem: "dev.anglesite.app", category: "spotlight-indexer")
+private let contentLog = Logger(subsystem: "dev.anglesite.app", category: "content-spotlight-indexer")
 
 /// Public entry point that registers production dependencies with `AppDependencyManager` and
 /// hooks the Spotlight indexer to `SiteStore.shared`.
@@ -39,6 +40,20 @@ public enum AnglesiteIntents {
                 log.info("indexed=\(outcome.indexed, privacy: .public) removed=\(outcome.removed, privacy: .public)")
             } catch {
                 log.error("reindex failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        // Mirror the content graph (pages/posts/images) into the Spotlight semantic index the same
+        // way (A.3, #144). The handler fires per-siteID after every graph mutation — load on site
+        // open, upsert/remove on file-watch, unload on site close — and the indexer diffs that
+        // site's current snapshot against what it last published.
+        let contentIndexer = ContentSpotlightIndexer(graph: contentGraph, backend: LiveContentSpotlightBackend())
+        await contentGraph.setChangeHandler { siteID in
+            do {
+                let outcome = try await contentIndexer.reindex(siteID: siteID)
+                contentLog.info("indexed=\(outcome.indexed, privacy: .public) removed=\(outcome.removed, privacy: .public)")
+            } catch {
+                contentLog.error("reindex failed: \(error.localizedDescription, privacy: .public)")
             }
         }
         do {

--- a/Sources/AnglesiteIntents/ContentSpotlightIndexer.swift
+++ b/Sources/AnglesiteIntents/ContentSpotlightIndexer.swift
@@ -1,0 +1,163 @@
+import AppIntents
+import CoreSpotlight
+import Foundation
+import AnglesiteCore
+
+/// Conforming the content entities to `IndexedEntity` (done in `ContentEntities.swift`) is what
+/// lets `CSSearchableIndex.indexAppEntities` accept them and contribute to macOS 27's Spotlight
+/// semantic index. This indexer maintains that index off `SiteContentGraph` changes (A.3, #144).
+
+/// Pluggable seam over `CSSearchableIndex` so `ContentSpotlightIndexerTests` can verify the
+/// diff/upsert sequencing without hitting the live system index daemon. One method pair per
+/// entity type because `deleteAppEntities(identifiedBy:ofType:)` is type-specific.
+public protocol ContentSpotlightBackend: Sendable {
+    func indexPages(_ entities: [PageEntity]) async throws
+    func indexPosts(_ entities: [PostEntity]) async throws
+    func indexImages(_ entities: [ImageEntity]) async throws
+    func deletePages(identifiers: [String]) async throws
+    func deletePosts(identifiers: [String]) async throws
+    func deleteImages(identifiers: [String]) async throws
+}
+
+/// Maintains the Spotlight semantic index for an Anglesite site's pages, posts, and images.
+/// Single entry point: `reindex(siteID:)`, driven by `SiteContentGraph.setChangeHandler` (wired
+/// in `AnglesiteIntents.bootstrap`).
+///
+/// Diff-based like `SpotlightIndexer`, but **scoped per site**: the graph's change handler fires
+/// for one siteID at a time, and the index is shared across sites, so the last-indexed id sets
+/// are tracked per `siteID` per type. Reindexing site B must never delete site A's entities — a
+/// global id set would do exactly that, since B's snapshot doesn't contain A's ids.
+public actor ContentSpotlightIndexer {
+    private let graph: SiteContentGraph
+    private let backend: any ContentSpotlightBackend
+
+    /// Last-indexed id sets, per site. Pruned when a site goes empty so the map can't grow
+    /// unbounded across the app's lifetime as sites open and close.
+    private struct SiteState {
+        var pageIDs: Set<String> = []
+        var postIDs: Set<String> = []
+        var imageIDs: Set<String> = []
+        var isEmpty: Bool { pageIDs.isEmpty && postIDs.isEmpty && imageIDs.isEmpty }
+    }
+    private var lastIndexed: [String: SiteState] = [:]
+
+    /// Per-site serialization. `reindex` reads `lastIndexed[siteID]`, awaits the backend, then
+    /// writes back — and actors are reentrant across `await`, so a second graph mutation for the
+    /// same site (the change handler re-enters us while a pass is in flight) could split that
+    /// read-modify-write and clobber the newer snapshot, leaking stale entries in the system
+    /// index. `inFlight` makes the leader own the pass; concurrent calls just mark the site
+    /// `dirty` and return, and the leader re-runs once more to fold in whatever changed.
+    private var inFlight: Set<String> = []
+    private var dirty: Set<String> = []
+
+    public init(graph: SiteContentGraph, backend: any ContentSpotlightBackend) {
+        self.graph = graph
+        self.backend = backend
+    }
+
+    /// Result returned to callers (today: tests + the bootstrap log) so they can assert/observe
+    /// the diff outcome. Counts are summed across all three entity types.
+    public struct Outcome: Sendable, Equatable {
+        public let indexed: Int
+        public let removed: Int
+    }
+
+    /// Fetch the current page/post/image snapshot for `siteID` from the graph, diff each type
+    /// against the previously-indexed set for that site, delete anything dropped, then upsert the
+    /// current set.
+    ///
+    /// `lastIndexed[siteID]` only advances on full success: if a backend call throws partway, the
+    /// stored state stays at its pre-call value, so the next `reindex` replays the (id-set-
+    /// idempotent) deletes and retries the upserts. One extra harmless delete on the daemon beats
+    /// drifting into "the indexer thinks it published this but the index is missing entries."
+    /// Reindex `siteID`. Serialized per site (see `inFlight`/`dirty`): if a pass is already
+    /// running for this site, this call coalesces into it — it marks the site dirty so the
+    /// in-flight leader re-runs once more, and returns a no-op `Outcome` immediately.
+    @discardableResult
+    public func reindex(siteID: String) async throws -> Outcome {
+        // Check-and-set is synchronous (no `await` between), so the flag itself can't race.
+        if inFlight.contains(siteID) {
+            dirty.insert(siteID)
+            return Outcome(indexed: 0, removed: 0)
+        }
+        inFlight.insert(siteID)
+        defer { inFlight.remove(siteID) }
+        dirty.remove(siteID)
+
+        var outcome = try await performReindex(siteID: siteID)
+        // Fold in any mutations that arrived (and coalesced) while we were awaiting the backend.
+        while dirty.contains(siteID) {
+            dirty.remove(siteID)
+            outcome = try await performReindex(siteID: siteID)
+        }
+        return outcome
+    }
+
+    private func performReindex(siteID: String) async throws -> Outcome {
+        let pages = await graph.pages(for: siteID).map(PageEntity.init)
+        let posts = await graph.posts(for: siteID).map(PostEntity.init)
+        let images = await graph.images(for: siteID).map(ImageEntity.init)
+
+        var state = lastIndexed[siteID] ?? SiteState()
+
+        let pageResult = try await sync(pages, last: state.pageIDs, index: backend.indexPages, delete: backend.deletePages)
+        let postResult = try await sync(posts, last: state.postIDs, index: backend.indexPosts, delete: backend.deletePosts)
+        let imageResult = try await sync(images, last: state.imageIDs, index: backend.indexImages, delete: backend.deleteImages)
+
+        state.pageIDs = pageResult.current
+        state.postIDs = postResult.current
+        state.imageIDs = imageResult.current
+        if state.isEmpty {
+            lastIndexed.removeValue(forKey: siteID)
+        } else {
+            lastIndexed[siteID] = state
+        }
+
+        return Outcome(
+            indexed: pages.count + posts.count + images.count,
+            removed: pageResult.removed + postResult.removed + imageResult.removed
+        )
+    }
+
+    /// One type's diff: delete ids dropped since `last`, upsert the current set, and return the
+    /// new id set plus the removed count. No upsert when the set is empty (avoids daemon traffic).
+    private func sync<E: IndexedEntity & Identifiable>(
+        _ entities: [E],
+        last: Set<String>,
+        index: ([E]) async throws -> Void,
+        delete: ([String]) async throws -> Void
+    ) async throws -> (current: Set<String>, removed: Int) where E.ID == String {
+        let currentIDs = Set(entities.map(\.id))
+        let removedIDs = last.subtracting(currentIDs)
+        if !removedIDs.isEmpty {
+            try await delete(Array(removedIDs))
+        }
+        if !entities.isEmpty {
+            try await index(entities)
+        }
+        return (currentIDs, removedIDs.count)
+    }
+}
+
+/// Production backend. Routes to `CSSearchableIndex.default()`, the system-wide index used by
+/// Spotlight and Siri. macOS 27 routes `IndexedEntity` writes through the semantic index.
+struct LiveContentSpotlightBackend: ContentSpotlightBackend {
+    func indexPages(_ entities: [PageEntity]) async throws {
+        try await CSSearchableIndex.default().indexAppEntities(entities)
+    }
+    func indexPosts(_ entities: [PostEntity]) async throws {
+        try await CSSearchableIndex.default().indexAppEntities(entities)
+    }
+    func indexImages(_ entities: [ImageEntity]) async throws {
+        try await CSSearchableIndex.default().indexAppEntities(entities)
+    }
+    func deletePages(identifiers: [String]) async throws {
+        try await CSSearchableIndex.default().deleteAppEntities(identifiedBy: identifiers, ofType: PageEntity.self)
+    }
+    func deletePosts(identifiers: [String]) async throws {
+        try await CSSearchableIndex.default().deleteAppEntities(identifiedBy: identifiers, ofType: PostEntity.self)
+    }
+    func deleteImages(identifiers: [String]) async throws {
+        try await CSSearchableIndex.default().deleteAppEntities(identifiedBy: identifiers, ofType: ImageEntity.self)
+    }
+}

--- a/Tests/AnglesiteIntentsTests/ContentSpotlightIndexerTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentSpotlightIndexerTests.swift
@@ -1,0 +1,237 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+/// Verifies the per-site, per-type diff/upsert behavior of `ContentSpotlightIndexer` (A.3, #144)
+/// against a recording fake backend. The live `CSSearchableIndex` path isn't exercised — it talks
+/// to the system index daemon, which has no usable test seam. Reuses the `gPage/gPost/gImage`
+/// fixtures from `ContentEntitiesTests`.
+extension AppIntentsTests {
+    @Suite("ContentSpotlightIndexer")
+    struct ContentSpotlightIndexerTests {
+        actor RecordingBackend: ContentSpotlightBackend {
+            private(set) var indexedPages: [[PageEntity]] = []
+            private(set) var indexedPosts: [[PostEntity]] = []
+            private(set) var indexedImages: [[ImageEntity]] = []
+            private(set) var deletedPages: [[String]] = []
+            private(set) var deletedPosts: [[String]] = []
+            private(set) var deletedImages: [[String]] = []
+
+            func indexPages(_ entities: [PageEntity]) async throws { indexedPages.append(entities) }
+            func indexPosts(_ entities: [PostEntity]) async throws { indexedPosts.append(entities) }
+            func indexImages(_ entities: [ImageEntity]) async throws { indexedImages.append(entities) }
+            func deletePages(identifiers: [String]) async throws { deletedPages.append(identifiers) }
+            func deletePosts(identifiers: [String]) async throws { deletedPosts.append(identifiers) }
+            func deleteImages(identifiers: [String]) async throws { deletedImages.append(identifiers) }
+        }
+
+        private func makeGraph() -> SiteContentGraph { SiteContentGraph() }
+
+        @Test("first reindex publishes all three types and deletes nothing")
+        func firstReindexPublishesAll() async throws {
+            let graph = makeGraph()
+            await graph.load(
+                siteID: AppIntentsTests.aSite,
+                pages: [AppIntentsTests.gPage(route: "/about"), AppIntentsTests.gPage(route: "/contact")],
+                posts: [AppIntentsTests.gPost(slug: "hello")],
+                images: [AppIntentsTests.gImage()]
+            )
+            let backend = RecordingBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+
+            let outcome = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            #expect(outcome == .init(indexed: 4, removed: 0))
+            #expect(await Set(backend.indexedPages.first?.map(\.route) ?? []) == ["/about", "/contact"])
+            #expect(await backend.indexedPosts.first?.map(\.slug) == ["hello"])
+            #expect(await backend.indexedImages.first?.map(\.id) == [AppIntentsTests.gImage().id])
+            #expect(await backend.deletedPages.isEmpty)
+            #expect(await backend.deletedPosts.isEmpty)
+            #expect(await backend.deletedImages.isEmpty)
+        }
+
+        @Test("empty content types are not sent to index()")
+        func emptyTypesSkipIndex() async throws {
+            let graph = makeGraph()
+            await graph.load(siteID: AppIntentsTests.aSite, pages: [AppIntentsTests.gPage()], posts: [], images: [])
+            let backend = RecordingBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+
+            let outcome = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            #expect(outcome == .init(indexed: 1, removed: 0))
+            #expect(await backend.indexedPages.count == 1)
+            #expect(await backend.indexedPosts.isEmpty)
+            #expect(await backend.indexedImages.isEmpty)
+        }
+
+        @Test("dropping a page deletes just that id and re-upserts the rest")
+        func dropsOnePage() async throws {
+            let graph = makeGraph()
+            await graph.load(
+                siteID: AppIntentsTests.aSite,
+                pages: [AppIntentsTests.gPage(route: "/about"), AppIntentsTests.gPage(route: "/contact")],
+                posts: [], images: []
+            )
+            let backend = RecordingBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+            _ = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            await graph.removePage(id: AppIntentsTests.gPage(route: "/contact").id)
+            let outcome = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            #expect(outcome == .init(indexed: 1, removed: 1))
+            #expect(await backend.deletedPages == [[AppIntentsTests.gPage(route: "/contact").id]])
+            #expect(await backend.indexedPages.last?.map(\.route) == ["/about"])
+        }
+
+        @Test("unloading a site deletes everything previously published for it")
+        func unloadDeletesAll() async throws {
+            let graph = makeGraph()
+            await graph.load(
+                siteID: AppIntentsTests.aSite,
+                pages: [AppIntentsTests.gPage()],
+                posts: [AppIntentsTests.gPost()],
+                images: [AppIntentsTests.gImage()]
+            )
+            let backend = RecordingBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+            _ = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            await graph.unload(siteID: AppIntentsTests.aSite)
+            let outcome = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            #expect(outcome == .init(indexed: 0, removed: 3))
+            #expect(await backend.deletedPages == [[AppIntentsTests.gPage().id]])
+            #expect(await backend.deletedPosts == [[AppIntentsTests.gPost().id]])
+            #expect(await backend.deletedImages == [[AppIntentsTests.gImage().id]])
+        }
+
+        @Test("reindexing a second site never deletes the first site's entities")
+        func perSiteScoping() async throws {
+            let graph = makeGraph()
+            await graph.load(siteID: AppIntentsTests.aSite, pages: [AppIntentsTests.gPage(site: AppIntentsTests.aSite, route: "/about")], posts: [], images: [])
+            await graph.load(siteID: AppIntentsTests.bSite, pages: [AppIntentsTests.gPage(site: AppIntentsTests.bSite, route: "/contact")], posts: [], images: [])
+            let backend = RecordingBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+
+            _ = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+            let outcome = try await indexer.reindex(siteID: AppIntentsTests.bSite)
+
+            // B's first reindex must not delete A's previously-indexed page.
+            #expect(outcome == .init(indexed: 1, removed: 0))
+            #expect(await backend.deletedPages.isEmpty)
+            #expect(await backend.indexedPages.map { $0.map(\.route) } == [["/about"], ["/contact"]])
+        }
+
+        @Test("identical snapshot upserts again and deletes nothing")
+        func identicalSnapshotReupserts() async throws {
+            let graph = makeGraph()
+            await graph.load(siteID: AppIntentsTests.aSite, pages: [AppIntentsTests.gPage()], posts: [], images: [])
+            let backend = RecordingBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+            _ = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+            let outcome = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            #expect(outcome == .init(indexed: 1, removed: 0))
+            #expect(await backend.indexedPages.count == 2)
+            #expect(await backend.deletedPages.isEmpty)
+        }
+
+        @Test("dropping one post type leaves pages re-upserted and deletes only the post")
+        func mixedTypeDiff() async throws {
+            let graph = makeGraph()
+            await graph.load(
+                siteID: AppIntentsTests.aSite,
+                pages: [AppIntentsTests.gPage()],
+                posts: [AppIntentsTests.gPost(slug: "hello")],
+                images: []
+            )
+            let backend = RecordingBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+            _ = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            await graph.removePost(id: AppIntentsTests.gPost(slug: "hello").id)
+            let outcome = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            #expect(outcome == .init(indexed: 1, removed: 1))
+            #expect(await backend.deletedPosts == [[AppIntentsTests.gPost(slug: "hello").id]])
+            #expect(await backend.deletedPages.isEmpty)
+            #expect(await backend.indexedPages.last?.map(\.id) == [AppIntentsTests.gPage().id])
+        }
+
+        /// Backend that, on its first `indexPages`, mutates the graph and fires a *reentrant*
+        /// `reindex` for the same site — reproducing the interleaving the change handler causes
+        /// when a graph mutation lands while a pass is mid-flight. With per-site coalescing the
+        /// second call defers and the leader re-runs, so the new page ends up tracked; without
+        /// it, the leader's stale write clobbers the new page and it leaks in the index.
+        actor ReentrantBackend: ContentSpotlightBackend {
+            private(set) var indexedPages: [[PageEntity]] = []
+            private(set) var deletedPages: [[String]] = []
+            var indexer: ContentSpotlightIndexer?
+            var graph: SiteContentGraph?
+            var onFirstIndex: (@Sendable () async -> Void)?
+
+            func indexPages(_ entities: [PageEntity]) async throws {
+                indexedPages.append(entities)
+                if let hook = onFirstIndex {
+                    onFirstIndex = nil
+                    await hook()
+                }
+            }
+            func indexPosts(_ entities: [PostEntity]) async throws {}
+            func indexImages(_ entities: [ImageEntity]) async throws {}
+            func deletePages(identifiers: [String]) async throws { deletedPages.append(identifiers) }
+            func deletePosts(identifiers: [String]) async throws {}
+            func deleteImages(identifiers: [String]) async throws {}
+
+            func configure(indexer: ContentSpotlightIndexer, graph: SiteContentGraph, onFirstIndex: @escaping @Sendable () async -> Void) {
+                self.indexer = indexer
+                self.graph = graph
+                self.onFirstIndex = onFirstIndex
+            }
+        }
+
+        @Test("a reentrant reindex mid-pass does not lose the newly-added page")
+        func reentrantReindexDoesNotLoseUpdate() async throws {
+            let graph = makeGraph()
+            let site = AppIntentsTests.aSite
+            await graph.load(siteID: site, pages: [AppIntentsTests.gPage(route: "/about")], posts: [], images: [])
+
+            let backend = ReentrantBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+            // While the first indexPages([/about]) is awaiting, add /contact and fire a second
+            // reindex for the same site — exactly the change-handler reentrancy under load.
+            await backend.configure(indexer: indexer, graph: graph) {
+                await graph.upsertPage(AppIntentsTests.gPage(route: "/contact"))
+                _ = try? await indexer.reindex(siteID: site)
+            }
+
+            _ = try await indexer.reindex(siteID: site)
+
+            // The leader must have folded in /contact (coalesced re-run), so it's tracked. Proof:
+            // removing it now produces a delete. If it had leaked, the diff would never delete it.
+            await graph.removePage(id: AppIntentsTests.gPage(route: "/contact").id)
+            _ = try await indexer.reindex(siteID: site)
+            #expect(await backend.deletedPages == [[AppIntentsTests.gPage(route: "/contact").id]])
+        }
+
+        @Test("re-adding a previously-removed site re-publishes it")
+        func reAddAfterUnload() async throws {
+            let graph = makeGraph()
+            await graph.load(siteID: AppIntentsTests.aSite, pages: [AppIntentsTests.gPage()], posts: [], images: [])
+            let backend = RecordingBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+            _ = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+            await graph.unload(siteID: AppIntentsTests.aSite)
+            _ = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            await graph.load(siteID: AppIntentsTests.aSite, pages: [AppIntentsTests.gPage()], posts: [], images: [])
+            let outcome = try await indexer.reindex(siteID: AppIntentsTests.aSite)
+
+            #expect(outcome == .init(indexed: 1, removed: 0))
+            #expect(await backend.indexedPages.last?.map(\.id) == [AppIntentsTests.gPage().id])
+        }
+    }
+}


### PR DESCRIPTION
Closes #144 (Siri AI Phase A — A.3).

Mirrors `SiteContentGraph` (pages, posts, images) into the macOS 27 Spotlight semantic index — the same role `SpotlightIndexer` plays for `SiteEntity`/`SiteStore`. Wired in `AnglesiteIntents.bootstrap` via `SiteContentGraph.setChangeHandler`, which fires per-siteID after every graph mutation (load on open, upsert/remove on file-watch, unload on close).

## Design

- **Per-site, per-type diff.** Tracks last-indexed id sets per `(siteID, type)`. The critical reason this isn't just `SpotlightIndexer`: the change handler fires for one site at a time against a *shared* index, so a global id set would make reindexing site B delete site A's entities (B's snapshot doesn't contain A's ids). State is pruned when a site goes empty so the map can't grow unbounded.
- **Retry posture.** `lastIndexed[siteID]` advances only on full success; a backend failure replays idempotent deletes + retries upserts next pass (mirrors `SpotlightIndexer`'s comment).
- **Backend seam.** `ContentSpotlightBackend` has one index/delete pair per entity type (`deleteAppEntities(identifiedBy:ofType:)` is type-specific), so tests verify diff sequencing against a recording fake without the live `CSSearchableIndex` daemon.

## Concurrency fix (from review)

The graph fires the change handler from *inside* its own actor (`await handler(siteID)` in `emitChange`), and the handler re-enters the graph (`pages(for:)` etc.). Actors are reentrant across `await`, so two mutations for the same site can interleave and split a pass's read-modify-write of `lastIndexed` — the stale snapshot clobbers the newer one, **leaking stale entries in the system Spotlight index** that Siri/Spotlight keep surfacing.

Reindex is now **serialized per site with coalescing** (`inFlight`/`dirty`): a concurrent call for an in-flight site marks it dirty and returns immediately; the leader re-runs once more to fold in what changed. This is latent today (only `load`/`unload` fire), but goes live the moment A.8's file-watch `upsert*`/`remove*` events land — which this indexer exists to consume, so it's fixed now rather than left as a landmine.

Covered by a **deterministic regression test** that forces the exact reentrant interleaving (a backend that mutates the graph and fires a nested reindex mid-`indexPages`). Verified it fails without the coalescing guard and passes with it.

## Tests

9 in `ContentSpotlightIndexerTests`: per-type publish, empty-type skip, single-page drop, unload-deletes-all, **per-site scoping** (B never deletes A), identical-snapshot re-upsert, mixed-type diff, re-add after unload, and the **reentrancy regression**. Full suite green (303); `Anglesite` (DevID) and `AnglesiteMAS` both build.

Follow-up: #170 (batch entity lookups) becomes load-bearing once A.5 routes entity arrays through re-resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)