### PR TITLE
feat(intents): D.1 — Intent MCP readiness audit + safe adjustments (#162)

### DIFF
--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -24,7 +24,10 @@ public struct SearchContentIntent: AppIntent {
     public static let description = IntentDescription("Search a site's pages, posts, and images.")
 
     @Parameter(title: "Site") public var site: SiteEntity
-    @Parameter(title: "Search") public var query: String
+    @Parameter(
+        title: "Search",
+        description: "Words to match against page titles, post titles, slugs, tags, and image filenames."
+    ) public var query: String
     @Dependency private var graph: SiteContentGraph
 
     public init() {}
@@ -112,8 +115,14 @@ public struct AddPageIntent: AppIntent {
     public static let description = IntentDescription("Scaffold a new page on a site with Anglesite.")
 
     @Parameter(title: "Site") public var site: SiteEntity
-    @Parameter(title: "Name") public var name: String
-    @Parameter(title: "Route") public var route: String?
+    @Parameter(
+        title: "Name",
+        description: "The page title, e.g. “About” or “Contact”."
+    ) public var name: String
+    @Parameter(
+        title: "Route",
+        description: "Optional URL path relative to the site root, e.g. “/about”. Derived from the name when omitted."
+    ) public var route: String?
     @Dependency private var content: any ContentOperationsService
 
     public init() {}
@@ -151,9 +160,18 @@ public struct AddPostIntent: AppIntent {
     public static let description = IntentDescription("Scaffold a new draft post on a site with Anglesite.")
 
     @Parameter(title: "Site") public var site: SiteEntity
-    @Parameter(title: "Title") public var title2: String
-    @Parameter(title: "Collection") public var collection: String?
-    @Parameter(title: "Slug") public var slug: String?
+    @Parameter(
+        title: "Title",
+        description: "The post title."
+    ) public var title2: String
+    @Parameter(
+        title: "Collection",
+        description: "Optional content collection to add the post to, e.g. “blog”. Uses the site default when omitted."
+    ) public var collection: String?
+    @Parameter(
+        title: "Slug",
+        description: "Optional URL slug for the post, e.g. “my-first-post”. Derived from the title when omitted."
+    ) public var slug: String?
     @Dependency private var content: any ContentOperationsService
 
     public init() {}

--- a/Sources/AnglesiteIntents/EditContentIntent.swift
+++ b/Sources/AnglesiteIntents/EditContentIntent.swift
@@ -41,7 +41,10 @@ public struct EditContentIntent: AppIntent {
     )
 
     @Parameter(title: "Element") public var element: ElementEntity
-    @Parameter(title: "Change") public var instruction: String
+    @Parameter(
+        title: "Change",
+        description: "A natural-language description of the change to apply, e.g. “make it bigger” or “change the color to teal”."
+    ) public var instruction: String
     @Dependency private var bridge: IntentEditBridge
 
     public init() {}

--- a/Sources/AnglesiteIntents/SiteIntents.swift
+++ b/Sources/AnglesiteIntents/SiteIntents.swift
@@ -25,7 +25,9 @@ public struct DeploySiteIntent: AppIntent {
 
     public static var parameterSummary: some ParameterSummary { Summary("Deploy \(\.$site)") }
 
-    public func perform() async throws -> some IntentResult & ProvidesDialog {
+    // Returns the site as a value (like AuditSiteIntent) so an agent/Shortcut can chain
+    // deploy→backup or audit→deploy→backup. The MCP bridge surfaces this as a typed output.
+    public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<SiteEntity> {
         let scoped = SiteOperationsOverride.scoped
         let ops: any SiteOperationsService
         if let scoped {
@@ -41,7 +43,7 @@ public struct DeploySiteIntent: AppIntent {
             ops = self.ops
         }
         guard let resolved = await ops.site(id: site.id) else {
-            return .result(dialog: "Couldn't find \(site.displayName).")
+            return .result(value: site, dialog: "Couldn't find \(site.displayName).")
         }
         // Deploys (build + wrangler) routinely exceed the default budget. On Xcode 27 we run via
         // `performBackgroundTask(onCancel:)` so the system can offer Cancel and we get extended
@@ -59,7 +61,7 @@ public struct DeploySiteIntent: AppIntent {
             result = await ops.deploy(site: resolved)
             #endif
         }
-        return .result(dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forDeploy: result)))
+        return .result(value: site, dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forDeploy: result)))
     }
 }
 
@@ -74,11 +76,13 @@ public struct BackupSiteIntent: AppIntent {
 
     public static var parameterSummary: some ParameterSummary { Summary("Back up \(\.$site)") }
 
-    public func perform() async throws -> some IntentResult & ProvidesDialog {
+    // Returns the site as a value (like Audit/Deploy) so an agent/Shortcut can chain backup
+    // into a follow-up site operation. The MCP bridge surfaces this as a typed output.
+    public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<SiteEntity> {
         let scoped = SiteOperationsOverride.scoped
         let ops = scoped ?? self.ops
         guard let resolved = await ops.site(id: site.id) else {
-            return .result(dialog: "Couldn't find \(site.displayName).")
+            return .result(value: site, dialog: "Couldn't find \(site.displayName).")
         }
         // git push on a slow connection or large repo can exceed the default budget. Same
         // long-running + cancellable adoption as deploy/audit on Xcode 27; fallback on 26.3.
@@ -94,7 +98,7 @@ public struct BackupSiteIntent: AppIntent {
             result = await ops.backup(site: resolved)
             #endif
         }
-        return .result(dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forBackup: result)))
+        return .result(value: site, dialog: IntentDialog(stringLiteral: SiteOperations.dialog(forBackup: result)))
     }
 }
 

--- a/Tests/AnglesiteIntentsTests/IntentChainingTests.swift
+++ b/Tests/AnglesiteIntentsTests/IntentChainingTests.swift
@@ -36,5 +36,30 @@ extension AppIntentsTests {
             #expect(fake.deployCalls.count == 1)
             #expect(fake.auditCalls.first?.id == fake.deployCalls.first?.id)
         }
+
+        // D.1 (#162): DeploySiteIntent and BackupSiteIntent now return the SiteEntity they
+        // processed (ReturnsValue<SiteEntity>), mirroring AuditSiteIntent, so an agent/Shortcut
+        // can pipe deploy→backup. Reproduce that wiring by feeding the same SiteEntity into both.
+        @Test("deploy output flows into backup as input")
+        func deployOutputFlowsIntoBackup() async throws {
+            let fake = FakeOperations()
+            let site = TestStore.site(id: "s1", name: "Portfolio")
+            fake.sites = [site.id: site]
+            fake.deployResult = .succeeded(url: URL(string: "https://example.com")!, duration: 1)
+            fake.backupResult = .succeeded(commitSHA: "abc1234", branch: "main", remote: "origin")
+
+            try await SiteOperationsOverride.$scoped.withValue(fake) {
+                var deploy = DeploySiteIntent()
+                deploy.site = SiteEntity(site)
+                _ = try await deploy.perform()
+
+                var backup = BackupSiteIntent()
+                backup.site = SiteEntity(site)
+                _ = try await backup.perform()
+            }
+            #expect(fake.deployCalls.count == 1)
+            #expect(fake.backupCalls.count == 1)
+            #expect(fake.deployCalls.first?.id == fake.backupCalls.first?.id)
+        }
     }
 }

--- a/docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md
+++ b/docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md
@@ -1,0 +1,153 @@
+# D.1 — Intent MCP Readiness Audit
+
+**Issue:** [#162](https://github.com/Anglesite/Anglesite-app/issues/162) (parent [#135](https://github.com/Anglesite/Anglesite-app/issues/135), Phase D — System-wide MCP exposure)
+**Date:** 2026-06-17
+**Spec:** [`docs/superpowers/specs/2026-06-11-siri-ai-integration-design.md`](../superpowers/specs/2026-06-11-siri-ai-integration-design.md) — Phase D
+
+## Why this audit exists
+
+macOS 27 exposes App Intents to external agents (Claude Code CLI, Xcode agents, other
+MCP-aware apps) via the platform `mcpbridge` over XPC. Apple's bridge **auto-derives MCP
+tool schemas from the App Intent / `AppEntity` schema metadata** — `@Parameter`
+titles/descriptions, `@Property`-annotated entity fields, and `ReturnsValue<T>` return
+types. Anything carried only in code (a plain `let`, a `displayRepresentation` subtitle
+string) is invisible to that derivation.
+
+So MCP-readiness is not about adding an MCP layer — it's about making sure the *existing*
+intent/entity schema is rich enough that the auto-derived tools are usable by an agent
+that has no human in the loop to read dialog strings.
+
+## Inventory
+
+| Intent | Module | Params | Returns | `ReturnsValue`? |
+|---|---|---|---|---|
+| `DeploySiteIntent` | `SiteIntents` | `site` | dialog | ✗ |
+| `BackupSiteIntent` | `SiteIntents` | `site` | dialog | ✗ |
+| `AuditSiteIntent` | `SiteIntents` | `site` | dialog + value | ✓ `SiteEntity` |
+| `OpenSiteIntent` | `SiteIntents` | `target` | dialog | ✗ (terminal — opens UI) |
+| `SearchContentIntent` | `ContentIntents` | `site`, `query` | dialog | ✗ |
+| `SiteStatusIntent` | `ContentIntents` | `site` | dialog | ✗ |
+| `PreviewSiteIntent` | `ContentIntents` | `site`, `page?` | dialog | ✗ (terminal — opens UI) |
+| `AddPageIntent` | `ContentIntents` | `site`, `name`, `route?` | dialog | ✗ |
+| `AddPostIntent` | `ContentIntents` | `site`, `title`, `collection?`, `slug?` | dialog | ✗ |
+| `EditContentIntent` | `EditContentIntent` | `element`, `instruction` | dialog | ✗ |
+
+| Entity | Disambiguating field (in `displayRepresentation`) | Carried as `@Property`? |
+|---|---|---|
+| `SiteEntity` | `directory.path` (subtitle) | ✗ (plain `let`) |
+| `PageEntity` | `route` (subtitle) | ✗ |
+| `PostEntity` | `collection/slug (+draft)` (subtitle) | ✗ |
+| `ImageEntity` | `relativePath` (subtitle) | ✗ |
+| `ElementEntity` | `pagePath` (subtitle) | ✗ |
+
+## Findings against the #162 checklist
+
+### 1. Every intent parameter has a clear `title` and type annotation — **PASS, with a gap**
+
+Every `@Parameter` has a `title` and a concrete type. ✓
+
+**Gap:** no parameter carries a `description:`. For entity parameters the entity's
+`typeDisplayRepresentation` supplies enough context, but the **free-form `String`
+parameters** (`query`, `instruction`, `name`, `route`, `title`, `collection`, `slug`)
+derive a thin MCP schema — an agent sees `"Route"` with no hint that it means a
+URL-path-relative slug like `/about`. These deserve a `description:` so the derived MCP
+tool input schema is self-documenting.
+
+→ **Action (this PR): add `@Parameter(description:)` to the free-form string params.**
+
+### 2. Entity `displayRepresentation` sufficient for programmatic disambiguation — **PASS for display, GAP for chaining**
+
+Every entity's `displayRepresentation` carries a disambiguating subtitle beyond the
+display name (`route`, `relativePath`, `collection/slug`, `pagePath`, directory path). So
+a human or an agent reading the rendered representation *can* tell two same-named entities
+apart. ✓
+
+**Gap:** those fields exist only as plain `let`s and as a formatted subtitle **string**.
+An agent cannot extract `route` as a *typed value* to pipe into the next tool call (e.g.
+"find the page → preview that page's route"). To make a field programmatically
+chainable it must be promoted to `@Property`, which adds it to the entity's derived
+schema.
+
+This was a **deliberate** prior choice: `ImageEntity` documents keeping `usedOnPages` out
+of the schema specifically to avoid "a source-breaking `AppEntity` schema change for
+Shortcuts persistence / donated interactions." Promoting fields to `@Property` is
+therefore a schema decision, **not** a "small adjustment," and is scoped as a follow-up
+rather than folded into this audit pass.
+
+→ **Action (follow-up, see below): promote `route` / `relativePath` / `slug` /
+`collection` / `siteID` to `@Property`.**
+
+### 3. Return values use `ReturnsValue<T>` where possible — **PARTIAL**
+
+Only `AuditSiteIntent` returns a value (`SiteEntity`, enabling the audit→deploy chain from
+#90). Every other intent returns dialog only, so an agent can't act on results.
+
+- **`DeploySiteIntent`, `BackupSiteIntent`** — operate on a site and currently return
+  nothing chainable. Mirroring `AuditSiteIntent` (`ReturnsValue<SiteEntity>`) lets an
+  agent build deploy→backup / audit→deploy→backup chains. **Low-risk, additive** — the
+  existing tests discard `perform()`'s result and assert on the injected fake's call log,
+  so the return-type change does not churn them.
+  → **Action (this PR).**
+- **`SearchContentIntent`** — returns a spoken count only. An agent searching for content
+  gets no entities back to act on. Should return the matched `PageEntity` / `PostEntity` /
+  `ImageEntity` set. This is a **structural** change (the intent searches three entity
+  types and currently only counts them), so it is scoped as a follow-up.
+  → **Action (follow-up).**
+- **`AddPageIntent`, `AddPostIntent`** — create content but return only a dialog. An agent
+  can't chain "create a page → preview it." Should return the created entity (or at least
+  its identifier/route). The create path returns a `ContentCreateResult`; surfacing the
+  created entity needs a small amount of plumbing, scoped as a follow-up.
+  → **Action (follow-up).**
+- **`OpenSiteIntent`, `PreviewSiteIntent`** — terminal UI actions; dialog-only is correct.
+
+### 4. `parameterSummary` descriptive enough for a useful MCP tool description — **PASS**
+
+Each intent pairs a `Summary(...)` with an `IntentDescription` (e.g. "Search a site's
+pages, posts, and images."). The `IntentDescription` is the natural source for the
+derived MCP tool description and is adequate across the board. No change needed; the
+`@Parameter(description:)` additions in finding 1 improve the *input-schema* half that the
+summaries don't cover.
+
+### 5. Entity queries handle edge cases an agent would hit — **PASS, one inconsistency**
+
+- `PageEntityQuery` / `PostEntityQuery` / `ImageEntityQuery`: guard empty/whitespace query
+  → `[]` (avoids doubling up with `suggestedEntities()` during disambiguation prefetch);
+  resolve unknown ids by skipping; deterministic sort. ✓
+- Ambiguous name match: queries return arrays → AppIntents disambiguates; an MCP agent
+  receives all candidates. ✓
+- **Inconsistency:** `SiteEntityQuery.entities(matching:)` does **not** guard the empty
+  string — `name.lowercased().contains("")` is always true, so an empty query returns
+  *all* sites. For `SiteEntity` (few entries) "list all" is arguably useful behavior, so
+  this is recorded as an observation, **not** changed — flipping it could alter existing
+  Siri/Shortcuts behavior. Noted for awareness.
+
+## Change set applied in this PR (D.1)
+
+1. `ReturnsValue<SiteEntity>` on `DeploySiteIntent` and `BackupSiteIntent` (all return
+   paths return `.result(value: site, dialog:)`), with a deploy→backup chaining test in
+   the established `IntentChainingTests` style (reconstruct the entity, assert both ops
+   saw the same site id).
+2. `@Parameter(description:)` on the free-form string parameters across the intents.
+
+Both are additive, schema-safe, and match the issue's "likely small parameter/return-type
+adjustments" framing.
+
+## Recommended follow-ups (scoped out of D.1)
+
+These are higher-value for full agent autonomy but are deliberate schema/structural
+changes, so they get their own reviewed change rather than riding in an "audit" PR. They
+fit naturally alongside **D.2 (#163 — custom MCP tool descriptors)**:
+
+- **F-1 `@Property` promotion.** Promote `route` (Page), `relativePath` (Image), `slug` +
+  `collection` (Post), and `siteID` (Page/Post/Image) to `@Property` so agents can extract
+  typed fields for chaining. Verify Shortcuts persistence of already-donated interactions
+  survives the schema bump.
+- **F-2 `SearchContentIntent` structured return.** Return matched entities (not just a
+  count) so an agent can search-then-act.
+- **F-3 `AddPage`/`AddPostIntent` structured return.** Return the created entity/identifier
+  so an agent can create-then-preview/deploy.
+
+These map directly onto the D.2 candidate tools (`anglesite_apply_edit`,
+`anglesite_list_content`): if Apple's bridge auto-derives well-shaped tools from the
+improved intents above, the custom descriptors in D.2 may be unnecessary — which is what
+this audit set out to determine.


### PR DESCRIPTION
## D.1 — Intent MCP Readiness Audit (#162, Phase D #135)

macOS 27's platform `mcpbridge` auto-derives MCP tool schemas from App Intent / `AppEntity` **schema metadata**. Anything carried only in code — a plain `let`, a `displayRepresentation` subtitle string — is invisible to an external agent (Claude Code CLI, Xcode agents). This audits the existing intents/entities for that and applies the small, schema-safe fixes the issue anticipated.

### Deliverable
- **Audit report:** `docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md` — full findings against all 5 checklist items across 10 intents + 5 entities.

### Findings
| Checklist item | Verdict |
|---|---|
| 1. Param `title` + type | ✅ Pass; gap: no `description:` on free-form strings → **fixed** |
| 2. Entity `displayRepresentation` disambiguation | ✅ Pass for display; fields not `@Property` → **follow-up F-1** |
| 3. `ReturnsValue<T>` for chaining | ⚠️ Partial — Deploy/Backup **fixed**; Search/Add* → **follow-up F-2/F-3** |
| 4. `parameterSummary` quality | ✅ Pass |
| 5. Query edge cases | ✅ Pass; noted `SiteEntityQuery` empty-string inconsistency (left as-is) |

### Applied here (small, schema-safe)
- `ReturnsValue<SiteEntity>` on `DeploySiteIntent` + `BackupSiteIntent` (mirroring `AuditSiteIntent`) → all three site-ops intents are agent-chainable (deploy→backup, audit→deploy→backup). Non-breaking: existing tests assert via the injected fake's call log, not the opaque result type. Added a deploy→backup chaining test.
- `@Parameter(description:)` on `query`, `name`, `route`, `title`, `collection`, `slug`, `instruction` → self-documenting auto-derived MCP input schemas.

### Scoped as follow-ups (deliberate schema/structural changes — fit alongside D.2 #163)
- **F-1:** promote entity payload fields (`route`/`relativePath`/`slug`/`collection`/`siteID`) to `@Property`. The code deliberately avoided this (`ImageEntity` schema-stability comment), so it warrants its own reviewed change.
- **F-2/F-3:** structured returns for `SearchContentIntent` and the create intents.

The audit also informs **D.2 (#163)**: if the bridge derives well-shaped tools from the improved intents, the custom `anglesite_apply_edit` / `anglesite_list_content` descriptors may be unnecessary — which is what D.1 set out to determine.

### Testing
- `AnglesiteIntents` suite: **146/146 pass** (incl. new chaining test + the Deploy/Backup tests now exercising the changed return paths).
- Full suite: only the known **#222** plugin-path e2e tests fail (`MCPClientHTTPEndToEndTests`, `AppliesEditEndToEndTests` — plugin checkout absent in worktree); unrelated to this change.

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)