### PR TITLE
fix(new-site): put bundled Node on PATH so npm install's native-addon scripts succeed (#229)

### DIFF
--- a/Sources/AnglesiteApp/NewSiteWizard.swift
+++ b/Sources/AnglesiteApp/NewSiteWizard.swift
@@ -170,10 +170,7 @@ struct NewSiteWizard: View {
             }
             if model.step == .content {
                 Button("Create Site") {
-                    // Auto-open only on a clean build. If the build warned (e.g. dependencies
-                    // failed to install), stay put so the owner reads the warning and opens
-                    // explicitly via "Open Site Anyway" below — rather than landing on a
-                    // dead-end "Can't preview" screen (#229).
+                    // Auto-open only on a clean build; with warnings, stay put so the owner sees them (#229).
                     Task {
                         _ = await model.build(using: scaffolder)
                         if model.didCompleteCleanly, let id = model.completedSiteID { onComplete(id) }

--- a/Sources/AnglesiteApp/NewSiteWizard.swift
+++ b/Sources/AnglesiteApp/NewSiteWizard.swift
@@ -118,6 +118,11 @@ struct NewSiteWizard: View {
                     .accessibilityLabel("Build failed")
                     .accessibilityValue(msg)
             }
+            if model.completedSiteID != nil && model.hasWarnings {
+                Text("Your site was created, but something above needs attention before it can preview. You can open it anyway and fix it from the site window.")
+                    .font(.caption).foregroundStyle(.secondary).textSelection(.enabled)
+                    .accessibilityLabel("Your site was created with warnings. You can open it anyway and fix it from the site window.")
+            }
         }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
@@ -165,11 +170,20 @@ struct NewSiteWizard: View {
             }
             if model.step == .content {
                 Button("Create Site") {
-                    Task { if let id = await model.build(using: scaffolder) { onComplete(id) } }
+                    // Auto-open only on a clean build. If the build warned (e.g. dependencies
+                    // failed to install), stay put so the owner reads the warning and opens
+                    // explicitly via "Open Site Anyway" below — rather than landing on a
+                    // dead-end "Can't preview" screen (#229).
+                    Task {
+                        _ = await model.build(using: scaffolder)
+                        if model.didCompleteCleanly, let id = model.completedSiteID { onComplete(id) }
+                    }
                 }.keyboardShortcut(.defaultAction).disabled(!model.canContinue)
             } else if model.step != .building {
                 Button("Continue") { model.advance() }
                     .keyboardShortcut(.defaultAction).disabled(!model.canContinue)
+            } else if let id = model.completedSiteID, model.hasWarnings {
+                Button("Open Site Anyway") { onComplete(id) }.keyboardShortcut(.defaultAction)
             } else if model.completedSiteID == nil && model.fatal != nil {
                 Button("Close") { onCancel() }
             }

--- a/Sources/AnglesiteCore/NewSiteWizardModel.swift
+++ b/Sources/AnglesiteCore/NewSiteWizardModel.swift
@@ -24,18 +24,14 @@ public final class NewSiteWizardModel {
 
     public var slugPreview: String { SiteSlug.derive(from: draft.name) }
 
-    /// Non-fatal warnings collected during the build (e.g. dependencies failed to install). The
-    /// wizard surfaces these instead of silently opening the site on success — otherwise the owner
-    /// only discovers a failed `npm install` via a dead-end "Can't preview" screen (#229).
+    /// Non-fatal build warnings (e.g. a failed install), surfaced so a failure isn't hidden behind a dead-end preview (#229).
     public var warnings: [String] {
         progress.compactMap { if case .warning(_, let message) = $0 { return message } else { return nil } }
     }
 
     public var hasWarnings: Bool { !warnings.isEmpty }
 
-    /// True once the build registered the site *and* produced no warnings — only then may the wizard
-    /// open the site immediately. With warnings, the wizard stays on the building step so the owner
-    /// can read them and open explicitly (#229).
+    /// Site registered with no warnings — only then may the wizard open it immediately (else it stays put so warnings are read) (#229).
     public var didCompleteCleanly: Bool { completedSiteID != nil && !hasWarnings }
 
     public var detailsError: String? {

--- a/Sources/AnglesiteCore/NewSiteWizardModel.swift
+++ b/Sources/AnglesiteCore/NewSiteWizardModel.swift
@@ -24,6 +24,20 @@ public final class NewSiteWizardModel {
 
     public var slugPreview: String { SiteSlug.derive(from: draft.name) }
 
+    /// Non-fatal warnings collected during the build (e.g. dependencies failed to install). The
+    /// wizard surfaces these instead of silently opening the site on success — otherwise the owner
+    /// only discovers a failed `npm install` via a dead-end "Can't preview" screen (#229).
+    public var warnings: [String] {
+        progress.compactMap { if case .warning(_, let message) = $0 { return message } else { return nil } }
+    }
+
+    public var hasWarnings: Bool { !warnings.isEmpty }
+
+    /// True once the build registered the site *and* produced no warnings — only then may the wizard
+    /// open the site immediately. With warnings, the wizard stays on the building step so the owner
+    /// can read them and open explicitly (#229).
+    public var didCompleteCleanly: Bool { completedSiteID != nil && !hasWarnings }
+
     public var detailsError: String? {
         let name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
         if name.isEmpty { return nil }              // empty is "incomplete", not an error to show

--- a/Sources/AnglesiteCore/NodeRuntime.swift
+++ b/Sources/AnglesiteCore/NodeRuntime.swift
@@ -21,13 +21,7 @@ public enum NodeRuntime {
         return FileManager.default.isExecutableFile(atPath: candidate.path) ? candidate : nil
     }
 
-    /// Returns a copy of `base` with `directory` ensured at the front of `PATH` (existing
-    /// occurrences removed so it appears exactly once).
-    ///
-    /// We spawn the bundled `node` by absolute path, but dependency lifecycle scripts spawn
-    /// `node`/`npm`/`node-gyp` *by name* — `sharp`'s postinstall runs `sh -c node install/check`.
-    /// Without the bundled runtime's `bin` directory on `PATH` those die with
-    /// `node: command not found` (exit 127), which aborts `npm install` for new sites (#229).
+    /// `base` with `directory` prepended to `PATH` (deduped) so lifecycle scripts that invoke `node` by name resolve the bundled runtime instead of exiting 127 (#229).
     public static func environment(_ base: [String: String], prependingPATH directory: String) -> [String: String] {
         var env = base
         let existing = (env["PATH"] ?? "")
@@ -38,9 +32,7 @@ public enum NodeRuntime {
         return env
     }
 
-    /// The current process environment with the bundled Node's `bin` directory prepended to `PATH`,
-    /// or `nil` when the runtime isn't bundled (e.g. `swift test`) — callers then fall back to
-    /// inheriting the parent environment unchanged.
+    /// Process environment with the bundled Node's bin dir on `PATH`; `nil` when Node isn't bundled (e.g. `swift test`), so callers inherit the parent env unchanged.
     public static var environmentWithNodeOnPath: [String: String]? {
         guard let node = bundledExecutableURL else { return nil }
         return environment(ProcessInfo.processInfo.environment,

--- a/Sources/AnglesiteCore/NodeRuntime.swift
+++ b/Sources/AnglesiteCore/NodeRuntime.swift
@@ -20,4 +20,30 @@ public enum NodeRuntime {
             .appendingPathComponent("node")
         return FileManager.default.isExecutableFile(atPath: candidate.path) ? candidate : nil
     }
+
+    /// Returns a copy of `base` with `directory` ensured at the front of `PATH` (existing
+    /// occurrences removed so it appears exactly once).
+    ///
+    /// We spawn the bundled `node` by absolute path, but dependency lifecycle scripts spawn
+    /// `node`/`npm`/`node-gyp` *by name* — `sharp`'s postinstall runs `sh -c node install/check`.
+    /// Without the bundled runtime's `bin` directory on `PATH` those die with
+    /// `node: command not found` (exit 127), which aborts `npm install` for new sites (#229).
+    public static func environment(_ base: [String: String], prependingPATH directory: String) -> [String: String] {
+        var env = base
+        let existing = (env["PATH"] ?? "")
+            .split(separator: ":", omittingEmptySubsequences: true)
+            .map(String.init)
+            .filter { $0 != directory }
+        env["PATH"] = ([directory] + existing).joined(separator: ":")
+        return env
+    }
+
+    /// The current process environment with the bundled Node's `bin` directory prepended to `PATH`,
+    /// or `nil` when the runtime isn't bundled (e.g. `swift test`) — callers then fall back to
+    /// inheriting the parent environment unchanged.
+    public static var environmentWithNodeOnPath: [String: String]? {
+        guard let node = bundledExecutableURL else { return nil }
+        return environment(ProcessInfo.processInfo.environment,
+                           prependingPATH: node.deletingLastPathComponent().path)
+    }
 }

--- a/Sources/AnglesiteCore/ProcessSupervisor.swift
+++ b/Sources/AnglesiteCore/ProcessSupervisor.swift
@@ -26,12 +26,7 @@ public actor ProcessSupervisor {
 
     private let backend: SupervisorBackend
 
-    /// Environment applied to spawns that don't pass one explicitly. Defaults to
-    /// `NodeRuntime.environmentWithNodeOnPath` so every Node spawn (npm install, the MCP server, the
-    /// Astro dev server) gets the bundled runtime's `bin` directory on `PATH` — without it,
-    /// dependency lifecycle scripts that invoke `node` by name fail with exit 127 (#229). Returns
-    /// `nil` when Node isn't bundled (e.g. `swift test`), so spawns then inherit the parent
-    /// environment unchanged. Injectable for tests.
+    /// Environment for spawns that don't pass one — puts the bundled Node on `PATH` so node-by-name lifecycle scripts don't exit 127 (#229); `nil` when Node isn't bundled. Injectable for tests.
     private let defaultEnvironment: @Sendable () -> [String: String]?
 
     /// Source-compat re-exports. These used to be nested types; they now live at the protocol layer
@@ -57,8 +52,7 @@ public actor ProcessSupervisor {
         self.defaultEnvironment = { NodeRuntime.environmentWithNodeOnPath }
     }
 
-    /// Inject a backend explicitly (tests, future MAS wiring). `defaultEnvironment` is applied to
-    /// spawns that don't pass one — see the property doc.
+    /// Inject a backend explicitly (tests, future MAS wiring); `defaultEnvironment` applies to spawns that don't pass one.
     public init(backend: SupervisorBackend,
                 defaultEnvironment: @escaping @Sendable () -> [String: String]? = { NodeRuntime.environmentWithNodeOnPath }) {
         self.backend = backend

--- a/Sources/AnglesiteCore/ProcessSupervisor.swift
+++ b/Sources/AnglesiteCore/ProcessSupervisor.swift
@@ -26,6 +26,14 @@ public actor ProcessSupervisor {
 
     private let backend: SupervisorBackend
 
+    /// Environment applied to spawns that don't pass one explicitly. Defaults to
+    /// `NodeRuntime.environmentWithNodeOnPath` so every Node spawn (npm install, the MCP server, the
+    /// Astro dev server) gets the bundled runtime's `bin` directory on `PATH` — without it,
+    /// dependency lifecycle scripts that invoke `node` by name fail with exit 127 (#229). Returns
+    /// `nil` when Node isn't bundled (e.g. `swift test`), so spawns then inherit the parent
+    /// environment unchanged. Injectable for tests.
+    private let defaultEnvironment: @Sendable () -> [String: String]?
+
     /// Source-compat re-exports. These used to be nested types; they now live at the protocol layer
     /// (so the backend can speak them too), re-exposed here so existing call sites such as
     /// `ProcessSupervisor.RestartPolicy.onCrash(...)` and `ProcessSupervisor.ExitReason` compile
@@ -46,11 +54,15 @@ public actor ProcessSupervisor {
     /// separate process can't inherit the app's scoped grant).
     public init() {
         self.backend = InProcessBackend()
+        self.defaultEnvironment = { NodeRuntime.environmentWithNodeOnPath }
     }
 
-    /// Inject a backend explicitly (tests, future MAS wiring).
-    public init(backend: SupervisorBackend) {
+    /// Inject a backend explicitly (tests, future MAS wiring). `defaultEnvironment` is applied to
+    /// spawns that don't pass one — see the property doc.
+    public init(backend: SupervisorBackend,
+                defaultEnvironment: @escaping @Sendable () -> [String: String]? = { NodeRuntime.environmentWithNodeOnPath }) {
         self.backend = backend
+        self.defaultEnvironment = defaultEnvironment
     }
 
     // MARK: One-shot run
@@ -85,7 +97,7 @@ public actor ProcessSupervisor {
         let spec = SpawnSpec(
             executable: executable,
             arguments: arguments,
-            environment: environment,
+            environment: environment ?? defaultEnvironment(),
             workingDirectory: currentDirectoryURL,
             logSource: "run"
         )
@@ -135,7 +147,7 @@ public actor ProcessSupervisor {
         let spec = SpawnSpec(
             executable: executable,
             arguments: arguments,
-            environment: environment,
+            environment: environment ?? defaultEnvironment(),
             workingDirectory: currentDirectoryURL,
             stdinPipe: attachStdin,
             logSource: source

--- a/Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
@@ -33,4 +33,50 @@ final class NewSiteWizardModelTests: XCTestCase {
         m.draft.name = "My Cool Site"
         XCTAssertEqual(m.slugPreview, "my-cool-site")
     }
+
+    // MARK: Build warnings (#229)
+
+    /// A scaffolder whose `scaffold.sh` writes the template files the appliers expect, so the only
+    /// non-fatal warning comes from the install step (`NodeRuntime.bundledExecutableURL` is nil
+    /// under `swift test`, so the real pipeline emits "Bundled Node not found; skipped install.").
+    private func warningScaffolder(root: URL) -> SiteScaffolder {
+        SiteScaffolder(
+            sitesRoot: root,
+            pluginURL: URL(fileURLWithPath: "/plugin"),
+            catalog: catalog(),
+            run: { _, args, cwd in
+                if args.contains(where: { $0.hasSuffix("scaffold.sh") }), let cwd {
+                    let css = cwd.appendingPathComponent("src/styles/global.css")
+                    let astro = cwd.appendingPathComponent("src/pages/index.astro")
+                    try? FileManager.default.createDirectory(at: css.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try? FileManager.default.createDirectory(at: astro.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try? ":root { --color-primary: #2563eb; }".write(to: css, atomically: true, encoding: .utf8)
+                    try? "<h1>Welcome</h1>".write(to: astro, atomically: true, encoding: .utf8)
+                    try? "ANGLESITE_VERSION=1.0.0".write(to: cwd.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+                }
+                return ProcessSupervisor.RunResult(stdout: "", stderr: "", exitCode: 0)
+            },
+            register: { url in SiteStore.Site(id: url.path, name: url.lastPathComponent, path: url, isValid: true, missingSentinels: []) }
+        )
+    }
+
+    func testFreshModelHasNoWarningsAndIsNotCompletedCleanly() {
+        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { _ in false })
+        XCTAssertFalse(m.hasWarnings)
+        XCTAssertTrue(m.warnings.isEmpty)
+        XCTAssertFalse(m.didCompleteCleanly)
+    }
+
+    func testBuildWithInstallWarningSurfacesWarningAndBlocksCleanCompletion() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { _ in false })
+        m.draft.name = "Warn Site"
+
+        let id = await m.build(using: warningScaffolder(root: root))
+
+        XCTAssertNotNil(id)                       // the site was still registered
+        XCTAssertTrue(m.hasWarnings)              // …but with a non-fatal warning
+        XCTAssertTrue(m.warnings.contains { $0.lowercased().contains("install") })
+        XCTAssertFalse(m.didCompleteCleanly)      // so the wizard must NOT auto-open
+    }
 }

--- a/Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
@@ -76,7 +76,10 @@ final class NewSiteWizardModelTests: XCTestCase {
 
         XCTAssertNotNil(id)                       // the site was still registered
         XCTAssertTrue(m.hasWarnings)              // …but with a non-fatal warning
-        XCTAssertTrue(m.warnings.contains { $0.lowercased().contains("install") })
+        // Assert on the stable step identifier, not the (rephrasable) message text.
+        XCTAssertTrue(m.progress.contains {
+            if case .warning(let step, _) = $0 { return step == "installing" } else { return false }
+        })
         XCTAssertFalse(m.didCompleteCleanly)      // so the wizard must NOT auto-open
     }
 }

--- a/Tests/AnglesiteCoreTests/NodeRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/NodeRuntimeTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct NodeRuntimeTests {
+    @Test("Prepends the directory to an existing PATH")
+    func prependsToExistingPath() {
+        let env = NodeRuntime.environment(["PATH": "/usr/bin:/bin"], prependingPATH: "/node/bin")
+        #expect(env["PATH"] == "/node/bin:/usr/bin:/bin")
+    }
+
+    @Test("Sets PATH to just the directory when none exists")
+    func setsPathWhenAbsent() {
+        let env = NodeRuntime.environment([:], prependingPATH: "/node/bin")
+        #expect(env["PATH"] == "/node/bin")
+    }
+
+    @Test("Treats an empty PATH as absent")
+    func emptyPathBecomesDirectory() {
+        let env = NodeRuntime.environment(["PATH": ""], prependingPATH: "/node/bin")
+        #expect(env["PATH"] == "/node/bin")
+    }
+
+    @Test("Moves the directory to the front without duplicating when already present")
+    func dedupesExistingEntry() {
+        let env = NodeRuntime.environment(["PATH": "/usr/bin:/node/bin:/bin"], prependingPATH: "/node/bin")
+        #expect(env["PATH"] == "/node/bin:/usr/bin:/bin")
+    }
+
+    @Test("Preserves other environment variables")
+    func preservesOtherVariables() {
+        let env = NodeRuntime.environment(["PATH": "/bin", "HOME": "/Users/x"], prependingPATH: "/node/bin")
+        #expect(env["HOME"] == "/Users/x")
+        #expect(env["PATH"] == "/node/bin:/bin")
+    }
+}

--- a/Tests/AnglesiteCoreTests/ProcessSupervisorTests.swift
+++ b/Tests/AnglesiteCoreTests/ProcessSupervisorTests.swift
@@ -53,4 +53,31 @@ struct ProcessSupervisorTests {
         )
         #expect(result.stdout == "phase-1")
     }
+
+    @Test("Run injects the default environment when none is passed")
+    func runInjectsDefaultEnvironment() async throws {
+        let supervisor = ProcessSupervisor(
+            backend: InProcessBackend(),
+            defaultEnvironment: { ["ANGLESITE_DEFAULT": "from-default", "PATH": "/usr/bin:/bin"] }
+        )
+        let result = try await supervisor.run(
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "printf %s \"$ANGLESITE_DEFAULT\""]
+        )
+        #expect(result.stdout == "from-default")
+    }
+
+    @Test("Explicit environment overrides the default")
+    func explicitEnvironmentOverridesDefault() async throws {
+        let supervisor = ProcessSupervisor(
+            backend: InProcessBackend(),
+            defaultEnvironment: { ["ANGLESITE_DEFAULT": "from-default"] }
+        )
+        let result = try await supervisor.run(
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "printf %s \"${ANGLESITE_DEFAULT:-none}\""],
+            environment: ["FOO": "bar"]
+        )
+        #expect(result.stdout == "none")
+    }
 }


### PR DESCRIPTION
Fixes #229.

## Problem

Creating a site via **File ▸ New Site** completed the wizard "successfully" but the site window immediately showed **Can't preview — dependencies not installed**. The scaffold's `npm install` ran against the primed cache (every package a cache hit) then aborted on `sharp`'s postinstall:

```
error code 127
error path …/node_modules/sharp
error command sh -c node install/check
error sh: node: command not found
```

We spawn the **bundled** Node by absolute path, but its directory was never on the child's `PATH`. A Finder-launched `.app` has a bare `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`), so any dependency whose lifecycle script invokes `node`/`npm`/`node-gyp` *by name* (every native addon — `sharp` comes from the Astro template) died with exit 127, aborting the install and leaving no usable `node_modules`. The failure was then invisible because the wizard auto-opened the site on `.done`.

## Fix

- **`NodeRuntime`** — pure `environment(_:prependingPATH:)` helper (prepend + dedupe) and `environmentWithNodeOnPath`, which resolves the bundled runtime's `bin` dir (nil under `swift test`, so callers fall back to inheriting the parent env unchanged).
- **`ProcessSupervisor`** — applies that as the **default environment** for any spawn that doesn't pass one. Since no call site passes an explicit environment today, this comprehensively covers `npm install`, the MCP server, the Astro dev server, and deploy's `npm run build` / wrangler — all of which previously had the same exit-127 exposure.
- **`NewSiteWizard`** — stops auto-opening the site when the build emitted a non-fatal warning; surfaces the warning and requires an explicit **Open Site Anyway**, so a failed install is never hidden behind a dead-end preview screen.

## Tests (TDD)

- `NodeRuntimeTests` — PATH prepend / dedupe / empty-PATH / preserves-other-vars.
- `ProcessSupervisorTests` — default-env injected when none passed; explicit env still overrides.
- `NewSiteWizardModelTests` — `warnings` / `hasWarnings` / `didCompleteCleanly` surface the install warning and block clean auto-completion.

## Verification

- `swift test` — 428 Core + 146 Intents + 13 Bridge pass, 0 failures.
- `xcodebuild -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED** (confirms the app target links, incl. the `NewSiteWizard` UI change that `swift test` doesn't compile).

Note: the end-to-end `sharp` install can't run under `swift test` (no app bundle → `bundledExecutableURL` is nil), so the PATH-construction logic is covered as a pure unit; the real install path is exercised by a write-heavy app smoke (Phase 10.1 Task 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)