### PR TITLE
feat: on-device alt-text generation for image drops (#157)

### DIFF
--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -51,13 +51,19 @@ final class PreviewModel {
     /// new router is re-registered in `EditRouterRegistry.shared` so `EditContentIntent`
     /// (B.5 / #149) routes through the same observer-equipped instance — otherwise the chat
     /// panel would miss Siri-driven edits.
-    func setEditObserver(_ onEdit: @escaping MCPApplyEditRouter.EditObserver) {
+    /// `postProcess` (optional) runs after each successful edit — wired by `SiteWindow` to
+    /// `AltTextGenerator` so an image drop auto-generates and applies alt text (C.7 / #157).
+    func setEditObserver(
+        _ onEdit: @escaping MCPApplyEditRouter.EditObserver,
+        postProcess: MCPApplyEditRouter.PostProcessor? = nil
+    ) {
         self.editRouter = MCPApplyEditRouter(
             mcpClient: { [weak self] in
                 guard let self else { return nil }
                 return await self.runtime.mcpClient
             },
-            onEdit: onEdit
+            onEdit: onEdit,
+            postProcess: postProcess
         )
         if let siteID = openSiteID {
             let current = self.editRouter

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -16,6 +16,7 @@ private struct AdvancedSettingsView: View {
     @AppStorage(AppSettings.Key.pluginPathOverride) private var pluginPathOverride: String = ""
     @AppStorage(AppSettings.Key.sitesRootOverride) private var sitesRootOverride: String = ""
     @AppStorage(AppSettings.Key.debugPaneEnabled) private var debugPaneEnabled: Bool = false
+    @AppStorage(AppSettings.Key.autoGenerateAltText) private var autoGenerateAltText: Bool = true
 
     var body: some View {
         Form {
@@ -25,6 +26,13 @@ private struct AdvancedSettingsView: View {
             #if !ANGLESITE_MAS
             AssistantSettingsSection()
             #endif
+
+            Section("Editing") {
+                Toggle("Auto-generate alt text for dropped images", isOn: $autoGenerateAltText)
+                Text("When you drop an image onto the preview, Anglesite uses Apple's on-device vision model to write descriptive `alt` text and applies it automatically. Runs locally; requires Apple Intelligence to be enabled. Purely decorative images get empty alt text and `role=\"presentation\"`.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
 
             Section("Anglesite plugin") {
                 FolderPickerRow(

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -29,7 +29,7 @@ private struct AdvancedSettingsView: View {
 
             Section("Editing") {
                 Toggle("Auto-generate alt text for dropped images", isOn: $autoGenerateAltText)
-                Text("When you drop an image onto the preview, Anglesite uses Apple's on-device vision model to write descriptive `alt` text and applies it automatically. Runs locally; requires Apple Intelligence to be enabled. Purely decorative images get empty alt text and `role=\"presentation\"`.")
+                Text("When you drop an image onto the preview, Anglesite uses Apple's on-device vision model to write descriptive alt text and applies it automatically. Runs locally; requires Apple Intelligence to be enabled. Purely decorative images get empty alt text and role=\"presentation\".")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -364,11 +364,36 @@ struct SiteWindow: View {
             : ClaudeAssistant(siteID: resolved.id, siteDirectory: resolved.path)
         chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.path, assistant: assistant, annotationFeed: feed, annotationResolver: annotationResolver, undoCommand: undoCommand)
         #endif
-        preview.setEditObserver { [weak chat] reply in
+        // Auto alt-text (C.7 / #157): after a successful image drop, generate alt text on-device and
+        // apply it to the `<img>`. Target-agnostic — the on-device vision model runs on both builds.
+        // The follow-up edit routes through its own (post-process-free) apply_edit router so it can't
+        // recurse. Best-effort and opt-out via Settings.
+        let altTextGenerator = AltTextGenerator(
+            siteID: resolved.id,
+            siteDirectory: resolved.path,
+            isEnabled: { AppSettings.shared.autoGenerateAltText },
+            produce: { imageURL, context in
+                try await FoundationModelAssistant(tier: .onDevice).generateStructured(
+                    prompt: "Generate concise, descriptive alt text for this image as it would appear on a website. If the image is purely decorative, mark it decorative and use empty alt text.",
+                    imageURL: imageURL,
+                    context: context,
+                    resultType: GeneratedAltText.self
+                )
+            },
+            apply: { edit in
+                _ = await MCPApplyEditRouter(mcpClient: mcpClient).apply(edit)
+            },
+            log: { message in
+                Task { await LogCenter.shared.append(source: "alt-text:\(resolved.id)", stream: .stderr, text: message) }
+            }
+        )
+        preview.setEditObserver({ [weak chat] reply in
             Task { @MainActor in
                 chat?.recordEdit(reply)
             }
-        }
+        }, postProcess: { reply, message in
+            await altTextGenerator.postProcess(reply: reply, message: message)
+        })
         deploy.onScanComplete = { [health] outcome in
             health.ingestDeployOutcome(outcome)
         }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -381,7 +381,16 @@ struct SiteWindow: View {
                 )
             },
             apply: { edit in
-                _ = await MCPApplyEditRouter(mcpClient: mcpClient).apply(edit)
+                // Surface a failed apply (MCP down, plugin error) — otherwise the drop would succeed
+                // with no alt text and nothing in the debug pane explaining why. Generation failures
+                // are handled separately via `log`.
+                let reply = await MCPApplyEditRouter(mcpClient: mcpClient).apply(edit)
+                if reply.status == .failed {
+                    await LogCenter.shared.append(
+                        source: "alt-text:\(resolved.id)", stream: .stderr,
+                        text: "applying generated alt text failed: \(reply.message ?? "unknown error")"
+                    )
+                }
             },
             log: { message in
                 Task { await LogCenter.shared.append(source: "alt-text:\(resolved.id)", stream: .stderr, text: message) }

--- a/Sources/AnglesiteCore/AltTextGenerator.swift
+++ b/Sources/AnglesiteCore/AltTextGenerator.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+// Gated to the Xcode-27 toolchain — `GeneratedAltText` is `@Generable` (FoundationModels), absent
+// at runtime on CI (#128). Same pattern as FoundationModelAssistant.swift / GenerableTypes.swift.
+#if compiler(>=6.4)
+
+/// Post-processes a successful image-drop edit by generating alt text with the on-device vision
+/// model and applying it to the `<img>` (C.7, #157).
+///
+/// Wired as ``MCPApplyEditRouter``'s post-processor: after the plugin writes a dropped image and
+/// returns `{ src, srcset }`, this resolves the written file, asks the model for a
+/// ``GeneratedAltText``, and issues a follow-up `replace-attr` edit setting `alt` on the same
+/// element (reusing the drop's `path`/`selector`). A decorative image gets `alt=""` plus
+/// `role="presentation"`. Everything is best-effort: generation failures are logged and swallowed
+/// so the original drop is never disturbed.
+///
+/// The vision call (`produce`) and the follow-up edit applier (`apply`) are injected, so the routing
+/// logic is fully testable without a live model.
+public struct AltTextGenerator: Sendable {
+    /// Produces alt text for the image at `imageURL`. Production wraps
+    /// `FoundationModelAssistant.generateStructured(prompt:imageURL:context:resultType:)`.
+    public typealias Producer = @Sendable (_ imageURL: URL, _ context: AssistantContext) async throws -> GeneratedAltText
+    /// Applies a follow-up edit (the generated `alt`/`role`). Production routes it through the
+    /// per-site `apply_edit` MCP tool.
+    public typealias Applier = @Sendable (_ edit: EditMessage) async -> Void
+
+    private let siteID: String
+    private let siteDirectory: URL
+    private let isEnabled: @Sendable () -> Bool
+    private let produce: Producer
+    private let apply: Applier
+    private let log: @Sendable (String) -> Void
+
+    public init(
+        siteID: String,
+        siteDirectory: URL,
+        isEnabled: @escaping @Sendable () -> Bool,
+        produce: @escaping Producer,
+        apply: @escaping Applier,
+        log: @escaping @Sendable (String) -> Void = { _ in }
+    ) {
+        self.siteID = siteID
+        self.siteDirectory = siteDirectory
+        self.isEnabled = isEnabled
+        self.produce = produce
+        self.apply = apply
+        self.log = log
+    }
+
+    /// Runs after a successful `apply_edit`. No-ops unless the setting is on and the edit was an
+    /// image drop (`replace-image-src`) that applied with a returned image `src`.
+    public func postProcess(reply: EditReply, message: EditMessage) async {
+        guard isEnabled(),
+              message.op == EditMessage.Op.replaceImageSrc,
+              reply.status == .applied,
+              let src = reply.result?.src
+        else { return }
+
+        let context = AssistantContext(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            currentPageRoute: message.path,
+            selectedElementSelector: message.selector
+        )
+        let alt: GeneratedAltText
+        do {
+            alt = try await produce(imageFileURL(forSrc: src), context)
+        } catch {
+            log("alt-text generation failed for \(src): \(error)")
+            return
+        }
+
+        // Decorative ⇒ empty alt + role="presentation"; otherwise the descriptive alt.
+        await apply(attrEdit(name: "alt", value: alt.isDecorative ? "" : alt.altText, from: message))
+        if alt.isDecorative {
+            await apply(attrEdit(name: "role", value: "presentation", from: message))
+        }
+    }
+
+    /// The plugin writes dropped images under `public/`, returning a site-relative `src` such as
+    /// `/images/hero.webp`. Resolve it back to the on-disk file for the vision model to read.
+    func imageFileURL(forSrc src: String) -> URL {
+        let relative = src.hasPrefix("/") ? String(src.dropFirst()) : src
+        return siteDirectory
+            .appendingPathComponent("public", isDirectory: true)
+            .appendingPathComponent(relative)
+    }
+
+    /// A `replace-attr` edit on the same element as `message`. The plugin's patcher expects the
+    /// value as `{ name, value }` (see `server/patcher.mjs`).
+    private func attrEdit(name: String, value: String, from message: EditMessage) -> EditMessage {
+        EditMessage(
+            id: UUID().uuidString,
+            type: .applyEdit,
+            path: message.path,
+            selector: message.selector,
+            op: EditMessage.Op.replaceAttr,
+            value: .object(["name": .string(name), "value": .string(value)])
+        )
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/AltTextGenerator.swift
+++ b/Sources/AnglesiteCore/AltTextGenerator.swift
@@ -79,7 +79,9 @@ public struct AltTextGenerator: Sendable {
 
     /// The plugin writes dropped images under `public/`, returning a site-relative `src` such as
     /// `/images/hero.webp`. Resolve it back to the on-disk file for the vision model to read.
-    func imageFileURL(forSrc src: String) -> URL {
+    /// Covered by the `resolvesImagePath` test through `postProcess` (which captures the URL it
+    /// passes to `produce`), so it needs no wider visibility.
+    private func imageFileURL(forSrc src: String) -> URL {
         let relative = src.hasPrefix("/") ? String(src.dropFirst()) : src
         return siteDirectory
             .appendingPathComponent("public", isDirectory: true)

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -19,6 +19,7 @@ public final class AppSettings: @unchecked Sendable {
         public static let sitesRootBookmark  = "anglesite.sitesRootBookmark"
         public static let preferFoundationModels = "anglesite.preferFoundationModels"
         public static let foundationModelTier    = "anglesite.foundationModelTier"
+        public static let autoGenerateAltText = "anglesite.autoGenerateAltText"
     }
 
     private let defaults: UserDefaults
@@ -98,6 +99,19 @@ public final class AppSettings: @unchecked Sendable {
     public var foundationModelTier: FoundationModelTier {
         get { FoundationModelTier(rawValue: defaults.string(forKey: Key.foundationModelTier) ?? "") ?? .onDevice }
         set { defaults.set(newValue.rawValue, forKey: Key.foundationModelTier) }
+    }
+
+    /// When on (the default), dropping an image onto the preview auto-generates alt text with the
+    /// on-device vision model and applies it to the `<img>` (C.7, #157). Both targets. No-ops
+    /// gracefully when Apple Intelligence is unavailable. Stored inverted-from-absent so an
+    /// untouched install defaults to `true`.
+    public var autoGenerateAltText: Bool {
+        get {
+            // Absent → on by default; an explicit stored value wins.
+            guard defaults.object(forKey: Key.autoGenerateAltText) != nil else { return true }
+            return defaults.bool(forKey: Key.autoGenerateAltText)
+        }
+        set { defaults.set(newValue, forKey: Key.autoGenerateAltText) }
     }
 
     /// The site that was most-recently focused. Used by the Sites launcher to auto-open

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -84,7 +84,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         AssistantCapabilities(
             supportsStreaming: true,
             supportsStructuredOutput: true,
-            supportsVision: false,
+            supportsVision: true,  // macOS 27 on-device model accepts image attachments (C.7, #157)
             supportsTools: editBridge != nil && contentGraph != nil,
             maxContextTokens: tier == .privateCloudCompute ? 32_768 : 4_096,
             providerName: tier == .privateCloudCompute ? "Private Cloud Compute" : "On-Device"
@@ -142,6 +142,24 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         // One-shot, like `generate`: a fresh session, never the cached conversational one.
         let oneShotSession = try makeSession(context: context)
         return try await oneShotSession.respond(to: prompt, generating: T.self).content
+    }
+
+    /// Vision variant of ``generateStructured(prompt:context:resultType:)``: attaches the image at
+    /// `imageURL` to the prompt so the macOS 27 on-device model can describe it (alt text, OCR,
+    /// screenshot analysis). One-shot — a fresh session per call. Throws
+    /// ``AssistantError/unavailable(_:)`` when the on-device model can't run on this host.
+    public func generateStructured<T: Generable>(
+        prompt: String,
+        imageURL: URL,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        let oneShotSession = try makeSession(context: context)
+        let image = Attachment(imageURL: imageURL)
+        return try await oneShotSession.respond(generating: T.self) {
+            prompt
+            image
+        }.content
     }
 
     // MARK: ConversationalAssistant

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -13,28 +13,37 @@ import Foundation
 public struct MCPApplyEditRouter: EditRouter {
     public typealias ToolCaller = @Sendable (_ name: String, _ arguments: JSONValue) async throws -> MCPClient.ToolCallResult
     public typealias EditObserver = @Sendable (EditReply) -> Void
+    /// Async hook fired (fire-and-forget) after a successful `.applied` edit, with both the reply and
+    /// the originating message. Used by the app to run on-device alt-text generation for image drops
+    /// (C.7 / `AltTextGenerator`) without coupling this router to FoundationModels. It runs detached
+    /// so the overlay's reply isn't blocked on the (multi-second) follow-up work.
+    public typealias PostProcessor = @Sendable (_ reply: EditReply, _ message: EditMessage) async -> Void
 
     private let toolCaller: ToolCaller
     private let onEdit: EditObserver?
+    private let postProcess: PostProcessor?
 
     /// Test seam — inject a closure that mimics `MCPClient.callTool` so the router's mapping
     /// logic is verifiable without a live MCP server.
-    public init(toolCaller: @escaping ToolCaller, onEdit: EditObserver? = nil) {
+    public init(toolCaller: @escaping ToolCaller, onEdit: EditObserver? = nil, postProcess: PostProcessor? = nil) {
         self.toolCaller = toolCaller
         self.onEdit = onEdit
+        self.postProcess = postProcess
     }
 
     /// Production hookup: bind to a getter for the currently-active `MCPClient`. Returns
     /// `.failed("MCP not running")` via a thrown `notInitialized` when the getter is `nil`.
     public init(
         mcpClient: @escaping @Sendable () async -> MCPClient?,
-        onEdit: EditObserver? = nil
+        onEdit: EditObserver? = nil,
+        postProcess: PostProcessor? = nil
     ) {
         self.toolCaller = { name, args in
             guard let client = await mcpClient() else { throw MCPClient.MCPError.notInitialized }
             return try await client.callTool(name: name, arguments: args)
         }
         self.onEdit = onEdit
+        self.postProcess = postProcess
     }
 
     public func apply(_ message: EditMessage) async -> EditReply {
@@ -63,6 +72,11 @@ public struct MCPApplyEditRouter: EditRouter {
                 result: parsed?.result
             )
             if reply.commit != nil { onEdit?(reply) }
+            // Fire-and-forget so the overlay gets its reply immediately; alt-text generation and the
+            // follow-up edit land a moment later (see `AltTextGenerator`).
+            if let postProcess {
+                Task { await postProcess(reply, message) }
+            }
             return reply
         } catch {
             return EditReply(id: message.id, status: .failed, message: "\(error)")

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -13,10 +13,15 @@ import Foundation
 public struct MCPApplyEditRouter: EditRouter {
     public typealias ToolCaller = @Sendable (_ name: String, _ arguments: JSONValue) async throws -> MCPClient.ToolCallResult
     public typealias EditObserver = @Sendable (EditReply) -> Void
-    /// Async hook fired (fire-and-forget) after a successful `.applied` edit, with both the reply and
-    /// the originating message. Used by the app to run on-device alt-text generation for image drops
+    /// Async hook fired (fire-and-forget) when an edit is `.applied`, with both the reply and the
+    /// originating message. Used by the app to run on-device alt-text generation for image drops
     /// (C.7 / `AltTextGenerator`) without coupling this router to FoundationModels. It runs detached
     /// so the overlay's reply isn't blocked on the (multi-second) follow-up work.
+    ///
+    /// Unlike ``EditObserver`` (`onEdit`), which requires a `commit`, this fires for *every* applied
+    /// edit — including non-git sites where `commit` is nil — because alt-text post-processing should
+    /// run whenever the image actually landed, committed or not. It never fires for `.failed` /
+    /// `.ambiguous` replies (those return before this point).
     public typealias PostProcessor = @Sendable (_ reply: EditReply, _ message: EditMessage) async -> Void
 
     private let toolCaller: ToolCaller

--- a/Tests/AnglesiteCoreTests/AltTextGeneratorTests.swift
+++ b/Tests/AnglesiteCoreTests/AltTextGeneratorTests.swift
@@ -1,0 +1,144 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Gated like the type under test — `AltTextGenerator` references `GeneratedAltText` (`@Generable`,
+// Xcode-27 only). The logic here is model-free: the vision call is injected as a closure.
+#if compiler(>=6.4)
+
+@Suite("AltTextGenerator")
+struct AltTextGeneratorTests {
+
+    /// Collects the follow-up edits the generator applies, so tests can assert on them.
+    private actor Recorder {
+        private(set) var edits: [EditMessage] = []
+        func record(_ edit: EditMessage) { edits.append(edit) }
+    }
+
+    private let siteDir = URL(fileURLWithPath: "/tmp/my-site", isDirectory: true)
+
+    /// An image-drop reply as `MCPApplyEditRouter` would produce it.
+    private func imageDropReply(src: String? = "/images/hero.webp") -> EditReply {
+        EditReply(
+            id: "drop-1", status: .applied, message: nil, file: "src/pages/index.md",
+            commit: "abc123", result: src.map { EditReply.ImageResult(src: $0, srcset: nil) }
+        )
+    }
+
+    /// The original drop message — its `path`/`selector` must be reused for the follow-up.
+    private func imageDropMessage() -> EditMessage {
+        EditMessage(
+            id: "drop-1", type: .applyEdit, path: "/about/",
+            selector: .object(["tag": .string("img"), "index": .int(0)]),
+            op: EditMessage.Op.replaceImageSrc, value: nil
+        )
+    }
+
+    private func makeGenerator(
+        enabled: Bool = true,
+        recorder: Recorder,
+        produce: @escaping AltTextGenerator.Producer
+    ) -> AltTextGenerator {
+        AltTextGenerator(
+            siteID: "site-1",
+            siteDirectory: siteDir,
+            isEnabled: { enabled },
+            produce: produce,
+            apply: { await recorder.record($0) },
+            log: { _ in }
+        )
+    }
+
+    @Test("applies a single replace-attr alt edit for a non-decorative image")
+    func appliesAltEdit() async {
+        let recorder = Recorder()
+        let gen = makeGenerator(recorder: recorder) { _, _ in
+            GeneratedAltText(altText: "A white circle on a blue square", isDecorative: false)
+        }
+        await gen.postProcess(reply: imageDropReply(), message: imageDropMessage())
+
+        let edits = await recorder.edits
+        #expect(edits.count == 1)
+        let edit = try? #require(edits.first)
+        #expect(edit?.op == EditMessage.Op.replaceAttr)
+        #expect(edit?.path == "/about/")
+        #expect(edit?.selector == .object(["tag": .string("img"), "index": .int(0)]))
+        #expect(edit?.value == .object(["name": .string("alt"), "value": .string("A white circle on a blue square")]))
+    }
+
+    @Test("decorative image sets empty alt and role=presentation (two edits)")
+    func decorativeAppliesAltAndRole() async {
+        let recorder = Recorder()
+        let gen = makeGenerator(recorder: recorder) { _, _ in
+            GeneratedAltText(altText: "", isDecorative: true)
+        }
+        await gen.postProcess(reply: imageDropReply(), message: imageDropMessage())
+
+        let edits = await recorder.edits
+        #expect(edits.count == 2)
+        #expect(edits.first?.value == .object(["name": .string("alt"), "value": .string("")]))
+        #expect(edits.last?.value == .object(["name": .string("role"), "value": .string("presentation")]))
+    }
+
+    @Test("resolves the site-relative src to a file under public/")
+    func resolvesImagePath() async {
+        let recorder = Recorder()
+        var seenURL: URL?
+        let gen = makeGenerator(recorder: recorder) { url, _ in
+            seenURL = url
+            return GeneratedAltText(altText: "x", isDecorative: false)
+        }
+        await gen.postProcess(reply: imageDropReply(src: "/images/hero.webp"), message: imageDropMessage())
+        #expect(seenURL?.path == "/tmp/my-site/public/images/hero.webp")
+    }
+
+    @Test("does nothing when disabled") func disabledNoOp() async {
+        let recorder = Recorder()
+        let gen = makeGenerator(enabled: false, recorder: recorder) { _, _ in
+            GeneratedAltText(altText: "x", isDecorative: false)
+        }
+        await gen.postProcess(reply: imageDropReply(), message: imageDropMessage())
+        #expect(await recorder.edits.isEmpty)
+    }
+
+    @Test("ignores non-image-drop edits") func ignoresNonImageOps() async {
+        let recorder = Recorder()
+        let gen = makeGenerator(recorder: recorder) { _, _ in
+            GeneratedAltText(altText: "x", isDecorative: false)
+        }
+        let textEdit = EditMessage(
+            id: "t-1", type: .applyEdit, path: "/about/",
+            selector: .object(["tag": .string("h1")]), op: EditMessage.Op.replaceText, value: .string("Hi")
+        )
+        await gen.postProcess(reply: imageDropReply(), message: textEdit)
+        #expect(await recorder.edits.isEmpty)
+    }
+
+    @Test("ignores failed replies") func ignoresFailedReplies() async {
+        let recorder = Recorder()
+        let gen = makeGenerator(recorder: recorder) { _, _ in
+            GeneratedAltText(altText: "x", isDecorative: false)
+        }
+        let failed = EditReply(id: "drop-1", status: .failed, message: "nope")
+        await gen.postProcess(reply: failed, message: imageDropMessage())
+        #expect(await recorder.edits.isEmpty)
+    }
+
+    @Test("ignores replies without an image result") func ignoresMissingResult() async {
+        let recorder = Recorder()
+        let gen = makeGenerator(recorder: recorder) { _, _ in
+            GeneratedAltText(altText: "x", isDecorative: false)
+        }
+        await gen.postProcess(reply: imageDropReply(src: nil), message: imageDropMessage())
+        #expect(await recorder.edits.isEmpty)
+    }
+
+    @Test("a failed generation is swallowed, leaving the edit untouched") func generationFailureIsBestEffort() async {
+        let recorder = Recorder()
+        struct Boom: Error {}
+        let gen = makeGenerator(recorder: recorder) { _, _ in throw Boom() }
+        await gen.postProcess(reply: imageDropReply(), message: imageDropMessage())
+        #expect(await recorder.edits.isEmpty)
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/AppSettingsTests.swift
+++ b/Tests/AnglesiteCoreTests/AppSettingsTests.swift
@@ -100,6 +100,21 @@ final class AppSettingsTests {
         #expect(settings.foundationModelTier == .onDevice)
     }
 
+    // MARK: Auto alt-text (C.7 — vision alt-text pipeline)
+
+    @Test("autoGenerateAltText defaults to true (on)") func autoAltTextDefaultsToTrue() {
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.autoGenerateAltText)
+    }
+
+    @Test("autoGenerateAltText round trip") func autoAltTextRoundTrip() {
+        let settings = AppSettings(defaults: defaults)
+        settings.autoGenerateAltText = false
+        #expect(!settings.autoGenerateAltText)
+        settings.autoGenerateAltText = true
+        #expect(settings.autoGenerateAltText)
+    }
+
     // MARK: DebugPaneVisibility
 
     @Test("Debug menu always visible in debug builds") func debugMenuAlwaysVisibleInDebugBuilds() {

--- a/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
@@ -1,5 +1,8 @@
 import Testing
 import Foundation
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
 @testable import AnglesiteCore
 
 // Gated like the type under test (#128). Capability/tier assertions run on any toolchain≥6.4;
@@ -30,7 +33,7 @@ struct FoundationModelAssistantTests {
         #expect(caps.supportsStreaming)
         #expect(caps.supportsStructuredOutput)
         #expect(!caps.supportsTools)
-        #expect(!caps.supportsVision)
+        #expect(caps.supportsVision)  // macOS 27 on-device model accepts image attachments (C.7)
     }
 
     @Test("PCC tier advertises a larger context window and PCC provider name")
@@ -95,6 +98,53 @@ struct FoundationModelAssistantTests {
         )
         #expect(!result.title.isEmpty)
     }
+
+    @Test("generateStructured(imageURL:) describes an image into GeneratedAltText")
+    func generateStructuredFromImage() async throws {
+        guard modelAvailable() else { return }
+        let imageURL = try Self.makeTempImage()
+        defer { try? FileManager.default.removeItem(at: imageURL) }
+        let assistant = FoundationModelAssistant()
+        // Proves the image→guided-generation path runs end-to-end. Exact content is model-dependent;
+        // the contract is that it returns a valid `GeneratedAltText` (decorative ⇒ empty alt).
+        let alt = try await assistant.generateStructured(
+            prompt: "Generate concise alt text for this image.",
+            imageURL: imageURL,
+            context: makeContext(),
+            resultType: GeneratedAltText.self
+        )
+        if alt.isDecorative {
+            #expect(alt.altText.isEmpty)
+        } else {
+            #expect(!alt.altText.isEmpty)
+        }
+    }
+
+    /// Writes a small two-color PNG to a temp file so the vision path has a real image to read.
+    private static func makeTempImage() throws -> URL {
+        let side = 64
+        let space = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(
+            data: nil, width: side, height: side, bitsPerComponent: 8, bytesPerRow: 0,
+            space: space, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { throw AltTextImageError.context }
+        ctx.setFillColor(CGColor(red: 0.1, green: 0.4, blue: 0.9, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: side, height: side))
+        ctx.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        ctx.fillEllipse(in: CGRect(x: 16, y: 16, width: 32, height: 32))
+        guard let image = ctx.makeImage() else { throw AltTextImageError.render }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alttext-\(UUID().uuidString).png")
+        guard let dest = CGImageDestinationCreateWithURL(
+            url as CFURL, UTType.png.identifier as CFString, 1, nil
+        ) else { throw AltTextImageError.destination }
+        CGImageDestinationAddImage(dest, image, nil)
+        guard CGImageDestinationFinalize(dest) else { throw AltTextImageError.write }
+        return url
+    }
+
+    private enum AltTextImageError: Error { case context, render, destination, write }
 
     // MARK: ConversationalAssistant conformance (C.9 — MAS chat backend)
 

--- a/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
@@ -143,6 +143,47 @@ struct MCPApplyEditRouterTests {
         let captured = await observed.replies
         #expect(captured.isEmpty)
     }
+
+    @Test("postProcess fires with reply and message for an applied edit") func postProcessFiresForAppliedEdit() async {
+        let body = #"{"type":"anglesite:edit-applied","id":"e-1","file":"src/pages/about.astro","commit":"deadbeef"}"#
+        let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(
+            content: [.init(type: "text", text: body)],
+            isError: false
+        )))
+        let observed = ObservedPostProcess()
+        let router = MCPApplyEditRouter(
+            toolCaller: { try await recorder.call(name: $0, arguments: $1) },
+            postProcess: { reply, message in Task { await observed.record(reply: reply, message: message) } }
+        )
+        _ = await router.apply(sampleMessage)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let captured = await observed.calls
+        #expect(captured.count == 1)
+        #expect(captured.first?.reply.status == .applied)
+        #expect(captured.first?.message.id == "e-1")
+    }
+
+    @Test("postProcess does not fire for a failed edit") func postProcessSkipsFailedEdit() async {
+        let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(
+            content: [.init(type: "text", text: "boom")],
+            isError: true
+        )))
+        let observed = ObservedPostProcess()
+        let router = MCPApplyEditRouter(
+            toolCaller: { try await recorder.call(name: $0, arguments: $1) },
+            postProcess: { reply, message in Task { await observed.record(reply: reply, message: message) } }
+        )
+        _ = await router.apply(sampleMessage)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await observed.calls.isEmpty)
+    }
+}
+
+/// Collects `(reply, message)` pairs from the router's post-process hook.
+private actor ObservedPostProcess {
+    struct Call: Sendable { let reply: EditReply; let message: EditMessage }
+    private(set) var calls: [Call] = []
+    func record(reply: EditReply, message: EditMessage) { calls.append(Call(reply: reply, message: message)) }
 }
 
 /// Thread-safe collector for the `onEdit` callback fired from the router's async context.

--- a/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
@@ -153,14 +153,14 @@ struct MCPApplyEditRouterTests {
         let observed = ObservedPostProcess()
         let router = MCPApplyEditRouter(
             toolCaller: { try await recorder.call(name: $0, arguments: $1) },
-            postProcess: { reply, message in Task { await observed.record(reply: reply, message: message) } }
+            // The closure records directly (no inner Task); `next()` rendezvouses with the router's
+            // detached post-process task, so the test needs no sleep.
+            postProcess: { reply, message in await observed.record(reply: reply, message: message) }
         )
         _ = await router.apply(sampleMessage)
-        try? await Task.sleep(nanoseconds: 50_000_000)
-        let captured = await observed.calls
-        #expect(captured.count == 1)
-        #expect(captured.first?.reply.status == .applied)
-        #expect(captured.first?.message.id == "e-1")
+        let call = await observed.next()
+        #expect(call.reply.status == .applied)
+        #expect(call.message.id == "e-1")
     }
 
     @Test("postProcess does not fire for a failed edit") func postProcessSkipsFailedEdit() async {
@@ -171,19 +171,38 @@ struct MCPApplyEditRouterTests {
         let observed = ObservedPostProcess()
         let router = MCPApplyEditRouter(
             toolCaller: { try await recorder.call(name: $0, arguments: $1) },
-            postProcess: { reply, message in Task { await observed.record(reply: reply, message: message) } }
+            postProcess: { reply, message in await observed.record(reply: reply, message: message) }
         )
         _ = await router.apply(sampleMessage)
-        try? await Task.sleep(nanoseconds: 50_000_000)
-        #expect(await observed.calls.isEmpty)
+        // `isError` ⇒ the router returns `.failed` before reaching postProcess, so no detached task is
+        // ever scheduled — the count is settled the moment `apply` returns (no sleep, no race).
+        #expect(await observed.count == 0)
     }
 }
 
-/// Collects `(reply, message)` pairs from the router's post-process hook.
+/// Rendezvous collector for the router's post-process hook: `record` hands the call to a waiting
+/// `next()` (or buffers it), so tests await the hook deterministically instead of sleeping.
 private actor ObservedPostProcess {
     struct Call: Sendable { let reply: EditReply; let message: EditMessage }
-    private(set) var calls: [Call] = []
-    func record(reply: EditReply, message: EditMessage) { calls.append(Call(reply: reply, message: message)) }
+    private var calls: [Call] = []
+    private var waiters: [CheckedContinuation<Call, Never>] = []
+
+    func record(reply: EditReply, message: EditMessage) {
+        let call = Call(reply: reply, message: message)
+        if waiters.isEmpty {
+            calls.append(call)
+        } else {
+            waiters.removeFirst().resume(returning: call)
+        }
+    }
+
+    /// Awaits the next recorded call, suspending until `record` runs.
+    func next() async -> Call {
+        if !calls.isEmpty { return calls.removeFirst() }
+        return await withCheckedContinuation { waiters.append($0) }
+    }
+
+    var count: Int { calls.count }
 }
 
 /// Thread-safe collector for the `onEdit` callback fired from the router's async context.


### PR DESCRIPTION
Closes #157 (C.7 — Vision: alt-text generation pipeline).

## What

Drop an image onto the preview → Anglesite generates descriptive `alt` text with the **macOS 27 on-device vision model** and applies it to the `<img>` automatically. Purely decorative images get `alt=""` + `role="presentation"`.

## How it works

1. The overlay drops an image; the plugin's `apply_edit` writes/optimizes it and returns `{ src, srcset }` (unchanged).
2. `MCPApplyEditRouter` fires a new **`postProcess(reply, message)`** hook (fire-and-forget, so the overlay reply isn't blocked).
3. **`AltTextGenerator`** resolves the returned `src` (`/images/x.webp` → `<site>/public/images/x.webp`), asks the model for a `GeneratedAltText`, and applies a follow-up `replace-attr` `alt` edit on the same element (reusing the drop's `path`/`selector`). Decorative ⇒ empty alt + `role="presentation"`.

## Changes

- **`FoundationModelAssistant`** — vision overload `generateStructured(prompt:imageURL:context:resultType:)` using `FoundationModels.Attachment(imageURL:)` (macOS 27) in a `@PromptBuilder`; `supportsVision` is now `true`.
- **`AltTextGenerator`** (AnglesiteCore, gated) — the routing/decorative/path-resolution logic. The vision call (`produce`) and follow-up applier (`apply`) are injected, so it's fully unit-tested **without a live model**. Best-effort: generation failures are logged and swallowed, never disturbing the original drop.
- **`MCPApplyEditRouter`** — optional `postProcess` hook; keeps FoundationModels out of the core router.
- **`AppSettings.autoGenerateAltText`** (default on) + a **Settings → Editing** toggle. Both targets — the on-device model runs sandboxed too.
- **`SiteWindow`/`PreviewModel`** — wire the generator as the post-processor; the follow-up edit routes through its own post-process-free `apply_edit` router (no recursion).

## Plugin contract

Verified against `../anglesite`: `replace-attr` value shape is `{ name, value }` (`server/patcher.mjs`); dropped images are written under `public/` with a site-relative `src` (`server/apply-edit-dispatcher.mjs`). No paired plugin change needed — this reuses existing `apply_edit` ops.

## Decisions / notes

- **Default ON.** `autoGenerateAltText` defaults to on (accessibility win; degrades gracefully when Apple Intelligence is off). The issue says "opt-in (user can disable)" — happy to flip to default-off if you'd rather.
- **Post-processor vs. in-router.** Implemented as a generic hook + a separate `AltTextGenerator` rather than inlining vision into `MCPApplyEditRouter`, to keep the gated FoundationModels code out of the core router.

## Testing

- `AltTextGenerator`: 8 unit tests (non-decorative, decorative two-edit, disabled, non-image op, failed reply, missing `src`, generation failure best-effort, `src`→path resolution).
- `MCPApplyEditRouter`: post-process fires on `.applied`, skips `.failed`.
- `FoundationModelAssistant`: live-model image→`GeneratedAltText` test (skips when Apple Intelligence is unavailable; ran green locally), `supportsVision` flipped.
- `AppSettings`: default + round-trip.
- Full `swift test` green (318 + 139 + 13); both schemes build.

## Remaining

Manual onscreen smoke: drop a real image in a running app, confirm alt text appears on the element (issue's manual-smoke step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)