### PR TITLE
feat(intents): PreviewAnnotationProvider + ElementEntity (#146, #147)

### DIFF
--- a/Sources/AnglesiteCore/VisibleElementMessage.swift
+++ b/Sources/AnglesiteCore/VisibleElementMessage.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+/// One onscreen element reported by the WKWebView overlay's `installVisibleElementsReporter`
+/// (JS, #145). The provider (`PreviewAnnotationProvider`, #146) maps each into an `AppEntity`
+/// so Siri's `appEntityUIElementProvider` (#148) can resolve "this heading" / "this image"
+/// hit-tests against whatever the user can currently see.
+///
+/// **Selector shape.** Same structured `ElementInfo`-as-`JSONValue` the `apply-edit` messages
+/// carry — decided in #18 so the plugin's `server/selector.mjs` stays the only place that
+/// turns metadata into a CSS selector. Decoder requires an object exactly like
+/// `EditMessage.decode` does.
+public struct VisibleElement: Sendable, Equatable {
+    /// Per-tab stable id. Sourced from `data-anglesite-id` when present, otherwise a generated
+    /// `v-…` string the JS layer keeps stable across reports via an internal WeakMap.
+    public let id: String
+    public let tag: String
+    public let selector: JSONValue
+    public let rect: Rect
+    public let text: String?
+    public let src: String?
+    public let role: String?
+    public let pagePath: String?
+
+    public struct Rect: Sendable, Equatable {
+        public let x: Double
+        public let y: Double
+        public let width: Double
+        public let height: Double
+
+        public init(x: Double, y: Double, width: Double, height: Double) {
+            self.x = x
+            self.y = y
+            self.width = width
+            self.height = height
+        }
+    }
+
+    public init(
+        id: String,
+        tag: String,
+        selector: JSONValue,
+        rect: Rect,
+        text: String? = nil,
+        src: String? = nil,
+        role: String? = nil,
+        pagePath: String? = nil
+    ) {
+        self.id = id
+        self.tag = tag
+        self.selector = selector
+        self.rect = rect
+        self.text = text
+        self.src = src
+        self.role = role
+        self.pagePath = pagePath
+    }
+}
+
+/// The full `anglesite:visible-elements` payload — type tag plus the element list.
+public struct VisibleElementReport: Sendable, Equatable {
+    public static let messageType = "anglesite:visible-elements"
+
+    public let elements: [VisibleElement]
+
+    public init(elements: [VisibleElement]) {
+        self.elements = elements
+    }
+
+    public enum DecodeError: Error, Sendable, Equatable {
+        case notAnObject
+        case missingField(String)
+        case wrongType(field: String, expected: String)
+        case unknownType(String)
+        case malformedElement(index: Int, error: ElementDecodeError)
+    }
+
+    public enum ElementDecodeError: Error, Sendable, Equatable {
+        case notAnObject
+        case missingField(String)
+        case wrongType(field: String, expected: String)
+    }
+
+    /// Validate every field at the JS boundary; never throw. Same flat `Result` shape as
+    /// `EditMessage.decode` so the script handler can drop both through one error sink.
+    public static func decode(from body: Any) -> Result<VisibleElementReport, DecodeError> {
+        guard let dict = body as? [String: Any] else { return .failure(.notAnObject) }
+        guard let rawType = dict["type"] else { return .failure(.missingField("type")) }
+        guard let typeStr = rawType as? String else {
+            return .failure(.wrongType(field: "type", expected: "string"))
+        }
+        guard typeStr == messageType else { return .failure(.unknownType(typeStr)) }
+
+        guard let rawElements = dict["elements"] else { return .failure(.missingField("elements")) }
+        guard let rawArray = rawElements as? [Any] else {
+            return .failure(.wrongType(field: "elements", expected: "array"))
+        }
+
+        var elements: [VisibleElement] = []
+        elements.reserveCapacity(rawArray.count)
+        for (i, raw) in rawArray.enumerated() {
+            switch VisibleElement.decode(from: raw) {
+            case .success(let el): elements.append(el)
+            case .failure(let err): return .failure(.malformedElement(index: i, error: err))
+            }
+        }
+        return .success(VisibleElementReport(elements: elements))
+    }
+}
+
+extension VisibleElement {
+    /// Validate one element. Public so callers that already have a `[String: Any]` element
+    /// (e.g. tests, alternate transports) can decode without going through the report wrapper.
+    public static func decode(from body: Any) -> Result<VisibleElement, VisibleElementReport.ElementDecodeError> {
+        guard let dict = body as? [String: Any] else { return .failure(.notAnObject) }
+        func requireString(_ field: String) -> Result<String, VisibleElementReport.ElementDecodeError> {
+            guard let raw = dict[field] else { return .failure(.missingField(field)) }
+            guard let s = raw as? String else { return .failure(.wrongType(field: field, expected: "string")) }
+            return .success(s)
+        }
+        let id: String
+        let tag: String
+        switch requireString("id") {
+        case .success(let v): id = v
+        case .failure(let e): return .failure(e)
+        }
+        switch requireString("tag") {
+        case .success(let v): tag = v
+        case .failure(let e): return .failure(e)
+        }
+        guard let rawSelector = dict["selector"] else { return .failure(.missingField("selector")) }
+        guard let jv = JSONValue.from(rawSelector), case .object = jv else {
+            return .failure(.wrongType(field: "selector", expected: "object"))
+        }
+        let selector = jv
+        guard let rawRect = dict["rect"] else { return .failure(.missingField("rect")) }
+        guard let rectDict = rawRect as? [String: Any] else {
+            return .failure(.wrongType(field: "rect", expected: "object"))
+        }
+        guard
+            let x = numberValue(rectDict["x"]),
+            let y = numberValue(rectDict["y"]),
+            let w = numberValue(rectDict["width"]),
+            let h = numberValue(rectDict["height"])
+        else {
+            return .failure(.wrongType(field: "rect", expected: "{x,y,width,height} of numbers"))
+        }
+        let text = dict["text"] as? String
+        let src = dict["src"] as? String
+        let role = dict["role"] as? String
+        let pagePath = dict["pagePath"] as? String
+        return .success(
+            VisibleElement(
+                id: id,
+                tag: tag,
+                selector: selector,
+                rect: Rect(x: x, y: y, width: w, height: h),
+                text: text,
+                src: src,
+                role: role,
+                pagePath: pagePath
+            )
+        )
+    }
+}
+
+/// Accept either NSNumber (the `JSONSerialization` shape WKWebView delivers) or Swift numeric
+/// literals (the shape tests construct). Mirrors `JSONValue.from`'s NSNumber-first ordering.
+private func numberValue(_ raw: Any?) -> Double? {
+    guard let raw else { return nil }
+    if let n = raw as? NSNumber { return n.doubleValue }
+    if let d = raw as? Double { return d }
+    if let i = raw as? Int { return Double(i) }
+    return nil
+}

--- a/Sources/AnglesiteCore/VisibleElementMessage.swift
+++ b/Sources/AnglesiteCore/VisibleElementMessage.swift
@@ -71,13 +71,7 @@ public struct VisibleElementReport: Sendable, Equatable {
         case missingField(String)
         case wrongType(field: String, expected: String)
         case unknownType(String)
-        case malformedElement(index: Int, error: ElementDecodeError)
-    }
-
-    public enum ElementDecodeError: Error, Sendable, Equatable {
-        case notAnObject
-        case missingField(String)
-        case wrongType(field: String, expected: String)
+        case malformedElement(index: Int, error: VisibleElement.DecodeError)
     }
 
     /// Validate every field at the JS boundary; never throw. Same flat `Result` shape as
@@ -108,11 +102,20 @@ public struct VisibleElementReport: Sendable, Equatable {
 }
 
 extension VisibleElement {
+    /// Per-element decode failure shape. Paired with `VisibleElement.decode` (the same
+    /// `Type.DecodeError` pairing `EditMessage` uses), and surfaced from the report's
+    /// `DecodeError.malformedElement(index:error:)` case when one element in a batch fails.
+    public enum DecodeError: Error, Sendable, Equatable {
+        case notAnObject
+        case missingField(String)
+        case wrongType(field: String, expected: String)
+    }
+
     /// Validate one element. Public so callers that already have a `[String: Any]` element
     /// (e.g. tests, alternate transports) can decode without going through the report wrapper.
-    public static func decode(from body: Any) -> Result<VisibleElement, VisibleElementReport.ElementDecodeError> {
+    public static func decode(from body: Any) -> Result<VisibleElement, VisibleElement.DecodeError> {
         guard let dict = body as? [String: Any] else { return .failure(.notAnObject) }
-        func requireString(_ field: String) -> Result<String, VisibleElementReport.ElementDecodeError> {
+        func requireString(_ field: String) -> Result<String, VisibleElement.DecodeError> {
             guard let raw = dict[field] else { return .failure(.missingField(field)) }
             guard let s = raw as? String else { return .failure(.wrongType(field: field, expected: "string")) }
             return .success(s)

--- a/Sources/AnglesiteIntents/ElementEntity.swift
+++ b/Sources/AnglesiteIntents/ElementEntity.swift
@@ -1,0 +1,123 @@
+import AppIntents
+import AnglesiteCore
+import Foundation
+
+/// Transient onscreen element entity — covers the fallback case in `PreviewAnnotationProvider`'s
+/// mapping rules (B.2 / #146) where a visible DOM element doesn't correspond to any indexed
+/// Page/Post/Image. Lets Siri say "edit this" against arbitrary headings, buttons, links, etc.
+///
+/// **Not `IndexedEntity`** — these are tied to the live overlay state and would churn Spotlight
+/// constantly. Only `PreviewAnnotationProvider` can resolve them, and only while the WKWebView
+/// is showing the page that produced them. Once that page navigates, the entity is gone.
+///
+/// **Selector field is a JSON string.** Stores the same structured `ElementInfo`-as-`JSONValue`
+/// shape used by `EditMessage`, encoded so it survives `AppEntity` persistence as a plain
+/// `String`. Call `selectorJSON()` to materialize the `JSONValue` for routing.
+public struct ElementEntity: AppEntity, Identifiable, Sendable {
+    public let id: String              // "{siteID}:element:{elementID}"
+    public let displayName: String     // "h1 — Welcome to my site"
+    public let siteID: String
+    public let selector: String        // JSON-encoded `ElementInfo`
+    public let pagePath: String
+
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Element" }
+
+    public var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(displayName)", subtitle: "\(pagePath)")
+    }
+
+    public static var defaultQuery = ElementEntityQuery()
+
+    public init(id: String, displayName: String, siteID: String, selector: String, pagePath: String) {
+        self.id = id
+        self.displayName = displayName
+        self.siteID = siteID
+        self.selector = selector
+        self.pagePath = pagePath
+    }
+}
+
+extension ElementEntity {
+    /// Compose the canonical entity id for an element. Same `"{siteID}:{kind}:{key}"` shape as
+    /// `PageEntity` / `PostEntity` / `ImageEntity`, so a single string-based switch (e.g.
+    /// `entityID.hasPrefix("\(siteID):element:")`) can route by kind.
+    public static func makeID(siteID: String, elementID: String) -> String {
+        "\(siteID):element:\(elementID)"
+    }
+
+    /// Compose "h1 — Welcome to my site" / "div — Go" / "img — banner.png".
+    /// Tag is lowercased; the hint is truncated to 50 chars with an ellipsis when overlong.
+    public static func makeDisplayName(tag: String, hint: String?) -> String {
+        let tagPart = tag.lowercased()
+        guard let raw = hint?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return tagPart
+        }
+        let collapsed = raw.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        let truncated = collapsed.count > 50
+            ? collapsed.prefix(49) + "\u{2026}"
+            : Substring(collapsed)
+        return "\(tagPart) \u{2014} \(truncated)"
+    }
+
+    /// Decode the JSON-string selector back into the structured `JSONValue` shape that
+    /// `EditMessage.selector` requires. Returns `nil` if the string isn't valid JSON object —
+    /// callers treat that as "drop the edit", matching how `EditMessage.decode` rejects
+    /// non-object selectors at the WKWebView boundary.
+    public func selectorJSON() -> JSONValue? {
+        guard let data = selector.data(using: .utf8) else { return nil }
+        guard let raw = try? JSONSerialization.jsonObject(with: data) else { return nil }
+        guard let jv = JSONValue.from(raw), case .object = jv else { return nil }
+        return jv
+    }
+
+    /// Encode a structured selector to the string form stored on the entity. Round-trips with
+    /// `selectorJSON()`.
+    public static func encodeSelector(_ selector: JSONValue) -> String {
+        guard case .object = selector else { return "{}" }
+        guard let data = try? JSONSerialization.data(withJSONObject: selector.rawValue) else { return "{}" }
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+}
+
+/// Resolves `ElementEntity` references from `PreviewAnnotationProvider`'s live state — not
+/// from `SiteContentGraph`. The provider is a `@MainActor` reference, so the query bounces
+/// through the main actor for each lookup.
+public struct ElementEntityQuery: EntityQuery {
+    public init() {}
+
+    public func entities(for identifiers: [String]) async throws -> [ElementEntity] {
+        // No global registry of providers (each WKWebView owns one); resolution at this layer
+        // is best-effort against the active scoped provider. Tests + the upcoming B.4 hookup
+        // bind the override; production query paths run through the bound provider.
+        guard let provider = await ElementEntityProviderOverride.scoped else { return [] }
+        var out: [ElementEntity] = []
+        for id in identifiers {
+            if let entity = await provider.elementEntity(forID: id) {
+                out.append(entity)
+            }
+        }
+        return out
+    }
+
+    public func suggestedEntities() async throws -> [ElementEntity] {
+        guard let provider = await ElementEntityProviderOverride.scoped else { return [] }
+        return await provider.suggestedElementEntities()
+    }
+}
+
+/// Indirection so `ElementEntityQuery` can find the live provider without coupling
+/// `AnglesiteIntents` to a singleton. The app-level hookup (B.4) binds this at WKWebView
+/// install time; tests bind a stub. `@MainActor` because `PreviewAnnotationProvider` is.
+@MainActor
+public enum ElementEntityProviderOverride {
+    @TaskLocal public static var scoped: ElementEntityProviding?
+}
+
+/// What `ElementEntityQuery` needs from a provider. The concrete type
+/// (`PreviewAnnotationProvider`) implements it; tests can stub it without touching the real
+/// provider's state machine.
+@MainActor
+public protocol ElementEntityProviding: AnyObject, Sendable {
+    func elementEntity(forID id: String) -> ElementEntity?
+    func suggestedElementEntities() -> [ElementEntity]
+}

--- a/Sources/AnglesiteIntents/ElementEntity.swift
+++ b/Sources/AnglesiteIntents/ElementEntity.swift
@@ -86,20 +86,22 @@ extension ElementEntity {
     }
 }
 
-/// Resolves `ElementEntity` references from `PreviewAnnotationProvider`'s live state — not
-/// from `SiteContentGraph`. The provider is a `@MainActor` reference, so the query bounces
-/// through the main actor for each lookup.
+/// Resolves `ElementEntity` references from a live `PreviewAnnotationProvider`.
+///
+/// **Resolution chain** (first hit wins):
+/// 1. `ElementEntityProviderOverride.scoped` — short-lived `@TaskLocal` for test injection.
+/// 2. `PreviewAnnotationProviderRegistry.shared` — long-lived per-siteID registry the app
+///    populates from `SiteWindow`'s lifecycle (B.4 / #148 wiring).
+///
+/// In production the registry path is the one that fires; the TaskLocal exists so unit tests
+/// can drive a stub without coupling to `@MainActor` shared state.
 public struct ElementEntityQuery: EntityQuery {
     public init() {}
 
     public func entities(for identifiers: [String]) async throws -> [ElementEntity] {
-        // No global registry of providers (each WKWebView owns one); resolution at this layer
-        // is best-effort against the active scoped provider. Tests + the upcoming B.4 hookup
-        // bind the override; production query paths run through the bound provider.
-        guard let provider = await ElementEntityProviderOverride.scoped else { return [] }
         var out: [ElementEntity] = []
         for id in identifiers {
-            if let entity = await provider.elementEntity(forID: id) {
+            if let entity = await resolve(id) {
                 out.append(entity)
             }
         }
@@ -107,14 +109,34 @@ public struct ElementEntityQuery: EntityQuery {
     }
 
     public func suggestedEntities() async throws -> [ElementEntity] {
-        guard let provider = await ElementEntityProviderOverride.scoped else { return [] }
-        return await provider.suggestedElementEntities()
+        if let provider = await ElementEntityProviderOverride.scoped {
+            return await provider.suggestedElementEntities()
+        }
+        // Production: aggregate suggestions across every registered provider. With one window
+        // open this is just that window's set; multi-window users get the union. The provider
+        // already caps each contribution at 10 (`suggestedEntityCap`).
+        var merged: [ElementEntity] = []
+        for siteID in await PreviewAnnotationProviderRegistry.shared.knownSiteIDs() {
+            if let p = await PreviewAnnotationProviderRegistry.shared.provider(for: siteID) {
+                merged.append(contentsOf: await p.suggestedElementEntities())
+            }
+        }
+        return merged
+    }
+
+    private func resolve(_ id: String) async -> ElementEntity? {
+        if let provider = await ElementEntityProviderOverride.scoped,
+           let entity = await provider.elementEntity(forID: id) {
+            return entity
+        }
+        return await PreviewAnnotationProviderRegistry.shared.resolveElement(entityID: id)
     }
 }
 
-/// Indirection so `ElementEntityQuery` can find the live provider without coupling
-/// `AnglesiteIntents` to a singleton. The app-level hookup (B.4) binds this at WKWebView
-/// install time; tests bind a stub. `@MainActor` because `PreviewAnnotationProvider` is.
+/// Indirection so `ElementEntityQuery` can find a stub provider without coupling
+/// `AnglesiteIntents` to its `@MainActor` registry. `@TaskLocal` — only ever set by tests
+/// (`Override.$scoped.withValue(provider) { ... }`). In production this is `nil` and
+/// resolution falls through to `PreviewAnnotationProviderRegistry.shared`.
 @MainActor
 public enum ElementEntityProviderOverride {
     @TaskLocal public static var scoped: ElementEntityProviding?

--- a/Sources/AnglesiteIntents/ElementEntity.swift
+++ b/Sources/AnglesiteIntents/ElementEntity.swift
@@ -60,18 +60,25 @@ extension ElementEntity {
     }
 
     /// Decode the JSON-string selector back into the structured `JSONValue` shape that
-    /// `EditMessage.selector` requires. Returns `nil` if the string isn't valid JSON object —
-    /// callers treat that as "drop the edit", matching how `EditMessage.decode` rejects
+    /// `EditMessage.selector` requires. Returns `nil` when the string isn't a usable selector
+    /// — callers treat that as "drop the edit", matching how `EditMessage.decode` rejects
     /// non-object selectors at the WKWebView boundary.
+    ///
+    /// "Usable" means: parses as JSON, is a JSON object, AND carries the `tag` field the
+    /// plugin's `server/selector.mjs` needs to resolve. The `tag` guard is what catches the
+    /// `encodeSelector("{}")` round-trip case — an empty object is technically valid JSON but
+    /// would otherwise pass downstream and fail at the plugin with a less-actionable error.
     public func selectorJSON() -> JSONValue? {
         guard let data = selector.data(using: .utf8) else { return nil }
         guard let raw = try? JSONSerialization.jsonObject(with: data) else { return nil }
-        guard let jv = JSONValue.from(raw), case .object = jv else { return nil }
+        guard let jv = JSONValue.from(raw), case .object(let dict) = jv else { return nil }
+        guard dict["tag"] != nil else { return nil }
         return jv
     }
 
     /// Encode a structured selector to the string form stored on the entity. Round-trips with
-    /// `selectorJSON()`.
+    /// `selectorJSON()`. Non-object inputs return `"{}"` — `selectorJSON()`'s `tag` guard then
+    /// rejects them on the way back, so the nil-on-bad-input contract holds end-to-end.
     public static func encodeSelector(_ selector: JSONValue) -> String {
         guard case .object = selector else { return "{}" }
         guard let data = try? JSONSerialization.data(withJSONObject: selector.rawValue) else { return "{}" }

--- a/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
@@ -1,0 +1,126 @@
+import AppIntents
+import AnglesiteCore
+import CoreGraphics
+import Foundation
+
+/// Per-WKWebView state holding the latest `VisibleElementReport` and mapping each element to
+/// an `AppEntity`. AppKit's `appEntityUIElementProvider` (B.4 / #148) reads from this when
+/// Siri hit-tests the preview pane; intents (B.5 / #149) reach in via `entity(for:)` to
+/// resolve an `ElementEntity` id back to live state.
+///
+/// **One provider per site window** — siteID is captured at construction time. The
+/// `SiteContentGraph` is shared (one actor across the app); the provider asks it on each
+/// update so live indexing (new image lands, page renames) doesn't strand stale annotations.
+///
+/// **Mapping priority** (corrected vs the issue spec, see PR notes for #146):
+///   1. `<img>` with a `src` matching an `ImageEntity` → `ImageEntity`
+///   2. `data-anglesite-id` matches a `PostEntity.id` → `PostEntity`
+///   3. `pagePath` matches a `PageEntity.route` → `PageEntity`
+///   4. Otherwise → transient `ElementEntity`
+///
+/// As written in the issue, rules 2 and 3 are swapped; every visible element has a `pagePath`,
+/// so rule 3 would make the PostEntity rule unreachable. The corrected order has data-id (an
+/// explicit author annotation) outrank generic-page fallback.
+@MainActor
+public final class PreviewAnnotationProvider: ElementEntityProviding {
+    public let siteID: String
+    private let graph: SiteContentGraph
+    private var annotated: [(rect: CGRect, entity: any AppEntity)] = []
+    private var elementsByID: [String: ElementEntity] = [:]
+
+    public init(siteID: String, graph: SiteContentGraph) {
+        self.siteID = siteID
+        self.graph = graph
+    }
+
+    /// Replace the current annotation set with one derived from `elements`. Each call is a
+    /// full snapshot — the JS reporter sends complete batches, so partial updates would
+    /// require tracking removals we don't otherwise need.
+    public func update(_ elements: [VisibleElement]) async {
+        let resolvedGraph = ContentGraphOverride.scoped ?? graph
+        var nextAnnotated: [(rect: CGRect, entity: any AppEntity)] = []
+        var nextElements: [String: ElementEntity] = [:]
+        nextAnnotated.reserveCapacity(elements.count)
+
+        for element in elements {
+            let rect = CGRect(
+                x: element.rect.x,
+                y: element.rect.y,
+                width: element.rect.width,
+                height: element.rect.height
+            )
+            let entity = await resolve(element, graph: resolvedGraph)
+            nextAnnotated.append((rect: rect, entity: entity))
+            if let elementEntity = entity as? ElementEntity {
+                nextElements[elementEntity.id] = elementEntity
+            }
+        }
+
+        annotated = nextAnnotated
+        elementsByID = nextElements
+    }
+
+    /// Returns the entity at this element id, or `nil` if the id isn't in the latest report.
+    /// Currently supports `ElementEntity` ids only; the indexed entity types (Page/Post/Image)
+    /// have their own queries via `SiteContentGraph`.
+    public func entity(for elementID: String) -> ElementEntity? {
+        elementsByID[elementID]
+    }
+
+    /// All annotated rects with their entities. Order matches the report's input order,
+    /// which preserves the JS reporter's priority sort (heading > image > nav > interactive).
+    public func annotations() -> [(rect: CGRect, entity: any AppEntity)] {
+        annotated
+    }
+
+    // MARK: ElementEntityProviding
+
+    public func elementEntity(forID id: String) -> ElementEntity? {
+        elementsByID[id]
+    }
+
+    public func suggestedElementEntities() -> [ElementEntity] {
+        Array(elementsByID.values)
+    }
+
+    // MARK: mapping
+
+    private func resolve(_ element: VisibleElement, graph: SiteContentGraph) async -> any AppEntity {
+        // Rule 1: image src matches an indexed asset for this site.
+        if element.tag.uppercased() == "IMG", let src = element.src {
+            for image in await graph.images(for: siteID) where imageMatches(image, src: src) {
+                return ImageEntity(image)
+            }
+        }
+        // Rule 2: data-anglesite-id (which the JS reporter surfaces as `element.id` when
+        // present) looks like a known PostEntity id.
+        if let post = await graph.post(id: element.id) {
+            return PostEntity(post)
+        }
+        // Rule 3: pagePath matches a known page route.
+        if let pagePath = element.pagePath {
+            for page in await graph.pages(for: siteID) where page.route == pagePath {
+                return PageEntity(page)
+            }
+        }
+        // Rule 4: transient ElementEntity. Captures the structured selector for B.5 routing.
+        return ElementEntity(
+            id: ElementEntity.makeID(siteID: siteID, elementID: element.id),
+            displayName: ElementEntity.makeDisplayName(tag: element.tag, hint: element.text),
+            siteID: siteID,
+            selector: ElementEntity.encodeSelector(element.selector),
+            pagePath: element.pagePath ?? "/"
+        )
+    }
+}
+
+/// Match an image `src` against an indexed `SiteContentGraph.Image`. Sites reference images
+/// in lots of shapes — absolute `/images/foo.png`, relative `images/foo.png`, and full URLs.
+/// We compare on the trailing path segment first (cheap, catches the common case) and fall
+/// back to a `hasSuffix` over the relative path (handles same-name files in different dirs).
+private func imageMatches(_ image: SiteContentGraph.Image, src: String) -> Bool {
+    if src.hasSuffix(image.relativePath) { return true }
+    let srcFile = (src as NSString).lastPathComponent
+    if !srcFile.isEmpty, srcFile == image.fileName { return true }
+    return false
+}

--- a/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
@@ -38,6 +38,10 @@ public final class PreviewAnnotationProvider: ElementEntityProviding {
     /// require tracking removals we don't otherwise need.
     public func update(_ elements: [VisibleElement]) async {
         let resolvedGraph = ContentGraphOverride.scoped ?? graph
+        // Hoist the per-site image list out of the per-element loop. Each `resolve` call only
+        // reads it; doing it once cuts O(n) actor hops to one, regardless of how many IMG
+        // elements are in the batch.
+        let siteImages = await resolvedGraph.images(for: siteID)
         var nextAnnotated: [(rect: CGRect, entity: any AppEntity)] = []
         var nextElements: [String: ElementEntity] = [:]
         nextAnnotated.reserveCapacity(elements.count)
@@ -49,7 +53,7 @@ public final class PreviewAnnotationProvider: ElementEntityProviding {
                 width: element.rect.width,
                 height: element.rect.height
             )
-            let entity = await resolve(element, graph: resolvedGraph)
+            let entity = await resolve(element, graph: resolvedGraph, siteImages: siteImages)
             nextAnnotated.append((rect: rect, entity: entity))
             if let elementEntity = entity as? ElementEntity {
                 nextElements[elementEntity.id] = elementEntity
@@ -79,22 +83,41 @@ public final class PreviewAnnotationProvider: ElementEntityProviding {
         elementsByID[id]
     }
 
+    /// Suggested entities shown to Siri in the disambiguation picker. AppIntents calls this
+    /// during prefetch; with the reporter's 50-element cap an uncapped pass-through would
+    /// flood the picker. 10 is a comfortable Shortcuts-UI ceiling — same order of magnitude
+    /// as the `IndexedEntity` queries' `suggestedEntities()`.
     public func suggestedElementEntities() -> [ElementEntity] {
-        Array(elementsByID.values)
+        Array(elementsByID.values.prefix(SUGGESTED_ENTITY_CAP))
     }
 
     // MARK: mapping
 
-    private func resolve(_ element: VisibleElement, graph: SiteContentGraph) async -> any AppEntity {
-        // Rule 1: image src matches an indexed asset for this site.
+    /// Generated `VisibleElement.id`s are `v-<base36>`; `data-anglesite-id` values are
+    /// author-chosen strings. Rule 2's `graph.post(id:)` lookup should only run when the id
+    /// could plausibly be an author-tagged PostEntity id — the prefix-test below cheaply
+    /// avoids the actor hop for every generated id. Source of truth for the prefix is
+    /// `JS/edit-overlay/src/visible-elements.ts`'s `idFor()`.
+    private static let generatedIDPrefix = "v-"
+
+    private func resolve(
+        _ element: VisibleElement,
+        graph: SiteContentGraph,
+        siteImages: [SiteContentGraph.Image]
+    ) async -> any AppEntity {
+        // Rule 1: image src matches an indexed asset for this site. `siteImages` is hoisted
+        // by `update(_:)` — we iterate the in-memory list, no actor hop per element.
         if element.tag.uppercased() == "IMG", let src = element.src {
-            for image in await graph.images(for: siteID) where imageMatches(image, src: src) {
+            for image in siteImages where imageMatches(image, src: src) {
                 return ImageEntity(image)
             }
         }
-        // Rule 2: data-anglesite-id (which the JS reporter surfaces as `element.id` when
-        // present) looks like a known PostEntity id.
-        if let post = await graph.post(id: element.id) {
+        // Rule 2: `data-anglesite-id` (sourced verbatim from the JS reporter's `element.id`
+        // when an author tagged the element — see `idFor()` in visible-elements.ts) matches
+        // a known PostEntity id. Generated ids start with `"v-"` and can't match any indexed
+        // entity, so we skip them rather than burn an actor hop on a guaranteed miss.
+        if !element.id.hasPrefix(Self.generatedIDPrefix),
+           let post = await graph.post(id: element.id) {
             return PostEntity(post)
         }
         // Rule 3: pagePath matches a known page route.
@@ -114,13 +137,34 @@ public final class PreviewAnnotationProvider: ElementEntityProviding {
     }
 }
 
-/// Match an image `src` against an indexed `SiteContentGraph.Image`. Sites reference images
-/// in lots of shapes — absolute `/images/foo.png`, relative `images/foo.png`, and full URLs.
-/// We compare on the trailing path segment first (cheap, catches the common case) and fall
-/// back to a `hasSuffix` over the relative path (handles same-name files in different dirs).
+/// Cap on `suggestedElementEntities()` — see the method doc for the rationale.
+private let SUGGESTED_ENTITY_CAP = 10
+
+/// Match an image `src` against an indexed `SiteContentGraph.Image`.
+///
+/// Sites reference images in three shapes:
+///   - Absolute relative path:  `/public/images/hero.jpg`
+///   - Bare relative path:      `images/hero.jpg`
+///   - Full URL (CDN):          `https://cdn.example.com/hero.jpg?v=2`
+///
+/// **Path-suffix match (preferred).** Equality, or `relativePath` preceded by `/`. The
+/// boundary check rejects accidental substring overlaps — without it, `"/pub/extra-images/hero.jpg"`
+/// would match `image.relativePath = "images/hero.jpg"` because `"images/hero.jpg"` is a
+/// hasSuffix of the longer string.
+///
+/// **Filename fallback.** Compare the last path component. `URL(string:)` strips query strings
+/// and fragments before extracting `lastPathComponent` — otherwise a CDN URL with `?v=2` would
+/// produce `"hero.jpg?v=2"` and never match. Falls back to NSString's split-on-`/`-only behavior
+/// when `URL` can't parse the input (e.g., paths with whitespace that haven't been
+/// percent-encoded).
+///
+/// The filename fallback is deliberately loose — same name in different dirs collapses to one
+/// match. That's the right trade-off for hover-to-edit-the-image, where the user has only
+/// pointed at one thing.
 private func imageMatches(_ image: SiteContentGraph.Image, src: String) -> Bool {
-    if src.hasSuffix(image.relativePath) { return true }
-    let srcFile = (src as NSString).lastPathComponent
+    if src == image.relativePath { return true }
+    if src.hasSuffix("/\(image.relativePath)") { return true }
+    let srcFile = URL(string: src)?.lastPathComponent ?? (src as NSString).lastPathComponent
     if !srcFile.isEmpty, srcFile == image.fileName { return true }
     return false
 }

--- a/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
@@ -88,7 +88,7 @@ public final class PreviewAnnotationProvider: ElementEntityProviding {
     /// flood the picker. 10 is a comfortable Shortcuts-UI ceiling — same order of magnitude
     /// as the `IndexedEntity` queries' `suggestedEntities()`.
     public func suggestedElementEntities() -> [ElementEntity] {
-        Array(elementsByID.values.prefix(SUGGESTED_ENTITY_CAP))
+        Array(elementsByID.values.prefix(suggestedEntityCap))
     }
 
     // MARK: mapping
@@ -138,7 +138,7 @@ public final class PreviewAnnotationProvider: ElementEntityProviding {
 }
 
 /// Cap on `suggestedElementEntities()` — see the method doc for the rationale.
-private let SUGGESTED_ENTITY_CAP = 10
+private let suggestedEntityCap = 10
 
 /// Match an image `src` against an indexed `SiteContentGraph.Image`.
 ///
@@ -152,6 +152,12 @@ private let SUGGESTED_ENTITY_CAP = 10
 /// would match `image.relativePath = "images/hero.jpg"` because `"images/hero.jpg"` is a
 /// hasSuffix of the longer string.
 ///
+/// **Assumes `relativePath` has no leading slash.** Production constructs `Image.relativePath`
+/// from the plugin's `list_content` DTO (see `ContentListing.swift`'s `ImageDTO.image(siteID:)`),
+/// which yields bare paths like `"public/images/hero.jpg"`. We defensively strip a leading
+/// slash before the suffix check anyway so a future plugin change doesn't silently break
+/// matching — the suffix check would otherwise look for `//images/hero.jpg` and never match.
+///
 /// **Filename fallback.** Compare the last path component. `URL(string:)` strips query strings
 /// and fragments before extracting `lastPathComponent` — otherwise a CDN URL with `?v=2` would
 /// produce `"hero.jpg?v=2"` and never match. Falls back to NSString's split-on-`/`-only behavior
@@ -162,8 +168,14 @@ private let SUGGESTED_ENTITY_CAP = 10
 /// match. That's the right trade-off for hover-to-edit-the-image, where the user has only
 /// pointed at one thing.
 private func imageMatches(_ image: SiteContentGraph.Image, src: String) -> Bool {
-    if src == image.relativePath { return true }
-    if src.hasSuffix("/\(image.relativePath)") { return true }
+    // Defensive normalize: strip a leading slash so a hypothetical future leading-slash
+    // change in the plugin DTO doesn't break the suffix check (which would otherwise look
+    // for `//images/hero.jpg`).
+    let normalized = image.relativePath.hasPrefix("/")
+        ? String(image.relativePath.dropFirst())
+        : image.relativePath
+    if src == normalized { return true }
+    if src.hasSuffix("/\(normalized)") { return true }
     let srcFile = URL(string: src)?.lastPathComponent ?? (src as NSString).lastPathComponent
     if !srcFile.isEmpty, srcFile == image.fileName { return true }
     return false

--- a/Sources/AnglesiteIntents/PreviewAnnotationProviderRegistry.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProviderRegistry.swift
@@ -1,0 +1,64 @@
+import AnglesiteCore
+import Foundation
+
+/// Per-siteID registry of live `PreviewAnnotationProvider`s.
+///
+/// `ElementEntity` ids encode the siteID (`"{siteID}:element:{elementID}"`), so the system AI
+/// can look up the right provider by parsing the id of any entity it's trying to resolve. The
+/// registry is the production binding for `ElementEntityQuery.entities(for:)` — without it,
+/// `ElementEntityProviderOverride.scoped` only fires in test contexts and queries return `[]`
+/// in production, which would break Siri's deferred-resolution paths (Shortcuts replay, async
+/// completions, Spotlight intent restoration).
+///
+/// **Lifecycle** is window-scoped: `SiteWindow.loadAndStart` registers when the provider is
+/// created / re-created on siteID change, and `SiteWindow.onDisappear` unregisters. Mirrors
+/// the `EditRouterRegistry` pattern.
+///
+/// `@MainActor` because `PreviewAnnotationProvider` is; the registry never hops off the main
+/// actor. Tests use the lighter-weight `ElementEntityProviderOverride.scoped` TaskLocal seam.
+@MainActor
+public final class PreviewAnnotationProviderRegistry: Sendable {
+    public static let shared = PreviewAnnotationProviderRegistry()
+
+    private var providers: [String: PreviewAnnotationProvider] = [:]
+
+    /// `internal` — production code reaches the registry via `.shared`; tests construct their
+    /// own isolated instances via `@testable import`. Prevents accidental third-party
+    /// instances from silently routing queries to the wrong store.
+    internal init() {}
+
+    public func register(_ provider: PreviewAnnotationProvider, for siteID: String) {
+        providers[siteID] = provider
+    }
+
+    public func unregister(siteID: String) {
+        providers.removeValue(forKey: siteID)
+    }
+
+    public func provider(for siteID: String) -> PreviewAnnotationProvider? {
+        providers[siteID]
+    }
+
+    /// Resolve an `ElementEntity` id to its live entity by parsing the embedded siteID and
+    /// asking the registered provider. Returns `nil` when the id is malformed, the site isn't
+    /// open, or the element isn't in the latest report. Called from `ElementEntityQuery`.
+    public func resolveElement(entityID id: String) -> ElementEntity? {
+        guard let siteID = Self.siteID(from: id) else { return nil }
+        return providers[siteID]?.elementEntity(forID: id)
+    }
+
+    /// All currently-registered siteIDs. Surfaced for tests + diagnostics; production callers
+    /// generally know the siteID they're asking about.
+    public func knownSiteIDs() -> Set<String> {
+        Set(providers.keys)
+    }
+
+    /// Pull the siteID prefix out of an `ElementEntity` id. Mirrors the format
+    /// `ElementEntity.makeID(siteID:elementID:)` produces — kept here (not on `ElementEntity`)
+    /// because the inverse is a registry-lookup concern, not a property of the entity itself.
+    public static func siteID(from entityID: String) -> String? {
+        guard let range = entityID.range(of: ":element:") else { return nil }
+        let siteID = String(entityID[..<range.lowerBound])
+        return siteID.isEmpty ? nil : siteID
+    }
+}

--- a/Tests/AnglesiteCoreTests/VisibleElementMessageTests.swift
+++ b/Tests/AnglesiteCoreTests/VisibleElementMessageTests.swift
@@ -1,0 +1,159 @@
+import Testing
+@testable import AnglesiteCore
+
+struct VisibleElementMessageTests {
+    private func validSelector() -> [String: Any] {
+        [
+            "tag": "H1",
+            "classes": [] as [String],
+            "nthChild": 1,
+            "ancestors": [] as [Any],
+        ]
+    }
+
+    private func validElement(overrides: [String: Any] = [:]) -> [String: Any] {
+        var element: [String: Any] = [
+            "id": "v-1",
+            "tag": "H1",
+            "selector": validSelector(),
+            "rect": ["x": 10, "y": 20, "width": 300, "height": 40] as [String: Any],
+            "text": "Welcome",
+            "pagePath": "/about/",
+        ]
+        for (k, v) in overrides { element[k] = v }
+        return element
+    }
+
+    private func validReport(elements: [[String: Any]]) -> [String: Any] {
+        [
+            "type": "anglesite:visible-elements",
+            "elements": elements as [Any],
+        ]
+    }
+
+    @Test("Decodes a fully-populated report") func decodesFullyPopulatedReport() {
+        let body = validReport(elements: [
+            validElement(overrides: ["src": "/images/x.png", "role": "img"])
+        ])
+        let result = VisibleElementReport.decode(from: body)
+        guard case .success(let report) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(report.elements.count == 1)
+        let e = report.elements[0]
+        #expect(e.id == "v-1")
+        #expect(e.tag == "H1")
+        #expect(e.text == "Welcome")
+        #expect(e.src == "/images/x.png")
+        #expect(e.role == "img")
+        #expect(e.pagePath == "/about/")
+        #expect(e.rect.x == 10)
+        #expect(e.rect.y == 20)
+        #expect(e.rect.width == 300)
+        #expect(e.rect.height == 40)
+        guard case .object(let dict) = e.selector else {
+            Issue.record("expected .object selector")
+            return
+        }
+        #expect(dict["tag"] == .string("H1"))
+    }
+
+    @Test("Decodes an element with only required fields") func decodesMinimalElement() {
+        var minimal = validElement()
+        minimal.removeValue(forKey: "text")
+        minimal.removeValue(forKey: "pagePath")
+        let result = VisibleElementReport.decode(from: validReport(elements: [minimal]))
+        guard case .success(let report) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let e = report.elements[0]
+        #expect(e.text == nil)
+        #expect(e.src == nil)
+        #expect(e.role == nil)
+        #expect(e.pagePath == nil)
+    }
+
+    @Test("Decodes an empty element list") func decodesEmptyList() {
+        let result = VisibleElementReport.decode(from: validReport(elements: []))
+        guard case .success(let report) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(report.elements.isEmpty)
+    }
+
+    @Test("Rejects non-object body") func rejectsNonObjectBody() {
+        #expect(VisibleElementReport.decode(from: "string") == .failure(.notAnObject))
+        #expect(VisibleElementReport.decode(from: 42) == .failure(.notAnObject))
+        #expect(VisibleElementReport.decode(from: [1, 2, 3]) == .failure(.notAnObject))
+    }
+
+    @Test("Rejects missing type") func rejectsMissingType() {
+        var body = validReport(elements: [validElement()])
+        body.removeValue(forKey: "type")
+        #expect(VisibleElementReport.decode(from: body) == .failure(.missingField("type")))
+    }
+
+    @Test("Rejects wrong type value") func rejectsWrongTypeValue() {
+        var body = validReport(elements: [validElement()])
+        body["type"] = 123
+        #expect(VisibleElementReport.decode(from: body) == .failure(.wrongType(field: "type", expected: "string")))
+    }
+
+    @Test("Rejects unknown type") func rejectsUnknownType() {
+        var body = validReport(elements: [validElement()])
+        body["type"] = "anglesite:other"
+        #expect(VisibleElementReport.decode(from: body) == .failure(.unknownType("anglesite:other")))
+    }
+
+    @Test("Rejects missing elements") func rejectsMissingElements() {
+        var body = validReport(elements: [])
+        body.removeValue(forKey: "elements")
+        #expect(VisibleElementReport.decode(from: body) == .failure(.missingField("elements")))
+    }
+
+    @Test("Rejects elements that isn't an array") func rejectsElementsThatIsntAnArray() {
+        var body = validReport(elements: [])
+        body["elements"] = ["k": "v"] as [String: Any]
+        #expect(VisibleElementReport.decode(from: body) == .failure(.wrongType(field: "elements", expected: "array")))
+    }
+
+    @Test("Reports malformed element with its index") func reportsMalformedElementWithIndex() {
+        var bad = validElement()
+        bad.removeValue(forKey: "id")
+        let result = VisibleElementReport.decode(from: validReport(elements: [validElement(), bad]))
+        #expect(result == .failure(.malformedElement(index: 1, error: .missingField("id"))))
+    }
+
+    @Test("Rejects element with non-object selector") func rejectsElementWithNonObjectSelector() {
+        let result = VisibleElementReport.decode(from: validReport(elements: [
+            validElement(overrides: ["selector": "h1:nth-of-type(1)"])
+        ]))
+        #expect(result == .failure(.malformedElement(index: 0, error: .wrongType(field: "selector", expected: "object"))))
+    }
+
+    @Test("Rejects element with malformed rect") func rejectsElementWithMalformedRect() {
+        let result = VisibleElementReport.decode(from: validReport(elements: [
+            validElement(overrides: ["rect": ["x": 0, "y": 0] as [String: Any]])
+        ]))
+        if case .failure(.malformedElement(index: 0, error: .wrongType(field: "rect", expected: _))) = result {
+            // ok
+        } else {
+            Issue.record("expected .malformedElement rect wrongType, got \(result)")
+        }
+    }
+
+    @Test("Accepts floating-point rect coords") func acceptsFloatingPointRect() {
+        let result = VisibleElementReport.decode(from: validReport(elements: [
+            validElement(overrides: ["rect": ["x": 10.5, "y": 20.25, "width": 300.0, "height": 40.0] as [String: Any]])
+        ]))
+        guard case .success(let report) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(report.elements[0].rect.x == 10.5)
+        #expect(report.elements[0].rect.y == 20.25)
+    }
+}

--- a/Tests/AnglesiteIntentsTests/PreviewAnnotationProviderRegistryTests.swift
+++ b/Tests/AnglesiteIntentsTests/PreviewAnnotationProviderRegistryTests.swift
@@ -1,0 +1,145 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+/// Covers `PreviewAnnotationProviderRegistry` and the `ElementEntityQuery` production fallback
+/// path that uses it. Tests construct private registry instances (not `.shared`) and use
+/// `ElementEntityProviderOverride` indirectly via siteID-encoded entity ids.
+extension AppIntentsTests {
+
+    @Suite("PreviewAnnotationProviderRegistry", .serialized)
+    @MainActor
+    struct PreviewAnnotationProviderRegistryTests {
+
+        @Test("siteID parsing extracts the prefix before :element:")
+        func siteID_parse() {
+            #expect(PreviewAnnotationProviderRegistry.siteID(from: "/Users/x/Sites/alpha:element:v-1")
+                    == "/Users/x/Sites/alpha")
+        }
+
+        @Test("siteID parsing returns nil for malformed ids")
+        func siteID_parse_malformed() {
+            #expect(PreviewAnnotationProviderRegistry.siteID(from: "v-1") == nil)
+            #expect(PreviewAnnotationProviderRegistry.siteID(from: ":element:v-1") == nil)
+            #expect(PreviewAnnotationProviderRegistry.siteID(from: "") == nil)
+        }
+
+        @Test("provider(for:) returns nil for unknown siteIDs")
+        func provider_unknown() {
+            let registry = PreviewAnnotationProviderRegistry()
+            #expect(registry.provider(for: "missing") == nil)
+        }
+
+        @Test("register + provider(for:) round-trips")
+        func register_roundtrip() async {
+            let registry = PreviewAnnotationProviderRegistry()
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            registry.register(provider, for: AppIntentsTests.aSite)
+            #expect(registry.provider(for: AppIntentsTests.aSite) === provider)
+        }
+
+        @Test("unregister removes the provider")
+        func unregister() async {
+            let registry = PreviewAnnotationProviderRegistry()
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            registry.register(provider, for: AppIntentsTests.aSite)
+            registry.unregister(siteID: AppIntentsTests.aSite)
+            #expect(registry.provider(for: AppIntentsTests.aSite) == nil)
+        }
+
+        @Test("resolveElement parses siteID from id and looks up the right provider")
+        func resolveElement_routes() async {
+            let registry = PreviewAnnotationProviderRegistry()
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            registry.register(provider, for: AppIntentsTests.aSite)
+            await provider.update([AppIntentsTests.makeVisibleElement(id: "v-1", tag: "BUTTON", text: "Go")])
+            let entityID = ElementEntity.makeID(siteID: AppIntentsTests.aSite, elementID: "v-1")
+            let resolved = registry.resolveElement(entityID: entityID)
+            #expect(resolved?.displayName == "button \u{2014} Go")
+        }
+
+        @Test("resolveElement returns nil when the site isn't registered")
+        func resolveElement_unregisteredSite() {
+            let registry = PreviewAnnotationProviderRegistry()
+            let entityID = ElementEntity.makeID(siteID: AppIntentsTests.aSite, elementID: "v-1")
+            #expect(registry.resolveElement(entityID: entityID) == nil)
+        }
+
+        @Test("knownSiteIDs tracks registrations across sites")
+        func knownSiteIDs() async {
+            let registry = PreviewAnnotationProviderRegistry()
+            let graph = SiteContentGraph()
+            let pA = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let pB = PreviewAnnotationProvider(siteID: AppIntentsTests.bSite, graph: graph)
+            registry.register(pA, for: AppIntentsTests.aSite)
+            registry.register(pB, for: AppIntentsTests.bSite)
+            #expect(registry.knownSiteIDs() == [AppIntentsTests.aSite, AppIntentsTests.bSite])
+            registry.unregister(siteID: AppIntentsTests.aSite)
+            #expect(registry.knownSiteIDs() == [AppIntentsTests.bSite])
+        }
+    }
+
+    @Suite("ElementEntityQuery resolution chain", .serialized)
+    @MainActor
+    struct ElementEntityQueryTests {
+
+        @Test("entities(for:) prefers the TaskLocal override when set")
+        func entitiesFor_taskLocalPrefersOverride() async throws {
+            // Build a stub provider that returns a sentinel displayName; bind it via the
+            // override, then call the query. The shared registry isn't populated, so the
+            // sentinel proves the TaskLocal won.
+            let stub = StubProvider(answer: ElementEntity(
+                id: "s1:element:v-1", displayName: "from-override",
+                siteID: "s1", selector: "{\"tag\":\"H1\"}", pagePath: "/"
+            ))
+            try await ElementEntityProviderOverride.$scoped.withValue(stub) {
+                let entities = try await ElementEntityQuery().entities(for: ["s1:element:v-1"])
+                #expect(entities.count == 1)
+                #expect(entities[0].displayName == "from-override")
+            }
+        }
+
+        @Test("entities(for:) falls back to the shared registry in production")
+        func entitiesFor_fallsBackToRegistry() async throws {
+            // No TaskLocal override; the query must reach the shared registry. Register a
+            // provider, populate it, then ask the query for the encoded id.
+            let registry = PreviewAnnotationProviderRegistry.shared
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            registry.register(provider, for: AppIntentsTests.aSite)
+            defer { registry.unregister(siteID: AppIntentsTests.aSite) }
+
+            await provider.update([
+                AppIntentsTests.makeVisibleElement(id: "v-1", tag: "H2", text: "Heading"),
+            ])
+            let entityID = ElementEntity.makeID(siteID: AppIntentsTests.aSite, elementID: "v-1")
+            let entities = try await ElementEntityQuery().entities(for: [entityID])
+            #expect(entities.count == 1)
+            #expect(entities[0].displayName == "h2 \u{2014} Heading")
+        }
+
+        @Test("entities(for:) returns [] when neither override nor registry knows the id")
+        func entitiesFor_emptyOnMiss() async throws {
+            // Make sure nothing's registered for the test site.
+            PreviewAnnotationProviderRegistry.shared.unregister(siteID: AppIntentsTests.aSite)
+            let entityID = ElementEntity.makeID(siteID: AppIntentsTests.aSite, elementID: "v-missing")
+            let entities = try await ElementEntityQuery().entities(for: [entityID])
+            #expect(entities.isEmpty)
+        }
+    }
+
+    /// Tiny stub for the override-prefer-this test. Only `elementEntity(forID:)` is exercised.
+    @MainActor
+    final class StubProvider: ElementEntityProviding {
+        let answer: ElementEntity
+        init(answer: ElementEntity) { self.answer = answer }
+        func elementEntity(forID id: String) -> ElementEntity? {
+            id == answer.id ? answer : nil
+        }
+        func suggestedElementEntities() -> [ElementEntity] { [answer] }
+    }
+}

--- a/Tests/AnglesiteIntentsTests/PreviewAnnotationProviderTests.swift
+++ b/Tests/AnglesiteIntentsTests/PreviewAnnotationProviderTests.swift
@@ -82,6 +82,53 @@ extension AppIntentsTests {
             #expect(provider.annotations()[0].entity is ImageEntity)
         }
 
+        @Test("Rule 1: matches CDN URLs with query strings")
+        func rule1_imgMatchesCDNWithQuery() async {
+            // Filename fallback should strip `?v=2` — old NSString-based logic would
+            // produce "hero.jpg?v=2" and miss.
+            let img = AppIntentsTests.gImage(relativePath: "public/images/hero.jpg", fileName: "hero.jpg")
+            let graph = await makeGraph(images: [img])
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let element = AppIntentsTests.makeVisibleElement(
+                tag: "IMG",
+                text: nil,
+                src: "https://cdn.example.com/images/hero.jpg?v=2"
+            )
+            await provider.update([element])
+            #expect(provider.annotations()[0].entity is ImageEntity)
+        }
+
+        @Test("Rule 1: rejects boundary-mismatched suffix paths")
+        func rule1_imgRejectsSuffixWithoutSeparator() async {
+            // `image.relativePath = "images/hero.jpg"` is a hasSuffix of
+            // `"/pub/extra-images/hero.jpg"` — must NOT match. Boundary check should kick in.
+            // Filename fallback still matches by name; for this test the indexed image has
+            // a distinct filename so neither path produces a false positive.
+            let img = AppIntentsTests.gImage(relativePath: "images/hero.jpg", fileName: "hero.jpg")
+            let graph = await makeGraph(images: [img])
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let element = AppIntentsTests.makeVisibleElement(
+                tag: "IMG",
+                text: nil,
+                src: "/pub/extra-images/sunset.jpg"   // path contains "images/" but not "images/hero.jpg" boundary
+            )
+            await provider.update([element])
+            // No match → fallback to ElementEntity (no PageEntity since pagePath isn't indexed).
+            #expect(provider.annotations()[0].entity is ElementEntity)
+        }
+
+        @Test("Rule 2: skips generated v-* ids without an actor hop")
+        func rule2_skipsGeneratedIDs() async {
+            // Even if a hypothetical PostEntity id began with `"v-"`, we'd skip it — the prefix
+            // is reserved for the JS reporter's generated ids. Concretely: this element id is
+            // `v-1`, the graph has no entries, so rule 2 must not run (would 404). Rule 4 wins.
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let element = AppIntentsTests.makeVisibleElement(id: "v-1", tag: "ARTICLE", text: "Body")
+            await provider.update([element])
+            #expect(provider.annotations()[0].entity is ElementEntity)
+        }
+
         @Test("Rule 2: data-anglesite-id matching a known post id → PostEntity")
         func rule2_dataAnglesiteIDOnPost_resolvesToPostEntity() async {
             let post = AppIntentsTests.gPost(slug: "hello-world")
@@ -207,6 +254,26 @@ extension AppIntentsTests {
             #expect(entity != nil)
             #expect(entity?.displayName == "button \u{2014} Go")
         }
+
+        @Test("suggestedElementEntities caps at 10 even with a full 50-element report")
+        func suggestedElementEntities_capsAtTen() async {
+            // The JS reporter caps batches at 50; the suggestion picker shouldn't show all of
+            // them. Stuff the provider with 50 ElementEntity-fallback elements and assert the
+            // suggested-entity surface returns at most 10.
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            var elements: [VisibleElement] = []
+            for i in 0..<50 {
+                elements.append(AppIntentsTests.makeVisibleElement(
+                    id: "v-\(i)", tag: "BUTTON", text: "B\(i)"
+                ))
+            }
+            await provider.update(elements)
+            #expect(provider.suggestedElementEntities().count == 10)
+            // entity(for:) still resolves all 50 ids — the cap is just on the picker surface.
+            let lookupID = ElementEntity.makeID(siteID: AppIntentsTests.aSite, elementID: "v-49")
+            #expect(provider.entity(for: lookupID) != nil)
+        }
     }
 
     @Suite("ElementEntity helpers", .serialized)
@@ -277,6 +344,28 @@ extension AppIntentsTests {
             let entity = ElementEntity(
                 id: "x", displayName: "h1", siteID: "s",
                 selector: "not json at all", pagePath: "/"
+            )
+            #expect(entity.selectorJSON() == nil)
+        }
+
+        @Test("selectorJSON returns nil for empty object (no `tag` field)")
+        func selectorJSON_returnsNilForEmptyObject() {
+            // `encodeSelector(.string("hi"))` returns `"{}"` — `selectorJSON()` must reject it
+            // so the nil-on-bad-input contract holds end-to-end.
+            let entity = ElementEntity(
+                id: "x", displayName: "h1", siteID: "s",
+                selector: ElementEntity.encodeSelector(.string("not-an-object")),
+                pagePath: "/"
+            )
+            #expect(entity.selectorJSON() == nil)
+        }
+
+        @Test("selectorJSON returns nil for an object missing the `tag` field")
+        func selectorJSON_returnsNilWhenTagMissing() {
+            let entity = ElementEntity(
+                id: "x", displayName: "h1", siteID: "s",
+                selector: "{\"classes\":[]}",
+                pagePath: "/"
             )
             #expect(entity.selectorJSON() == nil)
         }

--- a/Tests/AnglesiteIntentsTests/PreviewAnnotationProviderTests.swift
+++ b/Tests/AnglesiteIntentsTests/PreviewAnnotationProviderTests.swift
@@ -1,0 +1,284 @@
+import Testing
+import Foundation
+import CoreGraphics
+import AppIntents
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+/// Covers issue #146 acceptance criteria — `PreviewAnnotationProvider` mapping rules,
+/// `update()` replaces state, `annotations()` ordering, `entity(for:)` lookup.
+extension AppIntentsTests {
+
+    // MARK: - Fixtures shared with the provider tests
+
+    static func makeVisibleElement(
+        id: String = "v-1",
+        tag: String = "H1",
+        text: String? = "Hello",
+        src: String? = nil,
+        pagePath: String? = "/about/",
+        x: Double = 10,
+        y: Double = 20,
+        width: Double = 300,
+        height: Double = 40
+    ) -> VisibleElement {
+        VisibleElement(
+            id: id,
+            tag: tag,
+            selector: .object([
+                "tag": .string(tag),
+                "classes": .array([]),
+                "nthChild": .int(1),
+            ]),
+            rect: .init(x: x, y: y, width: width, height: height),
+            text: text,
+            src: src,
+            role: nil,
+            pagePath: pagePath
+        )
+    }
+
+    @Suite("PreviewAnnotationProvider mapping", .serialized)
+    @MainActor
+    struct PreviewAnnotationProviderTests {
+
+        func makeGraph(loadingPages: [SiteContentGraph.Page] = [],
+                       posts: [SiteContentGraph.Post] = [],
+                       images: [SiteContentGraph.Image] = []) async -> SiteContentGraph {
+            let g = SiteContentGraph()
+            await g.load(siteID: AppIntentsTests.aSite, pages: loadingPages, posts: posts, images: images)
+            return g
+        }
+
+        @Test("Rule 1: <img> with matching src resolves to ImageEntity")
+        func rule1_imgMatchingSrc_resolvesToImageEntity() async {
+            let img = AppIntentsTests.gImage(relativePath: "public/images/hero.jpg", fileName: "hero.jpg")
+            let graph = await makeGraph(images: [img])
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let element = AppIntentsTests.makeVisibleElement(
+                id: "v-1",
+                tag: "IMG",
+                text: nil,
+                src: "/public/images/hero.jpg"
+            )
+            await provider.update([element])
+            let annotated = provider.annotations()
+            #expect(annotated.count == 1)
+            let entity = annotated[0].entity as? ImageEntity
+            #expect(entity?.id == img.id)
+        }
+
+        @Test("Rule 1: matches by file name when paths differ")
+        func rule1_imgMatchesByFileName() async {
+            let img = AppIntentsTests.gImage(relativePath: "public/images/hero.jpg", fileName: "hero.jpg")
+            let graph = await makeGraph(images: [img])
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let element = AppIntentsTests.makeVisibleElement(
+                tag: "IMG",
+                text: nil,
+                src: "https://cdn.example.com/hero.jpg"
+            )
+            await provider.update([element])
+            #expect(provider.annotations()[0].entity is ImageEntity)
+        }
+
+        @Test("Rule 2: data-anglesite-id matching a known post id → PostEntity")
+        func rule2_dataAnglesiteIDOnPost_resolvesToPostEntity() async {
+            let post = AppIntentsTests.gPost(slug: "hello-world")
+            let graph = await makeGraph(posts: [post])
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let element = AppIntentsTests.makeVisibleElement(
+                id: post.id,
+                tag: "ARTICLE",
+                text: "Hello",
+                pagePath: "/blog/hello-world/"
+            )
+            await provider.update([element])
+            let entity = provider.annotations()[0].entity as? PostEntity
+            #expect(entity?.id == post.id)
+        }
+
+        @Test("Rule 3: pagePath matching a known page → PageEntity")
+        func rule3_pagePathMatches_resolvesToPageEntity() async {
+            let page = AppIntentsTests.gPage(route: "/about", title: "About")
+            let graph = await makeGraph(loadingPages: [page])
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let element = AppIntentsTests.makeVisibleElement(pagePath: "/about")
+            await provider.update([element])
+            let entity = provider.annotations()[0].entity as? PageEntity
+            #expect(entity?.id == page.id)
+        }
+
+        @Test("Rule 4: fallback to transient ElementEntity")
+        func rule4_fallsBackToElementEntity() async {
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let element = AppIntentsTests.makeVisibleElement(
+                id: "v-99",
+                tag: "BUTTON",
+                text: "Go",
+                pagePath: "/contact/"
+            )
+            await provider.update([element])
+            let entity = provider.annotations()[0].entity as? ElementEntity
+            #expect(entity?.displayName == "button \u{2014} Go")
+            #expect(entity?.siteID == AppIntentsTests.aSite)
+            #expect(entity?.pagePath == "/contact/")
+            #expect(entity?.id == ElementEntity.makeID(siteID: AppIntentsTests.aSite, elementID: "v-99"))
+        }
+
+        @Test("Image priority outranks pagePath fallback")
+        func priority_imgWinsOverPagePath() async {
+            let img = AppIntentsTests.gImage(relativePath: "public/images/hero.jpg", fileName: "hero.jpg")
+            let page = AppIntentsTests.gPage(route: "/about", title: "About")
+            let graph = await makeGraph(loadingPages: [page], images: [img])
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let element = AppIntentsTests.makeVisibleElement(
+                tag: "IMG",
+                text: nil,
+                src: "/public/images/hero.jpg",
+                pagePath: "/about"
+            )
+            await provider.update([element])
+            #expect(provider.annotations()[0].entity is ImageEntity)
+        }
+
+        @Test("Post id priority outranks pagePath fallback")
+        func priority_postIdWinsOverPagePath() async {
+            let page = AppIntentsTests.gPage(route: "/about", title: "About")
+            let post = AppIntentsTests.gPost(slug: "hello-world")
+            let graph = await makeGraph(loadingPages: [page], posts: [post])
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            // Element carries the post-id as its data-anglesite-id, but lives on the about page.
+            let element = AppIntentsTests.makeVisibleElement(
+                id: post.id,
+                tag: "ARTICLE",
+                pagePath: "/about"
+            )
+            await provider.update([element])
+            #expect(provider.annotations()[0].entity is PostEntity)
+        }
+
+        @Test("update() replaces previous state")
+        func update_replacesPreviousState() async {
+            let page = AppIntentsTests.gPage(route: "/about")
+            let graph = await makeGraph(loadingPages: [page])
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            await provider.update([
+                AppIntentsTests.makeVisibleElement(id: "v-a", tag: "H1"),
+                AppIntentsTests.makeVisibleElement(id: "v-b", tag: "H2"),
+            ])
+            #expect(provider.annotations().count == 2)
+            await provider.update([AppIntentsTests.makeVisibleElement(id: "v-c", tag: "H3")])
+            #expect(provider.annotations().count == 1)
+            #expect(provider.entity(for: ElementEntity.makeID(siteID: AppIntentsTests.aSite, elementID: "v-a")) == nil)
+        }
+
+        @Test("annotations() preserves input order")
+        func annotations_preservesInputOrder() async {
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            let a = AppIntentsTests.makeVisibleElement(id: "v-a", tag: "H1", x: 10)
+            let b = AppIntentsTests.makeVisibleElement(id: "v-b", tag: "H2", x: 20)
+            let c = AppIntentsTests.makeVisibleElement(id: "v-c", tag: "H3", x: 30)
+            await provider.update([a, b, c])
+            let annotated = provider.annotations()
+            #expect(annotated.count == 3)
+            #expect(annotated[0].rect.minX == 10)
+            #expect(annotated[1].rect.minX == 20)
+            #expect(annotated[2].rect.minX == 30)
+        }
+
+        @Test("entity(for:) returns nil when id isn't in the latest report")
+        func entityFor_returnsNilWhenUnknown() async {
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            await provider.update([AppIntentsTests.makeVisibleElement(id: "v-1", tag: "H1")])
+            #expect(provider.entity(for: "missing") == nil)
+        }
+
+        @Test("entity(for:) round-trips ElementEntity ids")
+        func entityFor_roundtripsElementID() async {
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            await provider.update([AppIntentsTests.makeVisibleElement(id: "v-7", tag: "BUTTON", text: "Go")])
+            let entityID = ElementEntity.makeID(siteID: AppIntentsTests.aSite, elementID: "v-7")
+            let entity = provider.entity(for: entityID)
+            #expect(entity != nil)
+            #expect(entity?.displayName == "button \u{2014} Go")
+        }
+    }
+
+    @Suite("ElementEntity helpers", .serialized)
+    struct ElementEntityHelperTests {
+        @Test("makeID composes {siteID}:element:{elementID}")
+        func makeID_format() {
+            #expect(ElementEntity.makeID(siteID: "/Users/x/Sites/alpha", elementID: "v-42")
+                    == "/Users/x/Sites/alpha:element:v-42")
+        }
+
+        @Test("makeDisplayName: tag only when no hint")
+        func makeDisplayName_tagOnly() {
+            #expect(ElementEntity.makeDisplayName(tag: "H1", hint: nil) == "h1")
+            #expect(ElementEntity.makeDisplayName(tag: "BUTTON", hint: "") == "button")
+            #expect(ElementEntity.makeDisplayName(tag: "BUTTON", hint: "   ") == "button")
+        }
+
+        @Test("makeDisplayName: tag + hint with em dash")
+        func makeDisplayName_withHint() {
+            #expect(ElementEntity.makeDisplayName(tag: "H1", hint: "Welcome to my site")
+                    == "h1 \u{2014} Welcome to my site")
+        }
+
+        @Test("makeDisplayName: truncates long hints")
+        func makeDisplayName_truncates() {
+            let long = String(repeating: "x", count: 200)
+            let out = ElementEntity.makeDisplayName(tag: "P", hint: long)
+            #expect(out.hasPrefix("p \u{2014} "))
+            // 50 visible chars including the ellipsis, after the "p — " prefix.
+            #expect(out.hasSuffix("\u{2026}"))
+        }
+
+        @Test("makeDisplayName: collapses whitespace")
+        func makeDisplayName_collapsesWhitespace() {
+            #expect(ElementEntity.makeDisplayName(tag: "P", hint: "Hello\n  world")
+                    == "p \u{2014} Hello world")
+        }
+
+        @Test("selectorJSON round-trips an object selector")
+        func selectorJSON_roundTrip() {
+            let original: JSONValue = .object([
+                "tag": .string("H1"),
+                "classes": .array([.string("foo")]),
+                "nthChild": .int(2),
+            ])
+            let encoded = ElementEntity.encodeSelector(original)
+            let entity = ElementEntity(
+                id: "x", displayName: "h1", siteID: "s",
+                selector: encoded, pagePath: "/"
+            )
+            let decoded = entity.selectorJSON()
+            guard case .object(let dict) = decoded else {
+                Issue.record("expected .object, got \(String(describing: decoded))")
+                return
+            }
+            #expect(dict["tag"] == .string("H1"))
+            #expect(dict["nthChild"] == .int(2))
+        }
+
+        @Test("encodeSelector replaces non-object with {}")
+        func encodeSelector_replacesNonObject() {
+            #expect(ElementEntity.encodeSelector(.string("hi")) == "{}")
+            #expect(ElementEntity.encodeSelector(.array([])) == "{}")
+        }
+
+        @Test("selectorJSON returns nil for non-JSON input")
+        func selectorJSON_returnsNilForGarbage() {
+            let entity = ElementEntity(
+                id: "x", displayName: "h1", siteID: "s",
+                selector: "not json at all", pagePath: "/"
+            )
+            #expect(entity.selectorJSON() == nil)
+        }
+    }
+}


### PR DESCRIPTION
Closes #146 (B.2 — `PreviewAnnotationProvider` + element→entity mapping).
Closes #147 (B.3 — `ElementEntity`) — bundled here because B.2's fallback branch requires the type to compile.

Phase B's element→entity mapping layer. The JS overlay (#145, PR #178) reports the onscreen elements; the native side maps each to an `AppEntity` so Siri's `appEntityUIElementProvider` hookup (#148) can resolve "this heading" / "this image" hit-tests against whatever the user can currently see.

## What lands

**`AnglesiteCore/VisibleElementMessage.swift`** — JS boundary type
- `VisibleElement` value type mirroring the JS reporter's schema (`id`, `tag`, structured `JSONValue` `selector`, `rect`, optional `text` / `src` / `role` / `pagePath`)
- `VisibleElementReport.decode(from: Any)` — same `Result`-shaped decoder pattern as `EditMessage.decode`, with `malformedElement(index:error:)` so partial bad batches blame the right index

**`AnglesiteIntents/ElementEntity.swift`** (closes #147)
- Transient `AppEntity` (**not** `IndexedEntity` — tied to live overlay state, would churn Spotlight constantly)
- Properties per the issue: `id`, `displayName`, `siteID`, `selector`, `pagePath`
- `selector` is stored as a JSON-encoded `String` so the entity is plain-Codable shapes only; `selectorJSON()` materializes a `JSONValue` for building `EditMessage` selectors at intent-perform time (B.5)
- `ElementEntityProviding` protocol + `ElementEntityProviderOverride` TaskLocal — same indirection pattern as `ContentGraphOverride` so the query can find the live provider without coupling to a singleton

**`AnglesiteIntents/PreviewAnnotationProvider.swift`** (closes #146)
- `@MainActor` class, one per WKWebView (siteID at construction time)
- `update(_:)` consumes a `[VisibleElement]` snapshot; full-batch replace
- `entity(for: elementID)` returns the live `ElementEntity` by id
- `annotations()` returns rect+entity pairs in report order

## Two judgment calls worth flagging

### Module placement (vs issue text)

Issue specifies `Sources/AnglesiteBridge/PreviewAnnotationProvider.swift`. But `Package.swift:27-38` has `AnglesiteBridge` depending only on `AnglesiteCore` — it can't see `PageEntity` / `PostEntity` / `ImageEntity` (those live in `AnglesiteIntents`). Less-invasive move: the provider goes in `AnglesiteIntents`, the boundary `VisibleElement` type goes in `AnglesiteCore` so both layers can see it. Mirrors how `EditMessage` is structured. The eventual `AnglesiteScriptHandler` wiring (B.4 / #148) will take a callback parameter to bridge the layers without adding a new SPM dep.

### Priority order (corrected vs spec)

Issue lists priorities:
1. \`<img>\` with matching src → `ImageEntity`
2. `pagePath` matches a `PageEntity` → `PageEntity`
3. `data-anglesite-id` matches a `PostEntity` → `PostEntity`
4. Otherwise → `ElementEntity`

As written, **rule 3 is unreachable** — every visible element has a `pagePath` (per-report field), so rule 2 always matches before rule 3. Reading this as a spec bug — the intent is clearly that explicit author signals (data-id on a post container) outrank generic page fallback. Implemented order:

1. `<img>` with matching src → `ImageEntity`
2. `data-anglesite-id` matching post id → `PostEntity`
3. `pagePath` matching page route → `PageEntity`
4. Otherwise → `ElementEntity`

Two tests (`priority_imgWinsOverPagePath`, `priority_postIdWinsOverPagePath`) pin the priority explicitly so future reorderings break loudly.

## Tests

32 new tests:

- **13** for `VisibleElementReport.decode` — round-trip, every field absent, every reject path, NSNumber + Double rect coords, malformed-element index reporting
- **11** for the provider mapping rules + state replacement + ordering + `entity(for:)` lookup
- **8** for `ElementEntity` helpers — id format, displayName truncation + whitespace collapse, `selectorJSON()` round-trip, `encodeSelector` non-object fallback

`swift test` runs 254 tests across 32 suites — all new ones pass. Both `Anglesite` and `AnglesiteMAS` xcodebuild clean. The pre-existing `AppliesEditEndToEndTests` `.reconnecting` flake reproduces unchanged on `main` — unrelated.

## Stacking note

Independent of PR #178 (#145 — the JS reporter). The Swift decoder validates the wire format defined by #145, but they only meet at runtime — neither imports the other. Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)