### PR TITLE
feat(apply-edit): dry_run preview + edit-style op (paired with app #251)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "author": {
     "name": "David W. Keith"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Anglesite is a Claude plugin that scaffolds and manages websites for small businesses. It works with Claude Cowork (non-technical site owners, GUI) and Claude Code (developers, CLI). It generates Astro + Keystatic sites deployed to Cloudflare Workers (Static Assets, via the `@astrojs/cloudflare` adapter).
 
-**Version:** 1.0.2 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
+**Version:** 1.1.0 · **License:** ISC · **Node:** >=22 · **Module system:** ESM
 
 ## Plugin structure
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anglesite",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "type": "module",
   "description": "AI webmaster that scaffolds, designs, and deploys Astro + Keystatic sites on Cloudflare Workers.",
   "scripts": {

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -35,6 +35,7 @@ import { optimizeImage } from "./optimize-images.mjs";
 import {
   createEditAppliedContent,
   createEditFailedContent,
+  createEditPreviewContent,
 } from "./apply-edit-schema.mjs";
 
 function failed(id, reason, detail) {
@@ -48,6 +49,19 @@ function applied(id, file, range, commit, result) {
 /** Splice `replacement` into `source` at the resolved byte range. */
 function spliceSource(source, range, replacement) {
   return source.slice(0, range.start) + replacement + source.slice(range.end);
+}
+
+/** Bounded before/after fragments around a [start,end) splice — keeps preview payloads small. */
+function windowAround(source, start, end, replacement, pad = 200) {
+  const from = Math.max(0, start - pad);
+  const to = Math.min(source.length, end + pad);
+  const before = source.slice(from, to);
+  const after = source.slice(from, start) + replacement + source.slice(end, to);
+  return { before, after };
+}
+
+function preview(id, file, range, op, before, after) {
+  return { content: [createEditPreviewContent(id, file, range, op, before, after)] };
 }
 
 /** Atomic write via temp-sibling + rename, so a crashed mid-write can't truncate the source. */
@@ -195,6 +209,11 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
   }
 
   const next = spliceSource(source, range, replacement);
+
+  if (edit.dry_run) {
+    const { before, after } = windowAround(source, range.start, range.end, replacement);
+    return preview(edit.id, file, range, edit.op, before, after);
+  }
 
   try {
     atomicWrite(absPath, next);

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -178,6 +178,12 @@ async function processImageDrop(projectRoot, edit) {
  * @param {{ onApplied?: (info: {file:string, range:{start:number,end:number}, projectRoot:string}) => Promise<string|undefined> | string | undefined }} [opts]
  */
 export async function applyEdit(projectRoot, edit, opts = {}) {
+  // dry_run is read-only. Image edits can't be previewed without writing optimized
+  // bytes to disk, so refuse rather than violate the no-write invariant.
+  if (edit.dry_run && edit.op === "replace-image-src") {
+    return failed(edit.id, "not-implemented", "dry-run preview is not supported for image edits");
+  }
+
   let effectiveEdit = edit;
   let imageResult;
 

--- a/server/apply-edit-dispatcher.mjs
+++ b/server/apply-edit-dispatcher.mjs
@@ -51,13 +51,19 @@ function spliceSource(source, range, replacement) {
   return source.slice(0, range.start) + replacement + source.slice(range.end);
 }
 
-/** Bounded before/after fragments around a [start,end) splice — keeps preview payloads small. */
-function windowAround(source, start, end, replacement, pad = 200) {
-  const from = Math.max(0, start - pad);
-  const to = Math.min(source.length, end + pad);
-  const before = source.slice(from, to);
-  const after = source.slice(from, start) + replacement + source.slice(end, to);
-  return { before, after };
+/** Bounded before/after fragments around the changed span — keeps preview payloads small for any op. */
+function windowAround(source, next, pad = 200) {
+  // common prefix
+  let p = 0;
+  const max = Math.min(source.length, next.length);
+  while (p < max && source[p] === next[p]) p++;
+  // common suffix (not overlapping the prefix)
+  let s = 0;
+  while (s < max - p && source[source.length - 1 - s] === next[next.length - 1 - s]) s++;
+  const from = Math.max(0, p - pad);
+  const beforeTo = source.length - Math.max(0, s - pad);
+  const afterTo = next.length - Math.max(0, s - pad);
+  return { before: source.slice(from, beforeTo), after: next.slice(from, afterTo) };
 }
 
 function preview(id, file, range, op, before, after) {
@@ -217,7 +223,7 @@ export async function applyEdit(projectRoot, edit, opts = {}) {
   const next = spliceSource(source, range, replacement);
 
   if (edit.dry_run) {
-    const { before, after } = windowAround(source, range.start, range.end, replacement);
+    const { before, after } = windowAround(source, next);
     return preview(edit.id, file, range, edit.op, before, after);
   }
 

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -88,3 +88,10 @@ export function createEditAppliedContent(id, file, range, commit, result) {
   if (result !== undefined) body.result = result;
   return { type: "text", text: JSON.stringify(body) };
 }
+
+/** Build the MCP `content` entry for an edit-preview (dry-run) response. `before`/`after` are the
+ *  windowed source fragments around the change — see dispatcher `windowAround`. */
+export function createEditPreviewContent(id, file, range, op, before, after) {
+  const body = { type: "anglesite:edit-preview", id, file, range, op, before, after };
+  return { type: "text", text: JSON.stringify(body) };
+}

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -38,7 +38,7 @@ export const elementInfoSchema = z.object({
 
 /** Edit operations the patcher knows how to apply. Phase 5's patcher (#295) implements these;
  *  new ops require an explicit enum addition + a resolver update. */
-export const editOps = ["replace-text", "replace-attr", "replace-image-src"];
+export const editOps = ["replace-text", "replace-attr", "replace-image-src", "edit-style"];
 
 /** The MCP tool's input shape, as passed to `server.tool(name, description, shape, handler)`. */
 export const applyEditInputShape = {
@@ -60,12 +60,12 @@ export const applyEditInputShape = {
   op: z
     .enum(editOps)
     .describe(
-      "Edit operation: replace-text (innerText), replace-attr (op needs value to be {name, value}), replace-image-src (value is {filename, mimeType, dataURL})",
+      "Edit operation: replace-text (innerText), replace-attr (op needs value to be {name, value}), replace-image-src (value is {filename, mimeType, dataURL}), edit-style (value is {property, value}; merges a rule into the owning component's scoped <style>)",
     ),
   value: z
     .unknown()
     .describe(
-      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src)",
+      "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src, {property, value} for edit-style)",
     ),
   dry_run: z
     .boolean()

--- a/server/apply-edit-schema.mjs
+++ b/server/apply-edit-schema.mjs
@@ -67,6 +67,12 @@ export const applyEditInputShape = {
     .describe(
       "Operation payload; varies by op (string for replace-text, {name, value} for replace-attr, {filename, mimeType, dataURL} for replace-image-src)",
     ),
+  dry_run: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, compute the would-be change and return an edit-preview {before, after} WITHOUT writing to disk or recording history",
+    ),
 };
 
 /** Build the MCP `content` entry for an edit-failed response. The handler wraps this in

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, extname, basename, dirname } from "node:path";
+import { rewriteAstroStyle } from "./style-edit.mjs";
 
 /**
  * @typedef {import('./apply-edit-schema.mjs').default} _unused
@@ -19,6 +20,9 @@ import { join, relative, extname, basename, dirname } from "node:path";
  * @returns {ResolveResult | ResolveRefusal}
  */
 export function resolve(projectRoot, edit) {
+  if (edit.op === "edit-style") {
+    return resolveStyle(projectRoot, edit);
+  }
   const resolvers = [resolveMdoc, resolveKeystatic, resolveAstro];
   let bestRefusal = /** @type {ResolveRefusal | null} */ (null);
 
@@ -428,6 +432,37 @@ function findValueInDataFile(source, needle, ext) {
 }
 
 // ── .astro resolver ───────────────────────────────────────────────
+
+/** Resolve an edit-style op to a whole-file rewrite of the owning .astro component. */
+function resolveStyle(projectRoot, edit) {
+  const { path: pagePath, selector, value } = edit;
+  if (!value || typeof value !== "object" || !value.property) {
+    return refuse("no-match", "edit-style value must be { property, value }");
+  }
+  const candidates = pathToAstroCandidates(projectRoot, pagePath);
+  if (candidates.length === 0) {
+    return refuse("no-match", `no .astro file found for path ${pagePath}`);
+  }
+  const hits = [];
+  for (const file of candidates) {
+    let source;
+    try {
+      source = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    const r = rewriteAstroStyle(source, selector, value.property, value.value);
+    if (!r.refused) hits.push({ file: relative(projectRoot, file), source, r });
+  }
+  if (hits.length === 0) {
+    return refuse("no-match", `could not locate <${selector.tag}> for style edit`);
+  }
+  if (hits.length > 1) {
+    return refuse("ambiguous", `element matched in ${hits.length} .astro files`);
+  }
+  const { file, source, r } = hits[0];
+  return { file, range: { start: 0, end: source.length }, replacement: r.next };
+}
 
 function resolveAstro(projectRoot, edit) {
   const { path: pagePath, selector, op, value } = edit;

--- a/server/patcher.mjs
+++ b/server/patcher.mjs
@@ -44,6 +44,7 @@ const REASON_PRIORITY = {
   "no-match": 1,
   "not-implemented": 0,
   "write-failed": 0,
+  "invalid-input": 0,
 };
 
 function refusalPriority(reason) {
@@ -436,8 +437,8 @@ function findValueInDataFile(source, needle, ext) {
 /** Resolve an edit-style op to a whole-file rewrite of the owning .astro component. */
 function resolveStyle(projectRoot, edit) {
   const { path: pagePath, selector, value } = edit;
-  if (!value || typeof value !== "object" || !value.property) {
-    return refuse("no-match", "edit-style value must be { property, value }");
+  if (!value || typeof value !== "object" || !value.property || value.value === undefined) {
+    return refuse("invalid-input", "edit-style value must be { property, value }");
   }
   const candidates = pathToAstroCandidates(projectRoot, pagePath);
   if (candidates.length === 0) {

--- a/server/style-edit.mjs
+++ b/server/style-edit.mjs
@@ -14,7 +14,12 @@ function refuse(reason, detail) {
   return { refused: true, reason, detail };
 }
 
-/** Locate the element's opening tag in `source`. Returns {start, end, tagText} or null. */
+/**
+ * Locate the element's opening tag in `source`.
+ * Returns {start, end, tagText} on success,
+ * {ambiguous: true} when multiple candidates exist but no text anchor resolves them,
+ * or null when no candidate found.
+ */
 function findOpeningTag(source, selector) {
   const tag = selector.tag?.toLowerCase();
   if (!tag) return null;
@@ -34,7 +39,9 @@ function findOpeningTag(source, selector) {
       if (owning) return owning;
     }
   }
-  return tags.length === 1 ? tags[0] : null; // ambiguous without text anchor
+  if (tags.length === 1) return tags[0];
+  // Multiple candidates but no usable text anchor — signal ambiguity to the caller.
+  return { ambiguous: true };
 }
 
 /** Derive the CSS selector for the element, mutating the tag to add a marker class if needed. */
@@ -54,26 +61,36 @@ function deriveSelector(tagText, selector) {
 /** Insert/merge `property: value` for `selectorUsed` in the file's scoped <style> block. */
 function upsertStyleRule(source, selectorUsed, property, value) {
   const decl = `${property}: ${value};`;
-  const styleRe = /<style>([\s\S]*?)<\/style>/i;
+  // Bug 1 fix: match any <style ...> opening tag (e.g. is:global, lang="scss") and capture it.
+  const styleRe = /(<style\b[^>]*>)([\s\S]*?)<\/style>/i;
   const sm = source.match(styleRe);
   if (!sm) {
     // No <style> block — append one at end of file.
     const block = `\n<style>\n  ${selectorUsed} { ${decl} }\n</style>\n`;
     return source.replace(/\s*$/, "") + block + "\n";
   }
-  const css = sm[1];
+  const openTag = sm[1];
+  const css = sm[2];
   // Existing rule for this selector?
   const ruleRe = new RegExp(`(${escapeRegex(selectorUsed)}\\s*\\{)([^}]*)(\\})`);
   const rm = css.match(ruleRe);
   let newCss;
   if (rm) {
-    const body = rm[2].trim();
-    const merged = body.length ? `${body} ${decl}` : decl;
+    // Bug 2 fix: strip any existing declaration for the same property before merging.
+    // Use a word-boundary-ish check: require the char before the property name to be start, `;`, or
+    // whitespace so that `color` doesn't incorrectly strip `background-color`.
+    const propRe = new RegExp(
+      `(^|;)(\\s*)(?<![\\w-])${escapeRegex(property)}\\s*:[^;]*;?`,
+      "gi",
+    );
+    const bodyStripped = rm[2].replace(propRe, "$1$2").trim();
+    const merged = bodyStripped.length ? `${bodyStripped} ${decl}` : decl;
     newCss = css.replace(ruleRe, `$1 ${merged} $3`);
   } else {
     newCss = `${css.replace(/\s*$/, "")}\n  ${selectorUsed} { ${decl} }\n`;
   }
-  return source.replace(styleRe, `<style>${newCss}</style>`);
+  // Bug 1 fix: reconstruct using the actual opening tag, not a hard-coded <style>.
+  return source.replace(styleRe, `${openTag}${newCss}</style>`);
 }
 
 function escapeRegex(s) {
@@ -83,6 +100,7 @@ function escapeRegex(s) {
 export function rewriteAstroStyle(source, selector, property, value) {
   const tag = findOpeningTag(source, selector);
   if (!tag) return refuse("no-match", `could not locate <${selector.tag}> for style edit`);
+  if (tag.ambiguous) return refuse("ambiguous", `multiple <${selector.tag}> candidates with no usable text anchor`);
   const { selectorUsed, addedMarkerClass, newTagText } = deriveSelector(tag.tagText, selector);
   let next = source;
   if (newTagText !== tag.tagText) {

--- a/server/style-edit.mjs
+++ b/server/style-edit.mjs
@@ -58,26 +58,44 @@ function deriveSelector(tagText, selector) {
   return { selectorUsed: `.${marker}`, addedMarkerClass: marker, newTagText };
 }
 
-/** Insert/merge `property: value` for `selectorUsed` in the file's scoped <style> block. */
+/** Insert/merge `property: value` for `selectorUsed` in the file's scoped <style> block.
+ *
+ * A scoped rule must NOT land in a block marked is:global or is:inline.
+ * Logic:
+ *   1. Find ALL <style …>…</style> blocks.
+ *   2. Pick the first whose opening tag has neither is:global nor is:inline.
+ *   3. If found, merge into it (preserving its exact opening tag).
+ *   4. If none found (only global/inline blocks, or no blocks at all), append a fresh
+ *      scoped <style> block — do NOT modify any global/inline block.
+ */
 function upsertStyleRule(source, selectorUsed, property, value) {
   const decl = `${property}: ${value};`;
-  // Bug 1 fix: match any <style ...> opening tag (e.g. is:global, lang="scss") and capture it.
-  const styleRe = /(<style\b[^>]*>)([\s\S]*?)<\/style>/i;
-  const sm = source.match(styleRe);
-  if (!sm) {
-    // No <style> block — append one at end of file.
+
+  // Collect all <style …>…</style> occurrences.
+  const styleRe = /(<style\b[^>]*>)([\s\S]*?)<\/style>/gi;
+  let m;
+  let scopedMatch = null;
+  while ((m = styleRe.exec(source)) !== null) {
+    const openTag = m[1];
+    // Skip global or inline blocks.
+    if (/\bis:global\b/.test(openTag) || /\bis:inline\b/.test(openTag)) continue;
+    scopedMatch = { full: m[0], openTag, css: m[2], index: m.index };
+    break;
+  }
+
+  if (!scopedMatch) {
+    // No scoped <style> block — append one at end of file.
     const block = `\n<style>\n  ${selectorUsed} { ${decl} }\n</style>\n`;
     return source.replace(/\s*$/, "") + block + "\n";
   }
-  const openTag = sm[1];
-  const css = sm[2];
-  // Existing rule for this selector?
+
+  const { full, openTag, css, index } = scopedMatch;
   const ruleRe = new RegExp(`(${escapeRegex(selectorUsed)}\\s*\\{)([^}]*)(\\})`);
   const rm = css.match(ruleRe);
   let newCss;
   if (rm) {
-    // Bug 2 fix: strip any existing declaration for the same property before merging.
-    // Use a word-boundary-ish check: require the char before the property name to be start, `;`, or
+    // Strip any existing declaration for the same property before merging.
+    // Word-boundary-ish check: require the char before the property name to be start, `;`, or
     // whitespace so that `color` doesn't incorrectly strip `background-color`.
     const propRe = new RegExp(
       `(^|;)(\\s*)(?<![\\w-])${escapeRegex(property)}\\s*:[^;]*;?`,
@@ -89,8 +107,9 @@ function upsertStyleRule(source, selectorUsed, property, value) {
   } else {
     newCss = `${css.replace(/\s*$/, "")}\n  ${selectorUsed} { ${decl} }\n`;
   }
-  // Bug 1 fix: reconstruct using the actual opening tag, not a hard-coded <style>.
-  return source.replace(styleRe, `${openTag}${newCss}</style>`);
+
+  const newBlock = `${openTag}${newCss}</style>`;
+  return source.slice(0, index) + newBlock + source.slice(index + full.length);
 }
 
 function escapeRegex(s) {

--- a/server/style-edit.mjs
+++ b/server/style-edit.mjs
@@ -1,0 +1,95 @@
+/**
+ * Pure scoped-<style> rewriter for the `edit-style` op.
+ *
+ * Component-encapsulation model: a style change lands in the owning .astro file's scoped
+ * <style> block (created if absent), targeting the element via its existing #id or .class.
+ * When the element has neither, a deterministic marker class (ang-<6 hex>) is added to its
+ * opening tag and used as the selector.
+ *
+ * Returns { next, selectorUsed, addedMarkerClass? } or { refused, reason, detail }.
+ */
+import { createHash } from "node:crypto";
+
+function refuse(reason, detail) {
+  return { refused: true, reason, detail };
+}
+
+/** Locate the element's opening tag in `source`. Returns {start, end, tagText} or null. */
+function findOpeningTag(source, selector) {
+  const tag = selector.tag?.toLowerCase();
+  if (!tag) return null;
+  // Prefer locating by the element's static text content (same heuristic the text resolver uses).
+  const re = new RegExp(`<${tag}\\b[^>]*>`, "gi");
+  let m;
+  const tags = [];
+  while ((m = re.exec(source)) !== null) {
+    tags.push({ start: m.index, end: m.index + m[0].length, tagText: m[0] });
+  }
+  if (tags.length === 0) return null;
+  if (selector.textContent) {
+    // pick the tag immediately preceding the textContent occurrence
+    const idx = source.indexOf(selector.textContent);
+    if (idx !== -1) {
+      const owning = tags.filter((t) => t.end <= idx).sort((a, b) => b.end - a.end)[0];
+      if (owning) return owning;
+    }
+  }
+  return tags.length === 1 ? tags[0] : null; // ambiguous without text anchor
+}
+
+/** Derive the CSS selector for the element, mutating the tag to add a marker class if needed. */
+function deriveSelector(tagText, selector) {
+  if (selector.id) return { selectorUsed: `#${selector.id}`, newTagText: tagText };
+  if (selector.classes && selector.classes.length > 0) {
+    return { selectorUsed: `.${selector.classes[0]}`, newTagText: tagText };
+  }
+  // No id/class: synthesize a deterministic marker class from tag + textContent.
+  const seed = `${selector.tag}|${selector.textContent ?? ""}|${selector.nthChild ?? 0}`;
+  const marker = "ang-" + createHash("sha1").update(seed).digest("hex").slice(0, 6);
+  // inject class="..." before the closing > (handle self-closing and existing attrs)
+  const newTagText = tagText.replace(/(\s*\/?>)$/, ` class="${marker}"$1`);
+  return { selectorUsed: `.${marker}`, addedMarkerClass: marker, newTagText };
+}
+
+/** Insert/merge `property: value` for `selectorUsed` in the file's scoped <style> block. */
+function upsertStyleRule(source, selectorUsed, property, value) {
+  const decl = `${property}: ${value};`;
+  const styleRe = /<style>([\s\S]*?)<\/style>/i;
+  const sm = source.match(styleRe);
+  if (!sm) {
+    // No <style> block — append one at end of file.
+    const block = `\n<style>\n  ${selectorUsed} { ${decl} }\n</style>\n`;
+    return source.replace(/\s*$/, "") + block + "\n";
+  }
+  const css = sm[1];
+  // Existing rule for this selector?
+  const ruleRe = new RegExp(`(${escapeRegex(selectorUsed)}\\s*\\{)([^}]*)(\\})`);
+  const rm = css.match(ruleRe);
+  let newCss;
+  if (rm) {
+    const body = rm[2].trim();
+    const merged = body.length ? `${body} ${decl}` : decl;
+    newCss = css.replace(ruleRe, `$1 ${merged} $3`);
+  } else {
+    newCss = `${css.replace(/\s*$/, "")}\n  ${selectorUsed} { ${decl} }\n`;
+  }
+  return source.replace(styleRe, `<style>${newCss}</style>`);
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function rewriteAstroStyle(source, selector, property, value) {
+  const tag = findOpeningTag(source, selector);
+  if (!tag) return refuse("no-match", `could not locate <${selector.tag}> for style edit`);
+  const { selectorUsed, addedMarkerClass, newTagText } = deriveSelector(tag.tagText, selector);
+  let next = source;
+  if (newTagText !== tag.tagText) {
+    next = source.slice(0, tag.start) + newTagText + source.slice(tag.end);
+  }
+  next = upsertStyleRule(next, selectorUsed, property, value);
+  const result = { next, selectorUsed };
+  if (addedMarkerClass) result.addedMarkerClass = addedMarkerClass;
+  return result;
+}

--- a/template/package.json
+++ b/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dwk/anglesite",
   "type": "module",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/tests/apply-edit-dry-run.test.ts
+++ b/tests/apply-edit-dry-run.test.ts
@@ -58,4 +58,21 @@ describe("apply_edit dry_run", () => {
     const { join: pathJoin } = await import("node:path");
     expect(existsSync(pathJoin(root, "public/images"))).toBe(false);
   });
+
+  it("dry_run edit-style returns a preview and leaves the file unchanged", async () => {
+    const file = join(root, "src/pages/about.astro");
+    writeFileSync(file, "---\n---\n<h1 id=\"t\">Welcome</h1>\n");
+    const before = readFileSync(file, "utf-8");
+    const res = await applyEdit(root, {
+      id: "9", path: "/about/",
+      selector: { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Welcome" },
+      op: "edit-style", value: { property: "color", value: "teal" }, dry_run: true,
+    });
+    expect(res.isError).toBeFalsy();
+    const body = JSON.parse(res.content[0].text);
+    expect(body.type).toBe("anglesite:edit-preview");
+    expect(body.op).toBe("edit-style");
+    expect(body.after).toMatch(/color:\s*teal/);
+    expect(readFileSync(file, "utf-8")).toBe(before); // unchanged
+  });
 });

--- a/tests/apply-edit-dry-run.test.ts
+++ b/tests/apply-edit-dry-run.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
+
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ang-dry-"));
+  mkdirSync(join(root, "src/pages"), { recursive: true });
+  writeFileSync(join(root, "src/pages/about.astro"), "---\n---\n<h1>Welcome</h1>\n");
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+const baseEdit = {
+  id: "1",
+  path: "/about/",
+  selector: { tag: "h1", classes: [], nthChild: 1, textContent: "Welcome" },
+  op: "replace-text",
+  value: "Hello",
+};
+
+describe("apply_edit dry_run", () => {
+  it("returns edit-preview without mutating the file", async () => {
+    const file = join(root, "src/pages/about.astro");
+    const before = readFileSync(file, "utf-8");
+    const res = await applyEdit(root, { ...baseEdit, dry_run: true });
+    expect(res.isError).toBeFalsy();
+    const body = JSON.parse(res.content[0].text);
+    expect(body.type).toBe("anglesite:edit-preview");
+    expect(body.before).toContain("Welcome");
+    expect(body.after).toContain("Hello");
+    // critical: file is byte-identical
+    expect(readFileSync(file, "utf-8")).toBe(before);
+  });
+
+  it("still refuses (no-match) under dry_run", async () => {
+    const res = await applyEdit(root, {
+      ...baseEdit, dry_run: true,
+      selector: { tag: "h1", classes: [], nthChild: 1, textContent: "Nonexistent" },
+    });
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content[0].text).reason).toBe("no-match");
+  });
+});

--- a/tests/apply-edit-dry-run.test.ts
+++ b/tests/apply-edit-dry-run.test.ts
@@ -42,4 +42,20 @@ describe("apply_edit dry_run", () => {
     expect(res.isError).toBe(true);
     expect(JSON.parse(res.content[0].text).reason).toBe("no-match");
   });
+
+  it("dry_run refuses replace-image-src without writing image files", async () => {
+    const res = await applyEdit(root, {
+      id: "img1", path: "/about/",
+      selector: { tag: "img", classes: [], nthChild: 1, textContent: "/images/hero.jpg" },
+      op: "replace-image-src",
+      value: { filename: "x.jpg", mimeType: "image/jpeg", dataURL: "data:image/jpeg;base64,AAAA" },
+      dry_run: true,
+    });
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content[0].text).reason).toBe("not-implemented");
+    // read-only: no public/images dir was created
+    const { existsSync } = await import("node:fs");
+    const { join: pathJoin } = await import("node:path");
+    expect(existsSync(pathJoin(root, "public/images"))).toBe(false);
+  });
 });

--- a/tests/apply-edit-dry-run.test.ts
+++ b/tests/apply-edit-dry-run.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { applyEdit } from "../server/apply-edit-dispatcher.mjs";
@@ -54,9 +54,7 @@ describe("apply_edit dry_run", () => {
     expect(res.isError).toBe(true);
     expect(JSON.parse(res.content[0].text).reason).toBe("not-implemented");
     // read-only: no public/images dir was created
-    const { existsSync } = await import("node:fs");
-    const { join: pathJoin } = await import("node:path");
-    expect(existsSync(pathJoin(root, "public/images"))).toBe(false);
+    expect(existsSync(join(root, "public/images"))).toBe(false);
   });
 
   it("dry_run edit-style returns a preview and leaves the file unchanged", async () => {
@@ -74,5 +72,28 @@ describe("apply_edit dry_run", () => {
     expect(body.op).toBe("edit-style");
     expect(body.after).toMatch(/color:\s*teal/);
     expect(readFileSync(file, "utf-8")).toBe(before); // unchanged
+  });
+
+  it("edit-style dry_run on a large file returns a bounded preview", async () => {
+    const file = join(root, "src/pages/about.astro");
+    // Build a ~300-line file: lots of filler <p> then the target <h1 id="t">
+    const filler = Array.from({ length: 300 }, (_, i) => `<p>Filler line ${i + 1} — padding content to make this file large enough to test the window bound.</p>`).join("\n");
+    const content = `---\n---\n${filler}\n<h1 id="t">Welcome</h1>\n`;
+    writeFileSync(file, content);
+    const wholeFileLength = content.length;
+    const res = await applyEdit(root, {
+      id: "big1", path: "/about/",
+      selector: { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Welcome" },
+      op: "edit-style", value: { property: "color", value: "navy" }, dry_run: true,
+    });
+    expect(res.isError).toBeFalsy();
+    const body = JSON.parse(res.content[0].text);
+    expect(body.type).toBe("anglesite:edit-preview");
+    // The preview fragments must be much smaller than the full file
+    expect(body.before.length).toBeLessThan(wholeFileLength);
+    expect(body.after.length).toBeLessThan(wholeFileLength);
+    // But the changed region (#t style) must appear in the after fragment
+    expect(body.after).toMatch(/color:\s*navy/);
+    expect(body.after).toMatch(/#t/);
   });
 });

--- a/tests/apply-edit-preview.test.ts
+++ b/tests/apply-edit-preview.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { createEditPreviewContent } from "../server/apply-edit-schema.mjs";
+
+describe("createEditPreviewContent", () => {
+  it("builds an edit-preview body with before/after", () => {
+    const entry = createEditPreviewContent(
+      "abc", "src/pages/about.astro", { start: 10, end: 17 },
+      "replace-text", "Welcome", "Hello",
+    );
+    expect(entry.type).toBe("text");
+    const body = JSON.parse(entry.text);
+    expect(body).toEqual({
+      type: "anglesite:edit-preview",
+      id: "abc",
+      file: "src/pages/about.astro",
+      range: { start: 10, end: 17 },
+      op: "replace-text",
+      before: "Welcome",
+      after: "Hello",
+    });
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -446,4 +446,57 @@ describe("MCP annotation server", () => {
       proc.kill();
     }
   });
+
+  it("apply_edit with op edit-style + dry_run returns edit-preview and leaves file unchanged", async () => {
+    mkdirSync(join(tmpDir, "src", "pages"), { recursive: true });
+    const filePath = join(tmpDir, "src", "pages", "about.astro");
+    writeFileSync(filePath, '---\n---\n<h1 id="t">Welcome</h1>\n');
+    const before = readFileSync(filePath);
+
+    const proc = startServer(tmpDir);
+    try {
+      await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+      sendNotification(proc, {
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      });
+
+      const response = await sendMessage(proc, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "apply_edit",
+          arguments: {
+            id: "9",
+            path: "/about/",
+            selector: { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Welcome" },
+            op: "edit-style",
+            value: { property: "color", value: "teal" },
+            dry_run: true,
+          },
+        },
+      });
+
+      const result = response.result as { content: { text: string }[]; isError?: boolean };
+      expect(result.isError).toBeFalsy();
+      const body = JSON.parse(result.content[0].text);
+      expect(body.type).toBe("anglesite:edit-preview");
+      expect(body.after).toMatch(/color:\s*teal/);
+
+      // File must be byte-identical — dry_run must not mutate disk
+      expect(readFileSync(filePath)).toEqual(before);
+    } finally {
+      proc.kill();
+    }
+  });
 });

--- a/tests/patcher-edit-style.test.ts
+++ b/tests/patcher-edit-style.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolve } from "../server/patcher.mjs";
+
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ang-style-"));
+  mkdirSync(join(root, "src/pages"), { recursive: true });
+  writeFileSync(join(root, "src/pages/about.astro"), "---\n---\n<h1 id=\"t\">Welcome</h1>\n");
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+describe("patcher resolve() for edit-style", () => {
+  it("returns whole-file replacement with the merged style", () => {
+    const r = resolve(root, {
+      path: "/about/",
+      selector: { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Welcome" },
+      op: "edit-style",
+      value: { property: "color", value: "teal" },
+    });
+    expect(r.refused).toBeFalsy();
+    expect(r.range).toEqual({ start: 0, end: expect.any(Number) });
+    expect(r.replacement).toMatch(/#t\s*\{[^}]*color:\s*teal/);
+  });
+});

--- a/tests/patcher-edit-style.test.ts
+++ b/tests/patcher-edit-style.test.ts
@@ -24,4 +24,15 @@ describe("patcher resolve() for edit-style", () => {
     expect(r.range).toEqual({ start: 0, end: expect.any(Number) });
     expect(r.replacement).toMatch(/#t\s*\{[^}]*color:\s*teal/);
   });
+
+  it("refuses with invalid-input when value.value is missing", () => {
+    const r = resolve(root, {
+      path: "/about/",
+      selector: { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Welcome" },
+      op: "edit-style",
+      value: { property: "color" },
+    });
+    expect(r.refused).toBe(true);
+    expect(r.reason).toBe("invalid-input");
+  });
 });

--- a/tests/style-edit.test.ts
+++ b/tests/style-edit.test.ts
@@ -37,4 +37,49 @@ describe("rewriteAstroStyle", () => {
     expect(r.refused).toBe(true);
     expect(r.reason).toBe("no-match");
   });
+
+  // Bug 1: <style> with attributes (lang, is:global, define:vars) must be edited, not duplicated
+  it("edits <style is:global> block without duplicating it", () => {
+    const src = `${FM}<h1 id="t">Hi</h1>\n<style is:global>\n  body { margin: 0; }\n</style>\n`;
+    const r = rewriteAstroStyle(src, { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Hi" }, "color", "teal");
+    expect(r.refused).toBeFalsy();
+    // Exactly one <style opening tag — no duplicate block appended
+    expect((r.next.match(/<style/g) || []).length).toBe(1);
+    // The new rule is present
+    expect(r.next).toMatch(/#t\s*\{[^}]*color:\s*teal/);
+    // The original opening tag is preserved
+    expect(r.next).toContain("<style is:global>");
+  });
+
+  // Bug 2: setting a property that already exists should replace it, not duplicate it
+  it("replaces an existing same-property declaration instead of duplicating it", () => {
+    const src = `${FM}<h1 id="t">Hi</h1>\n<style>\n  #t { color: red; }\n</style>\n`;
+    const r = rewriteAstroStyle(src, { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Hi" }, "color", "teal");
+    expect(r.refused).toBeFalsy();
+    expect(r.next).toContain("color: teal");
+    expect(r.next).not.toContain("color: red");
+    // Only one color declaration in the rule
+    const ruleMatch = r.next.match(/#t\s*\{([^}]*)\}/);
+    expect(ruleMatch).toBeTruthy();
+    expect((ruleMatch![1].match(/color\s*:/g) || []).length).toBe(1);
+  });
+
+  // Bug 2 (superset check): a superset property name must not be stripped
+  it("preserves background-color when setting color", () => {
+    const src = `${FM}<h1 class="c">Hi</h1>\n<style>\n  .c { background-color: blue; }\n</style>\n`;
+    const r = rewriteAstroStyle(src, { tag: "h1", classes: ["c"], nthChild: 1, textContent: "Hi" }, "color", "teal");
+    expect(r.refused).toBeFalsy();
+    expect(r.next).toContain("background-color: blue");
+    expect(r.next).toContain("color: teal");
+  });
+
+  // Minor #5: multiple ambiguous candidates with no usable text anchor → reason "ambiguous"
+  it("refuses with reason ambiguous when multiple candidate tags have no text anchor", () => {
+    // Two <h1> tags with different text so textContent won't match either precisely when omitted
+    const src = `${FM}<h1>Hello</h1>\n<h1>World</h1>\n`;
+    // Selector with no id/class and a textContent that doesn't appear in source → no anchor
+    const r = rewriteAstroStyle(src, { tag: "h1", classes: [], nthChild: 1, textContent: "NoSuchText" }, "color", "teal");
+    expect(r.refused).toBe(true);
+    expect(r.reason).toBe("ambiguous");
+  });
 });

--- a/tests/style-edit.test.ts
+++ b/tests/style-edit.test.ts
@@ -38,17 +38,32 @@ describe("rewriteAstroStyle", () => {
     expect(r.reason).toBe("no-match");
   });
 
-  // Bug 1: <style> with attributes (lang, is:global, define:vars) must be edited, not duplicated
-  it("edits <style is:global> block without duplicating it", () => {
+  // Fix 4: when only a <style is:global> block exists, a NEW scoped block is appended
+  it("appends a new scoped <style> block when only is:global is present", () => {
     const src = `${FM}<h1 id="t">Hi</h1>\n<style is:global>\n  body { margin: 0; }\n</style>\n`;
     const r = rewriteAstroStyle(src, { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Hi" }, "color", "teal");
     expect(r.refused).toBeFalsy();
-    // Exactly one <style opening tag — no duplicate block appended
-    expect((r.next.match(/<style/g) || []).length).toBe(1);
-    // The new rule is present
+    // Now TWO <style blocks — original global + new scoped
+    expect((r.next.match(/<style/g) || []).length).toBe(2);
+    // The new rule is in the result
     expect(r.next).toMatch(/#t\s*\{[^}]*color:\s*teal/);
-    // The original opening tag is preserved
-    expect(r.next).toContain("<style is:global>");
+    // The original is:global block is byte-identical (untouched)
+    expect(r.next).toContain("<style is:global>\n  body { margin: 0; }\n</style>");
+    // The new block is a plain scoped <style>
+    expect(r.next).toContain("<style>\n");
+  });
+
+  // Fix 4: two blocks — scoped block after global one receives the rule
+  it("targets the scoped block when is:global comes first", () => {
+    const src = `${FM}<h1 id="t">Hi</h1>\n<style is:global>\n  body { margin: 0; }\n</style>\n<style>\n  p { font-size: 1rem; }\n</style>\n`;
+    const r = rewriteAstroStyle(src, { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Hi" }, "color", "teal");
+    expect(r.refused).toBeFalsy();
+    // Still two <style blocks
+    expect((r.next.match(/<style/g) || []).length).toBe(2);
+    // Rule went into the SCOPED block
+    expect(r.next).toMatch(/#t\s*\{[^}]*color:\s*teal/);
+    // The is:global block is untouched
+    expect(r.next).toContain("<style is:global>\n  body { margin: 0; }\n</style>");
   });
 
   // Bug 2: setting a property that already exists should replace it, not duplicate it

--- a/tests/style-edit.test.ts
+++ b/tests/style-edit.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { rewriteAstroStyle } from "../server/style-edit.mjs";
+
+const FM = "---\n---\n";
+
+describe("rewriteAstroStyle", () => {
+  it("targets an existing id and creates a scoped <style> block", () => {
+    const src = `${FM}<h1 id="title">Welcome</h1>\n`;
+    const r = rewriteAstroStyle(src, { tag: "h1", id: "title", classes: [], nthChild: 1, textContent: "Welcome" }, "color", "teal");
+    expect(r.refused).toBeFalsy();
+    expect(r.selectorUsed).toBe("#title");
+    expect(r.next).toContain("<style>");
+    expect(r.next).toMatch(/#title\s*\{[^}]*color:\s*teal/);
+    expect(r.addedMarkerClass).toBeUndefined();
+  });
+
+  it("adds a marker class when the element has no id or class", () => {
+    const src = `${FM}<h1>Welcome</h1>\n`;
+    const r = rewriteAstroStyle(src, { tag: "h1", classes: [], nthChild: 1, textContent: "Welcome" }, "color", "teal");
+    expect(r.refused).toBeFalsy();
+    expect(r.addedMarkerClass).toMatch(/^ang-[0-9a-f]{6}$/);
+    expect(r.next).toContain(`class="${r.addedMarkerClass}"`);
+    expect(r.next).toMatch(new RegExp(`\\.${r.addedMarkerClass}\\s*\\{[^}]*color:\\s*teal`));
+  });
+
+  it("merges into an existing scoped <style> rule for the same selector", () => {
+    const src = `${FM}<h1 id="t">Hi</h1>\n<style>\n  #t { font-size: 2rem; }\n</style>\n`;
+    const r = rewriteAstroStyle(src, { tag: "h1", id: "t", classes: [], nthChild: 1, textContent: "Hi" }, "color", "teal");
+    expect(r.next).toMatch(/#t\s*\{[^}]*font-size:\s*2rem/);
+    expect(r.next).toMatch(/#t\s*\{[^}]*color:\s*teal/);
+    expect((r.next.match(/<style>/g) || []).length).toBe(1); // no duplicate block
+  });
+
+  it("refuses when the element cannot be located", () => {
+    const src = `${FM}<h1 id="t">Hi</h1>\n`;
+    const r = rewriteAstroStyle(src, { tag: "h2", classes: [], nthChild: 1, textContent: "Missing" }, "color", "teal");
+    expect(r.refused).toBe(true);
+    expect(r.reason).toBe("no-match");
+  });
+});


### PR DESCRIPTION
Plan A of the Anglesite-app **#251** epic (Siri natural-language edits with a reviewed before/after diff). This is the **plugin prerequisite**; the app PR (Plan B) follows after this release is tagged and bumps the bundled-plugin pointer.

## What this adds

**1. `apply_edit` `dry_run` mode (read-only preview)**
- New optional `dry_run: boolean`. When true, computes the would-be change and returns a new `anglesite:edit-preview` body `{ id, file, range, op, before, after }` **without writing to disk or committing history**.
- `before`/`after` are the spliced region plus a bounded ±200-char context window.
- Op-agnostic: text/attr/style all preview through the same short-circuit (after `spliceSource`, before `atomicWrite`).
- `replace-image-src` + `dry_run` refuses (`not-implemented`) **before** image processing, preserving the read-only invariant (image previews would require writing optimized bytes).
- Refusals (`no-match`/`ambiguous`/…) still return correctly under `dry_run`.

**2. New `edit-style` op**
- Value `{ property, value }`. Merges a CSS rule into the **owning Astro component's scoped `<style>`** (created if absent) — component-encapsulation as the CSS-location resolver.
- Targets the element by existing `#id`/`.class`; adds a deterministic marker class (`ang-<6hex>`) to the opening tag only when it has neither.
- Returns a whole-file replacement over `range {0, source.length}` (two disjoint edit regions), reusing the existing splice/write/dry_run path unchanged.
- Handles `<style lang=…>` / `<style is:global>` variants and dedups an already-present property (won't strip superset properties like `background-color` when setting `color`).

## Tests
22 feature tests across `apply-edit-preview`, `apply-edit-dry-run`, `style-edit`, `patcher-edit-style`, and `mcp-server` (stdio e2e). Read-only dry_run verified by byte-identical-file assertions at unit and e2e levels. (Two pre-existing, unrelated suite failures — `optimize-images-packaging`/sharp and an `update.test.ts` shell timeout — are not touched by this branch.)

## Release sequencing
Merge this, then tag **v1.1.0** (version bumped in `package.json` + `.claude-plugin/plugin.json` + `CLAUDE.md`) to publish the artifact the app's Plan B consumes.

## Follow-up (non-blocking)
Consider a `dry-run-unsupported` refusal reason (clearer than `not-implemented`) for image dry_run.

Design + plan: `Anglesite-app/docs/specs/2026-06-19-siri-nl-edit-{interpretation-design,plugin-plan}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)