### PR TITLE
feat(app): Dynamic Type + VoiceOver accessibility pass (#79, #80)

### DIFF
--- a/Sources/AnglesiteApp/BlockedDeploySheetView.swift
+++ b/Sources/AnglesiteApp/BlockedDeploySheetView.swift
@@ -49,6 +49,7 @@ struct BlockedDeploySheetView: View {
             Image(systemName: "shield.lefthalf.filled")
                 .font(.title)
                 .foregroundStyle(.orange)
+                .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 2) {
                 Text("Deploy blocked").font(.title3).fontWeight(.semibold)
                 Text("The pre-deploy scan found issues that need fixing before this site can ship.")
@@ -68,6 +69,7 @@ private struct FailureCard: View {
             HStack(spacing: 8) {
                 Image(systemName: categoryIcon(failure.category))
                     .foregroundStyle(.red)
+                    .accessibilityHidden(true)
                 Text(categoryLabel(failure.category))
                     .font(.subheadline).fontWeight(.semibold)
                 if let file = failure.file {
@@ -75,6 +77,9 @@ private struct FailureCard: View {
                         .font(.system(.caption, design: .monospaced))
                         .foregroundStyle(.secondary)
                         .lineLimit(1).truncationMode(.middle)
+                        // Path is middle-truncated for layout; read the whole thing aloud.
+                        .accessibilityLabel("File")
+                        .accessibilityValue(file)
                 }
             }
             Text(failure.detail).font(.callout)
@@ -116,6 +121,7 @@ private struct WarningCard: View {
             HStack(spacing: 8) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
+                    .accessibilityHidden(true)
                 Text(categoryLabel(warning.category))
                     .font(.subheadline).fontWeight(.semibold)
             }

--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -66,6 +66,8 @@ struct ChatView: View {
                 Text(usageSummary(usage))
                     .font(.system(.caption, design: .monospaced))
                     .foregroundStyle(.secondary)
+                    .accessibilityLabel("Token usage and cost")
+                    .accessibilityValue(usageSummary(usage))
             }
             Menu {
                 Button("Reset conversation", role: .destructive) {
@@ -211,6 +213,7 @@ private struct MessageRow: View {
             Rectangle()
                 .fill(Color.secondary.opacity(0.4))
                 .frame(width: 3)
+                .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 2) {
                 Text(message.content)
                     .font(.callout)
@@ -232,6 +235,10 @@ private struct MessageRow: View {
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                     .disabled(metadata.commit != model.currentHeadSHA)
+                    .accessibilityLabel("Undo this edit")
+                    .accessibilityHint(metadata.commit != model.currentHeadSHA
+                                       ? "Unavailable — newer edits have been made since"
+                                       : "")
                 }
             }
         }
@@ -257,6 +264,21 @@ private struct MessageRow: View {
                 .background(bubbleBackground)
                 .foregroundStyle(bubbleForeground)
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                // Prefix the spoken text with the speaker so VoiceOver users can follow the
+                // back-and-forth; the visual layout (left/right alignment) conveys this sightedly.
+                .accessibilityLabel(accessibilitySpokenContent)
+        }
+    }
+
+    /// Role-prefixed plain text for VoiceOver. Uses the raw message string (not the attributed
+    /// markdown) so symbols and code fences don't garble the reading.
+    private var accessibilitySpokenContent: String {
+        switch message.role {
+        case .user:      return "You said: \(message.content)"
+        case .assistant: return "Assistant said: \(message.content)"
+        case .error:     return "Error: \(message.content)"
+        case .system:    return "System: \(message.content)"
+        case .edit, .annotation: return message.content  // rendered by their own rows
         }
     }
 
@@ -298,6 +320,7 @@ private struct AnnotationRowView: View {
             Rectangle()
                 .fill(Color.orange.opacity(0.5))
                 .frame(width: 3)
+                .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 2) {
                 Text(message.content)
                     .font(.callout)
@@ -317,6 +340,7 @@ private struct AnnotationRowView: View {
             .buttonStyle(.bordered)
             .controlSize(.small)
             .disabled(isResolving)
+            .accessibilityLabel("Resolve this annotation")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -364,6 +388,7 @@ private struct ToolCallCard: View {
                 } else {
                     HStack(spacing: 6) {
                         ProgressView().controlSize(.small)
+                            .accessibilityHidden(true)
                         Text("running…").font(.caption).foregroundStyle(.secondary)
                     }
                 }
@@ -373,10 +398,17 @@ private struct ToolCallCard: View {
             HStack(spacing: 6) {
                 Image(systemName: call.isError ? "exclamationmark.triangle.fill" : (call.result == nil ? "wrench.and.screwdriver" : "wrench.and.screwdriver.fill"))
                     .foregroundStyle(call.isError ? .red : .secondary)
+                    .accessibilityHidden(true)
                 Text(call.name)
                     .font(.callout.weight(.medium))
+                    // Roll the tool state into the disclosure label so a collapsed card still
+                    // announces error/running/done without the icon (now hidden) carrying it.
+                    .accessibilityLabel("\(call.name) tool")
+                    .accessibilityValue(call.isError ? "Error"
+                                        : (call.result == nil ? "Running" : "Finished"))
                 if call.result == nil {
                     ProgressView().controlSize(.mini)
+                        .accessibilityHidden(true)
                 }
                 Spacer()
             }

--- a/Sources/AnglesiteApp/DeployDrawerView.swift
+++ b/Sources/AnglesiteApp/DeployDrawerView.swift
@@ -46,10 +46,12 @@ struct DeployDrawerView: View {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(url.absoluteString, forType: .string)
                 }
+                .accessibilityHint("Copies \(url.absoluteString) to the clipboard")
                 Button("Open in browser") {
                     NSWorkspace.shared.open(url)
                 }
                 .buttonStyle(.borderedProminent)
+                .accessibilityHint("Opens \(url.absoluteString)")
             }
         }
         .padding(.horizontal, 16)
@@ -61,14 +63,18 @@ struct DeployDrawerView: View {
         switch model.phase {
         case .running:
             ProgressView().controlSize(.small)
+                .accessibilityLabel("Deploying")
         case .succeeded:
             Image(systemName: "checkmark.circle.fill")
                 .foregroundStyle(.green).font(.title3)
+                .accessibilityHidden(true)
         case .failed:
             Image(systemName: "exclamationmark.octagon.fill")
                 .foregroundStyle(.red).font(.title3)
+                .accessibilityHidden(true)
         case .idle, .blocked:
             Image(systemName: "shippingbox").font(.title3)
+                .accessibilityHidden(true)
         }
     }
 
@@ -104,6 +110,8 @@ struct DeployDrawerView: View {
                             .foregroundStyle(line.stream == .stderr ? Color.red : Color.primary)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .id(line.id)
+                            // stderr is conveyed in red; name it so VoiceOver doesn't lose that.
+                            .accessibilityLabel(line.stream == .stderr ? "Error: \(line.text)" : line.text)
                     }
                     if model.logLines.isEmpty {
                         Text("Waiting for output…")

--- a/Sources/AnglesiteApp/HealthBadgeView.swift
+++ b/Sources/AnglesiteApp/HealthBadgeView.swift
@@ -21,6 +21,12 @@ struct HealthBadgeView: View {
     /// state-specific glyph instead of a plain dot (HIG: differentiate without color).
     @Environment(\.accessibilityDifferentiateWithoutColor) private var differentiateWithoutColor
 
+    /// Badge geometry scales with Dynamic Type so the differentiate-without-color glyph stays
+    /// legible at larger text sizes — the very users who turn that setting on. Anchored to
+    /// `.body` so it tracks the system text size rather than a fixed point size.
+    @ScaledMetric(relativeTo: .body) private var badgeDimension = 18
+    @ScaledMetric(relativeTo: .body) private var glyphSize = 11
+
     var body: some View {
         Button {
             popoverPresented.toggle()
@@ -45,7 +51,7 @@ struct HealthBadgeView: View {
         ZStack {
             if differentiateWithoutColor {
                 Image(systemName: stateSymbol)
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.system(size: glyphSize, weight: .bold))
                     .foregroundStyle(color)
             } else {
                 Circle()
@@ -58,7 +64,7 @@ struct HealthBadgeView: View {
                     .frame(width: 14, height: 14)
             }
         }
-        .frame(width: 18, height: 18, alignment: .center)
+        .frame(width: badgeDimension, height: badgeDimension, alignment: .center)
         .contentShape(Rectangle())
     }
 

--- a/Sources/AnglesiteApp/NewSiteWizard.swift
+++ b/Sources/AnglesiteApp/NewSiteWizard.swift
@@ -35,11 +35,17 @@ struct NewSiteWizard: View {
                 Button { model.choose(type: type) } label: {
                     HStack {
                         Image(systemName: type.symbol).frame(width: 24)
+                            .accessibilityHidden(true)
                         Text(type.label)
                         Spacer()
-                        if model.draft.siteType == type { Image(systemName: "checkmark") }
+                        if model.draft.siteType == type {
+                            Image(systemName: "checkmark").accessibilityHidden(true)
+                        }
                     }.contentShape(Rectangle())
-                }.buttonStyle(.plain).padding(.vertical, 4)
+                }
+                .buttonStyle(.plain).padding(.vertical, 4)
+                .accessibilityLabel(type.label)
+                .accessibilityValue(model.draft.siteType == type ? "Selected" : "")
             }
         }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -49,7 +55,11 @@ struct NewSiteWizard: View {
             Text("Name your site").font(.title2.bold())
             TextField("Site name", text: $model.draft.name)
             Text("Folder: ~/Sites/\(model.slugPreview)").font(.caption).foregroundStyle(.secondary)
-            if let err = model.detailsError { Text(err).font(.caption).foregroundStyle(.red) }
+            if let err = model.detailsError {
+                Text(err).font(.caption).foregroundStyle(.red)
+                    .accessibilityLabel("Error")
+                    .accessibilityValue(err)
+            }
             Text("Tagline (optional)").font(.headline).padding(.top, 8)
             TextField("A short line about your site", text: $model.draft.tagline)
         }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -68,13 +78,17 @@ struct NewSiteWizard: View {
                                         Color(hex: hex).frame(height: 28)
                                     }
                                 }.clipShape(RoundedRectangle(cornerRadius: 6))
+                                .accessibilityHidden(true)
                                 Text(theme.name).font(.subheadline.bold())
                                 Text(theme.blurb).font(.caption2).foregroundStyle(.secondary).lineLimit(2)
                             }
                             .padding(8)
                             .overlay(RoundedRectangle(cornerRadius: 8)
                                 .stroke(model.draft.themeID == theme.id ? Color.accentColor : Color.clear, lineWidth: 2))
-                        }.buttonStyle(.plain)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityValue(model.draft.themeID == theme.id ? "Selected" : "")
                     }
                 }
             }
@@ -96,9 +110,13 @@ struct NewSiteWizard: View {
             Text("Building your site\u{2026}").font(.title2.bold())
             ForEach(Array(model.progress.enumerated()), id: \.offset) { _, s in
                 Text(label(for: s)).font(.callout)
+                    // The visible label leads with an emoji status glyph; give VoiceOver clean text.
+                    .accessibilityLabel(accessibilityLabel(for: s))
             }
             if case .failed(_, let msg) = model.fatal {
                 Text(msg).font(.caption).foregroundStyle(.red).textSelection(.enabled)
+                    .accessibilityLabel("Build failed")
+                    .accessibilityValue(msg)
             }
         }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -114,6 +132,22 @@ struct NewSiteWizard: View {
         case .warning(_, let m): return "\u{26A0}\u{FE0F} \(m)"
         case .failed(_, let m): return "\u{274C} \(m)"
         case .done: return "\u{2705} Done"
+        }
+    }
+
+    /// Emoji-free version of `label(for:)` for VoiceOver, which would otherwise read the status
+    /// glyph as "check mark", "hourglass", etc. before the actual message.
+    private func accessibilityLabel(for step: SiteScaffolder.ScaffoldStep) -> String {
+        switch step {
+        case .creatingFolder:    return "Created the site folder"
+        case .copyingTemplate:   return "Copied the template"
+        case .applyingTheme:     return "Applied your theme"
+        case .writingContent:    return "Wrote your words"
+        case .installing:        return "Installing…"
+        case .registering:       return "Registering"
+        case .warning(_, let m): return "Warning: \(m)"
+        case .failed(_, let m):  return "Failed: \(m)"
+        case .done:              return "Done"
         }
     }
 

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -167,6 +167,8 @@ private struct CloudflareTokenRow: View {
                     SecureField("paste token", text: $token, prompt: Text(promptText))
                         .textFieldStyle(.roundedBorder)
                         .frame(minWidth: 240)
+                        .accessibilityLabel("Cloudflare API token")
+                        .accessibilityValue(statusDescription)
                     Button("Save") { save() }
                         .disabled(token.isEmpty)
                     Button("Clear") { clear() }
@@ -192,6 +194,16 @@ private struct CloudflareTokenRow: View {
         case .absent:  return "paste token"
         case .unknown: return ""
         case .error:   return "paste token"
+        }
+    }
+
+    /// Spoken status for VoiceOver — the redacted `SecureField` prompt isn't announced clearly.
+    private var statusDescription: String {
+        switch status {
+        case .present:           return "Token stored"
+        case .absent:            return "No token stored"
+        case .unknown:           return "Checking…"
+        case .error(let message): return "Error: \(message)"
         }
     }
 
@@ -263,6 +275,7 @@ private struct GitHubAuthRow: View {
                         sheetPresented = true
                     }
                     .disabled(isUnavailable)
+                    .accessibilityHint(isUnavailable ? "GitHub tools are unavailable on this Mac" : "")
                 }
                 if let resultMessage {
                     Text(resultMessage.text)
@@ -373,9 +386,14 @@ private struct FolderPickerRow: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    // The path is middle-truncated for layout; expose the full value to VoiceOver.
+                    .accessibilityLabel(label)
+                    .accessibilityValue(path.isEmpty ? "Default — \(placeholder)" : path)
                 Button("Choose…") { chooseFolder() }
+                    .accessibilityLabel("Choose \(label)")
                 Button("Clear") { path = "" }
                     .disabled(path.isEmpty)
+                    .accessibilityLabel("Clear \(label)")
             }
         }
     }


### PR DESCRIPTION
Second accessibility pass, extending the first (VoiceOver labels + differentiate-without-color in `9a39e9e`, Reduce Motion in `5ae8cbf`). Closes the two remaining follow-ups from #34.

## Dynamic Type (#79)
- **HealthBadgeView** — the differentiate-without-color glyph + badge frame were hard-coded at 11/18 pt; now `@ScaledMetric(relativeTo: .body)` so they scale with the system text size (the users who enable that setting are the ones who need it legible).
- **Middle-truncated path fields** (Settings folder pickers, BlockedDeploy file rows) — kept their one-line layout but expose the full path to VoiceOver via `.accessibilityValue` instead of reflowing list rows.
- **DebugPaneView** monospaced log columns left fixed — intentional, as the issue notes.
- Remaining views already use semantic styles and scale correctly.

## VoiceOver (#80)
- **ChatView** — message bubbles announce the speaker ("You said…" / "Assistant said…", backend-neutral for the MAS on-device case); tool-call cards fold error/running/finished state into the disclosure label and hide the decorative wrench/triangle/spinner; edit & annotation rows hide their accent bars and give Undo/Resolve real labels (+ a disabled-state hint); usage/telemetry line labeled.
- **SettingsView** — Cloudflare token field announces stored/absent/error status; GitHub Connect gets a disabled hint; folder-picker rows read the full path and Choose/Clear name their field.
- **DeployDrawerView** — status icons hidden (spinner labeled "Deploying"); Copy/Open buttons get URL hints; stderr log lines prefixed "Error:".
- **BlockedDeploySheetView** — decorative shield/category/warning icons hidden; file paths read in full.
- **NewSiteWizard** — site-type & theme pickers announce selection and hide decorative swatches/checkmarks; building-step rows get emoji-free labels; validation & build-failure errors labeled.

## Deliberately skipped
The audit surfaced two suggestions that don't apply to this target: `UIAccessibility.post(...)` (iOS-only — this is macOS) and `.accessibilityLiveRegion(...)` (not a real SwiftUI modifier). Live-region announcements for streaming chat / deploy logs would need a macOS-specific `AccessibilityNotification` approach and risk being noisy, so they're deferred rather than shipped unverified.

## Verification
Both `Anglesite` (DevID) and `AnglesiteMAS` (sandboxed) schemes build clean. Changes are labeling/scaling only — no behavior or logic changes. VoiceOver/Dynamic Type spot-checks across the high-traffic surfaces are best done interactively.

Closes #79, closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)