### PR TITLE
fix(#242): Export Site Source… permanently disabled — @FocusedValue in App struct

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -69,9 +69,6 @@ struct AnglesiteApp: App {
     /// Live mirror of the site registry for the File ▸ Open Recent submenu. Held as `@State`
     /// so SwiftUI re-evaluates `.commands` when its `sites` change. Started in AppDelegate.
     @State private var recent = RecentSitesModel.shared
-    /// Tracks the site id of the currently key site window. SwiftUI's `@FocusedValue` updates
-    /// automatically as windows gain and lose key status — no manual set/clear needed.
-    @FocusedValue(\.siteID) private var focusedSiteID
     #if !ANGLESITE_MAS
     /// Sparkle updater, held for the app's lifetime so its automatic-check timer keeps firing.
     /// MAS builds update through the App Store and have no Sparkle dependency (Phase 10.1).
@@ -185,18 +182,8 @@ struct AnglesiteApp: App {
                     .disabled(!updater.canCheckForUpdates)
             }
             #endif
-            // Export lives after the standard Save items. Enabled only when a site window is focused.
-            CommandGroup(after: .importExport) {
-                Button("Export Site Source…") {
-                    Task { @MainActor in
-                        if let id = focusedSiteID,
-                           let site = await SiteStore.shared.find(id: id) {
-                            SiteActions.exportSource(of: site)
-                        }
-                    }
-                }
-                .disabled(focusedSiteID == nil)
-            }
+            // Export is its own Commands type so @FocusedValue tracks scene focus (see ExportSiteCommands).
+            ExportSiteCommands()
             // Debug pane lives off the View menu — `⌥⌘D` keeps it discoverable without crowding
             // the primary commands. Hidden in Release unless explicitly enabled (see init()).
             CommandGroup(after: .toolbar) {

--- a/Sources/AnglesiteApp/FocusedSite.swift
+++ b/Sources/AnglesiteApp/FocusedSite.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AnglesiteCore
 
 private struct FocusedSiteIDKey: FocusedValueKey { typealias Value = String }
 
@@ -6,5 +7,28 @@ extension FocusedValues {
     var siteID: String? {
         get { self[FocusedSiteIDKey.self] }
         set { self[FocusedSiteIDKey.self] = newValue }
+    }
+}
+
+/// File ▸ Export Site Source… — targets the focused site window. This MUST live in a `Commands`
+/// type, not in the `App` struct: `@FocusedValue` only tracks scene focus inside a `View`/`Commands`
+/// graph node, so a copy declared on `App` (whose body returns a `Scene`) stays permanently `nil`
+/// and leaves the menu item disabled forever. `SiteWindow` publishes the id via `.focusedValue(\.siteID, …)`.
+struct ExportSiteCommands: Commands {
+    @FocusedValue(\.siteID) private var focusedSiteID
+
+    var body: some Commands {
+        // Export lives after the standard Save items. Enabled only when a site window is focused.
+        CommandGroup(after: .importExport) {
+            Button("Export Site Source…") {
+                Task { @MainActor in
+                    if let id = focusedSiteID,
+                       let site = await SiteStore.shared.find(id: id) {
+                        SiteActions.exportSource(of: site)
+                    }
+                }
+            }
+            .disabled(focusedSiteID == nil)
+        }
     }
 }

--- a/Sources/AnglesiteApp/FocusedSite.swift
+++ b/Sources/AnglesiteApp/FocusedSite.swift
@@ -21,9 +21,12 @@ struct ExportSiteCommands: Commands {
         // Export lives after the standard Save items. Enabled only when a site window is focused.
         CommandGroup(after: .importExport) {
             Button("Export Site Source…") {
+                // Capture the focused id at press time — reading it inside the Task would resolve it
+                // at execution time, so a focus shift between click and dispatch could export the
+                // wrong window.
+                guard let id = focusedSiteID else { return }
                 Task { @MainActor in
-                    if let id = focusedSiteID,
-                       let site = await SiteStore.shared.find(id: id) {
+                    if let site = await SiteStore.shared.find(id: id) {
                         SiteActions.exportSource(of: site)
                     }
                 }


### PR DESCRIPTION
## Problem

#261 shipped File ▸ Export Site Source… with its `@FocusedValue(\.siteID)` consumer declared on `struct AnglesiteApp: App`. An `App` body returns a `Scene`, not a `View`, so the wrapper is never installed in a focus-tracking graph node — it stays permanently `nil`. Result: **`.disabled(focusedSiteID == nil)` is always true and Export can never be invoked.**

## Fix

Move the `@FocusedValue` consumer and the Export `CommandGroup` into a dedicated `ExportSiteCommands: Commands` type, where `@FocusedValue` tracks scene focus correctly. `SiteWindow` already publishes the id via `.focusedValue(\.siteID, …)`; no producer change needed. The `App` struct loses its dead `focusedSiteID` property.

## Verification

- Both `Anglesite` and `AnglesiteMAS` targets BUILD SUCCEEDED.
- Behaviour: with a site window focused, Export is now enabled and resolves the focused site via `SiteStore.find(id:)`; with only the launcher focused, it's disabled.

## Context

This carries the one functional improvement from the duplicate PR #262 (which used the `Commands`-struct pattern from the start). #261 already landed the rest (Import/Export, `TransferError: LocalizedError`, 6 tests), so #262 is otherwise redundant and is being closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)