### PR TITLE
test(core): extract ConversationTranscript for testable chat accumulation (#161)

### DIFF
--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -27,61 +27,24 @@ import AnglesiteCore
 final class ChatModel {
     // MARK: Models
 
-    struct Message: Identifiable, Equatable {
-        let id: UUID
-        let role: Role
-        var content: String
-        var toolCalls: [ToolCall]
-        let timestamp: Date
-        /// Only set on `role: .edit` rows. Carries file + commit + undone flag.
-        var editMetadata: EditMetadata?
-        /// Only set on `role: .annotation` rows. Carries the backing annotation id.
-        var annotationMetadata: AnnotationMetadata?
-
-        enum Role: Equatable { case user, assistant, system, error, edit, annotation }
-
-        init(
-            id: UUID = UUID(),
-            role: Role,
-            content: String,
-            toolCalls: [ToolCall] = [],
-            timestamp: Date = Date(),
-            editMetadata: EditMetadata? = nil,
-            annotationMetadata: AnnotationMetadata? = nil
-        ) {
-            self.id = id
-            self.role = role
-            self.content = content
-            self.toolCalls = toolCalls
-            self.timestamp = timestamp
-            self.editMetadata = editMetadata
-            self.annotationMetadata = annotationMetadata
-        }
-    }
-
-    struct EditMetadata: Equatable {
-        let file: String
-        let commit: String
-        var undone: Bool
-    }
-
-    /// Identifies the backing annotation so its chat row can be resolved via MCP.
-    struct AnnotationMetadata: Equatable {
-        let annotationID: String
-    }
-
-    struct ToolCall: Identifiable, Equatable {
-        /// `toolUseID` from claude — used to pair `tool_use` with its later `tool_result`.
-        let id: String
-        let name: String
-        let inputDisplay: String
-        var result: String?
-        var isError: Bool
-    }
+    // The chat row value types live in `AnglesiteCore` as `ChatMessage`/`ChatToolCall`/… so the
+    // event-accumulation reducer (`ConversationTranscript`) can be unit-tested without the App
+    // shell (#161). They're re-exported here under their original names so `ChatView` and the rest
+    // of this file keep referring to `ChatModel.Message`, `ChatModel.ToolCall`, etc. unchanged.
+    typealias Message = ChatMessage
+    typealias ToolCall = ChatToolCall
+    typealias EditMetadata = ChatEditMetadata
+    typealias AnnotationMetadata = ChatAnnotationMetadata
 
     // MARK: State
 
-    private(set) var messages: [Message] = []
+    /// The provider-agnostic chat-row store + streaming-turn reducer (`AnglesiteCore`). `ChatModel`
+    /// wraps it with the SwiftUI/persistence/undo shell; mutating it (a value type) fires
+    /// `@Observable` change tracking, so SwiftUI re-renders when rows change.
+    private var transcript: ConversationTranscript
+
+    /// Chat rows in display order. Forwards to ``transcript`` so `@Observable` tracks reads.
+    var messages: [Message] { transcript.messages }
     private(set) var isStreaming: Bool = false
     private(set) var lastError: String?
     /// Mirrors the last `turnComplete.usage` claude reported. `ChatView` shows this in the
@@ -133,9 +96,6 @@ final class ChatModel {
     /// chat has no MCP backing yet.
     private let undoCommand: UndoCommand?
     private var streamTask: Task<Void, Never>?
-    /// Tracks the in-flight assistant message — text events extend its `content`, tool events
-    /// push into its `toolCalls`. Nil between turns.
-    private var inFlightAssistantIndex: Int?
     /// IDs of annotations already surfaced in chat, so repeated calls to `loadAnnotations()`
     /// don't double-post the same sticky note when the user revisits a site mid-session.
     private var surfacedAnnotationIDs: Set<String> = []
@@ -144,7 +104,9 @@ final class ChatModel {
     init(siteID: String, siteDirectory: URL, annotationFeed: AnnotationFeed? = nil, annotationResolver: AnnotationResolver? = nil, undoCommand: UndoCommand? = nil) {
         self.siteID = siteID
         self.siteDirectory = siteDirectory
-        self.assistant = ClaudeAssistant(siteID: siteID, siteDirectory: siteDirectory)
+        let assistant = ClaudeAssistant(siteID: siteID, siteDirectory: siteDirectory)
+        self.assistant = assistant
+        self.transcript = ConversationTranscript(providerName: assistant.capabilities.providerName)
         self.history = ChatHistoryStore(siteDirectory: siteDirectory)
         self.annotationFeed = annotationFeed
         self.annotationResolver = annotationResolver
@@ -158,6 +120,7 @@ final class ChatModel {
         self.siteID = siteID
         self.siteDirectory = siteDirectory
         self.assistant = assistant
+        self.transcript = ConversationTranscript(providerName: assistant.capabilities.providerName)
         self.history = history ?? ChatHistoryStore(siteDirectory: siteDirectory)
         self.annotationFeed = annotationFeed
         self.annotationResolver = annotationResolver
@@ -171,7 +134,8 @@ final class ChatModel {
     func loadHistory() async {
         do {
             let entries = try await history.load()
-            messages = entries.map(Message.init(persisted:))
+            transcript.reset()
+            for entry in entries { transcript.append(Message(persisted: entry)) }
         } catch {
             lastError = "couldn't load history: \(error)"
         }
@@ -194,7 +158,7 @@ final class ChatModel {
         for annotation in annotations where !annotation.resolved {
             guard !surfacedAnnotationIDs.contains(annotation.id) else { continue }
             surfacedAnnotationIDs.insert(annotation.id)
-            messages.append(.init(
+            transcript.append(.init(
                 role: .annotation,
                 content: ChatModel.renderAnnotation(annotation),
                 timestamp: annotation.createdAt,
@@ -222,19 +186,17 @@ final class ChatModel {
     /// set makes that re-surface a no-op. On success the row is simply gone (the resolved
     /// annotation is filtered out of future feeds anyway); on failure we re-insert the one row.
     func resolveAnnotation(messageID: UUID) async {
-        guard let idx = messages.firstIndex(where: { $0.id == messageID }),
-              let meta = messages[idx].annotationMetadata,
-              let resolver = annotationResolver else { return }
-
-        let removed = messages.remove(at: idx)              // optimistic: drop from the feed
+        guard let target = messages.first(where: { $0.id == messageID }),
+              let meta = target.annotationMetadata,
+              annotationResolver != nil else { return }
+        guard let removed = transcript.remove(id: messageID) else { return }  // optimistic: drop from the feed
         do {
-            try await resolver(meta.annotationID)
+            try await annotationResolver?(meta.annotationID)
         } catch {
-            // `idx` was captured before the await; messages may have shifted during the
-            // suspension (concurrent resolve, streaming send, loadAnnotations). Re-locate
-            // the chronological insertion point by timestamp instead of trusting idx.
-            let insertIdx = messages.firstIndex { $0.timestamp > removed.timestamp } ?? messages.count
-            messages.insert(removed, at: insertIdx)
+            // The row may have shifted during the suspension (concurrent resolve, streaming send,
+            // loadAnnotations). `insertByTimestamp` re-locates the chronological position rather
+            // than trusting a stale index.
+            transcript.insertByTimestamp(removed)
             lastError = "couldn't resolve annotation: \(error.localizedDescription)"
         }
     }
@@ -246,14 +208,10 @@ final class ChatModel {
         guard !trimmed.isEmpty, !isStreaming else { return }
 
         lastError = nil
-        let userMessage = Message(role: .user, content: trimmed)
-        messages.append(userMessage)
-        persist(userMessage)
-
-        // Empty assistant message; subsequent events extend it.
-        let assistantMessage = Message(role: .assistant, content: "")
-        messages.append(assistantMessage)
-        inFlightAssistantIndex = messages.count - 1
+        // `beginTurn` appends the user prompt and an empty assistant row (which streamed events
+        // extend) and marks the latter in-flight. The user row is second-to-last; persist it.
+        transcript.beginTurn(userPrompt: trimmed)
+        if messages.count >= 2 { persist(messages[messages.count - 2]) }
 
         isStreaming = true
         streamTask = Task { @MainActor [weak self] in
@@ -273,7 +231,7 @@ final class ChatModel {
             content: "Edited \(file)",
             editMetadata: metadata
         )
-        messages.append(message)
+        transcript.append(message)
         let entry = ChatHistoryStore.Entry(
             timestamp: message.timestamp,
             role: .edit,
@@ -291,9 +249,9 @@ final class ChatModel {
     /// row's `undone` flag and persist a sidecar. On working-tree drift, set `conflictPrompt`
     /// so the view shows a sheet. On failure, append an `.error` system message.
     func undoEdit(messageID: UUID, force: Bool = false) async {
-        guard let idx = messages.firstIndex(where: { $0.id == messageID }),
-              messages[idx].role == .edit,
-              let metadata = messages[idx].editMetadata,
+        guard let target = messages.first(where: { $0.id == messageID }),
+              target.role == .edit,
+              let metadata = target.editMetadata,
               !metadata.undone
         else { return }
         guard let undoCommand else {
@@ -303,9 +261,7 @@ final class ChatModel {
         let result = await undoCommand.undo(commit: metadata.commit, force: force)
         switch result {
         case .success(let newCommit):
-            var updated = metadata
-            updated.undone = true
-            messages[idx].editMetadata = updated
+            transcript.update(id: messageID) { $0.editMetadata?.undone = true }
             Task { [history] in
                 try? await history.appendUndone(messageID: messageID, newCommit: newCommit)
             }
@@ -313,7 +269,7 @@ final class ChatModel {
             conflictPrompt = ConflictPrompt(messageID: messageID, commit: metadata.commit, files: files)
         case .failed(let reason, let detail):
             let errorContent = "Couldn't undo: \(detail) (\(reason))"
-            messages.append(Message(role: .error, content: errorContent))
+            transcript.append(Message(role: .error, content: errorContent))
             lastError = errorContent
         }
     }
@@ -341,8 +297,7 @@ final class ChatModel {
     func resetConversation() async {
         cancel()
         streamTask = nil
-        messages = []
-        inFlightAssistantIndex = nil
+        transcript.reset()
         await assistant.resetSession()
         do { try await history.clear() } catch { lastError = "couldn't clear history: \(error)" }
     }
@@ -355,78 +310,41 @@ final class ChatModel {
             let context = AssistantContext(siteID: siteID, siteDirectory: siteDirectory)
             stream = try await assistant.converse(prompt: prompt, context: context)
         } catch {
-            inFlightAssistantIndex = nil
+            transcript.endTurn()
             isStreaming = false
             lastError = "couldn't start \(assistant.capabilities.providerName): \(error)"
             return
         }
 
         for await event in stream {
-            handle(event)
+            // The provider-agnostic accumulation (text deltas, tool pairing, error/cancel rows,
+            // usage capture) lives in `ConversationTranscript` (AnglesiteCore, fully unit-tested);
+            // `ChatModel` just forwards each event and mirrors the resulting telemetry into the
+            // `@Observable` UI properties `ChatView` binds to.
+            transcript.apply(event)
+            syncObservedTelemetry()
         }
 
-        if let idx = inFlightAssistantIndex {
-            let finalMessage = messages[idx]
-            // Persist the assistant turn now that it's complete. Empty text + no tool calls
-            // means the user sent a no-op or got a session-error — we still persist for audit.
+        // Persist the assistant turn now that it's complete. Empty text + no tool calls means the
+        // user sent a no-op or got a session-error — we still persist for audit.
+        if let finalMessage = transcript.endTurn() {
             persist(finalMessage)
         }
-        inFlightAssistantIndex = nil
         isStreaming = false
     }
 
-    private func handle(_ event: AssistantEvent) {
-        guard let idx = inFlightAssistantIndex, messages.indices.contains(idx) else { return }
-        switch event {
-        case .started:
-            // Surfaced as data only; no chat chrome in v0.5 (matches prior .sessionStarted arm).
-            break
-
-        case .textDelta(let text):
-            messages[idx].content += text
-
-        case .thinking:
-            // Captured but not rendered — thinking blocks already stream to the Debug pane.
-            break
-
-        case .toolUse(let toolID, let name, let input):
-            let display = ChatModel.renderJSON(input)
-            messages[idx].toolCalls.append(ToolCall(id: toolID, name: name, inputDisplay: display, result: nil, isError: false))
-
-        case .toolResult(let toolID, let content, let isError):
-            if let i = messages[idx].toolCalls.firstIndex(where: { $0.id == toolID }) {
-                messages[idx].toolCalls[i].result = content
-                messages[idx].toolCalls[i].isError = isError
-            } else {
-                // Result without a matching tool_use — happens if the agent crashed mid-turn
-                // and resumed without the original tool_use. Surface it as an unbound tool
-                // call so the user can still see what happened.
-                messages[idx].toolCalls.append(ToolCall(id: toolID, name: "(unbound)", inputDisplay: "", result: content, isError: isError))
-            }
-
-        case .turnComplete(let usage):
-            if let usage {
-                lastUsage = TurnTelemetry(
-                    inputTokens: usage.inputTokens,
-                    outputTokens: usage.outputTokens,
-                    costUSD: usage.costUSD,
-                    durationMs: usage.durationMs
-                )
-            }
-
-        case .failed(let message):
-            lastError = message
-            messages.append(.init(role: .error, content: message))
-
-        case .cancelled:
-            messages.append(.init(role: .system, content: "Cancelled."))
-
-        case .backendExited(let code):
-            if code != 0 && code != -15 {
-                let note = "\(assistant.capabilities.providerName) backend exited with code \(code)"
-                lastError = note
-                messages.append(.init(role: .error, content: note))
-            }
+    /// Mirrors the transcript's error + usage telemetry into the `@Observable` properties bound by
+    /// `ChatView`. Called after each applied event; the transcript is the source of truth during a
+    /// turn (out-of-band setters — load/undo/annotation failures — write `lastError` directly).
+    private func syncObservedTelemetry() {
+        lastError = transcript.lastError
+        if let usage = transcript.lastUsage {
+            lastUsage = TurnTelemetry(
+                inputTokens: usage.inputTokens,
+                outputTokens: usage.outputTokens,
+                costUSD: usage.costUSD,
+                durationMs: usage.durationMs
+            )
         }
     }
 
@@ -462,22 +380,6 @@ final class ChatModel {
         )
         // Persist async-fire-and-forget: an I/O failure is non-blocking for the UI.
         Task { [history] in try? await history.append(entry) }
-    }
-
-    /// Compact, deterministic pretty-print of a `JSONValue` for the tool-call card. Single-line
-    /// strings get displayed inline; objects/arrays get rendered with two-space indent so they
-    /// don't blow up the chat layout when the tool input is large.
-    static func renderJSON(_ value: JSONValue) -> String {
-        let raw = value.rawValue
-        guard JSONSerialization.isValidJSONObject(raw) || raw is String || raw is NSNumber else {
-            return String(describing: raw)
-        }
-        let opts: JSONSerialization.WritingOptions = [.prettyPrinted, .sortedKeys]
-        if let data = try? JSONSerialization.data(withJSONObject: raw, options: opts),
-           let string = String(data: data, encoding: .utf8) {
-            return string
-        }
-        return String(describing: raw)
     }
 }
 

--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -209,9 +209,9 @@ final class ChatModel {
 
         lastError = nil
         // `beginTurn` appends the user prompt and an empty assistant row (which streamed events
-        // extend) and marks the latter in-flight. The user row is second-to-last; persist it.
-        transcript.beginTurn(userPrompt: trimmed)
-        if messages.count >= 2 { persist(messages[messages.count - 2]) }
+        // extend), marks the latter in-flight, and returns the user row so we persist exactly it.
+        let userMessage = transcript.beginTurn(userPrompt: trimmed)
+        persist(userMessage)
 
         isStreaming = true
         streamTask = Task { @MainActor [weak self] in

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -372,15 +372,21 @@ struct SiteWindow: View {
         // `contentGraph` so it attaches `ApplyEditTool` + `SearchContentTool` and advertises
         // `supportsTools` (#193). The Claude path carries its own tool surface and ignores these.
         let settings = AppSettings.shared
-        // `makeEditBridge()` is only called in the on-device arm — the ternary doesn't evaluate the
-        // untaken branch, so the Claude path does no bridge work.
-        let assistant: any ConversationalAssistant = settings.preferFoundationModels
-            ? FoundationModelAssistant(
-                tier: settings.foundationModelTier,
+        // The settings → backend decision is a pure function in `AnglesiteCore`
+        // (`resolveAssistantChoice`) so it's unit-tested without the App target (#161 item 7);
+        // construction stays here because it needs App-owned deps (the edit bridge, content graph).
+        // `makeEditBridge()` is only called in the on-device arm — the Claude path does no bridge work.
+        let assistant: any ConversationalAssistant
+        switch resolveAssistantChoice(preferFoundationModels: settings.preferFoundationModels, tier: settings.foundationModelTier) {
+        case .foundationModel(let tier):
+            assistant = FoundationModelAssistant(
+                tier: tier,
                 editBridge: makeEditBridge(),
                 contentGraph: contentGraph
             )
-            : ClaudeAssistant(siteID: resolved.id, siteDirectory: resolved.path)
+        case .claude:
+            assistant = ClaudeAssistant(siteID: resolved.id, siteDirectory: resolved.path)
+        }
         chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.path, assistant: assistant, annotationFeed: feed, annotationResolver: annotationResolver, undoCommand: undoCommand)
         #endif
         // Auto alt-text (C.7 / #157): after a successful image drop, generate alt text on-device and

--- a/Sources/AnglesiteCore/ConversationTranscript.swift
+++ b/Sources/AnglesiteCore/ConversationTranscript.swift
@@ -85,8 +85,11 @@ public struct ConversationTranscript: Equatable, Sendable {
     /// The most recent in-band error (`.failed`) or non-clean backend exit.
     public private(set) var lastError: String?
 
-    /// Index of the in-flight assistant message that streamed events extend. `nil` between turns.
-    private var inFlightAssistantIndex: Int?
+    /// Id of the in-flight assistant message that streamed events extend. `nil` between turns.
+    /// Tracked by id (not array index) so out-of-band mutations during a turn — e.g.
+    /// `resolveAnnotation` calling ``remove(id:)``/``insertByTimestamp(_:)`` on the MainActor while
+    /// the stream loop is suspended — can't shift it onto the wrong row.
+    private var inFlightAssistantID: UUID?
     /// Names the backend in the `.backendExited` error string (e.g. "On-Device", "Claude").
     private let providerName: String
 
@@ -95,28 +98,35 @@ public struct ConversationTranscript: Equatable, Sendable {
     }
 
     /// Begins a turn: appends the user prompt and an empty assistant message (which subsequent
-    /// events extend), and clears any stale error.
-    public mutating func beginTurn(userPrompt: String) {
+    /// events extend), clears any stale error, and returns the appended user message so the caller
+    /// can persist it without relying on its position in ``messages``. Calling this while a turn is
+    /// already in flight simply starts a fresh turn — the previous assistant row is left finalized.
+    @discardableResult
+    public mutating func beginTurn(userPrompt: String) -> ChatMessage {
         lastError = nil
-        messages.append(ChatMessage(role: .user, content: userPrompt))
-        messages.append(ChatMessage(role: .assistant, content: ""))
-        inFlightAssistantIndex = messages.count - 1
+        let userMessage = ChatMessage(role: .user, content: userPrompt)
+        let assistantMessage = ChatMessage(role: .assistant, content: "")
+        messages.append(userMessage)
+        messages.append(assistantMessage)
+        inFlightAssistantID = assistantMessage.id
+        return userMessage
     }
 
     /// Ends the in-flight turn, clearing the in-flight marker. Returns the final assistant message
     /// (so the caller can persist it), or `nil` if no turn was in flight.
     @discardableResult
     public mutating func endTurn() -> ChatMessage? {
-        defer { inFlightAssistantIndex = nil }
-        guard let idx = inFlightAssistantIndex, messages.indices.contains(idx) else { return nil }
-        return messages[idx]
+        defer { inFlightAssistantID = nil }
+        guard let id = inFlightAssistantID else { return nil }
+        return messages.first { $0.id == id }
     }
 
     /// Clears all rows and the in-flight marker for a fresh conversation. Leaves `lastUsage`
-    /// intact (it reflects the last *completed* turn's telemetry, not in-flight state).
+    /// intact (it reflects the last *completed* turn's telemetry, not in-flight state), and leaves
+    /// `lastError` intact so a caller that resets after a failed turn can still inspect the reason.
     public mutating func reset() {
         messages = []
-        inFlightAssistantIndex = nil
+        inFlightAssistantID = nil
     }
 
     /// Appends an out-of-band row (an `.edit` from a successful apply, or an `.annotation`),
@@ -149,7 +159,7 @@ public struct ConversationTranscript: Equatable, Sendable {
     /// Applies one streamed event to the in-flight assistant message. Events that arrive with no
     /// in-flight turn are dropped (mirrors `ChatModel`'s guard — e.g. a late event after `reset`).
     public mutating func apply(_ event: AssistantEvent) {
-        guard let idx = inFlightAssistantIndex, messages.indices.contains(idx) else { return }
+        guard let id = inFlightAssistantID, let idx = messages.firstIndex(where: { $0.id == id }) else { return }
         switch event {
         case .started:
             // Surfaced as data only; no chat chrome.

--- a/Sources/AnglesiteCore/ConversationTranscript.swift
+++ b/Sources/AnglesiteCore/ConversationTranscript.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// A single chat row, provider-agnostic and free of SwiftUI/persistence concerns.
+///
+/// Extracted from `ChatModel.Message` (App target) so the event-accumulation logic that produces
+/// these rows can be unit-tested in `AnglesiteCore` without the App shell (#161). `ChatModel`
+/// re-exports this as `ChatModel.Message` via a typealias, so its SwiftUI views are unaffected.
+public struct ChatMessage: Identifiable, Equatable, Sendable {
+    public enum Role: Equatable, Sendable { case user, assistant, system, error, edit, annotation }
+
+    public let id: UUID
+    public let role: Role
+    public var content: String
+    public var toolCalls: [ChatToolCall]
+    public let timestamp: Date
+    /// Only set on `role: .edit` rows. Carries file + commit + undone flag.
+    public var editMetadata: ChatEditMetadata?
+    /// Only set on `role: .annotation` rows. Carries the backing annotation id.
+    public var annotationMetadata: ChatAnnotationMetadata?
+
+    public init(
+        id: UUID = UUID(),
+        role: Role,
+        content: String,
+        toolCalls: [ChatToolCall] = [],
+        timestamp: Date = Date(),
+        editMetadata: ChatEditMetadata? = nil,
+        annotationMetadata: ChatAnnotationMetadata? = nil
+    ) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.toolCalls = toolCalls
+        self.timestamp = timestamp
+        self.editMetadata = editMetadata
+        self.annotationMetadata = annotationMetadata
+    }
+}
+
+/// One tool invocation within an assistant turn. `id` pairs a `.toolUse` with its later `.toolResult`.
+public struct ChatToolCall: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let inputDisplay: String
+    public var result: String?
+    public var isError: Bool
+
+    public init(id: String, name: String, inputDisplay: String, result: String? = nil, isError: Bool = false) {
+        self.id = id
+        self.name = name
+        self.inputDisplay = inputDisplay
+        self.result = result
+        self.isError = isError
+    }
+}
+
+public struct ChatEditMetadata: Equatable, Sendable {
+    public let file: String
+    public let commit: String
+    public var undone: Bool
+    public init(file: String, commit: String, undone: Bool) {
+        self.file = file
+        self.commit = commit
+        self.undone = undone
+    }
+}
+
+public struct ChatAnnotationMetadata: Equatable, Sendable {
+    public let annotationID: String
+    public init(annotationID: String) { self.annotationID = annotationID }
+}
+
+/// The provider-agnostic reducer that turns a stream of ``AssistantEvent`` values into chat rows.
+///
+/// `ChatModel` (App target) owns one of these and forwards each streamed event to ``apply(_:)``;
+/// the SwiftUI/persistence/undo concerns stay in `ChatModel`. Keeping the accumulation here makes
+/// the streaming + tool-calling contract (#161 item 5) and conversation reset (#161 item 7)
+/// testable on CI without a live model or the App target.
+public struct ConversationTranscript: Equatable, Sendable {
+    /// All rows in display order: user prompts, assistant turns, tool calls, plus out-of-band
+    /// `.edit`/`.annotation` rows appended via ``append(_:)``.
+    public private(set) var messages: [ChatMessage] = []
+    /// Telemetry from the most recent `.turnComplete` that carried usage.
+    public private(set) var lastUsage: AssistantUsage?
+    /// The most recent in-band error (`.failed`) or non-clean backend exit.
+    public private(set) var lastError: String?
+
+    /// Index of the in-flight assistant message that streamed events extend. `nil` between turns.
+    private var inFlightAssistantIndex: Int?
+    /// Names the backend in the `.backendExited` error string (e.g. "On-Device", "Claude").
+    private let providerName: String
+
+    public init(providerName: String = "assistant") {
+        self.providerName = providerName
+    }
+
+    /// Begins a turn: appends the user prompt and an empty assistant message (which subsequent
+    /// events extend), and clears any stale error.
+    public mutating func beginTurn(userPrompt: String) {
+        lastError = nil
+        messages.append(ChatMessage(role: .user, content: userPrompt))
+        messages.append(ChatMessage(role: .assistant, content: ""))
+        inFlightAssistantIndex = messages.count - 1
+    }
+
+    /// Ends the in-flight turn, clearing the in-flight marker. Returns the final assistant message
+    /// (so the caller can persist it), or `nil` if no turn was in flight.
+    @discardableResult
+    public mutating func endTurn() -> ChatMessage? {
+        defer { inFlightAssistantIndex = nil }
+        guard let idx = inFlightAssistantIndex, messages.indices.contains(idx) else { return nil }
+        return messages[idx]
+    }
+
+    /// Clears all rows and the in-flight marker for a fresh conversation. Leaves `lastUsage`
+    /// intact (it reflects the last *completed* turn's telemetry, not in-flight state).
+    public mutating func reset() {
+        messages = []
+        inFlightAssistantIndex = nil
+    }
+
+    /// Appends an out-of-band row (an `.edit` from a successful apply, or an `.annotation`),
+    /// preserving order without disturbing the in-flight assistant message.
+    public mutating func append(_ message: ChatMessage) {
+        messages.append(message)
+    }
+
+    /// Mutates the message with the given id in place, if present.
+    public mutating func update(id: UUID, _ body: (inout ChatMessage) -> Void) {
+        guard let idx = messages.firstIndex(where: { $0.id == id }) else { return }
+        body(&messages[idx])
+    }
+
+    /// Removes the message with the given id, returning it (for an optimistic-drop-then-restore
+    /// flow). Returns `nil` if no message matched.
+    @discardableResult
+    public mutating func remove(id: UUID) -> ChatMessage? {
+        guard let idx = messages.firstIndex(where: { $0.id == id }) else { return nil }
+        return messages.remove(at: idx)
+    }
+
+    /// Re-inserts a message at its chronological position (before the first row newer than it,
+    /// else appended). Used to restore a row dropped optimistically when its async action fails.
+    public mutating func insertByTimestamp(_ message: ChatMessage) {
+        let idx = messages.firstIndex { $0.timestamp > message.timestamp } ?? messages.count
+        messages.insert(message, at: idx)
+    }
+
+    /// Applies one streamed event to the in-flight assistant message. Events that arrive with no
+    /// in-flight turn are dropped (mirrors `ChatModel`'s guard — e.g. a late event after `reset`).
+    public mutating func apply(_ event: AssistantEvent) {
+        guard let idx = inFlightAssistantIndex, messages.indices.contains(idx) else { return }
+        switch event {
+        case .started:
+            // Surfaced as data only; no chat chrome.
+            break
+
+        case .textDelta(let text):
+            messages[idx].content += text
+
+        case .thinking:
+            // Captured but not rendered — thinking blocks already stream to the Debug pane.
+            break
+
+        case .toolUse(let toolID, let name, let input):
+            let display = Self.renderJSON(input)
+            messages[idx].toolCalls.append(ChatToolCall(id: toolID, name: name, inputDisplay: display, result: nil, isError: false))
+
+        case .toolResult(let toolID, let content, let isError):
+            if let i = messages[idx].toolCalls.firstIndex(where: { $0.id == toolID }) {
+                messages[idx].toolCalls[i].result = content
+                messages[idx].toolCalls[i].isError = isError
+            } else {
+                // Result without a matching tool_use — happens if the agent crashed mid-turn and
+                // resumed without the original tool_use. Surface it as an unbound tool call so the
+                // user can still see what happened.
+                messages[idx].toolCalls.append(ChatToolCall(id: toolID, name: "(unbound)", inputDisplay: "", result: content, isError: isError))
+            }
+
+        case .turnComplete(let usage):
+            if let usage { lastUsage = usage }
+
+        case .failed(let message):
+            lastError = message
+            messages.append(ChatMessage(role: .error, content: message))
+
+        case .cancelled:
+            messages.append(ChatMessage(role: .system, content: "Cancelled."))
+
+        case .backendExited(let code):
+            if code != 0 && code != -15 {
+                let note = "\(providerName) backend exited with code \(code)"
+                lastError = note
+                messages.append(ChatMessage(role: .error, content: note))
+            }
+        }
+    }
+
+    /// Compact, deterministic pretty-print of a `JSONValue` for the tool-call card. Single-line
+    /// strings get displayed inline; objects/arrays get rendered with two-space indent so they
+    /// don't blow up the chat layout when the tool input is large.
+    public static func renderJSON(_ value: JSONValue) -> String {
+        let raw = value.rawValue
+        guard JSONSerialization.isValidJSONObject(raw) || raw is String || raw is NSNumber else {
+            return String(describing: raw)
+        }
+        let opts: JSONSerialization.WritingOptions = [.prettyPrinted, .sortedKeys]
+        if let data = try? JSONSerialization.data(withJSONObject: raw, options: opts),
+           let string = String(data: data, encoding: .utf8) {
+            return string
+        }
+        return String(describing: raw)
+    }
+}
+
+/// Which backend should serve a site window's chat. The decision (a pure function of the user's
+/// settings) is separated from construction (which needs App-target dependencies like the edit
+/// bridge and content graph) so it can be unit-tested in Core (#161 item 7).
+public enum AssistantChoice: Equatable, Sendable {
+    case claude
+    case foundationModel(FoundationModelTier)
+}
+
+/// Resolves the chat backend from the user's settings. Foundation Models off → Claude; on → the
+/// selected tier. `SiteWindow` calls this on the Developer ID path; the MAS build is on-device only.
+public func resolveAssistantChoice(preferFoundationModels: Bool, tier: FoundationModelTier) -> AssistantChoice {
+    preferFoundationModels ? .foundationModel(tier) : .claude
+}

--- a/Tests/AnglesiteCoreTests/ConversationTranscriptTests.swift
+++ b/Tests/AnglesiteCoreTests/ConversationTranscriptTests.swift
@@ -39,6 +39,27 @@ struct ConversationTranscriptLifecycleTests {
         #expect(t.messages.isEmpty)
     }
 
+    @Test("beginTurn returns the user message it appended")
+    func beginTurnReturnsUserMessage() {
+        var t = ConversationTranscript()
+        let user = t.beginTurn(userPrompt: "hi there")
+        #expect(user.role == .user)
+        #expect(user.content == "hi there")
+        // The returned message is the same one stored in the transcript.
+        #expect(t.messages.contains { $0.id == user.id })
+    }
+
+    @Test("beginTurn while a turn is in flight starts a fresh turn and re-points the in-flight row")
+    func beginTurnWhileInFlightStartsFreshTurn() {
+        var t = ConversationTranscript()
+        t.beginTurn(userPrompt: "first")
+        t.apply(.textDelta("one"))
+        t.beginTurn(userPrompt: "second")
+        t.apply(.textDelta("two"))
+        // The previous assistant row is left finalized; deltas now extend the new assistant row.
+        #expect(t.messages.map(\.content) == ["first", "one", "second", "two"])
+    }
+
     @Test("endTurn returns the in-flight assistant message and clears the in-flight marker")
     func endTurnReturnsAssistantAndClearsInFlight() {
         var t = ConversationTranscript()
@@ -258,6 +279,40 @@ struct ConversationTranscriptAppendTests {
         t.append(ChatMessage(role: .annotation, content: "old", timestamp: base))
         t.insertByTimestamp(ChatMessage(role: .annotation, content: "new", timestamp: base.addingTimeInterval(50)))
         #expect(t.messages.map(\.content) == ["old", "new"])
+    }
+
+    // Regression: `resolveAnnotation` can `remove`/`insertByTimestamp` rows *during* a streaming
+    // turn (it suspends on the MainActor at its `await`, letting the stream loop resume). If the
+    // in-flight assistant row were tracked by array index, these mutations would shift it and send
+    // deltas to the wrong row. The in-flight row is tracked by id, so the turn is unaffected.
+
+    @Test("removing a row before the in-flight assistant keeps deltas on the assistant")
+    func removeBeforeInFlightKeepsDeltasOnAssistant() {
+        var t = ConversationTranscript()
+        let note = ChatMessage(role: .annotation, content: "note", timestamp: Date(timeIntervalSince1970: 1))
+        t.append(note)                  // [note]
+        t.beginTurn(userPrompt: "go")   // [note, user, assistant]
+        t.apply(.textDelta("A"))
+        t.remove(id: note.id)           // [user, assistant] — assistant shifts down by one
+        t.apply(.textDelta("B"))
+        let assistant = t.messages.first { $0.role == .assistant }
+        #expect(assistant?.content == "AB")
+        #expect(t.messages.first?.role == .user)
+    }
+
+    @Test("inserting a row before the in-flight assistant keeps deltas on the assistant")
+    func insertBeforeInFlightKeepsDeltasOnAssistant() {
+        var t = ConversationTranscript()
+        t.beginTurn(userPrompt: "go")   // [user, assistant], both stamped "now"
+        t.apply(.textDelta("A"))
+        // A restored annotation with an older timestamp lands at the front, shifting the assistant.
+        let note = ChatMessage(role: .annotation, content: "note", timestamp: Date(timeIntervalSince1970: 1))
+        t.insertByTimestamp(note)       // [note, user, assistant]
+        t.apply(.textDelta("B"))
+        let assistant = t.messages.first { $0.role == .assistant }
+        #expect(assistant?.content == "AB")
+        // The user row must be untouched (a stale index would have appended "B" here).
+        #expect(t.messages.first { $0.role == .user }?.content == "go")
     }
 }
 

--- a/Tests/AnglesiteCoreTests/ConversationTranscriptTests.swift
+++ b/Tests/AnglesiteCoreTests/ConversationTranscriptTests.swift
@@ -1,0 +1,278 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// `ConversationTranscript` is the provider-agnostic event-accumulation reducer extracted from
+// `ChatModel` (App target) so it can be unit-tested without the App's SwiftUI/persistence shell
+// (#161 items 5 & 7). It depends only on `AssistantEvent`/`JSONValue`/`FoundationModelTier`, none
+// of which are behind the `compiler(>=6.4)` FoundationModels gate, so the suite runs on CI.
+
+@Suite("ConversationTranscript: turn lifecycle")
+struct ConversationTranscriptLifecycleTests {
+
+    @Test("beginTurn appends the user prompt and an empty assistant message")
+    func beginTurnAppendsUserAndEmptyAssistant() {
+        var t = ConversationTranscript()
+        t.beginTurn(userPrompt: "hi")
+        #expect(t.messages.count == 2)
+        #expect(t.messages[0].role == .user)
+        #expect(t.messages[0].content == "hi")
+        #expect(t.messages[1].role == .assistant)
+        #expect(t.messages[1].content == "")
+    }
+
+    @Test("beginTurn clears a stale lastError")
+    func beginTurnClearsLastError() {
+        var t = ConversationTranscript()
+        t.beginTurn(userPrompt: "first")
+        t.apply(.failed(message: "boom"))
+        #expect(t.lastError == "boom")
+        t.beginTurn(userPrompt: "second")
+        #expect(t.lastError == nil)
+    }
+
+    @Test("events before beginTurn are ignored (no in-flight message)")
+    func eventsBeforeBeginTurnAreIgnored() {
+        var t = ConversationTranscript()
+        t.apply(.textDelta("x"))
+        t.apply(.toolResult(id: "a", content: "b", isError: false))
+        #expect(t.messages.isEmpty)
+    }
+
+    @Test("endTurn returns the in-flight assistant message and clears the in-flight marker")
+    func endTurnReturnsAssistantAndClearsInFlight() {
+        var t = ConversationTranscript()
+        t.beginTurn(userPrompt: "hi")
+        t.apply(.textDelta("done"))
+        let final = t.endTurn()
+        #expect(final?.role == .assistant)
+        #expect(final?.content == "done")
+        // After endTurn, further deltas have no in-flight target and are dropped.
+        t.apply(.textDelta(" more"))
+        #expect(t.messages[1].content == "done")
+    }
+
+    @Test("reset clears messages and the in-flight marker")
+    func resetClearsMessagesAndInFlight() {
+        var t = ConversationTranscript()
+        t.beginTurn(userPrompt: "hi")
+        t.apply(.textDelta("partial"))
+        t.reset()
+        #expect(t.messages.isEmpty)
+        // A subsequent delta is ignored until a new turn begins.
+        t.apply(.textDelta("ignored"))
+        #expect(t.messages.isEmpty)
+        // A fresh turn works cleanly.
+        t.beginTurn(userPrompt: "again")
+        #expect(t.messages.count == 2)
+    }
+}
+
+@Suite("ConversationTranscript: event accumulation")
+struct ConversationTranscriptEventTests {
+
+    private func started() -> ConversationTranscript {
+        var t = ConversationTranscript()
+        t.beginTurn(userPrompt: "go")
+        return t
+    }
+
+    @Test("textDeltas accumulate into the in-flight assistant message")
+    func textDeltasAccumulate() {
+        var t = started()
+        t.apply(.textDelta("Hel"))
+        t.apply(.textDelta("lo"))
+        #expect(t.messages[1].content == "Hello")
+    }
+
+    @Test(".started and .thinking do not mutate the transcript")
+    func startedAndThinkingAreInert() {
+        var t = started()
+        let before = t.messages
+        t.apply(.started(model: "on-device", toolNames: ["apply_edit"]))
+        t.apply(.thinking("hmm"))
+        #expect(t.messages.map(\.content) == before.map(\.content))
+        #expect(t.messages[1].toolCalls.isEmpty)
+    }
+
+    @Test("toolUse then toolResult pair by id on the assistant message")
+    func toolUseThenResultPairsByID() {
+        var t = started()
+        t.apply(.toolUse(id: "t1", name: "apply_edit", input: .object(["op": .string("replace")])))
+        t.apply(.toolResult(id: "t1", content: "applied", isError: false))
+        #expect(t.messages[1].toolCalls.count == 1)
+        let call = t.messages[1].toolCalls[0]
+        #expect(call.id == "t1")
+        #expect(call.name == "apply_edit")
+        #expect(call.result == "applied")
+        #expect(call.isError == false)
+        #expect(call.inputDisplay.contains("replace"))
+    }
+
+    @Test("a toolResult with no matching toolUse surfaces as an unbound call")
+    func toolResultWithoutMatchingUseIsUnbound() {
+        var t = started()
+        t.apply(.toolResult(id: "orphan", content: "result-only", isError: true))
+        #expect(t.messages[1].toolCalls.count == 1)
+        let call = t.messages[1].toolCalls[0]
+        #expect(call.name == "(unbound)")
+        #expect(call.result == "result-only")
+        #expect(call.isError == true)
+    }
+
+    @Test("turnComplete with usage captures lastUsage")
+    func turnCompleteCapturesUsage() {
+        var t = started()
+        t.apply(.turnComplete(AssistantUsage(inputTokens: 12, outputTokens: 7, costUSD: 0.01, durationMs: 200)))
+        #expect(t.lastUsage?.inputTokens == 12)
+        #expect(t.lastUsage?.outputTokens == 7)
+        #expect(t.lastUsage?.costUSD == 0.01)
+    }
+
+    @Test("turnComplete with nil usage leaves lastUsage unchanged")
+    func turnCompleteNilUsageIsNoOp() {
+        var t = started()
+        t.apply(.turnComplete(nil))
+        #expect(t.lastUsage == nil)
+    }
+
+    @Test("failed sets lastError and appends an error row")
+    func failedSetsErrorAndAppendsRow() {
+        var t = started()
+        t.apply(.failed(message: "model exploded"))
+        #expect(t.lastError == "model exploded")
+        #expect(t.messages.last?.role == .error)
+        #expect(t.messages.last?.content == "model exploded")
+    }
+
+    @Test("cancelled appends a system row")
+    func cancelledAppendsSystemRow() {
+        var t = started()
+        t.apply(.cancelled)
+        #expect(t.messages.last?.role == .system)
+        #expect(t.messages.last?.content == "Cancelled.")
+    }
+
+    @Test("backendExited with a nonzero code appends an error naming the provider")
+    func backendExitedNonzeroAppendsError() {
+        var t = ConversationTranscript(providerName: "On-Device")
+        t.beginTurn(userPrompt: "go")
+        t.apply(.backendExited(code: 1))
+        #expect(t.lastError?.contains("On-Device") == true)
+        #expect(t.lastError?.contains("1") == true)
+        #expect(t.messages.last?.role == .error)
+    }
+
+    @Test("backendExited with a clean (0) or SIGTERM (-15) code is ignored")
+    func backendExitedCleanCodesIgnored() {
+        var t = started()
+        t.apply(.backendExited(code: 0))
+        t.apply(.backendExited(code: -15))
+        #expect(t.lastError == nil)
+        #expect(!t.messages.contains { $0.role == .error })
+    }
+
+    @Test("a full tool-using turn accumulates text + a paired tool call + usage")
+    func fullToolUsingTurnSmoke() {
+        var t = ConversationTranscript(providerName: "On-Device")
+        t.beginTurn(userPrompt: "edit my homepage")
+        t.apply(.started(model: "on-device", toolNames: ["apply_edit", "search_content"]))
+        t.apply(.textDelta("Sure, "))
+        t.apply(.toolUse(id: "u1", name: "apply_edit", input: .object(["selector": .string("h1")])))
+        t.apply(.toolResult(id: "u1", content: "edited index.md", isError: false))
+        t.apply(.textDelta("done."))
+        t.apply(.turnComplete(AssistantUsage(inputTokens: 30, outputTokens: 9, costUSD: nil, durationMs: nil)))
+        let final = t.endTurn()
+
+        #expect(t.messages.count == 2)
+        #expect(t.messages[0].role == .user)
+        #expect(final?.content == "Sure, done.")
+        #expect(final?.toolCalls.count == 1)
+        #expect(final?.toolCalls.first?.result == "edited index.md")
+        #expect(t.lastUsage?.inputTokens == 30)
+        #expect(t.lastError == nil)
+    }
+}
+
+@Suite("ConversationTranscript: out-of-band rows")
+struct ConversationTranscriptAppendTests {
+
+    @Test("append preserves order and does not redirect in-flight text deltas")
+    func appendPreservesOrderDuringTurn() {
+        var t = ConversationTranscript()
+        t.beginTurn(userPrompt: "hi")
+        t.apply(.textDelta("partial"))
+        let edit = ChatMessage(role: .edit, content: "Edited index.md",
+                               editMetadata: ChatEditMetadata(file: "index.md", commit: "abc123", undone: false))
+        t.append(edit)
+        // Order: [user, assistant, edit]
+        #expect(t.messages.map(\.role) == [.user, .assistant, .edit])
+        // The in-flight assistant message (not the appended edit row) keeps receiving deltas.
+        t.apply(.textDelta(" more"))
+        #expect(t.messages[1].content == "partial more")
+        #expect(t.messages[2].content == "Edited index.md")
+    }
+
+    @Test("update mutates the identified message in place")
+    func updateMutatesByID() {
+        var t = ConversationTranscript()
+        let edit = ChatMessage(role: .edit, content: "Edited index.md",
+                               editMetadata: ChatEditMetadata(file: "index.md", commit: "abc123", undone: false))
+        t.append(edit)
+        t.update(id: edit.id) { $0.editMetadata?.undone = true }
+        #expect(t.messages[0].editMetadata?.undone == true)
+    }
+
+    @Test("remove returns and drops the identified message; missing id is a no-op")
+    func removeReturnsAndDrops() {
+        var t = ConversationTranscript()
+        let a = ChatMessage(role: .annotation, content: "note A")
+        let b = ChatMessage(role: .annotation, content: "note B")
+        t.append(a)
+        t.append(b)
+        let removed = t.remove(id: a.id)
+        #expect(removed?.content == "note A")
+        #expect(t.messages.map(\.content) == ["note B"])
+        #expect(t.remove(id: a.id) == nil)
+        #expect(t.messages.count == 1)
+    }
+
+    @Test("insertByTimestamp restores a row at its chronological position")
+    func insertByTimestampRestoresOrder() {
+        let base = Date(timeIntervalSince1970: 1_000)
+        var t = ConversationTranscript()
+        let first = ChatMessage(role: .annotation, content: "first", timestamp: base)
+        let third = ChatMessage(role: .annotation, content: "third", timestamp: base.addingTimeInterval(20))
+        let second = ChatMessage(role: .annotation, content: "second", timestamp: base.addingTimeInterval(10))
+        t.append(first)
+        t.append(third)
+        // Re-inserting `second` must land it between `first` and `third` by timestamp.
+        t.insertByTimestamp(second)
+        #expect(t.messages.map(\.content) == ["first", "second", "third"])
+    }
+
+    @Test("insertByTimestamp appends when newest")
+    func insertByTimestampAppendsWhenNewest() {
+        let base = Date(timeIntervalSince1970: 1_000)
+        var t = ConversationTranscript()
+        t.append(ChatMessage(role: .annotation, content: "old", timestamp: base))
+        t.insertByTimestamp(ChatMessage(role: .annotation, content: "new", timestamp: base.addingTimeInterval(50)))
+        #expect(t.messages.map(\.content) == ["old", "new"])
+    }
+}
+
+@Suite("resolveAssistantChoice: tier selection seam")
+struct AssistantChoiceTests {
+
+    @Test("with Foundation Models off, the choice is Claude regardless of tier")
+    func prefersClaudeWhenFlagOff() {
+        #expect(resolveAssistantChoice(preferFoundationModels: false, tier: .onDevice) == .claude)
+        #expect(resolveAssistantChoice(preferFoundationModels: false, tier: .privateCloudCompute) == .claude)
+    }
+
+    @Test("with Foundation Models on, the choice carries the selected tier")
+    func picksFoundationModelWithTierWhenFlagOn() {
+        #expect(resolveAssistantChoice(preferFoundationModels: true, tier: .onDevice) == .foundationModel(.onDevice))
+        #expect(resolveAssistantChoice(preferFoundationModels: true, tier: .privateCloudCompute) == .foundationModel(.privateCloudCompute))
+    }
+}


### PR DESCRIPTION
Closes the two open C.11 (#161) checklist items that lived in the untested `AnglesiteApp` target.

## Background

Phase C's on-device chat stack (#189–#204) already shipped with strong test coverage — `FoundationModelAssistantTests` (16), `GenerableTypesTests` (5/5), `OnDeviceToolsTests` (9), `AltTextGeneratorTests` (7), and the `ClaudeAssistant` wrapper. A coverage audit against the C.11 checklist found **5 of 7 items fully covered**. The remaining two — the **ChatModel + FoundationModelAssistant streaming/tool-calling smoke** (item 5) and the **model-tier switch** (item 7) — lived in `ChatModel`/`SiteWindow` in the `AnglesiteApp` target, which `swift test` never builds (no app test target exists). They were structurally unreachable.

## Approach: extract the seams into `AnglesiteCore`, then test

- **`ConversationTranscript`** — the provider-agnostic event-accumulation reducer lifted verbatim from `ChatModel.handle`, plus the `ChatMessage`/`ChatToolCall`/`ChatEditMetadata`/`ChatAnnotationMetadata` value types and `renderJSON`. **23 new tests** cover the full `AssistantEvent` contract: text-delta accumulation, `tool_use`/`tool_result` pairing, unbound results, usage capture, `failed`/`cancelled`/`backendExited` rows, turn lifecycle, reset, and out-of-band row ops.
- **`resolveAssistantChoice(preferFoundationModels:tier:)`** — the settings → backend decision, separated from construction (which still needs App-owned deps).

`ChatModel` keeps its `@MainActor @Observable`/persistence/undo shell, re-exports the Core value types via `typealias Message = ChatMessage` (so **`ChatView` is unchanged**), and delegates all message-array mutation to the transcript — **net −98 lines**. `SiteWindow`'s DevID branch routes through `resolveAssistantChoice`, preserving the lazy `makeEditBridge()` evaluation.

## Verification

- `swift test`: green except two **pre-existing environmental** e2e failures (`MCPClientHTTPEndToEndTests` `.sessionLost` needs a live HTTP MCP server; `AppliesEditEndToEndTests` `.reconnecting` needs the sibling plugin/node checkout). Neither touches changed code.
- `xcodebuild` **Anglesite** (DevID) and **AnglesiteMAS** schemes both **BUILD SUCCEEDED** — confirms the typealias/delegation rewire links in the real app, including the MAS `#if` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)