### PR TITLE
fix(siri): prevent empty, undismissable Siri AI Readiness sheet

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -57,9 +57,8 @@ struct SiteWindow: View {
     @State private var startup = StartupProgressModel()
     /// Observed so an already-open window reacts to a `PreviewSiteIntent` navigation request.
     @State private var router = WindowRouter.shared
-    /// Drives the Siri AI Readiness sheet via `.sheet(item:)`: non-nil ⟺ presented. Coupling the
-    /// sheet to the model (rather than a separate Bool) makes an empty, undismissable sheet
-    /// impossible — the content always receives a non-nil model and "Done" nils it out.
+    /// Non-nil ⟺ the Siri AI Readiness sheet is presented (`.sheet(item:)`); coupling presentation
+    /// to the model rather than a separate Bool makes an empty, undismissable sheet impossible.
     @State private var siriReadinessModel: SiriReadinessModel?
 
     @Environment(\.openWindow) private var openWindow
@@ -251,13 +250,13 @@ struct SiteWindow: View {
             // Siri AI Readiness — secondary action, visible when a site is loaded.
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    // Only present when the model can actually be built — never flip on a
-                    // presentation flag independently of its content (that was the empty-sheet bug).
-                    if let indexer = contentIndexerStore.indexer {
-                        siriReadinessModel = SiriReadinessModel(
-                            probes: SiriReadinessProbes.site(siteID: site.id, graph: contentGraph, indexer: indexer)
-                        )
-                    }
+                    // Build the model only when absent and buildable: presenting without a model
+                    // is the empty-sheet bug; rebuilding while open flashes the sheet (new identity
+                    // → dismiss + re-present).
+                    guard siriReadinessModel == nil, let indexer = contentIndexerStore.indexer else { return }
+                    siriReadinessModel = SiriReadinessModel(
+                        probes: SiriReadinessProbes.site(siteID: site.id, graph: contentGraph, indexer: indexer)
+                    )
                 } label: {
                     Label("Siri AI Readiness", systemImage: "sparkles")
                 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -57,7 +57,9 @@ struct SiteWindow: View {
     @State private var startup = StartupProgressModel()
     /// Observed so an already-open window reacts to a `PreviewSiteIntent` navigation request.
     @State private var router = WindowRouter.shared
-    @State private var siriReadinessPresented = false
+    /// Drives the Siri AI Readiness sheet via `.sheet(item:)`: non-nil ⟺ presented. Coupling the
+    /// sheet to the model (rather than a separate Bool) makes an empty, undismissable sheet
+    /// impossible — the content always receives a non-nil model and "Done" nils it out.
     @State private var siriReadinessModel: SiriReadinessModel?
 
     @Environment(\.openWindow) private var openWindow
@@ -249,12 +251,13 @@ struct SiteWindow: View {
             // Siri AI Readiness — secondary action, visible when a site is loaded.
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    if siriReadinessModel == nil, let indexer = contentIndexerStore.indexer {
+                    // Only present when the model can actually be built — never flip on a
+                    // presentation flag independently of its content (that was the empty-sheet bug).
+                    if let indexer = contentIndexerStore.indexer {
                         siriReadinessModel = SiriReadinessModel(
                             probes: SiriReadinessProbes.site(siteID: site.id, graph: contentGraph, indexer: indexer)
                         )
                     }
-                    siriReadinessPresented = true
                 } label: {
                     Label("Siri AI Readiness", systemImage: "sparkles")
                 }
@@ -281,23 +284,21 @@ struct SiteWindow: View {
                 onRunAgain: { audit.audit(siteID: site.id, siteDirectory: site.path) }
             )
         }
-        .sheet(isPresented: $siriReadinessPresented) {
-            if let model = siriReadinessModel {
-                NavigationStack {
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text("Siri AI readiness for \u{201C}\(site.name)\u{201D}.")
-                                .font(.caption).foregroundStyle(.secondary)
-                            SiriReadinessList(model: model)
-                        }
-                        .padding()
+        .sheet(item: $siriReadinessModel) { model in
+            NavigationStack {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Siri AI readiness for \u{201C}\(site.name)\u{201D}.")
+                            .font(.caption).foregroundStyle(.secondary)
+                        SiriReadinessList(model: model)
                     }
-                    .frame(minWidth: 420, minHeight: 260)
-                    .navigationTitle("Siri AI Readiness")
-                    .toolbar {
-                        ToolbarItem(placement: .confirmationAction) {
-                            Button("Done") { siriReadinessPresented = false }
-                        }
+                    .padding()
+                }
+                .frame(minWidth: 420, minHeight: 260)
+                .navigationTitle("Siri AI Readiness")
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") { siriReadinessModel = nil }
                     }
                 }
             }

--- a/Sources/AnglesiteCore/SiriReadiness.swift
+++ b/Sources/AnglesiteCore/SiriReadiness.swift
@@ -43,7 +43,11 @@ public protocol ReadinessProbe: Sendable {
 /// for deterministic ordering.
 @MainActor
 @Observable
-public final class SiriReadinessModel {
+public final class SiriReadinessModel: Identifiable {
+    /// Identity for SwiftUI's `.sheet(item:)`, which drives the readiness sheet off this model's
+    /// existence — presenting it is impossible without a model, so the sheet can never render empty.
+    public nonisolated var id: ObjectIdentifier { ObjectIdentifier(self) }
+
     public private(set) var findings: [ReadinessFinding] = []
     public private(set) var isChecking: Bool = false
     public private(set) var lastChecked: Date?

--- a/Sources/AnglesiteCore/SiriReadiness.swift
+++ b/Sources/AnglesiteCore/SiriReadiness.swift
@@ -44,8 +44,7 @@ public protocol ReadinessProbe: Sendable {
 @MainActor
 @Observable
 public final class SiriReadinessModel: Identifiable {
-    /// Identity for SwiftUI's `.sheet(item:)`, which drives the readiness sheet off this model's
-    /// existence — presenting it is impossible without a model, so the sheet can never render empty.
+    // Identity lets the readiness sheet bind via `.sheet(item:)`.
     public nonisolated var id: ObjectIdentifier { ObjectIdentifier(self) }
 
     public private(set) var findings: [ReadinessFinding] = []


### PR DESCRIPTION
## Problem

Pressing the Siri ✨ (Siri AI Readiness) toolbar button could open an empty dialog with no contents and no way to close it.

## Root cause

The sheet was driven by a standalone `siriReadinessPresented` Bool that the toolbar button set to `true` **unconditionally**, while the sheet's content — including its only **Done** button — lived inside `if let model = siriReadinessModel`. When the model wasn't built (`contentIndexerStore.indexer` still `nil`: bootstrap unfinished or returned nil), the flag flipped anyway and the sheet presented empty with no dismiss control. The `.disabled(indexer == nil)` guard is meant to block the click, but the design still permitted the invalid "presented but no model" state.

## Fix

Make the invalid state unrepresentable by driving the sheet off the optional model itself:

- `SiriReadinessModel` conforms to `Identifiable` (stable `ObjectIdentifier`).
- `.sheet(isPresented:)` → `.sheet(item: $siriReadinessModel)` — the sheet exists **iff** a model exists, and the content always receives a non-nil model.
- The button sets the model only when the indexer is available (no independent presentation flag); **Done** nils the model out to dismiss. Esc also dismisses.

Behavior note: the model is now rebuilt on each open (probes re-run fresh) rather than cached for the window's lifetime — a minor, arguably better change.

## Verification

- `swift build --target AnglesiteCore` ✅
- `xcodebuild -scheme Anglesite` ✅ BUILD SUCCEEDED
- `swift test --filter SiriReadiness` ✅ 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)