### PR TITLE
feat(server): add list_content MCP tool (pages/posts/images)

### DIFF
--- a/server/index-tools.mjs
+++ b/server/index-tools.mjs
@@ -10,6 +10,7 @@ import { applyEditInputShape } from "./apply-edit-schema.mjs";
 import { applyEdit } from "./apply-edit-dispatcher.mjs";
 import { recordEdit } from "./edit-history.mjs";
 import { undoEdit } from "./undo-edit.mjs";
+import { listContent } from "./list-content.mjs";
 
 /**
  * Build the Anglesite MCP server with every tool registered against `projectRoot`.
@@ -105,6 +106,23 @@ export function buildServer(projectRoot) {
         content: [{ type: "text", text: JSON.stringify(result) }],
         isError: result.status === "refused",
       };
+    },
+  );
+
+  server.tool(
+    "list_content",
+    "List the site's content — pages (routes), posts (content-collection entries), and images — as a site-agnostic JSON snapshot. Consumed by the Anglesite-app to build its content graph for Siri entity resolution. No entity ids or siteID are emitted; the host stamps those.",
+    {},
+    () => {
+      try {
+        const listing = listContent(projectRoot);
+        return { content: [{ type: "text", text: JSON.stringify(listing) }] };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: error.message }],
+          isError: true,
+        };
+      }
     },
   );
 

--- a/server/list-content.mjs
+++ b/server/list-content.mjs
@@ -1,0 +1,242 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+/**
+ * Discover a site's content (pages, posts, images) for the `list_content` MCP tool.
+ *
+ * The payload is **site-agnostic**: no `siteID`, no entity `id` — the Anglesite-app
+ * stamps those itself (`Sources/AnglesiteCore/ContentListing.swift`). Timestamps are
+ * ISO-8601; `filePath`/`relativePath` are projectRoot-relative with POSIX separators.
+ *
+ * @param {string} projectRoot Absolute path to the site root.
+ * @returns {{ pages: object[], posts: object[], images: object[] }}
+ */
+export function listContent(projectRoot) {
+  return {
+    pages: discoverPages(projectRoot),
+    posts: discoverPosts(projectRoot),
+    images: discoverImages(projectRoot),
+  };
+}
+
+// ── Pages ─────────────────────────────────────────────────────────
+
+const PAGE_EXTENSIONS = [".astro", ".md", ".mdx", ".html"];
+
+function discoverPages(projectRoot) {
+  const pagesDir = join(projectRoot, "src", "pages");
+  const files = walkFiles(pagesDir, (name) =>
+    PAGE_EXTENSIONS.some((ext) => name.endsWith(ext)),
+  );
+  const pages = [];
+  for (const file of files) {
+    const routePath = relative(pagesDir, file);
+    // Dynamic routes (`[slug]`, `[...rest]`) need params we can't enumerate
+    // statically — skip them rather than emit a literal `/blog/[slug]` route.
+    if (routePath.includes("[")) continue;
+    const page = {
+      route: deriveRoute(routePath),
+      filePath: toRelativePosix(projectRoot, file),
+      lastModified: mtimeISO(file),
+    };
+    const title = scalar(frontmatterBlock(readFileSafe(file)), "title");
+    if (title) page.title = title;
+    pages.push(page);
+  }
+  return pages;
+}
+
+/** `index.astro` → `/`, `about.astro` → `/about`, `blog/index.astro` → `/blog`. */
+function deriveRoute(routePath) {
+  let r = routePath.split(sep).join("/");
+  r = r.replace(/\.[^.]+$/, ""); // drop extension
+  r = r.replace(/(^|\/)index$/, ""); // collapse trailing index
+  return "/" + r;
+}
+
+// ── Images ────────────────────────────────────────────────────────
+
+const IMAGE_EXTENSIONS = [
+  ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".avif", ".ico",
+];
+
+function discoverImages(projectRoot) {
+  const dirs = [join(projectRoot, "public"), join(projectRoot, "src", "assets")];
+  const isImage = (name) =>
+    IMAGE_EXTENSIONS.some((ext) => name.toLowerCase().endsWith(ext));
+
+  // Precompute (route, source) for every page once, so usedOnPages is a
+  // substring scan rather than a re-walk per image.
+  const pagesDir = join(projectRoot, "src", "pages");
+  const pageRefs = walkFiles(pagesDir, (name) =>
+    PAGE_EXTENSIONS.some((ext) => name.endsWith(ext)),
+  ).map((file) => ({
+    route: deriveRoute(relative(pagesDir, file)),
+    text: readFileSafe(file),
+  }));
+
+  const images = [];
+  for (const dir of dirs) {
+    for (const file of walkFiles(dir, isImage)) {
+      const fileName = file.split(sep).pop();
+      const usedOnPages = pageRefs
+        .filter((p) => p.text.includes(fileName))
+        .map((p) => p.route);
+      images.push({
+        relativePath: toRelativePosix(projectRoot, file),
+        fileName,
+        byteSize: statSync(file).size,
+        usedOnPages: [...new Set(usedOnPages)].sort(),
+        lastModified: mtimeISO(file),
+      });
+    }
+  }
+  return images;
+}
+
+// ── Posts ─────────────────────────────────────────────────────────
+
+const POST_EXTENSIONS = [".mdoc", ".mdx", ".md"];
+
+function discoverPosts(projectRoot) {
+  const contentDir = join(projectRoot, "src", "content");
+  let collections;
+  try {
+    collections = readdirSync(contentDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const posts = [];
+  for (const entry of collections) {
+    if (!entry.isDirectory()) continue;
+    const collection = entry.name;
+    const collectionDir = join(contentDir, collection);
+    const files = walkFiles(collectionDir, (name) =>
+      POST_EXTENSIONS.some((ext) => name.endsWith(ext)),
+    );
+    for (const file of files) {
+      const slug = deriveSlug(relative(collectionDir, file));
+      const fm = frontmatterBlock(readFileSafe(file));
+      const post = {
+        collection,
+        slug,
+        title: scalar(fm, "title") ?? slug,
+        draft: boolean(fm, "draft") ?? false,
+        tags: stringArray(fm, "tags"),
+        filePath: toRelativePosix(projectRoot, file),
+        lastModified: mtimeISO(file),
+      };
+      const publishDate = normalizeDate(scalar(fm, "publishDate"));
+      if (publishDate) post.publishDate = publishDate;
+      posts.push(post);
+    }
+  }
+  return posts;
+}
+
+/** Astro glob-loader id: path under the collection base, minus extension. */
+function deriveSlug(entryPath) {
+  return entryPath.split(sep).join("/").replace(/\.[^.]+$/, "");
+}
+
+// ── Shared helpers ──────────────────────────────────────────────────
+
+/** Recursively collect files matching `predicate`. Skips build/vcs dirs. */
+function walkFiles(dir, predicate) {
+  const results = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    if (["node_modules", ".git", "dist", ".astro"].includes(entry.name)) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkFiles(full, predicate));
+    } else if (predicate(entry.name)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function toRelativePosix(projectRoot, file) {
+  return relative(projectRoot, file).split(sep).join("/");
+}
+
+function mtimeISO(file) {
+  return statSync(file).mtime.toISOString();
+}
+
+function readFileSafe(file) {
+  try {
+    return readFileSync(file, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+// ── Minimal frontmatter parsing ─────────────────────────────────────
+// The repo ships no YAML dependency; these cover the scalar/boolean/list
+// shapes the content schemas use (see template/src/content.config.ts).
+
+/** The raw text inside a leading `---` … `---` block, or "" if absent. */
+function frontmatterBlock(source) {
+  const m = source.match(/^---\n([\s\S]*?)\n---/);
+  return m ? m[1] : "";
+}
+
+/** A single-line scalar value (`key: value`), quotes stripped. */
+function scalar(fm, key) {
+  const line = fm.match(new RegExp(`^${key}:[ \\t]*(.+)$`, "m"));
+  if (!line) return undefined;
+  const v = line[1].trim();
+  if (v === "" || v === "[]") return undefined;
+  return stripQuotes(v);
+}
+
+/** A boolean value; `undefined` when the key is absent. */
+function boolean(fm, key) {
+  const v = scalar(fm, key);
+  if (v === undefined) return undefined;
+  return v === "true";
+}
+
+/**
+ * A string array, supporting inline (`key: [a, b]`) and YAML block lists:
+ *   key:
+ *     - a
+ *     - b
+ * Returns `[]` when the key is absent or empty.
+ */
+function stringArray(fm, key) {
+  const inline = fm.match(new RegExp(`^${key}:[ \\t]*\\[(.*)\\]`, "m"));
+  if (inline) {
+    return inline[1]
+      .split(",")
+      .map((s) => stripQuotes(s.trim()))
+      .filter(Boolean);
+  }
+  const block = fm.match(new RegExp(`^${key}:[ \\t]*\\n((?:[ \\t]+.*(?:\\n|$))+)`, "m"));
+  if (block) {
+    return block[1]
+      .split("\n")
+      .map((l) => l.match(/^[ \t]*-[ \t]*(.+)$/))
+      .filter(Boolean)
+      .map((m) => stripQuotes(m[1].trim()));
+  }
+  return [];
+}
+
+/** Normalize a date string to a full ISO-8601 datetime, or `undefined`. */
+function normalizeDate(raw) {
+  if (!raw) return undefined;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+function stripQuotes(v) {
+  return v.replace(/^["'](.*)["']$/, "$1");
+}

--- a/test/list-content.test.js
+++ b/test/list-content.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { listContent } from "../server/list-content.mjs";
+import { buildServer } from "../server/index-tools.mjs";
+
+// `buildServer` transitively imports `optimize-images.mjs` → `sharp` (a native
+// addon not resolvable in the test sandbox). The tool under test never touches
+// it; stub the module so the import chain loads. (vitest hoists vi.mock.)
+vi.mock("sharp", () => ({ default: () => ({}) }));
+
+let root;
+
+/** Write a file at a projectRoot-relative path, creating parent dirs. */
+function write(rel, contents = "") {
+  const full = join(root, rel);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, contents);
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "list-content-"));
+});
+afterEach(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe("listContent — pages", () => {
+  it("discovers pages under src/pages and derives Astro routes", () => {
+    write("src/pages/index.astro", "<h1>Home</h1>");
+    write("src/pages/about.astro", "---\ntitle: About Us\n---\n<h1>About</h1>");
+    write("src/pages/blog/index.astro", "<h1>Blog</h1>");
+
+    const { pages } = listContent(root);
+    const byRoute = Object.fromEntries(pages.map((p) => [p.route, p]));
+
+    expect(Object.keys(byRoute).sort()).toEqual(["/", "/about", "/blog"]);
+    expect(byRoute["/about"].title).toBe("About Us");
+    expect(byRoute["/about"].filePath).toBe("src/pages/about.astro");
+    expect(byRoute["/"].lastModified).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("skips dynamic-route pages whose params can't be enumerated", () => {
+    write("src/pages/index.astro", "<h1>Home</h1>");
+    write("src/pages/blog/[slug].astro", "<h1>Post</h1>");
+    write("src/pages/[...catchall].astro", "<h1>404</h1>");
+
+    const { pages } = listContent(root);
+    expect(pages.map((p) => p.route)).toEqual(["/"]);
+  });
+});
+
+describe("listContent — posts", () => {
+  it("discovers posts from content collections with frontmatter fields", () => {
+    write(
+      "src/content/posts/hello-world.md",
+      "---\ntitle: Hello World\npublishDate: 2026-06-12\ntags:\n  - smoke\n  - siri\ndraft: false\n---\nbody",
+    );
+    write(
+      "src/content/posts/wip.mdoc",
+      "---\ntitle: WIP\ndraft: true\n---\nbody",
+    );
+
+    const { posts } = listContent(root);
+    const bySlug = Object.fromEntries(posts.map((p) => [p.slug, p]));
+
+    expect(Object.keys(bySlug).sort()).toEqual(["hello-world", "wip"]);
+
+    const hw = bySlug["hello-world"];
+    expect(hw.collection).toBe("posts");
+    expect(hw.title).toBe("Hello World");
+    expect(hw.draft).toBe(false);
+    expect(hw.tags).toEqual(["smoke", "siri"]);
+    // publishDate must be normalized to a FULL ISO-8601 datetime — the app's
+    // ISO8601DateFormatter rejects date-only "2026-06-12".
+    expect(hw.publishDate).toBe("2026-06-12T00:00:00.000Z");
+    expect(hw.filePath).toBe("src/content/posts/hello-world.md");
+    expect(hw.lastModified).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+
+    // Defaults: draft true when set, tags default to [], publishDate omitted.
+    expect(bySlug["wip"].draft).toBe(true);
+    expect(bySlug["wip"].tags).toEqual([]);
+    expect(bySlug["wip"].publishDate).toBeUndefined();
+  });
+});
+
+describe("listContent — images", () => {
+  it("discovers images from public/ and src/assets with metadata", () => {
+    write("public/images/hero.svg", "<svg></svg>");
+    write("src/assets/logo.png", "PNGDATA");
+    write("public/notes.txt", "not an image");
+
+    const { images } = listContent(root);
+    const byPath = Object.fromEntries(images.map((i) => [i.relativePath, i]));
+
+    expect(Object.keys(byPath).sort()).toEqual([
+      "public/images/hero.svg",
+      "src/assets/logo.png",
+    ]);
+
+    const hero = byPath["public/images/hero.svg"];
+    expect(hero.fileName).toBe("hero.svg");
+    expect(hero.relativePath.startsWith("/")).toBe(false);
+    expect(hero.byteSize).toBe(11); // "<svg></svg>".length
+    expect(hero.lastModified).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(Array.isArray(hero.usedOnPages)).toBe(true);
+  });
+
+  it("populates usedOnPages (best-effort) from page references", () => {
+    write("public/images/hero.svg", "<svg></svg>");
+    write("src/pages/index.astro", '<img src="/images/hero.svg">');
+    write("src/pages/about.astro", "<h1>About</h1>");
+
+    const { images } = listContent(root);
+    const hero = images.find((i) => i.fileName === "hero.svg");
+    expect(hero.usedOnPages).toEqual(["/"]);
+  });
+});
+
+describe("list_content MCP tool", () => {
+  it("registers list_content and returns the discovered listing", async () => {
+    write("src/pages/index.astro", "<h1>Home</h1>");
+    write("src/content/posts/hello.md", "---\ntitle: Hello\n---\nbody");
+    write("public/images/hero.svg", "<svg></svg>");
+
+    const server = buildServer(root);
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test", version: "0.0.0" });
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("list_content");
+
+    const res = await client.callTool({ name: "list_content", arguments: {} });
+    expect(res.isError).toBeFalsy();
+    const payload = JSON.parse(res.content[0].text);
+    expect(payload.pages.map((p) => p.route)).toEqual(["/"]);
+    expect(payload.posts.map((p) => p.slug)).toEqual(["hello"]);
+    expect(payload.images.map((i) => i.fileName)).toEqual(["hero.svg"]);
+
+    await client.close();
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -182,6 +182,7 @@ describe("MCP annotation server", () => {
         "add_annotation",
         "apply_edit",
         "list_annotations",
+        "list_content",
         "resolve_annotation",
         "undo_edit",
       ]);


### PR DESCRIPTION
## Summary

Adds a `list_content` MCP tool that returns a site's **pages, posts, and images** as a site-agnostic JSON snapshot. This is the **plugin half of a paired feature** (per the two-repo flow): the Anglesite-app already calls `list_content` to populate its `SiteContentGraph` and currently logs *"list_content not available (older plugin) — content graph left empty"*, so Siri's typed-entity resolution (`PageEntity`/`PostEntity`/`ImageEntity`) never fires. This tool is the unblocker.

## What it discovers

- **pages** — `src/pages/**`, Astro route derivation (`index` → `/`, dynamic `[slug]`/`[...rest]` routes skipped); `title` from frontmatter.
- **posts** — `src/content/<collection>/**` (`.md`/`.mdx`/`.mdoc`): `collection`, `slug` (glob-loader id), `title`, `draft`, `tags`; `publishDate` **normalized to full ISO-8601** (the app's `ISO8601DateFormatter` rejects date-only strings).
- **images** — `public/**` + `src/assets/**`: `relativePath` (no leading slash), `fileName`, `byteSize`, `lastModified`, best-effort `usedOnPages`.

Payload is site-agnostic — no `siteID`, no entity ids; the host stamps those (`Sources/AnglesiteCore/ContentListing.swift`). Frontmatter is parsed with a small no-dependency helper (repo ships no YAML lib).

## Tests (TDD)

`test/list-content.test.js` — 6 tests, each written failing-first:
- pages discovery + route derivation; dynamic-route skip
- posts: fields, defaults (`draft`/`tags`), `publishDate` ISO-8601 normalization
- images: metadata; best-effort `usedOnPages`
- `list_content` MCP-tool registration + return shape (in-memory client/server)

Also updated `tests/mcp-server.test.ts`'s exact tool-name set to include `list_content`.

**Verification:** all 6 new tests green; real end-to-end run against a seeded site produced correct pages + image with accurate `usedOnPages`. The 5 unrelated failing suites locally are the pre-existing `sharp`-not-installed gap (module-load errors in `optimize-images.mjs`, untouched here) — they pass in CI.

## Follow-up (app side)

Bump the app's bundled-plugin pointer once this ships in a tagged plugin release, then the app's content graph populates and `ImageEntity`/`PostEntity` resolution comes alive for the #150 smoke.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)