### PR TITLE
chore: untrack accidentally-committed vendored symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,10 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 
 # Embedded runtimes (vendored at build time, not committed)
-Resources/node-runtime/
-Resources/plugin/
+# No trailing slash: also ignores a stray symlink at the bare path, which is
+# how self-referential symlinks were accidentally committed before (see #260).
+Resources/node-runtime
+Resources/plugin
 Resources/npm-cache/
 Resources/edit-overlay/
 node_modules/

--- a/Resources/node-runtime
+++ b/Resources/node-runtime
@@ -1,1 +1,0 @@
-/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/Resources/node-runtime

--- a/Resources/plugin
+++ b/Resources/plugin
@@ -1,1 +1,0 @@
-/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/Resources/plugin


### PR DESCRIPTION
## Problem

`Resources/node-runtime` and `Resources/plugin` were tracked as **self-referential symlinks** — each pointing at its own absolute path. They were committed by accident in #260, even though both paths are vendored at build time (`vendor-node.sh`, `copy-plugin.sh`) and already gitignored.

Symptoms:
- *"Too many levels of symbolic links"* build failures.
- Spurious `deleted: Resources/node-runtime` / `deleted: Resources/plugin` in **every** working tree once the vendor/copy scripts replace the symlinks with the real populated directories.

## Fix

`git rm --cached` both paths to untrack the bogus symlinks (on-disk content untouched). The existing `.gitignore` entries (`Resources/node-runtime/`, `Resources/plugin/`) already ignore the populated directories, so once the symlinks are no longer tracked the working tree stays clean.

## Verification

`git status` is clean after the change — the vendored directories are properly ignored rather than showing as untracked or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)