### PR TITLE
perf(intents): batch entity lookups in entities(for:) (#170)

### DIFF
--- a/Sources/AnglesiteCore/SiteContentGraph.swift
+++ b/Sources/AnglesiteCore/SiteContentGraph.swift
@@ -225,6 +225,17 @@ public actor SiteContentGraph {
     public func post(id: String) -> Post? { posts[id] }
     public func image(id: String) -> Image? { images[id] }
 
+    // MARK: - Batched id lookup
+
+    /// Resolve many ids in a single actor hop (#170). Returns matches in the input order, skipping
+    /// unknown ids — same semantics as a serial `page(id:)` loop, but one hop instead of N. Used by
+    /// `PageEntityQuery.entities(for:)` etc., which Shortcuts re-resolution can call with dozens of
+    /// ids after a multi-pick. Takes an ordered `[String]` (not a `Set`) to preserve the
+    /// input-order contract the entity queries' tests assert.
+    public func pages(ids: [String]) -> [Page] { ids.compactMap { pages[$0] } }
+    public func posts(ids: [String]) -> [Post] { ids.compactMap { posts[$0] } }
+    public func images(ids: [String]) -> [Image] { ids.compactMap { images[$0] } }
+
     // MARK: - Search
 
     /// Case-insensitive substring search on a page's `title` and `route`. Empty `query`

--- a/Sources/AnglesiteIntents/ContentEntities.swift
+++ b/Sources/AnglesiteIntents/ContentEntities.swift
@@ -42,14 +42,8 @@ public struct PageEntityQuery: EntityStringQuery {
     }
 
     public func entities(for identifiers: [String]) async throws -> [PageEntity] {
-        let g = resolved
-        var found: [PageEntity] = []
-        for id in identifiers {
-            if let page = await g.page(id: id) {
-                found.append(PageEntity(page))
-            }
-        }
-        return found
+        // Single actor hop for all ids (#170); the graph preserves input order and skips unknowns.
+        await resolved.pages(ids: identifiers).map(PageEntity.init)
     }
 
     public func entities(matching string: String) async throws -> [PageEntity] {
@@ -135,14 +129,8 @@ public struct PostEntityQuery: EntityStringQuery {
     }
 
     public func entities(for identifiers: [String]) async throws -> [PostEntity] {
-        let g = resolved
-        var found: [PostEntity] = []
-        for id in identifiers {
-            if let post = await g.post(id: id) {
-                found.append(PostEntity(post))
-            }
-        }
-        return found
+        // Single actor hop for all ids (#170); the graph preserves input order and skips unknowns.
+        await resolved.posts(ids: identifiers).map(PostEntity.init)
     }
 
     public func entities(matching string: String) async throws -> [PostEntity] {
@@ -224,14 +212,8 @@ public struct ImageEntityQuery: EntityStringQuery {
     }
 
     public func entities(for identifiers: [String]) async throws -> [ImageEntity] {
-        let g = resolved
-        var found: [ImageEntity] = []
-        for id in identifiers {
-            if let image = await g.image(id: id) {
-                found.append(ImageEntity(image))
-            }
-        }
-        return found
+        // Single actor hop for all ids (#170); the graph preserves input order and skips unknowns.
+        await resolved.images(ids: identifiers).map(ImageEntity.init)
     }
 
     public func entities(matching string: String) async throws -> [ImageEntity] {

--- a/Tests/AnglesiteCoreTests/SiteContentGraphTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteContentGraphTests.swift
@@ -525,4 +525,57 @@ struct SiteContentGraphTests {
         #expect(pages.count == 100)
         #expect(Set(pages.map(\.route)).count == 100)
     }
+
+    // MARK: - Batched id lookup (#170)
+
+    @Test("pages(ids:) returns matches in input order, skipping unknown ids")
+    func batchedPagesPreserveOrderAndSkipUnknown() async {
+        let graph = SiteContentGraph()
+        let a = Self.page(route: "/a"), b = Self.page(route: "/b"), c = Self.page(route: "/c")
+        await graph.load(siteID: Self.siteA, pages: [a, b, c], posts: [], images: [])
+
+        let result = await graph.pages(ids: [c.id, "unknown:page:/zzz", a.id, b.id])
+        #expect(result.map(\.id) == [c.id, a.id, b.id])
+    }
+
+    @Test("posts(ids:) returns matches in input order, skipping unknown ids")
+    func batchedPostsPreserveOrderAndSkipUnknown() async {
+        let graph = SiteContentGraph()
+        let a = Self.post(slug: "a"), b = Self.post(slug: "b")
+        await graph.load(siteID: Self.siteA, pages: [], posts: [a, b], images: [])
+
+        let result = await graph.posts(ids: [b.id, "unknown:post:zzz", a.id])
+        #expect(result.map(\.id) == [b.id, a.id])
+    }
+
+    @Test("images(ids:) returns matches in input order, skipping unknown ids")
+    func batchedImagesPreserveOrderAndSkipUnknown() async {
+        let graph = SiteContentGraph()
+        let a = Self.image(relativePath: "public/a.png"), b = Self.image(relativePath: "public/b.png")
+        await graph.load(siteID: Self.siteA, pages: [], posts: [], images: [a, b])
+
+        let result = await graph.images(ids: [b.id, a.id, "unknown:image:zzz.png"])
+        #expect(result.map(\.id) == [b.id, a.id])
+    }
+
+    @Test("batched lookups return empty for an empty id list")
+    func batchedEmpty() async {
+        let graph = SiteContentGraph()
+        await graph.load(siteID: Self.siteA, pages: [Self.page()], posts: [Self.post()], images: [Self.image()])
+        #expect(await graph.pages(ids: []).isEmpty)
+        #expect(await graph.posts(ids: []).isEmpty)
+        #expect(await graph.images(ids: []).isEmpty)
+    }
+
+    @Test("batched lookups resolve ids across sites by id alone")
+    func batchedCrossSite() async {
+        let graph = SiteContentGraph()
+        let pa = Self.page(site: Self.siteA, route: "/a")
+        let pb = Self.page(site: Self.siteB, route: "/b")
+        await graph.load(siteID: Self.siteA, pages: [pa], posts: [], images: [])
+        await graph.load(siteID: Self.siteB, pages: [pb], posts: [], images: [])
+
+        let result = await graph.pages(ids: [pb.id, pa.id])
+        #expect(result.map(\.id) == [pb.id, pa.id])
+    }
 }


### PR DESCRIPTION
Closes #170 (Siri AI Phase A perf follow-up, surfaced by review on #169).

`PageEntityQuery` / `PostEntityQuery` / `ImageEntityQuery.entities(for:)` resolved ids in a serial for-loop — one `await graph.page(id:)` per id, so **N actor hops** for N ids. Now that the A.5 intents route entity arrays through Shortcuts re-resolution (a multi-pick can hit dozens of ids), that's the load-bearing path.

## Change

- `SiteContentGraph` gains `pages(ids:)` / `posts(ids:)` / `images(ids:)` — **one actor hop**, one `compactMap` over the requested ids.
- The three `entities(for:)` implementations collapse to a single `await`.
- Semantics unchanged: **input order preserved, unknown ids skipped** — identical to the old loop, so the existing order-preservation / skip-unknown tests in `ContentEntitiesTests` still pass.

## Note on the signature

The issue sketched `pages(ids: Set<String>)`, but `ContentEntitiesTests` has explicit **"entities(for:) preserves input order"** tests — a `Set` is unordered and would break them (and "existing tests still pass" is an acceptance criterion). So the methods take an ordered `[String]`; dedup isn't needed since callers pass identifier lists.

## Tests

5 new `SiteContentGraphTests` for the batched methods (order preserved, unknown skipped, empty, cross-site resolution by id). Full suite green (334); both targets build.

Rounds out Phase A — the content stack (plugin scan → graph → entities + Spotlight → intents → Siri phrases) is now complete and the hot re-resolution path is single-hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)