### PR TITLE
ci: guard against project.yml ↔ source-tree drift (#123)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,21 @@ jobs:
 
       - name: Run relay suites under ThreadSanitizer
         run: scripts/test-relay-tsan.sh
+
+  xcodeproj-sync:
+    name: Anglesite.xcodeproj ↔ project.yml in sync
+    runs-on: macos-15
+    timeout-minutes: 10
+    # Anglesite.xcodeproj is gitignored and regenerated from project.yml via XcodeGen, so a
+    # stale/drifted spec never trips `swift build` above — it only bites a contributor running
+    # `xcodebuild` with "cannot find … in scope" (#123). This lane regenerates the project and
+    # asserts every app target still compiles the full Sources/AnglesiteApp tree. It needs only
+    # xcodegen + python3 (no Xcode 27 SDK, Node, or sibling plugin), so it's fast and parallel.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: command -v xcodegen >/dev/null 2>&1 || brew install xcodegen
+
+      - name: Check project sync
+        run: scripts/check-xcodeproj-sync.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,16 +118,26 @@ jobs:
     name: Anglesite.xcodeproj ↔ project.yml in sync
     runs-on: macos-15
     timeout-minutes: 10
+    permissions:
+      contents: read
     # Anglesite.xcodeproj is gitignored and regenerated from project.yml via XcodeGen, so a
     # stale/drifted spec never trips `swift build` above — it only bites a contributor running
     # `xcodebuild` with "cannot find … in scope" (#123). This lane regenerates the project and
     # asserts every app target still compiles the full Sources/AnglesiteApp tree. It needs only
     # xcodegen + python3 (no Xcode 27 SDK, Node, or sibling plugin), so it's fast and parallel.
+    env:
+      # Pinned so a future XcodeGen release can't silently change what this guard accepts.
+      # Bump deliberately; keep in sync with MIN_XCODEGEN in scripts/check-xcodeproj-sync.sh.
+      XCODEGEN_VERSION: 2.45.4
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install XcodeGen
-        run: command -v xcodegen >/dev/null 2>&1 || brew install xcodegen
+      - name: Install XcodeGen (pinned)
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip" -o /tmp/xcodegen.zip
+          unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
+          echo "/tmp/xcodegen-dist/xcodegen/bin" >> "$GITHUB_PATH"
 
       - name: Check project sync
         run: scripts/check-xcodeproj-sync.sh

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ xcodegen generate
 # and Sources/ without manual `xcodegen generate` calls.
 git config core.hooksPath scripts/git-hooks
 
-# Verify project.yml hasn't drifted from the source tree (regenerates the .xcodeproj
-# and checks every app target compiles all of Sources/AnglesiteApp). CI runs this too.
+# (Optional one-time verification) Confirm project.yml hasn't drifted from the
+# source tree — regenerates the .xcodeproj and checks every app target compiles all
+# of Sources/AnglesiteApp. CI runs this too, so it's not a required setup step.
 scripts/check-xcodeproj-sync.sh
 
 # Build via CLI (ad-hoc signed; no Apple account required)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ xcodegen generate
 # and Sources/ without manual `xcodegen generate` calls.
 git config core.hooksPath scripts/git-hooks
 
+# Verify project.yml hasn't drifted from the source tree (regenerates the .xcodeproj
+# and checks every app target compiles all of Sources/AnglesiteApp). CI runs this too.
+scripts/check-xcodeproj-sync.sh
+
 # Build via CLI (ad-hoc signed; no Apple account required)
 xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
 

--- a/scripts/check-xcodeproj-sync.sh
+++ b/scripts/check-xcodeproj-sync.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Guards against project.yml ↔ source-tree drift for the gitignored Anglesite.xcodeproj.
+#
+# Anglesite.xcodeproj/ is regenerated from project.yml via XcodeGen and never committed,
+# so a stale or malformed spec never fails `swift build` CI — it only surfaces later as
+# `error: cannot find 'X' in scope` from `xcodebuild` on a contributor's machine (#123).
+#
+# This check regenerates the project, then asserts that every application target actually
+# *compiles* every Swift file under Sources/AnglesiteApp. It catches the drift modes CI can
+# see on a fresh generate:
+#   1. A malformed/typo'd path in project.yml — XcodeGen exits non-zero on spec validation.
+#   2. A narrowed/removed `sources:` entry that silently drops files from a target's compile
+#      phase — XcodeGen exits 0, but the dropped files are then absent from that target's
+#      Sources build phase (this script fails, naming the target and files).
+#
+# Membership is checked per target (via the target's PBXSourcesBuildPhase), not by mere
+# presence of a file reference — because both the Anglesite and AnglesiteMAS targets share
+# Sources/AnglesiteApp, a file dropped from one but kept by the other would otherwise slip by.
+#
+# It deliberately does NOT run a full `xcodebuild` of the app: the app target needs the
+# macOS 27 SDK (Xcode 27), which CI runners don't yet ship (see #128). XcodeGen only needs
+# the spec + sources, so this guard runs anywhere xcodegen + python3 are installed.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! command -v xcodegen >/dev/null 2>&1; then
+  echo "error: xcodegen not found on PATH." >&2
+  echo "       Install with: brew install xcodegen" >&2
+  exit 1
+fi
+
+# The app target's `sources:` root in project.yml. The AnglesiteCore/Bridge/Intents trees are
+# SwiftPM package products (compiled by SwiftPM, not file-referenced in the pbxproj), so only
+# this app-target tree is verifiable against the generated project.
+sources_root="Sources/AnglesiteApp"
+
+# Regenerate the project. A spec-validation error (e.g. a path typo) exits non-zero here and
+# `set -e` aborts. --quiet suppresses the success banner but still emits warnings/errors.
+echo "Regenerating Anglesite.xcodeproj via xcodegen…"
+xcodegen generate --quiet
+
+pbxproj="Anglesite.xcodeproj/project.pbxproj"
+if [[ ! -f "$pbxproj" ]]; then
+  echo "error: $pbxproj not found after xcodegen generate." >&2
+  exit 1
+fi
+
+# Resolve, per application target, the set of Swift files it compiles, and compare against the
+# Swift files on disk under $sources_root. plutil reads the old-style pbxproj plist; python3
+# walks the object graph (target → PBXSourcesBuildPhase → PBXBuildFile → PBXFileReference).
+plutil -convert json -o /tmp/anglesite-pbxproj.json "$pbxproj"
+
+python3 - "$sources_root" /tmp/anglesite-pbxproj.json <<'PY'
+import json, os, sys
+
+sources_root, pbx_json = sys.argv[1], sys.argv[2]
+
+on_disk = {
+    f for _root, _dirs, files in os.walk(sources_root)
+    for f in files if f.endswith(".swift")
+}
+if not on_disk:
+    sys.exit(f"error: no .swift files found under {sources_root} — is the working tree intact?")
+
+objects = json.load(open(pbx_json))["objects"]
+app_targets = [
+    v for v in objects.values()
+    if v.get("isa") == "PBXNativeTarget"
+    and v.get("productType") == "com.apple.product-type.application"
+]
+if not app_targets:
+    sys.exit("error: no application targets found in the generated project.")
+
+failed = False
+for target in sorted(app_targets, key=lambda t: t["name"]):
+    compiled = set()
+    for phase_id in target.get("buildPhases", []):
+        phase = objects.get(phase_id, {})
+        if phase.get("isa") != "PBXSourcesBuildPhase":
+            continue
+        for build_file_id in phase.get("files", []):
+            ref = objects.get(objects.get(build_file_id, {}).get("fileRef", ""), {})
+            path = ref.get("path", "")
+            if path.endswith(".swift"):
+                compiled.add(os.path.basename(path))
+
+    missing = sorted(on_disk - compiled)
+    if missing:
+        failed = True
+        print(
+            f"error: target '{target['name']}' does not compile {len(missing)} file(s) that "
+            f"exist under {sources_root}.", file=sys.stderr)
+        print(
+            "       project.yml's sources have drifted from disk; an xcodebuild of this target "
+            "would fail with 'cannot find … in scope':", file=sys.stderr)
+        for f in missing:
+            print(f"         - {sources_root}/{f}", file=sys.stderr)
+
+if failed:
+    sys.exit(1)
+
+names = ", ".join(sorted(t["name"] for t in app_targets))
+print(f"✓ Anglesite.xcodeproj is in sync: {len(on_disk)} file(s) under {sources_root} "
+      f"compiled by every app target ({names}).")
+PY

--- a/scripts/check-xcodeproj-sync.sh
+++ b/scripts/check-xcodeproj-sync.sh
@@ -16,11 +16,20 @@
 # Membership is checked per target (via the target's PBXSourcesBuildPhase), not by mere
 # presence of a file reference — because both the Anglesite and AnglesiteMAS targets share
 # Sources/AnglesiteApp, a file dropped from one but kept by the other would otherwise slip by.
+# Files are compared by their path *relative to* Sources/AnglesiteApp (reconstructed from the
+# PBX group hierarchy), not by bare basename, so two same-named files in different subdirs
+# (e.g. Views/Settings.swift vs Overlays/Settings.swift) are distinguished.
 #
 # It deliberately does NOT run a full `xcodebuild` of the app: the app target needs the
 # macOS 27 SDK (Xcode 27), which CI runners don't yet ship (see #128). XcodeGen only needs
 # the spec + sources, so this guard runs anywhere xcodegen + python3 are installed.
+#
+# XcodeGen version: CI pins 2.45.4 (see .github/workflows/ci.yml). This script requires at
+# least the MIN_XCODEGEN below; the project graph keys it reads (PBXSourcesBuildPhase,
+# productType, --quiet) are stable across the 2.x line.
 set -euo pipefail
+
+MIN_XCODEGEN="2.38.0"
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
@@ -28,6 +37,16 @@ cd "$repo_root"
 if ! command -v xcodegen >/dev/null 2>&1; then
   echo "error: xcodegen not found on PATH." >&2
   echo "       Install with: brew install xcodegen" >&2
+  exit 1
+fi
+
+# Fail loudly on an xcodegen too old to be trusted, rather than silently accepting whatever
+# the local/Homebrew formula happens to provide.
+xcodegen_version="$(xcodegen --version 2>/dev/null | sed -n 's/^Version: //p')"
+if [[ -n "$xcodegen_version" ]] \
+   && [[ "$(printf '%s\n%s\n' "$MIN_XCODEGEN" "$xcodegen_version" | sort -V | head -1)" != "$MIN_XCODEGEN" ]]; then
+  echo "error: xcodegen $xcodegen_version is older than the required $MIN_XCODEGEN." >&2
+  echo "       Upgrade with: brew upgrade xcodegen" >&2
   exit 1
 fi
 
@@ -49,22 +68,46 @@ fi
 
 # Resolve, per application target, the set of Swift files it compiles, and compare against the
 # Swift files on disk under $sources_root. plutil reads the old-style pbxproj plist; python3
-# walks the object graph (target → PBXSourcesBuildPhase → PBXBuildFile → PBXFileReference).
-plutil -convert json -o /tmp/anglesite-pbxproj.json "$pbxproj"
+# walks the object graph (target → PBXSourcesBuildPhase → PBXBuildFile → PBXFileReference),
+# rebuilding each file's path from its enclosing PBXGroup chain.
+pbx_json="$(mktemp "${TMPDIR:-/tmp}/anglesite-pbxproj.XXXXXX.json")"
+trap 'rm -f "$pbx_json"' EXIT
+plutil -convert json -o "$pbx_json" "$pbxproj"
 
-python3 - "$sources_root" /tmp/anglesite-pbxproj.json <<'PY'
+python3 - "$sources_root" "$pbx_json" <<'PY'
 import json, os, sys
 
 sources_root, pbx_json = sys.argv[1], sys.argv[2]
 
+# On-disk Swift files, as paths relative to sources_root (e.g. "Foo.swift", "Views/Bar.swift").
 on_disk = {
-    f for _root, _dirs, files in os.walk(sources_root)
+    os.path.relpath(os.path.join(root, f), sources_root)
+    for root, _dirs, files in os.walk(sources_root)
     for f in files if f.endswith(".swift")
 }
 if not on_disk:
     sys.exit(f"error: no .swift files found under {sources_root} — is the working tree intact?")
 
-objects = json.load(open(pbx_json))["objects"]
+with open(pbx_json) as fh:
+    objects = json.load(fh)["objects"]
+
+# child id → enclosing PBXGroup id, so a file reference's full path can be rebuilt from the
+# chain of group `path` components (XcodeGen emits one group per source directory).
+parent = {
+    child: gid
+    for gid, obj in objects.items() if obj.get("isa") == "PBXGroup"
+    for child in obj.get("children", [])
+}
+
+def full_path(obj_id):
+    parts, node = [], obj_id
+    while node is not None:
+        path = objects.get(node, {}).get("path")
+        if path:
+            parts.append(path)
+        node = parent.get(node)
+    return os.path.normpath(os.path.join(*reversed(parts))) if parts else ""
+
 app_targets = [
     v for v in objects.values()
     if v.get("isa") == "PBXNativeTarget"
@@ -81,10 +124,10 @@ for target in sorted(app_targets, key=lambda t: t["name"]):
         if phase.get("isa") != "PBXSourcesBuildPhase":
             continue
         for build_file_id in phase.get("files", []):
-            ref = objects.get(objects.get(build_file_id, {}).get("fileRef", ""), {})
-            path = ref.get("path", "")
-            if path.endswith(".swift"):
-                compiled.add(os.path.basename(path))
+            ref_id = objects.get(build_file_id, {}).get("fileRef")
+            ref = objects.get(ref_id, {})
+            if str(ref.get("path", "")).endswith(".swift"):
+                compiled.add(os.path.relpath(full_path(ref_id), sources_root))
 
     missing = sorted(on_disk - compiled)
     if missing:
@@ -95,8 +138,8 @@ for target in sorted(app_targets, key=lambda t: t["name"]):
         print(
             "       project.yml's sources have drifted from disk; an xcodebuild of this target "
             "would fail with 'cannot find … in scope':", file=sys.stderr)
-        for f in missing:
-            print(f"         - {sources_root}/{f}", file=sys.stderr)
+        for rel in missing:
+            print(f"         - {sources_root}/{rel}", file=sys.stderr)
 
 if failed:
     sys.exit(1)


### PR DESCRIPTION
Closes #123.

## Problem

`Anglesite.xcodeproj/` is gitignored and regenerated from `project.yml` via XcodeGen. CI runs `swift build` only, so a stale/drifted spec never fails CI — it only surfaces later as `error: cannot find 'X' in scope` from `xcodebuild` on a contributor's machine (hit during #122 smoke testing). Nothing in the repo caught it.

## What this adds

**`scripts/check-xcodeproj-sync.sh`** — regenerates the project, then asserts (via `plutil` → `python3`) that **every application target's `PBXSourcesBuildPhase` compiles every `.swift` under `Sources/AnglesiteApp`**.

Catches both CI-visible drift modes on a fresh generate:
1. **Path typo / missing dir in `project.yml`** → XcodeGen exits non-zero on spec validation.
2. **Narrowed/removed `sources:` entry** that silently drops files from a target's compile phase → XcodeGen exits 0, but the script fails, naming the target and each missing file.

Per-target build-phase membership (not mere file-reference presence) is necessary: the `Anglesite` and `AnglesiteMAS` targets share `Sources/AnglesiteApp`, so a file dropped from one but kept by the other would otherwise slip by.

**`.github/workflows/ci.yml`** — new parallel `xcodeproj-sync` job (`macos-15`). Needs only `xcodegen` + `python3` (no Xcode 27 SDK, Node, or sibling plugin), so it's fast and isn't blocked by the runner Xcode-version ceiling that rules out a full app `xcodebuild` (#128).

**`README.md`** — one line pointing contributors at the script, beside the existing git-hooks opt-in.

## Scope

This is option **(3)** from the issue. Option (2) (local auto-regen) already shipped as the opt-in git hooks in #51, so this fills the remaining CI gap. A full `xcodebuild` of the app isn't viable on CI yet (Xcode 27 not on runners), so the guard works at the XcodeGen layer — exactly where the drift the issue hit originates.

## Verification

Ran locally against three cases:
- ✅ Clean tree → passes (25 files × 2 app targets)
- ✅ Single-target source drop → fails, naming `Anglesite` + the 25 missing files
- ✅ `project.yml` path typo → `Spec validation error`, non-zero exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)