### PR TITLE
feat(core): on-device ApplyEditTool + SearchContentTool (#156)

### DIFF
--- a/Sources/AnglesiteCore/ApplyEditTool.swift
+++ b/Sources/AnglesiteCore/ApplyEditTool.swift
@@ -9,7 +9,7 @@ import FoundationModels
 /// on a page of the current site, routing through ``IntentEditBridge`` (and on to the plugin's
 /// edit pipeline). Reuses ``GeneratedEditCommand`` (#154) as its arguments so the model speaks one
 /// edit vocabulary.
-public struct ApplyEditTool: Tool {
+public struct ApplyEditTool: Tool, Sendable {
     public let name = "applyEdit"
     public let description = "Apply a structured text, attribute, or image edit to a specific element in a page's source file. Provide the source file path, an element selector (or a simple tag like h1), the operation kind, and the replacement value."
 
@@ -59,6 +59,9 @@ public struct ApplyEditTool: Tool {
         if let contextSelector { return contextSelector }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard Self.isBareTag(trimmed) else { return nil }
+        // Best-effort convenience only: a bare tag always resolves to the FIRST element of that tag
+        // (`nthChild: 1` is synthesized, not parsed). The model cannot target a later occurrence
+        // this way — precise targeting comes from `contextSelector` (a real overlay `ElementInfo`).
         return .object([
             "tag": .string(trimmed.lowercased()),
             "classes": .array([]),

--- a/Sources/AnglesiteCore/ApplyEditTool.swift
+++ b/Sources/AnglesiteCore/ApplyEditTool.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).
+// Same pattern as FoundationModelAssistant.swift / GenerableTypes.swift.
+#if compiler(>=6.4)
+import FoundationModels
+
+/// A FoundationModels ``Tool`` that lets the on-device model apply a structured edit to an element
+/// on a page of the current site, routing through ``IntentEditBridge`` (and on to the plugin's
+/// edit pipeline). Reuses ``GeneratedEditCommand`` (#154) as its arguments so the model speaks one
+/// edit vocabulary.
+public struct ApplyEditTool: Tool {
+    public let name = "applyEdit"
+    public let description = "Apply a structured text, attribute, or image edit to a specific element in a page's source file. Provide the source file path, an element selector (or a simple tag like h1), the operation kind, and the replacement value."
+
+    private let bridge: IntentEditBridge
+    private let siteID: String
+    /// The structured `ElementInfo` for the element the user selected in the overlay, if any —
+    /// taken from `AssistantContext.selectedElementSelector`. Preferred over a model-supplied
+    /// selector because it's a real, resolved selector rather than a guess.
+    private let contextSelector: JSONValue?
+
+    public init(bridge: IntentEditBridge, siteID: String, contextSelector: JSONValue?) {
+        self.bridge = bridge
+        self.siteID = siteID
+        self.contextSelector = contextSelector
+    }
+
+    public func call(arguments: GeneratedEditCommand) async throws -> String {
+        guard let selector = resolveSelector(arguments.selector) else {
+            return "Couldn't identify which element to edit — select one in the preview, or name a simple tag like h1."
+        }
+        let reply = await bridge.applyEdit(
+            siteID: siteID,
+            filePath: arguments.filePath,
+            selector: selector,
+            op: Self.opString(for: arguments.operation),
+            value: .string(arguments.value)
+        )
+        switch reply.status {
+        case .applied:
+            return "Applied edit to \(arguments.filePath)." + (reply.message.map { " \($0)" } ?? "")
+        case .ambiguous:
+            return "Edit not applied — the selector matched more than one element. "
+                + (reply.message.map { "\($0) " } ?? "")
+                + "Select a specific element in the preview and try again."
+        case .failed:
+            return "Edit failed: \(reply.message ?? "unknown error")."
+        }
+    }
+
+    // MARK: Selector resolution (hybrid: context first, bare-tag fallback, else nil)
+
+    /// Resolve the structured `ElementInfo` the plugin's `selector.mjs` requires.
+    /// 1. Prefer the overlay-resolved context selector.
+    /// 2. Else, if the model's selector is a bare tag (`h1`, `p`), build a minimal ElementInfo.
+    /// 3. Else, give up — we don't fabricate complex selectors.
+    private func resolveSelector(_ raw: String) -> JSONValue? {
+        if let contextSelector { return contextSelector }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isBareTag(trimmed) else { return nil }
+        return .object([
+            "tag": .string(trimmed.lowercased()),
+            "classes": .array([]),
+            "nthChild": .int(1),
+        ])
+    }
+
+    /// A bare HTML tag: letters then alphanumerics, nothing else (no combinators, classes, pseudo).
+    private static func isBareTag(_ s: String) -> Bool {
+        guard let first = s.first, first.isLetter else { return false }
+        return s.allSatisfy { $0.isLetter || $0.isNumber }
+    }
+
+    /// Map the #154 ``EditOperation`` onto the `EditMessage.Op` string vocabulary (the bridge
+    /// deferred in `GenerableTypes.swift`'s doc-comment, "TODO(#156)").
+    private static func opString(for op: EditOperation) -> String {
+        switch op {
+        case .replaceText: return EditMessage.Op.replaceText
+        case .replaceAttr: return EditMessage.Op.replaceAttr
+        case .replaceImageSrc: return EditMessage.Op.replaceImageSrc
+        case .applyInstruction: return EditMessage.Op.applyInstruction
+        }
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -29,10 +29,21 @@ public enum FoundationModelTier: Sendable, Equatable {
 /// it is the on-device path usable from the sandboxed MAS build.
 public actor FoundationModelAssistant: ContentAssistant {
     private let tier: FoundationModelTier
+    private let editBridge: IntentEditBridge?
+    private let contentGraph: SiteContentGraph?
     private let logger = Logger(subsystem: "dev.anglesite.app", category: "FoundationModelAssistant")
 
-    public init(tier: FoundationModelTier = .onDevice) {
+    /// `editBridge` + `contentGraph` are optional. When **both** are supplied, the assistant
+    /// attaches ``ApplyEditTool`` + ``SearchContentTool`` to each session (a local agentic loop)
+    /// and advertises `supportsTools`. When either is `nil`, behavior is the tool-less default.
+    public init(
+        tier: FoundationModelTier = .onDevice,
+        editBridge: IntentEditBridge? = nil,
+        contentGraph: SiteContentGraph? = nil
+    ) {
         self.tier = tier
+        self.editBridge = editBridge
+        self.contentGraph = contentGraph
         if tier == .privateCloudCompute {
             // v1 has no separate PCC session; fall back to on-device with a logged warning so the
             // requested tier degrades gracefully rather than erroring (see spec / #155).
@@ -45,7 +56,7 @@ public actor FoundationModelAssistant: ContentAssistant {
             supportsStreaming: true,
             supportsStructuredOutput: true,
             supportsVision: false,
-            supportsTools: false,
+            supportsTools: editBridge != nil && contentGraph != nil,
             maxContextTokens: tier == .privateCloudCompute ? 32_768 : 4_096,
             providerName: tier == .privateCloudCompute ? "Private Cloud Compute" : "On-Device"
         )
@@ -113,7 +124,19 @@ public actor FoundationModelAssistant: ContentAssistant {
         @unknown default:
             throw AssistantError.unavailable("The on-device model is unavailable on this device.")
         }
-        return LanguageModelSession(instructions: Self.instructions(for: context))
+        let instructions = Self.instructions(for: context)
+        if let editBridge, let contentGraph {
+            let tools: [any Tool] = [
+                ApplyEditTool(
+                    bridge: editBridge,
+                    siteID: context.siteID,
+                    contextSelector: context.selectedElementSelector
+                ),
+                SearchContentTool(contentGraph: contentGraph, siteID: context.siteID),
+            ]
+            return LanguageModelSession(tools: tools, instructions: instructions)
+        }
+        return LanguageModelSession(instructions: instructions)
     }
 
     /// Folds the situational ``AssistantContext`` into session instructions.

--- a/Sources/AnglesiteCore/SearchContentTool.swift
+++ b/Sources/AnglesiteCore/SearchContentTool.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).
+#if compiler(>=6.4)
+import FoundationModels
+
+/// A FoundationModels ``Tool`` that lets the on-device model search the current site's pages and
+/// posts (by title, route, slug, collection, or tag) via ``SiteContentGraph`` — local RAG with no
+/// network call.
+public struct SearchContentTool: Tool {
+    public let name = "searchContent"
+    public let description = "Search the current site's pages and posts by title, route, slug, tag, or collection."
+
+    @Generable
+    public struct Arguments {
+        @Guide(description: "What to search for — words from a page title, route, post slug, or tag.")
+        public var query: String
+    }
+
+    /// Largest site without flooding the small on-device context window. Truncation is surfaced
+    /// in the output trailer (never silent).
+    private static let resultCap = 20
+
+    private let contentGraph: SiteContentGraph
+    private let siteID: String
+
+    public init(contentGraph: SiteContentGraph, siteID: String) {
+        self.contentGraph = contentGraph
+        self.siteID = siteID
+    }
+
+    public func call(arguments: Arguments) async throws -> String {
+        let query = arguments.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            return "Provide a search term — a word from a page title, route, post slug, or tag."
+        }
+        let pages = await contentGraph.searchPages(siteID: siteID, matching: query).sorted { $0.route < $1.route }
+        let posts = await contentGraph.searchPosts(siteID: siteID, matching: query).sorted { $0.slug < $1.slug }
+
+        var lines: [String] = []
+        for page in pages {
+            lines.append("PAGE  \(page.route)  (\(page.filePath))")
+        }
+        for post in posts {
+            let draft = post.draft ? " [draft]" : ""
+            lines.append("POST  \(post.slug)\(draft)  (\(post.filePath))")
+        }
+
+        if lines.isEmpty { return "No matching pages or posts." }
+        if lines.count > Self.resultCap {
+            let shown = lines.prefix(Self.resultCap).joined(separator: "\n")
+            return shown + "\n… +\(lines.count - Self.resultCap) more (refine your query to narrow results)."
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/SearchContentTool.swift
+++ b/Sources/AnglesiteCore/SearchContentTool.swift
@@ -13,7 +13,7 @@ public struct SearchContentTool: Tool {
 
     @Generable
     public struct Arguments {
-        @Guide(description: "What to search for — words from a page title, route, post slug, or tag.")
+        @Guide(description: "What to search for — words from a page title, route, post slug, tag, or collection.")
         public var query: String
     }
 

--- a/Sources/AnglesiteCore/SearchContentTool.swift
+++ b/Sources/AnglesiteCore/SearchContentTool.swift
@@ -7,7 +7,7 @@ import FoundationModels
 /// A FoundationModels ``Tool`` that lets the on-device model search the current site's pages and
 /// posts (by title, route, slug, collection, or tag) via ``SiteContentGraph`` — local RAG with no
 /// network call.
-public struct SearchContentTool: Tool {
+public struct SearchContentTool: Tool, Sendable {
     public let name = "searchContent"
     public let description = "Search the current site's pages and posts by title, route, slug, tag, or collection."
 
@@ -37,21 +37,41 @@ public struct SearchContentTool: Tool {
         let pages = await contentGraph.searchPages(siteID: siteID, matching: query).sorted { $0.route < $1.route }
         let posts = await contentGraph.searchPosts(siteID: siteID, matching: query).sorted { $0.slug < $1.slug }
 
-        var lines: [String] = []
-        for page in pages {
-            lines.append("PAGE  \(page.route)  (\(page.filePath))")
-        }
-        for post in posts {
+        let pageLines = pages.map { "PAGE  \($0.route)  (\($0.filePath))" }
+        let postLines = posts.map { post -> String in
             let draft = post.draft ? " [draft]" : ""
-            lines.append("POST  \(post.slug)\(draft)  (\(post.filePath))")
+            return "POST  \(post.slug)\(draft)  (\(post.filePath))"
         }
 
-        if lines.isEmpty { return "No matching pages or posts." }
-        if lines.count > Self.resultCap {
-            let shown = lines.prefix(Self.resultCap).joined(separator: "\n")
-            return shown + "\n… +\(lines.count - Self.resultCap) more (refine your query to narrow results)."
+        if pageLines.isEmpty && postLines.isEmpty { return "No matching pages or posts." }
+
+        // Budget the combined cap across both categories so a flood of one can't crowd the other
+        // out of the results entirely (a model that only sees pages can't learn there were posts).
+        let (pageTake, postTake) = Self.fairBudget(pages: pageLines.count, posts: postLines.count)
+        var out = (pageLines.prefix(pageTake) + postLines.prefix(postTake)).joined(separator: "\n")
+
+        // Surface truncation per-category so the model knows what kind of result it's missing.
+        let hiddenPages = pageLines.count - pageTake
+        let hiddenPosts = postLines.count - postTake
+        var hidden: [String] = []
+        if hiddenPages > 0 { hidden.append("+\(hiddenPages) more page\(hiddenPages == 1 ? "" : "s")") }
+        if hiddenPosts > 0 { hidden.append("+\(hiddenPosts) more post\(hiddenPosts == 1 ? "" : "s")") }
+        if !hidden.isEmpty {
+            out += "\n… " + hidden.joined(separator: ", ") + " — refine your query to narrow results."
         }
-        return lines.joined(separator: "\n")
+        return out
+    }
+
+    /// Split ``resultCap`` between pages and posts so a flood of one category can't hide the other.
+    /// Each category is guaranteed up to half the budget; whatever half a smaller category leaves
+    /// unused is lent to the larger one. Returns how many of each to show.
+    static func fairBudget(pages: Int, posts: Int) -> (pages: Int, posts: Int) {
+        let cap = resultCap
+        guard pages + posts > cap else { return (pages, posts) }
+        let postFloor = min(posts, cap / 2)
+        let pageTake = min(pages, cap - postFloor)
+        let postTake = min(posts, cap - pageTake)
+        return (pageTake, postTake)
     }
 }
 #endif

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -176,4 +176,27 @@ struct SearchContentToolTests {
         #expect(out == "No matching pages or posts.")
     }
 }
+
+@Suite("FoundationModelAssistant tool wiring")
+struct FoundationModelAssistantToolWiringTests {
+
+    @Test("supportsTools is true only when both dependencies are injected")
+    func capabilitiesReflectDeps() async {
+        let router = FakeEditRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let bridge = makeBridge(router)
+        let graph = SiteContentGraph()
+
+        let withTools = FoundationModelAssistant(tier: .onDevice, editBridge: bridge, contentGraph: graph)
+        #expect(withTools.capabilities.supportsTools == true)
+
+        let withoutTools = FoundationModelAssistant(tier: .onDevice)
+        #expect(withoutTools.capabilities.supportsTools == false)
+
+        let partial = FoundationModelAssistant(tier: .onDevice, editBridge: bridge, contentGraph: nil)
+        #expect(partial.capabilities.supportsTools == false)
+
+        let partialGraph = FoundationModelAssistant(tier: .onDevice, editBridge: nil, contentGraph: graph)
+        #expect(partialGraph.capabilities.supportsTools == false)
+    }
+}
 #endif

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -1,0 +1,125 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Gated like the types under test — FoundationModels is unavailable at runtime on CI (#128).
+// These tests need no live model: the tools' `call(...)` is pure mapping/routing/query logic.
+#if compiler(>=6.4)
+import FoundationModels
+
+/// Records the EditMessage it receives and returns a canned reply.
+private actor FakeEditRouter: EditRouter {
+    private(set) var received: EditMessage?
+    private let reply: EditReply
+    init(reply: EditReply) { self.reply = reply }
+    func apply(_ message: EditMessage) async -> EditReply {
+        received = message
+        return reply
+    }
+}
+
+private func makeBridge(_ router: FakeEditRouter) -> IntentEditBridge {
+    IntentEditBridge(routerProvider: { _ in router }, makeID: { "test-id" })
+}
+
+@Suite("On-device tools: ApplyEditTool")
+struct ApplyEditToolTests {
+
+    @Test("context selector is used verbatim; operation maps to the op string; value is wrapped")
+    func usesContextSelectorAndMapsOp() async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: "ok"))
+        let element: JSONValue = .object([
+            "tag": .string("h1"), "classes": .array([]), "nthChild": .int(1),
+        ])
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: element)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/about.md",
+            selector: "ignored-by-tool",
+            operation: .replaceText,
+            value: "New Title",
+            explanation: "rename heading"
+        )
+
+        let out = try await tool.call(arguments: cmd)
+
+        let msg = await router.received
+        #expect(msg?.op == "replace-text")
+        #expect(msg?.selector == element)
+        #expect(msg?.value == .string("New Title"))
+        #expect(msg?.path == "src/pages/about.md")
+        #expect(out.contains("Applied"))
+    }
+
+    @Test("no context selector + bare-tag selector builds a minimal ElementInfo")
+    func bareTagBuildsMinimalElementInfo() async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: nil))
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: nil)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/index.md",
+            selector: "H1",
+            operation: .replaceAttr,
+            value: "hello",
+            explanation: "x"
+        )
+
+        _ = try await tool.call(arguments: cmd)
+
+        let msg = await router.received
+        #expect(msg?.selector == .object([
+            "tag": .string("h1"), "classes": .array([]), "nthChild": .int(1),
+        ]))
+        #expect(msg?.op == "replace-attr")
+    }
+
+    @Test("no context selector + complex selector fails gracefully without calling the bridge")
+    func complexSelectorFailsGracefully() async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: "ok"))
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: nil)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/index.md",
+            selector: "p:nth-of-type(2)",
+            operation: .replaceText,
+            value: "x",
+            explanation: "x"
+        )
+
+        let out = try await tool.call(arguments: cmd)
+
+        #expect(await router.received == nil)
+        #expect(out.contains("Couldn't identify"))
+    }
+
+    @Test("a failed reply surfaces its message in the tool output")
+    func failedReplySurfacesMessage() async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .failed, message: "no router for this site"))
+        let element: JSONValue = .object(["tag": .string("h1"), "classes": .array([]), "nthChild": .int(1)])
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: element)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/about.md", selector: "h1",
+            operation: .applyInstruction, value: "make it punchier", explanation: "x"
+        )
+
+        let out = try await tool.call(arguments: cmd)
+
+        #expect(out.contains("failed"))
+        #expect(out.contains("no router for this site"))
+    }
+
+    @Test("an ambiguous reply returns a distinct, recoverable message")
+    func ambiguousReplyIsDistinct() async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .ambiguous, message: "3 elements matched."))
+        let element: JSONValue = .object(["tag": .string("p"), "classes": .array([]), "nthChild": .int(1)])
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: element)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/about.md", selector: "p",
+            operation: .replaceText, value: "x", explanation: "x"
+        )
+
+        let out = try await tool.call(arguments: cmd)
+
+        #expect(out.contains("more than one element"))
+        #expect(out.contains("3 elements matched."))
+        #expect(!out.contains("Edit failed"))
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -122,4 +122,58 @@ struct ApplyEditToolTests {
         #expect(!out.contains("Edit failed"))
     }
 }
+
+@Suite("On-device tools: SearchContentTool")
+struct SearchContentToolTests {
+
+    private func makeGraph() async -> SiteContentGraph {
+        let graph = SiteContentGraph()
+        await graph.upsertPage(.init(
+            id: "site1:page:/about", siteID: "site1", route: "/about",
+            filePath: "src/pages/about.md", title: "About Us",
+            lastModified: Date(timeIntervalSince1970: 0)
+        ))
+        await graph.upsertPost(.init(
+            id: "site1:post:hello", siteID: "site1", collection: "posts", slug: "hello-world",
+            title: "Hello World", draft: true, publishDate: nil, tags: ["intro"],
+            filePath: "src/posts/hello.md", lastModified: Date(timeIntervalSince1970: 0)
+        ))
+        return graph
+    }
+
+    @Test("finds a page by title and formats it")
+    func findsPageByTitle() async throws {
+        let tool = SearchContentTool(contentGraph: await makeGraph(), siteID: "site1")
+        let out = try await tool.call(arguments: .init(query: "about"))
+        #expect(out.contains("PAGE"))
+        #expect(out.contains("/about"))
+        #expect(out.contains("src/pages/about.md"))
+    }
+
+    @Test("marks a draft post and includes its file path")
+    func findsDraftPost() async throws {
+        let tool = SearchContentTool(contentGraph: await makeGraph(), siteID: "site1")
+        let out = try await tool.call(arguments: .init(query: "hello"))
+        #expect(out.contains("POST"))
+        #expect(out.contains("hello-world"))
+        #expect(out.contains("[draft]"))
+        #expect(out.contains("src/posts/hello.md"))
+    }
+
+    @Test("an empty query is rejected without dumping all content")
+    func emptyQueryIsRejected() async throws {
+        let tool = SearchContentTool(contentGraph: await makeGraph(), siteID: "site1")
+        let out = try await tool.call(arguments: .init(query: "   "))
+        #expect(out == "Provide a search term — a word from a page title, route, post slug, or tag.")
+        #expect(!out.contains("PAGE"))
+        #expect(!out.contains("POST"))
+    }
+
+    @Test("no matches returns an explicit message, not an empty string")
+    func noMatchesIsExplicit() async throws {
+        let tool = SearchContentTool(contentGraph: await makeGraph(), siteID: "site1")
+        let out = try await tool.call(arguments: .init(query: "zzz-no-such-thing"))
+        #expect(out == "No matching pages or posts.")
+    }
+}
 #endif

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -175,6 +175,38 @@ struct SearchContentToolTests {
         let out = try await tool.call(arguments: .init(query: "zzz-no-such-thing"))
         #expect(out == "No matching pages or posts.")
     }
+
+    @Test("a flood of pages does not silently exclude posts; truncation is reported per category")
+    func truncationIsFairAndReportedPerCategory() async throws {
+        let graph = SiteContentGraph()
+        // 20 matching pages + 3 matching posts = 23 > the 20-result cap.
+        for i in 0..<20 {
+            let n = String(format: "%02d", i)
+            await graph.upsertPage(.init(
+                id: "site1:page:/p\(n)", siteID: "site1", route: "/p\(n)",
+                filePath: "src/pages/p\(n).md", title: "Page \(n)",
+                lastModified: Date(timeIntervalSince1970: 0)
+            ))
+        }
+        for i in 0..<3 {
+            await graph.upsertPost(.init(
+                id: "site1:post:post\(i)", siteID: "site1", collection: "posts", slug: "post-\(i)",
+                title: "Post \(i)", draft: false, publishDate: nil, tags: [],
+                filePath: "src/posts/post\(i).md", lastModified: Date(timeIntervalSince1970: 0)
+            ))
+        }
+        let tool = SearchContentTool(contentGraph: graph, siteID: "site1")
+        // "p" matches every page route (/pNN) and every post slug (post-N).
+        let out = try await tool.call(arguments: .init(query: "p"))
+
+        // The bug being fixed: posts must NOT be crowded out by the 20 pages.
+        let postCount = out.split(separator: "\n").filter { $0.hasPrefix("POST") }.count
+        #expect(postCount == 3)
+        // 17 pages shown, 3 hidden; all 3 posts shown, 0 hidden — reported per category.
+        #expect(out.contains("+3 more pages"))
+        #expect(!out.contains("more post"))
+        #expect(out.contains("refine your query to narrow results."))
+    }
 }
 
 @Suite("FoundationModelAssistant tool wiring")

--- a/docs/specs/2026-06-13-on-device-tools-design.md
+++ b/docs/specs/2026-06-13-on-device-tools-design.md
@@ -1,0 +1,194 @@
+# Design: On-device tools — `ApplyEditTool` + `SearchContentTool` (#156, C.6)
+
+**Date:** 2026-06-13
+**Issue:** #156 — On-device tools: `ApplyEditTool` + `SearchContentTool`
+**Parent:** #134 (Siri AI Phase C — Foundation Models for on-device intelligence)
+**Depends on:** #155 (`FoundationModelAssistant`), #154 (`@Generable` types), `SiteContentGraph` (A.1), `IntentEditBridge` (A.4)
+
+## Goal
+
+Give the on-device Foundation Models session two `Tool` conformances so the ~3B model can,
+without any network call, **search the current site's content** and **apply structured edits**
+back into the app's edit pipeline. Together they form a local agentic loop: the model can look up
+a page, then edit it, inside a single `LanguageModelSession`.
+
+## Scope decision
+
+Full integration (not tool-types-only): the two tools are delivered **and** wired into
+`FoundationModelAssistant`, flipping `supportsTools` to `true` when the tool dependencies are
+present. The existing one-shot `ContentAssistant` API (`generate` / `generateStructured`) is
+**not** changed — Foundation Models runs the tool-call loop internally during
+`streamResponse`/`respond`, so attaching tools to the session is the only wiring required.
+
+## Architecture
+
+Two new files in `Sources/AnglesiteCore/`, both gated behind `#if compiler(>=6.4)` (the same
+toolchain guard used by `FoundationModelAssistant.swift` / `GenerableTypes.swift` / `ContentAssistant.swift`
+— `FoundationModels` is absent from CI's `macos-15` runner at runtime, #128):
+
+- `ApplyEditTool.swift`
+- `SearchContentTool.swift`
+
+### Dependency injection into `FoundationModelAssistant`
+
+```swift
+public init(
+    tier: FoundationModelTier = .onDevice,
+    editBridge: IntentEditBridge? = nil,
+    contentGraph: SiteContentGraph? = nil
+)
+```
+
+- Both deps are **optional**. When absent, behavior is exactly today's tool-less session.
+- `capabilities.supportsTools` is computed: `editBridge != nil && contentGraph != nil`
+  (honest per-instance — `capabilities` stays a `nonisolated var` reading stored `let`s).
+- `makeSession(context:)` constructs the tools **per call**, capturing `context.siteID` and
+  `context.selectedElementSelector`, and only passes `tools:` when both deps exist:
+
+  ```swift
+  private func makeSession(context: AssistantContext) throws -> LanguageModelSession {
+      // ... availability check unchanged ...
+      let instructions = Self.instructions(for: context)
+      if let editBridge, let contentGraph {
+          let tools: [any Tool] = [
+              ApplyEditTool(bridge: editBridge, siteID: context.siteID,
+                            contextSelector: context.selectedElementSelector),
+              SearchContentTool(contentGraph: contentGraph, siteID: context.siteID),
+          ]
+          return LanguageModelSession(tools: tools, instructions: instructions)
+      }
+      return LanguageModelSession(instructions: instructions)
+  }
+  ```
+
+Apple's built-in `.spotlight` tool (shown in the issue's snippet) is **deferred to C.8 / #158**
+(Local RAG: Spotlight search wiring); this task ships only the two app-owned tools.
+
+## `ApplyEditTool`
+
+```swift
+struct ApplyEditTool: Tool {
+    let name = "applyEdit"
+    let description = "Apply a structured edit to an element on a page of the current site."
+    typealias Arguments = GeneratedEditCommand   // reuse the #154 @Generable vocabulary
+
+    let bridge: IntentEditBridge
+    let siteID: String
+    let contextSelector: JSONValue?              // captured from AssistantContext per session
+
+    func call(arguments: GeneratedEditCommand) async throws -> ToolOutput
+}
+```
+
+Reusing the existing `GeneratedEditCommand` (#154) as `Arguments` keeps a single edit vocabulary
+(`filePath` / `selector` / `operation` / `value` / `explanation`) with no duplication.
+
+`call(...)` performs three mappings, then routes through the bridge:
+
+1. **Operation → op string.** `EditOperation` case → `EditMessage.Op` constant:
+   - `.replaceText`      → `EditMessage.Op.replaceText`      (`"replace-text"`)
+   - `.replaceAttr`      → `EditMessage.Op.replaceAttr`      (`"replace-attr"`)
+   - `.replaceImageSrc`  → `EditMessage.Op.replaceImageSrc`  (`"replace-image-src"`)
+   - `.applyInstruction` → `EditMessage.Op.applyInstruction` (`"apply-instruction"`)
+
+   This is the case→string bridge the #154 `EditOperation` doc-comment explicitly deferred to #156.
+
+2. **Selector resolution (hybrid).** The plugin's `server/selector.mjs.buildSelector(info)` requires
+   a structured `ElementInfo` object (`{tag, classes, nthChild, dataAnglesiteId?, ...}`); there is no
+   raw-CSS passthrough. So:
+   - `contextSelector` present → use it verbatim (the real overlay `ElementInfo`).
+   - else if `arguments.selector` is a **bare tag** (matches `^[A-Za-z][A-Za-z0-9]*$`) → build a
+     minimal `ElementInfo`: `{"tag": <lowercased>, "classes": [], "nthChild": 1}`
+     (mirrors `selectorPart`'s `tag:nth-child(n)` fallback).
+   - else → return a **failure `ToolOutput`** ("Couldn't identify which element to edit — select one
+     in the preview, or name a simple tag like `h1`."). No fabricated complex selectors; the bridge
+     is **not** called.
+
+3. **Value.** Wrap `arguments.value` (a `String`) as `JSONValue.string(...)` for `EditMessage.value`.
+   For `.applyInstruction`, the value is the natural-language instruction.
+
+Then `await bridge.applyEdit(siteID:filePath:selector:op:value:)` and translate the returned
+`EditReply` (`.applied` / `.failed` + `message`) into the `ToolOutput` the model reads back. The
+bridge already returns a `.failed` reply with an explanatory message when no router is available
+for the site; that message is surfaced verbatim.
+
+## `SearchContentTool`
+
+```swift
+struct SearchContentTool: Tool {
+    let name = "searchContent"
+    let description = "Search the current site's pages and posts by title, route, slug, or tag."
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "What to search for — words from a page title, route, post slug, or tag.")
+        var query: String
+    }
+
+    let contentGraph: SiteContentGraph
+    let siteID: String
+
+    func call(arguments: Arguments) async throws -> ToolOutput
+}
+```
+
+`call(...)`:
+1. `await contentGraph.searchPages(siteID:matching: arguments.query)`
+2. `await contentGraph.searchPosts(siteID:matching: arguments.query)`
+3. Format a compact, model-readable text block, e.g.:
+   ```
+   PAGE  /about            (src/pages/about.md)
+   POST  my-first-post [draft]  (src/posts/my-first-post.md)
+   ```
+4. **Empty results → an explicit "No matching pages or posts." line**, never an empty string.
+5. **Cap at 20 results** (pages + posts combined) with a `+N more` trailer when truncated, so a
+   large site can't blow the small on-device context window. The cap is documented in the output
+   trailer (not a silent truncation).
+
+## Error handling
+
+- Tool `call` returns a **descriptive `ToolOutput`** on failure rather than throwing — the model
+  should be able to recover within the loop (re-search, change approach, or report to the user). A
+  thrown error would abort the whole generation.
+- The only thrown path remains genuine session setup failure (`AssistantError.unavailable`),
+  already handled in `makeSession`.
+
+## Testing (~6, `AnglesiteCoreTests`)
+
+Use the **real** `SiteContentGraph` actor (preloaded via `upsertPage` / `upsertPost`) and the
+**real** `IntentEditBridge` wired to a **fake `EditRouter`** that returns canned `EditReply`s and
+records the `EditMessage` it received.
+
+1. `SearchContentTool` finds a page by title and formats it.
+2. `SearchContentTool` no-match / empty query → "No matching pages or posts." output.
+3. `ApplyEditTool` **with** context selector → routes using that `ElementInfo`; assert the fake
+   router received the correctly mapped op string (e.g. `"replace-text"`) and `.string` value.
+4. `ApplyEditTool` **no** context, bare-tag selector → builds the minimal `ElementInfo`
+   (`{tag, classes:[], nthChild:1}`); assert the routed selector.
+5. `ApplyEditTool` **no** context, complex selector (`"p:nth-of-type(2)"`) → graceful failure
+   `ToolOutput`; assert the router was **never** called.
+6. `ApplyEditTool` router returns `.failed` → the failure message is surfaced in the `ToolOutput`.
+
+Optionally (capability assertion, may fold into an existing suite): `FoundationModelAssistant`
+constructed **with** both deps reports `capabilities.supportsTools == true`; **without** them,
+`false`.
+
+## Verify-against-SDK note
+
+The exact `FoundationModels.Tool` surface — `ToolOutput`'s initializer, whether `name`/`description`
+are stored `let`s vs. computed, and the `includesSchemaInInstructions` requirement — will be
+confirmed against the installed SDK during implementation rather than trusted from memory. The
+shapes above are the design intent and may need minor signature tweaks to compile.
+
+## Branch / coordination
+
+This is **single-repo** — no plugin change is required, because `ApplyEditTool` adapts to the
+plugin's existing `ElementInfo` selector schema rather than extending it. #156 stacks on the
+#154/#155 work (C.4/C.5); land those first (or branch #156 off them).
+
+## Out of scope (explicitly)
+
+- Apple's `.spotlight` built-in tool → C.8 / #158.
+- Vision / alt-text generation → C.7 / #157.
+- Surfacing tools in the chat UI / MAS chat pane → C.9 / #159.
+- A model-tier picker in Settings → C.10 / #160.

--- a/docs/specs/2026-06-13-on-device-tools-design.md
+++ b/docs/specs/2026-06-13-on-device-tools-design.md
@@ -173,12 +173,15 @@ Optionally (capability assertion, may fold into an existing suite): `FoundationM
 constructed **with** both deps reports `capabilities.supportsTools == true`; **without** them,
 `false`.
 
-## Verify-against-SDK note
+## Verify-against-SDK note (resolved)
 
-The exact `FoundationModels.Tool` surface — `ToolOutput`'s initializer, whether `name`/`description`
-are stored `let`s vs. computed, and the `includesSchemaInInstructions` requirement — will be
-confirmed against the installed SDK during implementation rather than trusted from memory. The
-shapes above are the design intent and may need minor signature tweaks to compile.
+Confirmed against the macOS 26 SDK during implementation:
+- `Tool.call(arguments:) async throws -> Output` where `Output: PromptRepresentable`; `String`
+  conforms, so both tools return `String`.
+- `Tool` requires only `name`, `description`, `call`; `parameters` is defaulted for
+  `Arguments: Generable`.
+- `LanguageModelSession(model:tools:instructions:)` accepts `instructions: String?`, so
+  `LanguageModelSession(tools:instructions:)` compiles.
 
 ## Branch / coordination
 

--- a/docs/specs/2026-06-13-on-device-tools-design.md
+++ b/docs/specs/2026-06-13-on-device-tools-design.md
@@ -76,7 +76,7 @@ struct ApplyEditTool: Tool {
     let siteID: String
     let contextSelector: JSONValue?              // captured from AssistantContext per session
 
-    func call(arguments: GeneratedEditCommand) async throws -> ToolOutput
+    func call(arguments: GeneratedEditCommand) async throws -> String
 }
 ```
 
@@ -100,7 +100,7 @@ Reusing the existing `GeneratedEditCommand` (#154) as `Arguments` keeps a single
    - else if `arguments.selector` is a **bare tag** (matches `^[A-Za-z][A-Za-z0-9]*$`) → build a
      minimal `ElementInfo`: `{"tag": <lowercased>, "classes": [], "nthChild": 1}`
      (mirrors `selectorPart`'s `tag:nth-child(n)` fallback).
-   - else → return a **failure `ToolOutput`** ("Couldn't identify which element to edit — select one
+   - else → return a **descriptive failure `String`** ("Couldn't identify which element to edit — select one
      in the preview, or name a simple tag like `h1`."). No fabricated complex selectors; the bridge
      is **not** called.
 
@@ -108,7 +108,7 @@ Reusing the existing `GeneratedEditCommand` (#154) as `Arguments` keeps a single
    For `.applyInstruction`, the value is the natural-language instruction.
 
 Then `await bridge.applyEdit(siteID:filePath:selector:op:value:)` and translate the returned
-`EditReply` (`.applied` / `.failed` + `message`) into the `ToolOutput` the model reads back. The
+`EditReply` (`.applied` / `.ambiguous` / `.failed` + `message`) into the `String` the model reads back. The
 bridge already returns a `.failed` reply with an explanatory message when no router is available
 for the site; that message is surfaced verbatim.
 
@@ -117,18 +117,18 @@ for the site; that message is surfaced verbatim.
 ```swift
 struct SearchContentTool: Tool {
     let name = "searchContent"
-    let description = "Search the current site's pages and posts by title, route, slug, or tag."
+    let description = "Search the current site's pages and posts by title, route, slug, tag, or collection."
 
     @Generable
     struct Arguments {
-        @Guide(description: "What to search for — words from a page title, route, post slug, or tag.")
+        @Guide(description: "What to search for — words from a page title, route, post slug, tag, or collection.")
         var query: String
     }
 
     let contentGraph: SiteContentGraph
     let siteID: String
 
-    func call(arguments: Arguments) async throws -> ToolOutput
+    func call(arguments: Arguments) async throws -> String
 }
 ```
 
@@ -147,7 +147,7 @@ struct SearchContentTool: Tool {
 
 ## Error handling
 
-- Tool `call` returns a **descriptive `ToolOutput`** on failure rather than throwing — the model
+- Tool `call` returns a **descriptive `String`** on failure rather than throwing — the model
   should be able to recover within the loop (re-search, change approach, or report to the user). A
   thrown error would abort the whole generation.
 - The only thrown path remains genuine session setup failure (`AssistantError.unavailable`),
@@ -166,8 +166,8 @@ records the `EditMessage` it received.
 4. `ApplyEditTool` **no** context, bare-tag selector → builds the minimal `ElementInfo`
    (`{tag, classes:[], nthChild:1}`); assert the routed selector.
 5. `ApplyEditTool` **no** context, complex selector (`"p:nth-of-type(2)"`) → graceful failure
-   `ToolOutput`; assert the router was **never** called.
-6. `ApplyEditTool` router returns `.failed` → the failure message is surfaced in the `ToolOutput`.
+   `String`; assert the router was **never** called.
+6. `ApplyEditTool` router returns `.failed` → the failure message is surfaced in the returned `String`.
 
 Optionally (capability assertion, may fold into an existing suite): `FoundationModelAssistant`
 constructed **with** both deps reports `capabilities.supportsTools == true`; **without** them,

--- a/docs/specs/2026-06-13-on-device-tools-plan.md
+++ b/docs/specs/2026-06-13-on-device-tools-plan.md
@@ -1,5 +1,12 @@
 # On-device Tools (`ApplyEditTool` + `SearchContentTool`) Implementation Plan
 
+> ⚠️ **Historical plan — superseded by the shipped code.** The implementation evolved during review:
+> the tools return `String` (not `ToolOutput`), `.ambiguous` gets its own message (so the Task 1
+> Step 3 snippet's `case .failed, .ambiguous` is stale and would fail the tests), and
+> `SearchContentTool` added an empty-query guard, deterministic sorting, and fair per-category cap
+> budgeting. **Follow the committed sources in `Sources/AnglesiteCore/` as authoritative**, not the
+> snippets below.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add two `FoundationModels.Tool` conformances (`ApplyEditTool`, `SearchContentTool`) and wire them into `FoundationModelAssistant`, so the on-device model can search site content and apply structured edits in a local agentic loop with no network calls (#156, C.6).

--- a/docs/specs/2026-06-13-on-device-tools-plan.md
+++ b/docs/specs/2026-06-13-on-device-tools-plan.md
@@ -1,0 +1,599 @@
+# On-device Tools (`ApplyEditTool` + `SearchContentTool`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two `FoundationModels.Tool` conformances (`ApplyEditTool`, `SearchContentTool`) and wire them into `FoundationModelAssistant`, so the on-device model can search site content and apply structured edits in a local agentic loop with no network calls (#156, C.6).
+
+**Architecture:** Two new struct tools in `AnglesiteCore`, gated behind `#if compiler(>=6.4)` (the toolchain guard already used by `FoundationModelAssistant`/`GenerableTypes` — FoundationModels is absent on CI's runtime, #128). `FoundationModelAssistant` gains optional `IntentEditBridge` + `SiteContentGraph` dependencies; when both are present, `makeSession` attaches the tools and `capabilities.supportsTools` flips to `true`. The one-shot `generate`/`generateStructured` API is untouched — Foundation Models drives the tool loop internally.
+
+**Tech Stack:** Swift 6.4 / Xcode 27, `FoundationModels`, Swift Testing (`@Test`/`@Suite`), SwiftPM (`swift test`).
+
+**Spec:** `docs/specs/2026-06-13-on-device-tools-design.md`
+
+---
+
+## Prerequisites
+
+- Branch `feat/156-on-device-tools` already exists (based on merged `main` containing #154/#155).
+- `swift test` needs the Xcode-27 toolchain. Per project memory, prefix with:
+  `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer`
+- The tool `call(...)` methods are pure mapping/routing/query logic — **all tests run without a live model** (no `LanguageModelSession` needed), so they execute on the dev machine wherever `#if compiler(>=6.4)` is satisfied.
+
+## Confirmed API facts (verified against the installed SDK)
+
+- `protocol Tool` requires `name`, `description`, and `func call(arguments:) async throws -> Output`. `parameters` is **defaulted** when `Arguments: Generable`; `name`/`includesSchemaInInstructions` have defaults too. Only provide `name`, `description`, `call`.
+- `Output: PromptRepresentable`; **`String` conforms**, so `call` returns `String`.
+- `LanguageModelSession(model: .default, tools: [any Tool] = [], instructions: String? = nil)` exists — `LanguageModelSession(tools: tools, instructions: instructions)` compiles.
+- `@Generable` synthesizes a memberwise init; reachable from tests via `@testable import AnglesiteCore`.
+- `EditMessage.Op` constants: `.replaceText` (`"replace-text"`), `.replaceAttr` (`"replace-attr"`), `.replaceImageSrc` (`"replace-image-src"`), `.applyInstruction` (`"apply-instruction"`).
+- `IntentEditBridge.applyEdit(siteID:filePath:selector:op:value:) async -> EditReply`; `EditReply.status` is `.applied | .failed | .ambiguous`, plus `message: String?`.
+- `JSONValue` cases: `.null`, `.bool`, `.int`, `.double`, `.string`, `.array([JSONValue])`, `.object([String: JSONValue])`.
+
+## File Structure
+
+- **Create** `Sources/AnglesiteCore/ApplyEditTool.swift` — `ApplyEditTool` struct: `EditOperation→Op` mapping, hybrid selector resolution, routes via `IntentEditBridge`. Gated `#if compiler(>=6.4)`.
+- **Create** `Sources/AnglesiteCore/SearchContentTool.swift` — `SearchContentTool` struct: queries `SiteContentGraph`, formats capped text. Gated `#if compiler(>=6.4)`.
+- **Modify** `Sources/AnglesiteCore/FoundationModelAssistant.swift` — optional deps in `init`, `capabilities.supportsTools`, tool attachment in `makeSession`.
+- **Create** `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift` — fake `EditRouter`, real `SiteContentGraph`, ~7 tests. Gated `#if compiler(>=6.4)`.
+
+---
+
+## Task 1: `ApplyEditTool` — op mapping + hybrid selector + routing
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ApplyEditTool.swift`
+- Test: `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift`
+
+- [ ] **Step 1: Write the failing tests (and the shared fake) for `ApplyEditTool`**
+
+Create `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Gated like the types under test — FoundationModels is unavailable at runtime on CI (#128).
+// These tests need no live model: the tools' `call(...)` is pure mapping/routing/query logic.
+#if compiler(>=6.4)
+import FoundationModels
+
+/// Records the EditMessage it receives and returns a canned reply.
+actor FakeEditRouter: EditRouter {
+    private(set) var received: EditMessage?
+    private let reply: EditReply
+    init(reply: EditReply) { self.reply = reply }
+    func apply(_ message: EditMessage) async -> EditReply {
+        received = message
+        return reply
+    }
+}
+
+private func makeBridge(_ router: FakeEditRouter) -> IntentEditBridge {
+    IntentEditBridge(routerProvider: { _ in router }, makeID: { "test-id" })
+}
+
+@Suite("On-device tools: ApplyEditTool")
+struct ApplyEditToolTests {
+
+    @Test("context selector is used verbatim; operation maps to the op string; value is wrapped")
+    func usesContextSelectorAndMapsOp() async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: "ok"))
+        let element: JSONValue = .object([
+            "tag": .string("h1"), "classes": .array([]), "nthChild": .int(1),
+        ])
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: element)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/about.md",
+            selector: "ignored-by-tool",
+            operation: .replaceText,
+            value: "New Title",
+            explanation: "rename heading"
+        )
+
+        let out = try await tool.call(arguments: cmd)
+
+        let msg = await router.received
+        #expect(msg?.op == "replace-text")
+        #expect(msg?.selector == element)
+        #expect(msg?.value == .string("New Title"))
+        #expect(msg?.path == "src/pages/about.md")
+        #expect(out.contains("Applied"))
+    }
+
+    @Test("no context selector + bare-tag selector builds a minimal ElementInfo")
+    func bareTagBuildsMinimalElementInfo() async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: nil))
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: nil)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/index.md",
+            selector: "H1",
+            operation: .replaceAttr,
+            value: "hello",
+            explanation: "x"
+        )
+
+        _ = try await tool.call(arguments: cmd)
+
+        let msg = await router.received
+        #expect(msg?.selector == .object([
+            "tag": .string("h1"), "classes": .array([]), "nthChild": .int(1),
+        ]))
+        #expect(msg?.op == "replace-attr")
+    }
+
+    @Test("no context selector + complex selector fails gracefully without calling the bridge")
+    func complexSelectorFailsGracefully() async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: "ok"))
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: nil)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/index.md",
+            selector: "p:nth-of-type(2)",
+            operation: .replaceText,
+            value: "x",
+            explanation: "x"
+        )
+
+        let out = try await tool.call(arguments: cmd)
+
+        #expect(await router.received == nil)
+        #expect(out.contains("Couldn't identify"))
+    }
+
+    @Test("a failed reply surfaces its message in the tool output")
+    func failedReplySurfacesMessage() async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .failed, message: "no router for this site"))
+        let element: JSONValue = .object(["tag": .string("h1"), "classes": .array([]), "nthChild": .int(1)])
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: element)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/about.md", selector: "h1",
+            operation: .applyInstruction, value: "make it punchier", explanation: "x"
+        )
+
+        let out = try await tool.call(arguments: cmd)
+
+        #expect(out.contains("failed"))
+        #expect(out.contains("no router for this site"))
+    }
+}
+#endif
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ApplyEditToolTests`
+Expected: FAIL — `cannot find 'ApplyEditTool' in scope`.
+
+- [ ] **Step 3: Implement `ApplyEditTool`**
+
+Create `Sources/AnglesiteCore/ApplyEditTool.swift`:
+
+```swift
+import Foundation
+
+// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).
+// Same pattern as FoundationModelAssistant.swift / GenerableTypes.swift.
+#if compiler(>=6.4)
+import FoundationModels
+
+/// A FoundationModels ``Tool`` that lets the on-device model apply a structured edit to an element
+/// on a page of the current site, routing through ``IntentEditBridge`` (and on to the plugin's
+/// edit pipeline). Reuses ``GeneratedEditCommand`` (#154) as its arguments so the model speaks one
+/// edit vocabulary.
+public struct ApplyEditTool: Tool {
+    public let name = "applyEdit"
+    public let description = "Apply a structured edit to an element on a page of the current site."
+
+    private let bridge: IntentEditBridge
+    private let siteID: String
+    /// The structured `ElementInfo` for the element the user selected in the overlay, if any —
+    /// taken from `AssistantContext.selectedElementSelector`. Preferred over a model-supplied
+    /// selector because it's a real, resolved selector rather than a guess.
+    private let contextSelector: JSONValue?
+
+    public init(bridge: IntentEditBridge, siteID: String, contextSelector: JSONValue?) {
+        self.bridge = bridge
+        self.siteID = siteID
+        self.contextSelector = contextSelector
+    }
+
+    public func call(arguments: GeneratedEditCommand) async throws -> String {
+        guard let selector = resolveSelector(arguments.selector) else {
+            return "Couldn't identify which element to edit — select one in the preview, or name a simple tag like h1."
+        }
+        let reply = await bridge.applyEdit(
+            siteID: siteID,
+            filePath: arguments.filePath,
+            selector: selector,
+            op: Self.opString(for: arguments.operation),
+            value: .string(arguments.value)
+        )
+        switch reply.status {
+        case .applied:
+            return "Applied edit to \(arguments.filePath)." + (reply.message.map { " \($0)" } ?? "")
+        case .failed, .ambiguous:
+            return "Edit failed: \(reply.message ?? "unknown error")."
+        }
+    }
+
+    // MARK: Selector resolution (hybrid: context first, bare-tag fallback, else nil)
+
+    /// Resolve the structured `ElementInfo` the plugin's `selector.mjs` requires.
+    /// 1. Prefer the overlay-resolved context selector.
+    /// 2. Else, if the model's selector is a bare tag (`h1`, `p`), build a minimal ElementInfo.
+    /// 3. Else, give up — we don't fabricate complex selectors.
+    private func resolveSelector(_ raw: String) -> JSONValue? {
+        if let contextSelector { return contextSelector }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isBareTag(trimmed) else { return nil }
+        return .object([
+            "tag": .string(trimmed.lowercased()),
+            "classes": .array([]),
+            "nthChild": .int(1),
+        ])
+    }
+
+    /// A bare HTML tag: letters then alphanumerics, nothing else (no combinators, classes, pseudo).
+    private static func isBareTag(_ s: String) -> Bool {
+        guard let first = s.first, first.isLetter else { return false }
+        return s.allSatisfy { $0.isLetter || $0.isNumber }
+    }
+
+    /// Map the #154 ``EditOperation`` onto the `EditMessage.Op` string vocabulary (the bridge
+    /// deferred in `GenerableTypes.swift`'s doc-comment, "TODO(#156)").
+    private static func opString(for op: EditOperation) -> String {
+        switch op {
+        case .replaceText: return EditMessage.Op.replaceText
+        case .replaceAttr: return EditMessage.Op.replaceAttr
+        case .replaceImageSrc: return EditMessage.Op.replaceImageSrc
+        case .applyInstruction: return EditMessage.Op.applyInstruction
+        }
+    }
+}
+#endif
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ApplyEditToolTests`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ApplyEditTool.swift Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+git commit -m "feat(core): ApplyEditTool — on-device structured edits via IntentEditBridge (#156)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `SearchContentTool` — query + formatted, capped output
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SearchContentTool.swift`
+- Test: `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift` (append a suite)
+
+- [ ] **Step 1: Write the failing tests for `SearchContentTool`**
+
+Append inside the `#if compiler(>=6.4)` block in `OnDeviceToolsTests.swift` (before the closing `#endif`):
+
+```swift
+@Suite("On-device tools: SearchContentTool")
+struct SearchContentToolTests {
+
+    private func makeGraph() async -> SiteContentGraph {
+        let graph = SiteContentGraph()
+        await graph.upsertPage(.init(
+            id: "site1:page:/about", siteID: "site1", route: "/about",
+            filePath: "src/pages/about.md", title: "About Us",
+            lastModified: Date(timeIntervalSince1970: 0)
+        ))
+        await graph.upsertPost(.init(
+            id: "site1:post:hello", siteID: "site1", collection: "posts", slug: "hello-world",
+            title: "Hello World", draft: true, publishDate: nil, tags: ["intro"],
+            filePath: "src/posts/hello.md", lastModified: Date(timeIntervalSince1970: 0)
+        ))
+        return graph
+    }
+
+    @Test("finds a page by title and formats it")
+    func findsPageByTitle() async throws {
+        let tool = SearchContentTool(contentGraph: await makeGraph(), siteID: "site1")
+        let out = try await tool.call(arguments: .init(query: "about"))
+        #expect(out.contains("PAGE"))
+        #expect(out.contains("/about"))
+        #expect(out.contains("src/pages/about.md"))
+    }
+
+    @Test("marks a draft post and includes its file path")
+    func findsDraftPost() async throws {
+        let tool = SearchContentTool(contentGraph: await makeGraph(), siteID: "site1")
+        let out = try await tool.call(arguments: .init(query: "hello"))
+        #expect(out.contains("POST"))
+        #expect(out.contains("hello-world"))
+        #expect(out.contains("[draft]"))
+    }
+
+    @Test("no matches returns an explicit message, not an empty string")
+    func noMatchesIsExplicit() async throws {
+        let tool = SearchContentTool(contentGraph: await makeGraph(), siteID: "site1")
+        let out = try await tool.call(arguments: .init(query: "zzz-no-such-thing"))
+        #expect(out == "No matching pages or posts.")
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SearchContentToolTests`
+Expected: FAIL — `cannot find 'SearchContentTool' in scope`.
+
+- [ ] **Step 3: Implement `SearchContentTool`**
+
+Create `Sources/AnglesiteCore/SearchContentTool.swift`:
+
+```swift
+import Foundation
+
+// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).
+#if compiler(>=6.4)
+import FoundationModels
+
+/// A FoundationModels ``Tool`` that lets the on-device model search the current site's pages and
+/// posts (by title, route, slug, collection, or tag) via ``SiteContentGraph`` — local RAG with no
+/// network call.
+public struct SearchContentTool: Tool {
+    public let name = "searchContent"
+    public let description = "Search the current site's pages and posts by title, route, slug, or tag."
+
+    @Generable
+    public struct Arguments {
+        @Guide(description: "What to search for — words from a page title, route, post slug, or tag.")
+        public var query: String
+    }
+
+    /// Largest site without flooding the small on-device context window. Truncation is surfaced
+    /// in the output trailer (never silent).
+    private static let resultCap = 20
+
+    private let contentGraph: SiteContentGraph
+    private let siteID: String
+
+    public init(contentGraph: SiteContentGraph, siteID: String) {
+        self.contentGraph = contentGraph
+        self.siteID = siteID
+    }
+
+    public func call(arguments: Arguments) async throws -> String {
+        let pages = await contentGraph.searchPages(siteID: siteID, matching: arguments.query)
+        let posts = await contentGraph.searchPosts(siteID: siteID, matching: arguments.query)
+
+        var lines: [String] = []
+        for page in pages {
+            lines.append("PAGE  \(page.route)  (\(page.filePath))")
+        }
+        for post in posts {
+            let draft = post.draft ? " [draft]" : ""
+            lines.append("POST  \(post.slug)\(draft)  (\(post.filePath))")
+        }
+
+        if lines.isEmpty { return "No matching pages or posts." }
+        if lines.count > Self.resultCap {
+            let shown = lines.prefix(Self.resultCap).joined(separator: "\n")
+            return shown + "\n… +\(lines.count - Self.resultCap) more (refine your query to narrow results)."
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+#endif
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SearchContentToolTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SearchContentTool.swift Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+git commit -m "feat(core): SearchContentTool — on-device site search via SiteContentGraph (#156)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Wire the tools into `FoundationModelAssistant`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/FoundationModelAssistant.swift`
+- Test: `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift` (append a suite)
+
+- [ ] **Step 1: Write the failing capability tests**
+
+Append inside the `#if compiler(>=6.4)` block in `OnDeviceToolsTests.swift` (before the closing `#endif`):
+
+```swift
+@Suite("FoundationModelAssistant tool wiring")
+struct FoundationModelAssistantToolWiringTests {
+
+    @Test("supportsTools is true only when both dependencies are injected")
+    func capabilitiesReflectDeps() async {
+        let router = FakeEditRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let bridge = makeBridge(router)
+        let graph = SiteContentGraph()
+
+        let withTools = FoundationModelAssistant(tier: .onDevice, editBridge: bridge, contentGraph: graph)
+        #expect(withTools.capabilities.supportsTools == true)
+
+        let withoutTools = FoundationModelAssistant(tier: .onDevice)
+        #expect(withoutTools.capabilities.supportsTools == false)
+
+        let partial = FoundationModelAssistant(tier: .onDevice, editBridge: bridge, contentGraph: nil)
+        #expect(partial.capabilities.supportsTools == false)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter FoundationModelAssistantToolWiringTests`
+Expected: FAIL — extra arguments `editBridge`/`contentGraph` in call to `init`.
+
+- [ ] **Step 3: Add the optional dependencies and store them**
+
+In `Sources/AnglesiteCore/FoundationModelAssistant.swift`, replace the stored property + `init` block (currently lines ~31–41):
+
+```swift
+    private let tier: FoundationModelTier
+    private let editBridge: IntentEditBridge?
+    private let contentGraph: SiteContentGraph?
+    private let logger = Logger(subsystem: "dev.anglesite.app", category: "FoundationModelAssistant")
+
+    /// `editBridge` + `contentGraph` are optional. When **both** are supplied, the assistant
+    /// attaches ``ApplyEditTool`` + ``SearchContentTool`` to each session (a local agentic loop)
+    /// and advertises `supportsTools`. When either is `nil`, behavior is the tool-less default.
+    public init(
+        tier: FoundationModelTier = .onDevice,
+        editBridge: IntentEditBridge? = nil,
+        contentGraph: SiteContentGraph? = nil
+    ) {
+        self.tier = tier
+        self.editBridge = editBridge
+        self.contentGraph = contentGraph
+        if tier == .privateCloudCompute {
+            // v1 has no separate PCC session; fall back to on-device with a logged warning so the
+            // requested tier degrades gracefully rather than erroring (see spec / #155).
+            logger.warning("privateCloudCompute tier requested; v1 backs it with the on-device session")
+        }
+    }
+```
+
+- [ ] **Step 4: Make `capabilities.supportsTools` reflect the deps**
+
+In the same file, change the `supportsTools:` line in the `capabilities` computed property (currently `supportsTools: false,`) to:
+
+```swift
+            supportsTools: editBridge != nil && contentGraph != nil,
+```
+
+(`capabilities` stays a `nonisolated var`; it reads the immutable `Sendable` `let`s, which is allowed from a `nonisolated` context.)
+
+- [ ] **Step 5: Run the capability test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter FoundationModelAssistantToolWiringTests`
+Expected: PASS (1 test).
+
+- [ ] **Step 6: Attach the tools in `makeSession`**
+
+In the same file, replace the final `return` of `makeSession(context:)` (currently `return LanguageModelSession(instructions: Self.instructions(for: context))`) with:
+
+```swift
+        let instructions = Self.instructions(for: context)
+        if let editBridge, let contentGraph {
+            let tools: [any Tool] = [
+                ApplyEditTool(
+                    bridge: editBridge,
+                    siteID: context.siteID,
+                    contextSelector: context.selectedElementSelector
+                ),
+                SearchContentTool(contentGraph: contentGraph, siteID: context.siteID),
+            ]
+            return LanguageModelSession(tools: tools, instructions: instructions)
+        }
+        return LanguageModelSession(instructions: instructions)
+```
+
+- [ ] **Step 7: Run the whole on-device tools suite to verify nothing regressed**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter OnDeviceTools`
+
+(Or run all three suites explicitly: `--filter ApplyEditToolTests --filter SearchContentToolTests --filter FoundationModelAssistantToolWiringTests`.)
+Expected: PASS (8 tests total: 4 + 3 + 1).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteCore/FoundationModelAssistant.swift Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+git commit -m "feat(core): wire ApplyEditTool + SearchContentTool into FoundationModelAssistant (#156)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Full suite + docs closeout
+
+**Files:**
+- Modify: `docs/specs/2026-06-13-on-device-tools-design.md` (correct the verify-against-SDK note)
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .`
+Expected: PASS — the pre-existing suite count plus the 8 new tests; no regressions.
+
+- [ ] **Step 2: Update the design doc's "Verify-against-SDK" section to record the resolved API**
+
+In `docs/specs/2026-06-13-on-device-tools-design.md`, replace the body of the
+"## Verify-against-SDK note" section with the confirmed facts:
+
+```markdown
+## Verify-against-SDK note (resolved)
+
+Confirmed against the macOS 26 SDK during implementation:
+- `Tool.call(arguments:) async throws -> Output` where `Output: PromptRepresentable`; `String`
+  conforms, so both tools return `String`.
+- `Tool` requires only `name`, `description`, `call`; `parameters` is defaulted for
+  `Arguments: Generable`.
+- `LanguageModelSession(model:tools:instructions:)` accepts `instructions: String?`, so
+  `LanguageModelSession(tools:instructions:)` compiles.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/specs/2026-06-13-on-device-tools-design.md
+git commit -m "docs(specs): record resolved FoundationModels Tool API for #156
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin feat/156-on-device-tools
+gh pr create --title "feat(core): on-device ApplyEditTool + SearchContentTool (#156)" \
+  --body "Implements C.6 (#156): two FoundationModels Tool conformances wired into FoundationModelAssistant, forming a local agentic loop (search site content + apply structured edits) with no network calls.
+
+- ApplyEditTool reuses the #154 GeneratedEditCommand; maps EditOperation→EditMessage.Op; hybrid selector resolution (context ElementInfo → bare-tag fallback → graceful failure).
+- SearchContentTool queries SiteContentGraph, capped/formatted output.
+- FoundationModelAssistant gains optional IntentEditBridge + SiteContentGraph deps; supportsTools reflects them.
+- 8 deterministic tests (no live model needed).
+
+Design: docs/specs/2026-06-13-on-device-tools-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Optional dep-injection + `supportsTools` → Task 3. ✅
+- `makeSession` attaches tools only when both deps present → Task 3, Step 6. ✅
+- `ApplyEditTool` reuses `GeneratedEditCommand`, op mapping, value wrap → Task 1. ✅
+- Hybrid selector (context → bare-tag → graceful fail) → Task 1 (3 of 4 tests cover the branches). ✅
+- `SearchContentTool` query + formatted + capped + explicit empty → Task 2 (+ cap logic implemented; cap path documented). ✅
+- Error-as-output (no throwing) → Task 1/2 `call` returns descriptive `String`. ✅
+- ~6 tests with fakes → 8 tests delivered (real graph + fake router). ✅
+- `.spotlight`/vision/chat-UI deferrals → out of scope, untouched. ✅
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows complete code. ✅
+
+**Type consistency:** `ApplyEditTool(bridge:siteID:contextSelector:)`, `SearchContentTool(contentGraph:siteID:)`, `SearchContentTool.Arguments(query:)`, `FoundationModelAssistant(tier:editBridge:contentGraph:)`, `EditMessage.Op.*`, `EditReply(id:status:message:)`, `JSONValue.object/.string/.array/.int`, `SiteContentGraph.Page/.Post` inits — all match the verified signatures and are used identically across tasks. ✅
+
+> Note: the cap-truncation path (`> 20` results) has implementation but no dedicated test (kept to the issue's ~6-test budget; the empty + populated paths are covered). Acceptable; add a 21-item test later if the path becomes load-bearing.


### PR DESCRIPTION
## Summary

Implements **C.6 (#156)**: two Apple `FoundationModels.Tool` conformances wired into `FoundationModelAssistant`, forming a local on-device agentic loop (search site content + apply structured edits) with **no network calls**.

- **`ApplyEditTool`** — reuses the #154 `GeneratedEditCommand` as its arguments; maps `EditOperation` → `EditMessage.Op`; **hybrid selector resolution** (overlay-resolved `ElementInfo` from context → bare-tag fallback → graceful give-up without calling the bridge). Routes through `IntentEditBridge`. `.applied`/`.ambiguous`/`.failed` each surface a distinct, recoverable message.
- **`SearchContentTool`** — queries `SiteContentGraph` pages + posts; deterministic (sorted) formatted output, capped at 20 with a surfaced truncation trailer; empty query is rejected (won't dump the whole site).
- **`FoundationModelAssistant`** — gains optional `IntentEditBridge` + `SiteContentGraph` deps; `makeSession` attaches the tools only when both are present; `supportsTools` reflects that. The one-shot `generate`/`generateStructured` API is unchanged — FoundationModels drives the tool loop internally.

Both new files use the established `#if compiler(>=6.4)` gating (#128). Errors surface as descriptive `String` (never thrown for recoverable cases) so the model can recover within the loop.

Design + plan: `docs/specs/2026-06-13-on-device-tools-design.md`, `docs/specs/2026-06-13-on-device-tools-plan.md`.

## Test Plan

- [x] 11 new deterministic tests (no live model needed): real `SiteContentGraph` actor + fake `EditRouter` recording the routed `EditMessage`.
- [x] Branches covered: context-selector verbatim + op mapping + value wrap, bare-tag synthesis, complex-selector give-up (bridge not called), `.failed` + `.ambiguous` messages, page/draft-post search + format, no-match sentinel, empty-query rejection, and all four dep permutations of `supportsTools`.
- [x] Full suite green: 296 Swift Testing + 13 bridge + 139 XCTest, no failures.

Out of scope (deferred): Apple `.spotlight` built-in tool → #158; vision/alt-text → #157; chat-UI surfacing → #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)