### PR TITLE
docs(#237): Siri AI smoke matrix + coverage anchor

### DIFF
--- a/Tests/AnglesiteIntentsTests/SmokeMatrixTests.swift
+++ b/Tests/AnglesiteIntentsTests/SmokeMatrixTests.swift
@@ -1,0 +1,185 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+/// Coverage anchor for the Siri AI smoke matrix (#237).
+///
+/// `docs/specs/2026-06-20-siri-smoke-matrix.md` documents the product-level acceptance matrix —
+/// the eight supported Siri workflows, their phrases, app states, and expected outcomes. A doc
+/// can silently drift from the code; this suite pins the *deterministic* claims of that doc to the
+/// shipped intent / operation registry so the matrix can't go stale unnoticed:
+///
+/// - every workflow row maps to a real `AnglesiteOperations` descriptor,
+/// - each row's side-effect + confirmation declaration matches the registry,
+/// - the curated-phrase set and the shortcuts-provider count stay aligned,
+/// - the two confirmation-gated workflows (deploy, edit) actually request confirmation at
+///   runtime — i.e. the "Confirms? yes" cells are behaviorally true, not just documented.
+///
+/// The manual-only rows (spoken-phrase recognition, onscreen-element resolution, on-device NL
+/// interpretation, system MCP, MAS sandbox grant) are deliberately NOT asserted green here — they
+/// are listed in `Self.manualOnly` and the doc's "Manual-only" section, and a guard test below
+/// asserts they remain disjoint from the CI-covered operations so they can never be mistaken for
+/// automated coverage.
+extension AppIntentsTests {
+    @Suite("SmokeMatrix")
+    struct SmokeMatrixTests {
+
+        /// One documented workflow row, reduced to its machine-checkable claims.
+        struct Workflow {
+            let label: String
+            /// `operationID` in `AnglesiteOperations`.
+            let operationID: String
+            let sideEffect: OperationSideEffect
+            /// Whether the workflow confirms before its side effect at *runtime*. This is the
+            /// matrix's "Confirms?" column. For `edit-content` this is `true` even though the
+            /// descriptor flag is still `false` (TODO #239/#250) — the runtime gate is live and is
+            /// behaviorally asserted in `confirmationGatedWorkflowsRequestConfirmationAtRuntime`.
+            let confirmsAtRuntime: Bool
+        }
+
+        /// The eight supported workflows, transcribed from the smoke-matrix doc. `site-status` is
+        /// the matrix's row 5b (a sibling read intent); `add-page`/`add-post` are row 6's two
+        /// intents. `OpenSiteIntent` is row 1 (no curated phrase — reached via entity tap).
+        static let workflows: [Workflow] = [
+            Workflow(label: "Open this site", operationID: "open-site", sideEffect: .readOnly, confirmsAtRuntime: false),
+            Workflow(label: "Back up this site", operationID: "backup-site", sideEffect: .createsContent, confirmsAtRuntime: false),
+            Workflow(label: "Audit this site", operationID: "audit-site", sideEffect: .readOnly, confirmsAtRuntime: false),
+            Workflow(label: "Deploy with confirmation", operationID: "deploy-site", sideEffect: .publishes, confirmsAtRuntime: true),
+            Workflow(label: "Search content", operationID: "search-content", sideEffect: .readOnly, confirmsAtRuntime: false),
+            Workflow(label: "Site status", operationID: "site-status", sideEffect: .readOnly, confirmsAtRuntime: false),
+            Workflow(label: "Add page", operationID: "add-page", sideEffect: .createsContent, confirmsAtRuntime: false),
+            Workflow(label: "Add post", operationID: "add-post", sideEffect: .createsContent, confirmsAtRuntime: false),
+            Workflow(label: "Preview a page", operationID: "preview-site", sideEffect: .readOnly, confirmsAtRuntime: false),
+            Workflow(label: "Edit visible content with confirmation", operationID: "edit-content", sideEffect: .modifiesContent, confirmsAtRuntime: true),
+        ]
+
+        /// Capabilities the doc marks manual-only. These map to no automated assertion by design;
+        /// the guard test below keeps them out of the CI-covered operation set.
+        static let manualOnly: Set<String> = [
+            "spoken-phrase-recognition",
+            "onscreen-element-resolution",
+            "foundation-models-nl-interpretation",
+            "system-mcp-bridge",
+            "mas-sandbox-grant",
+        ]
+
+        // MARK: - Matrix ↔ registry sync
+
+        @Test("every documented workflow maps to a shipped operation descriptor")
+        func everyWorkflowHasADescriptor() throws {
+            for wf in Self.workflows {
+                let descriptor = AnglesiteOperations.all.first { $0.operationID == wf.operationID }
+                #expect(descriptor != nil, "smoke-matrix workflow “\(wf.label)” references unknown operation \(wf.operationID)")
+            }
+        }
+
+        @Test("the matrix covers every shipped operation (no undocumented Siri surface)")
+        func everyOperationIsInTheMatrix() {
+            let documented = Set(Self.workflows.map(\.operationID))
+            let shipped = Set(AnglesiteOperations.all.map(\.operationID))
+            #expect(documented == shipped,
+                    "matrix/registry drift — documented: \(documented.sorted()), shipped: \(shipped.sorted())")
+        }
+
+        @Test("each workflow's documented side-effect matches the registry")
+        func sideEffectsMatchRegistry() throws {
+            for wf in Self.workflows {
+                let d = try #require(AnglesiteOperations.descriptor(forIntentTypeName: intentTypeName(for: wf.operationID)),
+                                     "no descriptor for \(wf.operationID)")
+                #expect(d.sideEffect == wf.sideEffect, "\(wf.operationID) side-effect drifted from the matrix")
+            }
+        }
+
+        // MARK: - Phrase surface
+
+        @Test("curated-phrase set and shortcuts-provider count stay aligned")
+        func phraseSurfaceIsConsistent() {
+            // The provider count is the only thing Apple lets us read back (AppShortcut is
+            // type-erased). The matrix's "curated phrase" column corresponds to the
+            // phrase-exposed name set; they must match the provider count.
+            #expect(AnglesiteShortcuts.appShortcuts.count == AnglesiteShortcuts.phraseExposedIntentNames.count)
+        }
+
+        @Test("every phrase-exposed intent is a documented workflow")
+        func phraseExposedIntentsAreDocumented() {
+            let documentedIntentNames = Set(Self.workflows.map { intentTypeName(for: $0.operationID) })
+            #expect(AnglesiteShortcuts.phraseExposedIntentNames.isSubset(of: documentedIntentNames),
+                    "a phrase-exposed intent is missing from the smoke matrix")
+        }
+
+        // MARK: - Confirmation gates
+
+        @Test("deploy is the publishing workflow and declares confirmation in the registry")
+        func deployDeclaresConfirmation() throws {
+            // The matrix's "Deploy with confirmation" row maps to the only `.publishes` operation,
+            // which must declare `requiresConfirmation: true`. The runtime gate itself
+            // (`requestConfirmation` before publishing) can't be exercised under `swift test` — no
+            // intentsd — so it is a manual-pass row; here we pin the registry declaration.
+            let deploy = try #require(AnglesiteOperations.all.first { $0.operationID == "deploy-site" })
+            #expect(deploy.sideEffect == .publishes)
+            #expect(deploy.requiresConfirmation, "deploy must declare confirmation before publishing")
+            // No other workflow should silently publish.
+            let publishers = AnglesiteOperations.all.filter { $0.sideEffect == .publishes }
+            #expect(publishers.map(\.operationID) == ["deploy-site"])
+        }
+
+        @Test("edit declines without writing when the user does not confirm")
+        func editConfirmationGateBlocksWriteOnDecline() async throws {
+            // Mirrors EditContentIntentFlowTests.declinePath: a declined edit dry-runs but never
+            // applies. This is the matrix's row-8 "Confirms? yes" claim made behavioral.
+            actor PhaseRouter: EditRouter {
+                private(set) var applies = 0
+                func apply(_ m: EditMessage) async -> EditReply {
+                    if m.dryRun {
+                        return EditReply(id: m.id, status: .preview, message: nil, before: "old", after: "new", op: m.op)
+                    }
+                    applies += 1
+                    return EditReply(id: m.id, status: .applied, message: nil, file: "src/pages/x.astro")
+                }
+            }
+            struct StubInterpreter: EditInterpreting {
+                func interpret(instruction: String, element: InterpretedElementContext) async throws -> InterpretedEdit {
+                    InterpretedEdit(kind: .text, newText: "new", attributeName: nil, attributeValue: nil,
+                                    styleProperty: nil, styleValue: nil, summary: "s")
+                }
+            }
+            let router = PhaseRouter()
+            let bridge = IntentEditBridge(routerProvider: { _ in router }, makeID: { "smoke-edit" })
+            let intent = EditContentIntent()
+            intent.element = ElementEntity(
+                id: "s:element:1",
+                displayName: "h1 \u{2014} Hi",
+                siteID: "s",
+                selector: #"{"tag":"h1","classes":[],"nthChild":1,"textContent":"Hi"}"#,
+                pagePath: "/about/"
+            )
+            intent.instruction = "make it shorter"
+
+            try await IntentEditBridgeOverride.$scoped.withValue(bridge) {
+                try await EditInterpreterOverride.$scoped.withValue(StubInterpreter()) {
+                    try await ConfirmationOverride.$scoped.withValue(.decline) {
+                        _ = try await intent.perform()
+                    }
+                }
+            }
+            #expect(await router.applies == 0, "a declined edit must never write")
+        }
+
+        // MARK: - Manual-only items are not faked green
+
+        @Test("manual-only capabilities are disjoint from the automated operation set")
+        func manualOnlyIsNotRepresentedAsAutomated() {
+            let automated = Set(AnglesiteOperations.all.map(\.operationID))
+            #expect(Self.manualOnly.isDisjoint(with: automated),
+                    "a manual-only capability is masquerading as an automated operation")
+        }
+
+        // MARK: - Helpers
+
+        /// Map a smoke-matrix `operationID` to its intent type name via the registry.
+        private func intentTypeName(for operationID: String) -> String {
+            AnglesiteOperations.all.first { $0.operationID == operationID }?.intentTypeName ?? operationID
+        }
+    }
+}

--- a/docs/specs/2026-06-20-siri-smoke-matrix.md
+++ b/docs/specs/2026-06-20-siri-smoke-matrix.md
@@ -1,0 +1,114 @@
+# Siri AI Smoke Matrix
+
+**Issue:** [#237](https://github.com/Anglesite/Anglesite-app/issues/237) (parent epic [#135](https://github.com/Anglesite/Anglesite-app/issues/135) — System-wide MCP exposure; Siri AI phases A–D)
+**Date:** 2026-06-20
+**Related:**
+[Siri AI integration design](../superpowers/specs/2026-06-11-siri-ai-integration-design.md) ·
+[D.1 Intent MCP readiness audit](2026-06-17-d1-intent-mcp-readiness-audit.md) ·
+[C.11 Phase C test-suite plan](../superpowers/plans/2026-06-17-c11-phase-c-test-suite.md) ·
+[Siri edit-confirmation design](2026-06-19-siri-edit-confirmation-design.md)
+
+## Why this exists
+
+The repo has phase trackers for App Intents (A/B), View Annotations, Foundation Models,
+Spotlight, and system-wide MCP (D). Each has unit coverage. What was missing is a single
+**product-level acceptance matrix**: the specific Siri/Shortcuts phrases, the app states they
+must work in, and the expected outcome — the checklist a human runs before tagging a DevID or
+MAS build, anchored to automated fixtures so it can't silently drift.
+
+This **complements, not replaces**, the Phase C test-suite audit and the D.5 manual MCP smoke.
+
+## Scope — the eight supported workflows
+
+Every row maps to a shipped intent in `Sources/AnglesiteIntents` with a curated Siri phrase in
+`AnglesiteShortcuts.appShortcuts`. Phrases below are verbatim from that provider; `Anglesite`
+is `\(.applicationName)` at runtime. (`OpenSiteIntent` ships but has **no** curated phrase — it
+is an `OpenIntent` reached from Spotlight result taps / Shortcuts chaining, so it is listed
+under "open" but is exercised via the entity-resolution path, not a spoken phrase.)
+
+| # | Workflow | Intent | Curated Siri phrase(s) | Side effect | Confirms? | Returns |
+|---|---|---|---|---|---|---|
+| 1 | Open this site | `OpenSiteIntent` | *(no phrase — Spotlight/Shortcuts entity tap)* | read-only | no | — (opens UI) |
+| 2 | Back up this site | `BackupSiteIntent` | "Back up my site with Anglesite" | creates content | no | `SiteEntity` |
+| 3 | Audit this site | `AuditSiteIntent` | "Check my site with Anglesite" | read-only | no | `SiteEntity` |
+| 4 | Deploy with confirmation | `DeploySiteIntent` | "Deploy my site with Anglesite" | publishes | **yes** | `SiteEntity` |
+| 5 | Search content | `SearchContentIntent` | "What's on my site …" / "Search my site …" | read-only | no | `[ContentMatchEntity]` |
+| 5b | Site status | `SiteStatusIntent` | "How is my site doing …" / "My site status …" | read-only | no | — (dialog) |
+| 6 | Add page / post | `AddPageIntent` / `AddPostIntent` | "Add a page …" / "Add a post …" | creates content | no | `PageEntity?` / `PostEntity?` |
+| 7 | Preview a page | `PreviewSiteIntent` | "Preview my site …" / "Open my site preview …" | read-only | no | — (opens UI) |
+| 8 | Edit visible content with confirmation | `EditContentIntent` | "Edit this with Anglesite" / "Change this with Anglesite" | modifies content | **yes** † | — (dialog) |
+
+† `EditContentIntent.perform()` calls `requestConfirmation` before any write (the dry-run →
+confirm → apply flow). The `AnglesiteOperations` descriptor for `edit-content` still declares
+`requiresConfirmation: false` with a `TODO(#239/#250)`; that flag flips when #239/#250 close.
+The **runtime gate is live regardless** — see `EditContentIntentFlowTests` /
+`EditContentIntentCancelTests`. The smoke-matrix coverage anchor (below) keys off the runtime
+behavior, not the stale descriptor flag.
+
+## Required app state per workflow
+
+States to exercise during a manual pass. "Resolves site" = how the `site`/`element` parameter
+is satisfied. Cold = app not running; Launcher = app open, no site window; Frontmost = a site
+window is key; Preview = the WKWebView preview is focused (onscreen-awareness path).
+
+| Workflow | Cold (no window) | Launcher open | Site window frontmost | Preview focused | MAS grant present | MAS grant missing |
+|---|---|---|---|---|---|---|
+| Open site | Launch + open; Siri prompts for site | Prompts for site, opens | No-op if same, else switches | n/a | opens | opens (read-only) |
+| Back up | Launch; prompts for site | Prompts for site | Acts on frontmost site | n/a | runs | **fails closed** ‡ |
+| Audit | Launch; prompts | Prompts | Acts on frontmost | n/a | runs | **fails closed** ‡ |
+| Deploy | Launch; prompts; **confirm** | Prompts; confirm | Confirm; runs | n/a | runs after confirm | **fails closed** ‡ |
+| Search content | Launch; prompts | Prompts | Searches frontmost | n/a | reads | reads (graph is app-owned) |
+| Site status | Launch; prompts | Prompts | Status of frontmost | n/a | reads | reads |
+| Add page/post | Launch; prompts | Prompts | Adds to frontmost | n/a | writes | **fails closed** ‡ |
+| Preview | Launch + open preview | Opens preview | Navigates preview | re-navigates current | opens | opens |
+| Edit visible content | n/a — needs onscreen element | n/a | n/a (no selection) | resolves `element`; **confirm**; writes | writes after confirm | **fails closed** ‡ |
+
+‡ **Fail closed** = on MAS without the per-package security-scoped grant, a write/spawn operation
+must surface a clear "open the site first / grant access" failure, **never** silently no-op
+(CLAUDE.md: "Logs are sacred", "surface failures rather than allowing override"). The grant is
+the `SiteWindow`-held bookmark; without an open window the sandboxed child can't reach `Source/`.
+
+## Coverage classification
+
+### CI-covered (deterministic — these gate every PR)
+
+Anchored by `SmokeMatrixTests` (`Tests/AnglesiteIntentsTests/SmokeMatrixTests.swift`), which
+asserts the matrix above stays in sync with the shipped code, plus the per-intent suites:
+
+- **Entity resolution** — `SiteEntityQueryTests`, `ContentEntitiesTests`, `ContentMatchEntityTests`, `SiteEntityAnnotationTests`.
+- **Intent dialog mapping** — `ContentIntentsTests` (pure `ContentDialogs`), `DeploySiteIntentTests`, `BackupSiteIntentTests`, `AuditSiteIntentTests`, `OpenSiteIntentTests`.
+- **Confirmation / cancel paths** — `EditContentIntentFlowTests`, `EditContentIntentCancelTests`, `EditConfirmationDialogTests`, `EditContentIntentSiteUnavailableTests`, and `SmokeMatrixTests.editConfirmationGateBlocksWriteOnDecline` (the edit "Confirms? yes" cell made behavioral: a declined edit dry-runs but never writes). Deploy's *runtime* confirmation gate (`requestConfirmation` before publishing) can't run under `swift test` — no intentsd — so it is a manual row; CI pins the **registry declaration** (`requiresConfirmation: true`, only `.publishes` op) instead.
+- **Content-graph fixtures** — `ContentPipelineE2ETests`, `ContentSpotlightIndexerTests`, `SpotlightIndexerTests`.
+- **Operation-descriptor contract** — `OperationDescriptorTests`, `OperationDescriptorBehavioralTests`.
+- **Chaining** (audit→deploy etc.) — `IntentChainingTests`.
+- **Window routing** (open/preview side effects) — `WindowRouterTests`.
+- **Readiness probes** — `SiriReadiness*ProbeTests`.
+
+### Manual-only (NOT represented as green CI)
+
+Apple's Siri runtime and Foundation Models tool calls are opaque to `swift test`; these are
+checked by hand against a fixture site and recorded in the PR description, never faked green:
+
+- **Spoken-phrase recognition** — that Siri actually maps each phrase to its intent. `appShortcuts` is type-erased `[AppShortcut]`; Apple exposes no public read-back of the phrase→intent map, so only the **count** is asserted in CI (`AnglesiteShortcutsTests`). Phrase wording is verified in Shortcuts.app / "Hey Siri".
+- **Onscreen-element resolution** — `appEntityUIElementProvider` feeding "edit this" / "change this" from the focused preview. The provider shaping is unit-tested (`PreviewAnnotationProviderTests`); the live Siri hand-off is manual.
+- **Foundation Models NL interpretation** — `EditContentIntent`'s on-device instruction → structured op. The interpreter seam is faked in CI (`EditInterpreterOverride`); the real on-device model output is manual (and unavailable on the CI runner).
+- **System-wide MCP bridge** — Phase D / #135, not yet built (`SystemMCPBridgeProbe` truthfully reports `.unsupported`). The D.5 MCP smoke covers this separately.
+- **MAS sandbox grant present/missing** — the security-scoped bookmark behavior needs a real sandboxed `AnglesiteMAS.app` launch (blocked on hosted CI per CLAUDE.md), so the "fail closed" column is a manual MAS pass.
+- **Deploy's live Siri confirmation prompt** — `requestConfirmation` needs intentsd / a registered app, absent under `swift test`. CI pins only the registry declaration; verify the actual "Deploy … to production?" prompt (and that declining aborts) by hand. The *edit* confirmation gate is the one with a behavioral CI test, via the `ConfirmationOverride` seam.
+
+## DevID vs MAS
+
+The same matrix applies to both targets. Differences to watch on the MAS pass:
+
+- The "MAS grant present/missing" columns only apply to `AnglesiteMAS`; on DevID (sandbox off) writes work without the bookmark.
+- Chat / Sparkle / `gh` are compiled out of MAS, but none of the eight workflows depend on them, so the matrix is identical.
+- Run the manual pass once per target before tagging a release.
+
+## How to run a pass
+
+1. **CI deterministic layer:** `swift test --package-path .` (needs Xcode 27 / Swift 6.4 — the
+   `AnglesiteIntentsTests` target is `#if compiler(>=6.4)`-gated in `Package.swift`, so it is
+   skipped on the older CI runner). `SmokeMatrixTests` fails loudly if the matrix and the
+   shipped intent/operation registry diverge.
+2. **Manual layer:** with a fixture site open, walk each "Required app state" cell for the
+   manual-only rows, on both DevID and MAS builds. Record results in the PR.


### PR DESCRIPTION
Closes #237.

Adds a product-level Siri AI acceptance matrix and an automated coverage anchor so supported Siri/Shortcuts workflows stay verified as the implementation changes.

## What
- `docs/specs/2026-06-20-siri-smoke-matrix.md` — 8 workflows (open / back up / audit / deploy-with-confirmation / search content / add page-post / preview / edit-with-confirmation), each mapped to a real shipped intent + verbatim phrase, with a per-workflow required-app-state table and a CI-covered vs manual-only split (nothing manual faked as green).
- `Tests/AnglesiteIntentsTests/SmokeMatrixTests.swift` — coverage anchor asserting every documented workflow ↔ a registry descriptor (both directions), side-effects match, deploy is the sole `.publishes` op declaring confirmation, edit gate blocks on decline, and manual-only items stay disjoint from the automated set.

## Verification
- `AnglesiteIntentsTests` full target: 212 tests pass (incl. 8 new).

## Notes
- Grounded entirely in already-shipped intents — no new phrases/intents invented; no existing code modified.
- Surfaced a pre-existing inconsistency (the `edit-content` descriptor declares `requiresConfirmation: false` while `EditContentIntent.perform()` calls `requestConfirmation` at runtime); documented and keyed to live runtime behavior, left for #239/#250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)