### PR TITLE
fix(#81): correct MAS smoke signing — usable-identity team + real provisioning

### DIFF
--- a/scripts/create-smoke-fixture.sh
+++ b/scripts/create-smoke-fixture.sh
@@ -111,9 +111,17 @@ fi
 
 # Refresh the (gitignored) Xcode project from project.yml — a stale Anglesite.xcodeproj
 # missing recently-added Sources/ files fails to compile (and CI regenerates anyway).
+# Let xcodegen's output show: a broken project.yml otherwise surfaces only as a confusing
+# downstream compile error, and a stdout-only failure would be invisible under a redirect.
 if command -v xcodegen >/dev/null 2>&1; then
     echo "==> xcodegen generate (refresh project from project.yml)"
-    (cd "$REPO_ROOT" && xcodegen generate >/dev/null)
+    if ! (cd "$REPO_ROOT" && xcodegen generate); then
+        echo "error: xcodegen generate failed — fix project.yml before re-running" >&2
+        exit 1
+    fi
+else
+    echo "warning: xcodegen not found; Anglesite.xcodeproj may be stale — run" >&2
+    echo "         'brew install xcodegen' if the build fails to find recent Sources/ files" >&2
 fi
 
 DERIVED="$REPO_ROOT/build/mas-smoke"
@@ -125,12 +133,16 @@ echo "==> building AnglesiteMAS (real-signed: Apple Development, team $DEV_TEAM)
 # the smoke would pass for the wrong reasons. The post-build guard below re-asserts this.
 BUILD_LOG="$DERIVED/xcodebuild.log"
 mkdir -p "$DERIVED"
+# Stream output live AND capture it (a Debug MAS build runs minutes — a blank terminal
+# reads as a hang). `tee` to the log so the failure branch can still grep it; under
+# `set -o pipefail` the pipeline reports xcodebuild's exit, not tee's. (Don't append a
+# `| grep` here: a matched "error:" would make grep exit 0 and mask the failure.)
 if ! xcodebuild -project "$REPO_ROOT/Anglesite.xcodeproj" \
     -scheme AnglesiteMAS -configuration Debug \
     -derivedDataPath "$DERIVED" \
     CODE_SIGN_STYLE=Automatic CODE_SIGN_IDENTITY="Apple Development" \
     DEVELOPMENT_TEAM="$DEV_TEAM" -allowProvisioningUpdates \
-    build >"$BUILD_LOG" 2>&1; then
+    build 2>&1 | tee "$BUILD_LOG"; then
     echo "error: AnglesiteMAS build/sign failed. Relevant lines:" >&2
     grep -iE "error:|No Account for Team|No signing certificate|provisioning" "$BUILD_LOG" | tail -10 >&2
     echo "       If you see 'No Account for Team \"$DEV_TEAM\"', add that Apple ID in" >&2

--- a/scripts/create-smoke-fixture.sh
+++ b/scripts/create-smoke-fixture.sh
@@ -97,26 +97,59 @@ if ! security find-identity -v -p codesigning | grep -q "Apple Development"; the
     exit 1
 fi
 
-# Manual signing with the Apple Development identity + team — no provisioning profile needed
-# for a local development run (Automatic style would try to fetch one and fail offline). Derive
-# the 10-char Team ID from the cert; override with DEVELOPMENT_TEAM=... if the default is wrong.
-DEV_TEAM="${DEVELOPMENT_TEAM:-$(security find-certificate -c "Apple Development" -p 2>/dev/null \
-    | openssl x509 -noout -subject 2>/dev/null | grep -oE 'OU *= *[A-Z0-9]{10}' | grep -oE '[A-Z0-9]{10}' | head -1)}"
+# Derive the 10-char Team ID from the first USABLE signing identity. `find-identity -v`
+# lists only certs that have a private key on this machine — unlike `find-certificate`,
+# which also returns stale/foreign certs (e.g. a revoked org cert) with no key, picking
+# the wrong team and failing the build. Override with DEVELOPMENT_TEAM=... for multi-team.
+DEV_TEAM="${DEVELOPMENT_TEAM:-$(security find-identity -v -p codesigning \
+    | grep "Apple Development" | head -1 \
+    | grep -oE '\([A-Z0-9]{10}\)' | tr -d '()')}"
 if [[ -z "$DEV_TEAM" ]]; then
     echo "error: couldn't derive the Apple Development Team ID; set DEVELOPMENT_TEAM=..." >&2
     exit 1
 fi
 
+# Refresh the (gitignored) Xcode project from project.yml — a stale Anglesite.xcodeproj
+# missing recently-added Sources/ files fails to compile (and CI regenerates anyway).
+if command -v xcodegen >/dev/null 2>&1; then
+    echo "==> xcodegen generate (refresh project from project.yml)"
+    (cd "$REPO_ROOT" && xcodegen generate >/dev/null)
+fi
+
 DERIVED="$REPO_ROOT/build/mas-smoke"
 echo "==> building AnglesiteMAS (real-signed: Apple Development, team $DEV_TEAM) into $DERIVED"
-xcodebuild -project "$REPO_ROOT/Anglesite.xcodeproj" \
+# Automatic provisioning + -allowProvisioningUpdates so Xcode mints/downloads the team's
+# "Mac Development" profile. This FAILS LOUDLY if the team's Apple ID isn't in Xcode →
+# Settings → Accounts — which is correct: the alternative (CODE_SIGN_IDENTITY="-") signs
+# AD-HOC, and the App Sandbox / hardened-runtime entitlements are NOT enforced ad-hoc, so
+# the smoke would pass for the wrong reasons. The post-build guard below re-asserts this.
+BUILD_LOG="$DERIVED/xcodebuild.log"
+mkdir -p "$DERIVED"
+if ! xcodebuild -project "$REPO_ROOT/Anglesite.xcodeproj" \
     -scheme AnglesiteMAS -configuration Debug \
     -derivedDataPath "$DERIVED" \
-    CODE_SIGN_IDENTITY="Apple Development" CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="$DEV_TEAM" \
-    build 2>&1 | tail -3
+    CODE_SIGN_STYLE=Automatic CODE_SIGN_IDENTITY="Apple Development" \
+    DEVELOPMENT_TEAM="$DEV_TEAM" -allowProvisioningUpdates \
+    build >"$BUILD_LOG" 2>&1; then
+    echo "error: AnglesiteMAS build/sign failed. Relevant lines:" >&2
+    grep -iE "error:|No Account for Team|No signing certificate|provisioning" "$BUILD_LOG" | tail -10 >&2
+    echo "       If you see 'No Account for Team \"$DEV_TEAM\"', add that Apple ID in" >&2
+    echo "       Xcode → Settings → Accounts, then re-run. Full log: $BUILD_LOG" >&2
+    exit 1
+fi
 
 APP="$DERIVED/Build/Products/Debug/AnglesiteMAS.app"
 NODE="$APP/Contents/Resources/node-runtime/bin/node"
+
+# Guard: a *successful* build can still be AD-HOC (TeamIdentifier=not set) if signing
+# silently fell back. That does NOT satisfy Task 11 — fail rather than mislead.
+if codesign -dv --verbose=4 "$APP" 2>&1 | grep -q "TeamIdentifier=not set"; then
+    echo "error: AnglesiteMAS signed AD-HOC (TeamIdentifier not set) — Task 11 needs a real" >&2
+    echo "       Team signature. Add team $DEV_TEAM's Apple ID in Xcode → Settings → Accounts" >&2
+    echo "       so automatic provisioning signs with the real cert, then re-run." >&2
+    exit 1
+fi
+
 echo "==> verifying the bundled Node is real-signed with our team + JIT/sandbox entitlements"
 codesign -dv --verbose=4 "$NODE" 2>&1 | grep -E "Authority=Apple Development|TeamIdentifier|flags=" || true
 codesign -d --entitlements :- "$NODE" 2>/dev/null | plutil -p - 2>/dev/null | grep -E "app-sandbox|allow-jit|inherit|disable-library-validation" || true


### PR DESCRIPTION
## What

Fixes the `scripts/create-smoke-fixture.sh --mas` harness (Phase 10.1 Task 11, #81) so it produces a **genuinely real-signed** `AnglesiteMAS.app` instead of silently falling back to ad-hoc.

Found while running the Task 11 smoke during Phase 10.1 closeout: the build failed (wrong team), then "succeeded" but **ad-hoc** (TeamIdentifier not set) — which the script's own comments warn "passes for the wrong reasons" because the App Sandbox / hardened-runtime entitlements aren't enforced under ad-hoc signing.

## Three fixes

1. **Team derivation** — was `security find-certificate -c "Apple Development"`, which returns *any* cert by name, including a stale revoked org cert (`M34HBJZNYA`, "Beyond Certified, Inc.") that has no private key on this machine and resolved to the wrong team. Now uses `security find-identity -v -p codesigning` (usable identities only) → correctly resolves the signable team.
2. **Stale project** — the build never refreshed the gitignored `Anglesite.xcodeproj`, so a project missing recently-added `Sources/` files (`StartupProgressModel`, `SiteNavigatorModel`, `FileEditorModel`) failed to compile. Now runs `xcodegen generate` first (guarded on `xcodegen` being installed), matching what CI does.
3. **Real signing, fail-loud** — Manual `CODE_SIGN_IDENTITY="Apple Development"` can't resolve a "Mac Development" provisioning profile and silently went ad-hoc. Now uses automatic provisioning (`-allowProvisioningUpdates`) so Xcode mints the team's profile, **fails loudly** with guidance if the team's Apple ID isn't in Xcode → Settings → Accounts, and a **post-build guard** rejects an ad-hoc (`TeamIdentifier=not set`) result outright.

## Verification

- `bash -n scripts/create-smoke-fixture.sh` — parses.
- Team derivation now resolves the usable identity (`KH7H8Y25RT`) instead of the stale `M34HBJZNYA`.
- Full real-signed end-to-end run still requires the signing team's Apple ID logged into **Xcode → Settings → Accounts** (the genuine #81 prerequisite) — once logged in, the script will mint the profile and the post-build guard confirms a real signature. No test references this script (manual smoke harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)