### PR TITLE
fix(intents): guard SearchContentIntent against a blank query (#234)

### DIFF
--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -46,6 +46,12 @@ public struct SearchContentIntent: AppIntent {
     /// Gather matches from the graph as a uniform list. Static + graph-injected so it's
     /// unit-testable without the AppIntents runtime (mirrors the prior `dialog` helper).
     static func matches(graph: SiteContentGraph, siteID: String, query: String) async -> [ContentMatchEntity] {
+        // Guard the intent surface against a blank query (#234). The graph helpers treat "empty =
+        // all" — fine for internal status/listing callers — but D.2 (#163) made this intent return a
+        // typed `ReturnsValue<[ContentMatchEntity]>`, so an empty query handed to an MCP agent or
+        // Shortcut would dump every page, post, and image for the site. Require a search term here
+        // while leaving the graph helpers' contract untouched.
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
         // Sort each kind's graph hits deterministically (lastModified desc, id asc — the same
         // comparator the entity queries use) BEFORE projecting, so the agent-facing result order
         // is stable across launches. `ContentMatchEntity` doesn't carry `lastModified`, so the
@@ -266,6 +272,11 @@ public enum ContentDialogs {
     public enum CreateKind: String, Sendable { case page, post }
 
     public static func search(query: String, pageCount: Int, postCount: Int, imageCount: Int) -> String {
+        // A blank/whitespace query is a missing search term, not a zero-result search (#234). Prompt
+        // for input rather than echoing `Nothing matched “”.`, which reads as a real empty result.
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return "Please tell me what to search for."
+        }
         let total = pageCount + postCount + imageCount
         guard total > 0 else { return "Nothing matched “\(query)”." }
         var parts: [String] = []

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -46,11 +46,7 @@ public struct SearchContentIntent: AppIntent {
     /// Gather matches from the graph as a uniform list. Static + graph-injected so it's
     /// unit-testable without the AppIntents runtime (mirrors the prior `dialog` helper).
     static func matches(graph: SiteContentGraph, siteID: String, query: String) async -> [ContentMatchEntity] {
-        // Guard the intent surface against a blank query (#234). The graph helpers treat "empty =
-        // all" — fine for internal status/listing callers — but D.2 (#163) made this intent return a
-        // typed `ReturnsValue<[ContentMatchEntity]>`, so an empty query handed to an MCP agent or
-        // Shortcut would dump every page, post, and image for the site. Require a search term here
-        // while leaving the graph helpers' contract untouched.
+        // #234: the graph treats an empty query as "match all"; guard here so the MCP/Shortcut surface can't leak the whole content graph.
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
         // Sort each kind's graph hits deterministically (lastModified desc, id asc — the same
         // comparator the entity queries use) BEFORE projecting, so the agent-facing result order
@@ -272,8 +268,7 @@ public enum ContentDialogs {
     public enum CreateKind: String, Sendable { case page, post }
 
     public static func search(query: String, pageCount: Int, postCount: Int, imageCount: Int) -> String {
-        // A blank/whitespace query is a missing search term, not a zero-result search (#234). Prompt
-        // for input rather than echoing `Nothing matched “”.`, which reads as a real empty result.
+        // #234: a blank query means "no term given", not "no results" — prompt instead of echoing `Nothing matched “”.`.
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return "Please tell me what to search for."
         }

--- a/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
@@ -176,9 +176,6 @@ extension AppIntentsTests {
 
         @Test("SearchContentIntent.matches guards a blank query instead of dumping the whole graph")
         func searchMatchesBlankQueryReturnsEmpty() async {
-            // #234: D.2 made this a typed ReturnsValue, so an empty query handed to an MCP agent or
-            // Shortcut would dump every page/post/image. The intent surface must require a term even
-            // though the graph helpers keep "empty = all" for internal callers.
             let graph = SiteContentGraph()
             await graph.load(
                 siteID: AppIntentsTests.aSite,
@@ -188,8 +185,10 @@ extension AppIntentsTests {
             )
             #expect(await SearchContentIntent.matches(graph: graph, siteID: AppIntentsTests.aSite, query: "").isEmpty)
             #expect(await SearchContentIntent.matches(graph: graph, siteID: AppIntentsTests.aSite, query: "   ").isEmpty)
-            // The graph helper itself still returns everything for an empty query (internal contract).
+            // The graph helpers keep "empty = all" for internal callers — verify across all three kinds.
             #expect(await graph.searchPages(siteID: AppIntentsTests.aSite, matching: "").count == 1)
+            #expect(await graph.searchPosts(siteID: AppIntentsTests.aSite, matching: "").count == 1)
+            #expect(await graph.searchImages(siteID: AppIntentsTests.aSite, matching: "").count == 1)
         }
 
         @Test("search match path is the route and resolves back to a page (chaining)")

--- a/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
@@ -40,6 +40,13 @@ extension AppIntentsTests {
             #expect(ContentDialogs.search(query: "x", pageCount: 0, postCount: 2, imageCount: 0) == "Found 2 posts matching “x”.")
         }
 
+        @Test("search dialog: blank or whitespace query asks for a term instead of 'nothing matched'")
+        func searchDialogBlankQuery() {
+            // #234: an empty/whitespace query must prompt for input, not echo `Nothing matched “”.`
+            #expect(ContentDialogs.search(query: "", pageCount: 0, postCount: 0, imageCount: 0) == "Please tell me what to search for.")
+            #expect(ContentDialogs.search(query: "   ", pageCount: 0, postCount: 0, imageCount: 0) == "Please tell me what to search for.")
+        }
+
         @Test("status dialog: drafts noted only when present; singular nouns")
         func statusDialog() {
             #expect(ContentDialogs.status(siteName: "Alpha", pages: 1, posts: 1, drafts: 0, images: 1) == "Alpha has 1 page, 1 post, and 1 image.")
@@ -165,6 +172,24 @@ extension AppIntentsTests {
             await graph.load(siteID: AppIntentsTests.aSite, pages: [newer, older], posts: [], images: [])
             let matches = await SearchContentIntent.matches(graph: graph, siteID: AppIntentsTests.aSite, query: "about")
             #expect(matches.map(\.id) == [newer.id, older.id])  // newer (later lastModified) first
+        }
+
+        @Test("SearchContentIntent.matches guards a blank query instead of dumping the whole graph")
+        func searchMatchesBlankQueryReturnsEmpty() async {
+            // #234: D.2 made this a typed ReturnsValue, so an empty query handed to an MCP agent or
+            // Shortcut would dump every page/post/image. The intent surface must require a term even
+            // though the graph helpers keep "empty = all" for internal callers.
+            let graph = SiteContentGraph()
+            await graph.load(
+                siteID: AppIntentsTests.aSite,
+                pages: [AppIntentsTests.gPage(route: "/about", title: "About")],
+                posts: [AppIntentsTests.gPost(slug: "notes", title: "Notes")],
+                images: [AppIntentsTests.gImage()]
+            )
+            #expect(await SearchContentIntent.matches(graph: graph, siteID: AppIntentsTests.aSite, query: "").isEmpty)
+            #expect(await SearchContentIntent.matches(graph: graph, siteID: AppIntentsTests.aSite, query: "   ").isEmpty)
+            // The graph helper itself still returns everything for an empty query (internal contract).
+            #expect(await graph.searchPages(siteID: AppIntentsTests.aSite, matching: "").count == 1)
         }
 
         @Test("search match path is the route and resolves back to a page (chaining)")


### PR DESCRIPTION
## Summary

Closes #234. `SearchContentIntent`'s empty/whitespace query no longer dumps the entire content graph as agent-visible structured results.

D.2 (#163, PRs #230/#232) changed this intent's `perform()` to return a typed `ReturnsValue<[ContentMatchEntity]>`. The underlying `SiteContentGraph.search*` helpers treat an empty query as "match everything" — fine for the spoken-count path, but it meant an empty query handed to an MCP agent or Shortcut would return **every page, post, and image** for the site.

This takes **option 1** from the issue: guard the intent surface, leave the graph helpers' contract alone.

## Changes

- `SearchContentIntent.matches(...)` returns `[]` for a blank/whitespace query (before hitting the graph), so the `ReturnsValue` is empty.
- `ContentDialogs.search(...)` returns `"Please tell me what to search for."` for a blank query instead of the misleading `Nothing matched “”.`.
- `SiteContentGraph.searchPages/Posts/Images` are **unchanged** — internal status/listing callers keep "empty = all".

The two guards are independent (data path + dialog path), so neither layer can leak the old behavior on its own.

## Testing

- New: `searchDialogBlankQuery` and `searchMatchesBlankQueryReturnsEmpty` (the latter also asserts the graph helper still returns all content for an empty query, locking in the preserved internal contract).
- Full `AnglesiteIntentsTests` suite green (157 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)