### PR TITLE
fix(core): drain-and-detach cancellation for the on-device assistant

### DIFF
--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -54,9 +54,14 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     private let editBridge: IntentEditBridge?
     private let contentGraph: SiteContentGraph?
     private let logger = Logger(subsystem: "dev.anglesite.app", category: "FoundationModelAssistant")
-    /// The in-flight ``converse(prompt:context:)`` pump, retained so ``cancel()`` can stop it. The
-    /// `generate` text stream it drains tears down transitively via that stream's `onTermination`.
-    private var activeTurn: Task<Void, Never>?
+    /// The current conversational turn's consumer-facing ``TurnRelay``, retained so ``cancel()`` can
+    /// wind it down. Cancelling stops *delivery* only — it never cancels the model stream, because
+    /// cancelling Apple's on-device `streamResponse` mid-iteration traps the process (see ``converse``).
+    private var activeRelay: TurnRelay?
+    /// How many background drain tasks are still iterating a `streamResponse` to completion. The
+    /// cached ``session`` is single-flight, so while any drain is in flight a new turn must open a
+    /// fresh session rather than reuse a busy one (a cancelled turn keeps draining in the background).
+    private var activeDrains = 0
     /// Cached session for the multi-turn ``converse(prompt:context:)`` path, so the on-device model
     /// retains conversation history across turns. Created lazily on the first turn and cleared by
     /// ``resetSession()``. The one-shot ``generate(prompt:context:)`` path deliberately bypasses it.
@@ -177,48 +182,67 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     /// on-device model exposes no discrete tool-use or token-usage telemetry, so tool invocations run
     /// opaquely inside the session and turns carry no usage.
     public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        // Re-entrancy: a new turn supersedes any still-running one for the *consumer* — its stream
+        // ends with `.cancelled`. Its background drain is deliberately left to finish (see below).
+        activeRelay?.cancel()
+        // A superseded/cancelled turn keeps draining on the cached session, which is single-flight;
+        // reusing it would throw "session busy". While any drain is in flight, open a fresh session.
+        // Once a drain finishes the session holds the *complete* response (cancel only hid the tail
+        // from the user, it didn't truncate the model's history), so later turns reuse it and keep
+        // conversation history.
+        if activeDrains > 0 { session = nil }
+
         let session = try conversationSession(for: context)
-        let textStream = Self.textStream(from: session, prompt: prompt)
         let providerName = capabilities.providerName
         let toolNames = attachedToolNames
-        // Re-entrancy: a new turn supersedes any still-running one. Cancel the old task before
-        // dropping its reference so it tears down rather than leaking onto a stream nobody reads.
-        activeTurn?.cancel()
+
         let (stream, continuation) = AsyncStream.makeStream(of: AssistantEvent.self)
-        let turn = Task {
-            continuation.yield(.started(model: providerName, toolNames: toolNames))
+        let relay = TurnRelay(continuation)
+        activeRelay = relay
+        relay.deliver(.started(model: providerName, toolNames: toolNames))
+
+        // Drain the model stream to completion on a task we NEVER cancel: cancelling Apple's
+        // on-device `streamResponse` mid-iteration traps the process (`brk 1`). `cancel()` stops
+        // consumer delivery via the relay instead, and the model finishes generating harmlessly in
+        // the background. `streamResponse` yields *cumulative* snapshots, so diff against the prior
+        // prefix to emit only the newly-appended tail (matching the per-chunk `.textDelta` contract).
+        activeDrains += 1
+        Task {
+            defer { activeDrains -= 1 }
             do {
-                for try await chunk in textStream {
-                    continuation.yield(.textDelta(chunk))
+                var previous = ""
+                for try await snapshot in session.streamResponse(to: prompt) {
+                    let full = snapshot.content
+                    let delta = full.hasPrefix(previous) ? String(full.dropFirst(previous.count)) : full
+                    previous = full
+                    relay.deliver(.textDelta(delta))
                 }
-                // The stream finishing while the turn task is cancelled means `cancel()` (or stream
-                // teardown) stopped us mid-response — `AsyncStream` iteration finishes rather than
-                // throwing on cancellation, so check the flag explicitly.
-                continuation.yield(Task.isCancelled ? .cancelled : .turnComplete(nil))
-            } catch is CancellationError {
-                continuation.yield(.cancelled)
+                relay.complete(.turnComplete(nil))
             } catch {
-                continuation.yield(.failed(message: error.localizedDescription))
+                relay.complete(.failed(message: error.localizedDescription))
             }
-            continuation.finish()
         }
-        activeTurn = turn
-        continuation.onTermination = { _ in turn.cancel() }
+
+        // Consumer dropped the stream: stop delivering, but keep draining (we never cancel the model).
+        continuation.onTermination = { _ in relay.detach() }
         return stream
     }
 
-    /// Cancels the in-flight ``converse(prompt:context:)`` turn, if any. The cached session is
-    /// preserved so the conversation can continue; use ``resetSession()`` to discard history.
+    /// Winds down the in-flight ``converse(prompt:context:)`` turn for the consumer: the event stream
+    /// ends promptly with `.cancelled`. The underlying model stream is **not** cancelled — it drains
+    /// to completion in the background (cancelling it mid-flight traps the process), leaving the
+    /// cached session coherent so the conversation can continue. Use ``resetSession()`` to forget it.
     public func cancel() async {
-        activeTurn?.cancel()
-        activeTurn = nil
+        activeRelay?.cancel()
+        activeRelay = nil
     }
 
-    /// Discards the cached ``LanguageModelSession`` (and cancels any in-flight turn) so the next
-    /// ``converse(prompt:context:)`` opens a fresh conversation with no memory of prior turns.
+    /// Discards the cached ``LanguageModelSession`` (and winds down any in-flight turn) so the next
+    /// ``converse(prompt:context:)`` opens a fresh conversation with no memory of prior turns. A
+    /// still-running background drain holds its own session reference and finishes harmlessly.
     public func resetSession() async {
-        activeTurn?.cancel()
-        activeTurn = nil
+        activeRelay?.cancel()
+        activeRelay = nil
         session = nil
     }
 

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -182,14 +182,12 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     /// on-device model exposes no discrete tool-use or token-usage telemetry, so tool invocations run
     /// opaquely inside the session and turns carry no usage.
     public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
-        // Re-entrancy: a new turn supersedes any still-running one for the *consumer* — its stream
-        // ends with `.cancelled`. Its background drain is deliberately left to finish (see below).
+        // A new turn supersedes the prior one for the consumer (its stream ends `.cancelled`); the
+        // prior drain is left to finish.
         activeRelay?.cancel()
-        // A superseded/cancelled turn keeps draining on the cached session, which is single-flight;
-        // reusing it would throw "session busy". While any drain is in flight, open a fresh session.
-        // Once a drain finishes the session holds the *complete* response (cancel only hid the tail
-        // from the user, it didn't truncate the model's history), so later turns reuse it and keep
-        // conversation history.
+        // The cached session is single-flight: reusing it while a drain still runs throws "session
+        // busy", so open a fresh one. (Once drained it holds the full response, so later turns reuse
+        // it and keep history.)
         if activeDrains > 0 { session = nil }
 
         let session = try conversationSession(for: context)
@@ -201,21 +199,25 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         activeRelay = relay
         relay.deliver(.started(model: providerName, toolNames: toolNames))
 
-        // Drain the model stream to completion on a task we NEVER cancel: cancelling Apple's
-        // on-device `streamResponse` mid-iteration traps the process (`brk 1`). `cancel()` stops
-        // consumer delivery via the relay instead, and the model finishes generating harmlessly in
-        // the background. `streamResponse` yields *cumulative* snapshots, so diff against the prior
-        // prefix to emit only the newly-appended tail (matching the per-chunk `.textDelta` contract).
+        // Drain to completion on a task we never cancel — cancelling `streamResponse` mid-iteration
+        // traps the process (`brk 1`); `cancel()` stops delivery via the relay instead.
         activeDrains += 1
+        // Unstructured `Task` in an actor inherits the actor's isolation (Swift 6), so these
+        // `activeDrains` mutations are actor-safe — keep it `Task`, not `Task.detached`.
         Task {
             defer { activeDrains -= 1 }
             do {
                 var previous = ""
                 for try await snapshot in session.streamResponse(to: prompt) {
+                    // `streamResponse` yields cumulative snapshots; emit only the newly-appended tail.
                     let full = snapshot.content
-                    let delta = full.hasPrefix(previous) ? String(full.dropFirst(previous.count)) : full
+                    if full.hasPrefix(previous) {
+                        relay.deliver(.textDelta(String(full.dropFirst(previous.count))))
+                    } else {
+                        logger.warning("streamResponse snapshot not cumulative — emitting full content as delta")
+                        relay.deliver(.textDelta(full))
+                    }
                     previous = full
-                    relay.deliver(.textDelta(delta))
                 }
                 relay.complete(.turnComplete(nil))
             } catch {

--- a/Sources/AnglesiteCore/TurnRelay.swift
+++ b/Sources/AnglesiteCore/TurnRelay.swift
@@ -1,17 +1,10 @@
 import Foundation
 
-/// Relays one conversational turn's ``AssistantEvent`` values to a single consumer `AsyncStream`,
-/// decoupling consumer-side cancellation from the underlying model stream.
-///
-/// The reason this exists: cancelling Apple's on-device `FoundationModels` `streamResponse`
-/// iteration *mid-flight* traps the process (`brk 1`). So ``FoundationModelAssistant`` drains the
-/// model stream to completion on a task it never cancels, funnelling every snapshot through a relay.
-/// `cancel()` here stops *delivering* to the consumer and emits a terminal `.cancelled` — it never
-/// touches the model. All terminal transitions (`complete`/`cancel`/`detach`) are once-only and
-/// thread-safe, since the draining task and the actor's `cancel()` race to end the same turn.
-///
-/// Ungated (no `FoundationModels` dependency) so it is unit-testable on any toolchain, including CI
-/// where the model is absent.
+/// Relays one conversational turn's ``AssistantEvent`` values to a consumer `AsyncStream`, so
+/// ``FoundationModelAssistant`` can stop *delivering* on cancel without cancelling the model stream
+/// (cancelling Apple's `streamResponse` mid-flight traps the process). Terminal transitions
+/// (`complete`/`cancel`/`detach`) are once-only and thread-safe — the draining task and `cancel()`
+/// race to end the same turn. Ungated, so it unit-tests on any toolchain (incl. CI without the model).
 final class TurnRelay: @unchecked Sendable {
     private let lock = NSLock()
     private var finished = false

--- a/Sources/AnglesiteCore/TurnRelay.swift
+++ b/Sources/AnglesiteCore/TurnRelay.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Relays one conversational turn's ``AssistantEvent`` values to a single consumer `AsyncStream`,
+/// decoupling consumer-side cancellation from the underlying model stream.
+///
+/// The reason this exists: cancelling Apple's on-device `FoundationModels` `streamResponse`
+/// iteration *mid-flight* traps the process (`brk 1`). So ``FoundationModelAssistant`` drains the
+/// model stream to completion on a task it never cancels, funnelling every snapshot through a relay.
+/// `cancel()` here stops *delivering* to the consumer and emits a terminal `.cancelled` — it never
+/// touches the model. All terminal transitions (`complete`/`cancel`/`detach`) are once-only and
+/// thread-safe, since the draining task and the actor's `cancel()` race to end the same turn.
+///
+/// Ungated (no `FoundationModels` dependency) so it is unit-testable on any toolchain, including CI
+/// where the model is absent.
+final class TurnRelay: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finished = false
+    private let continuation: AsyncStream<AssistantEvent>.Continuation
+
+    init(_ continuation: AsyncStream<AssistantEvent>.Continuation) {
+        self.continuation = continuation
+    }
+
+    /// Forward a non-terminal event (`.started`, `.textDelta`) to the consumer, unless the turn has
+    /// already ended (cancelled, detached, or completed). A no-op after the turn ends — so deltas
+    /// from the still-draining model stream after a cancel are silently dropped.
+    func deliver(_ event: AssistantEvent) {
+        lock.lock()
+        let done = finished
+        lock.unlock()
+        // A `yield` after `finish()` is a harmless no-op, so the brief unlocked window before this
+        // line can't double-deliver; the lock is only for `finished`'s memory visibility.
+        if !done { continuation.yield(event) }
+    }
+
+    /// End the turn with a terminal event the model produced (`.turnComplete`/`.failed`).
+    /// Ignored if the turn already ended (e.g. the consumer cancelled first).
+    func complete(_ event: AssistantEvent) { end(emitting: event) }
+
+    /// Consumer-initiated cancel: end the turn with `.cancelled`. Ignored if already ended.
+    func cancel() { end(emitting: .cancelled) }
+
+    /// The consumer dropped the stream: end silently with no terminal event. Ignored if already ended.
+    func detach() { end(emitting: nil) }
+
+    /// Once-only terminal transition: the draining task (`complete`) and the actor (`cancel`/`detach`)
+    /// race to end the same turn; the first wins and emits its event, the rest are no-ops.
+    private func end(emitting event: AssistantEvent?) {
+        lock.lock()
+        if finished {
+            lock.unlock()
+            return
+        }
+        finished = true
+        lock.unlock()
+        if let event { continuation.yield(event) }
+        continuation.finish()
+    }
+}

--- a/Tests/AnglesiteCoreTests/TurnRelayTests.swift
+++ b/Tests/AnglesiteCoreTests/TurnRelayTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// `TurnRelay` is the consumer-facing half of ``FoundationModelAssistant``'s drain-and-detach
+/// cancellation: it gates event delivery and enforces once-only terminal transitions, with no
+/// dependency on the live model — so these run on any toolchain.
+@Suite("TurnRelay")
+struct TurnRelayTests {
+
+    /// Drive `body` against a fresh relay, then collect everything the consumer stream emits.
+    /// The relay must reach a terminal state (`complete`/`cancel`/`detach`) or this would hang —
+    /// which is itself the contract under test.
+    private func collect(_ body: (TurnRelay) -> Void) async -> [AssistantEvent] {
+        let (stream, continuation) = AsyncStream.makeStream(of: AssistantEvent.self)
+        let relay = TurnRelay(continuation)
+        body(relay)
+        var events: [AssistantEvent] = []
+        for await event in stream { events.append(event) }
+        return events
+    }
+
+    @Test("delivers events in order, then a terminal complete")
+    func deliversThenCompletes() async {
+        let events = await collect { relay in
+            relay.deliver(.started(model: "On-Device", toolNames: []))
+            relay.deliver(.textDelta("Hello"))
+            relay.deliver(.textDelta(" world"))
+            relay.complete(.turnComplete(nil))
+        }
+        #expect(events == [
+            .started(model: "On-Device", toolNames: []),
+            .textDelta("Hello"),
+            .textDelta(" world"),
+            .turnComplete(nil),
+        ])
+    }
+
+    @Test("cancel emits .cancelled and suppresses later deliver/complete")
+    func cancelStopsDelivery() async {
+        let events = await collect { relay in
+            relay.deliver(.textDelta("partial"))
+            relay.cancel()
+            // These arrive from the still-draining model stream after the user cancelled — they
+            // must NOT reach the consumer, and must NOT produce a second terminal event.
+            relay.deliver(.textDelta("more"))
+            relay.complete(.turnComplete(nil))
+        }
+        #expect(events == [.textDelta("partial"), .cancelled])
+    }
+
+    @Test("complete is once-only")
+    func completeIsOnceOnly() async {
+        let events = await collect { relay in
+            relay.complete(.turnComplete(nil))
+            relay.complete(.failed(message: "late"))
+        }
+        #expect(events == [.turnComplete(nil)])
+    }
+
+    @Test("detach ends the stream silently with no terminal event")
+    func detachIsSilent() async {
+        let events = await collect { relay in
+            relay.deliver(.textDelta("partial"))
+            relay.detach()
+            relay.deliver(.textDelta("more"))
+            relay.complete(.turnComplete(nil))
+        }
+        #expect(events == [.textDelta("partial")])
+    }
+
+    @Test("cancel after a turn already ended is a no-op")
+    func cancelAfterEndIsNoOp() async {
+        let events = await collect { relay in
+            relay.complete(.turnComplete(nil))
+            relay.cancel()
+        }
+        #expect(events == [.turnComplete(nil)])
+    }
+}


### PR DESCRIPTION
## Problem

Cancelling Apple's FoundationModels `streamResponse` iteration **mid-flight traps the process** (`EXC_BREAKPOINT` / `brk 1`, surfaced by `swift test` as `exited with unexpected signal code 5`). `FoundationModelAssistant.cancel()` did exactly that — it cancelled the turn `Task`, whose `textStream` `onTermination` cancelled the `streamResponse` task.

This is a **production risk**, not just a test artifact: a user hitting "stop" mid-response runs the same `converse`/`cancel` path in the DevID + MAS chat panes. Locally it failed the model test suite ~33% of runs; bisected (serial mode, last-started-but-unfinished test) to `cancelMidStreamYieldsCancelled`, confirmed by exclusion — skipping it gave 8/8 clean. The trap is inside Apple's stripped shared-cache framework (not symbolicatable), so it's an Apple bug we mitigate rather than patch.

> Local-only for CI: CI runs where FoundationModels is absent at runtime (#128), so `modelAvailable()` is false and these tests skip — only model-capable Apple Silicon dev machines hit it.

## Fix — drain-and-detach

Drain the model stream to completion on a task that is **never cancelled**, funnelling snapshots through a new `TurnRelay`. `cancel()` ends the *consumer* stream with `.cancelled` but lets the model finish generating harmlessly in the background, so it never hits the crashy cancellation path.

Because the drain always completes, the cached session ends up holding the *full* response and stays coherent for later turns (cancel only hid the tail from the user). While any drain is still in flight, a fresh session is opened to avoid FoundationModels' single-flight "session busy" error (`activeDrains` counter).

`TurnRelay` is ungated (no FoundationModels dependency), so its once-only terminal-transition logic is unit-tested on any toolchain including CI.

## Verification

- Model suite **including** the cancel test: **~33% crash → 12/12 clean** (at a 33% baseline, 12 consecutive clean is <1% by chance).
- `TurnRelay`: 5 RED→GREEN unit tests.
- `swift build` clean (no concurrency/Sendable warnings).

## Follow-up (out of scope)

The one-shot `generate`/`textStream` path still cancels its task on early consumer teardown — same latent trap, lower risk (one-shot callers consume the stream fully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)