### PR TITLE
feat(#242): .anglesite package model — Phase 1 (format core) + P2–P5 plans

### DIFF
--- a/Resources/AnglesiteMAS-Info.plist
+++ b/Resources/AnglesiteMAS-Info.plist
@@ -42,5 +42,43 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Anglesite Site</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSTypeIsPackage</key>
+			<true/>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>dev.anglesite.site</string>
+			</array>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>dev.anglesite.site</string>
+			<key>UTTypeDescription</key>
+			<string>Anglesite Site</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.apple.package</string>
+				<string>public.composite-content</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>anglesite</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Resources/AnglesiteMAS-Info.plist
+++ b/Resources/AnglesiteMAS-Info.plist
@@ -69,6 +69,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>com.apple.package</string>
+				<string>public.directory</string>
 				<string>public.composite-content</string>
 			</array>
 			<key>UTTypeTagSpecification</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -85,6 +85,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>com.apple.package</string>
+				<string>public.directory</string>
 				<string>public.composite-content</string>
 			</array>
 			<key>UTTypeTagSpecification</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -58,5 +58,43 @@
 	<true/>
 	<key>SUEnableInstallerLauncherService</key>
 	<false/>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Anglesite Site</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSTypeIsPackage</key>
+			<true/>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>dev.anglesite.site</string>
+			</array>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>dev.anglesite.site</string>
+			<key>UTTypeDescription</key>
+			<string>Anglesite Site</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.apple.package</string>
+				<string>public.composite-content</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>anglesite</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Sources/AnglesiteCore/AnglesitePackage.swift
+++ b/Sources/AnglesiteCore/AnglesitePackage.swift
@@ -24,7 +24,7 @@ public struct AnglesitePackage: Sendable, Equatable {
 
     // MARK: - Layout
 
-    public var infoPlistURL: URL { url.appendingPathComponent("Info.plist") }
+    public var infoPlistURL: URL { url.appendingPathComponent("Info.plist", isDirectory: false) }
     public var sourceURL: URL { url.appendingPathComponent("Source", isDirectory: true) }
     public var configURL: URL { url.appendingPathComponent("Config", isDirectory: true) }
 

--- a/Sources/AnglesiteCore/AnglesitePackage.swift
+++ b/Sources/AnglesiteCore/AnglesitePackage.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// A `.anglesite` package on disk: a Finder-opaque directory (UTI `dev.anglesite.site`,
+/// `LSTypeIsPackage`) that wraps a git-tracked `Source/` Astro project, an app-owned `Config/`
+/// directory, and an `Info.plist` marker carrying a stable site UUID + a format version.
+///
+/// This is the single source of truth for the package's internal layout. Recents discovery,
+/// scaffold/deploy working directories, and the per-site config store all resolve paths through
+/// here so the layout lives in exactly one file (spec §1).
+public struct AnglesitePackage: Sendable, Equatable {
+    /// Filename extension and package UTI suffix.
+    public static let packageExtension = "anglesite"
+
+    /// Current on-disk format. Bump when the layout changes in a way older builds can't safely
+    /// write; `Marker.formatVersion` is compared against this on open (see `compatibility(for:)`).
+    public static let currentFormatVersion = 1
+
+    /// The package directory (`…/Name.anglesite`).
+    public let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    // MARK: - Layout
+
+    public var infoPlistURL: URL { url.appendingPathComponent("Info.plist") }
+    public var sourceURL: URL { url.appendingPathComponent("Source", isDirectory: true) }
+    public var configURL: URL { url.appendingPathComponent("Config", isDirectory: true) }
+
+    // MARK: - Marker
+
+    /// The `Info.plist` marker: stable identity + format version + provenance. Encoded with
+    /// `PropertyListEncoder`, so `createdDate` is a native plist date and `siteID` a plist string.
+    public struct Marker: Sendable, Codable, Equatable {
+        public var formatVersion: Int
+        public var siteID: UUID
+        public var displayName: String
+        public var createdDate: Date
+
+        public init(
+            formatVersion: Int = AnglesitePackage.currentFormatVersion,
+            siteID: UUID = UUID(),
+            displayName: String,
+            createdDate: Date = Date()
+        ) {
+            self.formatVersion = formatVersion
+            self.siteID = siteID
+            self.displayName = displayName
+            self.createdDate = createdDate
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case formatVersion = "AnglesiteFormatVersion"
+            case siteID = "AnglesiteSiteID"
+            case displayName = "AnglesiteDisplayName"
+            case createdDate = "AnglesiteCreatedDate"
+        }
+    }
+
+    /// Reads and decodes the `Info.plist` marker. (Error cases handled in Task 2.)
+    public func readMarker(fileManager: FileManager = .default) throws -> Marker {
+        let data = try Data(contentsOf: infoPlistURL)
+        return try PropertyListDecoder().decode(Marker.self, from: data)
+    }
+
+    /// Writes the marker to `Info.plist` (XML plist, atomic), creating the package dir if needed.
+    public func writeMarker(_ marker: Marker, fileManager: FileManager = .default) throws {
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(marker)
+        try data.write(to: infoPlistURL, options: [.atomic])
+    }
+}

--- a/Sources/AnglesiteCore/AnglesitePackage.swift
+++ b/Sources/AnglesiteCore/AnglesitePackage.swift
@@ -58,10 +58,35 @@ public struct AnglesitePackage: Sendable, Equatable {
         }
     }
 
+    public enum PackageError: Error, Equatable, Sendable {
+        case markerMissing(URL)
+        case markerUnreadable(URL)
+    }
+
+    /// Forward-compatibility verdict for an opened package's marker.
+    public enum Compatibility: Sendable, Equatable {
+        /// Same format the app writes — fully editable.
+        case current
+        /// Written by a newer build than this one. Open read-only and prompt to upgrade rather
+        /// than silently rewriting a format we don't understand (spec §9).
+        case readOnlyTooNew
+    }
+
+    public static func compatibility(for marker: Marker) -> Compatibility {
+        marker.formatVersion > currentFormatVersion ? .readOnlyTooNew : .current
+    }
+
     /// Reads and decodes the `Info.plist` marker. (Error cases handled in Task 2.)
     public func readMarker(fileManager: FileManager = .default) throws -> Marker {
-        let data = try Data(contentsOf: infoPlistURL)
-        return try PropertyListDecoder().decode(Marker.self, from: data)
+        guard fileManager.fileExists(atPath: infoPlistURL.path) else {
+            throw PackageError.markerMissing(infoPlistURL)
+        }
+        do {
+            let data = try Data(contentsOf: infoPlistURL)
+            return try PropertyListDecoder().decode(Marker.self, from: data)
+        } catch {
+            throw PackageError.markerUnreadable(infoPlistURL)
+        }
     }
 
     /// Writes the marker to `Info.plist` (XML plist, atomic), creating the package dir if needed.

--- a/Sources/AnglesiteCore/AnglesitePackage.swift
+++ b/Sources/AnglesiteCore/AnglesitePackage.swift
@@ -97,4 +97,39 @@ public struct AnglesitePackage: Sendable, Equatable {
         let data = try encoder.encode(marker)
         try data.write(to: infoPlistURL, options: [.atomic])
     }
+
+    // MARK: - Creation
+
+    /// Creates an empty package skeleton: the package dir, `Source/`, `Config/`, and a freshly
+    /// stamped `Info.plist`. Does **not** scaffold the Astro project — that runs later with cwd =
+    /// `sourceURL` (P2). Returns the package and its new marker.
+    @discardableResult
+    public static func createSkeleton(
+        at url: URL,
+        displayName: String,
+        fileManager: FileManager = .default
+    ) throws -> (AnglesitePackage, Marker) {
+        let pkg = AnglesitePackage(url: url)
+        try fileManager.createDirectory(at: pkg.sourceURL, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: pkg.configURL, withIntermediateDirectories: true)
+        // Round date to nearest second to match plist XML precision (seconds only, no fractional part)
+        let now = Date()
+        let roundedDate = Date(timeIntervalSinceReferenceDate: floor(now.timeIntervalSinceReferenceDate))
+        let marker = Marker(displayName: displayName, createdDate: roundedDate)
+        try pkg.writeMarker(marker, fileManager: fileManager)
+        return (pkg, marker)
+    }
+
+    // MARK: - Detection & validation
+
+    /// `true` when `url` is a `.anglesite` directory carrying a readable marker.
+    public static func isPackage(at url: URL, fileManager: FileManager = .default) -> Bool {
+        guard url.pathExtension == packageExtension else { return false }
+        return (try? AnglesitePackage(url: url).readMarker(fileManager: fileManager)) != nil
+    }
+
+    /// Validates the `Source/` tree against the Anglesite project sentinels.
+    public func sourceValidation(fileManager: FileManager = .default) -> ProjectValidator.Result {
+        ProjectValidator.validate(sourceURL, fileManager: fileManager)
+    }
 }

--- a/Sources/AnglesiteCore/AnglesitePackage.swift
+++ b/Sources/AnglesiteCore/AnglesitePackage.swift
@@ -47,7 +47,11 @@ public struct AnglesitePackage: Sendable, Equatable {
             self.formatVersion = formatVersion
             self.siteID = siteID
             self.displayName = displayName
-            self.createdDate = createdDate
+            // XML property-list <date> values have whole-second granularity, so we truncate to
+            // a second boundary here. This keeps an in-memory Marker equal to the one decoded
+            // back from Info.plist (the writeMarker→readMarker round-trip contract).
+            self.createdDate = Date(timeIntervalSinceReferenceDate:
+                floor(createdDate.timeIntervalSinceReferenceDate))
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -112,10 +116,7 @@ public struct AnglesitePackage: Sendable, Equatable {
         let pkg = AnglesitePackage(url: url)
         try fileManager.createDirectory(at: pkg.sourceURL, withIntermediateDirectories: true)
         try fileManager.createDirectory(at: pkg.configURL, withIntermediateDirectories: true)
-        // Round date to nearest second to match plist XML precision (seconds only, no fractional part)
-        let now = Date()
-        let roundedDate = Date(timeIntervalSinceReferenceDate: floor(now.timeIntervalSinceReferenceDate))
-        let marker = Marker(displayName: displayName, createdDate: roundedDate)
+        let marker = Marker(displayName: displayName)
         try pkg.writeMarker(marker, fileManager: fileManager)
         return (pkg, marker)
     }

--- a/Sources/AnglesiteCore/AnglesitePackage.swift
+++ b/Sources/AnglesiteCore/AnglesitePackage.swift
@@ -33,10 +33,13 @@ public struct AnglesitePackage: Sendable, Equatable {
     /// The `Info.plist` marker: stable identity + format version + provenance. Encoded with
     /// `PropertyListEncoder`, so `createdDate` is a native plist date and `siteID` a plist string.
     public struct Marker: Sendable, Codable, Equatable {
-        public var formatVersion: Int
-        public var siteID: UUID
+        // Identity + provenance are immutable: the point of the UUID redesign is that a package's
+        // identity never changes after creation. Only `displayName` has a legitimate reason to
+        // change (a rename), so it stays `var`.
+        public let formatVersion: Int
+        public let siteID: UUID
         public var displayName: String
-        public var createdDate: Date
+        public let createdDate: Date
 
         public init(
             formatVersion: Int = AnglesitePackage.currentFormatVersion,
@@ -62,9 +65,17 @@ public struct AnglesitePackage: Sendable, Equatable {
         }
     }
 
-    public enum PackageError: Error, Equatable, Sendable {
+    public enum PackageError: Error, Sendable {
+        /// `Info.plist` is absent (or was deleted out from under us).
         case markerMissing(URL)
-        case markerUnreadable(URL)
+        /// `Info.plist` exists but couldn't be read or decoded. Carries the underlying cause so a
+        /// permission error, a corrupt plist, and a decode mismatch are distinguishable downstream.
+        case markerUnreadable(URL, underlying: Error)
+        /// Refused to overwrite a marker written by a newer build (`.readOnlyTooNew`), per spec §9.
+        case markerTooNew(URL)
+        /// `createSkeleton` target already exists — overwriting would mint a new UUID and destroy
+        /// the existing site's stable identity.
+        case alreadyExists(URL)
     }
 
     /// Forward-compatibility verdict for an opened package's marker.
@@ -80,21 +91,32 @@ public struct AnglesitePackage: Sendable, Equatable {
         marker.formatVersion > currentFormatVersion ? .readOnlyTooNew : .current
     }
 
-    /// Reads and decodes the `Info.plist` marker. (Error cases handled in Task 2.)
+    /// Reads and decodes the `Info.plist` marker.
+    ///
+    /// No separate existence check: that would be a TOCTOU race (the file could vanish between the
+    /// check and the read). Instead we let `Data(contentsOf:)` throw and classify — a no-such-file
+    /// `CocoaError` becomes `.markerMissing`, anything else `.markerUnreadable` carrying the cause.
     public func readMarker(fileManager: FileManager = .default) throws -> Marker {
-        guard fileManager.fileExists(atPath: infoPlistURL.path) else {
-            throw PackageError.markerMissing(infoPlistURL)
-        }
         do {
             let data = try Data(contentsOf: infoPlistURL)
             return try PropertyListDecoder().decode(Marker.self, from: data)
+        } catch let error as CocoaError where error.code == .fileNoSuchFile || error.code == .fileReadNoSuchFile {
+            throw PackageError.markerMissing(infoPlistURL)
         } catch {
-            throw PackageError.markerUnreadable(infoPlistURL)
+            throw PackageError.markerUnreadable(infoPlistURL, underlying: error)
         }
     }
 
     /// Writes the marker to `Info.plist` (XML plist, atomic), creating the package dir if needed.
+    ///
+    /// Refuses to overwrite a marker written by a newer build (`.readOnlyTooNew`) so we never
+    /// silently downgrade a format we don't understand (spec §9). A fresh package has no marker
+    /// yet — `readMarker` throws, the `try?` yields `nil`, and creation proceeds.
     public func writeMarker(_ marker: Marker, fileManager: FileManager = .default) throws {
+        if let existing = try? readMarker(fileManager: fileManager),
+           AnglesitePackage.compatibility(for: existing) == .readOnlyTooNew {
+            throw PackageError.markerTooNew(infoPlistURL)
+        }
         try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
         let encoder = PropertyListEncoder()
         encoder.outputFormat = .xml
@@ -113,24 +135,58 @@ public struct AnglesitePackage: Sendable, Equatable {
         displayName: String,
         fileManager: FileManager = .default
     ) throws -> (AnglesitePackage, Marker) {
+        // Refuse to scaffold over an existing path: overwriting would mint a new UUID and silently
+        // destroy the existing site's stable identity (spec §9).
+        guard !fileManager.fileExists(atPath: url.path) else {
+            throw PackageError.alreadyExists(url)
+        }
         let pkg = AnglesitePackage(url: url)
+        // Roll back a half-written package if any step fails (disk full, permissions), so a failed
+        // create never leaves an orphaned partial package behind (spec §9).
+        var succeeded = false
+        defer { if !succeeded { try? fileManager.removeItem(at: url) } }
         try fileManager.createDirectory(at: pkg.sourceURL, withIntermediateDirectories: true)
         try fileManager.createDirectory(at: pkg.configURL, withIntermediateDirectories: true)
         let marker = Marker(displayName: displayName)
         try pkg.writeMarker(marker, fileManager: fileManager)
+        succeeded = true
         return (pkg, marker)
     }
 
     // MARK: - Detection & validation
 
-    /// `true` when `url` is a `.anglesite` directory carrying a readable marker.
+    /// `true` when `url` is a `.anglesite` **directory** carrying a readable marker. A regular file
+    /// with the `.anglesite` extension is not a package.
     public static func isPackage(at url: URL, fileManager: FileManager = .default) -> Bool {
         guard url.pathExtension == packageExtension else { return false }
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else { return false }
         return (try? AnglesitePackage(url: url).readMarker(fileManager: fileManager)) != nil
     }
 
     /// Validates the `Source/` tree against the Anglesite project sentinels.
     public func sourceValidation(fileManager: FileManager = .default) -> ProjectValidator.Result {
         ProjectValidator.validate(sourceURL, fileManager: fileManager)
+    }
+
+    /// Two packages are equal when they point at the same standardized location, so a path with a
+    /// trailing slash or `..` segment compares equal to its canonical form. (Symlink-level identity
+    /// is handled by `SiteStore`'s canonicalization at the recents layer.)
+    public static func == (lhs: AnglesitePackage, rhs: AnglesitePackage) -> Bool {
+        lhs.url.standardizedFileURL == rhs.url.standardizedFileURL
+    }
+}
+
+extension AnglesitePackage.PackageError: Equatable {
+    /// Equality by case + URL; the `markerUnreadable` underlying error is excluded (`Error` isn't
+    /// `Equatable`), so callers and tests can match on the case without constructing a cause.
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case let (.markerMissing(a), .markerMissing(b)): return a == b
+        case let (.markerUnreadable(a, _), .markerUnreadable(b, _)): return a == b
+        case let (.markerTooNew(a), .markerTooNew(b)): return a == b
+        case let (.alreadyExists(a), .alreadyExists(b)): return a == b
+        default: return false
+        }
     }
 }

--- a/Sources/AnglesiteCore/UTType+Anglesite.swift
+++ b/Sources/AnglesiteCore/UTType+Anglesite.swift
@@ -1,0 +1,13 @@
+import UniformTypeIdentifiers
+
+public extension UTType {
+    /// The `.anglesite` site package type the app exports (declared in both targets' Info.plist as
+    /// `dev.anglesite.site`).
+    ///
+    /// Uses `exportedAs:` (non-failable) rather than `UTType("dev.anglesite.site")` (failable):
+    /// the failable initializer returns `nil` when the UTI hasn't been registered in the current
+    /// process — which includes `swift test`/CI contexts — and a `nil` slipped into
+    /// `NSOpenPanel.allowedContentTypes` silently makes the panel accept every file type. All
+    /// call sites should use `.anglesiteSite`.
+    static let anglesiteSite = UTType(exportedAs: "dev.anglesite.site")
+}

--- a/Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
+++ b/Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
@@ -30,7 +30,7 @@ struct AnglesitePackageTests {
         let pkg = AnglesitePackage(url: dir.appendingPathComponent("Acme.anglesite", isDirectory: true))
 
         let marker = AnglesitePackage.Marker(
-            siteID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            siteID: UUID(),
             displayName: "Acme",
             createdDate: Date(timeIntervalSince1970: 1_700_000_000)
         )
@@ -66,25 +66,32 @@ struct AnglesitePackageTests {
         }
     }
 
-    @Test("readMarker throws markerUnreadable when Info.plist is corrupt")
+    @Test("readMarker throws markerUnreadable (carrying the cause) when Info.plist is corrupt")
     func readMarkerCorrupt() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pkg = AnglesitePackage(url: dir.appendingPathComponent("Bad.anglesite", isDirectory: true))
         try FileManager.default.createDirectory(at: pkg.url, withIntermediateDirectories: true)
         try Data("not a plist".utf8).write(to: pkg.infoPlistURL)
-        #expect(throws: AnglesitePackage.PackageError.markerUnreadable(pkg.infoPlistURL)) {
-            try pkg.readMarker()
+        do {
+            _ = try pkg.readMarker()
+            Issue.record("expected readMarker to throw")
+        } catch let AnglesitePackage.PackageError.markerUnreadable(url, underlying) {
+            #expect(url == pkg.infoPlistURL)
+            #expect(!(underlying is AnglesitePackage.PackageError), "underlying should be the real decode/read error")
         }
     }
 
-    @Test("compatibility flags a newer format version as read-only")
+    @Test("compatibility: equal or older format is current; newer is read-only")
     func compatibilityGate() {
         let current = AnglesitePackage.Marker(
             formatVersion: AnglesitePackage.currentFormatVersion, displayName: "A")
         let future = AnglesitePackage.Marker(
             formatVersion: AnglesitePackage.currentFormatVersion + 1, displayName: "B")
+        // An older format opened by a newer build stays editable (guards against a `>=` typo).
+        let past = AnglesitePackage.Marker(formatVersion: 0, displayName: "C")
         #expect(AnglesitePackage.compatibility(for: current) == .current)
+        #expect(AnglesitePackage.compatibility(for: past) == .current)
         #expect(AnglesitePackage.compatibility(for: future) == .readOnlyTooNew)
     }
 
@@ -113,10 +120,67 @@ struct AnglesitePackageTests {
         try FileManager.default.createDirectory(at: wrongExt, withIntermediateDirectories: true)
         let noMarker = dir.appendingPathComponent("Hollow.anglesite", isDirectory: true)
         try FileManager.default.createDirectory(at: noMarker, withIntermediateDirectories: true)
+        // A regular file with the package extension is not a package.
+        let fileNotDir = dir.appendingPathComponent("File.anglesite", isDirectory: false)
+        try Data("x".utf8).write(to: fileNotDir)
 
         #expect(AnglesitePackage.isPackage(at: good))
         #expect(!AnglesitePackage.isPackage(at: wrongExt))
         #expect(!AnglesitePackage.isPackage(at: noMarker))
+        #expect(!AnglesitePackage.isPackage(at: fileNotDir))
+    }
+
+    @Test("createSkeleton refuses to overwrite an existing path (protects the site UUID)")
+    func createSkeletonRejectsExisting() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkgURL = dir.appendingPathComponent("Dupe.anglesite", isDirectory: true)
+        let (_, first) = try AnglesitePackage.createSkeleton(at: pkgURL, displayName: "Dupe")
+
+        #expect(throws: AnglesitePackage.PackageError.alreadyExists(pkgURL)) {
+            _ = try AnglesitePackage.createSkeleton(at: pkgURL, displayName: "Dupe2")
+        }
+        // The original marker (and its UUID) is untouched.
+        #expect(try AnglesitePackage(url: pkgURL).readMarker().siteID == first.siteID)
+    }
+
+    /// A FileManager that fails when asked to create the `Config/` directory, to exercise the
+    /// mid-creation rollback in `createSkeleton` (Source/ created, then Config/ throws).
+    private final class FailOnConfigFileManager: FileManager, @unchecked Sendable {
+        override func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool,
+                                      attributes: [FileAttributeKey: Any]? = nil) throws {
+            if url.lastPathComponent == "Config" { throw CocoaError(.fileWriteNoPermission) }
+            try super.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attributes)
+        }
+    }
+
+    @Test("createSkeleton rolls back the half-written package when a later step fails")
+    func createSkeletonRollsBackOnFailure() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkgURL = dir.appendingPathComponent("Boom.anglesite", isDirectory: true)
+
+        #expect(throws: (any Error).self) {
+            _ = try AnglesitePackage.createSkeleton(at: pkgURL, displayName: "Boom", fileManager: FailOnConfigFileManager())
+        }
+        // Source/ was created before Config/ failed; the defer must have removed the whole package.
+        #expect(!FileManager.default.fileExists(atPath: pkgURL.path))
+    }
+
+    @Test("sourceValidation distinguishes missing-required from a partially-populated Source/")
+    func sourceValidationPartialRequired() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let (pkg, _) = try AnglesitePackage.createSkeleton(
+            at: dir.appendingPathComponent("Partial.anglesite", isDirectory: true), displayName: "Partial")
+
+        // Write only the first required sentinel; at least one required remains missing → invalid.
+        let first = try #require(ProjectValidator.requiredSentinels.first)
+        try Data("{}".utf8).write(to: pkg.sourceURL.appendingPathComponent(first))
+        let result = pkg.sourceValidation()
+        #expect(!result.isValid)
+        #expect(!result.missingRequired.isEmpty)
+        #expect(!result.missingRequired.contains(first))
     }
 
     @Test("sourceValidation reports missing sentinels in Source/")

--- a/Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
+++ b/Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for `AnglesitePackage` (#242, P1): the `.anglesite` package on-disk format —
+/// layout URLs and the `Info.plist` marker round-trip.
+struct AnglesitePackageTests {
+    /// A fresh temp directory per test; caller removes it.
+    private func makeTempDir() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("anglesite-pkg-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("layout URLs resolve under the package directory")
+    func layoutURLs() throws {
+        let pkgURL = URL(fileURLWithPath: "/tmp/Acme.anglesite", isDirectory: true)
+        let pkg = AnglesitePackage(url: pkgURL)
+        #expect(pkg.infoPlistURL.lastPathComponent == "Info.plist")
+        #expect(pkg.sourceURL.lastPathComponent == "Source")
+        #expect(pkg.configURL.lastPathComponent == "Config")
+        #expect(pkg.sourceURL.deletingLastPathComponent().path == pkgURL.path)
+    }
+
+    @Test("marker written to Info.plist round-trips through read")
+    func markerRoundTrips() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkg = AnglesitePackage(url: dir.appendingPathComponent("Acme.anglesite", isDirectory: true))
+
+        let marker = AnglesitePackage.Marker(
+            siteID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            displayName: "Acme",
+            createdDate: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        try pkg.writeMarker(marker)
+
+        #expect(FileManager.default.fileExists(atPath: pkg.infoPlistURL.path))
+        let read = try pkg.readMarker()
+        #expect(read == marker)
+        #expect(read.formatVersion == AnglesitePackage.currentFormatVersion)
+    }
+
+    @Test("Info.plist uses the spec's exact marker keys")
+    func markerUsesSpecKeys() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkg = AnglesitePackage(url: dir.appendingPathComponent("Acme.anglesite", isDirectory: true))
+        try pkg.writeMarker(.init(displayName: "Acme"))
+
+        let plist = try #require(NSDictionary(contentsOf: pkg.infoPlistURL))
+        #expect(plist["AnglesiteFormatVersion"] != nil)
+        #expect(plist["AnglesiteSiteID"] != nil)
+        #expect(plist["AnglesiteDisplayName"] as? String == "Acme")
+        #expect(plist["AnglesiteCreatedDate"] != nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
+++ b/Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
@@ -87,4 +87,52 @@ struct AnglesitePackageTests {
         #expect(AnglesitePackage.compatibility(for: current) == .current)
         #expect(AnglesitePackage.compatibility(for: future) == .readOnlyTooNew)
     }
+
+    @Test("createSkeleton lays down Source/, Config/, and a stamped marker")
+    func createSkeletonLaysDownLayout() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkgURL = dir.appendingPathComponent("Acme.anglesite", isDirectory: true)
+
+        let (pkg, marker) = try AnglesitePackage.createSkeleton(at: pkgURL, displayName: "Acme")
+
+        var isDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: pkg.sourceURL.path, isDirectory: &isDir) && isDir.boolValue)
+        #expect(FileManager.default.fileExists(atPath: pkg.configURL.path, isDirectory: &isDir) && isDir.boolValue)
+        #expect(marker.displayName == "Acme")
+        #expect(try pkg.readMarker() == marker)
+    }
+
+    @Test("isPackage is true only for an .anglesite dir with a readable marker")
+    func isPackageDetection() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let good = dir.appendingPathComponent("Good.anglesite", isDirectory: true)
+        _ = try AnglesitePackage.createSkeleton(at: good, displayName: "Good")
+        let wrongExt = dir.appendingPathComponent("Plain", isDirectory: true)
+        try FileManager.default.createDirectory(at: wrongExt, withIntermediateDirectories: true)
+        let noMarker = dir.appendingPathComponent("Hollow.anglesite", isDirectory: true)
+        try FileManager.default.createDirectory(at: noMarker, withIntermediateDirectories: true)
+
+        #expect(AnglesitePackage.isPackage(at: good))
+        #expect(!AnglesitePackage.isPackage(at: wrongExt))
+        #expect(!AnglesitePackage.isPackage(at: noMarker))
+    }
+
+    @Test("sourceValidation reports missing sentinels in Source/")
+    func sourceValidationReportsMissing() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkgURL = dir.appendingPathComponent("Acme.anglesite", isDirectory: true)
+        let (pkg, _) = try AnglesitePackage.createSkeleton(at: pkgURL, displayName: "Acme")
+
+        // Empty Source/: invalid (all required sentinels missing).
+        #expect(!pkg.sourceValidation().isValid)
+
+        // Drop the required sentinels into Source/: now valid.
+        for name in ProjectValidator.requiredSentinels {
+            try Data("{}".utf8).write(to: pkg.sourceURL.appendingPathComponent(name))
+        }
+        #expect(pkg.sourceValidation().isValid)
+    }
 }

--- a/Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
+++ b/Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
@@ -55,4 +55,36 @@ struct AnglesitePackageTests {
         #expect(plist["AnglesiteDisplayName"] as? String == "Acme")
         #expect(plist["AnglesiteCreatedDate"] != nil)
     }
+
+    @Test("readMarker throws markerMissing when Info.plist is absent")
+    func readMarkerMissing() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkg = AnglesitePackage(url: dir.appendingPathComponent("Empty.anglesite", isDirectory: true))
+        #expect(throws: AnglesitePackage.PackageError.markerMissing(pkg.infoPlistURL)) {
+            try pkg.readMarker()
+        }
+    }
+
+    @Test("readMarker throws markerUnreadable when Info.plist is corrupt")
+    func readMarkerCorrupt() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkg = AnglesitePackage(url: dir.appendingPathComponent("Bad.anglesite", isDirectory: true))
+        try FileManager.default.createDirectory(at: pkg.url, withIntermediateDirectories: true)
+        try Data("not a plist".utf8).write(to: pkg.infoPlistURL)
+        #expect(throws: AnglesitePackage.PackageError.markerUnreadable(pkg.infoPlistURL)) {
+            try pkg.readMarker()
+        }
+    }
+
+    @Test("compatibility flags a newer format version as read-only")
+    func compatibilityGate() {
+        let current = AnglesitePackage.Marker(
+            formatVersion: AnglesitePackage.currentFormatVersion, displayName: "A")
+        let future = AnglesitePackage.Marker(
+            formatVersion: AnglesitePackage.currentFormatVersion + 1, displayName: "B")
+        #expect(AnglesitePackage.compatibility(for: current) == .current)
+        #expect(AnglesitePackage.compatibility(for: future) == .readOnlyTooNew)
+    }
 }

--- a/docs/superpowers/plans/2026-06-19-anglesite-package-model-p1-format-core.md
+++ b/docs/superpowers/plans/2026-06-19-anglesite-package-model-p1-format-core.md
@@ -1,0 +1,571 @@
+# `.anglesite` Package Model — Phase 1 (Format Core) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish the `.anglesite` package on-disk format — a `Source/` + `Config/` + `Info.plist`-marker layout with stable-UUID identity and a format-version gate — plus the macOS type declarations (UTI + `CFBundleDocumentTypes`) that make Finder treat it as an editable package.
+
+**Architecture:** A single `AnglesitePackage` value type in `AnglesiteCore` owns all knowledge of the package's internal layout and marker (`Info.plist`) read/write/create. Everything later (recents registry, scaffold/deploy cwd, config store) resolves paths through it, so the layout lives in exactly one file. Type declarations land in both targets' `Info.plist` files.
+
+**Tech Stack:** Swift 5.10 / SwiftPM (`AnglesiteCore` library), Swift Testing (`@Test`), `PropertyListEncoder`/`Decoder` for the marker, XcodeGen (`project.yml`) for the app targets.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-19-anglesite-package-model-design.md`. This is Phase 1 (P1) of that spec. Phases P2–P5 are separate plans.
+- **Toolchain:** prefix every `swift test` / `xcodegen` / `xcodebuild` command with `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` — the default `xcode-select` can't run `swift test`.
+- **ES Modules / Swift 6 concurrency:** `SWIFT_STRICT_CONCURRENCY: complete`. New types crossing actor/task boundaries must be `Sendable`.
+- **Testing framework:** new tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`), not XCTest. Tests live in `Tests/AnglesiteCoreTests/`, run on CI (no hosted app target), and inject a temp `FileManager`/URL — never touch real user dirs.
+- **Layout (verbatim from spec §1):** package dir `<Name>.anglesite` with `LSTypeIsPackage`; children `Info.plist` (marker), `Source/` (git repo, the Astro project), `Config/` (app-owned, not in git).
+- **Marker keys (verbatim from spec §1):** `AnglesiteFormatVersion` (Int), `AnglesiteSiteID` (String UUID), `AnglesiteDisplayName` (String), `AnglesiteCreatedDate` (Date).
+- **UTI (verbatim from spec §2):** exported type `dev.anglesite.site`, conforms to `com.apple.package` + `public.composite-content`, filename extension `anglesite`; a `CFBundleDocumentTypes` Editor entry with `LSTypeIsPackage` and `LSItemContentTypes = [dev.anglesite.site]`. Added to **both** targets (`Resources/Info.plist` and `Resources/AnglesiteMAS-Info.plist`).
+- **Branch:** `feat/242-anglesite-package-model` (already created).
+- **Commit style:** Conventional Commits; scope `(#242)`. End each commit body with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: `AnglesitePackage` layout + marker round-trip
+
+Create the core type with its layout URLs and `Info.plist` marker read/write.
+
+**Files:**
+- Create: `Sources/AnglesiteCore/AnglesitePackage.swift`
+- Test: `Tests/AnglesiteCoreTests/AnglesitePackageTests.swift`
+
+**Interfaces:**
+- Consumes: `ProjectValidator` (existing, `Sources/AnglesiteCore/ProjectValidator.swift`).
+- Produces (relied on by later tasks and P2+):
+  - `struct AnglesitePackage: Sendable, Equatable { let url: URL; init(url: URL) }`
+  - `static let packageExtension = "anglesite"`
+  - `static let currentFormatVersion = 1`
+  - `var infoPlistURL: URL`, `var sourceURL: URL`, `var configURL: URL`
+  - `struct AnglesitePackage.Marker: Sendable, Codable, Equatable` with `formatVersion: Int`, `siteID: UUID`, `displayName: String`, `createdDate: Date`
+  - `func readMarker(fileManager:) throws -> Marker`
+  - `func writeMarker(_:fileManager:) throws`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteCoreTests/AnglesitePackageTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for `AnglesitePackage` (#242, P1): the `.anglesite` package on-disk format —
+/// layout URLs and the `Info.plist` marker round-trip.
+struct AnglesitePackageTests {
+    /// A fresh temp directory per test; caller removes it.
+    private func makeTempDir() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("anglesite-pkg-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("layout URLs resolve under the package directory")
+    func layoutURLs() throws {
+        let pkgURL = URL(fileURLWithPath: "/tmp/Acme.anglesite", isDirectory: true)
+        let pkg = AnglesitePackage(url: pkgURL)
+        #expect(pkg.infoPlistURL.lastPathComponent == "Info.plist")
+        #expect(pkg.sourceURL.lastPathComponent == "Source")
+        #expect(pkg.configURL.lastPathComponent == "Config")
+        #expect(pkg.sourceURL.deletingLastPathComponent().path == pkgURL.path)
+    }
+
+    @Test("marker written to Info.plist round-trips through read")
+    func markerRoundTrips() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkg = AnglesitePackage(url: dir.appendingPathComponent("Acme.anglesite", isDirectory: true))
+
+        let marker = AnglesitePackage.Marker(
+            siteID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            displayName: "Acme",
+            createdDate: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        try pkg.writeMarker(marker)
+
+        #expect(FileManager.default.fileExists(atPath: pkg.infoPlistURL.path))
+        let read = try pkg.readMarker()
+        #expect(read == marker)
+        #expect(read.formatVersion == AnglesitePackage.currentFormatVersion)
+    }
+
+    @Test("Info.plist uses the spec's exact marker keys")
+    func markerUsesSpecKeys() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkg = AnglesitePackage(url: dir.appendingPathComponent("Acme.anglesite", isDirectory: true))
+        try pkg.writeMarker(.init(displayName: "Acme"))
+
+        let plist = try #require(NSDictionary(contentsOf: pkg.infoPlistURL))
+        #expect(plist["AnglesiteFormatVersion"] != nil)
+        #expect(plist["AnglesiteSiteID"] != nil)
+        #expect(plist["AnglesiteDisplayName"] as? String == "Acme")
+        #expect(plist["AnglesiteCreatedDate"] != nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesitePackageTests`
+Expected: FAIL — `cannot find 'AnglesitePackage' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `Sources/AnglesiteCore/AnglesitePackage.swift`:
+
+```swift
+import Foundation
+
+/// A `.anglesite` package on disk: a Finder-opaque directory (UTI `dev.anglesite.site`,
+/// `LSTypeIsPackage`) that wraps a git-tracked `Source/` Astro project, an app-owned `Config/`
+/// directory, and an `Info.plist` marker carrying a stable site UUID + a format version.
+///
+/// This is the single source of truth for the package's internal layout. Recents discovery,
+/// scaffold/deploy working directories, and the per-site config store all resolve paths through
+/// here so the layout lives in exactly one file (spec §1).
+public struct AnglesitePackage: Sendable, Equatable {
+    /// Filename extension and package UTI suffix.
+    public static let packageExtension = "anglesite"
+
+    /// Current on-disk format. Bump when the layout changes in a way older builds can't safely
+    /// write; `Marker.formatVersion` is compared against this on open (see `compatibility(for:)`).
+    public static let currentFormatVersion = 1
+
+    /// The package directory (`…/Name.anglesite`).
+    public let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    // MARK: - Layout
+
+    public var infoPlistURL: URL { url.appendingPathComponent("Info.plist") }
+    public var sourceURL: URL { url.appendingPathComponent("Source", isDirectory: true) }
+    public var configURL: URL { url.appendingPathComponent("Config", isDirectory: true) }
+
+    // MARK: - Marker
+
+    /// The `Info.plist` marker: stable identity + format version + provenance. Encoded with
+    /// `PropertyListEncoder`, so `createdDate` is a native plist date and `siteID` a plist string.
+    public struct Marker: Sendable, Codable, Equatable {
+        public var formatVersion: Int
+        public var siteID: UUID
+        public var displayName: String
+        public var createdDate: Date
+
+        public init(
+            formatVersion: Int = AnglesitePackage.currentFormatVersion,
+            siteID: UUID = UUID(),
+            displayName: String,
+            createdDate: Date = Date()
+        ) {
+            self.formatVersion = formatVersion
+            self.siteID = siteID
+            self.displayName = displayName
+            self.createdDate = createdDate
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case formatVersion = "AnglesiteFormatVersion"
+            case siteID = "AnglesiteSiteID"
+            case displayName = "AnglesiteDisplayName"
+            case createdDate = "AnglesiteCreatedDate"
+        }
+    }
+
+    /// Reads and decodes the `Info.plist` marker. (Error cases handled in Task 2.)
+    public func readMarker(fileManager: FileManager = .default) throws -> Marker {
+        let data = try Data(contentsOf: infoPlistURL)
+        return try PropertyListDecoder().decode(Marker.self, from: data)
+    }
+
+    /// Writes the marker to `Info.plist` (XML plist, atomic), creating the package dir if needed.
+    public func writeMarker(_ marker: Marker, fileManager: FileManager = .default) throws {
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(marker)
+        try data.write(to: infoPlistURL, options: [.atomic])
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesitePackageTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/AnglesitePackage.swift Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
+git commit -m "$(cat <<'EOF'
+feat(#242): AnglesitePackage layout + Info.plist marker round-trip
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Marker error handling + format-version gating
+
+Make `readMarker` throw typed errors for a missing/corrupt marker, and add the
+forward-compat gate that flags a newer-than-known format as read-only.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/AnglesitePackage.swift`
+- Test: `Tests/AnglesiteCoreTests/AnglesitePackageTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `enum AnglesitePackage.PackageError: Error, Equatable, Sendable { case markerMissing(URL); case markerUnreadable(URL) }`
+  - `enum AnglesitePackage.Compatibility: Sendable, Equatable { case current; case readOnlyTooNew }`
+  - `static func compatibility(for: Marker) -> Compatibility`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/AnglesiteCoreTests/AnglesitePackageTests.swift` (inside the struct):
+
+```swift
+    @Test("readMarker throws markerMissing when Info.plist is absent")
+    func readMarkerMissing() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkg = AnglesitePackage(url: dir.appendingPathComponent("Empty.anglesite", isDirectory: true))
+        #expect(throws: AnglesitePackage.PackageError.markerMissing(pkg.infoPlistURL)) {
+            try pkg.readMarker()
+        }
+    }
+
+    @Test("readMarker throws markerUnreadable when Info.plist is corrupt")
+    func readMarkerCorrupt() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkg = AnglesitePackage(url: dir.appendingPathComponent("Bad.anglesite", isDirectory: true))
+        try FileManager.default.createDirectory(at: pkg.url, withIntermediateDirectories: true)
+        try Data("not a plist".utf8).write(to: pkg.infoPlistURL)
+        #expect(throws: AnglesitePackage.PackageError.markerUnreadable(pkg.infoPlistURL)) {
+            try pkg.readMarker()
+        }
+    }
+
+    @Test("compatibility flags a newer format version as read-only")
+    func compatibilityGate() {
+        let current = AnglesitePackage.Marker(
+            formatVersion: AnglesitePackage.currentFormatVersion, displayName: "A")
+        let future = AnglesitePackage.Marker(
+            formatVersion: AnglesitePackage.currentFormatVersion + 1, displayName: "B")
+        #expect(AnglesitePackage.compatibility(for: current) == .current)
+        #expect(AnglesitePackage.compatibility(for: future) == .readOnlyTooNew)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesitePackageTests`
+Expected: FAIL — `cannot find 'PackageError'` / `cannot find 'compatibility'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteCore/AnglesitePackage.swift`, add the error + compatibility types and update `readMarker`. Add after the `Marker` struct:
+
+```swift
+    public enum PackageError: Error, Equatable, Sendable {
+        case markerMissing(URL)
+        case markerUnreadable(URL)
+    }
+
+    /// Forward-compatibility verdict for an opened package's marker.
+    public enum Compatibility: Sendable, Equatable {
+        /// Same format the app writes — fully editable.
+        case current
+        /// Written by a newer build than this one. Open read-only and prompt to upgrade rather
+        /// than silently rewriting a format we don't understand (spec §9).
+        case readOnlyTooNew
+    }
+
+    public static func compatibility(for marker: Marker) -> Compatibility {
+        marker.formatVersion > currentFormatVersion ? .readOnlyTooNew : .current
+    }
+```
+
+Replace the body of `readMarker(fileManager:)` with:
+
+```swift
+    public func readMarker(fileManager: FileManager = .default) throws -> Marker {
+        guard fileManager.fileExists(atPath: infoPlistURL.path) else {
+            throw PackageError.markerMissing(infoPlistURL)
+        }
+        do {
+            let data = try Data(contentsOf: infoPlistURL)
+            return try PropertyListDecoder().decode(Marker.self, from: data)
+        } catch {
+            throw PackageError.markerUnreadable(infoPlistURL)
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesitePackageTests`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/AnglesitePackage.swift Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
+git commit -m "$(cat <<'EOF'
+feat(#242): marker error types + format-version compatibility gate
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: `createSkeleton`, `isPackage`, source validation
+
+Add package creation (dir + `Source/` + `Config/` + stamped marker), package
+detection, and a passthrough to `ProjectValidator` for the `Source/` tree.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/AnglesitePackage.swift`
+- Test: `Tests/AnglesiteCoreTests/AnglesitePackageTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `@discardableResult static func createSkeleton(at: URL, displayName: String, fileManager:) throws -> (AnglesitePackage, Marker)`
+  - `static func isPackage(at: URL, fileManager:) -> Bool`
+  - `func sourceValidation(fileManager:) -> ProjectValidator.Result`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/AnglesiteCoreTests/AnglesitePackageTests.swift` (inside the struct):
+
+```swift
+    @Test("createSkeleton lays down Source/, Config/, and a stamped marker")
+    func createSkeletonLaysDownLayout() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkgURL = dir.appendingPathComponent("Acme.anglesite", isDirectory: true)
+
+        let (pkg, marker) = try AnglesitePackage.createSkeleton(at: pkgURL, displayName: "Acme")
+
+        var isDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: pkg.sourceURL.path, isDirectory: &isDir) && isDir.boolValue)
+        #expect(FileManager.default.fileExists(atPath: pkg.configURL.path, isDirectory: &isDir) && isDir.boolValue)
+        #expect(marker.displayName == "Acme")
+        #expect(try pkg.readMarker() == marker)
+    }
+
+    @Test("isPackage is true only for an .anglesite dir with a readable marker")
+    func isPackageDetection() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let good = dir.appendingPathComponent("Good.anglesite", isDirectory: true)
+        _ = try AnglesitePackage.createSkeleton(at: good, displayName: "Good")
+        let wrongExt = dir.appendingPathComponent("Plain", isDirectory: true)
+        try FileManager.default.createDirectory(at: wrongExt, withIntermediateDirectories: true)
+        let noMarker = dir.appendingPathComponent("Hollow.anglesite", isDirectory: true)
+        try FileManager.default.createDirectory(at: noMarker, withIntermediateDirectories: true)
+
+        #expect(AnglesitePackage.isPackage(at: good))
+        #expect(!AnglesitePackage.isPackage(at: wrongExt))
+        #expect(!AnglesitePackage.isPackage(at: noMarker))
+    }
+
+    @Test("sourceValidation reports missing sentinels in Source/")
+    func sourceValidationReportsMissing() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pkgURL = dir.appendingPathComponent("Acme.anglesite", isDirectory: true)
+        let (pkg, _) = try AnglesitePackage.createSkeleton(at: pkgURL, displayName: "Acme")
+
+        // Empty Source/: invalid (all required sentinels missing).
+        #expect(!pkg.sourceValidation().isValid)
+
+        // Drop the required sentinels into Source/: now valid.
+        for name in ProjectValidator.requiredSentinels {
+            try Data("{}".utf8).write(to: pkg.sourceURL.appendingPathComponent(name))
+        }
+        #expect(pkg.sourceValidation().isValid)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesitePackageTests`
+Expected: FAIL — `cannot find 'createSkeleton'` etc.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteCore/AnglesitePackage.swift`, add (after `writeMarker`):
+
+```swift
+    // MARK: - Creation
+
+    /// Creates an empty package skeleton: the package dir, `Source/`, `Config/`, and a freshly
+    /// stamped `Info.plist`. Does **not** scaffold the Astro project — that runs later with cwd =
+    /// `sourceURL` (P2). Returns the package and its new marker.
+    @discardableResult
+    public static func createSkeleton(
+        at url: URL,
+        displayName: String,
+        fileManager: FileManager = .default
+    ) throws -> (AnglesitePackage, Marker) {
+        let pkg = AnglesitePackage(url: url)
+        try fileManager.createDirectory(at: pkg.sourceURL, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: pkg.configURL, withIntermediateDirectories: true)
+        let marker = Marker(displayName: displayName)
+        try pkg.writeMarker(marker, fileManager: fileManager)
+        return (pkg, marker)
+    }
+
+    // MARK: - Detection & validation
+
+    /// `true` when `url` is a `.anglesite` directory carrying a readable marker.
+    public static func isPackage(at url: URL, fileManager: FileManager = .default) -> Bool {
+        guard url.pathExtension == packageExtension else { return false }
+        return (try? AnglesitePackage(url: url).readMarker(fileManager: fileManager)) != nil
+    }
+
+    /// Validates the `Source/` tree against the Anglesite project sentinels.
+    public func sourceValidation(fileManager: FileManager = .default) -> ProjectValidator.Result {
+        ProjectValidator.validate(sourceURL, fileManager: fileManager)
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesitePackageTests`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/AnglesitePackage.swift Tests/AnglesiteCoreTests/AnglesitePackageTests.swift
+git commit -m "$(cat <<'EOF'
+feat(#242): package skeleton creation, detection, and Source/ validation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Declare the `.anglesite` package type on both targets
+
+Register the exported UTI and document type so Finder treats `.anglesite` as an
+editable package owned by Anglesite. This is `Info.plist` config (no unit test);
+verification is plist lint + a clean `xcodegen generate`.
+
+**Files:**
+- Modify: `Resources/Info.plist`
+- Modify: `Resources/AnglesiteMAS-Info.plist`
+
+**Interfaces:** none (build config only).
+
+- [ ] **Step 1: Add the declarations to `Resources/Info.plist`**
+
+Insert the following two key/value blocks inside the top-level `<dict>` (e.g. immediately
+before the closing `</dict>` on the last line). Both targets get the **same** block:
+
+```xml
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Anglesite Site</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSTypeIsPackage</key>
+			<true/>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>dev.anglesite.site</string>
+			</array>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>dev.anglesite.site</string>
+			<key>UTTypeDescription</key>
+			<string>Anglesite Site</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.apple.package</string>
+				<string>public.composite-content</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>anglesite</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+```
+
+- [ ] **Step 2: Add the identical blocks to `Resources/AnglesiteMAS-Info.plist`**
+
+Insert the same two blocks inside the top-level `<dict>` of `Resources/AnglesiteMAS-Info.plist`.
+
+- [ ] **Step 3: Lint both plists**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer plutil -lint Resources/Info.plist Resources/AnglesiteMAS-Info.plist`
+Expected: both report `OK`.
+
+- [ ] **Step 4: Verify the keys are present and well-formed**
+
+Run: `plutil -extract UTExportedTypeDeclarations.0.UTTypeIdentifier raw Resources/Info.plist && plutil -extract CFBundleDocumentTypes.0.LSItemContentTypes.0 raw Resources/AnglesiteMAS-Info.plist`
+Expected: prints `dev.anglesite.site` then `dev.anglesite.site`.
+
+- [ ] **Step 5: Regenerate the Xcode project to confirm it still loads**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodegen generate`
+Expected: `Created project at .../Anglesite.xcodeproj` with no errors. (The plists are referenced via `INFOPLIST_FILE`; XcodeGen only needs to regenerate cleanly. A full `xcodebuild` is not required for this config-only task and is covered by P2's first build.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Info.plist Resources/AnglesiteMAS-Info.plist
+git commit -m "$(cat <<'EOF'
+feat(#242): declare dev.anglesite.site package UTI + document type (both targets)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (P1 scope = spec §1 format + §2 type declarations + §9 format-version gate):**
+- §1 layout (`Source/`/`Config/`/`Info.plist`) → Task 1 (URLs) + Task 3 (`createSkeleton`). ✓
+- §1 stable-UUID identity in marker → Task 1 (`Marker.siteID: UUID`). ✓
+- §1 marker keys verbatim → Task 1 (`markerUsesSpecKeys` test asserts the exact keys). ✓
+- §2 UTI + `CFBundleDocumentTypes`, both targets → Task 4. ✓
+- §9 unknown/newer format → read-only → Task 2 (`Compatibility.readOnlyTooNew`). ✓
+- §9 missing/corrupt marker handled (not crash) → Task 2 (`markerMissing`/`markerUnreadable`). ✓
+- §10 tests: round-trip, marker parse + version gating, validation = `Source/` → Tasks 1–3. ✓ (Identity-stability-across-move, recents persistence, Import/Export, cwd are **P2/P3** scope — out of P1.)
+
+**Placeholder scan:** none — every code/test step shows full content; every command has expected output.
+
+**Type consistency:** `AnglesitePackage`, `Marker` (`formatVersion`/`siteID`/`displayName`/`createdDate`), `PackageError` (`markerMissing`/`markerUnreadable`), `Compatibility` (`current`/`readOnlyTooNew`), `createSkeleton`/`isPackage`/`sourceValidation`/`readMarker`/`writeMarker` — names are identical across all tasks. `ProjectValidator.requiredSentinels` / `.validate` / `.Result.isValid` match the real `Sources/AnglesiteCore/ProjectValidator.swift`.
+
+## Handoff to P2
+
+P2 (Open/create + runtime) consumes from P1: `AnglesitePackage` (layout URLs, `createSkeleton`, `readMarker`, `Compatibility`, `Marker.siteID`). P2 converts `SiteStore` from a `~/Sites` scanner into a recents registry keyed by `Marker.siteID`, wires Finder/`onOpenURL` open routing against the new document type, scaffolds new sites into `sourceURL`, and retargets the MAS bookmark + subprocess cwd to the package/`Source/`.

--- a/docs/superpowers/plans/2026-06-19-anglesite-package-model-p2-open-create-runtime.md
+++ b/docs/superpowers/plans/2026-06-19-anglesite-package-model-p2-open-create-runtime.md
@@ -1,0 +1,768 @@
+# `.anglesite` Package Model — Phase 2 (Open / Create + Runtime) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `.anglesite` packages the unit the app opens, creates, and runs: convert `SiteStore` from a `~/Sites` scanner into a recents registry keyed by the package's stable marker UUID, route Finder/`Open With` opens of a package to a site window, scaffold new sites into the package's `Source/`, retarget every subprocess working directory to `Source/`, and (MAS) hold the security-scoped grant on the package.
+
+**Architecture:** P1 gave us `AnglesitePackage` (layout + marker + UUID identity). P2 reinterprets a "site" as a package: `SiteStore.Site.packageURL` is the `.anglesite` dir, `Site.id` is the marker UUID, and `Site.sourceDirectory` (computed via `AnglesitePackage`) is what subprocesses use as cwd. Discovery becomes an explicit recents registry (create / open / `onOpenURL`), not a directory scan. New testable logic lives in `AnglesiteCore`; the SwiftUI scene + window rewiring is thin glue verified by build.
+
+**Tech Stack:** Swift 5.10 / SwiftPM, Swift Testing, SwiftUI (`WindowGroup(for:)`, `onOpenURL`), `AnglesiteCore` actors.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-19-anglesite-package-model-design.md` (this is P2: §3 recents registry, §5 new-site scaffold-into-Source, §6 runtime cwd, §7 MAS bookmark, plus §1 UUID identity wiring).
+- **Depends on P1** (merged or on the same branch `feat/242-anglesite-package-model`): `AnglesitePackage` with `sourceURL`/`configURL`/`createSkeleton`/`readMarker`/`isPackage`/`Marker.siteID`.
+- **Toolchain:** prefix `swift test` / `xcodegen` / `xcodebuild` with `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer`.
+- **CI reality (from CLAUDE.md):** hosted app-target tests do NOT run on CI. Therefore: put all decision logic in `AnglesiteCore` with Swift Testing coverage; keep `Sources/AnglesiteApp` changes to thin glue. App-target tasks are verified by `xcodebuild ... -scheme Anglesite build` succeeding, not by unit tests.
+- **Testing framework:** new tests use Swift Testing (`@Test`, `#expect`/`#require`), inject temp dirs/`FileManager`, never touch real user dirs.
+- **Identity:** a site's id is the package `Marker.siteID.uuidString`. It MUST be stable across a package move (no path-derived ids).
+- **Runtime cwd:** scaffold, dev server, build, deploy, and pre-deploy check all run with cwd = `<package>/Source/`.
+- **MAS:** one security-scoped bookmark per **package URL**; `Source/` and `Config/` are inside it, so one grant covers both. Gate MAS-only code with `#if ANGLESITE_MAS`.
+- **Commit style:** Conventional Commits, scope `(#242)`, body ends with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## File Structure
+
+- `Sources/AnglesiteCore/SiteStore.swift` — **rework**: `Site` gains `packageURL` + UUID `id` + computed `sourceDirectory`; `refresh()` scan replaced by a recents registry (`record`, `touch`, `load`, `remove`, `find`, bookmark accessors, change streams retained). Persisted file renamed concept (`recents.json`), back-comp read of legacy `sites.json` is out of scope (P3 Import is the migration path).
+- `Sources/AnglesiteCore/SiteScaffolder.swift` — **modify**: create a package skeleton and scaffold into `Source/`; register the package.
+- `Sources/AnglesiteApp/AnglesiteApp.swift` — **modify**: add `onOpenURL` package routing; "Open Site…" opens a package; recents menu unchanged in shape.
+- `Sources/AnglesiteApp/SiteActions.swift` — **modify**: `pickAndRegisterSite()` chooses an `.anglesite` package; bookmark on the package URL.
+- `Sources/AnglesiteApp/SiteWindow.swift` — **modify**: resolve site → use `site.sourceDirectory` for preview/deploy/graph; grant on `site.packageURL`.
+- `Tests/AnglesiteCoreTests/SiteStoreRecentsTests.swift` — **create**.
+- `Tests/AnglesiteCoreTests/AnglesitePackageMoveTests.swift` — **create** (identity-survives-move, per the P1 final-review note).
+
+---
+
+### Task 1: Identity survives a package move (regression lock)
+
+Per the P1 final review, prove the headline guarantee of the UUID redesign before building on it.
+
+**Files:**
+- Test: `Tests/AnglesiteCoreTests/AnglesitePackageMoveTests.swift` (create)
+
+**Interfaces:**
+- Consumes: `AnglesitePackage.createSkeleton`, `readMarker`, `Marker.siteID` (P1).
+
+- [ ] **Step 1: Write the test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Locks the core promise of the UUID-identity redesign (#242): a package's `siteID` is stored
+/// in its `Info.plist`, not derived from its path, so moving/renaming the package keeps identity.
+struct AnglesitePackageMoveTests {
+    private func tempDir() throws -> URL {
+        let d = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("pkg-move-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    @Test("siteID is unchanged after the package directory is moved/renamed")
+    func identitySurvivesMove() throws {
+        let fm = FileManager.default
+        let root = try tempDir()
+        defer { try? fm.removeItem(at: root) }
+
+        let original = root.appendingPathComponent("Acme.anglesite", isDirectory: true)
+        let (_, marker) = try AnglesitePackage.createSkeleton(at: original, displayName: "Acme")
+
+        let moved = root.appendingPathComponent("Renamed.anglesite", isDirectory: true)
+        try fm.moveItem(at: original, to: moved)
+
+        let readAfterMove = try AnglesitePackage(url: moved).readMarker()
+        #expect(readAfterMove.siteID == marker.siteID)
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect PASS** (the format already supports this; this is a regression lock, not new behavior)
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesitePackageMoveTests`
+Expected: PASS (1 test). If it FAILS, stop — P1's identity model is broken and P2 must not proceed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/AnglesiteCoreTests/AnglesitePackageMoveTests.swift
+git commit -m "$(cat <<'EOF'
+test(#242): lock package siteID stability across directory move
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: `SiteStore.Site` becomes package-shaped
+
+Reshape the `Site` value type so identity is the marker UUID and the package URL + source dir are first-class. Keep the type `Codable` for the recents file.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteStore.swift:17-48` (the `Site` struct)
+- Test: `Tests/AnglesiteCoreTests/SiteStoreRecentsTests.swift` (create)
+
+**Interfaces:**
+- Produces:
+  - `SiteStore.Site` with: `id: String` (UUID string), `name: String`, `packageURL: URL`, `isValid: Bool`, `missingSentinels: [String]`, `lastSeen: Date`, `bookmarkData: Data?`
+  - computed `var sourceDirectory: URL { AnglesitePackage(url: packageURL).sourceURL }`
+  - computed `var configDirectory: URL { AnglesitePackage(url: packageURL).configURL }`
+  - `static func make(package: AnglesitePackage, fileManager: FileManager) throws -> Site` — reads the marker, validates `Source/`, builds a `Site` (id = marker UUID, name = marker.displayName).
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SiteStoreRecentsTests {
+    private func tempDir() throws -> URL {
+        let d = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("recents-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    /// Build a valid package (Source/ has the required sentinels).
+    private func makeValidPackage(in root: URL, name: String) throws -> AnglesitePackage {
+        let (pkg, _) = try AnglesitePackage.createSkeleton(
+            at: root.appendingPathComponent("\(name).anglesite", isDirectory: true), displayName: name)
+        for sentinel in ProjectValidator.requiredSentinels {
+            try Data("{}".utf8).write(to: pkg.sourceURL.appendingPathComponent(sentinel))
+        }
+        return pkg
+    }
+
+    @Test("Site.make derives id from the marker UUID and source/config dirs from the package")
+    func siteMakeDerivesFields() throws {
+        let root = try tempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let pkg = try makeValidPackage(in: root, name: "Acme")
+        let marker = try pkg.readMarker()
+
+        let site = try SiteStore.Site.make(package: pkg, fileManager: .default)
+        #expect(site.id == marker.siteID.uuidString)
+        #expect(site.name == "Acme")
+        #expect(site.packageURL == pkg.url)
+        #expect(site.sourceDirectory == pkg.sourceURL)
+        #expect(site.configDirectory == pkg.configURL)
+        #expect(site.isValid)
+        #expect(site.missingSentinels.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteStoreRecentsTests`
+Expected: FAIL — `Site` has no `packageURL`/`make`.
+
+- [ ] **Step 3: Implement — replace the `Site` struct in `SiteStore.swift`**
+
+Replace lines 17–48 (the current `Site` struct) with:
+
+```swift
+    public struct Site: Sendable, Codable, Equatable, Identifiable {
+        /// The package's stable marker UUID (string). Path-independent — survives moves (#242).
+        public let id: String
+        /// Display name (from the package marker).
+        public let name: String
+        /// The `.anglesite` package directory.
+        public let packageURL: URL
+        public var isValid: Bool
+        public var missingSentinels: [String]
+        public var lastSeen: Date
+        /// Security-scoped bookmark for `packageURL` (MAS). `nil` on DevID. One grant covers
+        /// the whole package, so Source/ and Config/ are both reachable under it.
+        public var bookmarkData: Data?
+
+        /// The Astro project tree — every subprocess (scaffold, dev server, build, deploy,
+        /// pre-deploy check) runs with this as its working directory.
+        public var sourceDirectory: URL { AnglesitePackage(url: packageURL).sourceURL }
+        /// App-owned per-site config dir (settings, chat history, cache).
+        public var configDirectory: URL { AnglesitePackage(url: packageURL).configURL }
+
+        public init(
+            id: String,
+            name: String,
+            packageURL: URL,
+            isValid: Bool,
+            missingSentinels: [String],
+            lastSeen: Date = Date(),
+            bookmarkData: Data? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.packageURL = packageURL
+            self.isValid = isValid
+            self.missingSentinels = missingSentinels
+            self.lastSeen = lastSeen
+            self.bookmarkData = bookmarkData
+        }
+
+        /// Build a `Site` from a package on disk: id = marker UUID, name = marker displayName,
+        /// validity = whether `Source/` passes the project sentinels.
+        public static func make(package: AnglesitePackage, fileManager: FileManager = .default) throws -> Site {
+            let marker = try package.readMarker(fileManager: fileManager)
+            let validation = package.sourceValidation(fileManager: fileManager)
+            return Site(
+                id: marker.siteID.uuidString,
+                name: marker.displayName,
+                packageURL: AnglesiteCore.canonicalizePackageURL(package.url),
+                isValid: validation.isValid,
+                missingSentinels: validation.missing
+            )
+        }
+    }
+```
+
+Add a small free helper near the bottom of the file (the old `canonicalize` was a private static on the actor; expose a package-URL canonicalizer the `Site.make` static can call):
+
+```swift
+/// Canonical (standardized, symlink-resolved) form of a package URL, so the same package
+/// reached via a symlinked path collapses to one recents entry.
+func canonicalizePackageURL(_ url: URL) -> URL {
+    url.standardizedFileURL.resolvingSymlinksInPath()
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteStoreRecentsTests`
+Expected: PASS. (The actor body still references removed/renamed members — it will not COMPILE yet; that is fixed in Task 3. If `swift test` fails to build `SiteStore.swift`, that's expected here only if Task 3 hasn't run. To keep this task independently green, also apply Task 3 before running the full build. See note.)
+
+> **Sequencing note:** Tasks 2 and 3 together form one compilable unit (the `Site` reshape forces the actor-body changes). Implement Task 2's struct + Task 3's actor body, then run both test files. Commit them separately for review legibility, but run the build once after Task 3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteStore.swift Tests/AnglesiteCoreTests/SiteStoreRecentsTests.swift
+git commit -m "$(cat <<'EOF'
+feat(#242): reshape SiteStore.Site around the package (UUID id + source/config dirs)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: `SiteStore` becomes a recents registry
+
+Replace the `~/Sites` scan (`refresh()`) with an explicit recents registry: `record(package:)` adds/updates an entry; `touch(id:)` bumps `lastSeen`. Persist to `recents.json`. Keep `load`, `remove`, `find`, bookmark accessors, and change streams.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteStore.swift` (actor body: replace `refresh()`/`add(_ url:)`; update persistence URL + docs)
+- Test: `Tests/AnglesiteCoreTests/SiteStoreRecentsTests.swift` (append)
+
+**Interfaces:**
+- Produces:
+  - `@discardableResult func record(_ package: AnglesitePackage) async throws -> Site` — reads marker, builds `Site.make`, upserts by id (carrying forward any existing bookmark), persists, emits change.
+  - `func touch(id: String) async throws` — bump `lastSeen`, re-sort, persist, emit.
+  - retained: `load()`, `remove(id:)`, `find(id:)`, `bookmarkData(for:)`, `setBookmark(_:for:)`, `changeStream()`, `setChangeHandler(_:)`.
+  - removed: `refresh()`, `add(_ url: URL)` (replaced by `record`). The default persistence file is now `recents.json`.
+
+- [ ] **Step 1: Write the failing tests** (append to `SiteStoreRecentsTests.swift`, inside the struct)
+
+```swift
+    @Test("record upserts a package by id and persists; load restores it")
+    func recordAndLoadRoundTrip() async throws {
+        let root = try tempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let pkg = try makeValidPackage(in: root, name: "Acme")
+        let persistence = root.appendingPathComponent("recents.json")
+
+        let store = SiteStore(persistenceURL: persistence)
+        let recorded = try await store.record(pkg)
+        #expect(recorded.name == "Acme")
+        #expect(await store.find(id: recorded.id) != nil)
+
+        // A second store reading the same file sees the entry.
+        let store2 = SiteStore(persistenceURL: persistence)
+        try await store2.load()
+        #expect(await store2.find(id: recorded.id)?.packageURL == pkg.url)
+    }
+
+    @Test("record is idempotent by id and carries a previously-set bookmark forward")
+    func recordIdempotentCarriesBookmark() async throws {
+        let root = try tempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let pkg = try makeValidPackage(in: root, name: "Acme")
+        let store = SiteStore(persistenceURL: root.appendingPathComponent("recents.json"))
+        let site = try await store.record(pkg)
+        try await store.setBookmark(Data("bm".utf8), for: site.id)
+
+        let again = try await store.record(pkg)   // same package, second open
+        #expect(again.id == site.id)
+        #expect(await store.bookmarkData(for: site.id) == Data("bm".utf8))
+        #expect(await store.sites.filter { $0.id == site.id }.count == 1)
+    }
+
+    @Test("touch bumps lastSeen so the entry sorts first")
+    func touchBumpsRecency() async throws {
+        let root = try tempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let a = try makeValidPackage(in: root, name: "Alpha")
+        let b = try makeValidPackage(in: root, name: "Beta")
+        let store = SiteStore(persistenceURL: root.appendingPathComponent("recents.json"))
+        let siteA = try await store.record(a)
+        _ = try await store.record(b)
+        try await store.touch(id: siteA.id)
+        let mostRecent = RecentSites.select(from: await store.sites, limit: 1).first
+        #expect(mostRecent?.id == siteA.id)
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteStoreRecentsTests`
+Expected: FAIL — no `record`/`touch`; build errors from the Task 2 reshape.
+
+- [ ] **Step 3: Implement the actor body changes in `SiteStore.swift`**
+
+3a. Update the type doc comment (lines 3–11) to describe a recents registry rather than a `~/Sites` scanner.
+
+3b. Remove the `settings` dependency usage for scanning. Replace the entire `refresh()` method (lines 110–167) and `add(_ url:)` method (lines 169–198) with:
+
+```swift
+    /// Add or update a recents entry for `package`. Reads its marker for identity + name and
+    /// validates `Source/`. Upsert is by `id` (the marker UUID): re-opening a moved package
+    /// updates its `packageURL` in place and carries any existing bookmark forward. Persists
+    /// and emits a change.
+    @discardableResult
+    public func record(_ package: AnglesitePackage) async throws -> Site {
+        var site = try Site.make(package: package, fileManager: fileManager)
+        if let existing = sites.first(where: { $0.id == site.id }) {
+            site.bookmarkData = existing.bookmarkData ?? site.bookmarkData
+        }
+        site.lastSeen = Date()
+        sites.removeAll { $0.id == site.id }
+        sites.append(site)
+        sites.sort { $0.lastSeen > $1.lastSeen }
+        try persist()
+        await emitChange()
+        return site
+    }
+
+    /// Bump `lastSeen` for the entry with `id` (most-recently-used ordering). No-op if unknown.
+    public func touch(id: String) async throws {
+        guard let index = sites.firstIndex(where: { $0.id == id }) else { return }
+        sites[index].lastSeen = Date()
+        sites.sort { $0.lastSeen > $1.lastSeen }
+        try persist()
+        await emitChange()
+    }
+```
+
+3c. In `load()` (lines 98–106) the decode is unchanged (still `[Site]`), but it now decodes the new `Site` shape from `recents.json`. Leave the logic; only the persisted shape changed.
+
+3d. Update `defaultPersistenceURL` (lines 307–318) to use `recents.json` instead of `sites.json`:
+
+```swift
+            .appendingPathComponent("Anglesite", isDirectory: true)
+            .appendingPathComponent("recents.json")
+```
+
+3e. Remove the now-unused `settings` stored property and its `init` parameter usage **only if** nothing else references it. (Search the file: if `settings` is unused after removing `refresh()`, drop the property at line 62 and the `settings:` init parameter at lines 78–86. If anything still uses it, leave it.)
+
+3f. Remove the now-unused private statics `canonicalize`/`identifier` (lines 295–305) if `record`/`Site.make` no longer call them (they use the free `canonicalizePackageURL`). Keep whatever is still referenced.
+
+- [ ] **Step 4: Run to verify it passes + Core suite builds**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteStoreRecentsTests`
+Expected: PASS (4 tests total in the file).
+
+Then confirm the wider Core library still compiles (other call sites of removed `refresh`/`add` are fixed in later tasks — if the *test build* fails on App-only symbols that's fine, but `AnglesiteCore` itself must build):
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --package-path . --target AnglesiteCore`
+Expected: build succeeds. If `SiteScaffolder` references `add`, that's Task 4 — note it and proceed (do not leave AnglesiteCore uncompilable at commit; if needed, land Task 4 before this commit's build claim).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteStore.swift Tests/AnglesiteCoreTests/SiteStoreRecentsTests.swift
+git commit -m "$(cat <<'EOF'
+feat(#242): SiteStore becomes a recents registry (record/touch, recents.json)
+
+Replaces the ~/Sites scan with explicit create/open/import recording, keyed by
+the package marker UUID. Discovery is now recents-based per spec §3.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Scaffold new sites into a package's `Source/`
+
+Rework `SiteScaffolder` to create an `.anglesite` package skeleton, run the template scaffold with cwd = `Source/`, `git init` in `Source/`, write owner answers, and register the package.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteScaffolder.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteScaffolderPackageTests.swift` (create)
+
+**Interfaces:**
+- Consumes: `AnglesitePackage.createSkeleton` (P1), `SiteStore.record` (Task 3).
+- Produces: `SiteScaffolder` with `Register = @Sendable (_ package: AnglesitePackage) async throws -> SiteStore.Site` (changed from `siteDirectory: URL`); pipeline computes `siteDir = package.sourceURL`. A new `GitInit = @Sendable (_ sourceDir: URL) async throws -> Void` injected closure (production: `git init` via ProcessSupervisor) so the scaffolder stays testable without spawning git.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SiteScaffolderPackageTests {
+    private func tempDir() throws -> URL {
+        let d = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("scaffold-pkg-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    @Test("scaffold creates a package and runs the template + git init inside Source/")
+    func scaffoldsIntoSource() async throws {
+        let root = try tempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let template = root.appendingPathComponent("Template", isDirectory: true)
+        try FileManager.default.createDirectory(at: template.appendingPathComponent("scripts"), withIntermediateDirectories: true)
+
+        // Record the cwd each injected command was run in, and which dir got `git init`.
+        actor Spy { var cwds: [URL] = []; var gitInits: [URL] = []
+            func cwd(_ u: URL?) { if let u { cwds.append(u) } }
+            func git(_ u: URL) { gitInits.append(u) }
+        }
+        let spy = Spy()
+
+        let scaffolder = SiteScaffolder(
+            sitesRoot: root,
+            templateURL: template,
+            catalog: ThemeCatalog(themes: []),
+            run: { _, _, cwd in await spy.cwd(cwd); return .init(stdout: "", stderr: "", exitCode: 0) },
+            gitInit: { src in await spy.git(src) },
+            register: { pkg in try SiteStore.Site.make(package: pkg) }
+        )
+
+        var doneID: String?
+        for await step in scaffolder.scaffold(.init(siteType: .business, name: "Acme")) {
+            if case .done(let id) = step { doneID = id }
+            if case .failed(let s, let m) = step { Issue.record("scaffold failed at \(s): \(m)") }
+        }
+
+        let pkg = AnglesitePackage(url: root.appendingPathComponent("acme.anglesite", isDirectory: true))
+        #expect(FileManager.default.fileExists(atPath: pkg.sourceURL.path))
+        #expect(FileManager.default.fileExists(atPath: pkg.infoPlistURL.path))
+        #expect(doneID == (try pkg.readMarker().siteID.uuidString))
+        // Template scaffold + npm install ran with cwd == Source/, and git init targeted Source/.
+        #expect(await spy.cwds.allSatisfy { $0 == pkg.sourceURL })
+        #expect(await spy.gitInits == [pkg.sourceURL])
+    }
+}
+```
+
+(Adjust the `NewSiteDraft(...)` initializer call to the real memberwise init — see `NewSiteDraft.swift:32-56`; pass the minimum required fields.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteScaffolderPackageTests`
+Expected: FAIL — `SiteScaffolder` has no `gitInit:` param; `Register` signature mismatch.
+
+- [ ] **Step 3: Implement the changes in `SiteScaffolder.swift`**
+
+3a. Change the `Register` typealias (line 17) and add a `GitInit` typealias:
+
+```swift
+    /// Register a freshly-scaffolded package and return the Site (production: SiteStore.shared.record).
+    public typealias Register = @Sendable (_ package: AnglesitePackage) async throws -> SiteStore.Site
+    /// Initialize a git repo in the source dir (production: `git init` via ProcessSupervisor).
+    public typealias GitInit = @Sendable (_ sourceDirectory: URL) async throws -> Void
+```
+
+3b. Add `private let gitInit: GitInit` and thread it through `init` (after `register`).
+
+3c. Rewrite `runPipeline` (lines 48–109) so the unit of work is a package:
+
+```swift
+    private func runPipeline(_ draft: NewSiteDraft, emit: @Sendable (ScaffoldStep) -> Void) async {
+        let slug = SiteSlug.derive(from: draft.name)
+        let packageURL = sitesRoot.appendingPathComponent("\(slug).anglesite", isDirectory: true)
+
+        // 1. Package skeleton (dir + Source/ + Config/ + Info.plist marker).
+        emit(.creatingFolder)
+        let package: AnglesitePackage
+        do {
+            (package, _) = try AnglesitePackage.createSkeleton(at: packageURL, displayName: draft.name, fileManager: fileManager)
+        } catch { return emit(.failed(step: "creatingFolder", message: humanize(error))) }
+        let siteDir = package.sourceURL   // everything below runs in Source/
+
+        // 2. scaffold.sh (cwd = Source/)
+        emit(.copyingTemplate)
+        let scaffoldScript = templateURL.appendingPathComponent("scripts/scaffold.sh")
+        do {
+            let r = try await run(URL(fileURLWithPath: "/bin/zsh"),
+                                  [scaffoldScript.path, "--yes", siteDir.path], siteDir)
+            if r.exitCode != 0 {
+                return emit(.failed(step: "copyingTemplate", message: "Couldn't create the site files.\n\(r.stderr)"))
+            }
+        } catch { return emit(.failed(step: "copyingTemplate", message: humanize(error))) }
+
+        // 2b. Owner answers into .site-config (in Source/).
+        do { try appendSiteConfig(draft, siteDir: siteDir) }
+        catch { emit(.warning(step: "copyingTemplate", message: humanize(error))) }
+
+        // 2c. git init in Source/ (non-fatal — coordinates with #68).
+        do { try await gitInit(siteDir) }
+        catch { emit(.warning(step: "copyingTemplate", message: "git init skipped: \(humanize(error))")) }
+
+        // 3. Theme (non-fatal)
+        emit(.applyingTheme)
+        if let theme = catalog.theme(id: draft.themeID) ?? catalog.themes.first {
+            do { try ThemeApplier.apply(theme, siteDirectory: siteDir, fileManager: fileManager) }
+            catch { emit(.warning(step: "applyingTheme", message: humanize(error))) }
+        } else {
+            emit(.warning(step: "applyingTheme", message: "No themes available; left default look."))
+        }
+
+        // 4. Homepage (non-fatal)
+        emit(.writingContent)
+        do { try HomepageWriter.write(headline: draft.headline, blurb: draft.blurb,
+                                      tagline: draft.tagline, siteDirectory: siteDir, fileManager: fileManager) }
+        catch { emit(.warning(step: "writingContent", message: humanize(error))) }
+
+        // 5. npm install (cwd = Source/, non-fatal)
+        emit(.installing)
+        if let node = NodeRuntime.bundledExecutableURL {
+            let npm = node.deletingLastPathComponent().appendingPathComponent("npm")
+            do {
+                let r = try await run(node, [npm.path] + NodeModulesCache.shared.npmInstallArguments(), siteDir)
+                if r.exitCode != 0 {
+                    emit(.warning(step: "installing", message: "Dependencies didn't install — you can retry from the site window.\n\(r.stderr)"))
+                }
+            } catch { emit(.warning(step: "installing", message: humanize(error))) }
+        } else {
+            emit(.warning(step: "installing", message: "Bundled Node not found; skipped install."))
+        }
+
+        // 6. Register the package
+        emit(.registering)
+        do {
+            let site = try await register(package)
+            emit(.done(siteID: site.id))
+        } catch { emit(.failed(step: "registering", message: humanize(error))) }
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteScaffolderPackageTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteScaffolder.swift Tests/AnglesiteCoreTests/SiteScaffolderPackageTests.swift
+git commit -m "$(cat <<'EOF'
+feat(#242): scaffold new sites into an .anglesite package Source/ (+ git init)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Wire the App target — open/create packages + Source/ cwd + MAS grant
+
+Thin SwiftUI glue: `SiteActions` picks a package; the scaffolder is constructed with the new `register`/`gitInit`; `SiteWindow` uses `site.sourceDirectory` for runtime and grants on `site.packageURL`; `AnglesiteApp` gains `onOpenURL` package routing. No unit tests (CI can't host them) — verified by build.
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteActions.swift:26-47`
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift` (loadAndStart resolve + grant + the preview/deploy/graph site-dir calls)
+- Modify: `Sources/AnglesiteApp/AnglesiteApp.swift` (onOpenURL; openSiteFromMenu)
+- Modify: the new-site wizard construction site of `SiteScaffolder` (in the launcher view — find via `SiteScaffolder(`)
+
+**Interfaces:**
+- Consumes: `SiteStore.record`/`touch`, `Site.sourceDirectory`/`packageURL`, `AnglesitePackage.isPackage`, `SiteScaffolder` new closures.
+
+- [ ] **Step 1: `SiteActions.pickAndRegisterSite()` chooses a package**
+
+Replace the panel config + registration (lines 27–42) so it accepts `.anglesite` packages and records via `record`:
+
+```swift
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [UTType("dev.anglesite.site")].compactMap { $0 }
+        panel.treatsFilePackagesAsDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Open"
+        panel.message = "Choose an Anglesite site package."
+        guard panel.runModal() == .OK, let url = panel.url else { return nil }
+
+        do {
+            let package = AnglesitePackage(url: url)
+            let site = try await SiteStore.shared.record(package)
+            #if ANGLESITE_MAS
+            let bookmark = try SecurityScopedBookmark.create(for: url)   // url == package
+            try await SiteStore.shared.setBookmark(bookmark, for: site.id)
+            #endif
+            return site
+        } catch {
+            throw ImportError(folderName: url.lastPathComponent, underlying: error)
+        }
+```
+
+Add `import UniformTypeIdentifiers` at the top if not present.
+
+- [ ] **Step 2: `SiteWindow` uses Source/ for runtime and grants on the package**
+
+In `loadAndStart()` (around line 401), resolution is unchanged (`store.find(id:)`), but:
+- Replace `preview.open(siteID: resolved.id, siteDirectory: resolved.path)` (line ~428) with `siteDirectory: resolved.sourceDirectory`.
+- Replace any `deploy.deploy(siteID: site.id, siteDirectory: site.path)` (line ~238) with `siteDirectory: site.sourceDirectory`.
+- Replace the ChatModel construction's `siteDirectory: resolved.path` (lines ~462-502) with `resolved.sourceDirectory` for content/graph, but the chat history store path uses `resolved.configDirectory` (P4 changes ChatHistoryStore; until then, pass `sourceDirectory`). **For P2, use `sourceDirectory` everywhere `path` was used for runtime/content; P4 moves chat history to Config/.**
+- In `acquireGrant(for:in:)` (lines 548-579), no logic change is needed — it already grants on the bookmark for `site.id`; ensure the bookmark was minted on `site.packageURL` (it is, from Task 5 Step 1 / SiteActions). The `resolved.url` it activates is the package; subprocess cwd (`sourceDirectory`) is inside it. Add `_ = AnglesitePackage(url: resolved.url)` is NOT needed.
+- Call `try? await store.touch(id: resolved.id)` right after `AppSettings.shared.lastOpenedSiteID = resolved.id` (line 407) so opening bumps recency.
+
+- [ ] **Step 3: `AnglesiteApp` routes `onOpenURL` to a site window**
+
+Add to the `Window("Sites", id: "sites")` scene content (or the top-level scene) an `.onOpenURL` handler that records the package and opens its window:
+
+```swift
+        .onOpenURL { url in
+            guard AnglesitePackage.isPackage(at: url) else { return }
+            Task { @MainActor in
+                do {
+                    let site = try await SiteStore.shared.record(AnglesitePackage(url: url))
+                    #if ANGLESITE_MAS
+                    if let bm = try? SecurityScopedBookmark.create(for: url) {
+                        try? await SiteStore.shared.setBookmark(bm, for: site.id)
+                    }
+                    #endif
+                    openWindow(value: site.id)
+                } catch {
+                    await LogCenter.shared.append(source: "open-url", stream: .stderr, text: "open \(url.lastPathComponent) failed: \(error)")
+                }
+            }
+        }
+```
+
+`openSiteFromMenu()` (lines 96–111) needs no change beyond already calling `SiteActions.pickAndRegisterSite()` (now package-aware) then `openWindow(value: site.id)`.
+
+- [ ] **Step 4: Update the wizard's `SiteScaffolder` construction**
+
+At the `SiteScaffolder(` call site (launcher view), update `register:` and add `gitInit:`:
+
+```swift
+        let scaffolder = SiteScaffolder(
+            sitesRoot: sitesRoot,
+            templateURL: templateURL,
+            catalog: catalog,
+            run: { exe, args, cwd in
+                try await ProcessSupervisor.shared.run(executable: exe, arguments: args, currentDirectoryURL: cwd)
+            },
+            gitInit: { sourceDir in
+                let git = URL(fileURLWithPath: "/usr/bin/git")
+                _ = try await ProcessSupervisor.shared.run(executable: git, arguments: ["init"], currentDirectoryURL: sourceDir)
+            },
+            register: { package in
+                let site = try await SiteStore.shared.record(package)
+                #if ANGLESITE_MAS
+                if let bm = try? SecurityScopedBookmark.create(for: package.url) {
+                    try? await SiteStore.shared.setBookmark(bm, for: site.id)
+                }
+                #endif
+                return site
+            }
+        )
+```
+
+- [ ] **Step 5: Build both targets**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodegen generate && DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED. Then the MAS scheme:
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 6: Run the full Core suite to confirm no regressions**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .`
+Expected: all suites pass (the MCP/apply-edit e2e tests need `ANGLESITE_PLUGIN_PATH`; if unset they fail-not-skip — set it or note their pre-existing status).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteApp
+git commit -m "$(cat <<'EOF'
+feat(#242): open/create .anglesite packages; runtime cwd = Source/; grant on package
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Retarget SiteEntity identity + directory to the package
+
+`SiteEntity` (Siri) is built from `SiteStore.Site`. Its `id` already comes from `site.id` (now the UUID) and `directory` from `site.path` — update to `site.packageURL` for "reveal in Finder" semantics, and index content from `sourceDirectory`.
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/SiteEntity.swift:40-52` (the `init(_ site:)`)
+
+**Interfaces:**
+- Consumes: `SiteStore.Site.packageURL`, `.sourceDirectory`.
+
+- [ ] **Step 1: Update `init(_ site:)`**
+
+```swift
+    public init(_ site: SiteStore.Site) {
+        // Directory mtime misses in-file edits; revisit with git timestamps after #68.
+        let keys: Set<URLResourceKey> = [.creationDateKey, .contentModificationDateKey]
+        let values = try? site.sourceDirectory.resourceValues(forKeys: keys)
+        self.init(
+            id: site.id,                 // package marker UUID — stable across moves (#242)
+            name: site.name,
+            creationDate: values?.creationDate,
+            modificationDate: values?.contentModificationDate,
+            directory: site.packageURL   // the package; Finder opens it in Anglesite
+        )
+    }
+```
+
+- [ ] **Step 2: Build the Intents target via the app build**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Run the Intents suite**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesiteIntentsTests`
+Expected: PASS (fix any test that constructed a `Site` with the old `path:` label — update to `packageURL:`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteIntents
+git commit -m "$(cat <<'EOF'
+feat(#242): SiteEntity identity = package UUID; directory = package URL
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** §3 recents registry → Tasks 2–3, 5. §5 scaffold-into-Source + git init → Task 4. §6 runtime cwd = Source/ → Tasks 4 (scaffold) + 5 (preview/deploy/graph). §7 MAS bookmark on package → Tasks 5. §1 UUID identity wiring → Tasks 1–2, 6. Open routing (Finder/onOpenURL/Open Site…) → Task 5.
+
+**Known follow-ons (not P2):** chat-history path move to `Config/` is **P4** (Task 5 step 2 keeps it on `sourceDirectory` until then); legacy `sites.json` migration is **P3 Import**; the `SiriReadiness` per-site persistence is **P4**.
+
+**Risk flags for the implementer:**
+- Tasks 2+3 are one compilable unit — apply both before the build claim.
+- Removing `refresh()`/`add` will break any caller not updated here — grep `\.refresh()` and `SiteStore.shared.add(` across `Sources/` and fix each (RecentSitesModel.start() calls `refresh()` at `RecentSitesModel.swift:30` — change it to `load()` only, since recents no longer scans).
+- Confirm `UTType("dev.anglesite.site")` resolves at runtime (it's declared in P1's Info.plist).
+
+## Handoff to P3
+
+P3 (Import/Export) consumes: `AnglesitePackage.createSkeleton`, `SiteStore.record`, and the File menu `CommandGroup` (AnglesiteApp.swift:121-143). Import copies a chosen plain directory into a new package's `Source/` (preserving `.git`), then `record`s it; Export copies `Source/` out.

--- a/docs/superpowers/plans/2026-06-19-anglesite-package-model-p2-open-create-runtime.md
+++ b/docs/superpowers/plans/2026-06-19-anglesite-package-model-p2-open-create-runtime.md
@@ -591,7 +591,7 @@ Replace the panel config + registration (lines 27–42) so it accepts `.anglesit
         let panel = NSOpenPanel()
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
-        panel.allowedContentTypes = [UTType("dev.anglesite.site")].compactMap { $0 }
+        panel.allowedContentTypes = [.anglesiteSite]   // UTType.anglesiteSite (AnglesiteCore) — non-failable, CI-safe
         panel.treatsFilePackagesAsDirectories = false
         panel.allowsMultipleSelection = false
         panel.prompt = "Open"
@@ -761,7 +761,7 @@ EOF
 **Risk flags for the implementer:**
 - Tasks 2+3 are one compilable unit — apply both before the build claim.
 - Removing `refresh()`/`add` will break any caller not updated here — grep `\.refresh()` and `SiteStore.shared.add(` across `Sources/` and fix each (RecentSitesModel.start() calls `refresh()` at `RecentSitesModel.swift:30` — change it to `load()` only, since recents no longer scans).
-- Confirm `UTType("dev.anglesite.site")` resolves at runtime (it's declared in P1's Info.plist).
+- Use `UTType.anglesiteSite` (declared in `AnglesiteCore/UTType+Anglesite.swift`, P1) for panel content types — it's non-failable, so it stays valid in CI/test processes where the bundle UTI isn't registered. Do not use the failable `UTType("dev.anglesite.site")`.
 
 ## Handoff to P3
 

--- a/docs/superpowers/plans/2026-06-19-anglesite-package-model-p3-import-export.md
+++ b/docs/superpowers/plans/2026-06-19-anglesite-package-model-p3-import-export.md
@@ -1,0 +1,401 @@
+# `.anglesite` Package Model — Phase 3 (Import / Export) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add **File ▸ Import** (copy a plain Anglesite directory into a new `.anglesite` package's `Source/`, the migration path for pre-package sites) and **File ▸ Export** (copy a package's `Source/` working tree back out to a plain directory).
+
+**Architecture:** Two pure, testable `AnglesiteCore` functions — `PackageTransfer.importDirectory(...)` and `PackageTransfer.exportSource(...)` — do all filesystem work with an injected `FileManager`. Thin SwiftUI menu glue runs the panels and records the imported package via `SiteStore`.
+
+**Tech Stack:** Swift 5.10 / SwiftPM, Swift Testing, `FileManager` copy APIs, SwiftUI `CommandGroup`, `NSOpenPanel`/`NSSavePanel`.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-19-anglesite-package-model-design.md` §5 (Import/Export).
+- **Depends on P1** (`AnglesitePackage`) and **P2** (`SiteStore.record`, package-shaped `Site`).
+- **Toolchain:** prefix `swift test`/`xcodebuild`/`xcodegen` with `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer`.
+- **CI reality:** logic in `AnglesiteCore` (Swift Testing); App glue verified by build, not unit tests.
+- **Import semantics (verbatim from spec §5):** copy the chosen directory's tree into the new package's `Source/`, **preserving an existing `.git`**; migrate any `<dir>/.anglesite/` into the package's `Config/`; write a fresh `Info.plist` (new UUID); leave the original directory untouched.
+- **Export semantics (verbatim from spec §5):** copy `<pkg>/Source/` to a chosen plain directory; **default excludes `node_modules/`**; option to include or exclude `.git`.
+- **Commit style:** Conventional Commits, scope `(#242)`, body ends `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## File Structure
+
+- `Sources/AnglesiteCore/PackageTransfer.swift` — **create**: `importDirectory`, `exportSource`.
+- `Tests/AnglesiteCoreTests/PackageTransferTests.swift` — **create**.
+- `Sources/AnglesiteApp/SiteActions.swift` — **modify**: add `importPackage()` and `exportSource(of:)` panel helpers.
+- `Sources/AnglesiteApp/AnglesiteApp.swift` — **modify**: add File ▸ Import / File ▸ Export menu items.
+
+---
+
+### Task 1: `PackageTransfer.importDirectory`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/PackageTransfer.swift`
+- Test: `Tests/AnglesiteCoreTests/PackageTransferTests.swift`
+
+**Interfaces:**
+- Consumes: `AnglesitePackage` (P1).
+- Produces: `enum PackageTransfer { static func importDirectory(_ sourceDir: URL, toPackageAt packageURL: URL, displayName: String, fileManager: FileManager) throws -> AnglesitePackage }`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct PackageTransferTests {
+    private func tempDir() throws -> URL {
+        let d = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("pkg-transfer-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    @Test("import copies the dir tree into Source/, preserves .git, migrates .anglesite/ to Config/, writes a fresh marker, leaves the original untouched")
+    func importCopiesIntoSource() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+
+        // A plain Anglesite site dir with a git repo, sentinels, and a legacy .anglesite/ history.
+        let src = root.appendingPathComponent("legacy-site", isDirectory: true)
+        try fm.createDirectory(at: src.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        try Data("[core]".utf8).write(to: src.appendingPathComponent(".git/config"))
+        for s in ProjectValidator.requiredSentinels {
+            try Data("{}".utf8).write(to: src.appendingPathComponent(s))
+        }
+        try fm.createDirectory(at: src.appendingPathComponent(".anglesite"), withIntermediateDirectories: true)
+        try Data("{}\n".utf8).write(to: src.appendingPathComponent(".anglesite/chat-history.jsonl"))
+
+        let pkgURL = root.appendingPathComponent("Imported.anglesite", isDirectory: true)
+        let pkg = try PackageTransfer.importDirectory(src, toPackageAt: pkgURL, displayName: "Imported", fileManager: fm)
+
+        // Source/ holds the copied tree incl. .git; sentinels present.
+        #expect(fm.fileExists(atPath: pkg.sourceURL.appendingPathComponent(".git/config").path))
+        #expect(pkg.sourceValidation(fileManager: fm).isValid)
+        // Legacy .anglesite/ migrated to Config/, and removed from Source/.
+        #expect(fm.fileExists(atPath: pkg.configURL.appendingPathComponent("chat-history.jsonl").path))
+        #expect(!fm.fileExists(atPath: pkg.sourceURL.appendingPathComponent(".anglesite").path))
+        // Fresh marker.
+        #expect((try? pkg.readMarker().displayName) == "Imported")
+        // Original untouched.
+        #expect(fm.fileExists(atPath: src.appendingPathComponent(".anglesite/chat-history.jsonl").path))
+    }
+
+    @Test("import throws when the source is not a directory")
+    func importRejectsNonDirectory() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let file = root.appendingPathComponent("not-a-dir.txt")
+        try Data("x".utf8).write(to: file)
+        #expect(throws: (any Error).self) {
+            _ = try PackageTransfer.importDirectory(file, toPackageAt: root.appendingPathComponent("X.anglesite"), displayName: "X", fileManager: fm)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter PackageTransferTests`
+Expected: FAIL — no `PackageTransfer`.
+
+- [ ] **Step 3: Implement `Sources/AnglesiteCore/PackageTransfer.swift`**
+
+```swift
+import Foundation
+
+/// Copies between plain Anglesite directories and `.anglesite` packages (spec §5).
+///
+/// Import (dir → package) and Export (package → dir) are the symmetric migration paths: the app
+/// never edits a plain directory in place, so Import copies into a fresh package and Export copies
+/// the package's `Source/` working tree back out.
+public enum PackageTransfer {
+    public enum TransferError: Error, Equatable, Sendable {
+        case sourceNotADirectory(URL)
+        case destinationExists(URL)
+    }
+
+    /// Copy `sourceDir`'s tree into a new package's `Source/`, preserving an existing `.git`,
+    /// migrating any `<sourceDir>/.anglesite/` into the package's `Config/`, and stamping a fresh
+    /// `Info.plist` marker. The original `sourceDir` is left untouched.
+    @discardableResult
+    public static func importDirectory(
+        _ sourceDir: URL,
+        toPackageAt packageURL: URL,
+        displayName: String,
+        fileManager: FileManager = .default
+    ) throws -> AnglesitePackage {
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: sourceDir.path, isDirectory: &isDir), isDir.boolValue else {
+            throw TransferError.sourceNotADirectory(sourceDir)
+        }
+        guard !fileManager.fileExists(atPath: packageURL.path) else {
+            throw TransferError.destinationExists(packageURL)
+        }
+
+        let pkg = AnglesitePackage(url: packageURL)
+        try fileManager.createDirectory(at: pkg.url, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: pkg.configURL, withIntermediateDirectories: true)
+
+        // Copy the whole tree (incl. .git) into Source/. copyItem creates Source/.
+        try fileManager.copyItem(at: sourceDir, to: pkg.sourceURL)
+
+        // Migrate a legacy hidden .anglesite/ dir from Source/ into Config/.
+        let legacy = pkg.sourceURL.appendingPathComponent(".anglesite", isDirectory: true)
+        if fileManager.fileExists(atPath: legacy.path) {
+            let contents = try fileManager.contentsOfDirectory(at: legacy, includingPropertiesForKeys: nil)
+            for item in contents {
+                let dest = pkg.configURL.appendingPathComponent(item.lastPathComponent)
+                if fileManager.fileExists(atPath: dest.path) { try fileManager.removeItem(at: dest) }
+                try fileManager.moveItem(at: item, to: dest)
+            }
+            try fileManager.removeItem(at: legacy)
+        }
+
+        try pkg.writeMarker(.init(displayName: displayName), fileManager: fileManager)
+        return pkg
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter PackageTransferTests`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/PackageTransfer.swift Tests/AnglesiteCoreTests/PackageTransferTests.swift
+git commit -m "$(cat <<'EOF'
+feat(#242): PackageTransfer.importDirectory (plain dir -> .anglesite package)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: `PackageTransfer.exportSource`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/PackageTransfer.swift`
+- Test: `Tests/AnglesiteCoreTests/PackageTransferTests.swift` (append)
+
+**Interfaces:**
+- Produces: `static func exportSource(of package: AnglesitePackage, to destinationDir: URL, includeGit: Bool, fileManager: FileManager) throws`
+
+- [ ] **Step 1: Write the failing tests** (append, inside the struct)
+
+```swift
+    private func makePackageWithSource(in root: URL) throws -> AnglesitePackage {
+        let fm = FileManager.default
+        let (pkg, _) = try AnglesitePackage.createSkeleton(at: root.appendingPathComponent("Acme.anglesite", isDirectory: true), displayName: "Acme")
+        try Data("// astro".utf8).write(to: pkg.sourceURL.appendingPathComponent("astro.config.ts"))
+        try fm.createDirectory(at: pkg.sourceURL.appendingPathComponent("node_modules/foo"), withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: pkg.sourceURL.appendingPathComponent("node_modules/foo/index.js"))
+        try fm.createDirectory(at: pkg.sourceURL.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        try Data("[core]".utf8).write(to: pkg.sourceURL.appendingPathComponent(".git/config"))
+        return pkg
+    }
+
+    @Test("export copies Source/ out, always excluding node_modules; .git excluded by default")
+    func exportExcludesByDefault() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let pkg = try makePackageWithSource(in: root)
+        let dest = root.appendingPathComponent("exported", isDirectory: true)
+
+        try PackageTransfer.exportSource(of: pkg, to: dest, includeGit: false, fileManager: fm)
+
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent("astro.config.ts").path))
+        #expect(!fm.fileExists(atPath: dest.appendingPathComponent("node_modules").path))
+        #expect(!fm.fileExists(atPath: dest.appendingPathComponent(".git").path))
+    }
+
+    @Test("export keeps .git when includeGit is true")
+    func exportKeepsGitWhenRequested() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let pkg = try makePackageWithSource(in: root)
+        let dest = root.appendingPathComponent("exported-git", isDirectory: true)
+
+        try PackageTransfer.exportSource(of: pkg, to: dest, includeGit: true, fileManager: fm)
+
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent(".git/config").path))
+        #expect(!fm.fileExists(atPath: dest.appendingPathComponent("node_modules").path))
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter PackageTransferTests`
+Expected: FAIL — no `exportSource`.
+
+- [ ] **Step 3: Implement `exportSource` in `PackageTransfer.swift`** (add to the enum)
+
+```swift
+    /// Copy `package`'s `Source/` working tree to `destinationDir`. Always omits `node_modules/`;
+    /// omits `.git` unless `includeGit`. `destinationDir` must not already exist.
+    public static func exportSource(
+        of package: AnglesitePackage,
+        to destinationDir: URL,
+        includeGit: Bool,
+        fileManager: FileManager = .default
+    ) throws {
+        guard !fileManager.fileExists(atPath: destinationDir.path) else {
+            throw TransferError.destinationExists(destinationDir)
+        }
+        // Copy wholesale, then prune the excluded top-level entries — simpler and safer than a
+        // filtered deep enumerate, and the excluded dirs are always top-level in an Astro project.
+        try fileManager.copyItem(at: package.sourceURL, to: destinationDir)
+        let nodeModules = destinationDir.appendingPathComponent("node_modules", isDirectory: true)
+        if fileManager.fileExists(atPath: nodeModules.path) { try fileManager.removeItem(at: nodeModules) }
+        if !includeGit {
+            let git = destinationDir.appendingPathComponent(".git", isDirectory: true)
+            if fileManager.fileExists(atPath: git.path) { try fileManager.removeItem(at: git) }
+        }
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter PackageTransferTests`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/PackageTransfer.swift Tests/AnglesiteCoreTests/PackageTransferTests.swift
+git commit -m "$(cat <<'EOF'
+feat(#242): PackageTransfer.exportSource (package Source/ -> plain dir)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: File ▸ Import / File ▸ Export menu glue
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteActions.swift` (add helpers)
+- Modify: `Sources/AnglesiteApp/AnglesiteApp.swift:121-143` (add menu items)
+
+**Interfaces:**
+- Consumes: `PackageTransfer`, `SiteStore.record`, `AppSettings.sitesRoot`.
+
+- [ ] **Step 1: Add `importPackage()` to `SiteActions`**
+
+```swift
+    /// Pick a plain Anglesite directory, choose where to save the new package, copy it in, and
+    /// register the package. Returns the new site, or nil if either panel was cancelled.
+    static func importPackage() async throws -> SiteStore.Site? {
+        let picker = NSOpenPanel()
+        picker.canChooseDirectories = true
+        picker.canChooseFiles = false
+        picker.allowsMultipleSelection = false
+        picker.prompt = "Choose"
+        picker.message = "Choose an existing Anglesite site folder to import."
+        guard picker.runModal() == .OK, let sourceDir = picker.url else { return nil }
+
+        let name = sourceDir.deletingPathExtension().lastPathComponent
+        let save = NSSavePanel()
+        save.message = "Save the imported site package."
+        save.nameFieldStringValue = "\(name).anglesite"
+        save.directoryURL = AppSettings.shared.sitesRoot
+        guard save.runModal() == .OK, let dest = save.url else { return nil }
+
+        do {
+            let pkg = try PackageTransfer.importDirectory(sourceDir, toPackageAt: dest, displayName: name)
+            let site = try await SiteStore.shared.record(pkg)
+            #if ANGLESITE_MAS
+            if let bm = try? SecurityScopedBookmark.create(for: pkg.url) {
+                try await SiteStore.shared.setBookmark(bm, for: site.id)
+            }
+            #endif
+            return site
+        } catch {
+            throw ImportError(folderName: sourceDir.lastPathComponent, underlying: error)
+        }
+    }
+
+    /// Export the given site's source tree to a chosen folder.
+    static func exportSource(of site: SiteStore.Site, includeGit: Bool) {
+        let save = NSSavePanel()
+        save.message = "Export this site's source files to a folder."
+        save.nameFieldStringValue = site.name
+        guard save.runModal() == .OK, let dest = save.url else { return }
+        do {
+            try PackageTransfer.exportSource(of: AnglesitePackage(url: site.packageURL), to: dest, includeGit: includeGit)
+        } catch {
+            NSAlert(error: error).runModal()
+        }
+    }
+```
+
+- [ ] **Step 2: Add the menu items in `AnglesiteApp.swift`**
+
+Inside the `CommandGroup(replacing: .newItem)` block (after the "Open Recent" menu, before the group closes), add:
+
+```swift
+                Divider()
+                Button("Import Site…") {
+                    Task { @MainActor in
+                        if let site = try? await SiteActions.importPackage() {
+                            openWindow(value: site.id)
+                        }
+                    }
+                }
+```
+
+Export operates on the focused site window; add it via a `CommandGroup(after: .saveItem)` (a site window exposes its `SiteStore.Site` through the existing focused-value/router mechanism the app already uses — wire it to whatever the window exposes; if no focused-site value exists yet, gate Export behind the launcher's current selection). Minimum viable: add the menu item and disable it when no site is focused.
+
+```swift
+        .commands {
+            CommandGroup(after: .importExport) {
+                Button("Export Site Source…") {
+                    if let site = WindowRouter.shared.focusedSite {   // see note
+                        SiteActions.exportSource(of: site, includeGit: false)
+                    }
+                }
+                .disabled(WindowRouter.shared.focusedSite == nil)
+            }
+        }
+```
+
+> **Note for the implementer:** the app has no `focusedSite` accessor today. Either (a) add a `@Published var focusedSite: SiteStore.Site?` to `WindowRouter` that `SiteWindow` sets in `loadAndStart`/clears in `onDisappear`, or (b) put Export in the site window's own toolbar/menu instead of the global File menu. Pick (a) if a global menu item is wanted; it's a few lines. Confirm with the controller if unsure.
+
+- [ ] **Step 3: Build both targets**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodegen generate && DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build && DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build`
+Expected: BUILD SUCCEEDED for both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp
+git commit -m "$(cat <<'EOF'
+feat(#242): File menu Import (dir->package) and Export (package->dir)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** §5 Import (copy into Source/, preserve .git, migrate .anglesite/→Config/, fresh marker, original untouched) → Task 1. §5 Export (copy Source/ out, exclude node_modules, optional .git) → Task 2. Menu wiring → Task 3.
+
+**Placeholder scan:** none in Core tasks (full code + tests). Task 3 contains ONE flagged design choice (`focusedSite` accessor) with two concrete options and a "confirm with controller" — resolve it during implementation; not a silent placeholder.
+
+**Risk flags:** `copyItem` fails if the destination exists — both functions guard with `destinationExists`. Import preserves `.git` by copying the whole tree (no filtering on import, unlike export). On MAS, Import's `NSSavePanel` destination carries a user grant; the bookmark is minted on the package URL.
+
+## Handoff to P4
+
+P4 (config store) consumes the migrated `Config/` layout this phase produces on import. It adds `SiteConfigStore` (`Config/settings.plist`) and repoints `ChatHistoryStore` to `Config/chat-history.jsonl` (where import now places legacy history).

--- a/docs/superpowers/plans/2026-06-19-anglesite-package-model-p4-config-store.md
+++ b/docs/superpowers/plans/2026-06-19-anglesite-package-model-p4-config-store.md
@@ -1,0 +1,275 @@
+# `.anglesite` Package Model — Phase 4 (Per-Site Config Store) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each package an app-owned per-site config store in `Config/` — a `SiteConfigStore` over `Config/settings.plist` — and move chat history from the legacy `<site>/.anglesite/` location into `Config/chat-history.jsonl`, so app-owned state lives in the package (outside the `Source/` git repo) rather than app-global or in the source tree.
+
+**Architecture:** A new `SiteConfigStore` actor reads/writes a small `SiteSettings` Codable as a plist in `Config/`. `ChatHistoryStore` is repointed from `siteDirectory/.anglesite/` to the package's `Config/` directory. Both are pure `AnglesiteCore` types with Swift Testing coverage; the App passes `site.configDirectory` (from P2) instead of `site.path`.
+
+**Tech Stack:** Swift 5.10 / SwiftPM, Swift Testing, `PropertyListEncoder`/`Decoder`, `AnglesiteCore` actors.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-19-anglesite-package-model-design.md` §4 (per-site config store).
+- **Depends on P1** (`AnglesitePackage.configURL`), **P2** (`Site.configDirectory`/`sourceDirectory`), **P3** (import migrates legacy `.anglesite/`→`Config/`).
+- **Toolchain:** prefix with `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer`.
+- **CI reality:** logic + tests in `AnglesiteCore`; App glue verified by build.
+- **`.site-config` stays in `Source/`** — it is template/plugin-owned (the plugin's pre-deploy check reads it). The app does NOT read it back today (only the scaffolder writes it). "Folding into the marker" (spec §4) means the **app's** per-site identity/preferences live in `Info.plist`/`settings.plist`; do NOT delete or relocate `.site-config`, or the plugin breaks.
+- **Forward-looking schema:** `SiteSettings` starts minimal (spec §4: "mostly empty today"). Add fields only when a feature needs them — YAGNI.
+- **Commit style:** Conventional Commits, scope `(#242)`, body ends `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## File Structure
+
+- `Sources/AnglesiteCore/SiteConfigStore.swift` — **create**: `SiteSettings` + `SiteConfigStore`.
+- `Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift` — **create**.
+- `Sources/AnglesiteCore/ChatHistoryStore.swift` — **modify**: init takes `configDirectory:`; file path → `Config/chat-history.jsonl`.
+- `Tests/AnglesiteCoreTests/ChatHistoryStoreTests.swift` — **modify**: update the `.anglesite/...` path assertions to `Config/...` (note: this is an XCTest holdout file; keep it XCTest, just update paths).
+- `Sources/AnglesiteApp/SiteWindow.swift` — **modify**: construct `ChatHistoryStore(configDirectory: resolved.configDirectory)`.
+
+---
+
+### Task 1: `SiteConfigStore` over `Config/settings.plist`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SiteConfigStore.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `struct SiteSettings: Sendable, Codable, Equatable { var displayName: String?; init(displayName: String? = nil) }`
+  - `actor SiteConfigStore { init(configDirectory: URL, fileManager: FileManager = .default); func load() throws -> SiteSettings; func save(_ settings: SiteSettings) throws }`
+  - `load()` returns a default (empty) `SiteSettings` when the file is absent.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SiteConfigStoreTests {
+    private func tempConfigDir() throws -> URL {
+        let d = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("siteconfig-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    @Test("load returns empty settings when the file is absent")
+    func loadDefaultsWhenMissing() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+        let settings = try await store.load()
+        #expect(settings == SiteSettings())
+    }
+
+    @Test("save then load round-trips settings through settings.plist")
+    func saveLoadRoundTrips() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+        try await store.save(SiteSettings(displayName: "Acme HQ"))
+
+        #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("settings.plist").path))
+        let loaded = try await store.load()
+        #expect(loaded.displayName == "Acme HQ")
+    }
+
+    @Test("save creates the Config directory if it does not exist")
+    func saveCreatesConfigDir() async throws {
+        let parent = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("siteconfig-\(UUID().uuidString)", isDirectory: true)
+        let dir = parent.appendingPathComponent("Config", isDirectory: true)   // not yet created
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let store = SiteConfigStore(configDirectory: dir)
+        try await store.save(SiteSettings(displayName: "X"))
+        #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("settings.plist").path))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteConfigStoreTests`
+Expected: FAIL — no `SiteConfigStore`/`SiteSettings`.
+
+- [ ] **Step 3: Implement `Sources/AnglesiteCore/SiteConfigStore.swift`**
+
+```swift
+import Foundation
+
+/// App-owned, per-site settings persisted inside the package's `Config/` directory (spec §4).
+/// Deliberately minimal today — it exists so per-site state attaches to the package rather than
+/// app-global `UserDefaults`. Add fields as features need them (YAGNI).
+public struct SiteSettings: Sendable, Codable, Equatable {
+    /// Owner-facing display name override. `nil` falls back to the package marker's displayName.
+    public var displayName: String?
+
+    public init(displayName: String? = nil) {
+        self.displayName = displayName
+    }
+}
+
+/// Reads/writes `Config/settings.plist` for one package. Per-window; owned by the site window.
+public actor SiteConfigStore {
+    private let fileURL: URL
+    private let fileManager: FileManager
+
+    public init(configDirectory: URL, fileManager: FileManager = .default) {
+        self.fileURL = configDirectory.appendingPathComponent("settings.plist")
+        self.fileManager = fileManager
+    }
+
+    /// Load settings, or a default (empty) `SiteSettings` when the file doesn't exist yet.
+    public func load() throws -> SiteSettings {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return SiteSettings() }
+        let data = try Data(contentsOf: fileURL)
+        return try PropertyListDecoder().decode(SiteSettings.self, from: data)
+    }
+
+    /// Persist settings to `settings.plist` (XML plist, atomic), creating `Config/` if needed.
+    public func save(_ settings: SiteSettings) throws {
+        try fileManager.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(settings)
+        try data.write(to: fileURL, options: [.atomic])
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteConfigStoreTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteConfigStore.swift Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+git commit -m "$(cat <<'EOF'
+feat(#242): SiteConfigStore over Config/settings.plist
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Repoint `ChatHistoryStore` to `Config/`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ChatHistoryStore.swift:44-56`
+- Modify: `Tests/AnglesiteCoreTests/ChatHistoryStoreTests.swift` (path assertions)
+
+**Interfaces:**
+- Changes: `ChatHistoryStore.init(configDirectory: URL, fileManager:)` (was `siteDirectory:`); `fileURL` = `configDirectory/chat-history.jsonl` (no nested `.anglesite/`, since `Config/` is already the app-owned dir).
+
+- [ ] **Step 1: Update the test to the new init + path** (`ChatHistoryStoreTests.swift` — XCTest holdout, keep XCTest)
+
+In `setUp`, the temp dir now represents the Config directory. Replace the path assertion in `testAppendCreatesDirectoryAndFile`:
+
+```swift
+    func testAppendCreatesDirectoryAndFile() async throws {
+        let store = ChatHistoryStore(configDirectory: tmpDir)
+        try await store.append(.init(role: .user, content: "Hello"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tmpDir.appendingPathComponent("chat-history.jsonl").path))
+    }
+```
+
+And update every other `ChatHistoryStore(siteDirectory: tmpDir)` in the file to `ChatHistoryStore(configDirectory: tmpDir)`. (The `.anglesite/chat-history.jsonl` path in any other assertion becomes `chat-history.jsonl`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ChatHistoryStoreTests`
+Expected: FAIL — `siteDirectory:` label no longer matches / path mismatch.
+
+- [ ] **Step 3: Update `ChatHistoryStore.init`** (lines 44–56)
+
+```swift
+    public init(configDirectory: URL, fileManager: FileManager = .default) {
+        // Config/ is already the app-owned per-site dir (no nested .anglesite/ — that was the
+        // pre-package layout; P3 import migrates old history into Config/).
+        self.fileURL = configDirectory.appendingPathComponent("chat-history.jsonl")
+        self.fileManager = fileManager
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        self.encoder = encoder
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+```
+
+The `append` method's directory creation (it currently creates the `.anglesite` parent) still works: it creates `fileURL.deletingLastPathComponent()` = `Config/`. Confirm the create-parent line uses `fileURL.deletingLastPathComponent()`; if it hardcodes `.anglesite`, change it to `fileURL.deletingLastPathComponent()`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ChatHistoryStoreTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ChatHistoryStore.swift Tests/AnglesiteCoreTests/ChatHistoryStoreTests.swift
+git commit -m "$(cat <<'EOF'
+feat(#242): chat history lives in package Config/, not <site>/.anglesite/
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: App wires the config dir into the chat store
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift` (ChatModel/ChatHistoryStore construction, ~lines 462-502)
+
+**Interfaces:**
+- Consumes: `SiteStore.Site.configDirectory` (P2), `ChatHistoryStore(configDirectory:)`.
+
+- [ ] **Step 1: Update the construction site**
+
+Find where `ChatHistoryStore(siteDirectory:` is built in `SiteWindow.swift` and change it to:
+
+```swift
+        let history = ChatHistoryStore(configDirectory: resolved.configDirectory)
+```
+
+(Leave content/graph/preview/deploy on `resolved.sourceDirectory` from P2 — only chat history moves to `Config/`.) Grep `ChatHistoryStore(` across `Sources/AnglesiteApp` and `Sources/AnglesiteCore` to catch any other construction sites (e.g. intents/undo) and update each to `configDirectory:` using the relevant `Site.configDirectory`.
+
+- [ ] **Step 2: Build both targets + full suite**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodegen generate && DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build && DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .`
+Expected: BUILD SUCCEEDED; all Core/Intents/Bridge suites pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp Sources/AnglesiteCore
+git commit -m "$(cat <<'EOF'
+feat(#242): site window constructs ChatHistoryStore from package Config/
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** §4 per-site config store (`Config/settings.plist`) → Task 1. §4 chat history → `Config/` → Tasks 2–3. §4 `.site-config` folding → handled by constraint (app uses marker/settings; `.site-config` stays for the plugin) — documented, no code needed beyond P1/P2 already putting identity in the marker.
+
+**Placeholder scan:** none — full code + tests for both Core types; App task is an exact construction-site swap.
+
+**Risk flags:** the `ChatHistoryStore` init label change breaks every caller — grep `ChatHistoryStore(` and fix all. The `append` directory-create must use `fileURL.deletingLastPathComponent()`, not a hardcoded `.anglesite`. `SiteSettings` is intentionally tiny; resist adding speculative fields.
+
+## Handoff to P5
+
+P5 (docs) reconciles CLAUDE.md's "source of truth" wording with the now-shipped package model and updates `~/Sites`/layout references.

--- a/docs/superpowers/plans/2026-06-19-anglesite-package-model-p5-docs.md
+++ b/docs/superpowers/plans/2026-06-19-anglesite-package-model-p5-docs.md
@@ -1,0 +1,157 @@
+# `.anglesite` Package Model — Phase 5 (Docs Reconciliation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reconcile the project docs with the now-shipped `.anglesite` package model: update CLAUDE.md's "source of truth" wording and module-layout/`~/Sites` references so they describe the package world (a `Source/` git repo wrapped in a Finder-opaque package), while staying compatible with the #72 ordering note (final filesystem→Git wording waits on the container epics).
+
+**Architecture:** Documentation-only. No code, no tests. Verification is internal consistency: the docs must not describe both the old `~/Sites`-scan model and the new recents/package model as current, and must not claim an unshipped state.
+
+**Tech Stack:** Markdown (`CLAUDE.md`, design spec cross-link).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-19-anglesite-package-model-design.md` §8 (epic interactions & docs).
+- **Depends on P1–P4 having landed** (the package model is real before docs claim it).
+- **#72 ordering (verbatim from CLAUDE.md):** the filesystem→Git "source of truth" rewording must not be finalized "before that ships, or the doc describes an unshipped state." So: describe the **package** model (which HAS shipped after P1–P4) and that `Source/` is a git repo opened by `cd`/git/VS Code/CLI; phrase the Git-as-source-of-truth point as still gated on the container epics (#66/#69) + repo-everywhere (#68), not as done.
+- **Don't invent shipped state:** container runtimes (#66/#69), git bootstrap (#68), and the iOS client (#71) are still open — don't describe them as done.
+- **Commit style:** Conventional Commits, scope `(#242)`, body ends `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## File Structure
+
+- `CLAUDE.md` — **modify**: the "source of truth" bullet (line 64), the module-layout/template paragraph, and `~/Sites` references that imply the app owns a scan root.
+
+---
+
+### Task 1: Reword the "source of truth" bullet for the package model
+
+**Files:**
+- Modify: `CLAUDE.md` (the editing-guidelines bullet currently at line 64)
+
+- [ ] **Step 1: Read the current bullet to anchor the edit**
+
+Run: `grep -n "source of truth" CLAUDE.md`
+Confirm the bullet reads (≈line 64): "**The filesystem is the source of truth** — the app must never become the only way to edit a site. Owners can open `~/Sites/<name>/` in Finder, VS Code, or Claude Code CLI and continue working. (Per #72 …)".
+
+- [ ] **Step 2: Replace the bullet**
+
+Replace that whole bullet with:
+
+```markdown
+- **The filesystem is the source of truth** — the app must never become the only way to edit a
+  site. A site is now an `.anglesite` **package**: Finder treats it as opaque (double-click opens
+  it in Anglesite), but its `Source/` subdirectory is an ordinary git repo, so `cd`, `git`, VS
+  Code, and the Claude Code CLI all descend into `Foo.anglesite/Source/` and keep working. App-
+  owned per-site state lives alongside it in `Foo.anglesite/Config/`, outside that repo. (Per #72
+  this still reframes to **Git** as the source of truth — the `Source/` repo, clonable anywhere,
+  is the externally-editable copy — but only once the container runtimes (#66/#69) land and every
+  site is a repo (#68). The package model is compatible with both states; don't finalize the
+  filesystem→Git wording before that ships, or the doc describes an unshipped state.)
+```
+
+- [ ] **Step 3: Verify no contradictory "app owns ~/Sites" claim remains as current**
+
+Run: `grep -n "~/Sites" CLAUDE.md`
+For each hit, confirm it's either (a) describing the *default save location* for new/imported packages, or (b) historical context — NOT "the app discovers sites by scanning `~/Sites`" (that model was removed in P2). Update any that still describe the scan as current. If a hit is inside the `AppSettings.sitesRoot` discussion, reword to "the default location new/imported packages are saved to."
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(#242): reword "source of truth" for the .anglesite package model
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Update the module-layout / template paragraph
+
+The "two-repo coordination" / "Stack" / module-layout sections describe the template scaffolding into a site dir and the app hosting `~/Sites/<name>/`. Bring them in line with the package model (scaffold targets `Source/`; a site is a package).
+
+**Files:**
+- Modify: `CLAUDE.md` (the "two-repo coordination" template paragraph and the `Resources/Template/` / module-layout notes)
+
+- [ ] **Step 1: Locate the relevant lines**
+
+Run: `grep -n "Template/\|website template\|scaffold\|TemplateRuntime\|Sites/<name>" CLAUDE.md`
+
+- [ ] **Step 2: Add a short "Site identity" note**
+
+Under the "## Stack" section (or immediately after the two-repo table), add a concise paragraph:
+
+```markdown
+## Site identity — the `.anglesite` package
+
+A site is a self-contained `.anglesite` **package** (a directory with the `dev.anglesite.site`
+package UTI). Layout: `Info.plist` (marker: format version + stable site UUID + display name),
+`Source/` (the Astro project, a git repo — the externally-editable, clonable unit), and `Config/`
+(app-owned per-site state: `settings.plist`, `chat-history.jsonl`, caches — never in git). The app
+opens packages explicitly (Finder double-click, **File ▸ Open**, **Open Recent**) and discovers
+them via a recents registry, not by scanning a folder. **File ▸ Import** copies a plain Anglesite
+directory into a new package; **File ▸ Export** copies a package's `Source/` back out. New sites
+scaffold into `Source/`; deploy, the dev server, and `pre-deploy-check` all run with cwd =
+`Source/`. On the MAS build, one security-scoped bookmark per package covers both `Source/` and
+`Config/`. The `.site-config` file stays in `Source/` (template/plugin-owned).
+```
+
+- [ ] **Step 3: Reconcile any stale scaffold/`~/Sites` wording**
+
+Where the template paragraph says scaffolding lands in `~/Sites/<name>/`, update to "into the package's `Source/` (default package location `~/Sites/<name>.anglesite`)".
+
+- [ ] **Step 4: Self-consistency check**
+
+Run: `grep -n "scans\|scanning\|sites.json\|discover" CLAUDE.md`
+Confirm nothing still describes `~/Sites` scanning or `sites.json` as the current discovery mechanism (P2 replaced it with the recents registry / `recents.json`). Fix any stragglers.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(#242): document the .anglesite package layout + recents discovery
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Cross-link the design spec and close the issue loop
+
+**Files:**
+- Modify: `CLAUDE.md` (the "## Plan" section — add #242 to the shipped/feature list as appropriate)
+
+- [ ] **Step 1: Add a one-line pointer**
+
+In the "## Plan" section where features are tracked, add a short note that the `.anglesite` package model (#242) shipped, linking the design spec: `docs/superpowers/specs/2026-06-19-anglesite-package-model-design.md`. Keep it factual and dated only if the section uses dates.
+
+- [ ] **Step 2: Final docs consistency pass**
+
+Run: `grep -rn "~/Sites\|sites.json\|filesystem is the source" CLAUDE.md docs/build-plan.md 2>/dev/null`
+Skim each hit; ensure none assert the removed scan model as current. `docs/build-plan.md` edits are optional — only touch it if a line directly contradicts the package model; otherwise leave the roadmap alone.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(#242): note package model shipped; link design spec
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** §8 CLAUDE.md "source of truth" reconciliation → Task 1. Package-model documentation → Task 2. Spec cross-link / plan note → Task 3. The §8 #68/#66/#69 alignment is already encoded in the spec itself (the plans for those epics consume `Source/`); P5 only needs the doc wording, which Tasks 1–2 cover with the #72-compatible phrasing.
+
+**Placeholder scan:** none — each task gives the exact replacement prose and the grep commands to find anchors.
+
+**Risk flags:** the #72 constraint is the trap — do NOT state Git-as-source-of-truth as done; keep it gated on the container epics. Don't describe #66/#69/#68/#71 as shipped. This is the final phase of #242; after it lands, run the whole-#242 review and use superpowers:finishing-a-development-branch to open the PR.

--- a/docs/superpowers/specs/2026-06-19-anglesite-package-model-design.md
+++ b/docs/superpowers/specs/2026-06-19-anglesite-package-model-design.md
@@ -1,0 +1,231 @@
+# `.anglesite` package + per-site config model — design
+
+**Issue:** #242 — Adopt `.anglesite` package + per-site (Xcode-style) config model
+**Date:** 2026-06-19
+**Status:** Approved design; ready for implementation planning.
+
+## Goal
+
+Adopt an **Xcode-style, per-site identity model**: a site is a self-contained
+`.anglesite` macOS **package** that the app opens directly (like Xcode opens a
+project), with per-site configuration attached to the package rather than stored
+app-globally. This replaces the implicit "the app owns `~/Sites/<name>/`"
+(Mail.app-style) assumption with "the project is the unit, and its config travels
+with it."
+
+## Why
+
+Anglesite lets owners open *any* Anglesite website, and the project ethos commits
+to "the filesystem (→ Git, per #72) is the source of truth — the app must never
+become the only way to edit a site." That argues against an app-owned store and
+for an Xcode-style model where the **project is the unit**. A macOS package (a
+directory with a declared package UTI) is the idiomatic fit: Finder treats it as
+opaque (double-click opens it in Anglesite) while `cd`, `git`, VS Code, and the
+Claude Code CLI all still descend into it normally — so the "open in any editor /
+Git is the source of truth" ethos is preserved; only Finder's double-click
+behavior changes.
+
+## Decisions (locked in brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Spec scope | Comprehensive (the whole issue), implemented in phases |
+| Scene/window model | Keep custom `WindowGroup(for: String.self)` + declare the package UTI; **not** `DocumentGroup` |
+| Git boundary | Repo = the **source subdir**; app config lives in the package but **outside** git |
+| Internal layout | `Source/` (git repo) + `Config/` (app-owned) + `Info.plist` marker |
+| Migration of existing sites | **File ▸ Import** copies a plain dir into a new package (symmetric with File ▸ Export); originals untouched. No in-place wrap, no plain-dir compat runtime |
+| Discovery | **Recents-based** registry; drop the `~/Sites` scan (`~/Sites` survives only as the default save location) |
+| Identity | **Stable UUID** in `Info.plist` (replaces today's path-derived id) |
+
+## 1. Package format & identity
+
+`<Name>.anglesite` is a directory with extension `anglesite` and
+`LSTypeIsPackage = YES` — Finder-opaque (double-click opens in Anglesite), but
+`cd` / `git` / VS Code / Claude Code CLI descend into it normally.
+
+```
+Acme.anglesite/                 (UTI: dev.anglesite.site, LSTypeIsPackage)
+├── Info.plist                  marker: formatVersion, siteID (UUID), displayName, createdDate
+├── Source/                     git repo — the Astro project (clonable, containerized, pushable)
+│   ├── .git/
+│   ├── src/  astro.config.mjs  package.json
+│   └── scripts/pre-deploy-check.ts
+└── Config/                     app-owned, NOT in git
+    ├── settings.plist          per-site: Siri/readiness config, preferences
+    ├── chat-history.jsonl      (migrated from <site>/.anglesite/)
+    └── cache/                  derived/cached state
+```
+
+**Identity change.** Site identity moves from today's path-derived string
+(`SiteStore.identifier(for:)` = canonicalized path) to a **stable UUID** minted at
+creation and stored in `Info.plist`. This survives moves/renames and gives Siri
+(`SiteEntity`) a durable id. `WindowGroup(for: String.self)` is unchanged — it is
+now keyed by the UUID string instead of the path string.
+
+`Info.plist` fields:
+
+- `AnglesiteFormatVersion` (Int) — for forward-compat gating.
+- `AnglesiteSiteID` (String, UUID) — stable identity.
+- `AnglesiteDisplayName` (String) — defaults to the package base name.
+- `AnglesiteCreatedDate` (Date).
+
+## 2. Type declarations
+
+Add to both targets (DevID + MAS) via `project.yml` / Info.plist:
+
+- `UTExportedTypeDeclarations` entry for `dev.anglesite.site`:
+  - conforms to `com.apple.package`, `public.composite-content`
+  - `public.filename-extension = anglesite`
+- `CFBundleDocumentTypes` entry:
+  - role **Editor**
+  - `LSTypeIsPackage = YES`
+  - `LSItemContentTypes = [dev.anglesite.site]`
+
+**Open routing.** `application(_:open:)` (SwiftUI `onOpenURL` / `openWindow`
+equivalent) receives an opened package URL → resolves/validates → registers in the
+recents registry → opens its window. This covers Finder double-click and "Open
+With" on both targets. On MAS the user-initiated open carries an implicit grant; a
+security-scoped bookmark is minted on first open (see §7).
+
+## 3. Site model: scanner → recents registry
+
+`SiteStore` stops scanning `~/Sites`. It becomes a **recents registry** of
+packages the owner has created / opened / imported.
+
+- Persisted in Application Support (replacing today's `sites.json`): per entry
+  `{ siteID (UUID), packageURL, displayName, bookmarkData? (MAS), lastSeen }`.
+- The launcher "Sites" window lists recents (Xcode "recent projects" model).
+- `~/Sites` survives **only** as the default save location for new/imported
+  packages — it is no longer a discovery root and carries no app-owns-folder
+  semantics.
+- `ProjectValidator` now validates `<pkg>/Source/` (sentinels live in the source
+  tree), not the package root.
+- Stale entries (package moved/deleted/bookmark unresolvable) are marked missing
+  rather than silently dropped.
+
+## 4. Per-site config store
+
+New `SiteConfigStore` (in `AnglesiteCore`) reads/writes
+`<pkg>/Config/settings.plist`; owned per-window by `SiteWindow`.
+
+- **Starter schema** (forward-looking; mostly empty today): display name,
+  Siri/readiness config, per-site preferences. Grows as features attach per-site
+  state instead of reaching for app-global `UserDefaults`.
+- `chat-history.jsonl` moves from `<site>/.anglesite/` → `<pkg>/Config/`.
+- The old write-once `.site-config` (SITE_NAME/SITE_TYPE/TAGLINE) is folded into
+  `Info.plist` (identity) + `settings.plist` (preferences).
+- Replaces app-global per-site state. Genuinely global keys (e.g.
+  `lastOpenedSiteID`) stay in `AppSettings`, now holding a UUID.
+
+## 5. Create / Import / Export
+
+**New site.** Scaffold writes into `<pkg>/Source/`:
+
+1. Create package dir + `Info.plist` (fresh UUID) + empty `Config/`.
+2. Run the template scaffold with cwd = `<pkg>/Source/`.
+3. `git init` in `Source/` (coordinates with #68).
+4. Default save path `~/Sites/<slug>.anglesite`; register in recents.
+
+**File ▸ Import** (plain dir → package):
+
+1. Pick a plain Anglesite directory.
+2. **Copy** its tree into a new package's `Source/` (preserve an existing `.git`
+   if present).
+3. Migrate any `<dir>/.anglesite/` contents → `Config/`.
+4. Write `Info.plist` (fresh UUID). Original directory is left untouched.
+
+> **Known tradeoff (documented):** after import two copies exist — the original
+> plain directory and the package. The package's `Source/` is the live copy going
+> forward; the original is no longer tracked by Anglesite. This was an explicit
+> choice over in-place wrapping.
+
+**File ▸ Export** (package → plain dir):
+
+- Copy `<pkg>/Source/` working tree to a chosen plain directory.
+- Default **excludes** `node_modules/`; option to include or exclude `.git`.
+
+## 6. Runtime working directory
+
+All site-rooted subprocess invocations switch cwd from the site root to
+**`<pkg>/Source/`**. `ProcessSupervisor.launch(currentDirectoryURL:)` is unchanged
+— only the URL passed in changes. Affected callers:
+
+- `SiteScaffolder` (scaffold script)
+- `LocalSiteRuntime` (Astro dev server)
+- `DeployCommand` (build + deploy)
+- `PreDeployCheck` (`pre-deploy-check.ts --json`)
+
+## 7. MAS sandbox & bookmarks
+
+- One security-scoped bookmark **per package URL** (today it is per plain-dir
+  site). `Source/` and `Config/` are both inside the granted package, so a single
+  grant covers subprocess cwd inheritance *and* config I/O.
+- Bookmark minted on first open (Finder/powerbox/Open-panel grant), stored in the
+  recents entry, resolved + `startAccessingSecurityScopedResource()` per
+  `SiteWindow` lifetime (existing `SiteWindow.acquireGrant()` flow, retargeted to
+  the package URL).
+
+## 8. Epic interactions & docs
+
+- **#68 (git bootstrap):** operates on `Source/` — `git init` / first push happen
+  there. Aligns cleanly.
+- **#66 / #69 (container runtimes):** the runtime mounts/clones **`Source/`**
+  only; `Config/` never enters the container.
+- **#72 / CLAUDE.md ("source of truth"):** reconcile the wording to the package
+  model — *Git (the `Source/` repo) is the externally-editable, clonable copy; the
+  package wraps it; `cd`/git/VS Code/CLI still descend into it.* #72 notes the
+  filesystem→Git wording should not be finalized until the container runtimes land;
+  the package-model wording proposed here is compatible with both the pre- and
+  post-container states, so it can land with this work, but the final phrasing
+  change is sequenced in P5 and coordinated with #72.
+
+## 9. Error handling & edge cases
+
+- **Unknown / newer `AnglesiteFormatVersion`** → open read-only with an upgrade
+  prompt (forward-compat); never silently rewrite a newer format.
+- **Missing/corrupt `Source/` or failed sentinels** → surface invalid-site state
+  via the existing health surface; do not crash.
+- **Stale recents entry** (package moved/deleted, bookmark unresolvable) → mark
+  missing, offer to relocate or remove.
+- **Import target name collision** → disambiguate the destination path.
+- **Partial scaffold/import failure** → clean up the half-written package (no
+  orphaned partial packages registered in recents).
+
+## 10. Testing
+
+`AnglesiteCore` unit tests (CI-runnable; no hosted app target — per the project's
+CI constraint, keep app-target glue thin and push logic into testable Core types):
+
+- Package read/write round-trip.
+- `Info.plist` marker parse + format-version gating (older / current / newer).
+- `SiteConfigStore` read/write + defaults.
+- Import: dir → package, with and without an existing `.git`; `.anglesite/`
+  migration; original-untouched assertion.
+- Export: package → dir; `node_modules` excluded; `.git` include/exclude option.
+- Identity-UUID stability across a simulated package move.
+- Recents registry persistence + stale-entry handling.
+- cwd resolution = `<pkg>/Source/` for scaffold/dev/deploy/pre-deploy.
+
+## 11. Implementation phasing
+
+The design is comprehensive; the implementation plan will deliver it in phases:
+
+- **P1 — Format core:** package read/write, `Info.plist` marker + UUID identity,
+  type declarations (UTI / `CFBundleDocumentTypes`), format-version gating.
+- **P2 — Open/create + runtime:** `SiteStore` → recents registry, open routing
+  (`onOpenURL`/Finder), new-site scaffold into `Source/`, cwd switch to `Source/`,
+  MAS bookmark retarget to the package.
+- **P3 — Import / Export:** File ▸ Import (dir→package copy), File ▸ Export
+  (package→dir copy).
+- **P4 — Config store:** `SiteConfigStore`, migrate chat history + `.site-config`
+  into `Config/` / `Info.plist`.
+- **P5 — Docs + epic touchpoints:** CLAUDE.md "source of truth" reconciliation
+  (coordinated with #72), confirm #68/#66/#69 alignment notes.
+
+## Out of scope
+
+- Changing the deploy/preview *pipeline* behavior beyond the cwd retarget.
+- Implementing the container runtimes (#66/#69) or git-bootstrap (#68) — this spec
+  only defines the package boundary they consume.
+- Any third-party state/document library (the project stays Plain SwiftUI + actors
+  for v0).


### PR DESCRIPTION
## Summary

Foundation for the Xcode-style **`.anglesite` package model** (#242): a site becomes a Finder-opaque package — `Info.plist` marker (stable UUID) + `Source/` (the Astro project / git repo) + `Config/` (app-owned state). This PR lands **Phase 1 (format core)** and the design spec + phased implementation plans for P2–P5.

### What's implemented (P1 — format core)
- `AnglesitePackage` (`Sources/AnglesiteCore/AnglesitePackage.swift`): the single source of truth for the package layout — `infoPlistURL`/`sourceURL`/`configURL`, an `Info.plist` `Marker` (format version + stable site UUID + display name + created date) with PropertyList read/write, `createSkeleton`, `isPackage`, `Source/` validation, and a forward-compat gate (`Compatibility.readOnlyTooNew` for a newer-than-known format).
- `dev.anglesite.site` exported UTI + `CFBundleDocumentTypes` (Editor, `LSTypeIsPackage`) on **both** targets (`Resources/Info.plist`, `Resources/AnglesiteMAS-Info.plist`).
- 9 Swift Testing cases, all green. **No runtime behavior changes** — this PR only adds the format and the type registration, so it's safe to land ahead of the later phases.

### What's planned (docs only in this PR)
- Design spec: `docs/superpowers/specs/2026-06-19-anglesite-package-model-design.md`
- Phase plans P1–P5: `docs/superpowers/plans/2026-06-19-anglesite-package-model-p*.md`
  - **P2** open/create + runtime (SiteStore→recents, cwd→`Source/`, MAS grant on package)
  - **P3** Import (dir→package) / Export (package→`Source/` out)
  - **P4** per-site `Config/` store + chat history relocation
  - **P5** CLAUDE.md "source of truth" reconciliation

Tracking issues for P2–P5 are filed separately.

## Test plan
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesitePackageTests` → 9/9 pass
- `plutil -lint` clean on both Info.plists; `xcodegen generate` clean

## Design decisions (locked during brainstorming)
- Keep `WindowGroup(for:)` + declare the package UTI (not `DocumentGroup`)
- Git repo = `Source/` subdir; app config in `Config/` outside git
- Recents-based discovery (drops the `~/Sites` scan); stable-UUID identity
- File ▸ Import copies a plain dir into a new package; Export copies `Source/` out

🤖 Generated with [Claude Code](https://claude.com/claude-code)