### PR TITLE
fix(backup): push an unpushed commit left by a cancelled backup

### DIFF
--- a/Sources/AnglesiteCore/BackupCommand.swift
+++ b/Sources/AnglesiteCore/BackupCommand.swift
@@ -97,8 +97,10 @@ public actor BackupCommand {
         }
 
         // 2. Remote — refuse when `origin` isn't configured. `git remote get-url`
-        // exits non-zero with an empty stdout when the remote doesn't exist.
-        let remote: String
+        // exits non-zero with an empty stdout when the remote doesn't exist. This is the
+        // remote *URL*; the git operations below address the remote by name (`origin`), so the
+        // URL is only carried through to the `.succeeded` result for the caller's reference.
+        let remoteURL: String
         do {
             let result = try await runner(siteDirectory, ["remote", "get-url", "origin"])
             guard result.exitCode == 0 else {
@@ -107,8 +109,8 @@ public actor BackupCommand {
                     exitCode: nil
                 )
             }
-            remote = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !remote.isEmpty else {
+            remoteURL = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !remoteURL.isEmpty else {
                 return .failed(reason: "the `origin` remote is configured but empty.", exitCode: nil)
             }
         } catch {
@@ -126,7 +128,7 @@ public actor BackupCommand {
                 return .failed(reason: "`git status` exited \(result.exitCode)", exitCode: result.exitCode)
             }
             if result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                return await pushPendingCommitsIfAhead(branch: branch, remote: remote, in: siteDirectory, source: source)
+                return await pushPendingCommitsIfAhead(branch: branch, remoteURL: remoteURL, in: siteDirectory, source: source)
             }
         } catch {
             return .failed(reason: "couldn't run `git status`: \(error)", exitCode: nil)
@@ -156,7 +158,7 @@ public actor BackupCommand {
             return failure
         }
 
-        return .succeeded(commitSHA: sha, branch: branch, remote: remote)
+        return .succeeded(commitSHA: sha, branch: branch, remote: remoteURL)
     }
 
     // MARK: - Helpers
@@ -193,7 +195,7 @@ public actor BackupCommand {
     /// and preserve the historical `.noChanges` rather than erroring or pushing blindly.
     private func pushPendingCommitsIfAhead(
         branch: String,
-        remote: String,
+        remoteURL: String,
         in siteDirectory: URL,
         source: String
     ) async -> Result {
@@ -219,10 +221,15 @@ public actor BackupCommand {
             return .failed(reason: "couldn't read commit SHA: \(error)", exitCode: nil)
         }
 
+        // Bail before the push if the task was cancelled during the rev-list/rev-parse hops.
+        // `Task.isCancelled` (not `try? Task.checkCancellation()` — which would swallow the
+        // error and push anyway) actually short-circuits, matching the step-level guards the
+        // normal add→commit→push path gets from the cancellation work (#238).
+        if Task.isCancelled { return .failed(reason: "backup canceled", exitCode: nil) }
         if let failure = await streamGit(["push", "origin", branch], in: siteDirectory, source: source, label: "git push") {
             return failure
         }
-        return .succeeded(commitSHA: sha, branch: branch, remote: remote)
+        return .succeeded(commitSHA: sha, branch: branch, remote: remoteURL)
     }
 
     /// ISO-8601 timestamps in commit messages so they sort correctly under `git log` and

--- a/Sources/AnglesiteCore/BackupCommand.swift
+++ b/Sources/AnglesiteCore/BackupCommand.swift
@@ -14,8 +14,9 @@ import Foundation
 ///      pipeline. We surface a `.failed` with no override and let the user switch
 ///      branches (or use the chat-routed path, which can auto-switch to `draft`).
 ///   2. Remote: refuse if `origin` isn't configured. There's nowhere to push to.
-///   3. Status: bail with `.noChanges` if the working tree is clean — no point
-///      generating a no-op commit.
+///   3. Status: on a clean working tree, generate no commit — but if HEAD is ahead of
+///      `origin/<branch>` (an unpushed commit from a prior cancelled backup, #246), push it
+///      and report `.succeeded`; only a clean tree that's also in sync yields `.noChanges`.
 ///
 /// Then the action steps stream their output to `LogCenter` under
 /// `backup:<siteID>`, so the drawer UI can show progress in real time.
@@ -114,14 +115,18 @@ public actor BackupCommand {
             return .failed(reason: "couldn't read `origin` remote: \(error)", exitCode: nil)
         }
 
-        // 3. Status — bail early on a clean working tree.
+        // 3. Status — on a clean working tree there's nothing new to commit, but HEAD may
+        // still be *ahead* of the remote: a prior backup that committed and was cancelled (or
+        // failed) before its push leaves an unpushed commit (#246). A naive `.noChanges` here
+        // would silently strand that work. So on a clean tree we check the ahead-count and,
+        // when there are pending commits, push them and report `.succeeded` instead.
         do {
             let result = try await runner(siteDirectory, ["status", "--porcelain"])
             guard result.exitCode == 0 else {
                 return .failed(reason: "`git status` exited \(result.exitCode)", exitCode: result.exitCode)
             }
             if result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                return .noChanges
+                return await pushPendingCommitsIfAhead(branch: branch, remote: remote, in: siteDirectory, source: source)
             }
         } catch {
             return .failed(reason: "couldn't run `git status`: \(error)", exitCode: nil)
@@ -175,6 +180,49 @@ public actor BackupCommand {
         } catch {
             return .failed(reason: "couldn't spawn `\(label)`: \(error)", exitCode: nil)
         }
+    }
+
+    /// Handles the clean-tree case: pushes any commit(s) that are ahead of `origin/<branch>`
+    /// and reports `.succeeded`, otherwise returns `.noChanges`. Covers the cancelled-after-
+    /// commit backup (#246), where a commit was made locally but never pushed.
+    ///
+    /// Ahead-ness is measured against the remote-tracking ref (`origin/<branch>`), which
+    /// `git push origin <branch>` keeps current — rather than `@{u}`, since a plain push
+    /// (no `-u`) never configures upstream tracking. If that ref doesn't exist (the branch
+    /// was never pushed), `git rev-list` exits non-zero; we treat that as "can't determine"
+    /// and preserve the historical `.noChanges` rather than erroring or pushing blindly.
+    private func pushPendingCommitsIfAhead(
+        branch: String,
+        remote: String,
+        in siteDirectory: URL,
+        source: String
+    ) async -> Result {
+        let aheadCount: Int
+        do {
+            let result = try await runner(siteDirectory, ["rev-list", "--count", "origin/\(branch)..HEAD"])
+            guard result.exitCode == 0 else { return .noChanges }
+            aheadCount = Int(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+        } catch {
+            return .noChanges
+        }
+        guard aheadCount > 0 else { return .noChanges }
+
+        // Read the SHA we'll report before pushing it.
+        let sha: String
+        do {
+            let result = try await runner(siteDirectory, ["rev-parse", "HEAD"])
+            guard result.exitCode == 0 else {
+                return .failed(reason: "couldn't read commit SHA (`git rev-parse HEAD` exit \(result.exitCode))", exitCode: result.exitCode)
+            }
+            sha = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return .failed(reason: "couldn't read commit SHA: \(error)", exitCode: nil)
+        }
+
+        if let failure = await streamGit(["push", "origin", branch], in: siteDirectory, source: source, label: "git push") {
+            return failure
+        }
+        return .succeeded(commitSHA: sha, branch: branch, remote: remote)
     }
 
     /// ISO-8601 timestamps in commit messages so they sort correctly under `git log` and

--- a/Tests/AnglesiteCoreTests/BackupCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/BackupCommandTests.swift
@@ -67,15 +67,74 @@ struct BackupCommandTests {
 
     // MARK: noChanges
 
-    @Test("Returns .noChanges when git status is empty")
-    func returnsNoChangesWhenStatusEmpty() async {
+    @Test("Returns .noChanges when the tree is clean and in sync with origin")
+    func returnsNoChangesWhenCleanAndInSync() async {
+        // Clean tree (empty status) and HEAD not ahead of origin/<branch> (rev-list count 0)
+        // → genuinely nothing to back up.
         let cmd = makeCommand(runner: runner([
             "status": ("", 0),
             "rev-parse": ("draft\n", 0),
-            "remote": ("git@github.com:owner/site.git\n", 0)
+            "remote": ("git@github.com:owner/site.git\n", 0),
+            "rev-list": ("0\n", 0)
         ]))
         let result = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
         #expect(result == .noChanges)
+    }
+
+    @Test("Returns .noChanges when ahead-count can't be determined (no remote-tracking ref)")
+    func returnsNoChangesWhenAheadCountUnknown() async {
+        // A branch that was never pushed has no `origin/<branch>` ref, so
+        // `git rev-list --count origin/<branch>..HEAD` exits non-zero. With a clean tree we
+        // preserve the historical .noChanges rather than erroring or pushing blindly.
+        let pushed = LockedSourceList()
+        let cmd = makeCommand(
+            runner: runner([
+                "status": ("", 0),
+                "rev-parse": ("draft\n", 0),
+                "remote": ("git@github.com:owner/site.git\n", 0),
+                "rev-list": ("", 128)  // fatal: ambiguous argument 'origin/draft..HEAD'
+            ]),
+            streamer: { _, args, _ in pushed.add(args.first ?? ""); return (0, "") }
+        )
+        let result = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
+        #expect(result == .noChanges)
+        #expect(pushed.snapshot().isEmpty, "must not push when ahead-count is unknown")
+    }
+
+    // MARK: Clean-but-ahead push (#246)
+
+    @Test("Pushes the pending commit when the tree is clean but ahead of origin")
+    func pushesPendingCommitWhenCleanButAhead() async {
+        // The cancelled-after-commit case: a prior backup committed but never pushed, so the
+        // tree is clean yet HEAD is ahead of origin/<branch>. Backup must push the pending
+        // commit and report .succeeded — not mask it behind .noChanges.
+        let pushed = LockedSourceList()
+        let runner: BackupCommand.GitRunner = { _, args in
+            switch args.first {
+            case "status":   return .init(stdout: "", stderr: "", exitCode: 0)  // clean tree
+            case "remote":   return .init(stdout: "git@github.com:owner/site.git\n", stderr: "", exitCode: 0)
+            case "rev-list": return .init(stdout: "1\n", stderr: "", exitCode: 0) // 1 commit ahead
+            case "rev-parse":
+                if args.contains("--abbrev-ref") {
+                    return .init(stdout: "draft\n", stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "abc1234deadbeef0000000000000000000000000\n", stderr: "", exitCode: 0)
+            default:
+                return .init(stdout: "", stderr: "unmocked", exitCode: 1)
+            }
+        }
+        let cmd = makeCommand(runner: runner, streamer: { _, args, _ in pushed.add(args.first ?? ""); return (0, "") })
+
+        let result = await cmd.backup(siteID: "site", siteDirectory: tmpDir)
+        guard case .succeeded(let sha, let branch, let remote) = result else {
+            Issue.record("expected .succeeded for the unpushed commit, got \(result)")
+            return
+        }
+        #expect(sha == "abc1234deadbeef0000000000000000000000000")
+        #expect(branch == "draft")
+        #expect(remote == "git@github.com:owner/site.git")
+        // Only a push runs — no add/commit, since there's nothing new to commit.
+        #expect(pushed.snapshot() == ["push"], "expected a single push of the pending commit, got \(pushed.snapshot())")
     }
 
     // MARK: Main-branch refusal

--- a/Tests/AnglesiteCoreTests/BackupCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/BackupCommandTests.swift
@@ -137,6 +137,47 @@ struct BackupCommandTests {
         #expect(pushed.snapshot() == ["push"], "expected a single push of the pending commit, got \(pushed.snapshot())")
     }
 
+    @Test("Cancelling during the clean-but-ahead path prevents the pending push")
+    func cancelPreventsPendingPush() async {
+        // Park at the first git call until the test has captured the task handle, so the cancel
+        // lands deterministically before the push guard — no reliance on scheduling races.
+        let pushed = LockedSourceList()
+        let holder = CancelHolder()
+        let runner: BackupCommand.GitRunner = { _, args in
+            switch args.first {
+            case "status":   return .init(stdout: "", stderr: "", exitCode: 0)  // clean tree
+            case "remote":   return .init(stdout: "git@github.com:owner/site.git\n", stderr: "", exitCode: 0)
+            case "rev-list":
+                await holder.cancelSelf()  // task is held by now → cancels before the push guard
+                return .init(stdout: "1\n", stderr: "", exitCode: 0)
+            case "rev-parse":
+                if args.contains("--is-inside-work-tree") {
+                    await holder.awaitHeld()  // step 0 — park until the handle is stored
+                    return .init(stdout: "true\n", stderr: "", exitCode: 0)
+                }
+                if args.contains("--abbrev-ref") {
+                    return .init(stdout: "draft\n", stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "abc1234\n", stderr: "", exitCode: 0)
+            default:
+                return .init(stdout: "", stderr: "unmocked", exitCode: 1)
+            }
+        }
+        let cmd = makeCommand(runner: runner, streamer: { _, args, _ in pushed.add(args.first ?? ""); return (0, "") })
+
+        let task = Task { await cmd.backup(siteID: "site", siteDirectory: tmpDir) }
+        await holder.hold(task)
+        let result = await task.value
+
+        guard case .failed(let reason, let exit) = result else {
+            Issue.record("expected .failed on cancellation, got \(result)")
+            return
+        }
+        #expect(reason.contains("canceled"), "reason should name the cancellation: \(reason)")
+        #expect(exit == nil, "cancellation is pre-spawn for the push — no exit code")
+        #expect(pushed.snapshot().isEmpty, "must not push the pending commit once cancelled, got \(pushed.snapshot())")
+    }
+
     // MARK: Main-branch refusal
 
     @Test("Refuses when current branch is main")
@@ -330,4 +371,27 @@ private final class LockedSourceList: @unchecked Sendable {
     private var values: [String] = []
     func add(_ v: String) { lock.lock(); values.append(v); lock.unlock() }
     func snapshot() -> [String] { lock.lock(); defer { lock.unlock() }; return values }
+}
+
+/// Lets a test cancel the very `backup()` task it's awaiting, deterministically: the runner
+/// parks at the first git call via `awaitHeld()` until the test stores the handle with `hold(_:)`,
+/// then a later runner step calls `cancelSelf()` to cancel before the push guard is reached.
+private actor CancelHolder {
+    private var task: Task<BackupCommand.Result, Never>?
+    private var held = false
+    private var waiter: CheckedContinuation<Void, Never>?
+
+    func hold(_ t: Task<BackupCommand.Result, Never>) {
+        task = t
+        held = true
+        waiter?.resume()
+        waiter = nil
+    }
+
+    func awaitHeld() async {
+        if held { return }
+        await withCheckedContinuation { waiter = $0 }
+    }
+
+    func cancelSelf() { task?.cancel() }
 }


### PR DESCRIPTION
## Problem

`BackupCommand.backup` runs `add → commit → rev-parse HEAD → push`. If a backup committed but was cancelled (or failed) before its push, it left a **local commit that was never pushed**. The next backup saw a clean tree via `git status --porcelain` and returned `.noChanges`, **silently stranding that commit** — the owner could believe everything was backed up. Surfaced by the whole-branch review of #238 (PR #245).

## Fix

On a clean working tree, `BackupCommand` now checks whether `HEAD` is ahead of `origin/<branch>` (`git rev-list --count origin/<branch>..HEAD`) and, if so, pushes the pending commit(s) and reports `.succeeded` instead of `.noChanges`.

- Ahead-ness is measured against the **remote-tracking ref** (`origin/<branch>`), which a plain `git push origin <branch>` keeps current — not `@{u}`, since backup never configures upstream tracking.
- When that ref is absent (branch never pushed), the count command exits non-zero; we **preserve the historical `.noChanges`** rather than erroring or pushing blindly.
- A clean tree that's also in sync still returns `.noChanges`.

## Tests

TDD'd against the injected `GitRunner`/`GitStreamer` seams (no live network):

- `pushesPendingCommitWhenCleanButAhead` — RED-driven: clean tree + ahead → pushes, returns `.succeeded` with the pending SHA, runs only a push (no add/commit).
- `returnsNoChangesWhenCleanAndInSync` — clean + in sync (`rev-list` count 0) → `.noChanges`.
- `returnsNoChangesWhenAheadCountUnknown` — clean + missing remote-tracking ref → `.noChanges`, no push.

Full `swift test` suite green.

Closes #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)