### PR TITLE
feat(siri): local readiness diagnostics for Siri workflows (#236)

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -11,6 +11,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `AnglesiteIntents.bootstrap` so it can be registered with `AppDependencyManager`;
     /// will also be threaded into `LocalSiteRuntime` in A.8 (#142).
     let contentGraph = SiteContentGraph()
+    var contentIndexer: ContentSpotlightIndexer?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Register App Intents dependencies before the app surface comes up so backgrounded
@@ -19,7 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // we kick it off here without waiting — the launcher view's `task` modifier doesn't
         // block on it, and bootstrap's own defensive `load()` closes any race.
         Task { [contentGraph] in
-            await AnglesiteIntents.bootstrap(contentGraph: contentGraph)
+            self.contentIndexer = await AnglesiteIntents.bootstrap(contentGraph: contentGraph)
         }
 
         // Begin mirroring the site registry so the File ▸ Open Recent submenu is populated
@@ -159,7 +160,7 @@ struct AnglesiteApp: App {
             // route to the launcher when restoration hands us a nil or unresolvable
             // id. If we short-circuit with `if let siteID` here the SiteWindow never
             // instantiates and an empty restored window strands the user.
-            SiteWindow(siteID: siteID, contentGraph: appDelegate.contentGraph)
+            SiteWindow(siteID: siteID, contentGraph: appDelegate.contentGraph, contentIndexer: appDelegate.contentIndexer)
                 .frame(minWidth: 960, minHeight: 600)
         }
         .windowStyle(.titleBar)

--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -6,12 +6,23 @@ import AnglesiteIntents
 
 /// Owns process-level lifecycle that SwiftUI's `App` value type can't: prime the npm cache on
 /// launch, and drain every supervised child on quit so nothing outlives the app.
+/// Holds the app-lifetime `ContentSpotlightIndexer` once `bootstrap` finishes populating it.
+/// `@Observable` so a `SiteWindow` constructed *before* bootstrap completes still reacts when the
+/// indexer arrives (enabling its Siri AI Readiness button) — passing the bare optional through the
+/// `WindowGroup` constructor would freeze whatever value existed at body-eval time.
+@MainActor
+@Observable
+final class ContentIndexerStore {
+    var indexer: ContentSpotlightIndexer?
+}
+
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Single shared `SiteContentGraph` for the app's lifetime. Passed into
     /// `AnglesiteIntents.bootstrap` so it can be registered with `AppDependencyManager`;
     /// will also be threaded into `LocalSiteRuntime` in A.8 (#142).
     let contentGraph = SiteContentGraph()
-    var contentIndexer: ContentSpotlightIndexer?
+    let contentIndexerStore = ContentIndexerStore()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Register App Intents dependencies before the app surface comes up so backgrounded
@@ -19,8 +30,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // `bootstrap()` is async (it awaits the Spotlight handler installation on `SiteStore`);
         // we kick it off here without waiting — the launcher view's `task` modifier doesn't
         // block on it, and bootstrap's own defensive `load()` closes any race.
-        Task { [contentGraph] in
-            self.contentIndexer = await AnglesiteIntents.bootstrap(contentGraph: contentGraph)
+        Task { [contentGraph, contentIndexerStore] in
+            // This Task inherits the @MainActor context, so the store write needs no extra hop.
+            contentIndexerStore.indexer = await AnglesiteIntents.bootstrap(contentGraph: contentGraph)
         }
 
         // Begin mirroring the site registry so the File ▸ Open Recent submenu is populated
@@ -160,7 +172,7 @@ struct AnglesiteApp: App {
             // route to the launcher when restoration hands us a nil or unresolvable
             // id. If we short-circuit with `if let siteID` here the SiteWindow never
             // instantiates and an empty restored window strands the user.
-            SiteWindow(siteID: siteID, contentGraph: appDelegate.contentGraph, contentIndexer: appDelegate.contentIndexer)
+            SiteWindow(siteID: siteID, contentGraph: appDelegate.contentGraph, contentIndexerStore: appDelegate.contentIndexerStore)
                 .frame(minWidth: 960, minHeight: 600)
         }
         .windowStyle(.titleBar)

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -7,8 +7,10 @@ struct SettingsView: View {
         TabView {
             AdvancedSettingsView()
                 .tabItem { Label("Advanced", systemImage: "gearshape.2") }
+            SiriReadinessSettingsView()
+                .tabItem { Label("Siri AI", systemImage: "sparkles") }
         }
-        .frame(width: 540, height: 320)
+        .frame(width: 540, height: 360)
     }
 }
 

--- a/Sources/AnglesiteApp/SiriReadinessView.swift
+++ b/Sources/AnglesiteApp/SiriReadinessView.swift
@@ -54,7 +54,7 @@ struct ReadinessRow: View {
 /// Renders a readiness model: the findings list, a re-check button, and a last-checked stamp.
 /// Drives an initial check on appear. Reused by Settings (system) and the per-window sheet.
 struct SiriReadinessList: View {
-    @State var model: SiriReadinessModel
+    let model: SiriReadinessModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/Sources/AnglesiteApp/SiriReadinessView.swift
+++ b/Sources/AnglesiteApp/SiriReadinessView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+import AnglesiteCore
+import AnglesiteIntents
+
+/// One capability row: status glyph + title + concrete detail + optional remediation.
+struct ReadinessRow: View {
+    let finding: ReadinessFinding
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: glyph)
+                .foregroundStyle(tint)
+                .accessibilityLabel(accessibilityStatus)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(finding.title).font(.body)
+                Text(finding.detail).font(.caption).foregroundStyle(.secondary)
+                if let remediation = finding.remediation {
+                    Text(remediation).font(.caption).foregroundStyle(.blue)
+                }
+            }
+            Spacer()
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var glyph: String {
+        switch finding.level {
+        case .ok: return "checkmark.circle.fill"
+        case .warning: return "exclamationmark.triangle.fill"
+        case .failure: return "xmark.octagon.fill"
+        case .unsupported: return "minus.circle"
+        }
+    }
+
+    private var tint: Color {
+        switch finding.level {
+        case .ok: return .green
+        case .warning: return .orange
+        case .failure: return .red
+        case .unsupported: return .secondary
+        }
+    }
+
+    private var accessibilityStatus: String {
+        switch finding.level {
+        case .ok: return "OK"
+        case .warning: return "Warning"
+        case .failure: return "Failure"
+        case .unsupported: return "Not available"
+        }
+    }
+}
+
+/// Renders a readiness model: the findings list, a re-check button, and a last-checked stamp.
+/// Drives an initial check on appear. Reused by Settings (system) and the per-window sheet.
+struct SiriReadinessList: View {
+    @State var model: SiriReadinessModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(model.findings) { finding in
+                ReadinessRow(finding: finding)
+            }
+            HStack {
+                Button("Re-check") { model.recheck() }
+                    .disabled(model.isChecking)
+                if model.isChecking {
+                    ProgressView().controlSize(.small)
+                }
+                Spacer()
+                if let checked = model.lastChecked {
+                    Text("Last checked \(checked.formatted(date: .omitted, time: .shortened))")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+        .task { if model.findings.isEmpty { model.recheck() } }
+    }
+}
+
+/// Settings ▸ Siri AI. System-wide capabilities only; per-site readiness lives in each site window.
+struct SiriReadinessSettingsView: View {
+    @State private var model = SiriReadinessModel(probes: SiriReadinessProbes.system())
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Whether this Mac can run Siri-driven Anglesite workflows. Per-site readiness is in each site window (Site ▸ Siri AI Readiness).")
+                    .font(.caption).foregroundStyle(.secondary)
+                SiriReadinessList(model: model)
+            }
+            .padding()
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -272,7 +272,7 @@ struct SiteWindow: View {
                 NavigationStack {
                     ScrollView {
                         VStack(alignment: .leading, spacing: 12) {
-                            Text("Siri AI readiness for \u{201C}\(site.id)\u{201D}.")
+                            Text("Siri AI readiness for \u{201C}\(site.name)\u{201D}.")
                                 .font(.caption).foregroundStyle(.secondary)
                             SiriReadinessList(model: model)
                         }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -18,10 +18,12 @@ struct SiteWindow: View {
     /// The app-lifetime content graph (held by `AppDelegate`), seeded into this window's
     /// `PreviewModel` so opening the site populates the shared graph (A.8, #142).
     private let contentGraph: SiteContentGraph
+    private let contentIndexer: ContentSpotlightIndexer?
 
-    init(siteID: String?, contentGraph: SiteContentGraph) {
+    init(siteID: String?, contentGraph: SiteContentGraph, contentIndexer: ContentSpotlightIndexer?) {
         self.siteID = siteID
         self.contentGraph = contentGraph
+        self.contentIndexer = contentIndexer
         _preview = State(initialValue: PreviewModel(contentGraph: contentGraph))
     }
 
@@ -51,6 +53,8 @@ struct SiteWindow: View {
     @State private var health = HealthModel(runner: DefaultHealthCheckRunner())
     /// Observed so an already-open window reacts to a `PreviewSiteIntent` navigation request.
     @State private var router = WindowRouter.shared
+    @State private var siriReadinessPresented = false
+    @State private var siriReadinessModel: SiriReadinessModel?
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -227,6 +231,22 @@ struct SiteWindow: View {
                       : "Site is missing required files")
             }
             .visibilityPriority(.high)
+
+            // Siri AI Readiness — secondary action, visible when a site is loaded.
+            ToolbarItem {
+                Button {
+                    if siriReadinessModel == nil, let contentIndexer {
+                        siriReadinessModel = SiriReadinessModel(
+                            probes: SiriReadinessProbes.site(siteID: site.id, graph: contentGraph, indexer: contentIndexer)
+                        )
+                    }
+                    siriReadinessPresented = true
+                } label: {
+                    Label("Siri AI Readiness", systemImage: "sparkles")
+                }
+                .help("Check whether Siri workflows are ready for this site")
+                .disabled(contentIndexer == nil)
+            }
         }
         .sheet(isPresented: $deploy.blockedPresented) {
             if case .blocked(let failures, let warnings) = deploy.phase {
@@ -246,6 +266,27 @@ struct SiteWindow: View {
                 siteName: site.name,
                 onRunAgain: { audit.audit(siteID: site.id, siteDirectory: site.path) }
             )
+        }
+        .sheet(isPresented: $siriReadinessPresented) {
+            if let model = siriReadinessModel {
+                NavigationStack {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Siri AI readiness for \u{201C}\(site.id)\u{201D}.")
+                                .font(.caption).foregroundStyle(.secondary)
+                            SiriReadinessList(model: model)
+                        }
+                        .padding()
+                    }
+                    .frame(minWidth: 420, minHeight: 260)
+                    .navigationTitle("Siri AI Readiness")
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") { siriReadinessPresented = false }
+                        }
+                    }
+                }
+            }
         }
         .annotatedAsSite(site)
     }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -18,12 +18,14 @@ struct SiteWindow: View {
     /// The app-lifetime content graph (held by `AppDelegate`), seeded into this window's
     /// `PreviewModel` so opening the site populates the shared graph (A.8, #142).
     private let contentGraph: SiteContentGraph
-    private let contentIndexer: ContentSpotlightIndexer?
+    /// Observed (not a bare optional) so the Siri AI Readiness button enables itself if `bootstrap`
+    /// populates the indexer after this window was constructed — see `ContentIndexerStore`.
+    private let contentIndexerStore: ContentIndexerStore
 
-    init(siteID: String?, contentGraph: SiteContentGraph, contentIndexer: ContentSpotlightIndexer?) {
+    init(siteID: String?, contentGraph: SiteContentGraph, contentIndexerStore: ContentIndexerStore) {
         self.siteID = siteID
         self.contentGraph = contentGraph
-        self.contentIndexer = contentIndexer
+        self.contentIndexerStore = contentIndexerStore
         _preview = State(initialValue: PreviewModel(contentGraph: contentGraph))
     }
 
@@ -77,6 +79,12 @@ struct SiteWindow: View {
         // pairs `.onChange` with an initial consume for `newSiteRequested`.
         .onChange(of: router.pendingNavigation) { _, _ in
             if let id = site?.id { applyPendingNavigation(for: id) }
+        }
+        // SwiftUI can replay a different site into the same window instance (state restoration,
+        // window reuse). Drop the cached readiness model so the next tap rebuilds its probes for
+        // the current site — otherwise it holds stale probes scoped to the original site.id.
+        .onChange(of: site?.id) { _, _ in
+            siriReadinessModel = nil
         }
         .onDisappear {
             preview.close()
@@ -233,11 +241,11 @@ struct SiteWindow: View {
             .visibilityPriority(.high)
 
             // Siri AI Readiness — secondary action, visible when a site is loaded.
-            ToolbarItem {
+            ToolbarItem(placement: .primaryAction) {
                 Button {
-                    if siriReadinessModel == nil, let contentIndexer {
+                    if siriReadinessModel == nil, let indexer = contentIndexerStore.indexer {
                         siriReadinessModel = SiriReadinessModel(
-                            probes: SiriReadinessProbes.site(siteID: site.id, graph: contentGraph, indexer: contentIndexer)
+                            probes: SiriReadinessProbes.site(siteID: site.id, graph: contentGraph, indexer: indexer)
                         )
                     }
                     siriReadinessPresented = true
@@ -245,7 +253,7 @@ struct SiteWindow: View {
                     Label("Siri AI Readiness", systemImage: "sparkles")
                 }
                 .help("Check whether Siri workflows are ready for this site")
-                .disabled(contentIndexer == nil)
+                .disabled(contentIndexerStore.indexer == nil)
             }
         }
         .sheet(isPresented: $deploy.blockedPresented) {

--- a/Sources/AnglesiteCore/SiriReadiness.swift
+++ b/Sources/AnglesiteCore/SiriReadiness.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Observation
+
+/// Severity of a single capability check. `unsupported` means "not available in this
+/// build/OS yet" (a truthful absence, not a failure the user caused).
+public enum ReadinessLevel: String, Sendable, Equatable, CaseIterable {
+    case ok
+    case warning
+    case failure
+    case unsupported
+}
+
+/// The result of one probe. Concrete `detail` (what the probe found), with optional
+/// user-actionable `remediation`.
+public struct ReadinessFinding: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let level: ReadinessLevel
+    public let detail: String
+    public let remediation: String?
+
+    public init(id: String, title: String, level: ReadinessLevel, detail: String, remediation: String? = nil) {
+        self.id = id
+        self.title = title
+        self.level = level
+        self.detail = detail
+        self.remediation = remediation
+    }
+}
+
+/// A single capability check. Never throws — a failure is a `ReadinessFinding` with a
+/// failing `level`. Injectable so tests can supply canned probes.
+public protocol ReadinessProbe: Sendable {
+    var id: String { get }
+    var title: String { get }
+    func check() async -> ReadinessFinding
+}
+
+/// Drives a readiness surface. Mirrors `HealthModel`: `@MainActor @Observable`, injectable
+/// dependencies, `recheck()` returns the `Task` so tests can await it. Probes run serially
+/// for deterministic ordering.
+@MainActor
+@Observable
+public final class SiriReadinessModel {
+    public private(set) var findings: [ReadinessFinding] = []
+    public private(set) var isChecking: Bool = false
+    public private(set) var lastChecked: Date?
+
+    @ObservationIgnored private let probes: [any ReadinessProbe]
+    @ObservationIgnored private let now: @Sendable () -> Date
+    @ObservationIgnored private var inFlight: Task<Void, Never>?
+
+    public init(probes: [any ReadinessProbe], now: @escaping @Sendable () -> Date = { Date() }) {
+        self.probes = probes
+        self.now = now
+    }
+
+    /// Worst level across all findings. Empty / all-unsupported collapses to `.unsupported`.
+    public var overallLevel: ReadinessLevel {
+        if findings.contains(where: { $0.level == .failure }) { return .failure }
+        if findings.contains(where: { $0.level == .warning }) { return .warning }
+        if findings.contains(where: { $0.level == .ok }) { return .ok }
+        return .unsupported
+    }
+
+    /// Run every probe and publish the findings. Cancels any in-flight run first.
+    @discardableResult
+    public func recheck() -> Task<Void, Never> {
+        inFlight?.cancel()
+        isChecking = true
+        let probes = self.probes
+        let task = Task { @MainActor [weak self] in
+            var collected: [ReadinessFinding] = []
+            for probe in probes {
+                if Task.isCancelled { return }
+                collected.append(await probe.check())
+            }
+            guard !Task.isCancelled else { return }
+            self?.commit(collected)
+        }
+        inFlight = task
+        return task
+    }
+
+    private func commit(_ findings: [ReadinessFinding]) {
+        self.findings = findings
+        self.lastChecked = now()
+        self.isChecking = false
+    }
+}

--- a/Sources/AnglesiteCore/SiriReadiness.swift
+++ b/Sources/AnglesiteCore/SiriReadiness.swift
@@ -30,9 +30,11 @@ public struct ReadinessFinding: Identifiable, Sendable, Equatable {
 
 /// A single capability check. Never throws — a failure is a `ReadinessFinding` with a
 /// failing `level`. Injectable so tests can supply canned probes.
+///
+/// The user-facing title is carried by the `ReadinessFinding` each probe returns, so it is not
+/// part of the protocol surface — consumers read `finding.title`, never `probe.title`.
 public protocol ReadinessProbe: Sendable {
     var id: String { get }
-    var title: String { get }
     func check() async -> ReadinessFinding
 }
 
@@ -49,6 +51,9 @@ public final class SiriReadinessModel {
     @ObservationIgnored private let probes: [any ReadinessProbe]
     @ObservationIgnored private let now: @Sendable () -> Date
     @ObservationIgnored private var inFlight: Task<Void, Never>?
+    /// Bumped on every `recheck()`. A cancelled run uses it to tell "I was cancelled and nobody
+    /// replaced me" (clear the spinner) from "a newer run superseded me" (leave its spinner alone).
+    @ObservationIgnored private var generation = 0
 
     public init(probes: [any ReadinessProbe], now: @escaping @Sendable () -> Date = { Date() }) {
         self.probes = probes
@@ -67,15 +72,17 @@ public final class SiriReadinessModel {
     @discardableResult
     public func recheck() -> Task<Void, Never> {
         inFlight?.cancel()
+        generation += 1
+        let runGeneration = generation
         isChecking = true
         let probes = self.probes
         let task = Task { @MainActor [weak self] in
             var collected: [ReadinessFinding] = []
             for probe in probes {
-                if Task.isCancelled { return }
+                if Task.isCancelled { self?.cancelled(runGeneration); return }
                 collected.append(await probe.check())
             }
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else { self?.cancelled(runGeneration); return }
             self?.commit(collected)
         }
         inFlight = task
@@ -86,5 +93,13 @@ public final class SiriReadinessModel {
         self.findings = findings
         self.lastChecked = now()
         self.isChecking = false
+    }
+
+    /// Clear the spinner for a cancelled run — but only if no later `recheck()` has superseded it.
+    /// A newer run owns `isChecking` (it set its own `true` and will `commit`), so a stale
+    /// cancellation must not flip it back to `false` underneath the live run.
+    private func cancelled(_ runGeneration: Int) {
+        guard runGeneration == generation else { return }
+        isChecking = false
     }
 }

--- a/Sources/AnglesiteCore/SiriReadinessSiteProbes.swift
+++ b/Sources/AnglesiteCore/SiriReadinessSiteProbes.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Reports whether a site's content is loaded into the in-memory graph (the data Siri's
+/// search/status intents read). Empty is a warning, not a failure — the user just needs to
+/// open the site.
+public struct ContentGraphProbe: ReadinessProbe {
+    public let id = "site.graph"
+    public let title = "Site content index"
+    private let siteID: String
+    private let graph: SiteContentGraph
+
+    public init(siteID: String, graph: SiteContentGraph) {
+        self.siteID = siteID
+        self.graph = graph
+    }
+
+    public func check() async -> ReadinessFinding {
+        let pages = await graph.pages(for: siteID).count
+        let posts = await graph.posts(for: siteID).count
+        let images = await graph.images(for: siteID).count
+        if pages + posts + images > 0 {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "\(pages) pages, \(posts) posts, \(images) images are loaded for Siri to search.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .warning,
+            detail: "No content is loaded for this site yet.",
+            remediation: "Open this site's window so Anglesite can index its content.")
+    }
+}

--- a/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
+++ b/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
@@ -1,0 +1,100 @@
+import Foundation
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// Confirms the running OS meets Anglesite's macOS floor. Version is injectable so the
+/// mapping is testable without spoofing the process environment.
+public struct OSRuntimeProbe: ReadinessProbe {
+    public let id = "os.runtime"
+    public let title = "macOS runtime"
+    private let version: OperatingSystemVersion
+    private let minimumMajor: Int
+
+    public init(
+        version: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion,
+        minimumMajor: Int = 27
+    ) {
+        self.version = version
+        self.minimumMajor = minimumMajor
+    }
+
+    public func check() async -> ReadinessFinding {
+        let running = "\(version.majorVersion).\(version.minorVersion)"
+        if version.majorVersion >= minimumMajor {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "macOS \(running) meets the macOS \(minimumMajor) requirement for Siri workflows.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .failure,
+            detail: "macOS \(running) is below the macOS \(minimumMajor) requirement.",
+            remediation: "Update to macOS \(minimumMajor) or later in System Settings ▸ General ▸ Software Update.")
+    }
+}
+
+/// Normalized Foundation Models availability, decoupled from the SDK enum so the probe
+/// mapping is testable without the framework.
+public enum FoundationModelsAvailability: Sendable, Equatable {
+    case available
+    case appleIntelligenceNotEnabled
+    case modelNotReady
+    case deviceNotEligible
+    case unknown(String)
+}
+
+/// Reports whether Apple's on-device language model is usable. Availability is injected so
+/// tests never touch the live model; the live source reads `SystemLanguageModel` (no inference).
+public struct FoundationModelsProbe: ReadinessProbe {
+    public let id = "foundation.models"
+    public let title = "Apple Foundation Models"
+    private let availability: @Sendable () -> FoundationModelsAvailability
+
+    public init(availability: @escaping @Sendable () -> FoundationModelsAvailability) {
+        self.availability = availability
+    }
+
+    public func check() async -> ReadinessFinding {
+        switch availability() {
+        case .available:
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "The on-device language model is available for summarization and chat.")
+        case .appleIntelligenceNotEnabled:
+            return ReadinessFinding(id: id, title: title, level: .warning,
+                detail: "Apple Intelligence is turned off.",
+                remediation: "Enable Apple Intelligence in System Settings ▸ Apple Intelligence & Siri.")
+        case .modelNotReady:
+            return ReadinessFinding(id: id, title: title, level: .warning,
+                detail: "The on-device model is still downloading or preparing.",
+                remediation: "Wait for the model to finish downloading, then re-check.")
+        case .deviceNotEligible:
+            return ReadinessFinding(id: id, title: title, level: .unsupported,
+                detail: "This Mac does not support Apple Foundation Models.")
+        case .unknown(let reason):
+            return ReadinessFinding(id: id, title: title, level: .warning,
+                detail: "Foundation Models availability could not be determined: \(reason).")
+        }
+    }
+}
+
+/// Live availability source. Reads `SystemLanguageModel.default.availability` (no inference).
+/// Case names below must match the `FoundationModels` SDK; `@unknown default` absorbs drift.
+public enum LiveFoundationModelsAvailability {
+    public static func current() -> FoundationModelsAvailability {
+        #if canImport(FoundationModels)
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return .available
+        case .unavailable(let reason):
+            switch reason {
+            case .appleIntelligenceNotEnabled: return .appleIntelligenceNotEnabled
+            case .modelNotReady: return .modelNotReady
+            case .deviceNotEligible: return .deviceNotEligible
+            @unknown default: return .unknown("\(reason)")
+            }
+        @unknown default:
+            return .unknown("unrecognized availability")
+        }
+        #else
+        return .unknown("FoundationModels unavailable at build time")
+        #endif
+    }
+}

--- a/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
+++ b/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if compiler(>=6.4) && canImport(FoundationModels)
+#if compiler(>=6.4)
 import FoundationModels
 #endif
 
@@ -20,7 +20,8 @@ public struct OSRuntimeProbe: ReadinessProbe {
     }
 
     public func check() async -> ReadinessFinding {
-        let running = "\(version.majorVersion).\(version.minorVersion)"
+        // Include the patch so a user on e.g. 26.9.5 doesn't see a misleading "26.9 is below…".
+        let running = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
         if version.majorVersion >= minimumMajor {
             return ReadinessFinding(id: id, title: title, level: .ok,
                 detail: "macOS \(running) meets the macOS \(minimumMajor) requirement for Siri workflows.")
@@ -79,7 +80,7 @@ public struct FoundationModelsProbe: ReadinessProbe {
 /// Case names below must match the `FoundationModels` SDK; `@unknown default` absorbs drift.
 public enum LiveFoundationModelsAvailability {
     public static func current() -> FoundationModelsAvailability {
-        #if compiler(>=6.4) && canImport(FoundationModels)
+        #if compiler(>=6.4)
         switch SystemLanguageModel.default.availability {
         case .available:
             return .available

--- a/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
+++ b/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if canImport(FoundationModels)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -79,7 +79,7 @@ public struct FoundationModelsProbe: ReadinessProbe {
 /// Case names below must match the `FoundationModels` SDK; `@unknown default` absorbs drift.
 public enum LiveFoundationModelsAvailability {
     public static func current() -> FoundationModelsAvailability {
-        #if canImport(FoundationModels)
+        #if compiler(>=6.4) && canImport(FoundationModels)
         switch SystemLanguageModel.default.availability {
         case .available:
             return .available

--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -25,7 +25,8 @@ private let contentLog = Logger(subsystem: "dev.anglesite.app", category: "conte
 /// before the load here, so the load *will* emit even if the launcher already raced ahead and
 /// missed it — emission is idempotent (the indexer dedups by id set).
 public enum AnglesiteIntents {
-    public static func bootstrap(contentGraph: SiteContentGraph) async {
+    @discardableResult
+    public static func bootstrap(contentGraph: SiteContentGraph) async -> ContentSpotlightIndexer {
         // Singleton-factory: the closure always returns the same pre-constructed `contentGraph`
         // instance. `AppDependencyManager.add` accepts a factory because dependencies may be
         // per-resolution, but our graph is process-wide, so we capture and re-yield.
@@ -76,5 +77,6 @@ public enum AnglesiteIntents {
         } catch {
             log.error("initial load failed: \(error.localizedDescription, privacy: .public)")
         }
+        return contentIndexer
     }
 }

--- a/Sources/AnglesiteIntents/ContentSpotlightIndexer.swift
+++ b/Sources/AnglesiteIntents/ContentSpotlightIndexer.swift
@@ -62,6 +62,26 @@ public actor ContentSpotlightIndexer {
         public let removed: Int
     }
 
+    /// Snapshot of how many entities are currently published to Spotlight for a site. Reads the
+    /// `lastIndexed` set this indexer maintains — the truthful "what we've put in the index" count
+    /// without querying the system daemon. Returns zeros for an unknown / never-indexed site.
+    public struct IndexedCounts: Sendable, Equatable {
+        public let pages: Int
+        public let posts: Int
+        public let images: Int
+        public var total: Int { pages + posts + images }
+        public init(pages: Int, posts: Int, images: Int) {
+            self.pages = pages
+            self.posts = posts
+            self.images = images
+        }
+    }
+
+    public func indexedCounts(for siteID: String) -> IndexedCounts {
+        guard let state = lastIndexed[siteID] else { return IndexedCounts(pages: 0, posts: 0, images: 0) }
+        return IndexedCounts(pages: state.pageIDs.count, posts: state.postIDs.count, images: state.imageIDs.count)
+    }
+
     /// Fetch the current page/post/image snapshot for `siteID` from the graph, diff each type
     /// against the previously-indexed set for that site, delete anything dropped, then upsert the
     /// current set.

--- a/Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
+++ b/Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
@@ -1,6 +1,6 @@
 // Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
 import AnglesiteCore
-import AppIntents
+import AppIntents  // load-bearing: AnglesiteShortcuts.appShortcuts default-arg resolves [AppShortcut]
 
 /// Confirms Anglesite's App Shortcuts are registered (the surface Siri/Spotlight enumerate).
 /// Count is injectable; the default reads the live provider.

--- a/Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
+++ b/Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
@@ -7,13 +7,18 @@ import AppIntents  // load-bearing: AnglesiteShortcuts.appShortcuts default-arg 
 public struct AppIntentsRegistrationProbe: ReadinessProbe {
     public let id = "intents.registration"
     public let title = "App Intents & Shortcuts"
-    private let shortcutCount: Int
+    /// `nil` means "read the live count at `check()` time". Resolving it lazily (rather than as a
+    /// default argument) avoids reading the provider at struct-construction time, which can run
+    /// before `AppDependencyManager` finishes wiring App Intents. `AnglesiteShortcuts.appShortcuts`
+    /// is a static `@AppShortcutsBuilder` literal, so the live count is environment-independent.
+    private let shortcutCount: Int?
 
-    public init(shortcutCount: Int = AnglesiteShortcuts.appShortcuts.count) {
+    public init(shortcutCount: Int? = nil) {
         self.shortcutCount = shortcutCount
     }
 
     public func check() async -> ReadinessFinding {
+        let shortcutCount = self.shortcutCount ?? AnglesiteShortcuts.appShortcuts.count
         if shortcutCount > 0 {
             return ReadinessFinding(id: id, title: title, level: .ok,
                 detail: "\(shortcutCount) Anglesite shortcuts are registered for Siri and Spotlight.")
@@ -61,6 +66,8 @@ public struct SystemMCPBridgeProbe: ReadinessProbe {
     public let title = "System-wide MCP bridge"
     private let registered: Bool
 
+    // TODO(#135): replace the `false` default with a live system-MCP-bridge registration check
+    // once Phase D lands (#164/#101). Until then this probe truthfully reports `.unsupported`.
     public init(registered: Bool = false) {
         self.registered = registered
     }

--- a/Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
+++ b/Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
@@ -1,0 +1,76 @@
+// Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
+import AnglesiteCore
+import AppIntents
+
+/// Confirms Anglesite's App Shortcuts are registered (the surface Siri/Spotlight enumerate).
+/// Count is injectable; the default reads the live provider.
+public struct AppIntentsRegistrationProbe: ReadinessProbe {
+    public let id = "intents.registration"
+    public let title = "App Intents & Shortcuts"
+    private let shortcutCount: Int
+
+    public init(shortcutCount: Int = AnglesiteShortcuts.appShortcuts.count) {
+        self.shortcutCount = shortcutCount
+    }
+
+    public func check() async -> ReadinessFinding {
+        if shortcutCount > 0 {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "\(shortcutCount) Anglesite shortcuts are registered for Siri and Spotlight.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .warning,
+            detail: "No Anglesite shortcuts are registered.",
+            remediation: "Relaunch Anglesite so the system re-registers its App Shortcuts.")
+    }
+}
+
+/// Reports whether the build includes Swift 6.4 View Annotations (the onscreen-awareness path
+/// that lets Siri act on the site you're viewing). Compile-time gated; injectable for tests.
+public struct ViewAnnotationsProbe: ReadinessProbe {
+    public let id = "view.annotations"
+    public let title = "Onscreen awareness (View Annotations)"
+    private let compiled: Bool
+
+    public init(compiled: Bool = ViewAnnotationsProbe.builtWithAnnotations) {
+        self.compiled = compiled
+    }
+
+    public static var builtWithAnnotations: Bool {
+        #if compiler(>=6.4)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    public func check() async -> ReadinessFinding {
+        if compiled {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "Site windows publish an entity identifier, so Siri can act on the site you're viewing.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .unsupported,
+            detail: "This build was compiled without Swift 6.4 view-annotation support.",
+            remediation: "Use a build produced with Xcode 27 / Swift 6.4 or later.")
+    }
+}
+
+/// Reports whether Anglesite's tools are exposed to the system-wide MCP bridge. Unbuilt today
+/// (Phase D, #135) — defaults to `.unsupported`; flips to a real check when #164/#101 land.
+public struct SystemMCPBridgeProbe: ReadinessProbe {
+    public let id = "mcp.bridge"
+    public let title = "System-wide MCP bridge"
+    private let registered: Bool
+
+    public init(registered: Bool = false) {
+        self.registered = registered
+    }
+
+    public func check() async -> ReadinessFinding {
+        if registered {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "Anglesite's tools are exposed to the system MCP bridge for Claude Code and other agents.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .unsupported,
+            detail: "System-wide MCP exposure is not available in this build (Phase D, #135).")
+    }
+}

--- a/Sources/AnglesiteIntents/SiriReadinessProbes.swift
+++ b/Sources/AnglesiteIntents/SiriReadinessProbes.swift
@@ -23,7 +23,7 @@ public enum SiriReadinessProbes {
     ) -> [any ReadinessProbe] {
         [
             ContentGraphProbe(siteID: siteID, graph: graph),
-            SpotlightIndexProbe(siteID: siteID, indexer: indexer),
+            SpotlightIndexProbe(siteID: siteID, counter: indexer),
         ]
     }
 }

--- a/Sources/AnglesiteIntents/SiriReadinessProbes.swift
+++ b/Sources/AnglesiteIntents/SiriReadinessProbes.swift
@@ -1,0 +1,29 @@
+// Sources/AnglesiteIntents/SiriReadinessProbes.swift
+import AnglesiteCore
+
+/// Assembles the readiness probe sets. Lives in AnglesiteIntents — the one module that can see
+/// both the Core probes and the Intents probes.
+public enum SiriReadinessProbes {
+    /// Global capabilities, independent of any site.
+    public static func system() -> [any ReadinessProbe] {
+        [
+            OSRuntimeProbe(),
+            AppIntentsRegistrationProbe(),
+            ViewAnnotationsProbe(),
+            FoundationModelsProbe(availability: { LiveFoundationModelsAvailability.current() }),
+            SystemMCPBridgeProbe(),
+        ]
+    }
+
+    /// Per-site readiness for one open/known site.
+    public static func site(
+        siteID: String,
+        graph: SiteContentGraph,
+        indexer: ContentSpotlightIndexer
+    ) -> [any ReadinessProbe] {
+        [
+            ContentGraphProbe(siteID: siteID, graph: graph),
+            SpotlightIndexProbe(siteID: siteID, indexer: indexer),
+        ]
+    }
+}

--- a/Sources/AnglesiteIntents/SiriReadinessSpotlightProbe.swift
+++ b/Sources/AnglesiteIntents/SiriReadinessSpotlightProbe.swift
@@ -1,0 +1,38 @@
+import AnglesiteCore
+import CoreSpotlight
+
+/// Reports how many of a site's items are published to the Spotlight semantic index Siri reads.
+/// `indexingAvailable` is injected; the default reads `CSSearchableIndex.isIndexingAvailable()`.
+public struct SpotlightIndexProbe: ReadinessProbe {
+    public let id = "site.spotlight"
+    public let title = "Spotlight index"
+    private let siteID: String
+    private let indexer: ContentSpotlightIndexer
+    private let indexingAvailable: Bool
+
+    public init(
+        siteID: String,
+        indexer: ContentSpotlightIndexer,
+        indexingAvailable: Bool = CSSearchableIndex.isIndexingAvailable()
+    ) {
+        self.siteID = siteID
+        self.indexer = indexer
+        self.indexingAvailable = indexingAvailable
+    }
+
+    public func check() async -> ReadinessFinding {
+        guard indexingAvailable else {
+            return ReadinessFinding(id: id, title: title, level: .warning,
+                detail: "Spotlight indexing is unavailable on this Mac.",
+                remediation: "Make sure Spotlight is enabled in System Settings ▸ Siri & Spotlight.")
+        }
+        let counts = await indexer.indexedCounts(for: siteID)
+        if counts.total > 0 {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "\(counts.total) items are indexed in Spotlight for this site.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .warning,
+            detail: "Nothing is indexed in Spotlight for this site yet.",
+            remediation: "Open this site's window so its content is indexed.")
+    }
+}

--- a/Sources/AnglesiteIntents/SiriReadinessSpotlightProbe.swift
+++ b/Sources/AnglesiteIntents/SiriReadinessSpotlightProbe.swift
@@ -1,22 +1,31 @@
 import AnglesiteCore
 import CoreSpotlight
 
+/// Thin counting seam over the indexer, so the probe can take a flat fake in tests instead of
+/// standing up a full `ContentSpotlightIndexer` + backend just to vary a count. The production
+/// indexer conforms below.
+public protocol SpotlightIndexCounting: Sendable {
+    func indexedCounts(for siteID: String) async -> ContentSpotlightIndexer.IndexedCounts
+}
+
+extension ContentSpotlightIndexer: SpotlightIndexCounting {}
+
 /// Reports how many of a site's items are published to the Spotlight semantic index Siri reads.
 /// `indexingAvailable` is injected; the default reads `CSSearchableIndex.isIndexingAvailable()`.
 public struct SpotlightIndexProbe: ReadinessProbe {
     public let id = "site.spotlight"
     public let title = "Spotlight index"
     private let siteID: String
-    private let indexer: ContentSpotlightIndexer
+    private let counter: any SpotlightIndexCounting
     private let indexingAvailable: Bool
 
     public init(
         siteID: String,
-        indexer: ContentSpotlightIndexer,
+        counter: any SpotlightIndexCounting,
         indexingAvailable: Bool = CSSearchableIndex.isIndexingAvailable()
     ) {
         self.siteID = siteID
-        self.indexer = indexer
+        self.counter = counter
         self.indexingAvailable = indexingAvailable
     }
 
@@ -26,7 +35,7 @@ public struct SpotlightIndexProbe: ReadinessProbe {
                 detail: "Spotlight indexing is unavailable on this Mac.",
                 remediation: "Make sure Spotlight is enabled in System Settings ▸ Siri & Spotlight.")
         }
-        let counts = await indexer.indexedCounts(for: siteID)
+        let counts = await counter.indexedCounts(for: siteID)
         if counts.total > 0 {
             return ReadinessFinding(id: id, title: title, level: .ok,
                 detail: "\(counts.total) items are indexed in Spotlight for this site.")

--- a/Tests/AnglesiteCoreTests/SiriReadinessModelTests.swift
+++ b/Tests/AnglesiteCoreTests/SiriReadinessModelTests.swift
@@ -5,11 +5,9 @@ import Foundation
 
 private struct StubProbe: ReadinessProbe {
     let id: String
-    let title: String
     let finding: ReadinessFinding
     init(_ finding: ReadinessFinding) {
         self.id = finding.id
-        self.title = finding.title
         self.finding = finding
     }
     func check() async -> ReadinessFinding { finding }
@@ -63,5 +61,27 @@ private func makeFinding(_ id: String, _ level: ReadinessLevel) -> ReadinessFind
         ])
         await model.recheck().value
         #expect(model.overallLevel == .ok)
+    }
+
+    @Test func recheck_cancelled_resetsIsChecking() async {
+        // A cancelled run must clear the spinner — otherwise `isChecking` is stuck `true`
+        // forever and the Re-check button stays permanently disabled.
+        let model = SiriReadinessModel(probes: [StubProbe(makeFinding("a", .ok))])
+        let task = model.recheck()
+        task.cancel()
+        await task.value
+        #expect(model.isChecking == false)
+    }
+
+    @Test func recheck_rapidDouble_firstCancelled_endsNotChecking() async {
+        // The second recheck cancels the first via `inFlight?.cancel()`. The superseded run must
+        // not clobber the live one, and the final state must reflect the second run's commit.
+        let model = SiriReadinessModel(probes: [StubProbe(makeFinding("a", .ok))])
+        let first = model.recheck()
+        let second = model.recheck()
+        await first.value
+        await second.value
+        #expect(model.isChecking == false)
+        #expect(model.findings.map(\.id) == ["a"])
     }
 }

--- a/Tests/AnglesiteCoreTests/SiriReadinessModelTests.swift
+++ b/Tests/AnglesiteCoreTests/SiriReadinessModelTests.swift
@@ -1,0 +1,67 @@
+// Tests/AnglesiteCoreTests/SiriReadinessModelTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+private struct StubProbe: ReadinessProbe {
+    let id: String
+    let title: String
+    let finding: ReadinessFinding
+    init(_ finding: ReadinessFinding) {
+        self.id = finding.id
+        self.title = finding.title
+        self.finding = finding
+    }
+    func check() async -> ReadinessFinding { finding }
+}
+
+private func makeFinding(_ id: String, _ level: ReadinessLevel) -> ReadinessFinding {
+    ReadinessFinding(id: id, title: id, level: level, detail: "detail")
+}
+
+@MainActor
+@Suite struct SiriReadinessModelTests {
+    @Test func initialState_isEmpty() {
+        let model = SiriReadinessModel(probes: [])
+        #expect(model.findings.isEmpty)
+        #expect(model.isChecking == false)
+        #expect(model.lastChecked == nil)
+    }
+
+    @Test func recheck_collectsFindingsInOrder_andStampsTime() async {
+        let stamp = Date(timeIntervalSince1970: 1000)
+        let model = SiriReadinessModel(
+            probes: [StubProbe(makeFinding("a", .ok)), StubProbe(makeFinding("b", .warning))],
+            now: { stamp }
+        )
+        await model.recheck().value
+        #expect(model.findings.map(\.id) == ["a", "b"])
+        #expect(model.isChecking == false)
+        #expect(model.lastChecked == stamp)
+    }
+
+    @Test func overallLevel_failureWins() async {
+        let model = SiriReadinessModel(probes: [
+            StubProbe(makeFinding("a", .ok)),
+            StubProbe(makeFinding("b", .warning)),
+            StubProbe(makeFinding("c", .failure)),
+        ])
+        await model.recheck().value
+        #expect(model.overallLevel == .failure)
+    }
+
+    @Test func overallLevel_allUnsupported_isUnsupported() async {
+        let model = SiriReadinessModel(probes: [StubProbe(makeFinding("a", .unsupported))])
+        await model.recheck().value
+        #expect(model.overallLevel == .unsupported)
+    }
+
+    @Test func overallLevel_mixOkAndUnsupported_isOk() async {
+        let model = SiriReadinessModel(probes: [
+            StubProbe(makeFinding("a", .ok)),
+            StubProbe(makeFinding("b", .unsupported)),
+        ])
+        await model.recheck().value
+        #expect(model.overallLevel == .ok)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiriReadinessSiteProbeTests.swift
+++ b/Tests/AnglesiteCoreTests/SiriReadinessSiteProbeTests.swift
@@ -1,0 +1,26 @@
+// Tests/AnglesiteCoreTests/SiriReadinessSiteProbeTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct SiriReadinessSiteProbeTests {
+    private func page(_ site: String, _ route: String) -> SiteContentGraph.Page {
+        SiteContentGraph.Page(id: "\(site):page:\(route)", siteID: site, route: route,
+                              filePath: "/\(route).md", title: route, lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test func contentGraph_populated_isOk() async {
+        let graph = SiteContentGraph()
+        await graph.load(siteID: "blog", pages: [page("blog", "about")], posts: [], images: [])
+        let finding = await ContentGraphProbe(siteID: "blog", graph: graph).check()
+        #expect(finding.id == "site.graph")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func contentGraph_empty_isWarning_withRemediation() async {
+        let graph = SiteContentGraph()
+        let finding = await ContentGraphProbe(siteID: "blog", graph: graph).check()
+        #expect(finding.level == .warning)
+        #expect(finding.remediation != nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiriReadinessSystemProbeTests.swift
+++ b/Tests/AnglesiteCoreTests/SiriReadinessSystemProbeTests.swift
@@ -1,0 +1,46 @@
+// Tests/AnglesiteCoreTests/SiriReadinessSystemProbeTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct SiriReadinessSystemProbeTests {
+    @Test func osRuntime_meetsMinimum_isOk() async {
+        let probe = OSRuntimeProbe(
+            version: OperatingSystemVersion(majorVersion: 27, minorVersion: 1, patchVersion: 0),
+            minimumMajor: 27
+        )
+        let finding = await probe.check()
+        #expect(finding.id == "os.runtime")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func osRuntime_belowMinimum_isFailure_withRemediation() async {
+        let probe = OSRuntimeProbe(
+            version: OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0),
+            minimumMajor: 27
+        )
+        let finding = await probe.check()
+        #expect(finding.level == .failure)
+        #expect(finding.remediation != nil)
+    }
+
+    @Test func foundationModels_available_isOk() async {
+        let probe = FoundationModelsProbe(availability: { .available })
+        let finding = await probe.check()
+        #expect(finding.id == "foundation.models")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func foundationModels_appleIntelligenceOff_isWarning_withRemediation() async {
+        let probe = FoundationModelsProbe(availability: { .appleIntelligenceNotEnabled })
+        let finding = await probe.check()
+        #expect(finding.level == .warning)
+        #expect(finding.remediation != nil)
+    }
+
+    @Test func foundationModels_deviceNotEligible_isUnsupported() async {
+        let probe = FoundationModelsProbe(availability: { .deviceNotEligible })
+        let finding = await probe.check()
+        #expect(finding.level == .unsupported)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiriReadinessSystemProbeTests.swift
+++ b/Tests/AnglesiteCoreTests/SiriReadinessSystemProbeTests.swift
@@ -43,4 +43,16 @@ import Foundation
         let finding = await probe.check()
         #expect(finding.level == .unsupported)
     }
+
+    @Test func foundationModels_modelNotReady_isWarning() async {
+        let probe = FoundationModelsProbe(availability: { .modelNotReady })
+        let finding = await probe.check()
+        #expect(finding.level == .warning)
+    }
+
+    @Test func foundationModels_unknown_isWarning() async {
+        let probe = FoundationModelsProbe(availability: { .unknown("test") })
+        let finding = await probe.check()
+        #expect(finding.level == .warning)
+    }
 }

--- a/Tests/AnglesiteIntentsTests/SiriReadinessIntentProbeTests.swift
+++ b/Tests/AnglesiteIntentsTests/SiriReadinessIntentProbeTests.swift
@@ -1,0 +1,46 @@
+// Tests/AnglesiteIntentsTests/SiriReadinessIntentProbeTests.swift
+import Testing
+import AnglesiteCore
+@testable import AnglesiteIntents
+
+@Suite struct SiriReadinessIntentProbeTests {
+    @Test func appIntents_withShortcuts_isOk() async {
+        let finding = await AppIntentsRegistrationProbe(shortcutCount: 9).check()
+        #expect(finding.id == "intents.registration")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func appIntents_noShortcuts_isWarning() async {
+        let finding = await AppIntentsRegistrationProbe(shortcutCount: 0).check()
+        #expect(finding.level == .warning)
+        #expect(finding.remediation != nil)
+    }
+
+    @Test func appIntents_defaultUsesRealShortcuts() async {
+        // The real provider ships curated shortcuts, so the default init must report ok.
+        let finding = await AppIntentsRegistrationProbe().check()
+        #expect(finding.level == .ok)
+    }
+
+    @Test func viewAnnotations_compiled_isOk() async {
+        let finding = await ViewAnnotationsProbe(compiled: true).check()
+        #expect(finding.id == "view.annotations")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func viewAnnotations_notCompiled_isUnsupported() async {
+        let finding = await ViewAnnotationsProbe(compiled: false).check()
+        #expect(finding.level == .unsupported)
+    }
+
+    @Test func mcpBridge_unregistered_isUnsupported() async {
+        let finding = await SystemMCPBridgeProbe(registered: false).check()
+        #expect(finding.id == "mcp.bridge")
+        #expect(finding.level == .unsupported)
+    }
+
+    @Test func mcpBridge_registered_isOk() async {
+        let finding = await SystemMCPBridgeProbe(registered: true).check()
+        #expect(finding.level == .ok)
+    }
+}

--- a/Tests/AnglesiteIntentsTests/SiriReadinessProbesTests.swift
+++ b/Tests/AnglesiteIntentsTests/SiriReadinessProbesTests.swift
@@ -1,0 +1,28 @@
+// Tests/AnglesiteIntentsTests/SiriReadinessProbesTests.swift
+import Testing
+import AnglesiteCore
+@testable import AnglesiteIntents
+
+@Suite struct SiriReadinessProbesTests {
+    @Test func system_isNonEmpty_withUniqueIDs() {
+        let ids = SiriReadinessProbes.system().map(\.id)
+        #expect(!ids.isEmpty)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test func site_isNonEmpty_withUniqueIDs() {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: LiveContentSpotlightBackend())
+        let ids = SiriReadinessProbes.site(siteID: "blog", graph: graph, indexer: indexer).map(\.id)
+        #expect(!ids.isEmpty)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test func system_andSite_idsDoNotCollide() {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: LiveContentSpotlightBackend())
+        let system = Set(SiriReadinessProbes.system().map(\.id))
+        let site = Set(SiriReadinessProbes.site(siteID: "blog", graph: graph, indexer: indexer).map(\.id))
+        #expect(system.isDisjoint(with: site))
+    }
+}

--- a/Tests/AnglesiteIntentsTests/SiriReadinessSpotlightProbeTests.swift
+++ b/Tests/AnglesiteIntentsTests/SiriReadinessSpotlightProbeTests.swift
@@ -13,7 +13,25 @@ private actor NoopSpotlightBackend: ContentSpotlightBackend {
     func deleteImages(identifiers: [String]) async throws {}
 }
 
+/// Flat stub for the counting seam — returns canned counts without standing up a full indexer.
+private struct StubIndexCounter: SpotlightIndexCounting {
+    let counts: ContentSpotlightIndexer.IndexedCounts
+    func indexedCounts(for siteID: String) async -> ContentSpotlightIndexer.IndexedCounts { counts }
+}
+
 @Suite struct SiriReadinessSpotlightProbeTests {
+    @Test func spotlight_flatStubWithCounts_isOk() async {
+        let counter = StubIndexCounter(counts: .init(pages: 3, posts: 1, images: 0))
+        let finding = await SpotlightIndexProbe(siteID: "blog", counter: counter, indexingAvailable: true).check()
+        #expect(finding.level == .ok)
+    }
+
+    @Test func spotlight_flatStubEmpty_isWarning() async {
+        let counter = StubIndexCounter(counts: .init(pages: 0, posts: 0, images: 0))
+        let finding = await SpotlightIndexProbe(siteID: "blog", counter: counter, indexingAvailable: true).check()
+        #expect(finding.level == .warning)
+    }
+
     private func page(_ site: String, _ route: String) -> SiteContentGraph.Page {
         SiteContentGraph.Page(id: "\(site):page:\(route)", siteID: site, route: route,
                               filePath: "/\(route).md", title: route, lastModified: Date(timeIntervalSince1970: 0))
@@ -34,7 +52,7 @@ private actor NoopSpotlightBackend: ContentSpotlightBackend {
         let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
         await graph.load(siteID: "blog", pages: [page("blog", "about")], posts: [], images: [])
         _ = try await indexer.reindex(siteID: "blog")
-        let finding = await SpotlightIndexProbe(siteID: "blog", indexer: indexer, indexingAvailable: true).check()
+        let finding = await SpotlightIndexProbe(siteID: "blog", counter: indexer, indexingAvailable: true).check()
         #expect(finding.id == "site.spotlight")
         #expect(finding.level == .ok)
     }
@@ -42,7 +60,7 @@ private actor NoopSpotlightBackend: ContentSpotlightBackend {
     @Test func spotlight_nothingIndexed_isWarning() async {
         let graph = SiteContentGraph()
         let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
-        let finding = await SpotlightIndexProbe(siteID: "blog", indexer: indexer, indexingAvailable: true).check()
+        let finding = await SpotlightIndexProbe(siteID: "blog", counter: indexer, indexingAvailable: true).check()
         #expect(finding.level == .warning)
         #expect(finding.remediation != nil)
     }
@@ -50,7 +68,7 @@ private actor NoopSpotlightBackend: ContentSpotlightBackend {
     @Test func spotlight_unavailable_isWarning_withRemediation() async {
         let graph = SiteContentGraph()
         let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
-        let finding = await SpotlightIndexProbe(siteID: "blog", indexer: indexer, indexingAvailable: false).check()
+        let finding = await SpotlightIndexProbe(siteID: "blog", counter: indexer, indexingAvailable: false).check()
         #expect(finding.level == .warning)
         #expect(finding.remediation != nil)
     }

--- a/Tests/AnglesiteIntentsTests/SiriReadinessSpotlightProbeTests.swift
+++ b/Tests/AnglesiteIntentsTests/SiriReadinessSpotlightProbeTests.swift
@@ -1,0 +1,56 @@
+// Tests/AnglesiteIntentsTests/SiriReadinessSpotlightProbeTests.swift
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteIntents
+
+private actor NoopSpotlightBackend: ContentSpotlightBackend {
+    func indexPages(_ entities: [PageEntity]) async throws {}
+    func indexPosts(_ entities: [PostEntity]) async throws {}
+    func indexImages(_ entities: [ImageEntity]) async throws {}
+    func deletePages(identifiers: [String]) async throws {}
+    func deletePosts(identifiers: [String]) async throws {}
+    func deleteImages(identifiers: [String]) async throws {}
+}
+
+@Suite struct SiriReadinessSpotlightProbeTests {
+    private func page(_ site: String, _ route: String) -> SiteContentGraph.Page {
+        SiteContentGraph.Page(id: "\(site):page:\(route)", siteID: site, route: route,
+                              filePath: "/\(route).md", title: route, lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test func indexedCounts_reflectReindex() async throws {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
+        await graph.load(siteID: "blog", pages: [page("blog", "about")], posts: [], images: [])
+        _ = try await indexer.reindex(siteID: "blog")
+        let counts = await indexer.indexedCounts(for: "blog")
+        #expect(counts.pages == 1)
+        #expect(counts.total == 1)
+    }
+
+    @Test func spotlight_indexed_isOk() async throws {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
+        await graph.load(siteID: "blog", pages: [page("blog", "about")], posts: [], images: [])
+        _ = try await indexer.reindex(siteID: "blog")
+        let finding = await SpotlightIndexProbe(siteID: "blog", indexer: indexer, indexingAvailable: true).check()
+        #expect(finding.id == "site.spotlight")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func spotlight_nothingIndexed_isWarning() async {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
+        let finding = await SpotlightIndexProbe(siteID: "blog", indexer: indexer, indexingAvailable: true).check()
+        #expect(finding.level == .warning)
+    }
+
+    @Test func spotlight_unavailable_isWarning_withRemediation() async {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
+        let finding = await SpotlightIndexProbe(siteID: "blog", indexer: indexer, indexingAvailable: false).check()
+        #expect(finding.level == .warning)
+        #expect(finding.remediation != nil)
+    }
+}

--- a/Tests/AnglesiteIntentsTests/SiriReadinessSpotlightProbeTests.swift
+++ b/Tests/AnglesiteIntentsTests/SiriReadinessSpotlightProbeTests.swift
@@ -44,6 +44,7 @@ private actor NoopSpotlightBackend: ContentSpotlightBackend {
         let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
         let finding = await SpotlightIndexProbe(siteID: "blog", indexer: indexer, indexingAvailable: true).check()
         #expect(finding.level == .warning)
+        #expect(finding.remediation != nil)
     }
 
     @Test func spotlight_unavailable_isWarning_withRemediation() async {

--- a/docs/specs/2026-06-18-siri-readiness-design.md
+++ b/docs/specs/2026-06-18-siri-readiness-design.md
@@ -1,0 +1,171 @@
+# Siri AI Readiness Diagnostics — Design
+
+- **Issue:** #236 (Siri AI: add local readiness diagnostics for supported workflows)
+- **Date:** 2026-06-18
+- **Status:** Design — pending implementation plan
+- **Related:** #135 (Phase D), #232/#225 (D.1/D.2 MCP readiness), #242 (`.anglesite` package + per-site config model — foundational follow-up this design's seam migrates to)
+
+## Summary
+
+Add a read-only, network-free diagnostic that tells a user whether the Siri-driven
+workflows can work on their Mac and for a given site. Each reported status is produced
+by a **concrete probe** (not static text), every probe is **injectable** for tests, and
+the work lives in `AnglesiteCore` so it is covered on CI (app-target UI stays thin).
+
+The diagnostic is split across two surfaces following Xcode's per-project model (not
+Mail's app-owned-store model — see Decisions):
+
+- **System capabilities** → a new **"Siri AI" tab in Settings** (global, no site list).
+- **Per-site readiness** → a **per-`SiteWindow` "Siri AI Readiness…" command** scoped to
+  that window's site.
+
+## Decisions (from brainstorming)
+
+1. **UI home:** dedicated Settings tab for system capabilities (discoverable for a normal
+   user, room to grow as Phase C/D land).
+2. **Probe all listed capabilities, report honestly.** Capabilities the build can't fully
+   exercise yet (System MCP bridge — unbuilt; Foundation Models — partially built) return
+   a real `.unsupported` finding ("Not yet available in this build"), never a fake ✅ and
+   never omitted. A truthful absence-detection is still a concrete probe.
+3. **Per-site config follows Xcode, not Mail.** Per-site state belongs *with the site*
+   (window), not in app-global Settings. This dissolves the "site picker in Settings"
+   question — there is no picker; per-site readiness is a per-window surface. The deeper
+   `.anglesite` package model that this implies is tracked separately as **#242** and is
+   *not* a blocker for this work.
+4. **No new seam type (YAGNI).** #236's per-site probes read *runtime* state (content graph,
+   Spotlight index counts) keyed by `siteID`, so no persisted per-site config store and no new
+   location type is introduced here. The SiteWindow already carries the site's id + directory,
+   and `AppSettings.sitesRoot` already resolves `~/Sites/<name>/`. *That existing resolution* is
+   the seam #242 migrates to the `.anglesite` package — #236 adds nothing for it to replace.
+
+## Architecture
+
+### Module placement
+
+The shared types (`ReadinessLevel`, `ReadinessFinding`, `ReadinessProbe`,
+`SiriReadinessModel`) and the probes needing only Foundation/Core APIs (OS runtime,
+Foundation Models, content-graph freshness) live in **`AnglesiteCore`**. Probes that read
+App-Intents / Spotlight surfaces (App Intents registration, View Annotations, Spotlight
+index status, MCP bridge) live in **`AnglesiteIntents`** (which depends on Core). Both
+modules are covered by CI tests; only the SwiftUI views live in the app target. The probe
+arrays are assembled in `AnglesiteIntents` (the one module that can see both probe sets).
+
+### Core types (`AnglesiteCore`)
+
+A probe never throws; a failure is a finding. This mirrors the shipped
+`HealthModel` / `HealthCheckRunner` pattern (injectable runner, `@MainActor @Observable`
+model, fakeable in tests).
+
+```swift
+enum ReadinessLevel: Sendable { case ok, warning, failure, unsupported }
+
+struct ReadinessFinding: Identifiable, Sendable {
+    let id: String            // stable capability id (also the row identity)
+    let title: String         // "App Intents registration"
+    let level: ReadinessLevel
+    let detail: String        // what the probe actually found (concrete)
+    let remediation: String?  // user-actionable next step, nil if none
+}
+
+protocol ReadinessProbe: Sendable {
+    var id: String { get }
+    var title: String { get }
+    func check() async -> ReadinessFinding
+}
+
+@MainActor @Observable
+final class SiriReadinessModel {
+    @ObservationIgnored private let probes: [any ReadinessProbe]
+    var findings: [ReadinessFinding] = []
+    var isChecking = false
+    var lastChecked: Date?
+
+    init(probes: [any ReadinessProbe]) { self.probes = probes }
+    func recheck() async { /* set isChecking, run probes, collect findings, stamp lastChecked */ }
+}
+```
+
+One model type, two instantiations:
+
+- **Settings tab** constructs `SiriReadinessModel(probes: systemProbes())`.
+- **SiteWindow** constructs `SiriReadinessModel(probes: siteProbes(for: location))`.
+
+### Site identity
+
+Site probes are keyed by `siteID: String` (the folder name). The SiteWindow already holds
+the site's id + directory; `AppSettings.sitesRoot` resolves `~/Sites/<name>/`. No new type
+is added. #242 migrates that existing resolution to the `.anglesite` package.
+
+## Probe inventory
+
+All checks are **local**; none performs network I/O. The Foundation Models probe checks
+*availability only* — it never runs inference.
+
+### System probes (global)
+
+| id | Concrete check | Levels |
+|---|---|---|
+| `os.runtime` | `ProcessInfo.processInfo.operatingSystemVersion` ≥ macOS 27 | ok / failure |
+| `intents.registration` | `AnglesiteShortcuts.appShortcuts` non-empty; cross-check `AppIntentInfo` enumeration if the SDK exposes it | ok / warning |
+| `view.annotations` | `#if compiler(>=6.4)` availability of `appEntityIdentifier` / `EntityIdentifier(for:)` | ok / unsupported |
+| `foundation.models` | `SystemLanguageModel.default.availability` (`.available` / `.unavailable(reason)`) | ok / warning / unsupported |
+| `mcp.bridge` | system MCP bridge registration present? (Phase D unbuilt) | unsupported |
+
+### Site probes (scoped to a `SiteLocation`)
+
+| id | Concrete check | Levels |
+|---|---|---|
+| `site.graph` | `SiteContentGraph` for the site: populated? page/post/image counts, last-update time | ok / warning |
+| `site.spotlight` | `ContentSpotlightIndexer.lastIndexed` for the site; `CSSearchableIndex.default()` reachable | ok / warning |
+
+Each probe with a non-`ok` level supplies remediation text where the user can act
+(e.g. "Open this site to index its content", "Enable Apple Intelligence in System
+Settings", "Upgrade to macOS 27"). `.unsupported` rows explain *why* and reference the
+phase that will deliver them.
+
+## UI
+
+- `SiriReadinessSettingsView` — new tab in `SettingsView`'s `TabView`, alongside
+  `AdvancedSettingsView`. Renders system findings, a "Re-check" button, and a
+  "Last checked" timestamp.
+- `SiteReadinessCommand` / sheet — a `SiteWindow` command "Siri AI Readiness…" presenting
+  the site-scoped findings for that window's site.
+- `ReadinessRow` — shared SwiftUI row: status glyph (✅ ok / ⚠️ warning / ❌ failure /
+  ⊘ unsupported) + title + detail + optional remediation.
+
+## Build / MAS differences
+
+- Foundation Models probe runs on both targets (MAS always uses Foundation Models).
+- The Settings tab needs no filesystem access (global only) — sandbox-safe.
+- Per-site probes run from a `SiteWindow`, which already holds the per-site
+  security-scoped bookmark grant on MAS.
+- `#if ANGLESITE_MAS` only where strictly required.
+
+## Testing
+
+- **Per probe:** unit tests with injected fakes (fake content graph, fake Spotlight
+  indexer exposing `lastIndexed`, fake availability source, fake OS-version source).
+- **`SiriReadinessModel`:** stub probes returning canned findings → assert aggregation,
+  `isChecking` true→false transition, `lastChecked` stamped.
+- **Registry:** probe ids are unique and the known set is non-empty.
+- Logic split across `AnglesiteCore` + `AnglesiteIntents` (both CI-covered). New tests use
+  Swift Testing (`@Test`) per the suite migration (#74). UI kept thin; an `xcodebuild` link
+  check on both schemes confirms the `.app` builds with the new views.
+
+## Acceptance-criteria mapping (#236)
+
+- *User can open the app and determine whether Siri workflows should work for the current
+  site* → Settings tab (system) + per-window sheet (current site).
+- *Each reported status is backed by a concrete probe rather than static text* → every
+  finding is produced by a `ReadinessProbe.check()`.
+- *Testable with injectable/fake probes* → `ReadinessProbe` protocol + DI into the model.
+- *Does not require network access* → all probes local; FM probe checks availability only,
+  never runs inference.
+
+## Out of scope
+
+- The `.anglesite` package + per-site config model (#242).
+- Predicting Apple's regional Siri rollout (issue explicitly excludes this).
+- System MCP bridge implementation (Phase D #164/#101) — this design only *reports* its
+  absence; the probe upgrades to richer results when the bridge lands, with no UI change.
+- Foundation Models *inference* wiring (#105) — only availability is probed here.

--- a/docs/specs/2026-06-18-siri-readiness-plan.md
+++ b/docs/specs/2026-06-18-siri-readiness-plan.md
@@ -1,0 +1,1250 @@
+# Siri AI Readiness Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only, network-free diagnostic that reports whether Siri-driven workflows can work — globally (Settings "Siri AI" tab) and per-site (a `SiteWindow` command).
+
+**Architecture:** A `ReadinessProbe` protocol (each probe returns a `ReadinessFinding`, never throws) feeds a `@MainActor @Observable SiriReadinessModel`, mirroring the shipped `HealthModel`/`HealthCheckRunner` pattern. Shared types + Foundation-only probes live in `AnglesiteCore`; App-Intents/Spotlight probes live in `AnglesiteIntents`; probe arrays are assembled in `AnglesiteIntents`; only SwiftUI views live in the app target. Every probe's mapping is pure given injected primitives, so all logic is CI-testable without touching system frameworks.
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27), Swift Testing for new tests, `FoundationModels` + `CoreSpotlight` + `AppIntents` system frameworks (read-only, behind injected seams).
+
+**Spec:** `docs/specs/2026-06-18-siri-readiness-design.md`
+
+## Global Constraints
+
+- Target **macOS 27+**, Swift 6.4 / Xcode 27. No `@available` fallbacks; use `#if compiler(>=6.4)` where needed.
+- **No third-party frameworks.** Apple frameworks only.
+- **New tests use Swift Testing** (`@Test` / `#expect`), per the suite migration (#74).
+- **Probe/model logic lives in `AnglesiteCore` or `AnglesiteIntents`** (both CI-covered), never the app target. App target gets SwiftUI views only.
+- **No network access** in any probe. The Foundation Models probe checks *availability only* — it never runs inference.
+- **MAS:** the Settings tab needs no filesystem access; per-site probes run from a `SiteWindow` that already holds the security-scoped grant. Guard with `#if ANGLESITE_MAS` only where strictly required (none expected in this plan).
+- Verify with `swift test --package-path .` AND an `xcodebuild` build of both `Anglesite` and `AnglesiteMAS` schemes (per project: `swift test` alone doesn't prove the `.app` links).
+- Commit after every green step.
+
+---
+
+### Task 1: Core readiness primitives + model
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SiriReadiness.swift`
+- Test: `Tests/AnglesiteCoreTests/SiriReadinessModelTests.swift`
+
+**Interfaces:**
+- Produces: `ReadinessLevel`, `ReadinessFinding`, `ReadinessProbe`, `SiriReadinessModel` — consumed by every later task.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// Tests/AnglesiteCoreTests/SiriReadinessModelTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+private struct StubProbe: ReadinessProbe {
+    let id: String
+    let title: String
+    let finding: ReadinessFinding
+    init(_ finding: ReadinessFinding) {
+        self.id = finding.id
+        self.title = finding.title
+        self.finding = finding
+    }
+    func check() async -> ReadinessFinding { finding }
+}
+
+private func makeFinding(_ id: String, _ level: ReadinessLevel) -> ReadinessFinding {
+    ReadinessFinding(id: id, title: id, level: level, detail: "detail")
+}
+
+@MainActor
+@Suite struct SiriReadinessModelTests {
+    @Test func initialState_isEmpty() {
+        let model = SiriReadinessModel(probes: [])
+        #expect(model.findings.isEmpty)
+        #expect(model.isChecking == false)
+        #expect(model.lastChecked == nil)
+    }
+
+    @Test func recheck_collectsFindingsInOrder_andStampsTime() async {
+        let stamp = Date(timeIntervalSince1970: 1000)
+        let model = SiriReadinessModel(
+            probes: [StubProbe(makeFinding("a", .ok)), StubProbe(makeFinding("b", .warning))],
+            now: { stamp }
+        )
+        await model.recheck().value
+        #expect(model.findings.map(\.id) == ["a", "b"])
+        #expect(model.isChecking == false)
+        #expect(model.lastChecked == stamp)
+    }
+
+    @Test func overallLevel_failureWins() async {
+        let model = SiriReadinessModel(probes: [
+            StubProbe(makeFinding("a", .ok)),
+            StubProbe(makeFinding("b", .warning)),
+            StubProbe(makeFinding("c", .failure)),
+        ])
+        await model.recheck().value
+        #expect(model.overallLevel == .failure)
+    }
+
+    @Test func overallLevel_allUnsupported_isUnsupported() async {
+        let model = SiriReadinessModel(probes: [StubProbe(makeFinding("a", .unsupported))])
+        await model.recheck().value
+        #expect(model.overallLevel == .unsupported)
+    }
+
+    @Test func overallLevel_mixOkAndUnsupported_isOk() async {
+        let model = SiriReadinessModel(probes: [
+            StubProbe(makeFinding("a", .ok)),
+            StubProbe(makeFinding("b", .unsupported)),
+        ])
+        await model.recheck().value
+        #expect(model.overallLevel == .ok)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter SiriReadinessModelTests`
+Expected: FAIL — `cannot find 'SiriReadinessModel' in scope` (and the other types).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+// Sources/AnglesiteCore/SiriReadiness.swift
+import Foundation
+import Observation
+
+/// Severity of a single capability check. `unsupported` means "not available in this
+/// build/OS yet" (a truthful absence, not a failure the user caused).
+public enum ReadinessLevel: String, Sendable, Equatable, CaseIterable {
+    case ok
+    case warning
+    case failure
+    case unsupported
+}
+
+/// The result of one probe. Concrete `detail` (what the probe found), with optional
+/// user-actionable `remediation`.
+public struct ReadinessFinding: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let level: ReadinessLevel
+    public let detail: String
+    public let remediation: String?
+
+    public init(id: String, title: String, level: ReadinessLevel, detail: String, remediation: String? = nil) {
+        self.id = id
+        self.title = title
+        self.level = level
+        self.detail = detail
+        self.remediation = remediation
+    }
+}
+
+/// A single capability check. Never throws — a failure is a `ReadinessFinding` with a
+/// failing `level`. Injectable so tests can supply canned probes.
+public protocol ReadinessProbe: Sendable {
+    var id: String { get }
+    var title: String { get }
+    func check() async -> ReadinessFinding
+}
+
+/// Drives a readiness surface. Mirrors `HealthModel`: `@MainActor @Observable`, injectable
+/// dependencies, `recheck()` returns the `Task` so tests can await it. Probes run serially
+/// for deterministic ordering.
+@MainActor
+@Observable
+public final class SiriReadinessModel {
+    public private(set) var findings: [ReadinessFinding] = []
+    public private(set) var isChecking: Bool = false
+    public private(set) var lastChecked: Date?
+
+    @ObservationIgnored private let probes: [any ReadinessProbe]
+    @ObservationIgnored private let now: @Sendable () -> Date
+    @ObservationIgnored private var inFlight: Task<Void, Never>?
+
+    public init(probes: [any ReadinessProbe], now: @escaping @Sendable () -> Date = { Date() }) {
+        self.probes = probes
+        self.now = now
+    }
+
+    /// Worst level across all findings. Empty / all-unsupported collapses to `.unsupported`.
+    public var overallLevel: ReadinessLevel {
+        if findings.contains(where: { $0.level == .failure }) { return .failure }
+        if findings.contains(where: { $0.level == .warning }) { return .warning }
+        if findings.contains(where: { $0.level == .ok }) { return .ok }
+        return .unsupported
+    }
+
+    /// Run every probe and publish the findings. Cancels any in-flight run first.
+    @discardableResult
+    public func recheck() -> Task<Void, Never> {
+        inFlight?.cancel()
+        isChecking = true
+        let probes = self.probes
+        let task = Task { @MainActor [weak self] in
+            var collected: [ReadinessFinding] = []
+            for probe in probes {
+                if Task.isCancelled { return }
+                collected.append(await probe.check())
+            }
+            guard !Task.isCancelled else { return }
+            self?.commit(collected)
+        }
+        inFlight = task
+        return task
+    }
+
+    private func commit(_ findings: [ReadinessFinding]) {
+        self.findings = findings
+        self.lastChecked = now()
+        self.isChecking = false
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter SiriReadinessModelTests`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiriReadiness.swift Tests/AnglesiteCoreTests/SiriReadinessModelTests.swift
+git commit -m "feat(siri): readiness probe protocol + observable model (#236)"
+```
+
+---
+
+### Task 2: Core system probes — OS runtime + Foundation Models
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SiriReadinessSystemProbes.swift`
+- Test: `Tests/AnglesiteCoreTests/SiriReadinessSystemProbeTests.swift`
+
+**Interfaces:**
+- Consumes: `ReadinessProbe`, `ReadinessFinding`, `ReadinessLevel` (Task 1).
+- Produces: `OSRuntimeProbe`, `FoundationModelsAvailability`, `FoundationModelsProbe`, `LiveFoundationModelsAvailability.current()` — consumed by Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// Tests/AnglesiteCoreTests/SiriReadinessSystemProbeTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct SiriReadinessSystemProbeTests {
+    @Test func osRuntime_meetsMinimum_isOk() async {
+        let probe = OSRuntimeProbe(
+            version: OperatingSystemVersion(majorVersion: 27, minorVersion: 1, patchVersion: 0),
+            minimumMajor: 27
+        )
+        let finding = await probe.check()
+        #expect(finding.id == "os.runtime")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func osRuntime_belowMinimum_isFailure_withRemediation() async {
+        let probe = OSRuntimeProbe(
+            version: OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0),
+            minimumMajor: 27
+        )
+        let finding = await probe.check()
+        #expect(finding.level == .failure)
+        #expect(finding.remediation != nil)
+    }
+
+    @Test func foundationModels_available_isOk() async {
+        let probe = FoundationModelsProbe(availability: { .available })
+        let finding = await probe.check()
+        #expect(finding.id == "foundation.models")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func foundationModels_appleIntelligenceOff_isWarning_withRemediation() async {
+        let probe = FoundationModelsProbe(availability: { .appleIntelligenceNotEnabled })
+        let finding = await probe.check()
+        #expect(finding.level == .warning)
+        #expect(finding.remediation != nil)
+    }
+
+    @Test func foundationModels_deviceNotEligible_isUnsupported() async {
+        let probe = FoundationModelsProbe(availability: { .deviceNotEligible })
+        let finding = await probe.check()
+        #expect(finding.level == .unsupported)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter SiriReadinessSystemProbeTests`
+Expected: FAIL — `cannot find 'OSRuntimeProbe' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+// Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
+import Foundation
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// Confirms the running OS meets Anglesite's macOS floor. Version is injectable so the
+/// mapping is testable without spoofing the process environment.
+public struct OSRuntimeProbe: ReadinessProbe {
+    public let id = "os.runtime"
+    public let title = "macOS runtime"
+    private let version: OperatingSystemVersion
+    private let minimumMajor: Int
+
+    public init(
+        version: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion,
+        minimumMajor: Int = 27
+    ) {
+        self.version = version
+        self.minimumMajor = minimumMajor
+    }
+
+    public func check() async -> ReadinessFinding {
+        let running = "\(version.majorVersion).\(version.minorVersion)"
+        if version.majorVersion >= minimumMajor {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "macOS \(running) meets the macOS \(minimumMajor) requirement for Siri workflows.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .failure,
+            detail: "macOS \(running) is below the macOS \(minimumMajor) requirement.",
+            remediation: "Update to macOS \(minimumMajor) or later in System Settings ▸ General ▸ Software Update.")
+    }
+}
+
+/// Normalized Foundation Models availability, decoupled from the SDK enum so the probe
+/// mapping is testable without the framework.
+public enum FoundationModelsAvailability: Sendable, Equatable {
+    case available
+    case appleIntelligenceNotEnabled
+    case modelNotReady
+    case deviceNotEligible
+    case unknown(String)
+}
+
+/// Reports whether Apple's on-device language model is usable. Availability is injected so
+/// tests never touch the live model; the live source reads `SystemLanguageModel` (no inference).
+public struct FoundationModelsProbe: ReadinessProbe {
+    public let id = "foundation.models"
+    public let title = "Apple Foundation Models"
+    private let availability: @Sendable () -> FoundationModelsAvailability
+
+    public init(availability: @escaping @Sendable () -> FoundationModelsAvailability) {
+        self.availability = availability
+    }
+
+    public func check() async -> ReadinessFinding {
+        switch availability() {
+        case .available:
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "The on-device language model is available for summarization and chat.")
+        case .appleIntelligenceNotEnabled:
+            return ReadinessFinding(id: id, title: title, level: .warning,
+                detail: "Apple Intelligence is turned off.",
+                remediation: "Enable Apple Intelligence in System Settings ▸ Apple Intelligence & Siri.")
+        case .modelNotReady:
+            return ReadinessFinding(id: id, title: title, level: .warning,
+                detail: "The on-device model is still downloading or preparing.",
+                remediation: "Wait for the model to finish downloading, then re-check.")
+        case .deviceNotEligible:
+            return ReadinessFinding(id: id, title: title, level: .unsupported,
+                detail: "This Mac does not support Apple Foundation Models.")
+        case .unknown(let reason):
+            return ReadinessFinding(id: id, title: title, level: .warning,
+                detail: "Foundation Models availability could not be determined: \(reason).")
+        }
+    }
+}
+
+/// Live availability source. Reads `SystemLanguageModel.default.availability` (no inference).
+/// Case names below must match the `FoundationModels` SDK; `@unknown default` absorbs drift.
+public enum LiveFoundationModelsAvailability {
+    public static func current() -> FoundationModelsAvailability {
+        #if canImport(FoundationModels)
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return .available
+        case .unavailable(let reason):
+            switch reason {
+            case .appleIntelligenceNotEnabled: return .appleIntelligenceNotEnabled
+            case .modelNotReady: return .modelNotReady
+            case .deviceNotEligible: return .deviceNotEligible
+            @unknown default: return .unknown("\(reason)")
+            }
+        @unknown default:
+            return .unknown("unrecognized availability")
+        }
+        #else
+        return .unknown("FoundationModels unavailable at build time")
+        #endif
+    }
+}
+```
+
+> **Implementer note:** if the SDK enum case labels differ (e.g. `.unavailable(.appleIntelligenceNotEnabled)` spelled differently), adjust the mapping in `LiveFoundationModelsAvailability.current()` only — the probe and its tests are insulated from the SDK names.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter SiriReadinessSystemProbeTests`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiriReadinessSystemProbes.swift Tests/AnglesiteCoreTests/SiriReadinessSystemProbeTests.swift
+git commit -m "feat(siri): OS-runtime + Foundation Models readiness probes (#236)"
+```
+
+---
+
+### Task 3: Intents-module system probes — App Intents, View Annotations, MCP bridge
+
+**Files:**
+- Create: `Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift`
+- Test: `Tests/AnglesiteIntentsTests/SiriReadinessIntentProbeTests.swift`
+
+**Interfaces:**
+- Consumes: `ReadinessProbe`/`ReadinessFinding` (from `AnglesiteCore`), `AnglesiteShortcuts.appShortcuts`.
+- Produces: `AppIntentsRegistrationProbe`, `ViewAnnotationsProbe` (+ static `builtWithAnnotations`), `SystemMCPBridgeProbe` — consumed by Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// Tests/AnglesiteIntentsTests/SiriReadinessIntentProbeTests.swift
+import Testing
+import AnglesiteCore
+@testable import AnglesiteIntents
+
+@Suite struct SiriReadinessIntentProbeTests {
+    @Test func appIntents_withShortcuts_isOk() async {
+        let finding = await AppIntentsRegistrationProbe(shortcutCount: 9).check()
+        #expect(finding.id == "intents.registration")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func appIntents_noShortcuts_isWarning() async {
+        let finding = await AppIntentsRegistrationProbe(shortcutCount: 0).check()
+        #expect(finding.level == .warning)
+        #expect(finding.remediation != nil)
+    }
+
+    @Test func appIntents_defaultUsesRealShortcuts() async {
+        // The real provider ships curated shortcuts, so the default init must report ok.
+        let finding = await AppIntentsRegistrationProbe().check()
+        #expect(finding.level == .ok)
+    }
+
+    @Test func viewAnnotations_compiled_isOk() async {
+        let finding = await ViewAnnotationsProbe(compiled: true).check()
+        #expect(finding.id == "view.annotations")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func viewAnnotations_notCompiled_isUnsupported() async {
+        let finding = await ViewAnnotationsProbe(compiled: false).check()
+        #expect(finding.level == .unsupported)
+    }
+
+    @Test func mcpBridge_unregistered_isUnsupported() async {
+        let finding = await SystemMCPBridgeProbe(registered: false).check()
+        #expect(finding.id == "mcp.bridge")
+        #expect(finding.level == .unsupported)
+    }
+
+    @Test func mcpBridge_registered_isOk() async {
+        let finding = await SystemMCPBridgeProbe(registered: true).check()
+        #expect(finding.level == .ok)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter SiriReadinessIntentProbeTests`
+Expected: FAIL — `cannot find 'AppIntentsRegistrationProbe' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+// Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
+import AnglesiteCore
+import AppIntents
+
+/// Confirms Anglesite's App Shortcuts are registered (the surface Siri/Spotlight enumerate).
+/// Count is injectable; the default reads the live provider.
+public struct AppIntentsRegistrationProbe: ReadinessProbe {
+    public let id = "intents.registration"
+    public let title = "App Intents & Shortcuts"
+    private let shortcutCount: Int
+
+    public init(shortcutCount: Int = AnglesiteShortcuts.appShortcuts.count) {
+        self.shortcutCount = shortcutCount
+    }
+
+    public func check() async -> ReadinessFinding {
+        if shortcutCount > 0 {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "\(shortcutCount) Anglesite shortcuts are registered for Siri and Spotlight.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .warning,
+            detail: "No Anglesite shortcuts are registered.",
+            remediation: "Relaunch Anglesite so the system re-registers its App Shortcuts.")
+    }
+}
+
+/// Reports whether the build includes Swift 6.4 View Annotations (the onscreen-awareness path
+/// that lets Siri act on the site you're viewing). Compile-time gated; injectable for tests.
+public struct ViewAnnotationsProbe: ReadinessProbe {
+    public let id = "view.annotations"
+    public let title = "Onscreen awareness (View Annotations)"
+    private let compiled: Bool
+
+    public init(compiled: Bool = ViewAnnotationsProbe.builtWithAnnotations) {
+        self.compiled = compiled
+    }
+
+    public static var builtWithAnnotations: Bool {
+        #if compiler(>=6.4)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    public func check() async -> ReadinessFinding {
+        if compiled {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "Site windows publish an entity identifier, so Siri can act on the site you're viewing.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .unsupported,
+            detail: "This build was compiled without Swift 6.4 view-annotation support.",
+            remediation: "Use a build produced with Xcode 27 / Swift 6.4 or later.")
+    }
+}
+
+/// Reports whether Anglesite's tools are exposed to the system-wide MCP bridge. Unbuilt today
+/// (Phase D, #135) — defaults to `.unsupported`; flips to a real check when #164/#101 land.
+public struct SystemMCPBridgeProbe: ReadinessProbe {
+    public let id = "mcp.bridge"
+    public let title = "System-wide MCP bridge"
+    private let registered: Bool
+
+    public init(registered: Bool = false) {
+        self.registered = registered
+    }
+
+    public func check() async -> ReadinessFinding {
+        if registered {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "Anglesite's tools are exposed to the system MCP bridge for Claude Code and other agents.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .unsupported,
+            detail: "System-wide MCP exposure is not available in this build (Phase D, #135).")
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter SiriReadinessIntentProbeTests`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift Tests/AnglesiteIntentsTests/SiriReadinessIntentProbeTests.swift
+git commit -m "feat(siri): App Intents / View Annotations / MCP-bridge readiness probes (#236)"
+```
+
+---
+
+### Task 4: Site probes — content-graph freshness + Spotlight index status
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/ContentSpotlightIndexer.swift` (add `IndexedCounts` + `indexedCounts(for:)`)
+- Modify: `Sources/AnglesiteIntents/Bootstrap.swift` (return the `ContentSpotlightIndexer` so the app can hold it)
+- Create: `Sources/AnglesiteCore/SiriReadinessSiteProbes.swift` (content-graph probe)
+- Create: `Sources/AnglesiteIntents/SiriReadinessSpotlightProbe.swift` (Spotlight probe)
+- Test: `Tests/AnglesiteCoreTests/SiriReadinessSiteProbeTests.swift`, `Tests/AnglesiteIntentsTests/SiriReadinessSpotlightProbeTests.swift`
+
+**Interfaces:**
+- Consumes: `ReadinessProbe`/`ReadinessFinding` (Task 1), `SiteContentGraph` (Core), `ContentSpotlightIndexer` (Intents).
+- Produces: `ContentSpotlightIndexer.IndexedCounts`, `ContentSpotlightIndexer.indexedCounts(for:) -> IndexedCounts`, `AnglesiteIntents.bootstrap(contentGraph:) async -> ContentSpotlightIndexer`, `ContentGraphProbe`, `SpotlightIndexProbe` — consumed by Tasks 5 & 7.
+
+- [ ] **Step 1: Write the failing test (content-graph probe, Core)**
+
+```swift
+// Tests/AnglesiteCoreTests/SiriReadinessSiteProbeTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct SiriReadinessSiteProbeTests {
+    private func page(_ site: String, _ route: String) -> SiteContentGraph.Page {
+        SiteContentGraph.Page(id: "\(site):page:\(route)", siteID: site, route: route,
+                              filePath: "/\(route).md", title: route, lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test func contentGraph_populated_isOk() async {
+        let graph = SiteContentGraph()
+        await graph.load(siteID: "blog", pages: [page("blog", "about")], posts: [], images: [])
+        let finding = await ContentGraphProbe(siteID: "blog", graph: graph).check()
+        #expect(finding.id == "site.graph")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func contentGraph_empty_isWarning_withRemediation() async {
+        let graph = SiteContentGraph()
+        let finding = await ContentGraphProbe(siteID: "blog", graph: graph).check()
+        #expect(finding.level == .warning)
+        #expect(finding.remediation != nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter SiriReadinessSiteProbeTests`
+Expected: FAIL — `cannot find 'ContentGraphProbe' in scope`.
+
+- [ ] **Step 3: Implement the content-graph probe**
+
+```swift
+// Sources/AnglesiteCore/SiriReadinessSiteProbes.swift
+import Foundation
+
+/// Reports whether a site's content is loaded into the in-memory graph (the data Siri's
+/// search/status intents read). Empty is a warning, not a failure — the user just needs to
+/// open the site.
+public struct ContentGraphProbe: ReadinessProbe {
+    public let id = "site.graph"
+    public let title = "Site content index"
+    private let siteID: String
+    private let graph: SiteContentGraph
+
+    public init(siteID: String, graph: SiteContentGraph) {
+        self.siteID = siteID
+        self.graph = graph
+    }
+
+    public func check() async -> ReadinessFinding {
+        let pages = await graph.pages(for: siteID).count
+        let posts = await graph.posts(for: siteID).count
+        let images = await graph.images(for: siteID).count
+        if pages + posts + images > 0 {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "\(pages) pages, \(posts) posts, \(images) images are loaded for Siri to search.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .warning,
+            detail: "No content is loaded for this site yet.",
+            remediation: "Open this site's window so Anglesite can index its content.")
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `swift test --package-path . --filter SiriReadinessSiteProbeTests`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Write the failing test (indexer accessor + Spotlight probe, Intents)**
+
+```swift
+// Tests/AnglesiteIntentsTests/SiriReadinessSpotlightProbeTests.swift
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteIntents
+
+private actor NoopSpotlightBackend: ContentSpotlightBackend {
+    func indexPages(_ entities: [PageEntity]) async throws {}
+    func indexPosts(_ entities: [PostEntity]) async throws {}
+    func indexImages(_ entities: [ImageEntity]) async throws {}
+    func deletePages(identifiers: [String]) async throws {}
+    func deletePosts(identifiers: [String]) async throws {}
+    func deleteImages(identifiers: [String]) async throws {}
+}
+
+@Suite struct SiriReadinessSpotlightProbeTests {
+    private func page(_ site: String, _ route: String) -> SiteContentGraph.Page {
+        SiteContentGraph.Page(id: "\(site):page:\(route)", siteID: site, route: route,
+                              filePath: "/\(route).md", title: route, lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test func indexedCounts_reflectReindex() async throws {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
+        await graph.load(siteID: "blog", pages: [page("blog", "about")], posts: [], images: [])
+        _ = try await indexer.reindex(siteID: "blog")
+        let counts = await indexer.indexedCounts(for: "blog")
+        #expect(counts.pages == 1)
+        #expect(counts.total == 1)
+    }
+
+    @Test func spotlight_indexed_isOk() async throws {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
+        await graph.load(siteID: "blog", pages: [page("blog", "about")], posts: [], images: [])
+        _ = try await indexer.reindex(siteID: "blog")
+        let finding = await SpotlightIndexProbe(siteID: "blog", indexer: indexer, indexingAvailable: true).check()
+        #expect(finding.id == "site.spotlight")
+        #expect(finding.level == .ok)
+    }
+
+    @Test func spotlight_nothingIndexed_isWarning() async {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
+        let finding = await SpotlightIndexProbe(siteID: "blog", indexer: indexer, indexingAvailable: true).check()
+        #expect(finding.level == .warning)
+    }
+
+    @Test func spotlight_unavailable_isWarning_withRemediation() async {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: NoopSpotlightBackend())
+        let finding = await SpotlightIndexProbe(siteID: "blog", indexer: indexer, indexingAvailable: false).check()
+        #expect(finding.level == .warning)
+        #expect(finding.remediation != nil)
+    }
+}
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `swift test --package-path . --filter SiriReadinessSpotlightProbeTests`
+Expected: FAIL — `value of type 'ContentSpotlightIndexer' has no member 'indexedCounts'`.
+
+- [ ] **Step 7: Add the indexer accessor**
+
+In `Sources/AnglesiteIntents/ContentSpotlightIndexer.swift`, add inside the `ContentSpotlightIndexer` actor (e.g. just after the `Outcome` struct):
+
+```swift
+    /// Snapshot of how many entities are currently published to Spotlight for a site. Reads the
+    /// `lastIndexed` set this indexer maintains — the truthful "what we've put in the index" count
+    /// without querying the system daemon. Returns zeros for an unknown / never-indexed site.
+    public struct IndexedCounts: Sendable, Equatable {
+        public let pages: Int
+        public let posts: Int
+        public let images: Int
+        public var total: Int { pages + posts + images }
+        public init(pages: Int, posts: Int, images: Int) {
+            self.pages = pages
+            self.posts = posts
+            self.images = images
+        }
+    }
+
+    public func indexedCounts(for siteID: String) -> IndexedCounts {
+        guard let state = lastIndexed[siteID] else { return IndexedCounts(pages: 0, posts: 0, images: 0) }
+        return IndexedCounts(pages: state.pageIDs.count, posts: state.postIDs.count, images: state.imageIDs.count)
+    }
+```
+
+- [ ] **Step 8: Implement the Spotlight probe**
+
+```swift
+// Sources/AnglesiteIntents/SiriReadinessSpotlightProbe.swift
+import AnglesiteCore
+import CoreSpotlight
+
+/// Reports how many of a site's items are published to the Spotlight semantic index Siri reads.
+/// `indexingAvailable` is injected; the default reads `CSSearchableIndex.isIndexingAvailable()`.
+public struct SpotlightIndexProbe: ReadinessProbe {
+    public let id = "site.spotlight"
+    public let title = "Spotlight index"
+    private let siteID: String
+    private let indexer: ContentSpotlightIndexer
+    private let indexingAvailable: Bool
+
+    public init(
+        siteID: String,
+        indexer: ContentSpotlightIndexer,
+        indexingAvailable: Bool = CSSearchableIndex.isIndexingAvailable()
+    ) {
+        self.siteID = siteID
+        self.indexer = indexer
+        self.indexingAvailable = indexingAvailable
+    }
+
+    public func check() async -> ReadinessFinding {
+        guard indexingAvailable else {
+            return ReadinessFinding(id: id, title: title, level: .warning,
+                detail: "Spotlight indexing is unavailable on this Mac.",
+                remediation: "Make sure Spotlight is enabled in System Settings ▸ Siri & Spotlight.")
+        }
+        let counts = await indexer.indexedCounts(for: siteID)
+        if counts.total > 0 {
+            return ReadinessFinding(id: id, title: title, level: .ok,
+                detail: "\(counts.total) items are indexed in Spotlight for this site.")
+        }
+        return ReadinessFinding(id: id, title: title, level: .warning,
+            detail: "Nothing is indexed in Spotlight for this site yet.",
+            remediation: "Open this site's window so its content is indexed.")
+    }
+}
+```
+
+- [ ] **Step 9: Run to verify pass**
+
+Run: `swift test --package-path . --filter SiriReadinessSpotlightProbeTests`
+Expected: PASS (4 tests).
+
+- [ ] **Step 10: Expose the indexer from `bootstrap`**
+
+In `Sources/AnglesiteIntents/Bootstrap.swift`, change the signature and return the indexer so the app can hold it (mirrors how `contentGraph` is app-owned). Change:
+
+```swift
+    public static func bootstrap(contentGraph: SiteContentGraph) async {
+```
+to:
+```swift
+    @discardableResult
+    public static func bootstrap(contentGraph: SiteContentGraph) async -> ContentSpotlightIndexer {
+```
+and at the end of the method (after the `do { try await SiteStore.shared.load() } …` block), add:
+```swift
+        return contentIndexer
+```
+
+(`contentIndexer` is already the local created at the existing line `let contentIndexer = ContentSpotlightIndexer(...)`.)
+
+- [ ] **Step 11: Run the full Intents + Core suites to confirm nothing regressed**
+
+Run: `swift test --package-path . --filter AnglesiteIntentsTests`
+Then: `swift test --package-path . --filter SiriReadiness`
+Expected: PASS. (The `@discardableResult` keeps existing `await AnglesiteIntents.bootstrap(...)` call sites valid.)
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/ContentSpotlightIndexer.swift Sources/AnglesiteIntents/Bootstrap.swift Sources/AnglesiteCore/SiriReadinessSiteProbes.swift Sources/AnglesiteIntents/SiriReadinessSpotlightProbe.swift Tests/AnglesiteCoreTests/SiriReadinessSiteProbeTests.swift Tests/AnglesiteIntentsTests/SiriReadinessSpotlightProbeTests.swift
+git commit -m "feat(siri): per-site content-graph + Spotlight readiness probes (#236)"
+```
+
+---
+
+### Task 5: Probe assembly
+
+**Files:**
+- Create: `Sources/AnglesiteIntents/SiriReadinessProbes.swift`
+- Test: `Tests/AnglesiteIntentsTests/SiriReadinessProbesTests.swift`
+
+**Interfaces:**
+- Consumes: all probe types (Tasks 2–4), `SiteContentGraph`, `ContentSpotlightIndexer`.
+- Produces: `SiriReadinessProbes.system() -> [any ReadinessProbe]`, `SiriReadinessProbes.site(siteID:graph:indexer:) -> [any ReadinessProbe]` — consumed by Tasks 6 & 7.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// Tests/AnglesiteIntentsTests/SiriReadinessProbesTests.swift
+import Testing
+import AnglesiteCore
+@testable import AnglesiteIntents
+
+@Suite struct SiriReadinessProbesTests {
+    @Test func system_isNonEmpty_withUniqueIDs() {
+        let ids = SiriReadinessProbes.system().map(\.id)
+        #expect(!ids.isEmpty)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test func site_isNonEmpty_withUniqueIDs() {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: LiveContentSpotlightBackend())
+        let ids = SiriReadinessProbes.site(siteID: "blog", graph: graph, indexer: indexer).map(\.id)
+        #expect(!ids.isEmpty)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test func system_andSite_idsDoNotCollide() {
+        let graph = SiteContentGraph()
+        let indexer = ContentSpotlightIndexer(graph: graph, backend: LiveContentSpotlightBackend())
+        let system = Set(SiriReadinessProbes.system().map(\.id))
+        let site = Set(SiriReadinessProbes.site(siteID: "blog", graph: graph, indexer: indexer).map(\.id))
+        #expect(system.isDisjoint(with: site))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter SiriReadinessProbesTests`
+Expected: FAIL — `cannot find 'SiriReadinessProbes' in scope`.
+
+- [ ] **Step 3: Implement the assembly**
+
+```swift
+// Sources/AnglesiteIntents/SiriReadinessProbes.swift
+import AnglesiteCore
+
+/// Assembles the readiness probe sets. Lives in AnglesiteIntents — the one module that can see
+/// both the Core probes and the Intents probes.
+public enum SiriReadinessProbes {
+    /// Global capabilities, independent of any site.
+    public static func system() -> [any ReadinessProbe] {
+        [
+            OSRuntimeProbe(),
+            AppIntentsRegistrationProbe(),
+            ViewAnnotationsProbe(),
+            FoundationModelsProbe(availability: { LiveFoundationModelsAvailability.current() }),
+            SystemMCPBridgeProbe(),
+        ]
+    }
+
+    /// Per-site readiness for one open/known site.
+    public static func site(
+        siteID: String,
+        graph: SiteContentGraph,
+        indexer: ContentSpotlightIndexer
+    ) -> [any ReadinessProbe] {
+        [
+            ContentGraphProbe(siteID: siteID, graph: graph),
+            SpotlightIndexProbe(siteID: siteID, indexer: indexer),
+        ]
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `swift test --package-path . --filter SiriReadinessProbesTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/SiriReadinessProbes.swift Tests/AnglesiteIntentsTests/SiriReadinessProbesTests.swift
+git commit -m "feat(siri): assemble system + per-site readiness probe sets (#236)"
+```
+
+---
+
+### Task 6: Settings "Siri AI" tab
+
+**Files:**
+- Create: `Sources/AnglesiteApp/SiriReadinessView.swift` (shared `ReadinessRow` + `SiriReadinessList` + `SiriReadinessSettingsView`)
+- Modify: `Sources/AnglesiteApp/SettingsView.swift` (add the tab)
+
+**Interfaces:**
+- Consumes: `SiriReadinessModel` (Core), `SiriReadinessProbes.system()` (Intents), `ReadinessFinding`/`ReadinessLevel` (Core).
+- Produces: `ReadinessRow`, `SiriReadinessList`, `SiriReadinessSettingsView` — `SiriReadinessList` reused by Task 7.
+
+This task has no unit test (SwiftUI views in the app target aren't CI-hosted — per CLAUDE.md). It is verified by the `xcodebuild` link check in Step 3 and the manual check note.
+
+- [ ] **Step 1: Create the shared views + settings tab content**
+
+```swift
+// Sources/AnglesiteApp/SiriReadinessView.swift
+import SwiftUI
+import AnglesiteCore
+
+/// One capability row: status glyph + title + concrete detail + optional remediation.
+struct ReadinessRow: View {
+    let finding: ReadinessFinding
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: glyph)
+                .foregroundStyle(tint)
+                .accessibilityLabel(accessibilityStatus)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(finding.title).font(.body)
+                Text(finding.detail).font(.caption).foregroundStyle(.secondary)
+                if let remediation = finding.remediation {
+                    Text(remediation).font(.caption).foregroundStyle(.blue)
+                }
+            }
+            Spacer()
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var glyph: String {
+        switch finding.level {
+        case .ok: return "checkmark.circle.fill"
+        case .warning: return "exclamationmark.triangle.fill"
+        case .failure: return "xmark.octagon.fill"
+        case .unsupported: return "minus.circle"
+        }
+    }
+
+    private var tint: Color {
+        switch finding.level {
+        case .ok: return .green
+        case .warning: return .orange
+        case .failure: return .red
+        case .unsupported: return .secondary
+        }
+    }
+
+    private var accessibilityStatus: String {
+        switch finding.level {
+        case .ok: return "OK"
+        case .warning: return "Warning"
+        case .failure: return "Failure"
+        case .unsupported: return "Not available"
+        }
+    }
+}
+
+/// Renders a readiness model: the findings list, a re-check button, and a last-checked stamp.
+/// Drives an initial check on appear. Reused by Settings (system) and the per-window sheet.
+struct SiriReadinessList: View {
+    @State var model: SiriReadinessModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(model.findings) { finding in
+                ReadinessRow(finding: finding)
+            }
+            HStack {
+                Button("Re-check") { model.recheck() }
+                    .disabled(model.isChecking)
+                if model.isChecking {
+                    ProgressView().controlSize(.small)
+                }
+                Spacer()
+                if let checked = model.lastChecked {
+                    Text("Last checked \(checked.formatted(date: .omitted, time: .shortened))")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+        .task { if model.findings.isEmpty { model.recheck() } }
+    }
+}
+
+/// Settings ▸ Siri AI. System-wide capabilities only; per-site readiness lives in each site window.
+struct SiriReadinessSettingsView: View {
+    @State private var model = SiriReadinessModel(probes: SiriReadinessProbes.system())
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Whether this Mac can run Siri-driven Anglesite workflows. Per-site readiness is in each site window (Site ▸ Siri AI Readiness).")
+                    .font(.caption).foregroundStyle(.secondary)
+                SiriReadinessList(model: model)
+            }
+            .padding()
+        }
+    }
+}
+```
+
+> **Import note:** `SiriReadinessProbes` is in `AnglesiteIntents`. If the app target file does not already transitively import it, add `import AnglesiteIntents` at the top of this file. (The app target links `AnglesiteIntents` for App Shortcuts.)
+
+- [ ] **Step 2: Add the tab to `SettingsView`**
+
+In `Sources/AnglesiteApp/SettingsView.swift`, change the `TabView` body:
+
+```swift
+struct SettingsView: View {
+    var body: some View {
+        TabView {
+            AdvancedSettingsView()
+                .tabItem { Label("Advanced", systemImage: "gearshape.2") }
+            SiriReadinessSettingsView()
+                .tabItem { Label("Siri AI", systemImage: "sparkles") }
+        }
+        .frame(width: 540, height: 360)
+    }
+}
+```
+
+(Height bumped 320 → 360 to fit the readiness list; if `import AnglesiteIntents` is needed it goes at the top of `SettingsView.swift` too — only if the build complains.)
+
+- [ ] **Step 3: Build both schemes to verify it links**
+
+Run:
+```bash
+xcodegen generate
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -5
+xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **` for both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiriReadinessView.swift Sources/AnglesiteApp/SettingsView.swift
+git commit -m "feat(siri): Settings 'Siri AI' tab with system readiness (#236)"
+```
+
+---
+
+### Task 7: Per-`SiteWindow` "Siri AI Readiness" command
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/AnglesiteApp.swift` (hold the `ContentSpotlightIndexer`, pass to `SiteWindow`)
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift` (accept indexer; add toolbar button + sheet scoped to the window's site)
+
+**Interfaces:**
+- Consumes: `AnglesiteIntents.bootstrap(...) -> ContentSpotlightIndexer` (Task 4), `SiriReadinessProbes.site(...)` (Task 5), `SiriReadinessList` (Task 6).
+
+This task has no unit test (app-target SwiftUI). Verified by the `xcodebuild` link check + the manual-check note.
+
+- [ ] **Step 1: Hold the indexer in `AppDelegate` and pass it through**
+
+In `Sources/AnglesiteApp/AnglesiteApp.swift`:
+
+Near `let contentGraph = SiteContentGraph()` (line ~13), add a stored property:
+```swift
+    var contentIndexer: ContentSpotlightIndexer?
+```
+Change the bootstrap call (line ~22) from:
+```swift
+            await AnglesiteIntents.bootstrap(contentGraph: contentGraph)
+```
+to:
+```swift
+            self.contentIndexer = await AnglesiteIntents.bootstrap(contentGraph: contentGraph)
+```
+Change the `SiteWindow(...)` construction (line ~162) from:
+```swift
+            SiteWindow(siteID: siteID, contentGraph: appDelegate.contentGraph)
+```
+to:
+```swift
+            SiteWindow(siteID: siteID, contentGraph: appDelegate.contentGraph, contentIndexer: appDelegate.contentIndexer)
+```
+
+> If `AppDelegate` is an actor/`@MainActor`-isolated type, `self.contentIndexer = …` inside the existing `Task { … }` is already on the right actor; no extra annotation needed.
+
+- [ ] **Step 2: Accept the indexer in `SiteWindow` and add the readiness surface**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`:
+
+Add stored property + init param (next to `contentGraph`, lines ~20-25):
+```swift
+    private let contentIndexer: ContentSpotlightIndexer?
+
+    init(siteID: String?, contentGraph: SiteContentGraph, contentIndexer: ContentSpotlightIndexer?) {
+        self.siteID = siteID
+        self.contentGraph = contentGraph
+        self.contentIndexer = contentIndexer
+        _preview = State(initialValue: PreviewModel(contentGraph: contentGraph))
+    }
+```
+
+Add window state (next to the other `@State`, ~line 50):
+```swift
+    @State private var siriReadinessPresented = false
+```
+
+Add a toolbar button. Inside the existing `.toolbar { … }` (around line 140), add a new `ToolbarItem` (only meaningful once `site` is resolved — guard like the existing items do):
+```swift
+            ToolbarItem {
+                Button {
+                    siriReadinessPresented = true
+                } label: {
+                    Label("Siri AI Readiness", systemImage: "sparkles")
+                }
+                .help("Check whether Siri workflows are ready for this site")
+                .disabled(site == nil)
+            }
+```
+
+Add a sheet (next to the other `.sheet` modifiers, ~line 231). Build the per-site model from the resolved `site` + shared graph/indexer:
+```swift
+        .sheet(isPresented: $siriReadinessPresented) {
+            if let site, let contentIndexer {
+                NavigationStack {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Siri AI readiness for “\(site.id)”.")
+                                .font(.caption).foregroundStyle(.secondary)
+                            SiriReadinessList(
+                                model: SiriReadinessModel(
+                                    probes: SiriReadinessProbes.site(
+                                        siteID: site.id, graph: contentGraph, indexer: contentIndexer
+                                    )
+                                )
+                            )
+                        }
+                        .padding()
+                    }
+                    .frame(minWidth: 420, minHeight: 260)
+                    .navigationTitle("Siri AI Readiness")
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") { siriReadinessPresented = false }
+                        }
+                    }
+                }
+            }
+        }
+```
+
+> If `SiriReadinessProbes` / `SiriReadinessList` aren't visible, add `import AnglesiteIntents` (for the probes) — `SiriReadinessList` is same-target. `SiteWindow` already imports `AnglesiteCore`.
+
+- [ ] **Step 3: Build both schemes to verify it links**
+
+Run:
+```bash
+xcodegen generate
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -5
+xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **` for both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/AnglesiteApp.swift Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat(siri): per-site Siri AI Readiness command in site window (#236)"
+```
+
+---
+
+### Task 8: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full Swift test suite**
+
+Run: `swift test --package-path .`
+Expected: all tests pass, including the new `SiriReadiness*` suites. (Baseline was 665; this adds ~26 `@Test` cases. The MCP/apply-edit e2e tests need the sibling plugin + node — set `ANGLESITE_PLUGIN_PATH` if running them, otherwise they fail-not-skip per CLAUDE.md.)
+
+- [ ] **Step 2: Build both schemes clean**
+
+Run:
+```bash
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -3
+xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build 2>&1 | tail -3
+```
+Expected: `** BUILD SUCCEEDED **` for both.
+
+- [ ] **Step 3: Manual smoke (per CLAUDE.md GUI-verify gotchas)**
+
+Launch `Anglesite`, open Settings ▸ Siri AI — confirm rows render with statuses and "Re-check" updates the timestamp. Open a site window, click the ✨ toolbar button — confirm the per-site sheet shows content-graph + Spotlight rows for that site. Watch for the known gotchas (duplicate instances, plugin-not-bundled) before trusting any FAIL row.
+
+- [ ] **Step 4: Update issue + finish the branch**
+
+This is where `superpowers:finishing-a-development-branch` takes over (PR to `main`, stacked per project preference). Reference #236; note #242 as the follow-up the seam migrates to.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Two surfaces (Settings tab + per-window) → Tasks 6, 7. ✓
+- All seven probes → OS runtime (T2), Foundation Models (T2), App Intents (T3), View Annotations (T3), MCP bridge (T3), content-graph (T4), Spotlight (T4). ✓
+- Honest `.unsupported` for unbuilt capabilities → MCP bridge (T3), device-not-eligible FM (T2), uncompiled annotations (T3). ✓
+- Injectable/fake probes → every probe takes injected primitives; `SiriReadinessModel` takes `[any ReadinessProbe]`; tests use stubs/fakes. ✓
+- No network; FM availability-only → `FoundationModelsProbe` reads availability, never inference (T2). ✓
+- Registry uniqueness test → T5. ✓
+- Logic in Core/Intents, UI thin → T1–T5 are Core/Intents with tests; T6–T7 are views verified by build. ✓
+- Both schemes build → T6, T7, T8. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every run step has an expected result. The one SDK-name caveat (FoundationModels enum cases) is isolated to `LiveFoundationModelsAvailability` with an `@unknown default` and a flagged implementer note — not a placeholder.
+
+**Type consistency:** `ReadinessFinding(id:title:level:detail:remediation:)`, `ReadinessProbe.check() async -> ReadinessFinding`, `SiriReadinessModel(probes:now:)`, `SiriReadinessProbes.system()` / `.site(siteID:graph:indexer:)`, `ContentSpotlightIndexer.indexedCounts(for:) -> IndexedCounts`, and `bootstrap(contentGraph:) async -> ContentSpotlightIndexer` are used identically across tasks. ✓

--- a/docs/specs/2026-06-18-siri-readiness-plan.md
+++ b/docs/specs/2026-06-18-siri-readiness-plan.md
@@ -999,7 +999,7 @@ struct ReadinessRow: View {
 /// Renders a readiness model: the findings list, a re-check button, and a last-checked stamp.
 /// Drives an initial check on appear. Reused by Settings (system) and the per-window sheet.
 struct SiriReadinessList: View {
-    @State var model: SiriReadinessModel
+    let model: SiriReadinessModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
Closes #236.

## What

A read-only, **network-free** diagnostic that tells a user whether the Siri-driven workflows can work — on their Mac and for a given site. Two surfaces, following Xcode's per-project model (not Mail's app-owned-store model):

- **Settings ▸ "Siri AI" tab** — system-wide capabilities (no site list).
- **Per-`SiteWindow` "Siri AI Readiness" command** (✨ toolbar button → sheet) — scoped to that window's site.

## How

A `ReadinessProbe` protocol (each probe returns a `ReadinessFinding`; never throws — a failure is a finding) feeds a `@MainActor @Observable SiriReadinessModel`, mirroring the shipped `HealthModel`/`HealthCheckRunner` pattern. Every probe's mapping is **pure given injected primitives**, with the live system-framework read isolated to one factory each — so all logic is CI-testable without touching the real APIs.

**Module placement:** shared types + Foundation-only probes in `AnglesiteCore`; App-Intents/Spotlight probes in `AnglesiteIntents`; probe assembly in `AnglesiteIntents`; SwiftUI views in the app target.

### Seven probes
| Probe | Concrete check |
|---|---|
| macOS runtime | OS version ≥ 27 |
| App Intents registration | `AnglesiteShortcuts.appShortcuts` non-empty |
| View Annotations | `#if compiler(>=6.4)` availability |
| Foundation Models | `SystemLanguageModel.default.availability` (availability only — **never runs inference**) |
| System MCP bridge | unbuilt → honest `.unsupported` (Phase D, #135) |
| Content-graph freshness | `SiteContentGraph` counts for the site |
| Spotlight index status | `ContentSpotlightIndexer` indexed counts + `CSSearchableIndex.isIndexingAvailable()` |

Capabilities the build can't fully exercise yet (System MCP bridge, FM device-ineligible, uncompiled view annotations) report a truthful `.unsupported` — never a fake ✅ — and upgrade to richer results with no UI change when the underlying feature lands.

## Notable design decisions
- **No new seam type (YAGNI):** per-site probes are keyed by `siteID`; the SiteWindow already carries the site, and `AppSettings.sitesRoot` already resolves `~/Sites/<name>/`. That existing resolution is the seam **#242** (`.anglesite` package model) migrates — #236 adds nothing for it to replace.
- `bootstrap` now returns the `ContentSpotlightIndexer` (`@discardableResult`) so the app can hold it and feed the per-site Spotlight probe; the existing call site is unchanged.

## Testing
- `swift test`: **632 green** (448 AnglesiteCore + 171 AnglesiteIntents + 13 AnglesiteBridge), 0 failures. ~26 new Swift Testing cases across the probes, model, and assembly.
- `xcodebuild` **both schemes** (`Anglesite` DevID + `AnglesiteMAS`): `** BUILD SUCCEEDED **`.
- Probes tested via injected fakes (fake content graph, fake Spotlight indexer, fake availability/OS-version sources).

## Docs
- Design: `docs/specs/2026-06-18-siri-readiness-design.md`
- Plan: `docs/specs/2026-06-18-siri-readiness-plan.md`

## Follow-up
- #242 — adopt the `.anglesite` package + per-site (Xcode-style) config model, which this feature's site-identity resolution migrates to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)