### PR TITLE
Move website template from plugin repo into the app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,19 @@ This is the **native macOS app** that hosts the Anglesite Claude plugin. The plu
 
 | Repo | Role |
 |---|---|
-| `Anglesite/anglesite` | Claude plugin: skills, hooks, MCP server, template, docs |
-| `Anglesite/Anglesite-app` *(this repo)* | macOS app: SwiftUI shell, embedded Node, WKWebView preview, edit overlay |
+| `Anglesite/anglesite` | Claude plugin: skills, hooks, MCP server, docs |
+| `Anglesite/Anglesite-app` *(this repo)* | macOS app: SwiftUI shell, website template, embedded Node, WKWebView preview, edit overlay |
+
+The **website template** (Astro project skeleton, themes, scaffold script, pre-deploy check) lives in this repo at `Resources/Template/`. It is a committed, first-class app resource — not copied from the plugin at build time. `TemplateRuntime` resolves it from the app bundle (with a Settings override for development).
 
 Cross-cutting work (e.g. extending the MCP server with `apply-edit` messages) lands as paired PRs:
 
 1. Plugin PR adds the server-side support and ships in a tagged plugin release.
 2. App PR consumes it and bumps the bundled-plugin pointer.
 
-When in doubt, the plugin is the source of truth for skills, hooks, and the MCP message schema. The app is a *host* — it does not own those.
+Paired PRs are only needed for MCP schema changes and skill additions — template changes are app-only.
+
+When in doubt, the plugin is the source of truth for skills, hooks, and the MCP message schema. The app is a *host* — it does not own those. The app *does* own the template.
 
 ## Stack
 
@@ -43,9 +47,10 @@ Sources/
 JS/
 └── edit-overlay/      TypeScript edit overlay compiled and bundled into app resources
 Resources/
+├── Template/          Website template (themes, scaffold script, Astro source, pre-deploy check) — committed
 ├── node-runtime/      (gitignored) Vendored Node binary, populated by scripts/vendor-node.sh
-├── plugin/            (gitignored) Copy of ../anglesite, populated by scripts/copy-plugin.sh
-│                      (runs as a pre-build phase; respects $ANGLESITE_PLUGIN_SRC override)
+├── plugin/            (gitignored) Plugin MCP server + skills, populated by scripts/copy-plugin.sh
+│                      (template excluded — lives in Resources/Template/ instead)
 ├── Anglesite.help/    Apple Help Book (HTML pages; hiutil index built by scripts/build-help-index.sh)
 └── *.entitlements     Per-target sandbox/signing entitlements (incl. node-runtime.entitlements for the MAS Node re-sign)
 ```

--- a/Resources/Template/astro.config.mjs
+++ b/Resources/Template/astro.config.mjs
@@ -1,0 +1,3 @@
+import { defineConfig } from "astro/config";
+
+export default defineConfig({});

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "anglesite-site",
+  "type": "module",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "check": "npx tsx scripts/pre-deploy-check.ts"
+  },
+  "dependencies": {
+    "astro": "^5.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0"
+  }
+}

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env npx tsx
+/**
+ * Pre-deploy security scan. Runs from the scaffolded site directory (not the template).
+ *
+ * Checks:
+ * - No PII patterns (emails, phone numbers) in generated output
+ * - No exposed API tokens or secrets
+ * - No third-party tracking scripts
+ * - No Keystatic admin routes in production output
+ *
+ * Usage: npx tsx scripts/pre-deploy-check.ts [--json]
+ *
+ * Exit code 0: all clear. Exit code 1: issues found.
+ * With --json: prints a JSON array of { severity, message, file } objects.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+interface Issue {
+  severity: "error" | "warning";
+  message: string;
+  file?: string;
+}
+
+const JSON_MODE = process.argv.includes("--json");
+const DIST_DIR = join(process.cwd(), "dist");
+
+const PII_PATTERNS = [
+  { name: "email", pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g },
+  { name: "phone", pattern: /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/g },
+  { name: "SSN", pattern: /\b\d{3}-\d{2}-\d{4}\b/g },
+];
+
+const SECRET_PATTERNS = [
+  { name: "API key", pattern: /(?:api[_-]?key|apikey)\s*[:=]\s*["']?[a-zA-Z0-9_-]{20,}/gi },
+  { name: "AWS key", pattern: /AKIA[0-9A-Z]{16}/g },
+  { name: "private key", pattern: /-----BEGIN (?:RSA |EC )?PRIVATE KEY-----/g },
+];
+
+const BLOCKED_SCRIPTS = [
+  /google-analytics\.com/i,
+  /googletagmanager\.com/i,
+  /facebook\.net.*fbevents/i,
+  /hotjar\.com/i,
+];
+
+const BLOCKED_ROUTES = [/\/keystatic(?:\/|$)/i, /\/api\/keystatic/i];
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+async function scan(): Promise<Issue[]> {
+  const issues: Issue[] = [];
+
+  try {
+    await stat(DIST_DIR);
+  } catch {
+    issues.push({ severity: "warning", message: "No dist/ directory found — nothing to scan." });
+    return issues;
+  }
+
+  for await (const file of walk(DIST_DIR)) {
+    if (!/\.(html?|js|css|json|xml|txt)$/i.test(file)) continue;
+    const content = await readFile(file, "utf-8");
+    const rel = relative(process.cwd(), file);
+
+    for (const { name, pattern } of PII_PATTERNS) {
+      pattern.lastIndex = 0;
+      if (pattern.test(content)) {
+        issues.push({ severity: "error", message: `Possible ${name} found`, file: rel });
+      }
+    }
+
+    for (const { name, pattern } of SECRET_PATTERNS) {
+      pattern.lastIndex = 0;
+      if (pattern.test(content)) {
+        issues.push({ severity: "error", message: `Possible ${name} exposed`, file: rel });
+      }
+    }
+
+    if (/\.html?$/i.test(file)) {
+      for (const pattern of BLOCKED_SCRIPTS) {
+        if (pattern.test(content)) {
+          issues.push({
+            severity: "warning",
+            message: `Third-party tracking script detected: ${pattern.source}`,
+            file: rel,
+          });
+        }
+      }
+
+      for (const pattern of BLOCKED_ROUTES) {
+        if (pattern.test(content)) {
+          issues.push({
+            severity: "error",
+            message: "Keystatic admin route found in production output",
+            file: rel,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+async function main() {
+  const issues = await scan();
+
+  if (JSON_MODE) {
+    process.stdout.write(JSON.stringify(issues, null, 2) + "\n");
+  } else {
+    if (issues.length === 0) {
+      console.log("Pre-deploy check passed — no issues found.");
+    } else {
+      for (const issue of issues) {
+        const prefix = issue.severity === "error" ? "ERROR" : "WARN";
+        const loc = issue.file ? ` (${issue.file})` : "";
+        console.log(`[${prefix}] ${issue.message}${loc}`);
+      }
+    }
+  }
+
+  const hasErrors = issues.some((i) => i.severity === "error");
+  process.exit(hasErrors ? 1 : 0);
+}
+
+main();

--- a/Resources/Template/scripts/scaffold.sh
+++ b/Resources/Template/scripts/scaffold.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env zsh
+#
+# Scaffold a new Anglesite site by copying the template into the target directory.
+#
+# Usage: scaffold.sh [--yes] <target-dir>
+#
+# --yes  Skip interactive confirmation (used by the app's SiteScaffolder).
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${(%):-%x}")" && pwd)
+TEMPLATE_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+YES=false
+TARGET=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --yes) YES=true ;;
+        *) TARGET="$arg" ;;
+    esac
+done
+
+if [[ -z "$TARGET" ]]; then
+    echo "Usage: scaffold.sh [--yes] <target-dir>" >&2
+    exit 1
+fi
+
+if [[ "$YES" != true ]]; then
+    echo "Will scaffold a new Anglesite site in: $TARGET"
+    echo -n "Continue? [y/N] "
+    read -r reply
+    [[ "$reply" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
+fi
+
+mkdir -p "$TARGET"
+
+# Copy the template tree, excluding scaffold infrastructure and dev-only files.
+rsync -a \
+    --exclude='scripts/scaffold.sh' \
+    --exclude='scripts/themes.ts' \
+    --exclude='node_modules/' \
+    --exclude='.DS_Store' \
+    "$TEMPLATE_ROOT/" "$TARGET/"
+
+# Stamp the scaffolded site with the Anglesite version.
+VERSION="1.0.0"
+echo "ANGLESITE_VERSION=$VERSION" > "$TARGET/.site-config"
+
+echo "==> Scaffolded Anglesite site in $TARGET"

--- a/Resources/Template/scripts/themes.ts
+++ b/Resources/Template/scripts/themes.ts
@@ -1,0 +1,97 @@
+export interface Theme {
+  displayName: string;
+  description: string;
+  bestFor: string[];
+  vars: Record<string, string>;
+}
+
+export const THEMES: Record<string, Theme> = {
+  classic: {
+    displayName: "Classic",
+    description: "Traditional, trustworthy, professional",
+    bestFor: ["legal", "finance", "consulting"],
+    vars: {
+      "color-primary": "#1e3a5f",
+      "color-accent": "#c8a951",
+      "font-heading": "Georgia, 'Times New Roman', serif",
+      "font-body": "system-ui, -apple-system, sans-serif",
+    },
+  },
+  elegant: {
+    displayName: "Elegant",
+    description: "Refined and sophisticated with a modern edge",
+    bestFor: ["photography", "luxury", "personal"],
+    vars: {
+      "color-primary": "#2d2d2d",
+      "color-accent": "#b08d57",
+      "font-heading": "'Palatino Linotype', 'Book Antiqua', serif",
+      "font-body": "system-ui, -apple-system, sans-serif",
+    },
+  },
+  warm: {
+    displayName: "Warm",
+    description: "Friendly, inviting, approachable",
+    bestFor: ["blog", "cafe", "bakery", "lifestyle"],
+    vars: {
+      "color-primary": "#8b4513",
+      "color-accent": "#d4956a",
+      "font-heading": "Georgia, 'Times New Roman', serif",
+      "font-body": "system-ui, -apple-system, sans-serif",
+    },
+  },
+  bold: {
+    displayName: "Bold",
+    description: "High contrast, confident, striking",
+    bestFor: ["portfolio", "agency", "startup"],
+    vars: {
+      "color-primary": "#1a1a2e",
+      "color-accent": "#e94560",
+      "font-heading": "system-ui, -apple-system, sans-serif",
+      "font-body": "system-ui, -apple-system, sans-serif",
+    },
+  },
+  community: {
+    displayName: "Community",
+    description: "Open, inclusive, collaborative",
+    bestFor: ["nonprofit", "organization", "club"],
+    vars: {
+      "color-primary": "#2e7d32",
+      "color-accent": "#ff8f00",
+      "font-heading": "system-ui, -apple-system, sans-serif",
+      "font-body": "system-ui, -apple-system, sans-serif",
+    },
+  },
+  studio: {
+    displayName: "Studio",
+    description: "Dark mode for creative coders",
+    bestFor: ["generative-art", "developer", "creative"],
+    vars: {
+      "color-primary": "#00ff88",
+      "color-accent": "#00ff88",
+      "font-heading": "monospace",
+      "font-body": "monospace",
+    },
+  },
+  coastal: {
+    displayName: "Coastal",
+    description: "Calm, breezy, ocean-inspired",
+    bestFor: ["wellness", "travel", "retreat"],
+    vars: {
+      "color-primary": "#1a5276",
+      "color-accent": "#48c9b0",
+      "font-heading": "system-ui, -apple-system, sans-serif",
+      "font-body": "system-ui, -apple-system, sans-serif",
+    },
+  },
+  minimal: {
+    displayName: "Minimal",
+    description: "Clean, focused, distraction-free",
+    bestFor: ["writer", "researcher", "documentation"],
+    vars: {
+      "color-primary": "#333333",
+      "color-accent": "#0066cc",
+      "font-heading": "system-ui, -apple-system, sans-serif",
+      "font-body": "system-ui, -apple-system, sans-serif",
+    },
+  },
+};

--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -1,0 +1,23 @@
+---
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="generator" content={Astro.generator} />
+    {description && <meta name="description" content={description} />}
+    <title>{title}</title>
+    <link rel="stylesheet" href="/src/styles/global.css" />
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/Resources/Template/src/pages/index.astro
+++ b/Resources/Template/src/pages/index.astro
@@ -1,0 +1,15 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout
+  title="Welcome — Your New Anglesite Business Website"
+  description="Your business website is ready to set up. Run /start in Claude to begin the guided setup."
+>
+  <main>
+    <section class="hero">
+      <h1>Welcome</h1>
+      <p>This site is ready to set up. Type <code>/start</code> in Claude Desktop to get started.</p>
+    </section>
+  </main>
+</BaseLayout>

--- a/Resources/Template/src/styles/global.css
+++ b/Resources/Template/src/styles/global.css
@@ -1,0 +1,76 @@
+:root {
+  --color-primary: #2563eb;
+  --color-accent: #f59e0b;
+  --color-background: #ffffff;
+  --color-surface: #f8fafc;
+  --color-text: #1e293b;
+  --color-text-muted: #64748b;
+  --font-heading: system-ui, -apple-system, sans-serif;
+  --font-body: system-ui, -apple-system, sans-serif;
+  --spacing-unit: 0.25rem;
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 1rem;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background-color: var(--color-background);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  line-height: 1.2;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+main {
+  flex: 1;
+  width: 100%;
+  max-width: 72rem;
+  margin-inline: auto;
+  padding-inline: calc(var(--spacing-unit) * 6);
+}
+
+.hero {
+  padding-block: calc(var(--spacing-unit) * 24);
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  margin-block-end: calc(var(--spacing-unit) * 4);
+}
+
+.hero p {
+  font-size: 1.25rem;
+  color: var(--color-text-muted);
+  max-width: 40rem;
+  margin-inline: auto;
+}

--- a/Resources/Template/tsconfig.json
+++ b/Resources/Template/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -272,13 +272,13 @@ struct SitesLauncherView: View {
         guard newSiteSession == nil, !preparingNewSite else { return }
         preparingNewSite = true
         defer { preparingNewSite = false }
-        let resolution = PluginRuntime.resolve()
-        guard let pluginURL = resolution.url else {
-            loadError = "Plugin not found — can't create a site. Reinstall the app."
+        let resolution = TemplateRuntime.resolve()
+        guard let templateURL = resolution.url else {
+            loadError = "Template not found — can't create a site. Reinstall the app."
             return
         }
         let catalog: ThemeCatalog
-        do { catalog = try ThemeCatalog.load(pluginURL: pluginURL) }
+        do { catalog = try ThemeCatalog.load(templateURL: templateURL) }
         catch { loadError = "Couldn't load themes: \(error.localizedDescription)"; return }
 
         // Effective sites root (override or ~/Sites) — the same accessor SiteStore uses.
@@ -297,7 +297,7 @@ struct SitesLauncherView: View {
 
         let scaffolder = SiteScaffolder(
             sitesRoot: sitesRoot,
-            pluginURL: pluginURL,
+            templateURL: templateURL,
             catalog: catalog,
             run: { exe, args, cwd in
                 try await ProcessSupervisor.shared.run(executable: exe, arguments: args, currentDirectoryURL: cwd)

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -12,8 +12,9 @@ public final class AppSettings: @unchecked Sendable {
 
     /// UserDefaults keys. Public so the SwiftUI side can use them with `@AppStorage`.
     public enum Key {
-        public static let pluginPathOverride = "anglesite.pluginPathOverride"
-        public static let sitesRootOverride  = "anglesite.sitesRootOverride"
+        public static let pluginPathOverride   = "anglesite.pluginPathOverride"
+        public static let templatePathOverride = "anglesite.templatePathOverride"
+        public static let sitesRootOverride    = "anglesite.sitesRootOverride"
         public static let debugPaneEnabled   = "anglesite.debugPaneEnabled"
         public static let lastOpenedSiteID   = "anglesite.lastOpenedSiteID"
         public static let sitesRootBookmark  = "anglesite.sitesRootBookmark"
@@ -41,6 +42,22 @@ public final class AppSettings: @unchecked Sendable {
                 defaults.set(url.path, forKey: Key.pluginPathOverride)
             } else {
                 defaults.removeObject(forKey: Key.pluginPathOverride)
+            }
+        }
+    }
+
+    /// Optional override for the bundled website template path. Lets template authors iterate
+    /// on `Resources/Template/` content without rebuilding the app.
+    public var templatePathOverride: URL? {
+        get {
+            guard let path = defaults.string(forKey: Key.templatePathOverride), !path.isEmpty else { return nil }
+            return URL(fileURLWithPath: path, isDirectory: true)
+        }
+        set {
+            if let url = newValue {
+                defaults.set(url.path, forKey: Key.templatePathOverride)
+            } else {
+                defaults.removeObject(forKey: Key.templatePathOverride)
             }
         }
     }

--- a/Sources/AnglesiteCore/SiteScaffolder.swift
+++ b/Sources/AnglesiteCore/SiteScaffolder.swift
@@ -17,7 +17,7 @@ public actor SiteScaffolder {
     public typealias Register = @Sendable (_ siteDirectory: URL) async throws -> SiteStore.Site
 
     private let sitesRoot: URL
-    private let pluginURL: URL
+    private let templateURL: URL
     private let catalog: ThemeCatalog
     private let run: CommandRunner
     private let register: Register
@@ -25,11 +25,11 @@ public actor SiteScaffolder {
 
     /// `catalog` (not a fixed theme) so the owner's Look-step choice resolves at pipeline time
     /// from `draft.themeID`.
-    public init(sitesRoot: URL, pluginURL: URL, catalog: ThemeCatalog,
+    public init(sitesRoot: URL, templateURL: URL, catalog: ThemeCatalog,
                 run: @escaping CommandRunner, register: @escaping Register,
                 fileManager: FileManager = .default) {
         self.sitesRoot = sitesRoot
-        self.pluginURL = pluginURL
+        self.templateURL = templateURL
         self.catalog = catalog
         self.run = run
         self.register = register
@@ -56,7 +56,7 @@ public actor SiteScaffolder {
 
         // 2. scaffold.sh
         emit(.copyingTemplate)
-        let scaffoldScript = pluginURL.appendingPathComponent("scripts/scaffold.sh")
+        let scaffoldScript = templateURL.appendingPathComponent("scripts/scaffold.sh")
         do {
             let r = try await run(URL(fileURLWithPath: "/bin/zsh"),
                                   [scaffoldScript.path, "--yes", siteDir.path], siteDir)

--- a/Sources/AnglesiteCore/TemplateRuntime.swift
+++ b/Sources/AnglesiteCore/TemplateRuntime.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Locates the website template that ships with the app.
+///
+/// The template (Astro project skeleton, themes, scaffold script, pre-deploy check) is committed
+/// directly to this repo at `Resources/Template/`. It was previously part of the sibling plugin
+/// checkout and bundled at build time — now it's a first-class app resource.
+///
+/// The Settings → Advanced → Template path override lets template authors point a running app at
+/// a working copy without rebuilding.
+public enum TemplateRuntime {
+    public struct Resolution: Sendable, Equatable {
+        public enum Source: Sendable, Equatable {
+            case override(URL)
+            case bundled(URL)
+            case missing
+        }
+
+        public let source: Source
+
+        public var url: URL? {
+            switch source {
+            case .override(let url), .bundled(let url): return url
+            case .missing: return nil
+            }
+        }
+
+        public var description: String {
+            switch source {
+            case .override(let url): return "override: \(url.path)"
+            case .bundled(let url):  return "bundled: \(url.path)"
+            case .missing:           return "not found"
+            }
+        }
+    }
+
+    public static func resolve(settings: AppSettings = .shared, bundle: Bundle = .main) -> Resolution {
+        if let override = settings.templatePathOverride, isTemplateDirectory(override) {
+            return Resolution(source: .override(override))
+        }
+        if let bundled = bundledURL(in: bundle), isTemplateDirectory(bundled) {
+            return Resolution(source: .bundled(bundled))
+        }
+        return Resolution(source: .missing)
+    }
+
+    public static func bundledURL(in bundle: Bundle = .main) -> URL? {
+        guard let resourceURL = bundle.resourceURL else { return nil }
+        let candidate = resourceURL.appendingPathComponent("Template", isDirectory: true)
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue else {
+            return nil
+        }
+        return candidate
+    }
+
+    /// True if `url` looks like the Anglesite website template — has the scaffold script and themes.
+    public static func isTemplateDirectory(_ url: URL) -> Bool {
+        let themes = url.appendingPathComponent("scripts/themes.ts")
+        return FileManager.default.fileExists(atPath: themes.path)
+    }
+}

--- a/Sources/AnglesiteCore/ThemeCatalog.swift
+++ b/Sources/AnglesiteCore/ThemeCatalog.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// One built-in visual theme, parsed from the plugin's `template/scripts/themes.ts`.
+/// One built-in visual theme, parsed from `Resources/Template/scripts/themes.ts`.
 public struct Theme: Sendable, Identifiable, Equatable {
     public let id: String                    // THEMES record key, e.g. "warm"
     public let name: String                  // displayName
@@ -34,10 +34,10 @@ public struct ThemeCatalog: Sendable {
         return themes.first?.id ?? want
     }
 
-    /// Load + parse the bundled plugin's themes.ts. `pluginURL` is the plugin root
-    /// (`PluginRuntime.resolve().url`); themes.ts lives at template/scripts/themes.ts.
-    public static func load(pluginURL: URL) throws -> ThemeCatalog {
-        let url = pluginURL.appendingPathComponent("template/scripts/themes.ts")
+    /// Load + parse the bundled template's themes.ts. `templateURL` is the template root
+    /// (`TemplateRuntime.resolve().url`); themes.ts lives at scripts/themes.ts.
+    public static func load(templateURL: URL) throws -> ThemeCatalog {
+        let url = templateURL.appendingPathComponent("scripts/themes.ts")
         let ts = try String(contentsOf: url, encoding: .utf8)
         return ThemeCatalog(themes: try parse(themesTS: ts))
     }

--- a/Tests/AnglesiteCoreTests/HomepageWriterTests.swift
+++ b/Tests/AnglesiteCoreTests/HomepageWriterTests.swift
@@ -41,13 +41,11 @@ final class HomepageWriterTests: XCTestCase {
     }
 
     // DRIFT GUARD: the real scaffolded index.astro must still contain the exact strings
-    // HomepageWriter replaces. If the plugin template changes them, fill() would silently
-    // no-op and ship template copy instead of the owner's content. Skips when the sibling
-    // plugin checkout isn't present.
+    // HomepageWriter replaces. If the template changes them, fill() would silently no-op
+    // and ship template copy instead of the owner's content.
     func testRealIndexAstroContainsAllSentinels() throws {
-        guard let url = Self.realIndexAstroURL(), let src = try? String(contentsOf: url, encoding: .utf8) else {
-            throw XCTSkip("plugin index.astro not found; set ANGLESITE_PLUGIN_PATH or check out ../anglesite")
-        }
+        let url = Self.realIndexAstroURL()
+        let src = try String(contentsOf: url, encoding: .utf8)
         XCTAssertTrue(src.contains(HomepageWriter.titleLine), "titleLine sentinel drifted from template")
         XCTAssertTrue(src.contains(HomepageWriter.h1Line),    "h1Line sentinel drifted from template")
         XCTAssertTrue(src.contains(HomepageWriter.descLine),  "descLine sentinel drifted from template")
@@ -62,17 +60,10 @@ final class HomepageWriterTests: XCTestCase {
         XCTAssertFalse(out.contains("<script>"))
     }
 
-    /// Resolve the real index.astro via env override or the sibling repo relative to this source file.
-    static func realIndexAstroURL() -> URL? {
-        let fm = FileManager.default
-        if let env = ProcessInfo.processInfo.environment["ANGLESITE_PLUGIN_PATH"] {
-            let u = URL(fileURLWithPath: env).appendingPathComponent("template/src/pages/index.astro")
-            if fm.fileExists(atPath: u.path) { return u }
-        }
+    /// Resolve the real index.astro from the in-repo template (Resources/Template/).
+    static func realIndexAstroURL() -> URL {
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-        let sibling = repoRoot.deletingLastPathComponent()
-            .appendingPathComponent("anglesite/template/src/pages/index.astro")
-        return fm.fileExists(atPath: sibling.path) ? sibling : nil
+        return repoRoot.appendingPathComponent("Resources/Template/src/pages/index.astro")
     }
 }

--- a/Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
@@ -42,7 +42,7 @@ final class NewSiteWizardModelTests: XCTestCase {
     private func warningScaffolder(root: URL) -> SiteScaffolder {
         SiteScaffolder(
             sitesRoot: root,
-            pluginURL: URL(fileURLWithPath: "/plugin"),
+            templateURL: URL(fileURLWithPath: "/template"),
             catalog: catalog(),
             run: { _, args, cwd in
                 if args.contains(where: { $0.hasSuffix("scaffold.sh") }), let cwd {

--- a/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
@@ -44,7 +44,7 @@ final class SiteScaffolderTests: XCTestCase {
         let calls = CallRecorder()
         let scaffolder = SiteScaffolder(
             sitesRoot: root,
-            pluginURL: URL(fileURLWithPath: "/plugin"),
+            templateURL: URL(fileURLWithPath: "/template"),
             catalog: ThemeCatalog(themes: [theme]),
             run: fakeRunner(calls: calls),
             register: { url in SiteStore.Site(id: url.path, name: url.lastPathComponent, path: url, isValid: true, missingSentinels: []) }
@@ -67,7 +67,7 @@ final class SiteScaffolderTests: XCTestCase {
     func testScaffoldFailureIsFatal() async throws {
         let root = tmpDir()
         let scaffolder = SiteScaffolder(
-            sitesRoot: root, pluginURL: URL(fileURLWithPath: "/plugin"), catalog: ThemeCatalog(themes: [theme]),
+            sitesRoot: root, templateURL: URL(fileURLWithPath: "/template"), catalog: ThemeCatalog(themes: [theme]),
             run: fakeRunner(scaffoldExit: 1, calls: CallRecorder()),
             register: { _ in XCTFail("must not register on scaffold failure"); fatalError() }
         )
@@ -81,7 +81,7 @@ final class SiteScaffolderTests: XCTestCase {
         let root = tmpDir()
         let registered = OSAllocatedUnfairLock<Bool>(initialState: false)
         let scaffolder = SiteScaffolder(
-            sitesRoot: root, pluginURL: URL(fileURLWithPath: "/plugin"), catalog: ThemeCatalog(themes: [theme]),
+            sitesRoot: root, templateURL: URL(fileURLWithPath: "/template"), catalog: ThemeCatalog(themes: [theme]),
             run: fakeRunner(npmExit: 1, calls: CallRecorder()),
             register: { url in
                 registered.withLock { $0 = true }

--- a/Tests/AnglesiteCoreTests/TemplateRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/TemplateRuntimeTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+final class TemplateRuntimeTests {
+    private let tempDir: URL
+    private let suiteName: String
+    private let defaults: UserDefaults
+    private let fileManager = FileManager.default
+
+    init() throws {
+        tempDir = fileManager.temporaryDirectory.appendingPathComponent("anglesite-template-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let suite = "test-anglesite-\(UUID().uuidString)"
+        suiteName = suite
+        defaults = UserDefaults(suiteName: suite)!
+    }
+
+    deinit {
+        try? fileManager.removeItem(at: tempDir)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    @Test("Is template directory recognizes themes.ts") func isTemplateDirectoryRecognizesThemes() throws {
+        let template = tempDir.appendingPathComponent("Template", isDirectory: true)
+        let scriptsDir = template.appendingPathComponent("scripts", isDirectory: true)
+        try fileManager.createDirectory(at: scriptsDir, withIntermediateDirectories: true)
+        try Data("export const THEMES".utf8).write(to: scriptsDir.appendingPathComponent("themes.ts"))
+
+        #expect(TemplateRuntime.isTemplateDirectory(template))
+    }
+
+    @Test("Is template directory rejects bare directory") func isTemplateDirectoryRejectsBareDirectory() {
+        #expect(!TemplateRuntime.isTemplateDirectory(tempDir))
+    }
+
+    @Test("Resolve reports missing when no source found") func resolveReportsMissingWhenNoSourceFound() {
+        let settings = AppSettings(defaults: defaults)
+        let resolution = TemplateRuntime.resolve(settings: settings)
+        #expect(resolution.source == .missing)
+        #expect(resolution.url == nil)
+    }
+
+    @Test("Resolve honors override when valid") func resolveHonorsOverrideWhenValid() throws {
+        let template = tempDir.appendingPathComponent("Template", isDirectory: true)
+        let scriptsDir = template.appendingPathComponent("scripts", isDirectory: true)
+        try fileManager.createDirectory(at: scriptsDir, withIntermediateDirectories: true)
+        try Data("export const THEMES".utf8).write(to: scriptsDir.appendingPathComponent("themes.ts"))
+
+        let settings = AppSettings(defaults: defaults)
+        settings.templatePathOverride = template
+
+        let resolution = TemplateRuntime.resolve(settings: settings)
+        #expect(resolution.source == .override(template))
+        #expect(resolution.url?.path == template.path)
+    }
+
+    @Test("Resolve ignores invalid override") func resolveIgnoresInvalidOverride() {
+        let settings = AppSettings(defaults: defaults)
+        settings.templatePathOverride = tempDir
+        let resolution = TemplateRuntime.resolve(settings: settings)
+        #expect(resolution.source == .missing)
+    }
+}

--- a/Tests/AnglesiteCoreTests/ThemeCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/ThemeCatalogTests.swift
@@ -62,12 +62,10 @@ final class ThemeCatalogTests: XCTestCase {
         XCTAssertEqual(catalog.defaultThemeID(for: .organization), "community")
     }
 
-    // DRIFT GUARD: parse the REAL bundled plugin themes.ts. Skips when the sibling
-    // plugin checkout isn't present (e.g. CI without it / pure `swift test`).
+    // DRIFT GUARD: parse the REAL bundled themes.ts from the in-repo template.
     func testRealThemesFileParsesToEightCompleteThemes() throws {
-        guard let url = Self.realThemesURL(), let ts = try? String(contentsOf: url, encoding: .utf8) else {
-            throw XCTSkip("plugin themes.ts not found; set ANGLESITE_PLUGIN_PATH or check out ../anglesite")
-        }
+        let url = Self.realThemesURL()
+        let ts = try String(contentsOf: url, encoding: .utf8)
         let themes = try ThemeCatalog.parse(themesTS: ts)
         XCTAssertEqual(themes.count, 8, "expected 8 built-in themes")
         for t in themes {
@@ -81,19 +79,10 @@ final class ThemeCatalogTests: XCTestCase {
         }
     }
 
-    /// Resolve the real themes.ts via env override or the sibling repo relative to this source file.
-    static func realThemesURL() -> URL? {
-        let fm = FileManager.default
-        if let env = ProcessInfo.processInfo.environment["ANGLESITE_PLUGIN_PATH"] {
-            let u = URL(fileURLWithPath: env)
-                .appendingPathComponent("template/scripts/themes.ts")
-            if fm.fileExists(atPath: u.path) { return u }
-        }
-        // <repo>/Tests/AnglesiteCoreTests/ThemeCatalogTests.swift -> repo root is 3 up.
+    /// Resolve the real themes.ts from the in-repo template (Resources/Template/).
+    static func realThemesURL() -> URL {
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-        let sibling = repoRoot.deletingLastPathComponent()
-            .appendingPathComponent("anglesite/template/scripts/themes.ts")
-        return fm.fileExists(atPath: sibling.path) ? sibling : nil
+        return repoRoot.appendingPathComponent("Resources/Template/scripts/themes.ts")
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -24,6 +24,9 @@ targets:
     sources:
       - path: Sources/AnglesiteApp
       - path: Resources/Assets.xcassets
+      - path: Resources/Template
+        type: folder
+        buildPhase: resources
       - path: Resources/node-runtime
         type: folder
         buildPhase: resources
@@ -107,6 +110,9 @@ targets:
     sources:
       - path: Sources/AnglesiteApp
       - path: Resources/Assets.xcassets
+      - path: Resources/Template
+        type: folder
+        buildPhase: resources
       - path: Resources/node-runtime
         type: folder
         buildPhase: resources

--- a/scripts/build-container-image.sh
+++ b/scripts/build-container-image.sh
@@ -46,8 +46,9 @@ DEFAULT_SRC=$(cd "$REPO_ROOT/.." && pwd)/anglesite
 SRC="${ANGLESITE_PLUGIN_SRC:-$DEFAULT_SRC}"
 [[ -d "$SRC" ]] || { echo "plugin source not found at $SRC (set ANGLESITE_PLUGIN_SRC)" >&2; exit 1; }
 [[ -f "$SRC/.claude-plugin/plugin.json" ]] || { echo "$SRC is not the Anglesite plugin (no .claude-plugin/plugin.json)" >&2; exit 1; }
-[[ -f "$SRC/template/package.json" && -f "$SRC/template/package-lock.json" ]] \
-    || { echo "template manifests missing under $SRC/template" >&2; exit 1; }
+TEMPLATE_DIR="$REPO_ROOT/Resources/Template"
+[[ -f "$TEMPLATE_DIR/package.json" ]] \
+    || { echo "template manifests missing under $TEMPLATE_DIR" >&2; exit 1; }
 
 command -v docker >/dev/null 2>&1 || { echo "docker not found on PATH" >&2; exit 1; }
 
@@ -68,11 +69,13 @@ rsync -a \
     --exclude='.claude/' --exclude='dist/' --exclude='build/' \
     --exclude='tests/' --exclude='test/' --exclude='docs/' \
     --exclude='*.log' --exclude='.DS_Store' \
+    --exclude='template/' \
     "$SRC/" "$CTX/plugin/"
 
 # Template: manifests only. We bake the template's dependency closure, not its source.
 mkdir -p "$CTX/template"
-cp "$SRC/template/package.json" "$SRC/template/package-lock.json" "$CTX/template/"
+cp "$TEMPLATE_DIR/package.json" "$CTX/template/"
+[[ -f "$TEMPLATE_DIR/package-lock.json" ]] && cp "$TEMPLATE_DIR/package-lock.json" "$CTX/template/"
 
 # ---- Build --------------------------------------------------------------------
 IMAGE_REF="${IMAGE_REPO}:${IMAGE_TAG}"

--- a/scripts/copy-plugin.sh
+++ b/scripts/copy-plugin.sh
@@ -50,6 +50,7 @@ rsync -a --delete \
     --exclude='tests/' \
     --exclude='test/' \
     --exclude='*.log' \
+    --exclude='template/' \
     "$SRC/" "$DEST/"
 
 # Install the plugin's runtime dependencies into the bundle. The rsync above

--- a/scripts/create-smoke-fixture.sh
+++ b/scripts/create-smoke-fixture.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 #
 # Creates a smoke-test Anglesite site at ~/Sites/anglesite-smoke/, populated
-# from the bundled plugin template with `node_modules` installed.
+# from the in-repo template (Resources/Template/) with `node_modules` installed.
 #
 # Use this fixture to manually verify the dev-server lifecycle end-to-end:
 # PreviewModel → AstroDevServer → ProcessSupervisor → window-close teardown.
 # The template alone (without node_modules) leaves the preview in `.failed`
 # and never exercises the subprocess code path.
 #
-# Idempotent: re-running mirrors any template changes (the source of truth
-# lives in the sibling plugin repo) and runs `npm install` incrementally.
-# Respects $ANGLESITE_PLUGIN_SRC the same way scripts/copy-plugin.sh does.
+# Idempotent: re-running mirrors any template changes and runs `npm install`
+# incrementally.
 
 set -euo pipefail
 
@@ -28,14 +27,12 @@ done
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
-PLUGIN_SRC="${ANGLESITE_PLUGIN_SRC:-$REPO_ROOT/../anglesite}"
-TEMPLATE_SRC="$PLUGIN_SRC/template"
+TEMPLATE_SRC="$REPO_ROOT/Resources/Template"
 FIXTURE_DIR="$HOME/Sites/anglesite-smoke"
 
 if [[ ! -d "$TEMPLATE_SRC" ]]; then
     echo "error: template not found at $TEMPLATE_SRC" >&2
-    echo "       set ANGLESITE_PLUGIN_SRC to the plugin checkout root, or" >&2
-    echo "       clone Anglesite/anglesite alongside this repo." >&2
+    echo "       Resources/Template/ should be committed to the app repo." >&2
     exit 1
 fi
 

--- a/scripts/vendor-npm-cache.sh
+++ b/scripts/vendor-npm-cache.sh
@@ -94,7 +94,9 @@ mkdir -p "$CACHE"
 # Install each project into a throwaway copy, sharing one --cache so it accumulates
 # every package tarball. --prefer-online to get fresh tarballs; --ignore-scripts so
 # no postinstall hooks run during the build.
-find "$PLUGIN_DIR" -name package.json -not -path '*/node_modules/*' -print0 | while IFS= read -r -d '' pkgjson; do
+{ find "$PLUGIN_DIR" -name package.json -not -path '*/node_modules/*' -print0 2>/dev/null; \
+  find "$REPO_ROOT/Resources/Template" -name package.json -not -path '*/node_modules/*' -print0 2>/dev/null; \
+} | while IFS= read -r -d '' pkgjson; do
     dir=$(dirname "$pkgjson")
     work="$TMP/work-$RANDOM"
     mkdir -p "$work"


### PR DESCRIPTION
## Summary

- **Move the website template** (Astro skeleton, themes, scaffold script, pre-deploy check) from the sibling plugin repo into `Resources/Template/` as a committed, first-class app resource
- **Introduce `TemplateRuntime`** (peer to `PluginRuntime`) for template path resolution, with a `templatePathOverride` in AppSettings for development iteration
- **Update all template consumers** (`ThemeCatalog.load`, `SiteScaffolder`, `SitesLauncherView`) to resolve via `TemplateRuntime` instead of `PluginRuntime`
- **Update build scripts** (`copy-plugin.sh` excludes `template/`, `create-smoke-fixture.sh` and `build-container-image.sh` source from in-repo template, `vendor-npm-cache.sh` primes cache from both plugin and template)
- **Simplify drift-guard tests** — `ThemeCatalogTests` and `HomepageWriterTests` now resolve from the in-repo template (no more `XCTSkip` when the plugin checkout is absent)

### Motivation

The app is the sole consumer of the template — `SiteScaffolder`, `ThemeCatalog`, and `PreDeployCheck` all parse template files directly. Having the template in the plugin repo meant every template change required a paired cross-repo PR, even though skills and the MCP server (which stay in the plugin) were unaffected. This eliminates that coordination overhead.

### What stays in the plugin

- MCP server (`server/index.mjs`) — `LocalSiteRuntime` + `ClaudeAgent` still use `PluginRuntime`
- Skills and hooks — chat-routed, invoked by Claude, not by Swift code
- Plugin marketplace manifest (`.claude-plugin/plugin.json`)

## Test plan

- [ ] `swift test` passes — `TemplateRuntimeTests` (5 tests), updated `ThemeCatalogTests`, `HomepageWriterTests`, `SiteScaffolderTests` all green
- [ ] `ThemeCatalogTests.testRealThemesFileParsesToEightCompleteThemes` no longer skips (resolves from in-repo `Resources/Template/scripts/themes.ts`)
- [ ] `HomepageWriterTests.testRealIndexAstroContainsAllSentinels` no longer skips (resolves from in-repo `Resources/Template/src/pages/index.astro`)
- [ ] `xcodegen generate` + build both targets (`Anglesite`, `AnglesiteMAS`) — `Resources/Template` bundled as a non-optional resource
- [ ] New Site wizard still scaffolds correctly (scaffold.sh runs from template root)
- [ ] `scripts/copy-plugin.sh` excludes `template/` from plugin bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01928EgL9mgtLQAm6yzZiFFw

---
_Generated by [Claude Code](https://claude.ai/code/session_01928EgL9mgtLQAm6yzZiFFw)_