### PR TITLE
fix(core): drain-and-detach cancellation for the one-shot generate path (#201)

### DIFF
--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -111,31 +111,37 @@ public actor FoundationModelAssistant: ConversationalAssistant {
 
     /// Streams a session's response as incremental text deltas. `streamResponse` yields *cumulative*
     /// snapshots, so we diff against the prior prefix to emit only newly-appended text (matching the
-    /// ``ContentAssistant`` per-chunk contract). Shared by `generate` (fresh session) and `converse`
-    /// (cached session).
+    /// ``ContentAssistant`` per-chunk contract). Backs the one-shot `generate` path; `converse` runs
+    /// its own ``TurnRelay`` drain over the cached session for the multi-turn `AssistantEvent` stream.
     private static func textStream(from session: LanguageModelSession, prompt: String) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
-            let task = Task {
+            let relay = TextStreamRelay(continuation)
+            // Drain to completion on a task we never cancel — cancelling `streamResponse`
+            // mid-iteration traps the process (`brk 1`, #200/#201). If the consumer drops the stream
+            // early the drain keeps running and its chunks are discarded (the session is per-call and
+            // unreferenced afterwards), mirroring `converse`'s drain-and-detach.
+            Task {
                 do {
                     var previous = ""
                     for try await snapshot in session.streamResponse(to: prompt) {
                         let full = snapshot.content
                         if full.hasPrefix(previous) {
                             // Confirmed cumulative prefix — emit only the newly-appended tail.
-                            continuation.yield(String(full.dropFirst(previous.count)))
+                            relay.deliver(String(full.dropFirst(previous.count)))
                         } else {
                             // The model revised earlier text (same or different length), so the
                             // snapshot isn't an extension of `previous`; yield it whole.
-                            continuation.yield(full)
+                            relay.deliver(full)
                         }
                         previous = full
                     }
-                    continuation.finish()
+                    relay.complete()
                 } catch {
-                    continuation.finish(throwing: error)
+                    relay.fail(error)
                 }
             }
-            continuation.onTermination = { _ in task.cancel() }
+            // Consumer dropped the stream: stop delivering, but keep draining (we never cancel the model).
+            continuation.onTermination = { _ in relay.detach() }
         }
     }
 

--- a/Sources/AnglesiteCore/TextStreamRelay.swift
+++ b/Sources/AnglesiteCore/TextStreamRelay.swift
@@ -26,8 +26,9 @@ final class TextStreamRelay: @unchecked Sendable {
         lock.lock()
         let done = finished
         lock.unlock()
-        // A `yield` after `finish()` is a harmless no-op, so the brief unlocked window before this
-        // line can't double-deliver; the lock is only for `finished`'s memory visibility.
+        // Releasing the lock before `yield` is safe: if `end(throwing:)` races in on another thread
+        // between the unlock and this line, a stale `yield` after `continuation.finish()` is
+        // documented as a no-op. The lock only guards `finished`'s memory visibility.
         if !done { continuation.yield(text) }
     }
 

--- a/Sources/AnglesiteCore/TextStreamRelay.swift
+++ b/Sources/AnglesiteCore/TextStreamRelay.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Relays one one-shot generation's text chunks to a consumer `AsyncThrowingStream<String, Error>`,
+/// so ``FoundationModelAssistant``'s `generate`/`textStream` path can stop *delivering* when the
+/// consumer drops the stream without cancelling the model iteration (cancelling Apple's
+/// `streamResponse` mid-flight traps the process — `brk 1`; see ``TurnRelay`` and #200/#201).
+///
+/// The throwing-`String` sibling of ``TurnRelay``: where `TurnRelay` carries an in-band terminal
+/// ``AssistantEvent``, a text stream's terminal is just the stream ending (`complete`/`detach`) or
+/// ending with an error (`fail`). Terminal transitions are once-only and thread-safe — the draining
+/// task and the consumer's `onTermination` race to end the same stream. Ungated, so it unit-tests on
+/// any toolchain (incl. CI without the model).
+final class TextStreamRelay: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finished = false
+    private let continuation: AsyncThrowingStream<String, Error>.Continuation
+
+    init(_ continuation: AsyncThrowingStream<String, Error>.Continuation) {
+        self.continuation = continuation
+    }
+
+    /// Forward a text chunk to the consumer, unless the stream has already ended (completed, failed,
+    /// or detached). A no-op after the stream ends — so chunks from the still-draining model stream
+    /// after a detach are silently dropped.
+    func deliver(_ text: String) {
+        lock.lock()
+        let done = finished
+        lock.unlock()
+        // A `yield` after `finish()` is a harmless no-op, so the brief unlocked window before this
+        // line can't double-deliver; the lock is only for `finished`'s memory visibility.
+        if !done { continuation.yield(text) }
+    }
+
+    /// End the stream normally (the drain reached the model's end-of-response). Ignored if the
+    /// stream already ended (e.g. the consumer dropped it first).
+    func complete() { end(throwing: nil) }
+
+    /// End the stream with an error the model produced. Ignored if the stream already ended.
+    func fail(_ error: Error) { end(throwing: error) }
+
+    /// The consumer dropped the stream: end delivery without surfacing an error, never cancelling the
+    /// model iteration. Ignored if already ended. Distinct from ``complete()`` only in intent — both
+    /// finish without throwing — so a detach can't leak a late `fail` to a consumer that already left.
+    func detach() { end(throwing: nil) }
+
+    /// Once-only terminal transition: the draining task (`complete`/`fail`) and the consumer's
+    /// `onTermination` (`detach`) race to end the same stream; the first wins, the rest are no-ops.
+    private func end(throwing error: Error?) {
+        lock.lock()
+        if finished {
+            lock.unlock()
+            return
+        }
+        finished = true
+        lock.unlock()
+        continuation.finish(throwing: error)
+    }
+}

--- a/Sources/AnglesiteCore/TurnRelay.swift
+++ b/Sources/AnglesiteCore/TurnRelay.swift
@@ -21,8 +21,9 @@ final class TurnRelay: @unchecked Sendable {
         lock.lock()
         let done = finished
         lock.unlock()
-        // A `yield` after `finish()` is a harmless no-op, so the brief unlocked window before this
-        // line can't double-deliver; the lock is only for `finished`'s memory visibility.
+        // Releasing the lock before `yield` is safe: if `end(emitting:)` races in on another thread
+        // between the unlock and this line, a stale `yield` after `continuation.finish()` is
+        // documented as a no-op. The lock only guards `finished`'s memory visibility.
         if !done { continuation.yield(event) }
     }
 

--- a/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
@@ -87,6 +87,28 @@ struct FoundationModelAssistantTests {
         #expect(!collected.isEmpty)
     }
 
+    @Test("abandoning a generate stream mid-generation drains without trapping (#201)")
+    func abandonGenerateMidStreamDoesNotTrap() async throws {
+        guard modelAvailable() else { return }
+        let assistant = FoundationModelAssistant()
+        // Repeatedly drop the stream after the first chunk while the model is still producing. Before
+        // #201 this fired `task.cancel()` in `onTermination`, cancelling `streamResponse` mid-iteration
+        // and trapping the process (`brk 1`, signal 5); the drain-and-detach fix lets it finish in the
+        // background. The trap is timing-dependent, so loop to make the regression reliable to catch —
+        // against the buggy code this crashes within a handful of iterations.
+        for _ in 0..<10 {
+            for try await _ in try await assistant.generate(
+                prompt: "Write a long, detailed, multi-paragraph history of typography.",
+                context: makeContext()
+            ) {
+                break
+            }
+        }
+        // Give the abandoned background drains time to keep iterating the model stream — if an early
+        // teardown still cancelled one, the trap would crash the test process rather than survive.
+        try await Task.sleep(for: .seconds(1))
+    }
+
     @Test("generateStructured returns the requested Generable type")
     func generateStructuredReturnsType() async throws {
         guard modelAvailable() else { return }

--- a/Tests/AnglesiteCoreTests/TextStreamRelayTests.swift
+++ b/Tests/AnglesiteCoreTests/TextStreamRelayTests.swift
@@ -92,4 +92,45 @@ struct TextStreamRelayTests {
         #expect(result.chunks.isEmpty)
         #expect(result.error == nil)
     }
+
+    /// Exercises the actual race the lock guards: a draining producer (`deliver`×N then `complete`)
+    /// against a consumer-teardown `detach`, with the consumer reading concurrently. The sequential
+    /// tests above can't reach this path — they finish all relay calls before the stream is read.
+    /// Repeated trials make a torn read or missing-lock crash likely to surface; each trial asserts
+    /// the consumer never hangs and sees an in-order, gap-free prefix of the delivered chunks.
+    @Test("concurrent deliver/complete vs detach terminates cleanly with ordered chunks")
+    func concurrentDeliverDetachRace() async {
+        let chunkCount = 100
+        for _ in 0..<200 {
+            let (stream, continuation) = AsyncThrowingStream.makeStream(of: String.self)
+            let relay = TextStreamRelay(continuation)
+
+            // Consumer reads concurrently with the producers below.
+            async let collected: [String] = {
+                var chunks: [String] = []
+                do {
+                    for try await chunk in stream { chunks.append(chunk) }
+                } catch {
+                    // A detach/complete race never finishes with an error; tolerate it regardless.
+                }
+                return chunks
+            }()
+
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    for i in 0..<chunkCount { relay.deliver(String(i)) }
+                    relay.complete()
+                }
+                group.addTask { relay.detach() }
+            }
+
+            // Whatever survived the race is a contiguous prefix of 0,1,2,… — a single in-order
+            // producer plus the once-finished gate can drop a suffix but never reorder or skip.
+            let result = await collected
+            for (i, chunk) in result.enumerated() {
+                #expect(chunk == String(i))
+            }
+            #expect(result.count <= chunkCount)
+        }
+    }
 }

--- a/Tests/AnglesiteCoreTests/TextStreamRelayTests.swift
+++ b/Tests/AnglesiteCoreTests/TextStreamRelayTests.swift
@@ -1,0 +1,95 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// `TextStreamRelay` is the consumer-facing half of ``FoundationModelAssistant``'s one-shot
+/// (`generate`/`textStream`) drain-and-detach cancellation: it gates text delivery and enforces
+/// once-only terminal transitions, with no dependency on the live model — so these run on any
+/// toolchain. It mirrors ``TurnRelay`` for the throwing `String` stream the one-shot path yields.
+@Suite("TextStreamRelay")
+struct TextStreamRelayTests {
+
+    private struct SampleError: Error, Equatable { let message: String }
+
+    /// Drive `body` against a fresh relay, then collect the consumer stream's chunks plus any
+    /// thrown terminal error. The relay must reach a terminal state (`complete`/`fail`/`detach`)
+    /// or this would hang — which is itself the contract under test.
+    private func collect(_ body: (TextStreamRelay) -> Void) async -> (chunks: [String], error: Error?) {
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: String.self)
+        let relay = TextStreamRelay(continuation)
+        body(relay)
+        var chunks: [String] = []
+        do {
+            for try await chunk in stream { chunks.append(chunk) }
+            return (chunks, nil)
+        } catch {
+            return (chunks, error)
+        }
+    }
+
+    @Test("delivers text in order, then a terminal complete with no error")
+    func deliversThenCompletes() async {
+        let result = await collect { relay in
+            relay.deliver("Hello")
+            relay.deliver(" world")
+            relay.complete()
+        }
+        #expect(result.chunks == ["Hello", " world"])
+        #expect(result.error == nil)
+    }
+
+    @Test("detach stops delivery and ends without error")
+    func detachStopsDelivery() async {
+        let result = await collect { relay in
+            relay.deliver("partial")
+            // The consumer dropped the stream. Chunks arriving afterwards from the still-draining
+            // model task must NOT reach the consumer, and the drain's own `complete()` is a no-op.
+            relay.detach()
+            relay.deliver("more")
+            relay.complete()
+        }
+        #expect(result.chunks == ["partial"])
+        #expect(result.error == nil)
+    }
+
+    @Test("fail surfaces the error to the consumer")
+    func failSurfacesError() async {
+        let result = await collect { relay in
+            relay.deliver("partial")
+            relay.fail(SampleError(message: "boom"))
+        }
+        #expect(result.chunks == ["partial"])
+        #expect((result.error as? SampleError) == SampleError(message: "boom"))
+    }
+
+    @Test("complete is once-only and suppresses a later fail")
+    func completeIsOnceOnly() async {
+        let result = await collect { relay in
+            relay.complete()
+            relay.fail(SampleError(message: "late"))
+        }
+        #expect(result.chunks.isEmpty)
+        #expect(result.error == nil)
+    }
+
+    @Test("fail after detach is suppressed — no error leaks to a detached consumer")
+    func failAfterDetachIsSuppressed() async {
+        let result = await collect { relay in
+            relay.deliver("partial")
+            relay.detach()
+            relay.fail(SampleError(message: "after detach"))
+        }
+        #expect(result.chunks == ["partial"])
+        #expect(result.error == nil)
+    }
+
+    @Test("detach after complete is a no-op")
+    func detachAfterCompleteIsNoOp() async {
+        let result = await collect { relay in
+            relay.complete()
+            relay.detach()
+        }
+        #expect(result.chunks.isEmpty)
+        #expect(result.error == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/TurnRelayTests.swift
+++ b/Tests/AnglesiteCoreTests/TurnRelayTests.swift
@@ -77,4 +77,59 @@ struct TurnRelayTests {
         }
         #expect(events == [.turnComplete(nil)])
     }
+
+    /// Exercises the actual race the lock guards: a draining producer (`deliver`×N then `complete`)
+    /// against a consumer-initiated `cancel`, with the consumer reading concurrently. The sequential
+    /// tests above finish all relay calls before the stream is read, so they never reach this path.
+    /// Repeated trials make a torn read or missing-lock crash likely to surface; each trial asserts
+    /// the consumer never hangs, sees an in-order prefix of the deltas, and ends with exactly one
+    /// terminal event (`.turnComplete` or `.cancelled` — whichever won the race).
+    @Test("concurrent deliver/complete vs cancel terminates with one terminal and ordered deltas")
+    func concurrentDeliverCancelRace() async {
+        let deltaCount = 100
+        for _ in 0..<200 {
+            let (stream, continuation) = AsyncStream.makeStream(of: AssistantEvent.self)
+            let relay = TurnRelay(continuation)
+
+            async let collected: [AssistantEvent] = {
+                var events: [AssistantEvent] = []
+                for await event in stream { events.append(event) }
+                return events
+            }()
+
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    for i in 0..<deltaCount { relay.deliver(.textDelta(String(i))) }
+                    relay.complete(.turnComplete(nil))
+                }
+                group.addTask { relay.cancel() }
+            }
+
+            let events = await collected
+            // Exactly one terminal event, and it is last.
+            let terminals = events.filter {
+                if case .turnComplete = $0 { return true }
+                if case .cancelled = $0 { return true }
+                if case .failed = $0 { return true }
+                return false
+            }
+            #expect(terminals.count == 1)
+            if let last = events.last {
+                let lastIsTerminal: Bool = {
+                    if case .turnComplete = last { return true }
+                    if case .cancelled = last { return true }
+                    return false
+                }()
+                #expect(lastIsTerminal)
+            }
+            // The text deltas that survived the race are a contiguous, in-order prefix of 0,1,2,…
+            let deltas: [String] = events.compactMap {
+                if case .textDelta(let text) = $0 { return text }
+                return nil
+            }
+            for (i, text) in deltas.enumerated() {
+                #expect(text == String(i))
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #200, which fixed the conversational `converse` path. The one-shot `generate` path retained the same latent trap: `textStream` cancelled the underlying `session.streamResponse` iteration via `task.cancel()` in `onTermination`.

If a consumer drops the returned stream early (a timeout, view teardown, or cancelled enclosing task), `task.cancel()` cancels Apple's on-device model stream **mid-flight** — the exact path that traps the process with `EXC_BREAKPOINT` / `brk 1` (signal 5).

Scope note: only `generate` is affected. `generateStructured` calls `oneShotSession.respond(to:generating:)` directly — a plain `async throws` returning `T`, never `textStream`/`streamResponse` — so it was never on this trap's path.

## Fix

Apply #200's principle to the one-shot path: never cancel the model iteration on teardown. `textStream` now routes through a new **`TextStreamRelay`** — the throwing-`String` sibling of `TurnRelay` — that gates delivery and enforces once-only terminal transitions. On consumer teardown it `detach()`es: delivery stops, the drain finishes in the background, and its chunks are discarded (the session is per-call and unreferenced afterwards).

## Tests

- **`TextStreamRelayTests`** — ungated unit tests for the gating discipline (deliver / complete / fail / detach, once-only terminals), CI-runnable without the model, mirroring `TurnRelayTests`.
- **Concurrent race tests** (both relays) — read the stream concurrently while a producer delivers N chunks + completes and a second task detaches/cancels, across 200 trials. Asserts the consumer never hangs, sees a gap-free in-order prefix, and ends with exactly one terminal. These exercise the actual lock-guarded race the sequential tests can't reach.
- **Model-gated soak** — abandons a `generate` stream mid-generation, looped `10×` (the trap lands within ~4 iterations against the buggy code, so 10 is ample margin). Separately verified by hand: the fix survives a 20-iteration run, while reverting to the old `task.cancel()` crashes with **signal 5 within ~4 iterations** — confirming the soak genuinely catches the regression.

Full `swift test` suite green.

## Acceptance (#201)

- [x] Dropping a `generate` stream early never cancels a live `streamResponse`.
- [x] Soak: abandoning a one-shot stream mid-generation does not crash (model-capable host).

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)