### PR TITLE
feat(navigator): Xcode-style Site Navigator sidebar + inline editor

### DIFF
--- a/Resources/node-runtime
+++ b/Resources/node-runtime
@@ -1,0 +1,1 @@
+/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/Resources/node-runtime

--- a/Resources/plugin
+++ b/Resources/plugin
@@ -1,0 +1,1 @@
+/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/Resources/plugin

--- a/Sources/AnglesiteApp/FileEditorModel.swift
+++ b/Sources/AnglesiteApp/FileEditorModel.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Editor state for one open file, owned by `SiteWindow` so navigating away from the editor can
+/// flush unsaved edits to disk (auto-save-on-leave) and the Preview/Editor toggle can keep the
+/// buffer alive. `MainPaneEditorView` binds to this. The reconcile/IO logic lives in
+/// `AnglesiteCore.FileDocumentIO`; this is the App-side @Observable buffer around it.
+@MainActor
+@Observable
+final class FileEditorModel {
+    let file: FileRef
+    var text: String = ""
+    private(set) var savedText: String = ""
+    private(set) var lastModified: Date?
+    private(set) var loadError: String?
+    /// Non-nil ⟺ the on-disk file changed under a dirty buffer and the user must choose
+    /// Keep/Reload. Drives the conflict alert in `MainPaneEditorView`.
+    var conflictDiskContents: String?
+
+    var isDirty: Bool { text != savedText && loadError == nil }
+
+    init(file: FileRef) {
+        self.file = file
+        load()
+    }
+
+    func load() {
+        do {
+            let loaded = try FileDocumentIO.load(file.url)
+            text = loaded.contents
+            savedText = loaded.contents
+            lastModified = loaded.modificationDate
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    /// Explicit ⌘S / Save. Returns true when the buffer is clean afterward.
+    @discardableResult
+    func save() -> Bool {
+        guard isDirty else { return true }
+        do {
+            lastModified = try FileDocumentIO.save(text, to: file.url)
+            savedText = text
+            return true
+        } catch {
+            loadError = "Save failed: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    /// Auto-save when navigating away from the editor. Saves a dirty buffer to disk, EXCEPT when the
+    /// file changed externally under the dirty buffer — then it surfaces the conflict (returns false)
+    /// rather than clobbering the other tool's edit. Returns true when it is safe to leave.
+    func flushBeforeLeaving() -> Bool {
+        guard isDirty else { return true }
+        let change = try? FileDocumentIO.externalChange(
+            at: file.url, lastKnownModificationDate: lastModified, bufferIsDirty: true)
+        if case .conflict(let disk) = change {
+            conflictDiskContents = disk
+            return false
+        }
+        return save()
+    }
+
+    /// Re-check the file when the window regains focus — chat/overlay/CLI may have written it.
+    func checkExternalChange() {
+        guard loadError == nil else { return }
+        guard let change = try? FileDocumentIO.externalChange(
+            at: file.url, lastKnownModificationDate: lastModified, bufferIsDirty: isDirty
+        ) else { return }
+        switch change {
+        case .none:
+            break
+        case .reloadable(let disk):
+            text = disk; savedText = disk
+            lastModified = try? FileDocumentIO.load(file.url).modificationDate
+        case .conflict(let disk):
+            conflictDiskContents = disk
+        }
+    }
+
+    func keepMyChanges() { conflictDiskContents = nil }
+
+    func reloadFromDisk() {
+        if let disk = conflictDiskContents {
+            text = disk; savedText = disk
+            lastModified = try? FileDocumentIO.load(file.url).modificationDate
+        }
+        conflictDiskContents = nil
+    }
+}

--- a/Sources/AnglesiteApp/FileEditorModel.swift
+++ b/Sources/AnglesiteApp/FileEditorModel.swift
@@ -6,6 +6,10 @@ import AnglesiteCore
 /// flush unsaved edits to disk (auto-save-on-leave) and the Preview/Editor toggle can keep the
 /// buffer alive. `MainPaneEditorView` binds to this. The reconcile/IO logic lives in
 /// `AnglesiteCore.FileDocumentIO`; this is the App-side @Observable buffer around it.
+///
+/// All disk IO runs off the main actor (`Task.detached`) and publishes back on the main actor:
+/// `FileDocumentIO`'s reads/writes are synchronous syscalls, and a slow/large/NFS file must never
+/// block the UI. `load()` is therefore async and called after construction (not from `init`).
 @MainActor
 @Observable
 final class FileEditorModel {
@@ -14,39 +18,52 @@ final class FileEditorModel {
     private(set) var savedText: String = ""
     private(set) var lastModified: Date?
     private(set) var loadError: String?
+    private(set) var isLoading = false
     /// Non-nil ⟺ the on-disk file changed under a dirty buffer and the user must choose
     /// Keep/Reload. Drives the conflict alert in `MainPaneEditorView`.
     var conflictDiskContents: String?
 
-    /// True only when there are unsaved edits AND the file loaded cleanly. The `loadError == nil`
-    /// term means an errored file is never "dirty", so callers (e.g. the Save button's
-    /// `disabled(!isDirty)`) don't need a separate `loadError` guard — this property absorbs it.
-    var isDirty: Bool { text != savedText && loadError == nil }
+    /// True only when there are unsaved edits AND the file loaded cleanly and isn't mid-load. The
+    /// `loadError == nil` term means an errored file is never "dirty", so callers (e.g. the Save
+    /// button's `disabled(!isDirty)`) don't need a separate `loadError` guard — this absorbs it.
+    var isDirty: Bool { text != savedText && loadError == nil && !isLoading }
 
     init(file: FileRef) {
         self.file = file
-        load()
     }
 
-    func load() {
+    /// Reads the file off the main actor and publishes the result. Call once after construction.
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        let url = file.url
         do {
-            let loaded = try FileDocumentIO.load(file.url)
+            let loaded = try await Task.detached(priority: .userInitiated) {
+                try FileDocumentIO.load(url)
+            }.value
             text = loaded.contents
             savedText = loaded.contents
             lastModified = loaded.modificationDate
             loadError = nil
+            warnIfNoModificationDate(after: "load")
         } catch {
             loadError = error.localizedDescription
         }
     }
 
-    /// Explicit ⌘S / Save. Returns true when the buffer is clean afterward.
+    /// Explicit ⌘S / Save. Writes off the main actor. Returns true when the buffer is clean afterward.
     @discardableResult
-    func save() -> Bool {
+    func save() async -> Bool {
         guard isDirty else { return true }
+        let url = file.url
+        let contents = text
         do {
-            lastModified = try FileDocumentIO.save(text, to: file.url)
-            savedText = text
+            let mtime = try await Task.detached(priority: .userInitiated) {
+                try FileDocumentIO.save(contents, to: url)
+            }.value
+            lastModified = mtime
+            savedText = contents
+            warnIfNoModificationDate(after: "save")
             return true
         } catch {
             loadError = "Save failed: \(error.localizedDescription)"
@@ -57,29 +74,36 @@ final class FileEditorModel {
     /// Auto-save when navigating away from the editor. Saves a dirty buffer to disk, EXCEPT when the
     /// file changed externally under the dirty buffer — then it surfaces the conflict (returns false)
     /// rather than clobbering the other tool's edit. Returns true when it is safe to leave.
-    func flushBeforeLeaving() -> Bool {
+    func flushBeforeLeaving() async -> Bool {
         guard isDirty else { return true }
-        let change = try? FileDocumentIO.externalChange(
-            at: file.url, lastKnownModificationDate: lastModified, bufferIsDirty: true)
-        if case .conflict(let disk) = change {
+        let url = file.url
+        let known = lastModified
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: true)
+        }.value
+        if case .conflict(let disk)? = change {
             conflictDiskContents = disk
             return false
         }
-        return save()
+        return await save()
     }
 
     /// Re-check the file when the window regains focus — chat/overlay/CLI may have written it.
-    func checkExternalChange() {
+    func checkExternalChange() async {
         guard loadError == nil else { return }
-        guard let change = try? FileDocumentIO.externalChange(
-            at: file.url, lastKnownModificationDate: lastModified, bufferIsDirty: isDirty
-        ) else { return }
+        let url = file.url
+        let known = lastModified
+        let dirty = isDirty
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
+        }.value
+        guard let change else { return }
         switch change {
         case .none:
             break
         case .reloadable(let disk):
             text = disk; savedText = disk
-            lastModified = try? FileDocumentIO.load(file.url).modificationDate
+            lastModified = await freshModificationDate()
         case .conflict(let disk):
             conflictDiskContents = disk
         }
@@ -87,11 +111,32 @@ final class FileEditorModel {
 
     func keepMyChanges() { conflictDiskContents = nil }
 
-    func reloadFromDisk() {
-        if let disk = conflictDiskContents {
-            text = disk; savedText = disk
-            lastModified = try? FileDocumentIO.load(file.url).modificationDate
-        }
+    func reloadFromDisk() async {
+        guard let disk = conflictDiskContents else { return }
+        text = disk
+        savedText = disk
+        lastModified = await freshModificationDate()
         conflictDiskContents = nil
+    }
+
+    private func freshModificationDate() async -> Date? {
+        let url = file.url
+        return try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.load(url).modificationDate
+        }.value
+    }
+
+    /// Surface (in the debug pane) when a file has no modification date after a successful load/save:
+    /// `FileDocumentIO.externalChange` keys on mtime, so a `nil` here silently disables external-change
+    /// detection for this file. "Logs are sacred" — make it visible rather than failing quietly.
+    private func warnIfNoModificationDate(after op: String) {
+        guard lastModified == nil else { return }
+        let path = file.url.path(percentEncoded: false)
+        Task {
+            await LogCenter.shared.append(
+                source: "editor", stream: .stderr,
+                text: "No modification date for \(path) after \(op); external-change detection is disabled for this file."
+            )
+        }
     }
 }

--- a/Sources/AnglesiteApp/FileEditorModel.swift
+++ b/Sources/AnglesiteApp/FileEditorModel.swift
@@ -18,6 +18,9 @@ final class FileEditorModel {
     /// Keep/Reload. Drives the conflict alert in `MainPaneEditorView`.
     var conflictDiskContents: String?
 
+    /// True only when there are unsaved edits AND the file loaded cleanly. The `loadError == nil`
+    /// term means an errored file is never "dirty", so callers (e.g. the Save button's
+    /// `disabled(!isDirty)`) don't need a separate `loadError` guard — this property absorbs it.
     var isDirty: Bool { text != savedText && loadError == nil }
 
     init(file: FileRef) {

--- a/Sources/AnglesiteApp/MainPaneEditorView.swift
+++ b/Sources/AnglesiteApp/MainPaneEditorView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 import AnglesiteCore
 
-/// Inline editor for a navigator-selected file. v1 is a plain text editor (`editorKind` always
-/// `.text`); the `switch` is where future file-specific editors attach. State lives in
-/// `FileEditorModel` (owned by `SiteWindow`) so navigating away can auto-save and the buffer
-/// survives the Preview/Editor toggle.
+/// Inline editor for a navigator-selected file. v1 is a plain text editor (`EditorKind.resolve`
+/// always returns `.text`); the `switch` is where future file-specific editors attach. State lives
+/// in `FileEditorModel` (owned by `SiteWindow`) so navigating away can auto-save and the buffer
+/// survives the Preview/Editor toggle. All IO is async/off-main in the model.
 struct MainPaneEditorView: View {
     @Bindable var model: FileEditorModel
     @Environment(\.controlActiveState) private var controlActiveState
@@ -22,8 +22,10 @@ struct MainPaneEditorView: View {
                     } actions: {
                         Button("Reveal in Finder") { NSWorkspace.shared.activateFileViewerSelecting([model.file.url]) }
                     }
+                } else if model.isLoading {
+                    ProgressView().controlSize(.small)
                 } else {
-                    switch editorKind(for: model.file) {
+                    switch EditorKind.resolve(for: model.file) {
                     case .text:
                         TextEditor(text: $model.text)
                             .font(.system(.body, design: .monospaced))
@@ -33,16 +35,21 @@ struct MainPaneEditorView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        // Load off-main when the file changes; re-fires for a new file id.
+        .task(id: model.file.id) { await model.load() }
         // Re-check the file when the window regains focus — chat/overlay/CLI may have written it.
         .onChange(of: controlActiveState) { _, new in
-            if new == .key { model.checkExternalChange() }
+            if new == .key { Task { await model.checkExternalChange() } }
         }
         .background(
-            Button("") { model.save() }.keyboardShortcut("s", modifiers: [.command]).hidden()
+            Button("") { Task { await model.save() } }.keyboardShortcut("s", modifiers: [.command]).hidden()
         )
         .alert("\(model.file.name) changed on disk", isPresented: conflictBinding) {
+            // Each button is solely responsible for resolving the conflict; the binding's setter has
+            // NO side effect, so a system-initiated dismissal can't silently pick "Keep" (or race the
+            // "Reload" action and clear the disk contents before it reads them).
             Button("Keep My Changes", role: .cancel) { model.keepMyChanges() }
-            Button("Reload from Disk") { model.reloadFromDisk() }
+            Button("Reload from Disk") { Task { await model.reloadFromDisk() } }
         } message: {
             Text("Another tool edited this file while you had unsaved changes.")
         }
@@ -57,13 +64,15 @@ struct MainPaneEditorView: View {
                     .help("Unsaved changes")
             }
             Spacer()
-            Button("Save") { model.save() }
+            Button("Save") { Task { await model.save() } }
                 .disabled(!model.isDirty)
         }
         .padding(.horizontal, 12).padding(.vertical, 8)
     }
 
+    /// Read-only presentation: the get reflects model state, the set is a no-op. Conflict resolution
+    /// happens exclusively in the two alert button actions — never as a binding side effect.
     private var conflictBinding: Binding<Bool> {
-        Binding(get: { model.conflictDiskContents != nil }, set: { if !$0 { model.keepMyChanges() } })
+        Binding(get: { model.conflictDiskContents != nil }, set: { _ in })
     }
 }

--- a/Sources/AnglesiteApp/MainPaneEditorView.swift
+++ b/Sources/AnglesiteApp/MainPaneEditorView.swift
@@ -2,38 +2,30 @@ import SwiftUI
 import AnglesiteCore
 
 /// Inline editor for a navigator-selected file. v1 is a plain text editor (`editorKind` always
-/// `.text`); the `switch` is where future file-specific editors attach. Honors the source-of-truth
-/// rule: explicit ⌘S save and a non-clobbering external-change guard.
+/// `.text`); the `switch` is where future file-specific editors attach. State lives in
+/// `FileEditorModel` (owned by `SiteWindow`) so navigating away can auto-save and the buffer
+/// survives the Preview/Editor toggle.
 struct MainPaneEditorView: View {
-    let file: FileRef
-
-    @State private var text: String = ""
-    @State private var savedText: String = ""
-    @State private var lastModified: Date?
-    @State private var loadError: String?
-    @State private var conflictDiskContents: String?
-
+    @Bindable var model: FileEditorModel
     @Environment(\.controlActiveState) private var controlActiveState
-
-    private var isDirty: Bool { text != savedText }
 
     var body: some View {
         VStack(spacing: 0) {
             header
             Divider()
             Group {
-                if let loadError {
+                if let loadError = model.loadError {
                     ContentUnavailableView {
-                        Label("Can't open \(file.name)", systemImage: "exclamationmark.triangle")
+                        Label("Can't open \(model.file.name)", systemImage: "exclamationmark.triangle")
                     } description: {
                         Text(loadError)
                     } actions: {
-                        Button("Reveal in Finder") { NSWorkspace.shared.activateFileViewerSelecting([file.url]) }
+                        Button("Reveal in Finder") { NSWorkspace.shared.activateFileViewerSelecting([model.file.url]) }
                     }
                 } else {
-                    switch editorKind(for: file) {
+                    switch editorKind(for: model.file) {
                     case .text:
-                        TextEditor(text: $text)
+                        TextEditor(text: $model.text)
                             .font(.system(.body, design: .monospaced))
                             .scrollContentBackground(.hidden)
                     }
@@ -41,23 +33,16 @@ struct MainPaneEditorView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .task(id: file.id) { load() }
         // Re-check the file when the window regains focus — chat/overlay/CLI may have written it.
         .onChange(of: controlActiveState) { _, new in
-            if new == .key { checkExternalChange() }
+            if new == .key { model.checkExternalChange() }
         }
         .background(
-            Button("") { save() }.keyboardShortcut("s", modifiers: [.command]).hidden()
+            Button("") { model.save() }.keyboardShortcut("s", modifiers: [.command]).hidden()
         )
-        .alert("\(file.name) changed on disk", isPresented: conflictBinding) {
-            Button("Keep My Changes", role: .cancel) { conflictDiskContents = nil }
-            Button("Reload from Disk") {
-                if let disk = conflictDiskContents {
-                    text = disk; savedText = disk
-                    lastModified = try? FileDocumentIO.load(file.url).modificationDate
-                }
-                conflictDiskContents = nil
-            }
+        .alert("\(model.file.name) changed on disk", isPresented: conflictBinding) {
+            Button("Keep My Changes", role: .cancel) { model.keepMyChanges() }
+            Button("Reload from Disk") { model.reloadFromDisk() }
         } message: {
             Text("Another tool edited this file while you had unsaved changes.")
         }
@@ -65,58 +50,20 @@ struct MainPaneEditorView: View {
 
     private var header: some View {
         HStack {
-            Label(file.name, systemImage: "doc.text")
+            Label(model.file.name, systemImage: "doc.text")
                 .font(.headline)
-            if isDirty {
+            if model.isDirty {
                 Circle().fill(.secondary).frame(width: 7, height: 7)
                     .help("Unsaved changes")
             }
             Spacer()
-            Button("Save") { save() }
-                .disabled(!isDirty || loadError != nil)
+            Button("Save") { model.save() }
+                .disabled(!model.isDirty)
         }
         .padding(.horizontal, 12).padding(.vertical, 8)
     }
 
     private var conflictBinding: Binding<Bool> {
-        Binding(get: { conflictDiskContents != nil }, set: { if !$0 { conflictDiskContents = nil } })
-    }
-
-    private func load() {
-        do {
-            let loaded = try FileDocumentIO.load(file.url)
-            text = loaded.contents
-            savedText = loaded.contents
-            lastModified = loaded.modificationDate
-            loadError = nil
-        } catch {
-            loadError = error.localizedDescription
-        }
-    }
-
-    private func save() {
-        guard isDirty, loadError == nil else { return }
-        do {
-            lastModified = try FileDocumentIO.save(text, to: file.url)
-            savedText = text
-        } catch {
-            loadError = "Save failed: \(error.localizedDescription)"
-        }
-    }
-
-    private func checkExternalChange() {
-        guard loadError == nil else { return }
-        guard let change = try? FileDocumentIO.externalChange(
-            at: file.url, lastKnownModificationDate: lastModified, bufferIsDirty: isDirty
-        ) else { return }
-        switch change {
-        case .none:
-            break
-        case .reloadable(let disk):
-            text = disk; savedText = disk
-            lastModified = try? FileDocumentIO.load(file.url).modificationDate
-        case .conflict(let disk):
-            conflictDiskContents = disk
-        }
+        Binding(get: { model.conflictDiskContents != nil }, set: { if !$0 { model.keepMyChanges() } })
     }
 }

--- a/Sources/AnglesiteApp/MainPaneEditorView.swift
+++ b/Sources/AnglesiteApp/MainPaneEditorView.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Inline editor for a navigator-selected file. v1 is a plain text editor (`editorKind` always
+/// `.text`); the `switch` is where future file-specific editors attach. Honors the source-of-truth
+/// rule: explicit ⌘S save and a non-clobbering external-change guard.
+struct MainPaneEditorView: View {
+    let file: FileRef
+
+    @State private var text: String = ""
+    @State private var savedText: String = ""
+    @State private var lastModified: Date?
+    @State private var loadError: String?
+    @State private var conflictDiskContents: String?
+
+    @Environment(\.controlActiveState) private var controlActiveState
+
+    private var isDirty: Bool { text != savedText }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            Group {
+                if let loadError {
+                    ContentUnavailableView {
+                        Label("Can't open \(file.name)", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text(loadError)
+                    } actions: {
+                        Button("Reveal in Finder") { NSWorkspace.shared.activateFileViewerSelecting([file.url]) }
+                    }
+                } else {
+                    switch editorKind(for: file) {
+                    case .text:
+                        TextEditor(text: $text)
+                            .font(.system(.body, design: .monospaced))
+                            .scrollContentBackground(.hidden)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .task(id: file.id) { load() }
+        // Re-check the file when the window regains focus — chat/overlay/CLI may have written it.
+        .onChange(of: controlActiveState) { _, new in
+            if new == .key { checkExternalChange() }
+        }
+        .background(
+            Button("") { save() }.keyboardShortcut("s", modifiers: [.command]).hidden()
+        )
+        .alert("\(file.name) changed on disk", isPresented: conflictBinding) {
+            Button("Keep My Changes", role: .cancel) { conflictDiskContents = nil }
+            Button("Reload from Disk") {
+                if let disk = conflictDiskContents {
+                    text = disk; savedText = disk
+                    lastModified = try? FileDocumentIO.load(file.url).modificationDate
+                }
+                conflictDiskContents = nil
+            }
+        } message: {
+            Text("Another tool edited this file while you had unsaved changes.")
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Label(file.name, systemImage: "doc.text")
+                .font(.headline)
+            if isDirty {
+                Circle().fill(.secondary).frame(width: 7, height: 7)
+                    .help("Unsaved changes")
+            }
+            Spacer()
+            Button("Save") { save() }
+                .disabled(!isDirty || loadError != nil)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
+    private var conflictBinding: Binding<Bool> {
+        Binding(get: { conflictDiskContents != nil }, set: { if !$0 { conflictDiskContents = nil } })
+    }
+
+    private func load() {
+        do {
+            let loaded = try FileDocumentIO.load(file.url)
+            text = loaded.contents
+            savedText = loaded.contents
+            lastModified = loaded.modificationDate
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    private func save() {
+        guard isDirty, loadError == nil else { return }
+        do {
+            lastModified = try FileDocumentIO.save(text, to: file.url)
+            savedText = text
+        } catch {
+            loadError = "Save failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func checkExternalChange() {
+        guard loadError == nil else { return }
+        guard let change = try? FileDocumentIO.externalChange(
+            at: file.url, lastKnownModificationDate: lastModified, bufferIsDirty: isDirty
+        ) else { return }
+        switch change {
+        case .none:
+            break
+        case .reloadable(let disk):
+            text = disk; savedText = disk
+            lastModified = try? FileDocumentIO.load(file.url).modificationDate
+        case .conflict(let disk):
+            conflictDiskContents = disk
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the Site Navigator sidebar for one window. Reads pages/posts from the shared
+/// `SiteContentGraph` and the filesystem-backed groups from `SiteFileTree`, then merges them via
+/// `buildNavigatorTree`. Refreshes when the content graph emits for this site. App glue only —
+/// all logic under test lives in AnglesiteCore.
+@MainActor
+@Observable
+final class SiteNavigatorModel {
+    private(set) var sections: [NavigatorSection] = []
+    var selection: String?
+
+    private let graph: SiteContentGraph
+    private var siteID: String?
+    private var siteRoot: URL?
+    private var observeTask: Task<Void, Never>?
+
+    init(graph: SiteContentGraph) {
+        self.graph = graph
+    }
+
+    func start(siteID: String, siteRoot: URL) {
+        self.siteID = siteID
+        self.siteRoot = siteRoot
+        Task { await refresh() }
+        observeTask?.cancel()
+        observeTask = Task { [graph, siteID] in
+            // `changeStream()` is actor-isolated (Task 1) — await it to subscribe before iterating.
+            for await changedSiteID in await graph.changeStream() {
+                if Task.isCancelled { break }
+                if changedSiteID == siteID { await refresh() }
+            }
+        }
+    }
+
+    func stop() {
+        observeTask?.cancel()
+        observeTask = nil
+    }
+
+    func target(for id: String) -> NavigatorTarget? {
+        for section in sections {
+            if let item = section.items.first(where: { $0.id == id }) { return item.target }
+        }
+        return nil
+    }
+
+    private func refresh() async {
+        guard let siteID, let siteRoot else { return }
+        let pages = await graph.pages(for: siteID)
+        let posts = await graph.posts(for: siteID)
+        // Filesystem scan is synchronous + cheap; run off the main actor to avoid stutter.
+        let fileGroups = await Task.detached { SiteFileTree.scan(siteRoot: siteRoot) }.value
+        sections = buildNavigatorTree(pages: pages, posts: posts, fileGroups: fileGroups)
+    }
+}

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -24,9 +24,13 @@ final class SiteNavigatorModel {
     func start(siteID: String, siteRoot: URL) {
         self.siteID = siteID
         self.siteRoot = siteRoot
-        Task { await refresh() }
+        // Cancel any prior observer (window reuse: SwiftUI can replay a different site into the
+        // same window) BEFORE starting the new one, so a stale refresh can't overwrite the new
+        // site's sections. The initial load runs as the new task's first step, so it is tracked
+        // and cancellable too.
         observeTask?.cancel()
         observeTask = Task { [graph, siteID] in
+            await refresh()
             // `changeStream()` is actor-isolated (Task 1) — await it to subscribe before iterating.
             for await changedSiteID in await graph.changeStream() {
                 if Task.isCancelled { break }
@@ -53,6 +57,9 @@ final class SiteNavigatorModel {
         let posts = await graph.posts(for: siteID)
         // Filesystem scan is synchronous + cheap; run off the main actor to avoid stutter.
         let fileGroups = await Task.detached { SiteFileTree.scan(siteRoot: siteRoot) }.value
+        // The task may have been cancelled (stop()/re-start) while we awaited — don't write stale
+        // content into the @Observable sections after teardown.
+        if Task.isCancelled { return }
         sections = buildNavigatorTree(pages: pages, posts: posts, fileGroups: fileGroups)
     }
 }

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -13,8 +13,6 @@ final class SiteNavigatorModel {
     var selection: String?
 
     private let graph: SiteContentGraph
-    private var siteID: String?
-    private var siteRoot: URL?
     private var observeTask: Task<Void, Never>?
 
     init(graph: SiteContentGraph) {
@@ -22,19 +20,19 @@ final class SiteNavigatorModel {
     }
 
     func start(siteID: String, siteRoot: URL) {
-        self.siteID = siteID
-        self.siteRoot = siteRoot
         // Cancel any prior observer (window reuse: SwiftUI can replay a different site into the
         // same window) BEFORE starting the new one, so a stale refresh can't overwrite the new
         // site's sections. The initial load runs as the new task's first step, so it is tracked
-        // and cancellable too.
+        // and cancellable too. `[weak self]` so the long-lived stream loop doesn't retain the model.
         observeTask?.cancel()
-        observeTask = Task { [graph, siteID] in
-            await refresh()
-            // `changeStream()` is actor-isolated (Task 1) — await it to subscribe before iterating.
-            for await changedSiteID in await graph.changeStream() {
+        observeTask = Task { [weak self, graph, siteID, siteRoot] in
+            // Subscribe BEFORE the initial refresh so a mutation that lands between the snapshot and
+            // the subscription isn't missed — the stream buffers it until the loop drains it.
+            let stream = await graph.changeStream()
+            await self?.refresh(siteID: siteID, siteRoot: siteRoot)
+            for await changedSiteID in stream {
                 if Task.isCancelled { break }
-                if changedSiteID == siteID { await refresh() }
+                if changedSiteID == siteID { await self?.refresh(siteID: siteID, siteRoot: siteRoot) }
             }
         }
     }
@@ -51,14 +49,22 @@ final class SiteNavigatorModel {
         return nil
     }
 
-    private func refresh() async {
-        guard let siteID, let siteRoot else { return }
+    /// Rebuilds `sections` for the given site. Takes `siteID`/`siteRoot` as parameters (the values
+    /// captured by `observeTask`) rather than reading mutable state, so a refresh in flight from a
+    /// prior `start()` can't populate sections with data tagged to a newer site. Checks cancellation
+    /// at each suspension point so a `stop()` mid-flight doesn't write stale content after teardown.
+    private func refresh(siteID: String, siteRoot: URL) async {
         let pages = await graph.pages(for: siteID)
+        if Task.isCancelled { return }
         let posts = await graph.posts(for: siteID)
-        // Filesystem scan is synchronous + cheap; run off the main actor to avoid stutter.
-        let fileGroups = await Task.detached { SiteFileTree.scan(siteRoot: siteRoot) }.value
-        // The task may have been cancelled (stop()/re-start) while we awaited — don't write stale
-        // content into the @Observable sections after teardown.
+        if Task.isCancelled { return }
+        // Run the filesystem scan off the main actor (it can block on a slow/large tree). Detached
+        // doesn't inherit cancellation and the scan isn't internally cancellable, so we guard the
+        // write below rather than trying to interrupt the scan; `.userInitiated` keeps the
+        // interactive sidebar population from being deprioritized behind background work.
+        let fileGroups = await Task.detached(priority: .userInitiated) {
+            SiteFileTree.scan(siteRoot: siteRoot)
+        }.value
         if Task.isCancelled { return }
         sections = buildNavigatorTree(pages: pages, posts: posts, fileGroups: fileGroups)
     }

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Xcode-Project-Navigator-style sidebar. Selection is bound to the model; `SiteWindow` reacts to
+/// changes and either navigates the preview or opens the editor.
+struct SiteNavigatorView: View {
+    @Bindable var model: SiteNavigatorModel
+
+    var body: some View {
+        List(selection: $model.selection) {
+            ForEach(model.sections) { section in
+                Section(section.title) {
+                    ForEach(section.items) { item in
+                        Label(item.title, systemImage: icon(for: section.id))
+                            .tag(item.id)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .overlay {
+            if model.sections.isEmpty {
+                ContentUnavailableView("No content yet", systemImage: "sidebar.left")
+            }
+        }
+    }
+
+    private func icon(for group: FileGroup) -> String {
+        switch group {
+        case .pages: return "doc.richtext"
+        case .posts: return "text.document"
+        case .components: return "square.stack.3d.up"
+        case .styles: return "paintbrush"
+        case .metadata: return "gearshape"
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -2,6 +2,13 @@ import SwiftUI
 import AnglesiteCore
 import AnglesiteIntents
 
+/// Which content the main pane shows: the live preview, or the inline text editor
+/// for a specific file. Driven by navigator selection (`applyNavigatorSelection`).
+private enum MainPaneMode: Equatable {
+    case preview
+    case editor(FileRef)
+}
+
 /// Root view for a single per-site window. Owns the site's `PreviewModel`,
 /// `DeployModel`, and `ChatModel` as `@State` — lifecycle is bound to the window:
 /// when the window opens we resolve the `siteID` to a `SiteStore.Site` and start
@@ -60,6 +67,8 @@ struct SiteWindow: View {
     /// Non-nil ⟺ the Siri AI Readiness sheet is presented (`.sheet(item:)`); coupling presentation
     /// to the model rather than a separate Bool makes an empty, undismissable sheet impossible.
     @State private var siriReadinessModel: SiriReadinessModel?
+    @State private var navigator: SiteNavigatorModel?
+    @State private var mainPaneMode: MainPaneMode = .preview
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -103,6 +112,8 @@ struct SiteWindow: View {
                 annotationProvider = nil
             }
             chat = nil
+            navigator?.stop()
+            navigator = nil
             #if ANGLESITE_MAS
             scopedURL?.stopAccessingSecurityScopedResource()
             scopedURL = nil
@@ -112,10 +123,21 @@ struct SiteWindow: View {
 
     @ViewBuilder
     private func siteUI(for site: SiteStore.Site) -> some View {
-        ZStack(alignment: .bottom) {
-            VStack(spacing: 0) {
-                HStack(spacing: 0) {
-                    mainPane(for: site)
+        NavigationSplitView {
+            if let navigator {
+                SiteNavigatorView(model: navigator)
+                    .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 360)
+                    .onChange(of: navigator.selection) { _, newID in
+                        applyNavigatorSelection(newID)
+                    }
+            } else {
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        } detail: {
+            ZStack(alignment: .bottom) {
+                VStack(spacing: 0) {
+                    HStack(spacing: 0) {
+                        mainPane(for: site)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                     if chatPresented, let chat {
                         Divider()
@@ -303,10 +325,52 @@ struct SiteWindow: View {
             }
         }
         .annotatedAsSite(site)
+        }
     }
 
     @ViewBuilder
     private func mainPane(for site: SiteStore.Site) -> some View {
+        VStack(spacing: 0) {
+            if case .editor = mainPaneMode {
+                Picker("", selection: Binding(
+                    get: { paneSelection },
+                    set: { setPaneSelection($0, for: site) }
+                )) {
+                    Text("Preview").tag(0)
+                    Text("Editor").tag(1)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 180)
+                .padding(6)
+                Divider()
+            }
+            mainPaneContent(for: site)
+        }
+    }
+
+    private var paneSelection: Int {
+        if case .editor = mainPaneMode { return 1 }
+        return 0
+    }
+
+    private func setPaneSelection(_ value: Int, for site: SiteStore.Site) {
+        if value == 0 { mainPaneMode = .preview }
+        // value == 1 keeps the current .editor(file); no-op when already editing.
+    }
+
+    @ViewBuilder
+    private func mainPaneContent(for site: SiteStore.Site) -> some View {
+        switch mainPaneMode {
+        case .editor(let file):
+            MainPaneEditorView(file: file)
+        case .preview:
+            previewPane(for: site)
+        }
+    }
+
+    @ViewBuilder
+    private func previewPane(for site: SiteStore.Site) -> some View {
         switch preview.state {
         case .ready(_, let url):
             PreviewView(url: preview.displayURL ?? url, router: preview.editRouter, annotationProvider: annotationProvider)
@@ -380,6 +444,23 @@ struct SiteWindow: View {
         }
     }
 
+    /// Route a navigator selection: pages/posts switch to preview and navigate; files open the editor.
+    @MainActor
+    private func applyNavigatorSelection(_ id: String?) {
+        guard let id, let target = navigator?.target(for: id) else { return }
+        switch target {
+        case .route(let route):
+            mainPaneMode = .preview
+            if route.isEmpty || route == "/" {
+                preview.clearRoute()
+            } else {
+                preview.navigate(toRoute: route)
+            }
+        case .file(let file):
+            mainPaneMode = .editor(file)
+        }
+    }
+
     private func loadAndStart() async {
         // SwiftUI's NSPersistentUIManager will happily restore a WindowGroup with a
         // nil payload, or one whose value no longer matches a known site (sites.json
@@ -426,6 +507,11 @@ struct SiteWindow: View {
         }
 
         preview.open(siteID: resolved.id, siteDirectory: resolved.sourceDirectory)
+        // Scan the Astro source tree (Source/), the same dir the preview opens — that's where the
+        // owner's editable files live under the #242 package model (resolved.path is gone).
+        let navModel = SiteNavigatorModel(graph: contentGraph)
+        navModel.start(siteID: resolved.id, siteRoot: resolved.sourceDirectory)
+        navigator = navModel
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
         applyPendingNavigation(for: resolved.id)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -540,10 +540,11 @@ struct SiteWindow: View {
         }
 
         preview.open(siteID: resolved.id, siteDirectory: resolved.sourceDirectory)
-        // Scan the Astro source tree (Source/), the same dir the preview opens — that's where the
-        // owner's editable files live under the #242 package model (resolved.path is gone).
+        // Scan from the package ROOT (not Source/): SiteFileTree's adaptive layout detects the
+        // `.anglesite` package here and resolves Source/ for Components/Styles plus the sibling
+        // Config/ + Info.plist for the Metadata group. Handing it Source/ would hide Metadata.
         let navModel = SiteNavigatorModel(graph: contentGraph)
-        navModel.start(siteID: resolved.id, siteRoot: resolved.sourceDirectory)
+        navModel.start(siteID: resolved.id, siteRoot: resolved.packageURL)
         navigator = navModel
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -69,6 +69,10 @@ struct SiteWindow: View {
     @State private var siriReadinessModel: SiriReadinessModel?
     @State private var navigator: SiteNavigatorModel?
     @State private var mainPaneMode: MainPaneMode = .preview
+    /// The open file's editor state. Owned here (not in `MainPaneEditorView`) so navigating away can
+    /// auto-save it and the Preview/Editor toggle keeps the buffer alive. Replaced when a different
+    /// file opens; cleared on window close / site replay.
+    @State private var editorModel: FileEditorModel?
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -97,6 +101,8 @@ struct SiteWindow: View {
         // the current site — otherwise it holds stale probes scoped to the original site.id.
         .onChange(of: site?.id) { _, _ in
             siriReadinessModel = nil
+            editorModel = nil
+            mainPaneMode = .preview
         }
         .onChange(of: preview.state) { _, newState in
             startup.ingest(state: newState)
@@ -114,6 +120,8 @@ struct SiteWindow: View {
             chat = nil
             navigator?.stop()
             navigator = nil
+            _ = editorModel?.flushBeforeLeaving()
+            editorModel = nil
             #if ANGLESITE_MAS
             scopedURL?.stopAccessingSecurityScopedResource()
             scopedURL = nil
@@ -331,10 +339,10 @@ struct SiteWindow: View {
     @ViewBuilder
     private func mainPane(for site: SiteStore.Site) -> some View {
         VStack(spacing: 0) {
-            if case .editor = mainPaneMode {
+            if editorModel != nil {
                 Picker("", selection: Binding(
                     get: { paneSelection },
-                    set: { setPaneSelection($0, for: site) }
+                    set: { setPaneSelection($0) }
                 )) {
                     Text("Preview").tag(0)
                     Text("Editor").tag(1)
@@ -354,16 +362,34 @@ struct SiteWindow: View {
         return 0
     }
 
-    private func setPaneSelection(_ value: Int, for site: SiteStore.Site) {
-        if value == 0 { mainPaneMode = .preview }
-        // value == 1 keeps the current .editor(file); no-op when already editing.
+    private func setPaneSelection(_ value: Int) {
+        if value == 0 {
+            // Switching to Preview auto-saves the open editor (abort on an unresolved conflict).
+            guard leaveCurrentEditor() else { return }
+            mainPaneMode = .preview
+        } else if value == 1, let model = editorModel {
+            mainPaneMode = .editor(model.file)
+        }
+    }
+
+    /// Flush the open editor before leaving it: auto-saves a dirty buffer, but returns false (and the
+    /// model raises its conflict alert) when the file changed externally — so the caller aborts the
+    /// switch instead of clobbering the other tool's edit. Safe to call when not editing.
+    @discardableResult
+    private func leaveCurrentEditor() -> Bool {
+        guard case .editor = mainPaneMode, let model = editorModel else { return true }
+        return model.flushBeforeLeaving()
     }
 
     @ViewBuilder
     private func mainPaneContent(for site: SiteStore.Site) -> some View {
         switch mainPaneMode {
-        case .editor(let file):
-            MainPaneEditorView(file: file)
+        case .editor:
+            if let editorModel {
+                MainPaneEditorView(model: editorModel)
+            } else {
+                previewPane(for: site)
+            }
         case .preview:
             previewPane(for: site)
         }
@@ -450,6 +476,7 @@ struct SiteWindow: View {
         guard let id, let target = navigator?.target(for: id) else { return }
         switch target {
         case .route(let route):
+            guard leaveCurrentEditor() else { return }   // abort if a conflict needs resolving
             mainPaneMode = .preview
             if route.isEmpty || route == "/" {
                 preview.clearRoute()
@@ -457,6 +484,12 @@ struct SiteWindow: View {
                 preview.navigate(toRoute: route)
             }
         case .file(let file):
+            if editorModel?.file.id == file.id {
+                mainPaneMode = .editor(file)   // re-show the already-open file (buffer intact)
+                return
+            }
+            guard leaveCurrentEditor() else { return }   // flush the previous file first
+            editorModel = FileEditorModel(file: file)
             mainPaneMode = .editor(file)
         }
     }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -69,6 +69,9 @@ struct SiteWindow: View {
     @State private var siriReadinessModel: SiriReadinessModel?
     @State private var navigator: SiteNavigatorModel?
     @State private var mainPaneMode: MainPaneMode = .preview
+    /// Sidebar visibility persisted per scene (window), per the design spec. Column WIDTH is restored
+    /// automatically by `NavigationSplitView`'s own scene state, so only explicit visibility is wired.
+    @SceneStorage("siteNavigator.sidebarVisible") private var sidebarVisible = true
     /// The open file's editor state. Owned here (not in `MainPaneEditorView`) so navigating away can
     /// auto-save it and the Preview/Editor toggle keeps the buffer alive. Replaced when a different
     /// file opens; cleared on window close / site replay.
@@ -101,6 +104,8 @@ struct SiteWindow: View {
         // the current site — otherwise it holds stale probes scoped to the original site.id.
         .onChange(of: site?.id) { _, _ in
             siriReadinessModel = nil
+            // Persist any unsaved edits before dropping the old site's editor on replay (#188 reuse).
+            persistEditorBufferBestEffort()
             editorModel = nil
             mainPaneMode = .preview
         }
@@ -120,7 +125,10 @@ struct SiteWindow: View {
             chat = nil
             navigator?.stop()
             navigator = nil
-            _ = editorModel?.flushBeforeLeaving()
+            // Window closing: persist unsaved edits unconditionally (consistent with
+            // auto-save-on-leave). No conflict dialog is possible during teardown, so we don't gate
+            // on a flush return value — just write the buffer best-effort, off the main actor.
+            persistEditorBufferBestEffort()
             editorModel = nil
             #if ANGLESITE_MAS
             scopedURL?.stopAccessingSecurityScopedResource()
@@ -131,7 +139,10 @@ struct SiteWindow: View {
 
     @ViewBuilder
     private func siteUI(for site: SiteStore.Site) -> some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: Binding(
+            get: { sidebarVisible ? .all : .detailOnly },
+            set: { sidebarVisible = ($0 != .detailOnly) }
+        )) {
             if let navigator {
                 SiteNavigatorView(model: navigator)
                     .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 360)
@@ -365,8 +376,8 @@ struct SiteWindow: View {
     private func setPaneSelection(_ value: Int) {
         if value == 0 {
             // Switching to Preview auto-saves the open editor (abort on an unresolved conflict).
-            guard leaveCurrentEditor() else { return }
-            mainPaneMode = .preview
+            // The flush is async (off-main IO), so do it in a Task and only switch on success.
+            Task { if await leaveCurrentEditor() { mainPaneMode = .preview } }
         } else if value == 1, let model = editorModel {
             mainPaneMode = .editor(model.file)
         }
@@ -374,11 +385,21 @@ struct SiteWindow: View {
 
     /// Flush the open editor before leaving it: auto-saves a dirty buffer, but returns false (and the
     /// model raises its conflict alert) when the file changed externally — so the caller aborts the
-    /// switch instead of clobbering the other tool's edit. Safe to call when not editing.
-    @discardableResult
-    private func leaveCurrentEditor() -> Bool {
+    /// switch instead of clobbering the other tool's edit. Safe to call when not editing. Async
+    /// because the save/check IO runs off the main actor.
+    private func leaveCurrentEditor() async -> Bool {
         guard case .editor = mainPaneMode, let model = editorModel else { return true }
-        return model.flushBeforeLeaving()
+        return await model.flushBeforeLeaving()
+    }
+
+    /// Best-effort off-main save of the open editor's buffer when the editor is torn down (window
+    /// close or site replay), where no conflict dialog can be shown. Consistent with the
+    /// auto-save-on-leave model; last-writer-wins on the rare teardown-time external conflict.
+    private func persistEditorBufferBestEffort() {
+        guard let model = editorModel, model.isDirty else { return }
+        let url = model.file.url
+        let contents = model.text
+        Task.detached(priority: .userInitiated) { try? FileDocumentIO.save(contents, to: url) }
     }
 
     @ViewBuilder
@@ -471,26 +492,32 @@ struct SiteWindow: View {
     }
 
     /// Route a navigator selection: pages/posts switch to preview and navigate; files open the editor.
+    /// Async — leaving the current editor flushes it to disk off the main actor first, and aborts the
+    /// switch if an external conflict needs resolving.
     @MainActor
     private func applyNavigatorSelection(_ id: String?) {
         guard let id, let target = navigator?.target(for: id) else { return }
         switch target {
         case .route(let route):
-            guard leaveCurrentEditor() else { return }   // abort if a conflict needs resolving
-            mainPaneMode = .preview
-            if route.isEmpty || route == "/" {
-                preview.clearRoute()
-            } else {
-                preview.navigate(toRoute: route)
+            Task {
+                guard await leaveCurrentEditor() else { return }   // abort if a conflict needs resolving
+                mainPaneMode = .preview
+                if route.isEmpty || route == "/" {
+                    preview.clearRoute()
+                } else {
+                    preview.navigate(toRoute: route)
+                }
             }
         case .file(let file):
             if editorModel?.file.id == file.id {
                 mainPaneMode = .editor(file)   // re-show the already-open file (buffer intact)
                 return
             }
-            guard leaveCurrentEditor() else { return }   // flush the previous file first
-            editorModel = FileEditorModel(file: file)
-            mainPaneMode = .editor(file)
+            Task {
+                guard await leaveCurrentEditor() else { return }   // flush the previous file first
+                editorModel = FileEditorModel(file: file)
+                mainPaneMode = .editor(file)
+            }
         }
     }
 
@@ -543,6 +570,11 @@ struct SiteWindow: View {
         // Scan from the package ROOT (not Source/): SiteFileTree's adaptive layout detects the
         // `.anglesite` package here and resolves Source/ for Components/Styles plus the sibling
         // Config/ + Info.plist for the Metadata group. Handing it Source/ would hide Metadata.
+        // Stop any prior navigator (window replay into the same instance) right before replacing it,
+        // so its observe task doesn't leak and keep streaming for the stale site. Done here at the
+        // deterministic replacement point rather than in `onChange(of: site?.id)`, which could race
+        // this creation and stop the freshly-made navigator instead.
+        navigator?.stop()
         let navModel = SiteNavigatorModel(graph: contentGraph)
         navModel.start(siteID: resolved.id, siteRoot: resolved.packageURL)
         navigator = navModel

--- a/Sources/AnglesiteCore/EditorKind.swift
+++ b/Sources/AnglesiteCore/EditorKind.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Which editor surface a navigator file opens in. v1 ships only `.text`; future cases
+/// (`.metadataForm`, etc.) slot in by extending this enum and the `editorKind(for:)` mapping —
+/// call sites switch on the kind and need no change beyond adding the new view.
+public enum EditorKind: Sendable, Equatable {
+    case text
+    // future: case metadataForm
+}
+
+/// Resolves the editor for a file. Intentionally a free function with a single decision point so
+/// the routing rule lives in one tested place.
+public func editorKind(for file: FileRef) -> EditorKind {
+    .text
+}

--- a/Sources/AnglesiteCore/EditorKind.swift
+++ b/Sources/AnglesiteCore/EditorKind.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 /// Which editor surface a navigator file opens in. v1 ships only `.text`; future cases
-/// (`.metadataForm`, etc.) slot in by extending this enum and the `editorKind(for:)` mapping —
+/// (`.metadataForm`, etc.) slot in by extending this enum and the `resolve(for:)` mapping —
 /// call sites switch on the kind and need no change beyond adding the new view.
 public enum EditorKind: Sendable, Equatable {
     case text
     // future: case metadataForm
-}
 
-/// Resolves the editor for a file. Intentionally a free function with a single decision point so
-/// the routing rule lives in one tested place.
-public func editorKind(for file: FileRef) -> EditorKind {
-    .text
+    /// Resolves the editor for a file. A single decision point so the routing rule lives in one
+    /// tested place; kept on the enum to keep the public API surface tidy.
+    public static func resolve(for file: FileRef) -> EditorKind {
+        .text
+    }
 }

--- a/Sources/AnglesiteCore/FileDocumentIO.swift
+++ b/Sources/AnglesiteCore/FileDocumentIO.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Stateless file IO for the navigator's inline editor, plus the external-change decision.
+/// The App view owns the text buffer + dirty flag; this type only touches disk and reports
+/// what changed. Keeping it stateless makes the reconcile rules unit-testable without UI.
+public enum FileDocumentIO {
+    public struct Loaded: Sendable, Equatable {
+        public let contents: String
+        public let modificationDate: Date?
+    }
+
+    /// What the editor should do when the on-disk file no longer matches what we last saw.
+    public enum ExternalChange: Sendable, Equatable {
+        case none
+        /// Disk changed and the buffer is clean — safe to swap in `contents` silently.
+        case reloadable(String)
+        /// Disk changed and the buffer is dirty — must ask the user; `contents` is the disk copy.
+        case conflict(String)
+    }
+
+    public static func load(_ url: URL, fileManager: FileManager = .default) throws -> Loaded {
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        let mtime = try modificationDate(of: url, fileManager: fileManager)
+        return Loaded(contents: contents, modificationDate: mtime)
+    }
+
+    @discardableResult
+    public static func save(_ contents: String, to url: URL, fileManager: FileManager = .default) throws -> Date? {
+        try Data(contents.utf8).write(to: url, options: [.atomic])
+        return try modificationDate(of: url, fileManager: fileManager)
+    }
+
+    public static func externalChange(
+        at url: URL,
+        lastKnownModificationDate: Date?,
+        bufferIsDirty: Bool,
+        fileManager: FileManager = .default
+    ) throws -> ExternalChange {
+        let current = try modificationDate(of: url, fileManager: fileManager)
+        // Treat a strictly-newer disk mtime as an external write. Equal/nil → no change.
+        guard let current, let last = lastKnownModificationDate, current > last else {
+            return .none
+        }
+        let diskContents = try String(contentsOf: url, encoding: .utf8)
+        return bufferIsDirty ? .conflict(diskContents) : .reloadable(diskContents)
+    }
+
+    private static func modificationDate(of url: URL, fileManager: FileManager) throws -> Date? {
+        try fileManager.attributesOfItem(atPath: url.path)[.modificationDate] as? Date
+    }
+}

--- a/Sources/AnglesiteCore/FileDocumentIO.swift
+++ b/Sources/AnglesiteCore/FileDocumentIO.swift
@@ -38,6 +38,10 @@ public enum FileDocumentIO {
     ) throws -> ExternalChange {
         let current = try modificationDate(of: url, fileManager: fileManager)
         // Treat a strictly-newer disk mtime as an external write. Equal/nil → no change.
+        // Known limitation: HFS+ has 1-second mtime granularity, so two writes within the same
+        // second can carry identical mtimes and a second external change made that quickly is not
+        // detected. APFS (the macOS 27 default) has nanosecond granularity, so this only affects
+        // legacy HFS+ volumes.
         guard let current, let last = lastKnownModificationDate, current > last else {
             return .none
         }
@@ -46,6 +50,6 @@ public enum FileDocumentIO {
     }
 
     private static func modificationDate(of url: URL, fileManager: FileManager) throws -> Date? {
-        try fileManager.attributesOfItem(atPath: url.path)[.modificationDate] as? Date
+        try fileManager.attributesOfItem(atPath: url.path(percentEncoded: false))[.modificationDate] as? Date
     }
 }

--- a/Sources/AnglesiteCore/NavigatorTree.swift
+++ b/Sources/AnglesiteCore/NavigatorTree.swift
@@ -26,7 +26,11 @@ public struct NavigatorSection: Sendable, Equatable, Identifiable {
 
 /// Derived preview route for a post. See the plan's documented assumption.
 public func postRoute(for post: SiteContentGraph.Post) -> String {
-    "/\(post.collection)/\(post.slug)/"
+    // Percent-encode each component: a collection/slug with spaces, Unicode, or reserved chars
+    // would otherwise produce an invalid URL path and 404 silently in the preview.
+    let collection = post.collection.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? post.collection
+    let slug = post.slug.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? post.slug
+    return "/\(collection)/\(slug)/"
 }
 
 /// Display titles for the five groups, in canonical sidebar order.

--- a/Sources/AnglesiteCore/NavigatorTree.swift
+++ b/Sources/AnglesiteCore/NavigatorTree.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// What selecting a navigator row does: navigate the preview to a route, or open a file in the editor.
+public enum NavigatorTarget: Sendable, Equatable {
+    case route(String)
+    case file(FileRef)
+}
+
+public struct NavigatorItem: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let title: String
+    public let target: NavigatorTarget
+    public init(id: String, title: String, target: NavigatorTarget) {
+        self.id = id; self.title = title; self.target = target
+    }
+}
+
+public struct NavigatorSection: Sendable, Equatable, Identifiable {
+    public let id: FileGroup
+    public let title: String
+    public let items: [NavigatorItem]
+    public init(id: FileGroup, title: String, items: [NavigatorItem]) {
+        self.id = id; self.title = title; self.items = items
+    }
+}
+
+/// Derived preview route for a post. See the plan's documented assumption.
+public func postRoute(for post: SiteContentGraph.Post) -> String {
+    "/\(post.collection)/\(post.slug)/"
+}
+
+/// Display titles for the five groups, in canonical sidebar order.
+private let groupTitles: [(FileGroup, String)] = [
+    (.pages, "Pages"), (.posts, "Posts"),
+    (.components, "Components"), (.styles, "Styles"), (.metadata, "Metadata"),
+]
+
+/// Merges content-graph pages/posts with the filesystem scan into ordered, non-empty sections.
+public func buildNavigatorTree(
+    pages: [SiteContentGraph.Page],
+    posts: [SiteContentGraph.Post],
+    fileGroups: [FileGroup: [FileRef]]
+) -> [NavigatorSection] {
+    let pageItems = pages
+        .sorted { $0.route < $1.route }
+        .map { NavigatorItem(id: $0.id, title: $0.title ?? $0.route, target: .route($0.route)) }
+    let postItems = posts
+        .sorted { $0.title < $1.title }
+        .map { NavigatorItem(id: $0.id, title: $0.title, target: .route(postRoute(for: $0))) }
+
+    var sections: [NavigatorSection] = []
+    for (group, title) in groupTitles {
+        let items: [NavigatorItem]
+        switch group {
+        case .pages: items = pageItems
+        case .posts: items = postItems
+        default:
+            items = (fileGroups[group] ?? []).map {
+                NavigatorItem(id: $0.id, title: $0.name, target: .file($0))
+            }
+        }
+        if !items.isEmpty { sections.append(NavigatorSection(id: group, title: title, items: items)) }
+    }
+    return sections
+}

--- a/Sources/AnglesiteCore/SiteContentGraph.swift
+++ b/Sources/AnglesiteCore/SiteContentGraph.swift
@@ -111,15 +111,43 @@ public actor SiteContentGraph {
     private var images: [String: Image] = [:]
     private var changeHandler: ChangeHandler?
 
+    /// Additive multi-subscriber broadcast for UI observers (the Site Navigator), keyed by a
+    /// per-subscription `UUID`. Distinct from `changeHandler` (the indexer's single awaited hook):
+    /// these are fire-and-forget siteID feeds. Pruned via the stream's `onTermination`.
+    private var changeStreamContinuations: [UUID: AsyncStream<String>.Continuation] = [:]
+
     public init() {}
 
     public func setChangeHandler(_ handler: ChangeHandler?) {
         changeHandler = handler
     }
 
+    /// A multi-subscriber stream of affected siteIDs, one per real mutation. Actor-isolated so the
+    /// continuation registers synchronously before this returns: there is no subscribe-time snapshot
+    /// to mask a registration race, so a caller that subscribes then mutates must not miss the emit.
+    /// (A content change is an event — the navigator reads the graph back itself on first load.)
+    /// Callers `await` it.
+    public func changeStream() -> AsyncStream<String> {
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: String.self, bufferingPolicy: .bufferingNewest(8))
+        let id = UUID()
+        changeStreamContinuations[id] = continuation
+        continuation.onTermination = { [weak self] _ in
+            // onTermination runs off-actor at an arbitrary time; hop back to prune.
+            Task { await self?.removeContinuation(id) }
+        }
+        return stream
+    }
+
+    private func removeContinuation(_ id: UUID) {
+        changeStreamContinuations[id] = nil
+    }
+
     private func emitChange(_ siteID: String) async {
-        guard let handler = changeHandler else { return }
-        await handler(siteID)
+        if let handler = changeHandler { await handler(siteID) }
+        for continuation in changeStreamContinuations.values {
+            continuation.yield(siteID)
+        }
     }
 
     // MARK: - Bulk load

--- a/Sources/AnglesiteCore/SiteFileTree.swift
+++ b/Sources/AnglesiteCore/SiteFileTree.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Curated, group-oriented view of a site's filesystem-backed parts for the Site Navigator.
+/// Pages/Posts are sourced from `SiteContentGraph`, not here — this scanner covers only the
+/// Components, Styles, and Metadata groups.
+///
+/// Roots are resolved adaptively: an `.anglesite` package (#242) exposes `Source/` and `Config/`;
+/// a plain directory (the current pre-package layout) is treated as the project root directly.
+public enum FileGroup: String, Sendable, CaseIterable {
+    case pages, posts, components, styles, metadata
+}
+
+public struct FileRef: Sendable, Equatable, Identifiable {
+    public var id: String { url.path }
+    public let url: URL
+    public let group: FileGroup
+    public let name: String
+
+    public init(url: URL, group: FileGroup, name: String) {
+        self.url = url
+        self.group = group
+        self.name = name
+    }
+}
+
+public enum SiteFileTree {
+    public struct Layout: Sendable, Equatable {
+        public let sourceDir: URL
+        public let configDir: URL?
+        public let infoPlist: URL?
+    }
+
+    /// Directory names never descended into or listed.
+    private static let excludedDirNames: Set<String> = ["node_modules", "dist", ".astro", ".git"]
+    private static let excludedFileNames: Set<String> = [".DS_Store"]
+
+    public static func layout(for siteRoot: URL, fileManager: FileManager = .default) -> Layout {
+        if AnglesitePackage.isPackage(at: siteRoot, fileManager: fileManager) {
+            let pkg = AnglesitePackage(url: siteRoot)
+            return Layout(sourceDir: pkg.sourceURL, configDir: pkg.configURL, infoPlist: pkg.infoPlistURL)
+        }
+        return Layout(sourceDir: siteRoot, configDir: nil, infoPlist: nil)
+    }
+
+    public static func scan(siteRoot: URL, fileManager: FileManager = .default) -> [FileGroup: [FileRef]] {
+        let layout = layout(for: siteRoot, fileManager: fileManager)
+        var result: [FileGroup: [FileRef]] = [:]
+
+        // Components: layouts + components dirs under src/.
+        let componentDirs = ["src/layouts", "src/components"].map { layout.sourceDir.appendingPathComponent($0) }
+        let components = componentDirs.flatMap { files(in: $0, group: .components, fileManager: fileManager) }
+        if !components.isEmpty { result[.components] = components.sorted { $0.name < $1.name } }
+
+        // Styles: src/styles.
+        let styles = files(in: layout.sourceDir.appendingPathComponent("src/styles"),
+                           group: .styles, fileManager: fileManager)
+        if !styles.isEmpty { result[.styles] = styles.sorted { $0.name < $1.name } }
+
+        // Metadata: everything in Config/ plus the package Info.plist marker.
+        var metadata: [FileRef] = []
+        if let configDir = layout.configDir {
+            metadata += files(in: configDir, group: .metadata, fileManager: fileManager)
+        }
+        if let infoPlist = layout.infoPlist, fileManager.fileExists(atPath: infoPlist.path) {
+            metadata.append(FileRef(url: infoPlist, group: .metadata, name: infoPlist.lastPathComponent))
+        }
+        if !metadata.isEmpty { result[.metadata] = metadata.sorted { $0.name < $1.name } }
+
+        return result
+    }
+
+    /// Recursively lists files under `dir`, skipping excluded dirs/files. Returns [] if `dir` is absent.
+    private static func files(in dir: URL, group: FileGroup, fileManager: FileManager) -> [FileRef] {
+        guard let enumerator = fileManager.enumerator(
+            at: dir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        var refs: [FileRef] = []
+        for case let url as URL in enumerator {
+            let name = url.lastPathComponent
+            let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+            if isDir {
+                if excludedDirNames.contains(name) { enumerator.skipDescendants() }
+                continue
+            }
+            if excludedFileNames.contains(name) { continue }
+            refs.append(FileRef(url: url, group: group, name: name))
+        }
+        return refs
+    }
+}

--- a/Sources/AnglesiteCore/SiteFileTree.swift
+++ b/Sources/AnglesiteCore/SiteFileTree.swift
@@ -11,7 +11,7 @@ public enum FileGroup: String, Sendable, CaseIterable {
 }
 
 public struct FileRef: Sendable, Equatable, Identifiable {
-    public var id: String { url.path }
+    public var id: String { url.path(percentEncoded: false) }
     public let url: URL
     public let group: FileGroup
     public let name: String
@@ -61,7 +61,7 @@ public enum SiteFileTree {
         if let configDir = layout.configDir {
             metadata += files(in: configDir, group: .metadata, fileManager: fileManager)
         }
-        if let infoPlist = layout.infoPlist, fileManager.fileExists(atPath: infoPlist.path) {
+        if let infoPlist = layout.infoPlist, fileManager.fileExists(atPath: infoPlist.path(percentEncoded: false)) {
             metadata.append(FileRef(url: infoPlist, group: .metadata, name: infoPlist.lastPathComponent))
         }
         if !metadata.isEmpty { result[.metadata] = metadata.sorted { $0.name < $1.name } }
@@ -73,15 +73,19 @@ public enum SiteFileTree {
     private static func files(in dir: URL, group: FileGroup, fileManager: FileManager) -> [FileRef] {
         guard let enumerator = fileManager.enumerator(
             at: dir,
-            includingPropertiesForKeys: [.isDirectoryKey],
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
             options: [.skipsHiddenFiles]
         ) else { return [] }
 
         var refs: [FileRef] = []
         for case let url as URL in enumerator {
             let name = url.lastPathComponent
-            let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
-            if isDir {
+            let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            // Skip symlinks entirely: the exclusion set only matches real directory names, so a
+            // symlinked tree (e.g. pnpm's symlinked node_modules) would slip past it, and a symlink
+            // cycle would loop forever. `skipDescendants()` only works on real directories.
+            if values?.isSymbolicLink == true { continue }
+            if values?.isDirectory == true {
                 if excludedDirNames.contains(name) { enumerator.skipDescendants() }
                 continue
             }

--- a/Tests/AnglesiteCoreTests/EditorKindTests.swift
+++ b/Tests/AnglesiteCoreTests/EditorKindTests.swift
@@ -7,7 +7,7 @@ struct EditorKindTests {
     func everythingIsText() {
         for group in FileGroup.allCases {
             let ref = FileRef(url: URL(fileURLWithPath: "/tmp/x"), group: group, name: "x")
-            #expect(editorKind(for: ref) == .text)
+            #expect(EditorKind.resolve(for: ref) == .text)
         }
     }
 }

--- a/Tests/AnglesiteCoreTests/EditorKindTests.swift
+++ b/Tests/AnglesiteCoreTests/EditorKindTests.swift
@@ -1,0 +1,13 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct EditorKindTests {
+    @Test("v1 routes every file group to the text editor")
+    func everythingIsText() {
+        for group in FileGroup.allCases {
+            let ref = FileRef(url: URL(fileURLWithPath: "/tmp/x"), group: group, name: "x")
+            #expect(editorKind(for: ref) == .text)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/FileDocumentIOTests.swift
+++ b/Tests/AnglesiteCoreTests/FileDocumentIOTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct FileDocumentIOTests {
+    private func tempFile(_ contents: String) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("doc-\(UUID().uuidString).txt")
+        try Data(contents.utf8).write(to: url)
+        return url
+    }
+
+    @Test("load reads contents and a modification date")
+    func loadReads() throws {
+        let url = try tempFile("hello"); defer { try? FileManager.default.removeItem(at: url) }
+        let loaded = try FileDocumentIO.load(url)
+        #expect(loaded.contents == "hello")
+        #expect(loaded.modificationDate != nil)
+    }
+
+    @Test("save writes the bytes and returns a fresh mtime")
+    func saveWrites() throws {
+        let url = try tempFile("old"); defer { try? FileManager.default.removeItem(at: url) }
+        let mtime = try FileDocumentIO.save("new contents", to: url)
+        #expect(try String(contentsOf: url, encoding: .utf8) == "new contents")
+        #expect(mtime != nil)
+    }
+
+    @Test("externalChange returns .none when disk mtime is unchanged")
+    func noChange() throws {
+        let url = try tempFile("a"); defer { try? FileManager.default.removeItem(at: url) }
+        let loaded = try FileDocumentIO.load(url)
+        let change = try FileDocumentIO.externalChange(
+            at: url, lastKnownModificationDate: loaded.modificationDate, bufferIsDirty: false)
+        #expect(change == .none)
+    }
+
+    @Test("clean buffer + external write → .reloadable(newContents)")
+    func reloadableWhenClean() throws {
+        let url = try tempFile("a"); defer { try? FileManager.default.removeItem(at: url) }
+        let loaded = try FileDocumentIO.load(url)
+        // Simulate another tool writing the file with a strictly newer mtime.
+        let newer = (loaded.modificationDate ?? Date()).addingTimeInterval(2)
+        try Data("b".utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: newer], ofItemAtPath: url.path)
+        let change = try FileDocumentIO.externalChange(
+            at: url, lastKnownModificationDate: loaded.modificationDate, bufferIsDirty: false)
+        #expect(change == .reloadable("b"))
+    }
+
+    @Test("dirty buffer + external write → .conflict(newContents)")
+    func conflictWhenDirty() throws {
+        let url = try tempFile("a"); defer { try? FileManager.default.removeItem(at: url) }
+        let loaded = try FileDocumentIO.load(url)
+        let newer = (loaded.modificationDate ?? Date()).addingTimeInterval(2)
+        try Data("b".utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: newer], ofItemAtPath: url.path)
+        let change = try FileDocumentIO.externalChange(
+            at: url, lastKnownModificationDate: loaded.modificationDate, bufferIsDirty: true)
+        #expect(change == .conflict("b"))
+    }
+}

--- a/Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
+++ b/Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
@@ -1,0 +1,49 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct NavigatorTreeTests {
+    private func page(_ route: String, title: String?) -> SiteContentGraph.Page {
+        SiteContentGraph.Page(id: "s:page:\(route)", siteID: "s", route: route,
+            filePath: "/tmp\(route).astro", title: title, lastModified: Date(timeIntervalSince1970: 0))
+    }
+    private func post(_ collection: String, _ slug: String, _ title: String) -> SiteContentGraph.Post {
+        SiteContentGraph.Post(id: "s:post:\(slug)", siteID: "s", collection: collection, slug: slug,
+            title: title, draft: false, publishDate: nil, tags: [],
+            filePath: "/tmp/\(slug).md", lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("post route derives /collection/slug/")
+    func postRouteDerivation() {
+        #expect(postRoute(for: post("blog", "hello-world", "Hello")) == "/blog/hello-world/")
+    }
+
+    @Test("sections appear in canonical order and only when non-empty")
+    func sectionOrderAndEmpties() {
+        let sections = buildNavigatorTree(
+            pages: [page("/about/", title: "About")],
+            posts: [],
+            fileGroups: [.styles: [FileRef(url: URL(fileURLWithPath: "/tmp/g.css"), group: .styles, name: "g.css")]]
+        )
+        #expect(sections.map(\.id) == [.pages, .styles])   // posts/components/metadata empty → omitted
+    }
+
+    @Test("page item uses title when present and route as fallback; target is the route")
+    func pageItems() {
+        let sections = buildNavigatorTree(
+            pages: [page("/about/", title: "About"), page("/contact/", title: nil)],
+            posts: [], fileGroups: [:])
+        let pages = sections.first { $0.id == .pages }!
+        #expect(pages.items.map(\.title) == ["About", "/contact/"])
+        #expect(pages.items.first?.target == .route("/about/"))
+    }
+
+    @Test("file item target carries the FileRef")
+    func fileItems() {
+        let ref = FileRef(url: URL(fileURLWithPath: "/tmp/Base.astro"), group: .components, name: "Base.astro")
+        let sections = buildNavigatorTree(pages: [], posts: [], fileGroups: [.components: [ref]])
+        let item = sections.first { $0.id == .components }!.items.first!
+        #expect(item.title == "Base.astro")
+        #expect(item.target == .file(ref))
+    }
+}

--- a/Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
+++ b/Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
@@ -29,20 +29,21 @@ struct NavigatorTreeTests {
     }
 
     @Test("page item uses title when present and route as fallback; target is the route")
-    func pageItems() {
+    func pageItems() throws {
         let sections = buildNavigatorTree(
             pages: [page("/about/", title: "About"), page("/contact/", title: nil)],
             posts: [], fileGroups: [:])
-        let pages = sections.first { $0.id == .pages }!
+        let pages = try #require(sections.first { $0.id == .pages })
         #expect(pages.items.map(\.title) == ["About", "/contact/"])
         #expect(pages.items.first?.target == .route("/about/"))
     }
 
     @Test("file item target carries the FileRef")
-    func fileItems() {
+    func fileItems() throws {
         let ref = FileRef(url: URL(fileURLWithPath: "/tmp/Base.astro"), group: .components, name: "Base.astro")
         let sections = buildNavigatorTree(pages: [], posts: [], fileGroups: [.components: [ref]])
-        let item = sections.first { $0.id == .components }!.items.first!
+        let components = try #require(sections.first { $0.id == .components })
+        let item = try #require(components.items.first)
         #expect(item.title == "Base.astro")
         #expect(item.target == .file(ref))
     }

--- a/Tests/AnglesiteCoreTests/SiteContentGraphStreamTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteContentGraphStreamTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SiteContentGraphStreamTests {
+    private func makePage(_ siteID: String, route: String) -> SiteContentGraph.Page {
+        SiteContentGraph.Page(
+            id: "\(siteID):page:\(route)", siteID: siteID, route: route,
+            filePath: "/tmp/\(route).astro", title: route, lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("changeStream yields the siteID on a real mutation")
+    func yieldsOnMutation() async throws {
+        let graph = SiteContentGraph()
+        var iterator = (await graph.changeStream()).makeAsyncIterator()
+        await graph.upsertPage(makePage("siteA", route: "/about/"))
+        let received = await iterator.next()
+        #expect(received == "siteA")
+    }
+
+    @Test("two independent subscribers both receive the change")
+    func broadcastsToAll() async throws {
+        let graph = SiteContentGraph()
+        var it1 = (await graph.changeStream()).makeAsyncIterator()
+        var it2 = (await graph.changeStream()).makeAsyncIterator()
+        await graph.upsertPage(makePage("siteB", route: "/x/"))
+        let a = await it1.next()
+        let b = await it2.next()
+        #expect(a == "siteB")
+        #expect(b == "siteB")
+    }
+
+    @Test("an equal upsert does not emit (real-mutation only)")
+    func noEmitOnEqualUpsert() async throws {
+        let graph = SiteContentGraph()
+        let page = makePage("siteC", route: "/y/")
+        await graph.upsertPage(page)              // first insert emits
+        var it = (await graph.changeStream()).makeAsyncIterator()
+        await graph.upsertPage(page)              // equal → no emit
+        await graph.upsertPage(makePage("siteC", route: "/z/")) // emits
+        let received = await it.next()
+        #expect(received == "siteC")              // the /z/ emit, not a phantom /y/ emit
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteFileTreeTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteFileTreeTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SiteFileTreeTests {
+    private func makeTempDir() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("anglesite-filetree-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func write(_ relative: String, under root: URL) throws {
+        let url = root.appendingPathComponent(relative)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: url)
+    }
+
+    @Test("plain (non-package) site resolves layout to the site root, no config")
+    func plainLayout() throws {
+        let root = try makeTempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let layout = SiteFileTree.layout(for: root)
+        #expect(layout.sourceDir == root)
+        #expect(layout.configDir == nil)
+        #expect(layout.infoPlist == nil)
+    }
+
+    @Test("package site resolves layout to Source/ and Config/")
+    func packageLayout() throws {
+        let parent = try makeTempDir(); defer { try? FileManager.default.removeItem(at: parent) }
+        let pkgURL = parent.appendingPathComponent("Acme.anglesite", isDirectory: true)
+        let pkg = AnglesitePackage(url: pkgURL)
+        try FileManager.default.createDirectory(at: pkg.sourceURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: pkg.configURL, withIntermediateDirectories: true)
+        try pkg.writeMarker(AnglesitePackage.Marker(siteID: UUID(), displayName: "Acme", createdDate: Date(timeIntervalSince1970: 0)))
+
+        let layout = SiteFileTree.layout(for: pkgURL)
+        #expect(layout.sourceDir == pkg.sourceURL)
+        #expect(layout.configDir == pkg.configURL)
+        #expect(layout.infoPlist == pkg.infoPlistURL)
+    }
+
+    @Test("scan groups components, styles, and metadata; excludes plumbing")
+    func scanGroups() throws {
+        let root = try makeTempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        try write("src/layouts/BaseLayout.astro", under: root)
+        try write("src/components/Card.astro", under: root)
+        try write("src/styles/global.css", under: root)
+        try write("src/pages/index.astro", under: root)        // pages handled elsewhere — NOT in scan
+        try write("node_modules/pkg/index.js", under: root)    // plumbing — excluded
+        try write("dist/index.html", under: root)              // build output — excluded
+
+        let groups = SiteFileTree.scan(siteRoot: root)
+        let componentNames = (groups[.components] ?? []).map(\.name).sorted()
+        let styleNames = (groups[.styles] ?? []).map(\.name).sorted()
+        #expect(componentNames == ["BaseLayout.astro", "Card.astro"])
+        #expect(styleNames == ["global.css"])
+        #expect(groups[.pages] == nil)   // pages are content-graph sourced, never filesystem-scanned
+        let allURLs = groups.values.flatMap { $0 }.map(\.url.path)
+        #expect(!allURLs.contains { $0.contains("node_modules") })
+        #expect(!allURLs.contains { $0.contains("/dist/") })
+    }
+
+    @Test("empty groups are absent from the result")
+    func emptyGroupsAbsent() throws {
+        let root = try makeTempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        try write("src/styles/only.css", under: root)
+        let groups = SiteFileTree.scan(siteRoot: root)
+        #expect(groups[.styles]?.count == 1)
+        #expect(groups[.components] == nil)
+    }
+}

--- a/docs/superpowers/plans/2026-06-19-site-navigator.md
+++ b/docs/superpowers/plans/2026-06-19-site-navigator.md
@@ -1,0 +1,1276 @@
+# Site Navigator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an Xcode-Project-Navigator-style sidebar to each site window that lists the site as curated groups (Pages/Posts/Components/Styles/Metadata); selecting a page navigates the preview, selecting a non-page file opens it in an inline text editor.
+
+**Architecture:** All decision/IO logic lands in `AnglesiteCore` as small, CI-testable units (a content-graph broadcast stream, a filesystem scanner, file IO + external-change reconcile, a navigator-tree builder, an editor-routing seam). The App target adds thin SwiftUI glue: a `@Observable` navigator model, the sidebar view, a text-editor pane, and a `NavigationSplitView` wrap of `SiteWindow` with a `MainPaneMode` (preview vs. editor).
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27+), Swift Testing (`import Testing`, `@Test`, `#expect`), `AnglesitePackage` (#242) for layout resolution.
+
+## Global Constraints
+
+- **ES/Swift module style:** `AnglesiteCore` is a library; no SwiftUI imports in Core files. Use `import Foundation` (+ `import Testing` in tests).
+- **Swift toolchain:** `swift test` / `swift build` require `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` (the default CommandLineTools swift is too old). Prefix every `swift` command with it.
+- **Test framework:** Swift Testing only for new tests (`struct …Tests { @Test … }`), matching `Tests/AnglesiteCoreTests/AnglesitePackageTests.swift`.
+- **Source of truth is the filesystem.** The editor must never become the only writer: explicit save (⌘S), and an external-change guard that never silently clobbers on-disk edits made by chat/overlay/CLI.
+- **Logs are sacred:** App-side failures (save errors) surface to the user and may also log, but never get swallowed silently.
+- **Branch:** Work is on `feat/site-navigator` (based on `feat/242-anglesite-package-model`). Do not merge to `main` until #242 merges.
+- **App-target logic is not CI-tested** (hosted app tests can't launch a macOS-27 `.app` on CI runners). Keep App glue thin; all testable logic lives in Core. App tasks verify via `xcodebuild … build` and a final manual smoke.
+
+---
+
+### Task 1: `SiteContentGraph.changeStream()` broadcast
+
+The navigator needs live page/post updates, but `SiteContentGraph`'s single `changeHandler` is already taken by the Spotlight indexer. Add an additive multi-subscriber `AsyncStream<String>` (siteID per change), mirroring `SiteStore.changeStream()`. The existing handler is untouched.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteContentGraph.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteContentGraphStreamTests.swift` (create)
+
+**Interfaces:**
+- Consumes: existing `SiteContentGraph` actor, `emitChange(_:)`.
+- Produces: `nonisolated func changeStream() -> AsyncStream<String>` — yields the affected `siteID` on every real mutation; no subscribe-time yield (a change is an event, not a snapshot).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteCoreTests/SiteContentGraphStreamTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SiteContentGraphStreamTests {
+    private func makePage(_ siteID: String, route: String) -> SiteContentGraph.Page {
+        SiteContentGraph.Page(
+            id: "\(siteID):page:\(route)", siteID: siteID, route: route,
+            filePath: "/tmp/\(route).astro", title: route, lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("changeStream yields the siteID on a real mutation")
+    func yieldsOnMutation() async throws {
+        let graph = SiteContentGraph()
+        var iterator = graph.changeStream().makeAsyncIterator()
+        await graph.upsertPage(makePage("siteA", route: "/about/"))
+        let received = await iterator.next()
+        #expect(received == "siteA")
+    }
+
+    @Test("two independent subscribers both receive the change")
+    func broadcastsToAll() async throws {
+        let graph = SiteContentGraph()
+        var it1 = graph.changeStream().makeAsyncIterator()
+        var it2 = graph.changeStream().makeAsyncIterator()
+        await graph.upsertPage(makePage("siteB", route: "/x/"))
+        let a = await it1.next()
+        let b = await it2.next()
+        #expect(a == "siteB")
+        #expect(b == "siteB")
+    }
+
+    @Test("an equal upsert does not emit (real-mutation only)")
+    func noEmitOnEqualUpsert() async throws {
+        let graph = SiteContentGraph()
+        let page = makePage("siteC", route: "/y/")
+        await graph.upsertPage(page)              // first insert emits
+        var it = graph.changeStream().makeAsyncIterator()
+        await graph.upsertPage(page)              // equal → no emit
+        await graph.upsertPage(makePage("siteC", route: "/z/")) // emits
+        let received = await it.next()
+        #expect(received == "siteC")              // the /z/ emit, not a phantom /y/ emit
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteContentGraphStreamTests`
+Expected: FAIL — `value of type 'SiteContentGraph' has no member 'changeStream'`.
+
+- [ ] **Step 3: Add the broadcast to `SiteContentGraph`**
+
+In `Sources/AnglesiteCore/SiteContentGraph.swift`, add a continuations dictionary next to `changeHandler`:
+
+```swift
+    private var changeHandler: ChangeHandler?
+
+    /// Additive multi-subscriber broadcast for UI observers (the Site Navigator), keyed by a
+    /// per-subscription `UUID`. Distinct from `changeHandler` (the indexer's single awaited hook):
+    /// these are fire-and-forget siteID feeds. Pruned via the stream's `onTermination`.
+    private var changeStreamContinuations: [UUID: AsyncStream<String>.Continuation] = [:]
+```
+
+Extend `emitChange` to fan out to both (replace the existing `emitChange`):
+
+```swift
+    private func emitChange(_ siteID: String) async {
+        if let handler = changeHandler { await handler(siteID) }
+        for continuation in changeStreamContinuations.values {
+            continuation.yield(siteID)
+        }
+    }
+```
+
+Add the stream factory + register/prune helpers (mirrors `SiteStore.changeStream()`):
+
+```swift
+    /// A multi-subscriber stream of affected siteIDs, one per real mutation. Unlike
+    /// `SiteStore.changeStream()` there is no subscribe-time snapshot — a content change is an
+    /// event, so the navigator reads the graph back itself on first load.
+    public nonisolated func changeStream() -> AsyncStream<String> {
+        let id = UUID()
+        return AsyncStream(bufferingPolicy: .bufferingNewest(8)) { continuation in
+            Task { await self.registerContinuation(continuation, id: id) }
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.removeContinuation(id) }
+            }
+        }
+    }
+
+    private func registerContinuation(_ continuation: AsyncStream<String>.Continuation, id: UUID) {
+        changeStreamContinuations[id] = continuation
+    }
+
+    private func removeContinuation(_ id: UUID) {
+        changeStreamContinuations[id] = nil
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteContentGraphStreamTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteContentGraph.swift Tests/AnglesiteCoreTests/SiteContentGraphStreamTests.swift
+git commit -m "feat(navigator): add multi-subscriber changeStream to SiteContentGraph"
+```
+
+---
+
+### Task 2: `SiteFileTree` — layout resolution + filesystem scan
+
+Scan the three filesystem-backed groups (Components/Styles/Metadata). Resolve roots adaptively: if the site is an `.anglesite` package use `Source/`+`Config/`; otherwise treat the site path itself as the project root (current pre-package reality).
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SiteFileTree.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteFileTreeTests.swift`
+
+**Interfaces:**
+- Consumes: `AnglesitePackage.isPackage(at:fileManager:)`, `AnglesitePackage(url:).sourceURL/configURL/infoPlistURL`.
+- Produces:
+  - `enum FileGroup: String, Sendable, CaseIterable { case pages, posts, components, styles, metadata }`
+  - `struct FileRef: Sendable, Equatable, Identifiable { var id: String; let url: URL; let group: FileGroup; let name: String }`
+  - `enum SiteFileTree` with `static func layout(for:fileManager:) -> Layout` and `static func scan(siteRoot:fileManager:) -> [FileGroup: [FileRef]]`
+  - `struct SiteFileTree.Layout: Sendable, Equatable { let sourceDir: URL; let configDir: URL?; let infoPlist: URL? }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteCoreTests/SiteFileTreeTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SiteFileTreeTests {
+    private func makeTempDir() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("anglesite-filetree-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func write(_ relative: String, under root: URL) throws {
+        let url = root.appendingPathComponent(relative)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: url)
+    }
+
+    @Test("plain (non-package) site resolves layout to the site root, no config")
+    func plainLayout() throws {
+        let root = try makeTempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let layout = SiteFileTree.layout(for: root)
+        #expect(layout.sourceDir == root)
+        #expect(layout.configDir == nil)
+        #expect(layout.infoPlist == nil)
+    }
+
+    @Test("package site resolves layout to Source/ and Config/")
+    func packageLayout() throws {
+        let parent = try makeTempDir(); defer { try? FileManager.default.removeItem(at: parent) }
+        let pkgURL = parent.appendingPathComponent("Acme.anglesite", isDirectory: true)
+        let pkg = AnglesitePackage(url: pkgURL)
+        try FileManager.default.createDirectory(at: pkg.sourceURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: pkg.configURL, withIntermediateDirectories: true)
+        try pkg.writeMarker(AnglesitePackage.Marker(siteID: UUID(), displayName: "Acme", createdDate: Date(timeIntervalSince1970: 0)))
+
+        let layout = SiteFileTree.layout(for: pkgURL)
+        #expect(layout.sourceDir == pkg.sourceURL)
+        #expect(layout.configDir == pkg.configURL)
+        #expect(layout.infoPlist == pkg.infoPlistURL)
+    }
+
+    @Test("scan groups components, styles, and metadata; excludes plumbing")
+    func scanGroups() throws {
+        let root = try makeTempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        try write("src/layouts/BaseLayout.astro", under: root)
+        try write("src/components/Card.astro", under: root)
+        try write("src/styles/global.css", under: root)
+        try write("src/pages/index.astro", under: root)        // pages handled elsewhere — NOT in scan
+        try write("node_modules/pkg/index.js", under: root)    // plumbing — excluded
+        try write("dist/index.html", under: root)              // build output — excluded
+
+        let groups = SiteFileTree.scan(siteRoot: root)
+        let componentNames = (groups[.components] ?? []).map(\.name).sorted()
+        let styleNames = (groups[.styles] ?? []).map(\.name).sorted()
+        #expect(componentNames == ["BaseLayout.astro", "Card.astro"])
+        #expect(styleNames == ["global.css"])
+        #expect(groups[.pages] == nil)   // pages are content-graph sourced, never filesystem-scanned
+        let allURLs = groups.values.flatMap { $0 }.map(\.url.path)
+        #expect(!allURLs.contains { $0.contains("node_modules") })
+        #expect(!allURLs.contains { $0.contains("/dist/") })
+    }
+
+    @Test("empty groups are absent from the result")
+    func emptyGroupsAbsent() throws {
+        let root = try makeTempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        try write("src/styles/only.css", under: root)
+        let groups = SiteFileTree.scan(siteRoot: root)
+        #expect(groups[.styles]?.count == 1)
+        #expect(groups[.components] == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteFileTreeTests`
+Expected: FAIL — `cannot find 'SiteFileTree' in scope`.
+
+- [ ] **Step 3: Implement `SiteFileTree`**
+
+Create `Sources/AnglesiteCore/SiteFileTree.swift`:
+
+```swift
+import Foundation
+
+/// Curated, group-oriented view of a site's filesystem-backed parts for the Site Navigator.
+/// Pages/Posts are sourced from `SiteContentGraph`, not here — this scanner covers only the
+/// Components, Styles, and Metadata groups.
+///
+/// Roots are resolved adaptively: an `.anglesite` package (#242) exposes `Source/` and `Config/`;
+/// a plain directory (the current pre-package layout) is treated as the project root directly.
+public enum FileGroup: String, Sendable, CaseIterable {
+    case pages, posts, components, styles, metadata
+}
+
+public struct FileRef: Sendable, Equatable, Identifiable {
+    public var id: String { url.path }
+    public let url: URL
+    public let group: FileGroup
+    public let name: String
+
+    public init(url: URL, group: FileGroup, name: String) {
+        self.url = url
+        self.group = group
+        self.name = name
+    }
+}
+
+public enum SiteFileTree {
+    public struct Layout: Sendable, Equatable {
+        public let sourceDir: URL
+        public let configDir: URL?
+        public let infoPlist: URL?
+    }
+
+    /// Directory names never descended into or listed.
+    private static let excludedDirNames: Set<String> = ["node_modules", "dist", ".astro", ".git"]
+    private static let excludedFileNames: Set<String> = [".DS_Store"]
+
+    public static func layout(for siteRoot: URL, fileManager: FileManager = .default) -> Layout {
+        if AnglesitePackage.isPackage(at: siteRoot, fileManager: fileManager) {
+            let pkg = AnglesitePackage(url: siteRoot)
+            return Layout(sourceDir: pkg.sourceURL, configDir: pkg.configURL, infoPlist: pkg.infoPlistURL)
+        }
+        return Layout(sourceDir: siteRoot, configDir: nil, infoPlist: nil)
+    }
+
+    public static func scan(siteRoot: URL, fileManager: FileManager = .default) -> [FileGroup: [FileRef]] {
+        let layout = layout(for: siteRoot, fileManager: fileManager)
+        var result: [FileGroup: [FileRef]] = [:]
+
+        // Components: layouts + components dirs under src/.
+        let componentDirs = ["src/layouts", "src/components"].map { layout.sourceDir.appendingPathComponent($0) }
+        let components = componentDirs.flatMap { files(in: $0, group: .components, fileManager: fileManager) }
+        if !components.isEmpty { result[.components] = components.sorted { $0.name < $1.name } }
+
+        // Styles: src/styles.
+        let styles = files(in: layout.sourceDir.appendingPathComponent("src/styles"),
+                           group: .styles, fileManager: fileManager)
+        if !styles.isEmpty { result[.styles] = styles.sorted { $0.name < $1.name } }
+
+        // Metadata: everything in Config/ plus the package Info.plist marker.
+        var metadata: [FileRef] = []
+        if let configDir = layout.configDir {
+            metadata += files(in: configDir, group: .metadata, fileManager: fileManager)
+        }
+        if let infoPlist = layout.infoPlist, fileManager.fileExists(atPath: infoPlist.path) {
+            metadata.append(FileRef(url: infoPlist, group: .metadata, name: infoPlist.lastPathComponent))
+        }
+        if !metadata.isEmpty { result[.metadata] = metadata.sorted { $0.name < $1.name } }
+
+        return result
+    }
+
+    /// Recursively lists files under `dir`, skipping excluded dirs/files. Returns [] if `dir` is absent.
+    private static func files(in dir: URL, group: FileGroup, fileManager: FileManager) -> [FileRef] {
+        guard let enumerator = fileManager.enumerator(
+            at: dir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        var refs: [FileRef] = []
+        for case let url as URL in enumerator {
+            let name = url.lastPathComponent
+            let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+            if isDir {
+                if excludedDirNames.contains(name) { enumerator.skipDescendants() }
+                continue
+            }
+            if excludedFileNames.contains(name) { continue }
+            refs.append(FileRef(url: url, group: group, name: name))
+        }
+        return refs
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteFileTreeTests`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteFileTree.swift Tests/AnglesiteCoreTests/SiteFileTreeTests.swift
+git commit -m "feat(navigator): SiteFileTree layout resolution + grouped filesystem scan"
+```
+
+---
+
+### Task 3: `FileDocumentIO` — load / save / external-change reconcile
+
+Pure file IO + the external-change decision the editor needs. Statics so they're trivially testable; the App view owns the buffer state.
+
+**Files:**
+- Create: `Sources/AnglesiteCore/FileDocumentIO.swift`
+- Test: `Tests/AnglesiteCoreTests/FileDocumentIOTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `struct FileDocumentIO.Loaded: Sendable, Equatable { let contents: String; let modificationDate: Date? }`
+  - `enum FileDocumentIO.ExternalChange: Sendable, Equatable { case none; case reloadable(String); case conflict(String) }`
+  - `static func load(_ url:fileManager:) throws -> Loaded`
+  - `static func save(_ contents:to:fileManager:) throws -> Date?`  (returns the post-write mtime)
+  - `static func externalChange(at:lastKnownModificationDate:bufferIsDirty:fileManager:) throws -> ExternalChange`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteCoreTests/FileDocumentIOTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct FileDocumentIOTests {
+    private func tempFile(_ contents: String) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("doc-\(UUID().uuidString).txt")
+        try Data(contents.utf8).write(to: url)
+        return url
+    }
+
+    @Test("load reads contents and a modification date")
+    func loadReads() throws {
+        let url = try tempFile("hello"); defer { try? FileManager.default.removeItem(at: url) }
+        let loaded = try FileDocumentIO.load(url)
+        #expect(loaded.contents == "hello")
+        #expect(loaded.modificationDate != nil)
+    }
+
+    @Test("save writes the bytes and returns a fresh mtime")
+    func saveWrites() throws {
+        let url = try tempFile("old"); defer { try? FileManager.default.removeItem(at: url) }
+        let mtime = try FileDocumentIO.save("new contents", to: url)
+        #expect(try String(contentsOf: url, encoding: .utf8) == "new contents")
+        #expect(mtime != nil)
+    }
+
+    @Test("externalChange returns .none when disk mtime is unchanged")
+    func noChange() throws {
+        let url = try tempFile("a"); defer { try? FileManager.default.removeItem(at: url) }
+        let loaded = try FileDocumentIO.load(url)
+        let change = try FileDocumentIO.externalChange(
+            at: url, lastKnownModificationDate: loaded.modificationDate, bufferIsDirty: false)
+        #expect(change == .none)
+    }
+
+    @Test("clean buffer + external write → .reloadable(newContents)")
+    func reloadableWhenClean() throws {
+        let url = try tempFile("a"); defer { try? FileManager.default.removeItem(at: url) }
+        let loaded = try FileDocumentIO.load(url)
+        // Simulate another tool writing the file with a strictly newer mtime.
+        let newer = (loaded.modificationDate ?? Date()).addingTimeInterval(2)
+        try Data("b".utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: newer], ofItemAtPath: url.path)
+        let change = try FileDocumentIO.externalChange(
+            at: url, lastKnownModificationDate: loaded.modificationDate, bufferIsDirty: false)
+        #expect(change == .reloadable("b"))
+    }
+
+    @Test("dirty buffer + external write → .conflict(newContents)")
+    func conflictWhenDirty() throws {
+        let url = try tempFile("a"); defer { try? FileManager.default.removeItem(at: url) }
+        let loaded = try FileDocumentIO.load(url)
+        let newer = (loaded.modificationDate ?? Date()).addingTimeInterval(2)
+        try Data("b".utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: newer], ofItemAtPath: url.path)
+        let change = try FileDocumentIO.externalChange(
+            at: url, lastKnownModificationDate: loaded.modificationDate, bufferIsDirty: true)
+        #expect(change == .conflict("b"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter FileDocumentIOTests`
+Expected: FAIL — `cannot find 'FileDocumentIO' in scope`.
+
+- [ ] **Step 3: Implement `FileDocumentIO`**
+
+Create `Sources/AnglesiteCore/FileDocumentIO.swift`:
+
+```swift
+import Foundation
+
+/// Stateless file IO for the navigator's inline editor, plus the external-change decision.
+/// The App view owns the text buffer + dirty flag; this type only touches disk and reports
+/// what changed. Keeping it stateless makes the reconcile rules unit-testable without UI.
+public enum FileDocumentIO {
+    public struct Loaded: Sendable, Equatable {
+        public let contents: String
+        public let modificationDate: Date?
+    }
+
+    /// What the editor should do when the on-disk file no longer matches what we last saw.
+    public enum ExternalChange: Sendable, Equatable {
+        case none
+        /// Disk changed and the buffer is clean — safe to swap in `contents` silently.
+        case reloadable(String)
+        /// Disk changed and the buffer is dirty — must ask the user; `contents` is the disk copy.
+        case conflict(String)
+    }
+
+    public static func load(_ url: URL, fileManager: FileManager = .default) throws -> Loaded {
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        let mtime = try modificationDate(of: url, fileManager: fileManager)
+        return Loaded(contents: contents, modificationDate: mtime)
+    }
+
+    @discardableResult
+    public static func save(_ contents: String, to url: URL, fileManager: FileManager = .default) throws -> Date? {
+        try Data(contents.utf8).write(to: url, options: [.atomic])
+        return try modificationDate(of: url, fileManager: fileManager)
+    }
+
+    public static func externalChange(
+        at url: URL,
+        lastKnownModificationDate: Date?,
+        bufferIsDirty: Bool,
+        fileManager: FileManager = .default
+    ) throws -> ExternalChange {
+        let current = try modificationDate(of: url, fileManager: fileManager)
+        // Treat a strictly-newer disk mtime as an external write. Equal/nil → no change.
+        guard let current, let last = lastKnownModificationDate, current > last else {
+            return .none
+        }
+        let diskContents = try String(contentsOf: url, encoding: .utf8)
+        return bufferIsDirty ? .conflict(diskContents) : .reloadable(diskContents)
+    }
+
+    private static func modificationDate(of url: URL, fileManager: FileManager) throws -> Date? {
+        try fileManager.attributesOfItem(atPath: url.path)[.modificationDate] as? Date
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter FileDocumentIOTests`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/FileDocumentIO.swift Tests/AnglesiteCoreTests/FileDocumentIOTests.swift
+git commit -m "feat(navigator): FileDocumentIO load/save + external-change reconcile"
+```
+
+---
+
+### Task 4: `EditorKind` routing seam
+
+A one-function seam so file-specific editors (metadata form, etc.) can replace the generic text editor later without touching call sites. v1 returns `.text` for everything.
+
+**Files:**
+- Create: `Sources/AnglesiteCore/EditorKind.swift`
+- Test: `Tests/AnglesiteCoreTests/EditorKindTests.swift`
+
+**Interfaces:**
+- Consumes: `FileRef` (Task 2).
+- Produces: `enum EditorKind: Sendable, Equatable { case text }` and `func editorKind(for file: FileRef) -> EditorKind`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteCoreTests/EditorKindTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct EditorKindTests {
+    @Test("v1 routes every file group to the text editor")
+    func everythingIsText() {
+        for group in FileGroup.allCases {
+            let ref = FileRef(url: URL(fileURLWithPath: "/tmp/x"), group: group, name: "x")
+            #expect(editorKind(for: ref) == .text)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter EditorKindTests`
+Expected: FAIL — `cannot find 'editorKind' in scope`.
+
+- [ ] **Step 3: Implement the seam**
+
+Create `Sources/AnglesiteCore/EditorKind.swift`:
+
+```swift
+import Foundation
+
+/// Which editor surface a navigator file opens in. v1 ships only `.text`; future cases
+/// (`.metadataForm`, etc.) slot in by extending this enum and the `editorKind(for:)` mapping —
+/// call sites switch on the kind and need no change beyond adding the new view.
+public enum EditorKind: Sendable, Equatable {
+    case text
+    // future: case metadataForm
+}
+
+/// Resolves the editor for a file. Intentionally a free function with a single decision point so
+/// the routing rule lives in one tested place.
+public func editorKind(for file: FileRef) -> EditorKind {
+    .text
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter EditorKindTests`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/EditorKind.swift Tests/AnglesiteCoreTests/EditorKindTests.swift
+git commit -m "feat(navigator): EditorKind routing seam (text only for v1)"
+```
+
+---
+
+### Task 5: `buildNavigatorTree` — merge content graph + file scan into sections
+
+Pure builder that combines content-graph pages/posts with the filesystem scan into ordered sidebar sections. Keeps the App model thin.
+
+**Files:**
+- Create: `Sources/AnglesiteCore/NavigatorTree.swift`
+- Test: `Tests/AnglesiteCoreTests/NavigatorTreeTests.swift`
+
+**Interfaces:**
+- Consumes: `SiteContentGraph.Page`, `SiteContentGraph.Post`, `[FileGroup: [FileRef]]` (Task 2).
+- Produces:
+  - `enum NavigatorTarget: Sendable, Equatable { case route(String); case file(FileRef) }`
+  - `struct NavigatorItem: Sendable, Equatable, Identifiable { let id: String; let title: String; let target: NavigatorTarget }`
+  - `struct NavigatorSection: Sendable, Equatable, Identifiable { let id: FileGroup; let title: String; let items: [NavigatorItem] }`
+  - `func postRoute(for post: SiteContentGraph.Post) -> String`
+  - `func buildNavigatorTree(pages:posts:fileGroups:) -> [NavigatorSection]`
+
+> **Assumption (documented):** a post's preview route is derived as `/{collection}/{slug}/`. `SiteContentGraph.Post` has no stored route; this matches the common Astro content-collection URL shape. If the dev server 404s, the user sees the dev server's own 404 — acceptable for v1. A stored post route is a follow-up.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteCoreTests/NavigatorTreeTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct NavigatorTreeTests {
+    private func page(_ route: String, title: String?) -> SiteContentGraph.Page {
+        SiteContentGraph.Page(id: "s:page:\(route)", siteID: "s", route: route,
+            filePath: "/tmp\(route).astro", title: title, lastModified: Date(timeIntervalSince1970: 0))
+    }
+    private func post(_ collection: String, _ slug: String, _ title: String) -> SiteContentGraph.Post {
+        SiteContentGraph.Post(id: "s:post:\(slug)", siteID: "s", collection: collection, slug: slug,
+            title: title, draft: false, publishDate: nil, tags: [],
+            filePath: "/tmp/\(slug).md", lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("post route derives /collection/slug/")
+    func postRouteDerivation() {
+        #expect(postRoute(for: post("blog", "hello-world", "Hello")) == "/blog/hello-world/")
+    }
+
+    @Test("sections appear in canonical order and only when non-empty")
+    func sectionOrderAndEmpties() {
+        let sections = buildNavigatorTree(
+            pages: [page("/about/", title: "About")],
+            posts: [],
+            fileGroups: [.styles: [FileRef(url: URL(fileURLWithPath: "/tmp/g.css"), group: .styles, name: "g.css")]]
+        )
+        #expect(sections.map(\.id) == [.pages, .styles])   // posts/components/metadata empty → omitted
+    }
+
+    @Test("page item uses title when present and route as fallback; target is the route")
+    func pageItems() {
+        let sections = buildNavigatorTree(
+            pages: [page("/about/", title: "About"), page("/contact/", title: nil)],
+            posts: [], fileGroups: [:])
+        let pages = sections.first { $0.id == .pages }!
+        #expect(pages.items.map(\.title) == ["About", "/contact/"])
+        #expect(pages.items.first?.target == .route("/about/"))
+    }
+
+    @Test("file item target carries the FileRef")
+    func fileItems() {
+        let ref = FileRef(url: URL(fileURLWithPath: "/tmp/Base.astro"), group: .components, name: "Base.astro")
+        let sections = buildNavigatorTree(pages: [], posts: [], fileGroups: [.components: [ref]])
+        let item = sections.first { $0.id == .components }!.items.first!
+        #expect(item.title == "Base.astro")
+        #expect(item.target == .file(ref))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter NavigatorTreeTests`
+Expected: FAIL — `cannot find 'buildNavigatorTree' in scope`.
+
+- [ ] **Step 3: Implement the builder**
+
+Create `Sources/AnglesiteCore/NavigatorTree.swift`:
+
+```swift
+import Foundation
+
+/// What selecting a navigator row does: navigate the preview to a route, or open a file in the editor.
+public enum NavigatorTarget: Sendable, Equatable {
+    case route(String)
+    case file(FileRef)
+}
+
+public struct NavigatorItem: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let title: String
+    public let target: NavigatorTarget
+    public init(id: String, title: String, target: NavigatorTarget) {
+        self.id = id; self.title = title; self.target = target
+    }
+}
+
+public struct NavigatorSection: Sendable, Equatable, Identifiable {
+    public let id: FileGroup
+    public let title: String
+    public let items: [NavigatorItem]
+    public init(id: FileGroup, title: String, items: [NavigatorItem]) {
+        self.id = id; self.title = title; self.items = items
+    }
+}
+
+/// Derived preview route for a post. See the plan's documented assumption.
+public func postRoute(for post: SiteContentGraph.Post) -> String {
+    "/\(post.collection)/\(post.slug)/"
+}
+
+/// Display titles for the five groups, in canonical sidebar order.
+private let groupTitles: [(FileGroup, String)] = [
+    (.pages, "Pages"), (.posts, "Posts"),
+    (.components, "Components"), (.styles, "Styles"), (.metadata, "Metadata"),
+]
+
+/// Merges content-graph pages/posts with the filesystem scan into ordered, non-empty sections.
+public func buildNavigatorTree(
+    pages: [SiteContentGraph.Page],
+    posts: [SiteContentGraph.Post],
+    fileGroups: [FileGroup: [FileRef]]
+) -> [NavigatorSection] {
+    let pageItems = pages
+        .sorted { $0.route < $1.route }
+        .map { NavigatorItem(id: $0.id, title: $0.title ?? $0.route, target: .route($0.route)) }
+    let postItems = posts
+        .sorted { $0.title < $1.title }
+        .map { NavigatorItem(id: $0.id, title: $0.title, target: .route(postRoute(for: $0))) }
+
+    var sections: [NavigatorSection] = []
+    for (group, title) in groupTitles {
+        let items: [NavigatorItem]
+        switch group {
+        case .pages: items = pageItems
+        case .posts: items = postItems
+        default:
+            items = (fileGroups[group] ?? []).map {
+                NavigatorItem(id: $0.id, title: $0.name, target: .file($0))
+            }
+        }
+        if !items.isEmpty { sections.append(NavigatorSection(id: group, title: title, items: items)) }
+    }
+    return sections
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter NavigatorTreeTests`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NavigatorTree.swift Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
+git commit -m "feat(navigator): buildNavigatorTree merges content graph + file scan into sections"
+```
+
+---
+
+### Task 6: `SiteNavigatorModel` (App glue)
+
+Thin `@Observable @MainActor` model: loads the tree (graph snapshot + `SiteFileTree.scan`), refreshes on `SiteContentGraph.changeStream()`, and exposes `sections` + the resolved `NavigatorTarget` for a selected item id.
+
+**Files:**
+- Create: `Sources/AnglesiteApp/SiteNavigatorModel.swift`
+- Verify: build only (App-target; not CI unit-tested per Global Constraints).
+
+**Interfaces:**
+- Consumes: `SiteContentGraph` (actor), `buildNavigatorTree`, `SiteFileTree.scan`, `NavigatorTarget`, `NavigatorSection`.
+- Produces: `@MainActor @Observable final class SiteNavigatorModel` with `var sections: [NavigatorSection]`, `var selection: String?`, `func start(siteID:siteRoot:)`, `func stop()`, `func target(for id: String) -> NavigatorTarget?`.
+
+- [ ] **Step 1: Implement the model**
+
+Create `Sources/AnglesiteApp/SiteNavigatorModel.swift`:
+
+```swift
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the Site Navigator sidebar for one window. Reads pages/posts from the shared
+/// `SiteContentGraph` and the filesystem-backed groups from `SiteFileTree`, then merges them via
+/// `buildNavigatorTree`. Refreshes when the content graph emits for this site. App glue only —
+/// all logic under test lives in AnglesiteCore.
+@MainActor
+@Observable
+final class SiteNavigatorModel {
+    private(set) var sections: [NavigatorSection] = []
+    var selection: String?
+
+    private let graph: SiteContentGraph
+    private var siteID: String?
+    private var siteRoot: URL?
+    private var observeTask: Task<Void, Never>?
+
+    init(graph: SiteContentGraph) {
+        self.graph = graph
+    }
+
+    func start(siteID: String, siteRoot: URL) {
+        self.siteID = siteID
+        self.siteRoot = siteRoot
+        Task { await refresh() }
+        observeTask?.cancel()
+        observeTask = Task { [graph, siteID] in
+            for await changedSiteID in graph.changeStream() {
+                if Task.isCancelled { break }
+                if changedSiteID == siteID { await refresh() }
+            }
+        }
+    }
+
+    func stop() {
+        observeTask?.cancel()
+        observeTask = nil
+    }
+
+    func target(for id: String) -> NavigatorTarget? {
+        for section in sections {
+            if let item = section.items.first(where: { $0.id == id }) { return item.target }
+        }
+        return nil
+    }
+
+    private func refresh() async {
+        guard let siteID, let siteRoot else { return }
+        let pages = await graph.pages(for: siteID)
+        let posts = await graph.posts(for: siteID)
+        // Filesystem scan is synchronous + cheap; run off the main actor to avoid stutter.
+        let fileGroups = await Task.detached { SiteFileTree.scan(siteRoot: siteRoot) }.value
+        sections = buildNavigatorTree(pages: pages, posts: posts, fileGroups: fileGroups)
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -5`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteNavigatorModel.swift
+git commit -m "feat(navigator): SiteNavigatorModel (graph + file scan, live refresh)"
+```
+
+---
+
+### Task 7: `SiteNavigatorView` sidebar
+
+The sidebar List: sections as `Section`s, items as selectable rows with SF Symbols per group.
+
+**Files:**
+- Create: `Sources/AnglesiteApp/SiteNavigatorView.swift`
+- Verify: build only.
+
+**Interfaces:**
+- Consumes: `SiteNavigatorModel`, `NavigatorSection`, `FileGroup`.
+- Produces: `struct SiteNavigatorView: View` taking `@Bindable var model: SiteNavigatorModel`.
+
+- [ ] **Step 1: Implement the view**
+
+Create `Sources/AnglesiteApp/SiteNavigatorView.swift`:
+
+```swift
+import SwiftUI
+import AnglesiteCore
+
+/// Xcode-Project-Navigator-style sidebar. Selection is bound to the model; `SiteWindow` reacts to
+/// changes and either navigates the preview or opens the editor.
+struct SiteNavigatorView: View {
+    @Bindable var model: SiteNavigatorModel
+
+    var body: some View {
+        List(selection: $model.selection) {
+            ForEach(model.sections) { section in
+                Section(section.title) {
+                    ForEach(section.items) { item in
+                        Label(item.title, systemImage: icon(for: section.id))
+                            .tag(item.id)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .overlay {
+            if model.sections.isEmpty {
+                ContentUnavailableView("No content yet", systemImage: "sidebar.left")
+            }
+        }
+    }
+
+    private func icon(for group: FileGroup) -> String {
+        switch group {
+        case .pages: return "doc.richtext"
+        case .posts: return "text.document"
+        case .components: return "square.stack.3d.up"
+        case .styles: return "paintbrush"
+        case .metadata: return "gearshape"
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -5`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteNavigatorView.swift
+git commit -m "feat(navigator): SiteNavigatorView sidebar list"
+```
+
+---
+
+### Task 8: `MainPaneEditorView` text editor + conflict handling
+
+Inline text editor for a `FileRef`: load on appear, ⌘S to save, dirty indicator, external-change detection on window focus with a conflict dialog (Keep mine / Reload).
+
+**Files:**
+- Create: `Sources/AnglesiteApp/MainPaneEditorView.swift`
+- Verify: build only.
+
+**Interfaces:**
+- Consumes: `FileRef`, `FileDocumentIO`, `editorKind(for:)`.
+- Produces: `struct MainPaneEditorView: View` taking `let file: FileRef`.
+
+- [ ] **Step 1: Implement the view**
+
+Create `Sources/AnglesiteApp/MainPaneEditorView.swift`:
+
+```swift
+import SwiftUI
+import AnglesiteCore
+
+/// Inline editor for a navigator-selected file. v1 is a plain text editor (`editorKind` always
+/// `.text`); the `switch` is where future file-specific editors attach. Honors the source-of-truth
+/// rule: explicit ⌘S save and a non-clobbering external-change guard.
+struct MainPaneEditorView: View {
+    let file: FileRef
+
+    @State private var text: String = ""
+    @State private var savedText: String = ""
+    @State private var lastModified: Date?
+    @State private var loadError: String?
+    @State private var conflictDiskContents: String?
+
+    @Environment(\.controlActiveState) private var controlActiveState
+
+    private var isDirty: Bool { text != savedText }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            Group {
+                if let loadError {
+                    ContentUnavailableView {
+                        Label("Can't open \(file.name)", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text(loadError)
+                    } actions: {
+                        Button("Reveal in Finder") { NSWorkspace.shared.activateFileViewerSelecting([file.url]) }
+                    }
+                } else {
+                    switch editorKind(for: file) {
+                    case .text:
+                        TextEditor(text: $text)
+                            .font(.system(.body, design: .monospaced))
+                            .scrollContentBackground(.hidden)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .task(id: file.id) { load() }
+        // Re-check the file when the window regains focus — chat/overlay/CLI may have written it.
+        .onChange(of: controlActiveState) { _, new in
+            if new == .key { checkExternalChange() }
+        }
+        .background(
+            Button("") { save() }.keyboardShortcut("s", modifiers: [.command]).hidden()
+        )
+        .alert("\(file.name) changed on disk", isPresented: conflictBinding) {
+            Button("Keep My Changes", role: .cancel) { conflictDiskContents = nil }
+            Button("Reload from Disk") {
+                if let disk = conflictDiskContents {
+                    text = disk; savedText = disk
+                    lastModified = try? FileDocumentIO.load(file.url).modificationDate
+                }
+                conflictDiskContents = nil
+            }
+        } message: {
+            Text("Another tool edited this file while you had unsaved changes.")
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Label(file.name, systemImage: "doc.text")
+                .font(.headline)
+            if isDirty {
+                Circle().fill(.secondary).frame(width: 7, height: 7)
+                    .help("Unsaved changes")
+            }
+            Spacer()
+            Button("Save") { save() }
+                .disabled(!isDirty || loadError != nil)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
+    private var conflictBinding: Binding<Bool> {
+        Binding(get: { conflictDiskContents != nil }, set: { if !$0 { conflictDiskContents = nil } })
+    }
+
+    private func load() {
+        do {
+            let loaded = try FileDocumentIO.load(file.url)
+            text = loaded.contents
+            savedText = loaded.contents
+            lastModified = loaded.modificationDate
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    private func save() {
+        guard isDirty, loadError == nil else { return }
+        do {
+            lastModified = try FileDocumentIO.save(text, to: file.url)
+            savedText = text
+        } catch {
+            loadError = "Save failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func checkExternalChange() {
+        guard loadError == nil else { return }
+        guard let change = try? FileDocumentIO.externalChange(
+            at: file.url, lastKnownModificationDate: lastModified, bufferIsDirty: isDirty
+        ) else { return }
+        switch change {
+        case .none:
+            break
+        case .reloadable(let disk):
+            text = disk; savedText = disk
+            lastModified = try? FileDocumentIO.load(file.url).modificationDate
+        case .conflict(let disk):
+            conflictDiskContents = disk
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -5`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/MainPaneEditorView.swift
+git commit -m "feat(navigator): MainPaneEditorView inline text editor with external-change guard"
+```
+
+---
+
+### Task 9: Integrate into `SiteWindow` — split view + main-pane mode
+
+Wrap `siteUI` in a `NavigationSplitView` with the navigator as sidebar; add `MainPaneMode` (preview vs. editor) with a `Preview | Editor` segmented control; route selection to either `preview.navigate`/`clearRoute` or the editor.
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift`
+- Verify: build + manual smoke.
+
+**Interfaces:**
+- Consumes: `SiteNavigatorModel`, `SiteNavigatorView`, `MainPaneEditorView`, `NavigatorTarget`, `FileRef`, `contentGraph` (already a `SiteWindow` property), `preview.navigate(toRoute:)`, `preview.clearRoute()`.
+- Produces: navigator wired into the window; no new public API.
+
+- [ ] **Step 1: Add mode + navigator state**
+
+In `SiteWindow.swift`, add a private mode enum above the struct (or in the same file):
+
+```swift
+private enum MainPaneMode: Equatable {
+    case preview
+    case editor(FileRef)
+}
+```
+
+Add `@State` to `SiteWindow` near the other models (after `siriReadinessModel`):
+
+```swift
+    @State private var navigator: SiteNavigatorModel?
+    @State private var mainPaneMode: MainPaneMode = .preview
+```
+
+- [ ] **Step 2: Create the navigator in `loadAndStart`**
+
+In `loadAndStart()`, right after `preview.open(siteID: resolved.id, siteDirectory: resolved.path)`:
+
+```swift
+        let navModel = SiteNavigatorModel(graph: contentGraph)
+        navModel.start(siteID: resolved.id, siteRoot: resolved.path)
+        navigator = navModel
+```
+
+And in `.onDisappear` (in `body`), after `chat = nil`:
+
+```swift
+            navigator?.stop()
+            navigator = nil
+```
+
+- [ ] **Step 3: Wrap `siteUI` content in a `NavigationSplitView`**
+
+In `siteUI(for:)`, wrap the existing `ZStack(alignment: .bottom) { … }` so the navigator is the sidebar and the existing content is the detail. Replace the outer `ZStack(alignment: .bottom) {` … matching `}` (the one carrying `.navigationTitle`/`.toolbar`/`.sheet`s) with:
+
+```swift
+        NavigationSplitView {
+            if let navigator {
+                SiteNavigatorView(model: navigator)
+                    .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 360)
+                    .onChange(of: navigator.selection) { _, newID in
+                        applyNavigatorSelection(newID)
+                    }
+            } else {
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        } detail {
+            ZStack(alignment: .bottom) {
+                // … the existing VStack + drawers, UNCHANGED …
+            }
+            // … the existing .animation/.navigationTitle/.toolbar/.sheet modifiers, UNCHANGED …
+        }
+```
+
+> Keep all existing modifiers (`.navigationTitle`, `.navigationSubtitle`, `.toolbar`, every `.sheet`, `.annotatedAsSite`) attached to the **detail** `ZStack` exactly as they are today. Only the `NavigationSplitView { … } detail { … }` wrapper is new.
+
+- [ ] **Step 4: Make the main pane honor the mode**
+
+Replace the `mainPane(for:)` body's preview branch so the segmented control + editor are shown. Change `mainPane(for:)` to:
+
+```swift
+    @ViewBuilder
+    private func mainPane(for site: SiteStore.Site) -> some View {
+        VStack(spacing: 0) {
+            if case .editor = mainPaneMode {
+                Picker("", selection: Binding(
+                    get: { paneSelection },
+                    set: { setPaneSelection($0, for: site) }
+                )) {
+                    Text("Preview").tag(0)
+                    Text("Editor").tag(1)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 180)
+                .padding(6)
+                Divider()
+            }
+            mainPaneContent(for: site)
+        }
+    }
+
+    private var paneSelection: Int {
+        if case .editor = mainPaneMode { return 1 }
+        return 0
+    }
+
+    private func setPaneSelection(_ value: Int, for site: SiteStore.Site) {
+        if value == 0 { mainPaneMode = .preview }
+        // value == 1 keeps the current .editor(file); no-op when already editing.
+    }
+
+    @ViewBuilder
+    private func mainPaneContent(for site: SiteStore.Site) -> some View {
+        switch mainPaneMode {
+        case .editor(let file):
+            MainPaneEditorView(file: file)
+        case .preview:
+            previewPane(for: site)   // the existing switch on preview.state, renamed
+        }
+    }
+```
+
+Rename the current `mainPane(for:)` switch body to `previewPane(for:)` (same `switch preview.state { … }` content, unchanged).
+
+- [ ] **Step 5: Add the selection router**
+
+Add to `SiteWindow`:
+
+```swift
+    /// Route a navigator selection: pages/posts switch to preview and navigate; files open the editor.
+    @MainActor
+    private func applyNavigatorSelection(_ id: String?) {
+        guard let id, let target = navigator?.target(for: id) else { return }
+        switch target {
+        case .route(let route):
+            mainPaneMode = .preview
+            if route.isEmpty || route == "/" {
+                preview.clearRoute()
+            } else {
+                preview.navigate(toRoute: route)
+            }
+        case .file(let file):
+            mainPaneMode = .editor(file)
+        }
+    }
+```
+
+- [ ] **Step 6: Build to verify it compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -5`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 7: Verify the full Core suite still passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .`
+Expected: all tests pass (existing suite + the new navigator tests from Tasks 1–5).
+
+- [ ] **Step 8: Manual smoke**
+
+Run the app (Xcode ⌘R or the built product). Open a site and confirm:
+1. The sidebar shows Pages plus any Components/Styles/Metadata present.
+2. Clicking a page navigates the preview to that route.
+3. Clicking a component/style/metadata file opens it in the editor; the `Preview | Editor` toggle appears and switches back to the live preview.
+4. Edit + ⌘S writes the file (dirty dot clears); the dev server rebuilds.
+5. Edit the same file externally (e.g. `echo` from a terminal) while the buffer is dirty, refocus the window → the conflict dialog appears with Keep/Reload.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat(navigator): wire Site Navigator sidebar + editor mode into SiteWindow"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Left sidebar / NavigationSplitView → Task 9. ✓
+- Five curated groups → Task 2 (scan) + Task 5 (sections) + Task 7 (view). ✓
+- Pages/Posts from content graph → Task 5 builder reads graph pages/posts; Task 6 loads them. ✓
+- Page→preview navigation → Task 9 `applyNavigatorSelection`. ✓
+- Non-page→inline text editor replacing preview (option A) → Task 8 + Task 9 `MainPaneMode`. ✓
+- Explicit save + dirty + external-change guard (option C) → Task 3 (logic) + Task 8 (UI/dialog). ✓
+- EditorKind routing seam → Task 4, consumed in Task 8. ✓
+- `SiteContentGraph` broadcast stream decision → Task 1. ✓
+- Testable logic in AnglesiteCore → Tasks 1–5 all CI-tested. ✓
+- MAS: reads/writes inside the existing security-scoped grant → no new file access introduced; editor uses `site.path` URLs already covered by `scopedURL`. ✓ (No new entitlement; confirm during Task 9 smoke if testing MAS.)
+
+**Deferred (per spec non-goals), intentionally not in any task:** file create/rename/delete, metadata form editor, multi-file tabs, split editor+preview. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows complete code. The one assumption (post route derivation) is documented in Task 5 with rationale and a code implementation. ✓
+
+**Type consistency:** `FileGroup`, `FileRef`, `NavigatorTarget`, `NavigatorItem`, `NavigatorSection`, `EditorKind`/`editorKind(for:)`, `FileDocumentIO.{Loaded,ExternalChange,load,save,externalChange}`, `buildNavigatorTree`, `postRoute(for:)`, `SiteNavigatorModel.{sections,selection,start,stop,target}`, `MainPaneMode` — names are used identically across the tasks that define and consume them. ✓

--- a/docs/superpowers/plans/2026-06-19-site-navigator.md
+++ b/docs/superpowers/plans/2026-06-19-site-navigator.md
@@ -30,7 +30,9 @@ The navigator needs live page/post updates, but `SiteContentGraph`'s single `cha
 
 **Interfaces:**
 - Consumes: existing `SiteContentGraph` actor, `emitChange(_:)`.
-- Produces: `nonisolated func changeStream() -> AsyncStream<String>` — yields the affected `siteID` on every real mutation; no subscribe-time yield (a change is an event, not a snapshot).
+- Produces: `func changeStream() -> AsyncStream<String>` (actor-isolated — callers `await`) — yields the affected `siteID` on every real mutation; no subscribe-time yield (a change is an event, not a snapshot).
+
+> **Why actor-isolated (not `nonisolated` like `SiteStore.changeStream()`):** `SiteStore` yields a subscribe-time snapshot, so a caller that subscribes then mutates always gets *something* and never hangs. This stream deliberately has **no** subscribe-time yield, so registering the continuation in a detached `Task {}` (as a `nonisolated` factory must) races the caller's next mutation — if the emit lands before registration, `next()` suspends forever. Making `changeStream()` actor-isolated and registering the continuation **synchronously** (via `AsyncStream.makeStream`) before returning closes the race. Consumers (Task 6) therefore `await graph.changeStream()`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -51,7 +53,7 @@ struct SiteContentGraphStreamTests {
     @Test("changeStream yields the siteID on a real mutation")
     func yieldsOnMutation() async throws {
         let graph = SiteContentGraph()
-        var iterator = graph.changeStream().makeAsyncIterator()
+        var iterator = (await graph.changeStream()).makeAsyncIterator()
         await graph.upsertPage(makePage("siteA", route: "/about/"))
         let received = await iterator.next()
         #expect(received == "siteA")
@@ -60,8 +62,8 @@ struct SiteContentGraphStreamTests {
     @Test("two independent subscribers both receive the change")
     func broadcastsToAll() async throws {
         let graph = SiteContentGraph()
-        var it1 = graph.changeStream().makeAsyncIterator()
-        var it2 = graph.changeStream().makeAsyncIterator()
+        var it1 = (await graph.changeStream()).makeAsyncIterator()
+        var it2 = (await graph.changeStream()).makeAsyncIterator()
         await graph.upsertPage(makePage("siteB", route: "/x/"))
         let a = await it1.next()
         let b = await it2.next()
@@ -74,7 +76,7 @@ struct SiteContentGraphStreamTests {
         let graph = SiteContentGraph()
         let page = makePage("siteC", route: "/y/")
         await graph.upsertPage(page)              // first insert emits
-        var it = graph.changeStream().makeAsyncIterator()
+        var it = (await graph.changeStream()).makeAsyncIterator()
         await graph.upsertPage(page)              // equal → no emit
         await graph.upsertPage(makePage("siteC", route: "/z/")) // emits
         let received = await it.next()
@@ -112,24 +114,24 @@ Extend `emitChange` to fan out to both (replace the existing `emitChange`):
     }
 ```
 
-Add the stream factory + register/prune helpers (mirrors `SiteStore.changeStream()`):
+Add the stream factory + prune helper. Unlike `SiteStore.changeStream()` this is **actor-isolated**, so the continuation is registered synchronously before the call returns — no detached registration `Task`, no race (see the Interfaces note above):
 
 ```swift
-    /// A multi-subscriber stream of affected siteIDs, one per real mutation. Unlike
-    /// `SiteStore.changeStream()` there is no subscribe-time snapshot — a content change is an
-    /// event, so the navigator reads the graph back itself on first load.
-    public nonisolated func changeStream() -> AsyncStream<String> {
+    /// A multi-subscriber stream of affected siteIDs, one per real mutation. Actor-isolated so the
+    /// continuation registers synchronously before this returns: there is no subscribe-time snapshot
+    /// to mask a registration race, so a caller that subscribes then mutates must not miss the emit.
+    /// (A content change is an event — the navigator reads the graph back itself on first load.)
+    /// Callers `await` it.
+    public func changeStream() -> AsyncStream<String> {
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: String.self, bufferingPolicy: .bufferingNewest(8))
         let id = UUID()
-        return AsyncStream(bufferingPolicy: .bufferingNewest(8)) { continuation in
-            Task { await self.registerContinuation(continuation, id: id) }
-            continuation.onTermination = { [weak self] _ in
-                Task { await self?.removeContinuation(id) }
-            }
-        }
-    }
-
-    private func registerContinuation(_ continuation: AsyncStream<String>.Continuation, id: UUID) {
         changeStreamContinuations[id] = continuation
+        continuation.onTermination = { [weak self] _ in
+            // onTermination runs off-actor at an arbitrary time; hop back to prune.
+            Task { await self?.removeContinuation(id) }
+        }
+        return stream
     }
 
     private func removeContinuation(_ id: UUID) {
@@ -812,7 +814,8 @@ final class SiteNavigatorModel {
         Task { await refresh() }
         observeTask?.cancel()
         observeTask = Task { [graph, siteID] in
-            for await changedSiteID in graph.changeStream() {
+            // `changeStream()` is actor-isolated (Task 1) — await it to subscribe before iterating.
+            for await changedSiteID in await graph.changeStream() {
                 if Task.isCancelled { break }
                 if changedSiteID == siteID { await refresh() }
             }

--- a/docs/superpowers/specs/2026-06-19-site-navigator-design.md
+++ b/docs/superpowers/specs/2026-06-19-site-navigator-design.md
@@ -1,0 +1,193 @@
+# Site Navigator — design
+
+**Date:** 2026-06-19
+**Status:** Approved (brainstorm)
+
+## Summary
+
+Add an Xcode-Project-Navigator-style sidebar to each site window. It presents
+the site's content as curated semantic groups (Pages, Posts, Components, Styles,
+Metadata). Selecting a page navigates the live preview; selecting a non-page file
+opens it in an inline text editor that replaces the preview in the main pane. The
+editor is fronted by a routing seam so file-specific editors (a metadata form
+editor especially) can replace the generic text editor later without touching
+call sites.
+
+## Motivation
+
+Today a site window is a preview (WKWebView) plus an optional chat panel — there
+is no way to browse a site's structure or jump directly to a page, component, or
+metadata file. Owners expect a navigator like Xcode's: a stable left sidebar that
+lists the site's parts and lets them open any one for editing.
+
+## Goals (v1)
+
+- A persistent, collapsible left sidebar listing the site's content in five
+  curated groups.
+- Selecting a **page/post** navigates the preview to that route.
+- Selecting a **non-page file** (component, style, metadata) opens it in an
+  inline text editor that replaces the preview in the main pane.
+- The text editor uses explicit save (⌘S), shows dirty state, and guards against
+  external changes (other tools — chat, edit overlay, Claude Code CLI — write the
+  same files).
+- An editor-routing seam (`EditorKind`) so file-specific editors slot in later.
+
+## Non-goals (deferred)
+
+- File-specific editors (metadata form editor, etc.) — the seam is built, only
+  `.text` is implemented.
+- Creating / renaming / deleting / moving files from the tree. v1 is **read +
+  edit-existing only**.
+- Multi-file tabs, split editor+preview, drag-to-reorder.
+
+## Architecture
+
+### Layout
+
+Wrap the current `siteUI(for:)` content in a `NavigationSplitView`:
+
+- **Sidebar** — the navigator (`SiteNavigatorView`).
+- **Detail** — the existing main-pane + chat panel + deploy/backup drawers,
+  unchanged except that the main pane gains a *mode* (below).
+
+`NavigationSplitView` supplies the standard collapsible sidebar and toolbar
+toggle. Sidebar visibility/width persist with `@SceneStorage` (per window) so the
+choice survives relaunch and state restoration.
+
+### Main-pane mode
+
+The main pane is currently always the preview. Introduce:
+
+```swift
+enum MainPaneMode: Equatable {
+    case preview
+    case editor(FileRef)
+}
+```
+
+held as `@State` in `SiteWindow`.
+
+- Selecting a **page/post** → `mode = .preview`, then
+  `preview.navigate(toRoute:)` (or `preview.clearRoute()` for the site root).
+- Selecting a **non-page file** → `mode = .editor(file)`. The editor **replaces**
+  the preview (chosen layout: option A). A small segmented control at the top of
+  the main pane toggles `Preview | Editor` so the user can flip back without
+  losing the open file.
+
+`FileRef` is a small value type (`Sendable`, `Equatable`, `Identifiable`)
+identifying a file by absolute URL plus its group and display name.
+
+### The tree (curated groups)
+
+Five disclosure groups, in order:
+
+| Group       | Source                                              |
+|-------------|-----------------------------------------------------|
+| Pages       | `SiteContentGraph.Page` (title + route)             |
+| Posts       | `SiteContentGraph.Post` (title, draft, date)        |
+| Components  | filesystem: `Source/src/layouts`, `Source/src/components` (if present) |
+| Styles      | filesystem: `Source/src/styles`                     |
+| Metadata    | filesystem: `Config/`, the package `Info.plist` marker |
+
+Excluded everywhere: `node_modules`, build output (`dist`/`.astro`), lockfiles,
+VCS dirs. Empty groups are hidden.
+
+Pages/Posts are semantic (from the content graph); the other three are raw file
+listings rooted via `AnglesitePackage` (`sourceURL`, `Config/`).
+
+### Editor + routing seam
+
+```swift
+enum EditorKind { case text /* future: .metadataForm, ... */ }
+func editorKind(for file: FileRef) -> EditorKind   // v1: always .text
+```
+
+`MainPaneEditorView` switches on the kind. v1 implements only the text path; the
+function and enum exist so adding `.metadataForm` later is a one-line mapping plus
+a new view — no call-site churn.
+
+Text editor behavior (chosen: option C — explicit save + external-change aware):
+
+- Loads file contents into a buffer; tracks `isDirty`.
+- ⌘S writes the buffer to disk. Dirty state shown in both the tree row and the
+  main pane.
+- Watches the open file for external modification (mtime/content). On an external
+  change while the buffer is clean → reload silently; while dirty → warn and let
+  the user choose **Keep my changes** or **Reload from disk**. Never silently
+  clobbers either side.
+- A save writes to disk → existing dev-server file-watch rebuilds → the preview
+  reflects the change next time the user switches to Preview.
+
+### Where the logic lives
+
+Testable, App-independent types in `AnglesiteCore` (CI-runnable via `swift test`):
+
+- **`SiteFileTree`** — given an `AnglesitePackage`, scans the filesystem-backed
+  groups (Components/Styles/Metadata) into grouped `FileRef`s. `FileManager`
+  injected; exclusion rules unit-tested.
+- **`FileDocumentModel`** — load / dirty / save state machine plus
+  external-change detection. The reconcile logic (clean→reload, dirty→prompt) is
+  the core under test.
+
+App-target glue (not CI-tested through a hosted app target, kept thin):
+
+- **`SiteNavigatorModel`** (`@MainActor @Observable`) — merges content-graph
+  pages/posts with the `SiteFileTree` scan into the grouped tree, owns the
+  selection, and drives `MainPaneMode`. Refreshes on content-graph changes and on
+  filesystem changes.
+- **`SiteNavigatorView`** / **`MainPaneEditorView`** — SwiftUI.
+
+### Content-graph observation
+
+`SiteContentGraph`'s change handler is **single-subscriber by design** and is
+already taken by the Spotlight indexer (`ContentSpotlightIndexer`). The navigator
+needs independent live updates, so:
+
+**Decision:** add an `AsyncStream`-based broadcast to `SiteContentGraph`
+(mirroring `SiteStore.changeStream()`), allowing multiple independent observers
+(indexer + navigator). The existing single-subscriber handler stays for
+backward compatibility, or the indexer migrates to the stream — to be settled in
+the plan. The navigator consumes the stream to refresh Pages/Posts; it watches
+the filesystem (or piggybacks on the dev-server watch) to refresh the other three
+groups.
+
+## Data flow
+
+1. Window opens → `SiteNavigatorModel` reads a `SiteContentGraph` snapshot
+   (Pages/Posts) and runs a `SiteFileTree` scan (Components/Styles/Metadata),
+   builds the grouped tree.
+2. User selects a row:
+   - page/post → `mode = .preview` + `preview.navigate(toRoute:)`.
+   - file → `mode = .editor(file)`; `FileDocumentModel` loads it.
+3. User edits + ⌘S → `FileDocumentModel` writes to disk → dev-server file-watch →
+   rebuild → preview updated.
+4. External tool writes an open file → `FileDocumentModel` detects it → silent
+   reload (clean) or prompt (dirty).
+5. Content/filesystem changes → model refreshes the affected group(s).
+
+## Error handling
+
+- Unreadable / vanished file on open → editor shows an inline error state with a
+  "Reveal in Finder" affordance; selection does not crash the window.
+- Save failure (permissions, MAS sandbox grant lapsed) → non-destructive error;
+  buffer stays dirty; message surfaced (and logged to the debug pane per the
+  "logs are sacred" rule).
+- Empty / missing groups (e.g. no `Config/` yet) → group hidden, not an error.
+- MAS: all file reads/writes occur within the window's existing security-scoped
+  grant (`scopedURL`); no new entitlement.
+
+## Testing
+
+- `SiteFileTreeTests` — grouping, exclusion of plumbing, empty-dir handling,
+  package roots resolved via `AnglesitePackage`.
+- `FileDocumentModelTests` — dirty tracking, save writes bytes, external-change
+  reconcile (clean→reload, dirty→prompt outcomes).
+- `SiteContentGraph` broadcast — multiple subscribers each receive change
+  notifications; emit-on-real-mutation semantics preserved.
+
+## Open questions for the plan
+
+- Whether `ContentSpotlightIndexer` migrates to the new broadcast stream or the
+  single-subscriber handler is kept alongside it.
+- Exact filesystem-watch mechanism for the non-content groups (dedicated watcher
+  vs. reuse of the dev-server watch signal).


### PR DESCRIPTION
## Summary

Adds an Xcode-style **Site Navigator** sidebar to the per-site window, plus an inline text editor for navigator-selected files. The sidebar merges the live content graph with a filesystem scan of the Astro source tree (`Source/`), grouped into sections; selecting a route shows the preview, selecting a file opens it in an inline editor.

## What's in it

- **`SiteContentGraph` multi-subscriber `changeStream`** — lets the navigator observe content changes live without disturbing existing subscribers.
- **`SiteFileTree` + `buildNavigatorTree`** — resolves the site layout, scans `Source/` into grouped sections, and merges in the content graph's routes.
- **`SiteNavigatorModel` / `SiteNavigatorView`** — the sidebar list with live refresh.
- **`FileDocumentIO`** (in `AnglesiteCore`) — load/save with an external-change reconcile (`none` / `reloadable` / `conflict`), honoring the filesystem-source-of-truth rule.
- **`MainPaneEditorView` + `FileEditorModel`** — a plain-text editor (v1; `EditorKind` is the routing seam for future file-specific editors). State lives in a `SiteWindow`-owned `@Observable` model so navigating away **auto-saves**, the buffer **survives the Preview/Editor toggle**, and external-change conflicts **abort the switch** (raising the alert) rather than clobbering another tool's edit.

## Notes

- Rebased onto `main` after #242 P1+P2 squash-merged. The navigator scans `resolved.sourceDirectory` (the `Source/` tree under the `.anglesite` package), consistent with where the preview now opens.
- App target builds clean (`xcodebuild -scheme Anglesite` → **BUILD SUCCEEDED**); full test sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)