### PR TITLE
fix: resolve Swift 6 concurrency build warnings

### DIFF
--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -171,7 +171,10 @@ struct ChatView: View {
 
 // MARK: - Shared formatter
 
-nonisolated(unsafe) private let sharedRelativeTimeFormatter: RelativeDateTimeFormatter = {
+// Configured once and only read via `localizedString(for:relativeTo:)` afterward. Apple doesn't
+// document `RelativeDateTimeFormatter` as thread-safe, so `nonisolated(unsafe)` is a deliberate
+// choice asserting that never-mutated-after-init invariant.
+private nonisolated(unsafe) let sharedRelativeTimeFormatter: RelativeDateTimeFormatter = {
     let f = RelativeDateTimeFormatter()
     f.unitsStyle = .short
     return f

--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -171,7 +171,7 @@ struct ChatView: View {
 
 // MARK: - Shared formatter
 
-private let sharedRelativeTimeFormatter: RelativeDateTimeFormatter = {
+nonisolated(unsafe) private let sharedRelativeTimeFormatter: RelativeDateTimeFormatter = {
     let f = RelativeDateTimeFormatter()
     f.unitsStyle = .short
     return f

--- a/Sources/AnglesiteCore/BackupCommand.swift
+++ b/Sources/AnglesiteCore/BackupCommand.swift
@@ -48,7 +48,7 @@ public actor BackupCommand {
     public init(
         runner: @escaping GitRunner = BackupCommand.defaultRunner,
         streamer: @escaping GitStreamer = BackupCommand.defaultStreamer,
-        clock: @escaping @Sendable () -> Date = Date.init
+        clock: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.runner = runner
         self.streamer = streamer
@@ -179,7 +179,7 @@ public actor BackupCommand {
 
     /// ISO-8601 timestamps in commit messages so they sort correctly under `git log` and
     /// stay locale-agnostic. `Backup 2026-06-10T14:13:20Z` — unambiguous, machine-friendly.
-    private static let iso8601Formatter: ISO8601DateFormatter = {
+    nonisolated(unsafe) private static let iso8601Formatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime]
         return f

--- a/Sources/AnglesiteCore/BackupCommand.swift
+++ b/Sources/AnglesiteCore/BackupCommand.swift
@@ -179,7 +179,11 @@ public actor BackupCommand {
 
     /// ISO-8601 timestamps in commit messages so they sort correctly under `git log` and
     /// stay locale-agnostic. `Backup 2026-06-10T14:13:20Z` — unambiguous, machine-friendly.
-    nonisolated(unsafe) private static let iso8601Formatter: ISO8601DateFormatter = {
+    ///
+    /// Configured once here and only read via `string(from:)` afterward. Apple doesn't document
+    /// `ISO8601DateFormatter` as thread-safe, so `nonisolated(unsafe)` is a deliberate choice
+    /// asserting that never-mutated-after-init invariant.
+    private nonisolated(unsafe) static let iso8601Formatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime]
         return f

--- a/Sources/AnglesiteCore/ClaudeAssistant.swift
+++ b/Sources/AnglesiteCore/ClaudeAssistant.swift
@@ -88,7 +88,7 @@ public actor ClaudeAssistant: ConversationalAssistant {
     }
 
     #if compiler(>=6.4)
-    public func generateStructured<T: Generable>(
+    public func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,
         resultType: T.Type

--- a/Sources/AnglesiteCore/ContentAssistant.swift
+++ b/Sources/AnglesiteCore/ContentAssistant.swift
@@ -36,6 +36,11 @@ public protocol ContentAssistant: Sendable {
     ///
     /// - Note: Requires `FoundationModels`, so it's gated to the Xcode-27 toolchain (#128).
     ///   Production builds always have it; CI on Xcode 26.3 sees the streaming surface only.
+    /// - Note: `T` is constrained to `Sendable` so the actor-isolated conformers
+    ///   (``FoundationModelAssistant``, ``ClaudeAssistant``) can return it across this
+    ///   `nonisolated` boundary without a data-race warning. Tightening a `public` requirement is
+    ///   technically source-breaking for out-of-module conformers, but every conformer is internal
+    ///   to this app, and all `@Generable` result types already conform to `Sendable`.
     #if compiler(>=6.4)
     func generateStructured<T: Generable & Sendable>(
         prompt: String,

--- a/Sources/AnglesiteCore/ContentAssistant.swift
+++ b/Sources/AnglesiteCore/ContentAssistant.swift
@@ -37,7 +37,7 @@ public protocol ContentAssistant: Sendable {
     /// - Note: Requires `FoundationModels`, so it's gated to the Xcode-27 toolchain (#128).
     ///   Production builds always have it; CI on Xcode 26.3 sees the streaming surface only.
     #if compiler(>=6.4)
-    func generateStructured<T: Generable>(
+    func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,
         resultType: T.Type

--- a/Sources/AnglesiteCore/ContentListing.swift
+++ b/Sources/AnglesiteCore/ContentListing.swift
@@ -115,15 +115,22 @@ public struct ContentListing: Sendable, Equatable {
 
     // MARK: - Date parsing
 
-    /// `ISO8601DateFormatter` instances are not cheap to build and are thread-safe once
-    /// configured, so cache one per format variant.
-    nonisolated(unsafe) private static let plainFormatter = ISO8601DateFormatter()
-    nonisolated(unsafe) private static let fractionalFormatter: ISO8601DateFormatter = {
+    /// `ISO8601DateFormatter` instances are not cheap to build, so cache one per format
+    /// variant. We configure each once at init and only ever call the read-only `date(from:)`
+    /// thereafter. Apple doesn't *document* `ISO8601DateFormatter` as thread-safe, so the
+    /// `nonisolated(unsafe)` here is a deliberate choice: it asserts the never-mutated-after-init
+    /// invariant we enforce above, accepting responsibility for it rather than relying on a
+    /// documented guarantee.
+    private nonisolated(unsafe) static let plainFormatter = ISO8601DateFormatter()
+    private nonisolated(unsafe) static let fractionalFormatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f
     }()
 
+    /// `@Sendable` so this can back the `.custom` date-decoding strategy assigned in
+    /// `parse(jsonText:siteID:)` above (`decoder.dateDecodingStrategy = .custom(decodeISO8601)`),
+    /// whose parameter is `@Sendable (any Decoder) throws -> Date`.
     @Sendable private static func decodeISO8601(_ decoder: Decoder) throws -> Date {
         let raw = try decoder.singleValueContainer().decode(String.self)
         if let date = fractionalFormatter.date(from: raw) ?? plainFormatter.date(from: raw) {

--- a/Sources/AnglesiteCore/ContentListing.swift
+++ b/Sources/AnglesiteCore/ContentListing.swift
@@ -117,14 +117,14 @@ public struct ContentListing: Sendable, Equatable {
 
     /// `ISO8601DateFormatter` instances are not cheap to build and are thread-safe once
     /// configured, so cache one per format variant.
-    private static let plainFormatter = ISO8601DateFormatter()
-    private static let fractionalFormatter: ISO8601DateFormatter = {
+    nonisolated(unsafe) private static let plainFormatter = ISO8601DateFormatter()
+    nonisolated(unsafe) private static let fractionalFormatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f
     }()
 
-    private static func decodeISO8601(_ decoder: Decoder) throws -> Date {
+    @Sendable private static func decodeISO8601(_ decoder: Decoder) throws -> Date {
         let raw = try decoder.singleValueContainer().decode(String.self)
         if let date = fractionalFormatter.date(from: raw) ?? plainFormatter.date(from: raw) {
             return date

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -134,7 +134,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         }
     }
 
-    public func generateStructured<T: Generable>(
+    public func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,
         resultType: T.Type
@@ -148,7 +148,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     /// `imageURL` to the prompt so the macOS 27 on-device model can describe it (alt text, OCR,
     /// screenshot analysis). One-shot — a fresh session per call. Throws
     /// ``AssistantError/unavailable(_:)`` when the on-device model can't run on this host.
-    public func generateStructured<T: Generable>(
+    public func generateStructured<T: Generable & Sendable>(
         prompt: String,
         imageURL: URL,
         context: AssistantContext,

--- a/Sources/AnglesiteIntents/ContentEntities.swift
+++ b/Sources/AnglesiteIntents/ContentEntities.swift
@@ -18,7 +18,7 @@ public struct PageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         DisplayRepresentation(title: "\(displayName)", subtitle: "\(route)")
     }
 
-    public static var defaultQuery = PageEntityQuery()
+    public static let defaultQuery = PageEntityQuery()
 
     public init(_ page: SiteContentGraph.Page) {
         self.id = page.id
@@ -104,7 +104,7 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         )
     }
 
-    public static var defaultQuery = PostEntityQuery()
+    public static let defaultQuery = PostEntityQuery()
 
     public init(_ post: SiteContentGraph.Post) {
         self.id = post.id
@@ -189,7 +189,7 @@ public struct ImageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         DisplayRepresentation(title: "\(displayName)", subtitle: "\(relativePath)")
     }
 
-    public static var defaultQuery = ImageEntityQuery()
+    public static let defaultQuery = ImageEntityQuery()
 
     public init(_ image: SiteContentGraph.Image) {
         self.id = image.id

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -20,8 +20,8 @@ import AnglesiteCore
 // MARK: - Search
 
 public struct SearchContentIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Search Site Content"
-    public static var description = IntentDescription("Search a site's pages, posts, and images.")
+    public static let title: LocalizedStringResource = "Search Site Content"
+    public static let description = IntentDescription("Search a site's pages, posts, and images.")
 
     @Parameter(title: "Site") public var site: SiteEntity
     @Parameter(title: "Search") public var query: String
@@ -51,8 +51,8 @@ public struct SearchContentIntent: AppIntent {
 // MARK: - Status
 
 public struct SiteStatusIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Site Content Status"
-    public static var description = IntentDescription("Report how much content a site has.")
+    public static let title: LocalizedStringResource = "Site Content Status"
+    public static let description = IntentDescription("Report how much content a site has.")
 
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var graph: SiteContentGraph
@@ -89,9 +89,9 @@ public struct SiteStatusIntent: AppIntent {
 /// navigation to that page — delivering the route to the right `SiteWindow`'s WKWebView is a
 /// follow-up. Today the intent opens the site; the dialog deliberately doesn't claim more.
 public struct PreviewSiteIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Preview Site"
-    public static var description = IntentDescription("Open a site's live preview in Anglesite.")
-    public static var openAppWhenRun = true
+    public static let title: LocalizedStringResource = "Preview Site"
+    public static let description = IntentDescription("Open a site's live preview in Anglesite.")
+    public static let openAppWhenRun = true
 
     @Parameter(title: "Site") public var site: SiteEntity
     @Parameter(title: "Page") public var page: PageEntity?
@@ -110,8 +110,8 @@ public struct PreviewSiteIntent: AppIntent {
 // MARK: - Add Page
 
 public struct AddPageIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Add Page"
-    public static var description = IntentDescription("Scaffold a new page on a site with Anglesite.")
+    public static let title: LocalizedStringResource = "Add Page"
+    public static let description = IntentDescription("Scaffold a new page on a site with Anglesite.")
 
     @Parameter(title: "Site") public var site: SiteEntity
     @Parameter(title: "Name") public var name: String
@@ -149,8 +149,8 @@ public struct AddPageIntent: AppIntent {
 // MARK: - Add Post
 
 public struct AddPostIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Add Post"
-    public static var description = IntentDescription("Scaffold a new draft post on a site with Anglesite.")
+    public static let title: LocalizedStringResource = "Add Post"
+    public static let description = IntentDescription("Scaffold a new draft post on a site with Anglesite.")
 
     @Parameter(title: "Site") public var site: SiteEntity
     @Parameter(title: "Title") public var title2: String

--- a/Sources/AnglesiteIntents/EditContentIntent.swift
+++ b/Sources/AnglesiteIntents/EditContentIntent.swift
@@ -35,8 +35,8 @@ import Foundation
 /// edit naturally supersedes a stale one, and the chat panel's edit log surfaces the
 /// landed-but-cancelled patch for inspection.
 public struct EditContentIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Edit Content"
-    public static var description = IntentDescription(
+    public static let title: LocalizedStringResource = "Edit Content"
+    public static let description = IntentDescription(
         "Apply a natural-language edit to an onscreen element of a site."
     )
 

--- a/Sources/AnglesiteIntents/ElementEntity.swift
+++ b/Sources/AnglesiteIntents/ElementEntity.swift
@@ -26,7 +26,7 @@ public struct ElementEntity: AppEntity, Identifiable, Sendable {
         DisplayRepresentation(title: "\(displayName)", subtitle: "\(pagePath)")
     }
 
-    public static var defaultQuery = ElementEntityQuery()
+    public static let defaultQuery = ElementEntityQuery()
 
     public init(id: String, displayName: String, siteID: String, selector: String, pagePath: String) {
         self.id = id

--- a/Sources/AnglesiteIntents/SiteEntity.swift
+++ b/Sources/AnglesiteIntents/SiteEntity.swift
@@ -15,7 +15,7 @@ public struct SiteEntity: AppEntity, Identifiable, Sendable {
         DisplayRepresentation(title: "\(displayName)", subtitle: "\(directory.path)")
     }
 
-    public static var defaultQuery = SiteEntityQuery()
+    public static let defaultQuery = SiteEntityQuery()
 
     public init(_ site: SiteStore.Site) {
         self.id = site.id

--- a/Sources/AnglesiteIntents/SiteIntents.swift
+++ b/Sources/AnglesiteIntents/SiteIntents.swift
@@ -15,8 +15,8 @@ import AnglesiteCore
 /// (no extended budget, no Cancel UI). See #128 for cleanup once CI catches up.
 
 public struct DeploySiteIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Deploy Site"
-    public static var description = IntentDescription("Deploy a site to production with Anglesite.")
+    public static let title: LocalizedStringResource = "Deploy Site"
+    public static let description = IntentDescription("Deploy a site to production with Anglesite.")
 
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var ops: any SiteOperationsService
@@ -64,8 +64,8 @@ public struct DeploySiteIntent: AppIntent {
 }
 
 public struct BackupSiteIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Back Up Site"
-    public static var description = IntentDescription("Commit and push a site backup with Anglesite.")
+    public static let title: LocalizedStringResource = "Back Up Site"
+    public static let description = IntentDescription("Commit and push a site backup with Anglesite.")
 
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var ops: any SiteOperationsService
@@ -99,8 +99,8 @@ public struct BackupSiteIntent: AppIntent {
 }
 
 public struct AuditSiteIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Check Site"
-    public static var description = IntentDescription("Run an Anglesite audit and report findings.")
+    public static let title: LocalizedStringResource = "Check Site"
+    public static let description = IntentDescription("Run an Anglesite audit and report findings.")
 
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var ops: any SiteOperationsService
@@ -139,9 +139,9 @@ public struct AuditSiteIntent: AppIntent {
 /// entity parameter to be named `target` — that contract is also why Shortcuts can chain
 /// "find a site" → "open that site" by piping the resolved entity straight in.
 public struct OpenSiteIntent: OpenIntent {
-    public static var title: LocalizedStringResource = "Open Site"
-    public static var description = IntentDescription("Open a site window in Anglesite.")
-    public static var openAppWhenRun = true
+    public static let title: LocalizedStringResource = "Open Site"
+    public static let description = IntentDescription("Open a site window in Anglesite.")
+    public static let openAppWhenRun = true
 
     @Parameter(title: "Site") public var target: SiteEntity
 


### PR DESCRIPTION
Clears every build warning originating in our own source, across both the **Anglesite** (DevID) and **AnglesiteMAS** targets. Both targets now build clean except for Apple's macro-emitted deprecations (see below).

## Changes

| Warning | Files | Fix |
|---|---|---|
| `static var` global mutable state (`title`, `description`, `defaultQuery`, `openAppWhenRun`) | 6 files in `AnglesiteIntents/` | `static var` → `static let` (immutable protocol-conformance constants) |
| Non-Sendable `ISO8601DateFormatter` / `RelativeDateTimeFormatter` statics | `ContentListing.swift`, `BackupCommand.swift`, `ChatView.swift` | `nonisolated(unsafe)` — thread-safe once configured (already noted in comments) |
| `Date.init` → `@Sendable () -> Date` conversion | `BackupCommand.swift` | Default to `{ Date() }` |
| static func → `@Sendable` decoder conversion | `ContentListing.swift` | Mark `decodeISO8601` `@Sendable` |
| Non-Sendable `T` returned from actor across protocol boundary | `ContentAssistant.swift` + `FoundationModelAssistant.swift`, `ClaudeAssistant.swift` | Constrain generic to `T: Generable & Sendable` (all `@Generable` types already conform) |

## Remaining (not fixable here)

18 `GenerationError`/`decodingFailure` deprecation warnings are emitted inside Apple's `@Generable` **macro expansion** in the macOS 27.0 SDK — Apple's macro generates a call to an API Apple deprecated in the same release. These are independent of our deployment target and will only clear with an SDK/toolchain update that regenerates the expansion against `GeneratedContent.ParsingError`.

## Verification

- `xcodebuild -scheme Anglesite -configuration Debug clean build` → **BUILD SUCCEEDED**, no non-deprecation warnings
- `xcodebuild -scheme AnglesiteMAS -configuration Debug clean build` → **BUILD SUCCEEDED**, no non-deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)