### PR TITLE
fix(test): make MCP e2e startup wait death-aware, not just time-bounded (#221)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ var packageTargets: [Target] = [
     // the app/xcodeproj never links it — only `swift test` builds it.
     .target(
         name: "AnglesiteTestSupport",
+        dependencies: ["AnglesiteCore"],
         path: "Tests/AnglesiteTestSupport",
         swiftSettings: strictConcurrency
     ),

--- a/Sources/AnglesiteCore/ProcessSupervisor.swift
+++ b/Sources/AnglesiteCore/ProcessSupervisor.swift
@@ -158,6 +158,12 @@ public actor ProcessSupervisor {
     /// (either the process exited and isn't being restarted, or `terminate(_:)` ran). If the
     /// awaiting task is cancelled, returns `.terminated` immediately — letting task groups
     /// unwind without waiting for the real process exit.
+    ///
+    /// Contract: this **returns** on cancellation (it is non-`throws`), it does not raise
+    /// `CancellationError`. Callers that race it inside a task group — e.g. `E2EServer.awaitReady`,
+    /// which parks a death-waiter against a readiness poll — rely on a cancelled wait unwinding as a
+    /// plain return so it can't surface as a spurious error. Preserve that if this ever gains
+    /// cooperative cancellation.
     public func waitForExit(_ handle: Handle) async -> ExitReason {
         await backend.waitForExit(backendHandle(for: handle))
     }

--- a/Tests/AnglesiteBridgeTests/AppliesEditEndToEndTests.swift
+++ b/Tests/AnglesiteBridgeTests/AppliesEditEndToEndTests.swift
@@ -46,7 +46,7 @@ final class AppliesEditEndToEndTests {
         "Apply edit end to end mutates the file on disk",
         .enabled(
             if: E2EPrerequisites.prerequisitesMet,
-            "requires the sibling Anglesite plugin checkout (ANGLESITE_PLUGIN_PATH, or ../anglesite with node_modules) and a Node ≥22 binary"
+            "requires the sibling Anglesite plugin checkout with a complete install (ANGLESITE_PLUGIN_PATH, or ../anglesite — run `npm install` in the plugin so sharp is present) and a Node ≥22 binary"
         )
     )
     func applyEditEndToEndMutatesTheFileOnDisk() async throws {

--- a/Tests/AnglesiteCoreTests/E2EServerReadinessTests.swift
+++ b/Tests/AnglesiteCoreTests/E2EServerReadinessTests.swift
@@ -68,4 +68,39 @@ struct E2EServerReadinessTests {
             try await Task.sleep(nanoseconds: 50_000_000)
         }
     }
+
+    @Test("awaitReady reports a budget overrun as ServerTimedOut, not a phantom crash")
+    func timeoutIsDistinctFromCrash() async throws {
+        let supervisor = ProcessSupervisor()
+        let logCenter = LogCenter()
+        // A healthy-but-slow server: the process stays alive (so the death branch never fires), but
+        // readiness never completes, so only the timeout can settle the outcome.
+        let handle = try await supervisor.launch(
+            source: "e2e-readiness-timeout",
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "sleep 30"],
+            restartPolicy: .never,
+            logCenter: logCenter
+        )
+        defer { Task { await supervisor.terminate(handle, timeout: 2) } }
+
+        let start = Date()
+        do {
+            try await E2EServer.awaitReady(
+                handle: handle,
+                supervisor: supervisor,
+                logCenter: logCenter,
+                timeout: 0.3
+            ) {
+                while true { try await Task.sleep(nanoseconds: 50_000_000) }
+            }
+            Issue.record("expected awaitReady to throw ServerTimedOut, but it returned")
+        } catch let error as E2EServer.ServerTimedOut {
+            #expect(error.timeout == 0.3)
+        } catch let error as E2EServer.ServerExited {
+            Issue.record("a live-but-slow server must time out, not be reported as exited: \(error)")
+        }
+        // The budget, not the 30s process lifetime, bounds the wait.
+        #expect(Date().timeIntervalSince(start) < 5)
+    }
 }

--- a/Tests/AnglesiteCoreTests/E2EServerReadinessTests.swift
+++ b/Tests/AnglesiteCoreTests/E2EServerReadinessTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+import AnglesiteTestSupport
+
+/// Unit coverage for `E2EServer.awaitReady` — the death-detecting startup wait shared by the MCP
+/// end-to-end tests. These use throwaway `/bin/sh` processes (no plugin / Node needed) so they run
+/// everywhere, unlike the gated e2e tests they harden.
+@Suite(.serialized)
+struct E2EServerReadinessTests {
+    @Test("awaitReady fails fast with captured stderr when the server dies before readiness")
+    func deathSurfacesStderr() async throws {
+        let supervisor = ProcessSupervisor()
+        let logCenter = LogCenter()
+        let marker = "BOOT_CRASH_\(UUID().uuidString)"
+        let handle = try await supervisor.launch(
+            source: "e2e-readiness-death",
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "echo \(marker) 1>&2; exit 7"],
+            restartPolicy: .never,
+            logCenter: logCenter
+        )
+
+        let start = Date()
+        do {
+            try await E2EServer.awaitReady(
+                handle: handle,
+                supervisor: supervisor,
+                logCenter: logCenter,
+                timeout: 20
+            ) {
+                // Readiness never succeeds — mimics polling a server that will never start listening.
+                while true { try await Task.sleep(nanoseconds: 50_000_000) }
+            }
+            Issue.record("expected awaitReady to throw ServerExited, but it returned")
+        } catch let error as E2EServer.ServerExited {
+            #expect(error.stderr.contains(marker), "stderr should surface the real crash output")
+            #expect(error.reason == .exited(code: 7))
+        }
+        #expect(
+            Date().timeIntervalSince(start) < 10,
+            "should fail fast on process death, not wait out the timeout budget"
+        )
+    }
+
+    @Test("awaitReady returns cleanly when readiness wins against a still-alive server")
+    func readinessWinsWithoutFalseDeath() async throws {
+        let supervisor = ProcessSupervisor()
+        let logCenter = LogCenter()
+        // Long-lived process: it must NOT exit while readiness completes, so the death branch
+        // stays parked and the only finisher is `readiness`.
+        let handle = try await supervisor.launch(
+            source: "e2e-readiness-alive",
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "sleep 30"],
+            restartPolicy: .never,
+            logCenter: logCenter
+        )
+        defer { Task { await supervisor.terminate(handle, timeout: 2) } }
+
+        // Should return normally — cancelling the parked death-waiter must not surface as a crash.
+        try await E2EServer.awaitReady(
+            handle: handle,
+            supervisor: supervisor,
+            logCenter: logCenter,
+            timeout: 20
+        ) {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
@@ -17,7 +17,7 @@ struct MCPClientHTTPEndToEndTests {
         "HTTP end-to-end: connect, list tools, call list_annotations",
         .enabled(
             if: E2EPrerequisites.prerequisitesMet,
-            "requires the sibling Anglesite plugin checkout (ANGLESITE_PLUGIN_PATH, or ../anglesite with node_modules) and a Node ≥22 binary"
+            "requires the sibling Anglesite plugin checkout with a complete install (ANGLESITE_PLUGIN_PATH, or ../anglesite — run `npm install` in the plugin so sharp is present) and a Node ≥22 binary"
         )
     )
     func httpEndToEnd() async throws {
@@ -54,13 +54,26 @@ struct MCPClientHTTPEndToEndTests {
         let endpoint = URL(string: "http://127.0.0.1:\(port)/mcp")!
         let client = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
 
-        // Poll connect until the server is listening (cold node start can take a moment).
-        let deadline = Date().addingTimeInterval(20)
-        while true {
-            do { try await client.connect(httpEndpoint: endpoint); break }
-            catch {
-                guard Date() < deadline else { throw error }
-                try await Task.sleep(nanoseconds: 200_000_000)
+        // Wait for the server to accept the MCP handshake, but abort the instant the spawned process
+        // dies — `awaitReady` then throws with the server's stderr instead of letting this spin the
+        // whole budget and report an opaque `.sessionLost`. A healthy cold start connects in well
+        // under a second; the generous budget only covers a genuinely slow start.
+        try await E2EServer.awaitReady(
+            handle: handle,
+            supervisor: supervisor,
+            logCenter: logCenter,
+            timeout: 60
+        ) {
+            // Retry the handshake until it succeeds. The inner deadline (< the outer budget) surfaces
+            // the real connect error if the server is up but never completes the handshake; a crashed
+            // server is caught by `awaitReady`'s death detection, not this loop.
+            let deadline = Date().addingTimeInterval(55)
+            while true {
+                do { try await client.connect(httpEndpoint: endpoint); return }
+                catch {
+                    guard Date() < deadline else { throw error }
+                    try await Task.sleep(nanoseconds: 200_000_000)
+                }
             }
         }
         defer { Task { await client.stop() } }

--- a/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift
@@ -58,16 +58,18 @@ struct MCPClientHTTPEndToEndTests {
         // dies — `awaitReady` then throws with the server's stderr instead of letting this spin the
         // whole budget and report an opaque `.sessionLost`. A healthy cold start connects in well
         // under a second; the generous budget only covers a genuinely slow start.
+        let readyBudget: TimeInterval = 60
         try await E2EServer.awaitReady(
             handle: handle,
             supervisor: supervisor,
             logCenter: logCenter,
-            timeout: 60
+            timeout: readyBudget
         ) {
             // Retry the handshake until it succeeds. The inner deadline (< the outer budget) surfaces
             // the real connect error if the server is up but never completes the handshake; a crashed
-            // server is caught by `awaitReady`'s death detection, not this loop.
-            let deadline = Date().addingTimeInterval(55)
+            // server is caught by `awaitReady`'s death detection, not this loop. Derived from the
+            // outer budget so the two stay in sync if it's ever bumped.
+            let deadline = Date().addingTimeInterval(readyBudget - 5)
             while true {
                 do { try await client.connect(httpEndpoint: endpoint); return }
                 catch {

--- a/Tests/AnglesiteTestSupport/E2EPrerequisites.swift
+++ b/Tests/AnglesiteTestSupport/E2EPrerequisites.swift
@@ -24,10 +24,19 @@ public enum E2EPrerequisites {
             let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
             return cwd.deletingLastPathComponent().appendingPathComponent("anglesite", isDirectory: true)
         }()
+        // The check must reflect "can the server actually boot", not just "is there a checkout".
+        // `server/apply-edit-dispatcher.mjs` eagerly imports `optimize-images.mjs`, which eagerly
+        // imports `sharp` — so a checkout whose `node_modules` is missing `sharp` (a partial/stale
+        // install) crashes the server on load before it ever listens. Gating on both the MCP SDK and
+        // `sharp` means an incomplete install yields a *skip* with a clear reason instead of an
+        // opaque connect timeout. (CI installs deps fresh, so this only bites stale local checkouts.)
+        let bootCriticalDeps = ["@modelcontextprotocol/sdk", "sharp"]
         guard FileManager.default.isReadableFile(
                 atPath: candidate.appendingPathComponent("server/index.mjs").path),
-              FileManager.default.fileExists(
-                atPath: candidate.appendingPathComponent("node_modules/@modelcontextprotocol/sdk").path)
+              bootCriticalDeps.allSatisfy({ dep in
+                  FileManager.default.fileExists(
+                    atPath: candidate.appendingPathComponent("node_modules/\(dep)").path)
+              })
         else { return nil }
         return candidate
     }

--- a/Tests/AnglesiteTestSupport/E2EServer.swift
+++ b/Tests/AnglesiteTestSupport/E2EServer.swift
@@ -32,6 +32,36 @@ public enum E2EServer {
         }
     }
 
+    /// The readiness budget elapsed while the server was still running (it just never became ready).
+    /// Distinct from `ServerExited`: the process is alive here, so there is no exit reason and no
+    /// crash stderr to report — conflating the two (e.g. `ServerExited(reason: .terminated, …)`)
+    /// would send a reader chasing a phantom signal kill.
+    public struct ServerTimedOut: Error, CustomStringConvertible {
+        public let timeout: TimeInterval
+
+        public init(timeout: TimeInterval) {
+            self.timeout = timeout
+        }
+
+        public var description: String {
+            "MCP server did not become ready within \(timeout)s (process still running)."
+        }
+    }
+
+    /// Records which of the racing tasks (readiness / death / timeout) settled first. Exactly one
+    /// `claim()` returns `true`; the losers see `false` and bow out without throwing. This replaces a
+    /// `Task.isCancelled` check, which is timing-dependent: when the process exits at the same instant
+    /// readiness succeeds, `group.cancelAll()` hasn't propagated yet, so the death task would observe
+    /// `isCancelled == false` and throw a spurious `ServerExited` even though readiness won.
+    private actor Outcome {
+        private var settled = false
+        func claim() -> Bool {
+            if settled { return false }
+            settled = true
+            return true
+        }
+    }
+
     /// Run `readiness` (typically a connect/handshake poll), but abort the moment the supervised
     /// `handle` process exits — throwing `ServerExited` with the captured stderr instead of letting
     /// the poll spin until `timeout`. The budget can therefore be generous (real cold starts vary)
@@ -47,14 +77,20 @@ public enum E2EServer {
         timeout: TimeInterval = 60,
         readiness: @Sendable @escaping () async throws -> Void
     ) async throws {
+        let outcome = Outcome()
         try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { try await readiness() }
+            group.addTask {
+                try await readiness()
+                // Mark readiness as the winner if it got here first; if the death/timeout task
+                // already claimed the outcome, this is a no-op and we just return success.
+                _ = await outcome.claim()
+            }
 
             group.addTask {
                 let reason = await supervisor.waitForExit(handle)
-                // `waitForExit` returns `.terminated` immediately when *this* task is cancelled
-                // (readiness already won) — don't misreport that as a crash.
-                if Task.isCancelled { return }
+                // Throw only if we won the race. If readiness already claimed the outcome, the
+                // process exit is just the cleanup that follows a successful start — not a crash.
+                guard await outcome.claim() else { return }
                 let stderr = await logCenter.snapshot()
                     .filter { $0.source == handle.source && $0.stream == .stderr }
                     .map(\.text)
@@ -64,15 +100,13 @@ public enum E2EServer {
 
             group.addTask {
                 try await Task.sleep(nanoseconds: UInt64(max(timeout, 0) * 1_000_000_000))
-                throw ServerExited(
-                    reason: .terminated,
-                    stderr: "timed out after \(timeout)s waiting for the server to become ready"
-                )
+                guard await outcome.claim() else { return }
+                throw ServerTimedOut(timeout: timeout)
             }
 
             defer { group.cancelAll() }
             // First task to finish decides the outcome: readiness success returns, a crash or
-            // timeout throws.
+            // timeout throws. The `Outcome` gate guarantees the loser tasks can't also throw.
             try await group.next()
         }
     }

--- a/Tests/AnglesiteTestSupport/E2EServer.swift
+++ b/Tests/AnglesiteTestSupport/E2EServer.swift
@@ -1,0 +1,79 @@
+import Foundation
+import AnglesiteCore
+
+/// Robust startup waiting for the MCP / apply-edit end-to-end tests, which spawn the *real* plugin
+/// Node server. Cold startup is fast (<1 s) when healthy, but a broken plugin install — e.g. a
+/// missing native dep like `sharp`, which `server/apply-edit-dispatcher.mjs` imports eagerly — makes
+/// the server crash on load before it ever listens. Polling the connect/handshake alone can't tell
+/// "still booting" from "already dead", so it would burn the entire timeout budget and then report
+/// an opaque transport error (`.sessionLost`) instead of the real crash.
+///
+/// `awaitReady` races the readiness operation against the supervised process's exit: if the process
+/// dies first, it throws `ServerExited` carrying the captured stderr, surfacing the real cause
+/// immediately.
+public enum E2EServer {
+    /// The spawned server process exited before it became ready. Carries the captured stderr so the
+    /// real failure (e.g. `Cannot find package 'sharp'`) is visible in the test output.
+    public struct ServerExited: Error, CustomStringConvertible {
+        public let reason: ProcessSupervisor.ExitReason
+        public let stderr: String
+
+        public init(reason: ProcessSupervisor.ExitReason, stderr: String) {
+            self.reason = reason
+            self.stderr = stderr
+        }
+
+        public var description: String {
+            """
+            MCP server process exited (\(reason)) before becoming ready.
+            --- captured stderr ---
+            \(stderr.isEmpty ? "(no stderr captured)" : stderr)
+            """
+        }
+    }
+
+    /// Run `readiness` (typically a connect/handshake poll), but abort the moment the supervised
+    /// `handle` process exits — throwing `ServerExited` with the captured stderr instead of letting
+    /// the poll spin until `timeout`. The budget can therefore be generous (real cold starts vary)
+    /// without making a *dead* server slow to diagnose: it fails in the time the process takes to
+    /// crash, not the time the budget allows.
+    ///
+    /// `InProcessBackend` drains the stdout/stderr pipes before resuming exit waiters, so the stderr
+    /// snapshot taken after `waitForExit` is guaranteed to include the crash output.
+    public static func awaitReady(
+        handle: ProcessSupervisor.Handle,
+        supervisor: ProcessSupervisor,
+        logCenter: LogCenter,
+        timeout: TimeInterval = 60,
+        readiness: @Sendable @escaping () async throws -> Void
+    ) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await readiness() }
+
+            group.addTask {
+                let reason = await supervisor.waitForExit(handle)
+                // `waitForExit` returns `.terminated` immediately when *this* task is cancelled
+                // (readiness already won) — don't misreport that as a crash.
+                if Task.isCancelled { return }
+                let stderr = await logCenter.snapshot()
+                    .filter { $0.source == handle.source && $0.stream == .stderr }
+                    .map(\.text)
+                    .joined(separator: "\n")
+                throw ServerExited(reason: reason, stderr: stderr)
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(max(timeout, 0) * 1_000_000_000))
+                throw ServerExited(
+                    reason: .terminated,
+                    stderr: "timed out after \(timeout)s waiting for the server to become ready"
+                )
+            }
+
+            defer { group.cancelAll() }
+            // First task to finish decides the outcome: readiness success returns, a crash or
+            // timeout throws.
+            try await group.next()
+        }
+    }
+}


### PR DESCRIPTION
Closes #221.

## TL;DR
The "cold-start poll-budget flake" turned out **not** to be a timing issue. Instrumenting the spawn showed the plugin's `node server/index.mjs` crashes immediately:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'sharp' imported from .../server/optimize-images.mjs
```

`server/apply-edit-dispatcher.mjs` eagerly imports `optimize-images.mjs`, which eagerly imports `sharp`. A stale/partial local `node_modules` (missing `sharp`, a declared `^0.33.0` dep) kills the server **before it ever listens**. CI installs deps fresh → server boots → tests pass; a developer's stale checkout → server dies → the HTTP test polls a dead port for its full 20 s budget and reports an opaque `.sessionLost`. That's the "local-only flake."

Bumping the budget would only make a healthy test slower and a broken test fail *later*. So this fixes the actual fault.

## Changes (test-target only)
- **`E2EServer.awaitReady`** (new, `AnglesiteTestSupport`) — races the connect/handshake poll against `supervisor.waitForExit(handle)`. If the server process dies first, throws `ServerExited` with the **captured stderr**, surfacing the real crash in ~0.5 s instead of an opaque timeout. The budget can now be generous for genuinely-slow starts without making a dead server slow to diagnose. (`InProcessBackend` drains pipes before resuming exit waiters, so the stderr snapshot is race-free.)
- **`E2EPrerequisites`** — gate on `node_modules/sharp` in addition to the MCP SDK, so an incomplete install yields a **skip** with an actionable reason (“run `npm install` in the plugin”) instead of a confusing failure. Consistent with #224's skip-not-fail.
- **`MCPClientHTTPEndToEndTests`** — replaces the manual 20 s poll with `awaitReady`.
- **`E2EServerReadinessTests`** (new) — unit-tests the helper with throwaway `/bin/sh` processes, so they run everywhere (no plugin/Node needed): death→fast-fail-with-stderr, and readiness-wins→no-false-death.

## Verification
| Scenario | Before | After |
|---|---|---|
| Healthy plugin | pass | pass — HTTP **0.46 s**, stdio **0.27 s** |
| Stale checkout (no `sharp`) | **fail @ 20.2 s** `.sessionLost` | **skip @ 0.001 s** with actionable reason |
| Full suite | — | **582 tests, 0 issues** |

All changes are in test targets / the `AnglesiteTestSupport` package target, which the app/xcodeproj never links — so `swift test` is complete proof (no xcodebuild needed).

## Recommended follow-up (plugin repo `Anglesite/anglesite`)
Make `optimize-images.mjs` **lazy-import** `sharp` (dynamic `import()` inside the handler) so the server boots without it and only the image-optimization tool fails at call time. That removes this whole failure class at the source — the paired-PR concern the issue anticipated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)