### PR TITLE
ci: harden xcodeproj-sync guard (SHA-pinned actions, verified artifact)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       run:
         working-directory: JS/edit-overlay
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           cache: npm
@@ -39,19 +39,19 @@ jobs:
     env:
       ANGLESITE_BUILD_NPM_CACHE: '0'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # The end-to-end test in AnglesiteBridgeTests spawns the real plugin's MCP server, so
       # CI needs the sibling repo present and `npm ci`-installed. Without these the test cleanly
       # `XCTSkip`s; with them, the full overlay → patcher → file-on-disk round-trip is exercised.
       - name: Checkout sibling Anglesite plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: Anglesite/anglesite
           path: anglesite-plugin
 
       - name: Set up Node (for the bundled plugin's MCP server)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
@@ -98,7 +98,7 @@ jobs:
     # skips the sibling-plugin checkout. TSan deterministically flags data races the probabilistic
     # `concurrentDeliver*` tests would otherwise only catch by timing luck (#203).
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Select latest available Xcode
         # Same toolchain rationale as build-test: CLAUDE.md mandates Xcode 27+.
@@ -129,14 +129,20 @@ jobs:
       # Pinned so a future XcodeGen release can't silently change what this guard accepts.
       # Bump deliberately; keep in sync with MIN_XCODEGEN in scripts/check-xcodeproj-sync.sh.
       XCODEGEN_VERSION: 2.45.4
+      # SHA-256 of the pinned release's xcodegen.zip — verified after download so a compromised
+      # release (or MITM) can't substitute a different binary. Re-fetch and update on every bump.
+      XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install XcodeGen (pinned)
         run: |
           set -euo pipefail
           curl -fsSL "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip" -o /tmp/xcodegen.zip
+          echo "${XCODEGEN_SHA256}  /tmp/xcodegen.zip" | shasum -a 256 --check
           unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
+          test -x /tmp/xcodegen-dist/xcodegen/bin/xcodegen \
+            || { echo "error: xcodegen binary not found at expected path after unzip — check zip layout" >&2; exit 1; }
           echo "/tmp/xcodegen-dist/xcodegen/bin" >> "$GITHUB_PATH"
 
       - name: Check project sync

--- a/scripts/check-xcodeproj-sync.sh
+++ b/scripts/check-xcodeproj-sync.sh
@@ -22,7 +22,9 @@
 #
 # It deliberately does NOT run a full `xcodebuild` of the app: the app target needs the
 # macOS 27 SDK (Xcode 27), which CI runners don't yet ship (see #128). XcodeGen only needs
-# the spec + sources, so this guard runs anywhere xcodegen + python3 are installed.
+# the spec + sources, so this guard runs anywhere xcodegen + python3 + plutil are installed.
+# `plutil` (used below to convert the pbxproj plist to JSON) is macOS-only, so in practice
+# this script requires macOS.
 #
 # XcodeGen version: CI pins 2.45.4 (see .github/workflows/ci.yml). This script requires at
 # least the MIN_XCODEGEN below; the project graph keys it reads (PBXSourcesBuildPhase,
@@ -43,8 +45,11 @@ fi
 # Fail loudly on an xcodegen too old to be trusted, rather than silently accepting whatever
 # the local/Homebrew formula happens to provide.
 xcodegen_version="$(xcodegen --version 2>/dev/null | sed -n 's/^Version: //p')"
-if [[ -n "$xcodegen_version" ]] \
-   && [[ "$(printf '%s\n%s\n' "$MIN_XCODEGEN" "$xcodegen_version" | sort -V | head -1)" != "$MIN_XCODEGEN" ]]; then
+if [[ -z "$xcodegen_version" ]]; then
+  # An unparseable --version means an unexpected build; warn rather than silently skipping, so a
+  # stale xcodegen can't masquerade as "checked" and produce a confusing result downstream.
+  echo "warning: could not parse 'xcodegen --version'; skipping minimum-version ($MIN_XCODEGEN) check." >&2
+elif [[ "$(printf '%s\n%s\n' "$MIN_XCODEGEN" "$xcodegen_version" | sort -V | head -1)" != "$MIN_XCODEGEN" ]]; then
   echo "error: xcodegen $xcodegen_version is older than the required $MIN_XCODEGEN." >&2
   echo "       Upgrade with: brew upgrade xcodegen" >&2
   exit 1
@@ -100,8 +105,11 @@ parent = {
 }
 
 def full_path(obj_id):
-    parts, node = [], obj_id
-    while node is not None:
+    # `seen` guards against a malformed pbxproj with a circular group hierarchy (A → B → A).
+    # XcodeGen's generated output won't cycle, but the set keeps the failure mode obvious.
+    parts, node, seen = [], obj_id, set()
+    while node is not None and node not in seen:
+        seen.add(node)
         path = objects.get(node, {}).get("path")
         if path:
             parts.append(path)


### PR DESCRIPTION
Follow-up to #217 (which landed the #123 `xcodeproj-sync` guard). This applies the six review points raised on the original change, none of which were in #217:

**Supply-chain**
- Pin every `actions/checkout` to `11bd719` (v4.2.2) and `actions/setup-node` to `49933ea` (v4.4.0) — mutable tags are a supply-chain vector.
- Verify the downloaded `xcodegen.zip` against a pinned `XCODEGEN_SHA256` (`090ec29…`); bumping the version forces a hash update.

**Correctness / robustness**
- Fast-fail if the xcodegen binary isn't at the expected path after unzip, instead of a confusing "xcodegen not found" two steps later.
- Document `plutil` (macOS-only) as a dependency — the guard requires macOS in practice.
- Warn instead of silently skipping the minimum-version check when `xcodegen --version` is unparseable.
- Add a cycle guard to `full_path()` so a malformed circular group hierarchy terminates.

Rebased onto current `main`, so it's a clean single-commit delta. Verified locally: `scripts/check-xcodeproj-sync.sh` passes with xcodegen 2.45.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)