### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "author": {
     "name": "David W. Keith"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Anglesite is a Claude plugin that scaffolds and manages websites for small businesses. It works with Claude Cowork (non-technical site owners, GUI) and Claude Code (developers, CLI). It generates Astro + Keystatic sites deployed to Cloudflare Workers (Static Assets, via the `@astrojs/cloudflare` adapter).
 
-**Version:** 1.0.2 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
+**Version:** 1.1.0 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
 
 ## Plugin structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anglesite",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anglesite",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "scripts": {


### PR DESCRIPTION
Cuts plugin **v1.1.0** — the first release containing the content MCP tools (`list_content`, `create_page`, `create_post`) merged via #356/#140 since v1.0.2.

- Bumps `.claude-plugin/plugin.json`, `package.json`, and `package-lock.json` to `1.1.0`.
- Minor bump (semver): new, backward-compatible MCP tools.
- After merge, tagging `v1.1.0` triggers `release.yml` (verifies versions match the tag, packs the zip, creates the GitHub release with auto-generated notes).

**Why now:** the Anglesite-app bundles the plugin at build time and its `SiteContentGraph` calls `list_content`; this release is what unblocks Siri typed-entity resolution (`PageEntity`/`PostEntity`/`ImageEntity`) once the app's checkout tracks the tag. See Anglesite-app#150.

_Note: `CHANGELOG.md` is stale (last entry `1.0.0-beta.7`, missing 1.0.0–1.0.2); release notes come from `--generate-notes`, so not blocking — flagged for separate cleanup._

🤖 Generated with [Claude Code](https://claude.com/claude-code)