### PR TITLE
feat(#266): wire SiteSettings.displayName override into the displayed site name

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -92,7 +92,7 @@ struct SiteWindow: View {
             }
         }
         .task(id: siteID) { await loadAndStart() }
-        .task(id: site?.id) { await observeRemoval() }
+        .task(id: site?.id) { await observeStoreChanges() }
         // Warm path: an already-open window reacts to a new `PreviewSiteIntent` request (the
         // cold path is `applyPendingNavigation` in `loadAndStart`). Mirrors how `SitesLauncherView`
         // pairs `.onChange` with an initial consume for `newSiteRequested`.
@@ -460,19 +460,24 @@ struct SiteWindow: View {
         IntentEditBridge(routerProvider: { id in await EditRouterRegistry.shared.router(for: id) })
     }
 
-    /// Auto-close this window when its site leaves the registry (#188). Subscribes to the store's
-    /// broadcast only after `site` is resolved; on the first snapshot that no longer contains this
+    /// React to registry changes for this window's site (#188, #266). Subscribes to the store's
+    /// broadcast only after `site` is resolved. On the first snapshot that no longer contains this
     /// site's id — an explicit `remove(id:)` from the launcher, or a `refresh()` that prunes a stale
-    /// entry — dismisses the window. `dismissWindow()` triggers `onDisappear`, which stops the
+    /// entry — dismisses the window: `dismissWindow()` triggers `onDisappear`, which stops the
     /// dev-server/MCP subprocess and releases the MAS security-scoped grant, so no teardown is
-    /// duplicated here. The `for await` loop is cancelled when the window tears down or `site`
-    /// changes, which terminates the stream and prunes the store-side continuation.
-    private func observeRemoval() async {
+    /// duplicated here. Otherwise, if the entry's `name` changed (a rename via `setDisplayName`),
+    /// refresh the local `@State site` so `.navigationTitle` and the drawer headings update live.
+    /// The `for await` loop is cancelled when the window tears down or `site` changes, which
+    /// terminates the stream and prunes the store-side continuation.
+    private func observeStoreChanges() async {
         guard let resolvedID = site?.id else { return }
         for await snapshot in SiteStore.shared.changeStream() {
-            if !snapshot.contains(where: { $0.id == resolvedID }) {
+            guard let entry = snapshot.first(where: { $0.id == resolvedID }) else {
                 dismissWindow()
                 return
+            }
+            if entry.name != site?.name {
+                site?.name = entry.name
             }
         }
     }

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -33,6 +33,10 @@ struct SitesLauncherView: View {
     /// stays stable through the dismiss animation — reading `siteToRemove?.name` directly would
     /// collapse to "" the instant the dialog clears the optional.
     @State private var siteToRemoveName = ""
+    /// The site awaiting a rename, or nil when no rename prompt is up. Drives the rename `.alert`.
+    @State private var siteToRename: SiteStore.Site?
+    /// Bound to the rename alert's text field; seeded with the current name when the prompt opens.
+    @State private var renameText = ""
     private struct NewSiteSession: Identifiable {
         let id = UUID()
         let model: NewSiteWizardModel
@@ -147,6 +151,9 @@ struct SitesLauncherView: View {
                   ? "Open \(site.name) in its own window"
                   : "Site is missing required files: \(site.missingSentinels.joined(separator: ", "))")
             .contextMenu {
+                Button("Rename…", systemImage: "pencil") {
+                    promptRename(site)
+                }
                 Button("Remove from Anglesite…", systemImage: "minus.circle", role: .destructive) {
                     promptRemove(site)
                 }
@@ -173,6 +180,19 @@ struct SitesLauncherView: View {
             // Removal only forgets the site here — the package on disk is untouched, matching
             // `SiteStore.remove(id:)`. Owners can still open it in Finder, VS Code, or the CLI.
             Text("This removes it from Anglesite's list only. The files in \(site.packageURL.path) are left on disk.")
+        }
+        .alert(
+            "Rename Site",
+            isPresented: Binding(
+                get: { siteToRename != nil },
+                set: { if !$0 { siteToRename = nil } }
+            )
+        ) {
+            TextField("Site name", text: $renameText)
+            Button("Rename") { if let site = siteToRename { commitRename(site) } }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Sets a display name just for Anglesite. Leave blank to use the site's built-in name.")
         }
     }
 
@@ -232,6 +252,28 @@ struct SitesLauncherView: View {
     private func promptRemove(_ site: SiteStore.Site) {
         siteToRemoveName = site.name
         siteToRemove = site
+    }
+
+    /// Open the rename alert for `site`, seeding the field with its current name.
+    private func promptRename(_ site: SiteStore.Site) {
+        renameText = site.name
+        siteToRename = site
+    }
+
+    /// Persist a display-name override for `site` via `SiteStore.setDisplayName` (blank clears it
+    /// back to the marker name) and refresh the local list. An open `SiteWindow` for this site
+    /// updates its title independently — it observes `SiteStore.changeStream()`.
+    private func commitRename(_ site: SiteStore.Site) {
+        Task {
+            do {
+                guard let updated = try await SiteStore.shared.setDisplayName(renameText, for: site.id) else { return }
+                if let index = sites.firstIndex(where: { $0.id == updated.id }) {
+                    sites[index].name = updated.name
+                }
+            } catch {
+                loadError = "Couldn't rename \(site.name): \(error)"
+            }
+        }
     }
 
     /// Forget `site` from the registry without touching its files. On MAS this also drops the

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -39,6 +39,19 @@ public actor SiteConfigStore {
     /// a corrupt one, must never block opening a site — the next `save` rewrites it cleanly. I/O
     /// errors reading an existing file still throw.
     public func load() throws -> SiteSettings {
+        try Self.read(from: fileURL.deletingLastPathComponent(), fileManager: fileManager)
+    }
+
+    /// Synchronous, actor-independent read of a package's `settings.plist`. Same contract as
+    /// `load()` — absent or undecodable file → default `SiteSettings`; an I/O error reading an
+    /// existing file throws. Exists so synchronous call sites (e.g. `SiteStore.Site.make`, which
+    /// resolves the `displayName` override at construction, #266) can read settings without
+    /// hopping onto the actor.
+    public nonisolated static func read(
+        from configDirectory: URL,
+        fileManager: FileManager = .default
+    ) throws -> SiteSettings {
+        let fileURL = configDirectory.appendingPathComponent("settings.plist")
         guard fileManager.fileExists(atPath: fileURL.path) else { return SiteSettings() }
         let data = try Data(contentsOf: fileURL)
         return (try? PropertyListDecoder().decode(SiteSettings.self, from: data)) ?? SiteSettings()

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -47,6 +47,11 @@ public actor SiteConfigStore {
     /// existing file throws. Exists so synchronous call sites (e.g. `SiteStore.Site.make`, which
     /// resolves the `displayName` override at construction, #266) can read settings without
     /// hopping onto the actor.
+    ///
+    /// - Important: Performs synchronous, blocking file I/O on the calling executor. Today's only
+    ///   callers reach it via `Site.make` from `SiteStore` actor methods (off the main thread).
+    ///   Do not call it — or `Site.make` — from a `@MainActor` context, or it will block the main
+    ///   thread on disk.
     public nonisolated static func read(
         from configDirectory: URL,
         fileManager: FileManager = .default

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -17,8 +17,10 @@ public actor SiteStore {
     public struct Site: Sendable, Codable, Equatable, Identifiable {
         /// The package's stable marker UUID (string). Path-independent — survives moves (#242).
         public let id: String
-        /// Display name (from the package marker).
-        public let name: String
+        /// Resolved display name: the `Config/settings.plist` `displayName` override if set,
+        /// else the package marker's displayName (#266). Mutable — `SiteStore.setDisplayName`
+        /// updates it in place when an owner renames the site.
+        public var name: String
         /// The `.anglesite` package directory.
         public let packageURL: URL
         public var isValid: Bool
@@ -52,8 +54,9 @@ public actor SiteStore {
             self.bookmarkData = bookmarkData
         }
 
-        /// Build a `Site` from a package on disk: id = marker UUID, name = marker displayName,
-        /// validity = whether `Source/` passes the project sentinels.
+        /// Build a `Site` from a package on disk: id = marker UUID, name = resolved display name
+        /// (settings override ?? marker displayName), validity = whether `Source/` passes the
+        /// project sentinels.
         public static func make(package: AnglesitePackage, fileManager: FileManager = .default) throws -> Site {
             let marker = try package.readMarker(fileManager: fileManager)
             // Refuse a package written by a newer build rather than opening it and risking a
@@ -65,11 +68,27 @@ public actor SiteStore {
             let validation = package.sourceValidation(fileManager: fileManager)
             return Site(
                 id: marker.siteID.uuidString,
-                name: marker.displayName,
+                name: resolvedName(marker: marker, configURL: package.configURL, fileManager: fileManager),
                 packageURL: canonicalizePackageURL(package.url),
                 isValid: validation.isValid,
                 missingSentinels: validation.missing
             )
+        }
+
+        /// The owner-facing display name: a non-blank `settings.plist` override wins, otherwise the
+        /// marker's displayName. A settings read error never blocks opening a site — it falls back
+        /// to the marker name (settings are non-critical; #266).
+        static func resolvedName(
+            marker: AnglesitePackage.Marker,
+            configURL: URL,
+            fileManager: FileManager = .default
+        ) -> String {
+            let settings = (try? SiteConfigStore.read(from: configURL, fileManager: fileManager)) ?? SiteSettings()
+            if let override = settings.displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !override.isEmpty {
+                return override
+            }
+            return marker.displayName
         }
     }
 
@@ -181,6 +200,33 @@ public actor SiteStore {
         guard let index = sites.firstIndex(where: { $0.id == id }) else { return }
         sites[index].bookmarkData = data
         try persist()
+    }
+
+    /// Set (or clear, with a nil/blank `name`) the owner-facing display-name override for the site
+    /// with `id`. Writes `Config/settings.plist`, then re-resolves the in-memory + persisted name
+    /// via `Site.make` (so a clear falls back to the marker name) and broadcasts the change so an
+    /// open window's title and the launcher list refresh live (#266). Returns the updated site, or
+    /// `nil` if `id` is unknown.
+    @discardableResult
+    public func setDisplayName(_ name: String?, for id: String) async throws -> Site? {
+        guard let index = sites.firstIndex(where: { $0.id == id }) else { return nil }
+        let existing = sites[index]
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let override = (trimmed?.isEmpty == false) ? trimmed : nil
+
+        let package = AnglesitePackage(url: existing.packageURL)
+        let config = SiteConfigStore(configDirectory: package.configURL, fileManager: fileManager)
+        var settings = try await config.load()
+        settings.displayName = override
+        try await config.save(settings)
+
+        var updated = try Site.make(package: package, fileManager: fileManager)
+        updated.lastSeen = existing.lastSeen
+        updated.bookmarkData = existing.bookmarkData
+        sites[index] = updated
+        try persist()
+        await emitChange()
+        return updated
     }
 
     // MARK: - Change notification

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -217,6 +217,9 @@ public actor SiteStore {
         let package = AnglesitePackage(url: existing.packageURL)
         let config = SiteConfigStore(configDirectory: package.configURL, fileManager: fileManager)
         var settings = try await config.load()
+        // Renaming to the current value (or clearing an already-empty override) changes nothing —
+        // skip the disk write, the re-make, and the change broadcast.
+        guard settings.displayName != override else { return existing }
         settings.displayName = override
         try await config.save(settings)
 

--- a/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
@@ -64,4 +64,31 @@ struct SiteConfigStoreTests {
         try await store.save(SiteSettings(displayName: nil))
         #expect(try await store.load() == SiteSettings())
     }
+
+    // MARK: - Synchronous `read` seam (#266)
+
+    @Test("read returns empty settings when the file is absent")
+    func readDefaultsWhenMissing() throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        #expect(try SiteConfigStore.read(from: dir) == SiteSettings())
+    }
+
+    @Test("read decodes the same settings the actor's load returns")
+    func readMatchesLoad() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+        try await store.save(SiteSettings(displayName: "Acme HQ"))
+        #expect(try SiteConfigStore.read(from: dir) == (try await store.load()))
+        #expect(try SiteConfigStore.read(from: dir).displayName == "Acme HQ")
+    }
+
+    @Test("read falls back to defaults on a corrupt plist rather than throwing")
+    func readDefaultsWhenCorrupt() throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        try Data("not a plist".utf8).write(to: dir.appendingPathComponent("settings.plist"))
+        #expect(try SiteConfigStore.read(from: dir) == SiteSettings())
+    }
 }

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -90,6 +90,81 @@ final class SiteStoreTests {
         #expect(await reloaded.bookmarkData(for: site.id) == nil)
     }
 
+    // MARK: - displayName override (#266)
+
+    /// Write a `settings.plist` override into a package's `Config/`.
+    private func writeOverride(_ name: String?, into pkg: AnglesitePackage) async throws {
+        try await SiteConfigStore(configDirectory: pkg.configURL).save(SiteSettings(displayName: name))
+    }
+
+    @Test("Site.make prefers the settings displayName override over the marker name")
+    func makePrefersOverride() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        try await writeOverride("Alpha Production", into: pkg)
+        let site = try SiteStore.Site.make(package: pkg)
+        #expect(site.name == "Alpha Production")
+    }
+
+    @Test("Site.make falls back to the marker name when the override is nil")
+    func makeFallsBackWhenNoOverride() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        let site = try SiteStore.Site.make(package: pkg)
+        #expect(site.name == "alpha")
+    }
+
+    @Test("Site.make falls back to the marker name when the override is blank")
+    func makeFallsBackWhenOverrideBlank() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        try await writeOverride("   ", into: pkg)
+        let site = try SiteStore.Site.make(package: pkg)
+        #expect(site.name == "alpha")
+    }
+
+    @Test("setDisplayName persists the override and updates the in-memory name")
+    func setDisplayNameUpdatesName() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        let store = SiteStore(persistenceURL: persistenceURL)
+        let site = try await store.record(pkg)
+
+        let updated = try await store.setDisplayName("Alpha Production", for: site.id)
+        #expect(updated?.name == "Alpha Production")
+        #expect(await store.find(id: site.id)?.name == "Alpha Production")
+        // Persisted to settings.plist (a fresh make() re-resolves it).
+        #expect(try SiteConfigStore.read(from: pkg.configURL).displayName == "Alpha Production")
+    }
+
+    @Test("setDisplayName with blank input clears the override back to the marker name")
+    func setDisplayNameClearsOnBlank() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        let store = SiteStore(persistenceURL: persistenceURL)
+        let site = try await store.record(pkg)
+        _ = try await store.setDisplayName("Alpha Production", for: site.id)
+
+        let cleared = try await store.setDisplayName("  ", for: site.id)
+        #expect(cleared?.name == "alpha")
+        #expect(try SiteConfigStore.read(from: pkg.configURL).displayName == nil)
+    }
+
+    @Test("setDisplayName persists the new name across a reload")
+    func setDisplayNamePersistsAcrossReload() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        let writer = SiteStore(persistenceURL: persistenceURL)
+        let site = try await writer.record(pkg)
+        _ = try await writer.setDisplayName("Alpha Production", for: site.id)
+
+        let reader = SiteStore(persistenceURL: persistenceURL)
+        try await reader.load()
+        #expect(await reader.find(id: site.id)?.name == "Alpha Production")
+    }
+
+    @Test("setDisplayName is a no-op for an unknown id")
+    func setDisplayNameUnknownIDNoOp() async throws {
+        let store = SiteStore(persistenceURL: persistenceURL)
+        let result = try await store.setDisplayName("ghost", for: "no-such-id")
+        #expect(result == nil)
+        #expect(await store.sites.isEmpty)
+    }
+
     // MARK: - Change handler
 
     actor ChangeRecorder {

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -165,6 +165,19 @@ final class SiteStoreTests {
         #expect(await reader.find(id: site.id)?.name == "Alpha Production")
     }
 
+    @Test("setDisplayName returns the unchanged site when the name is identical")
+    func setDisplayNameNoOpWhenUnchanged() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        let store = SiteStore(persistenceURL: persistenceURL)
+        let site = try await store.record(pkg)
+        let first = try await store.setDisplayName("Alpha Production", for: site.id)
+
+        // Re-applying the same override short-circuits to the existing entry.
+        let again = try await store.setDisplayName("Alpha Production", for: site.id)
+        #expect(again == first)
+        #expect(await store.find(id: site.id)?.name == "Alpha Production")
+    }
+
     @Test("setDisplayName is a no-op for an unknown id")
     func setDisplayNameUnknownIDNoOp() async throws {
         let store = SiteStore(persistenceURL: persistenceURL)

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -120,6 +120,14 @@ final class SiteStoreTests {
         #expect(site.name == "alpha")
     }
 
+    @Test("Site.make falls back to the marker name when settings.plist is corrupt")
+    func makeFallsBackWhenSettingsCorrupt() throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        try Data("not a plist".utf8).write(to: pkg.configURL.appendingPathComponent("settings.plist"))
+        let site = try SiteStore.Site.make(package: pkg)
+        #expect(site.name == "alpha")
+    }
+
     @Test("setDisplayName persists the override and updates the in-memory name")
     func setDisplayNameUpdatesName() async throws {
         let pkg = try makeValidPackage(named: "alpha")

--- a/docs/superpowers/specs/2026-06-20-displayname-override-design.md
+++ b/docs/superpowers/specs/2026-06-20-displayname-override-design.md
@@ -1,0 +1,133 @@
+# Wire `SiteSettings.displayName` override into the displayed site name (#266)
+
+**Date:** 2026-06-20
+**Issue:** #266 (follow-up from #242 P4 / PR #264)
+**Branch:** `fix/266-displayname-override`
+
+## Problem
+
+#242 P4 established `SiteConfigStore` (`Config/settings.plist`) with a
+`SiteSettings.displayName` field — "owner-facing display name override; nil falls
+back to the package marker's displayName." The store is in place and tested, but
+nothing consumes the override: the app shows the marker's `displayName`
+everywhere (launcher list, window title, drawers, `SiteEntity`/Siri). This makes
+`SiteConfigStore` forward infrastructure with no live consumer.
+
+This change makes the override live **and** adds a rename UI, closing #266.
+
+## Approach: bake the resolved name at `Site.make()`
+
+Every UI consumer reads `SiteStore.Site.name`, and `recents.json` persists it. So
+resolving the override **once**, where `Site` is constructed from disk,
+propagates it everywhere with a single change — consistent with how `isValid`
+and `lastSeen` are already cached at `make()` time.
+
+`Site.make()` will resolve:
+
+```
+name = settings.displayName?.trimmed.nonEmpty ?? marker.displayName
+```
+
+**Alternative considered — live resolution at each display site:** rejected. It
+would force async `SiteConfigStore` loads into every view and contradicts the
+existing "cache resolved fields in recents.json" model. The only staleness is a
+hand-edit of `settings.plist` while the app is closed — the same property the
+marker name already has; the next `record()` re-resolves it.
+
+## Components
+
+### 1. `SiteConfigStore` — sync read seam (Core)
+
+`SiteConfigStore.load()` is async (actor), but `Site.make()` is synchronous.
+Extract the decode logic into a `nonisolated static` helper and have `load()`
+delegate to it:
+
+```swift
+nonisolated static func read(from configDirectory: URL,
+                            fileManager: FileManager = .default) throws -> SiteSettings
+```
+
+Behaviour identical to today's `load()`: absent file → `SiteSettings()`; decode
+failure → `SiteSettings()`; I/O error reading an existing file → throws. The
+actor's `load()` becomes `try Self.read(from:fileManager:)`.
+
+### 2. `SiteStore.Site` — resolve override in `make()` (Core)
+
+- `Site.name` changes `let` → `var` (mutable via rename; `id`/`packageURL` stay `let`).
+- `make()` reads settings via `(try? SiteConfigStore.read(from: package.configURL,
+  fileManager: fileManager)) ?? SiteSettings()` so a settings read never blocks
+  opening a site, then resolves `name` as above.
+
+### 3. `SiteStore.setDisplayName` — rename mutator (Core)
+
+```swift
+@discardableResult
+func setDisplayName(_ name: String?, for id: String) async throws -> Site
+```
+
+1. Locate the entry; trim `name` → nil if empty (empty clears the override).
+2. Load current `SiteSettings`, set `displayName`, `save()` to `settings.plist`.
+3. Re-run `Site.make(package:)` to get the freshly-resolved name (handles both
+   set and clear via the marker fallback), carry forward `lastSeen` +
+   `bookmarkData`, replace in `sites`.
+4. `persist()` + `emitChange()` — broadcasts the new name to all observers.
+
+No-op (returns current) if `id` is unknown.
+
+### 4. Rename UI — launcher context menu + alert (App)
+
+`SitesLauncherView`:
+- Add "Rename…" to the existing row `contextMenu` (beside "Remove from Anglesite…").
+- Present a native `.alert` with a `TextField` prefilled with the current name,
+  mirroring the existing remove-confirmation pattern. "Rename" calls
+  `setDisplayName`; empty input clears the override back to the marker name.
+- Update the launcher's local `sites` from the result so the list refreshes.
+
+### 5. Window live-refresh (App)
+
+`SiteWindow` holds a `@State` snapshot of `site` and already consumes
+`SiteStore.changeStream()` via `observeRemoval()`. Generalize it to
+`observeStoreChanges()`: on each snapshot, if the matching entry is gone →
+dismiss (unchanged); otherwise refresh the `@State site` when the entry differs,
+so `.navigationTitle(site.name)` and the drawer headings update live after a
+rename.
+
+## Data flow
+
+```
+Rename… (launcher) ─▶ SiteStore.setDisplayName(name, for: id)
+                        ├─ SiteConfigStore.save(settings.plist)
+                        ├─ Site.make()  → resolved name
+                        ├─ sites[i] updated, persist(recents.json)
+                        └─ emitChange() ─▶ changeStream broadcast
+                                            ├─▶ launcher list (local sites updated)
+                                            └─▶ open SiteWindow: observeStoreChanges
+                                                 refreshes @State site → title/drawers
+```
+
+## Testing (Core, swift test)
+
+- `Site.make()`: prefers `displayName` override; falls back when nil; falls back
+  when empty/whitespace; falls back when `settings.plist` is unreadable/corrupt.
+- `SiteConfigStore.read` static: parity with instance `load()` across
+  absent/present/corrupt/IO-error cases.
+- `SiteStore.setDisplayName`: writes plist; updates in-memory `name`; persists to
+  `recents.json`; empty input clears override back to the marker name; unknown id
+  is a no-op.
+
+UI wiring (launcher alert, window observe) is exercised through the existing
+app-target patterns; the testable logic lives in Core per the project's
+"push logic into AnglesiteCore" rule (CLAUDE.md).
+
+## Files touched
+
+- `Sources/AnglesiteCore/SiteConfigStore.swift`
+- `Sources/AnglesiteCore/SiteStore.swift`
+- `Sources/AnglesiteApp/SitesLauncherView.swift`
+- `Sources/AnglesiteApp/SiteWindow.swift`
+- `Tests/AnglesiteCoreTests/…` (Site.make / SiteConfigStore.read / setDisplayName)
+
+## Out of scope
+
+- A `Get Info`-style settings pane (rename is the only `SiteSettings` consumer today).
+- Additional `SiteSettings` fields (YAGNI).


### PR DESCRIPTION
Closes #266.

Follow-up from #242 P4 (PR #264): `SiteConfigStore` (`Config/settings.plist`) had a `SiteSettings.displayName` field with no consumer — the app showed the marker's `displayName` everywhere. This makes the override live and adds a rename UI.

## Approach
Resolve the override once, at `Site.make()` — the single point every consumer of `Site.name` flows through (launcher, window title, drawers, `SiteEntity`/Siri). The resolved name is cached in `recents.json` like `isValid`/`lastSeen`, so no async loads leak into views.

```
name = settings.displayName (trimmed, non-empty) ?? marker.displayName
```

## Changes
**Core**
- `SiteConfigStore.read(from:fileManager:)` — `nonisolated static` sync seam so `Site.make` (sync) reads settings without hopping onto the actor; `load()` delegates to it.
- `Site.make` resolves the override; `Site.name` `let` → `var`.
- `SiteStore.setDisplayName(_:for:)` — writes the override, re-resolves via `Site.make` (a blank name clears it back to the marker name), and emits a change so observers refresh. Returns `nil` for an unknown id.

**App**
- `SitesLauncherView` — "Rename…" row context-menu item opens an alert; blank input clears the override. Refreshes the local list.
- `SiteWindow` — `observeRemoval` → `observeStoreChanges`, which also refreshes the `@State site` name on a rename, so an open window's title + drawer headings update live.

## Tests
9 new Core tests (override prefers/falls-back/blank-falls-back, `read` parity with `load`, `setDisplayName` persist/clear/reload/unknown-id). Full suite green (783 tests, e2e included); app target builds.

Design: `docs/superpowers/specs/2026-06-20-displayname-override-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)