### PR TITLE
feat(intents): Siri phrases for the Phase A content intents (#141)

### DIFF
--- a/Sources/AnglesiteIntents/AnglesiteShortcuts.swift
+++ b/Sources/AnglesiteIntents/AnglesiteShortcuts.swift
@@ -26,5 +26,53 @@ public struct AnglesiteShortcuts: AppShortcutsProvider {
             shortTitle: "Check Site",
             systemImageName: "checkmark.seal"
         )
+        // Phase A content intents (A.7, #141). Phrases avoid colliding with "Check my site"
+        // (AuditSiteIntent) above. Each intent's required parameters (site, query, name, …) are
+        // prompted by Siri when not supplied in the phrase, same as deploy/backup/audit.
+        AppShortcut(
+            intent: SearchContentIntent(),
+            phrases: [
+                "What's on my site with \(.applicationName)",
+                "Search my site with \(.applicationName)",
+            ],
+            shortTitle: "Search Content",
+            systemImageName: "magnifyingglass"
+        )
+        AppShortcut(
+            intent: SiteStatusIntent(),
+            phrases: [
+                "How is my site doing with \(.applicationName)",
+                "My site status with \(.applicationName)",
+            ],
+            shortTitle: "Site Status",
+            systemImageName: "chart.bar.doc.horizontal"
+        )
+        AppShortcut(
+            intent: AddPageIntent(),
+            phrases: [
+                "Add a page to my site with \(.applicationName)",
+                "Add a page with \(.applicationName)",
+            ],
+            shortTitle: "Add Page",
+            systemImageName: "doc.badge.plus"
+        )
+        AppShortcut(
+            intent: AddPostIntent(),
+            phrases: [
+                "Add a post to my site with \(.applicationName)",
+                "Add a post with \(.applicationName)",
+            ],
+            shortTitle: "Add Post",
+            systemImageName: "square.and.pencil"
+        )
+        AppShortcut(
+            intent: PreviewSiteIntent(),
+            phrases: [
+                "Preview my site with \(.applicationName)",
+                "Open my site preview with \(.applicationName)",
+            ],
+            shortTitle: "Preview Site",
+            systemImageName: "eye"
+        )
     }
 }

--- a/Tests/AnglesiteIntentsTests/AnglesiteShortcutsTests.swift
+++ b/Tests/AnglesiteIntentsTests/AnglesiteShortcutsTests.swift
@@ -4,12 +4,14 @@ import Testing
 extension AppIntentsTests {
     @Suite("AnglesiteShortcuts")
     struct AnglesiteShortcutsTests {
-        @Test("provider exposes three Siri-discoverable shortcuts (Open is intentionally omitted)")
-        func providerListsThreeSiriIntents() {
+        @Test("provider exposes deploy/backup/audit + the Phase A content shortcuts (Open omitted)")
+        func providerListsAllSiriIntents() {
             // AppShortcut doesn't expose intent metadata via public accessors, so we can only
             // assert on the count. The exact intent → phrase mapping is verified manually in
             // Shortcuts.app during the PR smoke test (see #122 smoke checklist).
-            #expect(AnglesiteShortcuts.appShortcuts.count == 3)
+            // 3 originals (deploy/backup/audit) + 5 Phase A content intents (A.7, #141):
+            // Search, Status, AddPage, AddPost, Preview.
+            #expect(AnglesiteShortcuts.appShortcuts.count == 8)
         }
     }
 }


### PR DESCRIPTION
Closes #141 (Siri AI Phase A — A.7).

Adds curated `AppShortcut` phrases so the A.5 content intents surface in Spotlight and Siri suggestions next to the existing deploy/backup/audit shortcuts:

| Intent | Phrases |
|---|---|
| `SearchContentIntent` | "What's on my site with Anglesite", "Search my site with Anglesite" |
| `SiteStatusIntent` | "How is my site doing with Anglesite", "My site status with Anglesite" |
| `AddPageIntent` | "Add a page to my site with Anglesite", "Add a page with Anglesite" |
| `AddPostIntent` | "Add a post to my site with Anglesite", "Add a post with Anglesite" |
| `PreviewSiteIntent` | "Preview my site with Anglesite", "Open my site preview with Anglesite" |

8 shortcuts total (under the 10-per-provider limit). Phrases avoid colliding with `AuditSiteIntent`'s "Check my site". Required parameters (site, query, name, …) are prompted by Siri when not spoken, same as the existing intents.

`AddPostIntent` gets a phrase too — the issue listed four, but the intent shipped in A.5 (#174), so it's included for parity.

`AppShortcut` exposes no public intent/phrase accessors, so the test asserts the provider count (now 8); the intent→phrase mapping is verified manually in Shortcuts.app per the #122 smoke checklist. `Anglesite` (DevID) and `AnglesiteMAS` both build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)