### PR TITLE
fix: align ProjectValidator sentinels with the actual template

### DIFF
--- a/Sources/AnglesiteCore/ProjectValidator.swift
+++ b/Sources/AnglesiteCore/ProjectValidator.swift
@@ -26,8 +26,10 @@ public enum ProjectValidator {
         "astro.config.mjs"
     ]
     public static let recommendedSentinels: [String] = []
-    /// Union of required + recommended. Existing callers (e.g., `SiteStore`'s "everything-missing
-    /// means this isn't a project directory at all" filter) still use this set.
+    /// Union of required + recommended — the full set a caller can check without caring about the
+    /// tier split. No production code depends on it today (`SiteStore` validates via `validate`'s
+    /// `Result`); it's retained as the tier-agnostic API surface and is exercised by the tests.
+    /// While `recommendedSentinels` is empty this equals `requiredSentinels`.
     public static let sentinels: [String] = requiredSentinels + recommendedSentinels
 
     public struct Result: Sendable, Equatable {

--- a/Sources/AnglesiteCore/ProjectValidator.swift
+++ b/Sources/AnglesiteCore/ProjectValidator.swift
@@ -2,26 +2,30 @@ import Foundation
 
 /// Decides whether a directory is an Anglesite site project.
 ///
+/// The sentinel filenames must match what the scaffolder actually writes (see
+/// `Resources/Template/` + `scaffold.sh`): the canonical markers are `.site-config` and
+/// `astro.config.mjs`. (They are *not* `anglesite.config.json` / `astro.config.ts`, which the
+/// template has never produced — using those flagged every freshly scaffolded site as invalid.)
+///
 /// Two tiers of sentinels:
 ///   - **Required** (`requiredSentinels`) — must be present for the directory to count as an
-///     Anglesite project at all: `anglesite.config.json` (identifies the project as Anglesite-
-///     managed) and `astro.config.ts` (it's an Astro site).
-///   - **Recommended** (`recommendedSentinels`) — written by `/anglesite:start` but not
-///     load-bearing for the core preview + edit pipeline: `keystatic.config.ts` (only needed
-///     if the owner wants Keystatic's CMS UI). A site missing only recommended sentinels is
-///     still valid; the UI can surface them as optional rather than blockers.
+///     Anglesite project at all: `.site-config` (identifies the project as Anglesite-managed and
+///     is read by `scripts/config.ts`'s `readConfig`) and `astro.config.mjs` (it's an Astro site).
+///   - **Recommended** (`recommendedSentinels`) — optional integration markers that aren't
+///     load-bearing for the core preview + edit pipeline. A site missing only recommended
+///     sentinels is still valid; the UI can surface them as optional rather than blockers.
+///     Currently empty (the template ships no optional-but-recommended marker), but the tier is
+///     retained for future integrations.
 ///
 /// `Result.isValid` checks required only. `Result.missing` reports everything missing (so the
-/// UI can show "missing: keystatic.config.ts" even on an otherwise-valid site).
-/// `Result.missingRequired` is the subset the UI uses to decide blocker vs. nice-to-have.
+/// UI can surface an otherwise-valid site's missing optional markers). `Result.missingRequired`
+/// is the subset the UI uses to decide blocker vs. nice-to-have.
 public enum ProjectValidator {
     public static let requiredSentinels: [String] = [
-        "anglesite.config.json",
-        "astro.config.ts"
+        ".site-config",
+        "astro.config.mjs"
     ]
-    public static let recommendedSentinels: [String] = [
-        "keystatic.config.ts"
-    ]
+    public static let recommendedSentinels: [String] = []
     /// Union of required + recommended. Existing callers (e.g., `SiteStore`'s "everything-missing
     /// means this isn't a project directory at all" filter) still use this set.
     public static let sentinels: [String] = requiredSentinels + recommendedSentinels

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -131,14 +131,49 @@ public actor SiteStore {
     /// Loads the persisted site list from disk into memory. Safe to call before `record()`
     /// when the UI wants to render quickly. Skips the change emit on a fresh-install no-file
     /// path — there's nothing to propagate.
+    ///
+    /// Validity is **recomputed live** here rather than trusted from disk: `isValid` /
+    /// `missingSentinels` are filesystem-derived and go stale between launches (files added or
+    /// removed outside the app, or a change to the sentinel set itself), so a cached verdict can
+    /// be wrong — which once left every scaffolded site greyed-out in the launcher even after the
+    /// sentinel list was corrected, because the launcher reads only the cached value. When the
+    /// fresh check disagrees, the corrected list is persisted back so the next launch and the
+    /// Spotlight change-handler start from the right values.
     public func load() async throws {
         guard fileManager.fileExists(atPath: persistenceURL.path) else {
             sites = []
             return
         }
         let data = try Data(contentsOf: persistenceURL)
-        sites = try Self.decoder.decode([Site].self, from: data)
+        var loaded = try Self.decoder.decode([Site].self, from: data)
+        let changed = Self.revalidate(&loaded, fileManager: fileManager)
+        sites = loaded
+        if changed { try? persist() }
         await emitChange()
+    }
+
+    /// Recompute each entry's filesystem-derived `isValid` / `missingSentinels`. On MAS the package
+    /// lives behind a security-scoped grant, so resolve and start the per-site bookmark for the
+    /// duration of the check; on DevID there is no bookmark and the read just works. Returns `true`
+    /// if any entry's verdict changed (so the caller can persist the correction).
+    private static func revalidate(_ sites: inout [Site], fileManager: FileManager) -> Bool {
+        var changed = false
+        for index in sites.indices {
+            var scoped: URL?
+            if let bookmark = sites[index].bookmarkData,
+               let resolved = try? SecurityScopedBookmark.resolve(bookmark),
+               resolved.url.startAccessingSecurityScopedResource() {
+                scoped = resolved.url
+            }
+            let validation = AnglesitePackage(url: sites[index].packageURL).sourceValidation(fileManager: fileManager)
+            scoped?.stopAccessingSecurityScopedResource()
+            if sites[index].isValid != validation.isValid || sites[index].missingSentinels != validation.missing {
+                sites[index].isValid = validation.isValid
+                sites[index].missingSentinels = validation.missing
+                changed = true
+            }
+        }
+        return changed
     }
 
     /// Add or update a recents entry for `package`. Reads its marker for identity + name and

--- a/Tests/AnglesiteCoreTests/ProjectValidatorTests.swift
+++ b/Tests/AnglesiteCoreTests/ProjectValidatorTests.swift
@@ -31,10 +31,9 @@ final class ProjectValidatorTests {
     }
 
     @Test("Is valid when only required sentinels present") func isValidWhenOnlyRequiredSentinelsPresent() throws {
-        // Smoke test (2026-05-22) exposed: a minimal site that has the *required* sentinels
-        // (anglesite.config.json + astro.config.ts) but is missing the *recommended* one
-        // (keystatic.config.ts) is a valid Anglesite project — keystatic is an optional
-        // integration, not a gating requirement. `isValid` should reflect that.
+        // A minimal site that has the *required* sentinels but is missing any *recommended*
+        // ones is still a valid Anglesite project — recommended markers are optional, not
+        // gating. `isValid` should reflect that.
         for name in ProjectValidator.requiredSentinels {
             try Data().write(to: tempDir.appendingPathComponent(name))
         }
@@ -44,14 +43,26 @@ final class ProjectValidatorTests {
         #expect(result.missingRequired == [])
     }
 
+    /// Regression for the Sites launcher showing every scaffolded site grayed-out with a warning
+    /// triangle: the validator required `anglesite.config.json` / `astro.config.ts`, filenames the
+    /// template never produced. The canonical scaffold (`scaffold.sh` + `Resources/Template/`)
+    /// writes `.site-config` and `astro.config.mjs`, so that exact pair must validate as a real
+    /// Anglesite site.
+    @Test("Canonical template layout (.site-config + astro.config.mjs) is valid") func canonicalTemplateLayoutIsValid() throws {
+        try Data().write(to: tempDir.appendingPathComponent(".site-config"))
+        try Data().write(to: tempDir.appendingPathComponent("astro.config.mjs"))
+        let result = ProjectValidator.validate(tempDir)
+        #expect(result.isValid, "a site scaffolded from the template must be valid")
+        #expect(result.missingRequired == [])
+    }
+
     @Test("Not valid when a required sentinel is missing") func notValidWhenARequiredSentinelIsMissing() throws {
-        // Only the recommended sentinel + one of the two required ones — still not a valid
-        // Anglesite project because anglesite.config.json is missing.
-        try Data().write(to: tempDir.appendingPathComponent("astro.config.ts"))
-        try Data().write(to: tempDir.appendingPathComponent("keystatic.config.ts"))
+        // Only one of the two required sentinels — still not a valid Anglesite project because
+        // `.site-config` (the Anglesite-managed marker) is missing.
+        try Data().write(to: tempDir.appendingPathComponent("astro.config.mjs"))
         let result = ProjectValidator.validate(tempDir)
         #expect(!result.isValid)
-        #expect(result.missingRequired == ["anglesite.config.json"])
+        #expect(result.missingRequired == [".site-config"])
     }
 
     @Test("Is valid when all sentinels present") func isValidWhenAllSentinelsPresent() throws {

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -61,6 +61,41 @@ final class SiteStoreTests {
         #expect(loaded.map(\.name) == ["alpha"])
     }
 
+    /// Regression: validity is cached in `recents.json` but recomputed on `load()`. A registry
+    /// written by an older build (or before a sentinel-list fix) can hold a stale `isValid:false`
+    /// for a package that is actually valid on disk — that left every site greyed-out in the
+    /// launcher even after the validator was corrected, because the launcher reads the cached
+    /// value and `load()` never re-checked. `load()` must heal the verdict, and persist it back.
+    @Test("load re-validates a stale isValid against the live filesystem") func loadRevalidatesStaleValidity() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        // Record normally, then corrupt the on-disk registry to a stale invalid verdict.
+        let writer = SiteStore(persistenceURL: persistenceURL)
+        let site = try await writer.record(pkg)
+        #expect(site.isValid)
+        let stale = SiteStore.Site(
+            id: site.id,
+            name: site.name,
+            packageURL: site.packageURL,
+            isValid: false,
+            missingSentinels: ["anglesite.config.json", "astro.config.ts"],
+            lastSeen: site.lastSeen
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode([stale]).write(to: persistenceURL)
+
+        let reader = SiteStore(persistenceURL: persistenceURL)
+        try await reader.load()
+        let loaded = await reader.sites
+        #expect(loaded.count == 1)
+        #expect(loaded[0].isValid, "load() should recompute validity from the live filesystem")
+        #expect(loaded[0].missingSentinels.isEmpty)
+
+        // The correction is healed back to disk, so a second reader sees it without re-checking.
+        let healed = try Data(contentsOf: persistenceURL)
+        #expect(String(decoding: healed, as: UTF8.self).contains("\"isValid\" : true"))
+    }
+
     @Test("Remove does not delete files") func removeDoesNotDeleteFiles() async throws {
         let pkg = try makeValidPackage(named: "alpha")
         let store = SiteStore(persistenceURL: persistenceURL)


### PR DESCRIPTION
## Problem

Every scaffolded site appeared **grayed out with an orange warning triangle** in the Sites launcher (and was un-openable). There were two independent causes — fixing only the first did not clear it.

### 1. Validator required filenames the template never produces

`ProjectValidator` — whose `isValid` drives `.disabled(!site.isValid)` in `SitesLauncherView` — required `anglesite.config.json` + `astro.config.ts`. The canonical template (`Resources/Template/` + `scaffold.sh`) actually ships `astro.config.mjs` and writes `.site-config` as the Anglesite marker (read by `scripts/config.ts`'s `readConfig`). Those phantom names existed only in the validator and its test, so `isValid` was `false` for every site the app creates.

### 2. Validity was cached in `recents.json` and never re-checked

`isValid` / `missingSentinels` are persisted per entry, and `SiteStore.load()` (which the launcher's Reload button calls) decoded them verbatim. So a registry written before the validator fix kept a stale `isValid:false` — and **no rebuild could clear it**, because the launcher only ever reads the cached value.

## Fix

- **Validator:** required sentinels now match reality — `.site-config` + `astro.config.mjs`. Dropped the never-scaffolded `keystatic.config.ts` recommended sentinel (tier retained for future integrations). Doc comment + hardcoded test filenames updated.
- **SiteStore.load():** recompute validity live against the filesystem instead of trusting the cached verdict, and persist the correction back when it disagrees (so the next launch and the Spotlight change-handler heal too). On MAS the per-site security-scoped bookmark is resolved/started for the duration of the check; on DevID there's no bookmark and the read just works.

## Verification

`ProjectValidatorTests`, `SiteStoreTests`, `SiteStoreRecentsTests`, and `RecentSites.select` all pass (44 tests). New regression tests:
- canonical template layout (`.site-config` + `astro.config.mjs`) validates;
- a stale `isValid:false` for a package that's valid on disk heals to valid (and back to disk) on `load()`.

After this, the existing `anglesite-test.anglesite` site self-heals on next launch — no manual registry edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)