### PR TITLE
feat(ui): "Remove Site" action wired to SiteStore.remove(id:) (#186)

### DIFF
--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -22,8 +22,13 @@ struct SitesLauncherView: View {
     @State private var deciding = true
     @State private var showingNewSite = false
     /// The site awaiting a remove confirmation, or nil when no prompt is up. Drives the
-    /// `.confirmationDialog`; cleared on confirm or cancel.
+    /// `.confirmationDialog`; SwiftUI clears it (via the `isPresented` binding) when any dialog
+    /// button is tapped.
     @State private var siteToRemove: SiteStore.Site?
+    /// The name shown in the confirmation title. Held separately from `siteToRemove` so the title
+    /// stays stable through the dismiss animation — reading `siteToRemove?.name` directly would
+    /// collapse to "" the instant the dialog clears the optional.
+    @State private var siteToRemoveName = ""
     @State private var wizardModel: NewSiteWizardModel?
     @State private var scaffolder: SiteScaffolder?
     @State private var sitesRootScopedURL: URL?
@@ -130,18 +135,18 @@ struct SitesLauncherView: View {
                   : "Site is missing required files: \(site.missingSentinels.joined(separator: ", "))")
             .contextMenu {
                 Button("Remove from Anglesite…", systemImage: "minus.circle", role: .destructive) {
-                    siteToRemove = site
+                    promptRemove(site)
                 }
             }
             .swipeActions(edge: .trailing) {
                 Button("Remove", systemImage: "minus.circle", role: .destructive) {
-                    siteToRemove = site
+                    promptRemove(site)
                 }
             }
         }
         .listStyle(.inset)
         .confirmationDialog(
-            "Remove “\(siteToRemove?.name ?? "")” from Anglesite?",
+            "Remove “\(siteToRemoveName)” from Anglesite?",
             isPresented: Binding(
                 get: { siteToRemove != nil },
                 set: { if !$0 { siteToRemove = nil } }
@@ -150,7 +155,7 @@ struct SitesLauncherView: View {
             presenting: siteToRemove
         ) { site in
             Button("Remove from Anglesite", role: .destructive) { removeSite(site) }
-            Button("Cancel", role: .cancel) { siteToRemove = nil }
+            Button("Cancel", role: .cancel) {}
         } message: { site in
             // Removal only forgets the site here — the folder on disk is untouched, matching
             // `SiteStore.remove(id:)`. Owners can still open it in Finder, VS Code, or the CLI.
@@ -209,13 +214,24 @@ struct SitesLauncherView: View {
         dismissWindow()
     }
 
+    /// Raise the remove-confirmation dialog for `site`. `siteToRemoveName` is captured here so the
+    /// dialog title survives the dismiss animation (see the property's note).
+    private func promptRemove(_ site: SiteStore.Site) {
+        siteToRemoveName = site.name
+        siteToRemove = site
+    }
+
     /// Forget `site` from the registry without touching its files. On MAS this also drops the
     /// site's persisted security-scoped bookmark, since that lives inline in the `Site` entry.
     /// We prune the local list directly rather than re-running `refreshSites()`: a DevID rescan
     /// of `~/Sites` would immediately rediscover a still-present in-root folder, undoing the
     /// removal visually. Persistence is handled by `remove(id:)`.
+    ///
+    /// Note: an already-open `SiteWindow` for this site is *not* signalled — `SiteStore`'s change
+    /// handler is single-subscriber (the Spotlight indexer), so the window keeps running its
+    /// dev-server/MCP subprocess against a now-orphaned entry until the user closes it. Closing or
+    /// warning the open window is left as a follow-up.
     private func removeSite(_ site: SiteStore.Site) {
-        siteToRemove = nil
         Task {
             do {
                 try await SiteStore.shared.remove(id: site.id)

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -21,6 +21,9 @@ struct SitesLauncherView: View {
     @State private var loadError: String?
     @State private var deciding = true
     @State private var showingNewSite = false
+    /// The site awaiting a remove confirmation, or nil when no prompt is up. Drives the
+    /// `.confirmationDialog`; cleared on confirm or cancel.
+    @State private var siteToRemove: SiteStore.Site?
     @State private var wizardModel: NewSiteWizardModel?
     @State private var scaffolder: SiteScaffolder?
     @State private var sitesRootScopedURL: URL?
@@ -125,8 +128,34 @@ struct SitesLauncherView: View {
             .help(site.isValid
                   ? "Open \(site.name) in its own window"
                   : "Site is missing required files: \(site.missingSentinels.joined(separator: ", "))")
+            .contextMenu {
+                Button("Remove from Anglesite…", systemImage: "minus.circle", role: .destructive) {
+                    siteToRemove = site
+                }
+            }
+            .swipeActions(edge: .trailing) {
+                Button("Remove", systemImage: "minus.circle", role: .destructive) {
+                    siteToRemove = site
+                }
+            }
         }
         .listStyle(.inset)
+        .confirmationDialog(
+            "Remove “\(siteToRemove?.name ?? "")” from Anglesite?",
+            isPresented: Binding(
+                get: { siteToRemove != nil },
+                set: { if !$0 { siteToRemove = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: siteToRemove
+        ) { site in
+            Button("Remove from Anglesite", role: .destructive) { removeSite(site) }
+            Button("Cancel", role: .cancel) { siteToRemove = nil }
+        } message: { site in
+            // Removal only forgets the site here — the folder on disk is untouched, matching
+            // `SiteStore.remove(id:)`. Owners can still open it in Finder, VS Code, or the CLI.
+            Text("This removes it from Anglesite's list only. The files in \(site.path.path) are left on disk.")
+        }
     }
 
     private var emptyState: some View {
@@ -178,6 +207,23 @@ struct SitesLauncherView: View {
     private func open(site: SiteStore.Site) {
         openWindow(value: site.id)
         dismissWindow()
+    }
+
+    /// Forget `site` from the registry without touching its files. On MAS this also drops the
+    /// site's persisted security-scoped bookmark, since that lives inline in the `Site` entry.
+    /// We prune the local list directly rather than re-running `refreshSites()`: a DevID rescan
+    /// of `~/Sites` would immediately rediscover a still-present in-root folder, undoing the
+    /// removal visually. Persistence is handled by `remove(id:)`.
+    private func removeSite(_ site: SiteStore.Site) {
+        siteToRemove = nil
+        Task {
+            do {
+                try await SiteStore.shared.remove(id: site.id)
+                sites.removeAll { $0.id == site.id }
+            } catch {
+                loadError = "Couldn't remove \(site.name): \(error)"
+            }
+        }
     }
 
     private func openFolder() {

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -164,6 +164,34 @@ final class SiteStoreTests {
         #expect(fileManager.fileExists(atPath: dir.path), "files on disk must be untouched")
     }
 
+    /// The #186 case: a bookmarked entry must stay gone after removal, even across a reload +
+    /// refresh that can't rediscover it. This is the only way to drop a bookmarked site, since
+    /// `refresh()` deliberately never prunes one (#184/#185). The site lives *outside* the scanned
+    /// root so the post-remove refresh has no chance to re-add it, and removing the inline-stored
+    /// `bookmarkData` is what drops the MAS security-scoped grant.
+    @Test("Remove drops a bookmarked entry permanently across reload")
+    func removeBookmarkedSitePermanent() async throws {
+        let outside = tempDir.appendingPathComponent("external-site", isDirectory: true)
+        try fileManager.createDirectory(at: outside, withIntermediateDirectories: true)
+        for sentinel in ProjectValidator.sentinels {
+            try Data().write(to: outside.appendingPathComponent(sentinel))
+        }
+        let store = SiteStore(settings: settings, persistenceURL: persistenceURL)
+        let site = try await store.add(outside)
+        try await store.setBookmark(Data([0xAB, 0xCD]), for: site.id)
+        #expect(await store.bookmarkData(for: site.id) != nil)
+
+        try await store.remove(id: site.id)
+
+        // A fresh store proves the entry (and its bookmark) is gone from sites.json and stays gone
+        // even after a refresh that scans the root it never lived under.
+        let reloaded = SiteStore(settings: settings, persistenceURL: persistenceURL)
+        try await reloaded.load()
+        let afterRefresh = try await reloaded.refresh()
+        #expect(afterRefresh.isEmpty)
+        #expect(await reloaded.bookmarkData(for: site.id) == nil)
+    }
+
     // MARK: - Change handler (#102)
 
     /// Captures change-handler emissions so each test can assert on the post-mutation snapshot.


### PR DESCRIPTION
## Summary

Wires the existing `SiteStore.remove(id:)` to a UI action — closes #186. The store method was correct but had **zero UI consumers**, so an owner had no way to forget a site from the app's list. This became load-bearing after #184/#185 made `refresh()` deliberately never auto-prune a bookmarked entry: an explicit user action is now the only correct way to drop a stale/abandoned site.

## Changes

- **`SitesLauncherView`** — each site row gets a right-click **context menu** *and* a trailing **swipe action** ("Remove from Anglesite…"), gated behind a `.confirmationDialog`. Copy makes clear this only forgets the site: *"The files in `<path>` are left on disk."*
- **`removeSite(_:)`** — calls `remove(id:)` then prunes the local list directly rather than re-running `refreshSites()`, which on DevID would instantly rediscover a still-present in-root folder and undo the removal visually.
- **MAS bookmark drop is automatic** — per-site bookmarks live inline in `Site.bookmarkData`, so `remove(id:)` already drops the security-scoped grant; no separate store to clean up.
- **Test** — `removeBookmarkedSitePermanent` proves a bookmarked entry (the #184/#185 case `refresh()` never prunes) stays gone, with its bookmark, across a reload + refresh that can't rediscover it.

## Acceptance criteria

- [x] User can remove a site via the UI; `sites.json` no longer contains it after relaunch
- [x] Files under the site folder remain on disk
- [x] (MAS) the entry's bookmark is dropped on removal
- [x] Test coverage for the action path

## Scope notes

- Skipped the optional focused-`SiteWindow` menu command (the issue lists it as "and/or"; extra FocusedValue plumbing for no added coverage).
- Inherent, consistent with the issue: on **DevID**, removing a site whose folder still lives under `~/Sites` reappears on the next rescan — removal is durable for out-of-root and bookmarked-but-deleted sites (the target case). `refresh()` retention is left untouched per the issue's out-of-scope note.

## Testing

- `swift test --filter SiteStoreTests` → 19/19 pass
- Both `Anglesite` (DevID) and `AnglesiteMAS` schemes build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)