### PR TITLE
ci: skip broken Xcode 26.3 runner image (fixes build-test + relay-tsan on main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,12 @@ jobs:
         run: |
           set -euo pipefail
           ls -d /Applications/Xcode*.app 2>/dev/null | sort -V
-          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          # Skip Xcode 26.3 on the current runner image: its toolchain builds test targets that
+          # link /usr/lib/swift/libswift_DarwinFoundation3.dylib, which the image does not ship, so
+          # `swift test` fails to load AnglesitePackageTests.xctest ("Library not loaded"). Prefer the
+          # newest *working* Xcode — 26.3 is excluded, so 27 is still auto-selected once it lands.
+          # Remove the grep once the 26.3 image is repaired (or Xcode 27 is available).
+          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | grep -vE '/Xcode_26\.3(\.app|\.[0-9]+\.app)$' | tail -1)
           echo "Selecting: $LATEST"
           sudo xcode-select -s "$LATEST"
 
@@ -104,7 +109,12 @@ jobs:
         # Same toolchain rationale as build-test: CLAUDE.md mandates Xcode 27+.
         run: |
           set -euo pipefail
-          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          # Skip Xcode 26.3 on the current runner image: its toolchain builds test targets that
+          # link /usr/lib/swift/libswift_DarwinFoundation3.dylib, which the image does not ship, so
+          # `swift test` fails to load AnglesitePackageTests.xctest ("Library not loaded"). Prefer the
+          # newest *working* Xcode — 26.3 is excluded, so 27 is still auto-selected once it lands.
+          # Remove the grep once the 26.3 image is repaired (or Xcode 27 is available).
+          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | grep -vE '/Xcode_26\.3(\.app|\.[0-9]+\.app)$' | tail -1)
           echo "Selecting: $LATEST"
           sudo xcode-select -s "$LATEST"
 
@@ -175,7 +185,12 @@ jobs:
         run: |
           set -euo pipefail
           ls -d /Applications/Xcode*.app 2>/dev/null | sort -V
-          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          # Skip Xcode 26.3 on the current runner image: its toolchain builds test targets that
+          # link /usr/lib/swift/libswift_DarwinFoundation3.dylib, which the image does not ship, so
+          # `swift test` fails to load AnglesitePackageTests.xctest ("Library not loaded"). Prefer the
+          # newest *working* Xcode — 26.3 is excluded, so 27 is still auto-selected once it lands.
+          # Remove the grep once the 26.3 image is repaired (or Xcode 27 is available).
+          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | grep -vE '/Xcode_26\.3(\.app|\.[0-9]+\.app)$' | tail -1)
           echo "Selecting: $LATEST"
           sudo xcode-select -s "$LATEST"
 


### PR DESCRIPTION
## Problem
CI is red on `main` and all PRs. The GitHub `macos` runner's **Xcode 26.3** builds the SwiftPM test bundle linking `/usr/lib/swift/libswift_DarwinFoundation3.dylib`, which that image does **not** ship:
```
Library not loaded: /usr/lib/swift/libswift_DarwinFoundation3.dylib
  tried: .../Xcode_26.3.app/.../libswift_DarwinFoundation3.dylib (no such file) …
The bundle "AnglesitePackageTests.xctest" couldn't be loaded.
```
The `Select latest available Xcode` step picks `sort -V | tail -1` → `Xcode_26.3`, so every run lands on the broken toolchain.

## Fix
Exclude `Xcode_26.3*` from the selection in all three lanes (`build-test`, `relay-tsan`, and the schema-conformance lane). The step still prefers the **newest working** Xcode — so `Xcode_27` is auto-selected once the runner provides it. Remove the `grep` when the 26.3 image is repaired.

Verified the selection locally: picks `Xcode_26.2.0` against the current runner's list, and `Xcode_27.0` when present.

This unblocks `main` as well as the in-flight feature PR (#283), whose own genuine failure (a SIGPIPE crash) is fixed separately on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)