### PR TITLE
fix(core): await one-shot process exit without blocking a cooperative thread

### DIFF
--- a/Sources/AnglesiteCore/InProcessBackend.swift
+++ b/Sources/AnglesiteCore/InProcessBackend.swift
@@ -36,6 +36,17 @@ public actor InProcessBackend: SupervisorBackend {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
+        // Bridge termination to async *before* `run()`: a fast child (e.g. `/usr/bin/true`) can exit
+        // before we reach the await, and a `terminationHandler` registered after termination never
+        // fires — the latch captures the status regardless of ordering. Crucially this never blocks a
+        // thread. The previous `process.waitUntilExit()` ran a CFRunLoop on the calling *cooperative*
+        // pool thread; under concurrent one-shot load the pool starved and the exit notification was
+        // never delivered, so the wait hung forever (a 0%-CPU deadlock — see
+        // ProcessSupervisorConcurrencyTests). The long-running `launch` path already avoids this via
+        // `awaitExit`; one-shot now matches.
+        let exitLatch = ExitLatch()
+        process.terminationHandler = { exitLatch.resume(with: $0.terminationStatus) }
+
         do {
             try process.run()
         } catch {
@@ -45,16 +56,51 @@ public actor InProcessBackend: SupervisorBackend {
         async let stdoutData = Self.readToEnd(stdoutPipe)
         async let stderrData = Self.readToEnd(stderrPipe)
         let (out, err) = await (stdoutData, stderrData)
+        let exitCode = await exitLatch.value()
 
-        process.waitUntilExit()
-
-        return ProcessResult(stdout: out, stderr: err, exitCode: process.terminationStatus)
+        return ProcessResult(stdout: out, stderr: err, exitCode: exitCode)
     }
 
     private static func readToEnd(_ pipe: Pipe) async -> Data {
         await Task.detached(priority: .userInitiated) {
             (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
         }.value
+    }
+
+    /// One-shot async bridge for `Process.terminationHandler`, which fires exactly once on a
+    /// libdispatch queue. Register the handler *before* `run()`; `value()` then returns the exit
+    /// status whether termination landed before or after the await, with no thread ever blocked.
+    /// The lock guards the early-exit vs. parked-continuation handoff; the continuation is always
+    /// resumed *outside* the lock.
+    private final class ExitLatch: @unchecked Sendable {
+        private let lock = NSLock()
+        private var status: Int32?
+        private var continuation: CheckedContinuation<Int32, Never>?
+
+        func resume(with status: Int32) {
+            lock.lock()
+            if let continuation {
+                self.continuation = nil
+                lock.unlock()
+                continuation.resume(returning: status)
+            } else {
+                self.status = status
+                lock.unlock()
+            }
+        }
+
+        func value() async -> Int32 {
+            await withCheckedContinuation { cont in
+                lock.lock()
+                if let status {
+                    lock.unlock()
+                    cont.resume(returning: status)
+                } else {
+                    continuation = cont
+                    lock.unlock()
+                }
+            }
+        }
     }
 
     // MARK: Long-running launch

--- a/Sources/AnglesiteCore/InProcessBackend.swift
+++ b/Sources/AnglesiteCore/InProcessBackend.swift
@@ -36,14 +36,9 @@ public actor InProcessBackend: SupervisorBackend {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        // Bridge termination to async *before* `run()`: a fast child (e.g. `/usr/bin/true`) can exit
-        // before we reach the await, and a `terminationHandler` registered after termination never
-        // fires — the latch captures the status regardless of ordering. Crucially this never blocks a
-        // thread. The previous `process.waitUntilExit()` ran a CFRunLoop on the calling *cooperative*
-        // pool thread; under concurrent one-shot load the pool starved and the exit notification was
-        // never delivered, so the wait hung forever (a 0%-CPU deadlock — see
-        // ProcessSupervisorConcurrencyTests). The long-running `launch` path already avoids this via
-        // `awaitExit`; one-shot now matches.
+        // Register before `run()` — a fast child can exit before the await, and a handler set after
+        // termination never fires. Non-blocking, unlike the old `waitUntilExit()` (which deadlocked a
+        // cooperative thread under load; see ProcessSupervisorConcurrencyTests).
         let exitLatch = ExitLatch()
         process.terminationHandler = { exitLatch.resume(with: $0.terminationStatus) }
 
@@ -67,11 +62,9 @@ public actor InProcessBackend: SupervisorBackend {
         }.value
     }
 
-    /// One-shot async bridge for `Process.terminationHandler`, which fires exactly once on a
-    /// libdispatch queue. Register the handler *before* `run()`; `value()` then returns the exit
-    /// status whether termination landed before or after the await, with no thread ever blocked.
-    /// The lock guards the early-exit vs. parked-continuation handoff; the continuation is always
-    /// resumed *outside* the lock.
+    /// One-shot async bridge for `Process.terminationHandler`: register before `run()`, then
+    /// `value()` returns the exit status (whether termination landed before or after the await)
+    /// without blocking a thread.
     private final class ExitLatch: @unchecked Sendable {
         private let lock = NSLock()
         private var status: Int32?

--- a/Tests/AnglesiteCoreTests/ProcessSupervisorConcurrencyTests.swift
+++ b/Tests/AnglesiteCoreTests/ProcessSupervisorConcurrencyTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Regression coverage for the `runOneShot` cooperative-pool deadlock.
+///
+/// The original defect: `InProcessBackend.runOneShot` awaited the child with the synchronous,
+/// run-loop-driven `Process.waitUntilExit()`. Called from `async` actor context it parked a Swift
+/// concurrency *cooperative* thread; under enough concurrent one-shot spawns the pool starved and
+/// the child-exit notification was never delivered, so `waitUntilExit` blocked forever (observed as
+/// a 0%-CPU hang in `swift test`, and as a `brk 1` trap when a concurrent FoundationModels inference
+/// was tipped over by the same starvation).
+///
+/// If the blocking wait is ever reintroduced this test hangs (and CI times out) rather than passing.
+struct ProcessSupervisorConcurrencyTests {
+
+    @Test("Many concurrent one-shot runs complete without deadlocking the cooperative pool")
+    func concurrentOneShotRunsDoNotDeadlock() async throws {
+        // Far more concurrent spawns than the cooperative pool has threads, each on its own
+        // supervisor (own `InProcessBackend` actor) exactly as independent call sites use it.
+        // A healthy run finishes in well under a second; the pre-fix blocking wait never returns.
+        let concurrency = 64
+        let iterationsPerTask = 16
+
+        let codes = try await withThrowingTaskGroup(of: [Int32].self) { group in
+            for _ in 0..<concurrency {
+                group.addTask {
+                    var results: [Int32] = []
+                    for _ in 0..<iterationsPerTask {
+                        let supervisor = ProcessSupervisor()
+                        let result = try await supervisor.run(
+                            executable: URL(fileURLWithPath: "/usr/bin/true")
+                        )
+                        results.append(result.exitCode)
+                    }
+                    return results
+                }
+            }
+            var all: [Int32] = []
+            for try await chunk in group { all.append(contentsOf: chunk) }
+            return all
+        }
+
+        #expect(codes.count == concurrency * iterationsPerTask)
+        #expect(codes.allSatisfy { $0 == 0 })
+    }
+
+    @Test("One-shot output is captured intact under concurrent load")
+    func concurrentOneShotRunsCaptureOutput() async throws {
+        // Same pressure, but each child prints a unique token — proves the non-blocking exit await
+        // still pairs with full pipe drainage (no truncated/missing stdout) when the pool is busy.
+        let concurrency = 48
+
+        let outputs = try await withThrowingTaskGroup(of: (Int, String).self) { group in
+            for i in 0..<concurrency {
+                group.addTask {
+                    let supervisor = ProcessSupervisor()
+                    let result = try await supervisor.run(
+                        executable: URL(fileURLWithPath: "/bin/sh"),
+                        arguments: ["-c", "printf 'token-%d' \"$IDX\""],
+                        environment: ["IDX": String(i)]
+                    )
+                    return (i, result.stdout)
+                }
+            }
+            var collected: [Int: String] = [:]
+            for try await (i, out) in group { collected[i] = out }
+            return collected
+        }
+
+        #expect(outputs.count == concurrency)
+        for i in 0..<concurrency {
+            #expect(outputs[i] == "token-\(i)")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/ProcessSupervisorConcurrencyTests.swift
+++ b/Tests/AnglesiteCoreTests/ProcessSupervisorConcurrencyTests.swift
@@ -2,16 +2,8 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
-/// Regression coverage for the `runOneShot` cooperative-pool deadlock.
-///
-/// The original defect: `InProcessBackend.runOneShot` awaited the child with the synchronous,
-/// run-loop-driven `Process.waitUntilExit()`. Called from `async` actor context it parked a Swift
-/// concurrency *cooperative* thread; under enough concurrent one-shot spawns the pool starved and
-/// the child-exit notification was never delivered, so `waitUntilExit` blocked forever (observed as
-/// a 0%-CPU hang in `swift test`, and as a `brk 1` trap when a concurrent FoundationModels inference
-/// was tipped over by the same starvation).
-///
-/// If the blocking wait is ever reintroduced this test hangs (and CI times out) rather than passing.
+/// Regression coverage for the `runOneShot` cooperative-pool deadlock (blocking `waitUntilExit` on
+/// an async actor thread). If the blocking wait returns, these hang rather than pass.
 struct ProcessSupervisorConcurrencyTests {
 
     @Test("Many concurrent one-shot runs complete without deadlocking the cooperative pool")


### PR DESCRIPTION
## Problem

`InProcessBackend.runOneShot` awaited the child with the synchronous, run-loop-driven `Process.waitUntilExit()`, which parks a Swift-concurrency **cooperative pool thread**. Under concurrent one-shot spawns the pool starved and the child-exit notification was never delivered, so the wait hung forever — surfacing as 0%-CPU deadlocks during `swift test` (and, when a concurrent FoundationModels inference was tipped over by the same starvation, intermittent `signal code 5`).

Diagnosed from a live `sample` of a wedged test host: blocked in `runOneShot → -[NSConcreteTask waitUntilExit]` at 0% CPU.

## Fix

Bridge termination through `Process.terminationHandler` + a race-safe `ExitLatch`, registering the handler **before** `run()` so a fast child (e.g. `/usr/bin/true`) that exits before the await still has its status captured. No thread is ever blocked. The long-running `launch` path already used this non-blocking pattern via `awaitExit`; one-shot now matches it.

## Verification

- New `ProcessSupervisorConcurrencyTests`: 64×16 concurrent one-shot runs **deadlock (80s+) on the old blocking wait, pass in ~0.4s** with the fix (watched it fail first).
- Full suite minus the live-model tests: 3/3 green, 0 hang, 0 crash.
- `hang=0` across 10 full-suite soak runs (serial runs previously wedged here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)