### PR TITLE
feat(core): IntentEditBridge + HeadlessRuntimePool (#138)

### DIFF
--- a/Sources/AnglesiteApp/PreviewView.swift
+++ b/Sources/AnglesiteApp/PreviewView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import WebKit
 import AnglesiteBridge
+import AnglesiteCore
 
 /// SwiftUI wrapper around a `WKWebView` showing the live Astro dev server.
 ///

--- a/Sources/AnglesiteCore/EditMessage.swift
+++ b/Sources/AnglesiteCore/EditMessage.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AnglesiteCore
 
 /// One edit request flowing JS → native, decoded from the `WKScriptMessage.body` JSON dict.
 ///

--- a/Sources/AnglesiteCore/EditRouter.swift
+++ b/Sources/AnglesiteCore/EditRouter.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AnglesiteCore
 
 /// What the bridge says back to the overlay after handling an `EditMessage`. The struct is
 /// `Encodable` because it gets `JSONEncoder()`'d straight into a `evaluateJavaScript` call —

--- a/Sources/AnglesiteCore/HeadlessRuntimePool.swift
+++ b/Sources/AnglesiteCore/HeadlessRuntimePool.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// A site runtime that can serve MCP tool calls without a dev-server / UI surface — the seam the
+/// `HeadlessRuntimePool` manages so intent-driven edits work when no site window is open. The
+/// production conformer is `LocalSiteRuntime` (its `startHeadlessMCP` spawns only the MCP client).
+public protocol HeadlessRuntime: Sendable {
+    /// The per-site MCP client, used to build an `EditRouter` / call `create_page` etc. `nonisolated`
+    /// so callers reach it without an actor hop (`LocalSiteRuntime.mcpClient` is a `let`).
+    nonisolated var mcpClient: MCPClient { get }
+    /// Spawn the MCP server for this site. Returns whether the client is running afterward.
+    func startHeadlessMCP(siteID: String, siteDirectory: URL) async -> Bool
+    /// Tear down the MCP client (and any other subprocesses).
+    func stop() async
+}
+
+/// Pools ephemeral `HeadlessRuntime`s keyed by siteID for intent-driven edits made while no site
+/// window is open (a headless Siri / Shortcuts invocation). Spawning Node per edit is expensive,
+/// so a runtime is cached for `ttl` seconds and its expiry is pushed out on every use — rapid
+/// successive edits to the same site reuse one MCP server. Expired runtimes are torn down
+/// (no zombie Node), matching `LocalSiteRuntime.stop()`.
+///
+/// `now`/`makeRuntime` are injectable so lifecycle is testable without a real clock or Node.
+public actor HeadlessRuntimePool {
+    public typealias RuntimeFactory = @Sendable () -> any HeadlessRuntime
+
+    private struct Entry {
+        let runtime: any HeadlessRuntime
+        var expiresAt: Date
+    }
+
+    private var entries: [String: Entry] = [:]
+    /// In-flight spawns, keyed by siteID. Concurrent `runtime(siteID:)` calls for the same
+    /// not-yet-cached site join the same spawn task instead of each spawning their own Node —
+    /// which would orphan all but the last (a zombie process the issue explicitly rules out).
+    private var spawning: [String: Task<(any HeadlessRuntime)?, Never>] = [:]
+    private let ttl: TimeInterval
+    private let now: @Sendable () -> Date
+    private let makeRuntime: RuntimeFactory
+
+    public init(
+        ttl: TimeInterval = 60,
+        now: @escaping @Sendable () -> Date = { Date() },
+        makeRuntime: @escaping RuntimeFactory = { LocalSiteRuntime() }
+    ) {
+        self.ttl = ttl
+        self.now = now
+        self.makeRuntime = makeRuntime
+    }
+
+    /// The siteIDs with a live cached runtime (post-eviction). Test/introspection surface.
+    public var cachedSiteIDs: Set<String> {
+        Set(entries.keys)
+    }
+
+    /// Return a started MCP-only runtime for `siteID`, spawning one on a cache miss and refreshing
+    /// the TTL on a hit. Returns `nil` if a freshly-spawned runtime's MCP client failed to start
+    /// (the runtime is torn down, not cached). Expired entries are evicted (and stopped) first.
+    public func runtime(siteID: String, siteDirectory: URL) async -> (any HeadlessRuntime)? {
+        await evictExpired()
+
+        if let entry = entries[siteID] {
+            entries[siteID]?.expiresAt = now().addingTimeInterval(ttl)
+            return entry.runtime
+        }
+
+        // Join an in-flight spawn for this site rather than starting a second one.
+        if let task = spawning[siteID] {
+            return await task.value
+        }
+
+        let factory = makeRuntime
+        let task = Task<(any HeadlessRuntime)?, Never> {
+            let runtime = factory()
+            guard await runtime.startHeadlessMCP(siteID: siteID, siteDirectory: siteDirectory) else {
+                await runtime.stop()
+                return nil
+            }
+            return runtime
+        }
+        spawning[siteID] = task
+        let runtime = await task.value
+        spawning[siteID] = nil
+
+        if let runtime {
+            entries[siteID] = Entry(runtime: runtime, expiresAt: now().addingTimeInterval(ttl))
+        }
+        return runtime
+    }
+
+    /// Convenience for the apply-edit path: a cached/fresh runtime wrapped in an `MCPApplyEditRouter`
+    /// over its MCP client. `nil` when the runtime couldn't start.
+    public func editRouter(siteID: String, siteDirectory: URL) async -> EditRouter? {
+        guard let runtime = await runtime(siteID: siteID, siteDirectory: siteDirectory) else { return nil }
+        let client = runtime.mcpClient
+        return MCPApplyEditRouter(mcpClient: { client })
+    }
+
+    /// Tear down every cached runtime and empty the pool (e.g. app teardown).
+    public func shutdown() async {
+        let runtimes = entries.values.map(\.runtime)
+        entries.removeAll()
+        for runtime in runtimes { await runtime.stop() }
+    }
+
+    private func evictExpired() async {
+        let cutoff = now()
+        let expired = entries.filter { $0.value.expiresAt <= cutoff }
+        guard !expired.isEmpty else { return }
+        for key in expired.keys { entries.removeValue(forKey: key) }
+        for entry in expired.values { await entry.runtime.stop() }
+    }
+}

--- a/Sources/AnglesiteCore/IntentEditBridge.swift
+++ b/Sources/AnglesiteCore/IntentEditBridge.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Translates a high-level intent edit request into an `EditMessage` and routes it through an
+/// `EditRouter` (A.4, #138). The router comes from a `RouterProvider`, which the app wires to
+/// look up the active site window's edit router and fall back to a `HeadlessRuntimePool`-backed
+/// `MCPApplyEditRouter` when no window is open — so a Siri/Shortcuts edit works whether or not
+/// the site is on screen. The bridge itself is UI-agnostic and lives in Core so the
+/// `AnglesiteIntents` (Siri) surface can use it without depending on the WKWebView layer.
+public struct IntentEditBridge: Sendable {
+    /// Resolve the `EditRouter` to use for a site, or `nil` if one can't be obtained.
+    public typealias RouterProvider = @Sendable (_ siteID: String) async -> EditRouter?
+
+    private let routerProvider: RouterProvider
+    private let makeID: @Sendable () -> String
+
+    /// `makeID` is injectable so the correlation id is deterministic in tests; production defaults
+    /// to a fresh UUID per edit.
+    public init(
+        routerProvider: @escaping RouterProvider,
+        makeID: @escaping @Sendable () -> String = { UUID().uuidString }
+    ) {
+        self.routerProvider = routerProvider
+        self.makeID = makeID
+    }
+
+    /// Build an `apply-edit` `EditMessage` and route it. Returns the router's `EditReply`, or a
+    /// `.failed` reply (carrying the generated id) when no router is available for the site.
+    ///
+    /// `filePath` is the page path the overlay would target (e.g. `/about`); `selector` is the
+    /// structured `ElementInfo` the plugin's `selector.mjs` resolves server-side; `op`/`value`
+    /// are the edit operation and its payload.
+    public func applyEdit(
+        siteID: String,
+        filePath: String,
+        selector: JSONValue,
+        op: String,
+        value: JSONValue?
+    ) async -> EditReply {
+        let id = makeID()
+        guard let router = await routerProvider(siteID) else {
+            return EditReply(
+                id: id,
+                status: .failed,
+                message: "No edit router available for this site — open it in Anglesite, or check that the plugin is bundled."
+            )
+        }
+        let message = EditMessage(id: id, type: .applyEdit, path: filePath, selector: selector, op: op, value: value)
+        return await router.apply(message)
+    }
+}

--- a/Sources/AnglesiteCore/LocalSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalSiteRuntime.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// This is the transitional implementation that keeps today's behavior; the Cloudflare (#66) and
 /// local-container (#69) runtimes will be alternate `SiteRuntime` conformers.
-public actor LocalSiteRuntime: SiteRuntime {
+public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
     /// How to run `astro dev` for a site directory — or why it can't be run.
     public enum LaunchPlan: Sendable, Equatable {
         case run(executable: URL, arguments: [String])
@@ -125,6 +125,15 @@ public actor LocalSiteRuntime: SiteRuntime {
                 setState(.failed(siteID: siteID, message: Self.friendlyMessage(for: error)))
             }
         }
+    }
+
+    /// Spawn only the MCP client for `siteID` — no dev server, no UI state machine. This is the
+    /// headless path `HeadlessRuntimePool` uses to serve intent-driven edits / `create_page` calls
+    /// when no site window is open. Returns whether the MCP client is running afterward; failures
+    /// are logged (via `startMCPClient`) and surface as `false` so the pool doesn't cache a dud.
+    public func startHeadlessMCP(siteID: String, siteDirectory: URL) async -> Bool {
+        await startMCPClient(siteID: siteID, siteDirectory: siteDirectory)
+        return await mcpClient.isRunning
     }
 
     /// Stop the dev server + MCP client and return to `.idle`.

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AnglesiteCore
 
 /// `EditRouter` backed by an `MCPClient` `tools/call` to the plugin's `apply_edit` tool.
 ///

--- a/Tests/AnglesiteCoreTests/EditMessageTests.swift
+++ b/Tests/AnglesiteCoreTests/EditMessageTests.swift
@@ -1,6 +1,5 @@
 import Testing
-@testable import AnglesiteBridge
-import AnglesiteCore
+@testable import AnglesiteCore
 
 struct EditMessageTests {
     /// Matches the `ElementInfo` shape the JS overlay sends — the plugin's `server/selector.mjs`

--- a/Tests/AnglesiteCoreTests/EditReplyAndRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/EditReplyAndRouterTests.swift
@@ -1,7 +1,6 @@
 import Testing
 import Foundation
-@testable import AnglesiteBridge
-import AnglesiteCore
+@testable import AnglesiteCore
 
 struct EditReplyAndRouterTests {
 

--- a/Tests/AnglesiteCoreTests/HeadlessRuntimePoolTests.swift
+++ b/Tests/AnglesiteCoreTests/HeadlessRuntimePoolTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Lifecycle tests for `HeadlessRuntimePool` (A.4, #138): spawn on miss, cache hit (no respawn,
+/// TTL refreshed), start-failure handling, TTL expiry teardown, and shutdown. Uses a fake
+/// `HeadlessRuntime` and an injected clock so nothing spawns Node and TTL is deterministic.
+struct HeadlessRuntimePoolTests {
+    /// Mutable, test-controlled clock. `@unchecked Sendable` is fine: tests drive it serially.
+    final class Clock: @unchecked Sendable {
+        var now: Date
+        init(_ start: Date) { now = start }
+        func advance(_ seconds: TimeInterval) { now.addTimeInterval(seconds) }
+    }
+
+    actor FakeRuntime: HeadlessRuntime {
+        nonisolated let mcpClient: MCPClient
+        private let startSucceeds: Bool
+        private(set) var startCount = 0
+        private(set) var stopCount = 0
+        /// When `gated`, `startHeadlessMCP` parks until `release()` — lets a test hold a spawn in
+        /// flight while it fires a second, concurrent request for the same site. `gateOpen` guards
+        /// against a lost wakeup if `release()` happens to run before the spawn reaches the gate.
+        private var gate: CheckedContinuation<Void, Never>?
+        private var gateOpen = false
+        private let gated: Bool
+
+        init(startSucceeds: Bool = true, gated: Bool = false) {
+            self.mcpClient = MCPClient(supervisor: ProcessSupervisor())
+            self.startSucceeds = startSucceeds
+            self.gated = gated
+        }
+        func startHeadlessMCP(siteID: String, siteDirectory: URL) async -> Bool {
+            startCount += 1
+            if gated && !gateOpen { await withCheckedContinuation { gate = $0 } }
+            return startSucceeds
+        }
+        func stop() async { stopCount += 1 }
+        func release() { gateOpen = true; gate?.resume(); gate = nil }
+    }
+
+    private let dir = URL(fileURLWithPath: "/tmp/site", isDirectory: true)
+    private let t0 = Date(timeIntervalSince1970: 1_750_000_000)
+
+    @Test("spawns a runtime on cache miss and starts MCP")
+    func spawnsOnMiss() async {
+        let clock = Clock(t0)
+        let made = FakeRuntime()
+        let pool = HeadlessRuntimePool(ttl: 60, now: { clock.now }, makeRuntime: { made })
+
+        let rt = await pool.runtime(siteID: "s1", siteDirectory: dir) as? FakeRuntime
+
+        #expect(rt === made)
+        #expect(await made.startCount == 1)
+        #expect(await pool.cachedSiteIDs == ["s1"])
+    }
+
+    @Test("cache hit returns the same instance without respawning and refreshes the TTL")
+    func cacheHitRefreshesTTL() async {
+        let clock = Clock(t0)
+        var built = 0
+        let pool = HeadlessRuntimePool(ttl: 60, now: { clock.now }, makeRuntime: { built += 1; return FakeRuntime() })
+
+        let first = await pool.runtime(siteID: "s1", siteDirectory: dir) as? FakeRuntime
+        clock.advance(30)                                   // within TTL; this hit pushes expiry to t0+90
+        let second = await pool.runtime(siteID: "s1", siteDirectory: dir) as? FakeRuntime
+        clock.advance(40)                                   // t0+70: past the original t0+60, within t0+90
+        let third = await pool.runtime(siteID: "s1", siteDirectory: dir) as? FakeRuntime
+
+        #expect(first === second)
+        #expect(second === third)
+        #expect(built == 1)
+        #expect(await first?.startCount == 1)
+    }
+
+    @Test("a runtime that fails to start MCP is stopped and not cached")
+    func startFailureNotCached() async {
+        let clock = Clock(t0)
+        let made = FakeRuntime(startSucceeds: false)
+        let pool = HeadlessRuntimePool(ttl: 60, now: { clock.now }, makeRuntime: { made })
+
+        let rt = await pool.runtime(siteID: "s1", siteDirectory: dir)
+
+        #expect(rt == nil)
+        #expect(await made.stopCount == 1)
+        #expect(await pool.cachedSiteIDs.isEmpty)
+    }
+
+    @Test("an expired runtime is torn down and a fresh one spawned on the next request")
+    func ttlExpiryTearsDownAndRespawns() async {
+        let clock = Clock(t0)
+        var runtimes: [FakeRuntime] = []
+        let pool = HeadlessRuntimePool(ttl: 60, now: { clock.now }, makeRuntime: {
+            let r = FakeRuntime(); runtimes.append(r); return r
+        })
+
+        let first = await pool.runtime(siteID: "s1", siteDirectory: dir) as? FakeRuntime
+        clock.advance(61)                                   // past TTL
+        let second = await pool.runtime(siteID: "s1", siteDirectory: dir) as? FakeRuntime
+
+        #expect(first !== second)
+        #expect(runtimes.count == 2)
+        #expect(await first?.stopCount == 1)               // evicted + torn down
+        #expect(await second?.stopCount == 0)
+    }
+
+    @Test("concurrent requests for the same uncached site spawn only one runtime")
+    func concurrentMissCoalesces() async {
+        let clock = Clock(t0)
+        let made = FakeRuntime(gated: true)
+        var built = 0
+        let pool = HeadlessRuntimePool(ttl: 60, now: { clock.now }, makeRuntime: { built += 1; return made })
+
+        // First request starts the (gated) spawn; second joins it while it's in flight.
+        async let first = pool.runtime(siteID: "s1", siteDirectory: dir)
+        // Give `first` a moment to register the in-flight spawn, then fire the second.
+        await Task.yield()
+        async let second = pool.runtime(siteID: "s1", siteDirectory: dir)
+        await Task.yield()
+        await made.release()
+
+        let r1 = await first as? FakeRuntime
+        let r2 = await second as? FakeRuntime
+
+        #expect(r1 === made)
+        #expect(r2 === made)
+        #expect(built == 1)                       // only one runtime ever constructed
+        #expect(await made.startCount == 1)       // and started once
+        #expect(await pool.cachedSiteIDs == ["s1"])
+    }
+
+    @Test("shutdown stops every cached runtime and empties the pool")
+    func shutdownStopsAll() async {
+        let clock = Clock(t0)
+        var made: [FakeRuntime] = []
+        let pool = HeadlessRuntimePool(ttl: 60, now: { clock.now }, makeRuntime: {
+            let r = FakeRuntime(); made.append(r); return r
+        })
+        _ = await pool.runtime(siteID: "s1", siteDirectory: dir)
+        _ = await pool.runtime(siteID: "s2", siteDirectory: dir)
+
+        await pool.shutdown()
+
+        #expect(await pool.cachedSiteIDs.isEmpty)
+        for r in made { #expect(await r.stopCount == 1) }
+    }
+}

--- a/Tests/AnglesiteCoreTests/IntentEditBridgeTests.swift
+++ b/Tests/AnglesiteCoreTests/IntentEditBridgeTests.swift
@@ -1,0 +1,98 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for `IntentEditBridge` (A.4, #138): builds an `EditMessage` from intent parameters and
+/// routes it through the `EditRouter` the provider supplies, with a graceful failure when no
+/// router is available. Uses a fake router + provider and an injected id so assertions are stable.
+struct IntentEditBridgeTests {
+    actor FakeRouter: EditRouter {
+        private(set) var received: [EditMessage] = []
+        private let status: EditReply.Status
+        private let file: String?
+
+        init(status: EditReply.Status = .applied, file: String? = "src/pages/about.astro") {
+            self.status = status
+            self.file = file
+        }
+        func apply(_ message: EditMessage) async -> EditReply {
+            received.append(message)
+            return EditReply(id: message.id, status: status, message: "from-router", file: file)
+        }
+    }
+
+    private let selector: JSONValue = .object(["tag": .string("h1"), "index": .int(0)])
+
+    private func bridge(id: String = "fixed-id", provider: @escaping IntentEditBridge.RouterProvider) -> IntentEditBridge {
+        IntentEditBridge(routerProvider: provider, makeID: { id })
+    }
+
+    @Test("routes the edit through the provider's router and returns its reply")
+    func routesThroughProvidedRouter() async {
+        let router = FakeRouter(status: .applied)
+        let edit = bridge { _ in router }
+
+        let reply = await edit.applyEdit(siteID: "s1", filePath: "/about", selector: selector, op: "replace-text", value: .string("Hi"))
+
+        #expect(reply.status == .applied)
+        #expect(reply.file == "src/pages/about.astro")
+        #expect(await router.received.count == 1)
+    }
+
+    @Test("builds the EditMessage from the intent parameters")
+    func buildsEditMessage() async {
+        let router = FakeRouter()
+        let edit = bridge(id: "abc") { _ in router }
+
+        _ = await edit.applyEdit(siteID: "s1", filePath: "/about", selector: selector, op: "replace-text", value: .string("Hi"))
+
+        let msg = await router.received.first
+        #expect(msg?.id == "abc")
+        #expect(msg?.type == .applyEdit)
+        #expect(msg?.path == "/about")
+        #expect(msg?.op == "replace-text")
+        #expect(msg?.value == .string("Hi"))
+        #expect(msg?.selector == selector)
+    }
+
+    @Test("passes the site id to the provider for router lookup")
+    func passesSiteIDToProvider() async {
+        let seen = LockedBox<String?>(nil)
+        let router = FakeRouter()
+        let edit = bridge { siteID in seen.set(siteID); return router }
+
+        _ = await edit.applyEdit(siteID: "/Users/x/Sites/alpha", filePath: "/", selector: selector, op: "x", value: nil)
+
+        #expect(seen.get() == "/Users/x/Sites/alpha")
+    }
+
+    @Test("no router for the site yields a failed reply carrying the message id")
+    func noRouterFails() async {
+        let edit = bridge(id: "no-router") { _ in nil }
+
+        let reply = await edit.applyEdit(siteID: "s1", filePath: "/about", selector: selector, op: "replace-text", value: nil)
+
+        #expect(reply.status == .failed)
+        #expect(reply.id == "no-router")
+        #expect(reply.message?.isEmpty == false)
+    }
+
+    @Test("a failed router reply propagates unchanged")
+    func propagatesRouterFailure() async {
+        let router = FakeRouter(status: .failed, file: nil)
+        let edit = bridge { _ in router }
+
+        let reply = await edit.applyEdit(siteID: "s1", filePath: "/about", selector: selector, op: "replace-text", value: nil)
+
+        #expect(reply.status == .failed)
+    }
+
+    /// Minimal thread-safe box so the provider closure can capture the siteID it saw.
+    final class LockedBox<T>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: T
+        init(_ v: T) { value = v }
+        func set(_ v: T) { lock.lock(); value = v; lock.unlock() }
+        func get() -> T { lock.lock(); defer { lock.unlock() }; return value }
+    }
+}

--- a/Tests/AnglesiteCoreTests/LocalSiteRuntimeGraphTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalSiteRuntimeGraphTests.swift
@@ -118,6 +118,24 @@ struct LocalSiteRuntimeGraphTests {
         #expect(await graph.knownSiteIDs().isEmpty)
     }
 
+    @Test("startHeadlessMCP spawns only the MCP client — no dev server, no graph population", .enabled(if: pythonAvailable))
+    func startHeadlessMCPSpawnsMCPOnly() async throws {
+        let graph = SiteContentGraph()
+        let runtime = makeRuntime(graph: graph, mcpScript: Self.populatingScript)
+
+        let ok = await runtime.startHeadlessMCP(siteID: Self.siteID, siteDirectory: tmpDir)
+
+        #expect(ok)
+        #expect(await runtime.mcpClient.isRunning)
+        // No dev server spawned → the UI state machine is never driven.
+        #expect(await runtime.state == .idle)
+        // Headless start does not run list_content population — the graph stays empty.
+        #expect(await graph.knownSiteIDs().isEmpty)
+
+        await runtime.stop()
+        #expect(await runtime.mcpClient.isRunning == false)
+    }
+
     @Test("Missing list_content tool leaves the graph empty and preview ready", .enabled(if: pythonAvailable))
     func missingToolIsGracefulFallback() async throws {
         let graph = SiteContentGraph()

--- a/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
@@ -1,6 +1,5 @@
 import Testing
-@testable import AnglesiteBridge
-import AnglesiteCore
+@testable import AnglesiteCore
 
 struct MCPApplyEditRouterTests {
     private static let sampleSelector: JSONValue = .object([


### PR DESCRIPTION
Closes #138 (Siri AI Phase A — A.4). Unblocks A.5's content-mutating intents (EditContent / AddPage / AddPost), which need to run MCP tools whether or not a site window is open.

## Two commits

**1. Refactor — move edit-pipeline types Bridge → Core.** `EditMessage`, `EditReply`, `EditRouter` (+`LoggingEditRouter`), and `MCPApplyEditRouter` are transport-agnostic (no WebKit — only Foundation + `JSONValue`/`LogCenter`/`MCPClient`). The module graph is `Bridge→Core` and `Intents→Core`, so for `IntentEditBridge` (Core) and A.5's intents (Intents) to reach the edit pipeline, these types must live in Core. Moving them keeps the Siri/intents surface WebKit-free. Pure relocation, no behavior change; the three type tests move to `AnglesiteCoreTests`.

**2. Feature — the A.4 components.**

- **`HeadlessRuntime` protocol + `LocalSiteRuntime.startHeadlessMCP`** — spawn only the MCP client (no dev server, no UI state machine, no `list_content` population) for headless tool calls.
- **`HeadlessRuntimePool`** — TTL-cached (default 60s) ephemeral runtimes keyed by siteID; rapid successive edits reuse one MCP server. Expired entries are torn down (**no zombie Node**), and **per-site spawn coalescing** means two concurrent requests for the same uncached site join one spawn instead of orphaning a process. Injectable clock + factory make the full lifecycle deterministically testable. Vends an `editRouter(...)` convenience (`MCPApplyEditRouter` over the pooled client).
- **`IntentEditBridge`** — builds an `apply-edit` `EditMessage` from intent parameters and routes it through a `RouterProvider`-supplied `EditRouter` (the active window's router, else the pool's). Graceful `.failed` reply when no router is available; injectable id for stable tests.

## How A.5 will use it

The app wires a `RouterProvider` = `{ siteID in activeWindowRouter(siteID) ?? pool.editRouter(siteID:, siteDirectory:) }`. `EditContentIntent` calls `IntentEditBridge.applyEdit`; `AddPage`/`AddPost` use the pool's MCP client to call `create_page`/`create_post`.

## Tests

- `HeadlessRuntimePoolTests` (6): spawn-on-miss, cache-hit + TTL refresh, start-failure (stopped, not cached), TTL-expiry teardown + respawn, shutdown, and a **gated concurrent-spawn coalescing regression** (wakeup-safe gate; verifies one runtime for concurrent same-site requests).
- `IntentEditBridgeTests` (5): routes through the provided router, builds the EditMessage, passes siteID to the provider, no-router failure, failure propagation.
- A Python-fake-MCP integration test for `startHeadlessMCP` (MCP-only: no dev server, no graph population).

Full suite green (315); `Anglesite` (DevID) and `AnglesiteMAS` both build.

Next: **#139 (A.5)** — the six content intents, now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)