### PR TITLE
feat(#91): Writing Tools API for Keystatic content editing

### DIFF
--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -78,6 +78,13 @@ function attachClickToEdit(awaitReply: (id: string, handler: (r: { status: strin
 
     const originalText = target.textContent ?? "";
 
+    // Apple Intelligence Writing Tools (#91) rides this same path with no extra wiring. Once the
+    // element is `contentEditable`, WebKit offers the system Writing Tools popover (rewrite /
+    // proofread / tone shift / summarize) on text selection — gated app-side by
+    // `WebViewBridge.enableWritingTools` setting `writingToolsBehavior = .complete`. A Writing
+    // Tools rewrite mutates `textContent` in place (WebKit applies it inline to the DOM), so the
+    // blur-time diff below captures it exactly like a typed edit: one `replace-text` apply-edit,
+    // one undoable commit. No new message type, and no Claude/LLM tokens.
     const finish = () => {
       target.contentEditable = "false";
       target.classList.remove(EDITABLE_CLASS);

--- a/JS/edit-overlay/test/overlay.test.ts
+++ b/JS/edit-overlay/test/overlay.test.ts
@@ -124,6 +124,29 @@ describe("click-to-edit", () => {
     expect(msg.selector.textContent).toBe("original-text");
     expect(msg.value).toBe("new-text-the-user-typed");
   });
+
+  it("captures a Writing Tools rewrite as a single replace-text edit (#91)", () => {
+    // Apple Intelligence Writing Tools applies its rewrite inline to the DOM while the element is
+    // still focused/contentEditable — modeled here by mutating `textContent` after the click but
+    // before blur. The blur-time diff must then send exactly one `replace-text` apply-edit carrying
+    // the rewritten text, so the rewrite lands as one undoable commit through the existing pipeline.
+    const main = document.createElement("main");
+    document.body.appendChild(main);
+    const p = makeText(main, "p", "we makes great stuff");
+
+    p.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    // WebKit's Writing Tools rewrite of the contentEditable element.
+    p.textContent = "We make great things.";
+    p.dispatchEvent(new FocusEvent("blur"));
+
+    expect(sent.length).toBe(1);
+    const msg = sent[0] as { type: string; op: string; selector: { textContent?: string }; value: unknown };
+    expect(msg.type).toBe("anglesite:apply-edit");
+    expect(msg.op).toBe("replace-text");
+    expect(msg.value).toBe("We make great things.");
+    // Selector snapshot reflects the pre-rewrite source text so the server-side patcher resolves it.
+    expect(msg.selector.textContent).toBe("we makes great stuff");
+  });
 });
 
 describe("image drop", () => {

--- a/Sources/AnglesiteBridge/WebViewBridge.swift
+++ b/Sources/AnglesiteBridge/WebViewBridge.swift
@@ -15,7 +15,9 @@ public enum WebViewBridge {
     /// the user-content controller under the `anglesite` namespace — that's the JS → native channel
     /// for edit messages from the overlay. The overlay bundle (`edit-overlay/overlay.js`) is
     /// injected via `WKUserScript` at `atDocumentEnd` when present; missing bundle is non-fatal —
-    /// the preview just loads without edit affordances.
+    /// the preview just loads without edit affordances. The configuration is also opted into the
+    /// full inline Writing Tools experience (#91, see `enableWritingTools`) so Apple Intelligence's
+    /// rewrite / proofread / tone / summarize popover is offered in editable Keystatic prose fields.
     ///
     /// `@MainActor` because every WebKit type touched here (`WKWebViewConfiguration`,
     /// `WKUserContentController`, `WKWebsiteDataStore`, `WKUserScript`) is main-actor isolated
@@ -27,6 +29,7 @@ public enum WebViewBridge {
         #if DEBUG
         config.websiteDataStore = .nonPersistent()
         #endif
+        enableWritingTools(on: config)
         if let handler {
             config.userContentController.add(handler, name: scriptMessageNamespace)
         }
@@ -61,5 +64,34 @@ public enum WebViewBridge {
         #if DEBUG
         webView.isInspectable = true
         #endif
+    }
+
+    /// Opt the preview into the full inline Writing Tools experience (#91).
+    ///
+    /// Writing Tools is Apple Intelligence's on-device / Private Cloud Compute rewrite engine —
+    /// rewrite, proofread, tone shift (friendly / professional / concise), and summarize, all with
+    /// **zero** external API / LLM token cost. WebKit surfaces the system popover natively for
+    /// *editable* web content (`contenteditable` / `<input>` / `<textarea>`): when the overlay
+    /// promotes a Keystatic prose element to `contentEditable = "true"` (see `overlay.ts`'s
+    /// click-to-edit), selecting text inside it offers the popover. The rewrite is applied **inline
+    /// to the DOM**, so it flows back through the existing pipeline unchanged — the overlay's
+    /// blur-time `replace-text` `apply-edit` captures the rewritten `textContent`, routes it through
+    /// `MCPApplyEditRouter` → the plugin's `apply_edit` tool, and lands as a single undoable commit.
+    /// No new message type is needed.
+    ///
+    /// On macOS the behavior is a **configuration** property (`WKWebViewConfiguration`, settable
+    /// before the web view is created), not a `WKWebView` instance property — `WKWebView` only
+    /// exposes the read-only `isWritingToolsActive`. `.complete` selects the full inline experience;
+    /// the WebKit default is `.limited` (a panel-only fallback), so this opt-in is required to get
+    /// the inline popover. Gated on macOS 15.0+ since `writingToolsBehavior` (and Writing Tools
+    /// itself) ships there; the app's deployment target is higher, but the guard keeps
+    /// `AnglesiteBridge` (which declares a lower SPM floor and builds on CI's older runners) honest.
+    /// On a Mac without Apple Intelligence this is a safe no-op: WebKit simply never offers the
+    /// affordance.
+    @MainActor
+    public static func enableWritingTools(on configuration: WKWebViewConfiguration) {
+        if #available(macOS 15.0, *) {
+            configuration.writingToolsBehavior = .complete
+        }
     }
 }

--- a/Tests/AnglesiteBridgeTests/WebViewBridgeTests.swift
+++ b/Tests/AnglesiteBridgeTests/WebViewBridgeTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import WebKit
 @testable import AnglesiteBridge
 
 /// `@MainActor` because `WebViewBridge.makeOverlayUserScript` builds a `WKUserScript`, and WebKit
@@ -32,6 +33,24 @@ struct WebViewBridgeTests {
         // The test runner's own bundle does not contain `edit-overlay/overlay.js`; it must report
         // that absence with `nil` rather than crashing.
         #expect(WebViewBridge.makeOverlayUserScript(in: Bundle(for: BundleAnchor.self)) == nil)
+    }
+
+    @available(macOS 15.0, *)
+    @Test("Enable Writing Tools opts the configuration into the complete behavior (#91)")
+    func enableWritingToolsSetsCompleteBehavior() {
+        let config = WKWebViewConfiguration()
+        // A fresh configuration is `.default` (raw 0) — which WebKit treats as the panel-only
+        // `.limited` experience. Confirm we move it to the full inline `.complete` experience.
+        #expect(config.writingToolsBehavior != .complete)
+        WebViewBridge.enableWritingTools(on: config)
+        #expect(config.writingToolsBehavior == .complete)
+    }
+
+    @available(macOS 15.0, *)
+    @Test("localDevConfiguration enables Writing Tools (#91)")
+    func localDevConfigurationEnablesWritingTools() {
+        let config = WebViewBridge.localDevConfiguration()
+        #expect(config.writingToolsBehavior == .complete)
     }
 }
 


### PR DESCRIPTION
Closes #91.

Surfaces the system Writing Tools popover (rewrite / proofread / tone shift / summarize) when editing Keystatic prose fields in the WKWebView edit overlay — on-device / Private Cloud Compute, zero LLM tokens.

## What
- `Sources/AnglesiteBridge/WebViewBridge.swift` — `enableWritingTools(on:)` sets `WKWebViewConfiguration.writingToolsBehavior = .complete` (guarded `#available(macOS 15.0, *)`), called from `localDevConfiguration`.
- `JS/edit-overlay/src/overlay.ts` — documents that Writing Tools rides the existing click-to-edit `contenteditable` path; no logic change needed.
- Tests: `WebViewBridgeTests.swift` (+2 `@Test`) and `JS/edit-overlay/test/overlay.test.ts` (Writing Tools rewrite lands as one `replace-text` edit).

## Design / seam
The settable knob is on `WKWebViewConfiguration` (the view's `isWritingToolsActive` is read-only), so the opt-in happens at config-creation time. WebKit natively surfaces the popover for editable web content; the overlay already promotes a clicked prose element to `contentEditable`, so the rewrite applies inline and the existing blur-time diff fires exactly one `replace-text` apply-edit → one undoable commit. No new message type.

## Verification
- JS overlay: `tsc --noEmit` clean; `vitest` 51 pass.
- `swift test`: 605 pass; `xcodebuild` **Anglesite**: BUILD SUCCEEDED.

## Notes
- Live popover / on-device rewrite / PCC fallback need a real Apple-Intelligence Mac — wiring + apply-edit capture are unit-verified, live UX needs manual smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)