### PR TITLE
fix(app): present New Site wizard via .sheet(item:) (#209)

### DIFF
--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -28,20 +28,14 @@ struct SitesLauncherView: View {
     /// stays stable through the dismiss animation — reading `siteToRemove?.name` directly would
     /// collapse to "" the instant the dialog clears the optional.
     @State private var siteToRemoveName = ""
-    /// The active New Site wizard session, or nil when the wizard isn't showing. A single
-    /// `Identifiable` payload — rather than a bool plus two optionals — so `.sheet(item:)` only
-    /// presents once both the model and the scaffolder exist. This closes the empty-sheet bug
-    /// (#209) where `.sheet(isPresented:)` flipped true before the content optionals were observed,
-    /// resolving the content builder to `EmptyView` and rendering a blank, default-sized sheet.
-    @State private var newSiteSession: NewSiteSession?
-    @State private var sitesRootScopedURL: URL?
-
-    /// Bundles the wizard model and its scaffolder so the New Site sheet presents atomically.
     private struct NewSiteSession: Identifiable {
         let id = UUID()
         let model: NewSiteWizardModel
         let scaffolder: SiteScaffolder
     }
+    /// Non-nil while the New Site wizard is showing; nil dismisses it.
+    @State private var newSiteSession: NewSiteSession?
+    @State private var sitesRootScopedURL: URL?
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -315,8 +309,6 @@ struct SitesLauncherView: View {
                 return site
             }
         )
-        // Assign the model and scaffolder together as one payload so the sheet can't present
-        // before both exist (see NewSiteSession / #209).
         newSiteSession = NewSiteSession(model: model, scaffolder: scaffolder)
     }
 

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -20,7 +20,6 @@ struct SitesLauncherView: View {
     @State private var sites: [SiteStore.Site] = []
     @State private var loadError: String?
     @State private var deciding = true
-    @State private var showingNewSite = false
     /// The site awaiting a remove confirmation, or nil when no prompt is up. Drives the
     /// `.confirmationDialog`; SwiftUI clears it (via the `isPresented` binding) when any dialog
     /// button is tapped.
@@ -29,9 +28,20 @@ struct SitesLauncherView: View {
     /// stays stable through the dismiss animation — reading `siteToRemove?.name` directly would
     /// collapse to "" the instant the dialog clears the optional.
     @State private var siteToRemoveName = ""
-    @State private var wizardModel: NewSiteWizardModel?
-    @State private var scaffolder: SiteScaffolder?
+    /// The active New Site wizard session, or nil when the wizard isn't showing. A single
+    /// `Identifiable` payload — rather than a bool plus two optionals — so `.sheet(item:)` only
+    /// presents once both the model and the scaffolder exist. This closes the empty-sheet bug
+    /// (#209) where `.sheet(isPresented:)` flipped true before the content optionals were observed,
+    /// resolving the content builder to `EmptyView` and rendering a blank, default-sized sheet.
+    @State private var newSiteSession: NewSiteSession?
     @State private var sitesRootScopedURL: URL?
+
+    /// Bundles the wizard model and its scaffolder so the New Site sheet presents atomically.
+    private struct NewSiteSession: Identifiable {
+        let id = UUID()
+        let model: NewSiteWizardModel
+        let scaffolder: SiteScaffolder
+    }
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -65,25 +75,23 @@ struct SitesLauncherView: View {
             footer
         }
         .frame(minWidth: 480, idealWidth: 520, minHeight: 360, idealHeight: 480)
-        .sheet(isPresented: $showingNewSite) {
-            if let wizardModel, let scaffolder {
-                NewSiteWizard(
-                    model: wizardModel,
-                    scaffolder: scaffolder,
-                    onComplete: { siteID in
-                        showingNewSite = false
-                        Task {
-                            await refreshSites()
-                            openWindow(value: siteID)
-                            dismissWindow()
-                        }
-                    },
-                    onCancel: { showingNewSite = false }
-                )
-                .onDisappear {
-                    sitesRootScopedURL?.stopAccessingSecurityScopedResource()
-                    sitesRootScopedURL = nil
-                }
+        .sheet(item: $newSiteSession) { session in
+            NewSiteWizard(
+                model: session.model,
+                scaffolder: session.scaffolder,
+                onComplete: { siteID in
+                    newSiteSession = nil
+                    Task {
+                        await refreshSites()
+                        openWindow(value: siteID)
+                        dismissWindow()
+                    }
+                },
+                onCancel: { newSiteSession = nil }
+            )
+            .onDisappear {
+                sitesRootScopedURL?.stopAccessingSecurityScopedResource()
+                sitesRootScopedURL = nil
             }
         }
     }
@@ -291,7 +299,7 @@ struct SitesLauncherView: View {
 
         let model = NewSiteWizardModel(catalog: catalog, slugTaken: { takenSlugs.contains($0) })
 
-        scaffolder = SiteScaffolder(
+        let scaffolder = SiteScaffolder(
             sitesRoot: sitesRoot,
             pluginURL: pluginURL,
             catalog: catalog,
@@ -307,8 +315,9 @@ struct SitesLauncherView: View {
                 return site
             }
         )
-        wizardModel = model
-        showingNewSite = true
+        // Assign the model and scaffolder together as one payload so the sheet can't present
+        // before both exist (see NewSiteSession / #209).
+        newSiteSession = NewSiteSession(model: model, scaffolder: scaffolder)
     }
 
     #if ANGLESITE_MAS


### PR DESCRIPTION
Fixes #209.

## Problem

Choosing **Add Site → "Create new site…"** in the Sites launcher rendered a blank, default-sized white sheet instead of the New Site wizard. The flow was a dead end.

## Root cause

`SitesLauncherView` presented the wizard with `.sheet(isPresented: $showingNewSite)` whose content was gated on two *separate* `@State` optionals via `if let wizardModel, let scaffolder`:

```swift
.sheet(isPresented: $showingNewSite) {
    if let wizardModel, let scaffolder { NewSiteWizard(...) }   // → EmptyView when either is nil
}
```

The boolean trigger and the content data are decoupled, so SwiftUI can build the sheet's `@ViewBuilder` content while the optionals are still observed as `nil` — resolving to `EmptyView` and presenting an empty, default-sized sheet (the small white box).

Note: the assignment order in `presentNewSite()` was already correct (`scaffolder` and `wizardModel` set *before* the flag) — ordering was **not** the cause, and the SwiftUI 27 `@State`-macro change is ruled out by the existing audit (`docs/specs/2026-06-10-xcode27-state-macro-audit-notes.md`, which classes these optionals as value-correct).

## Fix

Collapse the `Bool` + two optionals into a single `Identifiable` payload presented with `.sheet(item:)`:

```swift
private struct NewSiteSession: Identifiable {
    let id = UUID()
    let model: NewSiteWizardModel
    let scaffolder: SiteScaffolder
}
@State private var newSiteSession: NewSiteSession?

.sheet(item: $newSiteSession) { session in NewSiteWizard(model: session.model, scaffolder: session.scaffolder, ...) }
```

The content closure now receives a **non-optional** value, so presenting empty content is no longer representable — the entire bug class is gone, not just this instance. `presentNewSite()` assigns the payload atomically.

## Verification

- ✅ `xcodebuild` **BUILD SUCCEEDED** — `Anglesite` (DevID) target, `.app` links.
- ✅ `xcodebuild` **BUILD SUCCEEDED** — `AnglesiteMAS` target.
- ✅ App launches; main thread healthy (parked in the AppKit event loop, not hung).
- ⏳ **Runtime GUI confirmation pending.** Automated capture was blocked in the dev environment (Screen Recording + Accessibility TCC denied to the shell), and the author is remote. Reviewer/author: please click **+ Add Site → "Create new site…"** and confirm the wizard ("What kind of site?") appears instead of the blank box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)