### PR TITLE
feat(app): wire edit bridge + content graph into FoundationModelAssistant (#193)

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -333,15 +333,29 @@ struct SiteWindow: View {
                 throw NSError(domain: "AnnotationFeed", code: 2, userInfo: [NSLocalizedDescriptionKey: detail])
             }
         }
+        // Per-site edit bridge for the on-device assistant's `ApplyEditTool` (#193). Resolves the
+        // live router from `EditRouterRegistry` the same way `AnglesiteIntents.bootstrap` does — by
+        // this point `preview.open()` (above) has already registered this window's router under the
+        // site id, and `setEditObserver` (below) re-registers the observer-equipped one, so on-device
+        // edits route through the same instance the chat panel and Siri see. The bridge is a
+        // stateless struct keyed on the siteID passed at call time, so one instance serves the site.
+        let editBridge = IntentEditBridge(
+            routerProvider: { siteID in await EditRouterRegistry.shared.router(for: siteID) }
+        )
         #if ANGLESITE_MAS
         // Sandboxed App Store build: there's no `claude` CLI to shell out to, so chat is backed by
         // the on-device `FoundationModelAssistant` (#159). This is the MAS build's first chat pane.
-        // Constructed tool-less (no editBridge/contentGraph) for now, so `supportsTools` is false;
-        // wiring the on-device tools in is tracked in #193.
+        // The per-site `editBridge` + app-lifetime `contentGraph` attach `ApplyEditTool` +
+        // `SearchContentTool`, so the on-device path advertises `supportsTools` and runs a local
+        // agentic loop with no network (#193).
         chat = ChatModel(
             siteID: resolved.id,
             siteDirectory: resolved.path,
-            assistant: FoundationModelAssistant(tier: .onDevice),
+            assistant: FoundationModelAssistant(
+                tier: .onDevice,
+                editBridge: editBridge,
+                contentGraph: contentGraph
+            ),
             annotationFeed: feed,
             annotationResolver: annotationResolver,
             undoCommand: undoCommand
@@ -356,11 +370,16 @@ struct SiteWindow: View {
         // Xcode 27 / Swift 6.4; the MAS branch above relies on the same assumption. If the toolchain
         // floor ever drops below 6.4, both branches need a `#if compiler(>=6.4)` fallback.
         //
-        // Like the MAS branch, this is constructed tool-less for now (no editBridge/contentGraph);
-        // wiring the on-device tools in is tracked in #193.
+        // Like the MAS branch, the on-device path gets the per-site `editBridge` + app-lifetime
+        // `contentGraph` so it attaches `ApplyEditTool` + `SearchContentTool` and advertises
+        // `supportsTools` (#193). The Claude path carries its own tool surface and ignores these.
         let settings = AppSettings.shared
         let assistant: any ConversationalAssistant = settings.preferFoundationModels
-            ? FoundationModelAssistant(tier: settings.foundationModelTier)
+            ? FoundationModelAssistant(
+                tier: settings.foundationModelTier,
+                editBridge: editBridge,
+                contentGraph: contentGraph
+            )
             : ClaudeAssistant(siteID: resolved.id, siteDirectory: resolved.path)
         chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.path, assistant: assistant, annotationFeed: feed, annotationResolver: annotationResolver, undoCommand: undoCommand)
         #endif

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -264,6 +264,13 @@ struct SiteWindow: View {
 
     // MARK: - Lifecycle
 
+    /// Per-site edit bridge for the on-device assistant's `ApplyEditTool` (#193). Resolves the live
+    /// router from `EditRouterRegistry` lazily per call, so `setEditObserver`'s re-registration is
+    /// always visible — mirroring `AnglesiteIntents.bootstrap`.
+    private func makeEditBridge() -> IntentEditBridge {
+        IntentEditBridge(routerProvider: { id in await EditRouterRegistry.shared.router(for: id) })
+    }
+
     private func loadAndStart() async {
         // SwiftUI's NSPersistentUIManager will happily restore a WindowGroup with a
         // nil payload, or one whose value no longer matches a known site (sites.json
@@ -333,15 +340,6 @@ struct SiteWindow: View {
                 throw NSError(domain: "AnnotationFeed", code: 2, userInfo: [NSLocalizedDescriptionKey: detail])
             }
         }
-        // Per-site edit bridge for the on-device assistant's `ApplyEditTool` (#193). Resolves the
-        // live router from `EditRouterRegistry` the same way `AnglesiteIntents.bootstrap` does — by
-        // this point `preview.open()` (above) has already registered this window's router under the
-        // site id, and `setEditObserver` (below) re-registers the observer-equipped one, so on-device
-        // edits route through the same instance the chat panel and Siri see. The bridge is a
-        // stateless struct keyed on the siteID passed at call time, so one instance serves the site.
-        let editBridge = IntentEditBridge(
-            routerProvider: { siteID in await EditRouterRegistry.shared.router(for: siteID) }
-        )
         #if ANGLESITE_MAS
         // Sandboxed App Store build: there's no `claude` CLI to shell out to, so chat is backed by
         // the on-device `FoundationModelAssistant` (#159). This is the MAS build's first chat pane.
@@ -353,7 +351,7 @@ struct SiteWindow: View {
             siteDirectory: resolved.path,
             assistant: FoundationModelAssistant(
                 tier: .onDevice,
-                editBridge: editBridge,
+                editBridge: makeEditBridge(),
                 contentGraph: contentGraph
             ),
             annotationFeed: feed,
@@ -374,10 +372,12 @@ struct SiteWindow: View {
         // `contentGraph` so it attaches `ApplyEditTool` + `SearchContentTool` and advertises
         // `supportsTools` (#193). The Claude path carries its own tool surface and ignores these.
         let settings = AppSettings.shared
+        // `makeEditBridge()` is only called in the on-device arm — the ternary doesn't evaluate the
+        // untaken branch, so the Claude path does no bridge work.
         let assistant: any ConversationalAssistant = settings.preferFoundationModels
             ? FoundationModelAssistant(
                 tier: settings.foundationModelTier,
-                editBridge: editBridge,
+                editBridge: makeEditBridge(),
                 contentGraph: contentGraph
             )
             : ClaudeAssistant(siteID: resolved.id, siteDirectory: resolved.path)


### PR DESCRIPTION
## Summary

`SiteWindow` constructed the on-device `FoundationModelAssistant` without an `editBridge` or `contentGraph` on **both** the MAS and DevID paths, so it fell back to its tool-less default and advertised `supportsTools == false`. The on-device `ApplyEditTool` + `SearchContentTool` (#156) existed but nothing attached them to the live chat session — the Foundation Models pane could converse but couldn't search site content or apply edits.

This threads a per-site `IntentEditBridge` (registry-backed router provider, matching `AnglesiteIntents.bootstrap`) plus the app-lifetime `contentGraph` into both `FoundationModelAssistant` construction sites in `loadAndStart`. The on-device path now advertises `supportsTools` and runs a local agentic loop with no network.

The bridge resolves the live router from `EditRouterRegistry` the same way `AnglesiteIntents.bootstrap` does — by that point `preview.open()` has registered this window's router under the site id, and `setEditObserver` re-registers the observer-equipped one, so on-device edits route through the same instance the chat panel and Siri see.

## Acceptance

- [x] On-device chat sessions attach `ApplyEditTool` + `SearchContentTool` (local agentic loop, no network) — wiring lands on both branches.
- [x] `supportsTools` is `true` for the Foundation Models assistant when constructed from `SiteWindow` — covered by the existing `FoundationModelAssistant tool wiring` suite (`capabilitiesReflectDeps`).
- [x] Both `Anglesite` (DevID) and `AnglesiteMAS` schemes build clean — **BUILD SUCCEEDED** for both.

## Test

- `swift test --filter FoundationModelAssistant` → 19 tests, 2 suites pass.
- `xcodebuild` Debug build: `Anglesite` ✅ and `AnglesiteMAS` ✅.

Closes #193. Refs #156, #159, #160, #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)