### PR TITLE
fix(test): skip e2e tests instead of failing when prerequisites are absent (#222)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,15 +36,23 @@ var packageTargets: [Target] = [
         path: "Sources/AnglesiteIntents",
         swiftSettings: strictConcurrency
     ),
+    // Test-only support shared across the test targets (e.g. the e2e prerequisite probes used by
+    // both AnglesiteCoreTests and AnglesiteBridgeTests). Not exposed as a `.library` product, so
+    // the app/xcodeproj never links it — only `swift test` builds it.
+    .target(
+        name: "AnglesiteTestSupport",
+        path: "Tests/AnglesiteTestSupport",
+        swiftSettings: strictConcurrency
+    ),
     .testTarget(
         name: "AnglesiteCoreTests",
-        dependencies: ["AnglesiteCore"],
+        dependencies: ["AnglesiteCore", "AnglesiteTestSupport"],
         path: "Tests/AnglesiteCoreTests",
         swiftSettings: strictConcurrency
     ),
     .testTarget(
         name: "AnglesiteBridgeTests",
-        dependencies: ["AnglesiteBridge"],
+        dependencies: ["AnglesiteBridge", "AnglesiteTestSupport"],
         path: "Tests/AnglesiteBridgeTests",
         swiftSettings: strictConcurrency
     )

--- a/Tests/AnglesiteBridgeTests/AppliesEditEndToEndTests.swift
+++ b/Tests/AnglesiteBridgeTests/AppliesEditEndToEndTests.swift
@@ -6,9 +6,9 @@ import AnglesiteCore
 /// End-to-end: spawn the *real* bundled plugin's MCP server, drive an `apply_edit` through a
 /// real `MCPClient` via `MCPApplyEditRouter`, and assert the file's bytes change on disk.
 ///
-/// Cancels cleanly when the sibling plugin checkout or its `node_modules` aren't present —
-/// CI provides them via the `ANGLESITE_PLUGIN_PATH` env var; local dev relies on the
-/// `../anglesite` sibling layout documented in CLAUDE.md.
+/// Skipped (via the `.enabled(if:)` trait) when the sibling plugin checkout, its `node_modules`,
+/// or a Node binary aren't present — CI provides them via the `ANGLESITE_PLUGIN_PATH` env var;
+/// local dev relies on the `../anglesite` sibling layout documented in CLAUDE.md.
 ///
 /// A `final class` (not a `struct`) so `deinit` can tear down the temp site, mirroring the
 /// former `tearDownWithError`.
@@ -23,9 +23,8 @@ final class AppliesEditEndToEndTests {
     // MARK: setup / teardown
 
     init() throws {
-        try Self.requireSiblingPlugin()
-        _ = try Self.requireNode()
-
+        // Prerequisites are gated by the test's `.enabled(if:)` trait, so this initializer only
+        // runs when the plugin checkout and Node are present — no need to re-probe here.
         tmpSite = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("anglesite-e2e-\(UUID().uuidString)", isDirectory: true)
         let pagesDir = tmpSite.appendingPathComponent("src/pages", isDirectory: true)
@@ -42,9 +41,16 @@ final class AppliesEditEndToEndTests {
 
     // MARK: the test
 
-    @Test("Apply edit end to end mutates the file on disk") func applyEditEndToEndMutatesTheFileOnDisk() async throws {
-        let pluginRoot = try Self.requireSiblingPlugin()
-        let node = try Self.requireNode()
+    @Test(
+        "Apply edit end to end mutates the file on disk",
+        .enabled(
+            if: AppliesEditEndToEndTests.prerequisitesMet,
+            "requires the sibling Anglesite plugin checkout (ANGLESITE_PLUGIN_PATH, or ../anglesite with node_modules) and a Node ≥22 binary"
+        )
+    )
+    func applyEditEndToEndMutatesTheFileOnDisk() async throws {
+        let pluginRoot = try #require(Self.locateSiblingPlugin())
+        let node = try #require(Self.locateNode())
         let serverPath = pluginRoot.appendingPathComponent("server/index.mjs")
 
         // Real MCPClient against the real bundled plugin server, scoped to our tmp site.
@@ -100,35 +106,33 @@ final class AppliesEditEndToEndTests {
 
     // MARK: prerequisite probing
 
-    /// Returns the path to the sibling Anglesite plugin checkout, or cancels the test if absent.
-    @discardableResult
-    private static func requireSiblingPlugin() throws -> URL {
-        // Priority: explicit env var (CI), then `../anglesite` relative to the test's CWD
-        // (which is the package root under `swift test`).
+    /// True when both the sibling plugin checkout (with its `node_modules`) and a Node binary are
+    /// present. Drives the `.enabled(if:)` trait so the test is reported as *skipped* rather than
+    /// *failed* when the e2e prerequisites are absent.
+    static var prerequisitesMet: Bool {
+        locateSiblingPlugin() != nil && locateNode() != nil
+    }
+
+    /// The sibling Anglesite plugin checkout (MCP server + `node_modules`), or `nil` if absent.
+    /// Priority: explicit `ANGLESITE_PLUGIN_PATH` (CI), then `../anglesite` relative to the test's
+    /// CWD (the package root under `swift test`).
+    static func locateSiblingPlugin() -> URL? {
         let env = ProcessInfo.processInfo.environment["ANGLESITE_PLUGIN_PATH"]
         let candidate: URL = {
             if let env, !env.isEmpty { return URL(fileURLWithPath: env, isDirectory: true) }
             let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
             return cwd.deletingLastPathComponent().appendingPathComponent("anglesite", isDirectory: true)
         }()
-        let serverPath = candidate.appendingPathComponent("server/index.mjs")
-        guard FileManager.default.isReadableFile(atPath: serverPath.path) else {
-            throw SkipReason(
-                "Anglesite plugin checkout not found at \(candidate.path)/server/index.mjs. Set ANGLESITE_PLUGIN_PATH or clone Anglesite/anglesite as a sibling."
-            )
-        }
-        let sdkPath = candidate.appendingPathComponent("node_modules/@modelcontextprotocol/sdk")
-        guard FileManager.default.fileExists(atPath: sdkPath.path) else {
-            throw SkipReason(
-                "Plugin's node_modules are missing — run `npm ci` in \(candidate.path)"
-            )
-        }
+        guard FileManager.default.isReadableFile(
+                atPath: candidate.appendingPathComponent("server/index.mjs").path),
+              FileManager.default.fileExists(
+                atPath: candidate.appendingPathComponent("node_modules/@modelcontextprotocol/sdk").path)
+        else { return nil }
         return candidate
     }
 
-    @discardableResult
-    private static func requireNode() throws -> URL {
-        // Explicit override (CI / nvm shells) wins.
+    /// A Node binary: `NODE_BINARY` override, then common install paths, then nvm-managed versions.
+    static func locateNode() -> URL? {
         if let override = ProcessInfo.processInfo.environment["NODE_BINARY"], !override.isEmpty,
            FileManager.default.isExecutableFile(atPath: override) {
             return URL(fileURLWithPath: override)
@@ -147,18 +151,7 @@ final class AppliesEditEndToEndTests {
                 .filter { FileManager.default.isExecutableFile(atPath: $0) }
                 .sorted())
         }
-        for p in candidates where FileManager.default.isExecutableFile(atPath: p) {
-            return URL(fileURLWithPath: p)
-        }
-        throw SkipReason("node not found; set NODE_BINARY, install Node ≥22 in a common path, or via nvm")
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+            .map { URL(fileURLWithPath: $0) }
     }
-}
-
-/// Carries a precondition-skip message in the test's `throws` channel. Swift 6.0's Swift Testing
-/// has no runtime `Test.cancel` API; throwing surfaces the reason in the failure output so a
-/// local dev sees why the test didn't run, while CI (which provides ANGLESITE_PLUGIN_PATH and a
-/// Node install) never hits these paths.
-private struct SkipReason: Error, CustomStringConvertible {
-    let description: String
-    init(_ description: String) { self.description = description }
 }

--- a/Tests/AnglesiteBridgeTests/AppliesEditEndToEndTests.swift
+++ b/Tests/AnglesiteBridgeTests/AppliesEditEndToEndTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import AnglesiteBridge
 import AnglesiteCore
+import AnglesiteTestSupport
 
 /// End-to-end: spawn the *real* bundled plugin's MCP server, drive an `apply_edit` through a
 /// real `MCPClient` via `MCPApplyEditRouter`, and assert the file's bytes change on disk.
@@ -44,13 +45,13 @@ final class AppliesEditEndToEndTests {
     @Test(
         "Apply edit end to end mutates the file on disk",
         .enabled(
-            if: AppliesEditEndToEndTests.prerequisitesMet,
+            if: E2EPrerequisites.prerequisitesMet,
             "requires the sibling Anglesite plugin checkout (ANGLESITE_PLUGIN_PATH, or ../anglesite with node_modules) and a Node ≥22 binary"
         )
     )
     func applyEditEndToEndMutatesTheFileOnDisk() async throws {
-        let pluginRoot = try #require(Self.locateSiblingPlugin())
-        let node = try #require(Self.locateNode())
+        let pluginRoot = try #require(E2EPrerequisites.locateSiblingPlugin())
+        let node = try #require(E2EPrerequisites.locateNode())
         let serverPath = pluginRoot.appendingPathComponent("server/index.mjs")
 
         // Real MCPClient against the real bundled plugin server, scoped to our tmp site.
@@ -102,56 +103,5 @@ final class AppliesEditEndToEndTests {
         #expect(after.contains("Welcome to the new headline"), "new heading should be present")
 
         await mcp.stop()
-    }
-
-    // MARK: prerequisite probing
-
-    /// True when both the sibling plugin checkout (with its `node_modules`) and a Node binary are
-    /// present. Drives the `.enabled(if:)` trait so the test is reported as *skipped* rather than
-    /// *failed* when the e2e prerequisites are absent.
-    static var prerequisitesMet: Bool {
-        locateSiblingPlugin() != nil && locateNode() != nil
-    }
-
-    /// The sibling Anglesite plugin checkout (MCP server + `node_modules`), or `nil` if absent.
-    /// Priority: explicit `ANGLESITE_PLUGIN_PATH` (CI), then `../anglesite` relative to the test's
-    /// CWD (the package root under `swift test`).
-    static func locateSiblingPlugin() -> URL? {
-        let env = ProcessInfo.processInfo.environment["ANGLESITE_PLUGIN_PATH"]
-        let candidate: URL = {
-            if let env, !env.isEmpty { return URL(fileURLWithPath: env, isDirectory: true) }
-            let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            return cwd.deletingLastPathComponent().appendingPathComponent("anglesite", isDirectory: true)
-        }()
-        guard FileManager.default.isReadableFile(
-                atPath: candidate.appendingPathComponent("server/index.mjs").path),
-              FileManager.default.fileExists(
-                atPath: candidate.appendingPathComponent("node_modules/@modelcontextprotocol/sdk").path)
-        else { return nil }
-        return candidate
-    }
-
-    /// A Node binary: `NODE_BINARY` override, then common install paths, then nvm-managed versions.
-    static func locateNode() -> URL? {
-        if let override = ProcessInfo.processInfo.environment["NODE_BINARY"], !override.isEmpty,
-           FileManager.default.isExecutableFile(atPath: override) {
-            return URL(fileURLWithPath: override)
-        }
-        var candidates = [
-            "/opt/homebrew/bin/node",
-            "/usr/local/bin/node",
-            "/usr/bin/node",
-        ]
-        // nvm-managed installs live under ~/.nvm/versions/node/<version>/bin/node and aren't on
-        // any of the common paths; add whatever versions are present.
-        let nvmDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".nvm/versions/node")
-        if let versions = try? FileManager.default.contentsOfDirectory(at: nvmDir, includingPropertiesForKeys: nil) {
-            candidates.append(contentsOf: versions
-                .map { $0.appendingPathComponent("bin/node").path }
-                .filter { FileManager.default.isExecutableFile(atPath: $0) }
-                .sorted())
-        }
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
-            .map { URL(fileURLWithPath: $0) }
     }
 }

--- a/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
@@ -7,14 +7,21 @@ import Darwin
 /// `MCPClient.connect(httpEndpoint:)` against it. Asserts `tools/list` includes `list_annotations`
 /// and that calling it on an empty project returns `[]`.
 ///
-/// Skips (throws `SkipReason`) when the sibling plugin checkout / its node_modules / Node aren't
-/// present. Resolve the plugin via `ANGLESITE_PLUGIN_PATH` (default `../anglesite`); resolve Node via
-/// `NODE_BINARY`, common paths, or `~/.nvm/versions/node/*/bin/node`.
+/// Skipped (via the `.enabled(if:)` trait) when the sibling plugin checkout / its node_modules /
+/// Node aren't present. Resolve the plugin via `ANGLESITE_PLUGIN_PATH` (default `../anglesite`);
+/// resolve Node via `NODE_BINARY`, common paths, or `~/.nvm/versions/node/*/bin/node`.
 @Suite(.serialized)  // serial subprocess spawns — see MCPClientTests rationale (CI-flakiness fix)
 struct MCPClientHTTPEndToEndTests {
-    @Test("HTTP end-to-end: connect, list tools, call list_annotations") func httpEndToEnd() async throws {
-        let pluginRoot = try Self.requireSiblingPlugin()
-        let node = try Self.requireNode()
+    @Test(
+        "HTTP end-to-end: connect, list tools, call list_annotations",
+        .enabled(
+            if: MCPClientHTTPEndToEndTests.prerequisitesMet,
+            "requires the sibling Anglesite plugin checkout (ANGLESITE_PLUGIN_PATH, or ../anglesite with node_modules) and a Node ≥22 binary"
+        )
+    )
+    func httpEndToEnd() async throws {
+        let pluginRoot = try #require(Self.locateSiblingPlugin())
+        let node = try #require(Self.locateNode())
         let serverPath = pluginRoot.appendingPathComponent("server/index.mjs")
         let port = try Self.freePort()
 
@@ -67,27 +74,29 @@ struct MCPClientHTTPEndToEndTests {
 
     // MARK: prerequisite probing (mirrors AppliesEditEndToEndTests)
 
-    @discardableResult
-    private static func requireSiblingPlugin() throws -> URL {
+    /// True when both the sibling plugin checkout (with its `node_modules`) and a Node binary are
+    /// present. Drives the `.enabled(if:)` trait so the test is reported as *skipped* rather than
+    /// *failed* when the e2e prerequisites are absent.
+    static var prerequisitesMet: Bool {
+        locateSiblingPlugin() != nil && locateNode() != nil
+    }
+
+    static func locateSiblingPlugin() -> URL? {
         let env = ProcessInfo.processInfo.environment["ANGLESITE_PLUGIN_PATH"]
         let candidate: URL = {
             if let env, !env.isEmpty { return URL(fileURLWithPath: env, isDirectory: true) }
             let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
             return cwd.deletingLastPathComponent().appendingPathComponent("anglesite", isDirectory: true)
         }()
-        let serverPath = candidate.appendingPathComponent("server/index.mjs")
-        guard FileManager.default.isReadableFile(atPath: serverPath.path) else {
-            throw SkipReason("Anglesite plugin checkout not found at \(candidate.path)/server/index.mjs. Set ANGLESITE_PLUGIN_PATH or clone Anglesite/anglesite as a sibling.")
-        }
-        let sdkPath = candidate.appendingPathComponent("node_modules/@modelcontextprotocol/sdk")
-        guard FileManager.default.fileExists(atPath: sdkPath.path) else {
-            throw SkipReason("Plugin's node_modules are missing — run `npm ci` in \(candidate.path)")
-        }
+        guard FileManager.default.isReadableFile(
+                atPath: candidate.appendingPathComponent("server/index.mjs").path),
+              FileManager.default.fileExists(
+                atPath: candidate.appendingPathComponent("node_modules/@modelcontextprotocol/sdk").path)
+        else { return nil }
         return candidate
     }
 
-    @discardableResult
-    private static func requireNode() throws -> URL {
+    static func locateNode() -> URL? {
         if let override = ProcessInfo.processInfo.environment["NODE_BINARY"], !override.isEmpty,
            FileManager.default.isExecutableFile(atPath: override) {
             return URL(fileURLWithPath: override)
@@ -101,15 +110,13 @@ struct MCPClientHTTPEndToEndTests {
                 .sorted()
             candidates.append(contentsOf: nvmNodes)
         }
-        for p in candidates where FileManager.default.isExecutableFile(atPath: p) {
-            return URL(fileURLWithPath: p)
-        }
-        throw SkipReason("node not found; set NODE_BINARY or install Node ≥22")
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+            .map { URL(fileURLWithPath: $0) }
     }
 
     private static func freePort() throws -> Int {
         let fd = socket(AF_INET, SOCK_STREAM, 0)
-        guard fd >= 0 else { throw SkipReason("socket() failed") }
+        guard fd >= 0 else { throw FreePortError("socket() failed: errno \(errno)") }
         defer { close(fd) }
         var addr = sockaddr_in()
         addr.sin_family = sa_family_t(AF_INET)
@@ -120,7 +127,7 @@ struct MCPClientHTTPEndToEndTests {
                 Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
-        guard bindOK == 0 else { throw SkipReason("bind() failed") }
+        guard bindOK == 0 else { throw FreePortError("bind() failed: errno \(errno)") }
         var len = socklen_t(MemoryLayout<sockaddr_in>.size)
         _ = withUnsafeMutablePointer(to: &addr) {
             $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { getsockname(fd, $0, &len) }
@@ -129,7 +136,9 @@ struct MCPClientHTTPEndToEndTests {
     }
 }
 
-private struct SkipReason: Error, CustomStringConvertible {
+/// A genuine failure while reserving a loopback port — distinct from a missing-prerequisite skip.
+/// Surfaced through the test's `throws` channel so Swift Testing records it as an issue.
+private struct FreePortError: Error, CustomStringConvertible {
     let description: String
     init(_ description: String) { self.description = description }
 }

--- a/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
@@ -114,9 +114,13 @@ struct MCPClientHTTPEndToEndTests {
             .map { URL(fileURLWithPath: $0) }
     }
 
+    // NB: do not interpolate `errno` into these messages. Reading `errno` links
+    // `libswift_DarwinFoundation1.dylib` (the macOS-27 SDK vends it through that overlay), which
+    // is absent on the macOS-15 CI runner — the whole test bundle then fails to `dlopen`. The bare
+    // syscall name is enough; socket()/bind() failing here is vanishingly rare.
     private static func freePort() throws -> Int {
         let fd = socket(AF_INET, SOCK_STREAM, 0)
-        guard fd >= 0 else { throw FreePortError("socket() failed: errno \(errno)") }
+        guard fd >= 0 else { throw FreePortError("socket() failed") }
         defer { close(fd) }
         var addr = sockaddr_in()
         addr.sin_family = sa_family_t(AF_INET)
@@ -127,7 +131,7 @@ struct MCPClientHTTPEndToEndTests {
                 Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
-        guard bindOK == 0 else { throw FreePortError("bind() failed: errno \(errno)") }
+        guard bindOK == 0 else { throw FreePortError("bind() failed") }
         var len = socklen_t(MemoryLayout<sockaddr_in>.size)
         _ = withUnsafeMutablePointer(to: &addr) {
             $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { getsockname(fd, $0, &len) }

--- a/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 import Darwin
 @testable import AnglesiteCore
+import AnglesiteTestSupport
 
 /// End-to-end: spawn the real plugin MCP server in HTTP mode on a free port, then drive the real
 /// `MCPClient.connect(httpEndpoint:)` against it. Asserts `tools/list` includes `list_annotations`
@@ -15,13 +16,13 @@ struct MCPClientHTTPEndToEndTests {
     @Test(
         "HTTP end-to-end: connect, list tools, call list_annotations",
         .enabled(
-            if: MCPClientHTTPEndToEndTests.prerequisitesMet,
+            if: E2EPrerequisites.prerequisitesMet,
             "requires the sibling Anglesite plugin checkout (ANGLESITE_PLUGIN_PATH, or ../anglesite with node_modules) and a Node ≥22 binary"
         )
     )
     func httpEndToEnd() async throws {
-        let pluginRoot = try #require(Self.locateSiblingPlugin())
-        let node = try #require(Self.locateNode())
+        let pluginRoot = try #require(E2EPrerequisites.locateSiblingPlugin())
+        let node = try #require(E2EPrerequisites.locateNode())
         let serverPath = pluginRoot.appendingPathComponent("server/index.mjs")
         let port = try Self.freePort()
 
@@ -72,47 +73,8 @@ struct MCPClientHTTPEndToEndTests {
         #expect(result.content.first?.text == "[]")
     }
 
-    // MARK: prerequisite probing (mirrors AppliesEditEndToEndTests)
-
-    /// True when both the sibling plugin checkout (with its `node_modules`) and a Node binary are
-    /// present. Drives the `.enabled(if:)` trait so the test is reported as *skipped* rather than
-    /// *failed* when the e2e prerequisites are absent.
-    static var prerequisitesMet: Bool {
-        locateSiblingPlugin() != nil && locateNode() != nil
-    }
-
-    static func locateSiblingPlugin() -> URL? {
-        let env = ProcessInfo.processInfo.environment["ANGLESITE_PLUGIN_PATH"]
-        let candidate: URL = {
-            if let env, !env.isEmpty { return URL(fileURLWithPath: env, isDirectory: true) }
-            let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            return cwd.deletingLastPathComponent().appendingPathComponent("anglesite", isDirectory: true)
-        }()
-        guard FileManager.default.isReadableFile(
-                atPath: candidate.appendingPathComponent("server/index.mjs").path),
-              FileManager.default.fileExists(
-                atPath: candidate.appendingPathComponent("node_modules/@modelcontextprotocol/sdk").path)
-        else { return nil }
-        return candidate
-    }
-
-    static func locateNode() -> URL? {
-        if let override = ProcessInfo.processInfo.environment["NODE_BINARY"], !override.isEmpty,
-           FileManager.default.isExecutableFile(atPath: override) {
-            return URL(fileURLWithPath: override)
-        }
-        var candidates = ["/opt/homebrew/bin/node", "/usr/local/bin/node", "/usr/bin/node"]
-        let nvmDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".nvm/versions/node")
-        if let versions = try? FileManager.default.contentsOfDirectory(at: nvmDir, includingPropertiesForKeys: nil) {
-            let nvmNodes = versions
-                .map { $0.appendingPathComponent("bin/node").path }
-                .filter { FileManager.default.isExecutableFile(atPath: $0) }
-                .sorted()
-            candidates.append(contentsOf: nvmNodes)
-        }
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
-            .map { URL(fileURLWithPath: $0) }
-    }
+    // MARK: free-port probing
+    // (plugin / Node prerequisites live in `E2EPrerequisites`, shared with AppliesEditEndToEndTests)
 
     // NB: do not interpolate `errno` into these messages. Reading `errno` links
     // `libswift_DarwinFoundation1.dylib` (the macOS-27 SDK vends it through that overlay), which

--- a/Tests/AnglesiteTestSupport/E2EPrerequisites.swift
+++ b/Tests/AnglesiteTestSupport/E2EPrerequisites.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Shared prerequisite probing for the MCP / apply-edit end-to-end tests, which live in two
+/// different test targets (`AnglesiteCoreTests`, `AnglesiteBridgeTests`). Both drive their
+/// `@Test(.enabled(if:))` traits off `prerequisitesMet` so a missing plugin checkout or Node
+/// binary yields a *skipped* result instead of a failure.
+///
+/// Kept in a tiny support target (rather than copy-pasted) so the plugin layout / Node-discovery
+/// logic only has to change in one place.
+public enum E2EPrerequisites {
+    /// True when both the sibling plugin checkout (with its `node_modules`) and a Node binary are
+    /// present — i.e. the e2e tests can actually run.
+    public static var prerequisitesMet: Bool {
+        locateSiblingPlugin() != nil && locateNode() != nil
+    }
+
+    /// The sibling Anglesite plugin checkout (MCP server + `node_modules`), or `nil` if absent.
+    /// Priority: explicit `ANGLESITE_PLUGIN_PATH` (CI), then `../anglesite` relative to the test's
+    /// CWD (the package root under `swift test`).
+    public static func locateSiblingPlugin() -> URL? {
+        let env = ProcessInfo.processInfo.environment["ANGLESITE_PLUGIN_PATH"]
+        let candidate: URL = {
+            if let env, !env.isEmpty { return URL(fileURLWithPath: env, isDirectory: true) }
+            let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            return cwd.deletingLastPathComponent().appendingPathComponent("anglesite", isDirectory: true)
+        }()
+        guard FileManager.default.isReadableFile(
+                atPath: candidate.appendingPathComponent("server/index.mjs").path),
+              FileManager.default.fileExists(
+                atPath: candidate.appendingPathComponent("node_modules/@modelcontextprotocol/sdk").path)
+        else { return nil }
+        return candidate
+    }
+
+    /// A Node binary: `NODE_BINARY` override, then common install paths, then nvm-managed versions.
+    public static func locateNode() -> URL? {
+        if let override = ProcessInfo.processInfo.environment["NODE_BINARY"], !override.isEmpty,
+           FileManager.default.isExecutableFile(atPath: override) {
+            return URL(fileURLWithPath: override)
+        }
+        var candidates = [
+            "/opt/homebrew/bin/node",
+            "/usr/local/bin/node",
+            "/usr/bin/node",
+        ]
+        // nvm-managed installs live under ~/.nvm/versions/node/<version>/bin/node and aren't on
+        // any of the common paths; add whatever versions are present.
+        let nvmDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".nvm/versions/node")
+        if let versions = try? FileManager.default.contentsOfDirectory(at: nvmDir, includingPropertiesForKeys: nil) {
+            candidates.append(contentsOf: versions
+                .map { $0.appendingPathComponent("bin/node").path }
+                .filter { FileManager.default.isExecutableFile(atPath: $0) }
+                .sorted())
+        }
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+            .map { URL(fileURLWithPath: $0) }
+    }
+}


### PR DESCRIPTION
Closes #222.

## Problem

`AppliesEditEndToEndTests` and `MCPClientHTTPEndToEndTests` `throw` a private `SkipReason: Error` from their prerequisite probes to "skip" when the sibling plugin checkout, its `node_modules`, or a Node binary are missing. But **Swift Testing has no throw-to-skip convention** (unlike XCTest's `XCTSkip`) — a thrown error is recorded as an *issue*. So these read like skips but behave as failures: a `swift test` without `ANGLESITE_PLUGIN_PATH` set reports two red tests that are really just "prerequisites absent." The author's own comment acknowledged it: *"Swift 6.0's Swift Testing has no runtime `Test.cancel` API."*

## Fix

Use Swift Testing's pre-execution `.enabled(if:)` condition trait, which produces a genuine *skipped* result:

- `static var prerequisitesMet: Bool` backed by non-throwing `locateSiblingPlugin()` / `locateNode()` (`-> URL?`).
- `@Test(.enabled(if: prerequisitesMet, "<reason>"))` — a missing prereq now yields a real skip with the reason in the output.
- `try #require(...)` in the body to unwrap the located paths (gated by the trait, so never nil in practice).
- Dropped the redundant prereq guards from `AppliesEditEndToEndTests.init` — when the trait disables the test, the suite instance is never created.
- Removed both duplicated `SkipReason` structs. `freePort()`'s `socket()`/`bind()` failures are genuine errors (not skips), so they now throw a dedicated `FreePortError` that correctly surfaces as a test issue.

## Verification

| Condition | Before | After |
|---|---|---|
| No `ANGLESITE_PLUGIN_PATH` (prereqs absent) | ❌ 2 failures | ✅ 2 **skipped**, run passes |
| `ANGLESITE_PLUGIN_PATH` set (prereqs present) | runs | runs |

```
# prereqs absent:
✓ Test "HTTP end-to-end: …" skipped: "requires the sibling Anglesite plugin checkout …"
✓ Test "Apply edit end to end mutates the file on disk" skipped: "requires …"
  Test run … passed
```

With prereqs present the tests execute; the residual `.sessionLost` / `.reconnecting` they hit locally is the **separate, pre-existing MCP server-lifecycle flake** (passes in a clean CI run per #219), not introduced here — and it now fails at the `@Test` body, not the prereq probe, confirming the skip/fail paths are cleanly separated.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)