### PR TITLE
feat(intents): Search / Status / Preview / AddPage / AddPost intents (#139)

### DIFF
--- a/Sources/AnglesiteCore/ContentOperations.swift
+++ b/Sources/AnglesiteCore/ContentOperations.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Production `ContentOperationsService`: resolves the site's directory, gets an MCP client from a
+/// `HeadlessRuntimePool` (spawning one headlessly when no window is open), and calls the plugin's
+/// `create_page` / `create_post` tools (A.5/#139, backed by A.4 #138 and the plugin tools #140).
+public struct ContentOperations: ContentOperationsService {
+    private let pool: HeadlessRuntimePool
+    /// Maps a siteID to its on-disk directory (wired to `SiteStore` in bootstrap). `nil` → unknown site.
+    private let siteDirectory: @Sendable (_ siteID: String) async -> URL?
+
+    public init(
+        pool: HeadlessRuntimePool,
+        siteDirectory: @escaping @Sendable (_ siteID: String) async -> URL?
+    ) {
+        self.pool = pool
+        self.siteDirectory = siteDirectory
+    }
+
+    public func createPage(siteID: String, name: String, route: String?) async -> ContentCreateResult {
+        var args: [String: JSONValue] = ["name": .string(name)]
+        if let route, !route.isEmpty { args["route"] = .string(route) }
+        return await create(siteID: siteID, tool: "create_page", arguments: args, identifierKey: "route")
+    }
+
+    public func createPost(siteID: String, title: String, collection: String?, slug: String?) async -> ContentCreateResult {
+        var args: [String: JSONValue] = ["title": .string(title)]
+        if let collection, !collection.isEmpty { args["collection"] = .string(collection) }
+        if let slug, !slug.isEmpty { args["slug"] = .string(slug) }
+        return await create(siteID: siteID, tool: "create_post", arguments: args, identifierKey: "slug")
+    }
+
+    private func create(
+        siteID: String,
+        tool: String,
+        arguments: [String: JSONValue],
+        identifierKey: String
+    ) async -> ContentCreateResult {
+        guard let directory = await siteDirectory(siteID) else { return .siteNotFound }
+        guard let runtime = await pool.runtime(siteID: siteID, siteDirectory: directory) else {
+            return .failed(reason: "Couldn't start the Anglesite plugin for this site.")
+        }
+        let client = runtime.mcpClient
+        do {
+            let result = try await client.callTool(name: tool, arguments: .object(arguments))
+            let text = result.content.compactMap(\.text).joined(separator: "\n")
+            if result.isError {
+                return .failed(reason: text.isEmpty ? "The plugin rejected the request." : text)
+            }
+            guard let parsed = Self.parseCreated(text, identifierKey: identifierKey) else {
+                return .failed(reason: "The plugin's reply couldn't be read.")
+            }
+            return .created(filePath: parsed.filePath, identifier: parsed.identifier)
+        } catch {
+            return .failed(reason: "\(error)")
+        }
+    }
+
+    /// Pull `filePath` and the identifier (`route`/`slug`) out of the tool's JSON reply text.
+    static func parseCreated(_ text: String, identifierKey: String) -> (filePath: String, identifier: String)? {
+        guard !text.isEmpty,
+              let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let filePath = json["filePath"] as? String,
+              let identifier = json[identifierKey] as? String
+        else { return nil }
+        return (filePath, identifier)
+    }
+}

--- a/Sources/AnglesiteCore/ContentOperationsService.swift
+++ b/Sources/AnglesiteCore/ContentOperationsService.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Side-effecting content operations an intent can drive (A.5, #139). Reads (search, status) go
+/// straight to `SiteContentGraph`; this service covers the operations that spawn the plugin's MCP
+/// server — `create_page` / `create_post` — so they're injectable behind a test seam the way
+/// `SiteOperationsService` is for deploy/backup/audit.
+public protocol ContentOperationsService: Sendable {
+    func createPage(siteID: String, name: String, route: String?) async -> ContentCreateResult
+    func createPost(siteID: String, title: String, collection: String?, slug: String?) async -> ContentCreateResult
+}
+
+/// Outcome of a `create_page` / `create_post` call.
+public enum ContentCreateResult: Sendable, Equatable {
+    /// `identifier` is the route (page) or slug (post). `filePath` is relative to the site root.
+    case created(filePath: String, identifier: String)
+    /// The site id didn't resolve to a known site directory.
+    case siteNotFound
+    /// The plugin reported an error, the MCP server couldn't start, or the reply was unparseable.
+    case failed(reason: String)
+}

--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -33,6 +33,12 @@ public enum AnglesiteIntents {
         AppDependencyManager.shared.add { () -> any SiteOperationsService in
             SiteOperations(factory: LiveCommandFactory())
         }
+        // Content create intents (A.5 #139) run the plugin's create_page/create_post headlessly
+        // via a shared pool; pooled Node processes are drained on quit by ProcessSupervisor.
+        let headlessPool = HeadlessRuntimePool()
+        AppDependencyManager.shared.add { () -> any ContentOperationsService in
+            ContentOperations(pool: headlessPool, siteDirectory: { id in await SiteStore.shared.find(id: id)?.path })
+        }
 
         await SiteStore.shared.setChangeHandler { sites in
             do {

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -1,0 +1,240 @@
+import AppIntents
+import AnglesiteCore
+
+/// Phase A content intents (A.5, #139). Thin adapters, like `SiteIntents`:
+///
+/// - **Reads** (`SearchContentIntent`, `SiteStatusIntent`) go straight to `SiteContentGraph` via
+///   `@Dependency`, bypassed in tests by `ContentGraphOverride.scoped` (same seam the entity
+///   queries use).
+/// - **Preview** (`PreviewSiteIntent`) routes through `WindowRouter` like `OpenSiteIntent`.
+/// - **Creates** (`AddPageIntent`, `AddPostIntent`) go through `ContentOperationsService`
+///   (→ `HeadlessRuntimePool` → plugin `create_page`/`create_post`), bypassed by
+///   `ContentOperationsOverride.scoped`.
+///
+/// `EditContentIntent` is intentionally absent in Phase A: turning a natural-language edit
+/// description into a structured `apply_edit` needs the on-device model from Phase C (#155).
+///
+/// All dialog text is built by the pure `ContentDialogs` helpers so it's unit-testable without
+/// the AppIntents runtime.
+
+// MARK: - Search
+
+public struct SearchContentIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Search Site Content"
+    public static var description = IntentDescription("Search a site's pages, posts, and images.")
+
+    @Parameter(title: "Site") public var site: SiteEntity
+    @Parameter(title: "Search") public var query: String
+    @Dependency private var graph: SiteContentGraph
+
+    public init() {}
+
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Search \(\.$site) for \(\.$query)")
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        let dialog = await Self.dialog(graph: ContentGraphOverride.scoped ?? graph, siteID: site.id, query: query)
+        return .result(dialog: IntentDialog(stringLiteral: dialog))
+    }
+
+    /// Gather matches from the graph and format the spoken result. Static + graph-injected so the
+    /// read+format wiring is unit-testable without the AppIntents runtime.
+    static func dialog(graph: SiteContentGraph, siteID: String, query: String) async -> String {
+        let pages = await graph.searchPages(siteID: siteID, matching: query)
+        let posts = await graph.searchPosts(siteID: siteID, matching: query)
+        let images = await graph.searchImages(siteID: siteID, matching: query)
+        return ContentDialogs.search(query: query, pageCount: pages.count, postCount: posts.count, imageCount: images.count)
+    }
+}
+
+// MARK: - Status
+
+public struct SiteStatusIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Site Content Status"
+    public static var description = IntentDescription("Report how much content a site has.")
+
+    @Parameter(title: "Site") public var site: SiteEntity
+    @Dependency private var graph: SiteContentGraph
+
+    public init() {}
+
+    public static var parameterSummary: some ParameterSummary { Summary("Status of \(\.$site)") }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        let dialog = await Self.dialog(graph: ContentGraphOverride.scoped ?? graph, siteID: site.id, siteName: site.displayName)
+        return .result(dialog: IntentDialog(stringLiteral: dialog))
+    }
+
+    /// Gather counts from the graph and format the spoken result. Static + graph-injected so the
+    /// read+format wiring is unit-testable without the AppIntents runtime.
+    static func dialog(graph: SiteContentGraph, siteID: String, siteName: String) async -> String {
+        let posts = await graph.posts(for: siteID)
+        return ContentDialogs.status(
+            siteName: siteName,
+            pages: await graph.pages(for: siteID).count,
+            posts: posts.count,
+            drafts: posts.filter(\.draft).count,
+            images: await graph.images(for: siteID).count
+        )
+    }
+}
+
+// MARK: - Preview
+
+/// Opens the site window. `openAppWhenRun` brings Anglesite forward; the actual window open
+/// happens via `WindowRouter`, which the "Sites" scene observes.
+///
+/// The `page` parameter is accepted (per the A.5 spec) but does not yet drive in-preview
+/// navigation to that page — delivering the route to the right `SiteWindow`'s WKWebView is a
+/// follow-up. Today the intent opens the site; the dialog deliberately doesn't claim more.
+public struct PreviewSiteIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Preview Site"
+    public static var description = IntentDescription("Open a site's live preview in Anglesite.")
+    public static var openAppWhenRun = true
+
+    @Parameter(title: "Site") public var site: SiteEntity
+    @Parameter(title: "Page") public var page: PageEntity?
+
+    public init() {}
+
+    public static var parameterSummary: some ParameterSummary { Summary("Preview \(\.$site)") }
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        WindowRouter.shared.requestOpen(siteID: site.id)
+        return .result(dialog: IntentDialog(stringLiteral: ContentDialogs.preview(siteName: site.displayName)))
+    }
+}
+
+// MARK: - Add Page
+
+public struct AddPageIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Add Page"
+    public static var description = IntentDescription("Scaffold a new page on a site with Anglesite.")
+
+    @Parameter(title: "Site") public var site: SiteEntity
+    @Parameter(title: "Name") public var name: String
+    @Parameter(title: "Route") public var route: String?
+    @Dependency private var content: any ContentOperationsService
+
+    public init() {}
+
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Add page \(\.$name) to \(\.$site)")
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        let scoped = ContentOperationsOverride.scoped
+        let svc = scoped ?? content
+        // Spawning the plugin's Node MCP server on first use can exceed the default budget, so the
+        // real call runs as a background task (extended time + Cancel) on Xcode 27; the scoped-test
+        // path and the Xcode 26.3 fallback await inline. Mirrors SiteIntents (#128 cleanup pending).
+        let result: ContentCreateResult
+        if scoped != nil {
+            result = await svc.createPage(siteID: site.id, name: name, route: route)
+        } else {
+            #if compiler(>=6.4)
+            result = try await performBackgroundTask {
+                await svc.createPage(siteID: site.id, name: name, route: route)
+            } onCancel: { _ in }
+            #else
+            result = await svc.createPage(siteID: site.id, name: name, route: route)
+            #endif
+        }
+        return .result(dialog: IntentDialog(stringLiteral: ContentDialogs.created(result, kind: .page, siteName: site.displayName)))
+    }
+}
+
+// MARK: - Add Post
+
+public struct AddPostIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Add Post"
+    public static var description = IntentDescription("Scaffold a new draft post on a site with Anglesite.")
+
+    @Parameter(title: "Site") public var site: SiteEntity
+    @Parameter(title: "Title") public var title2: String
+    @Parameter(title: "Collection") public var collection: String?
+    @Parameter(title: "Slug") public var slug: String?
+    @Dependency private var content: any ContentOperationsService
+
+    public init() {}
+
+    // `title` is taken by `AppIntent.title`; the parameter is `title2` but presents as "Title".
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Add post \(\.$title2) to \(\.$site)")
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        let scoped = ContentOperationsOverride.scoped
+        let svc = scoped ?? content
+        let result: ContentCreateResult
+        if scoped != nil {
+            result = await svc.createPost(siteID: site.id, title: title2, collection: collection, slug: slug)
+        } else {
+            #if compiler(>=6.4)
+            result = try await performBackgroundTask {
+                await svc.createPost(siteID: site.id, title: title2, collection: collection, slug: slug)
+            } onCancel: { _ in }
+            #else
+            result = await svc.createPost(siteID: site.id, title: title2, collection: collection, slug: slug)
+            #endif
+        }
+        return .result(dialog: IntentDialog(stringLiteral: ContentDialogs.created(result, kind: .post, siteName: site.displayName)))
+    }
+}
+
+// `LongRunningIntent` / `CancellableIntent`: the create intents may spawn the plugin's Node MCP
+// server on first use, which can exceed the default budget. Gated until #128 (Xcode 27 on CI).
+#if compiler(>=6.4)
+extension AddPageIntent: LongRunningIntent, CancellableIntent {}
+extension AddPostIntent: LongRunningIntent, CancellableIntent {}
+#endif
+
+// MARK: - Dialog formatting (pure, unit-testable)
+
+public enum ContentDialogs {
+    public enum CreateKind: String, Sendable { case page, post }
+
+    public static func search(query: String, pageCount: Int, postCount: Int, imageCount: Int) -> String {
+        let total = pageCount + postCount + imageCount
+        guard total > 0 else { return "Nothing matched “\(query)”." }
+        var parts: [String] = []
+        if pageCount > 0 { parts.append(count(pageCount, "page")) }
+        if postCount > 0 { parts.append(count(postCount, "post")) }
+        if imageCount > 0 { parts.append(count(imageCount, "image")) }
+        return "Found \(list(parts)) matching “\(query)”."
+    }
+
+    public static func status(siteName: String, pages: Int, posts: Int, drafts: Int, images: Int) -> String {
+        let draftNote = drafts > 0 ? " (\(drafts) draft\(drafts == 1 ? "" : "s"))" : ""
+        return "\(siteName) has \(count(pages, "page")), \(count(posts, "post"))\(draftNote), and \(count(images, "image"))."
+    }
+
+    public static func preview(siteName: String) -> String {
+        "Opening \(siteName)."
+    }
+
+    public static func created(_ result: ContentCreateResult, kind: CreateKind, siteName: String) -> String {
+        switch result {
+        case .created(_, let identifier):
+            return "Added a \(kind.rawValue) at \(identifier) on \(siteName)."
+        case .siteNotFound:
+            return "Couldn’t find \(siteName)."
+        case .failed(let reason):
+            return "Couldn’t add the \(kind.rawValue): \(reason)"
+        }
+    }
+
+    private static func count(_ n: Int, _ noun: String) -> String { "\(n) \(noun)\(n == 1 ? "" : "s")" }
+
+    /// "a", "a and b", "a, b, and c".
+    private static func list(_ items: [String]) -> String {
+        switch items.count {
+        case 0: return ""
+        case 1: return items[0]
+        case 2: return "\(items[0]) and \(items[1])"
+        default: return items.dropLast().joined(separator: ", ") + ", and " + items.last!
+        }
+    }
+}

--- a/Sources/AnglesiteIntents/ContentOperationsOverride.swift
+++ b/Sources/AnglesiteIntents/ContentOperationsOverride.swift
@@ -1,0 +1,10 @@
+import AnglesiteCore
+
+/// Test-only escape hatch around `@Dependency` resolution of `ContentOperationsService`, mirroring
+/// `SiteOperationsOverride` (see #104/#127). `@Dependency` is gated to the AppIntents perform flow;
+/// direct `intent.perform()` calls from unit tests crash without it. Tests bind this `@TaskLocal`
+/// to a fake service before invoking the create intents; the intents read
+/// `ContentOperationsOverride.scoped ?? self.content`, so production flows through `@Dependency`.
+public enum ContentOperationsOverride {
+    @TaskLocal public static var scoped: (any ContentOperationsService)?
+}

--- a/Tests/AnglesiteCoreTests/ContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentOperationsTests.swift
@@ -1,0 +1,97 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for `ContentOperations` (A.5, #139): `parseCreated` reply parsing (unit) and the full
+/// create path through a real `HeadlessRuntimePool` driving a Python fake MCP server (integration).
+struct ContentOperationsTests {
+    private let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+    private static let pythonURL: URL = {
+        for path in ["/usr/bin/python3", "/opt/homebrew/bin/python3", "/usr/local/bin/python3"] {
+            if FileManager.default.isExecutableFile(atPath: path) { return URL(fileURLWithPath: path) }
+        }
+        return URL(fileURLWithPath: "/usr/bin/python3")
+    }()
+    private static var pythonAvailable: Bool { FileManager.default.isExecutableFile(atPath: pythonURL.path) }
+
+    /// Fake MCP server answering create_page / create_post with a fixed structured reply.
+    private static let createScript = """
+    import sys, json
+    for line in sys.stdin:
+        line = line.strip()
+        if not line: continue
+        try: msg = json.loads(line)
+        except Exception: continue
+        method = msg.get("method", ""); rid = msg.get("id")
+        if rid is None: continue
+        if method == "initialize":
+            resp = {"jsonrpc":"2.0","id":rid,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"fake","version":"0"}}}
+        elif method == "tools/call":
+            name = (msg.get("params") or {}).get("name")
+            if name == "create_page":
+                body = json.dumps({"filePath":"src/pages/about.astro","route":"/about","commit":None})
+                resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":body}],"isError":False}}
+            elif name == "create_post":
+                body = json.dumps({"filePath":"src/content/posts/hello.md","slug":"hello","collection":"posts","commit":None})
+                resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":body}],"isError":False}}
+            else:
+                resp = {"jsonrpc":"2.0","id":rid,"error":{"code":-32601,"message":"unknown tool"}}
+        else:
+            resp = {"jsonrpc":"2.0","id":rid,"error":{"code":-32601,"message":"method not found"}}
+        sys.stdout.write(json.dumps(resp) + chr(10)); sys.stdout.flush()
+    """
+
+    /// Each runtime gets its OWN `ProcessSupervisor` so parallel integration tests don't collide
+    /// on the shared supervisor (the MCP spawn source is derived from siteID; tests also use
+    /// distinct siteIDs). Production sites have distinct ids, so this is a test-only concern.
+    private func poolWithFakeServer() -> HeadlessRuntimePool {
+        HeadlessRuntimePool(makeRuntime: {
+            LocalSiteRuntime(
+                supervisor: ProcessSupervisor(),
+                resolveMCPCommand: { .run(executable: Self.pythonURL, arguments: ["-u", "-c", Self.createScript]) }
+            )
+        })
+    }
+
+    // MARK: - parseCreated
+
+    @Test("parseCreated reads filePath + the identifier key")
+    func parsesValidReply() {
+        let page = ContentOperations.parseCreated(#"{"filePath":"src/pages/a.astro","route":"/a"}"#, identifierKey: "route")
+        #expect(page?.filePath == "src/pages/a.astro")
+        #expect(page?.identifier == "/a")
+        let post = ContentOperations.parseCreated(#"{"filePath":"src/content/posts/h.md","slug":"h"}"#, identifierKey: "slug")
+        #expect(post?.identifier == "h")
+    }
+
+    @Test("parseCreated returns nil for malformed or incomplete replies")
+    func parseFailures() {
+        #expect(ContentOperations.parseCreated("", identifierKey: "route") == nil)
+        #expect(ContentOperations.parseCreated("not json", identifierKey: "route") == nil)
+        #expect(ContentOperations.parseCreated(#"{"filePath":"x"}"#, identifierKey: "route") == nil)   // missing route
+    }
+
+    // MARK: - Create path
+
+    @Test("createPage returns siteNotFound when the site directory can't be resolved")
+    func createPageSiteNotFound() async {
+        let ops = ContentOperations(pool: HeadlessRuntimePool(), siteDirectory: { _ in nil })
+        let result = await ops.createPage(siteID: "s1", name: "About", route: nil)
+        #expect(result == .siteNotFound)
+    }
+
+    @Test("createPage drives the pool → MCP → parse and returns the created page", .enabled(if: pythonAvailable))
+    func createPageThroughPool() async {
+        let ops = ContentOperations(pool: poolWithFakeServer(), siteDirectory: { _ in self.dir })
+        let result = await ops.createPage(siteID: "site-page", name: "About", route: nil)
+        #expect(result == .created(filePath: "src/pages/about.astro", identifier: "/about"))
+    }
+
+    @Test("createPost drives the pool → MCP → parse and returns the created post", .enabled(if: pythonAvailable))
+    func createPostThroughPool() async {
+        let ops = ContentOperations(pool: poolWithFakeServer(), siteDirectory: { _ in self.dir })
+        let result = await ops.createPost(siteID: "site-post", title: "Hello", collection: nil, slug: nil)
+        #expect(result == .created(filePath: "src/content/posts/hello.md", identifier: "hello"))
+    }
+}

--- a/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
@@ -1,0 +1,151 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+/// Covers the Phase A content intents (A.5, #139): the pure dialog formatting, the read intents'
+/// graph-gathering helpers, `PreviewSiteIntent`'s WindowRouter side-effect, and the create intents
+/// via a fake `ContentOperationsService`. Reuses the `gPage/gPost/gImage` fixtures.
+extension AppIntentsTests {
+    @Suite("ContentIntents")
+    @MainActor
+    struct ContentIntentsTests {
+        // MARK: Fake create service
+
+        final class FakeContentOps: ContentOperationsService, @unchecked Sendable {
+            var pageResult: ContentCreateResult = .created(filePath: "src/pages/x.astro", identifier: "/x")
+            var postResult: ContentCreateResult = .created(filePath: "src/content/posts/x.md", identifier: "x")
+            private(set) var pageCalls: [(siteID: String, name: String, route: String?)] = []
+            private(set) var postCalls: [(siteID: String, title: String, collection: String?, slug: String?)] = []
+
+            func createPage(siteID: String, name: String, route: String?) async -> ContentCreateResult {
+                pageCalls.append((siteID, name, route)); return pageResult
+            }
+            func createPost(siteID: String, title: String, collection: String?, slug: String?) async -> ContentCreateResult {
+                postCalls.append((siteID, title, collection, slug)); return postResult
+            }
+        }
+
+        private func entity(_ siteID: String = AppIntentsTests.aSite, name: String = "Alpha") -> SiteEntity {
+            SiteEntity(TestStore.site(id: siteID, name: name))
+        }
+
+        // MARK: - ContentDialogs (pure)
+
+        @Test("search dialog: mixed counts, singular/plural, and no-match")
+        func searchDialog() {
+            #expect(ContentDialogs.search(query: "x", pageCount: 0, postCount: 0, imageCount: 0) == "Nothing matched “x”.")
+            #expect(ContentDialogs.search(query: "x", pageCount: 1, postCount: 0, imageCount: 0) == "Found 1 page matching “x”.")
+            #expect(ContentDialogs.search(query: "x", pageCount: 2, postCount: 1, imageCount: 3) == "Found 2 pages, 1 post, and 3 images matching “x”.")
+            #expect(ContentDialogs.search(query: "x", pageCount: 0, postCount: 2, imageCount: 0) == "Found 2 posts matching “x”.")
+        }
+
+        @Test("status dialog: drafts noted only when present; singular nouns")
+        func statusDialog() {
+            #expect(ContentDialogs.status(siteName: "Alpha", pages: 1, posts: 1, drafts: 0, images: 1) == "Alpha has 1 page, 1 post, and 1 image.")
+            #expect(ContentDialogs.status(siteName: "Alpha", pages: 3, posts: 4, drafts: 2, images: 0) == "Alpha has 3 pages, 4 posts (2 drafts), and 0 images.")
+            #expect(ContentDialogs.status(siteName: "Alpha", pages: 0, posts: 1, drafts: 1, images: 0) == "Alpha has 0 pages, 1 post (1 draft), and 0 images.")
+        }
+
+        @Test("preview and created dialogs")
+        func previewAndCreatedDialogs() {
+            #expect(ContentDialogs.preview(siteName: "Alpha") == "Opening Alpha.")
+            #expect(ContentDialogs.created(.created(filePath: "f", identifier: "/about"), kind: .page, siteName: "Alpha") == "Added a page at /about on Alpha.")
+            #expect(ContentDialogs.created(.siteNotFound, kind: .post, siteName: "Alpha") == "Couldn’t find Alpha.")
+            #expect(ContentDialogs.created(.failed(reason: "boom"), kind: .page, siteName: "Alpha") == "Couldn’t add the page: boom")
+        }
+
+        // MARK: - Read intents (graph-gathering helpers)
+
+        @Test("SearchContentIntent gathers matches for the right site and query")
+        func searchHelper() async {
+            let graph = SiteContentGraph()
+            await graph.load(
+                siteID: AppIntentsTests.aSite,
+                pages: [AppIntentsTests.gPage(route: "/about", title: "About")],
+                posts: [AppIntentsTests.gPost(slug: "about-us", title: "About Us")],
+                images: []
+            )
+            // A different site's content must not leak into the result.
+            await graph.load(siteID: AppIntentsTests.bSite, pages: [AppIntentsTests.gPage(site: AppIntentsTests.bSite, route: "/about")], posts: [], images: [])
+
+            let dialog = await SearchContentIntent.dialog(graph: graph, siteID: AppIntentsTests.aSite, query: "about")
+            #expect(dialog == "Found 1 page and 1 post matching “about”.")
+        }
+
+        @Test("SiteStatusIntent counts pages, posts, drafts, and images for the site")
+        func statusHelper() async {
+            let graph = SiteContentGraph()
+            await graph.load(
+                siteID: AppIntentsTests.aSite,
+                pages: [AppIntentsTests.gPage(route: "/a"), AppIntentsTests.gPage(route: "/b")],
+                posts: [AppIntentsTests.gPost(slug: "p1", draft: false), AppIntentsTests.gPost(slug: "p2", draft: true)],
+                images: [AppIntentsTests.gImage()]
+            )
+            let dialog = await SiteStatusIntent.dialog(graph: graph, siteID: AppIntentsTests.aSite, siteName: "Alpha")
+            #expect(dialog == "Alpha has 2 pages, 2 posts (1 draft), and 1 image.")
+        }
+
+        // MARK: - Preview
+
+        @Test("PreviewSiteIntent requests the site window open")
+        func previewRequestsWindow() async throws {
+            WindowRouter.shared.requested = nil
+
+            var intent = PreviewSiteIntent()
+            intent.site = entity()
+            intent.page = PageEntity(AppIntentsTests.gPage(route: "/about"))
+            _ = try await intent.perform()
+
+            #expect(WindowRouter.shared.requested == AppIntentsTests.aSite)
+        }
+
+        // MARK: - Create intents (fake service)
+
+        @Test("AddPageIntent forwards name + route to the service")
+        func addPageForwards() async throws {
+            let fake = FakeContentOps()
+            try await ContentOperationsOverride.$scoped.withValue(fake) {
+                var intent = AddPageIntent()
+                intent.site = entity()
+                intent.name = "About Us"
+                intent.route = "/about"
+                _ = try await intent.perform()
+            }
+            #expect(fake.pageCalls.count == 1)
+            #expect(fake.pageCalls.first?.siteID == AppIntentsTests.aSite)
+            #expect(fake.pageCalls.first?.name == "About Us")
+            #expect(fake.pageCalls.first?.route == "/about")
+        }
+
+        @Test("AddPostIntent forwards title + collection + slug to the service")
+        func addPostForwards() async throws {
+            let fake = FakeContentOps()
+            try await ContentOperationsOverride.$scoped.withValue(fake) {
+                var intent = AddPostIntent()
+                intent.site = entity()
+                intent.title2 = "Hello World"
+                intent.collection = "notes"
+                intent.slug = "hello"
+                _ = try await intent.perform()
+            }
+            #expect(fake.postCalls.count == 1)
+            #expect(fake.postCalls.first?.title == "Hello World")
+            #expect(fake.postCalls.first?.collection == "notes")
+            #expect(fake.postCalls.first?.slug == "hello")
+        }
+
+        @Test("create intents tolerate a failed service result")
+        func createFailureIsHandled() async throws {
+            let fake = FakeContentOps()
+            fake.pageResult = .failed(reason: "nope")
+            try await ContentOperationsOverride.$scoped.withValue(fake) {
+                var intent = AddPageIntent()
+                intent.site = entity()
+                intent.name = "X"
+                _ = try await intent.perform()   // must not throw
+            }
+            #expect(fake.pageCalls.count == 1)
+        }
+    }
+}


### PR DESCRIPTION
Partially implements **#139** (Siri AI Phase A — A.5): five of the six content intents. Builds on A.4 (#138, merged) and the plugin's `create_page`/`create_post` (#356, merged).

## Intents

| Intent | Backing |
|---|---|
| `SearchContentIntent` | `SiteContentGraph` search → spoken summary |
| `SiteStatusIntent` | `SiteContentGraph` counts (pages/posts/drafts/images) |
| `PreviewSiteIntent` | `WindowRouter` (`openAppWhenRun`) |
| `AddPageIntent` | `ContentOperationsService` → pool → `create_page` |
| `AddPostIntent` | `ContentOperationsService` → pool → `create_post` |

Thin adapters over Core, exactly like `SiteIntents`. Reads hit `SiteContentGraph` via `@Dependency` (test-bypassed by `ContentGraphOverride.scoped`); creates go through a new `ContentOperationsService` (bypassed by `ContentOperationsOverride.scoped`) → `HeadlessRuntimePool` → plugin tool, parsing the `{filePath, route|slug}` reply. All spoken text is built by pure, unit-tested `ContentDialogs` helpers, and the read intents' gather logic is extracted into static `dialog(graph:…)` helpers so the read+format wiring is testable without the AppIntents runtime.

`AddPage`/`AddPost` run the real service call inside `performBackgroundTask` under `#if compiler(>=6.4)` (`LongRunningIntent`/`CancellableIntent`) — matching the sibling intents so a first-use Node spawn isn't killed mid-flight (a review fix; the marker conformance alone doesn't grant budget).

## Scope (agreed with maintainer)

- **`EditContentIntent` deferred** — turning a natural-language edit into a structured `apply_edit` needs the on-device model (Phase C, #155). Not faked.
- **`SiteStatusIntent`** reports graph-derived counts; live dev-server/health/deploy status needs app-state plumbing a headless intent can't reach — follow-up.
- **`PreviewSiteIntent`** keeps the `page` parameter (per spec) but does **not** yet navigate the preview to that page; delivering the route to the right `SiteWindow`'s WKWebView (keyed by siteID, no staleness) is a follow-up. The dialog deliberately doesn't claim navigation it doesn't perform (a review fix — was over-promising).

## Tests

- `ContentIntentsTests` — dialog grammar (singular/plural, drafts, no-match), read-intent gather helpers **with per-site scoping** (site B's content doesn't leak), Preview's `WindowRouter` side-effect, and the create intents via a fake service (arg forwarding + failure tolerance).
- `ContentOperationsTests` — `parseCreated` (valid + malformed) and a **Python-fake-MCP integration** driving the real `HeadlessRuntimePool` → MCP → parse path for both `create_page` and `create_post`.

Full suite green (329); `Anglesite` (DevID) and `AnglesiteMAS` both build.

## Follow-ups
- `EditContentIntent` (Phase C / #155).
- `PreviewSiteIntent` in-preview page navigation.
- `SiteStatusIntent` live runtime status.
- `AnglesiteShortcuts` phrases for these intents (A.7 / #141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)