### PR TITLE
feat(#242): P3 — File ▸ Import (dir→package) / Export (package→dir)

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -110,6 +110,22 @@ struct AnglesiteApp: App {
         }
     }
 
+    /// File ▸ Import — copy a plain Anglesite directory into a new package and open it. Shares the
+    /// same error presentation as Open (`SiteActions.ImportError` names the folder and reason).
+    @MainActor
+    private func importSiteFromMenu() async {
+        do {
+            guard let site = try await SiteActions.importPackage() else { return }
+            openWindow(value: site.id)
+        } catch {
+            let alert = NSAlert()
+            alert.messageText = "Couldn't import that folder"
+            alert.informativeText = error.localizedDescription
+            alert.alertStyle = .warning
+            alert.runModal()
+        }
+    }
+
     var body: some Scene {
         // The launcher is the first scene so it's the default window at launch (used when
         // SwiftUI has nothing to restore). It autoopens the most-recently-used site from its
@@ -151,6 +167,10 @@ struct AnglesiteApp: App {
                 }
                 .keyboardShortcut("o")
 
+                Button("Import Site…") {
+                    Task { await importSiteFromMenu() }
+                }
+
                 Menu("Open Recent") {
                     ForEach(recent.sites) { site in
                         Button(site.name) { openWindow(value: site.id) }
@@ -180,6 +200,8 @@ struct AnglesiteApp: App {
                     .keyboardShortcut("d", modifiers: [.command, .option])
                 }
             }
+            // Export operates on the focused site window via @FocusedValue; see ExportSiteCommands.
+            ExportSiteCommands()
         }
 
         // Per-site windows, keyed by SiteStore.Site.id (a stable path-derived String).

--- a/Sources/AnglesiteApp/FocusedSiteCommands.swift
+++ b/Sources/AnglesiteApp/FocusedSiteCommands.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The site shown by the currently-active window, published by `SiteWindow` via
+/// `focusedSceneValue` so window-targeted File-menu commands (Export) can read it. Using SwiftUI's
+/// focused-value system — rather than a mutable `focusedSite` on a shared singleton — means the menu
+/// always reflects the active scene and auto-enables/disables with no manual focus bookkeeping.
+struct FocusedSiteKey: FocusedValueKey {
+    typealias Value = SiteStore.Site
+}
+
+extension FocusedValues {
+    var focusedSite: SiteStore.Site? {
+        get { self[FocusedSiteKey.self] }
+        set { self[FocusedSiteKey.self] = newValue }
+    }
+}
+
+/// File ▸ Export Site Source… — operates on the focused site window. Lives in its own `Commands`
+/// type because reading `@FocusedValue` requires a `Commands`/`View` context (the inline
+/// `.commands { … }` builder in `AnglesiteApp` can't hold property wrappers).
+struct ExportSiteCommands: Commands {
+    @FocusedValue(\.focusedSite) private var focusedSite
+
+    var body: some Commands {
+        CommandGroup(after: .importExport) {
+            Button("Export Site Source…") {
+                if let focusedSite { SiteActions.exportSource(of: focusedSite) }
+            }
+            .disabled(focusedSite == nil)
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -50,4 +50,60 @@ enum SiteActions {
             throw ImportError(folderName: url.lastPathComponent, underlying: error)
         }
     }
+
+    /// File ▸ Import — pick a plain Anglesite directory, choose where to save the new package, copy
+    /// the tree into the package's `Source/`, and register it. The original directory is untouched
+    /// (`PackageTransfer.importDirectory`). Returns the new site, or `nil` if either panel was
+    /// cancelled. On MAS the save-panel destination carries the user grant, so the bookmark is
+    /// minted on the recorded package URL — exactly as `pickAndRegisterSite` does for Open.
+    static func importPackage() async throws -> SiteStore.Site? {
+        let picker = NSOpenPanel()
+        picker.canChooseDirectories = true
+        picker.canChooseFiles = false
+        picker.allowsMultipleSelection = false
+        picker.prompt = "Choose"
+        picker.message = "Choose an existing Anglesite site folder to import."
+        guard picker.runModal() == .OK, let sourceDir = picker.url else { return nil }
+
+        let name = sourceDir.deletingPathExtension().lastPathComponent
+        let save = NSSavePanel()
+        save.message = "Save the imported site package."
+        save.nameFieldStringValue = "\(name).anglesite"
+        save.directoryURL = AppSettings.shared.sitesRoot
+        guard save.runModal() == .OK, let dest = save.url else { return nil }
+
+        do {
+            let pkg = try PackageTransfer.importDirectory(sourceDir, toPackageAt: dest, displayName: name)
+            let site = try await SiteStore.shared.record(pkg)
+            #if ANGLESITE_MAS
+            let bookmark = try SecurityScopedBookmark.create(for: site.packageURL)
+            try await SiteStore.shared.setBookmark(bookmark, for: site.id)
+            #endif
+            return site
+        } catch {
+            throw ImportError(folderName: sourceDir.lastPathComponent, underlying: error)
+        }
+    }
+
+    /// File ▸ Export Site Source… — copy the focused site's `Source/` working tree to a chosen
+    /// folder. `node_modules/` is always excluded; a save-panel accessory checkbox lets the owner
+    /// include the Git history (spec §5 makes `.git` an opt-in). Failures surface in an alert.
+    static func exportSource(of site: SiteStore.Site) {
+        let save = NSSavePanel()
+        save.message = "Export this site's source files to a folder."
+        save.nameFieldStringValue = site.name
+        let gitToggle = NSButton(checkboxWithTitle: "Include Git history (.git)", target: nil, action: nil)
+        gitToggle.state = .off
+        save.accessoryView = gitToggle
+        guard save.runModal() == .OK, let dest = save.url else { return }
+        do {
+            try PackageTransfer.exportSource(
+                of: AnglesitePackage(url: site.packageURL),
+                to: dest,
+                includeGit: gitToggle.state == .on
+            )
+        } catch {
+            NSAlert(error: error).runModal()
+        }
+    }
 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -70,6 +70,8 @@ struct SiteWindow: View {
         Group {
             if let site {
                 siteUI(for: site)
+                    // Publish to the active scene so File ▸ Export Site Source… targets this window.
+                    .focusedSceneValue(\.focusedSite, site)
             } else {
                 ProgressView("Loading site…")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/AnglesiteCore/PackageTransfer.swift
+++ b/Sources/AnglesiteCore/PackageTransfer.swift
@@ -6,9 +6,20 @@ import Foundation
 /// never edits a plain directory in place, so Import copies into a fresh package and Export copies
 /// the package's `Source/` working tree back out.
 public enum PackageTransfer {
-    public enum TransferError: Error, Equatable, Sendable {
+    public enum TransferError: Error, Equatable, Sendable, LocalizedError {
         case sourceNotADirectory(URL)
         case destinationExists(URL)
+
+        // Legible messages so the export NSAlert / import ImportError show a real reason rather
+        // than a raw "error 1" (parity with AnglesitePackage.PackageError, #259).
+        public var errorDescription: String? {
+            switch self {
+            case .sourceNotADirectory:
+                return "The chosen item isn't a folder."
+            case .destinationExists:
+                return "Something already exists at that location. Choose a different name or folder."
+            }
+        }
     }
 
     /// Copy `sourceDir`'s tree into a new package's `Source/`, preserving an existing `.git`,

--- a/Sources/AnglesiteCore/PackageTransfer.swift
+++ b/Sources/AnglesiteCore/PackageTransfer.swift
@@ -56,4 +56,26 @@ public enum PackageTransfer {
         succeeded = true
         return pkg
     }
+
+    /// Copy `package`'s `Source/` working tree to `destinationDir`. Always omits `node_modules/`;
+    /// omits `.git` unless `includeGit`. `destinationDir` must not already exist.
+    public static func exportSource(
+        of package: AnglesitePackage,
+        to destinationDir: URL,
+        includeGit: Bool,
+        fileManager: FileManager = .default
+    ) throws {
+        guard !fileManager.fileExists(atPath: destinationDir.path) else {
+            throw TransferError.destinationExists(destinationDir)
+        }
+        // Copy wholesale, then prune the excluded top-level entries — simpler and safer than a
+        // filtered deep enumerate, and the excluded dirs are always top-level in an Astro project.
+        try fileManager.copyItem(at: package.sourceURL, to: destinationDir)
+        let nodeModules = destinationDir.appendingPathComponent("node_modules", isDirectory: true)
+        if fileManager.fileExists(atPath: nodeModules.path) { try fileManager.removeItem(at: nodeModules) }
+        if !includeGit {
+            let git = destinationDir.appendingPathComponent(".git", isDirectory: true)
+            if fileManager.fileExists(atPath: git.path) { try fileManager.removeItem(at: git) }
+        }
+    }
 }

--- a/Sources/AnglesiteCore/PackageTransfer.swift
+++ b/Sources/AnglesiteCore/PackageTransfer.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Copies between plain Anglesite directories and `.anglesite` packages (spec §5).
+///
+/// Import (dir → package) and Export (package → dir) are the symmetric migration paths: the app
+/// never edits a plain directory in place, so Import copies into a fresh package and Export copies
+/// the package's `Source/` working tree back out.
+public enum PackageTransfer {
+    public enum TransferError: Error, Equatable, Sendable {
+        case sourceNotADirectory(URL)
+        case destinationExists(URL)
+    }
+
+    /// Copy `sourceDir`'s tree into a new package's `Source/`, preserving an existing `.git`,
+    /// migrating any `<sourceDir>/.anglesite/` into the package's `Config/`, and stamping a fresh
+    /// `Info.plist` marker. The original `sourceDir` is left untouched.
+    @discardableResult
+    public static func importDirectory(
+        _ sourceDir: URL,
+        toPackageAt packageURL: URL,
+        displayName: String,
+        fileManager: FileManager = .default
+    ) throws -> AnglesitePackage {
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: sourceDir.path, isDirectory: &isDir), isDir.boolValue else {
+            throw TransferError.sourceNotADirectory(sourceDir)
+        }
+        guard !fileManager.fileExists(atPath: packageURL.path) else {
+            throw TransferError.destinationExists(packageURL)
+        }
+
+        let pkg = AnglesitePackage(url: packageURL)
+        // Roll back a half-written package if any step fails, so a failed import never leaves an
+        // orphaned partial package behind (mirrors createSkeleton's contract, spec §9).
+        var succeeded = false
+        defer { if !succeeded { try? fileManager.removeItem(at: pkg.url) } }
+        try fileManager.createDirectory(at: pkg.url, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: pkg.configURL, withIntermediateDirectories: true)
+
+        // Copy the whole tree (incl. .git) into Source/. copyItem creates Source/.
+        try fileManager.copyItem(at: sourceDir, to: pkg.sourceURL)
+
+        // Migrate a legacy hidden .anglesite/ dir from Source/ into Config/.
+        let legacy = pkg.sourceURL.appendingPathComponent(".anglesite", isDirectory: true)
+        if fileManager.fileExists(atPath: legacy.path) {
+            let contents = try fileManager.contentsOfDirectory(at: legacy, includingPropertiesForKeys: nil)
+            for item in contents {
+                let dest = pkg.configURL.appendingPathComponent(item.lastPathComponent)
+                if fileManager.fileExists(atPath: dest.path) { try fileManager.removeItem(at: dest) }
+                try fileManager.moveItem(at: item, to: dest)
+            }
+            try fileManager.removeItem(at: legacy)
+        }
+
+        try pkg.writeMarker(.init(displayName: displayName), fileManager: fileManager)
+        succeeded = true
+        return pkg
+    }
+}

--- a/Tests/AnglesiteCoreTests/PackageTransferTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageTransferTests.swift
@@ -50,4 +50,42 @@ struct PackageTransferTests {
             _ = try PackageTransfer.importDirectory(file, toPackageAt: root.appendingPathComponent("X.anglesite"), displayName: "X", fileManager: fm)
         }
     }
+
+    private func makePackageWithSource(in root: URL) throws -> AnglesitePackage {
+        let fm = FileManager.default
+        let (pkg, _) = try AnglesitePackage.createSkeleton(at: root.appendingPathComponent("Acme.anglesite", isDirectory: true), displayName: "Acme")
+        try Data("// astro".utf8).write(to: pkg.sourceURL.appendingPathComponent("astro.config.ts"))
+        try fm.createDirectory(at: pkg.sourceURL.appendingPathComponent("node_modules/foo"), withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: pkg.sourceURL.appendingPathComponent("node_modules/foo/index.js"))
+        try fm.createDirectory(at: pkg.sourceURL.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        try Data("[core]".utf8).write(to: pkg.sourceURL.appendingPathComponent(".git/config"))
+        return pkg
+    }
+
+    @Test("export copies Source/ out, always excluding node_modules; .git excluded by default")
+    func exportExcludesByDefault() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let pkg = try makePackageWithSource(in: root)
+        let dest = root.appendingPathComponent("exported", isDirectory: true)
+
+        try PackageTransfer.exportSource(of: pkg, to: dest, includeGit: false, fileManager: fm)
+
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent("astro.config.ts").path))
+        #expect(!fm.fileExists(atPath: dest.appendingPathComponent("node_modules").path))
+        #expect(!fm.fileExists(atPath: dest.appendingPathComponent(".git").path))
+    }
+
+    @Test("export keeps .git when includeGit is true")
+    func exportKeepsGitWhenRequested() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let pkg = try makePackageWithSource(in: root)
+        let dest = root.appendingPathComponent("exported-git", isDirectory: true)
+
+        try PackageTransfer.exportSource(of: pkg, to: dest, includeGit: true, fileManager: fm)
+
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent(".git/config").path))
+        #expect(!fm.fileExists(atPath: dest.appendingPathComponent("node_modules").path))
+    }
 }

--- a/Tests/AnglesiteCoreTests/PackageTransferTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageTransferTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct PackageTransferTests {
+    private func tempDir() throws -> URL {
+        let d = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("pkg-transfer-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    @Test("import copies the dir tree into Source/, preserves .git, migrates .anglesite/ to Config/, writes a fresh marker, leaves the original untouched")
+    func importCopiesIntoSource() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+
+        // A plain Anglesite site dir with a git repo, sentinels, and a legacy .anglesite/ history.
+        let src = root.appendingPathComponent("legacy-site", isDirectory: true)
+        try fm.createDirectory(at: src.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        try Data("[core]".utf8).write(to: src.appendingPathComponent(".git/config"))
+        for s in ProjectValidator.requiredSentinels {
+            try Data("{}".utf8).write(to: src.appendingPathComponent(s))
+        }
+        try fm.createDirectory(at: src.appendingPathComponent(".anglesite"), withIntermediateDirectories: true)
+        try Data("{}\n".utf8).write(to: src.appendingPathComponent(".anglesite/chat-history.jsonl"))
+
+        let pkgURL = root.appendingPathComponent("Imported.anglesite", isDirectory: true)
+        let pkg = try PackageTransfer.importDirectory(src, toPackageAt: pkgURL, displayName: "Imported", fileManager: fm)
+
+        // Source/ holds the copied tree incl. .git; sentinels present.
+        #expect(fm.fileExists(atPath: pkg.sourceURL.appendingPathComponent(".git/config").path))
+        #expect(pkg.sourceValidation(fileManager: fm).isValid)
+        // Legacy .anglesite/ migrated to Config/, and removed from Source/.
+        #expect(fm.fileExists(atPath: pkg.configURL.appendingPathComponent("chat-history.jsonl").path))
+        #expect(!fm.fileExists(atPath: pkg.sourceURL.appendingPathComponent(".anglesite").path))
+        // Fresh marker.
+        #expect((try? pkg.readMarker().displayName) == "Imported")
+        // Original untouched.
+        #expect(fm.fileExists(atPath: src.appendingPathComponent(".anglesite/chat-history.jsonl").path))
+    }
+
+    @Test("import throws when the source is not a directory")
+    func importRejectsNonDirectory() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let file = root.appendingPathComponent("not-a-dir.txt")
+        try Data("x".utf8).write(to: file)
+        #expect(throws: (any Error).self) {
+            _ = try PackageTransfer.importDirectory(file, toPackageAt: root.appendingPathComponent("X.anglesite"), displayName: "X", fileManager: fm)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/PackageTransferTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageTransferTests.swift
@@ -88,4 +88,31 @@ struct PackageTransferTests {
         #expect(fm.fileExists(atPath: dest.appendingPathComponent(".git/config").path))
         #expect(!fm.fileExists(atPath: dest.appendingPathComponent("node_modules").path))
     }
+
+    @Test("export throws .destinationExists when the destination already exists")
+    func exportRejectsExistingDestination() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let pkg = try makePackageWithSource(in: root)
+        let dest = root.appendingPathComponent("already-there", isDirectory: true)
+        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
+
+        #expect(throws: PackageTransfer.TransferError.destinationExists(dest)) {
+            try PackageTransfer.exportSource(of: pkg, to: dest, includeGit: false, fileManager: fm)
+        }
+    }
+
+    @Test("import throws .destinationExists when the package URL already exists")
+    func importRejectsExistingPackage() throws {
+        let fm = FileManager.default
+        let root = try tempDir(); defer { try? fm.removeItem(at: root) }
+        let src = root.appendingPathComponent("src", isDirectory: true)
+        try fm.createDirectory(at: src, withIntermediateDirectories: true)
+        let pkgURL = root.appendingPathComponent("Exists.anglesite", isDirectory: true)
+        try fm.createDirectory(at: pkgURL, withIntermediateDirectories: true)
+
+        #expect(throws: PackageTransfer.TransferError.destinationExists(pkgURL)) {
+            _ = try PackageTransfer.importDirectory(src, toPackageAt: pkgURL, displayName: "Exists", fileManager: fm)
+        }
+    }
 }


### PR DESCRIPTION
Phase 3 of the `.anglesite` package model epic (#242). Closes #255.

## Summary

Adds the two symmetric migration paths between plain Anglesite directories and `.anglesite` packages — the app never edits a plain directory in place, so **Import** copies into a fresh package and **Export** copies the package's `Source/` working tree back out.

## What's in it

- **`PackageTransfer.importDirectory`** (`AnglesiteCore`) — copy a plain dir's tree into a new package's `Source/`, preserving an existing `.git`, migrating any `<dir>/.anglesite/` → `Config/`, and stamping a fresh marker. Original left untouched; a rollback `defer` removes a half-written package on failure (mirrors `createSkeleton`).
- **`PackageTransfer.exportSource`** — copy `Source/` to a chosen dir; always excludes `node_modules/`; `.git` is opt-in.
- **File ▸ Import Site… / Export Site Source…** glue in `SiteActions` + `AnglesiteApp`. Import mirrors the Open flow's MAS security-scoped-bookmark minting. Export targets the focused window via **`@FocusedValue` + `focusedSceneValue`** (no mutable singleton focus state), and exposes the `.git` opt-in through a save-panel accessory checkbox.

## Design note

The plan flagged the Export focused-site accessor as an open decision (suggesting a mutable `focusedSite` on `WindowRouter`). I used SwiftUI's focused-value system instead — it tracks the active scene automatically and auto-enables/disables the menu item, avoiding the staleness of a global focus flag.

## Testing

- `PackageTransferTests` — 4 tests green (import: `.git` preserve, `.anglesite/`→`Config/` migration, fresh marker, original-untouched, non-dir rejection; export: `node_modules` always excluded, `.git` default-excluded / opt-in).
- Full suite green (535 tests, exit 0); **both** `Anglesite` and `AnglesiteMAS` targets BUILD SUCCEEDED.

## Next

P4 (#256) consumes the migrated `Config/` layout this phase produces on import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)