### PR TITLE
feat(#283): git-bundle iCloud sync channel for .anglesite packages

### DIFF
--- a/Sources/AnglesiteCore/AnglesitePackage.swift
+++ b/Sources/AnglesiteCore/AnglesitePackage.swift
@@ -28,6 +28,19 @@ public struct AnglesitePackage: Sendable, Equatable {
     public var sourceURL: URL { url.appendingPathComponent("Source", isDirectory: true) }
     public var configURL: URL { url.appendingPathComponent("Config", isDirectory: true) }
 
+    /// App-owned sync state, inside `Config/` (never in the `Source/` git repo).
+    public var syncDirectoryURL: URL { configURL.appendingPathComponent("sync", isDirectory: true) }
+
+    /// Single-file `git bundle` mirror of the `Source/` repo's history.
+    ///
+    /// This is the iCloud-syncable artifact (#283): iCloud Drive syncs a single opaque file
+    /// atomically and reliably, where a live `.git` directory — thousands of loose objects and
+    /// refs — desyncs, spawns `… 2` conflict copies, and corrupts under concurrent edits. The
+    /// bundle travels in `Config/sync/` so it rides along with the package in iCloud while staying
+    /// out of the `Source/` working tree. `BundleSync` writes it from `Source/` and, on a peer Mac,
+    /// fetches from it to fast-forward the local repo — the bundle acts as an iCloud-mediated remote.
+    public var syncBundleURL: URL { syncDirectoryURL.appendingPathComponent("source.bundle", isDirectory: false) }
+
     // MARK: - Marker
 
     /// The `Info.plist` marker: stable identity + format version + provenance. Encoded with

--- a/Sources/AnglesiteCore/BundleSync.swift
+++ b/Sources/AnglesiteCore/BundleSync.swift
@@ -1,0 +1,460 @@
+import Foundation
+
+/// Syncs an `.anglesite` package's `Source/` git history across Macs via a single-file `git bundle`
+/// that travels in iCloud Drive (#283).
+///
+/// **Why a bundle and not the live repo.** iCloud Drive syncs files, not git semantics. Putting a
+/// live `Source/.git` directory in iCloud is a known foot-gun: it's thousands of loose objects, packs
+/// and refs that sync out of order, race under concurrent edits, and surface as `…  2` conflict copies
+/// that quietly corrupt the repository. A `git bundle`, by contrast, packs the entire history + refs
+/// into one opaque file. iCloud moves a single file atomically and reliably, so the bundle is the unit
+/// that travels — `Config/sync/source.bundle` (see `AnglesitePackage.syncBundleURL`).
+///
+/// **The model: an iCloud-mediated remote.** `BundleSync` never merges history blindly. It behaves
+/// like a git remote whose transport is a file in iCloud:
+///   - `writeBundle` regenerates the bundle from `Source/` (the "push"). It's a no-op when the bundle
+///     already reflects the repo's heads + tags, so an idle site generates no iCloud churn.
+///   - `importBundle` fetches the bundle into `refs/remotes/icloud/*` and **fast-forwards only** (the
+///     "pull"). A diverged branch is reported, not auto-merged — the user (or a later increment) resolves
+///     it deliberately, the same contract a `git pull --ff-only` gives.
+///
+/// All git invocations go through an injected `GitRunner` (default: `ProcessSupervisor`), mirroring
+/// `BackupCommand`, so the orchestration is unit-testable with scripted subprocess results. The bundle
+/// file itself is replaced under `NSFileCoordinator`, the documented way to mutate an iCloud item.
+public actor BundleSync {
+    /// Runs a one-shot git command in `workingDirectory` and returns captured output.
+    /// Production shells out via `ProcessSupervisor.shared.run(...)`; tests fake it.
+    public typealias GitRunner = @Sendable (_ workingDirectory: URL, _ arguments: [String]) async throws -> ProcessSupervisor.RunResult
+
+    /// A git ref tip: `(oid, name)` such as `("a1b2…", "refs/heads/main")`.
+    public struct Ref: Sendable, Equatable, Hashable, Codable {
+        public let oid: String
+        public let name: String
+        public init(oid: String, name: String) {
+            self.oid = oid
+            self.name = name
+        }
+    }
+
+    public enum WriteResult: Sendable, Equatable {
+        /// The bundle was (re)written; carries the heads + tags it now contains.
+        case written(refs: [Ref])
+        /// The on-disk bundle already mirrors the repo's heads + tags — nothing to do.
+        case unchanged
+        /// `exitCode` is `nil` for pre-spawn refusals (not a repo, no commits) and spawn failures.
+        case failed(reason: String, exitCode: Int32?)
+    }
+
+    public enum ImportResult: Sendable, Equatable {
+        /// `Source/` had no repo (or no commits); it was initialized and checked out from the bundle.
+        case initialized(branch: String)
+        /// The current branch was strictly behind the bundle and fast-forwarded.
+        case fastForwarded(branch: String, from: String, to: String)
+        /// Local history already contains the bundle's — nothing to import.
+        case upToDate
+        /// The local branch is ahead of the bundle: this Mac has the newer history; call `writeBundle`.
+        case localAhead(branch: String)
+        /// The local branch and the bundle have diverged. Not auto-merged (matches `pull --ff-only`).
+        case diverged(branch: String)
+        case failed(reason: String, exitCode: Int32?)
+    }
+
+    public enum VerifyResult: Sendable, Equatable {
+        case valid
+        case invalid(reason: String)
+        case failed(reason: String, exitCode: Int32?)
+    }
+
+    /// Name of the synthetic remote the bundle is fetched into, kept out of the user's real remotes.
+    private static let remoteRefspace = "icloud"
+
+    private let runner: GitRunner
+
+    public init(runner: @escaping GitRunner = BundleSync.defaultRunner) {
+        self.runner = runner
+    }
+
+    /// File operations use the shared manager directly — `BundleSync` keeps no injected filesystem
+    /// seam (tests drive real temp directories), matching how the rest of AnglesiteCore treats
+    /// `FileManager` as a value, never stored actor state.
+    private var fileManager: FileManager { .default }
+
+    // MARK: - Write (push to iCloud)
+
+    /// Regenerates the bundle at `bundleURL` from the repo at `sourceDirectory`.
+    ///
+    /// Bundles `--branches --tags HEAD` (every local branch + tags + the default branch), not
+    /// `--all` — remote-tracking refs are local junk that shouldn't travel between Macs. Skips the
+    /// write when the existing bundle's heads + tags already match the repo, so an unchanged site
+    /// produces no iCloud traffic. Writes to a sibling temp file, `git bundle verify`s it, then
+    /// swaps it into place under `NSFileCoordinator` so a peer never observes a half-written bundle.
+    public func writeBundle(from sourceDirectory: URL, to bundleURL: URL) async -> WriteResult {
+        // 0. Must be a git work tree.
+        switch await isWorkTree(sourceDirectory) {
+        case .failure(let result): return result.asWrite
+        case .success(false):
+            return .failed(reason: "this site isn't a git repository yet — nothing to sync.", exitCode: nil)
+        case .success(true): break
+        }
+
+        // 1. Current heads + tags. An empty repo (no commits) has nothing to bundle.
+        let currentRefs: Set<Ref>
+        switch await refsToSync(in: sourceDirectory) {
+        case .failure(let result): return result.asWrite
+        case .success(let refs):
+            guard !refs.isEmpty else {
+                return .failed(reason: "this site has no commits yet — nothing to sync.", exitCode: nil)
+            }
+            currentRefs = refs
+        }
+
+        // 2. Skip when the existing bundle already mirrors the repo. Comparing ref tips (not file
+        //    bytes) is the meaningful test: identical heads + tags ⇒ identical reachable history.
+        if fileManager.fileExists(atPath: bundleURL.path),
+           let existing = await bundleRefs(at: bundleURL, cwd: sourceDirectory),
+           existing == currentRefs {
+            return .unchanged
+        }
+
+        // 3. Create into a sibling temp, verify, then atomically swap in.
+        do {
+            try fileManager.createDirectory(at: bundleURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        } catch {
+            return .failed(reason: "couldn't create the sync directory: \(error.localizedDescription)", exitCode: nil)
+        }
+        let tmpURL = bundleURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(bundleURL.lastPathComponent).tmp-\(UUID().uuidString)", isDirectory: false)
+
+        let created: ProcessSupervisor.RunResult
+        do {
+            created = try await runner(sourceDirectory, ["bundle", "create", tmpURL.path, "--branches", "--tags", "HEAD"])
+        } catch {
+            return .failed(reason: "couldn't run `git bundle create`: \(error.localizedDescription)", exitCode: nil)
+        }
+        guard created.exitCode == 0 else {
+            try? fileManager.removeItem(at: tmpURL)
+            return .failed(reason: gitMessage("git bundle create", created), exitCode: created.exitCode)
+        }
+
+        // Verify the freshly written bundle before it replaces a known-good one.
+        do {
+            let verified = try await runner(sourceDirectory, ["bundle", "verify", tmpURL.path])
+            guard verified.exitCode == 0 else {
+                try? fileManager.removeItem(at: tmpURL)
+                return .failed(reason: gitMessage("git bundle verify", verified), exitCode: verified.exitCode)
+            }
+        } catch {
+            try? fileManager.removeItem(at: tmpURL)
+            return .failed(reason: "couldn't verify the new bundle: \(error.localizedDescription)", exitCode: nil)
+        }
+
+        do {
+            try coordinatedReplace(at: bundleURL, withItemAt: tmpURL)
+        } catch {
+            try? fileManager.removeItem(at: tmpURL)
+            return .failed(reason: "couldn't write the bundle into the package: \(error.localizedDescription)", exitCode: nil)
+        }
+
+        return .written(refs: currentRefs.sorted { $0.name < $1.name })
+    }
+
+    // MARK: - Verify
+
+    /// `git bundle verify` — confirms the bundle is well-formed and self-contained.
+    public func verify(bundleURL: URL, in sourceDirectory: URL) async -> VerifyResult {
+        guard fileManager.fileExists(atPath: bundleURL.path) else {
+            return .invalid(reason: "no bundle to verify at \(bundleURL.lastPathComponent)")
+        }
+        do {
+            let result = try await runner(sourceDirectory, ["bundle", "verify", bundleURL.path])
+            return result.exitCode == 0 ? .valid : .invalid(reason: gitMessage("git bundle verify", result))
+        } catch {
+            return .failed(reason: "couldn't run `git bundle verify`: \(error.localizedDescription)", exitCode: nil)
+        }
+    }
+
+    // MARK: - Import (pull from iCloud)
+
+    /// Brings the repo at `sourceDirectory` up to date from the bundle at `bundleURL`.
+    ///
+    /// Fetches the bundle's branches into `refs/remotes/icloud/*` (non-destructive) and **fast-forwards
+    /// only**. If `Source/` has no repo yet — a fresh peer Mac that just received the package — it's
+    /// `git init`'d and checked out from the bundle. A diverged or locally-ahead branch is reported, not
+    /// merged: the bundle is a sync channel, not an authority that can rewind local work.
+    public func importBundle(at bundleURL: URL, into sourceDirectory: URL) async -> ImportResult {
+        guard fileManager.fileExists(atPath: bundleURL.path) else {
+            return .failed(reason: "no synced bundle found at \(bundleURL.lastPathComponent).", exitCode: nil)
+        }
+
+        let hasRepo: Bool
+        switch await isWorkTree(sourceDirectory) {
+        case .failure(let result): return result.asImport
+        case .success(let value): hasRepo = value
+        }
+
+        return hasRepo
+            ? await importIntoExistingRepo(at: bundleURL, into: sourceDirectory)
+            : await initializeFromBundle(at: bundleURL, into: sourceDirectory)
+    }
+
+    private func importIntoExistingRepo(at bundleURL: URL, into sourceDirectory: URL) async -> ImportResult {
+        // Refuse on a dirty tree — a fast-forward checkout would clobber uncommitted edits.
+        do {
+            let status = try await runner(sourceDirectory, ["status", "--porcelain"])
+            guard status.exitCode == 0 else {
+                return .failed(reason: gitMessage("git status", status), exitCode: status.exitCode)
+            }
+            if !status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return .failed(reason: "the working tree has uncommitted changes — commit or stash them before syncing.", exitCode: nil)
+            }
+        } catch {
+            return .failed(reason: "couldn't run `git status`: \(error.localizedDescription)", exitCode: nil)
+        }
+
+        let branch: String
+        switch await currentBranch(in: sourceDirectory) {
+        case .failure(let result): return result.asImport
+        case .success(let name):
+            guard let name else {
+                return .failed(reason: "the repo is in a detached-HEAD state — check out a branch before syncing.", exitCode: nil)
+            }
+            branch = name
+        }
+
+        switch await verify(bundleURL: bundleURL, in: sourceDirectory) {
+        case .valid: break
+        case .invalid(let reason): return .failed(reason: reason, exitCode: nil)
+        case .failed(let reason, let code): return .failed(reason: reason, exitCode: code)
+        }
+
+        if let failure = await fetchBundle(bundleURL, into: sourceDirectory) { return failure }
+
+        let icloudRef = "refs/remotes/\(Self.remoteRefspace)/\(branch)"
+        // The bundle may not carry this branch at all (e.g. peer is on a different branch).
+        guard await refExists(icloudRef, in: sourceDirectory) else { return .upToDate }
+
+        let headOID = (try? await runner(sourceDirectory, ["rev-parse", "HEAD"]))?.trimmedStdout ?? ""
+        let bundleOID = (try? await runner(sourceDirectory, ["rev-parse", icloudRef]))?.trimmedStdout ?? ""
+
+        let localIsAncestor = await isAncestor("HEAD", of: icloudRef, in: sourceDirectory)
+        let bundleIsAncestor = await isAncestor(icloudRef, of: "HEAD", in: sourceDirectory)
+
+        switch (localIsAncestor, bundleIsAncestor) {
+        case (true, true):
+            return .upToDate                                   // identical history
+        case (true, false):
+            // Behind: fast-forward the checked-out branch to the bundle's tip.
+            do {
+                let merge = try await runner(sourceDirectory, ["merge", "--ff-only", icloudRef])
+                guard merge.exitCode == 0 else {
+                    return .failed(reason: gitMessage("git merge --ff-only", merge), exitCode: merge.exitCode)
+                }
+            } catch {
+                return .failed(reason: "couldn't fast-forward: \(error.localizedDescription)", exitCode: nil)
+            }
+            return .fastForwarded(branch: branch, from: headOID, to: bundleOID)
+        case (false, true):
+            return .localAhead(branch: branch)                 // this Mac has the newer work
+        case (false, false):
+            return .diverged(branch: branch)
+        }
+    }
+
+    private func initializeFromBundle(at bundleURL: URL, into sourceDirectory: URL) async -> ImportResult {
+        do {
+            try fileManager.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+            let initResult = try await runner(sourceDirectory, ["init"])
+            guard initResult.exitCode == 0 else {
+                return .failed(reason: gitMessage("git init", initResult), exitCode: initResult.exitCode)
+            }
+        } catch {
+            return .failed(reason: "couldn't initialize the repository: \(error.localizedDescription)", exitCode: nil)
+        }
+
+        switch await verify(bundleURL: bundleURL, in: sourceDirectory) {
+        case .valid: break
+        case .invalid(let reason): return .failed(reason: reason, exitCode: nil)
+        case .failed(let reason, let code): return .failed(reason: reason, exitCode: code)
+        }
+
+        if let failure = await fetchBundle(bundleURL, into: sourceDirectory) { return failure }
+
+        guard let branch = await defaultBranch(of: bundleURL, cwd: sourceDirectory) else {
+            return .failed(reason: "the bundle has no branches to check out.", exitCode: nil)
+        }
+
+        do {
+            // `-B` creates-or-resets the branch from the bundle ref, working even on git's unborn
+            // initial branch (whatever `init.defaultBranch` named it).
+            let checkout = try await runner(sourceDirectory, ["checkout", "-B", branch, "refs/remotes/\(Self.remoteRefspace)/\(branch)"])
+            guard checkout.exitCode == 0 else {
+                return .failed(reason: gitMessage("git checkout", checkout), exitCode: checkout.exitCode)
+            }
+        } catch {
+            return .failed(reason: "couldn't check out from the bundle: \(error.localizedDescription)", exitCode: nil)
+        }
+        return .initialized(branch: branch)
+    }
+
+    // MARK: - Git helpers
+
+    private func fetchBundle(_ bundleURL: URL, into sourceDirectory: URL) async -> ImportResult? {
+        do {
+            let fetch = try await runner(sourceDirectory, [
+                "fetch", "--force", bundleURL.path,
+                "refs/heads/*:refs/remotes/\(Self.remoteRefspace)/*",
+                "refs/tags/*:refs/tags/*"
+            ])
+            guard fetch.exitCode == 0 else {
+                return .failed(reason: gitMessage("git fetch", fetch), exitCode: fetch.exitCode)
+            }
+            return nil
+        } catch {
+            return .failed(reason: "couldn't fetch from the bundle: \(error.localizedDescription)", exitCode: nil)
+        }
+    }
+
+    /// Wraps `rev-parse --is-inside-work-tree`. `.failure` carries a ready-made terminal result;
+    /// `.success(false)` means "a directory, but not a repo".
+    private func isWorkTree(_ directory: URL) async -> SwiftResult<Bool, GitFailure> {
+        do {
+            let result = try await runner(directory, ["rev-parse", "--is-inside-work-tree"])
+            return .success(result.exitCode == 0)
+        } catch {
+            return .failure(GitFailure(reason: "couldn't check the git repository: \(error.localizedDescription)", exitCode: nil))
+        }
+    }
+
+    /// The checked-out branch, or `nil` when HEAD is detached.
+    private func currentBranch(in directory: URL) async -> SwiftResult<String?, GitFailure> {
+        do {
+            let result = try await runner(directory, ["rev-parse", "--abbrev-ref", "HEAD"])
+            guard result.exitCode == 0 else {
+                return .failure(GitFailure(reason: gitMessage("git rev-parse", result), exitCode: result.exitCode))
+            }
+            let name = result.trimmedStdout
+            return .success(name == "HEAD" ? nil : name)
+        } catch {
+            return .failure(GitFailure(reason: "couldn't read the current branch: \(error.localizedDescription)", exitCode: nil))
+        }
+    }
+
+    /// Heads + tags of the working repo, the set `writeBundle` packs and compares against.
+    private func refsToSync(in directory: URL) async -> SwiftResult<Set<Ref>, GitFailure> {
+        do {
+            let result = try await runner(directory, ["show-ref", "--heads", "--tags"])
+            // `git show-ref` exits 1 with empty output when there are no matching refs — that's an
+            // empty set, not an error.
+            if result.exitCode != 0 && !result.stdout.isEmpty {
+                return .failure(GitFailure(reason: gitMessage("git show-ref", result), exitCode: result.exitCode))
+            }
+            return .success(Self.parseRefLines(result.stdout))
+        } catch {
+            return .failure(GitFailure(reason: "couldn't list refs: \(error.localizedDescription)", exitCode: nil))
+        }
+    }
+
+    /// Heads + tags recorded inside an existing bundle, via `git bundle list-heads`.
+    private func bundleRefs(at bundleURL: URL, cwd: URL) async -> Set<Ref>? {
+        guard let result = try? await runner(cwd, ["bundle", "list-heads", bundleURL.path]), result.exitCode == 0 else {
+            return nil
+        }
+        return Self.parseRefLines(result.stdout)
+            .filter { $0.name.hasPrefix("refs/heads/") || $0.name.hasPrefix("refs/tags/") }
+    }
+
+    /// The bundle's default branch: the `refs/heads/*` ref the bundle's `HEAD` points at, falling
+    /// back to the lexically-first head when no `HEAD` line is present.
+    private func defaultBranch(of bundleURL: URL, cwd: URL) async -> String? {
+        guard let result = try? await runner(cwd, ["bundle", "list-heads", bundleURL.path]), result.exitCode == 0 else {
+            return nil
+        }
+        let refs = Self.parseRefLines(result.stdout)
+        let heads = refs.filter { $0.name.hasPrefix("refs/heads/") }
+        guard !heads.isEmpty else { return nil }
+        if let head = refs.first(where: { $0.name == "HEAD" }),
+           let match = heads.first(where: { $0.oid == head.oid }) {
+            return String(match.name.dropFirst("refs/heads/".count))
+        }
+        let firstByName = heads.min { $0.name < $1.name }!
+        return String(firstByName.name.dropFirst("refs/heads/".count))
+    }
+
+    private func refExists(_ ref: String, in directory: URL) async -> Bool {
+        guard let result = try? await runner(directory, ["rev-parse", "--verify", "--quiet", ref]) else { return false }
+        return result.exitCode == 0
+    }
+
+    /// `git merge-base --is-ancestor <a> <b>` — exit 0 when `a` is an ancestor of `b`.
+    private func isAncestor(_ a: String, of b: String, in directory: URL) async -> Bool {
+        guard let result = try? await runner(directory, ["merge-base", "--is-ancestor", a, b]) else { return false }
+        return result.exitCode == 0
+    }
+
+    /// Parses `oid SP refname` lines (the shared format of `show-ref` and `bundle list-heads`).
+    static func parseRefLines(_ output: String) -> Set<Ref> {
+        var refs: Set<Ref> = []
+        for line in output.split(whereSeparator: \.isNewline) {
+            let parts = line.split(separator: " ", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else { continue }
+            refs.insert(Ref(oid: parts[0], name: parts[1].trimmingCharacters(in: .whitespaces)))
+        }
+        return refs
+    }
+
+    /// Builds a concise `<label> failed (exit N): <stderr>` message from a finished git run.
+    private func gitMessage(_ label: String, _ result: ProcessSupervisor.RunResult) -> String {
+        let detail = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return "`\(label)` failed (exit \(result.exitCode))" + (detail.isEmpty ? "" : ": \(detail)")
+    }
+
+    /// Replaces `destination` with `source` under `NSFileCoordinator` — the documented way to mutate
+    /// an item that may be syncing through iCloud, so peers see an atomic swap rather than a torn file.
+    private func coordinatedReplace(at destination: URL, withItemAt source: URL) throws {
+        var coordinationError: NSError?
+        var ioError: Error?
+        NSFileCoordinator().coordinate(writingItemAt: destination, options: .forReplacing, error: &coordinationError) { url in
+            do {
+                if fileManager.fileExists(atPath: url.path) {
+                    _ = try fileManager.replaceItemAt(url, withItemAt: source)
+                } else {
+                    try fileManager.moveItem(at: source, to: url)
+                }
+            } catch {
+                ioError = error
+            }
+        }
+        if let coordinationError { throw coordinationError }
+        if let ioError { throw ioError }
+    }
+
+    /// A failed git step, ready to be projected into either result type so the early-return helpers
+    /// don't have to know which operation called them. Conforms to `Error` only to satisfy
+    /// `Swift.Result`'s `Failure: Error` bound — it's never thrown.
+    private struct GitFailure: Error {
+        let reason: String
+        let exitCode: Int32?
+        var asWrite: WriteResult { .failed(reason: reason, exitCode: exitCode) }
+        var asImport: ImportResult { .failed(reason: reason, exitCode: exitCode) }
+    }
+
+    // MARK: - Default production seam
+
+    /// Default `GitRunner`: shells out to `git` via `ProcessSupervisor.shared.run(...)`, matching
+    /// `BackupCommand.defaultRunner` so both take the same path under the MAS sandbox grant.
+    public static let defaultRunner: GitRunner = { workingDirectory, arguments in
+        try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["git"] + arguments,
+            currentDirectoryURL: workingDirectory
+        )
+    }
+}
+
+// `Result` is shadowed inside several AnglesiteCore types by nested `Result` enums; alias the stdlib
+// type so this file's helpers stay unambiguous.
+private typealias SwiftResult = Swift.Result
+
+private extension ProcessSupervisor.RunResult {
+    var trimmedStdout: String { stdout.trimmingCharacters(in: .whitespacesAndNewlines) }
+}

--- a/Sources/AnglesiteCore/BundleSync.swift
+++ b/Sources/AnglesiteCore/BundleSync.swift
@@ -300,10 +300,19 @@ public actor BundleSync {
 
     private func fetchBundle(_ bundleURL: URL, into sourceDirectory: URL) async -> ImportResult? {
         do {
+            // Both branches and tags land in the synthetic `icloud/*` namespace we own, never in the
+            // user's real `refs/heads/*` / `refs/tags/*`. The `+` forces only those (ours-to-clobber)
+            // refs. This keeps the import non-destructive symmetrically: branches fast-forward only via
+            // the explicit `merge --ff-only` below, and a *diverged* local tag is preserved rather than
+            // force-overwritten. New tags still propagate — git's automatic tag-following materializes
+            // tags that point at fetched objects into `refs/tags/*`, and auto-follow only ever *creates*
+            // a missing tag, never rewrites an existing one. (Fetching tags straight into `refs/tags/*`
+            // without `--force` would instead make the whole fetch exit non-zero on any tag divergence,
+            // turning a benign tag conflict into a failed import.)
             let fetch = try await runner(sourceDirectory, [
-                "fetch", "--force", bundleURL.path,
-                "refs/heads/*:refs/remotes/\(Self.remoteRefspace)/*",
-                "refs/tags/*:refs/tags/*"
+                "fetch", bundleURL.path,
+                "+refs/heads/*:refs/remotes/\(Self.remoteRefspace)/*",
+                "+refs/tags/*:refs/remotes/\(Self.remoteRefspace)/tags/*"
             ])
             guard fetch.exitCode == 0 else {
                 return .failed(reason: gitMessage("git fetch", fetch), exitCode: fetch.exitCode)

--- a/Tests/AnglesiteCoreTests/BundleSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/BundleSyncTests.swift
@@ -199,7 +199,33 @@ struct BundleSyncTests {
         #expect(result == .initialized(branch: "main"))
     }
 
+    @Test("importBundle routes tags through the icloud namespace, never force-overwriting local refs/tags/*")
+    func importFetchKeepsTagsNonDestructive() async throws {
+        let (source, bundleURL) = try makeRepoWithBundle()
+        let recorder = ArgRecorder()
+        let base = existingRepoRunner(branch: "main", relation: .behind)
+        let sync = BundleSync(runner: { dir, args in
+            await recorder.record(args)
+            return try await base(dir, args)
+        })
+        _ = await sync.importBundle(at: bundleURL, into: source)
+
+        let fetch = try #require(await recorder.all.first { $0.first == "fetch" }, "expected a git fetch")
+        // Tags must not be force-fetched into the user's real tag namespace (would clobber a diverged
+        // local tag); they ride in the synthetic icloud namespace, symmetric with branches.
+        #expect(!fetch.contains("--force"))
+        #expect(!fetch.contains("refs/tags/*:refs/tags/*"))
+        #expect(fetch.contains("+refs/heads/*:refs/remotes/icloud/*"))
+        #expect(fetch.contains("+refs/tags/*:refs/remotes/icloud/tags/*"))
+    }
+
     // MARK: - Import runner helpers
+
+    /// Thread-safe collector for the argument vectors the fake runner sees.
+    private actor ArgRecorder {
+        private(set) var all: [[String]] = []
+        func record(_ args: [String]) { all.append(args) }
+    }
 
     private enum Relation { case behind, ahead, equal, diverged }
 

--- a/Tests/AnglesiteCoreTests/BundleSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/BundleSyncTests.swift
@@ -1,0 +1,240 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for `BundleSync` — the `git bundle`-over-iCloud sync channel (#283).
+///
+/// Style mirrors `BackupCommandTests`: a real temp filesystem with the `git` subprocess faked
+/// through the injected `GitRunner`. Each test scripts the exact subcommands `BundleSync` issues by
+/// matching on the argument vector, so no real git runs and outcomes are deterministic. The one
+/// real side effect is the `NSFileCoordinator` swap in `writeBundle`, exercised against a temp file
+/// the fake runner writes when it sees `git bundle create`.
+struct BundleSyncTests {
+
+    // MARK: - Fixtures
+
+    /// A unique scratch directory for one test.
+    private func makeTempDir() -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("BundleSyncTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func ok(_ stdout: String = "") -> ProcessSupervisor.RunResult {
+        ProcessSupervisor.RunResult(stdout: stdout, stderr: "", exitCode: 0)
+    }
+    private func fail(_ stderr: String = "fatal", _ code: Int32 = 1) -> ProcessSupervisor.RunResult {
+        ProcessSupervisor.RunResult(stdout: "", stderr: stderr, exitCode: code)
+    }
+
+    // MARK: - Package layout
+
+    @Test("The sync bundle lives at Config/sync/source.bundle, out of the Source/ repo")
+    func bundleLivesUnderConfig() {
+        let pkg = AnglesitePackage(url: URL(fileURLWithPath: "/tmp/Foo.anglesite"))
+        #expect(pkg.syncBundleURL.path == "/tmp/Foo.anglesite/Config/sync/source.bundle")
+        #expect(pkg.syncBundleURL.path.hasPrefix(pkg.configURL.path), "the bundle is app-owned Config state")
+        #expect(!pkg.syncBundleURL.path.hasPrefix(pkg.sourceURL.path), "and never inside the Source/ git repo")
+    }
+
+    // MARK: - parseRefLines
+
+    @Test("parseRefLines reads `oid SP refname` lines, skipping malformed ones")
+    func parsesRefLines() {
+        let refs = BundleSync.parseRefLines("""
+        aaaa refs/heads/main
+        bbbb refs/tags/v1
+        garbage-line-without-space
+        cccc refs/remotes/origin/main
+        """)
+        #expect(refs.contains(BundleSync.Ref(oid: "aaaa", name: "refs/heads/main")))
+        #expect(refs.contains(BundleSync.Ref(oid: "bbbb", name: "refs/tags/v1")))
+        #expect(refs.contains(BundleSync.Ref(oid: "cccc", name: "refs/remotes/origin/main")))
+        #expect(refs.count == 3, "the malformed line is skipped")
+    }
+
+    // MARK: - writeBundle
+
+    @Test("writeBundle refuses outside a git repository")
+    func writeRefusesNonRepo() async {
+        let source = makeTempDir()
+        let sync = BundleSync(runner: { _, args in
+            args == ["rev-parse", "--is-inside-work-tree"] ? self.fail() : self.fail("unexpected \(args)")
+        })
+        let result = await sync.writeBundle(from: source, to: source.appendingPathComponent("x.bundle"))
+        guard case .failed(let reason, _) = result else { Issue.record("expected .failed, got \(result)"); return }
+        #expect(reason.lowercased().contains("git repository"))
+    }
+
+    @Test("writeBundle refuses a repo with no commits")
+    func writeRefusesEmptyRepo() async {
+        let source = makeTempDir()
+        let sync = BundleSync(runner: { _, args in
+            if args == ["rev-parse", "--is-inside-work-tree"] { return self.ok("true\n") }
+            if args == ["show-ref", "--heads", "--tags"] { return self.fail("", 1) }  // no refs → exit 1, empty
+            return self.fail("unexpected \(args)")
+        })
+        let result = await sync.writeBundle(from: source, to: source.appendingPathComponent("x.bundle"))
+        guard case .failed(let reason, _) = result else { Issue.record("expected .failed, got \(result)"); return }
+        #expect(reason.lowercased().contains("no commits"))
+    }
+
+    @Test("writeBundle creates, verifies and swaps in the bundle file")
+    func writeCreatesBundle() async throws {
+        let source = makeTempDir()
+        let bundleURL = makeTempDir().appendingPathComponent("Config/sync/source.bundle")
+        let sync = BundleSync(runner: { _, args in
+            if args == ["rev-parse", "--is-inside-work-tree"] { return self.ok("true\n") }
+            if args == ["show-ref", "--heads", "--tags"] { return self.ok("aaaa refs/heads/main\n") }
+            if args.starts(with: ["bundle", "create"]) {
+                // Simulate git writing the bundle to the temp path it was handed (args[2]).
+                FileManager.default.createFile(atPath: args[2], contents: Data("PACK".utf8))
+                return self.ok()
+            }
+            if args.starts(with: ["bundle", "verify"]) { return self.ok() }
+            return self.fail("unexpected \(args)")
+        })
+        let result = await sync.writeBundle(from: source, to: bundleURL)
+        guard case .written(let refs) = result else { Issue.record("expected .written, got \(result)"); return }
+        #expect(refs == [BundleSync.Ref(oid: "aaaa", name: "refs/heads/main")])
+        #expect(FileManager.default.fileExists(atPath: bundleURL.path), "the bundle was swapped into place")
+    }
+
+    @Test("writeBundle is a no-op when the bundle already mirrors the repo's heads + tags")
+    func writeSkipsWhenUnchanged() async throws {
+        let source = makeTempDir()
+        let bundleURL = makeTempDir().appendingPathComponent("source.bundle")
+        FileManager.default.createFile(atPath: bundleURL.path, contents: Data("EXISTING".utf8))
+        let sync = BundleSync(runner: { _, args in
+            if args == ["rev-parse", "--is-inside-work-tree"] { return self.ok("true\n") }
+            if args == ["show-ref", "--heads", "--tags"] { return self.ok("aaaa refs/heads/main\nbbbb refs/tags/v1\n") }
+            // list-heads also reports HEAD; bundleRefs filters it out, so the sets still match.
+            if args.starts(with: ["bundle", "list-heads"]) { return self.ok("aaaa refs/heads/main\nbbbb refs/tags/v1\naaaa HEAD\n") }
+            if args.starts(with: ["bundle", "create"]) { Issue.record("must not rewrite an unchanged bundle"); return self.fail() }
+            return self.fail("unexpected \(args)")
+        })
+        let result = await sync.writeBundle(from: source, to: bundleURL)
+        #expect(result == .unchanged)
+    }
+
+    // MARK: - verify
+
+    @Test("verify reports invalid when there's no bundle file")
+    func verifyMissingFile() async {
+        let source = makeTempDir()
+        let sync = BundleSync(runner: { _, _ in self.fail() })
+        let result = await sync.verify(bundleURL: source.appendingPathComponent("missing.bundle"), in: source)
+        guard case .invalid = result else { Issue.record("expected .invalid, got \(result)"); return }
+    }
+
+    // MARK: - importBundle
+
+    @Test("importBundle fails when the synced bundle is missing")
+    func importMissingBundle() async {
+        let source = makeTempDir()
+        let sync = BundleSync(runner: { _, _ in self.fail() })
+        let result = await sync.importBundle(at: source.appendingPathComponent("nope.bundle"), into: source)
+        guard case .failed = result else { Issue.record("expected .failed, got \(result)"); return }
+    }
+
+    @Test("importBundle refuses a dirty working tree")
+    func importRefusesDirtyTree() async throws {
+        let (source, bundleURL) = try makeRepoWithBundle()
+        let sync = BundleSync(runner: { _, args in
+            if args == ["rev-parse", "--is-inside-work-tree"] { return self.ok("true\n") }
+            if args == ["status", "--porcelain"] { return self.ok(" M index.md\n") }  // dirty
+            return self.fail("unexpected \(args)")
+        })
+        let result = await sync.importBundle(at: bundleURL, into: source)
+        guard case .failed(let reason, _) = result else { Issue.record("expected .failed, got \(result)"); return }
+        #expect(reason.lowercased().contains("uncommitted"))
+    }
+
+    @Test("importBundle fast-forwards a branch that's behind the bundle")
+    func importFastForwards() async throws {
+        let (source, bundleURL) = try makeRepoWithBundle()
+        let sync = BundleSync(runner: existingRepoRunner(branch: "main", relation: .behind))
+        let result = await sync.importBundle(at: bundleURL, into: source)
+        #expect(result == .fastForwarded(branch: "main", from: "head000", to: "icld000"))
+    }
+
+    @Test("importBundle is up-to-date when local history already contains the bundle")
+    func importUpToDate() async throws {
+        let (source, bundleURL) = try makeRepoWithBundle()
+        let sync = BundleSync(runner: existingRepoRunner(branch: "main", relation: .equal))
+        let result = await sync.importBundle(at: bundleURL, into: source)
+        #expect(result == .upToDate)
+    }
+
+    @Test("importBundle reports localAhead when this Mac has the newer work")
+    func importLocalAhead() async throws {
+        let (source, bundleURL) = try makeRepoWithBundle()
+        let sync = BundleSync(runner: existingRepoRunner(branch: "main", relation: .ahead))
+        let result = await sync.importBundle(at: bundleURL, into: source)
+        #expect(result == .localAhead(branch: "main"))
+    }
+
+    @Test("importBundle reports divergence instead of auto-merging")
+    func importDiverged() async throws {
+        let (source, bundleURL) = try makeRepoWithBundle()
+        let sync = BundleSync(runner: existingRepoRunner(branch: "main", relation: .diverged))
+        let result = await sync.importBundle(at: bundleURL, into: source)
+        #expect(result == .diverged(branch: "main"))
+    }
+
+    @Test("importBundle initializes a fresh peer's repo from the bundle")
+    func importInitializes() async throws {
+        let (source, bundleURL) = try makeRepoWithBundle()
+        let sync = BundleSync(runner: { _, args in
+            if args == ["rev-parse", "--is-inside-work-tree"] { return self.fail("not a repo", 128) }  // no repo yet
+            if args == ["init"] { return self.ok() }
+            if args.starts(with: ["bundle", "verify"]) { return self.ok() }
+            if args.starts(with: ["fetch"]) { return self.ok() }
+            if args.starts(with: ["bundle", "list-heads"]) { return self.ok("icld000 refs/heads/main\nicld000 HEAD\n") }
+            if args.starts(with: ["checkout", "-B"]) { return self.ok() }
+            return self.fail("unexpected \(args)")
+        })
+        let result = await sync.importBundle(at: bundleURL, into: source)
+        #expect(result == .initialized(branch: "main"))
+    }
+
+    // MARK: - Import runner helpers
+
+    private enum Relation { case behind, ahead, equal, diverged }
+
+    /// Scripts the existing-repo import path. `relation` controls the two `merge-base --is-ancestor`
+    /// probes (local↦bundle, bundle↦local) that classify ff / up-to-date / ahead / diverged.
+    private func existingRepoRunner(branch: String, relation: Relation) -> BundleSync.GitRunner {
+        let icloudRef = "refs/remotes/icloud/\(branch)"
+        return { [self] _, args in
+            if args == ["rev-parse", "--is-inside-work-tree"] { return ok("true\n") }
+            if args == ["status", "--porcelain"] { return ok("") }
+            if args == ["rev-parse", "--abbrev-ref", "HEAD"] { return ok("\(branch)\n") }
+            if args.starts(with: ["bundle", "verify"]) { return ok() }
+            if args.starts(with: ["fetch"]) { return ok() }
+            if args == ["rev-parse", "--verify", "--quiet", icloudRef] { return ok("icld000\n") }
+            if args == ["rev-parse", "HEAD"] { return ok("head000\n") }
+            if args == ["rev-parse", icloudRef] { return ok("icld000\n") }
+            // local is ancestor of bundle ⇒ local is behind-or-equal
+            if args == ["merge-base", "--is-ancestor", "HEAD", icloudRef] {
+                return (relation == .behind || relation == .equal) ? ok() : fail("", 1)
+            }
+            // bundle is ancestor of local ⇒ local is ahead-or-equal
+            if args == ["merge-base", "--is-ancestor", icloudRef, "HEAD"] {
+                return (relation == .ahead || relation == .equal) ? ok() : fail("", 1)
+            }
+            if args.starts(with: ["merge", "--ff-only"]) { return ok() }
+            return fail("unexpected \(args)")
+        }
+    }
+
+    /// A source dir plus an on-disk (placeholder) bundle file, for import tests that only need the
+    /// file to exist — the fake runner supplies all git behavior.
+    private func makeRepoWithBundle() throws -> (source: URL, bundle: URL) {
+        let source = makeTempDir()
+        let bundle = makeTempDir().appendingPathComponent("source.bundle")
+        FileManager.default.createFile(atPath: bundle.path, contents: Data("PACK".utf8))
+        return (source, bundle)
+    }
+}

--- a/docs/specs/2026-06-21-icloud-bundle-sync-design.md
+++ b/docs/specs/2026-06-21-icloud-bundle-sync-design.md
@@ -1,0 +1,79 @@
+# `.anglesite` iCloud sync via `git bundle`
+
+**Status:** Phase 1 landed (AnglesiteCore `BundleSync`); app wiring is the next increment.
+**Issue:** #283 — "the `.anglesite` package should use `git bundle` internally so it can sync via iCloud between Macs."
+**Date:** 2026-06-21
+
+## Problem
+
+A `.anglesite` package is a directory whose `Source/` subdirectory is a live git repo (see CLAUDE.md
+"Site identity"). Users want to keep a package in iCloud Drive and have it follow them between Macs.
+
+Putting a **live `.git` directory** in iCloud Drive does not work reliably:
+
+- A repo is thousands of small files — loose objects, packs, `refs/`, `index`, `logs/`. iCloud syncs
+  files independently and out of order; a peer can observe a packfile before the ref that names it, or
+  an `index` that points at objects not yet downloaded.
+- Concurrent edits on two Macs produce iCloud conflict copies (`HEAD 2`, `index 2`), which git cannot
+  interpret — the repo silently corrupts.
+- iCloud's eviction / "Optimize Mac Storage" can dataless-fault objects out from under git.
+
+## Approach: a single-file bundle as an iCloud-mediated remote
+
+`git bundle` packs an entire repository (history + selected refs) into **one opaque file**. iCloud
+syncs a single file atomically and reliably. So the unit that travels through iCloud is a bundle, not
+the repo:
+
+```
+Foo.anglesite/
+├── Info.plist            # marker (stable UUID)
+├── Source/               # the live git repo — local working copy
+│   └── .git/             # NOT the sync unit (stays a normal local repo)
+└── Config/
+    └── sync/
+        └── source.bundle # ← the iCloud-synced artifact (AnglesitePackage.syncBundleURL)
+```
+
+The bundle behaves like a **git remote whose transport is a file in iCloud**:
+
+- **`writeBundle` (push):** regenerate `source.bundle` from `Source/` with `git bundle create
+  --branches --tags HEAD`. We bundle local branches + tags + the default branch — not `--all`, which
+  would also pack local-only remote-tracking refs. The write is skipped when the on-disk bundle's
+  heads + tags already match the repo (compared via `git bundle list-heads` vs `git show-ref`), so an
+  idle site generates **no iCloud churn**. The new bundle is written to a sibling temp, `git bundle
+  verify`'d, then swapped into place under `NSFileCoordinator` (the documented way to mutate an iCloud
+  item) so a peer never reads a torn file.
+- **`importBundle` (pull):** `git fetch` the bundle into `refs/remotes/icloud/*` (non-destructive),
+  then **fast-forward only**. A fresh peer Mac whose `Source/` has no repo yet is `git init`'d and
+  checked out from the bundle. A branch that has **diverged** from the bundle, or is **ahead** of it,
+  is reported — never auto-merged or rewound. This is the same safety contract as `git pull --ff-only`.
+
+`Config/` already holds app-owned per-site state and is excluded from the `Source/` git repo, so the
+bundle rides along in iCloud with the package while staying out of the user's git history.
+
+## Why not put the bundle in `Source/`?
+
+`Source/` is the externally-editable git repo (`cd`, VS Code, CLI all descend into it). A binary
+bundle there would either be tracked (bloating history with a packfile that duplicates that history)
+or need `.gitignore` upkeep. `Config/` is the natural home for app-owned sync state.
+
+## What landed in Phase 1
+
+- `AnglesitePackage.syncDirectoryURL` / `syncBundleURL` — single source of truth for the bundle path.
+- `BundleSync` actor (AnglesiteCore) — `writeBundle`, `importBundle`, `verify`, all driven through an
+  injected `GitRunner` (default: `ProcessSupervisor`), mirroring `BackupCommand`. Stateless: every
+  decision is derived from the repo + bundle, so there's no sync-state file to keep consistent.
+- `BundleSyncTests` — fakes the `git` subprocess and covers write (refuse non-repo / empty, create,
+  no-op-when-unchanged), verify, and import (missing, dirty-tree refusal, fast-forward, up-to-date,
+  local-ahead, diverged, fresh-peer init).
+
+## Next increments (not in this PR)
+
+1. **App wiring.** Trigger `importBundle` on site open (`SiteStore.record` / window open) and
+   `writeBundle` after a successful `BackupCommand`/deploy and on app background. Surface
+   `.diverged` / `.localAhead` in the UI rather than resolving silently.
+2. **Conflict UX.** When a branch diverges, offer the user a deliberate resolution (open the two tips,
+   or create a merge/rebase branch) — out of scope for the fast-forward-only v1.
+3. **Eviction hardening.** Ensure the bundle is materialized (not dataless) before reading via
+   `NSFileCoordinator` / `startDownloadingUbiquitousItem` when iCloud has evicted it.
+4. **Scheduling.** Debounce `writeBundle` so rapid edits coalesce into one bundle write.


### PR DESCRIPTION
## Why

Users want to keep a `.anglesite` package in iCloud Drive and have it follow them between Macs. But a `.anglesite` package's `Source/` is a **live git repo**, and putting a live `.git` directory in iCloud Drive is a known foot-gun:

- a repo is thousands of small files (loose objects, packs, refs, index) that iCloud syncs independently and out of order — a peer can see a packfile before the ref that names it;
- concurrent edits on two Macs produce iCloud conflict copies (`HEAD 2`, `index 2`) that git can't interpret → silent corruption;
- iCloud eviction ("Optimize Mac Storage") can dataless-fault objects out from under git.

## Approach — a bundle as an iCloud-mediated remote

`git bundle` packs the whole repo (history + refs) into **one opaque file**, which iCloud syncs atomically and reliably. So the unit that travels through iCloud is a bundle, not the repo. The bundle lives at `Foo.anglesite/Config/sync/source.bundle` — app-owned `Config/` state, riding along in iCloud with the package but outside the `Source/` git working tree.

The bundle behaves like a git remote whose transport is a file in iCloud:

- **`writeBundle` (push)** — regenerate from `--branches --tags HEAD`; **skip** when the on-disk bundle already mirrors the repo's heads+tags (no iCloud churn on idle sites); write to a temp, `git bundle verify`, then swap in under `NSFileCoordinator`.
- **`importBundle` (pull)** — `git fetch` into `refs/remotes/icloud/*` (non-destructive) and **fast-forward only**; `git init`+checkout a fresh peer's repo; report `diverged`/`localAhead` instead of auto-merging or rewinding local work (same contract as `git pull --ff-only`).

## What's in this PR (Phase 1 — AnglesiteCore only)

- `AnglesitePackage.syncDirectoryURL` / `syncBundleURL` — single source of truth for the bundle path.
- `BundleSync` actor — `writeBundle` / `importBundle` / `verify`, all driven through an injected `GitRunner` (default `ProcessSupervisor`), mirroring `BackupCommand`. Stateless: every decision is derived from the repo + bundle, so there's no sync-state file to keep consistent.
- `BundleSyncTests` — fakes the `git` subprocess and covers write (refuse non-repo/empty, create, no-op-when-unchanged), verify, and import (missing, dirty-tree refusal, fast-forward, up-to-date, local-ahead, diverged, fresh-peer init), plus the package path layout.
- `docs/specs/2026-06-21-icloud-bundle-sync-design.md`.

This deliberately lands the **testable core** (like `TokenOnboarding`) and leaves app wiring as the next increment — see the design doc:

1. Trigger `importBundle` on site open and `writeBundle` after backup/deploy and on app background; surface `diverged`/`localAhead` in the UI.
2. Conflict UX for diverged branches.
3. Eviction hardening (`startDownloadingUbiquitousItem` before reads).
4. Debounce `writeBundle`.

## Testing

⚠️ **Not compiled locally** — this session runs in a Linux container with no Swift/Xcode toolchain, so I couldn't run `swift test`. Code is written against the existing AnglesiteCore idioms (`BackupCommand`'s injected-`GitRunner` pattern) and Swift Testing style; **CI is the first real compile/test**. Worth a careful review of the `BundleSync` git-command sequencing in particular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4vgDEqjDreHwgzie5SexB)_