### PR TITLE
feat(a11y): VoiceOver live-region announcements for chat + deploy (#216)

### DIFF
--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -47,6 +47,19 @@ final class ChatModel {
     var messages: [Message] { transcript.messages }
     private(set) var isStreaming: Bool = false
     private(set) var lastError: String?
+    /// True when the user cancelled the in-flight turn — so the VoiceOver stop announcement says
+    /// "stopped" rather than "complete". Set by ``cancel()``, cleared when a new turn begins.
+    private(set) var wasCancelledMidTurn = false
+
+    /// The terminal outcome of the just-ended turn, for VoiceOver's stop announcement. Derived from
+    /// the same observable state `ChatView` already binds: an in-band error wins, then an explicit
+    /// cancel, else the assistant's final reply text (spoken so a non-sighted user hears the answer).
+    var liveAnnouncementOutcome: LiveRegionAnnouncer.ChatTurnOutcome {
+        if let lastError { return .failed(reason: lastError) }
+        if wasCancelledMidTurn { return .cancelled }
+        let reply = messages.last(where: { $0.role == .assistant })?.content ?? ""
+        return .completed(reply: reply)
+    }
     /// Mirrors the last `turnComplete.usage` claude reported. `ChatView` shows this in the
     /// footer so the user can see token + cost telemetry without diving into the Debug pane.
     private(set) var lastUsage: TurnTelemetry?
@@ -208,6 +221,7 @@ final class ChatModel {
         guard !trimmed.isEmpty, !isStreaming else { return }
 
         lastError = nil
+        wasCancelledMidTurn = false
         // `beginTurn` appends the user prompt and an empty assistant row (which streamed events
         // extend), marks the latter in-flight, and returns the user row so we persist exactly it.
         let userMessage = transcript.beginTurn(userPrompt: trimmed)
@@ -289,6 +303,7 @@ final class ChatModel {
 
     /// Stops the in-flight turn. The current assistant message is marked finished as-is.
     func cancel() {
+        wasCancelledMidTurn = true
         streamTask?.cancel()
         Task { await assistant.cancel() }
     }

--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -118,6 +118,16 @@ struct ChatView: View {
                 // Stream characters extend the last message; re-anchor on each chunk.
                 proxy.scrollTo("__bottom__", anchor: .bottom)
             }
+            // VoiceOver live region: announce the *transitions* into and out of streaming, so a
+            // non-sighted user knows a response started/finished without watching tokens arrive.
+            // Keyed off `isStreaming` (not message content) so it fires twice per turn, never
+            // per-chunk — see `LiveRegionAnnouncer` for the anti-flooding rationale.
+            .onChange(of: model.isStreaming) { wasStreaming, isStreaming in
+                if let announcement = LiveRegionAnnouncer.chatStreamingAnnouncement(
+                    wasStreaming: wasStreaming, isStreaming: isStreaming) {
+                    AccessibilityNotification.Announcement(announcement).post()
+                }
+            }
         }
     }
 

--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -119,13 +119,20 @@ struct ChatView: View {
                 proxy.scrollTo("__bottom__", anchor: .bottom)
             }
             // VoiceOver live region: announce the *transitions* into and out of streaming, so a
-            // non-sighted user knows a response started/finished without watching tokens arrive.
-            // Keyed off `isStreaming` (not message content) so it fires twice per turn, never
-            // per-chunk — see `LiveRegionAnnouncer` for the anti-flooding rationale.
+            // non-sighted user knows a response started, and hears the answer when it finishes —
+            // without watching tokens arrive. Keyed off `isStreaming` (not message content) so it
+            // fires twice per turn, never per-chunk; the stop announcement speaks the actual reply
+            // (or the failure/cancel reason). See `LiveRegionAnnouncer` for the rationale.
             .onChange(of: model.isStreaming) { wasStreaming, isStreaming in
-                if let announcement = LiveRegionAnnouncer.chatStreamingAnnouncement(
+                guard AppSettings.shared.announcesLiveUpdates else { return }
+                if let start = LiveRegionAnnouncer.chatStartAnnouncement(
                     wasStreaming: wasStreaming, isStreaming: isStreaming) {
-                    AccessibilityNotification.Announcement(announcement).post()
+                    AccessibilityNotification.Announcement(start).post()
+                }
+                if let stop = LiveRegionAnnouncer.chatStopAnnouncement(
+                    wasStreaming: wasStreaming, isStreaming: isStreaming,
+                    outcome: model.liveAnnouncementOutcome) {
+                    AccessibilityNotification.Announcement(stop).post()
                 }
             }
         }

--- a/Sources/AnglesiteApp/DeployDrawerView.swift
+++ b/Sources/AnglesiteApp/DeployDrawerView.swift
@@ -130,6 +130,27 @@ struct DeployDrawerView: View {
                     }
                 }
             }
+            // VoiceOver live region: announce only the terminal transition (running → succeeded /
+            // failed), not every appended log line. A non-sighted user who has navigated away from
+            // the drawer hears the outcome; the streaming lines stay silent to keep speech usable.
+            .onChange(of: model.phase) { oldPhase, newPhase in
+                if let announcement = LiveRegionAnnouncer.deployAnnouncement(
+                    from: Self.activity(for: oldPhase), to: Self.activity(for: newPhase)) {
+                    AccessibilityNotification.Announcement(announcement).post()
+                }
+            }
+        }
+    }
+
+    /// Collapses the app-target `DeployModel.Phase` onto the announceable substrate the decider
+    /// understands. `idle` and `blocked` are both pre-output states → `.inactive`.
+    private static func activity(for phase: DeployModel.Phase) -> LiveRegionAnnouncer.DeployActivity {
+        switch phase {
+        case .running: return .running
+        case .succeeded(let url, _): return .succeeded(url: url.absoluteString)
+        case .failed(let reason, let exit):
+            return .failed(reason: exit.map { "\(reason) (exit \($0))" } ?? reason)
+        case .idle, .blocked: return .inactive
         }
     }
 

--- a/Sources/AnglesiteApp/DeployDrawerView.swift
+++ b/Sources/AnglesiteApp/DeployDrawerView.swift
@@ -130,23 +130,39 @@ struct DeployDrawerView: View {
                     }
                 }
             }
-            // VoiceOver live region: announce only the terminal transition (running → succeeded /
-            // failed), not every appended log line. A non-sighted user who has navigated away from
-            // the drawer hears the outcome; the streaming lines stay silent to keep speech usable.
+            // VoiceOver live region: announce the deploy start ("Deploying <site>") and the terminal
+            // transition (running → succeeded / failed), not every appended log line. A non-sighted
+            // user who has navigated away from the drawer hears start and outcome; the streaming
+            // lines stay silent to keep speech usable.
             .onChange(of: model.phase) { oldPhase, newPhase in
+                guard AppSettings.shared.announcesLiveUpdates else { return }
                 if let announcement = LiveRegionAnnouncer.deployAnnouncement(
-                    from: Self.activity(for: oldPhase), to: Self.activity(for: newPhase)) {
+                    from: activity(for: oldPhase), to: activity(for: newPhase)) {
+                    AccessibilityNotification.Announcement(announcement).post()
+                }
+            }
+            // The one mid-flight exception: warn *once* when the deploy first writes to stderr, so a
+            // failing deploy is flagged before its terminal state — without announcing every line.
+            .onChange(of: stderrLineCount) { previous, current in
+                guard AppSettings.shared.announcesLiveUpdates else { return }
+                if let announcement = LiveRegionAnnouncer.deployStderrAnnouncement(
+                    previousStderrCount: previous, currentStderrCount: current) {
                     AccessibilityNotification.Announcement(announcement).post()
                 }
             }
         }
     }
 
+    /// Number of stderr lines captured so far — drives the one-shot first-error warning.
+    private var stderrLineCount: Int {
+        model.logLines.lazy.filter { $0.stream == .stderr }.count
+    }
+
     /// Collapses the app-target `DeployModel.Phase` onto the announceable substrate the decider
     /// understands. `idle` and `blocked` are both pre-output states → `.inactive`.
-    private static func activity(for phase: DeployModel.Phase) -> LiveRegionAnnouncer.DeployActivity {
+    private func activity(for phase: DeployModel.Phase) -> LiveRegionAnnouncer.DeployActivity {
         switch phase {
-        case .running: return .running
+        case .running: return .running(site: siteName)
         case .succeeded(let url, _): return .succeeded(url: url.absoluteString)
         case .failed(let reason, let exit):
             return .failed(reason: exit.map { "\(reason) (exit \($0))" } ?? reason)

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -17,6 +17,7 @@ private struct AdvancedSettingsView: View {
     @AppStorage(AppSettings.Key.sitesRootOverride) private var sitesRootOverride: String = ""
     @AppStorage(AppSettings.Key.debugPaneEnabled) private var debugPaneEnabled: Bool = false
     @AppStorage(AppSettings.Key.autoGenerateAltText) private var autoGenerateAltText: Bool = true
+    @AppStorage(AppSettings.Key.announcesLiveUpdates) private var announcesLiveUpdates: Bool = true
 
     var body: some View {
         Form {
@@ -30,6 +31,13 @@ private struct AdvancedSettingsView: View {
             Section("Editing") {
                 Toggle("Auto-generate alt text for dropped images", isOn: $autoGenerateAltText)
                 Text("When you drop an image onto the preview, Anglesite uses Apple's on-device vision model to write descriptive alt text and applies it automatically. Runs locally; requires Apple Intelligence to be enabled. Purely decorative images get empty alt text and role=\"presentation\".")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Accessibility") {
+                Toggle("Announce live updates to VoiceOver", isOn: $announcesLiveUpdates)
+                Text("Speaks streaming chat responses (start, and the reply when it finishes) and deploy progress (start, errors, and the final result) as VoiceOver announcements. Turn off if you prefer to read these surfaces by navigating to them yourself.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -20,6 +20,7 @@ public final class AppSettings: @unchecked Sendable {
         public static let preferFoundationModels = "anglesite.preferFoundationModels"
         public static let foundationModelTier    = "anglesite.foundationModelTier"
         public static let autoGenerateAltText = "anglesite.autoGenerateAltText"
+        public static let announcesLiveUpdates = "anglesite.announcesLiveUpdates"
     }
 
     private let defaults: UserDefaults
@@ -112,6 +113,18 @@ public final class AppSettings: @unchecked Sendable {
             return defaults.bool(forKey: Key.autoGenerateAltText)
         }
         set { defaults.set(newValue, forKey: Key.autoGenerateAltText) }
+    }
+
+    /// Whether the app posts VoiceOver live-region announcements for streaming chat and deploy
+    /// state (`LiveRegionAnnouncer`). On by default; an assistive-technology user who finds the
+    /// spoken cues noisy can switch them off. Stored inverted-from-absent so an untouched install
+    /// defaults to `true`.
+    public var announcesLiveUpdates: Bool {
+        get {
+            guard defaults.object(forKey: Key.announcesLiveUpdates) != nil else { return true }
+            return defaults.bool(forKey: Key.announcesLiveUpdates)
+        }
+        set { defaults.set(newValue, forKey: Key.announcesLiveUpdates) }
     }
 
     /// The site that was most-recently focused. Used by the Sites launcher to auto-open

--- a/Sources/AnglesiteCore/LiveRegionAnnouncer.swift
+++ b/Sources/AnglesiteCore/LiveRegionAnnouncer.swift
@@ -6,8 +6,9 @@ import Foundation
 ///
 /// The single design rule that keeps VoiceOver usable is encoded in the signatures: announcements
 /// are a pure function of a *coarse state transition* (`isStreaming` flipping, a deploy reaching a
-/// terminal phase), never of a per-token or per-line append. There is no debounce timer because
-/// there is nothing to debounce — the view feeds transitions, and a non-transition returns `nil`.
+/// terminal phase, the first stderr line appearing), never of a per-token or per-line append. There
+/// is no debounce timer because there is nothing to debounce — the view feeds transitions, and a
+/// non-transition returns `nil`.
 ///
 /// The caller (the view) is responsible only for posting a returned string via
 /// `AccessibilityNotification.Announcement(_:).post()` from an `.onChange` hook.
@@ -15,15 +16,41 @@ public enum LiveRegionAnnouncer {
 
     // MARK: Chat streaming
 
-    /// The announcement for a chat streaming-state transition, or `nil` if nothing changed.
+    /// The announcement when a chat turn *starts* streaming, or `nil`.
     ///
-    /// Keyed off the `isStreaming` Bool flipping — start and stop only — so a response that streams
-    /// token-by-token produces exactly two announcements, not one per chunk.
-    public static func chatStreamingAnnouncement(wasStreaming: Bool, isStreaming: Bool) -> String? {
-        switch (wasStreaming, isStreaming) {
-        case (false, true): return "Assistant is responding"
-        case (true, false): return "Response complete"
-        default: return nil
+    /// Keyed off `isStreaming` going `false → true`, so a response that streams token-by-token
+    /// produces exactly one start announcement, not one per chunk.
+    public static func chatStartAnnouncement(wasStreaming: Bool, isStreaming: Bool) -> String? {
+        (!wasStreaming && isStreaming) ? "Assistant is responding" : nil
+    }
+
+    /// How a chat turn ended — the view derives this from the model's terminal state when streaming
+    /// stops. Distinguishing these is what lets the stop announcement *speak the answer* rather than
+    /// a content-free "complete", and avoids saying "complete" for a turn that actually failed or
+    /// was cancelled.
+    public enum ChatTurnOutcome: Equatable {
+        /// The assistant finished; `reply` is its final message text (may be empty for a no-op turn).
+        case completed(reply: String)
+        case failed(reason: String)
+        case cancelled
+    }
+
+    /// The announcement when a chat turn *stops*, or `nil` if this isn't a stop transition.
+    ///
+    /// On success the assistant's reply is spoken directly so a VoiceOver user actually hears the
+    /// answer (an empty reply falls back to a generic cue); failure and cancellation get their own
+    /// cues instead of a misleading "complete". Keyed off `isStreaming` going `true → false`.
+    public static func chatStopAnnouncement(wasStreaming: Bool, isStreaming: Bool,
+                                            outcome: ChatTurnOutcome) -> String? {
+        guard wasStreaming && !isStreaming else { return nil }
+        switch outcome {
+        case .completed(let reply):
+            let trimmed = reply.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? "Response complete" : trimmed
+        case .failed(let reason):
+            return "Response failed. \(reason)"
+        case .cancelled:
+            return "Response stopped"
         }
     }
 
@@ -34,23 +61,31 @@ public enum LiveRegionAnnouncer {
     /// announcement are modelled; `idle` and `blocked` both collapse to `inactive`.
     public enum DeployActivity: Equatable {
         case inactive
-        case running
+        case running(site: String)
         case succeeded(url: String)
         case failed(reason: String)
     }
 
     /// The announcement for a deploy phase transition, or `nil`.
     ///
-    /// Only *terminal* transitions speak — reaching `succeeded`/`failed` — because that is the moment
-    /// a VoiceOver user who has navigated away from the drawer needs to hear. Starting a deploy is
-    /// silent here: the drawer appearing already moves and announces focus, so a second "Deploying"
-    /// would just double up.
+    /// Speaks the *start* (so a deploy kicked off from a keyboard menu is confirmed even if focus
+    /// doesn't move to the drawer) and the *terminal* transitions (succeeded/failed). Everything in
+    /// between — the streaming log — stays silent here; see `deployStderrAnnouncement` for the one
+    /// mid-flight exception.
     public static func deployAnnouncement(from old: DeployActivity, to new: DeployActivity) -> String? {
         guard old != new else { return nil }
         switch new {
+        case .running(let site): return "Deploying \(site)"
         case .succeeded(let url): return "Deploy succeeded. \(url)"
         case .failed(let reason): return "Deploy failed. \(reason)"
-        case .running, .inactive: return nil
+        case .inactive: return nil
         }
+    }
+
+    /// A one-shot warning the first time a deploy writes to stderr — keyed off the stderr line count
+    /// crossing `0 → ≥1`. Gives a VoiceOver user early notice that something is going wrong before
+    /// the terminal state, without announcing every subsequent error line (which would flood).
+    public static func deployStderrAnnouncement(previousStderrCount: Int, currentStderrCount: Int) -> String? {
+        (previousStderrCount == 0 && currentStderrCount > 0) ? "Deploy log has errors" : nil
     }
 }

--- a/Sources/AnglesiteCore/LiveRegionAnnouncer.swift
+++ b/Sources/AnglesiteCore/LiveRegionAnnouncer.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Decides *what*, if anything, to announce to VoiceOver as chat responses and deploys stream in —
+/// independent of any SwiftUI view, so the rules are unit-tested under `swift test` rather than only
+/// in a hosted app test (which CI can't run; see `TokenOnboarding` for the same boundary).
+///
+/// The single design rule that keeps VoiceOver usable is encoded in the signatures: announcements
+/// are a pure function of a *coarse state transition* (`isStreaming` flipping, a deploy reaching a
+/// terminal phase), never of a per-token or per-line append. There is no debounce timer because
+/// there is nothing to debounce — the view feeds transitions, and a non-transition returns `nil`.
+///
+/// The caller (the view) is responsible only for posting a returned string via
+/// `AccessibilityNotification.Announcement(_:).post()` from an `.onChange` hook.
+public enum LiveRegionAnnouncer {
+
+    // MARK: Chat streaming
+
+    /// The announcement for a chat streaming-state transition, or `nil` if nothing changed.
+    ///
+    /// Keyed off the `isStreaming` Bool flipping — start and stop only — so a response that streams
+    /// token-by-token produces exactly two announcements, not one per chunk.
+    public static func chatStreamingAnnouncement(wasStreaming: Bool, isStreaming: Bool) -> String? {
+        switch (wasStreaming, isStreaming) {
+        case (false, true): return "Assistant is responding"
+        case (true, false): return "Response complete"
+        default: return nil
+        }
+    }
+
+    // MARK: Deploy
+
+    /// The announceable substrate of a deploy, mapped from the app-target `DeployModel.Phase` (which
+    /// `AnglesiteCore` sits below and cannot reference). Only the distinctions that affect an
+    /// announcement are modelled; `idle` and `blocked` both collapse to `inactive`.
+    public enum DeployActivity: Equatable {
+        case inactive
+        case running
+        case succeeded(url: String)
+        case failed(reason: String)
+    }
+
+    /// The announcement for a deploy phase transition, or `nil`.
+    ///
+    /// Only *terminal* transitions speak — reaching `succeeded`/`failed` — because that is the moment
+    /// a VoiceOver user who has navigated away from the drawer needs to hear. Starting a deploy is
+    /// silent here: the drawer appearing already moves and announces focus, so a second "Deploying"
+    /// would just double up.
+    public static func deployAnnouncement(from old: DeployActivity, to new: DeployActivity) -> String? {
+        guard old != new else { return nil }
+        switch new {
+        case .succeeded(let url): return "Deploy succeeded. \(url)"
+        case .failed(let reason): return "Deploy failed. \(reason)"
+        case .running, .inactive: return nil
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/AppSettingsTests.swift
+++ b/Tests/AnglesiteCoreTests/AppSettingsTests.swift
@@ -115,6 +115,19 @@ final class AppSettingsTests {
         #expect(settings.autoGenerateAltText)
     }
 
+    @Test("announcesLiveUpdates defaults to true (on)") func announcesLiveUpdatesDefaultsToTrue() {
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.announcesLiveUpdates)
+    }
+
+    @Test("announcesLiveUpdates round trip") func announcesLiveUpdatesRoundTrip() {
+        let settings = AppSettings(defaults: defaults)
+        settings.announcesLiveUpdates = false
+        #expect(!settings.announcesLiveUpdates)
+        settings.announcesLiveUpdates = true
+        #expect(settings.announcesLiveUpdates)
+    }
+
     // MARK: DebugPaneVisibility
 
     @Test("Debug menu always visible in debug builds") func debugMenuAlwaysVisibleInDebugBuilds() {

--- a/Tests/AnglesiteCoreTests/LiveRegionAnnouncerTests.swift
+++ b/Tests/AnglesiteCoreTests/LiveRegionAnnouncerTests.swift
@@ -1,0 +1,67 @@
+import Testing
+@testable import AnglesiteCore
+
+/// Tests the *decision* of what to announce to VoiceOver as chat and deploy state stream in, in
+/// isolation from any SwiftUI view. The whole anti-flooding guarantee lives here: announcements
+/// fire only on coarse state transitions, never per-token (chat) or per-line (deploy), so these
+/// pure transition rules are what keeps the speech queue usable. Asserted under `swift test` rather
+/// than a hosted app test (which CI can't run).
+struct LiveRegionAnnouncerTests {
+
+    // MARK: Chat streaming
+
+    @Test("Entering the streaming state announces that the assistant has started")
+    func chatStartAnnouncesResponding() {
+        #expect(LiveRegionAnnouncer.chatStreamingAnnouncement(wasStreaming: false, isStreaming: true)
+                == "Assistant is responding")
+    }
+
+    @Test("Leaving the streaming state announces that the response is complete")
+    func chatStopAnnouncesComplete() {
+        #expect(LiveRegionAnnouncer.chatStreamingAnnouncement(wasStreaming: true, isStreaming: false)
+                == "Response complete")
+    }
+
+    @Test("Staying mid-stream announces nothing — no per-token flooding")
+    func chatStillStreamingIsSilent() {
+        #expect(LiveRegionAnnouncer.chatStreamingAnnouncement(wasStreaming: true, isStreaming: true) == nil)
+    }
+
+    @Test("Staying idle announces nothing")
+    func chatStillIdleIsSilent() {
+        #expect(LiveRegionAnnouncer.chatStreamingAnnouncement(wasStreaming: false, isStreaming: false) == nil)
+    }
+
+    // MARK: Deploy
+
+    @Test("Running → succeeded announces success with the deployed URL")
+    func deploySuccessAnnouncesURL() {
+        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .running,
+                                                       to: .succeeded(url: "https://acme.pages.dev"))
+                == "Deploy succeeded. https://acme.pages.dev")
+    }
+
+    @Test("Running → failed announces failure with the reason")
+    func deployFailureAnnouncesReason() {
+        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .running,
+                                                       to: .failed(reason: "wrangler exited 1"))
+                == "Deploy failed. wrangler exited 1")
+    }
+
+    @Test("Starting a deploy (inactive → running) is silent — the drawer appearing already speaks")
+    func deployStartIsSilent() {
+        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .inactive, to: .running) == nil)
+    }
+
+    @Test("A no-op transition (same terminal state re-emitted) announces nothing")
+    func deployUnchangedTerminalIsSilent() {
+        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .succeeded(url: "https://a.dev"),
+                                                       to: .succeeded(url: "https://a.dev")) == nil)
+    }
+
+    @Test("Dismissing a finished deploy (succeeded → inactive) is silent")
+    func deployDismissIsSilent() {
+        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .succeeded(url: "https://a.dev"),
+                                                       to: .inactive) == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/LiveRegionAnnouncerTests.swift
+++ b/Tests/AnglesiteCoreTests/LiveRegionAnnouncerTests.swift
@@ -8,53 +8,86 @@ import Testing
 /// than a hosted app test (which CI can't run).
 struct LiveRegionAnnouncerTests {
 
-    // MARK: Chat streaming
+    // MARK: Chat — start
 
     @Test("Entering the streaming state announces that the assistant has started")
     func chatStartAnnouncesResponding() {
-        #expect(LiveRegionAnnouncer.chatStreamingAnnouncement(wasStreaming: false, isStreaming: true)
+        #expect(LiveRegionAnnouncer.chatStartAnnouncement(wasStreaming: false, isStreaming: true)
                 == "Assistant is responding")
     }
 
-    @Test("Leaving the streaming state announces that the response is complete")
-    func chatStopAnnouncesComplete() {
-        #expect(LiveRegionAnnouncer.chatStreamingAnnouncement(wasStreaming: true, isStreaming: false)
+    @Test("Staying mid-stream announces nothing — no per-token flooding")
+    func chatStillStreamingIsSilentAtStart() {
+        #expect(LiveRegionAnnouncer.chatStartAnnouncement(wasStreaming: true, isStreaming: true) == nil)
+    }
+
+    @Test("A stop transition is not a start, so the start decider stays silent")
+    func chatStopIsNotAStart() {
+        #expect(LiveRegionAnnouncer.chatStartAnnouncement(wasStreaming: true, isStreaming: false) == nil)
+    }
+
+    // MARK: Chat — stop (outcome-aware, speaks the reply)
+
+    @Test("A completed turn speaks the assistant's reply, so VoiceOver users hear the answer")
+    func chatStopSpeaksReply() {
+        #expect(LiveRegionAnnouncer.chatStopAnnouncement(wasStreaming: true, isStreaming: false,
+                    outcome: .completed(reply: "The sky is blue because of Rayleigh scattering."))
+                == "The sky is blue because of Rayleigh scattering.")
+    }
+
+    @Test("A completed turn with empty reply falls back to a generic completion cue")
+    func chatStopEmptyReplyFallsBack() {
+        #expect(LiveRegionAnnouncer.chatStopAnnouncement(wasStreaming: true, isStreaming: false,
+                    outcome: .completed(reply: "   "))
                 == "Response complete")
     }
 
-    @Test("Staying mid-stream announces nothing — no per-token flooding")
-    func chatStillStreamingIsSilent() {
-        #expect(LiveRegionAnnouncer.chatStreamingAnnouncement(wasStreaming: true, isStreaming: true) == nil)
+    @Test("A failed turn announces the failure with its reason, not a misleading 'complete'")
+    func chatStopFailedAnnouncesReason() {
+        #expect(LiveRegionAnnouncer.chatStopAnnouncement(wasStreaming: true, isStreaming: false,
+                    outcome: .failed(reason: "Claude backend exited with code 1"))
+                == "Response failed. Claude backend exited with code 1")
     }
 
-    @Test("Staying idle announces nothing")
-    func chatStillIdleIsSilent() {
-        #expect(LiveRegionAnnouncer.chatStreamingAnnouncement(wasStreaming: false, isStreaming: false) == nil)
+    @Test("A cancelled turn announces that it was stopped, not 'complete'")
+    func chatStopCancelledAnnouncesStopped() {
+        #expect(LiveRegionAnnouncer.chatStopAnnouncement(wasStreaming: true, isStreaming: false,
+                    outcome: .cancelled)
+                == "Response stopped")
     }
 
-    // MARK: Deploy
+    @Test("The stop decider only fires on a true→false transition")
+    func chatStopOnlyOnTransition() {
+        #expect(LiveRegionAnnouncer.chatStopAnnouncement(wasStreaming: false, isStreaming: false,
+                    outcome: .completed(reply: "hi")) == nil)
+        #expect(LiveRegionAnnouncer.chatStopAnnouncement(wasStreaming: true, isStreaming: true,
+                    outcome: .completed(reply: "hi")) == nil)
+    }
+
+    // MARK: Deploy — start + terminal
+
+    @Test("Starting a deploy announces it by site name")
+    func deployStartAnnouncesSite() {
+        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .inactive, to: .running(site: "acme"))
+                == "Deploying acme")
+    }
 
     @Test("Running → succeeded announces success with the deployed URL")
     func deploySuccessAnnouncesURL() {
-        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .running,
+        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .running(site: "acme"),
                                                        to: .succeeded(url: "https://acme.pages.dev"))
                 == "Deploy succeeded. https://acme.pages.dev")
     }
 
     @Test("Running → failed announces failure with the reason")
     func deployFailureAnnouncesReason() {
-        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .running,
+        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .running(site: "acme"),
                                                        to: .failed(reason: "wrangler exited 1"))
                 == "Deploy failed. wrangler exited 1")
     }
 
-    @Test("Starting a deploy (inactive → running) is silent — the drawer appearing already speaks")
-    func deployStartIsSilent() {
-        #expect(LiveRegionAnnouncer.deployAnnouncement(from: .inactive, to: .running) == nil)
-    }
-
-    @Test("A no-op transition (same terminal state re-emitted) announces nothing")
-    func deployUnchangedTerminalIsSilent() {
+    @Test("A no-op transition (same state re-emitted) announces nothing")
+    func deployUnchangedIsSilent() {
         #expect(LiveRegionAnnouncer.deployAnnouncement(from: .succeeded(url: "https://a.dev"),
                                                        to: .succeeded(url: "https://a.dev")) == nil)
     }
@@ -63,5 +96,24 @@ struct LiveRegionAnnouncerTests {
     func deployDismissIsSilent() {
         #expect(LiveRegionAnnouncer.deployAnnouncement(from: .succeeded(url: "https://a.dev"),
                                                        to: .inactive) == nil)
+    }
+
+    // MARK: Deploy — first-stderr early warning
+
+    @Test("The first stderr line warns once, before any terminal state")
+    func deployFirstStderrWarns() {
+        #expect(LiveRegionAnnouncer.deployStderrAnnouncement(previousStderrCount: 0, currentStderrCount: 1)
+                == "Deploy log has errors")
+    }
+
+    @Test("Subsequent stderr lines stay silent — the warning fires once, not per line")
+    func deploySubsequentStderrIsSilent() {
+        #expect(LiveRegionAnnouncer.deployStderrAnnouncement(previousStderrCount: 1, currentStderrCount: 2) == nil)
+        #expect(LiveRegionAnnouncer.deployStderrAnnouncement(previousStderrCount: 3, currentStderrCount: 7) == nil)
+    }
+
+    @Test("No stderr means no warning")
+    func deployNoStderrIsSilent() {
+        #expect(LiveRegionAnnouncer.deployStderrAnnouncement(previousStderrCount: 0, currentStderrCount: 0) == nil)
     }
 }


### PR DESCRIPTION
Closes #216. Follow-up to #215 (which closed #79/#80 and deferred live-region announcements for the two surfaces where content streams in asynchronously).

Adds real-time VoiceOver awareness for streaming chat and live deploys. A VoiceOver smoke during review surfaced that the chat *content* was never read — the user heard "Response complete" but not the answer — so the scope grew to make the announcements genuinely useful.

## Design

The announcement *decision* lives in a pure `LiveRegionAnnouncer` in `AnglesiteCore` — same testability boundary as `TokenOnboarding`, since hosted app tests can't run on CI. Announcements are a pure function of a **coarse state transition** (`isStreaming` flipping; a deploy phase change; stderr first appearing), never of a per-token or per-line append — so there's no debounce timer, and the anti-flooding guarantee is locked in by 16 unit tests. The views are thin `.onChange` glue that post via `AccessibilityNotification.Announcement(_:).post()` (cross-platform, macOS 14+).

## What it announces

**Chat** (`ChatView`, keyed off `model.isStreaming`):
- start → "Assistant is responding"
- stop, success → **the assistant's reply text** (so VoiceOver users hear the answer; empty reply → "Response complete")
- stop, error → "Response failed. \<reason>"
- stop, cancel → "Response stopped"

**Deploy** (`DeployDrawerView`, keyed off `model.phase` + stderr count):
- start → "Deploying \<site>"
- first stderr line → "Deploy log has errors" (once, not per line)
- terminal → "Deploy succeeded. \<url>" / "Deploy failed. \<reason>"

**Opt-out:** `AppSettings.announcesLiveUpdates` (default on) gates all posting, with an "Accessibility" toggle in Settings for AT users who find the cues noisy.

## Changes

| File | Change |
|---|---|
| `AnglesiteCore/LiveRegionAnnouncer.swift` *(new)* | Pure decider: chat start/stop (outcome-aware) + deploy phase/stderr. |
| `AnglesiteCore/AppSettings.swift` | `announcesLiveUpdates` flag (default true). |
| `Tests/.../LiveRegionAnnouncerTests.swift` *(new)* | 16 `@Test`s incl. silent no-op cases. |
| `Tests/.../AppSettingsTests.swift` | default + round-trip for the new flag. |
| `AnglesiteApp/ChatView.swift` | start+stop `.onChange`, gated. |
| `AnglesiteApp/ChatModel.swift` | per-turn outcome + `wasCancelledMidTurn`. |
| `AnglesiteApp/DeployDrawerView.swift` | start/terminal + stderr `.onChange`, gated. |
| `AnglesiteApp/SettingsView.swift` | Accessibility toggle. |

## Verification

- ✅ `Anglesite` (DevID) + `AnglesiteMAS` targets build and link
- ✅ `swift test` green except the two pre-existing #221 MCP-spawn flakes (unrelated path)
- ✅ **VoiceOver smoke**: chat start/stop announcements fire at runtime (confirmed by hand). The reply-speaking change is being re-smoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)