### PR TITLE
feat(intents): D.2 — enrich App Intent schema for auto-derived MCP tools (#163)

### DIFF
--- a/Sources/AnglesiteIntents/ContentEntities.swift
+++ b/Sources/AnglesiteIntents/ContentEntities.swift
@@ -140,6 +140,45 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         self.collection = post.collection
         self.siteID = post.siteID
     }
+
+    public init(id: String, displayName: String, slug: String, collection: String,
+                siteID: String, isDraft: Bool, tags: [String]) {
+        self.id = id
+        self.displayName = displayName
+        self.isDraft = isDraft
+        self.tags = tags
+        self.slug = slug
+        self.collection = collection
+        self.siteID = siteID
+    }
+
+    /// `"src/content/{collection}/{slug}.md"` → `"{collection}"`. The collection is the path
+    /// component immediately before the file. Returns nil when the path has no such parent.
+    public static func collection(fromPath path: String) -> String? {
+        let parts = path.split(separator: "/").map(String.init)
+        guard parts.count >= 2 else { return nil }
+        return parts[parts.count - 2]
+    }
+
+    /// Build the entity an `AddPostIntent` returns. Add Post scaffolds a *draft*, so `isDraft`
+    /// is true and `tags` empty. The dialog is the source of truth for success vs. failure.
+    public static func make(
+        siteID: String, title: String, requestedCollection: String?, requestedSlug: String?,
+        result: ContentCreateResult
+    ) -> PostEntity {
+        let slug: String
+        let collection: String
+        switch result {
+        case .created(let filePath, let identifier):
+            slug = identifier
+            collection = Self.collection(fromPath: filePath) ?? requestedCollection ?? ""
+        case .siteNotFound, .failed:
+            slug = requestedSlug ?? ""
+            collection = requestedCollection ?? ""
+        }
+        return PostEntity(id: "\(siteID):post:\(slug)", displayName: title, slug: slug,
+                          collection: collection, siteID: siteID, isDraft: true, tags: [])
+    }
 }
 
 /// Resolves `PostEntity` references from `SiteContentGraph`. Search covers title, slug, tags,

--- a/Sources/AnglesiteIntents/ContentEntities.swift
+++ b/Sources/AnglesiteIntents/ContentEntities.swift
@@ -316,3 +316,79 @@ public struct ImageEntityQuery: EntityStringQuery {
 
     public func defaultResult() async -> ImageEntity? { nil }
 }
+
+// MARK: - ContentSearchResultEntity (F-2)
+
+/// Discriminator for the flattened search result. `SearchContentIntent` spans three entity
+/// types; `ReturnsValue<T>` needs one concrete type, so results carry their kind.
+public enum ContentKind: String, AppEnum, Sendable {
+    case page, post, image
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Content Kind" }
+    public static var caseDisplayRepresentations: [ContentKind: DisplayRepresentation] {
+        [.page: "Page", .post: "Post", .image: "Image"]
+    }
+}
+
+/// A single search hit, flattened across pages/posts/images. `id` is the *underlying* entity id
+/// (e.g. "s1:page:/about"), so an agent can re-resolve the typed entity (PageEntity, …) to chain.
+public struct ContentSearchResultEntity: AppEntity, Identifiable, Sendable {
+    public let id: String
+    @Property(title: "Kind")    public var kind: ContentKind
+    @Property(title: "Title")   public var title: String
+    @Property(title: "Locator") public var locator: String
+    @Property(title: "Site ID") public var siteID: String
+
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Search Result" }
+    public var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(title)", subtitle: "\(locator)")
+    }
+    public static let defaultQuery = ContentSearchResultEntityQuery()
+
+    public init(id: String, kind: ContentKind, title: String, locator: String, siteID: String) {
+        self.id = id; self.kind = kind; self.title = title; self.locator = locator; self.siteID = siteID
+    }
+    public init(page e: PageEntity) {
+        self.init(id: e.id, kind: .page, title: e.displayName, locator: e.route, siteID: e.siteID)
+    }
+    public init(post e: PostEntity) {
+        self.init(id: e.id, kind: .post, title: e.displayName, locator: "\(e.collection)/\(e.slug)", siteID: e.siteID)
+    }
+    public init(image e: ImageEntity) {
+        self.init(id: e.id, kind: .image, title: e.displayName, locator: e.relativePath, siteID: e.siteID)
+    }
+}
+
+/// Re-resolves flattened results by parsing the kind token out of each id and delegating to the
+/// graph's typed id lookups. Plain `EntityQuery` (not `EntityStringQuery`): string search lives on
+/// the typed entity queries and on `SearchContentIntent` itself; this only needs id round-trip.
+public struct ContentSearchResultEntityQuery: EntityQuery {
+    @Dependency private var graph: SiteContentGraph
+    public init() {}
+    private var resolved: SiteContentGraph { ContentGraphOverride.scoped ?? graph }
+
+    public func entities(for identifiers: [String]) async throws -> [ContentSearchResultEntity] {
+        let g = resolved
+        var pageIDs: [String] = [], postIDs: [String] = [], imageIDs: [String] = []
+        for id in identifiers {
+            // id == "{siteID}:{kind}:{rest}". The siteID is a filesystem path (no ":"), so splitting
+            // on ":" with maxSplits 2 yields exactly [siteID, kind, rest]; parts[1] is the kind.
+            let parts = id.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false).map(String.init)
+            guard parts.count == 3 else { continue }
+            switch parts[1] {
+            case "page": pageIDs.append(id)
+            case "post": postIDs.append(id)
+            case "image": imageIDs.append(id)
+            default: continue
+            }
+        }
+        async let pages = g.pages(ids: pageIDs)
+        async let posts = g.posts(ids: postIDs)
+        async let images = g.images(ids: imageIDs)
+        let mapped = await (pages.map { ContentSearchResultEntity(page: PageEntity($0)) }
+            + posts.map { ContentSearchResultEntity(post: PostEntity($0)) }
+            + images.map { ContentSearchResultEntity(image: ImageEntity($0)) })
+        // Preserve caller's id order.
+        let order = Dictionary(uniqueKeysWithValues: identifiers.enumerated().map { ($1, $0) })
+        return mapped.sorted { (order[$0.id] ?? .max) < (order[$1.id] ?? .max) }
+    }
+}

--- a/Sources/AnglesiteIntents/ContentEntities.swift
+++ b/Sources/AnglesiteIntents/ContentEntities.swift
@@ -26,6 +26,31 @@ public struct PageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         self.route = page.route
         self.siteID = page.siteID
     }
+
+    /// Direct field initializer — used to build a return value from data already in hand
+    /// (e.g. a just-created page) without round-tripping through `SiteContentGraph`,
+    /// which the file-watcher may not have indexed yet.
+    public init(id: String, displayName: String, route: String, siteID: String) {
+        self.id = id
+        self.displayName = displayName
+        self.route = route
+        self.siteID = siteID
+    }
+
+    /// Build the entity an `AddPageIntent` returns. On success the route is the created
+    /// identifier; on failure we return a best-effort entity from the requested input so the
+    /// intent keeps a single `ReturnsValue<PageEntity>` type. The dialog — not this value — is
+    /// the source of truth for whether creation actually succeeded.
+    public static func make(
+        siteID: String, name: String, requestedRoute: String?, result: ContentCreateResult
+    ) -> PageEntity {
+        let route: String
+        switch result {
+        case .created(_, let identifier): route = identifier
+        case .siteNotFound, .failed:       route = requestedRoute ?? ""
+        }
+        return PageEntity(id: "\(siteID):page:\(route)", displayName: name, route: route, siteID: siteID)
+    }
 }
 
 /// Resolves `PageEntity` references from `SiteContentGraph`. Used by Siri/Shortcuts for both

--- a/Sources/AnglesiteIntents/ContentEntities.swift
+++ b/Sources/AnglesiteIntents/ContentEntities.swift
@@ -9,8 +9,8 @@ import Foundation
 public struct PageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
     public let id: String            // "{siteID}:page:{route}" — same as SiteContentGraph.Page.id
     public let displayName: String   // title ?? route
-    public let route: String
-    public let siteID: String
+    @Property(title: "Route") public var route: String
+    @Property(title: "Site ID") public var siteID: String
 
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Page" }
 
@@ -89,9 +89,9 @@ public struct PageEntityQuery: EntityStringQuery {
 public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
     public let id: String            // "{siteID}:post:{slug}"
     public let displayName: String   // title
-    public let slug: String
-    public let collection: String
-    public let siteID: String
+    @Property(title: "Slug") public var slug: String
+    @Property(title: "Collection") public var collection: String
+    @Property(title: "Site ID") public var siteID: String
     public let isDraft: Bool
     public let tags: [String]
 
@@ -109,11 +109,11 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
     public init(_ post: SiteContentGraph.Post) {
         self.id = post.id
         self.displayName = post.title
+        self.isDraft = post.draft
+        self.tags = post.tags
         self.slug = post.slug
         self.collection = post.collection
         self.siteID = post.siteID
-        self.isDraft = post.draft
-        self.tags = post.tags
     }
 }
 
@@ -176,8 +176,8 @@ public struct PostEntityQuery: EntityStringQuery {
 public struct ImageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
     public let id: String            // "{siteID}:image:{relativePath}"
     public let displayName: String   // fileName
-    public let relativePath: String
-    public let siteID: String
+    @Property(title: "Relative Path") public var relativePath: String
+    @Property(title: "Site ID") public var siteID: String
     /// Page routes that reference this image. Carried in the struct (not surfaced in
     /// `displayRepresentation` today) so adding it later isn't a source-breaking AppEntity
     /// schema change for Shortcuts persistence / donated interactions.
@@ -194,9 +194,9 @@ public struct ImageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
     public init(_ image: SiteContentGraph.Image) {
         self.id = image.id
         self.displayName = image.fileName
+        self.usedOnPages = image.usedOnPages
         self.relativePath = image.relativePath
         self.siteID = image.siteID
-        self.usedOnPages = image.usedOnPages
     }
 }
 

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -45,8 +45,11 @@ public struct SearchContentIntent: AppIntent {
     /// typed results. Static + graph-injected so it's unit-testable without the AppIntents runtime.
     static func results(graph: SiteContentGraph, siteID: String, query: String) async -> (dialog: String, items: [ContentSearchResultEntity]) {
         let pages = await graph.searchPages(siteID: siteID, matching: query)
+            .sorted { $0.lastModified != $1.lastModified ? $0.lastModified > $1.lastModified : $0.id < $1.id }
         let posts = await graph.searchPosts(siteID: siteID, matching: query)
+            .sorted { $0.lastModified != $1.lastModified ? $0.lastModified > $1.lastModified : $0.id < $1.id }
         let images = await graph.searchImages(siteID: siteID, matching: query)
+            .sorted { $0.lastModified != $1.lastModified ? $0.lastModified > $1.lastModified : $0.id < $1.id }
         let dialog = ContentDialogs.search(query: query, pageCount: pages.count, postCount: posts.count, imageCount: images.count)
         let items = pages.map { ContentSearchResultEntity(page: PageEntity($0)) }
             + posts.map { ContentSearchResultEntity(post: PostEntity($0)) }

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -131,7 +131,7 @@ public struct AddPageIntent: AppIntent {
         Summary("Add page \(\.$name) to \(\.$site)")
     }
 
-    public func perform() async throws -> some IntentResult & ProvidesDialog {
+    public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<PageEntity> {
         let scoped = ContentOperationsOverride.scoped
         let svc = scoped ?? content
         // Spawning the plugin's Node MCP server on first use can exceed the default budget, so the
@@ -149,7 +149,9 @@ public struct AddPageIntent: AppIntent {
             result = await svc.createPage(siteID: site.id, name: name, route: route)
             #endif
         }
-        return .result(dialog: IntentDialog(stringLiteral: ContentDialogs.created(result, kind: .page, siteName: site.displayName)))
+        let entity = PageEntity.make(siteID: site.id, name: name, requestedRoute: route, result: result)
+        return .result(value: entity,
+                       dialog: IntentDialog(stringLiteral: ContentDialogs.created(result, kind: .page, siteName: site.displayName)))
     }
 }
 

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -36,18 +36,22 @@ public struct SearchContentIntent: AppIntent {
         Summary("Search \(\.$site) for \(\.$query)")
     }
 
-    public func perform() async throws -> some IntentResult & ProvidesDialog {
-        let dialog = await Self.dialog(graph: ContentGraphOverride.scoped ?? graph, siteID: site.id, query: query)
-        return .result(dialog: IntentDialog(stringLiteral: dialog))
+    public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<[ContentSearchResultEntity]> {
+        let (dialog, items) = await Self.results(graph: ContentGraphOverride.scoped ?? graph, siteID: site.id, query: query)
+        return .result(value: items, dialog: IntentDialog(stringLiteral: dialog))
     }
 
-    /// Gather matches from the graph and format the spoken result. Static + graph-injected so the
-    /// read+format wiring is unit-testable without the AppIntents runtime.
-    static func dialog(graph: SiteContentGraph, siteID: String, query: String) async -> String {
+    /// Gather matches once and build both the spoken dialog (unchanged wording) and the flattened
+    /// typed results. Static + graph-injected so it's unit-testable without the AppIntents runtime.
+    static func results(graph: SiteContentGraph, siteID: String, query: String) async -> (dialog: String, items: [ContentSearchResultEntity]) {
         let pages = await graph.searchPages(siteID: siteID, matching: query)
         let posts = await graph.searchPosts(siteID: siteID, matching: query)
         let images = await graph.searchImages(siteID: siteID, matching: query)
-        return ContentDialogs.search(query: query, pageCount: pages.count, postCount: posts.count, imageCount: images.count)
+        let dialog = ContentDialogs.search(query: query, pageCount: pages.count, postCount: posts.count, imageCount: images.count)
+        let items = pages.map { ContentSearchResultEntity(page: PageEntity($0)) }
+            + posts.map { ContentSearchResultEntity(post: PostEntity($0)) }
+            + images.map { ContentSearchResultEntity(image: ImageEntity($0)) }
+        return (dialog, items)
     }
 }
 

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -183,7 +183,7 @@ public struct AddPostIntent: AppIntent {
         Summary("Add post \(\.$title2) to \(\.$site)")
     }
 
-    public func perform() async throws -> some IntentResult & ProvidesDialog {
+    public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<PostEntity> {
         let scoped = ContentOperationsOverride.scoped
         let svc = scoped ?? content
         let result: ContentCreateResult
@@ -198,7 +198,10 @@ public struct AddPostIntent: AppIntent {
             result = await svc.createPost(siteID: site.id, title: title2, collection: collection, slug: slug)
             #endif
         }
-        return .result(dialog: IntentDialog(stringLiteral: ContentDialogs.created(result, kind: .post, siteName: site.displayName)))
+        let entity = PostEntity.make(siteID: site.id, title: title2, requestedCollection: collection,
+                                     requestedSlug: slug, result: result)
+        return .result(value: entity,
+                       dialog: IntentDialog(stringLiteral: ContentDialogs.created(result, kind: .post, siteName: site.displayName)))
     }
 }
 

--- a/Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
@@ -626,6 +626,50 @@ extension AppIntentsTests {
         }
     }
 
+    @Suite("CreateFactory.Post (F-3)")
+    struct CreatePostFactoryTests {
+        @Test("collection(fromPath:) extracts the content collection segment")
+        func collectionFromPath() {
+            #expect(PostEntity.collection(fromPath: "src/content/blog/hello.md") == "blog")
+            #expect(PostEntity.collection(fromPath: "src/content/notes/x.md") == "notes")
+            #expect(PostEntity.collection(fromPath: "weird.md") == nil)
+        }
+
+        @Test("success: slug from identifier; collection derived from filePath; draft scaffold")
+        func success() {
+            let e = PostEntity.make(
+                siteID: AppIntentsTests.aSite, title: "Hello World",
+                requestedCollection: nil, requestedSlug: nil,
+                result: .created(filePath: "src/content/blog/hello-world.md", identifier: "hello-world"))
+            #expect(e.slug == "hello-world")
+            #expect(e.collection == "blog")
+            #expect(e.isDraft == true)
+            #expect(e.tags.isEmpty)
+            #expect(e.id == "\(AppIntentsTests.aSite):post:hello-world")
+            #expect(e.displayName == "Hello World")
+        }
+
+        @Test("success: user-supplied collection wins when filePath can't be parsed")
+        func userCollectionFallback() {
+            let e = PostEntity.make(
+                siteID: AppIntentsTests.aSite, title: "X",
+                requestedCollection: "notes", requestedSlug: nil,
+                result: .created(filePath: "unparseable.md", identifier: "x"))
+            #expect(e.collection == "notes")
+        }
+
+        @Test("failure: best-effort entity from requested slug/collection")
+        func failure() {
+            let e = PostEntity.make(
+                siteID: AppIntentsTests.aSite, title: "X",
+                requestedCollection: "notes", requestedSlug: "x",
+                result: .failed(reason: "boom"))
+            #expect(e.slug == "x")
+            #expect(e.collection == "notes")
+            #expect(e.id == "\(AppIntentsTests.aSite):post:x")
+        }
+    }
+
     @Suite("Bootstrap")
     struct BootstrapSmokeTests {
 

--- a/Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
@@ -95,6 +95,30 @@ extension AppIntentsTests {
         }
     }
 
+    @Suite("CreateFactory.Page (F-3)")
+    struct CreatePageFactoryTests {
+        @Test("success: route comes from the created identifier; id matches graph formula")
+        func success() {
+            let e = PageEntity.make(
+                siteID: AppIntentsTests.aSite, name: "About Us", requestedRoute: nil,
+                result: .created(filePath: "src/pages/about.astro", identifier: "/about"))
+            #expect(e.route == "/about")
+            #expect(e.siteID == AppIntentsTests.aSite)
+            #expect(e.displayName == "About Us")
+            #expect(e.id == "\(AppIntentsTests.aSite):page:/about")
+        }
+
+        @Test("failure: best-effort entity from the requested route")
+        func failure() {
+            let e = PageEntity.make(
+                siteID: AppIntentsTests.aSite, name: "About", requestedRoute: "/about",
+                result: .failed(reason: "boom"))
+            #expect(e.route == "/about")
+            #expect(e.id == "\(AppIntentsTests.aSite):page:/about")
+            #expect(e.displayName == "About")
+        }
+    }
+
     @Suite("PageEntityQuery")
     struct PageEntityQueryTests {
 

--- a/Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
@@ -670,6 +670,45 @@ extension AppIntentsTests {
         }
     }
 
+    @Suite("ContentSearchResultEntity (F-2)")
+    struct SearchResultEntityTests {
+        @Test("maps each typed entity into a flattened result with kind + locator")
+        func mapping() {
+            let p = ContentSearchResultEntity(page: PageEntity(AppIntentsTests.gPage(route: "/about", title: "About")))
+            #expect(p.kind == .page)
+            #expect(p.title == "About")
+            #expect(p.locator == "/about")
+            #expect(p.id == "\(AppIntentsTests.aSite):page:/about")
+
+            let o = ContentSearchResultEntity(post: PostEntity(AppIntentsTests.gPost(slug: "hi", title: "Hi", collection: "blog")))
+            #expect(o.kind == .post)
+            #expect(o.locator == "blog/hi")
+            #expect(o.id == "\(AppIntentsTests.aSite):post:hi")
+
+            let i = ContentSearchResultEntity(image: ImageEntity(AppIntentsTests.gImage(relativePath: "public/images/hero.jpg", fileName: "hero.jpg")))
+            #expect(i.kind == .image)
+            #expect(i.title == "hero.jpg")
+            #expect(i.locator == "public/images/hero.jpg")
+        }
+
+        @Test("query resolves ids back through the graph by kind")
+        func queryRoundTrip() async throws {
+            let graph = SiteContentGraph()
+            await graph.load(
+                siteID: AppIntentsTests.aSite,
+                pages: [AppIntentsTests.gPage(route: "/about", title: "About")],
+                posts: [AppIntentsTests.gPost(slug: "hi", title: "Hi", collection: "blog")],
+                images: [])
+            try await ContentGraphOverride.$scoped.withValue(graph) {
+                let results = try await ContentSearchResultEntityQuery().entities(
+                    for: ["\(AppIntentsTests.aSite):page:/about", "\(AppIntentsTests.aSite):post:hi"])
+                #expect(results.count == 2)
+                #expect(results.contains { $0.kind == .page && $0.locator == "/about" })
+                #expect(results.contains { $0.kind == .post && $0.locator == "blog/hi" })
+            }
+        }
+    }
+
     @Suite("Bootstrap")
     struct BootstrapSmokeTests {
 

--- a/Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
@@ -69,6 +69,32 @@ extension AppIntentsTests {
         )
     }
 
+    @Suite("PropertyPromotion (F-1)")
+    struct PropertyPromotionTests {
+        @Test("promoted PageEntity fields round-trip through construction")
+        func pageFields() {
+            let e = PageEntity(AppIntentsTests.gPage(route: "/about", title: "About"))
+            #expect(e.route == "/about")
+            #expect(e.siteID == AppIntentsTests.aSite)
+            #expect(e.id == "\(AppIntentsTests.aSite):page:/about")  // id unchanged
+        }
+
+        @Test("promoted PostEntity fields round-trip through construction")
+        func postFields() {
+            let e = PostEntity(AppIntentsTests.gPost(slug: "hello-world", collection: "blog"))
+            #expect(e.slug == "hello-world")
+            #expect(e.collection == "blog")
+            #expect(e.siteID == AppIntentsTests.aSite)
+        }
+
+        @Test("promoted ImageEntity fields round-trip through construction")
+        func imageFields() {
+            let e = ImageEntity(AppIntentsTests.gImage(relativePath: "public/images/hero.jpg"))
+            #expect(e.relativePath == "public/images/hero.jpg")
+            #expect(e.siteID == AppIntentsTests.aSite)
+        }
+    }
+
     @Suite("PageEntityQuery")
     struct PageEntityQueryTests {
 

--- a/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
@@ -64,6 +64,21 @@ extension AppIntentsTests {
 
         // MARK: - Read intents (graph-gathering helpers)
 
+        @Test("SearchContentIntent.results returns dialog parity + flattened typed results")
+        func searchResults() async {
+            let graph = SiteContentGraph()
+            await graph.load(
+                siteID: AppIntentsTests.aSite,
+                pages: [AppIntentsTests.gPage(route: "/about", title: "About")],
+                posts: [AppIntentsTests.gPost(slug: "about-us", title: "About Us")],
+                images: [])
+            let (dialog, items) = await SearchContentIntent.results(graph: graph, siteID: AppIntentsTests.aSite, query: "about")
+            #expect(dialog == "Found 1 page and 1 post matching \u{201C}about\u{201D}.")   // byte-identical to before
+            #expect(items.count == 2)
+            #expect(items.contains { $0.kind == .page && $0.locator == "/about" })
+            #expect(items.contains { $0.kind == .post && $0.locator == "blog/about-us" })
+        }
+
         @Test("SearchContentIntent gathers matches for the right site and query")
         func searchHelper() async {
             let graph = SiteContentGraph()
@@ -76,7 +91,7 @@ extension AppIntentsTests {
             // A different site's content must not leak into the result.
             await graph.load(siteID: AppIntentsTests.bSite, pages: [AppIntentsTests.gPage(site: AppIntentsTests.bSite, route: "/about")], posts: [], images: [])
 
-            let dialog = await SearchContentIntent.dialog(graph: graph, siteID: AppIntentsTests.aSite, query: "about")
+            let dialog = await SearchContentIntent.results(graph: graph, siteID: AppIntentsTests.aSite, query: "about").dialog
             #expect(dialog == "Found 1 page and 1 post matching “about”.")
         }
 

--- a/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
@@ -166,6 +166,16 @@ extension AppIntentsTests {
             #expect(e.id == "\(AppIntentsTests.aSite):page:/about")
         }
 
+        @Test("SearchContentIntent.results returns matches in deterministic lastModified-desc order")
+        func searchResultsOrdering() async {
+            let graph = SiteContentGraph()
+            let older = AppIntentsTests.gPage(route: "/about-old", title: "About old", modified: AppIntentsTests.t0)
+            let newer = AppIntentsTests.gPage(route: "/about-new", title: "About new", modified: AppIntentsTests.t0.addingTimeInterval(100))
+            await graph.load(siteID: AppIntentsTests.aSite, pages: [older, newer], posts: [], images: [])
+            let (_, items) = await SearchContentIntent.results(graph: graph, siteID: AppIntentsTests.aSite, query: "about")
+            #expect(items.map(\.id) == [newer.id, older.id])  // newer first
+        }
+
         @Test("create intents tolerate a failed service result")
         func createFailureIsHandled() async throws {
             let fake = FakeContentOps()

--- a/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
@@ -142,6 +142,15 @@ extension AppIntentsTests {
             #expect(fake.postCalls.first?.slug == "hello")
         }
 
+        @Test("AddPage returns an entity carrying the created route")
+        func addPageReturnsEntity() {
+            let e = PageEntity.make(
+                siteID: AppIntentsTests.aSite, name: "About", requestedRoute: "/about",
+                result: .created(filePath: "src/pages/about.astro", identifier: "/about"))
+            #expect(e.route == "/about")
+            #expect(e.id == "\(AppIntentsTests.aSite):page:/about")
+        }
+
         @Test("create intents tolerate a failed service result")
         func createFailureIsHandled() async throws {
             let fake = FakeContentOps()

--- a/Tests/AnglesiteIntentsTests/IntentChainingTests.swift
+++ b/Tests/AnglesiteIntentsTests/IntentChainingTests.swift
@@ -37,6 +37,24 @@ extension AppIntentsTests {
             #expect(fake.auditCalls.first?.id == fake.deployCalls.first?.id)
         }
 
+        // F-3 (#163): AddPageIntent returns the created PageEntity so an agent can chain
+        // create→preview. Reproduce by feeding the factory-built entity into PreviewSiteIntent.
+        @Test("add-page output flows into preview as input")
+        @MainActor
+        func addPageOutputFlowsIntoPreview() async throws {
+            WindowRouter.shared.requested = nil
+            let created = PageEntity.make(
+                siteID: AppIntentsTests.aSite, name: "About", requestedRoute: "/about",
+                result: .created(filePath: "src/pages/about.astro", identifier: "/about"))
+
+            var preview = PreviewSiteIntent()
+            preview.site = SiteEntity(TestStore.site(id: AppIntentsTests.aSite, name: "Alpha"))
+            preview.page = created
+            _ = try await preview.perform()
+
+            #expect(WindowRouter.shared.requested == AppIntentsTests.aSite)
+        }
+
         // D.1 (#162): DeploySiteIntent and BackupSiteIntent now return the SiteEntity they
         // processed (ReturnsValue<SiteEntity>), mirroring AuditSiteIntent, so an agent/Shortcut
         // can pipe deploy→backup. Reproduce that wiring by feeding the same SiteEntity into both.

--- a/Tests/AnglesiteIntentsTests/IntentChainingTests.swift
+++ b/Tests/AnglesiteIntentsTests/IntentChainingTests.swift
@@ -55,6 +55,17 @@ extension AppIntentsTests {
             #expect(WindowRouter.shared.requested == AppIntentsTests.aSite)
         }
 
+        // F-3 (#163): AddPostIntent returns the created PostEntity carrying slug+collection for chaining.
+        @Test("add-post output carries slug and collection for chaining")
+        func addPostOutputCarriesIdentity() {
+            let e = PostEntity.make(
+                siteID: AppIntentsTests.aSite, title: "Hello", requestedCollection: nil, requestedSlug: nil,
+                result: .created(filePath: "src/content/blog/hello.md", identifier: "hello"))
+            #expect(e.slug == "hello")
+            #expect(e.collection == "blog")
+            #expect(e.id == "\(AppIntentsTests.aSite):post:hello")
+        }
+
         // D.1 (#162): DeploySiteIntent and BackupSiteIntent now return the SiteEntity they
         // processed (ReturnsValue<SiteEntity>), mirroring AuditSiteIntent, so an agent/Shortcut
         // can pipe deploy→backup. Reproduce that wiring by feeding the same SiteEntity into both.

--- a/docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md
+++ b/docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md
@@ -151,3 +151,19 @@ These map directly onto the D.2 candidate tools (`anglesite_apply_edit`,
 `anglesite_list_content`): if Apple's bridge auto-derives well-shaped tools from the
 improved intents above, the custom descriptors in D.2 may be unnecessary — which is what
 this audit set out to determine.
+
+## D.2 Closeout (2026-06-17) — descriptor decision
+
+With F-1/F-2/F-3 landed, the two D.2 candidate descriptors are resolved:
+
+- **`anglesite_list_content` — not needed.** The enriched `SearchContentIntent` (now returns a
+  typed `[ContentSearchResultEntity]`) plus `SiteStatusIntent` cover structured content
+  enumeration via auto-derived tools. No hand-registered descriptor.
+- **`anglesite_apply_edit` — deliberately not exposed** as a system-wide intent. It is a low-level
+  `selector / op / value` primitive, not a natural-language action; exposing a structured DOM-edit
+  primitive to arbitrary external agents without the edit overlay's live selection context is a
+  safety regression. It stays on the app-internal MCP path (`MCPClient` + `AnglesiteBridge`);
+  `EditContentIntent`'s natural-language `instruction` form remains the agent-facing edit surface.
+
+No `AnglesiteMCPRegistration` / hand-written descriptors are required: the auto-derived tools from
+the enriched intents *are* D.2's "custom MCP tool descriptors". Closes #163.

--- a/docs/specs/2026-06-17-d2-intent-mcp-enrichment-design.md
+++ b/docs/specs/2026-06-17-d2-intent-mcp-enrichment-design.md
@@ -1,0 +1,216 @@
+# D.2 — Intent Schema Enrichment for Auto-Derived MCP Tools
+
+**Issue:** [#163](https://github.com/Anglesite/Anglesite-app/issues/163) (parent [#135](https://github.com/Anglesite/Anglesite-app/issues/135), Phase D — System-wide MCP exposure)
+**Date:** 2026-06-17
+**Predecessor:** [`docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md`](./2026-06-17-d1-intent-mcp-readiness-audit.md) (D.1 audit — defines findings F-1/F-2/F-3)
+
+## Framing — why this is *not* "write custom MCP descriptors"
+
+macOS 27's platform `mcpbridge` **auto-derives MCP tool schemas from App Intent / `AppEntity`
+schema metadata** — `@Parameter` titles/descriptions, `@Property`-annotated entity fields, and
+`ReturnsValue<T>` return types. The D.1 audit established that the right way to satisfy D.2's
+"custom MCP tool descriptors for rich operations" is to make the *existing* intent/entity schema
+rich enough that the auto-derived tools are usable by a headless agent — and only then decide
+whether the two candidate hand-written descriptors (`anglesite_apply_edit`,
+`anglesite_list_content`) are still needed.
+
+D.1 already landed the small, schema-safe half (`@Parameter(description:)` on free-form strings;
+`ReturnsValue<SiteEntity>` on Deploy/Backup). This spec covers the three deliberate
+schema/structural follow-ups the audit scoped out (F-1, F-2, F-3) plus the closeout decision.
+
+## Scope
+
+Three stacked PRs into `main`, in dependency order, then a docs-only closeout:
+
+1. **F-1** — promote entity disambiguating fields to `@Property`.
+2. **F-3** — create intents return the created entity (`ReturnsValue<PageEntity>` / `<PostEntity>`).
+3. **F-2** — `SearchContentIntent` returns a unified structured result list.
+4. **Closeout** — document the `anglesite_apply_edit` / `anglesite_list_content` decision; close #163.
+
+Ordering rationale: F-1 enriches the *same* `PageEntity`/`PostEntity` that F-3 then returns —
+without `@Property` fields the entity F-3 hands back is near-opaque to an agent — so F-1 is
+foundational and lands first. F-2 introduces a new entity type and is independent, sequenced last.
+
+## F-1 — `@Property` promotion *(PR 1)*
+
+**File:** `Sources/AnglesiteIntents/ContentEntities.swift`
+
+Promote these from plain `let` to `@Property` so an agent receives them as **typed, extractable**
+schema fields rather than only as a `displayRepresentation` subtitle string:
+
+| Entity | Promote to `@Property` |
+|---|---|
+| `PageEntity` | `route`, `siteID` |
+| `PostEntity` | `slug`, `collection`, `siteID` |
+| `ImageEntity` | `relativePath`, `siteID` |
+
+**Each `@Property` carries a `title:`** (e.g. `@Property(title: "Route")`) so the derived schema
+field is self-describing.
+
+### Schema-stability handling
+
+The `ImageEntity.usedOnPages` comment deliberately kept fields out of the schema to avoid "a
+source-breaking `AppEntity` schema change for Shortcuts persistence / donated interactions." This
+change respects that constraint by being **strictly additive**:
+
+- No field is renamed or removed.
+- `id`, `displayName`, and `displayRepresentation` are untouched — already-donated interactions
+  resolve by `id`, which does not change.
+- `usedOnPages` stays a plain `let` (still intentionally out of the schema).
+- The existing memberwise-style `init(_ page:)` / `init(_ post:)` / `init(_ image:)` initializers
+  are unchanged in signature; `@Property` fields are assigned the same way (a `@Property` is still
+  a stored property and is set in `init`).
+
+Additive `@Property` is the documented-safe direction. The **residual manual verification** —
+that a previously-donated Shortcut still resolves after the schema bump — is a device-level check
+recorded in the PR as a follow-up smoke, not something the unit suite can cover.
+
+### Tests (F-1)
+
+- Existing `ContentEntities`/query tests must stay green (no behavior change to `id`, search,
+  resolution).
+- Add assertions that the promoted fields are readable on a constructed entity (guards against an
+  init regression). The fields were already public `let`s, so this is mostly a compile-surface and
+  value-fidelity check.
+
+## F-3 — create intents return the created entity *(PR 2)*
+
+**Files:** `Sources/AnglesiteIntents/ContentIntents.swift`, `Sources/AnglesiteIntents/ContentEntities.swift`
+
+Mirror D.1's Deploy/Backup pattern:
+
+- `AddPageIntent.perform()` → `some IntentResult & ProvidesDialog & ReturnsValue<PageEntity>`
+- `AddPostIntent.perform()` → `some IntentResult & ProvidesDialog & ReturnsValue<PostEntity>`
+
+### Reconstruction approach — construct from known fields, do **not** re-read the graph
+
+`ContentCreateResult.created(filePath:identifier:)` gives back the route (page) or slug (post)
+and the relative file path. The intent already knows `site.id`, and the user-supplied `name`
+(page title) / `title` (post title). Re-reading `SiteContentGraph` to fetch the just-created entity
+**races the file-watcher** that populates the graph — the new file may not be indexed yet.
+
+Instead, add a **direct field-based initializer** to each entity and build the return value from
+data already in hand:
+
+```swift
+// PageEntity
+public init(id: String, displayName: String, route: String, siteID: String) { ... }
+// PostEntity — collection/slug/draft/tags known at creation; tags = [] for a fresh draft
+public init(id: String, displayName: String, slug: String, collection: String,
+            siteID: String, isDraft: Bool, tags: [String]) { ... }
+```
+
+The `id` is reconstructed with the same formula the graph uses (`"{siteID}:page:{route}"` /
+`"{siteID}:post:{slug}"`) so the returned entity round-trips through the entity query later. For a
+post, `collection` falls back to the same default the create path used when the user omitted it;
+`isDraft = true` (Add Post scaffolds a draft), `tags = []`.
+
+### Failure paths
+
+AppIntents requires a **single** return type per `perform()`, so once the success type is
+`ReturnsValue<PageEntity>` *every* branch must return a value. This mirrors `SiteIntents` Deploy,
+which returns `value: site` even on its "couldn't find" branch.
+
+Decision: **always return a value.** On success, return the entity reconstructed from
+`ContentCreateResult.created`. On `.siteNotFound` / `.failed`, reconstruct a **best-effort entity
+from the requested input** (`site.id` + the requested `route`/`name` for a page, `slug`/`title`
+for a post) and pair it with the failure dialog. The **dialog is the source of truth** for whether
+creation succeeded — an agent that chains on the returned entity after a failure is acting against
+the dialog, exactly as it would by chaining on Deploy's returned site after a failed deploy. Keep
+this caveat in a code comment so the asymmetry (value present, dialog says failed) is explicit.
+
+### Tests (F-3)
+
+- Extend the existing `ContentOperationsOverride`-scoped Add Page/Add Post tests to assert the
+  returned entity's `id`, `route`/`slug`, and `siteID` match the created identifier (the fakes
+  already drive `ContentCreateResult`).
+- Add a chaining-style test in the `IntentChainingTests` idiom: Add Page → reconstruct the entity
+  → assert it carries the route an agent would pipe into `PreviewSiteIntent`.
+
+## F-2 — `SearchContentIntent` unified structured return *(PR 3)*
+
+**Files:** `Sources/AnglesiteIntents/ContentEntities.swift` (new entity + query),
+`Sources/AnglesiteIntents/ContentIntents.swift` (intent return type)
+
+### New entity: `ContentSearchResultEntity`
+
+`ReturnsValue<T>` takes a single concrete type, but search spans three entity types. Flatten them
+into one entity with a `kind` discriminator (the standard AppIntents answer to "no union return"):
+
+```swift
+public struct ContentSearchResultEntity: AppEntity, Identifiable, Sendable {
+    public let id: String          // the underlying entity id, e.g. "s1:page:/about"
+    @Property(title: "Kind")    public var kind: ContentKind   // page | post | image (AppEnum)
+    @Property(title: "Title")   public var title: String       // displayName of the underlying entity
+    @Property(title: "Locator") public var locator: String     // route | "collection/slug" | relativePath
+    @Property(title: "Site ID") public var siteID: String
+    // typeDisplayRepresentation "Search Result"; displayRepresentation title: title, subtitle: locator
+}
+
+public enum ContentKind: String, AppEnum { case page, post, image /* + CaseDisplayRepresentations */ }
+```
+
+The `id` **is** the underlying entity id, so it is lossless for re-resolution: an agent can take a
+`kind == .page` result and resolve the matching `PageEntity` (via `PageEntityQuery.entities(for:)`)
+to pipe into `PreviewSiteIntent`.
+
+### Query
+
+`ContentSearchResultEntity` needs an `EntityQuery` (AppEntity requirement). `entities(for:)` parses
+the `kind` token out of each id (`"{siteID}:{kind}:{locator}"`), groups ids by kind, and delegates
+to the existing graph lookups (`pages(ids:)` / `posts(ids:)` / `images(ids:)`), mapping each hit
+into a `ContentSearchResultEntity`. No `EntityStringQuery` (string search lives on the typed entity
+queries and on the intent itself) — a plain `EntityQuery` is sufficient for id round-trip.
+
+### Intent change
+
+`SearchContentIntent.perform()` →
+`some IntentResult & ProvidesDialog & ReturnsValue<[ContentSearchResultEntity]>`.
+
+The existing `static func dialog(...)` already gathers `pages`/`posts`/`images`. Refactor the
+gather step so `perform()` reuses the matched entities to build *both* the spoken count dialog
+(unchanged wording) **and** the flattened result array. Sort the combined results deterministically
+(reuse the lastModified-desc, id-asc ordering the entity queries use) so the returned list is stable.
+
+### Tests (F-2)
+
+- Pure mapping test: given known graph fixtures, `searchContent` produces the expected flattened
+  `[ContentSearchResultEntity]` with correct `kind`/`id`/`locator` per type.
+- Dialog parity: the spoken count string is byte-identical to today's `ContentDialogs.search(...)`.
+- Query round-trip: `ContentSearchResultEntity` ids resolve back through the new `EntityQuery`.
+
+## D.2 Closeout — the descriptor decision *(docs-only PR / folded into PR 3)*
+
+Update `docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md` (or append a short D.2 closeout
+note there) recording the resolution of the two D.2 candidate descriptors:
+
+- **`anglesite_list_content` — not needed.** The enriched `SearchContentIntent` (typed result
+  list) plus `SiteStatusIntent` cover structured content enumeration. No separate descriptor.
+- **`anglesite_apply_edit` — deliberately not exposed** as a system-wide intent. It is a low-level
+  `selector / op / value` primitive, not a natural-language action. Handing an arbitrary external
+  agent a structured DOM-edit primitive *without the edit overlay's live selection context* is a
+  safety regression (no human-in-the-loop targeting). It stays on the **app-internal** MCP path
+  (`MCPClient` + `AnglesiteBridge`). `EditContentIntent`'s natural-language `instruction` form
+  remains the agent-facing edit surface.
+
+With both candidates resolved, #163 closes: the auto-derived tools from the enriched intents are
+the "custom MCP tool descriptors," and no hand-registered `AnglesiteMCPRegistration` descriptors
+are required.
+
+## Out of scope
+
+- Device-level donated-Shortcut persistence verification after the F-1 schema bump (manual smoke,
+  tracked as a PR follow-up).
+- Any `AnglesiteMCPRegistration` / hand-written descriptor surface (explicitly decided against).
+- The `SiteEntityQuery` empty-string "list all" inconsistency (D.1 recorded it as intentional;
+  unchanged).
+- Phase D's remaining sub-issues (D.3 bootstrap wiring #164, D.4 security smoke #165, D.5 CLI smoke
+  #166) — separate work that consumes the schema this spec produces.
+
+## Testing summary
+
+All changes live in `AnglesiteIntents`, fully covered by the Swift Testing suite via the existing
+`ContentGraphOverride` / `ContentOperationsOverride` seams — no AppIntents runtime, no hosted app
+target, so it runs on CI. Target: `AnglesiteIntents` suite stays green and grows by the per-PR
+tests above. Full suite parity otherwise unchanged (the known #222 plugin-path e2e tests are
+unrelated).

--- a/docs/specs/2026-06-17-d2-intent-mcp-enrichment-plan.md
+++ b/docs/specs/2026-06-17-d2-intent-mcp-enrichment-plan.md
@@ -1,0 +1,780 @@
+# D.2 Intent Schema Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich the Anglesite App Intent / `AppEntity` schema so macOS 27's `mcpbridge` auto-derives agent-usable MCP tools — typed extractable entity fields, structured create-intent returns, and a unified search result — then record that no hand-written MCP descriptors are needed.
+
+**Architecture:** Three independent, additive changes to the `AnglesiteIntents` module, each landing as its own stacked PR into `main`: F-1 promotes entity fields to `@Property`; F-3 makes the create intents return the created entity via `ReturnsValue<T>`; F-2 adds a flattened `ContentSearchResultEntity` and gives `SearchContentIntent` a `ReturnsValue<[ContentSearchResultEntity]>`. All are covered by the existing Swift Testing seams (`ContentGraphOverride` / `ContentOperationsOverride`) — no AppIntents runtime, no hosted app target, so everything runs under `swift test` on CI.
+
+**Tech Stack:** Swift 6.4 / AppIntents (macOS 27), Swift Testing (`@Test`/`@Suite`), SwiftPM (`swift test`).
+
+**Spec:** [`docs/specs/2026-06-17-d2-intent-mcp-enrichment-design.md`](./2026-06-17-d2-intent-mcp-enrichment-design.md)
+
+## Global Constraints
+
+- **No frameworks beyond Apple's** — AppIntents + Swift Testing only; no new dependencies.
+- **Strictly additive schema changes** — never rename or remove an existing `AppEntity` field, and never change `id`, `displayName`, or `displayRepresentation`. Already-donated Shortcuts interactions resolve by `id`, which must stay stable.
+- **Entity id formulas are fixed** (must match `SiteContentGraph`): page `"{siteID}:page:{route}"`, post `"{siteID}:post:{slug}"`, image `"{siteID}:image:{relativePath}"`.
+- **Test seams** — bypass `@Dependency` via `ContentGraphOverride.$scoped.withValue(...)` (reads) and `ContentOperationsOverride.$scoped.withValue(...)` (creates). Direct `@Dependency` access outside the AppIntents runtime crashes.
+- **Tests assert via fakes / reconstructed entities**, never by reading `perform()`'s opaque `ReturnsValue` result (the return type is not destructurable in a unit test — this is why every "does it return the entity?" check is done against a pure helper, not `perform()`).
+- **Dialog wording is frozen** — `ContentDialogs.search(...)` / `.status(...)` output strings must stay byte-identical (existing tests assert exact strings).
+- **Worktree:** all work happens in `.claude/worktrees/d2-intent-enrichment` (already created off `main`, branch `feat/d2-intent-mcp-enrichment`, which already holds the spec + this plan commit). Run `swift test` from that directory.
+
+## PR sequencing
+
+Three stacked PRs, in this order (each builds on the prior so the schema compounds):
+
+1. **PR 1 — F-1** (`@Property` promotion). Base: current branch (`feat/d2-intent-mcp-enrichment`, holds spec+plan).
+2. **PR 2 — F-3** (create-intent structured returns). Branch off PR 1's head.
+3. **PR 3 — F-2** (unified search result + closeout). Branch off PR 2's head.
+
+Branch/commit/PR mechanics are handled by the execution skill; this plan defines the code and tests.
+
+## Test command reference
+
+- Run one suite: `swift test --package-path . --filter <SuiteName>` (e.g. `--filter ContentEntities`).
+- Run one test by function name: `swift test --package-path . --filter <funcName>`.
+- Full intents verification at PR end: `swift test --package-path . 2>&1 | tail -40`.
+  - **Expected baseline:** all `AnglesiteIntents` / `AnglesiteCore` / `AnglesiteBridge` suites pass; the two plugin-path e2e tests (`MCPClientHTTPEndToEndTests`, `AppliesEditEndToEndTests`) fail when the sibling plugin checkout is absent (known #222) — that is the unchanged baseline, not a regression from this work.
+
+---
+
+## PR 1 — F-1: `@Property` promotion
+
+**File structure:**
+- Modify: `Sources/AnglesiteIntents/ContentEntities.swift` — promote disambiguating fields on `PageEntity`, `PostEntity`, `ImageEntity` from `let` to `@Property var`.
+- Test: `Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift` — add a suite asserting promoted fields survive construction.
+
+### Task 1.1: Promote entity fields to `@Property`
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/ContentEntities.swift`
+- Test: `Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift`
+
+**Interfaces:**
+- Produces: `PageEntity.route`, `PageEntity.siteID`, `PostEntity.slug`, `PostEntity.collection`, `PostEntity.siteID`, `ImageEntity.relativePath`, `ImageEntity.siteID` as `@Property`-annotated `public var`s (same names, same types, same values — only the storage annotation changes). `id`, `displayName`, `displayRepresentation`, the `init(_:)` initializers, and all queries are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift` (inside `extension AppIntentsTests`, after the fixtures, before `PageEntityQueryTests`):
+
+```swift
+@Suite("PropertyPromotion (F-1)")
+struct PropertyPromotionTests {
+    @Test("promoted PageEntity fields round-trip through construction")
+    func pageFields() {
+        let e = PageEntity(AppIntentsTests.gPage(route: "/about", title: "About"))
+        #expect(e.route == "/about")
+        #expect(e.siteID == AppIntentsTests.aSite)
+        #expect(e.id == "\(AppIntentsTests.aSite):page:/about")  // id unchanged
+    }
+
+    @Test("promoted PostEntity fields round-trip through construction")
+    func postFields() {
+        let e = PostEntity(AppIntentsTests.gPost(slug: "hello-world", collection: "blog"))
+        #expect(e.slug == "hello-world")
+        #expect(e.collection == "blog")
+        #expect(e.siteID == AppIntentsTests.aSite)
+    }
+
+    @Test("promoted ImageEntity fields round-trip through construction")
+    func imageFields() {
+        let e = ImageEntity(AppIntentsTests.gImage(relativePath: "public/images/hero.jpg"))
+        #expect(e.relativePath == "public/images/hero.jpg")
+        #expect(e.siteID == AppIntentsTests.aSite)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it compiles+passes already (baseline) — fields are currently `let`**
+
+Run: `swift test --package-path . --filter PropertyPromotion`
+Expected: PASS (the fields are readable today as `let`). This test is a *regression guard* — it must still pass after the `let`→`@Property` change. (If you prefer a strict red phase, temporarily rename a field in the test to see it fail, then revert.)
+
+- [ ] **Step 3: Promote the fields in `ContentEntities.swift`**
+
+In `PageEntity`, change:
+```swift
+public let route: String
+public let siteID: String
+```
+to:
+```swift
+@Property(title: "Route") public var route: String
+@Property(title: "Site ID") public var siteID: String
+```
+Leave `public let id`, `public let displayName`, and the `init(_ page:)` body unchanged (`self.route = page.route` / `self.siteID = page.siteID` still compile — `@Property` is assignable in `init`).
+
+In `PostEntity`, change `public let slug`, `public let collection`, `public let siteID` to:
+```swift
+@Property(title: "Slug") public var slug: String
+@Property(title: "Collection") public var collection: String
+@Property(title: "Site ID") public var siteID: String
+```
+Leave `isDraft` and `tags` as plain `let` (not part of F-1).
+
+In `ImageEntity`, change `public let relativePath`, `public let siteID` to:
+```swift
+@Property(title: "Relative Path") public var relativePath: String
+@Property(title: "Site ID") public var siteID: String
+```
+Leave `usedOnPages` a plain `let` (intentionally out of schema — keep its existing comment).
+
+- [ ] **Step 4: Run the promotion test + the full entity suite**
+
+Run: `swift test --package-path . --filter ContentEntities`
+Expected: PASS — `PropertyPromotion` plus all existing `PageEntityQuery` / `PostEntityQuery` / `ImageEntityQuery` tests stay green (construction, search, and id resolution are unaffected).
+
+- [ ] **Step 5: Full intents-suite sanity**
+
+Run: `swift test --package-path . --filter AppIntentsTests`
+Expected: PASS for all nested intents suites (the `extension AppIntentsTests` suites share that root). No behavior change anywhere else.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/ContentEntities.swift Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
+git commit -m "feat(intents): F-1 — promote entity fields to @Property for typed MCP chaining (#163)
+
+route/siteID (Page), slug/collection/siteID (Post), relativePath/siteID (Image)
+become @Property so mcpbridge-derived tools expose them as extractable typed
+fields. Strictly additive: id/displayName/displayRepresentation unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## PR 2 — F-3: create intents return the created entity
+
+**File structure:**
+- Modify: `Sources/AnglesiteIntents/ContentEntities.swift` — add a direct field initializer and a `make(...)` factory to `PageEntity` and `PostEntity`.
+- Modify: `Sources/AnglesiteIntents/ContentIntents.swift` — `AddPageIntent` / `AddPostIntent` gain `ReturnsValue<…>` and call the factory.
+- Test: `Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift` (factory tests) and `Tests/AnglesiteIntentsTests/ContentIntentsTests.swift` + `IntentChainingTests.swift` (intent + chaining).
+
+### Task 2.1: `PageEntity` create-factory + `AddPageIntent` structured return
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/ContentEntities.swift`
+- Modify: `Sources/AnglesiteIntents/ContentIntents.swift:113-154` (`AddPageIntent`)
+- Test: `Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift`, `Tests/AnglesiteIntentsTests/ContentIntentsTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentCreateResult` (`.created(filePath:identifier:)` / `.siteNotFound` / `.failed(reason:)`) from `AnglesiteCore`.
+- Produces:
+  - `PageEntity.init(id: String, displayName: String, route: String, siteID: String)` — direct field init.
+  - `static func PageEntity.make(siteID: String, name: String, requestedRoute: String?, result: ContentCreateResult) -> PageEntity` — success uses `result`'s `identifier` as the route; failure falls back to `requestedRoute ?? ""`. Always returns an entity (never optional).
+  - `AddPageIntent.perform()` returns `some IntentResult & ProvidesDialog & ReturnsValue<PageEntity>`.
+
+- [ ] **Step 1: Write the failing factory test**
+
+Add to `ContentEntitiesTests.swift` inside the `PropertyPromotion` neighbor area, a new suite:
+
+```swift
+@Suite("CreateFactory.Page (F-3)")
+struct CreatePageFactoryTests {
+    @Test("success: route comes from the created identifier; id matches graph formula")
+    func success() {
+        let e = PageEntity.make(
+            siteID: AppIntentsTests.aSite, name: "About Us", requestedRoute: nil,
+            result: .created(filePath: "src/pages/about.astro", identifier: "/about"))
+        #expect(e.route == "/about")
+        #expect(e.siteID == AppIntentsTests.aSite)
+        #expect(e.displayName == "About Us")
+        #expect(e.id == "\(AppIntentsTests.aSite):page:/about")
+    }
+
+    @Test("failure: best-effort entity from the requested route")
+    func failure() {
+        let e = PageEntity.make(
+            siteID: AppIntentsTests.aSite, name: "About", requestedRoute: "/about",
+            result: .failed(reason: "boom"))
+        #expect(e.route == "/about")
+        #expect(e.id == "\(AppIntentsTests.aSite):page:/about")
+        #expect(e.displayName == "About")
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter CreateFactory.Page`
+Expected: FAIL — `PageEntity.make` / `PageEntity.init(id:displayName:route:siteID:)` do not exist (compile error).
+
+- [ ] **Step 3: Implement the init + factory in `ContentEntities.swift`**
+
+Add to `PageEntity` (after the existing `init(_ page:)`):
+
+```swift
+/// Direct field initializer — used to build a return value from data already in hand
+/// (e.g. a just-created page) without round-tripping through `SiteContentGraph`,
+/// which the file-watcher may not have indexed yet.
+public init(id: String, displayName: String, route: String, siteID: String) {
+    self.id = id
+    self.displayName = displayName
+    self.route = route
+    self.siteID = siteID
+}
+
+/// Build the entity an `AddPageIntent` returns. On success the route is the created
+/// identifier; on failure we return a best-effort entity from the requested input so the
+/// intent keeps a single `ReturnsValue<PageEntity>` type. The dialog — not this value — is
+/// the source of truth for whether creation actually succeeded.
+public static func make(
+    siteID: String, name: String, requestedRoute: String?, result: ContentCreateResult
+) -> PageEntity {
+    let route: String
+    switch result {
+    case .created(_, let identifier): route = identifier
+    case .siteNotFound, .failed:       route = requestedRoute ?? ""
+    }
+    return PageEntity(id: "\(siteID):page:\(route)", displayName: name, route: route, siteID: siteID)
+}
+```
+
+- [ ] **Step 4: Run the factory test to verify it passes**
+
+Run: `swift test --package-path . --filter CreateFactory.Page`
+Expected: PASS.
+
+- [ ] **Step 5: Change `AddPageIntent.perform()` to return the entity**
+
+In `ContentIntents.swift`, change `AddPageIntent.perform()`'s signature from
+`-> some IntentResult & ProvidesDialog` to
+`-> some IntentResult & ProvidesDialog & ReturnsValue<PageEntity>`,
+and change the final return from
+```swift
+return .result(dialog: IntentDialog(stringLiteral: ContentDialogs.created(result, kind: .page, siteName: site.displayName)))
+```
+to
+```swift
+let entity = PageEntity.make(siteID: site.id, name: name, requestedRoute: route, result: result)
+return .result(value: entity,
+               dialog: IntentDialog(stringLiteral: ContentDialogs.created(result, kind: .page, siteName: site.displayName)))
+```
+Leave the scoped/background-task branching above it unchanged.
+
+- [ ] **Step 6: Extend the intent test to assert the returned entity (via the factory, not perform's opaque result)**
+
+The existing `addPageForwards` / `createFailureIsHandled` tests in `ContentIntentsTests.swift` already prove `perform()` runs and forwards args. Add a dedicated factory-through-intent assertion (kept at the factory layer per the Global Constraints):
+
+```swift
+@Test("AddPage returns an entity carrying the created route")
+func addPageReturnsEntity() {
+    let e = PageEntity.make(
+        siteID: AppIntentsTests.aSite, name: "About", requestedRoute: "/about",
+        result: .created(filePath: "src/pages/about.astro", identifier: "/about"))
+    #expect(e.route == "/about")
+    #expect(e.id == "\(AppIntentsTests.aSite):page:/about")
+}
+```
+
+- [ ] **Step 7: Add a create→preview chaining test**
+
+Add to `Tests/AnglesiteIntentsTests/IntentChainingTests.swift` inside the `IntentChaining` suite:
+
+```swift
+// F-3 (#163): AddPageIntent returns the created PageEntity so an agent can chain
+// create→preview. Reproduce by feeding the factory-built entity into PreviewSiteIntent.
+@Test("add-page output flows into preview as input")
+@MainActor
+func addPageOutputFlowsIntoPreview() async throws {
+    WindowRouter.shared.requested = nil
+    let created = PageEntity.make(
+        siteID: AppIntentsTests.aSite, name: "About", requestedRoute: "/about",
+        result: .created(filePath: "src/pages/about.astro", identifier: "/about"))
+
+    var preview = PreviewSiteIntent()
+    preview.site = SiteEntity(TestStore.site(id: AppIntentsTests.aSite, name: "Alpha"))
+    preview.page = created
+    _ = try await preview.perform()
+
+    #expect(WindowRouter.shared.requested == AppIntentsTests.aSite)
+}
+```
+
+- [ ] **Step 8: Run page tests + full intents suite**
+
+Run: `swift test --package-path . --filter AppIntentsTests`
+Expected: PASS — new factory/chaining tests plus all existing `ContentIntents` tests (including `addPageForwards`, `createFailureIsHandled`, which still call `perform()` and must compile against the new return type).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/ContentEntities.swift Sources/AnglesiteIntents/ContentIntents.swift Tests/AnglesiteIntentsTests/
+git commit -m "feat(intents): F-3a — AddPageIntent returns created PageEntity (ReturnsValue) (#163)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 2.2: `PostEntity` create-factory + `AddPostIntent` structured return
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/ContentEntities.swift`
+- Modify: `Sources/AnglesiteIntents/ContentIntents.swift:158-201` (`AddPostIntent`)
+- Test: `Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift`, `Tests/AnglesiteIntentsTests/IntentChainingTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `PostEntity.init(id: String, displayName: String, slug: String, collection: String, siteID: String, isDraft: Bool, tags: [String])` — direct field init.
+  - `static func PostEntity.collection(fromPath: String) -> String?` — extracts the collection segment from a post file path `"src/content/{collection}/{slug}.md"` (the path component immediately before the file). Returns `nil` if it can't parse.
+  - `static func PostEntity.make(siteID: String, title: String, requestedCollection: String?, requestedSlug: String?, result: ContentCreateResult) -> PostEntity` — success: slug = identifier, collection = `collection(fromPath:) ?? requestedCollection ?? ""`, `isDraft = true`, `tags = []`; failure: slug = `requestedSlug ?? ""`, collection = `requestedCollection ?? ""`.
+  - `AddPostIntent.perform()` returns `some IntentResult & ProvidesDialog & ReturnsValue<PostEntity>`.
+
+- [ ] **Step 1: Write the failing factory + path-helper test**
+
+Add to `ContentEntitiesTests.swift`:
+
+```swift
+@Suite("CreateFactory.Post (F-3)")
+struct CreatePostFactoryTests {
+    @Test("collection(fromPath:) extracts the content collection segment")
+    func collectionFromPath() {
+        #expect(PostEntity.collection(fromPath: "src/content/blog/hello.md") == "blog")
+        #expect(PostEntity.collection(fromPath: "src/content/notes/x.md") == "notes")
+        #expect(PostEntity.collection(fromPath: "weird.md") == nil)
+    }
+
+    @Test("success: slug from identifier; collection derived from filePath; draft scaffold")
+    func success() {
+        let e = PostEntity.make(
+            siteID: AppIntentsTests.aSite, title: "Hello World",
+            requestedCollection: nil, requestedSlug: nil,
+            result: .created(filePath: "src/content/blog/hello-world.md", identifier: "hello-world"))
+        #expect(e.slug == "hello-world")
+        #expect(e.collection == "blog")
+        #expect(e.isDraft == true)
+        #expect(e.tags.isEmpty)
+        #expect(e.id == "\(AppIntentsTests.aSite):post:hello-world")
+        #expect(e.displayName == "Hello World")
+    }
+
+    @Test("success: user-supplied collection wins when filePath can't be parsed")
+    func userCollectionFallback() {
+        let e = PostEntity.make(
+            siteID: AppIntentsTests.aSite, title: "X",
+            requestedCollection: "notes", requestedSlug: nil,
+            result: .created(filePath: "unparseable.md", identifier: "x"))
+        #expect(e.collection == "notes")
+    }
+
+    @Test("failure: best-effort entity from requested slug/collection")
+    func failure() {
+        let e = PostEntity.make(
+            siteID: AppIntentsTests.aSite, title: "X",
+            requestedCollection: "notes", requestedSlug: "x",
+            result: .failed(reason: "boom"))
+        #expect(e.slug == "x")
+        #expect(e.collection == "notes")
+        #expect(e.id == "\(AppIntentsTests.aSite):post:x")
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter CreateFactory.Post`
+Expected: FAIL — `PostEntity.make` / `.collection(fromPath:)` / the direct init do not exist.
+
+- [ ] **Step 3: Implement init + helpers in `ContentEntities.swift`**
+
+Add to `PostEntity` (after `init(_ post:)`):
+
+```swift
+public init(id: String, displayName: String, slug: String, collection: String,
+            siteID: String, isDraft: Bool, tags: [String]) {
+    self.id = id
+    self.displayName = displayName
+    self.slug = slug
+    self.collection = collection
+    self.siteID = siteID
+    self.isDraft = isDraft
+    self.tags = tags
+}
+
+/// `"src/content/{collection}/{slug}.md"` → `"{collection}"`. The collection is the path
+/// component immediately before the file. Returns nil when the path has no such parent.
+public static func collection(fromPath path: String) -> String? {
+    let parts = path.split(separator: "/").map(String.init)
+    guard parts.count >= 2 else { return nil }
+    return parts[parts.count - 2]
+}
+
+/// Build the entity an `AddPostIntent` returns. Add Post scaffolds a *draft*, so `isDraft`
+/// is true and `tags` empty. The dialog is the source of truth for success vs. failure.
+public static func make(
+    siteID: String, title: String, requestedCollection: String?, requestedSlug: String?,
+    result: ContentCreateResult
+) -> PostEntity {
+    let slug: String
+    let collection: String
+    switch result {
+    case .created(let filePath, let identifier):
+        slug = identifier
+        collection = Self.collection(fromPath: filePath) ?? requestedCollection ?? ""
+    case .siteNotFound, .failed:
+        slug = requestedSlug ?? ""
+        collection = requestedCollection ?? ""
+    }
+    return PostEntity(id: "\(siteID):post:\(slug)", displayName: title, slug: slug,
+                      collection: collection, siteID: siteID, isDraft: true, tags: [])
+}
+```
+
+- [ ] **Step 4: Run the factory test to verify it passes**
+
+Run: `swift test --package-path . --filter CreateFactory.Post`
+Expected: PASS.
+
+- [ ] **Step 5: Change `AddPostIntent.perform()` to return the entity**
+
+In `ContentIntents.swift`, change `AddPostIntent.perform()`'s return type to
+`-> some IntentResult & ProvidesDialog & ReturnsValue<PostEntity>` and the final return to:
+```swift
+let entity = PostEntity.make(siteID: site.id, title: title2, requestedCollection: collection,
+                             requestedSlug: slug, result: result)
+return .result(value: entity,
+               dialog: IntentDialog(stringLiteral: ContentDialogs.created(result, kind: .post, siteName: site.displayName)))
+```
+
+- [ ] **Step 6: Add an add-post→preview-style chaining assertion**
+
+Posts don't preview via `PreviewSiteIntent` (that takes a `PageEntity`), so the chaining check stays at the factory layer. Add to `IntentChainingTests.swift`:
+
+```swift
+// F-3 (#163): AddPostIntent returns the created PostEntity carrying slug+collection for chaining.
+@Test("add-post output carries slug and collection for chaining")
+func addPostOutputCarriesIdentity() {
+    let e = PostEntity.make(
+        siteID: AppIntentsTests.aSite, title: "Hello", requestedCollection: nil, requestedSlug: nil,
+        result: .created(filePath: "src/content/blog/hello.md", identifier: "hello"))
+    #expect(e.slug == "hello")
+    #expect(e.collection == "blog")
+    #expect(e.id == "\(AppIntentsTests.aSite):post:hello")
+}
+```
+
+- [ ] **Step 7: Run post tests + full intents suite**
+
+Run: `swift test --package-path . --filter AppIntentsTests`
+Expected: PASS — new post factory/chaining tests plus existing `addPostForwards` / `createFailureIsHandled` (which call `AddPostIntent.perform()` and must compile against the new return type).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/ContentEntities.swift Sources/AnglesiteIntents/ContentIntents.swift Tests/AnglesiteIntentsTests/
+git commit -m "feat(intents): F-3b — AddPostIntent returns created PostEntity (ReturnsValue) (#163)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## PR 3 — F-2: unified `SearchContentIntent` structured return
+
+**File structure:**
+- Modify: `Sources/AnglesiteIntents/ContentEntities.swift` — add `ContentKind` (`AppEnum`), `ContentSearchResultEntity` (`AppEntity`), and `ContentSearchResultEntityQuery` (`EntityQuery`).
+- Modify: `Sources/AnglesiteIntents/ContentIntents.swift:22-52` (`SearchContentIntent`) — gather entities once, return `ReturnsValue<[ContentSearchResultEntity]>`, keep the dialog.
+- Modify: `docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md` — append the D.2 closeout note.
+- Test: `Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift`, `Tests/AnglesiteIntentsTests/ContentIntentsTests.swift`.
+
+### Task 3.1: `ContentSearchResultEntity` + query
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/ContentEntities.swift`
+- Test: `Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `enum ContentKind: String, AppEnum, Sendable { case page, post, image }` with `typeDisplayRepresentation` + `caseDisplayRepresentations`.
+  - `struct ContentSearchResultEntity: AppEntity, Identifiable, Sendable` with `let id: String` and `@Property` `kind: ContentKind`, `title: String`, `locator: String`, `siteID: String`; plus three convenience initializers `init(page:)`, `init(post:)`, `init(image:)` mapping the typed entities into a flattened result (`locator` = `route` / `"{collection}/{slug}"` / `relativePath`).
+  - `struct ContentSearchResultEntityQuery: EntityQuery` whose `entities(for:)` parses the kind token from each id (`"{siteID}:{kind}:{rest}"`) and delegates to `SiteContentGraph.pages(ids:)` / `.posts(ids:)` / `.images(ids:)`, mapping hits back into `ContentSearchResultEntity`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ContentEntitiesTests.swift`:
+
+```swift
+@Suite("ContentSearchResultEntity (F-2)")
+struct SearchResultEntityTests {
+    @Test("maps each typed entity into a flattened result with kind + locator")
+    func mapping() {
+        let p = ContentSearchResultEntity(page: PageEntity(AppIntentsTests.gPage(route: "/about", title: "About")))
+        #expect(p.kind == .page)
+        #expect(p.title == "About")
+        #expect(p.locator == "/about")
+        #expect(p.id == "\(AppIntentsTests.aSite):page:/about")
+
+        let o = ContentSearchResultEntity(post: PostEntity(AppIntentsTests.gPost(slug: "hi", collection: "blog", title: "Hi")))
+        #expect(o.kind == .post)
+        #expect(o.locator == "blog/hi")
+        #expect(o.id == "\(AppIntentsTests.aSite):post:hi")
+
+        let i = ContentSearchResultEntity(image: ImageEntity(AppIntentsTests.gImage(relativePath: "public/images/hero.jpg", fileName: "hero.jpg")))
+        #expect(i.kind == .image)
+        #expect(i.title == "hero.jpg")
+        #expect(i.locator == "public/images/hero.jpg")
+    }
+
+    @Test("query resolves ids back through the graph by kind")
+    func queryRoundTrip() async throws {
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: AppIntentsTests.aSite,
+            pages: [AppIntentsTests.gPage(route: "/about", title: "About")],
+            posts: [AppIntentsTests.gPost(slug: "hi", collection: "blog", title: "Hi")],
+            images: [])
+        try await ContentGraphOverride.$scoped.withValue(graph) {
+            let results = try await ContentSearchResultEntityQuery().entities(
+                for: ["\(AppIntentsTests.aSite):page:/about", "\(AppIntentsTests.aSite):post:hi"])
+            #expect(results.count == 2)
+            #expect(results.contains { $0.kind == .page && $0.locator == "/about" })
+            #expect(results.contains { $0.kind == .post && $0.locator == "blog/hi" })
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter ContentSearchResultEntity`
+Expected: FAIL — the new types don't exist (compile error).
+
+- [ ] **Step 3: Implement the enum, entity, and query in `ContentEntities.swift`**
+
+Append a new `MARK` section:
+
+```swift
+// MARK: - ContentSearchResultEntity (F-2)
+
+/// Discriminator for the flattened search result. `SearchContentIntent` spans three entity
+/// types; `ReturnsValue<T>` needs one concrete type, so results carry their kind.
+public enum ContentKind: String, AppEnum, Sendable {
+    case page, post, image
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Content Kind" }
+    public static var caseDisplayRepresentations: [ContentKind: DisplayRepresentation] {
+        [.page: "Page", .post: "Post", .image: "Image"]
+    }
+}
+
+/// A single search hit, flattened across pages/posts/images. `id` is the *underlying* entity id
+/// (e.g. "s1:page:/about"), so an agent can re-resolve the typed entity (PageEntity, …) to chain.
+public struct ContentSearchResultEntity: AppEntity, Identifiable, Sendable {
+    public let id: String
+    @Property(title: "Kind")    public var kind: ContentKind
+    @Property(title: "Title")   public var title: String
+    @Property(title: "Locator") public var locator: String
+    @Property(title: "Site ID") public var siteID: String
+
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Search Result" }
+    public var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(title)", subtitle: "\(locator)")
+    }
+    public static let defaultQuery = ContentSearchResultEntityQuery()
+
+    public init(id: String, kind: ContentKind, title: String, locator: String, siteID: String) {
+        self.id = id; self.kind = kind; self.title = title; self.locator = locator; self.siteID = siteID
+    }
+    public init(page e: PageEntity) {
+        self.init(id: e.id, kind: .page, title: e.displayName, locator: e.route, siteID: e.siteID)
+    }
+    public init(post e: PostEntity) {
+        self.init(id: e.id, kind: .post, title: e.displayName, locator: "\(e.collection)/\(e.slug)", siteID: e.siteID)
+    }
+    public init(image e: ImageEntity) {
+        self.init(id: e.id, kind: .image, title: e.displayName, locator: e.relativePath, siteID: e.siteID)
+    }
+}
+
+/// Re-resolves flattened results by parsing the kind token out of each id and delegating to the
+/// graph's typed id lookups. Plain `EntityQuery` (not `EntityStringQuery`): string search lives on
+/// the typed entity queries and on `SearchContentIntent` itself; this only needs id round-trip.
+public struct ContentSearchResultEntityQuery: EntityQuery {
+    @Dependency private var graph: SiteContentGraph
+    public init() {}
+    private var resolved: SiteContentGraph { ContentGraphOverride.scoped ?? graph }
+
+    public func entities(for identifiers: [String]) async throws -> [ContentSearchResultEntity] {
+        let g = resolved
+        var pageIDs: [String] = [], postIDs: [String] = [], imageIDs: [String] = []
+        for id in identifiers {
+            // id == "{siteID}:{kind}:{rest}". The siteID is a filesystem path (no ":"), so splitting
+            // on ":" with maxSplits 2 yields exactly [siteID, kind, rest]; parts[1] is the kind.
+            let parts = id.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false).map(String.init)
+            guard parts.count == 3 else { continue }
+            switch parts[1] {
+            case "page": pageIDs.append(id)
+            case "post": postIDs.append(id)
+            case "image": imageIDs.append(id)
+            default: continue
+            }
+        }
+        async let pages = g.pages(ids: pageIDs)
+        async let posts = g.posts(ids: postIDs)
+        async let images = g.images(ids: imageIDs)
+        let mapped = await (pages.map { ContentSearchResultEntity(page: PageEntity($0)) }
+            + posts.map { ContentSearchResultEntity(post: PostEntity($0)) }
+            + images.map { ContentSearchResultEntity(image: ImageEntity($0)) })
+        // Preserve caller's id order.
+        let order = Dictionary(uniqueKeysWithValues: identifiers.enumerated().map { ($1, $0) })
+        return mapped.sorted { (order[$0.id] ?? .max) < (order[$1.id] ?? .max) }
+    }
+}
+```
+
+> **Implementer note on id parsing:** a site id like `/Users/x/Sites/alpha` contains `/` but no `:`. The entity id is `"{siteID}:{kind}:{rest}"`. Splitting on `:` with `maxSplits: 2` yields exactly `[siteID, kind, rest]` — `parts[1]` is the kind. Verify with the `queryRoundTrip` test (the fixture siteID has no `:`).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --package-path . --filter ContentSearchResultEntity`
+Expected: PASS — both mapping and query round-trip.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/ContentEntities.swift Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
+git commit -m "feat(intents): F-2a — ContentSearchResultEntity flattened search result + query (#163)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 3.2: `SearchContentIntent` returns the flattened results
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/ContentIntents.swift:22-52`
+- Test: `Tests/AnglesiteIntentsTests/ContentIntentsTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentSearchResultEntity` (Task 3.1), `SiteContentGraph.searchPages/Posts/Images`.
+- Produces: `static func SearchContentIntent.results(graph:siteID:query:) async -> (dialog: String, items: [ContentSearchResultEntity])` — gathers matches once and returns both the (frozen-wording) dialog and the flattened, deterministically-sorted results. `perform()` returns `some IntentResult & ProvidesDialog & ReturnsValue<[ContentSearchResultEntity]>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ContentIntentsTests.swift`:
+
+```swift
+@Test("SearchContentIntent.results returns dialog parity + flattened typed results")
+func searchResults() async {
+    let graph = SiteContentGraph()
+    await graph.load(
+        siteID: AppIntentsTests.aSite,
+        pages: [AppIntentsTests.gPage(route: "/about", title: "About")],
+        posts: [AppIntentsTests.gPost(slug: "about-us", title: "About Us")],
+        images: [])
+    let (dialog, items) = await SearchContentIntent.results(graph: graph, siteID: AppIntentsTests.aSite, query: "about")
+    #expect(dialog == "Found 1 page and 1 post matching “about”.")   // byte-identical to before
+    #expect(items.count == 2)
+    #expect(items.contains { $0.kind == .page && $0.locator == "/about" })
+    #expect(items.contains { $0.kind == .post && $0.locator == "blog/about-us" })
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter searchResults`
+Expected: FAIL — `SearchContentIntent.results(...)` doesn't exist.
+
+- [ ] **Step 3: Refactor `SearchContentIntent` in `ContentIntents.swift`**
+
+Replace the existing `dialog(...)` helper and `perform()` with:
+
+```swift
+public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<[ContentSearchResultEntity]> {
+    let (dialog, items) = await Self.results(graph: ContentGraphOverride.scoped ?? graph, siteID: site.id, query: query)
+    return .result(value: items, dialog: IntentDialog(stringLiteral: dialog))
+}
+
+/// Gather matches once and build both the spoken dialog (unchanged wording) and the flattened
+/// typed results. Static + graph-injected so it's unit-testable without the AppIntents runtime.
+static func results(graph: SiteContentGraph, siteID: String, query: String) async -> (dialog: String, items: [ContentSearchResultEntity]) {
+    let pages = await graph.searchPages(siteID: siteID, matching: query)
+    let posts = await graph.searchPosts(siteID: siteID, matching: query)
+    let images = await graph.searchImages(siteID: siteID, matching: query)
+    let dialog = ContentDialogs.search(query: query, pageCount: pages.count, postCount: posts.count, imageCount: images.count)
+    let items = pages.map { ContentSearchResultEntity(page: PageEntity($0)) }
+        + posts.map { ContentSearchResultEntity(post: PostEntity($0)) }
+        + images.map { ContentSearchResultEntity(image: ImageEntity($0)) }
+    return (dialog, items)
+}
+```
+
+> Note: the old `static func dialog(...)` is removed. The existing `searchHelper` test in `ContentIntentsTests.swift` calls `SearchContentIntent.dialog(...)` — update it to call `SearchContentIntent.results(...).dialog` so it keeps asserting dialog parity. (`SiteStatusIntent.dialog(...)` is untouched.)
+
+- [ ] **Step 4: Update the existing `searchHelper` test to the new API**
+
+In `ContentIntentsTests.swift`, change the body of `searchHelper()` from
+`let dialog = await SearchContentIntent.dialog(graph: graph, siteID: AppIntentsTests.aSite, query: "about")`
+to
+`let dialog = await SearchContentIntent.results(graph: graph, siteID: AppIntentsTests.aSite, query: "about").dialog`
+(leave the `#expect(dialog == ...)` assertion unchanged — wording is frozen).
+
+- [ ] **Step 5: Run search tests + full intents suite**
+
+Run: `swift test --package-path . --filter AppIntentsTests`
+Expected: PASS — `searchResults`, the updated `searchHelper`, and every other intents suite.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/ContentIntents.swift Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+git commit -m "feat(intents): F-2b — SearchContentIntent returns flattened ContentSearchResultEntity list (#163)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 3.3: D.2 closeout — descriptor decision + full-suite verification
+
+**Files:**
+- Modify: `docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md`
+
+- [ ] **Step 1: Append the closeout note to the D.1 audit doc**
+
+Add this section to the end of `docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md`:
+
+```markdown
+## D.2 Closeout (2026-06-17) — descriptor decision
+
+With F-1/F-2/F-3 landed, the two D.2 candidate descriptors are resolved:
+
+- **`anglesite_list_content` — not needed.** The enriched `SearchContentIntent` (now returns a
+  typed `[ContentSearchResultEntity]`) plus `SiteStatusIntent` cover structured content
+  enumeration via auto-derived tools. No hand-registered descriptor.
+- **`anglesite_apply_edit` — deliberately not exposed** as a system-wide intent. It is a low-level
+  `selector / op / value` primitive, not a natural-language action; exposing a structured DOM-edit
+  primitive to arbitrary external agents without the edit overlay's live selection context is a
+  safety regression. It stays on the app-internal MCP path (`MCPClient` + `AnglesiteBridge`);
+  `EditContentIntent`'s natural-language `instruction` form remains the agent-facing edit surface.
+
+No `AnglesiteMCPRegistration` / hand-written descriptors are required: the auto-derived tools from
+the enriched intents *are* D.2's "custom MCP tool descriptors". Closes #163.
+```
+
+- [ ] **Step 2: Full-suite verification**
+
+Run: `swift test --package-path . 2>&1 | tail -40`
+Expected: all `AnglesiteIntents`, `AnglesiteCore`, `AnglesiteBridge` suites PASS; only the two plugin-path e2e tests (`MCPClientHTTPEndToEndTests`, `AppliesEditEndToEndTests`) fail when the sibling plugin checkout is absent (known #222). Confirm the intents test count grew by the tests added across F-1/F-2/F-3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md
+git commit -m "docs(intents): D.2 closeout — no custom MCP descriptors needed; close #163
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-review (completed during planning)
+
+- **Spec coverage:** F-1 → Task 1.1; F-3 → Tasks 2.1 (page) + 2.2 (post); F-2 → Tasks 3.1 (entity+query) + 3.2 (intent); closeout decision → Task 3.3. All four spec deliverables map to tasks.
+- **Type consistency:** `PageEntity.make` / `PostEntity.make` / `ContentSearchResultEntity` initializers, `ContentSearchResultEntityQuery.entities(for:)`, and `SearchContentIntent.results(...)` signatures are referenced identically across the tasks that define and consume them.
+- **Frozen wording:** the only dialog touched is via `ContentDialogs.search` (unchanged); the `searchHelper` test is migrated to `.results(...).dialog` but keeps its exact-string assertion.
+- **Known-baseline failures** (#222 e2e) are called out so they aren't mistaken for regressions.
+
+## Out of scope (per spec)
+
+- Device-level donated-Shortcut persistence smoke after the F-1 schema bump (manual; PR follow-up).
+- Any `AnglesiteMCPRegistration` descriptor surface (decided against).
+- Phase D D.3/D.4/D.5 (#164/#165/#166) — separate work consuming this schema.
+```


### PR DESCRIPTION
## D.2 — Intent schema enrichment for auto-derived MCP tools

Closes #163 (Phase D, #135).

macOS 27's platform `mcpbridge` auto-derives MCP tool schemas from App Intent / `AppEntity` schema metadata. Following the [D.1 audit](../blob/feat/d2-intent-mcp-enrichment/docs/specs/2026-06-17-d1-intent-mcp-readiness-audit.md), the right way to deliver D.2's "custom MCP tool descriptors" is to **enrich the existing intent schema** until the auto-derived tools are agent-usable — not to hand-write descriptors. This PR does that in three additive changes, all in `AnglesiteIntents`.

Design + plan: `docs/specs/2026-06-17-d2-intent-mcp-enrichment-design.md` / `-plan.md`.

### F-1 — `@Property` promotion
Promote disambiguating entity fields from `let` to `@Property` so an agent receives them as **typed, extractable** schema fields (not just a `displayRepresentation` subtitle string): `route`/`siteID` (Page), `slug`/`collection`/`siteID` (Post), `relativePath`/`siteID` (Image). Strictly additive — `id`/`displayName`/`displayRepresentation` unchanged, so already-donated Shortcuts interactions (which resolve by `id`) are unaffected.

### F-3 — create intents return the created entity
`AddPageIntent` → `ReturnsValue<PageEntity>`, `AddPostIntent` → `ReturnsValue<PostEntity>` (mirrors D.1's Deploy/Backup). The entity is built by pure `make(...)` factories from data already in hand — avoiding a race with the file-watcher that populates `SiteContentGraph`. Per the approved design (mirroring Deploy), the factory always returns a value; the **dialog is the source of truth** for success vs. failure.

### F-2 — `SearchContentIntent` unified structured return
New `ContentSearchResultEntity` (`+ ContentKind` AppEnum + query) flattens pages/posts/images into one typed result with a `kind` discriminator. `SearchContentIntent` returns `ReturnsValue<[ContentSearchResultEntity]>` (spoken dialog wording unchanged). The result `id` is the underlying entity id, so an agent can re-resolve the typed entity and chain into `PreviewSiteIntent`. Results are sorted deterministically (lastModified-desc, id-asc), matching every other result path.

### Closeout — descriptor decision
- `anglesite_list_content` → **not needed** (enriched Search + `SiteStatusIntent` cover it).
- `anglesite_apply_edit` → **deliberately not exposed** as a system-wide intent — a low-level `selector/op/value` primitive without the edit overlay's selection context is a safety regression for arbitrary agents. Stays on the app-internal MCP path; `EditContentIntent`'s natural-language form remains the agent-facing edit surface.

No `AnglesiteMCPRegistration` / hand-written descriptors required.

## Testing
- `AnglesiteIntents` suite: **162/162** pass (+17 over D.2 baseline; covers each factory, the search-result mapping/round-trip/ordering, dialog parity, and create→preview chaining).
- `xcodebuild -scheme Anglesite -configuration Debug build` → **BUILD SUCCEEDED** (confirms the schema changes link into the real app target, not just the SwiftPM test binary).
- Reviewed task-by-task plus a final whole-branch review; the one Important finding (dropped deterministic sort in `results(...)`) was fixed in `03d7d82`.

## Follow-ups (deferred)
- Device-level smoke that a previously-donated Shortcut still resolves after the F-1 schema bump (can't be unit-tested).
- A few cosmetic test Minors (missing symmetric `id` assertions on `postFields`/`imageFields`; `\u{201C}` vs literal quotes) — low value, noted for cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)