### PR TITLE
ci(core): run relay concurrency suites under ThreadSanitizer (#203)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,27 @@ jobs:
 
       - name: Build (release)
         run: swift build -c release
+
+  relay-tsan:
+    name: Relay concurrency suites (ThreadSanitizer)
+    runs-on: macos-15
+    timeout-minutes: 15
+    # The relay suites (TurnRelay/TextStreamRelay) have no plugin/Node dependency, so this lane
+    # skips the sibling-plugin checkout. TSan deterministically flags data races the probabilistic
+    # `concurrentDeliver*` tests would otherwise only catch by timing luck (#203).
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select latest available Xcode
+        # Same toolchain rationale as build-test: CLAUDE.md mandates Xcode 27+.
+        run: |
+          set -euo pipefail
+          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          echo "Selecting: $LATEST"
+          sudo xcode-select -s "$LATEST"
+
+      - name: Show toolchain versions
+        run: swift --version
+
+      - name: Run relay suites under ThreadSanitizer
+        run: scripts/test-relay-tsan.sh

--- a/Sources/AnglesiteCore/TurnRelay.swift
+++ b/Sources/AnglesiteCore/TurnRelay.swift
@@ -18,13 +18,16 @@ final class TurnRelay: @unchecked Sendable {
     /// already ended (cancelled, detached, or completed). A no-op after the turn ends — so deltas
     /// from the still-draining model stream after a cancel are silently dropped.
     func deliver(_ event: AssistantEvent) {
+        // Hold the lock across the `yield`: it serializes this delivery against `end`'s terminal
+        // `yield`, guaranteeing the terminal event is the last thing the consumer sees. Releasing
+        // the lock before yielding (as an earlier version did) lets a `deliver` land *between*
+        // `end`'s terminal yield and its `finish()`, leaving a non-terminal event after the
+        // terminal one. `yield` only buffers — it never re-enters the relay — so locking across it
+        // cannot deadlock; `finish()` can re-enter (via `onTermination`), which is why `end`
+        // releases the lock before calling it.
         lock.lock()
-        let done = finished
-        lock.unlock()
-        // Releasing the lock before `yield` is safe: if `end(emitting:)` races in on another thread
-        // between the unlock and this line, a stale `yield` after `continuation.finish()` is
-        // documented as a no-op. The lock only guards `finished`'s memory visibility.
-        if !done { continuation.yield(event) }
+        defer { lock.unlock() }
+        if !finished { continuation.yield(event) }
     }
 
     /// End the turn with a terminal event the model produced (`.turnComplete`/`.failed`).
@@ -46,8 +49,15 @@ final class TurnRelay: @unchecked Sendable {
             return
         }
         finished = true
-        lock.unlock()
+        // Yield the terminal event under the lock so a concurrent `deliver` (which checks
+        // `finished` and yields under the same lock) cannot interleave a non-terminal event after
+        // it — the terminal stays last in the buffer.
         if let event { continuation.yield(event) }
+        lock.unlock()
+        // `finish()` synchronously runs the consumer's `onTermination`, which re-enters this relay
+        // via `detach()`, so it must be outside the lock to avoid deadlocking on the non-recursive
+        // `NSLock`. By here `finished` is set, so any racing `deliver` that next acquires the lock
+        // sees it and skips — no stray yield can land after the terminal event.
         continuation.finish()
     }
 }

--- a/Sources/AnglesiteCore/TurnRelay.swift
+++ b/Sources/AnglesiteCore/TurnRelay.swift
@@ -22,12 +22,13 @@ final class TurnRelay: @unchecked Sendable {
         // `yield`, guaranteeing the terminal event is the last thing the consumer sees. Releasing
         // the lock before yielding (as an earlier version did) lets a `deliver` land *between*
         // `end`'s terminal yield and its `finish()`, leaving a non-terminal event after the
-        // terminal one. `yield` only buffers — it never re-enters the relay — so locking across it
-        // cannot deadlock; `finish()` can re-enter (via `onTermination`), which is why `end`
-        // releases the lock before calling it.
-        lock.lock()
-        defer { lock.unlock() }
-        if !finished { continuation.yield(event) }
+        // terminal one. `yield` is non-blocking (per the `AsyncStream.Continuation` docs it
+        // enqueues into the stream buffer and returns immediately, never calling back into user
+        // code on this thread), so locking across it cannot deadlock; `finish()` *can* re-enter
+        // (via `onTermination`), which is why `end` releases the lock before calling it.
+        lock.withLock {
+            if !finished { continuation.yield(event) }
+        }
     }
 
     /// End the turn with a terminal event the model produced (`.turnComplete`/`.failed`).
@@ -43,21 +44,21 @@ final class TurnRelay: @unchecked Sendable {
     /// Once-only terminal transition: the draining task (`complete`) and the actor (`cancel`/`detach`)
     /// race to end the same turn; the first wins and emits its event, the rest are no-ops.
     private func end(emitting event: AssistantEvent?) {
-        lock.lock()
-        if finished {
-            lock.unlock()
-            return
+        // Critical section: claim the once-only terminal transition and yield the terminal event
+        // under the lock, so a concurrent `deliver` (which checks `finished` and yields under the
+        // same lock) cannot interleave a non-terminal event after it — the terminal stays last in
+        // the buffer. Returns whether *this* call won the race and therefore owns the `finish()`.
+        let didFinish = lock.withLock { () -> Bool in
+            if finished { return false }
+            finished = true
+            if let event { continuation.yield(event) }
+            return true
         }
-        finished = true
-        // Yield the terminal event under the lock so a concurrent `deliver` (which checks
-        // `finished` and yields under the same lock) cannot interleave a non-terminal event after
-        // it — the terminal stays last in the buffer.
-        if let event { continuation.yield(event) }
-        lock.unlock()
-        // `finish()` synchronously runs the consumer's `onTermination`, which re-enters this relay
-        // via `detach()`, so it must be outside the lock to avoid deadlocking on the non-recursive
-        // `NSLock`. By here `finished` is set, so any racing `deliver` that next acquires the lock
-        // sees it and skips — no stray yield can land after the terminal event.
+        guard didFinish else { return }
+        // `finish()` runs *outside* the lock: it synchronously invokes the consumer's
+        // `onTermination`, which re-enters this relay via `detach()`, so locking across it would
+        // deadlock the non-recursive `NSLock`. `finished` is already set, so any racing `deliver`
+        // that next acquires the lock sees it and skips — no stray yield lands after the terminal.
         continuation.finish()
     }
 }

--- a/scripts/test-relay-tsan.sh
+++ b/scripts/test-relay-tsan.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Run the relay concurrency suites under ThreadSanitizer. Closes issue #203.
+#
+# TurnRelay/TextStreamRelay gate event delivery and enforce once-only terminal
+# transitions across a producer/consumer race. The `concurrentDeliver*` tests
+# exercise that race only *probabilistically* — under a normal Debug build the
+# window is tiny, so a regression (dropping the NSLock, a torn read of `finished`,
+# or yielding a non-terminal event after the terminal one) can slip through CI by
+# luck. TSan deterministically flags data races regardless of timing.
+#
+# Scoped to the relay suites (--filter Relay) to keep the run fast and avoid
+# sanitizing the model-gated FoundationModels tests.
+#
+# Prerequisites:
+#   - Xcode 27+ toolchain. Locally, point DEVELOPER_DIR at it (the default
+#     CommandLineTools swift is too old / broken for this package):
+#       export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+#     CI selects the newest installed Xcode before invoking this script.
+#
+# Usage:
+#   scripts/test-relay-tsan.sh
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "Running relay concurrency suites under ThreadSanitizer…"
+exec xcrun swift test --sanitize thread --filter Relay

--- a/scripts/test-relay-tsan.sh
+++ b/scripts/test-relay-tsan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Run the relay concurrency suites under ThreadSanitizer. Closes issue #203.
+# Run the relay concurrency suites under ThreadSanitizer.
 #
 # TurnRelay/TextStreamRelay gate event delivery and enforce once-only terminal
 # transitions across a producer/consumer race. The `concurrentDeliver*` tests


### PR DESCRIPTION
Closes #203.

## What

Adds a `relay-tsan` CI job (and a `scripts/test-relay-tsan.sh` opt-in for local runs) that runs the `TurnRelay`/`TextStreamRelay` suites under ThreadSanitizer. Scoped to `--filter Relay` so it stays fast and skips the model-gated FoundationModels tests.

The `concurrentDeliver*` tests race a producer against a consumer-initiated cancel/detach over 200 trials, but only *probabilistically* — under a normal Debug build the window is tiny, so a regression could pass CI by luck. TSan flags data races deterministically.

## The bug TSan caught

Wiring up the lane immediately surfaced a real ordering defect in `TurnRelay`: `deliver` released the lock before `continuation.yield`, so a `.textDelta` could land **between** `end`'s terminal `yield` and its `finish()` — leaving a non-terminal event after the terminal one. In practice the consumer (`FoundationModelAssistant`) would see content *after* it had already been told the turn ended (`.cancelled`/`.turnComplete`).

**Fix:** yield under the lock in both `deliver` and `end`, keeping `finish()` outside the lock — `finish()` re-enters the relay via `onTermination`→`detach`, so locking across it would deadlock the non-recursive `NSLock`.

`TextStreamRelay` needs no change: its terminal carries no buffered value (`finish(throwing:)` only), so a late chunk is simply dropped and its weaker contiguous-prefix invariant still holds.

## Acceptance

- [x] `TurnRelay` + `TextStreamRelay` concurrency tests run under TSan in CI + documented opt-in script
- [x] Suite is green under TSan
- [x] Has teeth: temporarily removing the lock produces a TSan `data race` report at `TurnRelay.deliver` plus the `lastIsTerminal` assertion failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)