### PR TITLE
feat(overlay): VisibleElementReport message + reporter (#145)

### DIFF
--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -13,6 +13,7 @@ import {
   type EditReply,
 } from "./messages.js";
 import { showToast } from "./toast.js";
+import { installVisibleElementsReporter } from "./visible-elements.js";
 
 export const HOVER_CLASS = "anglesite-hover";
 export const EDITABLE_CLASS = "anglesite-editing";
@@ -196,4 +197,5 @@ export function install(): void {
   attachHover();
   attachClickToEdit(awaitReply);
   attachImageDrop(awaitReply);
+  installVisibleElementsReporter();
 }

--- a/JS/edit-overlay/src/visible-elements.ts
+++ b/JS/edit-overlay/src/visible-elements.ts
@@ -1,0 +1,285 @@
+// VisibleElementReport collector — feeds Phase B onscreen awareness (App Intents).
+//
+// Watches priority-category elements (headings, images, nav items, interactive controls) via
+// IntersectionObserver, and posts a typed `anglesite:visible-elements` message whenever the
+// visible set changes. The native side (`PreviewAnnotationProvider`, #146) maps those reports
+// into `ElementEntity` instances that AppKit's `appEntityUIElementProvider` (#148) returns when
+// Siri hit-tests the WKWebView.
+//
+// Selector field: we send structured `ElementInfo` rather than a CSS string. The issue (#145)
+// sketched `selector: string`, but `selector.ts` (decided in #18) keeps the CSS-resolution
+// strategy in one place — the plugin's `server/selector.mjs`. The native side already knows
+// how to resolve `ElementInfo` for `apply-edit` messages; reusing the same shape here avoids
+// shipping a fork-prone JS port of `buildSelector`.
+
+import { elementInfoFor, type ElementInfo } from "./selector.js";
+
+export interface VisibleElement {
+  /** Stable per-tab id. Sourced from `data-anglesite-id` when present, otherwise a generated
+   *  `v-…` string kept stable across reports via an internal WeakMap (no DOM mutation). */
+  id: string;
+  tag: string;
+  /** Structured selector payload — same shape used by `apply-edit` messages. */
+  selector: ElementInfo;
+  rect: { x: number; y: number; width: number; height: number };
+  /** `innerText` whitespace-collapsed and truncated to 120 chars. Absent if empty. */
+  text?: string;
+  /** Present for `<img>` only. */
+  src?: string;
+  /** ARIA `role` attribute, if any. */
+  role?: string;
+  /** Current page route at report time (`location.pathname`). */
+  pagePath?: string;
+}
+
+export interface VisibleElementReport {
+  type: "anglesite:visible-elements";
+  elements: VisibleElement[];
+}
+
+const MAX_ELEMENTS = 50;
+const MAX_TEXT = 120;
+const SCROLL_DEBOUNCE_MS = 200;
+const MUTATION_DEBOUNCE_MS = 500;
+const RESIZE_DEBOUNCE_MS = 200;
+
+const INSTALLED_FLAG = "__anglesiteVisibleElementsInstalled" as const;
+
+/**
+ * Priority categories. Lower index = reported first. -1 means "not a candidate".
+ *
+ *   0: headings (H1–H6)
+ *   1: images  (IMG)
+ *   2: nav items (A inside <nav> or [role=navigation])
+ *   3: interactive (BUTTON, INPUT, SELECT, TEXTAREA, SUMMARY, A outside nav, [role=button/link/checkbox/…])
+ */
+function categoryOf(el: Element): number {
+  const tag = el.tagName;
+  if (/^H[1-6]$/.test(tag)) return 0;
+  if (tag === "IMG") return 1;
+  if (tag === "A" && isInsideNav(el)) return 2;
+  if (isInteractive(el)) return 3;
+  return -1;
+}
+
+function isInsideNav(el: Element): boolean {
+  let cur: Element | null = el.parentElement;
+  while (cur) {
+    if (cur.tagName === "NAV") return true;
+    if (cur.getAttribute("role") === "navigation") return true;
+    cur = cur.parentElement;
+  }
+  return false;
+}
+
+const INTERACTIVE_TAGS = new Set(["BUTTON", "INPUT", "SELECT", "TEXTAREA", "SUMMARY", "A"]);
+const INTERACTIVE_ROLES = new Set([
+  "button", "link", "checkbox", "radio", "switch", "menuitem", "tab", "option",
+]);
+
+function isInteractive(el: Element): boolean {
+  if (INTERACTIVE_TAGS.has(el.tagName)) return true;
+  const role = el.getAttribute("role");
+  if (role && INTERACTIVE_ROLES.has(role)) return true;
+  return false;
+}
+
+/** Single selector covering every candidate the IntersectionObserver should watch. */
+const CANDIDATE_SELECTOR =
+  "h1, h2, h3, h4, h5, h6, img, a, button, input, select, textarea, summary, " +
+  "[role=button], [role=link], [role=checkbox], [role=radio], [role=switch], " +
+  "[role=menuitem], [role=tab], [role=option]";
+
+function findCandidates(root: ParentNode = document): Element[] {
+  return Array.from(root.querySelectorAll(CANDIDATE_SELECTOR));
+}
+
+const idMap = new WeakMap<Element, string>();
+let idCounter = 0;
+function idFor(el: Element): string {
+  const fromAttr = el.getAttribute("data-anglesite-id");
+  if (fromAttr) return fromAttr;
+  const existing = idMap.get(el);
+  if (existing) return existing;
+  idCounter += 1;
+  const generated = `v-${idCounter.toString(36)}`;
+  idMap.set(el, generated);
+  return generated;
+}
+
+function condenseText(raw: string): string {
+  const normalized = raw.replace(/\s+/g, " ").trim();
+  if (normalized.length <= MAX_TEXT) return normalized;
+  return normalized.slice(0, MAX_TEXT - 1) + "…";
+}
+
+function shape(el: Element, pagePath: string): VisibleElement {
+  const rect = el.getBoundingClientRect();
+  const text = condenseText(el.textContent ?? "");
+  const role = el.getAttribute("role") ?? undefined;
+  const src = el.tagName === "IMG" ? (el as HTMLImageElement).getAttribute("src") ?? undefined : undefined;
+  const out: VisibleElement = {
+    id: idFor(el),
+    tag: el.tagName,
+    selector: elementInfoFor(el),
+    rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+    pagePath,
+  };
+  if (text) out.text = text;
+  if (src) out.src = src;
+  if (role) out.role = role;
+  return out;
+}
+
+/**
+ * Filter, prioritize, and shape a candidate list into a report payload.
+ *
+ * Pure (modulo the id WeakMap and rect / textContent reads) — given the same DOM state, the
+ * same input list, and the same `pagePath`, returns the same output. Stable sort within a
+ * category preserves DOM order, which gives Siri a predictable "first heading", "first image",
+ * etc.
+ */
+export function collectVisibleElements(
+  candidates: Element[],
+  pagePath: string,
+): VisibleElement[] {
+  const tagged = candidates
+    .map((el) => ({ el, cat: categoryOf(el) }))
+    .filter((x) => x.cat >= 0);
+  // Stable sort: JS Array.sort is stable as of ES2019.
+  tagged.sort((a, b) => a.cat - b.cat);
+  const capped = tagged.slice(0, MAX_ELEMENTS);
+  return capped.map(({ el }) => shape(el, pagePath));
+}
+
+interface WebKitWindow {
+  webkit?: {
+    messageHandlers?: {
+      anglesite?: { postMessage: (body: unknown) => void };
+    };
+  };
+}
+
+/** Post a report to native. Returns `false` (no throw) if the WKWebView bridge is absent —
+ *  e.g. when the overlay is loaded in a plain browser tab for local debugging. */
+export function postVisibleElements(
+  report: VisibleElementReport,
+  win: WebKitWindow = window as unknown as WebKitWindow,
+): boolean {
+  const handler = win.webkit?.messageHandlers?.anglesite;
+  if (!handler) return false;
+  handler.postMessage(report);
+  return true;
+}
+
+interface InstallableWindow {
+  [INSTALLED_FLAG]?: boolean;
+}
+
+/**
+ * Install the reporter: observe priority-category elements via IntersectionObserver, debounce
+ * scroll / mutation / resize triggers, and post a `VisibleElementReport` each time the
+ * visible set is non-empty.
+ *
+ * Idempotent — a second call is a no-op. Returns silently when `IntersectionObserver` is
+ * unavailable (older environments / non-WKWebView hosts).
+ */
+export function installVisibleElementsReporter(): void {
+  const win = window as unknown as InstallableWindow;
+  if (win[INSTALLED_FLAG]) return;
+  if (typeof IntersectionObserver === "undefined") return;
+  win[INSTALLED_FLAG] = true;
+
+  const visible = new Set<Element>();
+  const observed = new Set<Element>();
+
+  const observer = new IntersectionObserver((entries) => {
+    let changed = false;
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        if (!visible.has(entry.target)) {
+          visible.add(entry.target);
+          changed = true;
+        }
+      } else if (visible.delete(entry.target)) {
+        changed = true;
+      }
+    }
+    // The browser's IntersectionObserver batches per-frame, so emitting synchronously here
+    // doesn't fan out into a torrent. The 4 documented triggers (scroll/mutation/resize, plus
+    // initial load — all in the issue) are how we *throttle*: the observer is the gating
+    // mechanism, the triggers control rate. Emitting here also covers the initial-load case
+    // since the observer fires its first batch right after `observe()`.
+    if (changed) emit();
+  });
+
+  function reconcileObservations(): void {
+    const candidates = new Set(findCandidates());
+    for (const el of candidates) {
+      if (!observed.has(el)) {
+        observer.observe(el);
+        observed.add(el);
+      }
+    }
+    for (const el of observed) {
+      if (!candidates.has(el)) {
+        observer.unobserve(el);
+        observed.delete(el);
+        visible.delete(el);
+      }
+    }
+  }
+
+  function emit(): void {
+    if (visible.size === 0) return;
+    const report: VisibleElementReport = {
+      type: "anglesite:visible-elements",
+      elements: collectVisibleElements(Array.from(visible), location.pathname),
+    };
+    if (report.elements.length === 0) return;
+    postVisibleElements(report);
+  }
+
+  // Initial reconcile. The observer's first callback (async, on next layout) populates
+  // `visible` and triggers the initial-load emit — no explicit `emit()` needed here.
+  reconcileObservations();
+
+  // Scroll: debounced. Passive listener — we never preventDefault.
+  let scrollTimer: ReturnType<typeof setTimeout> | undefined;
+  window.addEventListener("scroll", () => {
+    if (scrollTimer !== undefined) clearTimeout(scrollTimer);
+    scrollTimer = setTimeout(() => {
+      scrollTimer = undefined;
+      emit();
+    }, SCROLL_DEBOUNCE_MS);
+  }, { passive: true, capture: true });
+
+  // Window resize: debounced, also re-reconciles since layout shifts may add/remove candidates.
+  let resizeTimer: ReturnType<typeof setTimeout> | undefined;
+  window.addEventListener("resize", () => {
+    if (resizeTimer !== undefined) clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      resizeTimer = undefined;
+      reconcileObservations();
+      emit();
+    }, RESIZE_DEBOUNCE_MS);
+  });
+
+  // DOM mutations: debounced. Re-reconcile so newly-added candidates start being observed
+  // (and removed ones are dropped from the visible set).
+  let mutationTimer: ReturnType<typeof setTimeout> | undefined;
+  const mutationObserver = new MutationObserver(() => {
+    if (mutationTimer !== undefined) clearTimeout(mutationTimer);
+    mutationTimer = setTimeout(() => {
+      mutationTimer = undefined;
+      reconcileObservations();
+      emit();
+    }, MUTATION_DEBOUNCE_MS);
+  });
+  mutationObserver.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["src", "alt", "role", "aria-label", "data-anglesite-id"],
+  });
+}

--- a/JS/edit-overlay/src/visible-elements.ts
+++ b/JS/edit-overlay/src/visible-elements.ts
@@ -22,10 +22,20 @@ export interface VisibleElement {
   /** Structured selector payload — same shape used by `apply-edit` messages. */
   selector: ElementInfo;
   rect: { x: number; y: number; width: number; height: number };
-  /** `innerText` whitespace-collapsed and truncated to 120 chars. Absent if empty. */
+  /** `textContent` whitespace-collapsed and truncated to 120 chars. Absent if empty.
+   *  Deliberately not `innerText` — `innerText` forces a layout flush per read, which would
+   *  pile up to 50× per emit on busy pages. `textContent` is essentially free; the trade-off
+   *  is that it can include hidden text (`display:none`, `aria-hidden`). For the Siri-match
+   *  use case the false positives are bounded and self-correcting (the user can rephrase). */
   text?: string;
   /** Present for `<img>` only. */
   src?: string;
+  /** `alt` attribute — only populated for `<img>`. Critical for the Siri use case: `<img>` has
+   *  no `textContent`, so without `alt` the only name to match against is the `src` path. */
+  alt?: string;
+  /** `aria-label` attribute, when present. Fills the name role for icon controls and other
+   *  elements whose visible text doesn't describe them ("✕" buttons, glyph-only links, etc.). */
+  ariaLabel?: string;
   /** ARIA `role` attribute, if any. */
   role?: string;
   /** Current page route at report time (`location.pathname`). */
@@ -117,7 +127,10 @@ function shape(el: Element, pagePath: string): VisibleElement {
   const rect = el.getBoundingClientRect();
   const text = condenseText(el.textContent ?? "");
   const role = el.getAttribute("role") ?? undefined;
-  const src = el.tagName === "IMG" ? (el as HTMLImageElement).getAttribute("src") ?? undefined : undefined;
+  const isImg = el.tagName === "IMG";
+  const src = isImg ? (el as HTMLImageElement).getAttribute("src") ?? undefined : undefined;
+  const alt = isImg ? (el as HTMLImageElement).getAttribute("alt") ?? undefined : undefined;
+  const ariaLabel = el.getAttribute("aria-label") ?? undefined;
   const out: VisibleElement = {
     id: idFor(el),
     tag: el.tagName,
@@ -127,6 +140,8 @@ function shape(el: Element, pagePath: string): VisibleElement {
   };
   if (text) out.text = text;
   if (src) out.src = src;
+  if (alt) out.alt = alt;
+  if (ariaLabel) out.ariaLabel = ariaLabel;
   if (role) out.role = role;
   return out;
 }
@@ -138,6 +153,13 @@ function shape(el: Element, pagePath: string): VisibleElement {
  * same input list, and the same `pagePath`, returns the same output. Stable sort within a
  * category preserves DOM order, which gives Siri a predictable "first heading", "first image",
  * etc.
+ *
+ * Performance: each `shape()` call invokes `getBoundingClientRect()`, which can force a
+ * style/layout flush. For pages with many priority elements this is a known cost — bounded
+ * by the 50-element cap. If it becomes a hot spot in real-world traces, the path forward is
+ * to cache `entry.boundingClientRect` from the `IntersectionObserver` callback (it's already
+ * computed by the browser at zero cost) and only fall back to a live read in the scroll /
+ * resize / mutation paths.
  */
 export function collectVisibleElements(
   candidates: Element[],
@@ -183,6 +205,10 @@ interface InstallableWindow {
  *
  * Idempotent — a second call is a no-op. Returns silently when `IntersectionObserver` is
  * unavailable (older environments / non-WKWebView hosts).
+ *
+ * Internal `emit()` posts via the default `window` — same convention as `messages.ts`'s
+ * `attachClickToEdit` etc. The `postVisibleElements` `win` seam exists for unit-test direct
+ * invocation; the install path is integration-tested via the global `window.webkit` stub.
  */
 export function installVisibleElementsReporter(): void {
   const win = window as unknown as InstallableWindow;
@@ -192,6 +218,9 @@ export function installVisibleElementsReporter(): void {
 
   const visible = new Set<Element>();
   const observed = new Set<Element>();
+  // Dedup key for the last-sent report — the sorted, joined `id` list. Avoids redundant IPC
+  // when the user scrolls slowly within a region whose visible set doesn't change.
+  let lastEmittedKey = "";
 
   const observer = new IntersectionObserver((entries) => {
     let changed = false;
@@ -221,7 +250,11 @@ export function installVisibleElementsReporter(): void {
         observed.add(el);
       }
     }
-    for (const el of observed) {
+    // Snapshot-then-iterate: mutating a `Set` during `for…of` is safe per ES2019 iterator
+    // semantics, but it reads like a bug. The spread copy is O(n) and n is bounded by the
+    // candidate count (≤50 in practice). Lint sees the spread as redundant — it isn't here.
+    // oxlint-disable-next-line no-useless-spread
+    for (const el of [...observed]) {
       if (!candidates.has(el)) {
         observer.unobserve(el);
         observed.delete(el);
@@ -232,11 +265,15 @@ export function installVisibleElementsReporter(): void {
 
   function emit(): void {
     if (visible.size === 0) return;
-    const report: VisibleElementReport = {
-      type: "anglesite:visible-elements",
-      elements: collectVisibleElements(Array.from(visible), location.pathname),
-    };
-    if (report.elements.length === 0) return;
+    const elements = collectVisibleElements(Array.from(visible), location.pathname);
+    if (elements.length === 0) return;
+    // Dedup against the previous report's id set (sorted so visible-set permutations don't
+    // count as changes). Rects-only changes between reports don't trigger a re-emit; the
+    // next mutation / resize will get a fresh batch when geometry actually matters.
+    const key = elements.map((e) => e.id).sort().join(",");
+    if (key === lastEmittedKey) return;
+    lastEmittedKey = key;
+    const report: VisibleElementReport = { type: "anglesite:visible-elements", elements };
     postVisibleElements(report);
   }
 
@@ -263,16 +300,22 @@ export function installVisibleElementsReporter(): void {
       reconcileObservations();
       emit();
     }, RESIZE_DEBOUNCE_MS);
-  });
+  }, { passive: true });
 
   // DOM mutations: debounced. Re-reconcile so newly-added candidates start being observed
-  // (and removed ones are dropped from the visible set).
+  // (and removed ones are dropped from the visible set). `alt` and `aria-label` are in the
+  // filter because `shape()` reads them — changes should refresh the report so Siri picks up
+  // renamed assets / relabeled controls without waiting for the next mutation cycle.
   let mutationTimer: ReturnType<typeof setTimeout> | undefined;
   const mutationObserver = new MutationObserver(() => {
     if (mutationTimer !== undefined) clearTimeout(mutationTimer);
     mutationTimer = setTimeout(() => {
       mutationTimer = undefined;
       reconcileObservations();
+      // Dedup is based on id set, which doesn't change just because `alt` changed. Force a
+      // re-emit by clearing the cache here — geometry / attribute changes are exactly the
+      // case the mutation trigger exists to surface.
+      lastEmittedKey = "";
       emit();
     }, MUTATION_DEBOUNCE_MS);
   });

--- a/JS/edit-overlay/test/visible-elements.test.ts
+++ b/JS/edit-overlay/test/visible-elements.test.ts
@@ -104,6 +104,27 @@ describe("collectVisibleElements (pure shape)", () => {
     expect(r.role).toBe("button");
   });
 
+  it("captures alt for images", () => {
+    const img = makeEl(document.body, "img", { src: "/a.png", alt: "beach sunset" });
+    stubRect(img);
+    const r = collectVisibleElements([img], "/")[0]!;
+    expect(r.alt).toBe("beach sunset");
+  });
+
+  it("does not set alt for non-image elements", () => {
+    const h1 = makeEl(document.body, "h1", { alt: "ignored" }, "Hi");
+    stubRect(h1);
+    const r = collectVisibleElements([h1], "/")[0]!;
+    expect(r.alt).toBeUndefined();
+  });
+
+  it("captures aria-label on any element", () => {
+    const btn = makeEl(document.body, "button", { "aria-label": "Close dialog" }, "✕");
+    stubRect(btn);
+    const r = collectVisibleElements([btn], "/")[0]!;
+    expect(r.ariaLabel).toBe("Close dialog");
+  });
+
   it("orders heading > image > nav-item > interactive", () => {
     const nav = makeEl(document.body, "nav");
     const navLink = makeEl(nav, "a", { href: "/x" }, "Link");
@@ -209,6 +230,38 @@ describe("installVisibleElementsReporter", () => {
     installVisibleElementsReporter();
     expect(observed.length).toBe(after1);
   });
+
+  it("dedupes identical reports — same visible set fires once", () => {
+    const h1 = makeEl(document.body, "h1", {}, "Title");
+    stubRect(h1);
+    installVisibleElementsReporter();
+    // Same element, two IO callbacks (e.g. the user scrolls but the visible set is stable).
+    lastCallback?.([{ target: h1, isIntersecting: true }]);
+    lastCallback?.([{ target: h1, isIntersecting: true }]);
+    const reports = sent.filter(
+      (m): m is VisibleElementReport =>
+        typeof m === "object" && m !== null && (m as { type?: string }).type === "anglesite:visible-elements",
+    );
+    // First fire emits; second is a no-op because the id key matches.
+    expect(reports.length).toBe(1);
+  });
+
+  it("emits a new report when the visible set changes", () => {
+    const h1 = makeEl(document.body, "h1", {}, "A");
+    const h2 = makeEl(document.body, "h2", {}, "B");
+    stubRect(h1);
+    stubRect(h2);
+    installVisibleElementsReporter();
+    lastCallback?.([{ target: h1, isIntersecting: true }]);
+    lastCallback?.([{ target: h2, isIntersecting: true }]);
+    const reports = sent.filter(
+      (m): m is VisibleElementReport =>
+        typeof m === "object" && m !== null && (m as { type?: string }).type === "anglesite:visible-elements",
+    );
+    // First report: just h1. Second: h1 + h2 — different id key, emits.
+    expect(reports.length).toBe(2);
+    expect(reports[1]!.elements.map((e) => e.tag).sort()).toEqual(["H1", "H2"]);
+  });
 });
 
 describe("VisibleElement type contract", () => {
@@ -219,8 +272,10 @@ describe("VisibleElement type contract", () => {
       tag: "IMG",
       selector: { tag: "IMG", classes: [], nthChild: 1 },
       rect: { x: 0, y: 0, width: 1, height: 1 },
-      text: "alt",
+      text: "alt text fallback",
       src: "/a.png",
+      alt: "alt",
+      ariaLabel: "label",
       role: "img",
       pagePath: "/",
     };

--- a/JS/edit-overlay/test/visible-elements.test.ts
+++ b/JS/edit-overlay/test/visible-elements.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  collectVisibleElements,
+  installVisibleElementsReporter,
+  type VisibleElement,
+  type VisibleElementReport,
+} from "../src/visible-elements.js";
+
+interface WebKit {
+  messageHandlers: { anglesite: { postMessage: (body: unknown) => void } };
+}
+
+let sent: unknown[] = [];
+
+function stubWebKit(): void {
+  (window as unknown as { webkit: WebKit }).webkit = {
+    messageHandlers: { anglesite: { postMessage: (body) => { sent.push(body); } } },
+  };
+}
+
+function clearBody(): void {
+  while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+}
+
+function makeEl<K extends keyof HTMLElementTagNameMap>(
+  parent: Element,
+  tag: K,
+  attrs: Record<string, string> = {},
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const el = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  if (text !== undefined) el.textContent = text;
+  parent.appendChild(el);
+  return el;
+}
+
+function stubRect(el: Element, x = 0, y = 0, w = 100, h = 50): void {
+  el.getBoundingClientRect = () => ({
+    x, y, width: w, height: h,
+    top: y, left: x, right: x + w, bottom: y + h,
+    toJSON() { return {}; },
+  });
+}
+
+beforeEach(() => {
+  clearBody();
+  sent = [];
+  stubWebKit();
+});
+
+describe("collectVisibleElements (pure shape)", () => {
+  it("returns the documented schema for a heading", () => {
+    const h1 = makeEl(document.body, "h1", {}, "Hello");
+    stubRect(h1, 10, 20, 200, 40);
+    const r = collectVisibleElements([h1], "/about/")[0]!;
+    expect(r.tag).toBe("H1");
+    expect(r.text).toBe("Hello");
+    expect(r.rect).toEqual({ x: 10, y: 20, width: 200, height: 40 });
+    expect(r.pagePath).toBe("/about/");
+    expect(typeof r.id).toBe("string");
+    // selector is structured ElementInfo (matches edit-message pattern; see selector.ts).
+    expect(r.selector.tag).toBe("H1");
+  });
+
+  it("reuses data-anglesite-id when present", () => {
+    const h1 = makeEl(document.body, "h1", { "data-anglesite-id": "hero" }, "Hi");
+    stubRect(h1);
+    const r = collectVisibleElements([h1], "/")[0]!;
+    expect(r.id).toBe("hero");
+  });
+
+  it("generates a stable id and reuses it across calls for the same element", () => {
+    const h1 = makeEl(document.body, "h1", {}, "Hi");
+    stubRect(h1);
+    const r1 = collectVisibleElements([h1], "/")[0]!;
+    const r2 = collectVisibleElements([h1], "/")[0]!;
+    expect(r1.id).toBe(r2.id);
+    expect(r1.id).toMatch(/^v-/); // generated ids are prefixed
+  });
+
+  it("captures src for images", () => {
+    const img = makeEl(document.body, "img", { src: "/a.png" });
+    stubRect(img);
+    const r = collectVisibleElements([img], "/")[0]!;
+    expect(r.tag).toBe("IMG");
+    expect(r.src).toBe("/a.png");
+  });
+
+  it("truncates text to 120 chars", () => {
+    const long = "x".repeat(300);
+    // <p> isn't a priority category, so route through a heading instead.
+    const h2 = makeEl(document.body, "h2", {}, long);
+    stubRect(h2);
+    const r = collectVisibleElements([h2], "/")[0]!;
+    expect(r.text!.length).toBeLessThanOrEqual(120);
+  });
+
+  it("captures ARIA role", () => {
+    const btn = makeEl(document.body, "div", { role: "button" }, "Go");
+    stubRect(btn);
+    const r = collectVisibleElements([btn], "/")[0]!;
+    expect(r.role).toBe("button");
+  });
+
+  it("orders heading > image > nav-item > interactive", () => {
+    const nav = makeEl(document.body, "nav");
+    const navLink = makeEl(nav, "a", { href: "/x" }, "Link");
+    const img = makeEl(document.body, "img", { src: "/i.png" });
+    const h2 = makeEl(document.body, "h2", {}, "Title");
+    const btn = makeEl(document.body, "button", {}, "Go");
+    for (const el of [navLink, img, h2, btn]) stubRect(el);
+    const out = collectVisibleElements([navLink, img, h2, btn], "/");
+    expect(out.map((x) => x.tag)).toEqual(["H2", "IMG", "A", "BUTTON"]);
+  });
+
+  it("caps the report at 50 elements", () => {
+    const items: Element[] = [];
+    for (let i = 0; i < 60; i++) {
+      const h = makeEl(document.body, "h2", {}, `H${i}`);
+      stubRect(h);
+      items.push(h);
+    }
+    const out = collectVisibleElements(items, "/");
+    expect(out.length).toBe(50);
+  });
+
+  it("drops elements outside any priority category", () => {
+    const div = makeEl(document.body, "div", {}, "structural");
+    stubRect(div);
+    expect(collectVisibleElements([div], "/")).toEqual([]);
+  });
+
+  it("classifies <a> outside nav as interactive (after nav items)", () => {
+    const nav = makeEl(document.body, "nav");
+    const navLink = makeEl(nav, "a", { href: "/x" }, "Nav");
+    const bodyLink = makeEl(document.body, "a", { href: "/y" }, "Body");
+    stubRect(navLink);
+    stubRect(bodyLink);
+    const out = collectVisibleElements([navLink, bodyLink], "/");
+    expect(out.map((x) => x.text)).toEqual(["Nav", "Body"]);
+  });
+});
+
+describe("installVisibleElementsReporter", () => {
+  type IOEntry = { target: Element; isIntersecting: boolean };
+  type IOCallback = (entries: IOEntry[]) => void;
+  let observed: Element[] = [];
+  let lastCallback: IOCallback | undefined;
+
+  beforeAll(() => {
+    class FakeIntersectionObserver {
+      constructor(cb: IOCallback) { lastCallback = cb; }
+      observe(el: Element): void { observed.push(el); }
+      unobserve(_el: Element): void { /* no-op */ }
+      disconnect(): void { /* no-op */ }
+      takeRecords(): IOEntry[] { return []; }
+    }
+    (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+      FakeIntersectionObserver;
+  });
+
+  beforeEach(() => {
+    observed = [];
+    lastCallback = undefined;
+    // The reporter's install flag lives on `window` for production idempotence; reset it
+    // here so each test exercises a fresh install. Idempotence itself is asserted below.
+    delete (window as unknown as Record<string, unknown>).__anglesiteVisibleElementsInstalled;
+  });
+
+  it("observes priority-category elements at install time", () => {
+    makeEl(document.body, "h1", {}, "Title");
+    makeEl(document.body, "img", { src: "/x.png" });
+    makeEl(document.body, "div", {}, "skip me");
+    installVisibleElementsReporter();
+    expect(observed.map((e) => e.tagName).sort()).toEqual(["H1", "IMG"]);
+  });
+
+  it("posts a report when elements become visible", () => {
+    const h1 = makeEl(document.body, "h1", {}, "Title");
+    stubRect(h1);
+    installVisibleElementsReporter();
+    lastCallback?.([{ target: h1, isIntersecting: true }]);
+    // Initial scan is sync; debounced triggers aren't tested here.
+    const reports = sent.filter(
+      (m): m is VisibleElementReport =>
+        typeof m === "object" && m !== null && (m as { type?: string }).type === "anglesite:visible-elements",
+    );
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    expect(reports[0]!.elements[0]!.tag).toBe("H1");
+  });
+
+  it("does not post when no elements are visible", () => {
+    makeEl(document.body, "h1", {}, "Title");
+    installVisibleElementsReporter();
+    // No callback fired -> nothing visible.
+    const reports = sent.filter(
+      (m): m is { type: string } =>
+        typeof m === "object" && m !== null && (m as { type?: string }).type === "anglesite:visible-elements",
+    );
+    expect(reports).toEqual([]);
+  });
+
+  it("is idempotent: calling install twice does not double-observe", () => {
+    makeEl(document.body, "h1", {}, "Title");
+    installVisibleElementsReporter();
+    const after1 = observed.length;
+    installVisibleElementsReporter();
+    expect(observed.length).toBe(after1);
+  });
+});
+
+describe("VisibleElement type contract", () => {
+  it("permits all documented optional fields", () => {
+    // Compile-only — fails the typecheck if the public surface drifts.
+    const _r: VisibleElement = {
+      id: "x",
+      tag: "IMG",
+      selector: { tag: "IMG", classes: [], nthChild: 1 },
+      rect: { x: 0, y: 0, width: 1, height: 1 },
+      text: "alt",
+      src: "/a.png",
+      role: "img",
+      pagePath: "/",
+    };
+    expect(_r.tag).toBe("IMG");
+  });
+});


### PR DESCRIPTION
Closes #145. First step of Siri AI Phase B (#133).

## Why

Phase B needs the native side to know what the user can currently see in the preview so `PreviewAnnotationProvider` (#146) can map onscreen elements to `ElementEntity` instances. That lets Siri resolve "edit this heading" / "replace this image" without naming things — the AppKit `appEntityUIElementProvider` (#148) hands back whatever the WKWebView is showing.

## What

- **New** `JS/edit-overlay/src/visible-elements.ts`
  - `VisibleElementReport` / `VisibleElement` types
  - `collectVisibleElements()` — pure filter/prioritize/cap (testable in isolation)
  - `installVisibleElementsReporter()` — `IntersectionObserver` + debounced scroll / mutation / resize triggers, idempotent
  - `postVisibleElements()` — same soft-fail-in-browser pattern as `postEdit`
- **Modified** `overlay.ts:install()` — wires the reporter in alongside hover / click-to-edit / image-drop

## Schema choice — `selector: ElementInfo`, not `string`

The issue sketched `selector: string` (a CSS selector), but the codebase made the opposite decision in [#18](https://github.com/Anglesite/Anglesite-app/issues/18) (see `selector.ts:1-7`): JS collects structured `ElementInfo`, and the plugin's `server/selector.mjs` resolves it. Shipping a CSS-builder in JS would fork that strategy. I followed the established pattern — both `apply-edit` and `visible-elements` messages now carry the same selector shape, so the native B.2 resolver has one path, one truth.

## Stable element ids without DOM mutation

`data-anglesite-id` is used when present. Otherwise an id is generated and kept stable across reports via a `WeakMap<Element, string>` — never written to the DOM, so the overlay leaves no trace in the source files.

## Triggers + cap

- `IntersectionObserver` gates visibility; emits sync when the visible set changes (the browser already batches entries per frame)
- Scroll: passive, capture, debounced 200ms
- Window resize: debounced 200ms, reconciles observations
- DOM mutations: `MutationObserver` debounced 500ms, reconciles observations
- 50-element cap per report; priority order is **heading > image > nav item > interactive** (button / input / select / textarea / `<a>` outside nav / `[role=button|link|checkbox|…]`)

## Tests

15 new vitest cases — schema shape, id stability, ARIA capture, priority ordering, the 50-cap, drop-on-no-category, install/observe wiring with a stubbed `IntersectionObserver`, idempotence. All 45 overlay tests pass; `npm run typecheck` + `npm run lint` clean. Both `Anglesite` and `AnglesiteMAS` Xcode schemes build clean. The Swift `AppliesEditEndToEndTests` `.reconnecting` failure reproduces on `main` without these changes — pre-existing local-env flake (sibling plugin / node setup), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)