### PR TITLE
feat: inline page/post re-titling in the project navigator

### DIFF
--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -12,6 +12,14 @@ final class SiteNavigatorModel {
     private(set) var sections: [NavigatorSection] = []
     var selection: String?
 
+    // Inline re-titling (Finder-style). `editingItemID` non-nil → that row shows a TextField.
+    var editingItemID: String?
+    var draftTitle: String = ""
+    var renameError: String?
+
+    private var sourceDirectory: URL?
+    private let renameService = NavigatorRenameService()
+
     private let graph: SiteContentGraph
     private var observeTask: Task<Void, Never>?
 
@@ -19,7 +27,8 @@ final class SiteNavigatorModel {
         self.graph = graph
     }
 
-    func start(siteID: String, siteRoot: URL) {
+    func start(siteID: String, siteRoot: URL, sourceDirectory: URL) {
+        self.sourceDirectory = sourceDirectory
         // Cancel any prior observer (window reuse: SwiftUI can replay a different site into the
         // same window) BEFORE starting the new one, so a stale refresh can't overwrite the new
         // site's sections. The initial load runs as the new task's first step, so it is tracked
@@ -47,6 +56,76 @@ final class SiteNavigatorModel {
             if let item = section.items.first(where: { $0.id == id }) { return item.target }
         }
         return nil
+    }
+
+    /// A row is renamable iff it is a page or post (route target). File rows (components/styles/
+    /// metadata) carry a `.file` target and are out of scope. The astro-without-title case is
+    /// caught at commit, not pre-disabled (pre-checking would read every page file per refresh).
+    func canRename(_ id: String) -> Bool {
+        guard let target = target(for: id) else { return false }
+        if case .route = target { return true }
+        return false
+    }
+
+    func beginEditing(_ id: String) {
+        guard canRename(id) else { return }
+        let current = sections.flatMap(\.items).first { $0.id == id }?.title ?? ""
+        draftTitle = current
+        editingItemID = id
+    }
+
+    func cancelEditing() {
+        editingItemID = nil
+    }
+
+    /// Resolve the editing row → page/post → file, run the rename service, then reflect the new
+    /// title into the graph (which re-emits and rebuilds the sidebar). Always clears edit state.
+    func commitEditing() async {
+        guard let id = editingItemID, let sourceDirectory else { editingItemID = nil; return }
+        editingItemID = nil
+
+        if let page = await graph.page(id: id) {
+            let url = sourceDirectory.appendingPathComponent(page.filePath)
+            let result = await renameService.rename(
+                fileURL: url,
+                fileExtension: (page.filePath as NSString).pathExtension,
+                projectRoot: sourceDirectory,
+                relativePath: page.filePath,
+                newTitle: draftTitle)
+            switch result {
+            case .success(let title):
+                await graph.upsertPage(SiteContentGraph.Page(
+                    id: page.id, siteID: page.siteID, route: page.route,
+                    filePath: page.filePath, title: title, lastModified: page.lastModified))
+            case .failure(.emptyTitle):
+                break  // no write happened; keep the old title silently
+            case .failure(.noEditableLocation):
+                renameError = "This page has no editable title to rename."
+            case .failure(.io(let msg)):
+                renameError = "Couldn't rename: \(msg)"
+            }
+        } else if let post = await graph.post(id: id) {
+            let url = sourceDirectory.appendingPathComponent(post.filePath)
+            let result = await renameService.rename(
+                fileURL: url,
+                fileExtension: (post.filePath as NSString).pathExtension,
+                projectRoot: sourceDirectory,
+                relativePath: post.filePath,
+                newTitle: draftTitle)
+            switch result {
+            case .success(let title):
+                await graph.upsertPost(SiteContentGraph.Post(
+                    id: post.id, siteID: post.siteID, collection: post.collection, slug: post.slug,
+                    title: title, draft: post.draft, publishDate: post.publishDate, tags: post.tags,
+                    filePath: post.filePath, lastModified: post.lastModified))
+            case .failure(.emptyTitle):
+                break
+            case .failure(.noEditableLocation):
+                renameError = "This post has no editable title to rename."
+            case .failure(.io(let msg)):
+                renameError = "Couldn't rename: \(msg)"
+            }
+        }
     }
 
     /// Rebuilds `sections` for the given site. Takes `siteID`/`siteRoot` as parameters (the values

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -82,8 +82,12 @@ final class SiteNavigatorModel {
     /// Resolve the editing row → page/post → file, run the rename service, then reflect the new
     /// title into the graph (which re-emits and rebuilds the sidebar). Always clears edit state.
     func commitEditing() async {
-        guard let id = editingItemID, let sourceDirectory else { editingItemID = nil; return }
+        guard let id = editingItemID, let sourceDirectory else { editingItemID = nil; draftTitle = ""; return }
+        // Capture the title before any await: the focus-loss path also calls commitEditing and a
+        // concurrent cancel/begin on the main actor could mutate `draftTitle` across a suspension.
+        let title = draftTitle
         editingItemID = nil
+        draftTitle = ""
 
         if let page = await graph.page(id: id) {
             let url = sourceDirectory.appendingPathComponent(page.filePath)
@@ -92,7 +96,7 @@ final class SiteNavigatorModel {
                 fileExtension: (page.filePath as NSString).pathExtension,
                 projectRoot: sourceDirectory,
                 relativePath: page.filePath,
-                newTitle: draftTitle)
+                newTitle: title)
             switch result {
             case .success(let title):
                 await graph.upsertPage(SiteContentGraph.Page(
@@ -112,7 +116,7 @@ final class SiteNavigatorModel {
                 fileExtension: (post.filePath as NSString).pathExtension,
                 projectRoot: sourceDirectory,
                 relativePath: post.filePath,
-                newTitle: draftTitle)
+                newTitle: title)
             switch result {
             case .success(let title):
                 await graph.upsertPost(SiteContentGraph.Post(

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -75,6 +75,7 @@ final class SiteNavigatorModel {
     }
 
     func cancelEditing() {
+        draftTitle = ""
         editingItemID = nil
     }
 

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -5,16 +5,14 @@ import AnglesiteCore
 /// changes and either navigates the preview or opens the editor.
 struct SiteNavigatorView: View {
     @Bindable var model: SiteNavigatorModel
+    @FocusState private var editingFocused: Bool
 
     var body: some View {
         List(selection: $model.selection) {
             ForEach(model.sections) { section in
                 Section(section.title) {
                     ForEach(section.items) { item in
-                        Label(item.title, systemImage: icon(for: section.id))
-                            .tag(item.id)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
+                        row(for: item, in: section)
                     }
                 }
             }
@@ -24,6 +22,53 @@ struct SiteNavigatorView: View {
             if model.sections.isEmpty {
                 ContentUnavailableView("No content yet", systemImage: "sidebar.left")
             }
+        }
+        .background {
+            Button("") {
+                if let id = model.selection, model.editingItemID == nil, model.canRename(id) {
+                    model.beginEditing(id)
+                }
+            }
+            .keyboardShortcut(.return, modifiers: [])
+            .hidden()
+        }
+        .alert(
+            "Rename failed",
+            isPresented: Binding(
+                get: { model.renameError != nil },
+                set: { if !$0 { model.renameError = nil } }),
+            presenting: model.renameError
+        ) { _ in
+            Button("OK", role: .cancel) { model.renameError = nil }
+        } message: { msg in
+            Text(msg)
+        }
+    }
+
+    @ViewBuilder
+    private func row(for item: NavigatorItem, in section: NavigatorSection) -> some View {
+        if model.editingItemID == item.id {
+            TextField("Title", text: $model.draftTitle)
+                .textFieldStyle(.plain)
+                .focused($editingFocused)
+                .onSubmit { Task { await model.commitEditing() } }
+                .onExitCommand { model.cancelEditing() }   // Esc
+                .onChange(of: editingFocused) { _, focused in
+                    // Clicking away ends editing without committing.
+                    if !focused && model.editingItemID == item.id { model.cancelEditing() }
+                }
+                .task { editingFocused = true }
+                .tag(item.id)
+        } else {
+            Label(item.title, systemImage: icon(for: section.id))
+                .tag(item.id)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .contextMenu {
+                    if model.canRename(item.id) {
+                        Button("Rename") { model.beginEditing(item.id) }
+                    }
+                }
         }
     }
 

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -31,6 +31,9 @@ struct SiteNavigatorView: View {
             }
             .keyboardShortcut(.return, modifiers: [])
             .hidden()
+            // Disabled while editing: otherwise this default-button shortcut swallows Return
+            // before the focused TextField's onSubmit, so commits never fire (#299 review).
+            .disabled(model.editingItemID != nil)
         }
         .alert(
             "Rename failed",
@@ -54,8 +57,13 @@ struct SiteNavigatorView: View {
                 .onSubmit { Task { await model.commitEditing() } }
                 .onExitCommand { model.cancelEditing() }   // Esc
                 .onChange(of: editingFocused) { _, focused in
-                    // Clicking away ends editing without committing.
-                    if !focused && model.editingItemID == item.id { model.cancelEditing() }
+                    // TextField.onSubmit does not fire reliably inside a sidebar List on macOS — Return is
+                    // consumed by the list and only surfaces as focus loss. So commit on focus loss
+                    // (Return / Tab / click-away, Finder-style). Esc cancels first via onExitCommand,
+                    // which clears editingItemID, so this guard then skips the commit.
+                    if !focused && model.editingItemID == item.id {
+                        Task { await model.commitEditing() }
+                    }
                 }
                 .task { editingFocused = true }
                 .tag(item.id)

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -31,6 +31,9 @@ struct SiteNavigatorView: View {
             }
             .keyboardShortcut(.return, modifiers: [])
             .hidden()
+            // `.hidden()` still exposes the empty-label button to VoiceOver; keep it out of the
+            // accessibility tree (it's a keyboard-shortcut affordance, not a real control).
+            .accessibilityHidden(true)
             // Disabled while editing: otherwise this default-button shortcut swallows Return
             // before the focused TextField's onSubmit, so commits never fire (#299 review).
             .disabled(model.editingItemID != nil)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -652,7 +652,7 @@ struct SiteWindow: View {
         // this creation and stop the freshly-made navigator instead.
         navigator?.stop()
         let navModel = SiteNavigatorModel(graph: contentGraph)
-        navModel.start(siteID: resolved.id, siteRoot: resolved.packageURL)
+        navModel.start(siteID: resolved.id, siteRoot: resolved.packageURL, sourceDirectory: resolved.sourceDirectory)
         navigator = navModel
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.

--- a/Sources/AnglesiteCore/ContentScanner.swift
+++ b/Sources/AnglesiteCore/ContentScanner.swift
@@ -83,9 +83,21 @@ public enum ContentScanner {
         let range = NSRange(text.startIndex..<text.endIndex, in: text)
         guard let m = titleAttrRegex.firstMatch(in: text, range: range) else { return nil }
         for group in [1, 2] {
-            if let r = Range(m.range(at: group), in: text) { return String(text[r]) }
+            if let r = Range(m.range(at: group), in: text) {
+                return decodeHTMLEntities(String(text[r]))
+            }
         }
         return nil
+    }
+
+    /// Decode exactly the five HTML entities emitted by `PageTitleEditor.attrEscaped(_:delimiter:)`.
+    /// `&amp;` is decoded last so that `&amp;lt;` becomes `&lt;` rather than `<`.
+    private static func decodeHTMLEntities(_ s: String) -> String {
+        s.replacingOccurrences(of: "&lt;",   with: "<")
+         .replacingOccurrences(of: "&gt;",   with: ">")
+         .replacingOccurrences(of: "&quot;", with: "\"")
+         .replacingOccurrences(of: "&#39;",  with: "'")
+         .replacingOccurrences(of: "&amp;",  with: "&")
     }
 
     // MARK: - Posts

--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -113,12 +113,57 @@ public enum Frontmatter {
         return .string(unquote(raw))
     }
 
-    /// Strip a single layer of matching `"` or `'` quotes, else return as-is.
+    /// Strip a single layer of matching `"` or `'` quotes and decode YAML escapes, else return as-is.
+    ///
+    /// - Double-quoted scalars: single-pass `\` decoding — `\"`→`"`, `\\`→`\`, `\n`→newline,
+    ///   `\t`→tab; unknown sequences keep both the backslash and the following character.
+    /// - Single-quoted scalars: `''`→`'` (YAML single-quote doubling). No backslash processing.
+    /// - Unquoted scalars: returned unchanged.
     private static func unquote(_ s: String) -> String {
-        if s.count >= 2,
-           (s.hasPrefix("\"") && s.hasSuffix("\"")) || (s.hasPrefix("'") && s.hasSuffix("'")) {
-            return String(s.dropFirst().dropLast())
+        guard s.count >= 2 else { return s }
+        if s.hasPrefix("\"") && s.hasSuffix("\"") {
+            return decodeDoubleQuoted(String(s.dropFirst().dropLast()))
+        }
+        if s.hasPrefix("'") && s.hasSuffix("'") {
+            // YAML single-quoted: only escape is '' → '
+            return String(s.dropFirst().dropLast()).replacingOccurrences(of: "''", with: "'")
         }
         return s
+    }
+
+    /// Single-pass YAML double-quoted escape decoder. Processes each character once so that
+    /// `\\n` (two source chars) decodes to `\` + `n` (not newline), guarding the chained-replace
+    /// pitfall.
+    private static func decodeDoubleQuoted(_ inner: String) -> String {
+        var result = ""
+        result.reserveCapacity(inner.unicodeScalars.count)
+        var idx = inner.startIndex
+        while idx < inner.endIndex {
+            let ch = inner[idx]
+            if ch == "\\" {
+                let next = inner.index(after: idx)
+                if next < inner.endIndex {
+                    switch inner[next] {
+                    case "\"": result.append("\"")
+                    case "\\": result.append("\\")
+                    case "n":  result.append("\n")
+                    case "t":  result.append("\t")
+                    default:
+                        // Unknown escape: keep backslash + char unchanged.
+                        result.append("\\")
+                        result.append(inner[next])
+                    }
+                    idx = inner.index(after: next)
+                } else {
+                    // Trailing backslash with no following char — keep it.
+                    result.append("\\")
+                    idx = next
+                }
+            } else {
+                result.append(ch)
+                idx = inner.index(after: idx)
+            }
+        }
+        return result
     }
 }

--- a/Sources/AnglesiteCore/NavigatorRenameService.swift
+++ b/Sources/AnglesiteCore/NavigatorRenameService.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// The page/post re-title pipeline: load the file, rewrite its title via `PageTitleEditor`, save,
+/// then commit best-effort. I/O and git are injected so the flow is unit-testable; the defaults are
+/// the real `FileDocumentIO` + `NativeContentOperations.processGitCommit`. Lives in AnglesiteCore
+/// (not the app-target model) so `swift test` covers it — the same split as `TokenOnboarding`.
+public struct NavigatorRenameService: Sendable {
+    public enum RenameError: Error, Equatable {
+        case emptyTitle
+        case noEditableLocation
+        case io(String)
+    }
+
+    public typealias GitCommit = NativeContentOperations.GitCommit
+
+    private let loadContents: @Sendable (URL) throws -> String
+    private let saveContents: @Sendable (String, URL) throws -> Void
+    private let gitCommit: GitCommit
+
+    public init(
+        loadContents: @escaping @Sendable (URL) throws -> String = { try FileDocumentIO.load($0).contents },
+        saveContents: @escaping @Sendable (String, URL) throws -> Void = { try FileDocumentIO.save($0, to: $1) },
+        gitCommit: @escaping GitCommit = NativeContentOperations.processGitCommit
+    ) {
+        self.loadContents = loadContents
+        self.saveContents = saveContents
+        self.gitCommit = gitCommit
+    }
+
+    public func rename(
+        fileURL: URL,
+        fileExtension: String,
+        projectRoot: URL,
+        relativePath: String,
+        newTitle: String
+    ) async -> Result<String, RenameError> {
+        let contents: String
+        do { contents = try loadContents(fileURL) }
+        catch { return .failure(.io("\(error)")) }
+
+        let rewritten: String
+        switch PageTitleEditor.rewrite(contents: contents, fileExtension: fileExtension, newTitle: newTitle) {
+        case .success(let s): rewritten = s
+        case .failure(.emptyTitle): return .failure(.emptyTitle)
+        case .failure(.noEditableLocation): return .failure(.noEditableLocation)
+        }
+
+        do { try saveContents(rewritten, fileURL) }
+        catch { return .failure(.io("\(error)")) }
+
+        let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Best-effort: a failed commit (not a repo, rejecting hook, git missing) is ignored —
+        // the file is saved and is the source of truth. Mirrors NativeContentOperations.
+        _ = await gitCommit(projectRoot, relativePath, "anglesite: rename title to \"\(trimmed)\"")
+        return .success(trimmed)
+    }
+}

--- a/Sources/AnglesiteCore/PageTitleEditor.swift
+++ b/Sources/AnglesiteCore/PageTitleEditor.swift
@@ -37,17 +37,25 @@ public enum PageTitleEditor {
     private static func rewriteMarkdown(_ contents: String, title: String) -> String {
         let yaml = "title: \(yamlQuoted(title))"
 
-        // A frontmatter block must start at byte 0 with `---` on its own line.
-        guard contents.hasPrefix("---\n") || contents == "---" || contents.hasPrefix("---\r\n") else {
-            return "---\n\(yaml)\n---\n\n\(contents)"
+        // Work in LF internally so the line logic is newline-agnostic, then restore CRLF on output
+        // if the source used it. (A trailing `\r` left on each split line would make `lines[0]`
+        // `"---\r"`, so the closing `---` fence is never found and a duplicate block gets prepended.)
+        let usesCRLF = contents.contains("\r\n")
+        let normalized = usesCRLF ? contents.replacingOccurrences(of: "\r\n", with: "\n") : contents
+        func finish(_ s: String) -> String {
+            usesCRLF ? s.replacingOccurrences(of: "\n", with: "\r\n") : s
         }
 
-        // Normalize to \n for line work; the templates use \n.
-        var lines = contents.components(separatedBy: "\n")
+        // A frontmatter block must start at byte 0 with `---` on its own line.
+        guard normalized.hasPrefix("---\n") || normalized == "---" else {
+            return finish("---\n\(yaml)\n---\n\n\(normalized)")
+        }
+
+        var lines = normalized.components(separatedBy: "\n")
         // lines[0] == "---". Find the closing fence.
         guard let close = lines.dropFirst().firstIndex(of: "---") else {
             // Malformed (no closing fence) — treat as no frontmatter and prepend a fresh block.
-            return "---\n\(yaml)\n---\n\n\(contents)"
+            return finish("---\n\(yaml)\n---\n\n\(normalized)")
         }
 
         // Look for an existing top-level `title:` between the fences.
@@ -56,7 +64,7 @@ public enum PageTitleEditor {
         } else {
             lines.insert(yaml, at: 1)
         }
-        return lines.joined(separator: "\n")
+        return finish(lines.joined(separator: "\n"))
     }
 
     /// The top-level key of a frontmatter line (`title: "x"` → `title`), or nil for indented /

--- a/Sources/AnglesiteCore/PageTitleEditor.swift
+++ b/Sources/AnglesiteCore/PageTitleEditor.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Rewrites a page/post's *title* in place — frontmatter `title:` for markdown-family files,
+/// the first `title="…"`/`title='…'` attribute for `.astro`/`.html`. Pure and I/O-free so the
+/// transform is fully unit-testable; `NavigatorRenameService` owns the disk + git side.
+///
+/// `.astro` files use a JavaScript component script between `---` fences (NOT YAML), so we never
+/// write YAML frontmatter there — the title lives in the layout invocation's `title=` prop.
+public enum PageTitleEditor {
+    public enum RewriteError: Error, Equatable {
+        case emptyTitle
+        case noEditableLocation
+    }
+
+    private static let markdownExts: Set<String> = ["md", "mdx", "mdoc", "markdown"]
+    private static let attributeExts: Set<String> = ["astro", "html"]
+
+    public static func rewrite(
+        contents: String,
+        fileExtension: String,
+        newTitle: String
+    ) -> Result<String, RewriteError> {
+        let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .failure(.emptyTitle) }
+
+        let ext = fileExtension.lowercased()
+        if markdownExts.contains(ext) { return .success(rewriteMarkdown(contents, title: trimmed)) }
+        if attributeExts.contains(ext) { return rewriteAttribute(contents, title: trimmed) }
+        // Unknown extension: nowhere defined to write a title.
+        return .failure(.noEditableLocation)
+    }
+
+    // MARK: - Markdown frontmatter
+
+    /// Replace the `title:` line inside a leading `---` block, insert one if the block lacks it,
+    /// or synthesize a block at the top of the file.
+    private static func rewriteMarkdown(_ contents: String, title: String) -> String {
+        let yaml = "title: \(yamlQuoted(title))"
+
+        // A frontmatter block must start at byte 0 with `---` on its own line.
+        guard contents.hasPrefix("---\n") || contents == "---" || contents.hasPrefix("---\r\n") else {
+            return "---\n\(yaml)\n---\n\n\(contents)"
+        }
+
+        // Normalize to \n for line work; the templates use \n.
+        var lines = contents.components(separatedBy: "\n")
+        // lines[0] == "---". Find the closing fence.
+        guard let close = lines.dropFirst().firstIndex(of: "---") else {
+            // Malformed (no closing fence) — treat as no frontmatter and prepend a fresh block.
+            return "---\n\(yaml)\n---\n\n\(contents)"
+        }
+
+        // Look for an existing top-level `title:` between the fences.
+        if let titleIdx = (1..<close).first(where: { lineKey(lines[$0]) == "title" }) {
+            lines[titleIdx] = yaml
+        } else {
+            lines.insert(yaml, at: 1)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// The top-level key of a frontmatter line (`title: "x"` → `title`), or nil for indented /
+    /// keyless lines. Mirrors `Frontmatter`'s "top-level keys only" rule.
+    private static func lineKey(_ line: String) -> String? {
+        guard let first = line.first, first != " ", first != "\t" else { return nil }
+        guard let colon = line.firstIndex(of: ":") else { return nil }
+        return String(line[line.startIndex..<colon]).trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Double-quote a YAML scalar, escaping `\` then `"`.
+    private static func yamlQuoted(_ s: String) -> String {
+        let escaped = s.replacingOccurrences(of: "\\", with: "\\\\")
+                       .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+
+    // MARK: - Attribute (astro / html)
+
+    /// Port of `ContentScanner.titleAttrRegex` — the first `title="…"` or `title='…'`.
+    private static let titleAttrRegex = try! NSRegularExpression(
+        pattern: #"\btitle\s*=\s*(?:"([^"]*)"|'([^']*)')"#
+    )
+
+    private static func rewriteAttribute(_ contents: String, title: String) -> Result<String, RewriteError> {
+        let full = NSRange(contents.startIndex..<contents.endIndex, in: contents)
+        guard let match = titleAttrRegex.firstMatch(in: contents, range: full) else {
+            return .failure(.noEditableLocation)
+        }
+        // Which capture group matched tells us the delimiter: group 1 = ", group 2 = '.
+        let usesDouble = match.range(at: 1).location != NSNotFound
+        let delimiter: Character = usesDouble ? "\"" : "'"
+        let replacement = "title=\(delimiter)\(attrEscaped(title, delimiter: delimiter))\(delimiter)"
+        guard let whole = Range(match.range, in: contents) else { return .failure(.noEditableLocation) }
+        return .success(contents.replacingCharacters(in: whole, with: replacement))
+    }
+
+    /// HTML-attribute-escape: always `&` and `<`/`>`, plus the active quote delimiter.
+    private static func attrEscaped(_ s: String, delimiter: Character) -> String {
+        var out = s.replacingOccurrences(of: "&", with: "&amp;")
+                   .replacingOccurrences(of: "<", with: "&lt;")
+                   .replacingOccurrences(of: ">", with: "&gt;")
+        out = delimiter == "\""
+            ? out.replacingOccurrences(of: "\"", with: "&quot;")
+            : out.replacingOccurrences(of: "'", with: "&#39;")
+        return out
+    }
+}

--- a/Tests/AnglesiteCoreTests/ContentScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScannerTests.swift
@@ -145,4 +145,19 @@ struct ContentScannerTests {
         let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
         #expect(pages.first?.title == "&lt;")
     }
+
+    @Test("round-trip: single-quoted .astro title with special chars survives rewrite → scan")
+    func astroSingleQuoteRoundTrip() {
+        // PageTitleEditor.attrEscaped (writer) must be symmetric with decodeHTMLEntities (reader),
+        // including the single-quote delimiter branch (&#39;).
+        let original = "Ben & Jerry's <Best> 'Picks'"
+        let written = PageTitleEditor.rewrite(
+            contents: "<Layout title='Old' />", fileExtension: "astro", newTitle: original)
+        guard case let .success(content) = written else {
+            Issue.record("rewrite failed: \(written)"); return
+        }
+        let root = makeSite(["src/pages/rt.astro": content])
+        let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
+        #expect(pages.first?.title == original)
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContentScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScannerTests.swift
@@ -112,4 +112,37 @@ struct ContentScannerTests {
         #expect(listing.posts.isEmpty)
         #expect(listing.images.isEmpty)
     }
+
+    // MARK: - HTML entity decoding in title attribute (Fix 2)
+
+    @Test("page title: title= attribute HTML entities are decoded")
+    func pageTitleAttrEntityDecoding() {
+        // Writer emits: title="Tom &amp; &quot;X&quot;"  for original title: Tom & "X"
+        let root = makeSite([
+            "src/pages/test.astro": "<Layout title=\"Tom &amp; &quot;X&quot;\" />"
+        ])
+        let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
+        #expect(pages.first?.title == "Tom & \"X\"")
+    }
+
+    @Test("page title: all five emitted entities decode correctly")
+    func pageTitleAttrAllEntities() {
+        // &amp; &lt; &gt; &quot; &#39;
+        let root = makeSite([
+            "src/pages/ent.astro": "<L title=\"a&amp;b&lt;c&gt;d&quot;e&#39;f\" />"
+        ])
+        let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
+        #expect(pages.first?.title == "a&b<c>d\"e'f")
+    }
+
+    @Test("page title: &amp;lt; decodes to &lt; not < (amp decoded last)")
+    func pageTitleAttrAmpLast() {
+        // If &amp; is decoded first, &amp;lt; would become &lt; then < — wrong.
+        // Correct: &amp;lt; → &lt; (only one decode pass, amp last).
+        let root = makeSite([
+            "src/pages/amp.astro": "<L title=\"&amp;lt;\" />"
+        ])
+        let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
+        #expect(pages.first?.title == "&lt;")
+    }
 }

--- a/Tests/AnglesiteCoreTests/FrontmatterTests.swift
+++ b/Tests/AnglesiteCoreTests/FrontmatterTests.swift
@@ -65,4 +65,46 @@ struct FrontmatterTests {
         #expect(fm["title"] == .string("T"))
         #expect(fm["draft"] == .bool(true))
     }
+
+    // MARK: - YAML escape decoding (Fix 1)
+
+    @Test("double-quoted scalar: decodes \\\" and \\\\ escapes")
+    func doubleQuotedEscapes() {
+        // Source line: title: "a\"b\\c"  — writer output for title a"b\c
+        let fm = Frontmatter.parse("---\ntitle: \"a\\\"b\\\\c\"\n---")
+        #expect(fm["title"] == .string("a\"b\\c"))
+    }
+
+    @Test("double-quoted scalar: \\n decodes to newline, \\t to tab")
+    func doubleQuotedNewlineTab() {
+        let fm = Frontmatter.parse("---\ntitle: \"line1\\nline2\"\ntag: \"a\\tb\"\n---")
+        #expect(fm["title"] == .string("line1\nline2"))
+        #expect(fm["tag"] == .string("a\tb"))
+    }
+
+    @Test("double-quoted scalar: \\\\n is backslash-then-n, NOT newline (single-pass guard)")
+    func doubleQuotedBackslashBackslashN() {
+        // Source: "a\\nb"  — escaped form of title a\nb (backslash then literal n)
+        let fm = Frontmatter.parse("---\ntitle: \"a\\\\nb\"\n---")
+        #expect(fm["title"] == .string("a\\nb"))
+    }
+
+    @Test("double-quoted scalar: unknown escape keeps backslash+char")
+    func doubleQuotedUnknownEscape() {
+        let fm = Frontmatter.parse("---\ntitle: \"hello\\xworld\"\n---")
+        #expect(fm["title"] == .string("hello\\xworld"))
+    }
+
+    @Test("single-quoted scalar: '' decodes to single quote")
+    func singleQuotedDoubling() {
+        // YAML single-quoted escape: '' → '
+        let fm = Frontmatter.parse("---\ntitle: 'it''s a test'\n---")
+        #expect(fm["title"] == .string("it's a test"))
+    }
+
+    @Test("unquoted scalar: returned as-is (no escape processing)")
+    func unquotedUnchanged() {
+        let fm = Frontmatter.parse("---\ntitle: plain value\n---")
+        #expect(fm["title"] == .string("plain value"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/NavigatorRenameServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/NavigatorRenameServiceTests.swift
@@ -61,6 +61,19 @@ struct NavigatorRenameServiceTests {
         if case .failure(.io) = r {} else { Issue.record("expected .io, got \(r)") }
     }
 
+    @Test("io: load failure maps to .io and never saves")
+    func loadFailure() async {
+        struct Boom: Error {}
+        let saved = Locked<Bool>(false)
+        let svc = NavigatorRenameService(
+            loadContents: { _ in throw Boom() },
+            saveContents: { _, _ in saved.set(true) },
+            gitCommit: { _, _, _ in "x" })
+        let r = await svc.rename(fileURL: url, fileExtension: "md", projectRoot: root, relativePath: "p.md", newTitle: "New")
+        if case .failure(.io) = r {} else { Issue.record("expected .io, got \(r)") }
+        #expect(saved.get() == false)
+    }
+
     @Test("git failure is best-effort: still success and the save happened")
     func gitBestEffort() async {
         let saved = Locked<Bool>(false)

--- a/Tests/AnglesiteCoreTests/NavigatorRenameServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/NavigatorRenameServiceTests.swift
@@ -1,0 +1,83 @@
+// Tests/AnglesiteCoreTests/NavigatorRenameServiceTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("NavigatorRenameService")
+struct NavigatorRenameServiceTests {
+    private let url = URL(fileURLWithPath: "/site/src/content/posts/p.md")
+    private let root = URL(fileURLWithPath: "/site")
+
+    @Test("success: rewrites markdown title, saves, commits, returns trimmed title")
+    func success() async {
+        let saved = Locked<String?>(nil)
+        let committed = Locked<(String, String)?>(nil)
+        let svc = NavigatorRenameService(
+            loadContents: { _ in "---\ntitle: \"Old\"\n---\n\nBody\n" },
+            saveContents: { contents, _ in saved.set(contents) },
+            gitCommit: { _, rel, msg in committed.set((rel, msg)); return "deadbeef" }
+        )
+        let result = await svc.rename(
+            fileURL: url, fileExtension: "md", projectRoot: root,
+            relativePath: "src/content/posts/p.md", newTitle: "  New  ")
+        #expect(result == .success("New"))
+        #expect(saved.get()?.contains("title: \"New\"") == true)
+        #expect(committed.get()?.0 == "src/content/posts/p.md")
+        #expect(committed.get()?.1.contains("New") == true)
+    }
+
+    @Test("emptyTitle: never saves")
+    func emptyTitle() async {
+        let saved = Locked<Bool>(false)
+        let svc = NavigatorRenameService(
+            loadContents: { _ in "---\ntitle: \"Old\"\n---\n" },
+            saveContents: { _, _ in saved.set(true) },
+            gitCommit: { _, _, _ in "x" })
+        let r = await svc.rename(fileURL: url, fileExtension: "md", projectRoot: root, relativePath: "p.md", newTitle: " ")
+        #expect(r == .failure(.emptyTitle))
+        #expect(saved.get() == false)
+    }
+
+    @Test("noEditableLocation: astro without a title attribute never saves")
+    func noLocation() async {
+        let saved = Locked<Bool>(false)
+        let svc = NavigatorRenameService(
+            loadContents: { _ in "<BaseLayout description=\"d\" />" },
+            saveContents: { _, _ in saved.set(true) },
+            gitCommit: { _, _, _ in "x" })
+        let r = await svc.rename(fileURL: url, fileExtension: "astro", projectRoot: root, relativePath: "p.astro", newTitle: "New")
+        #expect(r == .failure(.noEditableLocation))
+        #expect(saved.get() == false)
+    }
+
+    @Test("io: save failure maps to .io")
+    func ioFailure() async {
+        struct Boom: Error {}
+        let svc = NavigatorRenameService(
+            loadContents: { _ in "---\ntitle: \"Old\"\n---\n" },
+            saveContents: { _, _ in throw Boom() },
+            gitCommit: { _, _, _ in "x" })
+        let r = await svc.rename(fileURL: url, fileExtension: "md", projectRoot: root, relativePath: "p.md", newTitle: "New")
+        if case .failure(.io) = r {} else { Issue.record("expected .io, got \(r)") }
+    }
+
+    @Test("git failure is best-effort: still success and the save happened")
+    func gitBestEffort() async {
+        let saved = Locked<Bool>(false)
+        let svc = NavigatorRenameService(
+            loadContents: { _ in "---\ntitle: \"Old\"\n---\n" },
+            saveContents: { _, _ in saved.set(true) },
+            gitCommit: { _, _, _ in nil })
+        let r = await svc.rename(fileURL: url, fileExtension: "md", projectRoot: root, relativePath: "p.md", newTitle: "New")
+        #expect(r == .success("New"))
+        #expect(saved.get() == true)
+    }
+}
+
+/// Minimal thread-safe box so the @Sendable injection closures can record calls.
+private final class Locked<T>: @unchecked Sendable {
+    private let lock = NSLock(); private var value: T
+    init(_ v: T) { value = v }
+    func set(_ v: T) { lock.lock(); value = v; lock.unlock() }
+    func get() -> T { lock.lock(); defer { lock.unlock() }; return value }
+}

--- a/Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
@@ -113,4 +113,29 @@ struct PageTitleEditorTests {
         let r = PageTitleEditor.rewrite(contents: "---\ntitle: \"x\"\n---\n", fileExtension: "txt", newTitle: "New")
         #expect(r == .failure(.noEditableLocation))
     }
+
+    // MARK: - CRLF line endings
+
+    @Test("markdown CRLF: updates the title in place, no duplicate block, CRLF preserved")
+    func mdCRLF() {
+        let src = "---\r\ntitle: \"Old\"\r\npubDate: 2026-01-01\r\n---\r\n\r\nBody\r\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "md", newTitle: "New"))
+        // Title updated, parses back, and exactly one frontmatter block (no duplicate prepend).
+        #expect(Frontmatter.parse(out)["title"] == .string("New"))
+        #expect(out.components(separatedBy: "---").count == 3)
+        // Line endings preserved (no bare LF introduced).
+        #expect(!out.replacingOccurrences(of: "\r\n", with: "").contains("\n"))
+        #expect(out.contains("pubDate: 2026-01-01"))
+    }
+
+    // MARK: - lineKey matches top-level keys only
+
+    @Test("markdown: a `title:` substring inside another field's value is not mistaken for the key")
+    func mdTitleSubstringInValue() {
+        let src = "---\ndescription: \"has a title: suffix\"\ntitle: \"Old\"\n---\n\nBody\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "md", newTitle: "New"))
+        #expect(Frontmatter.parse(out)["title"] == .string("New"))
+        // The description value is untouched.
+        #expect(out.contains("description: \"has a title: suffix\""))
+    }
 }

--- a/Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
@@ -1,0 +1,80 @@
+// Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite("PageTitleEditor")
+struct PageTitleEditorTests {
+    private func ok(_ r: Result<String, PageTitleEditor.RewriteError>) -> String {
+        guard case let .success(s) = r else { Issue.record("expected success, got \(r)"); return "" }
+        return s
+    }
+
+    @Test("markdown: replaces an existing frontmatter title")
+    func mdReplace() {
+        let src = "---\ntitle: \"Old\"\npubDate: 2026-01-01\n---\n\nBody\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "md", newTitle: "New"))
+        #expect(out == "---\ntitle: \"New\"\npubDate: 2026-01-01\n---\n\nBody\n")
+    }
+
+    @Test("markdown: inserts title when frontmatter has none")
+    func mdInsert() {
+        let src = "---\npubDate: 2026-01-01\n---\n\nBody\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "mdx", newTitle: "New"))
+        #expect(out == "---\ntitle: \"New\"\npubDate: 2026-01-01\n---\n\nBody\n")
+    }
+
+    @Test("markdown: synthesizes a frontmatter block when absent")
+    func mdSynthesize() {
+        let src = "Just body, no frontmatter.\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "markdown", newTitle: "New"))
+        #expect(out == "---\ntitle: \"New\"\n---\n\nJust body, no frontmatter.\n")
+    }
+
+    @Test("astro: replaces a double-quoted title attribute, preserving the rest")
+    func astroDouble() {
+        let src = "---\nimport BaseLayout from \"../layouts/BaseLayout.astro\";\n---\n\n<BaseLayout title=\"Old Home\" description=\"d\">\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "astro", newTitle: "New Home"))
+        #expect(out.contains("title=\"New Home\""))
+        #expect(out.contains("description=\"d\""))
+        #expect(!out.contains("Old Home"))
+    }
+
+    @Test("astro: replaces a single-quoted title attribute")
+    func astroSingle() {
+        let src = "<BaseLayout title='Old' />"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "astro", newTitle: "New"))
+        #expect(out.contains("title='New'"))
+    }
+
+    @Test("html: replaces a title attribute")
+    func htmlAttr() {
+        let src = "<x title=\"Old\">"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "html", newTitle: "New"))
+        #expect(out == "<x title=\"New\">")
+    }
+
+    @Test("astro: no title attribute → noEditableLocation")
+    func astroNoAttr() {
+        let r = PageTitleEditor.rewrite(contents: "<BaseLayout description=\"d\" />", fileExtension: "astro", newTitle: "New")
+        #expect(r == .failure(.noEditableLocation))
+    }
+
+    @Test("empty or whitespace title → emptyTitle for any type")
+    func empty() {
+        #expect(PageTitleEditor.rewrite(contents: "---\ntitle: \"x\"\n---\n", fileExtension: "md", newTitle: "  ") == .failure(.emptyTitle))
+        #expect(PageTitleEditor.rewrite(contents: "<a title=\"x\">", fileExtension: "astro", newTitle: "") == .failure(.emptyTitle))
+    }
+
+    @Test("markdown: YAML-escapes quotes and backslashes")
+    func mdEscape() {
+        let out = ok(PageTitleEditor.rewrite(contents: "---\ntitle: \"x\"\n---\n", fileExtension: "md", newTitle: "a\"b\\c"))
+        #expect(out.contains("title: \"a\\\"b\\\\c\""))
+    }
+
+    @Test("astro: HTML-escapes the title value, preserving quote style")
+    func astroEscape() {
+        let out = ok(PageTitleEditor.rewrite(contents: "<a title=\"x\">", fileExtension: "astro", newTitle: "Tom & \"Jerry\" <b>"))
+        // Double-quoted delimiter: escape &, <, and the " delimiter; ' may stay literal.
+        #expect(out.contains("title=\"Tom &amp; &quot;Jerry&quot; &lt;b&gt;\""))
+    }
+}

--- a/Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
@@ -77,4 +77,40 @@ struct PageTitleEditorTests {
         // Double-quoted delimiter: escape &, <, and the " delimiter; ' may stay literal.
         #expect(out.contains("title=\"Tom &amp; &quot;Jerry&quot; &lt;b&gt;\""))
     }
+
+    // MARK: - Round-trip tests (Fix 1: Frontmatter.unquote decodes YAML escapes)
+
+    @Test("round-trip: markdown with quotes and backslashes survives write→parse")
+    func roundTripMarkdownEscapes() {
+        let originalTitle = "a\"b\\c&more"
+        let src = "---\ntitle: \"old\"\n---\nbody\n"
+        let rewritten = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "md", newTitle: originalTitle))
+        // Frontmatter.parse should now decode the YAML escapes and return the original title.
+        let parsed = Frontmatter.parse(rewritten)
+        #expect(parsed["title"] == .string(originalTitle))
+    }
+
+    @Test("round-trip: title with only backslash survives write→parse")
+    func roundTripBackslash() {
+        let originalTitle = "a\\b"
+        let src = "---\ntitle: \"x\"\n---\n"
+        let rewritten = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "md", newTitle: originalTitle))
+        let parsed = Frontmatter.parse(rewritten)
+        #expect(parsed["title"] == .string(originalTitle))
+    }
+
+    // MARK: - Missing coverage: mdoc extension and unknown extension
+
+    @Test("mdoc: replaces frontmatter title (mdoc is a markdown-family extension)")
+    func mdocReplace() {
+        let src = "---\ntitle: \"Old\"\n---\nBody\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "mdoc", newTitle: "New"))
+        #expect(out.contains("title: \"New\""))
+    }
+
+    @Test("unknown extension → noEditableLocation")
+    func unknownExtension() {
+        let r = PageTitleEditor.rewrite(contents: "---\ntitle: \"x\"\n---\n", fileExtension: "txt", newTitle: "New")
+        #expect(r == .failure(.noEditableLocation))
+    }
 }

--- a/docs/superpowers/plans/2026-06-23-navigator-rename-title.md
+++ b/docs/superpowers/plans/2026-06-23-navigator-rename-title.md
@@ -1,0 +1,781 @@
+# Navigator Page/Post Re-titling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user re-title a page or post in the project navigator by control-clicking the name and editing it in place (Finder-style), writing the new title to the correct location for the file type without moving the file or changing its URL.
+
+**Architecture:** A pure, fully-tested `PageTitleEditor` (AnglesiteCore) rewrites a file's title in memory — frontmatter `title:` for markdown, the `title="…"` attribute for `.astro`/`.html`. A `NavigatorRenameService` (AnglesiteCore) wires load → rewrite → save → best-effort git commit behind injected I/O seams so it is unit-testable. The app-target `SiteNavigatorModel` adds thin edit-state glue (begin/cancel/commit, `canRename`, error surface) and reflects the new title into `SiteContentGraph` via `upsertPage`/`upsertPost`; `SiteNavigatorView` renders an inline `TextField` plus a Rename context menu and Return-key path.
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27), Swift Testing (`@Test`), the existing `SiteContentGraph` actor, `FileDocumentIO`, and `NativeContentOperations.processGitCommit`.
+
+## Global Constraints
+
+- **Toolchain:** Xcode 27+ / Swift 6.4. `xcode-select -p` is already `/Applications/Xcode-beta.app/Contents/Developer`; if a run picks the wrong toolchain, prefix with `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer`.
+- **Run Core tests with:** `swift test --package-path . --filter <Name>` from the worktree root `/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/navigator-rename`.
+- **App-target build check:** `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`. The xcodeproj is generated; run `xcodegen generate` first if it is missing, and run `scripts/copy-plugin.sh` (with `ANGLESITE_PLUGIN_SRC` pointing at the real plugin checkout) if the build complains about `Resources/plugin`.
+- **ES Modules / vanilla:** N/A — this is pure Swift; no new third-party deps.
+- **Tests:** Swift Testing `@Test` in `@Suite` structs (see `Tests/AnglesiteCoreTests/ContentScannerTests.swift` for the temp-dir helper pattern). No XCTest.
+- **Commits:** Conventional commits, one per task. End every commit message body with:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- **Title-only invariant:** never change a file's path, name, or route. Only the title text changes.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `Sources/AnglesiteCore/PageTitleEditor.swift` | Pure title rewrite per file type | 1 |
+| `Tests/AnglesiteCoreTests/PageTitleEditorTests.swift` | Unit tests for the rewrite | 1 |
+| `Sources/AnglesiteCore/NavigatorRenameService.swift` | load → rewrite → save → best-effort commit | 2 |
+| `Tests/AnglesiteCoreTests/NavigatorRenameServiceTests.swift` | Unit tests for the flow | 2 |
+| `Sources/AnglesiteApp/SiteNavigatorModel.swift` | Edit-state glue, `canRename`, graph upsert, error surface, `sourceDirectory` | 3 |
+| `Sources/AnglesiteApp/SiteWindow.swift` | Pass `sourceDirectory` into `start(...)` | 3 |
+| `Sources/AnglesiteApp/SiteNavigatorView.swift` | Inline `TextField`, Rename menu, Return key, error alert | 4 |
+
+---
+
+## Task 1: `PageTitleEditor` (pure rewrite core)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/PageTitleEditor.swift`
+- Test: `Tests/AnglesiteCoreTests/PageTitleEditorTests.swift`
+
+**Interfaces:**
+- Consumes: nothing (pure, stdlib only).
+- Produces:
+  ```swift
+  public enum PageTitleEditor {
+      public enum RewriteError: Error, Equatable { case emptyTitle, noEditableLocation }
+      public static func rewrite(contents: String, fileExtension: String, newTitle: String)
+          -> Result<String, RewriteError>
+  }
+  ```
+  `fileExtension` is the lowercased extension **without** a leading dot (e.g. `"astro"`, `"md"`). Markdown family = `md`, `mdx`, `mdoc`, `markdown`. Attribute family = `astro`, `html`. Returns the full rewritten file contents on success.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/PageTitleEditorTests.swift`:
+
+```swift
+// Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite("PageTitleEditor")
+struct PageTitleEditorTests {
+    private func ok(_ r: Result<String, PageTitleEditor.RewriteError>) -> String {
+        guard case let .success(s) = r else { Issue.record("expected success, got \(r)"); return "" }
+        return s
+    }
+
+    @Test("markdown: replaces an existing frontmatter title")
+    func mdReplace() {
+        let src = "---\ntitle: \"Old\"\npubDate: 2026-01-01\n---\n\nBody\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "md", newTitle: "New"))
+        #expect(out == "---\ntitle: \"New\"\npubDate: 2026-01-01\n---\n\nBody\n")
+    }
+
+    @Test("markdown: inserts title when frontmatter has none")
+    func mdInsert() {
+        let src = "---\npubDate: 2026-01-01\n---\n\nBody\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "mdx", newTitle: "New"))
+        #expect(out == "---\ntitle: \"New\"\npubDate: 2026-01-01\n---\n\nBody\n")
+    }
+
+    @Test("markdown: synthesizes a frontmatter block when absent")
+    func mdSynthesize() {
+        let src = "Just body, no frontmatter.\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "markdown", newTitle: "New"))
+        #expect(out == "---\ntitle: \"New\"\n---\n\nJust body, no frontmatter.\n")
+    }
+
+    @Test("astro: replaces a double-quoted title attribute, preserving the rest")
+    func astroDouble() {
+        let src = "---\nimport BaseLayout from \"../layouts/BaseLayout.astro\";\n---\n\n<BaseLayout title=\"Old Home\" description=\"d\">\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "astro", newTitle: "New Home"))
+        #expect(out.contains("title=\"New Home\""))
+        #expect(out.contains("description=\"d\""))
+        #expect(!out.contains("Old Home"))
+    }
+
+    @Test("astro: replaces a single-quoted title attribute")
+    func astroSingle() {
+        let src = "<BaseLayout title='Old' />"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "astro", newTitle: "New"))
+        #expect(out.contains("title='New'"))
+    }
+
+    @Test("html: replaces a title attribute")
+    func htmlAttr() {
+        let src = "<x title=\"Old\">"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "html", newTitle: "New"))
+        #expect(out == "<x title=\"New\">")
+    }
+
+    @Test("astro: no title attribute → noEditableLocation")
+    func astroNoAttr() {
+        let r = PageTitleEditor.rewrite(contents: "<BaseLayout description=\"d\" />", fileExtension: "astro", newTitle: "New")
+        #expect(r == .failure(.noEditableLocation))
+    }
+
+    @Test("empty or whitespace title → emptyTitle for any type")
+    func empty() {
+        #expect(PageTitleEditor.rewrite(contents: "---\ntitle: \"x\"\n---\n", fileExtension: "md", newTitle: "  ") == .failure(.emptyTitle))
+        #expect(PageTitleEditor.rewrite(contents: "<a title=\"x\">", fileExtension: "astro", newTitle: "") == .failure(.emptyTitle))
+    }
+
+    @Test("markdown: YAML-escapes quotes and backslashes")
+    func mdEscape() {
+        let out = ok(PageTitleEditor.rewrite(contents: "---\ntitle: \"x\"\n---\n", fileExtension: "md", newTitle: "a\"b\\c"))
+        #expect(out.contains("title: \"a\\\"b\\\\c\""))
+    }
+
+    @Test("astro: HTML-escapes the title value, preserving quote style")
+    func astroEscape() {
+        let out = ok(PageTitleEditor.rewrite(contents: "<a title=\"x\">", fileExtension: "astro", newTitle: "Tom & \"Jerry\" <b>"))
+        // Double-quoted delimiter: escape &, <, and the " delimiter; ' may stay literal.
+        #expect(out.contains("title=\"Tom &amp; &quot;Jerry&quot; &lt;b&gt;\""))
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter PageTitleEditor`
+Expected: FAIL — `cannot find 'PageTitleEditor' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/PageTitleEditor.swift`:
+
+```swift
+import Foundation
+
+/// Rewrites a page/post's *title* in place — frontmatter `title:` for markdown-family files,
+/// the first `title="…"`/`title='…'` attribute for `.astro`/`.html`. Pure and I/O-free so the
+/// transform is fully unit-testable; `NavigatorRenameService` owns the disk + git side.
+///
+/// `.astro` files use a JavaScript component script between `---` fences (NOT YAML), so we never
+/// write YAML frontmatter there — the title lives in the layout invocation's `title=` prop.
+public enum PageTitleEditor {
+    public enum RewriteError: Error, Equatable {
+        case emptyTitle
+        case noEditableLocation
+    }
+
+    private static let markdownExts: Set<String> = ["md", "mdx", "mdoc", "markdown"]
+    private static let attributeExts: Set<String> = ["astro", "html"]
+
+    public static func rewrite(
+        contents: String,
+        fileExtension: String,
+        newTitle: String
+    ) -> Result<String, RewriteError> {
+        let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .failure(.emptyTitle) }
+
+        let ext = fileExtension.lowercased()
+        if markdownExts.contains(ext) { return .success(rewriteMarkdown(contents, title: trimmed)) }
+        if attributeExts.contains(ext) { return rewriteAttribute(contents, title: trimmed) }
+        // Unknown extension: nowhere defined to write a title.
+        return .failure(.noEditableLocation)
+    }
+
+    // MARK: - Markdown frontmatter
+
+    /// Replace the `title:` line inside a leading `---` block, insert one if the block lacks it,
+    /// or synthesize a block at the top of the file.
+    private static func rewriteMarkdown(_ contents: String, title: String) -> String {
+        let yaml = "title: \(yamlQuoted(title))"
+
+        // A frontmatter block must start at byte 0 with `---` on its own line.
+        guard contents.hasPrefix("---\n") || contents == "---" || contents.hasPrefix("---\r\n") else {
+            return "---\n\(yaml)\n---\n\n\(contents)"
+        }
+
+        // Normalize to \n for line work; the templates use \n.
+        var lines = contents.components(separatedBy: "\n")
+        // lines[0] == "---". Find the closing fence.
+        guard let close = lines.dropFirst().firstIndex(of: "---") else {
+            // Malformed (no closing fence) — treat as no frontmatter and prepend a fresh block.
+            return "---\n\(yaml)\n---\n\n\(contents)"
+        }
+
+        // Look for an existing top-level `title:` between the fences.
+        if let titleIdx = (1..<close).first(where: { lineKey(lines[$0]) == "title" }) {
+            lines[titleIdx] = yaml
+        } else {
+            lines.insert(yaml, at: 1)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// The top-level key of a frontmatter line (`title: "x"` → `title`), or nil for indented /
+    /// keyless lines. Mirrors `Frontmatter`'s "top-level keys only" rule.
+    private static func lineKey(_ line: String) -> String? {
+        guard let first = line.first, first != " ", first != "\t" else { return nil }
+        guard let colon = line.firstIndex(of: ":") else { return nil }
+        return String(line[line.startIndex..<colon]).trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Double-quote a YAML scalar, escaping `\` then `"`.
+    private static func yamlQuoted(_ s: String) -> String {
+        let escaped = s.replacingOccurrences(of: "\\", with: "\\\\")
+                       .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+
+    // MARK: - Attribute (astro / html)
+
+    /// Port of `ContentScanner.titleAttrRegex` — the first `title="…"` or `title='…'`.
+    private static let titleAttrRegex = try! NSRegularExpression(
+        pattern: #"\btitle\s*=\s*(?:"([^"]*)"|'([^']*)')"#
+    )
+
+    private static func rewriteAttribute(_ contents: String, title: String) -> Result<String, RewriteError> {
+        let full = NSRange(contents.startIndex..<contents.endIndex, in: contents)
+        guard let match = titleAttrRegex.firstMatch(in: contents, range: full) else {
+            return .failure(.noEditableLocation)
+        }
+        // Which capture group matched tells us the delimiter: group 1 = ", group 2 = '.
+        let usesDouble = match.range(at: 1).location != NSNotFound
+        let delimiter: Character = usesDouble ? "\"" : "'"
+        let replacement = "title=\(delimiter)\(attrEscaped(title, delimiter: delimiter))\(delimiter)"
+        guard let whole = Range(match.range, in: contents) else { return .failure(.noEditableLocation) }
+        return .success(contents.replacingCharacters(in: whole, with: replacement))
+    }
+
+    /// HTML-attribute-escape: always `&` and `<`/`>`, plus the active quote delimiter.
+    private static func attrEscaped(_ s: String, delimiter: Character) -> String {
+        var out = s.replacingOccurrences(of: "&", with: "&amp;")
+                   .replacingOccurrences(of: "<", with: "&lt;")
+                   .replacingOccurrences(of: ">", with: "&gt;")
+        out = delimiter == "\""
+            ? out.replacingOccurrences(of: "\"", with: "&quot;")
+            : out.replacingOccurrences(of: "'", with: "&#39;")
+        return out
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter PageTitleEditor`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/PageTitleEditor.swift Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
+git commit -m "feat: PageTitleEditor — rewrite page/post title per file type
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `NavigatorRenameService` (load → rewrite → save → commit)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/NavigatorRenameService.swift`
+- Test: `Tests/AnglesiteCoreTests/NavigatorRenameServiceTests.swift`
+
+**Interfaces:**
+- Consumes: `PageTitleEditor.rewrite(...)` (Task 1); `FileDocumentIO.load`/`save`; `NativeContentOperations.GitCommit` typealias = `@Sendable (_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?` and `NativeContentOperations.processGitCommit`.
+- Produces:
+  ```swift
+  public struct NavigatorRenameService: Sendable {
+      public enum RenameError: Error, Equatable { case emptyTitle, noEditableLocation, io(String) }
+      public typealias GitCommit = NativeContentOperations.GitCommit
+      public init(
+          loadContents: @escaping @Sendable (URL) throws -> String = { try FileDocumentIO.load($0).contents },
+          saveContents: @escaping @Sendable (String, URL) throws -> Void = { try FileDocumentIO.save($0, to: $1) },
+          gitCommit: @escaping GitCommit = NativeContentOperations.processGitCommit
+      )
+      public func rename(
+          fileURL: URL, fileExtension: String, projectRoot: URL, relativePath: String, newTitle: String
+      ) async -> Result<String, RenameError>
+  }
+  ```
+  On success returns the trimmed new title. Git commit is best-effort: a nil result is ignored.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/NavigatorRenameServiceTests.swift`:
+
+```swift
+// Tests/AnglesiteCoreTests/NavigatorRenameServiceTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("NavigatorRenameService")
+struct NavigatorRenameServiceTests {
+    private let url = URL(fileURLWithPath: "/site/src/content/posts/p.md")
+    private let root = URL(fileURLWithPath: "/site")
+
+    @Test("success: rewrites markdown title, saves, commits, returns trimmed title")
+    func success() async {
+        let saved = Locked<String?>(nil)
+        let committed = Locked<(String, String)?>(nil)
+        let svc = NavigatorRenameService(
+            loadContents: { _ in "---\ntitle: \"Old\"\n---\n\nBody\n" },
+            saveContents: { contents, _ in saved.set(contents) },
+            gitCommit: { _, rel, msg in committed.set((rel, msg)); return "deadbeef" }
+        )
+        let result = await svc.rename(
+            fileURL: url, fileExtension: "md", projectRoot: root,
+            relativePath: "src/content/posts/p.md", newTitle: "  New  ")
+        #expect(result == .success("New"))
+        #expect(saved.get()?.contains("title: \"New\"") == true)
+        #expect(committed.get()?.0 == "src/content/posts/p.md")
+        #expect(committed.get()?.1.contains("New") == true)
+    }
+
+    @Test("emptyTitle: never saves")
+    func emptyTitle() async {
+        let saved = Locked<Bool>(false)
+        let svc = NavigatorRenameService(
+            loadContents: { _ in "---\ntitle: \"Old\"\n---\n" },
+            saveContents: { _, _ in saved.set(true) },
+            gitCommit: { _, _, _ in "x" })
+        let r = await svc.rename(fileURL: url, fileExtension: "md", projectRoot: root, relativePath: "p.md", newTitle: " ")
+        #expect(r == .failure(.emptyTitle))
+        #expect(saved.get() == false)
+    }
+
+    @Test("noEditableLocation: astro without a title attribute never saves")
+    func noLocation() async {
+        let saved = Locked<Bool>(false)
+        let svc = NavigatorRenameService(
+            loadContents: { _ in "<BaseLayout description=\"d\" />" },
+            saveContents: { _, _ in saved.set(true) },
+            gitCommit: { _, _, _ in "x" })
+        let r = await svc.rename(fileURL: url, fileExtension: "astro", projectRoot: root, relativePath: "p.astro", newTitle: "New")
+        #expect(r == .failure(.noEditableLocation))
+        #expect(saved.get() == false)
+    }
+
+    @Test("io: save failure maps to .io")
+    func ioFailure() async {
+        struct Boom: Error {}
+        let svc = NavigatorRenameService(
+            loadContents: { _ in "---\ntitle: \"Old\"\n---\n" },
+            saveContents: { _, _ in throw Boom() },
+            gitCommit: { _, _, _ in "x" })
+        let r = await svc.rename(fileURL: url, fileExtension: "md", projectRoot: root, relativePath: "p.md", newTitle: "New")
+        if case .failure(.io) = r {} else { Issue.record("expected .io, got \(r)") }
+    }
+
+    @Test("git failure is best-effort: still success and the save happened")
+    func gitBestEffort() async {
+        let saved = Locked<Bool>(false)
+        let svc = NavigatorRenameService(
+            loadContents: { _ in "---\ntitle: \"Old\"\n---\n" },
+            saveContents: { _, _ in saved.set(true) },
+            gitCommit: { _, _, _ in nil })
+        let r = await svc.rename(fileURL: url, fileExtension: "md", projectRoot: root, relativePath: "p.md", newTitle: "New")
+        #expect(r == .success("New"))
+        #expect(saved.get() == true)
+    }
+}
+
+/// Minimal thread-safe box so the @Sendable injection closures can record calls.
+private final class Locked<T>: @unchecked Sendable {
+    private let lock = NSLock(); private var value: T
+    init(_ v: T) { value = v }
+    func set(_ v: T) { lock.lock(); value = v; lock.unlock() }
+    func get() -> T { lock.lock(); defer { lock.unlock() }; return value }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter NavigatorRenameService`
+Expected: FAIL — `cannot find 'NavigatorRenameService' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/NavigatorRenameService.swift`:
+
+```swift
+import Foundation
+
+/// The page/post re-title pipeline: load the file, rewrite its title via `PageTitleEditor`, save,
+/// then commit best-effort. I/O and git are injected so the flow is unit-testable; the defaults are
+/// the real `FileDocumentIO` + `NativeContentOperations.processGitCommit`. Lives in AnglesiteCore
+/// (not the app-target model) so `swift test` covers it — the same split as `TokenOnboarding`.
+public struct NavigatorRenameService: Sendable {
+    public enum RenameError: Error, Equatable {
+        case emptyTitle
+        case noEditableLocation
+        case io(String)
+    }
+
+    public typealias GitCommit = NativeContentOperations.GitCommit
+
+    private let loadContents: @Sendable (URL) throws -> String
+    private let saveContents: @Sendable (String, URL) throws -> Void
+    private let gitCommit: GitCommit
+
+    public init(
+        loadContents: @escaping @Sendable (URL) throws -> String = { try FileDocumentIO.load($0).contents },
+        saveContents: @escaping @Sendable (String, URL) throws -> Void = { try FileDocumentIO.save($0, to: $1) },
+        gitCommit: @escaping GitCommit = NativeContentOperations.processGitCommit
+    ) {
+        self.loadContents = loadContents
+        self.saveContents = saveContents
+        self.gitCommit = gitCommit
+    }
+
+    public func rename(
+        fileURL: URL,
+        fileExtension: String,
+        projectRoot: URL,
+        relativePath: String,
+        newTitle: String
+    ) async -> Result<String, RenameError> {
+        let contents: String
+        do { contents = try loadContents(fileURL) }
+        catch { return .failure(.io("\(error)")) }
+
+        let rewritten: String
+        switch PageTitleEditor.rewrite(contents: contents, fileExtension: fileExtension, newTitle: newTitle) {
+        case .success(let s): rewritten = s
+        case .failure(.emptyTitle): return .failure(.emptyTitle)
+        case .failure(.noEditableLocation): return .failure(.noEditableLocation)
+        }
+
+        do { try saveContents(rewritten, fileURL) }
+        catch { return .failure(.io("\(error)")) }
+
+        let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Best-effort: a failed commit (not a repo, rejecting hook, git missing) is ignored —
+        // the file is saved and is the source of truth. Mirrors NativeContentOperations.
+        _ = await gitCommit(projectRoot, relativePath, "anglesite: rename title to \"\(trimmed)\"")
+        return .success(trimmed)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter NavigatorRenameService`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NavigatorRenameService.swift Tests/AnglesiteCoreTests/NavigatorRenameServiceTests.swift
+git commit -m "feat: NavigatorRenameService — load/rewrite/save/best-effort-commit title
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `SiteNavigatorModel` edit-state glue + `sourceDirectory` plumbing
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteNavigatorModel.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:655` (the `navModel.start(...)` call)
+
+**Interfaces:**
+- Consumes: `NavigatorRenameService` (Task 2); `SiteContentGraph.page(id:)`/`post(id:)`, `upsertPage(_:)`/`upsertPost(_:)`; `NavigatorTarget` to classify a row.
+- Produces (used by Task 4):
+  ```swift
+  // on SiteNavigatorModel
+  var editingItemID: String?     // observable
+  var draftTitle: String         // observable
+  var renameError: String?       // observable; non-nil → view shows an alert
+  func canRename(_ id: String) -> Bool
+  func beginEditing(_ id: String)
+  func cancelEditing()
+  func commitEditing() async
+  // start gains a sourceDirectory parameter:
+  func start(siteID: String, siteRoot: URL, sourceDirectory: URL)
+  ```
+
+This is app-target glue (not under `swift test`); it is verified by the build in Step 4 and by Task 4's manual run.
+
+- [ ] **Step 1: Add stored config + edit state to `SiteNavigatorModel`**
+
+In `Sources/AnglesiteApp/SiteNavigatorModel.swift`, add stored properties after `var selection: String?`:
+
+```swift
+    // Inline re-titling (Finder-style). `editingItemID` non-nil → that row shows a TextField.
+    var editingItemID: String?
+    var draftTitle: String = ""
+    var renameError: String?
+
+    private var sourceDirectory: URL?
+    private let renameService = NavigatorRenameService()
+```
+
+- [ ] **Step 2: Thread `sourceDirectory` through `start`**
+
+Change the `start` signature and capture, storing `sourceDirectory`:
+
+```swift
+    func start(siteID: String, siteRoot: URL, sourceDirectory: URL) {
+        self.sourceDirectory = sourceDirectory
+        observeTask?.cancel()
+        observeTask = Task { [weak self, graph, siteID, siteRoot] in
+            let stream = await graph.changeStream()
+            await self?.refresh(siteID: siteID, siteRoot: siteRoot)
+            for await changedSiteID in stream {
+                if Task.isCancelled { break }
+                if changedSiteID == siteID { await self?.refresh(siteID: siteID, siteRoot: siteRoot) }
+            }
+        }
+    }
+```
+
+(`refresh` is unchanged — `SiteFileTree.scan` still uses `siteRoot`/`packageURL`.)
+
+- [ ] **Step 3: Add the edit-state methods**
+
+Add these methods to `SiteNavigatorModel` (after `target(for:)`):
+
+```swift
+    /// A row is renamable iff it is a page or post (route target). File rows (components/styles/
+    /// metadata) carry a `.file` target and are out of scope. The astro-without-title case is
+    /// caught at commit, not pre-disabled (pre-checking would read every page file per refresh).
+    func canRename(_ id: String) -> Bool {
+        guard let target = target(for: id) else { return false }
+        if case .route = target { return true }
+        return false
+    }
+
+    func beginEditing(_ id: String) {
+        guard canRename(id) else { return }
+        let current = sections.flatMap(\.items).first { $0.id == id }?.title ?? ""
+        draftTitle = current
+        editingItemID = id
+    }
+
+    func cancelEditing() {
+        editingItemID = nil
+    }
+
+    /// Resolve the editing row → page/post → file, run the rename service, then reflect the new
+    /// title into the graph (which re-emits and rebuilds the sidebar). Always clears edit state.
+    func commitEditing() async {
+        guard let id = editingItemID, let sourceDirectory else { editingItemID = nil; return }
+        editingItemID = nil
+
+        if let page = await graph.page(id: id) {
+            let url = sourceDirectory.appendingPathComponent(page.filePath)
+            let result = await renameService.rename(
+                fileURL: url,
+                fileExtension: (page.filePath as NSString).pathExtension,
+                projectRoot: sourceDirectory,
+                relativePath: page.filePath,
+                newTitle: draftTitle)
+            switch result {
+            case .success(let title):
+                await graph.upsertPage(SiteContentGraph.Page(
+                    id: page.id, siteID: page.siteID, route: page.route,
+                    filePath: page.filePath, title: title, lastModified: page.lastModified))
+            case .failure(.emptyTitle):
+                break  // no write happened; keep the old title silently
+            case .failure(.noEditableLocation):
+                renameError = "This page has no editable title to rename."
+            case .failure(.io(let msg)):
+                renameError = "Couldn't rename: \(msg)"
+            }
+        } else if let post = await graph.post(id: id) {
+            let url = sourceDirectory.appendingPathComponent(post.filePath)
+            let result = await renameService.rename(
+                fileURL: url,
+                fileExtension: (post.filePath as NSString).pathExtension,
+                projectRoot: sourceDirectory,
+                relativePath: post.filePath,
+                newTitle: draftTitle)
+            switch result {
+            case .success(let title):
+                await graph.upsertPost(SiteContentGraph.Post(
+                    id: post.id, siteID: post.siteID, collection: post.collection, slug: post.slug,
+                    title: title, draft: post.draft, publishDate: post.publishDate, tags: post.tags,
+                    filePath: post.filePath, lastModified: post.lastModified))
+            case .failure(.emptyTitle):
+                break
+            case .failure(.noEditableLocation):
+                renameError = "This post has no editable title to rename."
+            case .failure(.io(let msg)):
+                renameError = "Couldn't rename: \(msg)"
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Update the `start` call site in `SiteWindow`**
+
+In `Sources/AnglesiteApp/SiteWindow.swift` (~line 655), change:
+
+```swift
+        navModel.start(siteID: resolved.id, siteRoot: resolved.packageURL)
+```
+
+to:
+
+```swift
+        navModel.start(siteID: resolved.id, siteRoot: resolved.packageURL, sourceDirectory: resolved.sourceDirectory)
+```
+
+- [ ] **Step 5: Build the app target to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`. (If `Anglesite.xcodeproj` is missing, run `xcodegen generate` first; if the build complains about `Resources/plugin`, run `scripts/copy-plugin.sh` with `ANGLESITE_PLUGIN_SRC` set to the real plugin checkout.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteNavigatorModel.swift Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat: navigator model rename glue + sourceDirectory plumbing
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `SiteNavigatorView` inline editing UI
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteNavigatorView.swift`
+
+**Interfaces:**
+- Consumes: `model.editingItemID`, `model.draftTitle`, `model.renameError`, `model.canRename(_:)`, `model.beginEditing(_:)`, `model.cancelEditing()`, `model.commitEditing()` (Task 3).
+- Produces: no new API (terminal UI task).
+
+This is app-target UI, verified by build + manual run (hosted app tests don't run on CI).
+
+- [ ] **Step 1: Render an inline `TextField` for the editing row, with a Rename context menu**
+
+Replace the `ForEach(section.items)` row body in `Sources/AnglesiteApp/SiteNavigatorView.swift` so a row in edit mode shows a focused `TextField`, otherwise the existing `Label`. Add a `@FocusState` and bind `$model` so its observable edit state is writable:
+
+```swift
+struct SiteNavigatorView: View {
+    @Bindable var model: SiteNavigatorModel
+    @FocusState private var editingFocused: Bool
+
+    var body: some View {
+        List(selection: $model.selection) {
+            ForEach(model.sections) { section in
+                Section(section.title) {
+                    ForEach(section.items) { item in
+                        row(for: item, in: section)
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .overlay {
+            if model.sections.isEmpty {
+                ContentUnavailableView("No content yet", systemImage: "sidebar.left")
+            }
+        }
+        .alert(
+            "Rename failed",
+            isPresented: Binding(
+                get: { model.renameError != nil },
+                set: { if !$0 { model.renameError = nil } }),
+            presenting: model.renameError
+        ) { _ in
+            Button("OK", role: .cancel) { model.renameError = nil }
+        } message: { msg in
+            Text(msg)
+        }
+    }
+
+    @ViewBuilder
+    private func row(for item: NavigatorItem, in section: NavigatorSection) -> some View {
+        if model.editingItemID == item.id {
+            TextField("Title", text: $model.draftTitle)
+                .textFieldStyle(.plain)
+                .focused($editingFocused)
+                .onSubmit { Task { await model.commitEditing() } }
+                .onExitCommand { model.cancelEditing() }   // Esc
+                .onChange(of: editingFocused) { _, focused in
+                    // Clicking away ends editing without committing.
+                    if !focused && model.editingItemID == item.id { model.cancelEditing() }
+                }
+                .task { editingFocused = true }
+                .tag(item.id)
+        } else {
+            Label(item.title, systemImage: icon(for: section.id))
+                .tag(item.id)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .contextMenu {
+                    if model.canRename(item.id) {
+                        Button("Rename") { model.beginEditing(item.id) }
+                    }
+                }
+        }
+    }
+```
+
+(Leave the `icon(for:)` helper unchanged.)
+
+- [ ] **Step 2: Add a Return-key path to begin renaming the selected row**
+
+Add a hidden keyboard shortcut button to the `List` (inside `body`, e.g. as a `.background`) so pressing Return on the selected renamable row starts editing:
+
+```swift
+        .background {
+            Button("") {
+                if let id = model.selection, model.editingItemID == nil, model.canRename(id) {
+                    model.beginEditing(id)
+                }
+            }
+            .keyboardShortcut(.return, modifiers: [])
+            .hidden()
+        }
+```
+
+- [ ] **Step 3: Build the app target to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Manual smoke test (document the result)**
+
+Launch the app, open a site, and verify in the navigator:
+1. Control-click a Page → **Rename** appears → click it → the row becomes an editable field pre-filled with the title.
+2. Type a new title, press Return → the row shows the new title; open the `.astro` file and confirm the `title="…"` attribute changed and the file path/URL did not.
+3. Repeat for a Post (`.md`) → confirm frontmatter `title:` changed.
+4. Press Esc mid-edit → the original title is restored, nothing written.
+5. Select a Page and press Return → editing begins (keyboard path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteNavigatorView.swift
+git commit -m "feat: inline page/post rename in the project navigator
+
+Control-click → Rename (or Return on the selected row) edits the title in place,
+Finder-style; commit on Return, cancel on Esc.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Title-only, write-where-it-lives → Task 1 (`PageTitleEditor`: frontmatter vs `title=` attribute). ✓
+- Inline edit in place (control-click + Return, commit/cancel) → Task 4. ✓
+- File path/URL unchanged → guaranteed: no task touches the path; `PageTitleEditor` only edits the title text. ✓
+- Astro-no-attr → `.noEditableLocation` → alert at commit (Tasks 1, 3, 4). ✓
+- Best-effort git commit → Task 2. ✓
+- `NavigatorRenameService` testable in Core; model glue thin → Tasks 2, 3. ✓
+- `sourceDirectory` plumbing (filePath is source-relative, `start` got `packageURL`) → Task 3. ✓
+- Scope: pages/posts only (`canRename` = `.route` target) → Task 3. ✓
+- Testing matrix (markdown replace/insert/synthesize, astro single/double/none, html, escaping, empty; service success/empty/no-location/io/git-best-effort) → Tasks 1, 2. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code; commands have expected output. ✓
+
+**Type consistency:** `PageTitleEditor.RewriteError` (`.emptyTitle`/`.noEditableLocation`) is mapped explicitly in `NavigatorRenameService` to `RenameError` (adds `.io`). `start(siteID:siteRoot:sourceDirectory:)` defined in Task 3 Step 2, called in Task 3 Step 4. `SiteContentGraph.Page`/`Post` initializer argument lists match `SiteContentGraph.swift`. `NativeContentOperations.GitCommit` signature matches. ✓

--- a/docs/superpowers/specs/2026-06-23-navigator-rename-title-design.md
+++ b/docs/superpowers/specs/2026-06-23-navigator-rename-title-design.md
@@ -43,9 +43,11 @@ items that carry a title).
 
 - Component / Style / Metadata file rows — these are plain files, not titled
   content. A general "rename file" feature is future work.
-- An `.astro` / `.html` page with **no** `title=` attribute and no usable
-  frontmatter — there is no safe place to inject a title prop, so its Rename
-  affordance is disabled (not renamable).
+- An `.astro` / `.html` page with **no** `title=` attribute — there is no safe
+  place to inject a title prop, so renaming is **rejected at commit with an
+  alert** (no file change). It is not pre-disabled: pre-checking would require
+  reading every page file on each navigator refresh, so the check happens once,
+  on demand, when the user actually commits a rename.
 - Changing the filename, route, or URL.
 - Routing through the MCP/plugin server — this is a local file edit and runs
   entirely native.
@@ -87,37 +89,92 @@ Behavior:
 Escaping per format ensures quotes and special characters in a title cannot
 corrupt the file.
 
-### Rename flow — wired into `SiteNavigatorModel`
+### `NavigatorRenameService` (AnglesiteCore) — the testable flow
 
-The model already resolves navigator items against `SiteContentGraph` and the
-filesystem, so it can map a row id to a page/post and its `filePath` +
-extension.
+The load → rewrite → save → commit pipeline lives in AnglesiteCore (not the
+app-target model) because `swift test` covers Core but not the app target — the
+project's established pattern (cf. `TokenOnboarding`). File I/O and the git
+closure are injected so the flow is fully unit-testable.
 
 ```swift
-// Whether a row may be renamed (drives context-menu / Return availability).
-// False for non-titled file rows, and for astro/html pages with no title= attr.
-func canRename(_ id: String) -> Bool
+public struct NavigatorRenameService {
+    public enum RenameError: Error, Equatable {
+        case emptyTitle          // from PageTitleEditor
+        case noEditableLocation  // from PageTitleEditor
+        case io(String)          // load/save failure
+    }
+    public typealias GitCommit = NativeContentOperations.GitCommit
+        // (_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?
 
-// Perform the rename: load → rewrite → save → git commit → graph refresh.
-func rename(_ id: String, to newTitle: String) async
+    public init(
+        loadContents: @escaping @Sendable (URL) throws -> String = { try FileDocumentIO.load($0).contents },
+        saveContents: @escaping @Sendable (String, URL) throws -> Void = { try FileDocumentIO.save($0, to: $1) },
+        gitCommit: @escaping GitCommit = NativeContentOperations.processGitCommit
+    )
+
+    // Returns the trimmed new title on success.
+    public func rename(
+        fileURL: URL,
+        fileExtension: String,
+        projectRoot: URL,
+        relativePath: String,
+        newTitle: String
+    ) async -> Result<String, RenameError>
+}
 ```
 
 `rename` steps:
 
-1. Resolve the item → file URL + extension. Bail (no-op) if not renamable.
-2. `FileDocumentIO.load(url)` to read current contents.
-3. `PageTitleEditor.rewrite(contents:fileExtension:newTitle:)`.
-   - `.emptyTitle` → abort, keep original title, clear edit state.
-   - `.noEditableLocation` → abort, surface an alert (should be pre-empted by
-     `canRename`, but handled defensively).
-4. `FileDocumentIO.save(newContents, to: url)`.
-5. Git commit via the **same injected `gitCommit` closure** that
-   `NativeContentOperations` uses, message `Rename title to "<newTitle>"`.
-6. Trigger a content-graph refresh for the affected file so the row re-renders
-   with the new title.
+1. `loadContents(fileURL)` → current contents (`.io` on failure).
+2. `PageTitleEditor.rewrite(contents:fileExtension:newTitle:)` — maps
+   `.emptyTitle` / `.noEditableLocation` straight through to `RenameError`.
+3. `saveContents(newContents, fileURL)` (`.io` on failure).
+4. Git commit **best-effort** via the injected closure, message
+   `anglesite: rename title to "<newTitle>"`. A nil result (not a repo,
+   rejecting hook, git missing) is ignored — the file is already saved and is
+   the source of truth, so a failed commit never rolls back the title. This
+   mirrors `NativeContentOperations`.
+5. Return `.success(trimmedTitle)`.
 
-Any load/save/git failure surfaces an alert and leaves the original title
-intact. File I/O and the git closure are injectable so the flow is testable.
+### Rename glue — `SiteNavigatorModel` (app target, thin)
+
+The model maps a row id to its `SiteContentGraph.Page`/`Post`, drives the
+service, then reflects the result in the graph + UI. This glue is not unit-tested
+(app target; consistent with other app glue).
+
+```swift
+// Section-based: true iff the id belongs to the Pages or Posts section.
+// (The astro-no-title case is caught at commit, not pre-disabled — see spec.)
+func canRename(_ id: String) -> Bool
+
+func beginEditing(_ id: String)   // editingItemID = id; draftTitle = current title
+func cancelEditing()              // editingItemID = nil
+func commitEditing() async        // resolve id → page/post; run the service; update graph
+```
+
+`commitEditing` steps:
+
+1. Resolve `editingItemID` → `SiteContentGraph.Page`/`Post` via the graph; bail
+   if gone. Derive `fileURL = sourceDirectory.appending(filePath)`,
+   `fileExtension` from `filePath`, `relativePath = filePath`,
+   `projectRoot = sourceDirectory`.
+2. `await renameService.rename(...)`.
+3. On `.success(newTitle)`: build an updated `Page`/`Post` value (same id, same
+   fields, `title = newTitle`) and `await graph.upsertPage(_:)` /
+   `upsertPost(_:)`. The graph emits a change → the navigator's existing
+   observer rebuilds `sections` with the new title.
+4. On `.emptyTitle`: silently revert (no write happened).
+5. On `.noEditableLocation` / `.io`: set `renameError` (an observable `String?`)
+   so the view shows an `.alert`. Original title preserved.
+6. Clear `editingItemID` in all cases.
+
+**`sourceDirectory` plumbing.** `Page.filePath`/`Post.filePath` are relative to
+the site's **source directory** (the `ContentScanner` project root), but
+`start(siteID:siteRoot:)` currently receives `siteRoot = packageURL` (for
+`SiteFileTree`, which adaptively resolves `Source/`). So `start` gains a
+`sourceDirectory: URL` parameter, stored on the model and used to resolve
+absolute file paths; the single call site in `SiteWindow` passes
+`resolved.sourceDirectory`.
 
 ### Navigator UI (`SiteNavigatorView` + `SiteNavigatorModel`)
 
@@ -125,26 +182,28 @@ intact. File I/O and the git closure are injectable so the flow is testable.
   - `editingItemID: String?` — which row is in edit mode.
   - `draftTitle: String` — the in-progress text.
   - A `@FocusState`-driven focus on the `TextField` (held in the view).
-- A row renders an inline `TextField(text: $draftTitle)` when
-  `editingItemID == item.id`, otherwise the existing `Text`. `onSubmit` →
-  `await model.rename(id, to: draftTitle)`; Esc / focus loss with no submit →
-  cancel (clear `editingItemID`).
-- `.contextMenu { Button("Rename") { model.beginEditing(id) } }` shown only when
-  `model.canRename(id)`.
+- A row renders an inline `TextField(text: $model.draftTitle)` when
+  `editingItemID == item.id`, otherwise the existing `Label`. `onSubmit` →
+  `Task { await model.commitEditing() }`; Esc / focus loss → `cancelEditing()`.
+- `.contextMenu { Button("Rename") { model.beginEditing(item.id) } }` shown only
+  when `model.canRename(item.id)`.
 - A keyboard path (`Return` on the selected renamable row) calls
   `beginEditing`. (Double-click may also begin editing; optional, since single
   click already selects + navigates the preview.)
+- `.alert` bound to `model.renameError` surfaces `.noEditableLocation` / `.io`
+  failures.
 
 ## Data flow
 
 ```
 control-click / Return on row
-  → model.beginEditing(id)        (editingItemID = id, draftTitle = current)
+  → model.beginEditing(id)         (editingItemID = id, draftTitle = current)
   → inline TextField
-  → onSubmit
-  → model.rename(id, to: draft)
-       load → PageTitleEditor.rewrite → save → git commit → graph refresh
-  → navigator rebuilds section with new title
+  → onSubmit → model.commitEditing()
+       resolve id → page/post
+       → renameService.rename(...)  (load → rewrite → save → best-effort commit)
+       → graph.upsertPage/Post(title: new)  → emits change
+  → navigator's observer rebuilds sections with new title
   → editingItemID = nil
 ```
 
@@ -153,9 +212,9 @@ control-click / Return on row
 | Situation | Behavior |
 |---|---|
 | Empty / whitespace title | No write; revert to original; clear edit state |
-| `.astro`/`.html` with no `title=` attr | Not renamable — Rename affordance disabled |
-| File load / save failure | Alert; original title preserved |
-| Git commit failure | Alert; file change kept, surfaced to user (consistent with existing native ops) |
+| `.astro`/`.html` with no `title=` attr | Rename rejected at commit with an alert; no file change |
+| File load / save failure | Alert (`.io`); original title preserved |
+| Git commit failure | Best-effort; ignored. File change kept (consistent with `NativeContentOperations`) |
 | Special chars / quotes in title | Escaped per format (YAML quote / HTML attr escape) |
 
 ## Testing
@@ -172,10 +231,19 @@ control-click / Return on row
 - Title containing quotes / `&` / `<` → correctly escaped per format.
 - Empty / whitespace title → `.emptyTitle`.
 
-**Model-level rename test:** with injected file I/O and `gitCommit` closure,
-verify the full load → rewrite → save → commit → refresh path runs and the
-graph/navigator reflect the new title; verify failures preserve the original
-title.
+**`NavigatorRenameService` tests (Swift Testing `@Test`, AnglesiteCore):** with
+injected `loadContents` / `saveContents` / `gitCommit`:
+
+- Success (markdown): saved contents carry the new frontmatter title; result is
+  `.success(trimmedTitle)`; git closure invoked with the right relPath/message.
+- `.emptyTitle` propagates; `saveContents` is **not** called.
+- `.noEditableLocation` (astro, no attr) propagates; `saveContents` not called.
+- `saveContents` throws → `.io`.
+- Git commit returns nil → still `.success` (best-effort), and the save still
+  happened.
+
+The `SiteNavigatorModel` glue (graph upsert, edit state) is app-target and not
+unit-tested, consistent with other app glue — it is exercised by the build.
 
 ## Non-goals / future work
 

--- a/docs/superpowers/specs/2026-06-23-navigator-rename-title-design.md
+++ b/docs/superpowers/specs/2026-06-23-navigator-rename-title-design.md
@@ -1,0 +1,190 @@
+# Inline page/post re-titling in the project navigator
+
+**Date:** 2026-06-23
+**Status:** Approved (design)
+
+## Problem
+
+In the project navigator (the Xcode-style sidebar that lists a site's pages and
+posts), there is no way to change a page's displayed name. The user wants to
+re-title a page by control-clicking its name and editing it in place — the same
+interaction Finder offers for renaming a file.
+
+The navigator displays each item's **title**, not its filename. For pages that
+title comes from the layout invocation's `title="…"` attribute; for blog posts it
+comes from YAML frontmatter `title:`. So "re-title" means *edit the title*, not
+*rename the file*.
+
+## Decisions
+
+1. **Title only.** Editing changes only the title. The file path and the page's
+   URL/route are never touched. (Renaming the file/route is a separate, future
+   feature.)
+2. **Inline edit in place.** Control-click → context-menu **Rename**; pressing
+   **Return** on the selected renamable row also begins editing. The row's text
+   becomes an editable `TextField` in the sidebar. Return / focus-loss commits,
+   Esc cancels. This mirrors Finder.
+3. **Write where the title lives** (per file type):
+   - `.md` / `.mdx` / `.markdown` (posts) → YAML frontmatter `title:`.
+   - `.astro` / `.html` (pages) → the first `title="…"` / `title='…'` attribute.
+
+These reflect the real template: pages are `.astro` files that pass
+`title="…"` as a prop to `BaseLayout` (the `---` fence in an `.astro` file is a
+JavaScript component script, **not** YAML — writing YAML `title:` there would be
+invalid and would not change the rendered `<title>`), while blog posts are `.md`
+files in `src/content/blog/` with real YAML frontmatter.
+
+## Scope
+
+**In scope:** Page rows and Post rows in the navigator (content-graph–backed
+items that carry a title).
+
+**Out of scope:**
+
+- Component / Style / Metadata file rows — these are plain files, not titled
+  content. A general "rename file" feature is future work.
+- An `.astro` / `.html` page with **no** `title=` attribute and no usable
+  frontmatter — there is no safe place to inject a title prop, so its Rename
+  affordance is disabled (not renamable).
+- Changing the filename, route, or URL.
+- Routing through the MCP/plugin server — this is a local file edit and runs
+  entirely native.
+
+## Components
+
+### `PageTitleEditor` (AnglesiteCore) — pure, no I/O
+
+The testable core. Given file contents, the file extension, and a new title,
+returns the rewritten contents or a typed error. No filesystem access.
+
+```swift
+enum PageTitleEditor {
+    enum RewriteError: Error, Equatable {
+        case emptyTitle          // new title is empty/whitespace
+        case noEditableLocation  // astro/html with no title= attribute, etc.
+    }
+
+    static func rewrite(
+        contents: String,
+        fileExtension: String,
+        newTitle: String
+    ) -> Result<String, RewriteError>
+}
+```
+
+Behavior:
+
+- **Markdown family** (`md`, `mdx`, `markdown`): locate the leading `---` YAML
+  block. Replace the existing `title:` line, or insert a `title:` field if the
+  block exists without one, or synthesize a `---` block at the top of the file
+  if none exists. The value is YAML-quoted: wrapped in double quotes with `"` and
+  `\` escaped.
+- **Astro / HTML** (`astro`, `html`): find the first `title=` attribute
+  (double- or single-quoted) and replace its value, HTML-escaping `"`, `&`, and
+  `<`. If no `title=` attribute is present → `.noEditableLocation`.
+- Empty/whitespace `newTitle` → `.emptyTitle` (for any file type).
+
+Escaping per format ensures quotes and special characters in a title cannot
+corrupt the file.
+
+### Rename flow — wired into `SiteNavigatorModel`
+
+The model already resolves navigator items against `SiteContentGraph` and the
+filesystem, so it can map a row id to a page/post and its `filePath` +
+extension.
+
+```swift
+// Whether a row may be renamed (drives context-menu / Return availability).
+// False for non-titled file rows, and for astro/html pages with no title= attr.
+func canRename(_ id: String) -> Bool
+
+// Perform the rename: load → rewrite → save → git commit → graph refresh.
+func rename(_ id: String, to newTitle: String) async
+```
+
+`rename` steps:
+
+1. Resolve the item → file URL + extension. Bail (no-op) if not renamable.
+2. `FileDocumentIO.load(url)` to read current contents.
+3. `PageTitleEditor.rewrite(contents:fileExtension:newTitle:)`.
+   - `.emptyTitle` → abort, keep original title, clear edit state.
+   - `.noEditableLocation` → abort, surface an alert (should be pre-empted by
+     `canRename`, but handled defensively).
+4. `FileDocumentIO.save(newContents, to: url)`.
+5. Git commit via the **same injected `gitCommit` closure** that
+   `NativeContentOperations` uses, message `Rename title to "<newTitle>"`.
+6. Trigger a content-graph refresh for the affected file so the row re-renders
+   with the new title.
+
+Any load/save/git failure surfaces an alert and leaves the original title
+intact. File I/O and the git closure are injectable so the flow is testable.
+
+### Navigator UI (`SiteNavigatorView` + `SiteNavigatorModel`)
+
+- `SiteNavigatorModel` gains:
+  - `editingItemID: String?` — which row is in edit mode.
+  - `draftTitle: String` — the in-progress text.
+  - A `@FocusState`-driven focus on the `TextField` (held in the view).
+- A row renders an inline `TextField(text: $draftTitle)` when
+  `editingItemID == item.id`, otherwise the existing `Text`. `onSubmit` →
+  `await model.rename(id, to: draftTitle)`; Esc / focus loss with no submit →
+  cancel (clear `editingItemID`).
+- `.contextMenu { Button("Rename") { model.beginEditing(id) } }` shown only when
+  `model.canRename(id)`.
+- A keyboard path (`Return` on the selected renamable row) calls
+  `beginEditing`. (Double-click may also begin editing; optional, since single
+  click already selects + navigates the preview.)
+
+## Data flow
+
+```
+control-click / Return on row
+  → model.beginEditing(id)        (editingItemID = id, draftTitle = current)
+  → inline TextField
+  → onSubmit
+  → model.rename(id, to: draft)
+       load → PageTitleEditor.rewrite → save → git commit → graph refresh
+  → navigator rebuilds section with new title
+  → editingItemID = nil
+```
+
+## Error handling
+
+| Situation | Behavior |
+|---|---|
+| Empty / whitespace title | No write; revert to original; clear edit state |
+| `.astro`/`.html` with no `title=` attr | Not renamable — Rename affordance disabled |
+| File load / save failure | Alert; original title preserved |
+| Git commit failure | Alert; file change kept, surfaced to user (consistent with existing native ops) |
+| Special chars / quotes in title | Escaped per format (YAML quote / HTML attr escape) |
+
+## Testing
+
+**`PageTitleEditor` unit tests (Swift Testing `@Test`):**
+
+- Markdown with an existing `title:` → value replaced.
+- Markdown with frontmatter but no `title:` → field inserted.
+- Markdown with no frontmatter → `---` block synthesized at top.
+- Astro with a double-quoted `title="…"` → value replaced.
+- Astro with a single-quoted `title='…'` → value replaced.
+- Astro / HTML with no `title=` attribute → `.noEditableLocation`.
+- HTML with a `title="…"` attribute → value replaced.
+- Title containing quotes / `&` / `<` → correctly escaped per format.
+- Empty / whitespace title → `.emptyTitle`.
+
+**Model-level rename test:** with injected file I/O and `gitCommit` closure,
+verify the full load → rewrite → save → commit → refresh path runs and the
+graph/navigator reflect the new title; verify failures preserve the original
+title.
+
+## Non-goals / future work
+
+- Renaming the file / changing the route or URL.
+- Inline rename of component / style / metadata files.
+- Re-titling via a sheet/dialog (we chose inline).
+
+## Platform notes
+
+No new entitlements: the file editor already writes `Source/` files through
+`FileDocumentIO`, so write access (incl. the MAS security-scoped grant) is
+already in place. The feature is MAS-safe and routes no work through the plugin.


### PR DESCRIPTION
Re-title a page or post in the project navigator by control-clicking the name and editing it in place — the same interaction Finder uses for renaming a file. Pressing **Return** on the selected row also starts a rename; Return commits, Esc / focus-loss cancels.

## What it does
- **Title-only.** Only the displayed title changes — the file path, route, and URL are never touched.
- **Writes where the title lives** (per file type):
  - `.astro` / `.html` pages → the `title="…"` attribute on the layout call (HTML-escaped).
  - `.md` / `.mdx` posts → YAML frontmatter `title:` (created if absent; YAML-quoted).
- A page/post with no editable title location (e.g. an `.astro` page with no `title=` attribute) is rejected at commit with an alert — no file change.
- Git commit is **best-effort** (a failed commit is ignored; the saved file is the source of truth), matching `NativeContentOperations`.

## Architecture
- `PageTitleEditor` (AnglesiteCore, pure) — rewrites the title per file type; fully unit-tested.
- `NavigatorRenameService` (AnglesiteCore) — load → rewrite → save → best-effort commit, with injected I/O so it's unit-tested.
- `SiteNavigatorModel` (app) — edit-state glue (`canRename`, begin/cancel/commit), reflects the new title into `SiteContentGraph`; gains `sourceDirectory` plumbing (filePaths are source-relative).
- `SiteNavigatorView` (app) — inline `TextField`, Rename context menu, Return-key path, error alert.

Testable logic lives in AnglesiteCore (the project's `TokenOnboarding`-style split); app glue is verified by the build.

## Why the reader fix
`PageTitleEditor` writes valid escaped YAML / HTML so the real Astro build renders correctly. The navigator's readers (`Frontmatter.unquote`, `ContentScanner.firstTitleAttribute`) didn't reverse those escapes, so a title containing `"` or `\` would silently change in the sidebar on the next site open. Both readers now decode their respective escapes, with round-trip tests asserting `parse(rewrite(title)) == title`.

## Testing
- 15 new AnglesiteCore tests (PageTitleEditor rewrite + round-trip, NavigatorRenameService flow, Frontmatter escape decoding, ContentScanner entity decoding).
- Full suite green: 770 + 222 + 16 across targets, 0 failures. App target builds clean.
- ⚠️ **Manual GUI smoke test not yet run** — needs an interactive app launch to confirm the on-screen inline-edit interaction (context-menu Rename, Return-commit, Esc-cancel, focus-loss-cancel, Return-to-edit).

Design + plan: `docs/superpowers/specs/2026-06-23-navigator-rename-title-design.md`, `docs/superpowers/plans/2026-06-23-navigator-rename-title.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)