### PR TITLE
feat(#288): blog system for the base template (giscus host page)

### DIFF
--- a/Resources/Template/src/content.config.ts
+++ b/Resources/Template/src/content.config.ts
@@ -1,0 +1,17 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+// Blog posts live as Markdown in src/content/blog/. The glob loader derives each
+// entry's `id` from its filename (e.g. welcome-to-your-blog.md -> "welcome-to-your-blog"),
+// which becomes the /blog/<id>/ URL.
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    pubDate: z.coerce.date(),
+    description: z.string().optional(),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };

--- a/Resources/Template/src/content/blog/welcome-to-your-blog.md
+++ b/Resources/Template/src/content/blog/welcome-to-your-blog.md
@@ -1,0 +1,22 @@
+---
+title: "Welcome to your blog"
+pubDate: 2026-01-01
+description: "How to add and edit posts on your new Anglesite blog."
+---
+
+This is your blog's first post. Every Anglesite site comes with a blog ready to go.
+
+## Adding a post
+
+Create a new Markdown file in `src/content/blog/`. The file name becomes the
+post's URL — `my-first-update.md` is published at `/blog/my-first-update/`.
+
+Each post starts with frontmatter between `---` fences:
+
+- **title** — shown as the heading and in the post list (required)
+- **pubDate** — the publication date, e.g. `2026-01-15` (required)
+- **description** — a one-line summary for search engines and previews (optional)
+- **draft** — set to `true` to keep a post out of the build while you work on it (optional)
+
+Write the post body in Markdown below the frontmatter. Delete this starter post
+whenever you're ready to publish your own.

--- a/Resources/Template/src/layouts/BlogPost.astro
+++ b/Resources/Template/src/layouts/BlogPost.astro
@@ -1,9 +1,8 @@
 ---
-// BlogPost.astro — giscus injection target.
-// The template has no blog content collection yet; wiring real posts to this
-// layout is follow-up work. This file exists so that the /anglesite:giscus
-// skill's `injectAtAnchor` call has a target (<!-- anglesite:comments -->)
-// and the asset test passes. Tracked separately.
+// BlogPost.astro — layout for an individual blog post. The post route
+// src/pages/blog/[...slug].astro renders through this layout; the Markdown body
+// fills the <slot/>, and the comments anchor in the <article> below is where the
+// giscus integration injects its widget when comments are set up.
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {

--- a/Resources/Template/src/layouts/BlogPost.astro
+++ b/Resources/Template/src/layouts/BlogPost.astro
@@ -8,14 +8,24 @@ import BaseLayout from "./BaseLayout.astro";
 interface Props {
   title: string;
   description?: string;
+  pubDate?: Date;
 }
 
-const { title, description } = Astro.props;
+const { title, description, pubDate } = Astro.props;
 // anglesite:imports — integration component imports are injected here on setup
 ---
 
 <BaseLayout title={title} description={description}>
   <article>
+    <p><a href="/blog/">← All posts</a></p>
+    <h1>{title}</h1>
+    {
+      pubDate && (
+        <time datetime={pubDate.toISOString()}>
+          {pubDate.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })}
+        </time>
+      )
+    }
     <slot />
     <!-- anglesite:comments -->
   </article>

--- a/Resources/Template/src/pages/blog/[...slug].astro
+++ b/Resources/Template/src/pages/blog/[...slug].astro
@@ -1,0 +1,16 @@
+---
+import { getCollection, render } from "astro:content";
+import BlogPost from "../../layouts/BlogPost.astro";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  return posts.map((post) => ({ params: { slug: post.id }, props: { post } }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<BlogPost title={post.data.title} description={post.data.description}>
+  <Content />
+</BlogPost>

--- a/Resources/Template/src/pages/blog/[...slug].astro
+++ b/Resources/Template/src/pages/blog/[...slug].astro
@@ -11,6 +11,6 @@ const { post } = Astro.props;
 const { Content } = await render(post);
 ---
 
-<BlogPost title={post.data.title} description={post.data.description}>
+<BlogPost title={post.data.title} description={post.data.description} pubDate={post.data.pubDate}>
   <Content />
 </BlogPost>

--- a/Resources/Template/src/pages/blog/index.astro
+++ b/Resources/Template/src/pages/blog/index.astro
@@ -7,7 +7,7 @@ const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
 );
 ---
 
-<BaseLayout title="Blog" description="Latest posts">
+<BaseLayout title="Blog" description="Read the latest posts and updates.">
   <main>
     <h1>Blog</h1>
     {
@@ -18,6 +18,9 @@ const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
           {posts.map((post) => (
             <li>
               <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+              <time datetime={post.data.pubDate.toISOString()}>
+                {post.data.pubDate.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })}
+              </time>
               {post.data.description && <p>{post.data.description}</p>}
             </li>
           ))}

--- a/Resources/Template/src/pages/blog/index.astro
+++ b/Resources/Template/src/pages/blog/index.astro
@@ -1,0 +1,28 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+);
+---
+
+<BaseLayout title="Blog" description="Latest posts">
+  <main>
+    <h1>Blog</h1>
+    {
+      posts.length === 0 ? (
+        <p>No posts yet. Add a Markdown file in <code>src/content/blog/</code> to get started.</p>
+      ) : (
+        <ul>
+          {posts.map((post) => (
+            <li>
+              <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+              {post.data.description && <p>{post.data.description}</p>}
+            </li>
+          ))}
+        </ul>
+      )
+    }
+  </main>
+</BaseLayout>

--- a/Resources/Template/src/pages/index.astro
+++ b/Resources/Template/src/pages/index.astro
@@ -10,6 +10,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <section class="hero">
       <h1>Welcome</h1>
       <p>This site is ready to set up. Type <code>/start</code> in Claude Desktop to get started.</p>
+      <p><a href="/blog/">Read the blog</a></p>
     </section>
   </main>
 </BaseLayout>

--- a/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
@@ -68,4 +68,10 @@ import Foundation
         #expect(s.contains("/blog/"))
         #expect(s.contains("draft"))   // drafts filtered from the listing
     }
+
+    @Test func homepageLinksToBlog() throws {
+        let root = templateRoot()
+        let s = try String(contentsOf: root.appendingPathComponent("src/pages/index.astro"), encoding: .utf8)
+        #expect(s.contains("href=\"/blog/\""), "homepage should link to /blog/")
+    }
 }

--- a/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
@@ -56,6 +56,21 @@ import Foundation
         // post body rendered into the layout slot
         #expect(s.contains("<Content />"))
         #expect(s.contains("<BlogPost"))
+        // pubDate forwarded so the layout can display the publication date
+        #expect(s.contains("pubDate={post.data.pubDate}"))
+    }
+
+    @Test func blogPostLayoutRendersTitleAndDate() throws {
+        let root = templateRoot()
+        let s = try String(contentsOf: root.appendingPathComponent("src/layouts/BlogPost.astro"), encoding: .utf8)
+        // visible heading + publication date in the article body
+        #expect(s.contains("<h1>{title}</h1>"), "post should render its title as an <h1>")
+        #expect(s.contains("pubDate"), "layout should accept/render pubDate")
+        #expect(s.contains("<time"), "date should use a semantic <time> element")
+        // render the date in UTC so a build machine behind UTC doesn't shift it a day
+        #expect(s.contains("timeZone: \"UTC\""), "date must render in UTC to match the datetime attribute")
+        // the giscus import anchor must survive any layout edits (descriptor injects here)
+        #expect(s.contains("// anglesite:imports"), "imports anchor must remain for giscus injection")
     }
 
     @Test func blogIndexListsCollection() throws {
@@ -67,6 +82,9 @@ import Foundation
         #expect(s.contains("getCollection(\"blog\""))
         #expect(s.contains("/blog/"))
         #expect(s.contains("!data.draft"))   // drafts filtered from the listing
+        // each entry shows its publication date in a semantic <time> element
+        #expect(s.contains("<time"))
+        #expect(s.contains("pubDate"))
     }
 
     @Test func homepageLinksToBlog() throws {

--- a/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
@@ -41,4 +41,31 @@ import Foundation
         #expect(s.contains("title:"))
         #expect(s.contains("pubDate:"))
     }
+
+    @Test func postRouteRendersThroughBlogPostLayout() throws {
+        let root = templateRoot()
+        let route = root.appendingPathComponent("src/pages/blog/[...slug].astro")
+        #expect(FileManager.default.fileExists(atPath: route.path), "missing post route")
+        let s = try String(contentsOf: route, encoding: .utf8)
+        // renders through BlogPost (the giscus host layout)
+        #expect(s.contains("import BlogPost from \"../../layouts/BlogPost.astro\""))
+        #expect(s.contains("getStaticPaths"))
+        #expect(s.contains("getCollection(\"blog\""))
+        // drafts excluded from the generated paths
+        #expect(s.contains("draft"))
+        // post body rendered into the layout slot
+        #expect(s.contains("<Content />"))
+        #expect(s.contains("<BlogPost"))
+    }
+
+    @Test func blogIndexListsCollection() throws {
+        let root = templateRoot()
+        let index = root.appendingPathComponent("src/pages/blog/index.astro")
+        #expect(FileManager.default.fileExists(atPath: index.path), "missing blog index")
+        let s = try String(contentsOf: index, encoding: .utf8)
+        #expect(s.contains("import BaseLayout from \"../../layouts/BaseLayout.astro\""))
+        #expect(s.contains("getCollection(\"blog\""))
+        #expect(s.contains("/blog/"))
+        #expect(s.contains("draft"))   // drafts filtered from the listing
+    }
 }

--- a/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
@@ -1,0 +1,44 @@
+// Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+// Hermetic test — no app bundle or TemplateRuntime needed. Resolves the template
+// by walking up from #filePath (Tests/AnglesiteCoreTests/ -> Tests/ -> repo root).
+// Classic URL APIs only (see IntegrationTemplateAssetsTests / PR #283 CI notes).
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct BlogTemplateAssetsTests {
+
+    private func templateRoot() -> URL {
+        let here = URL(fileURLWithPath: #filePath)
+        let repoRoot = here
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        #expect(FileManager.default.fileExists(atPath: repoRoot.appendingPathComponent("Package.swift").path), "repo-root detection drifted")
+        return repoRoot.appendingPathComponent("Resources/Template")
+    }
+
+    @Test func contentConfigDefinesBlogCollection() throws {
+        let root = templateRoot()
+        let cfg = root.appendingPathComponent("src/content.config.ts")
+        #expect(FileManager.default.fileExists(atPath: cfg.path), "missing src/content.config.ts")
+        let s = try String(contentsOf: cfg, encoding: .utf8)
+        #expect(s.contains("defineCollection"))
+        #expect(s.contains("glob("))
+        #expect(s.contains("collections = { blog }"))
+        // minimal schema fields
+        for field in ["title:", "pubDate:", "description:", "draft:"] {
+            #expect(s.contains(field), "schema missing \(field)")
+        }
+    }
+
+    @Test func starterPostExistsWithRequiredFrontmatter() throws {
+        let root = templateRoot()
+        let post = root.appendingPathComponent("src/content/blog/welcome-to-your-blog.md")
+        #expect(FileManager.default.fileExists(atPath: post.path), "missing starter post")
+        let s = try String(contentsOf: post, encoding: .utf8)
+        #expect(s.hasPrefix("---"), "post must start with frontmatter")
+        #expect(s.contains("title:"))
+        #expect(s.contains("pubDate:"))
+    }
+}

--- a/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
@@ -74,4 +74,21 @@ import Foundation
         let s = try String(contentsOf: root.appendingPathComponent("src/pages/index.astro"), encoding: .utf8)
         #expect(s.contains("href=\"/blog/\""), "homepage should link to /blog/")
     }
+
+    @Test func giscusInjectsIntoBodyNotFrontmatter() throws {
+        // MarkerInjector matches the FIRST occurrence of the anchor. If the anchor text
+        // also appears in BlogPost.astro's frontmatter doc-comment, giscus injects into
+        // the frontmatter and never renders. Guard the real layout against that regression.
+        let root = templateRoot()
+        let src = try String(contentsOf: root.appendingPathComponent("src/layouts/BlogPost.astro"), encoding: .utf8)
+        let out = try MarkerInjector.inject(
+            snippet: "<Comments />", withID: "comments",
+            atAnchor: "<!-- anglesite:comments -->", into: src, style: .html).get()
+        let frontmatterClose = out.range(of: "\n---\n")  // closing fence of Astro frontmatter
+        let injected = out.range(of: "<Comments />")
+        #expect(frontmatterClose != nil, "BlogPost.astro should have an Astro frontmatter fence")
+        #expect(injected != nil, "injected giscus snippet should be present")
+        #expect(injected!.lowerBound > frontmatterClose!.upperBound,
+                "giscus must inject into the <article> body, not the frontmatter — a duplicate anchor in a frontmatter comment makes the first-match injector target the wrong spot")
+    }
 }

--- a/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
@@ -52,7 +52,7 @@ import Foundation
         #expect(s.contains("getStaticPaths"))
         #expect(s.contains("getCollection(\"blog\""))
         // drafts excluded from the generated paths
-        #expect(s.contains("draft"))
+        #expect(s.contains("!data.draft"))
         // post body rendered into the layout slot
         #expect(s.contains("<Content />"))
         #expect(s.contains("<BlogPost"))
@@ -66,7 +66,7 @@ import Foundation
         #expect(s.contains("import BaseLayout from \"../../layouts/BaseLayout.astro\""))
         #expect(s.contains("getCollection(\"blog\""))
         #expect(s.contains("/blog/"))
-        #expect(s.contains("draft"))   // drafts filtered from the listing
+        #expect(s.contains("!data.draft"))   // drafts filtered from the listing
     }
 
     @Test func homepageLinksToBlog() throws {

--- a/docs/superpowers/plans/2026-06-21-blog-system.md
+++ b/docs/superpowers/plans/2026-06-21-blog-system.md
@@ -424,3 +424,83 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 - Richer frontmatter (tags + tag pages, author, hero image, `updatedDate`).
 - RSS feed, pagination, reading-time.
 - Any change to the giscus descriptor, `MarkerInjector`, `IntegrationScaffolder`, or other Swift/engine source.
+
+---
+
+## Task 4: Fix duplicate giscus anchor in `BlogPost.astro` (added post-review)
+
+**Why:** Discovered during Task 3 review. The giscus descriptor (`IntegrationCatalog.swift:145`) injects at anchor `<!-- anglesite:comments -->` into `src/layouts/BlogPost.astro`, and `MarkerInjector.inject` finds the anchor with `content.range(of: anchor)` — the **first** occurrence. `BlogPost.astro` contains that exact string **twice**: once in the frontmatter `//` doc-comment (line 5) and once as the real HTML body anchor (line 21). So real giscus setup injects into the **frontmatter**, not the body — giscus never renders. This is a pre-existing latent bug (from #287) that #288 makes live, and it defeats the feature's purpose. The same doc-comment is now factually wrong (it says the blog is "follow-up work… Tracked separately" — that work is this branch). This task is a deliberate, reviewed exception to the "do not touch `BlogPost.astro`" constraint.
+
+**Files:**
+- Modify: `Resources/Template/src/layouts/BlogPost.astro` (frontmatter doc-comment only — anchors and code untouched)
+- Test: `Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift` (append one behavioral test)
+
+**Interfaces:**
+- Consumes: `MarkerInjector.inject(snippet:withID:atAnchor:into:style:)` (real AnglesiteCore symbol; `@testable import AnglesiteCore` already present in the test file).
+
+- [ ] **Step 1: Write the failing test** (append to `BlogTemplateAssetsTests.swift`)
+
+This is behavioral: it runs the real injector against the real layout and asserts the giscus block lands in the body (after the Astro frontmatter fence), not in the frontmatter.
+
+```swift
+    @Test func giscusInjectsIntoBodyNotFrontmatter() throws {
+        // MarkerInjector matches the FIRST occurrence of the anchor. If the anchor text
+        // also appears in BlogPost.astro's frontmatter doc-comment, giscus injects into
+        // the frontmatter and never renders. Guard the real layout against that regression.
+        let root = templateRoot()
+        let src = try String(contentsOf: root.appendingPathComponent("src/layouts/BlogPost.astro"), encoding: .utf8)
+        let out = try MarkerInjector.inject(
+            snippet: "<Comments />", withID: "comments",
+            atAnchor: "<!-- anglesite:comments -->", into: src, style: .html).get()
+        let frontmatterClose = out.range(of: "\n---\n")  // closing fence of Astro frontmatter
+        let injected = out.range(of: "<Comments />")
+        #expect(frontmatterClose != nil, "BlogPost.astro should have an Astro frontmatter fence")
+        #expect(injected != nil, "injected giscus snippet should be present")
+        #expect(injected!.lowerBound > frontmatterClose!.upperBound,
+                "giscus must inject into the <article> body, not the frontmatter — a duplicate anchor in a frontmatter comment makes the first-match injector target the wrong spot")
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter BlogTemplateAssetsTests`
+Expected: FAIL on `giscusInjectsIntoBodyNotFrontmatter` — the injected `<Comments />` lands before the frontmatter close (first anchor match is the line-5 doc-comment).
+
+- [ ] **Step 3: Rewrite the frontmatter doc-comment** (`Resources/Template/src/layouts/BlogPost.astro`)
+
+Replace the comment block at the top of the frontmatter (the six `//` lines from `// BlogPost.astro — giscus injection target.` through `// and the asset test passes. Tracked separately.`) with this — note it must **not** contain the literal string `<!-- anglesite:comments -->`:
+
+```astro
+---
+// BlogPost.astro — layout for an individual blog post. The post route
+// src/pages/blog/[...slug].astro renders through this layout; the Markdown body
+// fills the <slot/>, and the comments anchor in the <article> below is where the
+// giscus integration injects its widget when comments are set up.
+import BaseLayout from "./BaseLayout.astro";
+```
+
+Leave everything else unchanged — the `// anglesite:imports` anchor (frontmatter), the `Props` interface, `const { title, description }`, and the real `<!-- anglesite:comments -->` body anchor inside `<article>` all stay exactly as they are.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter BlogTemplateAssetsTests`
+Expected: PASS (6 tests). The anchor now appears once, so the injector targets the body.
+
+- [ ] **Step 5: Full Swift suite green** (the `IntegrationTemplateAssetsTests.layoutsHaveImportAndBodyAnchors` test asserts BlogPost.astro still contains `// anglesite:imports` and `<!-- anglesite:comments -->` — both remain, so it must still pass)
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer ANGLESITE_PLUGIN_PATH=/Users/dwk/Developer/github.com/Anglesite/anglesite swift test --package-path .`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/288-blog-system
+git add Resources/Template/src/layouts/BlogPost.astro Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+git commit -m "fix(#288): remove duplicate giscus anchor from BlogPost.astro frontmatter comment
+
+The anchor text appeared in both the doc-comment and the body, so MarkerInjector
+(first-match) injected giscus into the frontmatter. Rewrite the now-stale comment
+so the anchor occurs once and giscus lands in the post body.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```

--- a/docs/superpowers/plans/2026-06-21-blog-system.md
+++ b/docs/superpowers/plans/2026-06-21-blog-system.md
@@ -1,0 +1,426 @@
+# Blog System for the Base Template — Implementation Plan (#288)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `BlogPost.astro` a real, rendered route by adding an Astro content collection, a `/blog/` index, a `/blog/<slug>/` post route, one starter post, and a homepage link — so every site has a working blog and giscus (shipped in #287) gets a host page.
+
+**Architecture:** Pure Astro 5 content-collection wiring under `Resources/Template/src/`. Nothing in Swift/the engine changes — `BlogPost.astro` keeps its existing `// anglesite:imports` and `<!-- anglesite:comments -->` anchors, so the giscus descriptor's `injectAtAnchor` keeps working against a route that now actually renders. Automated regression guards are hermetic Swift tests that mirror `IntegrationTemplateAssetsTests`; the real build is proven by a scripted Astro build smoke.
+
+**Tech Stack:** Astro `^5.0.0`, TypeScript, Swift Testing (`@Test`). Spec: `docs/superpowers/specs/2026-06-21-blog-system-design.md`.
+
+## Global Constraints
+
+- **Worktree:** `/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/288-blog-system`, branch `feat/288-blog-system`. `cd` here before any git op.
+- **Template-side only.** No Swift/engine source changes (only a new test file). Do **not** touch the giscus descriptor, `MarkerInjector`, or `IntegrationScaffolder`.
+- **Classic Foundation/Darwin APIs only in test bundles** — `URL(fileURLWithPath:)`, `appendingPathComponent(_:)`, `.path`. Never `URL(filePath:)`, `.appending(path:)`, `.path(percentEncoded:)`, `SIG_IGN`, `EPIPE` (they link `libswift_DarwinFoundation3.dylib`, absent on macOS-26 CI runners → whole bundle won't load).
+- **`tsconfig` extends `astro/tsconfigs/strict` (`noUnusedLocals`)** — every imported symbol must be used.
+- **Swift tests run with:** `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer ANGLESITE_PLUGIN_PATH=/Users/dwk/Developer/github.com/Anglesite/anglesite swift test --package-path .` (default toolchain is too old).
+- **Minimal schema only:** `title`, `pubDate`, optional `description`, optional `draft`. No tags/author/hero-image (YAGNI; out of scope).
+- **Commit trailer on every commit:** `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File structure
+
+**`Resources/Template/` (create):**
+- `src/content.config.ts` — Astro 5 content collection `blog` (glob loader + Zod schema).
+- `src/content/blog/welcome-to-your-blog.md` — one starter post.
+- `src/pages/blog/[...slug].astro` — post route, renders through `BlogPost.astro`.
+- `src/pages/blog/index.astro` — blog index listing.
+
+**`Resources/Template/` (modify):**
+- `src/pages/index.astro` — add a `/blog/` nav link.
+
+**Tests (create):**
+- `Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift` — hermetic structural guards.
+
+No `scaffold.sh` change is needed: all new files live in `src/`, which is copied verbatim into every scaffold (only `scripts/scaffold.sh`, `scripts/themes.ts`, `integrations/`, `node_modules/`, `.DS_Store` are excluded).
+
+---
+
+## Task 1: Content collection + starter post
+
+**Files:**
+- Create: `Resources/Template/src/content.config.ts`
+- Create: `Resources/Template/src/content/blog/welcome-to-your-blog.md`
+- Test: `Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift`
+
+**Interfaces:**
+- Produces: a `blog` collection (consumed by Task 2's routes via `getCollection("blog")`), with entry data shape `{ title: string; pubDate: Date; description?: string; draft: boolean }` and entry `id` derived from the Markdown filename (`welcome-to-your-blog`).
+
+- [ ] **Step 1: Write the failing test** (create `Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift`)
+
+```swift
+// Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+// Hermetic test — no app bundle or TemplateRuntime needed. Resolves the template
+// by walking up from #filePath (Tests/AnglesiteCoreTests/ -> Tests/ -> repo root).
+// Classic URL APIs only (see IntegrationTemplateAssetsTests / PR #283 CI notes).
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct BlogTemplateAssetsTests {
+
+    private func templateRoot() -> URL {
+        let here = URL(fileURLWithPath: #filePath)
+        let repoRoot = here
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        #expect(FileManager.default.fileExists(atPath: repoRoot.appendingPathComponent("Package.swift").path), "repo-root detection drifted")
+        return repoRoot.appendingPathComponent("Resources/Template")
+    }
+
+    @Test func contentConfigDefinesBlogCollection() throws {
+        let root = templateRoot()
+        let cfg = root.appendingPathComponent("src/content.config.ts")
+        #expect(FileManager.default.fileExists(atPath: cfg.path), "missing src/content.config.ts")
+        let s = try String(contentsOf: cfg, encoding: .utf8)
+        #expect(s.contains("defineCollection"))
+        #expect(s.contains("glob("))
+        #expect(s.contains("collections = { blog }"))
+        // minimal schema fields
+        for field in ["title:", "pubDate:", "description:", "draft:"] {
+            #expect(s.contains(field), "schema missing \(field)")
+        }
+    }
+
+    @Test func starterPostExistsWithRequiredFrontmatter() throws {
+        let root = templateRoot()
+        let post = root.appendingPathComponent("src/content/blog/welcome-to-your-blog.md")
+        #expect(FileManager.default.fileExists(atPath: post.path), "missing starter post")
+        let s = try String(contentsOf: post, encoding: .utf8)
+        #expect(s.hasPrefix("---"), "post must start with frontmatter")
+        #expect(s.contains("title:"))
+        #expect(s.contains("pubDate:"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter BlogTemplateAssetsTests`
+Expected: FAIL — `missing src/content.config.ts` (and missing starter post).
+
+- [ ] **Step 3: Create the content collection config** (`Resources/Template/src/content.config.ts`)
+
+```ts
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+// Blog posts live as Markdown in src/content/blog/. The glob loader derives each
+// entry's `id` from its filename (e.g. welcome-to-your-blog.md -> "welcome-to-your-blog"),
+// which becomes the /blog/<id>/ URL.
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    pubDate: z.coerce.date(),
+    description: z.string().optional(),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };
+```
+
+- [ ] **Step 4: Create the starter post** (`Resources/Template/src/content/blog/welcome-to-your-blog.md`)
+
+```markdown
+---
+title: "Welcome to your blog"
+pubDate: 2026-01-01
+description: "How to add and edit posts on your new Anglesite blog."
+---
+
+This is your blog's first post. Every Anglesite site comes with a blog ready to go.
+
+## Adding a post
+
+Create a new Markdown file in `src/content/blog/`. The file name becomes the
+post's URL — `my-first-update.md` is published at `/blog/my-first-update/`.
+
+Each post starts with frontmatter between `---` fences:
+
+- **title** — shown as the heading and in the post list (required)
+- **pubDate** — the publication date, e.g. `2026-01-15` (required)
+- **description** — a one-line summary for search engines and previews (optional)
+- **draft** — set to `true` to keep a post out of the build while you work on it (optional)
+
+Write the post body in Markdown below the frontmatter. Delete this starter post
+whenever you're ready to publish your own.
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter BlogTemplateAssetsTests`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/288-blog-system
+git add Resources/Template/src/content.config.ts \
+        Resources/Template/src/content/blog/welcome-to-your-blog.md \
+        Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+git commit -m "feat(#288): blog content collection + starter post
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Blog routes (post page + index)
+
+**Files:**
+- Create: `Resources/Template/src/pages/blog/[...slug].astro`
+- Create: `Resources/Template/src/pages/blog/index.astro`
+- Test: `Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift` (append two tests)
+
+**Interfaces:**
+- Consumes: the `blog` collection from Task 1 via `getCollection("blog")`; `BlogPost.astro` (`Props { title: string; description?: string }`, default slot inside `<article>` above `<!-- anglesite:comments -->`); `BaseLayout.astro` (same Props).
+- Produces: built routes `/blog/` and `/blog/<id>/`. The post route is giscus's host page.
+
+- [ ] **Step 1: Write the failing tests** (append to `BlogTemplateAssetsTests.swift`, inside the `@Suite struct`)
+
+```swift
+    @Test func postRouteRendersThroughBlogPostLayout() throws {
+        let root = templateRoot()
+        let route = root.appendingPathComponent("src/pages/blog/[...slug].astro")
+        #expect(FileManager.default.fileExists(atPath: route.path), "missing post route")
+        let s = try String(contentsOf: route, encoding: .utf8)
+        // renders through BlogPost (the giscus host layout)
+        #expect(s.contains("import BlogPost from \"../../layouts/BlogPost.astro\""))
+        #expect(s.contains("getStaticPaths"))
+        #expect(s.contains("getCollection(\"blog\""))
+        // drafts excluded from the generated paths
+        #expect(s.contains("draft"))
+        // post body rendered into the layout slot
+        #expect(s.contains("<Content />"))
+        #expect(s.contains("<BlogPost"))
+    }
+
+    @Test func blogIndexListsCollection() throws {
+        let root = templateRoot()
+        let index = root.appendingPathComponent("src/pages/blog/index.astro")
+        #expect(FileManager.default.fileExists(atPath: index.path), "missing blog index")
+        let s = try String(contentsOf: index, encoding: .utf8)
+        #expect(s.contains("import BaseLayout from \"../../layouts/BaseLayout.astro\""))
+        #expect(s.contains("getCollection(\"blog\""))
+        #expect(s.contains("/blog/"))
+        #expect(s.contains("draft"))   // drafts filtered from the listing
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter BlogTemplateAssetsTests`
+Expected: FAIL — `missing post route`, `missing blog index`.
+
+- [ ] **Step 3: Create the post route** (`Resources/Template/src/pages/blog/[...slug].astro`)
+
+```astro
+---
+import { getCollection, render } from "astro:content";
+import BlogPost from "../../layouts/BlogPost.astro";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  return posts.map((post) => ({ params: { slug: post.id }, props: { post } }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<BlogPost title={post.data.title} description={post.data.description}>
+  <Content />
+</BlogPost>
+```
+
+- [ ] **Step 4: Create the blog index** (`Resources/Template/src/pages/blog/index.astro`)
+
+```astro
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+);
+---
+
+<BaseLayout title="Blog" description="Latest posts">
+  <main>
+    <h1>Blog</h1>
+    {
+      posts.length === 0 ? (
+        <p>No posts yet. Add a Markdown file in <code>src/content/blog/</code> to get started.</p>
+      ) : (
+        <ul>
+          {posts.map((post) => (
+            <li>
+              <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+              {post.data.description && <p>{post.data.description}</p>}
+            </li>
+          ))}
+        </ul>
+      )
+    }
+  </main>
+</BaseLayout>
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter BlogTemplateAssetsTests`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/288-blog-system
+git add Resources/Template/src/pages/blog/ Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+git commit -m "feat(#288): blog post route + index listing
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Homepage link + full build acceptance
+
+**Files:**
+- Modify: `Resources/Template/src/pages/index.astro`
+- Test: `Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift` (append one test)
+
+**Interfaces:**
+- Consumes: the `/blog/` route from Task 2.
+- Produces: a homepage link to the blog; no new exported interface.
+
+- [ ] **Step 1: Write the failing test** (append to `BlogTemplateAssetsTests.swift`)
+
+```swift
+    @Test func homepageLinksToBlog() throws {
+        let root = templateRoot()
+        let s = try String(contentsOf: root.appendingPathComponent("src/pages/index.astro"), encoding: .utf8)
+        #expect(s.contains("href=\"/blog/\""), "homepage should link to /blog/")
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter BlogTemplateAssetsTests`
+Expected: FAIL — `homepage should link to /blog/`.
+
+- [ ] **Step 3: Add the nav link** (`Resources/Template/src/pages/index.astro`)
+
+Replace the `<section class="hero">` block so it reads exactly:
+
+```astro
+    <section class="hero">
+      <h1>Welcome</h1>
+      <p>This site is ready to set up. Type <code>/start</code> in Claude Desktop to get started.</p>
+      <p><a href="/blog/">Read the blog</a></p>
+    </section>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter BlogTemplateAssetsTests`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Astro build smoke acceptance** (scripted — scaffold a temp site, build, assert blog output + draft exclusion)
+
+Run:
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/288-blog-system/Resources/Template
+SMOKE=$(mktemp -d)
+zsh scripts/scaffold.sh --yes "$SMOKE"
+cd "$SMOKE"
+npm install --silent
+# add a draft post that must NOT appear in the build
+cat > src/content/blog/draft-post.md <<'MD'
+---
+title: "Hidden draft"
+pubDate: 2026-02-01
+draft: true
+---
+This should not be built.
+MD
+npm run build
+echo "--- assertions ---"
+test -f dist/blog/index.html && echo "OK index" || { echo "FAIL: no /blog/ index"; exit 1; }
+test -f dist/blog/welcome-to-your-blog/index.html && echo "OK post" || { echo "FAIL: no post page"; exit 1; }
+test ! -e dist/blog/draft-post/index.html && echo "OK draft excluded" || { echo "FAIL: draft was built"; exit 1; }
+grep -q "/blog/welcome-to-your-blog/" dist/blog/index.html && echo "OK index links post" || { echo "FAIL: index missing post link"; exit 1; }
+```
+
+Expected: `OK index`, `OK post`, `OK draft excluded`, `OK index links post`. Clean up: `rm -rf "$SMOKE"`.
+
+- [ ] **Step 6: Giscus end-to-end acceptance** (proves the #287 gap is closed — giscus now has a host page)
+
+Run (continues conceptually from a fresh scaffold; the giscus injection is performed by the app's `IntegrationScaffolder`, so simulate its two writes — the import into `BlogPost.astro`'s `// anglesite:imports` anchor and the gated render at `<!-- anglesite:comments -->` — then build):
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/288-blog-system/Resources/Template
+GZ=$(mktemp -d)
+zsh scripts/scaffold.sh --yes "$GZ"
+cd "$GZ"
+npm install --silent
+# giscus config the app would write to .site-config
+cat >> .site-config <<'CFG'
+GISCUS_REPO=acme/site
+GISCUS_REPO_ID=R_test
+GISCUS_CATEGORY=Comments
+GISCUS_CATEGORY_ID=DIC_test
+GISCUS_MAPPING=pathname
+CFG
+# copy the staged Comments component (the app does this on-demand)
+mkdir -p src/components
+cp "$OLDPWD/integrations/components/Comments.astro" src/components/Comments.astro
+# inject import + gated render into BlogPost.astro (mirrors IntegrationScaffolder)
+perl -0pi -e 's{// anglesite:imports[^\n]*\n}{$&import Comments from "../components/Comments.astro";\nconst giscusRepo = readConfig("GISCUS_REPO");\n}' src/layouts/BlogPost.astro
+perl -0pi -e 's{<!-- anglesite:comments -->}{{giscusRepo && <Comments repo={giscusRepo} repoId={readConfig("GISCUS_REPO_ID")} category={readConfig("GISCUS_CATEGORY")} categoryId={readConfig("GISCUS_CATEGORY_ID")} mapping={readConfig("GISCUS_MAPPING")} />}}' src/layouts/BlogPost.astro
+# BlogPost.astro now imports readConfig — add the import alongside BaseLayout
+perl -0pi -e 's{import BaseLayout from "./BaseLayout.astro";}{$&\nimport { readConfig } from "../../scripts/config.ts";}' src/layouts/BlogPost.astro
+npm run build
+grep -q "giscus.app/client.js" dist/blog/welcome-to-your-blog/index.html \
+  && echo "OK giscus rendered on post page" \
+  || { echo "FAIL: giscus not on post page"; exit 1; }
+```
+
+Expected: `OK giscus rendered on post page`. Clean up: `rm -rf "$GZ"`.
+
+> **Note for the implementer:** Step 6 *simulates* the app-side injection to prove the host page works end-to-end; the exact `perl` rewrites approximate `IntegrationScaffolder`. If the real injected markup differs, the goal of the step is only to confirm that **a giscus-configured `BlogPost.astro` emits `giscus.app/client.js` into a built `/blog/<slug>/` page**. Adjust the injection lines to match the real descriptor output if needed; do not change `BlogPost.astro` in the committed template to make this pass.
+
+- [ ] **Step 7: Full Swift suite green** (catch any template-fixture regressions in scaffolder/scanner/graph suites)
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer ANGLESITE_PLUGIN_PATH=/Users/dwk/Developer/github.com/Anglesite/anglesite swift test --package-path .`
+Expected: all green. If `SiteScaffolderTests`, `SiteScaffolderPackageTests`, `IntegrationTemplateAssetsTests`, `TemplateRuntimeTests`, or any content-graph/scanner suite fails on the added `src/content/` + `src/pages/blog/` files, update that test's structural expectation to include the new blog files (do not remove the blog files).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/288-blog-system
+git add Resources/Template/src/pages/index.astro Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+git commit -m "feat(#288): link homepage to blog; build + giscus acceptance
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Acceptance (maps to spec)
+
+1. **Fresh scaffold builds the blog** — Task 3 Step 5 (`OK index`, `OK post`).
+2. **giscus end-to-end (closes #287 gap)** — Task 3 Step 6 (`OK giscus rendered on post page`).
+3. **Draft exclusion** — Task 3 Step 5 (`OK draft excluded`).
+4. **Swift suite stays green** — Task 3 Step 7.
+
+## Out of scope (do not implement)
+
+- Richer frontmatter (tags + tag pages, author, hero image, `updatedDate`).
+- RSS feed, pagination, reading-time.
+- Any change to the giscus descriptor, `MarkerInjector`, `IntegrationScaffolder`, or other Swift/engine source.

--- a/docs/superpowers/specs/2026-06-21-blog-system-design.md
+++ b/docs/superpowers/specs/2026-06-21-blog-system-design.md
@@ -1,0 +1,94 @@
+# Blog System for the Base Template — Design (#288)
+
+> **Status:** Approved design, pre-implementation. Follow-up split out from #282/#287.
+
+**Goal:** Make `BlogPost.astro` a real, rendered route. Today it exists only as a giscus injection target with no content collection and no route, so a giscus-configured site emits no commented page in `dist` (the gap #287 explicitly documented). This adds a working blog to every site's base template, which incidentally gives giscus a host page.
+
+**Tech stack:** Astro 5 (`^5.0.0`), TypeScript, `tsconfig` extends `astro/tsconfigs/strict` (`noUnusedLocals`). Template lives at `Resources/Template/` and is a committed, first-class app resource.
+
+## Scope decisions (from brainstorming)
+
+- **Placement: core base template**, not on-demand staging. A blog is content infrastructure, not a third-party embed, so it ships in `src/` and every fresh site has it. This means **no Swift/engine change** — unlike the `integrations/` staging model, nothing is conditionally copied.
+- **Surface: index + post pages + one starter post + a homepage nav link.** A complete, usable blog.
+- **Schema: minimal.** `title`, `pubDate`, optional `description`, optional `draft`. No tags/author/hero-image (YAGNI for a v1 business-site blog; can be added later).
+
+## Architecture
+
+Pure Astro content-collection wiring. The giscus mechanism is untouched: `BlogPost.astro` keeps its existing `// anglesite:imports` frontmatter anchor and `<!-- anglesite:comments -->` body anchor, so the giscus descriptor's `injectAtAnchor` (shipped in #287) keeps working — now against a route that actually renders.
+
+### Files (all under `Resources/Template/`)
+
+1. **`src/content.config.ts`** *(new)* — Astro 5 content collection `blog` via the `glob()` loader:
+   ```ts
+   import { defineCollection, z } from "astro:content";
+   import { glob } from "astro/loaders";
+
+   const blog = defineCollection({
+     loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+     schema: z.object({
+       title: z.string(),
+       pubDate: z.coerce.date(),
+       description: z.string().optional(),
+       draft: z.boolean().default(false),
+     }),
+   });
+
+   export const collections = { blog };
+   ```
+
+2. **`src/content/blog/welcome-to-your-blog.md`** *(new)* — one starter post. Frontmatter (`title`, `pubDate`, `description`) plus a few paragraphs of friendly placeholder copy explaining how to add and edit posts (where the Markdown lives, the frontmatter fields, the `draft` flag). Gives every fresh site a real page and giscus a host.
+
+3. **`src/pages/blog/[...slug].astro`** *(new)* — the post route:
+   ```astro
+   ---
+   import { getCollection, render } from "astro:content";
+   import BlogPost from "../../layouts/BlogPost.astro";
+
+   export async function getStaticPaths() {
+     const posts = await getCollection("blog", ({ data }) => !data.draft);
+     return posts.map((post) => ({ params: { slug: post.id }, props: { post } }));
+   }
+
+   const { post } = Astro.props;
+   const { Content } = await render(post);
+   ---
+
+   <BlogPost title={post.data.title} description={post.data.description}>
+     <Content />
+   </BlogPost>
+   ```
+   `<Content />` lands in `BlogPost.astro`'s default `<slot />` inside `<article>`, immediately above the `<!-- anglesite:comments -->` anchor — so giscus (when configured) renders after the post body.
+
+4. **`src/pages/blog/index.astro`** *(new)* — lists non-draft posts, newest first (`pubDate` desc), each linking to `/blog/<id>/`. Renders through `BaseLayout`. If the collection is empty (e.g. the only post is a draft), it renders an empty-state message and still builds.
+
+5. **`src/pages/index.astro`** *(edit)* — add a simple nav link to `/blog/` in the hero section.
+
+## Data flow
+
+```
+src/content/blog/*.md
+   → glob() loader → getCollection("blog")
+      → [...slug].astro getStaticPaths (drafts filtered) → /blog/<slug>/ via BlogPost.astro
+      → index.astro listing (drafts filtered) → /blog/
+BlogPost.astro <!-- anglesite:comments --> ← giscus <Comments> injected on setup (unchanged, #287)
+```
+
+## Error handling / edge cases
+
+- **Drafts** (`draft: true`) are excluded from both `getStaticPaths` and the index listing — no page emitted, no link shown.
+- **Empty collection** (all drafts / no posts) → index renders empty-state copy; `getStaticPaths` returns `[]`; build succeeds with no `/blog/<slug>/` pages.
+- **Schema violations** (missing `title`, unparseable `pubDate`) surface as Astro build errors — fail loud, not silent.
+- **`noUnusedLocals`** — every imported symbol (`getCollection`, `render`, `BlogPost`, `BaseLayout`) is used in each file.
+
+## Testing / acceptance
+
+1. **Fresh scaffold builds the blog:** `npm install && npm run build` on a freshly scaffolded site emits `dist/blog/index.html` and `dist/blog/welcome-to-your-blog/index.html`.
+2. **giscus end-to-end (closes the #287 gap):** a scaffold with giscus configured (`.site-config` giscus keys + the descriptor's inject run) emits `https://giscus.app/client.js` in the rendered post page. This is the concrete unblock #288 exists for.
+3. **Draft exclusion:** a post with `draft: true` produces no `dist/blog/<slug>/` output and no index link.
+4. **Swift suite stays green:** run the full `swift test` (`DEVELOPER_DIR` + `ANGLESITE_PLUGIN_PATH` set). Suites that load the real template fixture — `SiteScaffolderTests`, `SiteScaffolderPackageTests`, `IntegrationTemplateAssetsTests`, `TemplateRuntimeTests`, and the content-graph/scanner suites — must not regress on the added `src/content/` + `src/pages/blog/` files. Update any structural expectation that legitimately changes.
+
+## Out of scope
+
+- Richer frontmatter (tags + tag pages, author, hero image, `updatedDate`) — deferred; the schema is intentionally minimal.
+- RSS feed, pagination, reading-time — not needed for v1.
+- Any change to the giscus descriptor, `MarkerInjector`, or other Swift/engine code — the existing injection already works against `BlogPost.astro`.


### PR DESCRIPTION
Closes #288.

Makes the previously-stub `BlogPost.astro` a real rendered route, so every Anglesite site has a working blog — and giscus (shipped in #287) finally has a host page. **Template-side only**; no Swift/engine source changed except new tests.

## What it does
- **Content collection** — `Resources/Template/src/content.config.ts`: Astro 5 `glob()` loader + minimal Zod schema (`title`, `pubDate`, optional `description`/`draft`).
- **Routes** — `src/pages/blog/[...slug].astro` (renders through `BlogPost.astro`; `getStaticPaths` filters drafts; `<Content />` fills the slot above the giscus anchor) and `src/pages/blog/index.astro` (non-draft posts, newest-first, links to `/blog/<id>/`, empty-state fallback).
- **Starter post** — `src/content/blog/welcome-to-your-blog.md` so a fresh scaffold has a real page.
- **Homepage link** — `src/pages/index.astro` gains a `/blog/` link.

## Bug fixed in review (Task 4)
`BlogPost.astro` contained the giscus anchor text `<!-- anglesite:comments -->` **twice** — once in a frontmatter doc-comment, once as the real body anchor. `MarkerInjector.inject` matches the **first** occurrence (`content.range(of:)`), so real giscus setup would have injected into the frontmatter and never rendered. Rewrote the now-stale doc-comment so the anchor occurs once (in the body). Guarded by a behavioral test that runs the real `MarkerInjector` against the real layout and asserts the snippet lands after the frontmatter fence.

## Verification
- **Full suite green:** 978 tests (AnglesiteCore 740, AnglesiteIntents 222, AnglesiteBridge 16), 0 failures.
- **Astro build smoke (scripted, ran):** fresh scaffold emits `/blog/` + `/blog/welcome-to-your-blog/`; a `draft: true` post is excluded; index links the post.
- **giscus end-to-end (closes the #287 gap):** a giscus-configured scaffold emits `giscus.app/client.js` into the built post page.
- New hermetic guard suite `BlogTemplateAssetsTests` (6 tests); existing `IntegrationTemplateAssetsTests` still passes (both layout anchors preserved).

## Out of scope / follow-ups (non-blocking)
- Richer frontmatter (tags/author/hero), RSS, pagination — intentionally deferred.
- No committed CI job that actually builds the template (build is proven by manual/scripted acceptance) — template-wide gap, will file separately.
- Pre-existing `/src/styles/global.css` dev-path link in `BaseLayout.astro` can leave production pages unstyled — pre-existing, out of scope.

Design + plan: `docs/superpowers/specs|plans/2026-06-21-blog-system*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)