### PR TITLE
Close out Phase A: A.9 e2e test (#143) + PreviewSite navigation (#139)

### DIFF
--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -109,6 +109,10 @@ final class PreviewModel {
     /// derives the target lazily once a base URL exists (the cold-open Siri case).
     func navigate(toRoute route: String) { activeRoute = route }
 
+    /// Reset the preview to the site root — a plain "preview my site" issued after a prior page
+    /// navigation. Without this, `activeRoute` would persist and keep showing the old page.
+    func clearRoute() { activeRoute = nil }
+
     /// The URL the preview WKWebView should load: the active page route against the ready base
     /// URL, or the base URL itself when no route is active. `nil` until the runtime is `.ready`.
     var displayURL: URL? {

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -15,6 +15,11 @@ final class PreviewModel {
     /// the runtime is still `.starting`.
     private(set) var openSiteID: String?
 
+    /// The page route the preview should show, set by `navigate(toRoute:)` (e.g. from
+    /// `PreviewSiteIntent`). `nil` means the site root. Persisted, not consumed, so a dev-server
+    /// restart that rebinds the port re-derives the target against the new base URL.
+    private(set) var activeRoute: String?
+
     private let runtime: any SiteRuntime
 
     /// The `EditRouter` that the WKWebView's `AnglesiteScriptHandler` forwards overlay edits to.
@@ -98,6 +103,18 @@ final class PreviewModel {
     var readyURL: URL? {
         if case .ready(_, let url) = state { return url }
         return nil
+    }
+
+    /// Show `route` in the preview. Safe to call before the runtime is `.ready` — `displayURL`
+    /// derives the target lazily once a base URL exists (the cold-open Siri case).
+    func navigate(toRoute route: String) { activeRoute = route }
+
+    /// The URL the preview WKWebView should load: the active page route against the ready base
+    /// URL, or the base URL itself when no route is active. `nil` until the runtime is `.ready`.
+    var displayURL: URL? {
+        guard let base = readyURL else { return nil }
+        guard let route = activeRoute else { return base }
+        return PreviewNavigation.targetURL(base: base, route: route)
     }
 
     /// Exposes the runtime's `MCPClient` via the same weak-getter pattern `editRouter` uses,

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -234,7 +234,7 @@ struct SiteWindow: View {
 
             switch preview.state {
             case .ready(_, let url):
-                PreviewView(url: url, router: preview.editRouter, annotationProvider: annotationProvider)
+                PreviewView(url: preview.displayURL ?? url, router: preview.editRouter, annotationProvider: annotationProvider)
             case .starting:
                 centeredStatus { ProgressView("Starting dev server for \(site.name)…") }
             case .failed(_, let message):
@@ -335,6 +335,10 @@ struct SiteWindow: View {
         }
 
         preview.open(siteID: resolved.id, siteDirectory: resolved.path)
+        // A page route from `PreviewSiteIntent` (#139): navigate once the dev server is ready.
+        if let route = WindowRouter.shared.consumeRoute(for: resolved.id) {
+            preview.navigate(toRoute: route)
+        }
         // The annotation feed, undo command, and edit observer feed the chat panel. They're all
         // MCP-based (the edit overlay applies edits via MCP on both targets), so they're wired the
         // same way regardless of which assistant backs the chat.

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -49,6 +49,8 @@ struct SiteWindow: View {
     @State private var chat: ChatModel?
     @State private var chatPresented = false
     @State private var health = HealthModel(runner: DefaultHealthCheckRunner())
+    /// Observed so an already-open window reacts to a `PreviewSiteIntent` navigation request.
+    @State private var router = WindowRouter.shared
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -66,6 +68,12 @@ struct SiteWindow: View {
         }
         .task(id: siteID) { await loadAndStart() }
         .task(id: site?.id) { await observeRemoval() }
+        // Warm path: an already-open window reacts to a new `PreviewSiteIntent` request (the
+        // cold path is `applyPendingNavigation` in `loadAndStart`). Mirrors how `SitesLauncherView`
+        // pairs `.onChange` with an initial consume for `newSiteRequested`.
+        .onChange(of: router.pendingNavigation) { _, _ in
+            if let id = site?.id { applyPendingNavigation(for: id) }
+        }
         .onDisappear {
             preview.close()
             // Unregister the annotation provider from the shared registry so
@@ -300,6 +308,21 @@ struct SiteWindow: View {
         }
     }
 
+    /// Apply (and clear) any pending `PreviewSiteIntent` navigation for `siteID`: navigate to a
+    /// page route, or reset the preview to the site root. Called from `loadAndStart` (cold-open,
+    /// where `.onChange` won't fire for the value set before the window observed it) and from
+    /// `.onChange(of: router.pendingNavigation)` (an already-open window) — the dual cold/warm
+    /// handling `SitesLauncherView` uses for `newSiteRequested`. `consumeNavigation` is keyed by
+    /// siteID, so other sites' windows observing the same dict no-op here.
+    @MainActor
+    private func applyPendingNavigation(for siteID: String) {
+        switch router.consumeNavigation(for: siteID) {
+        case .some(.some(let route)): preview.navigate(toRoute: route)
+        case .some(.none): preview.clearRoute()
+        case .none: break
+        }
+    }
+
     private func loadAndStart() async {
         // SwiftUI's NSPersistentUIManager will happily restore a WindowGroup with a
         // nil payload, or one whose value no longer matches a known site (sites.json
@@ -346,10 +369,9 @@ struct SiteWindow: View {
         }
 
         preview.open(siteID: resolved.id, siteDirectory: resolved.path)
-        // A page route from `PreviewSiteIntent` (#139): navigate once the dev server is ready.
-        if let route = WindowRouter.shared.consumeRoute(for: resolved.id) {
-            preview.navigate(toRoute: route)
-        }
+        // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
+        // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
+        applyPendingNavigation(for: resolved.id)
         // The annotation feed, undo command, and edit observer feed the chat panel. They're all
         // MCP-based (the edit overlay applies edits via MCP on both targets), so they're wired the
         // same way regardless of which assistant backs the chat.

--- a/Sources/AnglesiteCore/PreviewNavigation.swift
+++ b/Sources/AnglesiteCore/PreviewNavigation.swift
@@ -6,13 +6,18 @@ import Foundation
 public enum PreviewNavigation {
     /// The absolute preview URL for `route` against the dev-server `base`.
     /// `route` is treated as a site-absolute path; `base`'s scheme/host/port are preserved.
-    /// An empty route or `"/"` returns `base` (the site root).
+    /// An empty route or `"/"` returns `base` (the site root). A query string or fragment in
+    /// `route` (e.g. `/about?preview=1#top`) is carried over to the result rather than being
+    /// percent-encoded into the path.
     public static func targetURL(base: URL, route: String) -> URL {
         let trimmed = route.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, trimmed != "/" else { return base }
-        let path = trimmed.hasPrefix("/") ? trimmed : "/" + trimmed
-        guard var comps = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return base }
-        comps.path = path
+        let normalized = trimmed.hasPrefix("/") ? trimmed : "/" + trimmed
+        guard var comps = URLComponents(url: base, resolvingAgainstBaseURL: false),
+              let routeComps = URLComponents(string: normalized) else { return base }
+        comps.path = routeComps.path
+        comps.query = routeComps.query
+        comps.fragment = routeComps.fragment
         return comps.url ?? base
     }
 }

--- a/Sources/AnglesiteCore/PreviewNavigation.swift
+++ b/Sources/AnglesiteCore/PreviewNavigation.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Composes the URL the live-preview WKWebView should load when a page route is requested
+/// (e.g. by `PreviewSiteIntent`). Pure and `AnglesiteCore`-scoped so it's unit-testable on CI —
+/// the App-target glue that calls it (`PreviewModel`) is not.
+public enum PreviewNavigation {
+    /// The absolute preview URL for `route` against the dev-server `base`.
+    /// `route` is treated as a site-absolute path; `base`'s scheme/host/port are preserved.
+    /// An empty route or `"/"` returns `base` (the site root).
+    public static func targetURL(base: URL, route: String) -> URL {
+        let trimmed = route.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "/" else { return base }
+        let path = trimmed.hasPrefix("/") ? trimmed : "/" + trimmed
+        guard var comps = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return base }
+        comps.path = path
+        return comps.url ?? base
+    }
+}

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -83,11 +83,9 @@ public struct SiteStatusIntent: AppIntent {
 // MARK: - Preview
 
 /// Opens the site window. `openAppWhenRun` brings Anglesite forward; the actual window open
-/// happens via `WindowRouter`, which the "Sites" scene observes.
-///
-/// The `page` parameter is accepted (per the A.5 spec) but does not yet drive in-preview
-/// navigation to that page — delivering the route to the right `SiteWindow`'s WKWebView is a
-/// follow-up. Today the intent opens the site; the dialog deliberately doesn't claim more.
+/// happens via `WindowRouter`, which the "Sites" scene observes. When a `page` is supplied, its
+/// route rides along on the open request; `SiteWindow` consumes it and navigates the preview's
+/// WKWebView to that page once the dev server is ready (cold-open included).
 public struct PreviewSiteIntent: AppIntent {
     public static let title: LocalizedStringResource = "Preview Site"
     public static let description = IntentDescription("Open a site's live preview in Anglesite.")
@@ -102,8 +100,8 @@ public struct PreviewSiteIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ProvidesDialog {
-        WindowRouter.shared.requestOpen(siteID: site.id)
-        return .result(dialog: IntentDialog(stringLiteral: ContentDialogs.preview(siteName: site.displayName)))
+        WindowRouter.shared.requestOpen(siteID: site.id, route: page?.route)
+        return .result(dialog: IntentDialog(stringLiteral: ContentDialogs.preview(siteName: site.displayName, pageName: page?.displayName)))
     }
 }
 
@@ -211,8 +209,9 @@ public enum ContentDialogs {
         return "\(siteName) has \(count(pages, "page")), \(count(posts, "post"))\(draftNote), and \(count(images, "image"))."
     }
 
-    public static func preview(siteName: String) -> String {
-        "Opening \(siteName)."
+    public static func preview(siteName: String, pageName: String? = nil) -> String {
+        if let pageName { return "Opening the \(pageName) page of \(siteName)." }
+        return "Opening \(siteName)."
     }
 
     public static func created(_ result: ContentCreateResult, kind: CreateKind, siteName: String) -> String {

--- a/Sources/AnglesiteIntents/WindowRouter.swift
+++ b/Sources/AnglesiteIntents/WindowRouter.swift
@@ -14,6 +14,7 @@ public final class WindowRouter {
 
     /// Pending page route per site, set alongside an open request and consumed once by the
     /// site's window. Keyed by siteID so one site's window can't pick up another's route.
+    /// Re-requesting a site overwrites any still-pending route (last request wins).
     private var pendingRoute: [String: String] = [:]
 
     public func requestOpen(siteID: String, route: String? = nil) {

--- a/Sources/AnglesiteIntents/WindowRouter.swift
+++ b/Sources/AnglesiteIntents/WindowRouter.swift
@@ -12,5 +12,18 @@ public final class WindowRouter {
     /// The site id the intent asked to open; the scene clears it after handling.
     public var requested: String?
 
-    public func requestOpen(siteID: String) { requested = siteID }
+    /// Pending page route per site, set alongside an open request and consumed once by the
+    /// site's window. Keyed by siteID so one site's window can't pick up another's route.
+    private var pendingRoute: [String: String] = [:]
+
+    public func requestOpen(siteID: String, route: String? = nil) {
+        requested = siteID
+        if let route { pendingRoute[siteID] = route }
+    }
+
+    /// Take (and clear) the route requested for `siteID`, if any. Returns `nil` after the first
+    /// read or when no route was requested.
+    public func consumeRoute(for siteID: String) -> String? {
+        pendingRoute.removeValue(forKey: siteID)
+    }
 }

--- a/Sources/AnglesiteIntents/WindowRouter.swift
+++ b/Sources/AnglesiteIntents/WindowRouter.swift
@@ -12,20 +12,28 @@ public final class WindowRouter {
     /// The site id the intent asked to open; the scene clears it after handling.
     public var requested: String?
 
-    /// Pending page route per site, set alongside an open request and consumed once by the
-    /// site's window. Keyed by siteID so one site's window can't pick up another's route.
-    /// Re-requesting a site overwrites any still-pending route (last request wins).
-    private var pendingRoute: [String: String] = [:]
+    /// Pending navigation per site, set with an open request and consumed once by that site's
+    /// window — which observes `pendingNavigation` and clears its own entry, the same shape
+    /// `newSiteRequested` uses below. It is *separate* from `requested` (the scene's open/focus
+    /// trigger, which the scene clears before the window ever sees it) because a window already
+    /// on screen must still react to a new page request. Keyed by siteID so one site's window
+    /// can't pick up another's; re-requesting overwrites the pending value (last request wins).
+    ///
+    /// The value is itself optional: a route navigates there; `nil` resets the preview to the
+    /// site root (a plain "preview my site" issued after a prior page navigation).
+    public private(set) var pendingNavigation: [String: String?] = [:]
 
     public func requestOpen(siteID: String, route: String? = nil) {
+        // `updateValue` (not `pendingNavigation[siteID] = route`) so a `nil` route records the
+        // key with a nil value — "reset to root" — instead of removing the entry.
+        pendingNavigation.updateValue(route, forKey: siteID)
         requested = siteID
-        if let route { pendingRoute[siteID] = route }
     }
 
-    /// Take (and clear) the route requested for `siteID`, if any. Returns `nil` after the first
-    /// read or when no route was requested.
-    public func consumeRoute(for siteID: String) -> String? {
-        pendingRoute.removeValue(forKey: siteID)
+    /// Take (and clear) the pending navigation for `siteID`. Returns `.none` when nothing is
+    /// pending, `.some(nil)` to reset to the site root, or `.some(route)` to navigate there.
+    public func consumeNavigation(for siteID: String) -> String?? {
+        pendingNavigation.removeValue(forKey: siteID)
     }
 
     /// Set by File ▸ New Site (which can't host the wizard sheet itself). The "Sites"

--- a/Tests/AnglesiteCoreTests/AstroDevServerTests.swift
+++ b/Tests/AnglesiteCoreTests/AstroDevServerTests.swift
@@ -189,10 +189,18 @@ struct AstroDevServerTests {
         )
         #expect(first == URL(string: "http://localhost:9001/"))
 
-        // Give the supervisor time to notice the crash, restart, and the watcher to pick up :9002/.
-        try? await Task.sleep(nanoseconds: 700_000_000)
-        let updated = await server.readyURL
-        #expect(updated == URL(string: "http://localhost:9002/"))
+        // Poll (instead of a single fixed sleep) for the supervisor to notice the crash, restart,
+        // and the watcher to pick up :9002/. A fixed 700 ms delay flakes on a loaded CI runner where
+        // this chain runs slower than locally (~0.7 s end to end).
+        let expected = URL(string: "http://localhost:9002/")
+        var updated = await server.readyURL
+        var waited = 0
+        while updated != expected && waited < 100 {   // up to ~5 s
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            updated = await server.readyURL
+            waited += 1
+        }
+        #expect(updated == expected)
 
         await server.stop(timeout: 2)
     }
@@ -224,10 +232,17 @@ struct AstroDevServerTests {
         )
         #expect(first == URL(string: "http://localhost:9101/"))
 
-        // Wait for the crash → restart → watcher → callback chain.
-        try? await Task.sleep(nanoseconds: 700_000_000)
-        let urls = await observed.urls
-        #expect(urls == [URL(string: "http://localhost:9102/")!])
+        // Poll for the crash → restart → watcher → callback chain rather than a fixed sleep, which
+        // flakes on a loaded CI runner where the chain runs slower than locally.
+        let expected = [URL(string: "http://localhost:9102/")!]
+        var urls = await observed.urls
+        var waited = 0
+        while urls != expected && waited < 100 {   // up to ~5 s
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            urls = await observed.urls
+            waited += 1
+        }
+        #expect(urls == expected)
 
         await server.stop(timeout: 2)
     }

--- a/Tests/AnglesiteCoreTests/PreviewNavigationTests.swift
+++ b/Tests/AnglesiteCoreTests/PreviewNavigationTests.swift
@@ -40,4 +40,12 @@ struct PreviewNavigationTests {
         #expect(PreviewNavigation.targetURL(base: base, route: "/about")
                 == URL(string: "http://localhost:4321/about")!)
     }
+
+    @Test("a query string and fragment in the route are carried over, not encoded into the path")
+    func routeWithQueryAndFragment() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "/about?preview=1")
+                == URL(string: "http://localhost:4321/about?preview=1")!)
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "/about#top")
+                == URL(string: "http://localhost:4321/about#top")!)
+    }
 }

--- a/Tests/AnglesiteCoreTests/PreviewNavigationTests.swift
+++ b/Tests/AnglesiteCoreTests/PreviewNavigationTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct PreviewNavigationTests {
+    static let base = URL(string: "http://localhost:4321/")!
+
+    @Test("absolute route is composed onto the base host/port")
+    func absoluteRoute() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "/about")
+                == URL(string: "http://localhost:4321/about")!)
+    }
+
+    @Test("route without a leading slash is normalized")
+    func normalizesLeadingSlash() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "about")
+                == URL(string: "http://localhost:4321/about")!)
+    }
+
+    @Test("nested route is preserved")
+    func nestedRoute() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "/blog/post-1")
+                == URL(string: "http://localhost:4321/blog/post-1")!)
+    }
+
+    @Test("root route returns the base")
+    func rootRoute() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "/") == Self.base)
+    }
+
+    @Test("empty / whitespace route returns the base")
+    func emptyRoute() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "") == Self.base)
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "   ") == Self.base)
+    }
+
+    @Test("base without a trailing slash does not double up")
+    func baseNoTrailingSlash() {
+        let base = URL(string: "http://localhost:4321")!
+        #expect(PreviewNavigation.targetURL(base: base, route: "/about")
+                == URL(string: "http://localhost:4321/about")!)
+    }
+}

--- a/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
@@ -55,6 +55,13 @@ extension AppIntentsTests {
             #expect(ContentDialogs.created(.failed(reason: "boom"), kind: .page, siteName: "Alpha") == "Couldn’t add the page: boom")
         }
 
+        @Test("preview dialog names the page when one is supplied")
+        func previewDialogWithPage() {
+            #expect(ContentDialogs.preview(siteName: "Alpha") == "Opening Alpha.")
+            #expect(ContentDialogs.preview(siteName: "Alpha", pageName: "About")
+                    == "Opening the About page of Alpha.")
+        }
+
         // MARK: - Read intents (graph-gathering helpers)
 
         @Test("SearchContentIntent gathers matches for the right site and query")

--- a/Tests/AnglesiteIntentsTests/ContentPipelineE2ETests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentPipelineE2ETests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+/// A.9 (#143). The one test that runs the full content pipeline end to end:
+/// `list_content` JSON → parser → `SiteContentGraph` → entity queries → `ContentSpotlightIndexer`
+/// diff, then a graph mutation → re-index diff. The individual segments are covered by
+/// `ContentListingTests`, `ContentEntitiesTests`, and `ContentSpotlightIndexerTests`; this stitches
+/// them together. Pure in-memory and always-on (no node/python): the real parser runs on a real
+/// `list_content`-shaped payload, but no subprocess is spawned (the MCP round-trip is covered by
+/// `LocalSiteRuntimeGraphTests`).
+extension AppIntentsTests {
+    @Suite("ContentPipelineE2E", .serialized)
+    struct ContentPipelineE2ETests {
+        /// Records backend calls so we can assert the index/delete diff. Mirrors the established
+        /// `RecordingBackend` pattern from `ContentSpotlightIndexerTests`.
+        actor RecordingBackend: ContentSpotlightBackend {
+            private(set) var indexedPages: [[PageEntity]] = []
+            private(set) var indexedPosts: [[PostEntity]] = []
+            private(set) var indexedImages: [[ImageEntity]] = []
+            private(set) var deletedPages: [[String]] = []
+            private(set) var deletedPosts: [[String]] = []
+            private(set) var deletedImages: [[String]] = []
+            func indexPages(_ e: [PageEntity]) async throws { indexedPages.append(e) }
+            func indexPosts(_ e: [PostEntity]) async throws { indexedPosts.append(e) }
+            func indexImages(_ e: [ImageEntity]) async throws { indexedImages.append(e) }
+            func deletePages(identifiers: [String]) async throws { deletedPages.append(identifiers) }
+            func deletePosts(identifiers: [String]) async throws { deletedPosts.append(identifiers) }
+            func deleteImages(identifiers: [String]) async throws { deletedImages.append(identifiers) }
+        }
+
+        /// Realistic `list_content` payload: 2 pages, 2 posts (one draft), 1 image.
+        static let payload = """
+        {
+          "pages": [
+            {"route": "/about", "filePath": "src/pages/about.astro", "title": "About", "lastModified": "2026-06-11T12:00:00Z"},
+            {"route": "/contact", "filePath": "src/pages/contact.astro", "title": "Contact", "lastModified": "2026-06-11T12:00:00Z"}
+          ],
+          "posts": [
+            {"collection": "blog", "slug": "hello", "title": "Hello World", "draft": false,
+             "publishDate": "2026-06-11T12:00:00Z", "tags": ["intro"],
+             "filePath": "src/content/blog/hello.md", "lastModified": "2026-06-11T12:00:00Z"},
+            {"collection": "blog", "slug": "draft-news", "title": "Draft News", "draft": true,
+             "tags": ["news"], "filePath": "src/content/blog/draft-news.md", "lastModified": "2026-06-11T12:00:00Z"}
+          ],
+          "images": [
+            {"relativePath": "public/images/hero.jpg", "fileName": "hero.jpg", "byteSize": 12345,
+             "usedOnPages": ["/about"], "lastModified": "2026-06-11T12:00:00Z"}
+          ]
+        }
+        """
+
+        @Test("list_content → graph → entity queries → Spotlight index → mutation diff")
+        func fullPipeline() async throws {
+            let site = AppIntentsTests.aSite
+
+            // 1. Parse the MCP list_content payload.
+            let listing = try ContentListing.parse(jsonText: Self.payload, siteID: site)
+            #expect(listing.pages.count == 2)
+            #expect(listing.posts.count == 2)
+            #expect(listing.posts.contains { $0.draft })
+            #expect(listing.images.count == 1)
+
+            // 2. Populate the graph.
+            let graph = SiteContentGraph()
+            await graph.load(siteID: site, pages: listing.pages, posts: listing.posts, images: listing.images)
+            #expect(await graph.pages(for: site).count == 2)
+            #expect(await graph.posts(for: site).count == 2)
+
+            // 3. Entity queries resolve from the graph.
+            try await ContentGraphOverride.$scoped.withValue(graph) {
+                let pages = try await PageEntityQuery().entities(for: ["\(site):page:/about"])
+                #expect(pages.first?.route == "/about")
+                let posts = try await PostEntityQuery().entities(matching: "hello")
+                #expect(posts.map(\.slug) == ["hello"])
+                let images = try await ImageEntityQuery().entities(matching: "hero")
+                #expect(images.count == 1)
+            }
+
+            // 4. Index into Spotlight (recording backend). 2 pages + 2 posts + 1 image = 5.
+            let backend = RecordingBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+            let first = try await indexer.reindex(siteID: site)
+            #expect(first == .init(indexed: 5, removed: 0))
+            #expect(await Set(backend.indexedPages.first?.map(\.route) ?? []) == ["/about", "/contact"])
+            #expect(await Set(backend.indexedPosts.first?.map(\.slug) ?? []) == ["hello", "draft-news"])
+            #expect(await backend.deletedPosts.isEmpty)
+
+            // 5. Mutate: remove the draft post, edit the about page. Re-index → correct diff.
+            await graph.removePost(id: "\(site):post:draft-news")
+            await graph.upsertPage(SiteContentGraph.Page(
+                id: "\(site):page:/about", siteID: site, route: "/about",
+                filePath: "src/pages/about.astro", title: "About Us",
+                lastModified: AppIntentsTests.t0
+            ))
+            let second = try await indexer.reindex(siteID: site)
+            #expect(second == .init(indexed: 4, removed: 1))            // 2 pages + 1 post + 1 image; 1 post removed
+            #expect(await backend.deletedPosts.last == ["\(site):post:draft-news"])
+            #expect(await backend.indexedPages.last?.contains { $0.displayName == "About Us" } == true)
+        }
+    }
+}

--- a/Tests/AnglesiteIntentsTests/ContentPipelineE2ETests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentPipelineE2ETests.swift
@@ -75,7 +75,7 @@ extension AppIntentsTests {
                 let posts = try await PostEntityQuery().entities(matching: "hello")
                 #expect(posts.map(\.slug) == ["hello"])
                 let images = try await ImageEntityQuery().entities(matching: "hero")
-                #expect(images.count == 1)
+                #expect(images.map(\.relativePath) == ["public/images/hero.jpg"])
             }
 
             // 4. Index into Spotlight (recording backend). 2 pages + 2 posts + 1 image = 5.
@@ -85,6 +85,7 @@ extension AppIntentsTests {
             #expect(first == .init(indexed: 5, removed: 0))
             #expect(await Set(backend.indexedPages.first?.map(\.route) ?? []) == ["/about", "/contact"])
             #expect(await Set(backend.indexedPosts.first?.map(\.slug) ?? []) == ["hello", "draft-news"])
+            #expect(await backend.indexedImages.first?.map(\.id) == ["\(site):image:public/images/hero.jpg"])
             #expect(await backend.deletedPosts.isEmpty)
 
             // 5. Mutate: remove the draft post, edit the about page. Re-index → correct diff.

--- a/Tests/AnglesiteIntentsTests/WindowRouterTests.swift
+++ b/Tests/AnglesiteIntentsTests/WindowRouterTests.swift
@@ -1,37 +1,57 @@
 import Testing
 @testable import AnglesiteIntents
 
+/// `.serialized` because every test mutates the `WindowRouter.shared` singleton (`requested` +
+/// `pendingNavigation`); without it Swift Testing may run them concurrently and one test's writes
+/// can clobber another's assertions. Matches the `ContentPipelineE2E` suite's serialization.
 @MainActor
+@Suite(.serialized)
 struct WindowRouterTests {
-    @Test("requestOpen with a route sets the open trigger and stores the route once")
-    func requestOpenWithRoute() {
+    /// Reset the shared singleton's state for the site ids a test touches.
+    private func freshRouter() -> WindowRouter {
         let router = WindowRouter.shared
         router.requested = nil
-        _ = router.consumeRoute(for: "siteA")   // clear any prior state
+        for id in ["siteA", "siteB", "siteC"] { _ = router.consumeNavigation(for: id) }
+        return router
+    }
 
+    @Test("requestOpen with a route sets the open trigger and stores the route once")
+    func requestOpenWithRoute() {
+        let router = freshRouter()
         router.requestOpen(siteID: "siteA", route: "/about")
         #expect(router.requested == "siteA")
-        #expect(router.consumeRoute(for: "siteA") == "/about")
-        // Consume-once: a second read is nil.
-        #expect(router.consumeRoute(for: "siteA") == nil)
+        #expect(router.consumeNavigation(for: "siteA") == "/about")   // navigate to the route
+        #expect(router.consumeNavigation(for: "siteA") == nil)        // consumed once → absent
     }
 
-    @Test("requestOpen without a route stores no route")
-    func requestOpenNoRoute() {
-        let router = WindowRouter.shared
-        _ = router.consumeRoute(for: "siteB")
+    @Test("requestOpen without a route records a reset-to-root request")
+    func requestOpenNoRouteResetsToRoot() {
+        let router = freshRouter()
         router.requestOpen(siteID: "siteB")
         #expect(router.requested == "siteB")
-        #expect(router.consumeRoute(for: "siteB") == nil)
+        // Present-but-nil ("reset the preview to the site root"), distinct from "nothing pending".
+        guard case .some(let route) = router.consumeNavigation(for: "siteB") else {
+            Issue.record("expected a pending reset entry for siteB")
+            return
+        }
+        #expect(route == nil)
+        #expect(router.consumeNavigation(for: "siteB") == nil)        // consumed once → absent
     }
 
-    @Test("a route requested for one site is not consumed by another")
-    func routeIsPerSite() {
-        let router = WindowRouter.shared
-        _ = router.consumeRoute(for: "siteA")
-        _ = router.consumeRoute(for: "siteB")
+    @Test("a navigation requested for one site is not consumed by another")
+    func navigationIsPerSite() {
+        let router = freshRouter()
         router.requestOpen(siteID: "siteA", route: "/contact")
-        #expect(router.consumeRoute(for: "siteB") == nil)
-        #expect(router.consumeRoute(for: "siteA") == "/contact")
+        #expect(router.consumeNavigation(for: "siteB") == nil)
+        #expect(router.consumeNavigation(for: "siteA") == "/contact")
+    }
+
+    @Test("re-requesting a site overwrites the still-pending navigation (last wins)")
+    func reRequestOverwrites() {
+        let router = freshRouter()
+        router.requestOpen(siteID: "siteA", route: "/about")
+        router.requestOpen(siteID: "siteA", route: "/contact")
+        #expect(router.consumeNavigation(for: "siteA") == "/contact")
+        #expect(router.consumeNavigation(for: "siteA") == nil)
     }
 }

--- a/Tests/AnglesiteIntentsTests/WindowRouterTests.swift
+++ b/Tests/AnglesiteIntentsTests/WindowRouterTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import AnglesiteIntents
+
+@MainActor
+struct WindowRouterTests {
+    @Test("requestOpen with a route sets the open trigger and stores the route once")
+    func requestOpenWithRoute() {
+        let router = WindowRouter.shared
+        router.requested = nil
+        _ = router.consumeRoute(for: "siteA")   // clear any prior state
+
+        router.requestOpen(siteID: "siteA", route: "/about")
+        #expect(router.requested == "siteA")
+        #expect(router.consumeRoute(for: "siteA") == "/about")
+        // Consume-once: a second read is nil.
+        #expect(router.consumeRoute(for: "siteA") == nil)
+    }
+
+    @Test("requestOpen without a route stores no route")
+    func requestOpenNoRoute() {
+        let router = WindowRouter.shared
+        _ = router.consumeRoute(for: "siteB")
+        router.requestOpen(siteID: "siteB")
+        #expect(router.requested == "siteB")
+        #expect(router.consumeRoute(for: "siteB") == nil)
+    }
+
+    @Test("a route requested for one site is not consumed by another")
+    func routeIsPerSite() {
+        let router = WindowRouter.shared
+        _ = router.consumeRoute(for: "siteA")
+        _ = router.consumeRoute(for: "siteB")
+        router.requestOpen(siteID: "siteA", route: "/contact")
+        #expect(router.consumeRoute(for: "siteB") == nil)
+        #expect(router.consumeRoute(for: "siteA") == "/contact")
+    }
+}

--- a/docs/superpowers/plans/2026-06-16-phase-a-closeout.md
+++ b/docs/superpowers/plans/2026-06-16-phase-a-closeout.md
@@ -1,0 +1,659 @@
+# Phase A Closeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish Phase A by adding the missing A.9 end-to-end integration test (#143) and wiring `PreviewSiteIntent`'s page-route navigation through to the live preview, then close #139 and #143.
+
+**Architecture:** The content intents already shipped; this plan adds (1) a deterministic in-memory e2e test of the `list_content → SiteContentGraph → entity query → Spotlight diff` pipeline, and (2) page navigation: `PreviewSiteIntent` carries `page?.route` through `WindowRouter` to the opened `SiteWindow`, which tells its `PreviewModel` to show that route. The only non-trivial logic — composing a target URL from the dev-server base URL and a route — lives in a pure, CI-tested `AnglesiteCore` helper; the SwiftUI/App glue stays mechanical and is build-verified only (App-target tests can't run on CI per CLAUDE.md).
+
+**Tech Stack:** Swift 6.4 / Xcode 27, Swift Testing (`@Test`/`#expect`), SwiftUI + `@Observable`, AppIntents, CoreSpotlight, SwiftPM (`swift test`) + `xcodebuild`.
+
+## Global Constraints
+
+- Swift Testing for new unit tests (`@Test` / `#expect`), not XCTest. Match the existing `AppIntentsTests` suite style.
+- New e2e + unit tests must run **always-on** under `swift test` — no `pythonAvailable`/node gating (Decision 1).
+- App-target types (`PreviewModel`, `SiteWindow`, `PreviewView`) are NOT CI-testable (hosted app tests blocked on macOS-15 runners) — push testable logic into `AnglesiteCore`/`AnglesiteIntents`; verify App glue with `xcodebuild` builds of both schemes.
+- Module dependency direction: `AnglesiteApp → AnglesiteIntents → AnglesiteCore`. Never import App into Intents/Core.
+- Worktree builds: run `xcodegen generate` first and set `ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite` before `xcodebuild` (the default `../anglesite` resolves wrong from a worktree).
+- New-type id format is fixed by the parser: page `"<siteID>:page:<route>"`, post `"<siteID>:post:<slug>"`, image `"<siteID>:image:<relativePath>"`.
+- Commit message trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- **Create** `Sources/AnglesiteCore/PreviewNavigation.swift` — pure `route + base → URL` composer (Task 1).
+- **Create** `Tests/AnglesiteCoreTests/PreviewNavigationTests.swift` — Task 1 tests.
+- **Modify** `Sources/AnglesiteIntents/WindowRouter.swift` — carry + consume a per-site route (Task 2).
+- **Create** `Tests/AnglesiteIntentsTests/WindowRouterTests.swift` — Task 2 tests.
+- **Modify** `Sources/AnglesiteIntents/ContentIntents.swift` — page-aware `ContentDialogs.preview`, `PreviewSiteIntent` wiring (Task 3).
+- **Modify** `Tests/AnglesiteIntentsTests/ContentIntentsTests.swift` — Task 3 dialog test.
+- **Modify** `Sources/AnglesiteApp/PreviewModel.swift` — `navigate(toRoute:)` + `displayURL` (Task 4).
+- **Modify** `Sources/AnglesiteApp/SiteWindow.swift` — consume route, render `displayURL` (Task 4).
+- **Create** `Tests/AnglesiteIntentsTests/ContentPipelineE2ETests.swift` — A.9 e2e test (Task 5).
+
+---
+
+## Task 1: `PreviewNavigation` URL composer (AnglesiteCore)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/PreviewNavigation.swift`
+- Test: `Tests/AnglesiteCoreTests/PreviewNavigationTests.swift`
+
+**Interfaces:**
+- Produces: `public enum PreviewNavigation { public static func targetURL(base: URL, route: String) -> URL }` — consumed by `PreviewModel.displayURL` (Task 4). `base` is the dev-server root URL (e.g. `http://localhost:4321/`); `route` is a site-absolute path (e.g. `/about`). Empty route or `"/"` returns `base` unchanged; a route without a leading slash is normalized to have one; the base's scheme/host/port are preserved with no double slash.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/PreviewNavigationTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct PreviewNavigationTests {
+    static let base = URL(string: "http://localhost:4321/")!
+
+    @Test("absolute route is composed onto the base host/port")
+    func absoluteRoute() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "/about")
+                == URL(string: "http://localhost:4321/about")!)
+    }
+
+    @Test("route without a leading slash is normalized")
+    func normalizesLeadingSlash() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "about")
+                == URL(string: "http://localhost:4321/about")!)
+    }
+
+    @Test("nested route is preserved")
+    func nestedRoute() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "/blog/post-1")
+                == URL(string: "http://localhost:4321/blog/post-1")!)
+    }
+
+    @Test("root route returns the base")
+    func rootRoute() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "/") == Self.base)
+    }
+
+    @Test("empty / whitespace route returns the base")
+    func emptyRoute() {
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "") == Self.base)
+        #expect(PreviewNavigation.targetURL(base: Self.base, route: "   ") == Self.base)
+    }
+
+    @Test("base without a trailing slash does not double up")
+    func baseNoTrailingSlash() {
+        let base = URL(string: "http://localhost:4321")!
+        #expect(PreviewNavigation.targetURL(base: base, route: "/about")
+                == URL(string: "http://localhost:4321/about")!)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --filter PreviewNavigationTests`
+Expected: FAIL — `cannot find 'PreviewNavigation' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/PreviewNavigation.swift`:
+
+```swift
+import Foundation
+
+/// Composes the URL the live-preview WKWebView should load when a page route is requested
+/// (e.g. by `PreviewSiteIntent`). Pure and `AnglesiteCore`-scoped so it's unit-testable on CI —
+/// the App-target glue that calls it (`PreviewModel`) is not.
+public enum PreviewNavigation {
+    /// The absolute preview URL for `route` against the dev-server `base`.
+    /// `route` is treated as a site-absolute path; `base`'s scheme/host/port are preserved.
+    /// An empty route or `"/"` returns `base` (the site root).
+    public static func targetURL(base: URL, route: String) -> URL {
+        let trimmed = route.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "/" else { return base }
+        let path = trimmed.hasPrefix("/") ? trimmed : "/" + trimmed
+        guard var comps = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return base }
+        comps.path = path
+        return comps.url ?? base
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --filter PreviewNavigationTests`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/PreviewNavigation.swift Tests/AnglesiteCoreTests/PreviewNavigationTests.swift
+git commit -m "feat(core): PreviewNavigation route→URL composer for preview navigation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `WindowRouter` per-site route plumbing (AnglesiteIntents)
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/WindowRouter.swift`
+- Test: `Tests/AnglesiteIntentsTests/WindowRouterTests.swift` (create)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `func requestOpen(siteID: String, route: String? = nil)` (route-carrying overload of the existing method) and `func consumeRoute(for siteID: String) -> String?` (consume-once, per-site). The existing `requested` open-trigger and its clearing by `SitesWindowRoot` are unchanged. `PreviewSiteIntent` (Task 3) calls `requestOpen(siteID:route:)`; `SiteWindow` (Task 4) calls `consumeRoute(for:)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteIntentsTests/WindowRouterTests.swift`:
+
+```swift
+import Testing
+@testable import AnglesiteIntents
+
+@MainActor
+struct WindowRouterTests {
+    @Test("requestOpen with a route sets the open trigger and stores the route once")
+    func requestOpenWithRoute() {
+        let router = WindowRouter.shared
+        router.requested = nil
+        _ = router.consumeRoute(for: "siteA")   // clear any prior state
+
+        router.requestOpen(siteID: "siteA", route: "/about")
+        #expect(router.requested == "siteA")
+        #expect(router.consumeRoute(for: "siteA") == "/about")
+        // Consume-once: a second read is nil.
+        #expect(router.consumeRoute(for: "siteA") == nil)
+    }
+
+    @Test("requestOpen without a route stores no route")
+    func requestOpenNoRoute() {
+        let router = WindowRouter.shared
+        _ = router.consumeRoute(for: "siteB")
+        router.requestOpen(siteID: "siteB")
+        #expect(router.requested == "siteB")
+        #expect(router.consumeRoute(for: "siteB") == nil)
+    }
+
+    @Test("a route requested for one site is not consumed by another")
+    func routeIsPerSite() {
+        let router = WindowRouter.shared
+        _ = router.consumeRoute(for: "siteA")
+        _ = router.consumeRoute(for: "siteB")
+        router.requestOpen(siteID: "siteA", route: "/contact")
+        #expect(router.consumeRoute(for: "siteB") == nil)
+        #expect(router.consumeRoute(for: "siteA") == "/contact")
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --filter WindowRouterTests`
+Expected: FAIL — `value of type 'WindowRouter' has no member 'consumeRoute'` / extra argument `route`.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace the body of `Sources/AnglesiteIntents/WindowRouter.swift` (keep the imports and the `@MainActor @Observable public final class WindowRouter` declaration; replace from `public static let shared` through the end of the class):
+
+```swift
+@MainActor
+@Observable
+public final class WindowRouter {
+    public static let shared = WindowRouter()
+    private init() {}
+
+    /// The site id the intent asked to open; the scene clears it after handling.
+    public var requested: String?
+
+    /// Pending page route per site, set alongside an open request and consumed once by the
+    /// site's window. Keyed by siteID so one site's window can't pick up another's route.
+    private var pendingRoute: [String: String] = [:]
+
+    public func requestOpen(siteID: String, route: String? = nil) {
+        requested = siteID
+        if let route { pendingRoute[siteID] = route }
+    }
+
+    /// Take (and clear) the route requested for `siteID`, if any. Returns `nil` after the first
+    /// read or when no route was requested.
+    public func consumeRoute(for siteID: String) -> String? {
+        pendingRoute.removeValue(forKey: siteID)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --filter WindowRouterTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/WindowRouter.swift Tests/AnglesiteIntentsTests/WindowRouterTests.swift
+git commit -m "feat(intents): WindowRouter carries a per-site preview route
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Page-aware preview dialog + `PreviewSiteIntent` wiring (AnglesiteIntents)
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/ContentIntents.swift` (the `PreviewSiteIntent` struct ~lines 85-108 and `ContentDialogs.preview` ~lines 214-216)
+- Test: `Tests/AnglesiteIntentsTests/ContentIntentsTests.swift` (add one test)
+
+**Interfaces:**
+- Consumes: `WindowRouter.requestOpen(siteID:route:)` (Task 2), `PageEntity.route` / `PageEntity.displayName` (existing).
+- Produces: `ContentDialogs.preview(siteName: String, pageName: String? = nil) -> String` — the default-`nil` parameter preserves existing call sites.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteIntentsTests/ContentIntentsTests.swift` (inside the existing test type for `ContentDialogs`; if unsure, add a new `@Suite` extension mirroring the file's style):
+
+```swift
+@Test("preview dialog names the page when one is supplied")
+func previewDialogWithPage() {
+    #expect(ContentDialogs.preview(siteName: "Alpha") == "Opening Alpha.")
+    #expect(ContentDialogs.preview(siteName: "Alpha", pageName: "About")
+            == "Opening the About page of Alpha.")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter previewDialogWithPage`
+Expected: FAIL — extra argument `pageName` in call.
+
+- [ ] **Step 3: Update `ContentDialogs.preview`**
+
+In `Sources/AnglesiteIntents/ContentIntents.swift`, replace:
+
+```swift
+    public static func preview(siteName: String) -> String {
+        "Opening \(siteName)."
+    }
+```
+
+with:
+
+```swift
+    public static func preview(siteName: String, pageName: String? = nil) -> String {
+        if let pageName { return "Opening the \(pageName) page of \(siteName)." }
+        return "Opening \(siteName)."
+    }
+```
+
+- [ ] **Step 4: Wire the route + page-aware dialog into `PreviewSiteIntent`**
+
+In the same file, replace the `PreviewSiteIntent` doc comment + `perform()` (the block at ~lines 85-108). Replace:
+
+```swift
+/// Opens the site window. `openAppWhenRun` brings Anglesite forward; the actual window open
+/// happens via `WindowRouter`, which the "Sites" scene observes.
+///
+/// The `page` parameter is accepted (per the A.5 spec) but does not yet drive in-preview
+/// navigation to that page — delivering the route to the right `SiteWindow`'s WKWebView is a
+/// follow-up. Today the intent opens the site; the dialog deliberately doesn't claim more.
+public struct PreviewSiteIntent: AppIntent {
+```
+
+with:
+
+```swift
+/// Opens the site window. `openAppWhenRun` brings Anglesite forward; the actual window open
+/// happens via `WindowRouter`, which the "Sites" scene observes. When a `page` is supplied, its
+/// route rides along on the open request; `SiteWindow` consumes it and navigates the preview's
+/// WKWebView to that page once the dev server is ready (cold-open included).
+public struct PreviewSiteIntent: AppIntent {
+```
+
+And replace the `perform()` body:
+
+```swift
+    @MainActor
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        WindowRouter.shared.requestOpen(siteID: site.id)
+        return .result(dialog: IntentDialog(stringLiteral: ContentDialogs.preview(siteName: site.displayName)))
+    }
+```
+
+with:
+
+```swift
+    @MainActor
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        WindowRouter.shared.requestOpen(siteID: site.id, route: page?.route)
+        return .result(dialog: IntentDialog(stringLiteral: ContentDialogs.preview(siteName: site.displayName, pageName: page?.displayName)))
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `swift test --filter previewDialogWithPage`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/ContentIntents.swift Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+git commit -m "feat(intents): PreviewSiteIntent carries page route + names the page
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `PreviewModel` navigation + `SiteWindow` glue (AnglesiteApp, build-verified)
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/PreviewModel.swift` (add after `openSiteID` ~line 16, and after `readyURL` ~line 101)
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift` (the `PreviewView(url:...)` call ~line 237 and after `preview.open(...)` ~line 337)
+
+**Interfaces:**
+- Consumes: `PreviewNavigation.targetURL(base:route:)` (Task 1), `WindowRouter.consumeRoute(for:)` (Task 2).
+- Produces: `PreviewModel.navigate(toRoute:)` and `PreviewModel.displayURL` — used by `SiteWindow`.
+
+**Note:** No unit test — `PreviewModel`/`SiteWindow` are App-target and not CI-testable (Global Constraints). The testable logic (URL composition) was covered in Task 1. This task is verified by the `xcodebuild` builds in Task 6. Still, write the exact code below.
+
+- [ ] **Step 1: Add navigation state to `PreviewModel`**
+
+In `Sources/AnglesiteApp/PreviewModel.swift`, immediately after the `openSiteID` property (the line `private(set) var openSiteID: String?`), add:
+
+```swift
+
+    /// The page route the preview should show, set by `navigate(toRoute:)` (e.g. from
+    /// `PreviewSiteIntent`). `nil` means the site root. Persisted, not consumed, so a dev-server
+    /// restart that rebinds the port re-derives the target against the new base URL.
+    private(set) var activeRoute: String?
+```
+
+- [ ] **Step 2: Add `navigate(toRoute:)` and `displayURL`**
+
+In the same file, immediately after the `readyURL` computed property (the closing `}` of `var readyURL`), add:
+
+```swift
+
+    /// Show `route` in the preview. Safe to call before the runtime is `.ready` — `displayURL`
+    /// derives the target lazily once a base URL exists (the cold-open Siri case).
+    func navigate(toRoute route: String) { activeRoute = route }
+
+    /// The URL the preview WKWebView should load: the active page route against the ready base
+    /// URL, or the base URL itself when no route is active. `nil` until the runtime is `.ready`.
+    var displayURL: URL? {
+        guard let base = readyURL else { return nil }
+        guard let route = activeRoute else { return base }
+        return PreviewNavigation.targetURL(base: base, route: route)
+    }
+```
+
+- [ ] **Step 3: Render `displayURL` and consume the route in `SiteWindow`**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, find the ready-state `PreviewView` call (~line 237):
+
+```swift
+                PreviewView(url: url, router: preview.editRouter, annotationProvider: annotationProvider)
+```
+
+replace with:
+
+```swift
+                PreviewView(url: preview.displayURL ?? url, router: preview.editRouter, annotationProvider: annotationProvider)
+```
+
+Then find, in `loadAndStart()`, the line (~337):
+
+```swift
+        preview.open(siteID: resolved.id, siteDirectory: resolved.path)
+```
+
+and add immediately after it:
+
+```swift
+        // A page route from `PreviewSiteIntent` (#139): navigate once the dev server is ready.
+        if let route = WindowRouter.shared.consumeRoute(for: resolved.id) {
+            preview.navigate(toRoute: route)
+        }
+```
+
+- [ ] **Step 4: Build the App target to verify it compiles**
+
+Run:
+```bash
+xcodegen generate
+ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite \
+  xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/PreviewModel.swift Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat(app): navigate the preview to a PreviewSiteIntent page route
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: A.9 end-to-end integration test (#143)
+
+**Files:**
+- Create: `Tests/AnglesiteIntentsTests/ContentPipelineE2ETests.swift`
+
+**Interfaces:**
+- Consumes (all existing, merged): `ContentListing.parse(jsonText:siteID:)`, `SiteContentGraph.load/pages(for:)/upsertPage/removePost`, `ContentGraphOverride.$scoped`, `PageEntityQuery/PostEntityQuery/ImageEntityQuery.entities`, `ContentSpotlightIndexer(graph:backend:)`/`reindex(siteID:)`/`Outcome`, `ContentSpotlightBackend`.
+- Produces: nothing (the test IS the deliverable).
+
+This is the missing seam: every segment is unit-tested in isolation, but no test runs the whole chain. The test is the deliverable, so steps 1–2 are write-then-run; there is no implementation step.
+
+- [ ] **Step 1: Write the e2e test**
+
+Create `Tests/AnglesiteIntentsTests/ContentPipelineE2ETests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+/// A.9 (#143). The one test that runs the full content pipeline end to end:
+/// `list_content` JSON → parser → `SiteContentGraph` → entity queries → `ContentSpotlightIndexer`
+/// diff, then a graph mutation → re-index diff. The individual segments are covered by
+/// `ContentListingTests`, `ContentEntitiesTests`, and `ContentSpotlightIndexerTests`; this stitches
+/// them together. Pure in-memory and always-on (no node/python): the real parser runs on a real
+/// `list_content`-shaped payload, but no subprocess is spawned (the MCP round-trip is covered by
+/// `LocalSiteRuntimeGraphTests`).
+extension AppIntentsTests {
+    @Suite("ContentPipelineE2E", .serialized)
+    struct ContentPipelineE2ETests {
+        /// Records backend calls so we can assert the index/delete diff. Mirrors the established
+        /// `RecordingBackend` pattern from `ContentSpotlightIndexerTests`.
+        actor RecordingBackend: ContentSpotlightBackend {
+            private(set) var indexedPages: [[PageEntity]] = []
+            private(set) var indexedPosts: [[PostEntity]] = []
+            private(set) var indexedImages: [[ImageEntity]] = []
+            private(set) var deletedPages: [[String]] = []
+            private(set) var deletedPosts: [[String]] = []
+            private(set) var deletedImages: [[String]] = []
+            func indexPages(_ e: [PageEntity]) async throws { indexedPages.append(e) }
+            func indexPosts(_ e: [PostEntity]) async throws { indexedPosts.append(e) }
+            func indexImages(_ e: [ImageEntity]) async throws { indexedImages.append(e) }
+            func deletePages(identifiers: [String]) async throws { deletedPages.append(identifiers) }
+            func deletePosts(identifiers: [String]) async throws { deletedPosts.append(identifiers) }
+            func deleteImages(identifiers: [String]) async throws { deletedImages.append(identifiers) }
+        }
+
+        /// Realistic `list_content` payload: 2 pages, 2 posts (one draft), 1 image.
+        static let payload = """
+        {
+          "pages": [
+            {"route": "/about", "filePath": "src/pages/about.astro", "title": "About", "lastModified": "2026-06-11T12:00:00Z"},
+            {"route": "/contact", "filePath": "src/pages/contact.astro", "title": "Contact", "lastModified": "2026-06-11T12:00:00Z"}
+          ],
+          "posts": [
+            {"collection": "blog", "slug": "hello", "title": "Hello World", "draft": false,
+             "publishDate": "2026-06-11T12:00:00Z", "tags": ["intro"],
+             "filePath": "src/content/blog/hello.md", "lastModified": "2026-06-11T12:00:00Z"},
+            {"collection": "blog", "slug": "draft-news", "title": "Draft News", "draft": true,
+             "tags": ["news"], "filePath": "src/content/blog/draft-news.md", "lastModified": "2026-06-11T12:00:00Z"}
+          ],
+          "images": [
+            {"relativePath": "public/images/hero.jpg", "fileName": "hero.jpg", "byteSize": 12345,
+             "usedOnPages": ["/about"], "lastModified": "2026-06-11T12:00:00Z"}
+          ]
+        }
+        """
+
+        @Test("list_content → graph → entity queries → Spotlight index → mutation diff")
+        func fullPipeline() async throws {
+            let site = AppIntentsTests.aSite
+
+            // 1. Parse the MCP list_content payload.
+            let listing = try ContentListing.parse(jsonText: Self.payload, siteID: site)
+            #expect(listing.pages.count == 2)
+            #expect(listing.posts.count == 2)
+            #expect(listing.posts.contains { $0.draft })
+            #expect(listing.images.count == 1)
+
+            // 2. Populate the graph.
+            let graph = SiteContentGraph()
+            await graph.load(siteID: site, pages: listing.pages, posts: listing.posts, images: listing.images)
+            #expect(await graph.pages(for: site).count == 2)
+            #expect(await graph.posts(for: site).count == 2)
+
+            // 3. Entity queries resolve from the graph.
+            try await ContentGraphOverride.$scoped.withValue(graph) {
+                let pages = try await PageEntityQuery().entities(for: ["\(site):page:/about"])
+                #expect(pages.first?.route == "/about")
+                let posts = try await PostEntityQuery().entities(matching: "hello")
+                #expect(posts.map(\.slug) == ["hello"])
+                let images = try await ImageEntityQuery().entities(matching: "hero")
+                #expect(images.count == 1)
+            }
+
+            // 4. Index into Spotlight (recording backend). 2 pages + 2 posts + 1 image = 5.
+            let backend = RecordingBackend()
+            let indexer = ContentSpotlightIndexer(graph: graph, backend: backend)
+            let first = try await indexer.reindex(siteID: site)
+            #expect(first == .init(indexed: 5, removed: 0))
+            #expect(await Set(backend.indexedPages.first?.map(\.route) ?? []) == ["/about", "/contact"])
+            #expect(await Set(backend.indexedPosts.first?.map(\.slug) ?? []) == ["hello", "draft-news"])
+            #expect(await backend.deletedPosts.isEmpty)
+
+            // 5. Mutate: remove the draft post, edit the about page. Re-index → correct diff.
+            await graph.removePost(id: "\(site):post:draft-news")
+            await graph.upsertPage(SiteContentGraph.Page(
+                id: "\(site):page:/about", siteID: site, route: "/about",
+                filePath: "src/pages/about.astro", title: "About Us",
+                lastModified: AppIntentsTests.t0
+            ))
+            let second = try await indexer.reindex(siteID: site)
+            #expect(second == .init(indexed: 4, removed: 1))            // 2 pages + 1 post + 1 image; 1 post removed
+            #expect(await backend.deletedPosts.last == ["\(site):post:draft-news"])
+            #expect(await backend.indexedPages.last?.contains { $0.displayName == "About Us" } == true)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `swift test --filter ContentPipelineE2E`
+Expected: PASS (1 test). If it fails on the indexed/removed counts, re-derive from the payload (5 entities initially; after removing 1 post and editing 1 page: 4 indexed, 1 removed) — do not weaken assertions to force a pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/AnglesiteIntentsTests/ContentPipelineE2ETests.swift
+git commit -m "test(intents): A.9 end-to-end content pipeline integration test (#143)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Closeout — build both schemes, full suite, close issues
+
+**Files:** none (verification + issue housekeeping).
+
+- [ ] **Step 1: Run the full SwiftPM test suite**
+
+Run: `swift test 2>&1 | tail -20`
+Expected: all tests pass (existing 270 + the new `PreviewNavigation` (6), `WindowRouter` (3), `previewDialogWithPage` (1), and `ContentPipelineE2E` (1)). If a stale lock hangs it, check `pgrep -fl swift-test` and kill the orphan.
+
+- [ ] **Step 2: Build the DevID scheme**
+
+Run:
+```bash
+xcodegen generate
+ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite \
+  xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Build the MAS scheme**
+
+Run:
+```bash
+ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite \
+  xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Verify #139's intents are present and tested (no code change expected)**
+
+Run: `swift test --filter ContentIntents 2>&1 | tail -5`
+Expected: PASS. This confirms the already-shipped A.5 intents compile and pass on this branch — the basis for closing #139.
+
+- [ ] **Step 5: Push the branch and open the PR**
+
+```bash
+git push -u origin worktree-phase-a-closeout
+gh pr create --title "Close out Phase A: A.9 e2e test (#143) + PreviewSite navigation (#139)" \
+  --body "$(cat <<'EOF'
+Finishes Phase A.
+
+- **#143 (A.9):** adds the end-to-end content-pipeline integration test (list_content → graph → entity queries → Spotlight diff → mutation diff), always-on under `swift test`.
+- **#139 (A.5):** the content intents already shipped (#136–#142); this wires the previously-unused `PreviewSiteIntent.page` route through `WindowRouter` → `SiteWindow` → `PreviewModel` so Siri "preview my about page" navigates the live preview (cold-open included). URL composition is a CI-tested `AnglesiteCore` helper.
+
+Both schemes build; full `swift test` green.
+
+Closes #143
+Closes #139
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Confirm the issues will close**
+
+The `Closes #143` / `Closes #139` lines close both on merge. Remove the `status:in-progress` label is automatic on close. Report the PR URL to the user.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #143 (A.9 e2e test) → Task 5. ✅
+- `PreviewSiteIntent` page navigation (incl. cold-open) → Tasks 1 (URL helper), 2 (route plumbing), 3 (intent wiring + dialog), 4 (App glue). ✅
+- In-memory always-on test substrate (Decision 1) → Task 5 (no python gating). ✅
+- Full cold-open navigation (Decision 2) → Task 4 `displayURL` derives lazily once `.ready`. ✅
+- CI-testable core / build-verified glue (CLAUDE.md) → Task 1 tested; Task 4 build-only; Task 6 builds both schemes. ✅
+- Verify #139 + close both (Part C) → Task 6 steps 4–6. ✅
+
+**Type consistency:** `PreviewNavigation.targetURL(base:route:)` defined in Task 1 is called identically in Task 4. `WindowRouter.requestOpen(siteID:route:)`/`consumeRoute(for:)` defined in Task 2 are called identically in Tasks 3/4. `ContentDialogs.preview(siteName:pageName:)` defined in Task 3 matches its test. `ContentSpotlightIndexer`/`Outcome`/`ContentSpotlightBackend` and `ContentListing.parse` signatures in Task 5 match the merged source. Graph id formats (`<site>:post:draft-news`, `<site>:page:/about`) match the parser. ✅
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to" — every code step has complete code. ✅
+
+**Note on spec refinement:** The spec sketched `pendingRoute` + `navigationTarget` on `PreviewModel`; this plan uses a computed `displayURL` + persisted `activeRoute` instead — same observable behavior (cold-open handled), but it also survives a dev-server port change and needs no `PreviewView` change. Consistent with the approved design's intent.

--- a/docs/superpowers/specs/2026-06-16-phase-a-closeout-design.md
+++ b/docs/superpowers/specs/2026-06-16-phase-a-closeout-design.md
@@ -1,0 +1,192 @@
+# Phase A Closeout — Design
+
+**Date:** 2026-06-16
+**Issues:** #143 (A.9 — e2e integration test), #139 (A.5 — content intents, verify + close)
+**Spec parent:** [`2026-06-11-siri-ai-integration-design.md`](2026-06-11-siri-ai-integration-design.md) — Phase A
+
+## Context
+
+Phase A's foundation shipped across PRs #136–#142, #170, #193 (June 12–14). An exploration
+of the merged code found that **the A.5 content intents are already implemented**:
+
+- `Sources/AnglesiteIntents/ContentIntents.swift` — `SearchContentIntent`, `SiteStatusIntent`,
+  `PreviewSiteIntent`, `AddPageIntent`, `AddPostIntent`, plus the pure `ContentDialogs` helpers.
+- `Sources/AnglesiteIntents/EditContentIntent.swift` — `EditContentIntent` (landed via B.5 / #149).
+- All registered with Siri phrases in `AnglesiteShortcuts.swift`; unit-tested in
+  `ContentIntentsTests.swift` / `EditContentIntentTests.swift`.
+
+So issue #139 is **stale** — the code landed but the issue was never closed. Two genuine gaps remain
+to close Phase A:
+
+1. **#143 (A.9)** — no single test stitches the full pipeline together. The segments are each
+   covered in isolation (`ContentListingTests`, `LocalSiteRuntimeGraphTests`, `ContentEntitiesTests`,
+   `ContentSpotlightIndexerTests`) but the end-to-end chain through to the Spotlight diff is untested.
+2. **`PreviewSiteIntent` page navigation** — the intent accepts a `page: PageEntity?` parameter it
+   does not use; a code comment (`ContentIntents.swift:88-90`) defers delivering the route to the
+   open window's `WKWebView`. This is a real, spec'd-but-deferred feature.
+
+Closing both finishes Phase A, which per the parent spec's dependency graph unblocks **all of
+Phase D** (system-wide MCP, #162–#166).
+
+## Goals
+
+- Add the A.9 end-to-end integration test (#143).
+- Implement `PreviewSiteIntent` page navigation, including the cold-open case.
+- Verify #139's intents compile and pass; close #139 and #143.
+
+## Non-goals (YAGNI)
+
+- No changes to `EditContentIntent` or the plugin's `apply-instruction` op (Phase C / plugin work).
+- No client-side in-page routing — a full `WKWebView` reload at the target route is fine for v0.
+- No multi-window route arbitration beyond the consume-once pairing described below.
+- No new plugin paired PR — `list_content` / `create_page` / `create_post` already shipped (#140).
+
+---
+
+## Part A — #143 (A.9) end-to-end integration test
+
+### Location & target
+
+`Tests/AnglesiteIntentsTests/` (new file, e.g. `ContentPipelineE2ETests.swift`), extending the
+existing `@Suite("AppIntents", .serialized)` suite. The chain spans both modules — the graph lives
+in `AnglesiteCore`, the entity queries and indexer in `AnglesiteIntents` — and only
+`AnglesiteIntentsTests` can `@testable import` both. `SiteContentGraph` and `ContentSpotlightBackend`
+are `public`; `ContentGraphOverride` is internal and reached via `@testable import AnglesiteIntents`.
+
+### Test substrate: pure in-memory, always-on (Decision 1)
+
+The test feeds a realistic `list_content`-shaped JSON payload through the **real**
+`ContentListing.parse(jsonText:siteID:)` — no Node, no Python, no gating. It runs on every CI push.
+
+Rationale for deviating from the parent spec's "XCTSkip when node absent": the MCP-round-trip →
+graph-population segment is already covered by `LocalSiteRuntimeGraphTests` (fake Python server,
+gated on `pythonAvailable`). A.9's *novel* coverage is steps 3–5 (entity-query resolution +
+Spotlight diff-on-mutation) — exactly the regression guard we want running everywhere, not skipped
+on runners without Python. Exercising the real parser on the real payload shape keeps the parse
+contract honest without the subprocess.
+
+### The chain asserted
+
+Using only APIs confirmed present in the merged code:
+
+1. **Parse** — `ContentListing.parse(jsonText:siteID:)` on a canned payload with ≥2 pages, ≥2 posts
+   (one `draft: true`), ≥1 image → assert counts and a sampling of fields (route, slug, draft).
+2. **Populate** — `graph.load(siteID:pages:posts:images:)` → `pages(for:)` / `posts(for:)` /
+   `images(for:)` return the loaded content.
+3. **Resolve entities** — inside `ContentGraphOverride.$scoped.withValue(graph)`, call
+   `PageEntityQuery().entities(for:)`, `PostEntityQuery().entities(for:)`,
+   `ImageEntityQuery().entities(for:)` → assert they resolve from the graph (ids + a field each).
+4. **Index** — `ContentSpotlightIndexer(graph:backend:)` with a `RecordingBackend` actor (the
+   established test-backend pattern from `ContentSpotlightIndexerTests`). `reindex(siteID:)` →
+   assert `Outcome(indexed:removed:)` and the backend's recorded `indexPages/Posts/Images` calls
+   match the loaded set.
+5. **Mutation diff** — `graph.upsertPage(_:)` (changed) and `graph.removePost(id:)` (removed),
+   then `reindex(siteID:)` again → assert the second pass re-indexes the changed page and calls
+   `deletePosts(identifiers:)` for the removed post, leaving untouched entities consistent.
+
+### Boundary
+
+This is a deterministic, in-process test of the data pipeline. It does **not** exercise the live
+`LocalSiteRuntime` MCP spawn (already covered) or the AppIntents runtime's `perform()` (covered by
+`ContentIntentsTests`). It is the missing seam: parser → graph → entity query → Spotlight diff.
+
+---
+
+## Part B — `PreviewSiteIntent` page navigation
+
+### Seam: extend `WindowRouter` (smallest change)
+
+`WindowRouter` (`Sources/AnglesiteIntents/WindowRouter.swift`, `@MainActor @Observable` singleton)
+gains an optional route paired with the open request:
+
+```swift
+public var requested: String?
+public var requestedRoute: String?           // route for `requested`, consumed once
+
+public func requestOpen(siteID: String, route: String? = nil) {
+    requested = siteID
+    requestedRoute = route
+}
+```
+
+The default-`nil` parameter preserves the existing no-route call sites. `PreviewSiteIntent.perform()`
+becomes `WindowRouter.shared.requestOpen(siteID: site.id, route: page?.route)`. The route and siteID
+are set and consumed together, so the route is unambiguously "the route for the site we just asked
+to open."
+
+### Pure, testable route→URL composition (Decision: CI-coverable core)
+
+Per CLAUDE.md, App-target types (`PreviewModel`, `PreviewView`, `SiteWindow`) are not CI-testable
+(hosted app tests are blocked on macOS-15 runners). So the only logic worth testing — composing the
+target URL from the dev-server base URL and a page route — is extracted into a pure helper in
+`AnglesiteCore`, unit-tested in `AnglesiteCoreTests`:
+
+```swift
+public enum PreviewNavigation {
+    /// Compose the absolute preview URL for `route` against the dev-server `base`.
+    /// `route` is treated as an absolute site path; the base's scheme/host/port are preserved.
+    public static func targetURL(base: URL, route: String) -> URL
+}
+```
+
+Behavior to specify and test:
+- `route == "/"` or empty → returns `base` (the site root).
+- `"/about"` → `<base scheme/host/port>/about`.
+- `"about"` (no leading slash) → same as `"/about"` (normalized).
+- Nested `"/blog/post-1"` → preserved.
+- A `base` carrying a trailing slash does not produce a double slash.
+- Implemented via `URLComponents(url: base)` with a normalized `path`, not naive string concat.
+
+### App-target glue (thin, not CI-tested)
+
+- **`PreviewModel`** gains `private(set) var navigationTarget: URL?` (`@Observable`) and a
+  `private var pendingRoute: String?`. New `func navigate(toRoute:)`:
+  - If the runtime is `.ready(_, base)`, set `navigationTarget = PreviewNavigation.targetURL(base:route:)`.
+  - Otherwise stash `pendingRoute`; when the runtime transitions to `.ready`, apply and clear it
+    (this is the **cold-open** case — Decision 2 — and is the common Siri path, where no window is
+    open yet).
+- **`PreviewView`** loads `navigationTarget ?? readyURL` so a route override navigates the same
+  `WKWebView` via the existing `webView.load(URLRequest:)` path. No new web-view API.
+- **`SiteWindow`**, when it handles the open for the requested site, consumes
+  `WindowRouter.shared.requestedRoute` (for the matching siteID), calls `preview.navigate(toRoute:)`,
+  and clears `requestedRoute`. The consume-once pairing avoids a route leaking into the wrong window.
+
+### Dialog
+
+`ContentDialogs.preview` gains an optional page so the spoken result reflects navigation, e.g.
+"Opening the About page of MySite." when a `page` is supplied, falling back to "Opening MySite."
+when not. Pure and unit-tested alongside the existing `ContentDialogs` tests.
+
+---
+
+## Part C — Verify #139 and close out
+
+1. Confirm the existing intents (`ContentIntents.swift`, `EditContentIntent.swift`) compile and
+   their tests pass on this branch — they predate the issue closure.
+2. Build **both** schemes with `xcodebuild` (not just `swift test` — App-target wiring like the
+   `PreviewModel`/`SiteWindow` glue only links in the real app): `Anglesite` (DevID) and
+   `AnglesiteMAS`. In this worktree, run `xcodegen generate` first and set `ANGLESITE_PLUGIN_SRC`
+   to the sibling plugin checkout (the default `../anglesite` resolves wrong from a worktree).
+3. Run `swift test` for the `AnglesiteCore` + `AnglesiteIntents` suites (new A.9, `PreviewNavigation`,
+   `WindowRouter`, `ContentDialogs` tests included).
+4. Close **#139** (code shipped earlier; note that in the close comment) and **#143** (delivered here).
+
+## Testing summary
+
+| Test | Target | CI |
+|---|---|---|
+| A.9 e2e pipeline (parse → graph → entity query → Spotlight diff) | `AnglesiteIntentsTests` | always-on |
+| `PreviewNavigation.targetURL` route→URL cases | `AnglesiteCoreTests` | always-on |
+| `WindowRouter.requestOpen(siteID:route:)` sets/omits route | `AnglesiteIntentsTests` | always-on |
+| `ContentDialogs.preview(page:)` phrasing | `AnglesiteIntentsTests` | always-on |
+| `PreviewModel` / `PreviewView` / `SiteWindow` glue | App target | build-verified only (per CLAUDE.md) |
+
+## Risks & mitigations
+
+- **App-glue untested on CI.** Mitigated by extracting the only non-trivial logic
+  (`PreviewNavigation`) into a CI-tested Core helper and keeping the glue mechanical; both schemes
+  are build-verified.
+- **Cold-open lifecycle race** (route applied before `.ready`). Mitigated by the `pendingRoute`
+  stash-then-apply on the `.ready` transition rather than a fire-and-forget navigate.
+- **Spec drift confirmed, not assumed.** The API surface was mapped against merged code before
+  designing; no reliance on the parent spec's idealized signatures.


### PR DESCRIPTION
Finishes Siri AI **Phase A**, which unblocks Phase D (system-wide MCP) per the design's dependency graph.

## What & why
Exploration of the merged code found the **A.5 content intents already shipped** (#136–#142) — issue #139 was just never closed. The genuine remaining work was two gaps:

### #143 (A.9) — end-to-end integration test
Adds the one test that runs the whole content pipeline together: `list_content` JSON → `ContentListing.parse` → `SiteContentGraph` → entity queries (`Page/Post/ImageEntityQuery` via `ContentGraphOverride.$scoped`) → `ContentSpotlightIndexer` diff → graph mutation → re-index diff (asserts `indexed: 5/removed: 0`, then `4/1`). Pure in-memory and **always-on** under `swift test` (the per-segment MCP-spawn path is already covered by `LocalSiteRuntimeGraphTests`), so the regression guard runs on every CI push instead of skipping.

### #139 (A.5) — PreviewSiteIntent page navigation
Wires the previously-unused `PreviewSiteIntent.page` route through to the live preview so Siri "preview my about page" navigates the WKWebView (cold-open included):
- `PreviewNavigation.targetURL(base:route:)` — pure, CI-tested URL composer in `AnglesiteCore` (6 tests).
- `WindowRouter` carries a consume-once, per-site route.
- `PreviewSiteIntent` passes `page?.route` and names the page in its dialog.
- App-target glue: `PreviewModel.displayURL`/`navigate(toRoute:)` + `SiteWindow` render `displayURL ?? url` and consume the route after open. (`displayURL` is computed, so it survives a dev-server port rebind for free.)

App-target logic stays untestable-on-CI by design (per CLAUDE.md); the only real logic lives in the tested Core helper.

## Verification
- New: `PreviewNavigationTests` (6), `WindowRouterTests` (4), `previewDialogWithPage` (1), `ContentPipelineE2ETests` (1) — all pass, always-on.
- Existing `ContentIntents` suite (10) passes — basis for closing #139.
- Both `Anglesite` (DevID) and `AnglesiteMAS` schemes build.
- (Pre-existing, unrelated: `AppliesEditEndToEndTests` is plugin/node-gated and doesn't run under a worktree `swift test`; this branch doesn't touch that pipeline.)

Closes #143
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)