### PR TITLE
feat(app): wire appEntityUIElementProvider on the preview WKWebView (#148)

### DIFF
--- a/Sources/AnglesiteApp/PreviewView.swift
+++ b/Sources/AnglesiteApp/PreviewView.swift
@@ -1,7 +1,10 @@
 import SwiftUI
+import AppKit
 import WebKit
+import AppIntents
 import AnglesiteBridge
 import AnglesiteCore
+import AnglesiteIntents
 
 /// SwiftUI wrapper around a `WKWebView` showing the live Astro dev server.
 ///
@@ -11,16 +14,34 @@ import AnglesiteCore
 /// `router` is the `EditRouter` the in-page overlay's `AnglesiteScriptHandler` forwards edits to.
 /// In production it's the `MCPApplyEditRouter` from `PreviewModel`, wrapping the session's
 /// `MCPClient`; tests can substitute any `EditRouter`.
+///
+/// `annotationProvider` is the per-window `PreviewAnnotationProvider` (Siri AI Phase B). When
+/// supplied, the script handler routes `anglesite:visible-elements` messages into it, and the
+/// WKWebView gets an `appEntityUIElementProvider` so AppKit's hit-test resolves visible regions
+/// to live entities. Nil → those features are inert (overlay still works for hover/click/drop).
 struct PreviewView: NSViewRepresentable {
     let url: URL
     let router: EditRouter
+    let annotationProvider: PreviewAnnotationProvider?
 
     func makeNSView(context: Context) -> WKWebView {
-        // Each webview gets its own script-message handler so the WKWebView retains the router for
-        // its lifetime. The router itself is shared (closure-captured by PreviewModel).
-        let handler = AnglesiteScriptHandler(router: router)
+        let onVisibleElements: AnglesiteScriptHandler.VisibleElementsHandler? = annotationProvider.map { provider in
+            // `provider` is `@MainActor`, so the implicit hop happens at the `update(_:)` call.
+            // Captured strongly: the handler is owned by the WKWebView, which is owned by
+            // SwiftUI's NSViewRepresentable lifecycle; the provider is owned by SiteWindow's
+            // `@State`, which outlives the WKWebView. The closure becomes unreachable when the
+            // WKWebView is torn down, releasing the strong reference.
+            { @Sendable elements in await provider.update(elements) }
+        }
+        let handler = AnglesiteScriptHandler(router: router, onVisibleElements: onVisibleElements)
         let webView = WKWebView(frame: .zero, configuration: WebViewBridge.localDevConfiguration(handler: handler))
         WebViewBridge.applyLocalDevDefaults(to: webView)
+        if let annotationProvider {
+            webView.appEntityUIElementProvider = { [weak annotationProvider] _, hitContext in
+                guard let annotationProvider else { return [] }
+                return annotationProvider.uiElements(for: hitContext)
+            }
+        }
         webView.load(URLRequest(url: url))
         context.coordinator.loadedURL = url
         return webView

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -66,6 +66,13 @@ struct SiteWindow: View {
         .task(id: siteID) { await loadAndStart() }
         .onDisappear {
             preview.close()
+            // Unregister the annotation provider from the shared registry so
+            // `ElementEntityQuery` stops resolving stale entity ids for a window that's no
+            // longer on screen.
+            if let provider = annotationProvider {
+                PreviewAnnotationProviderRegistry.shared.unregister(siteID: provider.siteID)
+                annotationProvider = nil
+            }
             #if !ANGLESITE_MAS
             chat = nil
             #endif
@@ -294,8 +301,19 @@ struct SiteWindow: View {
         await acquireGrant(for: resolved, in: store)
         #endif
 
-        if annotationProvider == nil {
-            annotationProvider = PreviewAnnotationProvider(siteID: resolved.id, graph: contentGraph)
+        // Recreate the provider whenever the resolved siteID changes — SwiftUI's
+        // `WindowGroup` can replay a different value into the same view instance on restore,
+        // so a `nil` check alone isn't enough; a stale provider would hold the wrong siteID
+        // and Siri would hit-test against the wrong site's entities.
+        if annotationProvider?.siteID != resolved.id {
+            if let old = annotationProvider {
+                PreviewAnnotationProviderRegistry.shared.unregister(siteID: old.siteID)
+            }
+            let provider = PreviewAnnotationProvider(siteID: resolved.id, graph: contentGraph)
+            annotationProvider = provider
+            // Register so `ElementEntityQuery` resolves entity ids in production (not just
+            // under the `ElementEntityProviderOverride.scoped` TaskLocal that tests use).
+            PreviewAnnotationProviderRegistry.shared.register(provider, for: resolved.id)
         }
 
         preview.open(siteID: resolved.id, siteDirectory: resolved.path)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AnglesiteCore
+import AnglesiteIntents
 
 /// Root view for a single per-site window. Owns the site's `PreviewModel`,
 /// `DeployModel`, and `ChatModel` as `@State` — lifecycle is bound to the window:
@@ -34,6 +35,11 @@ struct SiteWindow: View {
     #endif
 
     @State private var preview: PreviewModel
+    /// One per site window. Created lazily in `loadAndStart` once `siteID` is known; threaded
+    /// into `PreviewView` so the WKWebView's script handler can route `anglesite:visible-elements`
+    /// reports into it and AppKit's `appEntityUIElementProvider` can hit-test against its
+    /// annotations (Siri AI Phase B / #146 + #148).
+    @State private var annotationProvider: PreviewAnnotationProvider?
     @State private var deploy = DeployModel()
     @State private var backup = BackupModel()
     @State private var audit = AuditModel()
@@ -227,7 +233,7 @@ struct SiteWindow: View {
 
             switch preview.state {
             case .ready(_, let url):
-                PreviewView(url: url, router: preview.editRouter)
+                PreviewView(url: url, router: preview.editRouter, annotationProvider: annotationProvider)
             case .starting:
                 centeredStatus { ProgressView("Starting dev server for \(site.name)…") }
             case .failed(_, let message):
@@ -287,6 +293,10 @@ struct SiteWindow: View {
         #if ANGLESITE_MAS
         await acquireGrant(for: resolved, in: store)
         #endif
+
+        if annotationProvider == nil {
+            annotationProvider = PreviewAnnotationProvider(siteID: resolved.id, graph: contentGraph)
+        }
 
         preview.open(siteID: resolved.id, siteDirectory: resolved.path)
         #if !ANGLESITE_MAS

--- a/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
+++ b/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
@@ -11,6 +11,14 @@ import AnglesiteCore
 ///
 /// The interesting logic lives in `dispatch(body:via:onVisibleElements:)` — it's unit-tested
 /// independent of `WKScriptMessage`, which has no public initializer and is awkward to fake.
+///
+/// **API change vs prior versions:** the static `handle(body:via:)` method is gone, replaced
+/// by `dispatch(body:via:onVisibleElements:)`. All current callers are internal to this repo
+/// (the `WKScriptMessageHandler` impl below, the unit tests, and `PreviewView`'s production
+/// init); no deprecated shim is provided. If you're a downstream framework consumer hitting
+/// this, the migration is mechanical: rename `handle` → `dispatch`, pass `nil` for
+/// `onVisibleElements` to preserve the apply-edit-only behavior, and match on the richer
+/// `DispatchResult` enum instead of `Result<EditReply, EditMessage.DecodeError>`.
 public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
     public typealias VisibleElementsHandler = @Sendable ([VisibleElement]) async -> Void
 
@@ -109,8 +117,18 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
                 await MainActor.run {
                     webView.evaluateJavaScript(script)
                 }
-            case .visibleElementsHandled, .visibleElementsDropped:
+            case .visibleElementsHandled:
                 return
+            case .visibleElementsDropped:
+                // A visible-elements message arrived but no `onVisibleElements` handler is
+                // installed. Production wiring (PreviewView with an annotationProvider)
+                // always installs one; reaching here implies a regression. Log so the wiring
+                // failure is observable rather than silently swallowing all Siri reports.
+                await logCenter.append(
+                    source: "bridge",
+                    stream: .stderr,
+                    text: "visible-elements message dropped: no handler installed (provider not threaded through PreviewView?)"
+                )
             case .rejected(let reason):
                 await logCenter.append(
                     source: "bridge",

--- a/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
+++ b/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
@@ -2,32 +2,89 @@ import Foundation
 import WebKit
 import AnglesiteCore
 
-/// `WKScriptMessageHandler` for the `anglesite` namespace. Decodes each incoming `EditMessage`,
-/// routes it through the injected `EditRouter`, and posts the `EditReply` back to the originating
-/// WKWebView via `evaluateJavaScript("window.anglesite?._handleReply?.(<reply>)")`.
+/// `WKScriptMessageHandler` for the `anglesite` namespace. Two message types ride this bridge:
 ///
-/// The interesting logic lives in the pure `handle(body:via:)` static function — it's unit-tested
+/// 1. `anglesite:apply-edit` (an `EditMessage`) — routed through the injected `EditRouter`,
+///    reply delivered back to the WKWebView via `window.anglesite?._handleReply?.(<reply>)`.
+/// 2. `anglesite:visible-elements` (a `VisibleElementReport`, #145/B.1) — dispatched to the
+///    optional `onVisibleElements` callback. No reply; the JS side doesn't await one.
+///
+/// The interesting logic lives in `dispatch(body:via:onVisibleElements:)` — it's unit-tested
 /// independent of `WKScriptMessage`, which has no public initializer and is awkward to fake.
 public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
+    public typealias VisibleElementsHandler = @Sendable ([VisibleElement]) async -> Void
+
     private let router: EditRouter
+    private let onVisibleElements: VisibleElementsHandler?
     private let logCenter: LogCenter
 
-    public init(router: EditRouter, logCenter: LogCenter = .shared) {
+    public init(
+        router: EditRouter,
+        onVisibleElements: VisibleElementsHandler? = nil,
+        logCenter: LogCenter = .shared
+    ) {
         self.router = router
+        self.onVisibleElements = onVisibleElements
         self.logCenter = logCenter
         super.init()
     }
 
-    /// Pure decode → route → reply. Returns `.failure` for undecodable input (no reply: the JS
-    /// side never sent a correlation `id` we can trust, so callers should just log it). Returns
-    /// `.success(reply)` once the router has produced one.
-    public static func handle(body: Any, via router: EditRouter) async -> Result<EditReply, EditMessage.DecodeError> {
-        switch EditMessage.decode(from: body) {
-        case .failure(let error):
-            return .failure(error)
-        case .success(let message):
-            let reply = await router.apply(message)
-            return .success(reply)
+    /// Outcome of dispatching one incoming message body. The script handler's
+    /// `userContentController` reads this to decide whether to emit a reply or log a rejection.
+    public enum DispatchResult: Sendable {
+        /// `anglesite:apply-edit` succeeded; emit the reply back to the WKWebView.
+        case editReply(EditReply)
+        /// `anglesite:visible-elements` was forwarded to the optional handler.
+        case visibleElementsHandled
+        /// `anglesite:visible-elements` arrived but no `onVisibleElements` handler is installed.
+        /// Useful for tests; in production the wiring is checked at handler-init time.
+        case visibleElementsDropped
+        /// Body was undecodable. Log and move on.
+        case rejected(RejectionReason)
+
+        public enum RejectionReason: Sendable, Equatable {
+            case notAnObject
+            case missingType
+            case wrongType
+            case unknownType(String)
+            case editDecode(EditMessage.DecodeError)
+            case visibleElementsDecode(VisibleElementReport.DecodeError)
+        }
+    }
+
+    /// Peek at the `type` field, dispatch to the matching decoder, and route. Pure — no I/O
+    /// beyond the router call and the visible-elements handler call.
+    public static func dispatch(
+        body: Any,
+        via router: EditRouter,
+        onVisibleElements: VisibleElementsHandler? = nil
+    ) async -> DispatchResult {
+        guard let dict = body as? [String: Any] else { return .rejected(.notAnObject) }
+        guard let rawType = dict["type"] else { return .rejected(.missingType) }
+        guard let typeStr = rawType as? String else { return .rejected(.wrongType) }
+
+        switch typeStr {
+        case EditMessage.MessageType.applyEdit.rawValue:
+            switch EditMessage.decode(from: body) {
+            case .success(let message):
+                let reply = await router.apply(message)
+                return .editReply(reply)
+            case .failure(let error):
+                return .rejected(.editDecode(error))
+            }
+
+        case VisibleElementReport.messageType:
+            switch VisibleElementReport.decode(from: body) {
+            case .success(let report):
+                guard let handler = onVisibleElements else { return .visibleElementsDropped }
+                await handler(report.elements)
+                return .visibleElementsHandled
+            case .failure(let error):
+                return .rejected(.visibleElementsDecode(error))
+            }
+
+        default:
+            return .rejected(.unknownType(typeStr))
         }
     }
 
@@ -36,16 +93,11 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         let body = message.body
         let webView = message.webView
         let router = self.router
+        let onVisibleElements = self.onVisibleElements
         let logCenter = self.logCenter
         Task {
-            switch await Self.handle(body: body, via: router) {
-            case .failure(let error):
-                await logCenter.append(
-                    source: "bridge",
-                    stream: .stderr,
-                    text: "rejected edit message: \(error)"
-                )
-            case .success(let reply):
+            switch await Self.dispatch(body: body, via: router, onVisibleElements: onVisibleElements) {
+            case .editReply(let reply):
                 guard let webView else { return }
                 guard let data = try? JSONEncoder().encode(reply),
                       let json = String(data: data, encoding: .utf8)
@@ -57,6 +109,14 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
                 await MainActor.run {
                     webView.evaluateJavaScript(script)
                 }
+            case .visibleElementsHandled, .visibleElementsDropped:
+                return
+            case .rejected(let reason):
+                await logCenter.append(
+                    source: "bridge",
+                    stream: .stderr,
+                    text: "rejected message: \(reason)"
+                )
             }
         }
     }

--- a/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
+++ b/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
@@ -96,6 +96,37 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         }
     }
 
+    /// Deprecated forwarder for the old `handle(body:via:)` signature so out-of-tree adopters
+    /// get a fix-it instead of a cryptic missing-member error. Always passes `nil` for
+    /// `onVisibleElements`, matching the prior behavior (apply-edit only). Returns the same
+    /// `Result<EditReply, EditMessage.DecodeError>` shape callers were already matching on —
+    /// rejection reasons map back into the legacy decode-error type.
+    @available(*, deprecated, renamed: "dispatch(body:via:onVisibleElements:)",
+               message: "handle() is apply-edit only and returns a less expressive shape. Use dispatch(body:via:onVisibleElements:) — it covers visible-elements routing too and exposes the richer DispatchResult.")
+    public static func handle(body: Any, via router: EditRouter) async -> Result<EditReply, EditMessage.DecodeError> {
+        switch await dispatch(body: body, via: router, onVisibleElements: nil) {
+        case .editReply(let reply):
+            return .success(reply)
+        case .rejected(.editDecode(let error)):
+            return .failure(error)
+        case .rejected(.notAnObject):
+            return .failure(.notAnObject)
+        case .rejected(.missingType):
+            return .failure(.missingField("type"))
+        case .rejected(.wrongType):
+            return .failure(.wrongType(field: "type", expected: "string"))
+        case .rejected(.unknownType(let s)):
+            return .failure(.unknownType(s))
+        case .rejected(.visibleElementsDecode):
+            // Unreachable under `handle`'s contract (apply-edit only). Bubble up as
+            // unknown-type rather than crash; deprecated path, callers should migrate.
+            return .failure(.unknownType(VisibleElementReport.messageType))
+        case .visibleElementsHandled, .visibleElementsDropped:
+            // Unreachable: handler is nil. Same fallthrough as above.
+            return .failure(.unknownType(VisibleElementReport.messageType))
+        }
+    }
+
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard message.name == WebViewBridge.scriptMessageNamespace else { return }
         let body = message.body

--- a/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
@@ -22,7 +22,7 @@ import Foundation
 /// so rule 3 would make the PostEntity rule unreachable. The corrected order has data-id (an
 /// explicit author annotation) outrank generic-page fallback.
 @MainActor
-public final class PreviewAnnotationProvider: ElementEntityProviding {
+public final class PreviewAnnotationProvider: ElementEntityProviding, Sendable {
     public let siteID: String
     private let graph: SiteContentGraph
     private var annotated: [(rect: CGRect, entity: any AppEntity)] = []
@@ -75,6 +75,51 @@ public final class PreviewAnnotationProvider: ElementEntityProviding {
     /// which preserves the JS reporter's priority sort (heading > image > nav > interactive).
     public func annotations() -> [(rect: CGRect, entity: any AppEntity)] {
         annotated
+    }
+
+    /// Shape annotations into `[AppEntityUIElement]` for `NSView.appEntityUIElementProvider`
+    /// (B.4 / #148). The system asks for either `.visible(rect:)` — return everything whose
+    /// stored rect intersects `rect` — or `.selected`. We don't track an in-page selection
+    /// model (the overlay's hover/click states are transient), so `.selected` yields `[]`.
+    public func uiElements(for context: AppEntityUIElementsContext) -> [AppEntityUIElement] {
+        uiElements(forRequests: context.requests)
+    }
+
+    /// Inner helper taking the raw request set so tests can drive it directly —
+    /// `AppEntityUIElementsContext` has no public initializer.
+    public func uiElements(
+        forRequests requests: Set<AppEntityUIElementsContext.ElementsRequest>
+    ) -> [AppEntityUIElement] {
+        var out: [AppEntityUIElement] = []
+        for request in requests {
+            switch request {
+            case .visible(let rect):
+                for (annoRect, entity) in annotated where annoRect.intersects(rect) {
+                    out.append(makeUIElement(entity: entity, bounds: annoRect))
+                }
+            case .selected:
+                continue
+            @unknown default:
+                continue
+            }
+        }
+        return out
+    }
+
+    /// Existential-opening helper. `AppEntityUIElement.init<E: AppEntity>(_ entity:, bounds:)` is
+    /// generic over a concrete entity type; each of the four concrete types we map to gets a
+    /// dedicated branch so the compiler can specialize. The trailing fallback exists only to
+    /// satisfy the type checker — the four cases above are exhaustive given `resolve`'s rules.
+    private func makeUIElement(entity: any AppEntity, bounds: CGRect) -> AppEntityUIElement {
+        if let e = entity as? PageEntity { return AppEntityUIElement(e, bounds: bounds) }
+        if let e = entity as? PostEntity { return AppEntityUIElement(e, bounds: bounds) }
+        if let e = entity as? ImageEntity { return AppEntityUIElement(e, bounds: bounds) }
+        if let e = entity as? ElementEntity { return AppEntityUIElement(e, bounds: bounds) }
+        let placeholder = ElementEntity(
+            id: "unknown", displayName: "unknown", siteID: siteID,
+            selector: "{}", pagePath: "/"
+        )
+        return AppEntityUIElement(placeholder, bounds: bounds)
     }
 
     // MARK: ElementEntityProviding

--- a/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
@@ -1,7 +1,15 @@
 import AppIntents
+import AppKit
 import AnglesiteCore
 import CoreGraphics
 import Foundation
+
+// `AppEntityUIElement` and `AppEntityUIElementsContext` are defined by the
+// `_AppIntents_AppKit` cross-import overlay, which auto-loads when both `AppIntents` and
+// `AppKit` are imported explicitly in the consuming file. Swift's `MemberImportVisibility`
+// upcoming-feature (enabled by the macOS 27 SDK module flags) requires both base modules
+// here — transitive imports through other frameworks aren't enough, and the compile error
+// blames the type rather than the missing import.
 
 /// Per-WKWebView state holding the latest `VisibleElementReport` and mapping each element to
 /// an `AppEntity`. AppKit's `appEntityUIElementProvider` (B.4 / #148) reads from this when

--- a/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
@@ -110,11 +110,15 @@ public final class PreviewAnnotationProvider: ElementEntityProviding, Sendable {
     /// generic over a concrete entity type; each of the four concrete types we map to gets a
     /// dedicated branch so the compiler can specialize. The trailing fallback exists only to
     /// satisfy the type checker — the four cases above are exhaustive given `resolve`'s rules.
+    /// If a fifth entity type is ever returned by `resolve` without updating this switch, the
+    /// `assertionFailure` makes the regression loud in debug builds; release builds fall through
+    /// to the placeholder so production keeps working.
     private func makeUIElement(entity: any AppEntity, bounds: CGRect) -> AppEntityUIElement {
         if let e = entity as? PageEntity { return AppEntityUIElement(e, bounds: bounds) }
         if let e = entity as? PostEntity { return AppEntityUIElement(e, bounds: bounds) }
         if let e = entity as? ImageEntity { return AppEntityUIElement(e, bounds: bounds) }
         if let e = entity as? ElementEntity { return AppEntityUIElement(e, bounds: bounds) }
+        assertionFailure("makeUIElement: unhandled entity type \(type(of: entity)) — extend the switch in PreviewAnnotationProvider")
         let placeholder = ElementEntity(
             id: "unknown", displayName: "unknown", siteID: siteID,
             selector: "{}", pagePath: "/"

--- a/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
@@ -85,6 +85,13 @@ public final class PreviewAnnotationProvider: ElementEntityProviding, Sendable {
         annotated
     }
 
+    // `AppEntityUIElement` and `AppEntityUIElementsContext` are macOS 26+ symbols (Xcode 27 /
+    // Swift 6.4 SDK). CI's `macos-15` runner currently ships Xcode 26.3 / Swift 6.3 and doesn't
+    // have these types, so the methods that reference them are gated. Local Xcode 27 builds get
+    // the full surface; CI compiles the library without it. Same pattern as `Package.swift`'s
+    // `#if compiler(>=6.4)` gate around `AnglesiteIntentsTests`. Tracked for removal in #128
+    // when GH's runner ships Xcode 27.
+    #if compiler(>=6.4)
     /// Shape annotations into `[AppEntityUIElement]` for `NSView.appEntityUIElementProvider`
     /// (B.4 / #148). The system asks for either `.visible(rect:)` — return everything whose
     /// stored rect intersects `rect` — or `.selected`. We don't track an in-page selection
@@ -133,6 +140,7 @@ public final class PreviewAnnotationProvider: ElementEntityProviding, Sendable {
         )
         return AppEntityUIElement(placeholder, bounds: bounds)
     }
+    #endif
 
     // MARK: ElementEntityProviding
 

--- a/Tests/AnglesiteBridgeTests/AnglesiteScriptHandlerTests.swift
+++ b/Tests/AnglesiteBridgeTests/AnglesiteScriptHandlerTests.swift
@@ -3,7 +3,7 @@ import Testing
 import AnglesiteCore
 
 struct AnglesiteScriptHandlerTests {
-    private func validBody() -> [String: Any] {
+    private func validEditBody() -> [String: Any] {
         [
             "id": "e-99",
             "type": "anglesite:apply-edit",
@@ -18,11 +18,30 @@ struct AnglesiteScriptHandlerTests {
         ]
     }
 
-    @Test("Handle valid body routes and returns reply") func handleValidBodyRoutesAndReturnsReply() async {
+    private func validVisibleElementsBody() -> [String: Any] {
+        [
+            "type": "anglesite:visible-elements",
+            "elements": [
+                [
+                    "id": "v-1",
+                    "tag": "H1",
+                    "selector": [
+                        "tag": "H1",
+                        "classes": [] as [String],
+                        "nthChild": 1,
+                    ] as [String: Any],
+                    "rect": ["x": 0, "y": 0, "width": 100, "height": 40] as [String: Any],
+                    "text": "Heading",
+                ] as [String: Any]
+            ] as [Any],
+        ]
+    }
+
+    @Test("Dispatch routes apply-edit and returns reply") func dispatchRoutesApplyEdit() async {
         let router = RecordingRouter(reply: EditReply(id: "e-99", status: .applied, message: "done"))
-        let result = await AnglesiteScriptHandler.handle(body: validBody(), via: router)
-        guard case .success(let reply) = result else {
-            Issue.record("expected .success, got \(result)")
+        let result = await AnglesiteScriptHandler.dispatch(body: validEditBody(), via: router)
+        guard case .editReply(let reply) = result else {
+            Issue.record("expected .editReply, got \(result)")
             return
         }
         #expect(reply.id == "e-99")
@@ -33,19 +52,89 @@ struct AnglesiteScriptHandlerTests {
         #expect(received.first?.op == "replace-text")
     }
 
-    @Test("Handle invalid body returns decode error and does not route") func handleInvalidBodyReturnsDecodeErrorAndDoesNotRoute() async {
-        // Wrong type at the type field — strict decode rejects it before any routing.
-        var bad = validBody()
+    @Test("Dispatch rejects unknown message type") func dispatchRejectsUnknownType() async {
+        var bad = validEditBody()
         bad["type"] = "anglesite:not-real"
         let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
-        let result = await AnglesiteScriptHandler.handle(body: bad, via: router)
-        guard case .failure(let err) = result else {
-            Issue.record("expected .failure, got \(result)")
+        let result = await AnglesiteScriptHandler.dispatch(body: bad, via: router)
+        guard case .rejected(.unknownType(let t)) = result else {
+            Issue.record("expected .rejected(.unknownType), got \(result)")
             return
         }
-        #expect(err == .unknownType("anglesite:not-real"))
+        #expect(t == "anglesite:not-real")
         let received = await router.received
         #expect(received.isEmpty, "router must not see undecodable input")
+    }
+
+    @Test("Dispatch rejects body that is not an object") func dispatchRejectsNonObject() async {
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteScriptHandler.dispatch(body: "string", via: router)
+        guard case .rejected(.notAnObject) = result else {
+            Issue.record("expected .rejected(.notAnObject), got \(result)")
+            return
+        }
+    }
+
+    @Test("Dispatch reports missing type as missingType") func dispatchReportsMissingType() async {
+        var body = validEditBody()
+        body.removeValue(forKey: "type")
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteScriptHandler.dispatch(body: body, via: router)
+        guard case .rejected(.missingType) = result else {
+            Issue.record("expected .rejected(.missingType), got \(result)")
+            return
+        }
+    }
+
+    @Test("Dispatch forwards visible-elements to handler") func dispatchForwardsVisibleElements() async {
+        let collector = ElementCollector()
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteScriptHandler.dispatch(
+            body: validVisibleElementsBody(),
+            via: router,
+            onVisibleElements: { elements in await collector.append(elements) }
+        )
+        guard case .visibleElementsHandled = result else {
+            Issue.record("expected .visibleElementsHandled, got \(result)")
+            return
+        }
+        let captured = await collector.batches
+        #expect(captured.count == 1)
+        #expect(captured.first?.count == 1)
+        #expect(captured.first?.first?.id == "v-1")
+        let received = await router.received
+        #expect(received.isEmpty, "router must not see a visible-elements message")
+    }
+
+    @Test("Dispatch drops visible-elements when no handler is installed") func dispatchDropsVisibleElementsWithoutHandler() async {
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteScriptHandler.dispatch(
+            body: validVisibleElementsBody(),
+            via: router,
+            onVisibleElements: nil
+        )
+        guard case .visibleElementsDropped = result else {
+            Issue.record("expected .visibleElementsDropped, got \(result)")
+            return
+        }
+    }
+
+    @Test("Dispatch surfaces visible-elements decode failures") func dispatchSurfacesVisibleElementsDecodeFailure() async {
+        var body = validVisibleElementsBody()
+        body.removeValue(forKey: "elements")
+        let collector = ElementCollector()
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteScriptHandler.dispatch(
+            body: body,
+            via: router,
+            onVisibleElements: { elements in await collector.append(elements) }
+        )
+        guard case .rejected(.visibleElementsDecode(.missingField("elements"))) = result else {
+            Issue.record("expected .rejected(.visibleElementsDecode(.missingField(elements))), got \(result)")
+            return
+        }
+        let captured = await collector.batches
+        #expect(captured.isEmpty)
     }
 }
 
@@ -57,4 +146,9 @@ private actor RecordingRouter: EditRouter {
         received.append(message)
         return reply
     }
+}
+
+private actor ElementCollector {
+    private(set) var batches: [[VisibleElement]] = []
+    func append(_ batch: [VisibleElement]) { batches.append(batch) }
 }

--- a/Tests/AnglesiteBridgeTests/AnglesiteScriptHandlerTests.swift
+++ b/Tests/AnglesiteBridgeTests/AnglesiteScriptHandlerTests.swift
@@ -136,6 +136,37 @@ struct AnglesiteScriptHandlerTests {
         let captured = await collector.batches
         #expect(captured.isEmpty)
     }
+
+    // The deprecated `handle(body:via:)` shim exists so out-of-tree adopters of the old
+    // signature get a fix-it. These tests verify the migration path still routes correctly.
+    @Test("Deprecated handle() forwards apply-edit and returns success") func deprecatedHandle_routesApplyEdit() async {
+        let router = RecordingRouter(reply: EditReply(id: "e-99", status: .applied, message: "done"))
+        let result = await deprecatedHandle(body: validEditBody(), via: router)
+        guard case .success(let reply) = result else {
+            Issue.record("expected .success, got \(result)")
+            return
+        }
+        #expect(reply.id == "e-99")
+        #expect(reply.status == .applied)
+    }
+
+    @Test("Deprecated handle() preserves the legacy unknown-type failure mode") func deprecatedHandle_unknownType() async {
+        var body = validEditBody()
+        body["type"] = "anglesite:not-real"
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await deprecatedHandle(body: body, via: router)
+        guard case .failure(.unknownType("anglesite:not-real")) = result else {
+            Issue.record("expected .failure(.unknownType), got \(result)")
+            return
+        }
+    }
+
+    // Wrap the deprecated call so the deprecation warning lands once at the wrapper level
+    // rather than per-call-site. Swift Testing's `@available` propagation handles this.
+    @available(*, deprecated)
+    private func deprecatedHandle(body: Any, via router: EditRouter) async -> Result<EditReply, EditMessage.DecodeError> {
+        await AnglesiteScriptHandler.handle(body: body, via: router)
+    }
 }
 
 private actor RecordingRouter: EditRouter {

--- a/Tests/AnglesiteIntentsTests/PreviewAnnotationProviderTests.swift
+++ b/Tests/AnglesiteIntentsTests/PreviewAnnotationProviderTests.swift
@@ -274,6 +274,60 @@ extension AppIntentsTests {
             let lookupID = ElementEntity.makeID(siteID: AppIntentsTests.aSite, elementID: "v-49")
             #expect(provider.entity(for: lookupID) != nil)
         }
+
+        @Test(".visible(rect:) returns only elements intersecting the rect")
+        func uiElements_visibleRectFiltersByIntersection() async {
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            // Three elements at different x positions; the requested visible rect covers x: 0..100.
+            await provider.update([
+                AppIntentsTests.makeVisibleElement(id: "v-a", tag: "H1", x: 0,   width: 50),
+                AppIntentsTests.makeVisibleElement(id: "v-b", tag: "H2", x: 200, width: 50),
+                AppIntentsTests.makeVisibleElement(id: "v-c", tag: "H3", x: 90,  width: 100),
+            ])
+            let requests: Set<AppEntityUIElementsContext.ElementsRequest> = [
+                .visible(rect: CGRect(x: 0, y: 0, width: 100, height: 1000))
+            ]
+            let elements = provider.uiElements(forRequests: requests)
+            #expect(elements.count == 2)
+            #expect(elements.map(\.bounds.minX).sorted() == [0, 90])
+        }
+
+        @Test(".selected request returns empty (no selection model)")
+        func uiElements_selectedRequestIsEmpty() async {
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            await provider.update([AppIntentsTests.makeVisibleElement(id: "v-a", tag: "H1")])
+            #expect(provider.uiElements(forRequests: [.selected]).isEmpty)
+        }
+
+        @Test("Mixed .visible + .selected returns only visible matches")
+        func uiElements_mixedRequestsReturnVisibleOnly() async {
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            await provider.update([AppIntentsTests.makeVisibleElement(id: "v-a", tag: "H1", x: 0)])
+            let requests: Set<AppEntityUIElementsContext.ElementsRequest> = [
+                .visible(rect: CGRect(x: 0, y: 0, width: 1000, height: 1000)),
+                .selected,
+            ]
+            #expect(provider.uiElements(forRequests: requests).count == 1)
+        }
+
+        @Test("uiElements bounds equal the stored annotation rects")
+        func uiElements_boundsMatchAnnotations() async {
+            let graph = SiteContentGraph()
+            let provider = PreviewAnnotationProvider(siteID: AppIntentsTests.aSite, graph: graph)
+            await provider.update([
+                AppIntentsTests.makeVisibleElement(id: "v-a", tag: "H1",
+                    x: 10, y: 20, width: 300, height: 40)
+            ])
+            let requests: Set<AppEntityUIElementsContext.ElementsRequest> = [
+                .visible(rect: CGRect(x: 0, y: 0, width: 1000, height: 1000))
+            ]
+            let elements = provider.uiElements(forRequests: requests)
+            #expect(elements.count == 1)
+            #expect(elements[0].bounds == CGRect(x: 10, y: 20, width: 300, height: 40))
+        }
     }
 
     @Suite("ElementEntity helpers", .serialized)


### PR DESCRIPTION
Closes #148 — Siri AI Phase B.4.

**Stacked on #179** (`feat/146-preview-annotation-provider`). The Swift wiring depends on `PreviewAnnotationProvider` / `ElementEntity` / `VisibleElementMessage` types that ship there. Will rebase onto `main` before #179 merges (or re-land from `main` if #179 lands first), then verify per the stacking-pitfall convention.

## Why

Phase B's end state: Siri can resolve "edit this heading" / "replace this image" by hit-testing the live preview. Phases A (entities) + B.1 (JS reporter) + B.2/B.3 (provider + transient `ElementEntity`) supply the data; this PR is the AppKit hookup that lets the system *read* it.

## What

**`AnglesiteIntents/PreviewAnnotationProvider`**
- `uiElements(for: AppEntityUIElementsContext)` — main consumer surface (called from the WKWebView's `appEntityUIElementProvider` closure)
- `uiElements(forRequests:)` — testable inner helper. `AppEntityUIElementsContext` has no public initializer, so the only way to drive the provider with arbitrary requests in unit tests is via this overload
- Maps each priority-category entity to `AppEntityUIElement(_:bounds:)` via an existential-opening helper; `.selected` requests resolve to `[]` (no in-page selection model yet)
- Conforms to `Sendable` so the provider can be captured in the `@Sendable` callback the script handler stores

**`AnglesiteBridge/AnglesiteScriptHandler`**
- Replaces `handle(body:via:)` with `dispatch(body:via:onVisibleElements:)`
- Peeks at the message `type` field and routes to either `EditMessage` decode (existing apply-edit path) or `VisibleElementReport` decode (new)
- `DispatchResult` enum captures both reply-bearing and silent outcomes, plus a flat rejection bucket the `userContentController` impl logs

**`AnglesiteApp/PreviewView` + `SiteWindow`**
- `PreviewView` gains an optional `annotationProvider` prop. When supplied:
  - The `AnglesiteScriptHandler` callback hops to `MainActor` and forwards each `[VisibleElement]` batch into `provider.update(_:)`
  - The `WKWebView` gets `appEntityUIElementProvider = { ... }` capturing the provider weakly and returning `provider.uiElements(for:)`
- `SiteWindow` holds the provider as `@State` and lazily creates it in `loadAndStart` once `siteID` is resolved; threads it into `PreviewView`

## Two notes worth flagging

### `import AppKit` is explicit

`appEntityUIElementProvider` is defined on `NSView` by the `_AppIntents_AppKit` cross-import overlay, which auto-loads when both `AppKit` and `AppIntents` are imported. Swift's `MemberImportVisibility` upcoming-feature (enabled by the macOS 27 SDK module flags) requires those base modules be imported **explicitly** in the consuming file — `import WebKit` transitively brings AppKit but doesn't make the extension property visible. So `PreviewView` adds `import AppKit`. (Spent a build cycle figuring this out — the error message blames the WKWebView type, not the import.)

### API shape is richer than the issue sketched

The issue showed:
```swift
webView.appEntityUIElementProvider = { [weak provider] point in ...one entity }
```

The real API is:
```swift
((NSView, AppEntityUIElementsContext) -> [AppEntityUIElement])?
```

— a context with a `Set<ElementsRequest>` (`.visible(rect:)` or `.selected`) returning an array. We handle `.visible(rect:)` via rect-intersection filter and `.selected` by returning `[]`.

### Lifetime + threading on the visible-elements callback

The closure is `@Sendable` (the script handler captures it across actors), holds `provider` strongly, and dispatches to `MainActor` via the `@MainActor`-isolated `provider.update(_:)` call. Strong capture is intentional: the handler is owned by the `WKWebView`, which is owned by SwiftUI's `NSViewRepresentable` lifecycle; the provider is owned by `SiteWindow`'s `@State`, which outlives the WKWebView. Tearing down the window releases the closure before releasing the provider.

## Tests

**11 new tests:**

| Suite | Tests | Coverage |
|---|---|---|
| `AnglesiteScriptHandlerTests` | 7 | replaces the prior `handle` tests; apply-edit routing, visible-elements forward, drop-when-no-handler, decode failures, reject paths |
| `PreviewAnnotationProvider mapping` (new section) | 4 | `.visible(rect:)` intersection filter, `.selected` → empty, mixed requests, bounds preserved |

`swift test` passes for all new code (110 tests pass across 18 suites). Both `Anglesite` and `AnglesiteMAS` `xcodebuild` clean. Pre-existing `AppliesEditEndToEndTests` `.reconnecting` and `MCPClientHTTPEndToEndTests` `.sessionLost` flakes reproduce unchanged on `main` — unrelated to this PR.

## Manual smoke (deferred to B.6 / #150)

Per the issue, the canonical validation is a manual Siri invocation against a running preview. That sits in #150 (B.6 — Manual smoke: Siri + preview pane onscreen awareness). This PR's unit tests cover the deterministic mapping; the system-AI smoke is a separate workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)