### PR TITLE
test(intents): C.11 — Phase C test-suite audit + op-mapping gap-fill (#161)

### DIFF
--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -97,7 +97,7 @@ struct ApplyEditToolTests {
         #expect(msg?.selector == .object([
             "tag": .string("h1"), "classes": .array([]), "nthChild": .int(1),
         ]))
-        #expect(msg?.op == "replace-attr")
+        // Op-string mapping is asserted exhaustively in `mapsEveryOperationToItsOpString`.
     }
 
     @Test("no context selector + complex selector fails gracefully without calling the bridge")

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -97,7 +97,7 @@ struct ApplyEditToolTests {
         #expect(msg?.selector == .object([
             "tag": .string("h1"), "classes": .array([]), "nthChild": .int(1),
         ]))
-        // Op-string mapping is asserted exhaustively in `mapsEveryOperationToItsOpString`.
+        // Op-string mapping is exhaustively asserted in `mapsEveryOperationToItsOpString`.
     }
 
     @Test("no context selector + complex selector fails gracefully without calling the bridge")

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -25,7 +25,7 @@ private func makeBridge(_ router: FakeEditRouter) -> IntentEditBridge {
 @Suite("On-device tools: ApplyEditTool")
 struct ApplyEditToolTests {
 
-    @Test("context selector is used verbatim; operation maps to the op string; value is wrapped")
+    @Test("context selector is used verbatim; value is wrapped; path is forwarded")
     func usesContextSelectorAndMapsOp() async throws {
         let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: "ok"))
         let element: JSONValue = .object([
@@ -42,12 +42,41 @@ struct ApplyEditToolTests {
 
         let out = try await tool.call(arguments: cmd)
 
+        // Op-string mapping is exhaustively asserted in `mapsEveryOperationToItsOpString`.
         let msg = await router.received
-        #expect(msg?.op == "replace-text")
         #expect(msg?.selector == element)
         #expect(msg?.value == .string("New Title"))
         #expect(msg?.path == "src/pages/about.md")
         #expect(out.contains("Applied"))
+    }
+
+    /// The op-vocabulary bridge between #154 (`EditOperation`) and #156 (`ApplyEditTool`):
+    /// every `EditOperation` case must map onto its `EditMessage.Op` string. Single source of
+    /// truth for that mapping (see the C.11 audit, #161).
+    @Test("every EditOperation maps to its EditMessage.Op string", arguments: [
+        (EditOperation.replaceText, EditMessage.Op.replaceText),
+        (EditOperation.replaceAttr, EditMessage.Op.replaceAttr),
+        (EditOperation.replaceImageSrc, EditMessage.Op.replaceImageSrc),
+        (EditOperation.applyInstruction, EditMessage.Op.applyInstruction),
+    ])
+    func mapsEveryOperationToItsOpString(operation: EditOperation, expectedOp: String) async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: "ok"))
+        let element: JSONValue = .object([
+            "tag": .string("h1"), "classes": .array([]), "nthChild": .int(1),
+        ])
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: element)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/about.md",
+            selector: "ignored-by-tool",
+            operation: operation,
+            value: "value",
+            explanation: "x"
+        )
+
+        _ = try await tool.call(arguments: cmd)
+
+        let msg = await router.received
+        #expect(msg?.op == expectedOp)
     }
 
     @Test("no context selector + bare-tag selector builds a minimal ElementInfo")

--- a/docs/superpowers/plans/2026-06-17-c11-phase-c-test-suite.md
+++ b/docs/superpowers/plans/2026-06-17-c11-phase-c-test-suite.md
@@ -1,5 +1,7 @@
 # C.11 — Phase C Test Suite (Audit + Gap-Fill) Implementation Plan
 
+> **Status: Executed in PR #223.** The test landed as `mapsEveryOperationToItsOpString(operation:expectedOp:)` — the names in the steps below were the proposal (`opMappingCoversAllCases(operation:expected:)`) and have since been reconciled to what shipped. The redundant op assertion was removed from both `usesContextSelectorAndMapsOp` and `bareTagBuildsMinimalElementInfo`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Close the one confirmed Phase C coverage gap — `ApplyEditTool`'s `EditOperation → EditMessage.Op` mapping is asserted for only one of four cases — and verify the audited Phase C coverage stays green.
@@ -29,7 +31,7 @@
 
 > **Note on TDD:** the production mapping (`ApplyEditTool.opString`) is already correct for all four cases, so this coverage test passes the moment it is written — there is no genuine RED phase. Step 2 is a *deliberate, reverted* mutation check that proves the test is not vacuous, standing in for the RED step.
 
-- [ ] **Step 1: Add the parameterized test**
+- [x] **Step 1: Add the parameterized test**
 
 In `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift`, inside the `struct ApplyEditToolTests` suite (e.g. immediately after `usesContextSelectorAndMapsOp`), add:
 
@@ -41,7 +43,7 @@ In `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift`, inside the `struct Apply
               (EditOperation.replaceImageSrc, EditMessage.Op.replaceImageSrc),
               (EditOperation.applyInstruction, EditMessage.Op.applyInstruction),
           ])
-    func opMappingCoversAllCases(operation: EditOperation, expected: String) async throws {
+    func mapsEveryOperationToItsOpString(operation: EditOperation, expectedOp: String) async throws {
         // Guards the #154 EditOperation → #156 EditMessage.Op vocabulary bridge across all
         // four cases (previously only .replaceText was asserted). Pure routing logic, no model.
         let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: "ok"))
@@ -59,20 +61,20 @@ In `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift`, inside the `struct Apply
 
         _ = try await tool.call(arguments: cmd)
 
-        #expect(await router.received?.op == expected)
+        #expect(await router.received?.op == expectedOp)
     }
 ```
 
-- [ ] **Step 2: Prove the test is not vacuous (mutation check)**
+- [x] **Step 2: Prove the test is not vacuous (mutation check)**
 
 Temporarily edit `Sources/AnglesiteCore/ApplyEditTool.swift` `opString(for:)` so one case returns the wrong string, e.g. change `case .replaceAttr: return EditMessage.Op.replaceAttr` to `return EditMessage.Op.replaceText`. Run:
 ```bash
 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
-  swift test --package-path . --filter "opMappingCoversAllCases"
+  swift test --package-path . --filter "mapsEveryOperationToItsOpString"
 ```
 Expected: FAIL on the `.replaceAttr` argument case (`"replace-text"` ≠ `"replace-attr"`). **Then revert the `ApplyEditTool.swift` edit** (`git checkout -- Sources/AnglesiteCore/ApplyEditTool.swift`) — production code must be unchanged.
 
-- [ ] **Step 3: Remove the now-redundant single-op assertion**
+- [x] **Step 3: Remove the now-redundant single-op assertion**
 
 In `usesContextSelectorAndMapsOp` (`OnDeviceToolsTests.swift:46`), delete this line so op-string mapping is asserted in exactly one place:
 
@@ -82,16 +84,16 @@ In `usesContextSelectorAndMapsOp` (`OnDeviceToolsTests.swift:46`), delete this l
 
 Keep that test's other assertions (`msg?.selector`, `msg?.value`, `msg?.path`, `out.contains("Applied")`) — the new test does not cover those.
 
-- [ ] **Step 4: Run the ApplyEditTool tests to verify green**
+- [x] **Step 4: Run the ApplyEditTool tests to verify green**
 
 Run:
 ```bash
 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
   swift test --package-path . --filter "ApplyEditTool"
 ```
-Expected: PASS. `opMappingCoversAllCases` runs four argument cases, all pass; `usesContextSelectorAndMapsOp` still passes with its remaining assertions. Confirm `ApplyEditTool.swift` shows no diff (`git diff --stat Sources/` is empty).
+Expected: PASS. `mapsEveryOperationToItsOpString` runs four argument cases, all pass; `usesContextSelectorAndMapsOp` still passes with its remaining assertions. Confirm `ApplyEditTool.swift` shows no diff (`git diff --stat Sources/` is empty).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -110,15 +112,15 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 **Files:** No code changes. Verification + issue bookkeeping only.
 
-- [ ] **Step 1: Run the full suite**
+- [x] **Step 1: Run the full suite**
 
 ```bash
 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
   swift test --package-path . 2>&1 | tail -20
 ```
-Expected: all three bundles green; no new failures in `AnglesiteCoreTests` beyond the known plugin-gated e2e tests when `ANGLESITE_PLUGIN_PATH` is unset (see CLAUDE.md). The new `opMappingCoversAllCases` is included.
+Expected: all three bundles green; no new failures in `AnglesiteCoreTests` beyond the known plugin-gated e2e tests when `ANGLESITE_PLUGIN_PATH` is unset (see CLAUDE.md). The new `mapsEveryOperationToItsOpString` is included.
 
-- [ ] **Step 2: Post the audit conclusion on #161**
+- [x] **Step 2: Post the audit conclusion on #161**
 
 ```bash
 gh issue comment 161 --body "Phase C coverage audit complete (spec: docs/superpowers/specs/2026-06-17-c11-phase-c-test-suite-design.md).
@@ -131,7 +133,7 @@ All 7 checklist items are covered by existing tests (coverage map in the spec):
 One real gap was found and filled: ApplyEditTool asserted only .replaceText of four EditOperation→EditMessage.Op mappings — now parameterized across all four. No other gaps; no padding tests added."
 ```
 
-- [ ] **Step 3: No commit** (verification + issue comment only).
+- [x] **Step 3: No commit** (verification + issue comment only).
 
 ---
 

--- a/docs/superpowers/plans/2026-06-17-c11-phase-c-test-suite.md
+++ b/docs/superpowers/plans/2026-06-17-c11-phase-c-test-suite.md
@@ -1,0 +1,150 @@
+# C.11 — Phase C Test Suite (Audit + Gap-Fill) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the one confirmed Phase C coverage gap — `ApplyEditTool`'s `EditOperation → EditMessage.Op` mapping is asserted for only one of four cases — and verify the audited Phase C coverage stays green.
+
+**Architecture:** The coverage audit is already complete and committed as the spec's coverage map; #161 is otherwise satisfied by existing tests. The only code change is adding one parameterized test in `OnDeviceToolsTests.swift` that exercises all four op-string mappings through `ApplyEditTool.call(arguments:)` via the existing `FakeEditRouter`, and removing the now-redundant single-op assertion. No production code changes.
+
+**Tech Stack:** Swift 6.4 / Xcode 27, Swift Testing, FoundationModels (compile-gated).
+
+## Global Constraints
+
+- **Toolchain:** All `swift test` commands MUST run under Xcode 27 — prefix with `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer`. The default `xcode-select` path is too old for `#if compiler(>=6.4)` and silently compiles out the code under test. If a run hangs with no output, a stale SwiftPM process may hold the `.build` lock — `pgrep -fl swift-test` and kill the orphan.
+- **Compiler gate:** The edited test code stays inside the existing `#if compiler(>=6.4)` block in `OnDeviceToolsTests.swift`.
+- **No production changes:** This is a coverage-only task. Do NOT modify `ApplyEditTool.swift` or any `Sources/` file. If the new test reveals a real mapping bug, STOP and report it rather than "fixing" silently.
+- **No model needed:** The test uses `FakeEditRouter`, not a `LanguageModelSession`; it runs on CI.
+- **No green-coverage padding:** Add exactly the one test the spec identifies. Do not add speculative tests to raise counts.
+
+---
+
+### Task 1: Parameterized op-string mapping test for all EditOperation cases
+
+**Files:**
+- Test: `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift` (add one `@Test` to the `ApplyEditToolTests` suite; edit `usesContextSelectorAndMapsOp` at line ~46)
+
+**Interfaces:**
+- Consumes (all existing): `FakeEditRouter`, `makeBridge(_:)`, `ApplyEditTool(bridge:siteID:contextSelector:)`, `ApplyEditTool.call(arguments:)`, `GeneratedEditCommand(filePath:selector:operation:value:explanation:)`, `EditOperation` (`.replaceText`/`.replaceAttr`/`.replaceImageSrc`/`.applyInstruction`), `EditMessage.Op` constants (`replaceText="replace-text"`, `replaceAttr="replace-attr"`, `replaceImageSrc="replace-image-src"`, `applyInstruction="apply-instruction"`), `EditReply`, `JSONValue`.
+- Produces: no new symbols.
+
+> **Note on TDD:** the production mapping (`ApplyEditTool.opString`) is already correct for all four cases, so this coverage test passes the moment it is written — there is no genuine RED phase. Step 2 is a *deliberate, reverted* mutation check that proves the test is not vacuous, standing in for the RED step.
+
+- [ ] **Step 1: Add the parameterized test**
+
+In `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift`, inside the `struct ApplyEditToolTests` suite (e.g. immediately after `usesContextSelectorAndMapsOp`), add:
+
+```swift
+    @Test("every EditOperation maps to its EditMessage.Op string",
+          arguments: [
+              (EditOperation.replaceText, EditMessage.Op.replaceText),
+              (EditOperation.replaceAttr, EditMessage.Op.replaceAttr),
+              (EditOperation.replaceImageSrc, EditMessage.Op.replaceImageSrc),
+              (EditOperation.applyInstruction, EditMessage.Op.applyInstruction),
+          ])
+    func opMappingCoversAllCases(operation: EditOperation, expected: String) async throws {
+        // Guards the #154 EditOperation → #156 EditMessage.Op vocabulary bridge across all
+        // four cases (previously only .replaceText was asserted). Pure routing logic, no model.
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: "ok"))
+        let element: JSONValue = .object([
+            "tag": .string("h1"), "classes": .array([]), "nthChild": .int(1),
+        ])
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: element)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/about.md",
+            selector: "ignored-by-tool",
+            operation: operation,
+            value: "v",
+            explanation: "why"
+        )
+
+        _ = try await tool.call(arguments: cmd)
+
+        #expect(await router.received?.op == expected)
+    }
+```
+
+- [ ] **Step 2: Prove the test is not vacuous (mutation check)**
+
+Temporarily edit `Sources/AnglesiteCore/ApplyEditTool.swift` `opString(for:)` so one case returns the wrong string, e.g. change `case .replaceAttr: return EditMessage.Op.replaceAttr` to `return EditMessage.Op.replaceText`. Run:
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
+  swift test --package-path . --filter "opMappingCoversAllCases"
+```
+Expected: FAIL on the `.replaceAttr` argument case (`"replace-text"` ≠ `"replace-attr"`). **Then revert the `ApplyEditTool.swift` edit** (`git checkout -- Sources/AnglesiteCore/ApplyEditTool.swift`) — production code must be unchanged.
+
+- [ ] **Step 3: Remove the now-redundant single-op assertion**
+
+In `usesContextSelectorAndMapsOp` (`OnDeviceToolsTests.swift:46`), delete this line so op-string mapping is asserted in exactly one place:
+
+```swift
+        #expect(msg?.op == "replace-text")
+```
+
+Keep that test's other assertions (`msg?.selector`, `msg?.value`, `msg?.path`, `out.contains("Applied")`) — the new test does not cover those.
+
+- [ ] **Step 4: Run the ApplyEditTool tests to verify green**
+
+Run:
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
+  swift test --package-path . --filter "ApplyEditTool"
+```
+Expected: PASS. `opMappingCoversAllCases` runs four argument cases, all pass; `usesContextSelectorAndMapsOp` still passes with its remaining assertions. Confirm `ApplyEditTool.swift` shows no diff (`git diff --stat Sources/` is empty).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+git commit -m "test(intents): cover all EditOperation op-string mappings (#161)
+
+ApplyEditTool maps four EditOperation cases to EditMessage.Op strings but only
+.replaceText was asserted. Add a parameterized test over all four cases and
+drop the now-redundant single-op assertion. Coverage only; no production change.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Full-suite regression + record audit conclusion on #161
+
+**Files:** No code changes. Verification + issue bookkeeping only.
+
+- [ ] **Step 1: Run the full suite**
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
+  swift test --package-path . 2>&1 | tail -20
+```
+Expected: all three bundles green; no new failures in `AnglesiteCoreTests` beyond the known plugin-gated e2e tests when `ANGLESITE_PLUGIN_PATH` is unset (see CLAUDE.md). The new `opMappingCoversAllCases` is included.
+
+- [ ] **Step 2: Post the audit conclusion on #161**
+
+```bash
+gh issue comment 161 --body "Phase C coverage audit complete (spec: docs/superpowers/specs/2026-06-17-c11-phase-c-test-suite-design.md).
+
+All 7 checklist items are covered by existing tests (coverage map in the spec):
+- FoundationModelAssistant, @Generable round-trips, ApplyEditTool/SearchContentTool, alt-text, ContentAssistant/ClaudeAssistant, settings tier, transcript accumulation, chat history.
+- ChatModel-the-type glue is app-target (not swift-test reachable); its testable substance is already extracted into ConversationTranscript + ChatHistoryStore + the assistant protocols, all covered.
+- Mock LanguageModel seam intentionally deferred to #104.
+
+One real gap was found and filled: ApplyEditTool asserted only .replaceText of four EditOperation→EditMessage.Op mappings — now parameterized across all four. No other gaps; no padding tests added."
+```
+
+- [ ] **Step 3: No commit** (verification + issue comment only).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Audit method + coverage map → already committed in the spec; Task 2 Step 2 records the conclusion on the issue. ✓
+- The one gap-fill (parameterized op-string mapping over all 4 cases) → Task 1 Step 1. ✓
+- Remove redundant single-op assertion → Task 1 Step 3. ✓
+- No production changes / no padding → Global Constraints + Task 1 note. ✓
+- Mock seam deferred to #104, ChatModel glue documented as app-target → Task 2 Step 2 comment (mirrors spec). ✓
+- Full-suite green verification → Task 2 Step 1. ✓
+
+**Placeholder scan:** No TBD/TODO; the new test's full code is shown; the mutation check names the exact edit and its revert. ✓
+
+**Type consistency:** `EditOperation` cases, `EditMessage.Op` constant names + string values, `GeneratedEditCommand` initializer label order, `FakeEditRouter`/`makeBridge`/`ApplyEditTool` signatures all match the current source verified during the audit. ✓

--- a/docs/superpowers/specs/2026-06-17-c11-phase-c-test-suite-design.md
+++ b/docs/superpowers/specs/2026-06-17-c11-phase-c-test-suite-design.md
@@ -1,0 +1,82 @@
+# C.11 — Phase C Test Suite (Audit + Gap-Fill)
+
+**Issue:** [#161](https://github.com/Anglesite/Anglesite-app/issues/161) · **Parent:** #134 (Phase C) · **Date:** 2026-06-17
+
+## Goal
+
+Confirm Phase C (Foundation Models for on-device intelligence) has comprehensive, honest test
+coverage, and close #161. Phase C's tests landed incrementally during C.1–C.10, so the
+checklist in #161 is **already largely satisfied**. This task is therefore an *audit* that
+maps every checklist item to the tests that satisfy it, plus a single confirmed gap-fill —
+not a bulk test-writing effort. Padding tests to hit nominal counts would be the
+green-coverage theater this project guards against.
+
+## Audit method
+
+For each #161 checklist item, locate the covering test(s) and classify them:
+
+- **CI** — runs under `swift test` on CI with no model (pure logic / capability reads).
+- **Live** — guarded by `modelAvailable()`; runs on a host with Apple Intelligence, no-ops on CI.
+- **XCTest** — covered by an XCTest holdout suite (deliberate; see CLAUDE.md / #74).
+- **App-target** — logic in the `AnglesiteApp` target, not reachable by `swift test`; the
+  testable substance was already extracted into `AnglesiteCore` types that *are* covered.
+- **Deferred** — intentionally out of scope, tracked elsewhere.
+
+## Coverage map
+
+| # | #161 checklist item | Covering tests | Class |
+|---|---|---|---|
+| 1 | `FoundationModelAssistantTests`: generate, generateStructured, streaming (~8) | `FoundationModelAssistantTests.swift` (18 `@Test`): `onDeviceCapabilities`, `pccCapabilities`, `spotlightMakesToolsUnconditional` (CI); `generateStreamsText`, `generateStructuredReturnsType`, `converseEmitsLifecycleEvents`, `converseRemembersAcrossTurns`, `cancelMidStreamYieldsCancelled`, … (Live) | CI + Live |
+| 2 | `@Generable` round-trip per struct (~5) | `GenerableTypesTests.swift` (5 `@Test`): `GeneratedEditCommand`, `GeneratedPageMeta`, `GeneratedAltText`, `ContentSummary`, `ContentClassification` | Live |
+| 3 | `ApplyEditTool` + `SearchContentTool` with fakes (~6) | `OnDeviceToolsTests.swift` (12 `@Test`) via `FakeEditRouter` + in-memory `SiteContentGraph` | CI |
+| 4 | `ChatModel` protocol migration: works with the `ClaudeAssistant` wrapper | `ContentAssistantTests.swift` (7 `@Test`, `StubAssistant`), `ClaudeAssistantTests.swift` (4 `@Test`) — the `ContentAssistant`/`ConversationalAssistant` seam `ChatModel` depends on | CI (protocol); App-target (`ChatModel` glue) |
+| 5 | `ChatModel` + `FoundationModelAssistant`: streaming + tool-calling smoke | Streaming accumulation extracted to `ConversationTranscriptTests.swift` (27 `@Test`, CI); FM streaming/tool turns in `FoundationModelAssistantTests` converse tests (Live). `ChatModel`'s own event-loop orchestration is thin glue in the app target | CI + Live; App-target (glue) |
+| 6 | Alt-text: mock image → `GeneratedAltText` (~2) | `AltTextGeneratorTests.swift` (8 `@Test`) | CI + Live |
+| 7 | Settings: model tier switch resets conversation | Tier persistence: `AppSettingsTests.swift` `foundationModelTierDefaultsToOnDevice`, `foundationModelTierRoundTrip`, `foundationModelTierUnknownFallsBack` (CI). Session reset: `FoundationModelAssistantTests.resetSessionIsSafe` (Live-adjacent). `ChatModel.resetConversation()` calling `assistant.resetSession()` on tier change is app-target glue | CI; App-target (glue) |
+
+Supporting (not a checklist line but Phase C): `ChatHistoryStoreTests.swift` (11 XCTest cases,
+the chat persistence layer) — **XCTest**.
+
+### Items intentionally not given new CI tests
+
+- **`ChatModel`-the-type** (items 4, 5, 7 glue). `ChatModel` lives in `AnglesiteApp`; hosted app
+  tests are blocked on CI (CLAUDE.md). Its testable substance was already pushed into
+  `AnglesiteCore` (`ConversationTranscript`, `ChatHistoryStore`, the assistant protocols) and is
+  covered there. The remaining glue (wiring the event stream into `@Observable` state, calling
+  `resetSession()` on tier switch) is verified manually / by the app build, consistent with the
+  `DeployModel`→`TokenOnboarding` precedent.
+- **Mock `LanguageModel` seam.** The `FoundationModelAssistantTests` `TODO(#104/#161)` proposes
+  swapping the guarded-live tests for a deterministic mock session. That is tied to **#104**
+  (App Intents Testing) and is deferred there to avoid duplicating its work.
+
+## The one gap-fill
+
+`ApplyEditTool.opString(for:)` (`ApplyEditTool.swift:83`) maps all four `EditOperation` cases
+to their `EditMessage.Op` strings, but `OnDeviceToolsTests.swift:28`
+(`usesContextSelectorAndMapsOp`) asserts only `.replaceText` → `"replace-text"`. The other
+three mappings (`.replaceAttr` → `"replace-attr"`, `.replaceImageSrc` → `"replace-image-src"`,
+`.applyInstruction` → `"apply-instruction"`) are unverified. This is the op-vocabulary bridge
+between #154 (`EditOperation`) and #156 (`ApplyEditTool`) — a real, CI-testable, pure-logic
+behavior with a coverage hole.
+
+**Fill:** add one parameterized `@Test(arguments:)` over all four
+`(EditOperation, expected op string)` pairs that drives `ApplyEditTool.call(arguments:)`
+through a `FakeEditRouter` and asserts `router.received?.op`. To avoid asserting the same
+mapping in two places, **remove the lone `#expect(msg?.op == "replace-text")` line from
+`usesContextSelectorAndMapsOp`** (`OnDeviceToolsTests.swift:46`); that test keeps its
+selector / value / path / output assertions, which the new test does not cover. The new test
+becomes the single source of truth for op-string mapping across all cases.
+
+## Testing / verification
+
+- The new parameterized test runs under `swift test` with no model (it uses `FakeEditRouter`,
+  not `LanguageModelSession`).
+- Full `swift test` (under `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer`)
+  stays green across all three bundles.
+
+## Out of scope
+
+- Migrating XCTest holdouts to Swift Testing (#74).
+- The mock `LanguageModel` session (#104).
+- Any `AnglesiteApp`-target test host.
+- New Phase C product behavior — this is coverage only.


### PR DESCRIPTION
Closes #161 (C.11, Phase C / #134).

Phase C's test coverage landed incrementally across C.1–C.10, so #161's checklist was **already largely satisfied**. This PR is an **audit** (not a bulk test-writing effort): it maps every checklist item to its covering tests and fills the one real gap found — padding tests to hit nominal counts would be the green-coverage theater this project guards against.

## Coverage map (full table in the spec)
| Checklist item | Covered by | Class |
|---|---|---|
| FoundationModelAssistant generate/structured/streaming | `FoundationModelAssistantTests` (18) | CI + live |
| `@Generable` round-trips | `GenerableTypesTests` (5) | live |
| ApplyEditTool + SearchContentTool | `OnDeviceToolsTests` (12) | CI |
| Alt-text | `AltTextGeneratorTests` (8) | CI + live |
| ContentAssistant / ClaudeAssistant migration | `ContentAssistantTests` (7), `ClaudeAssistantTests` (4) | CI |
| Transcript accumulation / chat history | `ConversationTranscriptTests` (27), `ChatHistoryStoreTests` (11 XCTest) | CI / XCTest |
| Settings tier | `AppSettingsTests` (tier default/round-trip/unknown-fallback) | CI |

- **ChatModel-the-type** glue is app-target (not `swift test` reachable); its testable substance was already extracted into `ConversationTranscript` + `ChatHistoryStore` + the assistant protocols, all covered.
- **Mock `LanguageModel` seam** intentionally deferred to #104 (per the in-code TODO).

## The one gap-fill
`ApplyEditTool.opString(for:)` maps four `EditOperation` cases but only `.replaceText` was asserted. Added a parameterized `mapsEveryOperationToItsOpString` covering all four (`.replaceText`/`.replaceAttr`/`.replaceImageSrc`/`.applyInstruction`), and removed the now-redundant op assertions from two other tests so it's the single source of truth. Coverage only — no production change. A mutation check confirmed the test is non-vacuous.

## Verification
Full `swift test` (Xcode 27): 145 + 401 + 13 = 559 tests, 0 issues; live on-device tests ran.

Design: `docs/superpowers/specs/2026-06-17-c11-phase-c-test-suite-design.md` · Plan: `docs/superpowers/plans/2026-06-17-c11-phase-c-test-suite.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)