### PR TITLE
feat(#275): native list_content + annotations (Bucket 1 ports)

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -634,22 +634,15 @@ struct SiteWindow: View {
         let mcpClient: @Sendable () async -> MCPClient? = { [preview] in
             await preview.mcpClient()
         }
-        let feed = AnnotationFeedFactory.viaMCP(mcpClient: mcpClient)
+        // Annotations are read/resolved by the native `AnnotationStore` over
+        // `Source/annotations.json` (#275) — no MCP hop. `undo_edit` stays MCP-backed (Bucket 2).
+        let sourceDirectory = resolved.sourceDirectory
+        let feed = AnnotationFeedFactory.native(directory: sourceDirectory)
         let undoCommand = UndoCommand(mcpClient: mcpClient)
-        // Resolve directly via the same per-site MCP client the feed uses — only a
-        // `resolve_annotation` tool call, no chat backend involved.
+        // Resolve directly against the on-disk store — `AnnotationStore.resolve` throws if the id
+        // is unknown, surfacing as a chat error the same way the MCP path did.
         let annotationResolver: ChatModel.AnnotationResolver = { id in
-            guard let client = await mcpClient() else {
-                throw NSError(domain: "AnnotationFeed", code: 1, userInfo: [NSLocalizedDescriptionKey: "no MCP client"])
-            }
-            let result = try await client.callTool(
-                name: "resolve_annotation",
-                arguments: .object(["id": .string(id)])
-            )
-            if result.isError {
-                let detail = result.content.compactMap(\.text).joined(separator: "\n")
-                throw NSError(domain: "AnnotationFeed", code: 2, userInfo: [NSLocalizedDescriptionKey: detail])
-            }
+            try AnnotationStore.resolve(in: sourceDirectory, id: id)
         }
         #if ANGLESITE_MAS
         // Sandboxed App Store build: there's no `claude` CLI to shell out to, so chat is backed by

--- a/Sources/AnglesiteCore/AnnotationFeed.swift
+++ b/Sources/AnglesiteCore/AnnotationFeed.swift
@@ -48,6 +48,14 @@ public typealias AnnotationFeed = @Sendable () async throws -> [Annotation]
 
 /// Builds a production `AnnotationFeed` and parses the plugin's JSON shape.
 public enum AnnotationFeedFactory {
+    /// Builds an `AnnotationFeed` backed by the native `AnnotationStore` (#275) — reads the
+    /// unresolved annotations straight from `<sourceDirectory>/annotations.json` with no MCP hop.
+    /// `directory` is the site's `Source/` root (where the store and the edit overlay agree the
+    /// file lives). Never throws: a missing/empty file yields `[]`.
+    public static func native(directory: URL) -> AnnotationFeed {
+        return { AnnotationStore.list(in: directory) }
+    }
+
     /// Builds an `AnnotationFeed` that calls the plugin's `list_annotations` MCP tool through
     /// the supplied weak getter, and parses the first text content block as a JSON array of
     /// annotations. Tolerant of `nil` clients (returns `[]`) so a freshly-opened site whose

--- a/Sources/AnglesiteCore/AnnotationStore.swift
+++ b/Sources/AnglesiteCore/AnnotationStore.swift
@@ -50,7 +50,9 @@ public enum AnnotationStore {
     /// the Node store's `JSON.stringify({ version, annotations }, null, 2) + "\n"`.
     public static func save(_ annotations: [Annotation], in directory: URL) throws {
         let text = serialize(annotations) + "\n"
-        try Data(text.utf8).write(to: directory.appendingPathComponent(filename))
+        // `.atomic` writes to a sibling temp file and renames it over the target, so a crash
+        // mid-write can't truncate annotations.json (which `load` would then read back as []).
+        try Data(text.utf8).write(to: directory.appendingPathComponent(filename), options: .atomic)
     }
 
     /// Render the versioned wrapper exactly as `JSON.stringify(obj, null, 2)` would: keys in
@@ -171,6 +173,9 @@ public enum AnnotationStore {
         guard let index = annotations.firstIndex(where: { $0.id == id }) else {
             throw AnnotationStoreError.notFound(id)
         }
+        // NOTE: re-stamps `resolvedAt` even if already resolved — this deliberately mirrors
+        // `annotations.mjs`'s unconditional `resolveAnnotation`. Don't add an early-return guard
+        // without also changing the Node reference, or the two stores diverge.
         let existing = annotations[index]
         let resolved = Annotation(
             id: existing.id,

--- a/Sources/AnglesiteCore/AnnotationStore.swift
+++ b/Sources/AnglesiteCore/AnnotationStore.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+/// Native port of the plugin's `server/annotations.mjs` (Bucket 1, #275).
+///
+/// Reads and writes the owner's "sticky note" annotations at `<projectRoot>/annotations.json`,
+/// replacing the `add_annotation` / `list_annotations` / `resolve_annotation` MCP round-trips with
+/// direct filesystem work. Byte-compatible with the Node store it supersedes: it reads both the
+/// versioned wrapper (`{ version, annotations }`) and the legacy bare-array format, and writes the
+/// versioned wrapper with ISO-8601 (fractional-second) timestamps so an external `claude` CLI or
+/// the sidecar can still round-trip the file.
+///
+/// The filesystem is the source of truth; there is no in-memory cache — every call re-reads disk.
+public enum AnnotationStore {
+    /// On-disk filename, relative to the project (`Source/`) root. Matches `annotations.mjs`.
+    static let filename = "annotations.json"
+    /// Schema version stamped into the wrapper, mirroring the Node store.
+    static let schemaVersion = 1
+    /// Hard cap on unresolved annotations, mirroring `annotations.mjs`'s `MAX_UNRESOLVED`.
+    static let maxUnresolved = 50
+
+    /// nanoid alphabet from `annotations.mjs` — 64 URL-safe characters indexed by `byte & 63`.
+    private static let alphabet = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
+
+    public enum AnnotationStoreError: Error, Equatable {
+        /// `add` rejected because `maxUnresolved` unresolved annotations already exist.
+        case limitReached(Int)
+        /// `resolve` couldn't find an annotation with the given id.
+        case notFound(String)
+    }
+
+    // MARK: - Read / write
+
+    /// Load all annotations (resolved and unresolved). Returns `[]` if the file is missing or
+    /// unparseable, matching the Node store's tolerant behavior. Accepts both the versioned
+    /// wrapper and the legacy bare-array format.
+    public static func load(in directory: URL) -> [Annotation] {
+        let url = directory.appendingPathComponent(filename)
+        guard let data = try? Data(contentsOf: url) else { return [] }
+        let decoder = makeDecoder()
+        if let wrapper = try? decoder.decode(Wrapper.self, from: data) {
+            return wrapper.annotations
+        }
+        if let bare = try? decoder.decode([Annotation].self, from: data) {
+            return bare
+        }
+        return []
+    }
+
+    /// Persist `annotations` as the versioned wrapper with a trailing newline, byte-identical to
+    /// the Node store's `JSON.stringify({ version, annotations }, null, 2) + "\n"`.
+    public static func save(_ annotations: [Annotation], in directory: URL) throws {
+        let text = serialize(annotations) + "\n"
+        try Data(text.utf8).write(to: directory.appendingPathComponent(filename))
+    }
+
+    /// Render the versioned wrapper exactly as `JSON.stringify(obj, null, 2)` would: keys in
+    /// insertion order (`version`, then `annotations`; per-entry `id, path, selector, [sourceFile],
+    /// text, resolved, createdAt, [resolvedAt]`), two-space indentation, and ECMA string escaping.
+    /// Foundation's `JSONEncoder` can't be used here — it reorders keys and spaces colons
+    /// differently — so the small, well-bounded object shape is serialized by hand.
+    static func serialize(_ annotations: [Annotation]) -> String {
+        guard !annotations.isEmpty else {
+            return "{\n  \"version\": \(schemaVersion),\n  \"annotations\": []\n}"
+        }
+        let entries = annotations.map { entryJSON($0) }.joined(separator: ",\n")
+        return """
+        {
+          "version": \(schemaVersion),
+          "annotations": [
+        \(entries)
+          ]
+        }
+        """
+    }
+
+    /// Serialize one annotation as a `JSON.stringify(…, 2)` array element: the object opens at
+    /// four-space indent, its fields at six.
+    private static func entryJSON(_ a: Annotation) -> String {
+        var lines: [String] = []
+        lines.append("      \(field("id", a.id))")
+        lines.append("      \(field("path", a.path))")
+        lines.append("      \(field("selector", a.selector))")
+        if let sourceFile = a.sourceFile {
+            lines.append("      \(field("sourceFile", sourceFile))")
+        }
+        lines.append("      \(field("text", a.text))")
+        lines.append("      \"resolved\": \(a.resolved ? "true" : "false")")
+        lines.append("      \(field("createdAt", isoFractional.string(from: a.createdAt)))")
+        if let resolvedAt = a.resolvedAt {
+            lines.append("      \(field("resolvedAt", isoFractional.string(from: resolvedAt)))")
+        }
+        return "    {\n" + lines.joined(separator: ",\n") + "\n    }"
+    }
+
+    private static func field(_ key: String, _ value: String) -> String {
+        "\"\(key)\": \(escapeJSONString(value))"
+    }
+
+    /// Escape a string exactly as `JSON.stringify` does: quote/backslash and the C0 control set
+    /// (with the short forms `\b \t \n \f \r`), everything else emitted as raw UTF-8 — forward
+    /// slashes and non-ASCII are left untouched.
+    static func escapeJSONString(_ s: String) -> String {
+        var out = "\""
+        for scalar in s.unicodeScalars {
+            switch scalar {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\u{08}": out += "\\b"
+            case "\u{09}": out += "\\t"
+            case "\u{0A}": out += "\\n"
+            case "\u{0C}": out += "\\f"
+            case "\u{0D}": out += "\\r"
+            case let c where c.value < 0x20:
+                out += String(format: "\\u%04x", c.value)
+            default:
+                out.unicodeScalars.append(scalar)
+            }
+        }
+        out += "\""
+        return out
+    }
+
+    // MARK: - Operations
+
+    /// Create a new unresolved annotation, persist it, and return it. Throws `.limitReached` once
+    /// `maxUnresolved` unresolved annotations already exist.
+    @discardableResult
+    public static func add(
+        in directory: URL,
+        path: String,
+        selector: String,
+        text: String,
+        sourceFile: String?,
+        now: Date = Date()
+    ) throws -> Annotation {
+        var annotations = load(in: directory)
+        let unresolved = annotations.filter { !$0.resolved }.count
+        if unresolved >= maxUnresolved {
+            throw AnnotationStoreError.limitReached(maxUnresolved)
+        }
+        let annotation = Annotation(
+            id: nanoid(),
+            path: path,
+            selector: selector,
+            sourceFile: sourceFile,
+            text: text,
+            resolved: false,
+            createdAt: now,
+            resolvedAt: nil
+        )
+        annotations.append(annotation)
+        try save(annotations, in: directory)
+        return annotation
+    }
+
+    /// List unresolved annotations, optionally filtered to a single page `path`. Resolved
+    /// annotations are always excluded, mirroring `listAnnotations`.
+    public static func list(in directory: URL, path: String? = nil) -> [Annotation] {
+        var annotations = load(in: directory).filter { !$0.resolved }
+        if let path {
+            annotations = annotations.filter { $0.path == path }
+        }
+        return annotations
+    }
+
+    /// Mark the annotation with `id` resolved (stamping `resolvedAt`), persist, and return it.
+    /// Throws `.notFound` if no annotation has that id.
+    @discardableResult
+    public static func resolve(in directory: URL, id: String, now: Date = Date()) throws -> Annotation {
+        var annotations = load(in: directory)
+        guard let index = annotations.firstIndex(where: { $0.id == id }) else {
+            throw AnnotationStoreError.notFound(id)
+        }
+        let existing = annotations[index]
+        let resolved = Annotation(
+            id: existing.id,
+            path: existing.path,
+            selector: existing.selector,
+            sourceFile: existing.sourceFile,
+            text: existing.text,
+            resolved: true,
+            createdAt: existing.createdAt,
+            resolvedAt: now
+        )
+        annotations[index] = resolved
+        try save(annotations, in: directory)
+        return resolved
+    }
+
+    // MARK: - nanoid
+
+    /// Generate an 8-character nanoid, mirroring `annotations.mjs`: random bytes masked into the
+    /// 64-character alphabet.
+    static func nanoid(size: Int = 8) -> String {
+        var bytes = [UInt8](repeating: 0, count: size)
+        for i in 0..<size { bytes[i] = UInt8.random(in: 0...255) }
+        return String(bytes.map { alphabet[Int($0 & 63)] })
+    }
+
+    // MARK: - Coding
+
+    private struct Wrapper: Codable {
+        let version: Int
+        let annotations: [Annotation]
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let raw = try decoder.singleValueContainer().decode(String.self)
+            if let date = isoFractional.date(from: raw) ?? isoPlain.date(from: raw) { return date }
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "Expected an ISO-8601 timestamp, got \"\(raw)\""
+            ))
+        }
+        return decoder
+    }
+
+    private nonisolated(unsafe) static let isoPlain = ISO8601DateFormatter()
+    private nonisolated(unsafe) static let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+}

--- a/Sources/AnglesiteCore/ContentScanner.swift
+++ b/Sources/AnglesiteCore/ContentScanner.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// Native port of the plugin's `server/list-content.mjs` (Bucket 1, #275).
+///
+/// Scans a site's `Source/` directory — `src/pages/`, the article-like collections under
+/// `src/content/`, and `public/images/` — into a `ContentListing`, replacing the `list_content`
+/// MCP round-trip in `LocalSiteRuntime.populateContentGraph()`. The scan is read-only; the
+/// filesystem is the source of truth.
+///
+/// Unlike the Node tool (whose JSON payload is site-agnostic and stamped by `ContentListing.parse`),
+/// this builds the site-scoped `SiteContentGraph` structs directly, stamping `siteID` inline.
+/// Directory entries are visited in sorted order so the listing is deterministic.
+public enum ContentScanner {
+
+    /// Page source extensions that map to a navigable route.
+    private static let pageExtensions: Set<String> = [".astro", ".md", ".mdx", ".markdown", ".html"]
+    /// Content-collection entry extensions (Astro content layer glob: mdoc, mdx, md).
+    private static let entryExtensions: Set<String> = [".md", ".mdx", ".mdoc", ".markdown"]
+    /// Raster/vector image extensions surfaced from `public/images/`.
+    private static let imageExtensions: Set<String> = [".jpg", ".jpeg", ".png", ".webp", ".gif", ".svg", ".avif"]
+    /// Collections whose entries are "posts" in the graph's sense (title / publishDate / draft /
+    /// tags). Other collections (gallery, team, menus, …) don't fit the Post shape (#140).
+    private static let articleCollections = ["posts", "notes", "episodes", "experiments"]
+
+    public static func scan(projectRoot: URL, siteID: String) -> ContentListing {
+        ContentListing(
+            pages: scanPages(projectRoot, siteID: siteID),
+            posts: scanPosts(projectRoot, siteID: siteID),
+            images: scanImages(projectRoot, siteID: siteID)
+        )
+    }
+
+    // MARK: - Pages
+
+    private static func scanPages(_ projectRoot: URL, siteID: String) -> [SiteContentGraph.Page] {
+        let pagesDir = projectRoot.appendingPathComponent("src/pages")
+        var out: [SiteContentGraph.Page] = []
+        for abs in walk(pagesDir) {
+            let relPosix = relativePosix(abs, from: projectRoot)
+            // Skip dynamic routes (`[slug]`, `[...rest]`) — templates, not concrete pages.
+            if relPosix.contains("[") { continue }
+            if !pageExtensions.contains(fileExtension(abs)) { continue }
+            let route = routeFromPagePath(relPosix)
+            out.append(SiteContentGraph.Page(
+                id: "\(siteID):page:\(route)",
+                siteID: siteID,
+                route: route,
+                filePath: relPosix,
+                title: pageTitle(abs),
+                lastModified: mtime(abs)
+            ))
+        }
+        return out
+    }
+
+    /// `src/pages/index.astro` → `/`, `src/pages/blog/index.astro` → `/blog`, `…/about.astro` → `/about`.
+    static func routeFromPagePath(_ relPosix: String) -> String {
+        var r = relPosix
+        if r.hasPrefix("src/pages/") { r.removeFirst("src/pages/".count) }
+        if let dot = r.lastIndex(of: ".") { r = String(r[r.startIndex..<dot]) }  // strip final extension
+        // Drop a trailing `index` segment (`(^|/)index$`), keeping the preceding slash.
+        if r == "index" {
+            r = ""
+        } else if r.hasSuffix("/index") {
+            r.removeLast("index".count)
+        }
+        if r.hasSuffix("/") { r.removeLast() }
+        return "/" + r
+    }
+
+    /// Best-effort page title: frontmatter `title`, else the `title="…"`/`title='…'` prop, else nil.
+    private static func pageTitle(_ abs: URL) -> String? {
+        guard let text = try? String(contentsOf: abs, encoding: .utf8) else { return nil }
+        if case let .string(t)? = Frontmatter.parse(text)[ "title" ], !t.isEmpty { return t }
+        return firstTitleAttribute(in: text)
+    }
+
+    /// Port of `/\btitle\s*=\s*(?:"([^"]*)"|'([^']*)')/` — the first `title="…"` or `title='…'`.
+    private static let titleAttrRegex = try! NSRegularExpression(
+        pattern: #"\btitle\s*=\s*(?:"([^"]*)"|'([^']*)')"#
+    )
+    private static func firstTitleAttribute(in text: String) -> String? {
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let m = titleAttrRegex.firstMatch(in: text, range: range) else { return nil }
+        for group in [1, 2] {
+            if let r = Range(m.range(at: group), in: text) { return String(text[r]) }
+        }
+        return nil
+    }
+
+    // MARK: - Posts
+
+    private static func scanPosts(_ projectRoot: URL, siteID: String) -> [SiteContentGraph.Post] {
+        let contentDir = projectRoot.appendingPathComponent("src/content")
+        var out: [SiteContentGraph.Post] = []
+        for collection in articleCollections {
+            let dir = contentDir.appendingPathComponent(collection)
+            for abs in walk(dir) {
+                if !entryExtensions.contains(fileExtension(abs)) { continue }
+                let relPosix = relativePosix(abs, from: projectRoot)
+                let fm = readFrontmatter(abs)
+                let slug = stringField(fm, "slug") ?? basenameWithoutExtension(abs)
+                let title = stringField(fm, "title") ?? slug
+                let tags: [String]
+                if case let .array(t)? = fm["tags"] { tags = t } else { tags = [] }
+                out.append(SiteContentGraph.Post(
+                    id: "\(siteID):post:\(slug)",
+                    siteID: siteID,
+                    collection: collection,
+                    slug: slug,
+                    title: title,
+                    draft: fm["draft"] == .bool(true),
+                    publishDate: parseDate(stringField(fm, "publishDate") ?? stringField(fm, "date")),
+                    tags: tags,
+                    filePath: relPosix,
+                    lastModified: mtime(abs)
+                ))
+            }
+        }
+        return out
+    }
+
+    // MARK: - Images
+
+    private static func scanImages(_ projectRoot: URL, siteID: String) -> [SiteContentGraph.Image] {
+        let imagesDir = projectRoot.appendingPathComponent("public/images")
+        var out: [SiteContentGraph.Image] = []
+        for abs in walk(imagesDir) {
+            if !imageExtensions.contains(fileExtension(abs)) { continue }
+            let relPosix = relativePosix(abs, from: projectRoot)
+            out.append(SiteContentGraph.Image(
+                id: "\(siteID):image:\(relPosix)",
+                siteID: siteID,
+                relativePath: relPosix,
+                fileName: abs.lastPathComponent,
+                byteSize: fileSize(abs),
+                usedOnPages: [],  // reverse "which pages use this image" is deferred (#140)
+                lastModified: mtime(abs)
+            ))
+        }
+        return out
+    }
+
+    // MARK: - Frontmatter helpers
+
+    private static func readFrontmatter(_ abs: URL) -> [String: FrontmatterValue] {
+        guard let text = try? String(contentsOf: abs, encoding: .utf8) else { return [:] }
+        return Frontmatter.parse(text)
+    }
+
+    private static func stringField(_ fm: [String: FrontmatterValue], _ key: String) -> String? {
+        if case let .string(s)? = fm[key], !s.isEmpty { return s }
+        return nil
+    }
+
+    /// Parse a frontmatter date the way `new Date(value).toISOString()` would for the realistic
+    /// inputs: a date-only `YYYY-MM-DD` (UTC midnight) or a full ISO-8601 timestamp. Anything else
+    /// (or nil) → nil, matching `dateISO` returning null for unparseable values.
+    static func parseDate(_ value: String?) -> Date? {
+        guard let value, !value.isEmpty else { return nil }
+        if let date = isoFractional.date(from: value) ?? isoPlain.date(from: value) { return date }
+        return dateOnlyFormatter.date(from: value)
+    }
+
+    // MARK: - Filesystem helpers
+
+    /// Recursively collect files under `dir` in sorted order. Missing dir → empty.
+    private static func walk(_ dir: URL) -> [URL] {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.isDirectoryKey], options: []
+        ) else { return [] }
+        var files: [URL] = []
+        for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            let isDir = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDir == true {
+                files.append(contentsOf: walk(entry))
+            } else {
+                files.append(entry)
+            }
+        }
+        return files
+    }
+
+    /// POSIX path of `url` relative to `base` (forward slashes, no leading slash).
+    private static func relativePosix(_ url: URL, from base: URL) -> String {
+        let urlComponents = url.standardizedFileURL.pathComponents
+        let baseComponents = base.standardizedFileURL.pathComponents
+        guard urlComponents.starts(with: baseComponents) else { return url.path }
+        return urlComponents.dropFirst(baseComponents.count).joined(separator: "/")
+    }
+
+    /// Lowercased extension including the leading dot (e.g. `.astro`), or `""` if none.
+    private static func fileExtension(_ url: URL) -> String {
+        let ext = url.pathExtension
+        return ext.isEmpty ? "" : "." + ext.lowercased()
+    }
+
+    private static func basenameWithoutExtension(_ url: URL) -> String {
+        url.deletingPathExtension().lastPathComponent
+    }
+
+    private static func mtime(_ url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+            ?? Date(timeIntervalSince1970: 0)
+    }
+
+    private static func fileSize(_ url: URL) -> Int64? {
+        guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize else { return nil }
+        return Int64(size)
+    }
+
+    // MARK: - Date formatters
+
+    private nonisolated(unsafe) static let isoPlain = ISO8601DateFormatter()
+    private nonisolated(unsafe) static let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let dateOnlyFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+}

--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -60,12 +60,17 @@ public enum Frontmatter {
 
     // MARK: - Helpers
 
+    /// Compiled once — `frontmatterBlock` runs per page/post file during a scan, so recompiling
+    /// this dotall pattern each call would be O(files).
+    private static let frontmatterPattern = try! NSRegularExpression(
+        pattern: "^---\\r?\\n([\\s\\S]*?)\\r?\\n---"
+    )
+
     /// Extract the text between the opening `---<newline>` and the first following `<newline>---`,
     /// anchored at the very start of `source`. `nil` if there is no such block.
     private static func frontmatterBlock(_ source: String) -> String? {
-        let pattern = try! NSRegularExpression(pattern: "^---\\r?\\n([\\s\\S]*?)\\r?\\n---")
         let range = NSRange(source.startIndex..<source.endIndex, in: source)
-        guard let match = pattern.firstMatch(in: source, range: range),
+        guard let match = frontmatterPattern.firstMatch(in: source, range: range),
               let captured = Range(match.range(at: 1), in: source)
         else { return nil }
         return String(source[captured])

--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// A parsed frontmatter scalar/array value. Mirrors the `string | boolean | string[]` union the
+/// Node `parseFrontmatter` returns — the distinction matters to the scanner (`draft === true`
+/// wants a real boolean; `Array.isArray(tags)` wants a real array).
+public enum FrontmatterValue: Equatable, Sendable {
+    case string(String)
+    case bool(Bool)
+    case array([String])
+}
+
+/// Native port of `server/content-frontmatter.mjs` (Bucket 1, #275).
+///
+/// A deliberately minimal YAML reader for the handful of fields `list_content` needs off
+/// article-like collection entries (`title`, `slug`, `draft`, `publishDate`, `date`, `tags`).
+/// It parses exactly that subset — quoted/unquoted scalars, booleans, and string arrays in both
+/// inline (`[a, b]`) and block (`- a`) form, top-level keys only — and leaves anything it doesn't
+/// recognize out of the returned map rather than guessing.
+public enum Frontmatter {
+    /// Parse the leading `---` frontmatter block of `source`. Returns an empty map when there is
+    /// no frontmatter at the very start of the file.
+    public static func parse(_ source: String) -> [String: FrontmatterValue] {
+        guard let block = frontmatterBlock(source) else { return [:] }
+
+        var out: [String: FrontmatterValue] = [:]
+        // Split on `\n` and `\r\n` (the Node parser's `/\r?\n/`) by normalizing CRLF first.
+        let lines = block.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
+        var i = 0
+        while i < lines.count {
+            let line = lines[i]
+            defer { i += 1 }
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+            // Only top-level keys (no leading whitespace) start a new field.
+            if let first = line.first, first == " " || first == "\t" { continue }
+
+            guard let (key, rawValue) = splitKeyValue(line) else { continue }
+
+            if rawValue.isEmpty {
+                // Possible block array on the following indented `- item` lines.
+                var items: [String] = []
+                var j = i + 1
+                while j < lines.count, let item = blockArrayItem(lines[j]) {
+                    items.append(unquote(item))
+                    j += 1
+                }
+                if !items.isEmpty {
+                    out[key] = .array(items)
+                    i = j - 1
+                } else {
+                    out[key] = .string("")
+                }
+                continue
+            }
+
+            out[key] = parseScalarOrArray(rawValue)
+        }
+        return out
+    }
+
+    // MARK: - Helpers
+
+    /// Extract the text between the opening `---<newline>` and the first following `<newline>---`,
+    /// anchored at the very start of `source`. `nil` if there is no such block.
+    private static func frontmatterBlock(_ source: String) -> String? {
+        let pattern = try! NSRegularExpression(pattern: "^---\\r?\\n([\\s\\S]*?)\\r?\\n---")
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        guard let match = pattern.firstMatch(in: source, range: range),
+              let captured = Range(match.range(at: 1), in: source)
+        else { return nil }
+        return String(source[captured])
+    }
+
+    /// Split `key: value` where key is `[A-Za-z0-9_-]+`. Value is right-trimmed of surrounding
+    /// whitespace (`\s*(.*)` in the Node regex, then `.trim()`).
+    private static func splitKeyValue(_ line: String) -> (key: String, value: String)? {
+        guard let colon = line.firstIndex(of: ":") else { return nil }
+        let key = String(line[line.startIndex..<colon])
+        guard !key.isEmpty, key.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" || $0 == "-" }) else {
+            return nil
+        }
+        let value = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+        return (key, value)
+    }
+
+    /// If `line` is a block-array item (`^\s*-\s+item`), return its trimmed item text.
+    private static func blockArrayItem(_ line: String) -> String? {
+        let stripped = String(line.drop(while: { $0 == " " || $0 == "\t" }))
+        guard stripped.hasPrefix("-") else { return nil }
+        let afterDash = stripped.dropFirst()
+        // Require at least one whitespace after the dash (the `\s+` in `-\s+`).
+        guard let firstAfter = afterDash.first, firstAfter == " " || firstAfter == "\t" else { return nil }
+        return String(afterDash).trimmingCharacters(in: .whitespaces)
+    }
+
+    private static func parseScalarOrArray(_ raw: String) -> FrontmatterValue {
+        if raw == "true" { return .bool(true) }
+        if raw == "false" { return .bool(false) }
+        if raw.hasPrefix("["), raw.hasSuffix("]") {
+            let inner = String(raw.dropFirst().dropLast()).trimmingCharacters(in: .whitespaces)
+            if inner.isEmpty { return .array([]) }
+            // `omittingEmptySubsequences: false` matches JS `String.split(",")`, which keeps empties.
+            return .array(
+                inner.split(separator: ",", omittingEmptySubsequences: false)
+                    .map { unquote($0.trimmingCharacters(in: .whitespaces)) }
+            )
+        }
+        return .string(unquote(raw))
+    }
+
+    /// Strip a single layer of matching `"` or `'` quotes, else return as-is.
+    private static func unquote(_ s: String) -> String {
+        if s.count >= 2,
+           (s.hasPrefix("\"") && s.hasSuffix("\"")) || (s.hasPrefix("'") && s.hasSuffix("'")) {
+            return String(s.dropFirst().dropLast())
+        }
+        return s
+    }
+}

--- a/Sources/AnglesiteCore/LocalSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalSiteRuntime.swift
@@ -115,9 +115,10 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
                 // anyway (preview is the primary feature; the edit pipeline is an enhancement).
                 await startMCPClient(siteID: siteID, siteDirectory: siteDirectory)
                 guard gen == generation else { return }
-                // Populate the content graph from the now-initialized MCP server. Best-effort:
-                // a missing/erroring `list_content` (older plugin) just leaves the graph empty.
-                await populateContentGraph(siteID: siteID, generation: gen)
+                // Populate the content graph with a native scan of the site's `Source/` directory
+                // (Bucket 1, #275). Replaces the `list_content` MCP round-trip — same projection,
+                // no subprocess hop. An empty/unscannable site just leaves the graph empty.
+                await populateContentGraph(siteID: siteID, siteDirectory: siteDirectory, generation: gen)
                 guard gen == generation else { return }
                 setState(.ready(siteID: siteID, url: url))
             } catch {
@@ -154,43 +155,17 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
         }
     }
 
-    /// Call the plugin's `list_content` MCP tool and load the result into `contentGraph`. A no-op
-    /// when no graph is attached. The whole path is best-effort: a missing tool (older plugin,
-    /// surfaced as `MCPError.rpcError`), an `isError` result, a malformed payload, or the MCP
-    /// client not running all log a warning and leave the graph empty — preview is unaffected.
-    private func populateContentGraph(siteID: String, generation gen: Int) async {
+    /// Scan the site's `Source/` directory (`siteDirectory`) into `contentGraph` via the native
+    /// `ContentScanner` (Bucket 1, #275). A no-op when no graph is attached. The scan is read-only
+    /// and total — an empty or partial site simply yields fewer entries; nothing throws.
+    private func populateContentGraph(siteID: String, siteDirectory: URL, generation gen: Int) async {
         guard let graph = contentGraph else { return }
-        guard await mcpClient.isRunning else { return }
-        do {
-            let result = try await mcpClient.callTool(name: "list_content")
-            // A newer start() may have superseded us during the call — don't pollute the shared
-            // graph with a site this window is no longer showing; that start() loads its own.
-            guard gen == generation else { return }
-            guard !result.isError else {
-                await logCenter.append(
-                    source: "mcp:\(siteID)", stream: .stderr,
-                    text: "list_content returned an error result — content graph left empty"
-                )
-                return
-            }
-            let text = result.content.first(where: { $0.type == "text" })?.text ?? ""
-            let listing = try ContentListing.parse(jsonText: text, siteID: siteID)
-            await graph.load(siteID: siteID, pages: listing.pages, posts: listing.posts, images: listing.images)
-            loadedGraphSiteID = siteID
-        } catch let MCPClient.MCPError.rpcError(code, _) where code == -32601 {
-            // Method-not-found: older plugin without the tool — expected, not worth alarming about.
-            // Any *other* RPC error means `list_content` exists but failed, so it falls through to
-            // the stderr branch below where it stays visible in the Debug pane (logs are sacred).
-            await logCenter.append(
-                source: "mcp:\(siteID)", stream: .stdout,
-                text: "list_content not available (older plugin) — content graph left empty"
-            )
-        } catch {
-            await logCenter.append(
-                source: "mcp:\(siteID)", stream: .stderr,
-                text: "list_content population failed: \(error) — content graph left empty"
-            )
-        }
+        let listing = ContentScanner.scan(projectRoot: siteDirectory, siteID: siteID)
+        // A newer start() may have superseded us during the scan — don't pollute the shared graph
+        // with a site this window is no longer showing; that start() loads its own.
+        guard gen == generation else { return }
+        await graph.load(siteID: siteID, pages: listing.pages, posts: listing.posts, images: listing.images)
+        loadedGraphSiteID = siteID
     }
 
     private func startMCPClient(siteID: String, siteDirectory: URL) async {

--- a/Sources/AnglesiteCore/LocalSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalSiteRuntime.swift
@@ -160,7 +160,12 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
     /// and total — an empty or partial site simply yields fewer entries; nothing throws.
     private func populateContentGraph(siteID: String, siteDirectory: URL, generation gen: Int) async {
         guard let graph = contentGraph else { return }
-        let listing = ContentScanner.scan(projectRoot: siteDirectory, siteID: siteID)
+        // Run the recursive filesystem scan off the actor so it doesn't block this runtime from
+        // processing other messages (stop signals, state queries) for the scan's duration — the
+        // old MCP path yielded the actor on every `await`, and this preserves that.
+        let listing = await Task.detached(priority: .utility) {
+            ContentScanner.scan(projectRoot: siteDirectory, siteID: siteID)
+        }.value
         // A newer start() may have superseded us during the scan — don't pollute the shared graph
         // with a site this window is no longer showing; that start() loads its own.
         guard gen == generation else { return }

--- a/Tests/AnglesiteCoreTests/AnnotationStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/AnnotationStoreTests.swift
@@ -1,0 +1,160 @@
+// Tests/AnglesiteCoreTests/AnnotationStoreTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Native port of `server/annotations.mjs` — load/save/add/list/resolve over
+/// `<projectRoot>/annotations.json`. These tests pin the behavior to the Node source it replaces.
+@Suite("AnnotationStore")
+struct AnnotationStoreTests {
+
+    private func makeRoot() -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("annotation-store-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private let now = Date(timeIntervalSince1970: 1_750_000_000) // 2025-06-15T15:06:40Z
+
+    @Test("add persists a new unresolved annotation and returns it")
+    func addPersists() throws {
+        let root = makeRoot()
+        let a = try AnnotationStore.add(
+            in: root, path: "/about", selector: "h1", text: "tighter tone", sourceFile: nil, now: now
+        )
+        #expect(a.path == "/about")
+        #expect(a.selector == "h1")
+        #expect(a.text == "tighter tone")
+        #expect(a.resolved == false)
+        #expect(a.resolvedAt == nil)
+        #expect(a.sourceFile == nil)
+        #expect(a.createdAt == now)
+        #expect(a.id.count == 8)
+
+        // Persisted and reloadable.
+        let loaded = AnnotationStore.load(in: root)
+        #expect(loaded.count == 1)
+        #expect(loaded[0].id == a.id)
+    }
+
+    @Test("list excludes resolved and filters by path")
+    func listFilters() throws {
+        let root = makeRoot()
+        let home = try AnnotationStore.add(in: root, path: "/", selector: "#hero", text: "a", sourceFile: nil, now: now)
+        _ = try AnnotationStore.add(in: root, path: "/about", selector: "h1", text: "b", sourceFile: nil, now: now)
+        _ = try AnnotationStore.resolve(in: root, id: AnnotationStore.add(in: root, path: "/", selector: ".x", text: "c", sourceFile: nil, now: now).id, now: now)
+
+        // Default: only unresolved, all paths.
+        let all = AnnotationStore.list(in: root)
+        #expect(all.count == 2)
+        #expect(all.allSatisfy { !$0.resolved })
+
+        // Path filter.
+        let homeOnly = AnnotationStore.list(in: root, path: "/")
+        #expect(homeOnly.map(\.id) == [home.id])
+    }
+
+    @Test("resolve marks resolved with a timestamp and persists")
+    func resolveMarks() throws {
+        let root = makeRoot()
+        let a = try AnnotationStore.add(in: root, path: "/", selector: "#hero", text: "a", sourceFile: nil, now: now)
+        let resolvedAt = now.addingTimeInterval(60)
+        let resolved = try AnnotationStore.resolve(in: root, id: a.id, now: resolvedAt)
+        #expect(resolved.resolved == true)
+        #expect(resolved.resolvedAt == resolvedAt)
+        // Persisted: a fresh load reflects the resolution.
+        #expect(AnnotationStore.load(in: root).first?.resolved == true)
+    }
+
+    @Test("resolve throws notFound for an unknown id")
+    func resolveNotFound() throws {
+        let root = makeRoot()
+        #expect(throws: AnnotationStore.AnnotationStoreError.notFound("nope")) {
+            try AnnotationStore.resolve(in: root, id: "nope", now: now)
+        }
+    }
+
+    @Test("add throws once the unresolved limit is reached")
+    func addLimit() throws {
+        let root = makeRoot()
+        for i in 0..<50 {
+            _ = try AnnotationStore.add(in: root, path: "/", selector: "#\(i)", text: "n", sourceFile: nil, now: now)
+        }
+        #expect(throws: AnnotationStore.AnnotationStoreError.limitReached(50)) {
+            try AnnotationStore.add(in: root, path: "/", selector: "#over", text: "n", sourceFile: nil, now: now)
+        }
+        // Resolving one frees a slot.
+        let id = AnnotationStore.list(in: root).first!.id
+        _ = try AnnotationStore.resolve(in: root, id: id, now: now)
+        #expect(throws: Never.self) {
+            try AnnotationStore.add(in: root, path: "/", selector: "#ok", text: "n", sourceFile: nil, now: now)
+        }
+    }
+
+    @Test("load tolerates the legacy bare-array format")
+    func loadLegacyArray() throws {
+        let root = makeRoot()
+        let legacy = #"""
+        [{"id":"abc12345","path":"/about","selector":"h1","text":"old","resolved":false,"createdAt":"2026-05-24T10:00:00.000Z"}]
+        """#
+        try Data(legacy.utf8).write(to: root.appendingPathComponent("annotations.json"))
+        let loaded = AnnotationStore.load(in: root)
+        #expect(loaded.count == 1)
+        #expect(loaded[0].id == "abc12345")
+        #expect(loaded[0].path == "/about")
+    }
+
+    @Test("save writes the exact versioned-wrapper bytes the Node store would")
+    func saveByteFaithful() throws {
+        let root = makeRoot()
+        let annotation = Annotation(
+            id: "fixedid0", path: "/about", selector: "h1", sourceFile: nil,
+            text: "hello", resolved: false, createdAt: now, resolvedAt: nil
+        )
+        try AnnotationStore.save([annotation], in: root)
+        let written = try String(contentsOf: root.appendingPathComponent("annotations.json"), encoding: .utf8)
+        let expected = """
+        {
+          "version": 1,
+          "annotations": [
+            {
+              "id": "fixedid0",
+              "path": "/about",
+              "selector": "h1",
+              "text": "hello",
+              "resolved": false,
+              "createdAt": "2025-06-15T15:06:40.000Z"
+            }
+          ]
+        }
+
+        """
+        #expect(written == expected)
+    }
+
+    @Test("empty annotations serialize to the inline empty array")
+    func saveEmpty() throws {
+        let root = makeRoot()
+        try AnnotationStore.save([], in: root)
+        let written = try String(contentsOf: root.appendingPathComponent("annotations.json"), encoding: .utf8)
+        #expect(written == "{\n  \"version\": 1,\n  \"annotations\": []\n}\n")
+    }
+
+    @Test("string escaping matches JSON.stringify for tricky inputs")
+    func escapingFaithful() {
+        // (input, expected JSON literal incl. surrounding quotes) — mirrors JSON.stringify.
+        let cases: [(String, String)] = [
+            ("a\"b", "\"a\\\"b\""),                    // quote
+            ("a\\b", "\"a\\\\b\""),                    // backslash
+            ("line1\nline2", "\"line1\\nline2\""),     // newline → \n
+            ("tab\there", "\"tab\\there\""),           // tab → \t
+            ("a/b", "\"a/b\""),                          // forward slash NOT escaped
+            ("café ☕️ 日本", "\"café ☕️ 日本\""),         // non-ASCII emitted raw
+            ("bell\u{07}", "\"bell\\u0007\""),         // other control → \u00XX
+        ]
+        for (input, expected) in cases {
+            #expect(AnnotationStore.escapeJSONString(input) == expected)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/AnnotationStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/AnnotationStoreTests.swift
@@ -43,7 +43,8 @@ struct AnnotationStoreTests {
         let root = makeRoot()
         let home = try AnnotationStore.add(in: root, path: "/", selector: "#hero", text: "a", sourceFile: nil, now: now)
         _ = try AnnotationStore.add(in: root, path: "/about", selector: "h1", text: "b", sourceFile: nil, now: now)
-        _ = try AnnotationStore.resolve(in: root, id: AnnotationStore.add(in: root, path: "/", selector: ".x", text: "c", sourceFile: nil, now: now).id, now: now)
+        let toResolve = try AnnotationStore.add(in: root, path: "/", selector: ".x", text: "c", sourceFile: nil, now: now)
+        _ = try AnnotationStore.resolve(in: root, id: toResolve.id, now: now)
 
         // Default: only unresolved, all paths.
         let all = AnnotationStore.list(in: root)
@@ -65,6 +66,17 @@ struct AnnotationStoreTests {
         #expect(resolved.resolvedAt == resolvedAt)
         // Persisted: a fresh load reflects the resolution.
         #expect(AnnotationStore.load(in: root).first?.resolved == true)
+    }
+
+    @Test("resolve re-stamps resolvedAt on a second call (mirrors the Node store)")
+    func resolveReStamps() throws {
+        let root = makeRoot()
+        let a = try AnnotationStore.add(in: root, path: "/", selector: "#hero", text: "a", sourceFile: nil, now: now)
+        _ = try AnnotationStore.resolve(in: root, id: a.id, now: now)
+        let later = now.addingTimeInterval(120)
+        let second = try AnnotationStore.resolve(in: root, id: a.id, now: later)
+        // Deliberate: `annotations.mjs` re-stamps unconditionally, so we do too.
+        #expect(second.resolvedAt == later)
     }
 
     @Test("resolve throws notFound for an unknown id")

--- a/Tests/AnglesiteCoreTests/ContentScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScannerTests.swift
@@ -1,0 +1,114 @@
+// Tests/AnglesiteCoreTests/ContentScannerTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Native port of `server/list-content.mjs` — scans a site's `Source/` directory into a
+/// `ContentListing`, replacing the `list_content` MCP round-trip. Pins behavior to the Node tool.
+@Suite("ContentScanner")
+struct ContentScannerTests {
+
+    /// Build a temp site root and write `files` (relative path → contents).
+    private func makeSite(_ files: [String: String]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("content-scan-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    private let siteID = "site-1"
+
+    @Test("pages: route derivation, dynamic-route + non-page skips")
+    func pages() {
+        let root = makeSite([
+            "src/pages/index.astro": "<h1>Home</h1>",
+            "src/pages/about.astro": "<h1>About</h1>",
+            "src/pages/blog/index.astro": "<h1>Blog</h1>",
+            "src/pages/blog/[slug].astro": "<h1>dynamic</h1>",   // dynamic → skipped
+            "src/pages/styles.css": "body{}",                     // non-page ext → skipped
+        ])
+        let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
+        let routes = Set(pages.map(\.route))
+        #expect(routes == ["/", "/about", "/blog"])
+        #expect(pages.allSatisfy { $0.siteID == siteID })
+        let about = pages.first { $0.route == "/about" }
+        #expect(about?.id == "site-1:page:/about")
+        #expect(about?.filePath == "src/pages/about.astro")
+    }
+
+    @Test("page title: frontmatter title, then title= prop, else nil")
+    func pageTitles() {
+        let root = makeSite([
+            "src/pages/fm.md": "---\ntitle: From Frontmatter\n---\nbody",
+            "src/pages/prop.astro": "---\nimport L from '../layouts/Base.astro';\n---\n<L title=\"From Prop\">x</L>",
+            "src/pages/none.astro": "<h1>no title</h1>",
+        ])
+        let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
+        func title(_ route: String) -> String?? { pages.first { $0.route == route }?.title }
+        #expect(title("/fm") == "From Frontmatter")
+        #expect(title("/prop") == "From Prop")
+        #expect(title("/none") == .some(nil))
+    }
+
+    @Test("posts: article collections only, fields derived from frontmatter")
+    func posts() {
+        let root = makeSite([
+            "src/content/posts/hello-world.md": "---\ntitle: Hello World\npublishDate: 2026-06-01\ndraft: false\ntags: [intro, news]\n---\nBody",
+            "src/content/notes/2026-06-05-quick.md": "---\nslug: quick-note\npublishDate: 2026-06-05\ndraft: false\n---\njust a note",
+            "src/content/gallery/photo.md": "---\ntitle: Not A Post\n---\nx",  // non-article collection → ignored
+        ])
+        let posts = ContentScanner.scan(projectRoot: root, siteID: siteID).posts
+        #expect(posts.count == 2)
+
+        let hello = posts.first { $0.collection == "posts" }
+        #expect(hello?.slug == "hello-world")
+        #expect(hello?.title == "Hello World")
+        #expect(hello?.draft == false)
+        #expect(hello?.tags == ["intro", "news"])
+        #expect(hello?.id == "site-1:post:hello-world")
+        // publishDate 2026-06-01 → UTC midnight, matching `new Date("2026-06-01").toISOString()`.
+        #expect(hello?.publishDate == ISO8601DateFormatter().date(from: "2026-06-01T00:00:00Z"))
+
+        let note = posts.first { $0.collection == "notes" }
+        #expect(note?.slug == "quick-note")     // slug from frontmatter
+        #expect(note?.title == "quick-note")    // title falls back to slug
+    }
+
+    @Test("post slug falls back to filename when frontmatter omits it")
+    func postSlugFallback() {
+        let root = makeSite([
+            "src/content/posts/my-file.mdx": "---\ntitle: T\n---\nx",
+        ])
+        let posts = ContentScanner.scan(projectRoot: root, siteID: siteID).posts
+        #expect(posts.first?.slug == "my-file")
+    }
+
+    @Test("images: public/images scanned with byte size, non-images skipped")
+    func images() {
+        let root = makeSite([
+            "public/images/hero.png": "PNGDATA",
+            "public/images/nested/logo.svg": "<svg/>",
+            "public/images/readme.txt": "notes",   // non-image → skipped
+        ])
+        let images = ContentScanner.scan(projectRoot: root, siteID: siteID).images
+        #expect(images.count == 2)
+        let hero = images.first { $0.fileName == "hero.png" }
+        #expect(hero?.relativePath == "public/images/hero.png")
+        #expect(hero?.id == "site-1:image:public/images/hero.png")
+        #expect(hero?.byteSize == 7)               // "PNGDATA"
+        #expect(hero?.usedOnPages == [])
+    }
+
+    @Test("missing directories yield empty lists, not errors")
+    func emptySite() {
+        let root = makeSite(["README.md": "nothing here"])
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        #expect(listing.pages.isEmpty)
+        #expect(listing.posts.isEmpty)
+        #expect(listing.images.isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/ContentScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScannerTests.swift
@@ -14,8 +14,9 @@ struct ContentScannerTests {
             .appendingPathComponent("content-scan-\(UUID().uuidString)", isDirectory: true)
         for (rel, contents) in files {
             let url = root.appendingPathComponent(rel)
-            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try? Data(contents.utf8).write(to: url)
+            // `try!` so a failed setup write points here, not at a confusing downstream assertion.
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! Data(contents.utf8).write(to: url)
         }
         return root
     }

--- a/Tests/AnglesiteCoreTests/FrontmatterTests.swift
+++ b/Tests/AnglesiteCoreTests/FrontmatterTests.swift
@@ -1,0 +1,68 @@
+// Tests/AnglesiteCoreTests/FrontmatterTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Native port of `server/content-frontmatter.mjs` — a deliberately minimal YAML-frontmatter
+/// reader for the `list_content` scan. These tests pin it to the Node parser it replaces.
+@Suite("Frontmatter")
+struct FrontmatterTests {
+
+    @Test("no frontmatter delimiter yields an empty map")
+    func noFrontmatter() {
+        #expect(Frontmatter.parse("# Just a heading\n\nbody").isEmpty)
+        #expect(Frontmatter.parse("leading text\n---\ntitle: x\n---").isEmpty)
+    }
+
+    @Test("quoted and unquoted scalars")
+    func scalars() {
+        let fm = Frontmatter.parse("---\ntitle: Hello World\nslug: 'my-post'\nname: \"Quoted\"\n---\nbody")
+        #expect(fm["title"] == .string("Hello World"))
+        #expect(fm["slug"] == .string("my-post"))
+        #expect(fm["name"] == .string("Quoted"))
+    }
+
+    @Test("booleans parse to bool, not string")
+    func booleans() {
+        let fm = Frontmatter.parse("---\ndraft: true\npublished: false\n---")
+        #expect(fm["draft"] == .bool(true))
+        #expect(fm["published"] == .bool(false))
+    }
+
+    @Test("inline arrays")
+    func inlineArrays() {
+        let fm = Frontmatter.parse("---\ntags: [swift, ios, \"web dev\"]\nempty: []\n---")
+        #expect(fm["tags"] == .array(["swift", "ios", "web dev"]))
+        #expect(fm["empty"] == .array([]))
+    }
+
+    @Test("block arrays on following indented dash lines")
+    func blockArrays() {
+        let fm = Frontmatter.parse("---\ntags:\n  - swift\n  - 'ios'\nother: x\n---")
+        #expect(fm["tags"] == .array(["swift", "ios"]))
+        #expect(fm["other"] == .string("x"))
+    }
+
+    @Test("comments and blank lines are skipped")
+    func commentsSkipped() {
+        let fm = Frontmatter.parse("---\n# a comment\ntitle: T\n\n# another\n---")
+        #expect(fm["title"] == .string("T"))
+        #expect(fm.count == 1)
+    }
+
+    @Test("indented (nested) keys are ignored as top-level fields")
+    func nestedIgnored() {
+        let fm = Frontmatter.parse("---\nauthor:\n  name: Dana\ntitle: T\n---")
+        // `author:` has an empty value with no dash-lines → "" ; nested `name:` is indented, ignored.
+        #expect(fm["name"] == nil)
+        #expect(fm["author"] == .string(""))
+        #expect(fm["title"] == .string("T"))
+    }
+
+    @Test("CRLF line endings are handled")
+    func crlf() {
+        let fm = Frontmatter.parse("---\r\ntitle: T\r\ndraft: true\r\n---\r\nbody")
+        #expect(fm["title"] == .string("T"))
+        #expect(fm["draft"] == .bool(true))
+    }
+}

--- a/Tests/AnglesiteCoreTests/LocalSiteRuntimeGraphTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalSiteRuntimeGraphTests.swift
@@ -41,12 +41,13 @@ struct LocalSiteRuntimeGraphTests {
     private func makeSite(_ files: [String: String] = [:]) -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("runtime-graph-\(UUID().uuidString)", isDirectory: true)
+        // `try!` so a failed setup write points here, not at a confusing downstream assertion.
+        try! FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         for (rel, contents) in files {
             let url = root.appendingPathComponent(rel)
-            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try? Data(contents.utf8).write(to: url)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! Data(contents.utf8).write(to: url)
         }
-        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         return root
     }
 

--- a/Tests/AnglesiteCoreTests/LocalSiteRuntimeGraphTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalSiteRuntimeGraphTests.swift
@@ -2,16 +2,14 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
-/// A.8 (#142): `LocalSiteRuntime` populates a `SiteContentGraph` from the plugin's `list_content`
-/// MCP tool after the dev server is ready and the MCP client has initialized, and evicts the
-/// site's content from the graph on stop. A missing/erroring `list_content` (older plugin) is a
-/// no-op: the graph stays empty and preview is unaffected.
+/// A.8 (#142) / #275: `LocalSiteRuntime` populates a `SiteContentGraph` by natively scanning the
+/// site's `Source/` directory (`ContentScanner`, replacing the old `list_content` MCP round-trip)
+/// after the dev server is ready, and evicts the site's content from the graph on stop. An empty
+/// site is a no-op: the graph stays empty and preview is unaffected.
 @Suite(.serialized)  // serial subprocess spawns — see MCPClientTests rationale (CI-flakiness fix)
 struct LocalSiteRuntimeGraphTests {
     private let alwaysReady: AstroDevServer.ReadinessProbe = { _ in true }
-    private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
     private static let siteID = "/Users/x/Sites/alpha"
-    private static let noon = ISO8601DateFormatter().date(from: "2026-06-11T12:00:00Z")!
 
     private static let pythonURL: URL = {
         for path in ["/usr/bin/python3", "/opt/homebrew/bin/python3", "/usr/local/bin/python3"] {
@@ -21,22 +19,10 @@ struct LocalSiteRuntimeGraphTests {
     }()
     private static var pythonAvailable: Bool { FileManager.default.isExecutableFile(atPath: pythonURL.path) }
 
-    /// The JSON the fake `list_content` tool returns as its text content. Triple-quoted Python
-    /// string so the inner JSON needs no escaping; `json.dumps` re-escapes it into the response.
-    private static let listingJSON = """
-    {
-      "pages": [{"route":"/about","filePath":"src/pages/about.astro","title":"About","lastModified":"2026-06-11T12:00:00Z"}],
-      "posts": [{"collection":"blog","slug":"hello","title":"Hello","draft":false,"tags":["intro"],
-                 "filePath":"src/content/blog/hello.md","lastModified":"2026-06-11T12:00:00Z"}],
-      "images": [{"relativePath":"public/hero.jpg","fileName":"hero.jpg","byteSize":123,
-                  "usedOnPages":["/about"],"lastModified":"2026-06-11T12:00:00Z"}]
-    }
-    """
-
-    /// Fake MCP server that returns the listing above from `list_content`.
-    private static let populatingScript = """
+    /// Minimal MCP server: answers `initialize` and errors everything else. `LocalSiteRuntime`
+    /// still spawns an MCP client for the edit pipeline; graph population no longer uses it.
+    private static let initOnlyScript = """
     import sys, json
-    LISTING = '''\(listingJSON)'''
     for line in sys.stdin:
         line = line.strip()
         if not line: continue
@@ -46,31 +32,34 @@ struct LocalSiteRuntimeGraphTests {
         if rid is None: continue
         if method == "initialize":
             resp = {"jsonrpc":"2.0","id":rid,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"fake","version":"0"}}}
-        elif method == "tools/call" and (msg.get("params") or {}).get("name") == "list_content":
-            resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":LISTING}],"isError":False}}
         else:
             resp = {"jsonrpc":"2.0","id":rid,"error":{"code":-32601,"message":"method not found"}}
         sys.stdout.write(json.dumps(resp) + chr(10)); sys.stdout.flush()
     """
 
-    /// Fake MCP server that returns a JSON-RPC error for `list_content` (older plugin).
-    private static let noToolScript = """
-    import sys, json
-    for line in sys.stdin:
-        line = line.strip()
-        if not line: continue
-        try: msg = json.loads(line)
-        except Exception: continue
-        method = msg.get("method", ""); rid = msg.get("id")
-        if rid is None: continue
-        if method == "initialize":
-            resp = {"jsonrpc":"2.0","id":rid,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"fake","version":"0"}}}
-        else:
-            resp = {"jsonrpc":"2.0","id":rid,"error":{"code":-32601,"message":"unknown tool"}}
-        sys.stdout.write(json.dumps(resp) + chr(10)); sys.stdout.flush()
-    """
+    /// Create a fresh temp site `Source/` directory. `files` maps relative path → contents.
+    private func makeSite(_ files: [String: String] = [:]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("runtime-graph-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? Data(contents.utf8).write(to: url)
+        }
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
 
-    private func makeRuntime(graph: SiteContentGraph, mcpScript: String) -> LocalSiteRuntime {
+    /// A site with one page, one post, and one image — enough to exercise all three graph buckets.
+    private func populatedSite() -> URL {
+        makeSite([
+            "src/pages/about.md": "---\ntitle: About\n---\nbody",
+            "src/content/posts/hello.md": "---\ntitle: Hello\ndraft: false\ntags: [intro]\n---\nBody",
+            "public/images/hero.jpg": "JPEGBYTES",
+        ])
+    }
+
+    private func makeRuntime(graph: SiteContentGraph) -> LocalSiteRuntime {
         let supervisor = ProcessSupervisor()
         let center = LogCenter()
         let devServer = AstroDevServer(supervisor: supervisor, logCenter: center, readinessProbe: alwaysReady)
@@ -82,27 +71,28 @@ struct LocalSiteRuntimeGraphTests {
             logCenter: center,
             resolveCommand: { _ in .run(executable: URL(fileURLWithPath: "/bin/sh"),
                                         arguments: ["-c", "echo '  Local    http://localhost:4321/'; exec sleep 30"]) },
-            resolveMCPCommand: { .run(executable: Self.pythonURL, arguments: ["-u", "-c", mcpScript]) },
+            resolveMCPCommand: { .run(executable: Self.pythonURL, arguments: ["-u", "-c", Self.initOnlyScript]) },
             restartPolicy: .never
         )
     }
 
-    @Test("Populates the graph from list_content after start", .enabled(if: pythonAvailable))
+    @Test("Populates the graph by scanning Source/ after start", .enabled(if: pythonAvailable))
     func populatesGraphAfterStart() async throws {
         let graph = SiteContentGraph()
-        let runtime = makeRuntime(graph: graph, mcpScript: Self.populatingScript)
+        let runtime = makeRuntime(graph: graph)
+        let site = populatedSite()
 
-        await runtime.start(siteID: Self.siteID, siteDirectory: tmpDir)
+        await runtime.start(siteID: Self.siteID, siteDirectory: site)
 
         let pages = await graph.pages(for: Self.siteID)
         let posts = await graph.posts(for: Self.siteID)
         let images = await graph.images(for: Self.siteID)
         #expect(pages.map(\.route) == ["/about"])
         #expect(pages.first?.title == "About")
-        #expect(pages.first?.lastModified == Self.noon)
         #expect(posts.map(\.slug) == ["hello"])
+        #expect(posts.first?.tags == ["intro"])
         #expect(images.map(\.fileName) == ["hero.jpg"])
-        #expect(images.first?.byteSize == 123)
+        #expect(images.first?.byteSize == 9)  // "JPEGBYTES"
 
         await runtime.stop()
     }
@@ -110,9 +100,9 @@ struct LocalSiteRuntimeGraphTests {
     @Test("Evicts the site's content from the graph on stop", .enabled(if: pythonAvailable))
     func unloadsGraphOnStop() async throws {
         let graph = SiteContentGraph()
-        let runtime = makeRuntime(graph: graph, mcpScript: Self.populatingScript)
+        let runtime = makeRuntime(graph: graph)
 
-        await runtime.start(siteID: Self.siteID, siteDirectory: tmpDir)
+        await runtime.start(siteID: Self.siteID, siteDirectory: populatedSite())
         #expect(await !graph.pages(for: Self.siteID).isEmpty)
 
         await runtime.stop()
@@ -122,27 +112,27 @@ struct LocalSiteRuntimeGraphTests {
     @Test("startHeadlessMCP spawns only the MCP client — no dev server, no graph population", .enabled(if: pythonAvailable))
     func startHeadlessMCPSpawnsMCPOnly() async throws {
         let graph = SiteContentGraph()
-        let runtime = makeRuntime(graph: graph, mcpScript: Self.populatingScript)
+        let runtime = makeRuntime(graph: graph)
 
-        let ok = await runtime.startHeadlessMCP(siteID: Self.siteID, siteDirectory: tmpDir)
+        let ok = await runtime.startHeadlessMCP(siteID: Self.siteID, siteDirectory: populatedSite())
 
         #expect(ok)
         #expect(await runtime.mcpClient.isRunning)
         // No dev server spawned → the UI state machine is never driven.
         #expect(await runtime.state == .idle)
-        // Headless start does not run list_content population — the graph stays empty.
+        // Headless start does not run graph population — the graph stays empty.
         #expect(await graph.knownSiteIDs().isEmpty)
 
         await runtime.stop()
         #expect(await runtime.mcpClient.isRunning == false)
     }
 
-    @Test("Missing list_content tool leaves the graph empty and preview ready", .enabled(if: pythonAvailable))
-    func missingToolIsGracefulFallback() async throws {
+    @Test("An empty site leaves the graph empty and preview ready", .enabled(if: pythonAvailable))
+    func emptySiteIsGracefulFallback() async throws {
         let graph = SiteContentGraph()
-        let runtime = makeRuntime(graph: graph, mcpScript: Self.noToolScript)
+        let runtime = makeRuntime(graph: graph)
 
-        await runtime.start(siteID: Self.siteID, siteDirectory: tmpDir)
+        await runtime.start(siteID: Self.siteID, siteDirectory: makeSite())
 
         #expect(await graph.knownSiteIDs().isEmpty)
         let state = await runtime.state


### PR DESCRIPTION
Closes #275. Retire Claude Code, **step 2** — continues the removal roadmap (#272 was step 1).

## Why

Ports the remaining **Bucket 1** sidecar tools (`docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md`) off the Node MCP server into deterministic Swift, cutting subprocess hops. Mirrors #272's `create_page`/`create_post` port. The MCP-routed paths are **retained** until the later cleanup slice.

## What's in here

**Native ports (AnglesiteCore)**
- **`AnnotationStore`** — `load`/`save`/`add`/`list`/`resolve` over `<Source>/annotations.json`, byte-identical to `server/annotations.mjs`: schema-v1 wrapper + legacy bare-array read, nanoid ids, `MAX_UNRESOLVED=50`. The serializer is hand-rolled (Foundation's `JSONEncoder` reorders keys and spaces colons differently) and **verified byte-for-byte via `diff` against real Node output**, including JS string escaping.
- **`Frontmatter`** — port of `server/content-frontmatter.mjs` (the minimal YAML subset `list_content` needs: quoted/unquoted scalars, booleans, inline + block string arrays, top-level keys only).
- **`ContentScanner`** — port of `server/list-content.mjs`; scans `Source/` into a `ContentListing` (pages/posts/images). Cross-checked against the real Node tool on an identical tree (route derivation, title heuristics, post fields, `publishDate` UTC parsing, image sizes all match).

**Wiring**
- `LocalSiteRuntime.populateContentGraph` now scans `Source/` natively instead of the `list_content` MCP round-trip. Graph tests rewritten to drive a real `Source/` tree rather than a faked MCP server.
- `SiteWindow` reads/resolves annotations via the native store instead of `AnnotationFeedFactory.viaMCP`; `undo_edit` stays MCP-backed (Bucket 2).
- `viaMCP` / `ContentListing.parse` kept (retained-but-unused, still tested) per the roadmap's "keep MCP paths until the cleanup slice."

## Verification

- Full library suite green: **628 Core + 204 Intents + 14 Bridge** (incl. 23 new tests).
- **`Anglesite` (DevID)** and **`AnglesiteMAS`** both **BUILD SUCCEEDED**.
- `AnnotationStore` + `ContentScanner` output confirmed identical to the live Node sidecar via `diff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)