### PR TITLE
feat(#82): Mac App Store release pipeline (release-mas.sh)

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -1,15 +1,15 @@
 # Release pipeline
 
-This document covers the **Developer ID** distribution track for the `Anglesite` target, which
-ships auto-updates via [Sparkle 2.x](https://sparkle-project.org/). It walks the one-time setup
-and the per-release flow.
+Anglesite ships on two tracks:
 
-> **Mac App Store track (pending).** The sandboxed `AnglesiteMAS` target builds today, but its
-> submission pipeline — archive → export with `Apple Distribution` → `productbuild`/`altool`
-> upload to App Store Connect, including the bundled-Node re-sign (`scripts/resign-node.sh`) and
-> a WWDR-CA-G3 intermediate preflight — is **Phase 10.1 Task 12** and not yet built. The MAS build
-> has no Sparkle (the App Store handles its updates). See
-> [the sandboxed App Store plan](specs/2026-05-27-sandboxed-app-store-plan.md).
+- **Developer ID** (the `Anglesite` target) — self-distributed, auto-updated via
+  [Sparkle 2.x](https://sparkle-project.org/). Driven by `scripts/release.sh`.
+- **Mac App Store** (the sandboxed `AnglesiteMAS` target) — distributed through App Store
+  Connect, which handles its own updates (no Sparkle). Driven by `scripts/release-mas.sh`.
+  See [Mac App Store submission](#mac-app-store-submission) below.
+
+The first part of this document walks the Developer ID one-time setup and per-release flow;
+the App Store section follows.
 
 ## One-time setup (do once, ever)
 
@@ -96,6 +96,80 @@ scripts/generate-appcast.sh build/appcast.xml
 
 Drafts and prereleases are skipped. Releases missing the sparkle-* markers are skipped
 with a warning.
+
+## Mac App Store submission
+
+The sandboxed `AnglesiteMAS` target submits to App Store Connect via
+`scripts/release-mas.sh`. This is the App Store counterpart to the Developer ID flow above —
+no Sparkle, no appcast, no GitHub Release; App Store Connect is the distribution channel and
+ships updates itself.
+
+### One-time setup (App Store)
+
+1. **App Store Connect app record.** Create an app for bundle id `dev.anglesite.app.mas`
+   in [App Store Connect](https://appstoreconnect.apple.com/) → Apps. The build won't
+   upload until the record exists.
+
+2. **Certificates.** In the Apple Developer portal, create and install in your login keychain:
+   - an **Apple Distribution** certificate (signs the `.app`), and
+   - a **Mac Installer Distribution** certificate (signs the outer `.pkg`).
+   Also install the **Apple WWDR (G3)** intermediate from
+   <https://www.apple.com/certificateauthority/> — without it the distribution chain won't
+   validate at upload. `release-mas.sh` preflights all three and fails early with a pointer
+   if any is missing.
+
+3. **Provisioning profile.** Create a **Mac App Store** provisioning profile for
+   `dev.anglesite.app.mas` tied to the Apple Distribution cert, download it, and install it
+   (double-click, or drop into `~/Library/MobileDevice/Provisioning Profiles/`). Note its
+   name — you pass it as `PROVISIONING_PROFILE`.
+
+4. **App Store Connect API key** (keychain-free uploads). In App Store Connect → Users and
+   Access → Integrations → App Store Connect API, create a key with the *App Manager* role.
+   Download the `.p8` once and place it in `~/.appstoreconnect/private_keys/` (or
+   `~/.private_keys/`). Record the **Key ID** and **Issuer ID** — they become
+   `ASC_API_KEY_ID` and `ASC_API_ISSUER_ID`.
+
+### Per-release flow (App Store)
+
+Bump the version first if needed (same `project.yml` keys the Developer ID flow bumps —
+`MARKETING_VERSION` / `CURRENT_PROJECT_VERSION`; App Store builds must use a build number
+not previously uploaded for that version). Then:
+
+```sh
+TEAM_ID=YOUR_TEAM_ID \
+PROVISIONING_PROFILE="Anglesite MAS App Store" \
+ASC_API_KEY_ID=XXXXXXXXXX \
+ASC_API_ISSUER_ID=00000000-0000-0000-0000-000000000000 \
+  scripts/release-mas.sh
+```
+
+The script:
+
+1. **Preflights** `TEAM_ID`, the provisioning profile, `xcodegen`/`xcodebuild`/`altool`, the
+   Apple Distribution + Mac Installer Distribution identities, the WWDR intermediate, and (for
+   upload) the ASC API key/issuer.
+2. Runs `xcodegen generate` and writes `build/exportOptions-appstore.plist` from the template
+   (`scripts/exportOptions-appstore.plist`, `method = app-store-connect`), substituting
+   `TEAM_ID` and the profile name.
+3. `xcodebuild archive` of the `AnglesiteMAS` scheme (Release).
+4. **Verifies the bundled-Node re-sign survived the archive** — `codesign --verify` on the
+   embedded `node`, and that its `TeamIdentifier` matches the app's team. This is the
+   `scripts/resign-node.sh` post-build phase's output; if it didn't hold, the bundle seal and
+   App Store acceptance would fail.
+5. `xcodebuild -exportArchive` → a Mac Installer Distribution-signed `.pkg`.
+6. `xcrun altool --validate-app`, then `xcrun altool --upload-app`.
+
+Pass **`--validate-only`** to archive, export, and validate without uploading — the
+credential-free dry run analogous to `notarize-dry-run.sh`. (`ASC_API_KEY_ID` /
+`ASC_API_ISSUER_ID` are still needed for the App Store Connect *validation* step; without them
+the script skips ASC validation and just produces the `.pkg`.)
+
+`Transporter.app` is the GUI fallback for the upload step: drop the exported `.pkg` onto it.
+
+### After upload
+
+App Store Connect processes the build (a few minutes), after which it appears under
+TestFlight / the app version. Attach it to a version and submit for review there.
 
 ## Why a `release.sh` and not CI?
 

--- a/scripts/exportOptions-appstore.plist
+++ b/scripts/exportOptions-appstore.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Template for `xcodebuild -exportArchive` of the AnglesiteMAS (Mac App Store) target.
+  Consumed by scripts/release-mas.sh, which substitutes __TEAM_ID__ and
+  __PROVISIONING_PROFILE__ from the environment and writes the result to
+  build/exportOptions-appstore.plist (gitignored).
+
+  Counterpart to scripts/exportOptions.plist (the Developer ID / Sparkle export). The
+  difference that matters: method `app-store-connect` produces a Mac Installer
+  Distribution-signed .pkg ready for App Store Connect, vs. `developer-id` which
+  produces a notarizable, self-distributed .app.
+-->
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>teamID</key>
+    <string>__TEAM_ID__</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <!-- Signs the outer installer package. The .app inside is signed Apple Distribution
+         (project.yml AnglesiteMAS Release CODE_SIGN_IDENTITY); the .pkg wrapper needs the
+         Mac Installer Distribution cert. -->
+    <key>installerSigningCertificate</key>
+    <string>Mac Installer Distribution</string>
+    <!-- Manual signing requires an explicit App Store provisioning profile for the bundle id. -->
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>dev.anglesite.app.mas</key>
+        <string>__PROVISIONING_PROFILE__</string>
+    </dict>
+    <key>uploadSymbols</key>
+    <true/>
+    <!-- We bump MARKETING_VERSION / CURRENT_PROJECT_VERSION ourselves in project.yml;
+         don't let Xcode rewrite them at export. -->
+    <key>manageAppVersionAndBuildNumber</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/release-mas.sh
+++ b/scripts/release-mas.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# Phase 10.1 Task 12 (#82) — Mac App Store release pipeline for the AnglesiteMAS target.
+#
+# Archives the sandboxed AnglesiteMAS scheme, exports an App Store .pkg (signed with the
+# Apple Distribution + Mac Installer Distribution identities), verifies the bundled-Node
+# re-sign survived the archive, then validates and uploads to App Store Connect.
+#
+# This is the App Store counterpart to scripts/release.sh + scripts/notarize-dry-run.sh
+# (the Developer ID / Sparkle path). There is deliberately NO Sparkle / appcast / GitHub
+# Release step — on the App Store, App Store Connect *is* the distribution channel and
+# updates ship through it, not Sparkle.
+#
+# Prerequisites (one-time, see docs/release.md "Mac App Store submission"):
+#   - An App Store Connect app record for bundle id dev.anglesite.app.mas.
+#   - An "Apple Distribution" cert + a "Mac Installer Distribution" cert in the keychain.
+#   - The Apple WWDR (G3) intermediate cert (https://www.apple.com/certificateauthority/).
+#   - A Mac App Store provisioning profile for dev.anglesite.app.mas, installed.
+#   - An App Store Connect API key (.p8 in ~/.appstoreconnect/private_keys/ or
+#     ~/.private_keys/) plus its key id + issuer id, for keychain-free altool upload.
+#
+# Usage:
+#   TEAM_ID=ABCDE12345 \
+#   PROVISIONING_PROFILE="Anglesite MAS App Store" \
+#   ASC_API_KEY_ID=XXXXXXXXXX ASC_API_ISSUER_ID=00000000-0000-0000-0000-000000000000 \
+#     scripts/release-mas.sh [--validate-only]
+#
+#   --validate-only   Archive + export + `altool --validate-app`, but stop before upload.
+#                     The credential-free dry run analogous to notarize-dry-run.sh.
+#
+# Env:
+#   TEAM_ID               (required) 10-char Apple Developer Team ID.
+#   PROVISIONING_PROFILE  (required) Name of the installed App Store provisioning profile
+#                         for dev.anglesite.app.mas.
+#   ASC_API_KEY_ID        (required unless --validate-only) App Store Connect API key id.
+#   ASC_API_ISSUER_ID     (required unless --validate-only) App Store Connect API issuer id.
+
+set -euo pipefail
+
+VALIDATE_ONLY=0
+for arg in "$@"; do
+    case "$arg" in
+        --validate-only) VALIDATE_ONLY=1 ;;
+        -h|--help) sed -n '2,40p' "$0"; exit 0 ;;
+        *) echo "error: unknown argument '$arg'" >&2; exit 64 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$REPO_ROOT/build"
+ARCHIVE_PATH="$BUILD_DIR/AnglesiteMAS.xcarchive"
+EXPORT_DIR="$BUILD_DIR/export-mas"
+EXPORT_OPTIONS="$BUILD_DIR/exportOptions-appstore.plist"
+EXPORT_OPTIONS_TEMPLATE="$SCRIPT_DIR/exportOptions-appstore.plist"
+BUNDLE_ID="dev.anglesite.app.mas"
+SCHEME="AnglesiteMAS"
+CONFIGURATION="Release"
+
+bail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+step() { printf '\n=== %s ===\n' "$*"; }
+
+# --- Preflight ---------------------------------------------------------------
+step "0/6 preflight"
+
+[[ -n "${TEAM_ID:-}" ]] \
+    || bail "TEAM_ID is unset. Export your 10-character Apple Developer Team ID and re-run."
+[[ -n "${PROVISIONING_PROFILE:-}" ]] \
+    || bail "PROVISIONING_PROFILE is unset. Set it to the name of the App Store provisioning profile for $BUNDLE_ID."
+
+command -v xcodegen >/dev/null || bail "xcodegen not installed. brew install xcodegen"
+command -v xcodebuild >/dev/null || bail "xcodebuild not on PATH (install Xcode + command line tools)."
+xcrun --find altool >/dev/null 2>&1 || bail "xcrun altool unavailable. Use a full Xcode install (not just CLT)."
+
+# Apple Distribution signing identity (signs the .app).
+security find-identity -v -p codesigning 2>/dev/null | grep -q "Apple Distribution" \
+    || bail "no 'Apple Distribution' codesigning identity in the keychain. Create one in the Apple Developer portal and install it."
+
+# Mac Installer Distribution identity (signs the .pkg). Installer certs are not codesigning
+# certs, so they don't appear under -p codesigning; scan the full identity list.
+security find-identity -v 2>/dev/null | grep -Eq "Mac Installer Distribution|3rd Party Mac Developer Installer" \
+    || bail "no 'Mac Installer Distribution' (installer) identity in the keychain. App Store .pkg signing needs it."
+
+# WWDR-G3 intermediate cert — without it the distribution chain won't validate at upload.
+security find-certificate -a 2>/dev/null | grep -q "Apple Worldwide Developer Relations" \
+    || bail "Apple WWDR intermediate cert missing. Download G3 from https://www.apple.com/certificateauthority/ and add it to the keychain."
+
+if [[ "$VALIDATE_ONLY" -eq 0 ]]; then
+    [[ -n "${ASC_API_KEY_ID:-}" ]] \
+        || bail "ASC_API_KEY_ID is unset (needed for upload). Re-run with --validate-only to skip the upload step."
+    [[ -n "${ASC_API_ISSUER_ID:-}" ]] \
+        || bail "ASC_API_ISSUER_ID is unset (needed for upload). Re-run with --validate-only to skip the upload step."
+fi
+
+echo "  team:        $TEAM_ID"
+echo "  profile:     $PROVISIONING_PROFILE"
+echo "  mode:        $([[ "$VALIDATE_ONLY" -eq 1 ]] && echo 'validate-only (no upload)' || echo 'validate + upload')"
+
+# --- Generate project + export options ---------------------------------------
+step "1/6 xcodegen generate"
+(cd "$REPO_ROOT" && xcodegen generate)
+
+mkdir -p "$BUILD_DIR"
+sed -e "s/__TEAM_ID__/$TEAM_ID/g" \
+    -e "s/__PROVISIONING_PROFILE__/$PROVISIONING_PROFILE/g" \
+    "$EXPORT_OPTIONS_TEMPLATE" > "$EXPORT_OPTIONS"
+
+# --- Archive -----------------------------------------------------------------
+step "2/6 xcodebuild archive ($SCHEME)"
+rm -rf "$ARCHIVE_PATH"
+xcodebuild \
+    -project "$REPO_ROOT/Anglesite.xcodeproj" \
+    -scheme "$SCHEME" \
+    -configuration "$CONFIGURATION" \
+    -archivePath "$ARCHIVE_PATH" \
+    DEVELOPMENT_TEAM="$TEAM_ID" \
+    archive
+[[ -d "$ARCHIVE_PATH" ]] || bail "archive produced no .xcarchive at $ARCHIVE_PATH"
+
+# --- Verify the bundled-Node re-sign survived the archive --------------------
+# resign-node.sh runs as a post-build phase; confirm the embedded Node is signed with a
+# hardened runtime and the same team as the app, before we wrap it in the installer .pkg.
+step "3/6 verify bundled-Node re-sign"
+ARCHIVED_APP="$ARCHIVE_PATH/Products/Applications/$SCHEME.app"
+NODE_BIN="$ARCHIVED_APP/Contents/Resources/node-runtime/bin/node"
+if [[ -f "$NODE_BIN" ]]; then
+    codesign --verify --strict --verbose=2 "$NODE_BIN" \
+        || bail "bundled Node failed codesign --verify. The resign-node.sh post-build phase did not hold through archive."
+    node_team="$(codesign -dvv "$NODE_BIN" 2>&1 | sed -n 's/^TeamIdentifier=//p')"
+    [[ "$node_team" == "$TEAM_ID" ]] \
+        || bail "bundled Node TeamIdentifier '$node_team' != app team '$TEAM_ID' — bundle seal/App Store acceptance would fail."
+    codesign -d --entitlements - --xml "$NODE_BIN" 2>/dev/null | grep -q "com.apple.security.cs.allow-jit" \
+        && echo "  node: signed, team=$node_team, JIT entitlement present" \
+        || echo "  node: signed, team=$node_team (no JIT entitlement — confirm intended)"
+else
+    echo "  no bundled Node at $NODE_BIN — node-runtime is an optional resource; skipping."
+fi
+
+# --- Export ------------------------------------------------------------------
+step "4/6 xcodebuild -exportArchive (app-store-connect)"
+rm -rf "$EXPORT_DIR"
+xcodebuild -exportArchive \
+    -archivePath "$ARCHIVE_PATH" \
+    -exportPath "$EXPORT_DIR" \
+    -exportOptionsPlist "$EXPORT_OPTIONS"
+
+PKG_PATH="$(find "$EXPORT_DIR" -maxdepth 1 -name '*.pkg' -print -quit)"
+[[ -n "$PKG_PATH" && -f "$PKG_PATH" ]] || bail "export produced no .pkg under $EXPORT_DIR"
+echo "  → $PKG_PATH ($(stat -f%z "$PKG_PATH") bytes)"
+
+# --- Validate ----------------------------------------------------------------
+# Validation does not need ASC API creds when running purely against the package shape,
+# but App Store Connect validation (asset/entitlement checks) does — so it shares the
+# upload credentials. In --validate-only mode without creds we still run the local
+# package validation that altool can do offline.
+step "5/6 altool --validate-app"
+validate_args=(--validate-app --type macos --file "$PKG_PATH")
+upload_args=(--upload-app --type macos --file "$PKG_PATH")
+if [[ -n "${ASC_API_KEY_ID:-}" && -n "${ASC_API_ISSUER_ID:-}" ]]; then
+    validate_args+=(--apiKey "$ASC_API_KEY_ID" --apiIssuer "$ASC_API_ISSUER_ID")
+    upload_args+=(--apiKey "$ASC_API_KEY_ID" --apiIssuer "$ASC_API_ISSUER_ID")
+    xcrun altool "${validate_args[@]}"
+else
+    echo "  (no ASC API creds — skipping App Store Connect validation; supply ASC_API_KEY_ID/ISSUER to enable)"
+fi
+
+# --- Upload ------------------------------------------------------------------
+step "6/6 altool --upload-app"
+if [[ "$VALIDATE_ONLY" -eq 1 ]]; then
+    cat <<EOF
+
+✅ Validate-only run complete. Package ready at:
+     $PKG_PATH
+
+To upload to App Store Connect, re-run without --validate-only (and with
+ASC_API_KEY_ID / ASC_API_ISSUER_ID set), or drop the .pkg into Transporter.app.
+EOF
+    exit 0
+fi
+
+xcrun altool "${upload_args[@]}"
+
+cat <<EOF
+
+✅ Uploaded $SCHEME to App Store Connect.
+
+Next steps:
+  1. Wait for processing in App Store Connect → TestFlight / App Store.
+  2. Attach the build to a version and submit for review.
+See docs/release.md "Mac App Store submission" for the full flow.
+EOF


### PR DESCRIPTION
Phase 10.1 Task 12 (#82). Stands up the App Store submission pipeline for the sandboxed `AnglesiteMAS` target — the App Store counterpart to `scripts/release.sh` + `scripts/notarize-dry-run.sh` (the Developer ID / Sparkle track). No Sparkle/appcast/GitHub Release: App Store Connect is the distribution channel and ships its own updates.

## What's here
- **`scripts/release-mas.sh`** — preflight (`TEAM_ID`, provisioning profile, Apple Distribution + Mac Installer Distribution identities, WWDR-G3 intermediate, `altool`, ASC API creds) → `xcodegen` → archive `AnglesiteMAS` → **verify the bundled-Node re-sign survived the archive** (`codesign --verify` + `TeamIdentifier` matches the app's team) → export an `app-store-connect` `.pkg` → `altool --validate-app` → `--upload-app`. `--validate-only` is the credential-free dry run.
- **`scripts/exportOptions-appstore.plist`** — `app-store-connect` export template with `__TEAM_ID__` / `__PROVISIONING_PROFILE__` substitution.
- **`docs/release.md`** — new "Mac App Store submission" section (one-time ASC setup + per-release flow); intro reframed to two tracks; stale "pending" admonition removed.

## Why the Node re-sign check
`resign-node.sh` runs as a post-build phase, but Xcode's implicit final bundle seal re-signs the `.app` afterward. If the embedded node's team drifts from the app's, the App Store rejects the bundle. The script checks `codesign --verify` + `TeamIdentifier` on the archived `.app` (before the `.pkg` wraps it) to catch that before a wasted upload.

## Verification boundary
No signing cert exists in this environment, so the credentialed end-to-end run can't be exercised here (same gate as the existing `notarize-dry-run.sh`). Verified up to that boundary:
- `bash -n` clean, `plutil -lint` OK, `--help` exits 0, unknown arg → exit 64.
- Every preflight guard fail-fasts with a clear message (missing `TEAM_ID`, missing `PROVISIONING_PROFILE`, and the "no Apple Distribution identity" bail).
- `xcodebuild` / `altool` / `xcodegen` confirmed present — the only genuine blocker is the missing cert + `TEAM_ID`.

## Deferred (needs Apple credentials)
- The credentialed end-to-end / `--validate-only` run of `release-mas.sh`.
- #81 (real-signed write-heavy MAS smoke) — also settles the `cs.disable-library-validation` question.
- #83 (closeout) — blocked on #81 + the credentialed #82 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)