### PR TITLE
feat(app): adopt macOS 27 toolbar APIs for the SiteWindow action bar (#107)

### DIFF
--- a/Sources/AnglesiteApp/HealthBadgeView.swift
+++ b/Sources/AnglesiteApp/HealthBadgeView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 import AnglesiteCore
 
-/// Circular deploy-readiness indicator + popover, rendered in `SiteWindow`'s
-/// header row to the left of the Chat button.
+/// Circular deploy-readiness indicator + popover, rendered as a `ToolbarItem`
+/// in `SiteWindow`'s window toolbar (high `visibilityPriority`, so it stays
+/// visible as the window narrows).
 ///
 /// The view is intentionally dumb: it reads `HealthModel`'s settled state and
 /// surfaces the same data structures `BlockedDeploySheetView` already renders

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -245,27 +245,27 @@ struct SiteWindow: View {
     @ViewBuilder
     private func mainPane(for site: SiteStore.Site) -> some View {
         switch preview.state {
-            case .ready(_, let url):
-                PreviewView(url: url, router: preview.editRouter, annotationProvider: annotationProvider)
-            case .starting:
-                centeredStatus { ProgressView("Starting dev server for \(site.name)…") }
-            case .failed(_, let message):
-                centeredStatus {
-                    VStack(spacing: 12) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.largeTitle).foregroundStyle(.orange)
-                        Text("Can't preview \(site.name)").font(.headline)
-                        Text(message)
-                            .font(.callout).foregroundStyle(.secondary)
-                            .multilineTextAlignment(.center).frame(maxWidth: 420)
-                        Button("Retry") {
-                            preview.open(siteID: site.id, siteDirectory: site.path)
-                        }
+        case .ready(_, let url):
+            PreviewView(url: url, router: preview.editRouter, annotationProvider: annotationProvider)
+        case .starting:
+            centeredStatus { ProgressView("Starting dev server for \(site.name)…") }
+        case .failed(_, let message):
+            centeredStatus {
+                VStack(spacing: 12) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.largeTitle).foregroundStyle(.orange)
+                    Text("Can't preview \(site.name)").font(.headline)
+                    Text(message)
+                        .font(.callout).foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center).frame(maxWidth: 420)
+                    Button("Retry") {
+                        preview.open(siteID: site.id, siteDirectory: site.path)
                     }
                 }
-            case .idle:
-                centeredStatus { ProgressView() }
             }
+        case .idle:
+            centeredStatus { ProgressView() }
+        }
     }
 
     private func centeredStatus<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -128,6 +128,98 @@ struct SiteWindow: View {
         .animation(.easeInOut(duration: 0.18), value: deploy.drawerPresented)
         .animation(.easeInOut(duration: 0.18), value: backup.drawerPresented)
         .navigationTitle(site.name)
+        .navigationSubtitle(preview.readyURL?.absoluteString ?? "")
+        .toolbar {
+            // Backup — lowest priority, first to collapse into the native overflow chevron.
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    backup.backup(siteID: site.id, siteDirectory: site.path)
+                } label: {
+                    Label("Backup", systemImage: "externaldrive.fill.badge.icloud")
+                }
+                .disabled(backup.isRunning || audit.isRunning || deploy.isRunning || !site.isValid)
+                .help(site.isValid
+                      ? "Commit and push working-tree changes to your current branch"
+                      : "Site is missing required files")
+            }
+            .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
+
+            // Audit — low priority, collapses before Chat.
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    audit.audit(siteID: site.id, siteDirectory: site.path)
+                } label: {
+                    if audit.isRunning {
+                        Label("Auditing…", systemImage: "magnifyingglass")
+                    } else {
+                        Label("Audit", systemImage: "checkmark.shield.fill")
+                    }
+                }
+                .disabled(audit.isRunning || backup.isRunning || deploy.isRunning || !site.isValid)
+                .help(site.isValid
+                      ? "Run the structured accessibility audit against this site"
+                      : "Site is missing required files")
+            }
+            .visibilityPriority(.low)
+
+            // Chat — default priority, kept above Audit/Backup. Preserves ⌘K.
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    chatPresented.toggle()
+                } label: {
+                    Label("Chat", systemImage: chatPresented
+                        ? "bubble.left.and.bubble.right.fill"
+                        : "bubble.left.and.bubble.right")
+                }
+                .help(chatPresented ? "Hide chat panel" : "Show chat panel")
+                .keyboardShortcut("k", modifiers: [.command])
+            }
+            // .visibilityPriority(.automatic) is the default — left implicit.
+
+            // Open in browser — default priority, only when the dev server is ready.
+            ToolbarItem(placement: .primaryAction) {
+                if let url = preview.readyURL {
+                    Button {
+                        NSWorkspace.shared.open(url)
+                    } label: {
+                        Label("Open in browser", systemImage: "arrow.up.forward.app")
+                    }
+                    .help("Open the live preview in your default browser")
+                }
+            }
+            // .visibilityPriority(.automatic) is the default — left implicit.
+
+            // Health badge — high priority, stays visible.
+            ToolbarItem(placement: .primaryAction) {
+                HealthBadgeView(
+                    model: health,
+                    onRecheck: { health.recheck(siteID: site.id, siteDirectory: site.path) },
+                    onAskClaude: {
+                        #if !ANGLESITE_MAS
+                        chatPresented = true
+                        chat?.send("/anglesite:check")
+                        #endif
+                    }
+                )
+            }
+            .visibilityPriority(.high)
+
+            // Deploy — primary action, highest priority so it is the last to collapse.
+            // Declared LAST so it renders at the trailing edge (macOS primary-action position).
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    deploy.deploy(siteID: site.id, siteDirectory: site.path)
+                } label: {
+                    Label("Deploy", systemImage: "paperplane.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(deploy.isRunning || backup.isRunning || audit.isRunning || !site.isValid)
+                .help(site.isValid
+                      ? "Build, scan, and run wrangler deploy on this site"
+                      : "Site is missing required files")
+            }
+            .visibilityPriority(.high)
+        }
         .sheet(isPresented: $deploy.blockedPresented) {
             if case .blocked(let failures, let warnings) = deploy.phase {
                 BlockedDeploySheetView(failures: failures, warnings: warnings) {
@@ -152,87 +244,7 @@ struct SiteWindow: View {
 
     @ViewBuilder
     private func mainPane(for site: SiteStore.Site) -> some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 8) {
-                Text(site.name).font(.headline)
-                if let url = preview.readyURL {
-                    Text(url.absoluteString)
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                    Button("Open in browser") { NSWorkspace.shared.open(url) }
-                        .controlSize(.small)
-                } else {
-                    Spacer()
-                }
-                HealthBadgeView(
-                    model: health,
-                    onRecheck: { health.recheck(siteID: site.id, siteDirectory: site.path) },
-                    onAskClaude: {
-                        #if !ANGLESITE_MAS
-                        chatPresented = true
-                        chat?.send("/anglesite:check")
-                        #endif
-                    }
-                )
-
-                Button {
-                    chatPresented.toggle()
-                } label: {
-                    Label("Chat",
-                          systemImage: chatPresented
-                            ? "bubble.left.and.bubble.right.fill"
-                            : "bubble.left.and.bubble.right")
-                }
-                .controlSize(.small)
-                .help(chatPresented ? "Hide chat panel" : "Show chat panel")
-                .keyboardShortcut("k", modifiers: [.command])
-
-                Button {
-                    backup.backup(siteID: site.id, siteDirectory: site.path)
-                } label: {
-                    Label("Backup", systemImage: "externaldrive.fill.badge.icloud")
-                }
-                .controlSize(.small)
-                .buttonStyle(.bordered)
-                .disabled(backup.isRunning || audit.isRunning || deploy.isRunning || !site.isValid)
-                .help(site.isValid
-                      ? "Commit and push working-tree changes to your current branch"
-                      : "Site is missing required files")
-
-                Button {
-                    audit.audit(siteID: site.id, siteDirectory: site.path)
-                } label: {
-                    if audit.isRunning {
-                        Label("Auditing…", systemImage: "magnifyingglass")
-                    } else {
-                        Label("Audit", systemImage: "checkmark.shield.fill")
-                    }
-                }
-                .controlSize(.small)
-                .buttonStyle(.bordered)
-                .disabled(audit.isRunning || backup.isRunning || deploy.isRunning || !site.isValid)
-                .help(site.isValid
-                      ? "Run the structured accessibility audit against this site"
-                      : "Site is missing required files")
-
-                Button {
-                    deploy.deploy(siteID: site.id, siteDirectory: site.path)
-                } label: {
-                    Label("Deploy", systemImage: "paperplane.fill")
-                }
-                .controlSize(.small)
-                .buttonStyle(.borderedProminent)
-                .disabled(deploy.isRunning || backup.isRunning || audit.isRunning || !site.isValid)
-                .help(site.isValid
-                      ? "Build, scan, and run wrangler deploy on this site"
-                      : "Site is missing required files")
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            Divider()
-
-            switch preview.state {
+        switch preview.state {
             case .ready(_, let url):
                 PreviewView(url: url, router: preview.editRouter, annotationProvider: annotationProvider)
             case .starting:
@@ -254,7 +266,6 @@ struct SiteWindow: View {
             case .idle:
                 centeredStatus { ProgressView() }
             }
-        }
     }
 
     private func centeredStatus<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -177,8 +177,8 @@ struct SiteWindow: View {
             // .visibilityPriority(.automatic) is the default — left implicit.
 
             // Open in browser — default priority, only when the dev server is ready.
-            ToolbarItem(placement: .primaryAction) {
-                if let url = preview.readyURL {
+            if let url = preview.readyURL {
+                ToolbarItem(placement: .primaryAction) {
                     Button {
                         NSWorkspace.shared.open(url)
                     } label: {

--- a/docs/superpowers/plans/2026-06-16-107-toolbar-apis.md
+++ b/docs/superpowers/plans/2026-06-16-107-toolbar-apis.md
@@ -1,0 +1,340 @@
+# macOS 27 Toolbar APIs for the SiteWindow Action Bar — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the `SiteWindow` action bar from a hand-rolled content `HStack` to a native SwiftUI `.toolbar` that uses macOS 27's overflow APIs so Deploy stays pinned and secondary actions collapse into an overflow menu instead of vanishing as the window narrows.
+
+**Architecture:** Delete the content-header `HStack` in `SiteWindow.mainPane`; move Deploy / Backup / Audit / Chat / the health badge / "Open in browser" into a native `.toolbar { }` on the site UI; surface the live dev-server URL via `.navigationSubtitle`. Apply `visibilityPriority` / `toolbarOverflowMenu` / `topBarPinnedTrailing` so Deploy is pinned and Backup→Audit→Chat→"Open in browser" collapse in that order.
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27), Xcode 27, `xcodebuild` for both app schemes.
+
+## Global Constraints
+
+- Deployment target: **macOS 27.0** on both targets (`Package.swift`, `project.yml`). No `if #available` guards needed.
+- **No frameworks beyond Apple's** (v0 rule; Sparkle is the only third-party dep and is irrelevant here).
+- The change must build clean on **both** schemes: `Anglesite` (DevID) and `AnglesiteMAS`. `swift test` alone does not prove the `.app` links — use `xcodebuild`.
+- The toolbar is **target-agnostic**: do not add new `#if ANGLESITE_MAS` gates. The only existing gate ("Ask Claude") lives inside `HealthBadgeView`'s popover and is untouched.
+- Process spawning stays centralized in `AnglesiteCore/ProcessSupervisor`; this is a pure view change and spawns nothing new.
+- Spec: `docs/superpowers/specs/2026-06-16-107-toolbar-apis-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `Sources/AnglesiteApp/SiteWindow.swift` | Per-site window root view; hosts the action bar | Modify: remove header `HStack` from `mainPane`; add `.toolbar`, `.navigationSubtitle` to `siteUI(for:)` |
+| `docs/superpowers/specs/2026-06-16-107-toolbar-apis-design.md` | Approved design | Reference only |
+
+No new files. `HealthBadgeView.swift` is reused verbatim (it is already a self-contained `View` with closure callbacks).
+
+---
+
+### Task 1: Confirm the macOS 27 toolbar API surface
+
+**Files:**
+- Reference only (no edits). Inspect the Xcode 27 SDK / SwiftUI docs.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: confirmed spellings for the three APIs, recorded as a comment block appended to the plan or stated in the task's completion note. Specifically the answers to:
+  1. The exact pinned-trailing placement — is it `ToolbarItem(placement: .topBarPinnedTrailing)` or a modifier form?
+  2. The exact `visibilityPriority` API — modifier on `ToolbarItem` (`.visibilityPriority(_:)`) and its argument type (Double? named constants?).
+  3. The exact `toolbarOverflowMenu` form — a `.toolbar` content modifier vs. an automatic behavior of low-priority items.
+
+- [ ] **Step 1: Locate the SwiftUI toolbar symbols in the SDK**
+
+Run:
+```bash
+xcrun --sdk macosx --show-sdk-path
+# Then search the SwiftUI module interface for the symbols:
+SDK=$(xcrun --sdk macosx --show-sdk-path)
+find "$SDK"/../.. -name "SwiftUI.swiftinterface" 2>/dev/null | head -1
+```
+Open the `.swiftinterface` (or use Xcode's "Jump to Definition" on a stub call) and grep for `visibilityPriority`, `topBarPinnedTrailing`, `toolbarOverflowMenu`.
+
+Expected: the three symbols resolve. Record their exact signatures.
+
+- [ ] **Step 2: Write a throwaway compile probe**
+
+Create a scratch SwiftUI view in a temporary file and `xcodebuild` it (or paste into an Xcode playground/preview) using each API as you believe it is spelled. Example probe to confirm spellings:
+```swift
+import SwiftUI
+struct _ToolbarProbe: View {
+    var body: some View {
+        Text("probe")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) { Button("Deploy") {} }
+                    .visibilityPriority(10)
+            }
+    }
+}
+```
+Adjust until it compiles. The point is to discover the real spelling, not to keep the file.
+
+- [ ] **Step 3: Record findings and delete the probe**
+
+Write the confirmed signatures into Task 2's code (below) before implementing. If any named API does **not** exist, record the chosen fallback (native `.toolbar` + `visibilityPriority`/`ToolbarSpacer` with default overflow) and note it in the eventual PR description. Delete the scratch file.
+
+- [ ] **Step 4: Commit the findings note (only if the plan/spec is updated)**
+
+If you appended confirmed signatures to the spec or plan:
+```bash
+git add docs/superpowers/
+git commit -m "docs(spec): record confirmed macOS 27 toolbar API signatures (#107)"
+```
+Otherwise no commit — findings carry forward into Task 2.
+
+---
+
+### Task 2: Migrate the action bar to a native toolbar
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift`
+  - `siteUI(for:)` (~lines 86–151): add `.navigationSubtitle(...)` and `.toolbar { ... }`.
+  - `mainPane(for:)` (~lines 153–258): delete the header `HStack` (lines ~156–233) and its trailing `Divider()`, leaving only the `switch preview.state` body.
+
+**Interfaces:**
+- Consumes (from Task 1): confirmed spellings of `topBarPinnedTrailing`, `visibilityPriority(_:)`, `toolbarOverflowMenu`. The code below uses the issue's named forms; **adjust the spellings to match Task 1's findings** if they differ.
+- Consumes (existing, unchanged): `HealthBadgeView(model:onRecheck:onAskClaude:)`; `preview.readyURL: URL?`; `deploy`/`backup`/`audit` models with `.isRunning` and their `deploy/backup/audit(siteID:siteDirectory:)` methods; `site.isValid`; `chatPresented: Bool`; `chat: ChatModel?`.
+- Produces: `siteUI(for:)` now renders the action bar in the window title bar; `mainPane(for:)` renders only the preview content.
+
+- [ ] **Step 1: Delete the header `HStack` from `mainPane(for:)`**
+
+In `mainPane(for:)`, remove the entire leading block — from `HStack(spacing: 8) {` through its `.padding(.vertical, 8)` and the `Divider()` immediately after it (current lines ~156–233). The function body should start directly with `switch preview.state {`. Result:
+
+```swift
+@ViewBuilder
+private func mainPane(for site: SiteStore.Site) -> some View {
+    switch preview.state {
+    case .ready(_, let url):
+        PreviewView(url: url, router: preview.editRouter, annotationProvider: annotationProvider)
+    case .starting:
+        centeredStatus { ProgressView("Starting dev server for \(site.name)…") }
+    case .failed(_, let message):
+        centeredStatus {
+            VStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.largeTitle).foregroundStyle(.orange)
+                Text("Can't preview \(site.name)").font(.headline)
+                Text(message)
+                    .font(.callout).foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center).frame(maxWidth: 420)
+                Button("Retry") {
+                    preview.open(siteID: site.id, siteDirectory: site.path)
+                }
+            }
+        }
+    case .idle:
+        centeredStatus { ProgressView() }
+    }
+}
+```
+
+Note: `mainPane` previously wrapped the content in an outer `VStack(spacing: 0)`. With the header gone, the `switch` can return directly (it is already `@ViewBuilder`). Remove the now-empty `VStack` wrapper.
+
+- [ ] **Step 2: Add `.navigationSubtitle` and the `.toolbar` to `siteUI(for:)`**
+
+Attach to the `siteUI(for:)` view, alongside the existing `.navigationTitle(site.name)` (line 130). Add the URL subtitle and the toolbar. The toolbar code below uses the issue's named APIs — replace spellings with Task 1's confirmed forms if they differ:
+
+```swift
+.navigationTitle(site.name)
+.navigationSubtitle(preview.readyURL?.absoluteString ?? "")
+.toolbar {
+    // Deploy — pinned at the trailing edge, never collapses.
+    ToolbarItem(placement: .topBarPinnedTrailing) {
+        Button {
+            deploy.deploy(siteID: site.id, siteDirectory: site.path)
+        } label: {
+            Label("Deploy", systemImage: "paperplane.fill")
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(deploy.isRunning || backup.isRunning || audit.isRunning || !site.isValid)
+        .help(site.isValid
+              ? "Build, scan, and run wrangler deploy on this site"
+              : "Site is missing required files")
+    }
+
+    // Health badge — high priority, stays visible.
+    ToolbarItem(placement: .primaryAction) {
+        HealthBadgeView(
+            model: health,
+            onRecheck: { health.recheck(siteID: site.id, siteDirectory: site.path) },
+            onAskClaude: {
+                #if !ANGLESITE_MAS
+                chatPresented = true
+                chat?.send("/anglesite:check")
+                #endif
+            }
+        )
+    }
+    .visibilityPriority(40)
+
+    // Open in browser — medium priority, only when the dev server is ready.
+    ToolbarItem(placement: .primaryAction) {
+        if let url = preview.readyURL {
+            Button {
+                NSWorkspace.shared.open(url)
+            } label: {
+                Label("Open in browser", systemImage: "arrow.up.forward.app")
+            }
+            .help("Open the live preview in your default browser")
+        }
+    }
+    .visibilityPriority(30)
+
+    // Chat — lower priority, kept above Audit/Backup. Preserves ⌘K.
+    ToolbarItem(placement: .primaryAction) {
+        Button {
+            chatPresented.toggle()
+        } label: {
+            Label("Chat", systemImage: chatPresented
+                ? "bubble.left.and.bubble.right.fill"
+                : "bubble.left.and.bubble.right")
+        }
+        .help(chatPresented ? "Hide chat panel" : "Show chat panel")
+        .keyboardShortcut("k", modifiers: [.command])
+    }
+    .visibilityPriority(20)
+
+    // Audit — lower priority, collapses before Chat.
+    ToolbarItem(placement: .primaryAction) {
+        Button {
+            audit.audit(siteID: site.id, siteDirectory: site.path)
+        } label: {
+            if audit.isRunning {
+                Label("Auditing…", systemImage: "magnifyingglass")
+            } else {
+                Label("Audit", systemImage: "checkmark.shield.fill")
+            }
+        }
+        .disabled(audit.isRunning || backup.isRunning || deploy.isRunning || !site.isValid)
+        .help(site.isValid
+              ? "Run the structured accessibility audit against this site"
+              : "Site is missing required files")
+    }
+    .visibilityPriority(10)
+
+    // Backup — lowest priority, first to collapse.
+    ToolbarItem(placement: .primaryAction) {
+        Button {
+            backup.backup(siteID: site.id, siteDirectory: site.path)
+        } label: {
+            Label("Backup", systemImage: "externaldrive.fill.badge.icloud")
+        }
+        .disabled(backup.isRunning || audit.isRunning || deploy.isRunning || !site.isValid)
+        .help(site.isValid
+              ? "Commit and push working-tree changes to your current branch"
+              : "Site is missing required files")
+    }
+    .visibilityPriority(5)
+}
+.toolbarOverflowMenu()  // collapse low-priority items into an overflow menu (confirm spelling in Task 1)
+```
+
+Notes:
+- `visibilityPriority` numeric scale is illustrative — use whatever type/range Task 1 confirmed; only the *relative ordering* matters (Deploy implicitly highest via pinning; then badge 40 > Open 30 > Chat 20 > Audit 10 > Backup 5).
+- If `toolbarOverflowMenu` is a per-`ToolbarItemGroup` modifier rather than a `.toolbar`-level one, wrap the secondary items (Open/Chat/Audit/Backup) in a `ToolbarItemGroup` and apply it there.
+- The old `.controlSize(.small)` / `.buttonStyle(.bordered)` are dropped: native toolbar items get system-standard sizing and styling. Keep `.borderedProminent` on Deploy to preserve its emphasis.
+
+- [ ] **Step 3: Build the DevID scheme**
+
+Run:
+```bash
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -20
+```
+Expected: `** BUILD SUCCEEDED **`. Fix any compile errors (most likely API spelling mismatches from Task 1 — correct them here).
+
+- [ ] **Step 4: Build the MAS scheme**
+
+Run:
+```bash
+xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build 2>&1 | tail -20
+```
+Expected: `** BUILD SUCCEEDED **`. This proves no `#if ANGLESITE_MAS` regression and that the sandboxed target links.
+
+- [ ] **Step 5: Run the existing test suite (guard against unrelated breakage)**
+
+Run:
+```bash
+swift test --package-path . 2>&1 | tail -20
+```
+Expected: existing suite passes (the apply-edit e2e may `XCTSkip` if the sibling plugin/node aren't present — that is fine). No `SiteWindow`-specific unit tests exist or are added; this view change is verified by build + manual checks.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat(app): migrate SiteWindow action bar to native macOS 27 toolbar (#107)
+
+Move Deploy/Backup/Audit/Chat + health badge into a native .toolbar with
+visibilityPriority/topBarPinnedTrailing/toolbarOverflowMenu so Deploy stays
+pinned and secondary actions collapse into an overflow menu when the window
+narrows. Live dev-server URL moves to .navigationSubtitle; the content header
+row is removed.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Behavioral verification at narrow widths
+
+**Files:**
+- Reference only (manual run; capture a screenshot artifact for the PR).
+
+**Interfaces:**
+- Consumes: a built `Anglesite.app` from Task 2.
+- Produces: a narrow-width screenshot confirming the acceptance criteria, attached to the PR.
+
+- [ ] **Step 1: Launch the app on a real site**
+
+Use the `run` skill (or launch the built `.app`) and open a site window — the throwaway `~/Sites/smoke` site is appropriate test state.
+
+- [ ] **Step 2: Verify the acceptance criteria at narrow width**
+
+Drag the window narrow (and, on DevID, repeat with the chat pane open via ⌘K). Confirm:
+- Deploy remains visible and pinned at the trailing edge at all reasonable widths.
+- As width shrinks, Backup disappears into the overflow menu first, then Audit, then Chat, then "Open in browser" — none of them silently vanish; all are reachable via the overflow (`⋯`) menu.
+- The health badge stays visible and its popover still opens.
+- The live URL shows as the window subtitle once the dev server is ready.
+- ⌘K still toggles the chat pane even when Chat is in the overflow menu. (If it does not, add a `Commands` menu entry for "Toggle Chat" with ⌘K as a backstop — see spec — and amend Task 2's commit.)
+
+- [ ] **Step 3: Capture a screenshot for the PR**
+
+Take a screenshot at a narrow width showing Deploy pinned + the overflow menu open. Save it to attach to the PR description.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin feat/107-macos27-toolbar-apis
+gh pr create --title "feat(app): adopt macOS 27 toolbar overflow APIs for the SiteWindow action bar (#107)" \
+  --body "Closes #107. Migrates the SiteWindow action bar to a native .toolbar using visibilityPriority/topBarPinnedTrailing/toolbarOverflowMenu. Deploy stays pinned; Backup→Audit→Chat→Open-in-browser collapse into the overflow menu as the window narrows. Live URL moves to .navigationSubtitle. Built clean on both schemes; narrow-width screenshot attached.
+
+Stacked on the #188 branch (both touch SiteWindow.swift).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Note: this branch is stacked on `fix/188-orphaned-site-window`. If PR #208 (#188) has merged to `main` by now, rebase onto `main` before pushing; otherwise set the PR base to the #188 branch.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Migrate to native `.toolbar` → Task 2. ✓
+- `visibilityPriority` ordering (Deploy > badge > Open > Chat > Audit > Backup) → Task 2 Step 2. ✓
+- `toolbarOverflowMenu` collapse → Task 2 Step 2 + Task 3 Step 2. ✓
+- `topBarPinnedTrailing` for Deploy → Task 2 Step 2. ✓
+- URL as `.navigationSubtitle` → Task 2 Step 2. ✓
+- Content header row removed → Task 2 Step 1. ✓
+- API-surface risk / fallback → Task 1 + notes in Task 2. ✓
+- Both-scheme build → Task 2 Steps 3–4. ✓
+- MAS parity (no new gates) → Global Constraints + Task 2. ✓
+- ⌘K preserved incl. overflow case → Task 2 Step 2 + Task 3 Step 2 backstop. ✓
+- Narrow-width manual verification + screenshot → Task 3. ✓
+
+**Placeholder scan:** Task 1 is intentionally a discovery spike (it produces facts, not placeholders); all code steps show concrete code. No "TBD"/"handle edge cases"/"similar to". ✓
+
+**Type consistency:** `HealthBadgeView(model:onRecheck:onAskClaude:)`, `preview.readyURL`, `deploy/backup/audit.isRunning`, `chatPresented`, `site.isValid` all match `SiteWindow.swift` as read. `visibilityPriority` values are relative-only and flagged as such. ✓

--- a/docs/superpowers/plans/2026-06-16-107-toolbar-apis.md
+++ b/docs/superpowers/plans/2026-06-16-107-toolbar-apis.md
@@ -4,7 +4,7 @@
 
 **Goal:** Migrate the `SiteWindow` action bar from a hand-rolled content `HStack` to a native SwiftUI `.toolbar` that uses macOS 27's overflow APIs so Deploy stays pinned and secondary actions collapse into an overflow menu instead of vanishing as the window narrows.
 
-**Architecture:** Delete the content-header `HStack` in `SiteWindow.mainPane`; move Deploy / Backup / Audit / Chat / the health badge / "Open in browser" into a native `.toolbar { }` on the site UI; surface the live dev-server URL via `.navigationSubtitle`. Apply `visibilityPriority` / `toolbarOverflowMenu` / `topBarPinnedTrailing` so Deploy is pinned and Backup→Audit→Chat→"Open in browser" collapse in that order.
+**Architecture:** Delete the content-header `HStack` in `SiteWindow.mainPane`; move Deploy / Backup / Audit / Chat / the health badge / "Open in browser" into a native `.toolbar { }` on the site UI; surface the live dev-server URL via `.navigationSubtitle`. Use `visibilityPriority` (the one macOS-available API of the three) to order collapse so Deploy + the health badge stay `.high` and Backup→Audit→Chat→"Open in browser" collapse first. Deploy is pinned via `.primaryAction` placement; macOS's native NSToolbar chevron handles overflow automatically (the issue's `toolbarOverflowMenu`/`topBarPinnedTrailing` are iOS-only — see Task 1).
 
 **Tech Stack:** Swift 6.4 / SwiftUI (macOS 27), Xcode 27, `xcodebuild` for both app schemes.
 
@@ -95,7 +95,7 @@ Otherwise no commit — findings carry forward into Task 2.
   - `mainPane(for:)` (~lines 153–258): delete the header `HStack` (lines ~156–233) and its trailing `Divider()`, leaving only the `switch preview.state` body.
 
 **Interfaces:**
-- Consumes (from Task 1): confirmed spellings of `topBarPinnedTrailing`, `visibilityPriority(_:)`, `toolbarOverflowMenu`. The code below uses the issue's named forms; **adjust the spellings to match Task 1's findings** if they differ.
+- Consumes (from Task 1, compile-verified): `visibilityPriority(_:)` on `ToolbarContent` with `ToolbarItemVisibilityPriority` (`.high`/`.automatic`/`.low`, `init(lowerThan:)`). `toolbarOverflowMenu` and `topBarPinnedTrailing` are macOS-unavailable, so the code below uses `.primaryAction` + `.visibilityPriority(.high)` for Deploy and relies on macOS's automatic native overflow. Do NOT reintroduce the iOS-only symbols. Full findings: `/tmp/sdd-107/task-1-report.md`.
 - Consumes (existing, unchanged): `HealthBadgeView(model:onRecheck:onAskClaude:)`; `preview.readyURL: URL?`; `deploy`/`backup`/`audit` models with `.isRunning` and their `deploy/backup/audit(siteID:siteDirectory:)` methods; `site.isValid`; `chatPresented: Bool`; `chat: ChatModel?`.
 - Produces: `siteUI(for:)` now renders the action bar in the window title bar; `mainPane(for:)` renders only the preview content.
 
@@ -135,69 +135,27 @@ Note: `mainPane` previously wrapped the content in an outer `VStack(spacing: 0)`
 
 - [ ] **Step 2: Add `.navigationSubtitle` and the `.toolbar` to `siteUI(for:)`**
 
-Attach to the `siteUI(for:)` view, alongside the existing `.navigationTitle(site.name)` (line 130). Add the URL subtitle and the toolbar. The toolbar code below uses the issue's named APIs — replace spellings with Task 1's confirmed forms if they differ:
+Attach to the `siteUI(for:)` view, alongside the existing `.navigationTitle(site.name)` (line 130). Add the URL subtitle and the toolbar. **These spellings were compile-verified against the macOS 27.0 SDK in Task 1** (`toolbarOverflowMenu`/`topBarPinnedTrailing` do NOT exist on macOS — overflow is automatic, Deploy is pinned via `.primaryAction` + `.visibilityPriority(.high)`):
 
 ```swift
 .navigationTitle(site.name)
 .navigationSubtitle(preview.readyURL?.absoluteString ?? "")
 .toolbar {
-    // Deploy — pinned at the trailing edge, never collapses.
-    ToolbarItem(placement: .topBarPinnedTrailing) {
+    // Backup — lowest priority, first to collapse into the native overflow chevron.
+    ToolbarItem(placement: .primaryAction) {
         Button {
-            deploy.deploy(siteID: site.id, siteDirectory: site.path)
+            backup.backup(siteID: site.id, siteDirectory: site.path)
         } label: {
-            Label("Deploy", systemImage: "paperplane.fill")
+            Label("Backup", systemImage: "externaldrive.fill.badge.icloud")
         }
-        .buttonStyle(.borderedProminent)
-        .disabled(deploy.isRunning || backup.isRunning || audit.isRunning || !site.isValid)
+        .disabled(backup.isRunning || audit.isRunning || deploy.isRunning || !site.isValid)
         .help(site.isValid
-              ? "Build, scan, and run wrangler deploy on this site"
+              ? "Commit and push working-tree changes to your current branch"
               : "Site is missing required files")
     }
+    .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
 
-    // Health badge — high priority, stays visible.
-    ToolbarItem(placement: .primaryAction) {
-        HealthBadgeView(
-            model: health,
-            onRecheck: { health.recheck(siteID: site.id, siteDirectory: site.path) },
-            onAskClaude: {
-                #if !ANGLESITE_MAS
-                chatPresented = true
-                chat?.send("/anglesite:check")
-                #endif
-            }
-        )
-    }
-    .visibilityPriority(40)
-
-    // Open in browser — medium priority, only when the dev server is ready.
-    ToolbarItem(placement: .primaryAction) {
-        if let url = preview.readyURL {
-            Button {
-                NSWorkspace.shared.open(url)
-            } label: {
-                Label("Open in browser", systemImage: "arrow.up.forward.app")
-            }
-            .help("Open the live preview in your default browser")
-        }
-    }
-    .visibilityPriority(30)
-
-    // Chat — lower priority, kept above Audit/Backup. Preserves ⌘K.
-    ToolbarItem(placement: .primaryAction) {
-        Button {
-            chatPresented.toggle()
-        } label: {
-            Label("Chat", systemImage: chatPresented
-                ? "bubble.left.and.bubble.right.fill"
-                : "bubble.left.and.bubble.right")
-        }
-        .help(chatPresented ? "Hide chat panel" : "Show chat panel")
-        .keyboardShortcut("k", modifiers: [.command])
-    }
-    .visibilityPriority(20)
-
-    // Audit — lower priority, collapses before Chat.
+    // Audit — low priority, collapses before Chat.
     ToolbarItem(placement: .primaryAction) {
         Button {
             audit.audit(siteID: site.id, siteDirectory: site.path)
@@ -213,29 +171,74 @@ Attach to the `siteUI(for:)` view, alongside the existing `.navigationTitle(site
               ? "Run the structured accessibility audit against this site"
               : "Site is missing required files")
     }
-    .visibilityPriority(10)
+    .visibilityPriority(.low)
 
-    // Backup — lowest priority, first to collapse.
+    // Chat — default priority, kept above Audit/Backup. Preserves ⌘K.
     ToolbarItem(placement: .primaryAction) {
         Button {
-            backup.backup(siteID: site.id, siteDirectory: site.path)
+            chatPresented.toggle()
         } label: {
-            Label("Backup", systemImage: "externaldrive.fill.badge.icloud")
+            Label("Chat", systemImage: chatPresented
+                ? "bubble.left.and.bubble.right.fill"
+                : "bubble.left.and.bubble.right")
         }
-        .disabled(backup.isRunning || audit.isRunning || deploy.isRunning || !site.isValid)
+        .help(chatPresented ? "Hide chat panel" : "Show chat panel")
+        .keyboardShortcut("k", modifiers: [.command])
+    }
+    // .visibilityPriority(.automatic) is the default — left implicit.
+
+    // Open in browser — default priority, only when the dev server is ready.
+    ToolbarItem(placement: .primaryAction) {
+        if let url = preview.readyURL {
+            Button {
+                NSWorkspace.shared.open(url)
+            } label: {
+                Label("Open in browser", systemImage: "arrow.up.forward.app")
+            }
+            .help("Open the live preview in your default browser")
+        }
+    }
+    // .visibilityPriority(.automatic) is the default — left implicit.
+
+    // Health badge — high priority, stays visible.
+    ToolbarItem(placement: .primaryAction) {
+        HealthBadgeView(
+            model: health,
+            onRecheck: { health.recheck(siteID: site.id, siteDirectory: site.path) },
+            onAskClaude: {
+                #if !ANGLESITE_MAS
+                chatPresented = true
+                chat?.send("/anglesite:check")
+                #endif
+            }
+        )
+    }
+    .visibilityPriority(.high)
+
+    // Deploy — primary action, highest priority so it is the last to collapse.
+    // Declared LAST so it renders at the trailing edge (macOS primary-action position).
+    ToolbarItem(placement: .primaryAction) {
+        Button {
+            deploy.deploy(siteID: site.id, siteDirectory: site.path)
+        } label: {
+            Label("Deploy", systemImage: "paperplane.fill")
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(deploy.isRunning || backup.isRunning || audit.isRunning || !site.isValid)
         .help(site.isValid
-              ? "Commit and push working-tree changes to your current branch"
+              ? "Build, scan, and run wrangler deploy on this site"
               : "Site is missing required files")
     }
-    .visibilityPriority(5)
+    .visibilityPriority(.high)
 }
-.toolbarOverflowMenu()  // collapse low-priority items into an overflow menu (confirm spelling in Task 1)
 ```
 
 Notes:
-- `visibilityPriority` numeric scale is illustrative — use whatever type/range Task 1 confirmed; only the *relative ordering* matters (Deploy implicitly highest via pinning; then badge 40 > Open 30 > Chat 20 > Audit 10 > Backup 5).
-- If `toolbarOverflowMenu` is a per-`ToolbarItemGroup` modifier rather than a `.toolbar`-level one, wrap the secondary items (Open/Chat/Audit/Backup) in a `ToolbarItemGroup` and apply it there.
-- The old `.controlSize(.small)` / `.buttonStyle(.bordered)` are dropped: native toolbar items get system-standard sizing and styling. Keep `.borderedProminent` on Deploy to preserve its emphasis.
+- **Declaration order = left-to-right within the trailing `.primaryAction` cluster.** Deploy is declared last so it sits at the trailing edge with prominence; Backup (first to collapse) is declared first/leftmost. `visibilityPriority` governs *collapse* order independently of declaration order.
+- `visibilityPriority` is a modifier on the **`ToolbarItem`** (`ToolbarContent`), not on the inner `Button` — note it is chained after the closing `}` of each item. The argument type is `ToolbarItemVisibilityPriority` (`.high` / `.automatic` / `.low`, plus `init(lowerThan:)`). Higher = collapses last.
+- **No `.toolbarOverflowMenu()` call** — it is `@available(macOS, unavailable)`. macOS overflows into the native NSToolbar chevron automatically; `visibilityPriority` is the only lever.
+- The old `.controlSize(.small)` / `.buttonStyle(.bordered)` are dropped: native toolbar items get system-standard sizing. Keep `.borderedProminent` on Deploy to preserve its emphasis.
+- If `ToolbarItemVisibilityPriority(lowerThan: .low)` fails to type-check for any reason, fall back to `.low` on Backup (it then ties with Audit; collapse order between them falls to position, which already has Backup leftmost). Confirm the build in Step 3.
 
 - [ ] **Step 3: Build the DevID scheme**
 
@@ -316,7 +319,7 @@ Stacked on the #188 branch (both touch SiteWindow.swift).
 🤖 Generated with [Claude Code](https://claude.com/claude-code)"
 ```
 
-Note: this branch is stacked on `fix/188-orphaned-site-window`. If PR #208 (#188) has merged to `main` by now, rebase onto `main` before pushing; otherwise set the PR base to the #188 branch.
+Note: PR #208 (#188) has merged to `main`, and this branch was rebuilt on top of current `main`, so the PR targets `main` directly (no stacking).
 
 ---
 
@@ -324,12 +327,12 @@ Note: this branch is stacked on `fix/188-orphaned-site-window`. If PR #208 (#188
 
 **Spec coverage:**
 - Migrate to native `.toolbar` → Task 2. ✓
-- `visibilityPriority` ordering (Deploy > badge > Open > Chat > Audit > Backup) → Task 2 Step 2. ✓
-- `toolbarOverflowMenu` collapse → Task 2 Step 2 + Task 3 Step 2. ✓
-- `topBarPinnedTrailing` for Deploy → Task 2 Step 2. ✓
+- `visibilityPriority` ordering (Deploy/badge `.high` > Chat/Open `.automatic` > Audit `.low` > Backup `lowerThan(.low)`) → Task 2 Step 2. ✓
+- Collapse into overflow (native macOS chevron; `toolbarOverflowMenu` is iOS-only) → Task 2 Step 2 + Task 3 Step 2. ✓
+- Deploy pinned (`.primaryAction` + `.visibilityPriority(.high)`; `topBarPinnedTrailing` is iOS-only) → Task 2 Step 2. ✓
 - URL as `.navigationSubtitle` → Task 2 Step 2. ✓
 - Content header row removed → Task 2 Step 1. ✓
-- API-surface risk / fallback → Task 1 + notes in Task 2. ✓
+- API-surface reality verified → Task 1 (`/tmp/sdd-107/task-1-report.md`) + notes in Task 2. ✓
 - Both-scheme build → Task 2 Steps 3–4. ✓
 - MAS parity (no new gates) → Global Constraints + Task 2. ✓
 - ⌘K preserved incl. overflow case → Task 2 Step 2 + Task 3 Step 2 backstop. ✓
@@ -337,4 +340,4 @@ Note: this branch is stacked on `fix/188-orphaned-site-window`. If PR #208 (#188
 
 **Placeholder scan:** Task 1 is intentionally a discovery spike (it produces facts, not placeholders); all code steps show concrete code. No "TBD"/"handle edge cases"/"similar to". ✓
 
-**Type consistency:** `HealthBadgeView(model:onRecheck:onAskClaude:)`, `preview.readyURL`, `deploy/backup/audit.isRunning`, `chatPresented`, `site.isValid` all match `SiteWindow.swift` as read. `visibilityPriority` values are relative-only and flagged as such. ✓
+**Type consistency:** `HealthBadgeView(model:onRecheck:onAskClaude:)`, `preview.readyURL`, `deploy/backup/audit.isRunning`, `chatPresented`, `site.isValid` all match `SiteWindow.swift` as read. `visibilityPriority` uses the compile-verified `ToolbarItemVisibilityPriority` constants/inits from Task 1. ✓

--- a/docs/superpowers/specs/2026-06-16-107-toolbar-apis-design.md
+++ b/docs/superpowers/specs/2026-06-16-107-toolbar-apis-design.md
@@ -52,16 +52,18 @@ starting / failed / idle) with no header `HStack` and no leading `Divider`.
 
 | Item | Treatment | Rationale |
 |---|---|---|
-| **Deploy** | `topBarPinnedTrailing` + highest `visibilityPriority` | Load-bearing; never collapses |
-| **Health badge** | high `visibilityPriority` | Deploy-readiness must stay visible |
-| **Open in browser** | medium `visibilityPriority`, only when `readyURL != nil` | Useful, not critical |
-| **Chat** (⌘K) | lower priority | Toggled often → kept above Audit/Backup |
-| **Audit** | lower priority | Collapses before Chat |
-| **Backup** | lowest priority | First to collapse |
+| **Deploy** | `.primaryAction` + `.visibilityPriority(.high)` | Load-bearing; collapses last |
+| **Health badge** | `.visibilityPriority(.high)` | Deploy-readiness must stay visible |
+| **Open in browser** | `.automatic` (default), only when `readyURL != nil` | Useful, not critical |
+| **Chat** (⌘K) | `.automatic` (default) | Toggled often → kept above Audit/Backup |
+| **Audit** | `.low` | Collapses before Chat |
+| **Backup** | `ToolbarItemVisibilityPriority(lowerThan: .low)` | First to collapse |
 
 Collapse order as the window narrows (least critical first):
-**Backup → Audit → Chat → Open in browser**, all routed into the system overflow
-menu via `toolbarOverflowMenu`. Deploy and the health badge remain visible.
+**Backup → Audit → Chat → Open in browser**, all dropped into the **native macOS
+toolbar overflow chevron** automatically (there is no `toolbarOverflowMenu` on
+macOS — see API-surface reality below). Deploy and the health badge remain
+visible.
 
 ### Carried-over behavior (unchanged)
 
@@ -77,19 +79,33 @@ menu via `toolbarOverflowMenu`. Deploy and the health badge remain visible.
 - Deploy/Backup drawers, the deploy blocked/token sheets, and the audit sheet —
   all attached to the site UI, unaffected.
 
-## API-surface risk & fallback
+## API-surface reality (verified against the macOS 27.0 SDK)
 
-The macOS 27 toolbar APIs post-date this design's knowledge baseline, so exact
-signatures are **not** hardcoded blind. The implementation plan's first step
-confirms the precise spellings against the Xcode 27 SDK — e.g. whether it is
-`ToolbarItem(...).visibilityPriority(_:)`, and the exact placement/form of
-`toolbarOverflowMenu` and `topBarPinnedTrailing`.
+A compile-checked spike against the Xcode 27.0 / macOS 27.0 SDK established that
+**two of the three issue-named APIs are iOS/visionOS-only** and do not exist on
+macOS:
 
-If a named API does not exist as the issue describes, the documented fallback is:
-native `.toolbar` + `visibilityPriority` (and/or `ToolbarSpacer`) with SwiftUI's
-default overflow behavior, and the gap is flagged in the PR rather than worked
-around silently. No `if #available` guards are needed — the deployment target is
-macOS 27.0 across both targets (`Package.swift`, `project.yml`).
+| Issue named API | macOS reality |
+|---|---|
+| `visibilityPriority` | ✅ Exists. `.visibilityPriority(_ priority: ToolbarItemVisibilityPriority)` on `ToolbarContent` (the `ToolbarItem`, not the inner `Button`). Constants `.high` / `.automatic` (default) / `.low`, plus relative `init(lowerThan:)` / `init(higherThan:)`. Higher priority = collapses **last**. |
+| `toolbarOverflowMenu` | ❌ `@available(macOS, unavailable)`. macOS toolbars overflow **automatically** via the native NSToolbar chevron — there is no SwiftUI knob and none is needed. `visibilityPriority` is the lever that orders which items the native overflow drops first. |
+| `topBarPinnedTrailing` | ❌ `@available(macOS, unavailable)`. macOS equivalent for the primary pinned action is `.primaryAction` placement + `.visibilityPriority(.high)`. (A true un-removable pin would additionally need `.defaultCustomization(.visible, .alwaysAvailable)` inside a customizable `.toolbar(id:)` — explicitly out of scope, see Decision below.) |
+
+So the issue's *goal* is fully achievable on macOS — Deploy stays put, secondary
+actions collapse into the system overflow — but it is expressed through
+`visibilityPriority` + `.primaryAction` + the platform's automatic overflow, not
+the two iOS-only symbols. The PR must state this so the issue's acceptance
+criteria are read against the macOS-native mechanism. No `if #available` guards
+are needed — the deployment target is macOS 27.0 on both targets
+(`Package.swift`, `project.yml`).
+
+### Decision: non-customizable `.toolbar { }`
+
+Use a plain `.toolbar { }`, not a customizable `.toolbar(id:)`. Deploy is pinned
+via `.primaryAction` + `.visibilityPriority(.high)`; the native chevron handles
+overflow. This meets the issue's goal with the least surface area and adds no
+user-facing "Customize Toolbar" affordance (which `.toolbar(id:)` +
+`defaultCustomization` would introduce — beyond this issue's scope).
 
 ## MAS parity
 

--- a/docs/superpowers/specs/2026-06-16-107-toolbar-apis-design.md
+++ b/docs/superpowers/specs/2026-06-16-107-toolbar-apis-design.md
@@ -1,0 +1,125 @@
+# Adopt macOS 27 toolbar APIs for the SiteWindow action bar (#107)
+
+**Date:** 2026-06-16
+**Issue:** [#107](https://github.com/Anglesite/Anglesite-app/issues/107)
+**Status:** Design approved, pending implementation plan
+
+## Problem
+
+The `SiteWindow` action bar (Deploy, Backup, Audit, Chat, plus the deploy-readiness
+health badge) is currently a hand-rolled `HStack` inside the window *content*
+(`SiteWindow.mainPane`, lines 156–231), interleaved with the site name, live
+dev-server URL, and an "Open in browser" button.
+
+macOS 27 SwiftUI adds precise toolbar overflow control
+([What's new in SwiftUI, WWDC26](https://developer.apple.com/videos/play/wwdc2026/269/)):
+
+- `visibilityPriority` — order which items stay visible as the window narrows.
+- `toolbarOverflowMenu` — collapse lower-priority items into an overflow menu
+  instead of letting them vanish.
+- `topBarPinnedTrailing` — keep critical actions pinned at the trailing edge.
+
+These modifiers apply to native toolbar items (`ToolbarItem` / `ToolbarItemGroup`).
+They have **no effect on a plain `HStack`**. So adopting them is not "add three
+modifiers" — it requires migrating the action bar to a native `.toolbar`.
+
+The goal: the load-bearing actions — **Deploy above all** — must never silently
+disappear when the user narrows the `SiteWindow` alongside the preview pane.
+
+## Decisions
+
+1. **Migrate to a native `.toolbar`** (chosen over hand-rolling overflow with
+   `ViewThatFits` + a manual menu). This is the only way the named macOS 27 APIs
+   take effect, and it is the issue's stated intent.
+2. **Live URL → `.navigationSubtitle`**, shown under the site name in the title
+   bar once the dev server is ready. The content header row is removed entirely;
+   the preview webview reclaims that vertical space.
+
+## Architecture
+
+Replace the content-header `HStack` in `SiteWindow.mainPane` with a native
+`.toolbar { }` on the site UI. The window chrome carries identity:
+
+- `.navigationTitle(site.name)` — already present (line 130). The duplicate
+  `Text(site.name).font(.headline)` in the deleted header goes away.
+- `.navigationSubtitle(preview.readyURL?.absoluteString ?? "")` — live dev-server
+  URL, only meaningful once `readyURL` resolves (empty string until then).
+
+`mainPane` becomes just the `switch preview.state { … }` body (preview /
+starting / failed / idle) with no header `HStack` and no leading `Divider`.
+
+### Toolbar item inventory (trailing edge)
+
+| Item | Treatment | Rationale |
+|---|---|---|
+| **Deploy** | `topBarPinnedTrailing` + highest `visibilityPriority` | Load-bearing; never collapses |
+| **Health badge** | high `visibilityPriority` | Deploy-readiness must stay visible |
+| **Open in browser** | medium `visibilityPriority`, only when `readyURL != nil` | Useful, not critical |
+| **Chat** (⌘K) | lower priority | Toggled often → kept above Audit/Backup |
+| **Audit** | lower priority | Collapses before Chat |
+| **Backup** | lowest priority | First to collapse |
+
+Collapse order as the window narrows (least critical first):
+**Backup → Audit → Chat → Open in browser**, all routed into the system overflow
+menu via `toolbarOverflowMenu`. Deploy and the health badge remain visible.
+
+### Carried-over behavior (unchanged)
+
+- All `.disabled(...)` conditions: `site.isValid`, and the
+  `isRunning`-mutual-exclusion across Deploy / Backup / Audit.
+- All `.help(...)` tooltips.
+- The Chat ⌘K keyboard shortcut. (Verify the shortcut still fires when Chat is
+  collapsed into the overflow menu; if SwiftUI drops it, surface the shortcut via
+  a `Commands` menu as a backstop.)
+- The health badge's popover, its `onRecheck` / `onAskClaude` closures, and the
+  `#if ANGLESITE_MAS` gate on "Ask Claude" (which lives *inside* the popover,
+  untouched by this change).
+- Deploy/Backup drawers, the deploy blocked/token sheets, and the audit sheet —
+  all attached to the site UI, unaffected.
+
+## API-surface risk & fallback
+
+The macOS 27 toolbar APIs post-date this design's knowledge baseline, so exact
+signatures are **not** hardcoded blind. The implementation plan's first step
+confirms the precise spellings against the Xcode 27 SDK — e.g. whether it is
+`ToolbarItem(...).visibilityPriority(_:)`, and the exact placement/form of
+`toolbarOverflowMenu` and `topBarPinnedTrailing`.
+
+If a named API does not exist as the issue describes, the documented fallback is:
+native `.toolbar` + `visibilityPriority` (and/or `ToolbarSpacer`) with SwiftUI's
+default overflow behavior, and the gap is flagged in the PR rather than worked
+around silently. No `if #available` guards are needed — the deployment target is
+macOS 27.0 across both targets (`Package.swift`, `project.yml`).
+
+## MAS parity
+
+The toolbar is target-agnostic. Chat is on both targets now; the only
+`#if ANGLESITE_MAS` gate is the "Ask Claude" button inside the health-badge
+popover, which is not part of this migration. "No MAS regression" therefore means
+the MAS target builds and lays the toolbar out identically.
+
+## Testing & verification
+
+This is declarative SwiftUI with little unit-testable logic, so verification is
+behavioral:
+
+- `xcodebuild` both schemes — `Anglesite` (DevID) and `AnglesiteMAS` — to prove
+  the `.app` links, not just `swift test`.
+- Manual narrow-width check via the `run` skill: shrink the `SiteWindow`, confirm
+  Deploy stays pinned, secondary actions collapse into the overflow menu rather
+  than vanishing, and the health badge survives. With the chat pane open (DevID),
+  confirm the toolbar still behaves. Capture a narrow-width screenshot for the PR.
+
+## Acceptance criteria (from #107)
+
+- [ ] Deploy remains visible/pinned at all reasonable window widths.
+- [ ] Secondary actions collapse into the overflow menu rather than vanishing.
+- [ ] No regressions in the MAS target's toolbar layout. (The issue's original
+      "chat-less toolbar layout" wording is stale — MAS now has a chat pane via
+      the on-device assistant, #159 — but the toolbar is target-agnostic.)
+
+## Out of scope
+
+- The debug pane (a separate menu-opened `Window`, not part of this action bar).
+- Any change to the deploy/backup/audit command wiring (#84–#86, already done).
+- #94 (reducing the chat panel to open-ended tasks) — independent, still open.


### PR DESCRIPTION
Closes #107.

Migrates the `SiteWindow` action bar from a hand-rolled content `HStack` to a native SwiftUI `.toolbar`. The live dev-server URL moves to `.navigationSubtitle`; the content header row is removed (the preview reclaims that space).

## API reality (compile-verified against the macOS 27.0 SDK)

The issue named three macOS 27 APIs. A spike against the SDK found that **two are iOS/visionOS-only**:

| Issue named API | macOS reality |
|---|---|
| `visibilityPriority` | ✅ Exists. Used to order collapse. |
| `toolbarOverflowMenu` | ❌ `@available(macOS, unavailable)` — macOS toolbars overflow **automatically** via the native NSToolbar chevron; no SwiftUI knob exists or is needed. |
| `topBarPinnedTrailing` | ❌ `@available(macOS, unavailable)` — Deploy is pinned via `.primaryAction` + `.visibilityPriority(.high)` instead. |

So the issue's **goal** is met on macOS — Deploy stays put, secondary actions fold into the system overflow — but through `visibilityPriority` + `.primaryAction` + the platform's automatic overflow, not the two iOS-only symbols. (No customizable `.toolbar(id:)`; that would add a user "Customize Toolbar" surface beyond scope.)

## visibilityPriority gradient

Deploy `.high` · health badge `.high` · Chat / Open-in-browser `.automatic` · Audit `.low` · Backup `ToolbarItemVisibilityPriority(lowerThan: .low)`. Collapse order as the window narrows: **Backup → Audit → Chat → Open-in-browser**; Deploy and the health badge stay visible.

## Acceptance criteria (#107)
- [x] Deploy remains visible/pinned at reasonable window widths — `.primaryAction` + `.visibilityPriority(.high)`.
- [x] Secondary actions collapse into the (native macOS) overflow rather than vanishing — graded `visibilityPriority`.
- [x] No MAS regression — toolbar is target-agnostic; builds clean on both schemes.

## Verification
- `xcodebuild` **`** BUILD SUCCEEDED **`** on both `Anglesite` (DevID) and `AnglesiteMAS`.
- Existing `swift test` suite passes (apply-edit e2e `XCTSkip`/env-gated, unrelated).
- ⚠️ **Live narrow-width visual check pending** — the reviewer's machine lacked Screen Recording / Accessibility permissions to script the window-drag + screenshot. Please eyeball: open a site, drag narrow, confirm Deploy pins and secondaries fold into the `»` overflow. Screenshot to be attached.

Design + plan: `docs/superpowers/specs/2026-06-16-107-toolbar-apis-design.md`, `docs/superpowers/plans/2026-06-16-107-toolbar-apis.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)