### PR TITLE
style(#242): condense ExportSiteCommands comments to one line each

### DIFF
--- a/Sources/AnglesiteApp/FocusedSite.swift
+++ b/Sources/AnglesiteApp/FocusedSite.swift
@@ -10,10 +10,7 @@ extension FocusedValues {
     }
 }
 
-/// File ▸ Export Site Source… — targets the focused site window. This MUST live in a `Commands`
-/// type, not in the `App` struct: `@FocusedValue` only tracks scene focus inside a `View`/`Commands`
-/// graph node, so a copy declared on `App` (whose body returns a `Scene`) stays permanently `nil`
-/// and leaves the menu item disabled forever. `SiteWindow` publishes the id via `.focusedValue(\.siteID, …)`.
+/// Must be `Commands` (not `App`) — `@FocusedValue` only tracks scene focus inside a `View`/`Commands` node.
 struct ExportSiteCommands: Commands {
     @FocusedValue(\.siteID) private var focusedSiteID
 
@@ -21,9 +18,7 @@ struct ExportSiteCommands: Commands {
         // Export lives after the standard Save items. Enabled only when a site window is focused.
         CommandGroup(after: .importExport) {
             Button("Export Site Source…") {
-                // Capture the focused id at press time — reading it inside the Task would resolve it
-                // at execution time, so a focus shift between click and dispatch could export the
-                // wrong window.
+                // Capture now — focus may shift between press and Task execution.
                 guard let id = focusedSiteID else { return }
                 Task { @MainActor in
                     if let site = await SiteStore.shared.find(id: id) {


### PR DESCRIPTION
## What

Condenses the two comments in `ExportSiteCommands` (`FocusedSite.swift`) to one line each, per the review note on the original PR and the CLAUDE.md comment guideline:

- Doc comment: 4 lines → 1 line.
- Press-time-capture comment: 3 lines → 1 line.

## Context

The functional fix for File ▸ Export Site Source… (moving `@FocusedValue` out of the `App` struct into an `ExportSiteCommands: Commands` type, plus press-time id capture) already merged via #265. This PR is the leftover style-only follow-up — the duplicate fix commits were dropped during rebase. The full reasoning for the design lives in #265.

Comment-only change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)