### PR TITLE
test: stabilize flaky CI tests (timing races + subprocess contention)

### DIFF
--- a/Tests/AnglesiteCoreTests/ContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentOperationsTests.swift
@@ -4,6 +4,7 @@ import Foundation
 
 /// Tests for `ContentOperations` (A.5, #139): `parseCreated` reply parsing (unit) and the full
 /// create path through a real `HeadlessRuntimePool` driving a Python fake MCP server (integration).
+@Suite(.serialized)  // serial subprocess spawns — see MCPClientTests rationale (CI-flakiness fix)
 struct ContentOperationsTests {
     private let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
 

--- a/Tests/AnglesiteCoreTests/HealthModelTests.swift
+++ b/Tests/AnglesiteCoreTests/HealthModelTests.swift
@@ -111,13 +111,15 @@ final class HealthModelTests: XCTestCase {
         let runner = GateRunner()
         let model = HealthModel(runner: runner)
 
-        // Kick off two recheck calls back-to-back. The runner queues each pending
-        // continuation; the first one will be cancelled.
+        // Kick off two recheck calls. We must pin the registration ORDER so `respondOldestPending`
+        // (FIFO) targets the right task: wait for the first call to register before starting the
+        // second (which cancels the first), then wait for the second to register. Without this the
+        // task-start order is unspecified and the cancellation can land on the latest call,
+        // leaving badgeState `.unknown` (the flake).
         let first = model.recheck(siteID: "s", siteDirectory: tmpURL)
-        let second = model.recheck(siteID: "s", siteDirectory: tmpURL)
-
-        // Yield so both @MainActor tasks start and register their continuations.
-        await Task.yield()
+        await runner.waitForPending(1)                                   // first registered
+        let second = model.recheck(siteID: "s", siteDirectory: tmpURL)   // cancels first
+        await runner.waitForPending(2)                                   // second registered
 
         // Cancellation propagates to the gated runner via CancellationError; respond
         // to the second call with a blocked outcome.
@@ -209,6 +211,18 @@ final class GateRunner: HealthCheckRunner, @unchecked Sendable {
     func respondOldestPending(with result: Result<PreDeployCheck.Outcome, Error>) async {
         let cont = await dequeueOldest()
         deliver(cont, result)
+    }
+
+    /// Number of in-flight `run` calls currently suspended. Lets the cancellation test wait for a
+    /// known registration order before responding (see `waitForPending`).
+    var pendingCount: Int { lock.withLock { pending.count } }
+
+    /// Await until at least `count` `run` calls have registered their continuations. Makes the
+    /// cancellation test deterministic: without it the order in which the two back-to-back recheck
+    /// tasks reach `run` is unspecified, so `respondOldestPending` could deliver the cancellation
+    /// to the wrong task and leave the latest result unset (flaky `.unknown`).
+    func waitForPending(_ count: Int) async {
+        while pendingCount < count { try? await Task.sleep(for: .milliseconds(5)) }
     }
 
     private func dequeueOldest() async -> CheckedContinuation<PreDeployCheck.Outcome, Error> {

--- a/Tests/AnglesiteCoreTests/LocalSiteRuntimeGraphTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalSiteRuntimeGraphTests.swift
@@ -6,6 +6,7 @@ import Foundation
 /// MCP tool after the dev server is ready and the MCP client has initialized, and evicts the
 /// site's content from the graph on stop. A missing/erroring `list_content` (older plugin) is a
 /// no-op: the graph stays empty and preview is unaffected.
+@Suite(.serialized)  // serial subprocess spawns — see MCPClientTests rationale (CI-flakiness fix)
 struct LocalSiteRuntimeGraphTests {
     private let alwaysReady: AstroDevServer.ReadinessProbe = { _ in true }
     private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)

--- a/Tests/AnglesiteCoreTests/LocalSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalSiteRuntimeTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
+@Suite(.serialized)  // serial subprocess spawns — see MCPClientTests rationale (CI-flakiness fix)
 struct LocalSiteRuntimeTests {
     private let alwaysReady: AstroDevServer.ReadinessProbe = { _ in true }
     /// A real, existing directory — the supervisor `cd`s into the site dir before spawning, so a
@@ -81,9 +82,17 @@ struct LocalSiteRuntimeTests {
         let first = await runtime.state
         #expect(first == .ready(siteID: "mysite", url: URL(string: "http://localhost:9201/")!))
 
-        try? await Task.sleep(nanoseconds: 700_000_000)
-        let updated = await runtime.state
-        #expect(updated == .ready(siteID: "mysite", url: URL(string: "http://localhost:9202/")!))
+        // The dev server exits and is restarted on a new port. Wait for that transition rather
+        // than guessing a fixed delay — the crash→backoff→respawn→ready cycle can exceed any
+        // fixed sleep under CI load (this was flaky). Poll the state until it lands on 9202.
+        let target = SiteRuntimeState.ready(siteID: "mysite", url: URL(string: "http://localhost:9202/")!)
+        var reachedNewPort = false
+        let deadline = Date().addingTimeInterval(15)
+        while Date() < deadline {
+            if await runtime.state == target { reachedNewPort = true; break }
+            try? await Task.sleep(nanoseconds: 20_000_000)  // 20ms
+        }
+        #expect(reachedNewPort, "runtime did not reach the restarted port 9202 within 15s")
 
         await runtime.stop()
     }

--- a/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
@@ -10,6 +10,7 @@ import Darwin
 /// Skips (throws `SkipReason`) when the sibling plugin checkout / its node_modules / Node aren't
 /// present. Resolve the plugin via `ANGLESITE_PLUGIN_PATH` (default `../anglesite`); resolve Node via
 /// `NODE_BINARY`, common paths, or `~/.nvm/versions/node/*/bin/node`.
+@Suite(.serialized)  // serial subprocess spawns — see MCPClientTests rationale (CI-flakiness fix)
 struct MCPClientHTTPEndToEndTests {
     @Test("HTTP end-to-end: connect, list tools, call list_annotations") func httpEndToEnd() async throws {
         let pluginRoot = try Self.requireSiblingPlugin()

--- a/Tests/AnglesiteCoreTests/MCPClientTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientTests.swift
@@ -2,6 +2,11 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
+/// `.serialized` so this suite's many subprocess spawns (a fresh fake MCP server per test) don't
+/// run concurrently with each other under `swift test --parallel`. With ~6 subprocess suites each
+/// spawning serially, peak concurrent Node/Python spawns stays low enough that the `initialize`
+/// handshake doesn't time out on a CPU-saturated CI runner (the flake). See CI-flakiness fix.
+@Suite(.serialized)
 struct MCPClientTests {
     /// Python fake MCP server speaking JSON-RPC 2.0 over stdio. `-u` keeps it unbuffered.
     private static let fakeServerScript = """


### PR DESCRIPTION
Every PR this session needed 1–2 CI re-runs from *unrelated* flaky tests. Systematic-debugging found two root causes, fixed at the source.

## 1. Timing-assertion races (genuine test-logic bugs)

- **`LocalSiteRuntimeTests` "Ready URL updates when a dev server restart picks a new port"** — asserted state after a fixed `Task.sleep(0.7s)`. The crash → backoff → respawn → ready cycle can exceed any fixed delay under load, so it still saw the old port (`9201` vs `9202`). Now polls the runtime state until the restarted port lands (15s budget). *(condition-based waiting)*
- **`HealthModelTests` cancellation test** — assumed the first `recheck` registers its runner continuation before the second, but a single `Task.yield()` doesn't pin that order. When reversed, the `CancellationError` hit the *latest* task and the `.blocked` result landed on the superseded (discarded) task → `badgeState` stuck at `.unknown`. Added `GateRunner.waitForPending(_:)` and wait for ordered registration so `respondOldestPending` (FIFO) targets the right task.

## 2. Subprocess spawn/init timeouts under `swift test --parallel`

The MCP/runtime suites each spawn several Node/Python servers and run an `initialize` handshake. With ~6 such suites running their `@Test` methods concurrently, a 4-core CI runner saw **~30 simultaneous spawns**, saturating CPU so the 10s handshake timed out — a *different* unrelated test failed each run (`MCPClient` "timeout", `startHeadlessMCP`, `ContentOperations` create, dev-server restart).

Marked the heavy Node/Python suites **`@Suite(.serialized)`** — `MCPClientTests`, `MCPClientHTTPEndToEndTests`, `LocalSiteRuntimeTests`, `LocalSiteRuntimeGraphTests`, `ContentOperationsTests`. Peak concurrent spawns drops from ~30 to roughly one-per-suite, while the suites still run in parallel with each other and with the fast unit suites. The light `sh`/`echo` suites (`AstroDevServer`, `ProcessSupervisor`) stay parallel — cheap, never flaked.

## Verification

Test-only change (no production code). Full suite green locally (334), with negligible added wall time. The two timing tests are now deterministic; the contention fix is environmental, so the real proof is CI reliability — I'll let CI run a few times on this PR to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)