### PR TITLE
feat(#289): in-page booking 'button' placement (homepage hero CTA)

### DIFF
--- a/Resources/Template/src/pages/index.astro
+++ b/Resources/Template/src/pages/index.astro
@@ -11,8 +11,8 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <section class="hero">
       <h1>Welcome</h1>
       <p>This site is ready to set up. Type <code>/start</code> in Claude Desktop to get started.</p>
-      <p><a href="/blog/">Read the blog</a></p>
       <!-- anglesite:hero-cta -->
+      <p><a href="/blog/">Read the blog</a></p>
     </section>
   </main>
 </BaseLayout>

--- a/Resources/Template/src/pages/index.astro
+++ b/Resources/Template/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+// anglesite:imports — integration component imports are injected here on setup
 ---
 
 <BaseLayout
@@ -11,6 +12,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       <h1>Welcome</h1>
       <p>This site is ready to set up. Type <code>/start</code> in Claude Desktop to get started.</p>
       <p><a href="/blog/">Read the blog</a></p>
+      <!-- anglesite:hero-cta -->
     </section>
   </main>
 </BaseLayout>

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -68,9 +68,11 @@ public enum IntegrationCatalog {
             Field(key: "style", label: "Placement", kind: .choice([
                 Choice(value: "inline", label: "On a /book page"),
                 Choice(value: "floating", label: "Floating button (site-wide)"),
+                Choice(value: "button", label: "Button on the home page"),
             ]), defaultValue: "inline"),
             Field(key: "buttonText", label: "Button text", kind: .text, isOptional: true,
-                  defaultValue: "Book a time", visibleWhen: .fieldEquals(key: "style", value: "floating")),
+                  defaultValue: "Book a time",
+                  visibleWhen: .fieldIn(key: "style", values: ["floating", "button"])),
         ],
         operations: [
             .copyFile(from: TemplateRef("integrations/components/BookingWidget.astro"),
@@ -84,6 +86,12 @@ public enum IntegrationCatalog {
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "<!-- anglesite:body-end -->",
                             snippet: "{readConfig(\"BOOKING_STYLE\") === \"floating\" && (<BookingWidget provider={readConfig(\"BOOKING_PROVIDER\")} username={readConfig(\"BOOKING_USERNAME\")} eventSlug={readConfig(\"BOOKING_EVENT_SLUG\")} buttonText={readConfig(\"BOOKING_BUTTON_TEXT\")} style=\"floating\" />)}",
                             when: .fieldEquals(key: "style", value: "floating"), style: .html),
+            .injectAtAnchor(file: "src/pages/index.astro", anchor: "// anglesite:imports",
+                            snippet: "import BookingWidget from \"../components/BookingWidget.astro\";\nimport { readConfig } from \"../../scripts/config\";",
+                            when: .fieldEquals(key: "style", value: "button"), style: .line),
+            .injectAtAnchor(file: "src/pages/index.astro", anchor: "<!-- anglesite:hero-cta -->",
+                            snippet: "{readConfig(\"BOOKING_STYLE\") === \"button\" && (<BookingWidget provider={readConfig(\"BOOKING_PROVIDER\")} username={readConfig(\"BOOKING_USERNAME\")} eventSlug={readConfig(\"BOOKING_EVENT_SLUG\")} buttonText={readConfig(\"BOOKING_BUTTON_TEXT\")} style=\"button\" />)}",
+                            when: .fieldEquals(key: "style", value: "button"), style: .html),
             .writeConfig([
                 ConfigEntry(key: "BOOKING_PROVIDER", value: "{{provider}}"),
                 ConfigEntry(key: "BOOKING_USERNAME", value: "{{username}}"),

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -15,6 +15,8 @@ public extension IntegrationDescriptor {
                 problems.append("\(context): condition references unknown provider \"\(p)\"")
             case .fieldEquals(let key, _) where !fieldKeys.contains(key):
                 problems.append("\(context): condition references unknown field \"\(key)\"")
+            case .fieldIn(let key, _) where !fieldKeys.contains(key):
+                problems.append("\(context): condition references unknown field \"\(key)\"")
             default: break
             }
         }

--- a/Sources/AnglesiteCore/IntegrationDescriptor.swift
+++ b/Sources/AnglesiteCore/IntegrationDescriptor.swift
@@ -26,6 +26,7 @@ public enum Condition: Sendable, Equatable {
     case always
     case providerIs(String)
     case fieldEquals(key: String, value: String)
+    case fieldIn(key: String, values: [String])
 }
 
 public struct Field: Sendable, Equatable, Identifiable {

--- a/Sources/AnglesiteCore/IntegrationPlanner.swift
+++ b/Sources/AnglesiteCore/IntegrationPlanner.swift
@@ -104,6 +104,7 @@ public enum IntegrationPlanner {
         case .always: return true
         case .providerIs(let p): return providerID == p
         case .fieldEquals(let key, let value): return answers[key] == value
+        case .fieldIn(let key, let values): return values.contains(answers[key] ?? "")
         }
     }
 

--- a/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
@@ -16,7 +16,7 @@ import Testing
         let booking = IntegrationCatalog.descriptor(for: .booking)
         let style = booking.fields.first { $0.key == "style" }
         guard case .choice(let choices)? = style?.kind else { Issue.record("no style choice"); return }
-        #expect(Set(choices.map { $0.value }) == Set(["inline", "floating"]))
+        #expect(Set(choices.map { $0.value }) == Set(["inline", "floating", "button"]))
     }
 
     @Test func validateCatchesDanglingProviderReference() {

--- a/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
@@ -38,6 +38,16 @@ import Testing
         #expect(bad.validate().contains { $0.contains("nope") })
     }
 
+    @Test func validateCatchesDanglingFieldInReference() {
+        let bad = IntegrationDescriptor(
+            id: .booking, displayName: "B", summary: "s",
+            providers: [Provider(id: "cal", displayName: "Cal", cspDomains: ["app.cal.com"])],
+            fields: [Field(key: "f", label: "F", kind: .text,
+                           visibleWhen: .fieldIn(key: "nope", values: ["x"]))],
+            operations: [])
+        #expect(bad.validate().contains { $0.contains("nope") })
+    }
+
     /// `client:*` hydration directives are only valid on framework components; on a plain `.astro`
     /// component (which our injected widgets are) Astro errors at build. Guard every injected
     /// snippet against carrying one (regression guard for the build-breaker the final review found).

--- a/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -35,8 +35,8 @@ import Foundation
         if case .failure(.invalidValue(let key, _)) = r { #expect(key == "link") } else { Issue.record("expected invalidValue") }
     }
 
-    @Test func bookingInlineProducesBookPageNotAnchorInjection() {
-        let r = try! IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
+    @Test func bookingInlineProducesBookPageNotAnchorInjection() throws {
+        let r = try IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
             answers: ["provider": "cal", "username": "jane", "style": "inline"],
             sourceDirectory: makeSource(), templateDirectory: makeTemplate()).get()
         #expect(r.steps.contains { if case .createFile(let p, _) = $0 { return p == "src/pages/book.astro" }; return false })
@@ -57,8 +57,8 @@ import Foundation
         #expect(!r.steps.contains { if case .createFile(let p, _) = $0 { return p == "src/pages/book.astro" }; return false })
     }
 
-    @Test func bookingFloatingInjectsFrontmatterImportAndBodyRender() {
-        let r = try! IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
+    @Test func bookingFloatingInjectsFrontmatterImportAndBodyRender() throws {
+        let r = try IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
             answers: ["provider": "cal", "username": "jane", "style": "floating"],
             sourceDirectory: makeSource(), templateDirectory: makeTemplate()).get()
         let injects = r.steps.compactMap { step -> (String, MarkerInjector.CommentStyle)? in
@@ -68,16 +68,16 @@ import Foundation
         #expect(injects.contains { $0.0.contains("BaseLayout") && $0.1 == .html })
     }
 
-    @Test func providerSwitchSwapsCSPDomains() {
-        func csp(_ provider: String) -> [String] {
-            let r = try! IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
+    @Test func providerSwitchSwapsCSPDomains() throws {
+        func csp(_ provider: String) throws -> [String] {
+            let r = try IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
                 answers: ["provider": provider, "username": "j", "style": "inline"],
                 sourceDirectory: makeSource(), templateDirectory: makeTemplate()).get()
             for case .addCSP(let d) in r.steps { return d }
             return []
         }
-        #expect(csp("cal") == ["app.cal.com"])
-        #expect(Set(csp("calendly")) == Set(["assets.calendly.com", "calendly.com"]))
+        #expect(try csp("cal") == ["app.cal.com"])
+        #expect(Set(try csp("calendly")) == Set(["assets.calendly.com", "calendly.com"]))
     }
 
     @Test func missingProviderForProviderBackedIntegrationFails() {
@@ -168,15 +168,15 @@ import Foundation
         #expect(rFail == .failure(.missingRequiredField(key: "username")))
     }
 
-    @Test func giscusEmitsNoBrandColorWarning() {
-        let r = try! IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .giscus),
+    @Test func giscusEmitsNoBrandColorWarning() throws {
+        let r = try IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .giscus),
             answers: ["repo": "o/r", "repoId": "R", "category": "General", "categoryId": "C", "mapping": "pathname"],
             sourceDirectory: makeSource(), templateDirectory: makeTemplate()).get()
         #expect(r.warnings.isEmpty)
     }
 
-    @Test func summaryDescribesEachStepKind() {
-        let r = try! IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
+    @Test func summaryDescribesEachStepKind() throws {
+        let r = try IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
             answers: ["provider": "cal", "username": "jane", "style": "inline"],
             sourceDirectory: makeSource(), templateDirectory: makeTemplate()).get()
         let s = r.summary

--- a/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -222,6 +222,18 @@ import Foundation
         }
     }
 
+    @Test func bookingButtonInjectsIntoHomepageHero() {
+        let r = try! IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
+            answers: ["provider": "cal", "username": "jane", "style": "button"],
+            sourceDirectory: makeSource(), templateDirectory: makeTemplate()).get()
+        let injects = r.steps.compactMap { step -> (String, MarkerInjector.CommentStyle)? in
+            if case .injectAnchor(let f, _, _, _, let style) = step { return (f, style) }; return nil
+        }
+        #expect(injects.contains { $0.0.contains("index.astro") && $0.1 == .line })
+        #expect(injects.contains { $0.0.contains("index.astro") && $0.1 == .html })
+        #expect(!r.steps.contains { if case .createFile(let p, _) = $0 { return p == "src/pages/book.astro" }; return false })
+    }
+
     @Test func fieldInVisibilityMatchesAnyListedValue() {
         let cond = Condition.fieldIn(key: "style", values: ["floating", "button"])
         #expect(IntegrationPlanner.isVisible(cond, answers: ["style": "floating"], providerID: nil))

--- a/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -224,8 +224,8 @@ import Foundation
         }
     }
 
-    @Test func bookingButtonInjectsIntoHomepageHero() {
-        let r = try! IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
+    @Test func bookingButtonInjectsIntoHomepageHero() throws {
+        let r = try IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
             answers: ["provider": "cal", "username": "jane", "style": "button"],
             sourceDirectory: makeSource(), templateDirectory: makeTemplate()).get()
         let injects = r.steps.compactMap { step -> (String, MarkerInjector.CommentStyle)? in

--- a/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -43,8 +43,8 @@ import Foundation
         #expect(!r.steps.contains { if case .injectAnchor = $0 { return true }; return false })
     }
 
-    @Test func bookingFloatingInjectsIntoLayout() {
-        let r = try! IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
+    @Test func bookingFloatingInjectsIntoLayout() throws {
+        let r = try IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
             answers: ["provider": "cal", "username": "jane", "style": "floating"],
             sourceDirectory: makeSource(), templateDirectory: makeTemplate()).get()
         let injects = r.steps.compactMap { step -> (String, MarkerInjector.CommentStyle)? in

--- a/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -52,6 +52,8 @@ import Foundation
         }
         #expect(injects.contains { $0.0.contains("BaseLayout") && $0.1 == .line })
         #expect(injects.contains { $0.0.contains("BaseLayout") && $0.1 == .html })
+        // The button-only homepage injections must not leak into the floating plan.
+        #expect(!injects.contains { $0.0.contains("index.astro") })
         #expect(!r.steps.contains { if case .createFile(let p, _) = $0 { return p == "src/pages/book.astro" }; return false })
     }
 

--- a/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -221,4 +221,12 @@ import Foundation
             Issue.record("expected upsertConfig step, got \(String(describing: planB.steps.first))")
         }
     }
+
+    @Test func fieldInVisibilityMatchesAnyListedValue() {
+        let cond = Condition.fieldIn(key: "style", values: ["floating", "button"])
+        #expect(IntegrationPlanner.isVisible(cond, answers: ["style": "floating"], providerID: nil))
+        #expect(IntegrationPlanner.isVisible(cond, answers: ["style": "button"], providerID: nil))
+        #expect(!IntegrationPlanner.isVisible(cond, answers: ["style": "inline"], providerID: nil))
+        #expect(!IntegrationPlanner.isVisible(cond, answers: [:], providerID: nil))
+    }
 }

--- a/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
@@ -57,6 +57,13 @@ import Foundation
         #expect(blog.contains("<!-- anglesite:comments -->"))
     }
 
+    @Test func homepageHasImportAndHeroAnchors() throws {
+        let root = templateRoot()
+        let index = try String(contentsOf: root.appendingPathComponent("src/pages/index.astro"), encoding: .utf8)
+        #expect(index.contains("// anglesite:imports"))
+        #expect(index.contains("<!-- anglesite:hero-cta -->"))
+    }
+
     @Test func onDemandPagesUseReadConfigNotImportMetaEnv() throws {
         let root = templateRoot()
         for p in ["integrations/pages/book.astro", "integrations/pages/donate.astro"] {

--- a/docs/superpowers/plans/2026-06-22-booking-button-placement.md
+++ b/docs/superpowers/plans/2026-06-22-booking-button-placement.md
@@ -33,7 +33,7 @@ Add a multi-value visibility condition so a field can be shown for more than one
 **Interfaces:**
 - Produces: `Condition.fieldIn(key: String, values: [String])` — true when `answers[key]` is one of `values`. Consumed by Task 3's `buttonText` field.
 
-- [ ] **Step 1: Write the failing visibility test**
+- [x] **Step 1: Write the failing visibility test**
 
 In `Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift`, add inside the `IntegrationPlannerTests` suite:
 
@@ -47,7 +47,7 @@ In `Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift`, add inside the `Int
     }
 ```
 
-- [ ] **Step 2: Write the failing validation test**
+- [x] **Step 2: Write the failing validation test**
 
 In `Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift`, add inside the suite (mirrors `validateCatchesDanglingFieldReference`):
 
@@ -63,12 +63,12 @@ In `Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift`, add inside the suit
     }
 ```
 
-- [ ] **Step 3: Run both tests to verify they fail**
+- [x] **Step 3: Run both tests to verify they fail**
 
 Run: `swift test --package-path . --filter "fieldInVisibilityMatchesAnyListedValue|validateCatchesDanglingFieldInReference"`
 Expected: FAIL — compile error `type 'Condition' has no member 'fieldIn'`.
 
-- [ ] **Step 4: Add the enum case**
+- [x] **Step 4: Add the enum case**
 
 In `Sources/AnglesiteCore/IntegrationDescriptor.swift`, the `Condition` enum currently reads:
 
@@ -91,7 +91,7 @@ public enum Condition: Sendable, Equatable {
 }
 ```
 
-- [ ] **Step 5: Evaluate the case in `isVisible`**
+- [x] **Step 5: Evaluate the case in `isVisible`**
 
 In `Sources/AnglesiteCore/IntegrationPlanner.swift`, `isVisible` currently reads:
 
@@ -118,7 +118,7 @@ Add the new branch:
     }
 ```
 
-- [ ] **Step 6: Validate the case in `validate`'s `check`**
+- [x] **Step 6: Validate the case in `validate`'s `check`**
 
 In `Sources/AnglesiteCore/IntegrationCatalog.swift`, the `check` closure currently reads:
 
@@ -152,12 +152,12 @@ Add a `fieldIn` branch before `default`:
         }
 ```
 
-- [ ] **Step 7: Run both tests to verify they pass**
+- [x] **Step 7: Run both tests to verify they pass**
 
 Run: `swift test --package-path . --filter "fieldInVisibilityMatchesAnyListedValue|validateCatchesDanglingFieldInReference"`
 Expected: PASS (2 tests).
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add Sources/AnglesiteCore/IntegrationDescriptor.swift Sources/AnglesiteCore/IntegrationPlanner.swift Sources/AnglesiteCore/IntegrationCatalog.swift Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
@@ -179,7 +179,7 @@ Add the two inert anchors the `button` placement injects into. They are no-op co
 **Interfaces:**
 - Produces: anchors `// anglesite:imports` (frontmatter) and `<!-- anglesite:hero-cta -->` (inside `.hero`). Consumed by Task 3's injection ops.
 
-- [ ] **Step 1: Write the failing anchor test**
+- [x] **Step 1: Write the failing anchor test**
 
 In `Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift`, add inside the suite (mirrors `layoutsHaveImportAndBodyAnchors`):
 
@@ -192,12 +192,12 @@ In `Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift`, add inside t
     }
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 Run: `swift test --package-path . --filter homepageHasImportAndHeroAnchors`
 Expected: FAIL — `#expect(index.contains("// anglesite:imports"))` is false.
 
-- [ ] **Step 3: Add the anchors to `index.astro`**
+- [x] **Step 3: Add the anchors to `index.astro`**
 
 Replace the full contents of `Resources/Template/src/pages/index.astro` with:
 
@@ -222,12 +222,12 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 </BaseLayout>
 ```
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [x] **Step 4: Run the test to verify it passes**
 
 Run: `swift test --package-path . --filter homepageHasImportAndHeroAnchors`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add Resources/Template/src/pages/index.astro Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
@@ -251,7 +251,7 @@ Add the `button` choice, make `buttonText` visible for `button` too, and add the
 - Consumes: `Condition.fieldIn` (Task 1); homepage anchors `// anglesite:imports` and `<!-- anglesite:hero-cta -->` (Task 2).
 - Produces: a `style == "button"` plan that emits two `.injectAnchor` steps targeting `src/pages/index.astro` (one `.line` import, one `.html` render) and no `book.astro` `createFile`.
 
-- [ ] **Step 1: Update the choice-set assertion (failing test)**
+- [x] **Step 1: Update the choice-set assertion (failing test)**
 
 In `Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift`, `bookingHasStyleChoiceDrivingPlacement` currently asserts:
 
@@ -265,7 +265,7 @@ Change it to:
         #expect(Set(choices.map { $0.value }) == Set(["inline", "floating", "button"]))
 ```
 
-- [ ] **Step 2: Write the failing planner test**
+- [x] **Step 2: Write the failing planner test**
 
 In `Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift`, add inside the suite (mirrors `bookingFloatingInjectsIntoLayout`):
 
@@ -283,12 +283,12 @@ In `Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift`, add inside the suit
     }
 ```
 
-- [ ] **Step 3: Run both tests to verify they fail**
+- [x] **Step 3: Run both tests to verify they fail**
 
 Run: `swift test --package-path . --filter "bookingHasStyleChoiceDrivingPlacement|bookingButtonInjectsIntoHomepageHero"`
 Expected: FAIL — choice set is `{inline, floating}`; no `index.astro` injection steps.
 
-- [ ] **Step 4: Add the `button` choice and fix `buttonText` visibility**
+- [x] **Step 4: Add the `button` choice and fix `buttonText` visibility**
 
 In `Sources/AnglesiteCore/IntegrationCatalog.swift`, the booking `fields` `style`/`buttonText` entries currently read:
 
@@ -314,7 +314,7 @@ Replace with:
                   visibleWhen: .fieldIn(key: "style", values: ["floating", "button"])),
 ```
 
-- [ ] **Step 5: Add the two `button` injection operations**
+- [x] **Step 5: Add the two `button` injection operations**
 
 In the same booking descriptor, the `operations` array currently has the two `floating`-gated `injectAtAnchor` ops (targeting `src/layouts/BaseLayout.astro`) followed by `.writeConfig`. Insert the two `button`-gated ops immediately **after** the second floating `injectAtAnchor` (the `.html` one ending `style: .html)` for `BaseLayout.astro`) and **before** `.writeConfig`:
 
@@ -327,17 +327,17 @@ In the same booking descriptor, the `operations` array currently has the two `fl
                             when: .fieldEquals(key: "style", value: "button"), style: .html),
 ```
 
-- [ ] **Step 6: Run both tests to verify they pass**
+- [x] **Step 6: Run both tests to verify they pass**
 
 Run: `swift test --package-path . --filter "bookingHasStyleChoiceDrivingPlacement|bookingButtonInjectsIntoHomepageHero"`
 Expected: PASS (2 tests).
 
-- [ ] **Step 7: Run the full integration suite (regression + asset guards)**
+- [x] **Step 7: Run the full integration suite (regression + asset guards)**
 
 Run: `swift test --package-path . --filter Integration`
 Expected: PASS — all integration suites green, including `IntegrationCatalogTests.descriptorsValidate` (every descriptor's `validate()` returns `[]`), `bookingWritesEventSlugAndButtonText`, and `IntegrationTemplateAssetsTests`. If any asset-completeness fixture fails, update the expected fixture list to match.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add Sources/AnglesiteCore/IntegrationCatalog.swift Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -354,22 +354,22 @@ Prove the whole package still builds and that the app target links (per project 
 
 **Files:** none (verification only).
 
-- [ ] **Step 1: Run the full Swift test suite**
+- [x] **Step 1: Run the full Swift test suite**
 
 Run: `swift test --package-path .`
 Expected: PASS — full suite green (no regressions in `AnglesiteCoreTests`, `AnglesiteIntentsTests`, `AnglesiteBridgeTests`).
 
-- [ ] **Step 2: Generate the Xcode project (fresh worktree has none)**
+- [x] **Step 2: Generate the Xcode project (fresh worktree has none)**
 
 Run: `ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodegen generate`
 Expected: `Created project at Anglesite.xcodeproj`.
 
-- [ ] **Step 3: Build the app target**
+- [x] **Step 3: Build the app target**
 
 Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
 Expected: `** BUILD SUCCEEDED **`.
 
-- [ ] **Step 4: No commit needed** (verification task — nothing changed).
+- [x] **Step 4: No commit needed** (verification task — nothing changed).
 
 ---
 

--- a/docs/superpowers/plans/2026-06-22-booking-button-placement.md
+++ b/docs/superpowers/plans/2026-06-22-booking-button-placement.md
@@ -1,0 +1,387 @@
+# Booking `button` Placement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the already-built `button` variant of `BookingWidget.astro` as a third booking placement choice that injects an in-flow CTA button into the home page hero.
+
+**Architecture:** The booking integration is declarative — `IntegrationCatalog.booking` (a data descriptor) lists placement choices and `Operation`s; `IntegrationPlanner` turns a descriptor + owner answers into a step list; `MarkerInjector` applies `injectAtAnchor` snippets at named anchors. This plan (1) adds a `Condition.fieldIn` enum case so the `buttonText` field can show for two styles, (2) adds homepage injection anchors, and (3) adds the `button` choice + two `injectAtAnchor` ops to the booking descriptor. `BookingWidget.astro` already renders `button` for both providers — no component change.
+
+**Tech Stack:** Swift 6.4 (Swift Testing `@Test`), Astro template files.
+
+## Global Constraints
+
+- Worktree: `.claude/worktrees/booking-button-289/` on branch `worktree-booking-button-289`. Run all commands from there.
+- Run `swift test` from the worktree: `swift test --package-path .`
+- Editing template files (`index.astro`) trips `IntegrationTemplateAssetsTests` completeness guards — run `swift test --filter Integration` before pushing.
+- In test files use the classic URL APIs (`URL(fileURLWithPath:)` / `appendingPathComponent` / `.path`), NOT `URL(filePath:)` / `appending(path:)` — the macOS-26 CI runner can't load the swift-foundation overlay (see `IntegrationTemplateAssetsTests` header note).
+- Commit messages end with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- No new third-party dependencies (v0 rule).
+
+---
+
+### Task 1: `Condition.fieldIn` case
+
+Add a multi-value visibility condition so a field can be shown for more than one choice value. Needed so `buttonText` shows for both `floating` and `button`.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/IntegrationDescriptor.swift` (the `Condition` enum, ~line 25-29)
+- Modify: `Sources/AnglesiteCore/IntegrationPlanner.swift` (`isVisible`, ~line 101-107)
+- Modify: `Sources/AnglesiteCore/IntegrationCatalog.swift` (`validate`'s `check`, ~line 10-19)
+- Test: `Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift` (new `@Test`)
+- Test: `Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift` (new `@Test`)
+
+**Interfaces:**
+- Produces: `Condition.fieldIn(key: String, values: [String])` — true when `answers[key]` is one of `values`. Consumed by Task 3's `buttonText` field.
+
+- [ ] **Step 1: Write the failing visibility test**
+
+In `Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift`, add inside the `IntegrationPlannerTests` suite:
+
+```swift
+    @Test func fieldInVisibilityMatchesAnyListedValue() {
+        let cond = Condition.fieldIn(key: "style", values: ["floating", "button"])
+        #expect(IntegrationPlanner.isVisible(cond, answers: ["style": "floating"], providerID: nil))
+        #expect(IntegrationPlanner.isVisible(cond, answers: ["style": "button"], providerID: nil))
+        #expect(!IntegrationPlanner.isVisible(cond, answers: ["style": "inline"], providerID: nil))
+        #expect(!IntegrationPlanner.isVisible(cond, answers: [:], providerID: nil))
+    }
+```
+
+- [ ] **Step 2: Write the failing validation test**
+
+In `Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift`, add inside the suite (mirrors `validateCatchesDanglingFieldReference`):
+
+```swift
+    @Test func validateCatchesDanglingFieldInReference() {
+        let bad = IntegrationDescriptor(
+            id: .booking, displayName: "B", summary: "s",
+            providers: [Provider(id: "cal", displayName: "Cal", cspDomains: ["app.cal.com"])],
+            fields: [Field(key: "f", label: "F", kind: .text,
+                           visibleWhen: .fieldIn(key: "nope", values: ["x"]))],
+            operations: [])
+        #expect(bad.validate().contains { $0.contains("nope") })
+    }
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+Run: `swift test --package-path . --filter "fieldInVisibilityMatchesAnyListedValue|validateCatchesDanglingFieldInReference"`
+Expected: FAIL — compile error `type 'Condition' has no member 'fieldIn'`.
+
+- [ ] **Step 4: Add the enum case**
+
+In `Sources/AnglesiteCore/IntegrationDescriptor.swift`, the `Condition` enum currently reads:
+
+```swift
+public enum Condition: Sendable, Equatable {
+    case always
+    case providerIs(String)
+    case fieldEquals(key: String, value: String)
+}
+```
+
+Add the new case:
+
+```swift
+public enum Condition: Sendable, Equatable {
+    case always
+    case providerIs(String)
+    case fieldEquals(key: String, value: String)
+    case fieldIn(key: String, values: [String])
+}
+```
+
+- [ ] **Step 5: Evaluate the case in `isVisible`**
+
+In `Sources/AnglesiteCore/IntegrationPlanner.swift`, `isVisible` currently reads:
+
+```swift
+    static func isVisible(_ condition: Condition, answers: Answers, providerID: String?) -> Bool {
+        switch condition {
+        case .always: return true
+        case .providerIs(let p): return providerID == p
+        case .fieldEquals(let key, let value): return answers[key] == value
+        }
+    }
+```
+
+Add the new branch:
+
+```swift
+    static func isVisible(_ condition: Condition, answers: Answers, providerID: String?) -> Bool {
+        switch condition {
+        case .always: return true
+        case .providerIs(let p): return providerID == p
+        case .fieldEquals(let key, let value): return answers[key] == value
+        case .fieldIn(let key, let values): return values.contains(answers[key] ?? "")
+        }
+    }
+```
+
+- [ ] **Step 6: Validate the case in `validate`'s `check`**
+
+In `Sources/AnglesiteCore/IntegrationCatalog.swift`, the `check` closure currently reads:
+
+```swift
+        func check(_ condition: Condition, _ context: String) {
+            switch condition {
+            case .always: break
+            case .providerIs(let p) where !providerIDs.contains(p):
+                problems.append("\(context): condition references unknown provider \"\(p)\"")
+            case .fieldEquals(let key, _) where !fieldKeys.contains(key):
+                problems.append("\(context): condition references unknown field \"\(key)\"")
+            default: break
+            }
+        }
+```
+
+Add a `fieldIn` branch before `default`:
+
+```swift
+        func check(_ condition: Condition, _ context: String) {
+            switch condition {
+            case .always: break
+            case .providerIs(let p) where !providerIDs.contains(p):
+                problems.append("\(context): condition references unknown provider \"\(p)\"")
+            case .fieldEquals(let key, _) where !fieldKeys.contains(key):
+                problems.append("\(context): condition references unknown field \"\(key)\"")
+            case .fieldIn(let key, _) where !fieldKeys.contains(key):
+                problems.append("\(context): condition references unknown field \"\(key)\"")
+            default: break
+            }
+        }
+```
+
+- [ ] **Step 7: Run both tests to verify they pass**
+
+Run: `swift test --package-path . --filter "fieldInVisibilityMatchesAnyListedValue|validateCatchesDanglingFieldInReference"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteCore/IntegrationDescriptor.swift Sources/AnglesiteCore/IntegrationPlanner.swift Sources/AnglesiteCore/IntegrationCatalog.swift Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
+git commit -m "feat(#289): add Condition.fieldIn for multi-value field visibility
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Home page injection anchors
+
+Add the two inert anchors the `button` placement injects into. They are no-op comments in the shipped template.
+
+**Files:**
+- Modify: `Resources/Template/src/pages/index.astro`
+- Test: `Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift` (new `@Test`)
+
+**Interfaces:**
+- Produces: anchors `// anglesite:imports` (frontmatter) and `<!-- anglesite:hero-cta -->` (inside `.hero`). Consumed by Task 3's injection ops.
+
+- [ ] **Step 1: Write the failing anchor test**
+
+In `Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift`, add inside the suite (mirrors `layoutsHaveImportAndBodyAnchors`):
+
+```swift
+    @Test func homepageHasImportAndHeroAnchors() throws {
+        let root = templateRoot()
+        let index = try String(contentsOf: root.appendingPathComponent("src/pages/index.astro"), encoding: .utf8)
+        #expect(index.contains("// anglesite:imports"))
+        #expect(index.contains("<!-- anglesite:hero-cta -->"))
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --package-path . --filter homepageHasImportAndHeroAnchors`
+Expected: FAIL — `#expect(index.contains("// anglesite:imports"))` is false.
+
+- [ ] **Step 3: Add the anchors to `index.astro`**
+
+Replace the full contents of `Resources/Template/src/pages/index.astro` with:
+
+```astro
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+// anglesite:imports — integration component imports are injected here on setup
+---
+
+<BaseLayout
+  title="Welcome — Your New Anglesite Business Website"
+  description="Your business website is ready to set up. Run /start in Claude to begin the guided setup."
+>
+  <main>
+    <section class="hero">
+      <h1>Welcome</h1>
+      <p>This site is ready to set up. Type <code>/start</code> in Claude Desktop to get started.</p>
+      <p><a href="/blog/">Read the blog</a></p>
+      <!-- anglesite:hero-cta -->
+    </section>
+  </main>
+</BaseLayout>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --package-path . --filter homepageHasImportAndHeroAnchors`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Resources/Template/src/pages/index.astro Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
+git commit -m "feat(#289): add homepage injection anchors for booking button
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Booking descriptor `button` placement
+
+Add the `button` choice, make `buttonText` visible for `button` too, and add the two homepage injection operations. Update the choice-set assertion.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/IntegrationCatalog.swift` (the `booking` descriptor, ~line 53-93)
+- Test: `Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift` (`bookingHasStyleChoiceDrivingPlacement`, ~line 15-20)
+- Test: `Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift` (new `@Test`)
+
+**Interfaces:**
+- Consumes: `Condition.fieldIn` (Task 1); homepage anchors `// anglesite:imports` and `<!-- anglesite:hero-cta -->` (Task 2).
+- Produces: a `style == "button"` plan that emits two `.injectAnchor` steps targeting `src/pages/index.astro` (one `.line` import, one `.html` render) and no `book.astro` `createFile`.
+
+- [ ] **Step 1: Update the choice-set assertion (failing test)**
+
+In `Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift`, `bookingHasStyleChoiceDrivingPlacement` currently asserts:
+
+```swift
+        #expect(Set(choices.map { $0.value }) == Set(["inline", "floating"]))
+```
+
+Change it to:
+
+```swift
+        #expect(Set(choices.map { $0.value }) == Set(["inline", "floating", "button"]))
+```
+
+- [ ] **Step 2: Write the failing planner test**
+
+In `Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift`, add inside the suite (mirrors `bookingFloatingInjectsIntoLayout`):
+
+```swift
+    @Test func bookingButtonInjectsIntoHomepageHero() {
+        let r = try! IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
+            answers: ["provider": "cal", "username": "jane", "style": "button"],
+            sourceDirectory: makeSource(), templateDirectory: makeTemplate()).get()
+        let injects = r.steps.compactMap { step -> (String, MarkerInjector.CommentStyle)? in
+            if case .injectAnchor(let f, _, _, _, let style) = step { return (f, style) }; return nil
+        }
+        #expect(injects.contains { $0.0.contains("index.astro") && $0.1 == .line })
+        #expect(injects.contains { $0.0.contains("index.astro") && $0.1 == .html })
+        #expect(!r.steps.contains { if case .createFile(let p, _) = $0 { return p == "src/pages/book.astro" }; return false })
+    }
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+Run: `swift test --package-path . --filter "bookingHasStyleChoiceDrivingPlacement|bookingButtonInjectsIntoHomepageHero"`
+Expected: FAIL — choice set is `{inline, floating}`; no `index.astro` injection steps.
+
+- [ ] **Step 4: Add the `button` choice and fix `buttonText` visibility**
+
+In `Sources/AnglesiteCore/IntegrationCatalog.swift`, the booking `fields` `style`/`buttonText` entries currently read:
+
+```swift
+            Field(key: "style", label: "Placement", kind: .choice([
+                Choice(value: "inline", label: "On a /book page"),
+                Choice(value: "floating", label: "Floating button (site-wide)"),
+            ]), defaultValue: "inline"),
+            Field(key: "buttonText", label: "Button text", kind: .text, isOptional: true,
+                  defaultValue: "Book a time", visibleWhen: .fieldEquals(key: "style", value: "floating")),
+```
+
+Replace with:
+
+```swift
+            Field(key: "style", label: "Placement", kind: .choice([
+                Choice(value: "inline", label: "On a /book page"),
+                Choice(value: "floating", label: "Floating button (site-wide)"),
+                Choice(value: "button", label: "Button on the home page"),
+            ]), defaultValue: "inline"),
+            Field(key: "buttonText", label: "Button text", kind: .text, isOptional: true,
+                  defaultValue: "Book a time",
+                  visibleWhen: .fieldIn(key: "style", values: ["floating", "button"])),
+```
+
+- [ ] **Step 5: Add the two `button` injection operations**
+
+In the same booking descriptor, the `operations` array currently has the two `floating`-gated `injectAtAnchor` ops (targeting `src/layouts/BaseLayout.astro`) followed by `.writeConfig`. Insert the two `button`-gated ops immediately **after** the second floating `injectAtAnchor` (the `.html` one ending `style: .html)` for `BaseLayout.astro`) and **before** `.writeConfig`:
+
+```swift
+            .injectAtAnchor(file: "src/pages/index.astro", anchor: "// anglesite:imports",
+                            snippet: "import BookingWidget from \"../components/BookingWidget.astro\";\nimport { readConfig } from \"../../scripts/config\";",
+                            when: .fieldEquals(key: "style", value: "button"), style: .line),
+            .injectAtAnchor(file: "src/pages/index.astro", anchor: "<!-- anglesite:hero-cta -->",
+                            snippet: "{readConfig(\"BOOKING_STYLE\") === \"button\" && (<BookingWidget provider={readConfig(\"BOOKING_PROVIDER\")} username={readConfig(\"BOOKING_USERNAME\")} eventSlug={readConfig(\"BOOKING_EVENT_SLUG\")} buttonText={readConfig(\"BOOKING_BUTTON_TEXT\")} style=\"button\" />)}",
+                            when: .fieldEquals(key: "style", value: "button"), style: .html),
+```
+
+- [ ] **Step 6: Run both tests to verify they pass**
+
+Run: `swift test --package-path . --filter "bookingHasStyleChoiceDrivingPlacement|bookingButtonInjectsIntoHomepageHero"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Run the full integration suite (regression + asset guards)**
+
+Run: `swift test --package-path . --filter Integration`
+Expected: PASS — all integration suites green, including `IntegrationCatalogTests.descriptorsValidate` (every descriptor's `validate()` returns `[]`), `bookingWritesEventSlugAndButtonText`, and `IntegrationTemplateAssetsTests`. If any asset-completeness fixture fails, update the expected fixture list to match.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteCore/IntegrationCatalog.swift Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+git commit -m "feat(#289): booking 'button' placement injects CTA into homepage hero
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full suite + app build verification
+
+Prove the whole package still builds and that the app target links (per project memory, `swift test` alone doesn't prove the `.app` links).
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full Swift test suite**
+
+Run: `swift test --package-path .`
+Expected: PASS — full suite green (no regressions in `AnglesiteCoreTests`, `AnglesiteIntentsTests`, `AnglesiteBridgeTests`).
+
+- [ ] **Step 2: Generate the Xcode project (fresh worktree has none)**
+
+Run: `ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodegen generate`
+Expected: `Created project at Anglesite.xcodeproj`.
+
+- [ ] **Step 3: Build the app target**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: No commit needed** (verification task — nothing changed).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §1 (homepage anchors) → Task 2. ✓
+- Spec §2 (descriptor: button choice, buttonText visibility, two button ops; copyFile/writeConfig/addCSPDomains unchanged) → Task 3 (Steps 4-5). ✓
+- Spec §3 (`Condition.fieldIn` + two evaluation sites) → Task 1. ✓
+- Spec §4 (testing: planner button plan, fieldIn visibility, validate passes, template asset guard) → Task 1 (visibility + validate), Task 2 (anchors), Task 3 Steps 2/7 (planner plan + asset guard). ✓
+- Spec non-goals (no `BookingWidget.astro` change, no CSP change, no inline/floating change) → respected; `addCSPDomains`/`copyFile`/`writeConfig` untouched, floating regression covered by existing `bookingFloatingInjectsIntoLayout`. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `Condition.fieldIn(key:values:)` defined in Task 1 Step 4, evaluated in Task 1 Steps 5-6, consumed in Task 3 Step 4. Step types `.injectAnchor` / `.createFile` / `MarkerInjector.CommentStyle` match the existing planner test patterns. ✓

--- a/docs/superpowers/specs/2026-06-22-booking-button-placement-design.md
+++ b/docs/superpowers/specs/2026-06-22-booking-button-placement-design.md
@@ -1,0 +1,96 @@
+# Booking `button` placement (#289) — design
+
+**Issue:** #289 — Bucket 3 follow-up: in-page booking 'button' style placement
+**Split from:** #282 / PR #287, where booking `style` was reduced to `inline`/`floating` and the `button` variant was deferred.
+
+## Background
+
+`BookingWidget.astro` (`Resources/Template/integrations/components/`) already implements a
+complete `button` variant for both providers:
+
+- **Cal.com** — an in-flow `<button data-cal-link>` that triggers `Cal("pop")` (modal popup).
+- **Calendly** — an in-flow `<button>` whose click handler calls `Calendly.initPopupWidget`.
+
+Both share the existing `.booking-button` CSS. So the rendering path is done. What is missing
+is the **wiring**: the booking descriptor in `Sources/AnglesiteCore/IntegrationCatalog.swift`
+exposes only two placement choices and never stages the `button` variant.
+
+Current descriptor placement choices:
+
+- `inline` → `copyFile` a dedicated `src/pages/book.astro` (embedded scheduler).
+- `floating` → two `injectAtAnchor` ops into `src/layouts/BaseLayout.astro`
+  (import at `// anglesite:imports`, widget at `<!-- anglesite:body-end -->`), site-wide badge.
+
+`BOOKING_STYLE` and `BOOKING_BUTTON_TEXT` are already written by the `.always` `writeConfig` op,
+and `addCSPDomains(fromProvider: true)` is `.always`, so provider CSP domains already flow for
+every style (consistent with the `public/_headers` work in #290/PR #294 — no overlap).
+
+## Goal
+
+Expose the `button` variant as a third placement choice that injects an in-flow booking CTA
+button into the **home page hero**.
+
+## Design
+
+### 1. Template anchors — `Resources/Template/src/pages/index.astro`
+
+The homepage currently has no injection anchors. Add two, matching the `BaseLayout` convention:
+
+- `// anglesite:imports` in the frontmatter (for the component import).
+- `<!-- anglesite:hero-cta -->` inside the `.hero` `<section>`, **after** the existing hero
+  paragraphs (where the button lands).
+
+These are inert no-op comments in the shipped template; they are only populated when an owner
+selects the `button` placement.
+
+### 2. Booking descriptor — `Sources/AnglesiteCore/IntegrationCatalog.swift`
+
+- Add the third `style` choice:
+  `Choice(value: "button", label: "Button on the home page")`.
+- Change the `buttonText` field's `visibleWhen` so it shows for `floating` **and** `button`
+  (see §3).
+- Add two `button`-gated operations, mirroring the `floating` pair but targeting `index.astro`:
+  - `injectAtAnchor(file: "src/pages/index.astro", anchor: "// anglesite:imports", snippet:
+    "import BookingWidget from \"../components/BookingWidget.astro\";\nimport { readConfig } from \"../../scripts/config\";",
+    when: .fieldEquals(key: "style", value: "button"), style: .line)`
+  - `injectAtAnchor(file: "src/pages/index.astro", anchor: "<!-- anglesite:hero-cta -->",
+    snippet: "{readConfig(\"BOOKING_STYLE\") === \"button\" && (<BookingWidget provider={readConfig(\"BOOKING_PROVIDER\")} username={readConfig(\"BOOKING_USERNAME\")} eventSlug={readConfig(\"BOOKING_EVENT_SLUG\")} buttonText={readConfig(\"BOOKING_BUTTON_TEXT\")} style=\"button\" />)}",
+    when: .fieldEquals(key: "style", value: "button"), style: .html)`
+- `copyFile` (component), `writeConfig`, and `addCSPDomains` are unchanged (already `.always`).
+
+### 3. Condition model change — `Sources/AnglesiteCore/IntegrationDescriptor.swift`
+
+`buttonText` must be visible for `floating` and `button`, but `Condition` only supports
+single-value `.fieldEquals`. Add one case:
+
+```swift
+case fieldIn(key: String, values: [String])
+```
+
+evaluated in the two existing sites:
+
+- `IntegrationPlanner.isVisible` → `case .fieldIn(let key, let values): return values.contains(answers[key] ?? "")`
+- `IntegrationCatalog.check` → validate `key` exists in `fieldKeys` (same as `.fieldEquals`).
+
+`buttonText` then uses `visibleWhen: .fieldIn(key: "style", values: ["floating", "button"])`.
+
+*Rejected alternative:* make `buttonText` `visibleWhen: .always` (no model change) — but it would
+surface an irrelevant "Button text" field on the `inline` choice. The `.fieldIn` case is small
+and reusable, so it wins.
+
+## Testing
+
+- **`IntegrationPlanner`**: `style=button` answers produce exactly the two `index.astro`
+  injections + the `.always` ops, and the `inline`/`floating` plans are unaffected (regression
+  guard).
+- **`Condition.fieldIn` visibility**: `button` and `floating` show `buttonText`; `inline` hides it.
+- **`IntegrationCatalog.check`**: still passes with the new `.fieldIn` condition (validates `style`).
+- **Template asset guard**: editing `index.astro` will trip the `IntegrationTemplateAssetsTests`
+  fixture-completeness checks — run `swift test --filter Integration` and update expected fixtures
+  before pushing.
+
+## Scope / non-goals
+
+- No change to `BookingWidget.astro` (the `button` render path already exists).
+- No new CSP handling (provider domains already flow via the `.always` `addCSPDomains`).
+- No change to `inline`/`floating` behavior.


### PR DESCRIPTION
Closes #289. Bucket 3 follow-up split out from #282/PR #287.

## What

Exposes the already-built `button` variant of `BookingWidget.astro` as a third booking **placement** choice. When an owner picks it, a booking CTA button is injected into the **home page hero**; clicking it opens the scheduler in a modal popup (Cal.com `Cal("pop")` / Calendly `initPopupWidget`).

Previously `style` was reduced to `inline`/`floating` in #287 and the `button` variant was deferred. The component render path already existed — this PR is purely the **wiring**.

## Changes

- **`Condition.fieldIn(key:values:)`** — new enum case so a field can be visible for more than one choice value (evaluated in `IntegrationPlanner.isVisible` and validated in `IntegrationCatalog.validate`). Used so `buttonText` shows for both `floating` and `button`.
- **Homepage anchors** — added inert `// anglesite:imports` (frontmatter) and `<!-- anglesite:hero-cta -->` (hero) anchors to `Resources/Template/src/pages/index.astro`.
- **Booking descriptor** — added the `button` placement choice (`Button on the home page`) and two `button`-gated `injectAtAnchor` ops targeting `index.astro`, mirroring the existing `floating` pair.

`BookingWidget.astro` is unchanged. CSP/provider domains already flow via the `.always` `addCSPDomains` op, so this is consistent with the `public/_headers` work in #290/#294 — no overlap.

## Tests

- `Condition.fieldIn` visibility (incl. empty-answers edge) + dangling-field validation.
- Button plan emits both homepage injections (`.line` import + `.html` render) and no `book.astro` page.
- New `index.astro` anchor presence guard.
- Negative assertion that the `floating` plan does **not** leak homepage injections (locks in the "floating unchanged" guarantee).

Full suite green for this change: AnglesiteCore (746 Swift Testing + XCTest) + AnglesiteIntents (222). App target `xcodebuild` BUILD SUCCEEDED. (The unrelated `AppliesEditEndToEndTests` failure is a pre-existing MCP `apply_edit` plugin/app schema skew in the edit pipeline, which this branch does not touch.)

Design + plan: `docs/superpowers/specs/2026-06-22-booking-button-placement-design.md`, `docs/superpowers/plans/2026-06-22-booking-button-placement.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)