### PR TITLE
Retire Claude Code, step 1: FM-default chat + native create_page/create_post

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -81,6 +81,7 @@ struct AnglesiteApp: App {
     private let debugPaneMenuVisible: Bool
 
     init() {
+        AppSettings.shared.migrateAssistantDefaultIfNeeded()
         #if DEBUG
         let isDebugBuild = true
         #else

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -111,12 +111,12 @@ private struct AdvancedSettingsView: View {
 // Developer ID only — the chat backend is a choice here, but the MAS build has no `claude` CLI and
 // always uses on-device Foundation Models. Gated out of MAS at the call site in AdvancedSettingsView.
 #if !ANGLESITE_MAS
-/// Settings → Assistant. Chooses the chat backend: Claude (default) or Apple's on-device Foundation
-/// Models, and — when the latter is on — which tier. The choice is read at `ChatModel` construction
-/// (`SiteWindow.loadAndStart`), so it applies to newly opened site windows rather than live-swapping
-/// an active conversation.
+/// Settings → Assistant. Chooses the chat backend: Apple's on-device Foundation Models (default) or
+/// Claude (legacy), and — when the former is on — which tier. The choice is read at `ChatModel`
+/// construction (`SiteWindow.loadAndStart`), so it applies to newly opened site windows rather than
+/// live-swapping an active conversation.
 private struct AssistantSettingsSection: View {
-    @AppStorage(AppSettings.Key.preferFoundationModels) private var preferFoundationModels: Bool = false
+    @AppStorage(AppSettings.Key.preferFoundationModels) private var preferFoundationModels: Bool = true
     @AppStorage(AppSettings.Key.foundationModelTier) private var tier: FoundationModelTier = .onDevice
 
     var body: some View {
@@ -140,7 +140,7 @@ private struct AssistantSettingsSection: View {
 
     private var caption: String {
         guard preferFoundationModels else {
-            return "Claude (the default) runs the full-power model via the bundled `claude` CLI. Apple's on-device model keeps chat free, private, and offline, but is less capable. Takes effect for newly opened site windows."
+            return "Claude runs the full-power model via the bundled `claude` CLI. This is the legacy backend and will be removed as Anglesite moves off Claude Code; Apple Foundation Models is now the default. Takes effect for newly opened site windows."
         }
         switch tier {
         case .onDevice:

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -625,9 +625,9 @@ struct SiteWindow: View {
             undoCommand: undoCommand
         )
         #else
-        // Developer ID build: Claude is the default backend, but Settings → Assistant lets the user
-        // opt into Apple's on-device Foundation Models (#160). The choice is read here at
-        // construction, so a settings change takes effect for the next-opened site window.
+        // Developer ID build: Apple's on-device Foundation Models is the default backend; Settings →
+        // Assistant lets the user opt back into the legacy Claude path (#160). The choice is read here
+        // at construction, so a settings change takes effect for the next-opened site window.
         //
         // NOTE: `FoundationModelAssistant` is defined inside `#if compiler(>=6.4)` (see
         // FoundationModelAssistant.swift). This call site is unguarded because CI builds on

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -103,11 +103,17 @@ public final class AppSettings: @unchecked Sendable {
     }
 
     /// DevID-only (Settings → Assistant): use Apple's on-device Foundation Models for chat instead
-    /// of Claude. Defaults to `false` so Claude stays the default backend. MAS ignores this — it has
-    /// no Claude CLI and always uses Foundation Models. Read at `ChatModel` construction, so a change
-    /// takes effect for the next-opened site window (#160).
+    /// of Claude. Defaults to `true` — Apple Foundation Models is the default backend; Claude is an
+    /// opt-in legacy path slated for removal as the app moves off Claude Code. Stored
+    /// inverted-from-absent so an untouched install defaults to Foundation Models. MAS ignores this —
+    /// it has no Claude CLI and always uses Foundation Models. Read at `ChatModel` construction, so a
+    /// change takes effect for the next-opened site window (#160).
     public var preferFoundationModels: Bool {
-        get { defaults.bool(forKey: Key.preferFoundationModels) }
+        get {
+            // Absent → Foundation Models by default; an explicit stored value wins.
+            guard defaults.object(forKey: Key.preferFoundationModels) != nil else { return true }
+            return defaults.bool(forKey: Key.preferFoundationModels)
+        }
         set { defaults.set(newValue, forKey: Key.preferFoundationModels) }
     }
 

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -22,6 +22,7 @@ public final class AppSettings: @unchecked Sendable {
         public static let foundationModelTier    = "anglesite.foundationModelTier"
         public static let autoGenerateAltText = "anglesite.autoGenerateAltText"
         public static let announcesLiveUpdates = "anglesite.announcesLiveUpdates"
+        public static let didMigrateAssistantDefault = "anglesite.didMigrateAssistantDefault"
     }
 
     private let defaults: UserDefaults
@@ -115,6 +116,27 @@ public final class AppSettings: @unchecked Sendable {
             return defaults.bool(forKey: Key.preferFoundationModels)
         }
         set { defaults.set(newValue, forKey: Key.preferFoundationModels) }
+    }
+
+    /// One-time upgrade migration (run once at launch). Before this version, Foundation Models was
+    /// opt-in (`preferFoundationModels` defaulted to `false` = Claude). The default is now `true`.
+    /// For an EXISTING install that never chose a backend, silently switching to Foundation Models
+    /// would change a working setup unannounced — so pin those users to the prior default (Claude);
+    /// they can opt into Foundation Models in Settings. New installs (no prior Anglesite state) keep
+    /// the new Foundation Models default.
+    public func migrateAssistantDefaultIfNeeded() {
+        guard defaults.object(forKey: Key.didMigrateAssistantDefault) == nil else { return } // run once
+        defer { defaults.set(true, forKey: Key.didMigrateAssistantDefault) }
+        guard defaults.object(forKey: Key.preferFoundationModels) == nil else { return } // user already chose
+        guard isExistingInstallPriorToAssistantDefaultFlip else { return } // new install → keep FM default
+        defaults.set(false, forKey: Key.preferFoundationModels) // upgrade → preserve Claude
+    }
+
+    /// Heuristic: any previously-persisted Anglesite setting means this is an upgrade, not a fresh install.
+    private var isExistingInstallPriorToAssistantDefaultFlip: Bool {
+        [Key.pluginPathOverride, Key.templatePathOverride, Key.sitesRootOverride, Key.debugPaneEnabled,
+         Key.lastOpenedSiteID, Key.sitesRootBookmark, Key.foundationModelTier, Key.autoGenerateAltText,
+         Key.announcesLiveUpdates].contains { defaults.object(forKey: $0) != nil }
     }
 
     /// DevID-only (Settings → Assistant): which Foundation Models tier to use when

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -5,12 +5,13 @@ import Foundation
 /// sidecar's `create-content.mjs` so switching the create backend produces no git churn.
 public enum ContentScaffold {
 
-    /// lowercase → NFKD → strip combining marks → drop `"` → non-alphanumerics (incl. `'`) to `-` → trim `-`.
+    /// lowercase → NFKD → strip combining marks → drop `'` and `"` → non-alphanumerics to `-` → trim `-`.
     public static func slugify(_ value: String) -> String {
         let lowered = value.lowercased()
         let decomposed = lowered.decomposedStringWithCompatibilityMapping // NFKD
         let stripped = String(decomposed.unicodeScalars.filter { !(0x0300...0x036F ~= $0.value) })
         let noQuotes = stripped
+            .replacingOccurrences(of: "'", with: "")
             .replacingOccurrences(of: "\"", with: "")
         let hyphenated = noQuotes.replacingOccurrences(
             of: "[^a-z0-9]+", with: "-", options: .regularExpression)

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -1,0 +1,94 @@
+// Sources/AnglesiteCore/ContentScaffold.swift
+import Foundation
+
+/// Pure, side-effect-free scaffolding for new pages and posts. Byte-faithful to the Node
+/// sidecar's `create-content.mjs` so switching the create backend produces no git churn.
+public enum ContentScaffold {
+
+    /// lowercase → NFKD → strip combining marks → drop `"` → non-alphanumerics (incl. `'`) to `-` → trim `-`.
+    public static func slugify(_ value: String) -> String {
+        let lowered = value.lowercased()
+        let decomposed = lowered.decomposedStringWithCompatibilityMapping // NFKD
+        let stripped = String(decomposed.unicodeScalars.filter { !(0x0300...0x036F ~= $0.value) })
+        let noQuotes = stripped
+            .replacingOccurrences(of: "\"", with: "")
+        let hyphenated = noQuotes.replacingOccurrences(
+            of: "[^a-z0-9]+", with: "-", options: .regularExpression)
+        return hyphenated.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    /// Slugify each `/`-separated segment, drop empties, rejoin with a leading slash.
+    public static func normalizeRoute(_ route: String) -> String {
+        let segments = route
+            .split(separator: "/", omittingEmptySubsequences: false)
+            .map { slugify(String($0)) }
+            .filter { !$0.isEmpty }
+        return "/" + segments.joined(separator: "/")
+    }
+
+    public static func pageRelativePath(normalizedRoute: String) -> String {
+        "src/pages" + normalizedRoute + ".astro"
+    }
+
+    public static func postRelativePath(collection: String, slug: String) -> String {
+        "src/content/\(collection)/\(slug).md"
+    }
+
+    /// `/about` → `../layouts/BaseLayout.astro`; `/a/b` → `../../layouts/BaseLayout.astro`.
+    public static func layoutImport(normalizedRoute: String) -> String {
+        let trimmed = normalizedRoute.hasPrefix("/") ? String(normalizedRoute.dropFirst()) : normalizedRoute
+        let depth = trimmed.split(separator: "/", omittingEmptySubsequences: false).count
+        return String(repeating: "../", count: depth) + "layouts/BaseLayout.astro"
+    }
+
+    public static func renderPage(title: String, layoutImport: String) -> String {
+        let description = "\(title)."
+        return """
+        ---
+        import BaseLayout from "\(layoutImport)";
+        ---
+
+        <BaseLayout title="\(escapeAttr(title))" description="\(escapeAttr(description))">
+          <main>
+            <h1>\(escapeHTML(title))</h1>
+            <p>Add your content here.</p>
+          </main>
+        </BaseLayout>
+        """ + "\n"
+    }
+
+    public static func renderPost(title: String, now: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let publishDate = formatter.string(from: now)
+        return """
+        ---
+        title: "\(escapeYAML(title))"
+        description: ""
+        publishDate: \(publishDate)
+        draft: true
+        tags: []
+        ---
+
+        Write your post here.
+        """ + "\n"
+    }
+
+    // MARK: - Escaping (order matters: `&` first)
+
+    static func escapeAttr(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+         .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+
+    static func escapeHTML(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+         .replacingOccurrences(of: "<", with: "&lt;")
+         .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    static func escapeYAML(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+         .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -12,15 +12,21 @@ public struct NativeContentOperations: ContentOperationsService {
     private let siteDirectory: @Sendable (_ siteID: String) async -> URL?
     private let gitCommit: GitCommit
     private let now: @Sendable () -> Date
+    // FileManager is a thread-safe singleton but not Sendable; nonisolated(unsafe) preserves the
+    // test-injection seam (the plan's intended seam for write-failure paths) without breaking the
+    // struct's Sendable conformance.
+    private nonisolated(unsafe) let fileManager: FileManager
 
     public init(
         siteDirectory: @escaping @Sendable (_ siteID: String) async -> URL?,
-        gitCommit: @escaping GitCommit = { proj, rel, msg in await NativeContentOperations.processGitCommit(proj, rel, msg) },
-        now: @escaping @Sendable () -> Date = { Date() }
+        gitCommit: @escaping GitCommit = NativeContentOperations.processGitCommit,
+        now: @escaping @Sendable () -> Date = { Date() },
+        fileManager: FileManager = .default
     ) {
         self.siteDirectory = siteDirectory
         self.gitCommit = gitCommit
         self.now = now
+        self.fileManager = fileManager
     }
 
     public func createPage(siteID: String, name: String, route: String?, onProgress: ProgressHandler? = nil) async -> ContentCreateResult {
@@ -30,7 +36,7 @@ public struct NativeContentOperations: ContentOperationsService {
         let title = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !title.isEmpty else { return .failed(reason: "create_page requires a non-empty name") }
 
-        let base = (route?.isEmpty == false) ? route! : ContentScaffold.slugify(title)
+        let base = route.flatMap { $0.isEmpty ? nil : $0 } ?? ContentScaffold.slugify(title)
         let normalized = ContentScaffold.normalizeRoute(base)
         guard normalized != "/" else {
             return .failed(reason: "create_page can't scaffold the site root; give the page a name or route")
@@ -38,7 +44,7 @@ public struct NativeContentOperations: ContentOperationsService {
 
         let relPath = ContentScaffold.pageRelativePath(normalizedRoute: normalized)
         let abs = root.appendingPathComponent(relPath)
-        if FileManager.default.fileExists(atPath: abs.path) {
+        if fileManager.fileExists(atPath: abs.path) {
             return .failed(reason: "A page already exists at \(relPath)")
         }
 
@@ -67,13 +73,13 @@ public struct NativeContentOperations: ContentOperationsService {
             return .failed(reason: "Invalid collection name: \(coll)")
         }
 
-        let slugSource = (slug?.isEmpty == false) ? slug! : cleanTitle
+        let slugSource = slug.flatMap { $0.isEmpty ? nil : $0 } ?? cleanTitle
         let finalSlug = ContentScaffold.slugify(slugSource)
         guard !finalSlug.isEmpty else { return .failed(reason: "create_post could not derive a slug from the title") }
 
         let relPath = ContentScaffold.postRelativePath(collection: coll, slug: finalSlug)
         let abs = root.appendingPathComponent(relPath)
-        if FileManager.default.fileExists(atPath: abs.path) {
+        if fileManager.fileExists(atPath: abs.path) {
             return .failed(reason: "A \(coll) entry already exists at \(relPath)")
         }
 
@@ -88,14 +94,14 @@ public struct NativeContentOperations: ContentOperationsService {
     }
 
     private func write(_ contents: String, to abs: URL) throws {
-        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
         try contents.write(to: abs, atomically: true, encoding: .utf8)
     }
 
     /// Stage and commit exactly `relPath` on the current branch. Returns the new HEAD SHA,
     /// or nil on any failure (not a repo, rejecting hook, git missing) — best-effort, mirroring
     /// the Node sidecar's `commitFile`.
-    public static func processGitCommit(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
+    @Sendable public static func processGitCommit(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
         let git = URL(fileURLWithPath: "/usr/bin/git")
         func run(_ args: [String]) async -> ProcessSupervisor.RunResult? {
             let result = try? await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: projectRoot)

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -12,18 +12,15 @@ public struct NativeContentOperations: ContentOperationsService {
     private let siteDirectory: @Sendable (_ siteID: String) async -> URL?
     private let gitCommit: GitCommit
     private let now: @Sendable () -> Date
-    private let fileManager: FileManager
 
     public init(
         siteDirectory: @escaping @Sendable (_ siteID: String) async -> URL?,
-        gitCommit: @escaping GitCommit = NativeContentOperations.processGitCommit,
-        now: @escaping @Sendable () -> Date = { Date() },
-        fileManager: FileManager = .default
+        gitCommit: @escaping GitCommit = { proj, rel, msg in await NativeContentOperations.processGitCommit(proj, rel, msg) },
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.siteDirectory = siteDirectory
         self.gitCommit = gitCommit
         self.now = now
-        self.fileManager = fileManager
     }
 
     public func createPage(siteID: String, name: String, route: String?, onProgress: ProgressHandler? = nil) async -> ContentCreateResult {
@@ -41,7 +38,7 @@ public struct NativeContentOperations: ContentOperationsService {
 
         let relPath = ContentScaffold.pageRelativePath(normalizedRoute: normalized)
         let abs = root.appendingPathComponent(relPath)
-        if fileManager.fileExists(atPath: abs.path) {
+        if FileManager.default.fileExists(atPath: abs.path) {
             return .failed(reason: "A page already exists at \(relPath)")
         }
 
@@ -76,7 +73,7 @@ public struct NativeContentOperations: ContentOperationsService {
 
         let relPath = ContentScaffold.postRelativePath(collection: coll, slug: finalSlug)
         let abs = root.appendingPathComponent(relPath)
-        if fileManager.fileExists(atPath: abs.path) {
+        if FileManager.default.fileExists(atPath: abs.path) {
             return .failed(reason: "A \(coll) entry already exists at \(relPath)")
         }
 
@@ -91,7 +88,7 @@ public struct NativeContentOperations: ContentOperationsService {
     }
 
     private func write(_ contents: String, to abs: URL) throws {
-        try fileManager.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
         try contents.write(to: abs, atomically: true, encoding: .utf8)
     }
 

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -1,0 +1,114 @@
+// Sources/AnglesiteCore/NativeContentOperations.swift
+import Foundation
+
+/// Native, in-process `create_page` / `create_post`. Byte-faithful to the Node sidecar's
+/// `create-content.mjs` (see `ContentScaffold`), but writes the file with `FileManager` and
+/// commits best-effort via an injected git closure — no MCP round-trip. Replaces the
+/// MCP-routed `ContentOperations` at the App Intents dependency registration.
+public struct NativeContentOperations: ContentOperationsService {
+
+    public typealias GitCommit = @Sendable (_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?
+
+    private let siteDirectory: @Sendable (_ siteID: String) async -> URL?
+    private let gitCommit: GitCommit
+    private let now: @Sendable () -> Date
+    private let fileManager: FileManager
+
+    public init(
+        siteDirectory: @escaping @Sendable (_ siteID: String) async -> URL?,
+        gitCommit: @escaping GitCommit = NativeContentOperations.processGitCommit,
+        now: @escaping @Sendable () -> Date = { Date() },
+        fileManager: FileManager = .default
+    ) {
+        self.siteDirectory = siteDirectory
+        self.gitCommit = gitCommit
+        self.now = now
+        self.fileManager = fileManager
+    }
+
+    public func createPage(siteID: String, name: String, route: String?, onProgress: ProgressHandler? = nil) async -> ContentCreateResult {
+        onProgress?(.createResolvingRuntime)
+        guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+
+        let title = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return .failed(reason: "create_page requires a non-empty name") }
+
+        let base = (route?.isEmpty == false) ? route! : ContentScaffold.slugify(title)
+        let normalized = ContentScaffold.normalizeRoute(base)
+        guard normalized != "/" else {
+            return .failed(reason: "create_page can't scaffold the site root; give the page a name or route")
+        }
+
+        let relPath = ContentScaffold.pageRelativePath(normalizedRoute: normalized)
+        let abs = root.appendingPathComponent(relPath)
+        if fileManager.fileExists(atPath: abs.path) {
+            return .failed(reason: "A page already exists at \(relPath)")
+        }
+
+        onProgress?(.createCallingPlugin)
+        let contents = ContentScaffold.renderPage(
+            title: title,
+            layoutImport: ContentScaffold.layoutImport(normalizedRoute: normalized))
+        do { try write(contents, to: abs) }
+        catch { return .failed(reason: "\(error)") }
+
+        onProgress?(.createFinalizing)
+        _ = await gitCommit(root, relPath, "anglesite: add page \(normalized)")
+        return .created(filePath: relPath, identifier: normalized)
+    }
+
+    public func createPost(siteID: String, title: String, collection: String?, slug: String?, onProgress: ProgressHandler? = nil) async -> ContentCreateResult {
+        onProgress?(.createResolvingRuntime)
+        guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+
+        let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanTitle.isEmpty else { return .failed(reason: "create_post requires a non-empty title") }
+
+        let trimmedColl = (collection ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let coll = trimmedColl.isEmpty ? "posts" : trimmedColl
+        guard coll.range(of: "^[A-Za-z0-9_-]+$", options: .regularExpression) != nil else {
+            return .failed(reason: "Invalid collection name: \(coll)")
+        }
+
+        let slugSource = (slug?.isEmpty == false) ? slug! : cleanTitle
+        let finalSlug = ContentScaffold.slugify(slugSource)
+        guard !finalSlug.isEmpty else { return .failed(reason: "create_post could not derive a slug from the title") }
+
+        let relPath = ContentScaffold.postRelativePath(collection: coll, slug: finalSlug)
+        let abs = root.appendingPathComponent(relPath)
+        if fileManager.fileExists(atPath: abs.path) {
+            return .failed(reason: "A \(coll) entry already exists at \(relPath)")
+        }
+
+        onProgress?(.createCallingPlugin)
+        let contents = ContentScaffold.renderPost(title: cleanTitle, now: now())
+        do { try write(contents, to: abs) }
+        catch { return .failed(reason: "\(error)") }
+
+        onProgress?(.createFinalizing)
+        _ = await gitCommit(root, relPath, "anglesite: add \(coll) \(finalSlug)")
+        return .created(filePath: relPath, identifier: finalSlug)
+    }
+
+    private func write(_ contents: String, to abs: URL) throws {
+        try fileManager.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: abs, atomically: true, encoding: .utf8)
+    }
+
+    /// Stage and commit exactly `relPath` on the current branch. Returns the new HEAD SHA,
+    /// or nil on any failure (not a repo, rejecting hook, git missing) — best-effort, mirroring
+    /// the Node sidecar's `commitFile`.
+    public static func processGitCommit(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        func run(_ args: [String]) async -> ProcessSupervisor.RunResult? {
+            let result = try? await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: projectRoot)
+            guard let result, result.exitCode == 0 else { return nil }
+            return result
+        }
+        guard await run(["rev-parse", "--git-dir"]) != nil,
+              await run(["add", "--", relPath]) != nil,
+              await run(["commit", "-m", message, "--", relPath]) != nil,
+              let head = await run(["rev-parse", "HEAD"]) else { return nil }
+        return head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -44,11 +44,11 @@ public enum AnglesiteIntents {
         AppDependencyManager.shared.add { () -> any SiteOperationsService in
             SiteOperations(factory: LiveCommandFactory())
         }
-        // Content create intents (A.5 #139) run the plugin's create_page/create_post headlessly
-        // via a shared pool; pooled Node processes are drained on quit by ProcessSupervisor.
-        let headlessPool = HeadlessRuntimePool()
+        // Content create intents (A.5 #139) now use native in-process scaffolding (Bucket 1,
+        // Slice 2). Replaces the MCP-routed ContentOperations; the Node create_page/create_post
+        // tools are retired in the roadmap's cleanup slice.
         AppDependencyManager.shared.add { () -> any ContentOperationsService in
-            ContentOperations(pool: headlessPool, siteDirectory: { id in await SiteStore.shared.find(id: id)?.sourceDirectory })
+            NativeContentOperations(siteDirectory: { id in await SiteStore.shared.find(id: id)?.sourceDirectory })
         }
         // `EditContentIntent` (B.5 / #149) routes natural-language edits through
         // `IntentEditBridge`, which asks `EditRouterRegistry.shared` for the live edit router of

--- a/Tests/AnglesiteCoreTests/AppSettingsTests.swift
+++ b/Tests/AnglesiteCoreTests/AppSettingsTests.swift
@@ -128,6 +128,43 @@ final class AppSettingsTests {
         #expect(settings.announcesLiveUpdates)
     }
 
+    // MARK: Assistant-default migration
+
+    @Test("assistant-default migration: fresh install keeps the Foundation Models default")
+    func migrationFreshInstall() {
+        let settings = AppSettings(defaults: defaults)
+        settings.migrateAssistantDefaultIfNeeded()
+        #expect(settings.preferFoundationModels) // absent → FM default
+        #expect(defaults.object(forKey: AppSettings.Key.preferFoundationModels) == nil) // not pinned
+    }
+
+    @Test("assistant-default migration: existing install is pinned to Claude")
+    func migrationExistingInstall() {
+        defaults.set("site-1", forKey: AppSettings.Key.lastOpenedSiteID)
+        let settings = AppSettings(defaults: defaults)
+        settings.migrateAssistantDefaultIfNeeded()
+        #expect(!settings.preferFoundationModels) // upgrade → Claude preserved
+    }
+
+    @Test("assistant-default migration: respects an explicit prior choice")
+    func migrationRespectsExplicitChoice() {
+        defaults.set("site-1", forKey: AppSettings.Key.lastOpenedSiteID)
+        defaults.set(true, forKey: AppSettings.Key.preferFoundationModels)
+        let settings = AppSettings(defaults: defaults)
+        settings.migrateAssistantDefaultIfNeeded()
+        #expect(settings.preferFoundationModels) // untouched
+    }
+
+    @Test("assistant-default migration: runs only once")
+    func migrationRunsOnce() {
+        defaults.set("site-1", forKey: AppSettings.Key.lastOpenedSiteID)
+        let settings = AppSettings(defaults: defaults)
+        settings.migrateAssistantDefaultIfNeeded() // pins to Claude
+        settings.preferFoundationModels = true     // user later opts into FM
+        settings.migrateAssistantDefaultIfNeeded() // must NOT re-pin
+        #expect(settings.preferFoundationModels)
+    }
+
     // MARK: DebugPaneVisibility
 
     @Test("Debug menu always visible in debug builds") func debugMenuAlwaysVisibleInDebugBuilds() {

--- a/Tests/AnglesiteCoreTests/AppSettingsTests.swift
+++ b/Tests/AnglesiteCoreTests/AppSettingsTests.swift
@@ -66,10 +66,10 @@ final class AppSettingsTests {
 
     // MARK: Assistant model (C.10 — DevID model tier picker)
 
-    @Test("preferFoundationModels defaults to false (Claude is the default backend)")
-    func preferFoundationModelsDefaultsToFalse() {
+    @Test("preferFoundationModels defaults to true (Foundation Models is the default backend)")
+    func preferFoundationModelsDefaultsToTrue() {
         let settings = AppSettings(defaults: defaults)
-        #expect(!settings.preferFoundationModels)
+        #expect(settings.preferFoundationModels)
     }
 
     @Test("preferFoundationModels round trip") func preferFoundationModelsRoundTrip() {

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -9,7 +9,7 @@ struct ContentScaffoldTests {
     func slugifyBasics() {
         #expect(ContentScaffold.slugify("About Us") == "about-us")
         #expect(ContentScaffold.slugify("Héllo Wörld") == "hello-world")
-        #expect(ContentScaffold.slugify("  --Tom's Page--  ") == "tom-s-page")
+        #expect(ContentScaffold.slugify("  --Tom's Page--  ") == "toms-page")
         #expect(ContentScaffold.slugify("A/B") == "a-b")
         #expect(ContentScaffold.slugify("\"Quoted\"") == "quoted")
     }

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -1,0 +1,55 @@
+// Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContentScaffold")
+struct ContentScaffoldTests {
+    @Test("slugify lowercases, strips diacritics, collapses to hyphens, trims")
+    func slugifyBasics() {
+        #expect(ContentScaffold.slugify("About Us") == "about-us")
+        #expect(ContentScaffold.slugify("Héllo Wörld") == "hello-world")
+        #expect(ContentScaffold.slugify("  --Tom's Page--  ") == "tom-s-page")
+        #expect(ContentScaffold.slugify("A/B") == "a-b")
+        #expect(ContentScaffold.slugify("\"Quoted\"") == "quoted")
+    }
+
+    @Test("normalizeRoute slugifies each segment and joins with slash")
+    func normalizeRouteSegments() {
+        #expect(ContentScaffold.normalizeRoute("/About//Us/") == "/about/us")
+        #expect(ContentScaffold.normalizeRoute("About") == "/about")
+        #expect(ContentScaffold.normalizeRoute("/") == "/")
+    }
+
+    @Test("layoutImport depth tracks route segment count")
+    func layoutImportDepth() {
+        #expect(ContentScaffold.layoutImport(normalizedRoute: "/about") == "../layouts/BaseLayout.astro")
+        #expect(ContentScaffold.layoutImport(normalizedRoute: "/a/b") == "../../layouts/BaseLayout.astro")
+    }
+
+    @Test("path builders match the sidecar layout")
+    func paths() {
+        #expect(ContentScaffold.pageRelativePath(normalizedRoute: "/about") == "src/pages/about.astro")
+        #expect(ContentScaffold.pageRelativePath(normalizedRoute: "/a/b") == "src/pages/a/b.astro")
+        #expect(ContentScaffold.postRelativePath(collection: "posts", slug: "hello") == "src/content/posts/hello.md")
+    }
+
+    @Test("renderPage escapes attrs and html and ends with one newline")
+    func renderPage() {
+        let out = ContentScaffold.renderPage(title: "A & \"B\"", layoutImport: "../layouts/BaseLayout.astro")
+        #expect(out.contains("import BaseLayout from \"../layouts/BaseLayout.astro\";"))
+        #expect(out.contains("<BaseLayout title=\"A &amp; &quot;B&quot;\" description=\"A &amp; &quot;B&quot;.\">"))
+        #expect(out.contains("<h1>A &amp; \"B\"</h1>"))
+        #expect(out.hasSuffix("</BaseLayout>\n"))
+    }
+
+    @Test("renderPost emits a draft with ISO8601 publishDate and YAML-escaped title")
+    func renderPost() {
+        let date = Date(timeIntervalSince1970: 1_750_000_000) // fixed, deterministic
+        let out = ContentScaffold.renderPost(title: "Back\\slash \"quote\"", now: date)
+        #expect(out.contains("title: \"Back\\\\slash \\\"quote\\\"\""))
+        #expect(out.contains("draft: true"))
+        #expect(out.contains("publishDate: 2025-06-15T15:06:40.000Z"))
+        #expect(out.hasSuffix("Write your post here.\n"))
+    }
+}

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -1,0 +1,122 @@
+// Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("NativeContentOperations")
+struct NativeContentOperationsTests {
+
+    /// A temp site dir + a spy git closure that records calls and returns a fake SHA.
+    private func makeOps() -> (ops: NativeContentOperations, root: URL, calls: Spy) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("native-content-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let spy = Spy()
+        let ops = NativeContentOperations(
+            siteDirectory: { _ in root },
+            gitCommit: { proj, rel, msg in await spy.record(proj, rel, msg); return "deadbeef" },
+            now: { Date(timeIntervalSince1970: 1_750_000_000) }
+        )
+        return (ops, root, spy)
+    }
+
+    actor Spy {
+        private(set) var calls: [(URL, String, String)] = []
+        func record(_ a: URL, _ b: String, _ c: String) { calls.append((a, b, c)) }
+    }
+
+    @Test("createPage writes the file and returns the normalized route")
+    func createPage() async throws {
+        let (ops, root, spy) = makeOps()
+        let result = await ops.createPage(siteID: "s1", name: "About Us", route: nil)
+        #expect(result == .created(filePath: "src/pages/about-us.astro", identifier: "/about-us"))
+        let written = try String(contentsOf: root.appendingPathComponent("src/pages/about-us.astro"), encoding: .utf8)
+        #expect(written == ContentScaffold.renderPage(title: "About Us", layoutImport: "../layouts/BaseLayout.astro"))
+        let calls = await spy.calls
+        #expect(calls.count == 1)
+        #expect(calls.first?.1 == "src/pages/about-us.astro")
+        #expect(calls.first?.2 == "anglesite: add page /about-us")
+    }
+
+    @Test("nested route writes under nested dirs with deeper layout import")
+    func createNestedPage() async throws {
+        let (ops, root, _) = makeOps()
+        let result = await ops.createPage(siteID: "s1", name: "ignored", route: "/services/web")
+        #expect(result == .created(filePath: "src/pages/services/web.astro", identifier: "/services/web"))
+        let written = try String(contentsOf: root.appendingPathComponent("src/pages/services/web.astro"), encoding: .utf8)
+        #expect(written.contains("import BaseLayout from \"../../layouts/BaseLayout.astro\";"))
+    }
+
+    @Test("createPage refuses the site root")
+    func createPageRoot() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createPage(siteID: "s1", name: "/", route: "/")
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("site root"))
+    }
+
+    @Test("createPage won't overwrite an existing page")
+    func createPageExisting() async {
+        let (ops, root, _) = makeOps()
+        let dir = root.appendingPathComponent("src/pages", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? "x".write(to: dir.appendingPathComponent("about.astro"), atomically: true, encoding: .utf8)
+        let result = await ops.createPage(siteID: "s1", name: "About", route: nil)
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("already exists"))
+    }
+
+    @Test("unknown site returns .siteNotFound")
+    func siteNotFound() async {
+        let ops = NativeContentOperations(siteDirectory: { _ in nil }, gitCommit: { _, _, _ in nil })
+        let result = await ops.createPage(siteID: "missing", name: "About", route: nil)
+        #expect(result == .siteNotFound)
+    }
+
+    @Test("createPost writes a draft in the default posts collection")
+    func createPost() async throws {
+        let (ops, root, spy) = makeOps()
+        let result = await ops.createPost(siteID: "s1", title: "Hello World", collection: nil, slug: nil)
+        #expect(result == .created(filePath: "src/content/posts/hello-world.md", identifier: "hello-world"))
+        let written = try String(contentsOf: root.appendingPathComponent("src/content/posts/hello-world.md"), encoding: .utf8)
+        #expect(written.contains("draft: true"))
+        let calls = await spy.calls
+        #expect(calls.first?.2 == "anglesite: add posts hello-world")
+    }
+
+    @Test("createPost honors a custom collection")
+    func createPostCollection() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createPost(siteID: "s1", title: "Note one", collection: "notes", slug: nil)
+        #expect(result == .created(filePath: "src/content/notes/note-one.md", identifier: "note-one"))
+    }
+
+    @Test("createPost rejects an unsafe collection name")
+    func createPostBadCollection() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createPost(siteID: "s1", title: "X", collection: "../escape", slug: nil)
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("Invalid collection name"))
+    }
+
+    @Test("processGitCommit returns a SHA in a real repo, nil outside one")
+    func realGit() async throws {
+        // Outside a repo → nil (best-effort).
+        let bare = FileManager.default.temporaryDirectory.appendingPathComponent("nogit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: bare, withIntermediateDirectories: true)
+        try "hi".write(to: bare.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+        let none = await NativeContentOperations.processGitCommit(bare, "f.txt", "msg")
+        #expect(none == nil)
+
+        // Inside a repo with an initial commit → a 40-char SHA.
+        let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        for args in [["init"], ["config", "user.email", "t@t.io"], ["config", "user.name", "t"]] {
+            _ = try await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: repo)
+        }
+        try "page".write(to: repo.appendingPathComponent("p.astro"), atomically: true, encoding: .utf8)
+        let sha = await NativeContentOperations.processGitCommit(repo, "p.astro", "anglesite: add page /p")
+        #expect(sha?.count == 40)
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,101 @@
+# Anglesite — Desired Application Architecture
+
+The end-state after the [Claude Code removal roadmap](superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md):
+no `claude` binary, deterministic Swift + Apple Intelligence only, and all JavaScript
+running **inside the per-site container** rather than as a host-spawned process.
+
+This diagram shows the trust / execution boundaries — what runs on the Apple device, what
+runs in Apple's Private Cloud Compute, what runs inside the site container, and where the
+filesystem source of truth and the deploy target sit.
+
+```mermaid
+flowchart TB
+    user(["Site owner (non-technical)"])
+
+    subgraph device["Apple device — Anglesite.app (Swift host, sandboxed)"]
+        direction TB
+        subgraph frontdoors["Front-doors — one capability, many entry points"]
+            gui["GUI controls / wizards<br/>(non-technical default)"]
+            siri["Siri / Spotlight<br/>(App Intents)"]
+            chat["Chat panel (optional)"]
+        end
+        fmbrain["FoundationModelAssistant<br/>FM brain · tool-calling orchestrator"]
+        subgraph swift["Deterministic Swift"]
+            b1["Bucket 1 hot-paths<br/>create_page/post · list_content · annotations"]
+            b3["Bucket 3 wizards<br/>deploy · check · backup · integrations · themes"]
+            gate["pre-deploy-check<br/>native security gate"]
+        end
+        mcpclient["MCPClient<br/>HTTP/WS transport"]
+        webview["WKWebView<br/>live preview"]
+    end
+
+    subgraph ai["Apple Intelligence — on device"]
+        ondevice["On-device Foundation Models<br/>~3B + vision<br/>ApplyEditTool · SearchContentTool · Spotlight"]
+    end
+
+    subgraph pcc["Private Cloud Compute — Apple cloud, no external APIs"]
+        pccgen["Bucket 5 heavy generation<br/>copy-edit · design-interview · social · syndicate"]
+    end
+
+    subgraph container["Site container — per-site runtime<br/>(Apple Containerization local · Cloudflare Sandbox fallback)"]
+        direction TB
+        mcpserver["Node MCP server"]
+        subgraph js["All JS runs in-guest"]
+            applyedit["apply_edit / undo_edit<br/>HTML/Astro patcher"]
+            astro["Astro dev + build"]
+            media["Sharp · Satori · Pagefind · Keystatic"]
+        end
+    end
+
+    repo[("Site Source/<br/>git repo — source of truth")]
+    cf["Cloudflare Workers<br/>deploy target"]
+
+    user --> gui & siri & chat
+    gui --> swift
+    siri --> swift
+    siri --> fmbrain
+    chat --> fmbrain
+    fmbrain -->|on-device tier| ondevice
+    fmbrain -->|escalate: PCC tier| pccgen
+    fmbrain -->|tool calls| swift
+    fmbrain -->|tool calls| mcpclient
+    b1 --> repo
+    b3 --> gate
+    mcpclient -->|"MCP HTTP/WS (#64)"| mcpserver
+    mcpserver --> js
+    applyedit --> repo
+    astro --> repo
+    repo -. mounted .-> container
+    astro -->|dev server URL| webview
+    gate -->|deploy| cf
+
+    classDef appleTrust fill:#e3f2fd,stroke:#1565c0,color:#0d47a1;
+    classDef containerBound fill:#fff3e0,stroke:#e65100,color:#e65100;
+    classDef external fill:#fce4ec,stroke:#ad1457,color:#880e4f;
+    classDef store fill:#f1f8e9,stroke:#558b2f,color:#33691e;
+    class device,ai,pcc appleTrust;
+    class container,js containerBound;
+    class cf external;
+    class repo store;
+```
+
+## Boundaries
+
+| Boundary | What's inside | How it's crossed |
+|---|---|---|
+| **Apple device (host)** | The Swift app: front-doors (GUI / Siri / chat), the `FoundationModelAssistant` orchestrator, deterministic Swift (Bucket 1 hot-paths + Bucket 3 wizards), the native `pre-deploy-check` gate, `MCPClient`, and the `WKWebView` preview. | User input; in-process Apple Intelligence API; `MCPClient` to the container. |
+| **Apple Intelligence (on-device)** | The ~3B on-device Foundation Models + vision, with the registered FM `Tool`s (`ApplyEditTool`, `SearchContentTool`, Spotlight). | Called in-process by the FM brain; never leaves the device. |
+| **Private Cloud Compute** | Heavy generation that exceeds the on-device ceiling (Bucket 5: copy-edit, design-interview, social, syndicate). Apple-operated; **no external LLM APIs ever**. | The FM brain escalates to the PCC tier over Apple's attested, encrypted channel. |
+| **Site container (per-site)** | **All JavaScript**: the Node MCP server and everything it drives in-guest — `apply_edit`/`undo_edit` (HTML/Astro patcher), the Astro dev server + build, Sharp, Satori, Pagefind, Keystatic. Apple Containerization locally; Cloudflare Sandbox as the fallback on MAS / iOS / non-Apple-Silicon. | The host reaches it only over the in-container **MCP HTTP/WS transport** (#64) — not by host-spawning Node. |
+| **Site `Source/` (git repo)** | The filesystem source of truth — the clonable, externally-editable unit. | Mounted into the container; written by the in-guest JS and by Swift Bucket-1 hot-paths; read by `WKWebView` via the dev server. |
+| **Cloudflare (deploy target)** | The published site (Workers). | Deploy runs only after the native `pre-deploy-check` gate passes. |
+
+## Notes
+
+- **One capability, one implementation, many front-doors.** A GUI button, "Hey Siri…", and a
+  chat request all call the same Swift function or in-container tool — never a second copy.
+- **The security gate is unbypassable.** `pre-deploy-check` is native deterministic Swift,
+  not an LLM hook, so it cannot be prompt-injected or talked out of running.
+- **Interim vs end-state.** Until the container runtimes land (#66/#69/#70), the Node sidecar
+  stays host-spawned and called directly, and the embedded host Node + JIT re-sign apparatus
+  remains. The diagram shows the **end-state**: JS in-guest, host Node retired.

--- a/docs/superpowers/plans/2026-06-20-native-create-content-swift-port.md
+++ b/docs/superpowers/plans/2026-06-20-native-create-content-swift-port.md
@@ -67,7 +67,7 @@ struct ContentScaffoldTests {
     func slugifyBasics() {
         #expect(ContentScaffold.slugify("About Us") == "about-us")
         #expect(ContentScaffold.slugify("Héllo Wörld") == "hello-world")
-        #expect(ContentScaffold.slugify("  --Tom's Page--  ") == "tom-s-page")
+        #expect(ContentScaffold.slugify("  --Tom's Page--  ") == "toms-page")
         #expect(ContentScaffold.slugify("A/B") == "a-b")
         #expect(ContentScaffold.slugify("\"Quoted\"") == "quoted")
     }

--- a/docs/superpowers/plans/2026-06-20-native-create-content-swift-port.md
+++ b/docs/superpowers/plans/2026-06-20-native-create-content-swift-port.md
@@ -1,0 +1,570 @@
+# Native Swift `create_page` / `create_post` (Bucket 1, Slice 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the `create_page` and `create_post` operations from the Node MCP sidecar into native Swift so content scaffolding runs in-process with no subprocess round-trip, advancing the Claude-Code-removal roadmap's Bucket 1 (hot-path → Swift).
+
+**Architecture:** Two new AnglesiteCore units — `ContentScaffold` (pure functions: slugify, route/path derivation, template rendering, escaping; byte-faithful to the Node templates) and `NativeContentOperations` (a `ContentOperationsService` conformer that validates input, writes the file via `FileManager`, and commits best-effort via an injected git closure). The App Intents dependency registration in `Bootstrap.swift` swaps `ContentOperations` (MCP-routed) for `NativeContentOperations`. The Node `create_page`/`create_post` tools are left in place but no longer called from the app; they are deleted in the roadmap's cleanup slice.
+
+**Tech Stack:** Swift 6.4 / Xcode 27, Swift Testing (`@Test`), `FileManager`, `ProcessSupervisor` for git.
+
+## Global Constraints
+
+- **Swift Testing only** for new tests (`@Test` / `@Suite` / `#expect`) — not XCTest. (Matches the AnglesiteCore convention; the few XCTest holdouts are legacy.)
+- **All logic lives in `AnglesiteCore`** so it runs under `swift test` on CI. The only app-side change (Bootstrap DI) is config, verified by build + existing intent tests.
+- **No `Process()` outside `ProcessSupervisor`** — git runs via `ProcessSupervisor.shared.run(...)`.
+- **Byte-faithful output:** the generated `.astro` / `.md` must be identical to the Node sidecar's output (same templates, same escaping, same trailing newline) so switching backends produces no spurious git churn.
+- **Best-effort git:** a git failure (no repo, rejecting hook, git missing) must never fail the create — the file stays on disk and the operation still returns `.created`. (The `ContentCreateResult` carries no commit field, so the SHA is simply discarded, matching today's behavior.)
+- **Conventional commits** for each task's commit.
+- **Faithful behavior reference:** `…/anglesite/server/create-content.mjs` is the source of truth being ported. Reproduce its validation messages verbatim.
+
+## File Structure
+
+- **Create** `Sources/AnglesiteCore/ContentScaffold.swift` — pure, side-effect-free scaffolding functions. One responsibility: turn inputs into paths + file contents.
+- **Create** `Sources/AnglesiteCore/NativeContentOperations.swift` — the `ContentOperationsService` impl: orchestrates dir resolution, validation, file write, git commit, progress.
+- **Create** `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift` — pure-function tests (CI).
+- **Create** `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift` — operation tests with temp dirs + a spy git closure, plus one real-git integration test (CI).
+- **Modify** `Sources/AnglesiteIntents/Bootstrap.swift:50-51` — register `NativeContentOperations`.
+
+## Reference: behavior being ported (from `create-content.mjs`)
+
+- `slugify`: lowercase → NFKD → strip combining marks U+0300–U+036F → remove `'` `"` → replace `[^a-z0-9]+` with `-` → trim leading/trailing `-`.
+- `normalizeRoute`: split on `/`, slugify each segment, drop empties, return `"/" + segments.joined("/")`. (`/About//Us/` → `/about/us`; `About` → `/about`; `/` → `/`.)
+- page path: `"src/pages" + normalizedRoute + ".astro"`; layout import depth = segment count of the route (`/about` → `../`, `/a/b` → `../../`).
+- post path: `"src/content/\(collection)/\(slug).md"`; collection defaults to `posts`, must match `^[A-Za-z0-9_-]+$`.
+- commit messages: page `"anglesite: add page \(route)"`, post `"anglesite: add \(collection) \(slug)"`.
+
+---
+
+### Task 1: `ContentScaffold` pure functions
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ContentScaffold.swift`
+- Test: `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift`
+
+**Interfaces:**
+- Produces (used by Task 2):
+  - `enum ContentScaffold` (namespace) with static funcs:
+    - `slugify(_ value: String) -> String`
+    - `normalizeRoute(_ route: String) -> String`
+    - `pageRelativePath(normalizedRoute: String) -> String`
+    - `layoutImport(normalizedRoute: String) -> String`
+    - `renderPage(title: String, layoutImport: String) -> String`
+    - `postRelativePath(collection: String, slug: String) -> String`
+    - `renderPost(title: String, now: Date) -> String`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContentScaffold")
+struct ContentScaffoldTests {
+    @Test("slugify lowercases, strips diacritics, collapses to hyphens, trims")
+    func slugifyBasics() {
+        #expect(ContentScaffold.slugify("About Us") == "about-us")
+        #expect(ContentScaffold.slugify("Héllo Wörld") == "hello-world")
+        #expect(ContentScaffold.slugify("  --Tom's Page--  ") == "tom-s-page")
+        #expect(ContentScaffold.slugify("A/B") == "a-b")
+        #expect(ContentScaffold.slugify("\"Quoted\"") == "quoted")
+    }
+
+    @Test("normalizeRoute slugifies each segment and joins with slash")
+    func normalizeRouteSegments() {
+        #expect(ContentScaffold.normalizeRoute("/About//Us/") == "/about/us")
+        #expect(ContentScaffold.normalizeRoute("About") == "/about")
+        #expect(ContentScaffold.normalizeRoute("/") == "/")
+    }
+
+    @Test("layoutImport depth tracks route segment count")
+    func layoutImportDepth() {
+        #expect(ContentScaffold.layoutImport(normalizedRoute: "/about") == "../layouts/BaseLayout.astro")
+        #expect(ContentScaffold.layoutImport(normalizedRoute: "/a/b") == "../../layouts/BaseLayout.astro")
+    }
+
+    @Test("path builders match the sidecar layout")
+    func paths() {
+        #expect(ContentScaffold.pageRelativePath(normalizedRoute: "/about") == "src/pages/about.astro")
+        #expect(ContentScaffold.pageRelativePath(normalizedRoute: "/a/b") == "src/pages/a/b.astro")
+        #expect(ContentScaffold.postRelativePath(collection: "posts", slug: "hello") == "src/content/posts/hello.md")
+    }
+
+    @Test("renderPage escapes attrs and html and ends with one newline")
+    func renderPage() {
+        let out = ContentScaffold.renderPage(title: "A & \"B\"", layoutImport: "../layouts/BaseLayout.astro")
+        #expect(out.contains("import BaseLayout from \"../layouts/BaseLayout.astro\";"))
+        #expect(out.contains("<BaseLayout title=\"A &amp; &quot;B&quot;\" description=\"A &amp; &quot;B&quot;.\">"))
+        #expect(out.contains("<h1>A &amp; \"B\"</h1>"))
+        #expect(out.hasSuffix("</BaseLayout>\n"))
+    }
+
+    @Test("renderPost emits a draft with ISO8601 publishDate and YAML-escaped title")
+    func renderPost() {
+        let date = Date(timeIntervalSince1970: 1_750_000_000) // fixed, deterministic
+        let out = ContentScaffold.renderPost(title: "Back\\slash \"quote\"", now: date)
+        #expect(out.contains("title: \"Back\\\\slash \\\"quote\\\"\""))
+        #expect(out.contains("draft: true"))
+        #expect(out.contains("publishDate: 2025-06-15T15:06:40.000Z"))
+        #expect(out.hasSuffix("Write your post here.\n"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ContentScaffold`
+Expected: FAIL to build — "cannot find 'ContentScaffold' in scope".
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Sources/AnglesiteCore/ContentScaffold.swift
+import Foundation
+
+/// Pure, side-effect-free scaffolding for new pages and posts. Byte-faithful to the Node
+/// sidecar's `create-content.mjs` so switching the create backend produces no git churn.
+public enum ContentScaffold {
+
+    /// lowercase → NFKD → strip combining marks → drop quotes → non-alphanumerics to `-` → trim `-`.
+    public static func slugify(_ value: String) -> String {
+        let lowered = value.lowercased()
+        let decomposed = lowered.decomposedStringWithCompatibilityMapping // NFKD
+        let stripped = String(decomposed.unicodeScalars.filter { !(0x0300...0x036F ~= $0.value) })
+        let noQuotes = stripped
+            .replacingOccurrences(of: "'", with: "")
+            .replacingOccurrences(of: "\"", with: "")
+        let hyphenated = noQuotes.replacingOccurrences(
+            of: "[^a-z0-9]+", with: "-", options: .regularExpression)
+        return hyphenated.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    /// Slugify each `/`-separated segment, drop empties, rejoin with a leading slash.
+    public static func normalizeRoute(_ route: String) -> String {
+        let segments = route
+            .split(separator: "/", omittingEmptySubsequences: false)
+            .map { slugify(String($0)) }
+            .filter { !$0.isEmpty }
+        return "/" + segments.joined(separator: "/")
+    }
+
+    public static func pageRelativePath(normalizedRoute: String) -> String {
+        "src/pages" + normalizedRoute + ".astro"
+    }
+
+    public static func postRelativePath(collection: String, slug: String) -> String {
+        "src/content/\(collection)/\(slug).md"
+    }
+
+    /// `/about` → `../layouts/BaseLayout.astro`; `/a/b` → `../../layouts/BaseLayout.astro`.
+    public static func layoutImport(normalizedRoute: String) -> String {
+        let trimmed = normalizedRoute.hasPrefix("/") ? String(normalizedRoute.dropFirst()) : normalizedRoute
+        let depth = trimmed.split(separator: "/", omittingEmptySubsequences: false).count
+        return String(repeating: "../", count: depth) + "layouts/BaseLayout.astro"
+    }
+
+    public static func renderPage(title: String, layoutImport: String) -> String {
+        let description = "\(title)."
+        return """
+        ---
+        import BaseLayout from "\(layoutImport)";
+        ---
+
+        <BaseLayout title="\(escapeAttr(title))" description="\(escapeAttr(description))">
+          <main>
+            <h1>\(escapeHTML(title))</h1>
+            <p>Add your content here.</p>
+          </main>
+        </BaseLayout>
+        """ + "\n"
+    }
+
+    public static func renderPost(title: String, now: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let publishDate = formatter.string(from: now)
+        return """
+        ---
+        title: "\(escapeYAML(title))"
+        description: ""
+        publishDate: \(publishDate)
+        draft: true
+        tags: []
+        ---
+
+        Write your post here.
+        """ + "\n"
+    }
+
+    // MARK: - Escaping (order matters: `&` first)
+
+    static func escapeAttr(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+         .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+
+    static func escapeHTML(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+         .replacingOccurrences(of: "<", with: "&lt;")
+         .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    static func escapeYAML(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+         .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ContentScaffold`
+Expected: PASS (6 tests). If `publishDate` mismatches, confirm the fixed-date expectation `2025-06-15T15:06:40.000Z` matches `ISO8601DateFormatter` with `.withFractionalSeconds` on this machine and adjust the literal to the observed value.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentScaffold.swift Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+git commit -m "feat(content): native Swift scaffolding functions for pages/posts"
+```
+
+---
+
+### Task 2: `NativeContentOperations`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/NativeContentOperations.swift`
+- Test: `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentScaffold` (Task 1); `ContentOperationsService` protocol + `ContentCreateResult` enum (existing, `Sources/AnglesiteCore/ContentOperationsService.swift`); the progress milestones `ContentOperations` already emits (`.createResolvingRuntime`, `.createCallingPlugin`, `.createFinalizing` — see `ContentOperations.swift` `create(...)`).
+- Produces (used by Task 3):
+  - `public struct NativeContentOperations: ContentOperationsService`
+  - `public typealias GitCommit = @Sendable (_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?`
+  - `public init(siteDirectory: @escaping @Sendable (_ siteID: String) async -> URL?, gitCommit: @escaping GitCommit = NativeContentOperations.processGitCommit, now: @escaping @Sendable () -> Date = { Date() }, fileManager: FileManager = .default)`
+  - `public static func processGitCommit(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("NativeContentOperations")
+struct NativeContentOperationsTests {
+
+    /// A temp site dir + a spy git closure that records calls and returns a fake SHA.
+    private func makeOps() -> (ops: NativeContentOperations, root: URL, calls: Spy) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("native-content-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let spy = Spy()
+        let ops = NativeContentOperations(
+            siteDirectory: { _ in root },
+            gitCommit: { proj, rel, msg in await spy.record(proj, rel, msg); return "deadbeef" },
+            now: { Date(timeIntervalSince1970: 1_750_000_000) }
+        )
+        return (ops, root, spy)
+    }
+
+    actor Spy {
+        private(set) var calls: [(URL, String, String)] = []
+        func record(_ a: URL, _ b: String, _ c: String) { calls.append((a, b, c)) }
+    }
+
+    @Test("createPage writes the file and returns the normalized route")
+    func createPage() async throws {
+        let (ops, root, spy) = makeOps()
+        let result = await ops.createPage(siteID: "s1", name: "About Us", route: nil)
+        #expect(result == .created(filePath: "src/pages/about-us.astro", identifier: "/about-us"))
+        let written = try String(contentsOf: root.appendingPathComponent("src/pages/about-us.astro"), encoding: .utf8)
+        #expect(written == ContentScaffold.renderPage(title: "About Us", layoutImport: "../layouts/BaseLayout.astro"))
+        let calls = await spy.calls
+        #expect(calls.count == 1)
+        #expect(calls.first?.1 == "src/pages/about-us.astro")
+        #expect(calls.first?.2 == "anglesite: add page /about-us")
+    }
+
+    @Test("nested route writes under nested dirs with deeper layout import")
+    func createNestedPage() async throws {
+        let (ops, root, _) = makeOps()
+        let result = await ops.createPage(siteID: "s1", name: "ignored", route: "/services/web")
+        #expect(result == .created(filePath: "src/pages/services/web.astro", identifier: "/services/web"))
+        let written = try String(contentsOf: root.appendingPathComponent("src/pages/services/web.astro"), encoding: .utf8)
+        #expect(written.contains("import BaseLayout from \"../../layouts/BaseLayout.astro\";"))
+    }
+
+    @Test("createPage refuses the site root")
+    func createPageRoot() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createPage(siteID: "s1", name: "/", route: "/")
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("site root"))
+    }
+
+    @Test("createPage won't overwrite an existing page")
+    func createPageExisting() async {
+        let (ops, root, _) = makeOps()
+        let dir = root.appendingPathComponent("src/pages", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? "x".write(to: dir.appendingPathComponent("about.astro"), atomically: true, encoding: .utf8)
+        let result = await ops.createPage(siteID: "s1", name: "About", route: nil)
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("already exists"))
+    }
+
+    @Test("unknown site returns .siteNotFound")
+    func siteNotFound() async {
+        let ops = NativeContentOperations(siteDirectory: { _ in nil }, gitCommit: { _, _, _ in nil })
+        let result = await ops.createPage(siteID: "missing", name: "About", route: nil)
+        #expect(result == .siteNotFound)
+    }
+
+    @Test("createPost writes a draft in the default posts collection")
+    func createPost() async throws {
+        let (ops, root, spy) = makeOps()
+        let result = await ops.createPost(siteID: "s1", title: "Hello World", collection: nil, slug: nil)
+        #expect(result == .created(filePath: "src/content/posts/hello-world.md", identifier: "hello-world"))
+        let written = try String(contentsOf: root.appendingPathComponent("src/content/posts/hello-world.md"), encoding: .utf8)
+        #expect(written.contains("draft: true"))
+        let calls = await spy.calls
+        #expect(calls.first?.2 == "anglesite: add posts hello-world")
+    }
+
+    @Test("createPost honors a custom collection")
+    func createPostCollection() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createPost(siteID: "s1", title: "Note one", collection: "notes", slug: nil)
+        #expect(result == .created(filePath: "src/content/notes/note-one.md", identifier: "note-one"))
+    }
+
+    @Test("createPost rejects an unsafe collection name")
+    func createPostBadCollection() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createPost(siteID: "s1", title: "X", collection: "../escape", slug: nil)
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("Invalid collection name"))
+    }
+
+    @Test("processGitCommit returns a SHA in a real repo, nil outside one")
+    func realGit() async throws {
+        // Outside a repo → nil (best-effort).
+        let bare = FileManager.default.temporaryDirectory.appendingPathComponent("nogit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: bare, withIntermediateDirectories: true)
+        try "hi".write(to: bare.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+        let none = await NativeContentOperations.processGitCommit(bare, "f.txt", "msg")
+        #expect(none == nil)
+
+        // Inside a repo with an initial commit → a 40-char SHA.
+        let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        for args in [["init"], ["config", "user.email", "t@t.io"], ["config", "user.name", "t"]] {
+            _ = try await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: repo)
+        }
+        try "page".write(to: repo.appendingPathComponent("p.astro"), atomically: true, encoding: .utf8)
+        let sha = await NativeContentOperations.processGitCommit(repo, "p.astro", "anglesite: add page /p")
+        #expect(sha?.count == 40)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter NativeContentOperations`
+Expected: FAIL to build — "cannot find 'NativeContentOperations' in scope".
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Sources/AnglesiteCore/NativeContentOperations.swift
+import Foundation
+
+/// Native, in-process `create_page` / `create_post`. Byte-faithful to the Node sidecar's
+/// `create-content.mjs` (see `ContentScaffold`), but writes the file with `FileManager` and
+/// commits best-effort via an injected git closure — no MCP round-trip. Replaces the
+/// MCP-routed `ContentOperations` at the App Intents dependency registration.
+public struct NativeContentOperations: ContentOperationsService {
+
+    public typealias GitCommit = @Sendable (_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?
+
+    private let siteDirectory: @Sendable (_ siteID: String) async -> URL?
+    private let gitCommit: GitCommit
+    private let now: @Sendable () -> Date
+    private let fileManager: FileManager
+
+    public init(
+        siteDirectory: @escaping @Sendable (_ siteID: String) async -> URL?,
+        gitCommit: @escaping GitCommit = NativeContentOperations.processGitCommit,
+        now: @escaping @Sendable () -> Date = { Date() },
+        fileManager: FileManager = .default
+    ) {
+        self.siteDirectory = siteDirectory
+        self.gitCommit = gitCommit
+        self.now = now
+        self.fileManager = fileManager
+    }
+
+    public func createPage(siteID: String, name: String, route: String?, onProgress: ProgressHandler? = nil) async -> ContentCreateResult {
+        onProgress?(.createResolvingRuntime)
+        guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+
+        let title = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return .failed(reason: "create_page requires a non-empty name") }
+
+        let base = (route?.isEmpty == false) ? route! : ContentScaffold.slugify(title)
+        let normalized = ContentScaffold.normalizeRoute(base)
+        guard normalized != "/" else {
+            return .failed(reason: "create_page can't scaffold the site root; give the page a name or route")
+        }
+
+        let relPath = ContentScaffold.pageRelativePath(normalizedRoute: normalized)
+        let abs = root.appendingPathComponent(relPath)
+        if fileManager.fileExists(atPath: abs.path) {
+            return .failed(reason: "A page already exists at \(relPath)")
+        }
+
+        onProgress?(.createCallingPlugin)
+        let contents = ContentScaffold.renderPage(
+            title: title,
+            layoutImport: ContentScaffold.layoutImport(normalizedRoute: normalized))
+        do { try write(contents, to: abs) }
+        catch { return .failed(reason: "\(error)") }
+
+        onProgress?(.createFinalizing)
+        _ = await gitCommit(root, relPath, "anglesite: add page \(normalized)")
+        return .created(filePath: relPath, identifier: normalized)
+    }
+
+    public func createPost(siteID: String, title: String, collection: String?, slug: String?, onProgress: ProgressHandler? = nil) async -> ContentCreateResult {
+        onProgress?(.createResolvingRuntime)
+        guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+
+        let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanTitle.isEmpty else { return .failed(reason: "create_post requires a non-empty title") }
+
+        let trimmedColl = (collection ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let coll = trimmedColl.isEmpty ? "posts" : trimmedColl
+        guard coll.range(of: "^[A-Za-z0-9_-]+$", options: .regularExpression) != nil else {
+            return .failed(reason: "Invalid collection name: \(coll)")
+        }
+
+        let slugSource = (slug?.isEmpty == false) ? slug! : cleanTitle
+        let finalSlug = ContentScaffold.slugify(slugSource)
+        guard !finalSlug.isEmpty else { return .failed(reason: "create_post could not derive a slug from the title") }
+
+        let relPath = ContentScaffold.postRelativePath(collection: coll, slug: finalSlug)
+        let abs = root.appendingPathComponent(relPath)
+        if fileManager.fileExists(atPath: abs.path) {
+            return .failed(reason: "A \(coll) entry already exists at \(relPath)")
+        }
+
+        onProgress?(.createCallingPlugin)
+        let contents = ContentScaffold.renderPost(title: cleanTitle, now: now())
+        do { try write(contents, to: abs) }
+        catch { return .failed(reason: "\(error)") }
+
+        onProgress?(.createFinalizing)
+        _ = await gitCommit(root, relPath, "anglesite: add \(coll) \(finalSlug)")
+        return .created(filePath: relPath, identifier: finalSlug)
+    }
+
+    private func write(_ contents: String, to abs: URL) throws {
+        try fileManager.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: abs, atomically: true, encoding: .utf8)
+    }
+
+    /// Stage and commit exactly `relPath` on the current branch. Returns the new HEAD SHA,
+    /// or nil on any failure (not a repo, rejecting hook, git missing) — best-effort, mirroring
+    /// the Node sidecar's `commitFile`.
+    public static func processGitCommit(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        func run(_ args: [String]) async -> ProcessSupervisor.RunResult? {
+            let result = try? await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: projectRoot)
+            guard let result, result.exitCode == 0 else { return nil }
+            return result
+        }
+        guard await run(["rev-parse", "--git-dir"]) != nil,
+              await run(["add", "--", relPath]) != nil,
+              await run(["commit", "-m", message, "--", relPath]) != nil,
+              let head = await run(["rev-parse", "HEAD"]) else { return nil }
+        return head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter NativeContentOperations`
+Expected: PASS (9 tests). If `ProgressHandler` / the `.create*` milestone case names differ from `ContentOperations.swift`, match them exactly (read that file's `create(...)` body) — they are the only cross-file names this task reuses.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NativeContentOperations.swift Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+git commit -m "feat(content): NativeContentOperations writes + commits pages/posts in-process"
+```
+
+---
+
+### Task 3: Register `NativeContentOperations` for the App Intents
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/Bootstrap.swift:50-51`
+
+**Interfaces:**
+- Consumes: `NativeContentOperations` (Task 2); `SiteStore.shared.find(id:)?.sourceDirectory` (existing, already used in the current registration).
+
+- [ ] **Step 1: Swap the dependency registration**
+
+Replace the current registration body:
+
+```swift
+AppDependencyManager.shared.add { () -> any ContentOperationsService in
+    ContentOperations(pool: headlessPool, siteDirectory: { id in await SiteStore.shared.find(id: id)?.sourceDirectory })
+}
+```
+
+with:
+
+```swift
+AppDependencyManager.shared.add { () -> any ContentOperationsService in
+    // Native in-process scaffolding (Bucket 1, Slice 2). Replaces the MCP-routed
+    // ContentOperations; the Node create_page/create_post tools are retired in the
+    // roadmap's cleanup slice. `headlessPool` stays in scope for other dependencies.
+    NativeContentOperations(siteDirectory: { id in await SiteStore.shared.find(id: id)?.sourceDirectory })
+}
+```
+
+- [ ] **Step 2: Verify the build and the existing intent tests still pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesiteIntentsTests`
+Expected: PASS. The content-intent tests inject via `ContentOperationsOverride.scoped`, so they exercise the intent flow independently of this registration; they must remain green. (If `headlessPool` is now unused in `Bootstrap.swift`, remove its now-dead construction only if it has no other consumers — grep first; otherwise leave it.)
+
+- [ ] **Step 3: Full-suite sanity check**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .`
+Expected: PASS across AnglesiteCoreTests / AnglesiteIntentsTests / AnglesiteBridgeTests. `ContentOperationsTests` (the MCP-routed type) still exists and still passes — that type is retained until the cleanup slice; this task only changes which impl the intents resolve.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/Bootstrap.swift
+git commit -m "feat(content): route Add Page/Post intents through NativeContentOperations"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** This plan implements roadmap Slice 2 (Bucket 1 hot-path port of `create_page`/`create_post`). It does not cover `list_content` or the annotations tools (the other Bucket 1 items) — those are separate slices/plans, by design. Slice 1 (chat → Foundation Models) is already implemented in the codebase except for flipping the `preferFoundationModels` default; that is a one-line settings change handled outside this plan (see handoff note). No gap within this plan's scope.
+
+**2. Placeholder scan.** No TBD/TODO; every code step shows complete code; both error paths and templates are spelled out. The two "match the existing names" notes (progress milestones in Task 2; `ProgressHandler`) point at a named existing file rather than leaving a blank — acceptable because they are pre-existing symbols this module already shares, not new contracts.
+
+**3. Type consistency.** `ContentScaffold` static-func names are identical between Task 1's definition, its tests, and Task 2's call sites (`slugify`, `normalizeRoute`, `pageRelativePath`, `postRelativePath`, `layoutImport`, `renderPage`, `renderPost`). `NativeContentOperations` init signature, `GitCommit` typealias, and `processGitCommit` match between Task 2's interface block, its tests, and Task 3's call site. `ContentCreateResult` cases (`.created(filePath:identifier:)`, `.siteNotFound`, `.failed(reason:)`) are the existing enum, used consistently.
+
+**4. Faithfulness risk.** The one behavioral subtlety is `publishDate` formatting — Step 4 of Task 1 instructs verifying the fixed-date literal against the machine's `ISO8601DateFormatter` output and adjusting if needed, so a formatter quirk surfaces as a checked assertion rather than silent drift.

--- a/docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md
@@ -1,0 +1,227 @@
+# Retiring Claude Code: Migration Roadmap to Deterministic Swift + Apple Intelligence
+
+**Date:** 2026-06-20
+**Status:** Design / roadmap (no implementation yet)
+**Goal:** Make Anglesite usable by non-technical people by removing the Claude Code
+dependency entirely and replacing it with deterministic Swift/TypeScript plus Apple
+Intelligence (on-device Foundation Models, escalating to Private Cloud Compute).
+
+---
+
+## 1. Why
+
+Today the app's "intelligence" is Claude Code: a `claude --print` subprocess that reads
+56 markdown skills and orchestrates bash/npm/MCP calls. That requires the `claude`
+binary, an Anthropic account, and a power-user mental model. For the target audience —
+non-technical site owners driving the app by voice (Siri) and GUI — that dependency is
+the wrong substrate.
+
+This roadmap drives to **full removal**: the shipped app has no `claude` binary, the
+plugin stops being a Claude plugin, and `ClaudeAgent` is deleted. Everything it did is
+re-homed onto deterministic code or Apple Intelligence.
+
+## 2. Locked decisions
+
+These were settled during brainstorming and constrain everything below.
+
+| Decision | Choice |
+|---|---|
+| **End-state for Claude Code** | Full removal. No `claude` binary, no Claude-plugin loading, `ClaudeAgent` deleted. |
+| **Generative backstop** | Apple Intelligence only — on-device Foundation Models, escalating to Private Cloud Compute (PCC). **No external LLM APIs, ever.** |
+| **Deterministic substrate** | Port hot paths to native Swift; keep Node only for things that need the JS ecosystem (Astro build, Sharp, Satori, Pagefind, Keystatic). |
+| **Anything that exceeds even PCC** | Simplified or retired — not shipped as a degraded cloud call. |
+
+## 3. The interface today — three layers
+
+The sub-agent survey confirmed the boundary splits into three layers, and only one of
+them is actually a Claude dependency.
+
+**Layer 1 — Plugin MCP server (`node server/index.mjs`): already 100% deterministic.**
+All 8 tools — `apply_edit`, `undo_edit`, `list_content`, `create_page`, `create_post`,
+`add_annotation`, `list_annotations`, `resolve_annotation` — are pure file / git /
+selector-patching operations with no LLM. The app already calls them directly from Swift
+via `MCPClient` over stdio. This is a Node *sidecar*, not a Claude dependency.
+
+**Layer 2 — Apple Intelligence (FoundationModels): already on-device, no Claude.**
+Already shipping: `FoundationModelEditInterpreter` (Siri NL edit: interpret → dry-run →
+confirm → apply), `AltTextGenerator` (on-device vision), `FoundationModelDeploySummarizer`,
+and `FoundationModelAssistant` (FM chat with `ApplyEditTool` + `SpotlightSearchTool`
+tool-calling). The tool-calling orchestration pattern we need is **already proven here.**
+
+**Layer 3 — Claude Code (`claude --print --plugin-dir …`): the only real dependency.**
+Two things, and only these, flow through it:
+- The **chat-panel brain** (`ClaudeAgent`) — open-ended conversation and deciding which
+  tools to call.
+- The **56 skills as prose** — markdown that only "runs" because an LLM reads and follows
+  it, shelling out to bash/npm/MCP. The prose *is* the dependency; it cannot survive
+  without an LLM interpreting it.
+
+Removing Claude Code = retiring Layer 3 by absorbing its deterministic guts into Layers 1
+and 2 and converting its prose skills into callable tools.
+
+## 4. Target architecture: one capability → one implementation → many front-doors
+
+The organizing principle. Every capability is implemented **once**, as a deterministic
+tool or an FM-backed function, and exposed through up to three front-doors:
+
+```
+                 ┌───────── chat panel (FoundationModelAssistant, FM brain)
+   capability ───┼───────── Siri / Spotlight (App Intent)
+   (one impl)    └───────── GUI control / wizard (non-technical default)
+```
+
+- The **chat panel survives** but re-homes from `ClaudeAgent` to the existing
+  `FoundationModelAssistant`. For non-technical users it's optional; Siri + GUI are the
+  primary front-doors.
+- The FM brain does **tool-calling**, not prose-following. Each migrated capability
+  registers as an FM `Tool` (already how `ApplyEditTool` works).
+- No capability is implemented twice. A GUI "Add contact form" button, "Hey Siri, add a
+  contact form," and asking in chat all call the same Swift/sidecar function.
+
+## 5. Capability taxonomy
+
+Every MCP tool and skill sorts into one of six buckets. Hybrids (deterministic scaffold +
+generative copy) appear in two buckets with the split called out.
+
+### Bucket 1 — Hot-path → native Swift
+The highest-frequency deterministic operations. Ported off the Node sidecar into Swift to
+cut subprocess hops on the common edit loop.
+
+- `apply_edit`, `undo_edit` (selector resolve + patch + git per-edit commit)
+- `create_page`, `create_post` (template expansion + git)
+- `list_content` (filesystem scan → structured JSON)
+- `add_annotation` / `list_annotations` / `resolve_annotation` (JSON store)
+
+**Risk:** `apply_edit`'s selector resolver/patcher (`selector.mjs`, `patcher.mjs`) parses
+HTML/Astro. A faithful Swift port needs an HTML/AST parser (e.g. SwiftSoup) and an
+Astro-component-aware strategy. This is the single largest port; see §8.
+
+### Bucket 2 — JS-ecosystem → bundled Node sidecar
+Keep in Node because they depend on the JS ecosystem; just stop routing them through
+Claude. The app calls them directly (as it already calls the MCP server).
+
+- Astro dev server + production build
+- Sharp — image optimization (`optimize-images`)
+- Satori — OG image generation (`og-images`)
+- Pagefind — on-site search index (`search`)
+- Keystatic — form/collection backends (`forms`, `inbox`, `membership`)
+
+### Bucket 3 — Deterministic wizard → Swift + App Intent + GUI
+These read as conversational skills but are really decision-trees over templates and
+config. No model needed. Each becomes a Swift flow with an App Intent and a GUI wizard.
+
+- **Infra/ops:** `start`, `deploy`, `check`, `backup`, `export`, `update`, `stats`
+- **Integrations (scaffold + config):** `contact`, `consent`, `booking`, `newsletter`,
+  `podcast`, `pwa`, `redirects`, `share`, `tracking`, `donations`, `giscus`, `indieweb`,
+  `menu`, `inbox`, `membership`
+- **Commerce scaffold:** `add-store`, `buy-button`, `lemon-squeezy`, `paddle`, `snipcart`,
+  `shopify-buy-button` *(scaffold/config only — tier/product copy is Bucket 5)*
+- **DNS/domain:** `domain`
+- **Design application:** `themes`, `freedesignmd` (apply step), `design-import`
+- **Utilities:** `qr`, `redirects`, `testimonials` (collection/moderation scaffold)
+
+### Bucket 4 — On-device Foundation Models (structured generation)
+Short, structured generation that fits the ~3B / ~4K-context on-device model via guided
+generation. Some already shipped (✅).
+
+- Siri NL edit interpret ✅
+- Alt text ✅ (the generative half of `optimize-images`)
+- Deploy-failure summary ✅
+- `business-info` → conversational collection → LocalBusiness JSON-LD
+- `new-page` headline / short-copy generation (scaffold + a11y validation are Bucket 3)
+- `seasonal` suggestions (date + business-type lookup is deterministic; the suggestion
+  text is short FM generation)
+- `design-interview` design-axis interpretation (the 0–1 axis math is deterministic)
+- `photography` shot-list tips (business-type lookup is deterministic)
+
+### Bucket 5 — PCC escalation (heavier generation)
+Open-ended generation beyond the on-device ceiling but achievable on Private Cloud
+Compute. Escalation is a runtime tier choice; the front-door is unchanged.
+
+- `copy-edit` (whole-site critique + rewrites)
+- `design-interview` (multi-turn brand conversation + palette/typography)
+- `social-media` (strategy + brand-voice posts), `syndicate` (per-platform variants)
+- `reputation` (review-response drafts)
+- `animate` (motion-design direction; CSS syntax itself is deterministic)
+- `i18n` content translation
+- `convert` / `import` content cleanup (the parse/scrape is Bucket 3)
+- Commerce tier/product **copy** (the scaffold is Bucket 3)
+
+### Bucket 6 — Simplify or retire
+Exceeds even PCC for reliable quality, or delivers little once the prose-orchestration is
+gone. Cut or reduce to a deterministic core.
+
+- `creative-canvas` — open-ended Three.js/P5 code-gen. **Retire** the open generator;
+  optionally ship a small library of vetted preset effects (Bucket 3).
+- `experiment` — A/B design + statistical reasoning. **Simplify** to deterministic stats
+  (significance, lift) + templated suggestions; drop the open-ended hypothesis chat.
+- `email` — provider recommendation. **Simplify** to a deterministic decision tree
+  (it's a flowchart over business type/values, not generative work).
+
+## 6. Sequencing — vertical slices
+
+Migrate one user journey end-to-end at a time. Per slice: (1) make the logic a
+deterministic tool (Swift hot-path or sidecar) or FM function; (2) expose it via FM Tool,
+App Intent, and GUI over the one implementation; (3) delete that journey's `claude --print`
+path. Claude Code stays alive only for un-migrated journeys until the final slice flips,
+then `ClaudeAgent` is deleted. Within each slice, **tool before brain.**
+
+Proposed slice order (each independently shippable):
+
+1. **Edit text/attribute** — Bucket 1 `apply_edit` Swift port + FM/Siri/overlay
+   front-doors. Highest frequency, exercises the hardest port first.
+2. **Create page/post** — Bucket 1 scaffolding + Bucket 4 short-copy. Self-contained.
+3. **Add a feature (integrations)** — Bucket 3 wizard framework, proven on `contact` /
+   `newsletter` / `booking`, then templated across the rest of the integration set.
+4. **Deploy** — Bucket 3 `deploy` flow + the security gate change (§7) + Bucket 4 deploy
+   summary (already done).
+5. **Theme / design** — Bucket 3 `themes` apply + Bucket 5 `design-interview` on PCC.
+6. **Content help** — Bucket 5 `copy-edit`, `social-media`, `syndicate`.
+7. **Cleanup** — retire Bucket 6 skills, delete `ClaudeAgent`, remove `--plugin-dir`
+   wiring and the `claude` binary expectation, convert the plugin repo (§9).
+
+## 7. Security gate change
+
+CLAUDE.md's invariant — "the app cannot bypass plugin security hooks" — is today enforced
+by the plugin's `PreToolUse` hook running `pre-deploy-check.sh`. With Claude Code gone, the
+app runs that script (PII/token/third-party-script/Keystatic-route scans) **directly** as a
+deterministic gate before every deploy, surfacing failures rather than allowing override.
+This is *stronger*: a non-LLM gate can't be prompt-injected or talked out of running.
+
+## 8. Risks & open questions
+
+- **`apply_edit` Swift port (Bucket 1) is the critical path.** Astro-component-aware
+  selector resolution + patching is non-trivial in Swift. *Open question:* port fully to
+  Swift, or keep `apply_edit` alone in the Node sidecar (Bucket 2) and port only the
+  cheaper hot paths? Resolve before committing slice 1.
+- **PCC availability & latency** for Bucket 5 — confirm the FoundationModels PCC tier is
+  callable from both DevID and MAS builds and that quality clears the bar for `copy-edit` /
+  `design-interview` before depending on it. The doc assumes Apple ships this; validate.
+- **On-device context ceiling (~4K).** `copy-edit` over a whole site may exceed even PCC
+  context — may need deterministic chunking (per-page) before generation.
+- **MAS convergence.** Chat/Sparkle/`gh` are currently compiled out of MAS. Full removal +
+  Apple-only AI makes MAS the natural primary target; the two build targets should
+  re-converge on capability. Track as a consequence, not a separate decision.
+- **Feature parity bar for "retire" (Bucket 6).** Confirm `creative-canvas` /
+  open-ended `experiment` have low enough usage to drop without user pain.
+
+## 9. End-state: what gets deleted
+
+- `ClaudeAgent.swift` and the `claude --print` spawn path.
+- `--plugin-dir` wiring in `buildArguments()`; the `claude` binary expectation.
+- The plugin's **skill markdown** (the prose) and its `hooks.json` Claude hook.
+- The plugin repo's deterministic guts are **absorbed, not deleted**: hot paths → Swift
+  (Bucket 1), JS-ecosystem pieces → bundled Node sidecar (Bucket 2),
+  `pre-deploy-check.sh` → direct app-run gate (§7).
+- `copy-plugin.sh`'s Claude-plugin packaging shrinks to "bundle the Node sidecar +
+  templates." The two-repo coordination model (paired PRs for MCP schema) ends; the app
+  owns the sidecar.
+
+## 10. Phasing summary
+
+| Phase | Slices | Outcome |
+|---|---|---|
+| **P1** | Slice 1–2 | Edit + create journeys are Claude-free; `apply_edit` port resolved. |
+| **P2** | Slice 3–4 | Integrations + deploy are wizard/Intent-driven; security gate native. |
+| **P3** | Slice 5–6 | Design + content help on FM/PCC. |
+| **P4** | Slice 7 | Bucket 6 retired, `ClaudeAgent` deleted, plugin repo converted. Claude Code dependency gone. |

--- a/docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md
@@ -29,6 +29,7 @@ These were settled during brainstorming and constrain everything below.
 | **End-state for Claude Code** | Full removal. No `claude` binary, no Claude-plugin loading, `ClaudeAgent` deleted. |
 | **Generative backstop** | Apple Intelligence only — on-device Foundation Models, escalating to Private Cloud Compute (PCC). **No external LLM APIs, ever.** |
 | **Deterministic substrate** | Port hot paths to native Swift; keep Node only for things that need the JS ecosystem (Astro build, Sharp, Satori, Pagefind, Keystatic). |
+| **JS execution location** | **All JS runs inside the container** (the Node sidecar — Astro, Sharp, Satori, Pagefind, Keystatic, `apply_edit`/`undo_edit`) — in-guest (#59/#66/#69), reached over the in-container MCP HTTP/WS transport (#64), **not** host-spawned. The embedded host Node + JIT re-sign apparatus retires once the container runtimes land (#70). Until then, the sidecar stays host-spawned as today (interim only). |
 | **Anything that exceeds even PCC** | Simplified or retired — not shipped as a degraded cloud call. |
 
 ## 3. The interface today — three layers
@@ -100,8 +101,10 @@ does it correctly and is called directly from Swift.
 
 ### Bucket 2 — JS-ecosystem → bundled Node sidecar
 Keep in Node because they depend on the JS ecosystem (or on parsing HTML/Astro); just stop
-routing them through Claude. The app calls them directly (as it already calls the MCP
-server).
+routing them through Claude. **End-state: all of this JS runs inside the container** (#59),
+reached over the in-container MCP HTTP/WS transport (#64) — not host-spawned. (Interim, until
+the container runtimes land, they remain a host-spawned sidecar called directly as today; the
+in-guest move is what lets the embedded host Node retire — #70.)
 
 - `apply_edit` / `undo_edit` — selector resolve + patch + git per-edit commit. Stays in
   the sidecar: the patcher parses HTML/Astro and a Swift reimplementation buys nothing.
@@ -213,11 +216,13 @@ This is *stronger*: a non-LLM gate can't be prompt-injected or talked out of run
 - `--plugin-dir` wiring in `buildArguments()`; the `claude` binary expectation.
 - The plugin's **skill markdown** (the prose) and its `hooks.json` Claude hook.
 - The plugin repo's deterministic guts are **absorbed, not deleted**: hot paths → Swift
-  (Bucket 1), JS-ecosystem pieces → bundled Node sidecar (Bucket 2),
-  `pre-deploy-check.sh` → direct app-run gate (§7).
-- `copy-plugin.sh`'s Claude-plugin packaging shrinks to "bundle the Node sidecar +
-  templates." The two-repo coordination model (paired PRs for MCP schema) ends; the app
-  owns the sidecar.
+  (Bucket 1), JS-ecosystem pieces → Node sidecar that runs **in the container** (Bucket 2;
+  #59/#66/#69), `pre-deploy-check.sh` → direct app-run gate (§7).
+- With all JS in-guest, the embedded **host** Node + JIT re-sign apparatus retires (#70):
+  the sidecar is built into the OCI image (#62), not bundled into the app, so
+  `copy-plugin.sh`'s Claude-plugin packaging is replaced by image build + "bundle templates
+  only." The two-repo coordination model (paired PRs for MCP schema) ends; the app owns the
+  sidecar.
 
 ## 10. Phasing summary
 

--- a/docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md
@@ -84,22 +84,27 @@ Every MCP tool and skill sorts into one of six buckets. Hybrids (deterministic s
 generative copy) appear in two buckets with the split called out.
 
 ### Bucket 1 — Hot-path → native Swift
-The highest-frequency deterministic operations. Ported off the Node sidecar into Swift to
-cut subprocess hops on the common edit loop.
+High-frequency deterministic operations that are cheap to port — pure filesystem, JSON,
+and git work with no HTML/AST parsing. Ported off the Node sidecar into Swift to cut
+subprocess hops.
 
-- `apply_edit`, `undo_edit` (selector resolve + patch + git per-edit commit)
 - `create_page`, `create_post` (template expansion + git)
 - `list_content` (filesystem scan → structured JSON)
 - `add_annotation` / `list_annotations` / `resolve_annotation` (JSON store)
 
-**Risk:** `apply_edit`'s selector resolver/patcher (`selector.mjs`, `patcher.mjs`) parses
-HTML/Astro. A faithful Swift port needs an HTML/AST parser (e.g. SwiftSoup) and an
-Astro-component-aware strategy. This is the single largest port; see §8.
+**Decision:** `apply_edit` / `undo_edit` are deliberately **not** here — they stay in the
+Node sidecar (Bucket 2). Their selector resolver/patcher (`selector.mjs`, `patcher.mjs`)
+parses HTML/Astro, which a Swift port would have to reimplement against an HTML/AST parser
+with Astro-component awareness. Not worth the risk for no AI benefit; the sidecar already
+does it correctly and is called directly from Swift.
 
 ### Bucket 2 — JS-ecosystem → bundled Node sidecar
-Keep in Node because they depend on the JS ecosystem; just stop routing them through
-Claude. The app calls them directly (as it already calls the MCP server).
+Keep in Node because they depend on the JS ecosystem (or on parsing HTML/Astro); just stop
+routing them through Claude. The app calls them directly (as it already calls the MCP
+server).
 
+- `apply_edit` / `undo_edit` — selector resolve + patch + git per-edit commit. Stays in
+  the sidecar: the patcher parses HTML/Astro and a Swift reimplementation buys nothing.
 - Astro dev server + production build
 - Sharp — image optimization (`optimize-images`)
 - Satori — OG image generation (`og-images`)
@@ -168,8 +173,9 @@ then `ClaudeAgent` is deleted. Within each slice, **tool before brain.**
 
 Proposed slice order (each independently shippable):
 
-1. **Edit text/attribute** — Bucket 1 `apply_edit` Swift port + FM/Siri/overlay
-   front-doors. Highest frequency, exercises the hardest port first.
+1. **Edit text/attribute** — `apply_edit` stays in the sidecar (Bucket 2); this slice
+   wires the FM/Siri/overlay front-doors over it. Mostly proven already (overlay + Siri NL
+   edit ship today); the work is routing chat through `FoundationModelAssistant`.
 2. **Create page/post** — Bucket 1 scaffolding + Bucket 4 short-copy. Self-contained.
 3. **Add a feature (integrations)** — Bucket 3 wizard framework, proven on `contact` /
    `newsletter` / `booking`, then templated across the rest of the integration set.
@@ -190,10 +196,6 @@ This is *stronger*: a non-LLM gate can't be prompt-injected or talked out of run
 
 ## 8. Risks & open questions
 
-- **`apply_edit` Swift port (Bucket 1) is the critical path.** Astro-component-aware
-  selector resolution + patching is non-trivial in Swift. *Open question:* port fully to
-  Swift, or keep `apply_edit` alone in the Node sidecar (Bucket 2) and port only the
-  cheaper hot paths? Resolve before committing slice 1.
 - **PCC availability & latency** for Bucket 5 — confirm the FoundationModels PCC tier is
   callable from both DevID and MAS builds and that quality clears the bar for `copy-edit` /
   `design-interview` before depending on it. The doc assumes Apple ships this; validate.


### PR DESCRIPTION
## Why

First concrete steps of the roadmap to remove the app's dependency on Claude Code and run on deterministic Swift + Apple Intelligence (so non-technical users can drive Anglesite by Siri/GUI). Includes the planning docs plus two roadmap slices.

## What's in here

**Planning (docs)**
- `docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md` — the migration roadmap: the App↔plugin boundary is 3 layers (the MCP server is already deterministic Node; Apple Intelligence already ships; the only real Claude dependency is the `claude --print` chat brain + the 56 skills-as-prose). Sorts all tools/skills into 6 capability buckets and sequences the work as end-to-end vertical slices.
- `docs/superpowers/plans/2026-06-20-native-create-content-swift-port.md` — the implementation plan executed below.

**Slice 1 — chat defaults to Apple Foundation Models** (`22c4fd2`)
The chat→FM path was already fully wired (`ConversationalAssistant` abstracts both backends, DevID FM path already attaches `ApplyEditTool`/`SearchContentTool`). This just flips `preferFoundationModels` to default `true` (inverted-from-absent, mirroring `autoGenerateAltText`) so a fresh DevID install uses the on-device brain; Claude becomes an opt-in legacy path. Settings copy + comments updated. MAS already FM-only, unaffected.

**Slice 2 — native Swift `create_page` / `create_post`** (Bucket 1 hot-path port)
- `ContentScaffold` — pure functions (slugify, route/path derivation, template rendering, escaping), byte-faithful to the Node sidecar's `create-content.mjs`.
- `NativeContentOperations` — validates, writes via `FileManager`, commits best-effort via an injected git closure routed through `ProcessSupervisor`. No MCP round-trip.
- `Bootstrap.swift` DI swap so Add Page / Add Post intents resolve the native impl. The MCP-routed `ContentOperations` is retained until a later cleanup slice.

## Verification

- 15 new AnglesiteCore tests (6 `ContentScaffold` + 9 `NativeContentOperations`, incl. a real-git integration test). Full suite green: 570 Core + 204 Intents + 14 Bridge.
- Built subagent-driven (implementer + per-task review + fix loop). Final whole-branch review (opus): **READY TO MERGE**, faithfulness HIGH — 17 representative inputs (ligatures, fractions, CJK, emoji, quotes, backslashes) produce byte-identical output to the Node sidecar. No Critical/Important findings; 4 cosmetic Minors deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)