### PR TITLE
refactor(core): extract AssistantSelection to close #193 test gap

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -333,22 +333,13 @@ struct SiteWindow: View {
                 throw NSError(domain: "AnnotationFeed", code: 2, userInfo: [NSLocalizedDescriptionKey: detail])
             }
         }
-        // Pick the chat backend, then build it via `AssistantSelection.makeAssistant` — which keeps the
-        // "on-device path is always tool-equipped" invariant (#193) in one `AnglesiteCore`-testable
-        // place (see `AssistantSelectionTests`). Only the *selection* differs per target/settings.
-        //
-        // NOTE: `AssistantSelection` is defined inside `#if compiler(>=6.4)` (it constructs the
-        // 6.4-gated assistants). These call sites are unguarded because CI builds on Xcode 27 /
-        // Swift 6.4; if the toolchain floor ever drops below 6.4 they need a `#if compiler(>=6.4)`
-        // fallback.
+        // NOTE: AssistantSelection is compiler(>=6.4)-gated; call sites are unguarded because CI is Xcode 27.
         #if ANGLESITE_MAS
-        // Sandboxed App Store build: there's no `claude` CLI to shell out to, so chat is on-device
-        // only (#159) — the MAS build's first chat pane.
+        // Sandboxed App Store build: no `claude` CLI, so chat is on-device only (#159).
         let selection: AssistantSelection = .foundationModel(tier: .onDevice)
         #else
-        // Developer ID build: Claude is the default backend, but Settings → Assistant lets the user
-        // opt into Apple's on-device Foundation Models (#160). The choice is read here at
-        // construction, so a settings change takes effect for the next-opened site window.
+        // Developer ID build: Claude by default; Settings → Assistant opts into on-device FM (#160),
+        // read here so a change takes effect for the next-opened window.
         let selection: AssistantSelection = AppSettings.shared.preferFoundationModels
             ? .foundationModel(tier: AppSettings.shared.foundationModelTier)
             : .claude

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -264,11 +264,6 @@ struct SiteWindow: View {
 
     // MARK: - Lifecycle
 
-    // Lazy-resolved so setEditObserver's re-registration is always visible.
-    private func makeEditBridge() -> IntentEditBridge {
-        IntentEditBridge(routerProvider: { id in await EditRouterRegistry.shared.router(for: id) })
-    }
-
     private func loadAndStart() async {
         // SwiftUI's NSPersistentUIManager will happily restore a WindowGroup with a
         // nil payload, or one whose value no longer matches a known site (sites.json
@@ -338,47 +333,39 @@ struct SiteWindow: View {
                 throw NSError(domain: "AnnotationFeed", code: 2, userInfo: [NSLocalizedDescriptionKey: detail])
             }
         }
+        // Pick the chat backend, then build it via `AssistantSelection.makeAssistant` — which keeps the
+        // "on-device path is always tool-equipped" invariant (#193) in one `AnglesiteCore`-testable
+        // place (see `AssistantSelectionTests`). Only the *selection* differs per target/settings.
+        //
+        // NOTE: `AssistantSelection` is defined inside `#if compiler(>=6.4)` (it constructs the
+        // 6.4-gated assistants). These call sites are unguarded because CI builds on Xcode 27 /
+        // Swift 6.4; if the toolchain floor ever drops below 6.4 they need a `#if compiler(>=6.4)`
+        // fallback.
         #if ANGLESITE_MAS
-        // Sandboxed App Store build: there's no `claude` CLI to shell out to, so chat is backed by
-        // the on-device `FoundationModelAssistant` (#159). This is the MAS build's first chat pane.
-        // The per-site `editBridge` + app-lifetime `contentGraph` attach `ApplyEditTool` +
-        // `SearchContentTool`, so the on-device path advertises `supportsTools` and runs a local
-        // agentic loop with no network (#193).
-        chat = ChatModel(
-            siteID: resolved.id,
-            siteDirectory: resolved.path,
-            assistant: FoundationModelAssistant(
-                tier: .onDevice,
-                editBridge: makeEditBridge(),
-                contentGraph: contentGraph
-            ),
-            annotationFeed: feed,
-            annotationResolver: annotationResolver,
-            undoCommand: undoCommand
-        )
+        // Sandboxed App Store build: there's no `claude` CLI to shell out to, so chat is on-device
+        // only (#159) — the MAS build's first chat pane.
+        let selection: AssistantSelection = .foundationModel(tier: .onDevice)
         #else
         // Developer ID build: Claude is the default backend, but Settings → Assistant lets the user
         // opt into Apple's on-device Foundation Models (#160). The choice is read here at
         // construction, so a settings change takes effect for the next-opened site window.
-        //
-        // NOTE: `FoundationModelAssistant` is defined inside `#if compiler(>=6.4)` (see
-        // FoundationModelAssistant.swift). This call site is unguarded because CI builds on
-        // Xcode 27 / Swift 6.4; the MAS branch above relies on the same assumption. If the toolchain
-        // floor ever drops below 6.4, both branches need a `#if compiler(>=6.4)` fallback.
-        //
-        // Like the MAS branch, the on-device path gets the per-site `editBridge` + app-lifetime
-        // `contentGraph` so it attaches `ApplyEditTool` + `SearchContentTool` and advertises
-        // `supportsTools` (#193). The Claude path carries its own tool surface and ignores these.
-        let settings = AppSettings.shared
-        let assistant: any ConversationalAssistant = settings.preferFoundationModels
-            ? FoundationModelAssistant(
-                tier: settings.foundationModelTier,
-                editBridge: makeEditBridge(),
-                contentGraph: contentGraph
-            )
-            : ClaudeAssistant(siteID: resolved.id, siteDirectory: resolved.path)
-        chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.path, assistant: assistant, annotationFeed: feed, annotationResolver: annotationResolver, undoCommand: undoCommand)
+        let selection: AssistantSelection = AppSettings.shared.preferFoundationModels
+            ? .foundationModel(tier: AppSettings.shared.foundationModelTier)
+            : .claude
         #endif
+        let assistant = selection.makeAssistant(
+            siteID: resolved.id,
+            siteDirectory: resolved.path,
+            contentGraph: contentGraph
+        )
+        chat = ChatModel(
+            siteID: resolved.id,
+            siteDirectory: resolved.path,
+            assistant: assistant,
+            annotationFeed: feed,
+            annotationResolver: annotationResolver,
+            undoCommand: undoCommand
+        )
         // Auto alt-text (C.7 / #157): after a successful image drop, generate alt text on-device and
         // apply it to the `<img>`. Target-agnostic — the on-device vision model runs on both builds.
         // The follow-up edit routes through its own (post-process-free) apply_edit router so it can't

--- a/Sources/AnglesiteCore/AssistantSelection.swift
+++ b/Sources/AnglesiteCore/AssistantSelection.swift
@@ -1,35 +1,16 @@
 import Foundation
 
-// Gated like the assistants it constructs — `FoundationModelAssistant`/`ClaudeAssistant` are both
-// inside `#if compiler(>=6.4)` (FoundationModels is absent at runtime on CI, #128). The SwiftUI call
-// site is already 6.4-only by the same assumption.
+// Compiler-gated because `FoundationModelAssistant`/`ClaudeAssistant` require Swift 6.4 (#128).
 #if compiler(>=6.4)
 
-/// Which conversational backend a `SiteWindow` should construct for a site.
-///
-/// The MAS-vs-DevID target split and the DevID `preferFoundationModels` toggle are resolved at the
-/// SwiftUI call site — the `#if ANGLESITE_MAS` compilation condition is a no-op inside this SPM
-/// package (see CLAUDE.md), so it can't live here. The call site collapses that decision into one of
-/// these cases and hands it to ``makeAssistant(siteID:siteDirectory:contentGraph:)``, keeping the
-/// actual construction — and the invariant that the on-device path is *always* tool-equipped — in one
-/// testable place rather than inline in a `View` method.
+/// Conversational backend to construct for a site session.
 public enum AssistantSelection: Sendable, Equatable {
     /// Claude via the bundled `claude` CLI (DevID only; never selected in the MAS build).
     case claude
     /// Apple's on-device FoundationModels at the given tier.
     case foundationModel(tier: FoundationModelTier)
 
-    /// Builds the `ConversationalAssistant` for this selection.
-    ///
-    /// The `.foundationModel` case is why this is centralized: it *always* attaches the per-site
-    /// `IntentEditBridge` + `contentGraph`, so the on-device assistant advertises `supportsTools` and
-    /// runs the local `ApplyEditTool` + `SearchContentTool` loop with no network (#193). A regression
-    /// that drops either collaborator is now a single-site fix caught by `AssistantSelectionTests`,
-    /// instead of passing silently in a `View` method.
-    ///
-    /// The edit bridge is built only in the on-device case (`.claude` needs none) and is stateless —
-    /// keyed on the `siteID` passed to `applyEdit` at call time — so it resolves the live router from
-    /// `EditRouterRegistry` lazily and a fresh instance per call is correct.
+    // `.foundationModel` always attaches editBridge + contentGraph — invariant lives here, not in callers.
     public func makeAssistant(
         siteID: String,
         siteDirectory: URL,

--- a/Sources/AnglesiteCore/AssistantSelection.swift
+++ b/Sources/AnglesiteCore/AssistantSelection.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+// Gated like the assistants it constructs — `FoundationModelAssistant`/`ClaudeAssistant` are both
+// inside `#if compiler(>=6.4)` (FoundationModels is absent at runtime on CI, #128). The SwiftUI call
+// site is already 6.4-only by the same assumption.
+#if compiler(>=6.4)
+
+/// Which conversational backend a `SiteWindow` should construct for a site.
+///
+/// The MAS-vs-DevID target split and the DevID `preferFoundationModels` toggle are resolved at the
+/// SwiftUI call site — the `#if ANGLESITE_MAS` compilation condition is a no-op inside this SPM
+/// package (see CLAUDE.md), so it can't live here. The call site collapses that decision into one of
+/// these cases and hands it to ``makeAssistant(siteID:siteDirectory:contentGraph:)``, keeping the
+/// actual construction — and the invariant that the on-device path is *always* tool-equipped — in one
+/// testable place rather than inline in a `View` method.
+public enum AssistantSelection: Sendable, Equatable {
+    /// Claude via the bundled `claude` CLI (DevID only; never selected in the MAS build).
+    case claude
+    /// Apple's on-device FoundationModels at the given tier.
+    case foundationModel(tier: FoundationModelTier)
+
+    /// Builds the `ConversationalAssistant` for this selection.
+    ///
+    /// The `.foundationModel` case is why this is centralized: it *always* attaches the per-site
+    /// `IntentEditBridge` + `contentGraph`, so the on-device assistant advertises `supportsTools` and
+    /// runs the local `ApplyEditTool` + `SearchContentTool` loop with no network (#193). A regression
+    /// that drops either collaborator is now a single-site fix caught by `AssistantSelectionTests`,
+    /// instead of passing silently in a `View` method.
+    ///
+    /// The edit bridge is built only in the on-device case (`.claude` needs none) and is stateless —
+    /// keyed on the `siteID` passed to `applyEdit` at call time — so it resolves the live router from
+    /// `EditRouterRegistry` lazily and a fresh instance per call is correct.
+    public func makeAssistant(
+        siteID: String,
+        siteDirectory: URL,
+        contentGraph: SiteContentGraph
+    ) -> any ConversationalAssistant {
+        switch self {
+        case .claude:
+            return ClaudeAssistant(siteID: siteID, siteDirectory: siteDirectory)
+        case .foundationModel(let tier):
+            let editBridge = IntentEditBridge(
+                routerProvider: { id in await EditRouterRegistry.shared.router(for: id) }
+            )
+            return FoundationModelAssistant(tier: tier, editBridge: editBridge, contentGraph: contentGraph)
+        }
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/AssistantSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/AssistantSelectionTests.swift
@@ -5,10 +5,6 @@ import Foundation
 // Gated like the type under test — it constructs the 6.4-gated assistants (#128).
 #if compiler(>=6.4)
 
-/// Covers the `SiteWindow.loadAndStart` wiring seam that unit tests previously missed (#193 review):
-/// that the on-device *selection* always yields a tool-equipped assistant. The capabilities are the
-/// observable signal — if a future change drops the `IntentEditBridge`/`contentGraph` inside
-/// `makeAssistant`, `supportsTools` flips to `false` and these fail.
 @Suite("AssistantSelection.makeAssistant")
 struct AssistantSelectionTests {
     private let siteID = "site-1"
@@ -18,6 +14,7 @@ struct AssistantSelectionTests {
     func onDeviceIsToolEquipped() {
         let assistant = AssistantSelection.foundationModel(tier: .onDevice)
             .makeAssistant(siteID: siteID, siteDirectory: dir, contentGraph: SiteContentGraph())
+        #expect(assistant is FoundationModelAssistant)
         let caps = assistant.capabilities
         #expect(caps.providerName == "On-Device")
         #expect(caps.supportsTools)
@@ -27,6 +24,7 @@ struct AssistantSelectionTests {
     func pccIsToolEquipped() {
         let assistant = AssistantSelection.foundationModel(tier: .privateCloudCompute)
             .makeAssistant(siteID: siteID, siteDirectory: dir, contentGraph: SiteContentGraph())
+        #expect(assistant is FoundationModelAssistant)
         let caps = assistant.capabilities
         #expect(caps.providerName == "Private Cloud Compute")
         #expect(caps.supportsTools)
@@ -36,6 +34,10 @@ struct AssistantSelectionTests {
     func claudeSelectionYieldsClaude() {
         let assistant = AssistantSelection.claude
             .makeAssistant(siteID: siteID, siteDirectory: dir, contentGraph: SiteContentGraph())
+        // `ClaudeAssistant.supportsTools` is true by design (its tools come from the CLI agent, not
+        // the on-device bridge), so the meaningful check is that the factory dispatched the Claude
+        // backend rather than the bridge-equipped on-device one.
+        #expect(assistant is ClaudeAssistant)
         #expect(assistant.capabilities.providerName == "Claude")
     }
 }

--- a/Tests/AnglesiteCoreTests/AssistantSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/AssistantSelectionTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Gated like the type under test — it constructs the 6.4-gated assistants (#128).
+#if compiler(>=6.4)
+
+/// Covers the `SiteWindow.loadAndStart` wiring seam that unit tests previously missed (#193 review):
+/// that the on-device *selection* always yields a tool-equipped assistant. The capabilities are the
+/// observable signal — if a future change drops the `IntentEditBridge`/`contentGraph` inside
+/// `makeAssistant`, `supportsTools` flips to `false` and these fail.
+@Suite("AssistantSelection.makeAssistant")
+struct AssistantSelectionTests {
+    private let siteID = "site-1"
+    private let dir = URL(fileURLWithPath: "/tmp/site")
+
+    @Test("on-device selection yields a tool-equipped FoundationModelAssistant")
+    func onDeviceIsToolEquipped() {
+        let assistant = AssistantSelection.foundationModel(tier: .onDevice)
+            .makeAssistant(siteID: siteID, siteDirectory: dir, contentGraph: SiteContentGraph())
+        let caps = assistant.capabilities
+        #expect(caps.providerName == "On-Device")
+        #expect(caps.supportsTools)
+    }
+
+    @Test("PCC-tier selection also yields a tool-equipped assistant")
+    func pccIsToolEquipped() {
+        let assistant = AssistantSelection.foundationModel(tier: .privateCloudCompute)
+            .makeAssistant(siteID: siteID, siteDirectory: dir, contentGraph: SiteContentGraph())
+        let caps = assistant.capabilities
+        #expect(caps.providerName == "Private Cloud Compute")
+        #expect(caps.supportsTools)
+    }
+
+    @Test("claude selection yields the Claude backend")
+    func claudeSelectionYieldsClaude() {
+        let assistant = AssistantSelection.claude
+            .makeAssistant(siteID: siteID, siteDirectory: dir, contentGraph: SiteContentGraph())
+        #expect(assistant.capabilities.providerName == "Claude")
+    }
+}
+#endif


### PR DESCRIPTION
Stacked on #197 (base: `feat/193-wire-fm-assistant-tools`). Addresses point 3 of the #197 review — the `loadAndStart` assistant-wiring test gap — by closing it directly rather than tracking it.

## Problem

`SiteWindow.loadAndStart` decided *and* constructed the chat assistant inline. The capability behavior was covered by `FoundationModelAssistant` unit tests, but nothing verified that `loadAndStart` actually threads a non-nil `editBridge` + `contentGraph` into the on-device path. A future `nil` slip or a misplaced branch would leave unit tests green while on-device tools silently stopped attaching.

## Change

- **New `AssistantSelection` (AnglesiteCore)** — a `.claude` / `.foundationModel(tier:)` enum with `makeAssistant(siteID:siteDirectory:contentGraph:)`. The `.foundationModel` case *always* attaches the per-site `IntentEditBridge` + `contentGraph`, so the "on-device path is tool-equipped" invariant lives in one testable place.
- **`SiteWindow.loadAndStart`** now only *selects* a case (the `#if ANGLESITE_MAS` target split + DevID `preferFoundationModels` toggle stay at the call site, since that compilation condition is a no-op in the SPM package) and calls the factory. Both target branches collapse to a single `ChatModel` construction.
- The edit bridge is built inside the factory's on-device case only, so the Claude path still does no bridge work — and `SiteWindow` no longer needs its own `makeEditBridge()` helper.
- **`AssistantSelectionTests`** asserts the on-device + PCC selections yield `supportsTools == true` with the right `providerName`, and `.claude` yields the Claude backend.

## Test

- `swift test --filter AssistantSelection` → 3 tests pass.
- `xcodebuild` Debug: `Anglesite` ✅ and `AnglesiteMAS` ✅.

Refs #193, #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)