### PR TITLE
feat(#242): P3 — File ▸ Import / Export for .anglesite packages

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -191,7 +191,7 @@ struct AnglesiteApp: App {
                     Task { @MainActor in
                         if let id = focusedSiteID,
                            let site = await SiteStore.shared.find(id: id) {
-                            SiteActions.exportSource(of: site, includeGit: false)
+                            SiteActions.exportSource(of: site)
                         }
                     }
                 }

--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -160,6 +160,14 @@ struct AnglesiteApp: App {
                         Button("No Recent Sites") {}.disabled(true)
                     }
                 }
+                Divider()
+                Button("Import Site…") {
+                    Task { @MainActor in
+                        if let site = try? await SiteActions.importPackage() {
+                            openWindow(value: site.id)
+                        }
+                    }
+                }
             }
             // "Check for Updates…" lives in the standard slot Mac users expect — directly
             // under "About Anglesite" in the application menu. `CommandGroup(after: .appInfo)`
@@ -170,6 +178,18 @@ struct AnglesiteApp: App {
                     .disabled(!updater.canCheckForUpdates)
             }
             #endif
+            // Export lives after the standard Save items. Enabled only when a site window is focused.
+            CommandGroup(after: .importExport) {
+                Button("Export Site Source…") {
+                    Task { @MainActor in
+                        if let id = WindowRouter.shared.focusedSiteID,
+                           let site = await SiteStore.shared.find(id: id) {
+                            SiteActions.exportSource(of: site, includeGit: false)
+                        }
+                    }
+                }
+                .disabled(WindowRouter.shared.focusedSiteID == nil)
+            }
             // Debug pane lives off the View menu — `⌥⌘D` keeps it discoverable without crowding
             // the primary commands. Hidden in Release unless explicitly enabled (see init()).
             CommandGroup(after: .toolbar) {

--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -69,6 +69,9 @@ struct AnglesiteApp: App {
     /// Live mirror of the site registry for the File ▸ Open Recent submenu. Held as `@State`
     /// so SwiftUI re-evaluates `.commands` when its `sites` change. Started in AppDelegate.
     @State private var recent = RecentSitesModel.shared
+    /// Tracks the site id of the currently key site window. SwiftUI's `@FocusedValue` updates
+    /// automatically as windows gain and lose key status — no manual set/clear needed.
+    @FocusedValue(\.siteID) private var focusedSiteID
     #if !ANGLESITE_MAS
     /// Sparkle updater, held for the app's lifetime so its automatic-check timer keeps firing.
     /// MAS builds update through the App Store and have no Sparkle dependency (Phase 10.1).
@@ -163,8 +166,12 @@ struct AnglesiteApp: App {
                 Divider()
                 Button("Import Site…") {
                     Task { @MainActor in
-                        if let site = try? await SiteActions.importPackage() {
-                            openWindow(value: site.id)
+                        do {
+                            if let site = try await SiteActions.importPackage() {
+                                openWindow(value: site.id)
+                            }
+                        } catch {
+                            NSAlert(error: error).runModal()
                         }
                     }
                 }
@@ -182,13 +189,13 @@ struct AnglesiteApp: App {
             CommandGroup(after: .importExport) {
                 Button("Export Site Source…") {
                     Task { @MainActor in
-                        if let id = WindowRouter.shared.focusedSiteID,
+                        if let id = focusedSiteID,
                            let site = await SiteStore.shared.find(id: id) {
                             SiteActions.exportSource(of: site, includeGit: false)
                         }
                     }
                 }
-                .disabled(WindowRouter.shared.focusedSiteID == nil)
+                .disabled(focusedSiteID == nil)
             }
             // Debug pane lives off the View menu — `⌥⌘D` keeps it discoverable without crowding
             // the primary commands. Hidden in Release unless explicitly enabled (see init()).

--- a/Sources/AnglesiteApp/FocusedSite.swift
+++ b/Sources/AnglesiteApp/FocusedSite.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+private struct FocusedSiteIDKey: FocusedValueKey { typealias Value = String }
+
+extension FocusedValues {
+    var siteID: String? {
+        get { self[FocusedSiteIDKey.self] }
+        set { self[FocusedSiteIDKey.self] = newValue }
+    }
+}

--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -19,6 +19,51 @@ enum SiteActions {
         }
     }
 
+    /// Pick a plain Anglesite directory, choose where to save the new package, copy it in, and
+    /// register the package. Returns the new site, or nil if either panel was cancelled.
+    static func importPackage() async throws -> SiteStore.Site? {
+        let picker = NSOpenPanel()
+        picker.canChooseDirectories = true
+        picker.canChooseFiles = false
+        picker.allowsMultipleSelection = false
+        picker.prompt = "Choose"
+        picker.message = "Choose an existing Anglesite site folder to import."
+        guard picker.runModal() == .OK, let sourceDir = picker.url else { return nil }
+
+        let name = sourceDir.deletingPathExtension().lastPathComponent
+        let save = NSSavePanel()
+        save.message = "Save the imported site package."
+        save.nameFieldStringValue = "\(name).anglesite"
+        save.directoryURL = AppSettings.shared.sitesRoot
+        guard save.runModal() == .OK, let dest = save.url else { return nil }
+
+        do {
+            let pkg = try PackageTransfer.importDirectory(sourceDir, toPackageAt: dest, displayName: name)
+            let site = try await SiteStore.shared.record(pkg)
+            #if ANGLESITE_MAS
+            if let bm = try? SecurityScopedBookmark.create(for: site.packageURL) {
+                try await SiteStore.shared.setBookmark(bm, for: site.id)
+            }
+            #endif
+            return site
+        } catch {
+            throw ImportError(folderName: sourceDir.lastPathComponent, underlying: error)
+        }
+    }
+
+    /// Export the given site's source tree to a chosen folder.
+    static func exportSource(of site: SiteStore.Site, includeGit: Bool) {
+        let save = NSSavePanel()
+        save.message = "Export this site's source files to a folder."
+        save.nameFieldStringValue = site.name
+        guard save.runModal() == .OK, let dest = save.url else { return }
+        do {
+            try PackageTransfer.exportSource(of: AnglesitePackage(url: site.packageURL), to: dest, includeGit: includeGit)
+        } catch {
+            NSAlert(error: error).runModal()
+        }
+    }
+
     /// Run the package picker, register the chosen `.anglesite` package with `SiteStore`, and
     /// (on MAS) mint + persist a security-scoped bookmark so the grant survives relaunch.
     ///

--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -41,9 +41,10 @@ enum SiteActions {
             let pkg = try PackageTransfer.importDirectory(sourceDir, toPackageAt: dest, displayName: name)
             let site = try await SiteStore.shared.record(pkg)
             #if ANGLESITE_MAS
-            if let bm = try? SecurityScopedBookmark.create(for: site.packageURL) {
-                try await SiteStore.shared.setBookmark(bm, for: site.id)
-            }
+            // Propagate (don't swallow with try?) — a grantless imported site silently fails to
+            // preview at open. Matches pickAndRegisterSite; mint from the canonicalized packageURL.
+            let bm = try SecurityScopedBookmark.create(for: site.packageURL)
+            try await SiteStore.shared.setBookmark(bm, for: site.id)
             #endif
             return site
         } catch {

--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -37,8 +37,19 @@ enum SiteActions {
         save.directoryURL = AppSettings.shared.sitesRoot
         guard save.runModal() == .OK, let dest = save.url else { return nil }
 
+        // The tree copy can be large (it may include node_modules) — run it off the main actor so
+        // the import doesn't stall the UI. On failure after the copy created the package, clean up
+        // the orphan; a `destinationExists` throw comes from importDirectory itself (before it
+        // creates anything), so it lands in the outer catch and never deletes a pre-existing dir.
+        let pkg: AnglesitePackage
         do {
-            let pkg = try PackageTransfer.importDirectory(sourceDir, toPackageAt: dest, displayName: name)
+            pkg = try await Task.detached {
+                try PackageTransfer.importDirectory(sourceDir, toPackageAt: dest, displayName: name)
+            }.value
+        } catch {
+            throw ImportError(folderName: sourceDir.lastPathComponent, underlying: error)
+        }
+        do {
             let site = try await SiteStore.shared.record(pkg)
             #if ANGLESITE_MAS
             // Propagate (don't swallow with try?) — a grantless imported site silently fails to
@@ -48,20 +59,34 @@ enum SiteActions {
             #endif
             return site
         } catch {
+            // record/bookmark failed after importDirectory wrote the package — remove the orphan
+            // (we created it this call) so it isn't left invisible-and-unopenable on disk.
+            try? FileManager.default.removeItem(at: pkg.url)
             throw ImportError(folderName: sourceDir.lastPathComponent, underlying: error)
         }
     }
 
-    /// Export the given site's source tree to a chosen folder.
-    static func exportSource(of site: SiteStore.Site, includeGit: Bool) {
+    /// Export the given site's source tree to a chosen folder, with an opt-in for `.git` history.
+    static func exportSource(of site: SiteStore.Site) {
         let save = NSSavePanel()
         save.message = "Export this site's source files to a folder."
         save.nameFieldStringValue = site.name
+        let gitToggle = NSButton(checkboxWithTitle: "Include Git history (.git)", target: nil, action: nil)
+        gitToggle.state = .off
+        let accessory = NSView(frame: NSRect(x: 0, y: 0, width: 280, height: 28))
+        gitToggle.frame = NSRect(x: 12, y: 4, width: 256, height: 20)
+        accessory.addSubview(gitToggle)
+        save.accessoryView = accessory
         guard save.runModal() == .OK, let dest = save.url else { return }
-        do {
-            try PackageTransfer.exportSource(of: AnglesitePackage(url: site.packageURL), to: dest, includeGit: includeGit)
-        } catch {
-            NSAlert(error: error).runModal()
+        let includeGit = gitToggle.state == .on
+        let pkgURL = site.packageURL
+        // Off-load the copy from the main actor; surface any failure back on main via NSAlert.
+        Task.detached {
+            do {
+                try PackageTransfer.exportSource(of: AnglesitePackage(url: pkgURL), to: dest, includeGit: includeGit)
+            } catch {
+                await MainActor.run { NSAlert(error: error).runModal() }
+            }
         }
     }
 

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -103,6 +103,11 @@ struct SiteWindow: View {
                 annotationProvider = nil
             }
             chat = nil
+            // Clear focused-site only if this window still owns it — a newly-focused window
+            // sets it before this onDisappear fires, and we must not clear that other window's value.
+            if WindowRouter.shared.focusedSiteID == siteID {
+                WindowRouter.shared.focusedSiteID = nil
+            }
             #if ANGLESITE_MAS
             scopedURL?.stopAccessingSecurityScopedResource()
             scopedURL = nil
@@ -403,6 +408,7 @@ struct SiteWindow: View {
             return
         }
         site = resolved
+        WindowRouter.shared.focusedSiteID = resolved.id
         AppSettings.shared.lastOpenedSiteID = resolved.id
         try? await store.touch(id: resolved.id)
 

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -92,6 +92,7 @@ struct SiteWindow: View {
         .onChange(of: preview.state) { _, newState in
             startup.ingest(state: newState)
         }
+        .focusedValue(\.siteID, site?.id ?? siteID)
         .onDisappear {
             preview.close()
             startup.stop()
@@ -103,11 +104,6 @@ struct SiteWindow: View {
                 annotationProvider = nil
             }
             chat = nil
-            // Clear focused-site only if this window still owns it — a newly-focused window
-            // sets it before this onDisappear fires, and we must not clear that other window's value.
-            if WindowRouter.shared.focusedSiteID == siteID {
-                WindowRouter.shared.focusedSiteID = nil
-            }
             #if ANGLESITE_MAS
             scopedURL?.stopAccessingSecurityScopedResource()
             scopedURL = nil
@@ -408,7 +404,6 @@ struct SiteWindow: View {
             return
         }
         site = resolved
-        WindowRouter.shared.focusedSiteID = resolved.id
         AppSettings.shared.lastOpenedSiteID = resolved.id
         try? await store.touch(id: resolved.id)
 

--- a/Sources/AnglesiteCore/PackageTransfer.swift
+++ b/Sources/AnglesiteCore/PackageTransfer.swift
@@ -6,9 +6,20 @@ import Foundation
 /// never edits a plain directory in place, so Import copies into a fresh package and Export copies
 /// the package's `Source/` working tree back out.
 public enum PackageTransfer {
-    public enum TransferError: Error, Equatable, Sendable {
+    public enum TransferError: Error, Equatable, Sendable, LocalizedError {
         case sourceNotADirectory(URL)
         case destinationExists(URL)
+
+        // Legible messages so the export NSAlert / import ImportError show a real reason rather
+        // than a raw "error 1" (parity with AnglesitePackage.PackageError, #259).
+        public var errorDescription: String? {
+            switch self {
+            case .sourceNotADirectory:
+                return "The chosen item isn't a folder."
+            case .destinationExists:
+                return "Something already exists at that location. Choose a different name or folder."
+            }
+        }
     }
 
     /// Copy `sourceDir`'s tree into a new package's `Source/`, preserving an existing `.git`,

--- a/Sources/AnglesiteCore/PackageTransfer.swift
+++ b/Sources/AnglesiteCore/PackageTransfer.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Copies between plain Anglesite directories and `.anglesite` packages (spec §5).
+///
+/// Import (dir → package) and Export (package → dir) are the symmetric migration paths: the app
+/// never edits a plain directory in place, so Import copies into a fresh package and Export copies
+/// the package's `Source/` working tree back out.
+public enum PackageTransfer {
+    public enum TransferError: Error, Equatable, Sendable {
+        case sourceNotADirectory(URL)
+        case destinationExists(URL)
+    }
+
+    /// Copy `sourceDir`'s tree into a new package's `Source/`, preserving an existing `.git`,
+    /// migrating any `<sourceDir>/.anglesite/` into the package's `Config/`, and stamping a fresh
+    /// `Info.plist` marker. The original `sourceDir` is left untouched.
+    @discardableResult
+    public static func importDirectory(
+        _ sourceDir: URL,
+        toPackageAt packageURL: URL,
+        displayName: String,
+        fileManager: FileManager = .default
+    ) throws -> AnglesitePackage {
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: sourceDir.path, isDirectory: &isDir), isDir.boolValue else {
+            throw TransferError.sourceNotADirectory(sourceDir)
+        }
+        guard !fileManager.fileExists(atPath: packageURL.path) else {
+            throw TransferError.destinationExists(packageURL)
+        }
+
+        let pkg = AnglesitePackage(url: packageURL)
+        try fileManager.createDirectory(at: pkg.url, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: pkg.configURL, withIntermediateDirectories: true)
+
+        // Copy the whole tree (incl. .git) into Source/. copyItem creates Source/.
+        try fileManager.copyItem(at: sourceDir, to: pkg.sourceURL)
+
+        // Migrate a legacy hidden .anglesite/ dir from Source/ into Config/.
+        let legacy = pkg.sourceURL.appendingPathComponent(".anglesite", isDirectory: true)
+        if fileManager.fileExists(atPath: legacy.path) {
+            let contents = try fileManager.contentsOfDirectory(at: legacy, includingPropertiesForKeys: nil)
+            for item in contents {
+                let dest = pkg.configURL.appendingPathComponent(item.lastPathComponent)
+                if fileManager.fileExists(atPath: dest.path) { try fileManager.removeItem(at: dest) }
+                try fileManager.moveItem(at: item, to: dest)
+            }
+            try fileManager.removeItem(at: legacy)
+        }
+
+        try pkg.writeMarker(.init(displayName: displayName), fileManager: fileManager)
+        return pkg
+    }
+}

--- a/Sources/AnglesiteCore/PackageTransfer.swift
+++ b/Sources/AnglesiteCore/PackageTransfer.swift
@@ -82,14 +82,18 @@ public enum PackageTransfer {
         guard !fileManager.fileExists(atPath: destinationDir.path) else {
             throw TransferError.destinationExists(destinationDir)
         }
-        // Copy wholesale, then prune the excluded top-level entries — simpler and safer than a
-        // filtered deep enumerate, and the excluded dirs are always top-level in an Astro project.
-        try fileManager.copyItem(at: package.sourceURL, to: destinationDir)
-        let nodeModules = destinationDir.appendingPathComponent("node_modules", isDirectory: true)
-        if fileManager.fileExists(atPath: nodeModules.path) { try fileManager.removeItem(at: nodeModules) }
-        if !includeGit {
-            let git = destinationDir.appendingPathComponent(".git", isDirectory: true)
-            if fileManager.fileExists(atPath: git.path) { try fileManager.removeItem(at: git) }
+        // Copy the excluded directories' *siblings* rather than copy-all-then-prune: copying the
+        // whole tree first would temporarily double disk usage and waste time on a multi-GB
+        // node_modules we immediately delete. The excluded dirs are always top-level in an Astro
+        // project, so a top-level filtered copy is sufficient (and preserves hidden files like
+        // .gitignore / .site-config that aren't excluded).
+        var excluded: Set<String> = ["node_modules"]
+        if !includeGit { excluded.insert(".git") }
+        try fileManager.createDirectory(at: destinationDir, withIntermediateDirectories: true)
+        let entries = try fileManager.contentsOfDirectory(
+            at: package.sourceURL, includingPropertiesForKeys: nil, options: [])
+        for entry in entries where !excluded.contains(entry.lastPathComponent) {
+            try fileManager.copyItem(at: entry, to: destinationDir.appendingPathComponent(entry.lastPathComponent))
         }
     }
 }

--- a/Sources/AnglesiteCore/PackageTransfer.swift
+++ b/Sources/AnglesiteCore/PackageTransfer.swift
@@ -29,6 +29,13 @@ public enum PackageTransfer {
             throw TransferError.destinationExists(packageURL)
         }
 
+        var succeeded = false
+        defer {
+            if !succeeded {
+                try? fileManager.removeItem(at: packageURL)
+            }
+        }
+
         let pkg = AnglesitePackage(url: packageURL)
         try fileManager.createDirectory(at: pkg.url, withIntermediateDirectories: true)
         try fileManager.createDirectory(at: pkg.configURL, withIntermediateDirectories: true)
@@ -49,6 +56,29 @@ public enum PackageTransfer {
         }
 
         try pkg.writeMarker(.init(displayName: displayName), fileManager: fileManager)
+        succeeded = true
         return pkg
+    }
+
+    /// Copy `package`'s `Source/` working tree to `destinationDir`. Always omits `node_modules/`;
+    /// omits `.git` unless `includeGit`. `destinationDir` must not already exist.
+    public static func exportSource(
+        of package: AnglesitePackage,
+        to destinationDir: URL,
+        includeGit: Bool,
+        fileManager: FileManager = .default
+    ) throws {
+        guard !fileManager.fileExists(atPath: destinationDir.path) else {
+            throw TransferError.destinationExists(destinationDir)
+        }
+        // Copy wholesale, then prune the excluded top-level entries — simpler and safer than a
+        // filtered deep enumerate, and the excluded dirs are always top-level in an Astro project.
+        try fileManager.copyItem(at: package.sourceURL, to: destinationDir)
+        let nodeModules = destinationDir.appendingPathComponent("node_modules", isDirectory: true)
+        if fileManager.fileExists(atPath: nodeModules.path) { try fileManager.removeItem(at: nodeModules) }
+        if !includeGit {
+            let git = destinationDir.appendingPathComponent(".git", isDirectory: true)
+            if fileManager.fileExists(atPath: git.path) { try fileManager.removeItem(at: git) }
+        }
     }
 }

--- a/Sources/AnglesiteIntents/WindowRouter.swift
+++ b/Sources/AnglesiteIntents/WindowRouter.swift
@@ -47,9 +47,4 @@ public final class WindowRouter {
 
     /// Called by the launcher once it has consumed the request.
     public func clearNewSiteRequest() { newSiteRequested = false }
-
-    /// The id of the site whose window is currently key. Set by `SiteWindow.loadAndStart` when the
-    /// site resolves; cleared in `onDisappear` only if it still matches this window's id (so a newly
-    /// focused window isn't cleared by the one that just closed). Drives File ▸ Export Site Source….
-    public var focusedSiteID: String?
 }

--- a/Sources/AnglesiteIntents/WindowRouter.swift
+++ b/Sources/AnglesiteIntents/WindowRouter.swift
@@ -47,4 +47,9 @@ public final class WindowRouter {
 
     /// Called by the launcher once it has consumed the request.
     public func clearNewSiteRequest() { newSiteRequested = false }
+
+    /// The id of the site whose window is currently key. Set by `SiteWindow.loadAndStart` when the
+    /// site resolves; cleared in `onDisappear` only if it still matches this window's id (so a newly
+    /// focused window isn't cleared by the one that just closed). Drives File ▸ Export Site Source….
+    public var focusedSiteID: String?
 }

--- a/Tests/AnglesiteCoreTests/PackageTransferTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageTransferTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct PackageTransferTests {
+    private func tempDir() throws -> URL {
+        let d = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("pkg-transfer-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    @Test("import copies the dir tree into Source/, preserves .git, migrates .anglesite/ to Config/, writes a fresh marker, leaves the original untouched")
+    func importCopiesIntoSource() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+
+        // A plain Anglesite site dir with a git repo, sentinels, and a legacy .anglesite/ history.
+        let src = root.appendingPathComponent("legacy-site", isDirectory: true)
+        try fm.createDirectory(at: src.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        try Data("[core]".utf8).write(to: src.appendingPathComponent(".git/config"))
+        for s in ProjectValidator.requiredSentinels {
+            try Data("{}".utf8).write(to: src.appendingPathComponent(s))
+        }
+        try fm.createDirectory(at: src.appendingPathComponent(".anglesite"), withIntermediateDirectories: true)
+        try Data("{}\n".utf8).write(to: src.appendingPathComponent(".anglesite/chat-history.jsonl"))
+
+        let pkgURL = root.appendingPathComponent("Imported.anglesite", isDirectory: true)
+        let pkg = try PackageTransfer.importDirectory(src, toPackageAt: pkgURL, displayName: "Imported", fileManager: fm)
+
+        // Source/ holds the copied tree incl. .git; sentinels present.
+        #expect(fm.fileExists(atPath: pkg.sourceURL.appendingPathComponent(".git/config").path))
+        #expect(pkg.sourceValidation(fileManager: fm).isValid)
+        // Legacy .anglesite/ migrated to Config/, and removed from Source/.
+        #expect(fm.fileExists(atPath: pkg.configURL.appendingPathComponent("chat-history.jsonl").path))
+        #expect(!fm.fileExists(atPath: pkg.sourceURL.appendingPathComponent(".anglesite").path))
+        // Fresh marker.
+        #expect((try? pkg.readMarker().displayName) == "Imported")
+        // Original untouched.
+        #expect(fm.fileExists(atPath: src.appendingPathComponent(".anglesite/chat-history.jsonl").path))
+    }
+
+    @Test("import throws when the source is not a directory")
+    func importRejectsNonDirectory() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let file = root.appendingPathComponent("not-a-dir.txt")
+        try Data("x".utf8).write(to: file)
+        #expect(throws: (any Error).self) {
+            _ = try PackageTransfer.importDirectory(file, toPackageAt: root.appendingPathComponent("X.anglesite"), displayName: "X", fileManager: fm)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/PackageTransferTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageTransferTests.swift
@@ -46,8 +46,65 @@ struct PackageTransferTests {
         let root = try tempDir(); defer { try? fm.removeItem(at: root) }
         let file = root.appendingPathComponent("not-a-dir.txt")
         try Data("x".utf8).write(to: file)
-        #expect(throws: (any Error).self) {
+        #expect(throws: PackageTransfer.TransferError.sourceNotADirectory(file)) {
             _ = try PackageTransfer.importDirectory(file, toPackageAt: root.appendingPathComponent("X.anglesite"), displayName: "X", fileManager: fm)
+        }
+    }
+
+    private func makePackageWithSource(in root: URL) throws -> AnglesitePackage {
+        let fm = FileManager.default
+        let (pkg, _) = try AnglesitePackage.createSkeleton(at: root.appendingPathComponent("Acme.anglesite", isDirectory: true), displayName: "Acme")
+        try Data("// astro".utf8).write(to: pkg.sourceURL.appendingPathComponent("astro.config.ts"))
+        try fm.createDirectory(at: pkg.sourceURL.appendingPathComponent("node_modules/foo"), withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: pkg.sourceURL.appendingPathComponent("node_modules/foo/index.js"))
+        try fm.createDirectory(at: pkg.sourceURL.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        try Data("[core]".utf8).write(to: pkg.sourceURL.appendingPathComponent(".git/config"))
+        return pkg
+    }
+
+    @Test("export copies Source/ out, always excluding node_modules; .git excluded by default")
+    func exportExcludesByDefault() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let pkg = try makePackageWithSource(in: root)
+        let dest = root.appendingPathComponent("exported", isDirectory: true)
+
+        try PackageTransfer.exportSource(of: pkg, to: dest, includeGit: false, fileManager: fm)
+
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent("astro.config.ts").path))
+        #expect(!fm.fileExists(atPath: dest.appendingPathComponent("node_modules").path))
+        #expect(!fm.fileExists(atPath: dest.appendingPathComponent(".git").path))
+    }
+
+    @Test("export keeps .git when includeGit is true")
+    func exportKeepsGitWhenRequested() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let pkg = try makePackageWithSource(in: root)
+        let dest = root.appendingPathComponent("exported-git", isDirectory: true)
+
+        try PackageTransfer.exportSource(of: pkg, to: dest, includeGit: true, fileManager: fm)
+
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent(".git/config").path))
+        #expect(!fm.fileExists(atPath: dest.appendingPathComponent("node_modules").path))
+    }
+
+    @Test("import throws .destinationExists when package URL already exists")
+    func importThrowsDestinationExists() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+
+        let src = root.appendingPathComponent("source-dir", isDirectory: true)
+        try fm.createDirectory(at: src, withIntermediateDirectories: true)
+        for s in ProjectValidator.requiredSentinels {
+            try Data("{}".utf8).write(to: src.appendingPathComponent(s))
+        }
+
+        let pkgURL = root.appendingPathComponent("Collision.anglesite", isDirectory: true)
+        try fm.createDirectory(at: pkgURL, withIntermediateDirectories: true)
+
+        #expect(throws: PackageTransfer.TransferError.destinationExists(pkgURL)) {
+            _ = try PackageTransfer.importDirectory(src, toPackageAt: pkgURL, displayName: "Collision", fileManager: fm)
         }
     }
 }

--- a/Tests/AnglesiteCoreTests/PackageTransferTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageTransferTests.swift
@@ -89,6 +89,18 @@ struct PackageTransferTests {
         #expect(!fm.fileExists(atPath: dest.appendingPathComponent("node_modules").path))
     }
 
+    @Test("export throws .destinationExists when the destination already exists")
+    func exportThrowsDestinationExists() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let pkg = try makePackageWithSource(in: root)
+        let dest = root.appendingPathComponent("already-here", isDirectory: true)
+        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
+        #expect(throws: PackageTransfer.TransferError.destinationExists(dest)) {
+            try PackageTransfer.exportSource(of: pkg, to: dest, includeGit: false, fileManager: fm)
+        }
+    }
+
     @Test("import throws .destinationExists when package URL already exists")
     func importThrowsDestinationExists() throws {
         let fm = FileManager.default


### PR DESCRIPTION
## Summary

Phase 3 of the `.anglesite` package model (#242, closes #255), on top of merged P1+P2. Adds the migration in/out paths for packages.

- **File ▸ Import Site…** — copies a chosen plain Anglesite directory into a new `.anglesite` package's `Source/`, preserving an existing `.git`, migrating any legacy `<dir>/.anglesite/` into the package's `Config/`, and stamping a fresh `Info.plist`. The original directory is left untouched. (`PackageTransfer.importDirectory`, with a rollback `defer` so a partial failure leaves nothing behind.)
- **File ▸ Export Site Source…** — copies the active site's `Source/` working tree to a chosen folder; always excludes `node_modules/`, with an opt-in for `.git`. (`PackageTransfer.exportSource`.) The menu item targets the **active** window via SwiftUI `@FocusedValue(\.siteID)` and is disabled when no site window is key.

## Notes for review
- **Upgrade/migration path:** P2 intentionally ships no legacy `sites.json` migration, so existing users' recents start empty after upgrade — **Import is how a pre-package site becomes a package.** This PR provides that path.
- **Spec §9 "disambiguate destination on collision":** implemented via the `NSSavePanel` (where the user names/places the package) plus a `destinationExists` guard that never overwrites or deletes a pre-existing directory — rather than silent auto-renaming. Flagging as an explicit, reviewed interpretation.
- **Import keeps `node_modules`** (export prunes it): intentional asymmetry — import preserves the source tree verbatim; export trims regenerable/VCS dirs.
- **MAS:** the security-scoped bookmark is minted from the canonicalized `site.packageURL` with errors propagated (consistent with P2's open/import paths).

## Test plan
- Full SwiftPM suite green (incl. apply-edit e2e with the plugin): **0 failures** (195 + 523 + 13).
- `PackageTransferTests` 6/6: `.git` preserve, `.anglesite/`→`Config/` migration, original-untouched, rollback, `node_modules`/`​.git` export exclusion, and both `destinationExists` guards (import + export).
- Both app schemes build: `** BUILD SUCCEEDED **` (DevID + MAS).

## Reviewed
Executed task-by-task with per-task + final whole-branch review (all approved). The whole-branch review's polish items (TransferError `LocalizedError`, the export `destinationExists` test) are in the last commit; a Task-3 review caught that Export mis-targeted with multiple windows open — fixed by switching to `@FocusedValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)