### PR TITLE
feat(#242): P4 — per-site Config/ store + chat-history relocation

### DIFF
--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -114,13 +114,13 @@ final class ChatModel {
     private var surfacedAnnotationIDs: Set<String> = []
 
     #if !ANGLESITE_MAS
-    init(siteID: String, siteDirectory: URL, annotationFeed: AnnotationFeed? = nil, annotationResolver: AnnotationResolver? = nil, undoCommand: UndoCommand? = nil) {
+    init(siteID: String, siteDirectory: URL, configDirectory: URL, annotationFeed: AnnotationFeed? = nil, annotationResolver: AnnotationResolver? = nil, undoCommand: UndoCommand? = nil) {
         self.siteID = siteID
         self.siteDirectory = siteDirectory
         let assistant = ClaudeAssistant(siteID: siteID, siteDirectory: siteDirectory)
         self.assistant = assistant
         self.transcript = ConversationTranscript(providerName: assistant.capabilities.providerName)
-        self.history = ChatHistoryStore(siteDirectory: siteDirectory)
+        self.history = ChatHistoryStore(configDirectory: configDirectory)
         self.annotationFeed = annotationFeed
         self.annotationResolver = annotationResolver
         self.undoCommand = undoCommand
@@ -129,12 +129,12 @@ final class ChatModel {
 
     /// Test/injecting initializer: supply the assistant (typically a stub or fixture conforming to `ConversationalAssistant`)
     /// and an optional history-store override.
-    init(siteID: String, siteDirectory: URL, assistant: any ConversationalAssistant, history: ChatHistoryStore? = nil, annotationFeed: AnnotationFeed? = nil, annotationResolver: AnnotationResolver? = nil, undoCommand: UndoCommand? = nil) {
+    init(siteID: String, siteDirectory: URL, configDirectory: URL, assistant: any ConversationalAssistant, history: ChatHistoryStore? = nil, annotationFeed: AnnotationFeed? = nil, annotationResolver: AnnotationResolver? = nil, undoCommand: UndoCommand? = nil) {
         self.siteID = siteID
         self.siteDirectory = siteDirectory
         self.assistant = assistant
         self.transcript = ConversationTranscript(providerName: assistant.capabilities.providerName)
-        self.history = history ?? ChatHistoryStore(siteDirectory: siteDirectory)
+        self.history = history ?? ChatHistoryStore(configDirectory: configDirectory)
         self.annotationFeed = annotationFeed
         self.annotationResolver = annotationResolver
         self.undoCommand = undoCommand

--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -10,7 +10,7 @@ import AnglesiteCore
 
 /// SwiftUI-facing wrapper around ``ConversationalAssistant`` for one site. Owns the
 /// assistant, accumulates streamed events into typed `Message` values, persists every
-/// user/assistant/tool entry to `<site>/.anglesite/chat-history.jsonl`, and exposes the
+/// user/assistant/tool entry to the package's `Config/chat-history.jsonl`, and exposes the
 /// streaming + cancel surface that `ChatView` binds to.
 ///
 /// Threading: this model is `@MainActor` so all SwiftUI bindings stay on the main actor.

--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -440,7 +440,7 @@ private struct ToolCallCard: View {
 // compiles on both targets; only this preview needs the Claude-backed convenience init.
 #if !ANGLESITE_MAS
 #Preview {
-    ChatView(model: ChatModel(siteID: "preview", siteDirectory: URL(fileURLWithPath: NSTemporaryDirectory())))
+    ChatView(model: ChatModel(siteID: "preview", siteDirectory: URL(fileURLWithPath: NSTemporaryDirectory()), configDirectory: URL(fileURLWithPath: NSTemporaryDirectory())))
         .frame(width: 420, height: 560)
 }
 #endif

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -462,6 +462,7 @@ struct SiteWindow: View {
         chat = ChatModel(
             siteID: resolved.id,
             siteDirectory: resolved.sourceDirectory,
+            configDirectory: resolved.configDirectory,
             assistant: FoundationModelAssistant(
                 tier: .onDevice,
                 editBridge: makeEditBridge(),
@@ -500,7 +501,7 @@ struct SiteWindow: View {
         case .claude:
             assistant = ClaudeAssistant(siteID: resolved.id, siteDirectory: resolved.sourceDirectory)
         }
-        chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.sourceDirectory, assistant: assistant, annotationFeed: feed, annotationResolver: annotationResolver, undoCommand: undoCommand)
+        chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.sourceDirectory, configDirectory: resolved.configDirectory, assistant: assistant, annotationFeed: feed, annotationResolver: annotationResolver, undoCommand: undoCommand)
         #endif
         // Auto alt-text (C.7 / #157): after a successful image drop, generate alt text on-device and
         // apply it to the `<img>`. Target-agnostic — the on-device vision model runs on both builds.

--- a/Sources/AnglesiteCore/ChatHistoryStore.swift
+++ b/Sources/AnglesiteCore/ChatHistoryStore.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-/// Per-site chat history persisted to `<siteDirectory>/.anglesite/chat-history.jsonl` (per the
+/// Per-site chat history persisted to `<configDirectory>/chat-history.jsonl` (per the
 /// build-plan cross-cutting decision). Append-only JSONL — one record per line — so the file
 /// stays usable from the command line (`tail -f`, `grep`, `jq`) and from other tools that
 /// might want to read the history without going through Anglesite.
 ///
 /// Atomicity: appends use `FileHandle.write(_:)` after seeking to end. We don't rotate or
 /// truncate; the file is expected to grow slowly enough that disk pressure isn't a concern
-/// for v0.5. (Bigger sites can `truncate -s 0 .anglesite/chat-history.jsonl` manually.)
+/// for v0.5. (Bigger sites can `truncate -s 0 Config/chat-history.jsonl` manually.)
 public actor ChatHistoryStore {
     public enum Role: String, Sendable, Codable, Equatable {
         case user
@@ -41,10 +41,10 @@ public actor ChatHistoryStore {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    public init(siteDirectory: URL, fileManager: FileManager = .default) {
-        self.fileURL = siteDirectory
-            .appendingPathComponent(".anglesite", isDirectory: true)
-            .appendingPathComponent("chat-history.jsonl")
+    public init(configDirectory: URL, fileManager: FileManager = .default) {
+        // Config/ is already the app-owned per-site dir (no nested .anglesite/ — that was the
+        // pre-package layout; P3 import migrates old history into Config/).
+        self.fileURL = configDirectory.appendingPathComponent("chat-history.jsonl")
         self.fileManager = fileManager
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -103,7 +103,7 @@ public actor ChatHistoryStore {
         return entries
     }
 
-    /// Append one entry. Creates `<site>/.anglesite/` and the history file if missing.
+    /// Append one entry. Creates the Config/ parent directory and the history file if missing.
     public func append(_ entry: Entry) throws {
         let parent = fileURL.deletingLastPathComponent()
         if !fileManager.fileExists(atPath: parent.path) {

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -3,6 +3,12 @@ import Foundation
 /// App-owned, per-site settings persisted inside the package's `Config/` directory (spec §4).
 /// Deliberately minimal today — it exists so per-site state attaches to the package rather than
 /// app-global `UserDefaults`. Add fields as features need them (YAGNI).
+///
+/// **Forward-compat rule:** every field MUST stay `Optional` (or carry a default-on-decode). The
+/// plist on disk may have been written by an older build that lacked a field; a non-optional field
+/// would make `PropertyListDecoder` throw on those files. Optional fields decode missing keys as
+/// `nil`, so old and new configs both load. `SiteConfigStore.load()` also falls back to defaults
+/// if a decode fails outright, but keeping fields optional is the primary guarantee.
 public struct SiteSettings: Sendable, Codable, Equatable {
     /// Owner-facing display name override. `nil` falls back to the package marker's displayName.
     public var displayName: String?
@@ -13,6 +19,10 @@ public struct SiteSettings: Sendable, Codable, Equatable {
 }
 
 /// Reads/writes `Config/settings.plist` for one package. Per-window; owned by the site window.
+///
+/// Forward infrastructure established by #242 P4 alongside the chat-history relocation into
+/// `Config/`. Its first consumer — applying `SiteSettings.displayName` to the displayed site name —
+/// is tracked in #266; until then `Config/` holds chat history and this settings file.
 public actor SiteConfigStore {
     private let fileURL: URL
     private let fileManager: FileManager
@@ -22,11 +32,16 @@ public actor SiteConfigStore {
         self.fileManager = fileManager
     }
 
-    /// Load settings, or a default (empty) `SiteSettings` when the file doesn't exist yet.
+    /// Load settings, or a default (empty) `SiteSettings` when the file is absent or unreadable.
+    ///
+    /// A decode failure falls back to defaults rather than throwing: settings are non-critical
+    /// (every field is optional with a sensible default), so a config written by a newer build, or
+    /// a corrupt one, must never block opening a site — the next `save` rewrites it cleanly. I/O
+    /// errors reading an existing file still throw.
     public func load() throws -> SiteSettings {
         guard fileManager.fileExists(atPath: fileURL.path) else { return SiteSettings() }
         let data = try Data(contentsOf: fileURL)
-        return try PropertyListDecoder().decode(SiteSettings.self, from: data)
+        return (try? PropertyListDecoder().decode(SiteSettings.self, from: data)) ?? SiteSettings()
     }
 
     /// Persist settings to `settings.plist` (XML plist, atomic), creating `Config/` if needed.

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// App-owned, per-site settings persisted inside the package's `Config/` directory (spec §4).
+/// Deliberately minimal today — it exists so per-site state attaches to the package rather than
+/// app-global `UserDefaults`. Add fields as features need them (YAGNI).
+public struct SiteSettings: Sendable, Codable, Equatable {
+    /// Owner-facing display name override. `nil` falls back to the package marker's displayName.
+    public var displayName: String?
+
+    public init(displayName: String? = nil) {
+        self.displayName = displayName
+    }
+}
+
+/// Reads/writes `Config/settings.plist` for one package. Per-window; owned by the site window.
+public actor SiteConfigStore {
+    private let fileURL: URL
+    private let fileManager: FileManager
+
+    public init(configDirectory: URL, fileManager: FileManager = .default) {
+        self.fileURL = configDirectory.appendingPathComponent("settings.plist")
+        self.fileManager = fileManager
+    }
+
+    /// Load settings, or a default (empty) `SiteSettings` when the file doesn't exist yet.
+    public func load() throws -> SiteSettings {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return SiteSettings() }
+        let data = try Data(contentsOf: fileURL)
+        return try PropertyListDecoder().decode(SiteSettings.self, from: data)
+    }
+
+    /// Persist settings to `settings.plist` (XML plist, atomic), creating `Config/` if needed.
+    public func save(_ settings: SiteSettings) throws {
+        try fileManager.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(settings)
+        try data.write(to: fileURL, options: [.atomic])
+    }
+}

--- a/Tests/AnglesiteCoreTests/ChatHistoryStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/ChatHistoryStoreTests.swift
@@ -15,19 +15,19 @@ final class ChatHistoryStoreTests: XCTestCase {
     }
 
     func testLoadReturnsEmptyWhenFileMissing() async throws {
-        let store = ChatHistoryStore(siteDirectory: tmpDir)
+        let store = ChatHistoryStore(configDirectory: tmpDir)
         let entries = try await store.load()
         XCTAssertEqual(entries, [])
     }
 
     func testAppendCreatesDirectoryAndFile() async throws {
-        let store = ChatHistoryStore(siteDirectory: tmpDir)
+        let store = ChatHistoryStore(configDirectory: tmpDir)
         try await store.append(.init(role: .user, content: "Hello"))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: tmpDir.appendingPathComponent(".anglesite/chat-history.jsonl").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tmpDir.appendingPathComponent("chat-history.jsonl").path))
     }
 
     func testAppendThenLoadRoundTrips() async throws {
-        let store = ChatHistoryStore(siteDirectory: tmpDir)
+        let store = ChatHistoryStore(configDirectory: tmpDir)
         let entries: [ChatHistoryStore.Entry] = [
             .init(role: .user, content: "Hi"),
             .init(role: .assistant, content: "Hello there."),
@@ -42,7 +42,7 @@ final class ChatHistoryStoreTests: XCTestCase {
     }
 
     func testCorruptLineDoesNotDestroyHistory() async throws {
-        let store = ChatHistoryStore(siteDirectory: tmpDir)
+        let store = ChatHistoryStore(configDirectory: tmpDir)
         try await store.append(.init(role: .user, content: "good"))
         // Inject a junk line between two good ones.
         let url = await store.fileURL
@@ -57,7 +57,7 @@ final class ChatHistoryStoreTests: XCTestCase {
     }
 
     func testClearEmptiesTheFile() async throws {
-        let store = ChatHistoryStore(siteDirectory: tmpDir)
+        let store = ChatHistoryStore(configDirectory: tmpDir)
         try await store.append(.init(role: .user, content: "transient"))
         try await store.clear()
         let loaded = try await store.load()
@@ -65,7 +65,7 @@ final class ChatHistoryStoreTests: XCTestCase {
     }
 
     func testClearIsNoOpWhenFileMissing() async throws {
-        let store = ChatHistoryStore(siteDirectory: tmpDir)
+        let store = ChatHistoryStore(configDirectory: tmpDir)
         try await store.clear()  // should not throw
         let loaded = try await store.load()
         XCTAssertEqual(loaded, [])
@@ -74,7 +74,7 @@ final class ChatHistoryStoreTests: XCTestCase {
     // MARK: edit rows + undone records
 
     func testEditEntryRoundTripsWithMetadata() async throws {
-        let store = ChatHistoryStore(siteDirectory: tmpDir)
+        let store = ChatHistoryStore(configDirectory: tmpDir)
         let edit = ChatHistoryStore.Entry(
             role: .edit,
             content: "Edited src/pages/about.astro",
@@ -89,7 +89,7 @@ final class ChatHistoryStoreTests: XCTestCase {
     }
 
     func testUndoneRecordFlipsTheReferencedEditsUndoneFlag() async throws {
-        let store = ChatHistoryStore(siteDirectory: tmpDir)
+        let store = ChatHistoryStore(configDirectory: tmpDir)
         let editID = UUID()
         let edit = ChatHistoryStore.Entry(
             role: .edit,
@@ -106,14 +106,14 @@ final class ChatHistoryStoreTests: XCTestCase {
     }
 
     func testUndoneRecordWithoutMatchingEditIsIgnored() async throws {
-        let store = ChatHistoryStore(siteDirectory: tmpDir)
+        let store = ChatHistoryStore(configDirectory: tmpDir)
         try await store.appendUndone(messageID: UUID(), newCommit: "orphan")
         let loaded = try await store.load()
         XCTAssertEqual(loaded, [])
     }
 
     func testMixedHistoryPreservesOrderAndAppliesUndone() async throws {
-        let store = ChatHistoryStore(siteDirectory: tmpDir)
+        let store = ChatHistoryStore(configDirectory: tmpDir)
         let editID = UUID()
         try await store.append(.init(role: .user, content: "Hi"))
         try await store.append(.init(

--- a/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
@@ -43,6 +43,15 @@ struct SiteConfigStoreTests {
         #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("settings.plist").path))
     }
 
+    @Test("load falls back to defaults when settings.plist is corrupt/incompatible")
+    func loadFallsBackOnUndecodable() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        try Data("not a plist".utf8).write(to: dir.appendingPathComponent("settings.plist"))
+        let store = SiteConfigStore(configDirectory: dir)
+        #expect(try await store.load() == SiteSettings())
+    }
+
     @Test("a second save overwrites the first (atomic replace, not merge)")
     func saveOverwritesPrevious() async throws {
         let dir = try tempConfigDir()

--- a/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
@@ -42,4 +42,17 @@ struct SiteConfigStoreTests {
         try await store.save(SiteSettings(displayName: "X"))
         #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("settings.plist").path))
     }
+
+    @Test("a second save overwrites the first (atomic replace, not merge)")
+    func saveOverwritesPrevious() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+        try await store.save(SiteSettings(displayName: "First"))
+        try await store.save(SiteSettings(displayName: "Second"))
+        #expect(try await store.load() == SiteSettings(displayName: "Second"))
+        // Clearing a field round-trips too (overwrite, not stale-merge).
+        try await store.save(SiteSettings(displayName: nil))
+        #expect(try await store.load() == SiteSettings())
+    }
 }

--- a/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SiteConfigStoreTests {
+    private func tempConfigDir() throws -> URL {
+        let d = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("siteconfig-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    @Test("load returns empty settings when the file is absent")
+    func loadDefaultsWhenMissing() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+        let settings = try await store.load()
+        #expect(settings == SiteSettings())
+    }
+
+    @Test("save then load round-trips settings through settings.plist")
+    func saveLoadRoundTrips() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+        try await store.save(SiteSettings(displayName: "Acme HQ"))
+
+        #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("settings.plist").path))
+        let loaded = try await store.load()
+        #expect(loaded.displayName == "Acme HQ")
+    }
+
+    @Test("save creates the Config directory if it does not exist")
+    func saveCreatesConfigDir() async throws {
+        let parent = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("siteconfig-\(UUID().uuidString)", isDirectory: true)
+        let dir = parent.appendingPathComponent("Config", isDirectory: true)   // not yet created
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let store = SiteConfigStore(configDirectory: dir)
+        try await store.save(SiteSettings(displayName: "X"))
+        #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("settings.plist").path))
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4 of the `.anglesite` package model (#242, closes #256), on merged P1–P3. Moves app-owned per-site state into the package's `Config/` dir (outside the `Source/` git repo).

- **`SiteConfigStore`** — a small actor over `Config/settings.plist` with a minimal `SiteSettings` (Codable, just `displayName?` for now; grows as features need it — YAGNI). Atomic XML-plist writes; `load` returns defaults when absent; creates `Config/` on demand.
- **Chat history relocated** — `ChatHistoryStore` now reads/writes `Config/chat-history.jsonl` (init param `siteDirectory:` → `configDirectory:`), instead of the pre-package `<site>/.anglesite/chat-history.jsonl`. `ChatModel` (both inits), `SiteWindow` (both construction sites), and the `ChatView` preview pass `resolved.configDirectory`.

`siteDirectory`/`sourceDirectory` stays for content, the assistant, dev server, and deploy — **only** chat history moves to `Config/`. `.site-config` stays in `Source/` (template/plugin-owned).

## Migration
Existing histories survive the package conversion: P3's `PackageTransfer.importDirectory` moves a legacy `Source/.anglesite/` (incl. `chat-history.jsonl`) into `Config/` — exactly where the repointed store now reads.

## Test plan
- `SiteConfigStoreTests` 4/4 (default-when-missing, round-trip, dir-creation, overwrite/clear), `ChatHistoryStoreTests` 10/10 (all preserved, paths updated).
- Both app schemes build: `** BUILD SUCCEEDED **` (DevID + MAS).

## Reviewed
Executed task-by-task with per-task + final whole-branch review (all approved). Final-review fixes — stale `ChatModel` doc path + an overwrite test — are in the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)