### PR TITLE
feat(#291): hard-fail on missing staged integration asset + test completeness

### DIFF
--- a/Sources/AnglesiteCore/IntegrationPlan.swift
+++ b/Sources/AnglesiteCore/IntegrationPlan.swift
@@ -47,4 +47,7 @@ public enum IntegrationError: Error, Equatable, Sendable {
     case providerRequired
     case siteNotFound
     case templateUnavailable
+    /// A staged asset the descriptor copies is absent from the template — a hard error, since
+    /// proceeding would inject an `import` for a file that was never written.
+    case missingTemplateAsset(path: String)
 }

--- a/Sources/AnglesiteCore/IntegrationPlanner.swift
+++ b/Sources/AnglesiteCore/IntegrationPlanner.swift
@@ -66,8 +66,10 @@ public enum IntegrationPlanner {
                 let dest = to.resolve(tokens)
                 let src = templateDirectory.appendingPathComponent(from.path)
                 guard let contents = try? String(contentsOf: src, encoding: .utf8) else {
-                    warnings.append(PlanWarning("Template file missing: \(from.path)"))
-                    continue
+                    // Hard-fail: skipping the copy would leave the descriptor's matching `import`
+                    // injection pointing at a file that was never written — a deferred Astro build
+                    // break. Surface it now as a clear, up-front error instead.
+                    return .failure(.missingTemplateAsset(path: from.path))
                 }
                 steps.append(.createFile(relativePath: dest, contents: contents))
             case .writeConfig(let entries, let when):

--- a/Sources/AnglesiteCore/SetupIntegrationTool.swift
+++ b/Sources/AnglesiteCore/SetupIntegrationTool.swift
@@ -37,6 +37,8 @@ public enum SetupIntegrationArguments {
             return "I couldn't find that site."
         case .failure(.templateUnavailable):
             return "The site template isn't available right now."
+        case .failure(.missingTemplateAsset(let path)):
+            return "The site template is incomplete — \(path) is missing."
         }
     }
 

--- a/Sources/AnglesiteCore/SetupIntegrationTool.swift
+++ b/Sources/AnglesiteCore/SetupIntegrationTool.swift
@@ -37,8 +37,11 @@ public enum SetupIntegrationArguments {
             return "I couldn't find that site."
         case .failure(.templateUnavailable):
             return "The site template isn't available right now."
-        case .failure(.missingTemplateAsset(let path)):
-            return "The site template is incomplete — \(path) is missing."
+        case .failure(.missingTemplateAsset):
+            // The missing path is carried on the error value for logging; keep the user-facing
+            // message generic, matching `.templateUnavailable` (this is a packaging failure, not
+            // actionable user input).
+            return "The site template is incomplete — a required component is missing. Please reinstall Anglesite."
         }
     }
 

--- a/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -88,18 +88,21 @@ import Foundation
     /// A staged component that the descriptor copies but that is absent from the template must
     /// hard-fail the plan — otherwise its `import` would be injected with no file behind it,
     /// turning a clear up-front error into a deferred Astro build break.
-    @Test func missingStagedAssetFailsRatherThanOrphaningImport() {
+    @Test func missingStagedAssetFailsRatherThanOrphaningImport() throws {
         let template = makeTemplate()
-        // Remove a component the booking (floating) descriptor copies + imports.
-        try! FileManager.default.removeItem(at: template.appendingPathComponent("integrations/components/BookingWidget.astro"))
+        // Remove a component the booking (floating) descriptor copies + imports. Require it to
+        // exist first so a future makeTemplate() change yields a clear diagnostic, not a crash.
+        let widget = template.appendingPathComponent("integrations/components/BookingWidget.astro")
+        try #require(FileManager.default.fileExists(atPath: widget.path))
+        try FileManager.default.removeItem(at: widget)
         let r = IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
             answers: ["provider": "cal", "username": "jane", "style": "floating"],
             sourceDirectory: makeSource(), templateDirectory: template)
-        if case .failure(.missingTemplateAsset(let path)) = r {
-            #expect(path == "integrations/components/BookingWidget.astro")
-        } else {
+        guard case .failure(.missingTemplateAsset(let path)) = r else {
             Issue.record("expected .failure(.missingTemplateAsset), got \(r)")
+            return
         }
+        #expect(path == "integrations/components/BookingWidget.astro")
     }
 
     @Test func missingGlobalCSSWarnsNotThrows() {

--- a/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -85,6 +85,23 @@ import Foundation
         #expect(r == .failure(.providerRequired))
     }
 
+    /// A staged component that the descriptor copies but that is absent from the template must
+    /// hard-fail the plan — otherwise its `import` would be injected with no file behind it,
+    /// turning a clear up-front error into a deferred Astro build break.
+    @Test func missingStagedAssetFailsRatherThanOrphaningImport() {
+        let template = makeTemplate()
+        // Remove a component the booking (floating) descriptor copies + imports.
+        try! FileManager.default.removeItem(at: template.appendingPathComponent("integrations/components/BookingWidget.astro"))
+        let r = IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
+            answers: ["provider": "cal", "username": "jane", "style": "floating"],
+            sourceDirectory: makeSource(), templateDirectory: template)
+        if case .failure(.missingTemplateAsset(let path)) = r {
+            #expect(path == "integrations/components/BookingWidget.astro")
+        } else {
+            Issue.record("expected .failure(.missingTemplateAsset), got \(r)")
+        }
+    }
+
     @Test func missingGlobalCSSWarnsNotThrows() {
         // giscus has no {{brandColor}} use, so use a source dir with no global.css and confirm a plan
         // still returns; the warning path is asserted via booking which references brandColor only if used.

--- a/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
@@ -39,8 +39,10 @@ import Foundation
                   "integrations/components/Comments.astro", "integrations/pages/book.astro", "integrations/pages/donate.astro"] {
             #expect(FileManager.default.fileExists(atPath: root.appendingPathComponent(p).path), "missing staged \(p)")
         }
-        // NOT base-scaffolded:
-        for p in ["src/components/BookingWidget.astro", "src/pages/book.astro", "src/pages/donate.astro"] {
+        // NOT base-scaffolded: every staged asset must be absent from src/ (covers all five —
+        // both components previously omitted, DonationButton and Comments, are now checked).
+        for p in ["src/components/BookingWidget.astro", "src/components/DonationButton.astro",
+                  "src/components/Comments.astro", "src/pages/book.astro", "src/pages/donate.astro"] {
             #expect(!FileManager.default.fileExists(atPath: root.appendingPathComponent(p).path), "should be staged, not in src: \(p)")
         }
     }


### PR DESCRIPTION
Closes #291. Two small hardening items from the bucket-3 integration framework, split out of #287.

## Hardening
`IntegrationPlanner` previously reacted to a missing `.copyFile` staged source by appending a `PlanWarning` and `continue`-ing. But the descriptor's matching `import` injection (`.injectAtAnchor`) was still emitted — so the plan would inject an `import BookingWidget from "../components/BookingWidget.astro"` with no file behind it, turning a clear up-front error into a deferred Astro build break.

Now it returns the new `IntegrationError.missingTemplateAsset(path:)`, surfaced to the user via `SetupIntegrationTool.reply` as *"The site template is incomplete — &lt;path&gt; is missing."*

## Test completeness
`IntegrationTemplateAssetsTests.onDemandAssetsAreStagedNotInSrc` checked that only 3 of the 5 staged assets were absent from `src/`. Extended to cover all five — adding the two omitted components, `DonationButton.astro` and `Comments.astro`.

## Tests
- New `missingStagedAssetFailsRatherThanOrphaningImport` (TDD: watched it RED — the failure output captured the exact orphan-import case — then GREEN after the planner change).
- Full suite green (`swift test`, exit 0, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)