### PR TITLE
feat(#66,#67): RemoteSandboxSiteRuntime — AnglesiteCore layer + iOS design/plan

### DIFF
--- a/Sources/AnglesiteCore/HTTPSandboxControlClient.swift
+++ b/Sources/AnglesiteCore/HTTPSandboxControlClient.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// `SandboxControlClient` that calls the user's deployed Control Worker over HTTPS. No Cloudflare
+/// SDK — plain JSON. Used by the iOS app once onboarding has stored the Worker URL + API token.
+public struct HTTPSandboxControlClient: SandboxControlClient {
+    private let workerBaseURL: URL
+    private let apiToken: String
+    private let urlSession: URLSession
+
+    public init(workerBaseURL: URL, apiToken: String, urlSession: URLSession = .shared) {
+        self.workerBaseURL = workerBaseURL
+        self.apiToken = apiToken
+        self.urlSession = urlSession
+    }
+
+    private struct StartBody: Encodable { let siteID, gitRemote, gitRef, token: String }
+    private struct StartResponse: Decodable { let previewURL: URL; let mcpURL: URL }
+    private struct StopBody: Encodable { let siteID: String }
+
+    public func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
+        let body = StartBody(siteID: siteID, gitRemote: gitRemote.absoluteString, gitRef: gitRef, token: token.value)
+        let data = try await post("start", body: body)
+        do {
+            let r = try JSONDecoder().decode(StartResponse.self, from: data)
+            return SandboxSession(previewURL: r.previewURL, mcpURL: r.mcpURL)
+        } catch {
+            throw SandboxControlError.startFailed("bad response: \(error)")
+        }
+    }
+
+    public func stop(siteID: String) async throws {
+        _ = try await post("stop", body: StopBody(siteID: siteID))
+    }
+
+    private func post(_ path: String, body: some Encodable) async throws -> Data {
+        var req = URLRequest(url: workerBaseURL.appendingPathComponent(path))
+        req.httpMethod = "POST"
+        req.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONEncoder().encode(body)
+        let data: Data, resp: URLResponse
+        do { (data, resp) = try await urlSession.data(for: req) }
+        catch { throw SandboxControlError.unreachable(error.localizedDescription) }
+        let code = (resp as? HTTPURLResponse)?.statusCode ?? 0
+        switch code {
+        case 200...299: return data
+        case 401, 403: throw SandboxControlError.unauthorized
+        default: throw SandboxControlError.startFailed(String(data: data, encoding: .utf8) ?? "HTTP \(code)")
+        }
+    }
+}

--- a/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
+++ b/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
@@ -23,6 +23,10 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
         control: any SandboxControlClient,
         mcpClient: MCPClient,
         mintToken: @escaping @Sendable () -> SessionToken = SessionToken.mint,
+        // Default carries no bearer token. The in-container MCP sidecar bearer check + a
+        // token-carrying connect closure are deferred to the iOS onboarding sub-plan (see
+        // design 2026-06-23 §5 and the plan's Deferred sub-plans); this tokenless default
+        // must NOT be wired into production.
         connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { c, u in try await c.connect(httpEndpoint: u) }
     ) {
         self.gitRemote = gitRemote
@@ -82,6 +86,7 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
     }
 
     private func setState(_ s: SiteRuntimeState) {
+        guard s != current else { return }
         current = s
         for c in observers.values { c.yield(s) }
     }

--- a/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
+++ b/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
@@ -22,7 +22,7 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
         gitRef: String,
         control: any SandboxControlClient,
         mcpClient: MCPClient,
-        mintToken: @escaping @Sendable () -> SessionToken = SessionToken.mint,
+        mintToken: @escaping @Sendable () -> SessionToken = { SessionToken.mint() },
         // Default carries no bearer token. The in-container MCP sidecar bearer check + a
         // token-carrying connect closure are deferred to the iOS onboarding sub-plan (see
         // design 2026-06-23 §5 and the plan's Deferred sub-plans); this tokenless default

--- a/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
+++ b/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// `SiteRuntime` over a Cloudflare Sandbox (iOS-only; see design 2026-06-23). Mirrors
+/// `LocalSiteRuntime`'s state machine but drives a `SandboxControlClient` instead of a local
+/// subprocess: mint a token, start the session, connect the MCP client to the returned MCP tunnel,
+/// settle to `.ready`/`.failed`. Spawns nothing locally.
+public actor RemoteSandboxSiteRuntime: SiteRuntime {
+    private let gitRemote: URL
+    private let gitRef: String
+    private let control: any SandboxControlClient
+    public let mcpClient: MCPClient
+    private let mintToken: @Sendable () -> SessionToken
+    private let connect: @Sendable (MCPClient, URL) async throws -> Void
+
+    private var current: SiteRuntimeState = .idle
+    private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
+    private var generation = 0
+    private var activeSiteID: String?
+
+    public init(
+        gitRemote: URL,
+        gitRef: String,
+        control: any SandboxControlClient,
+        mcpClient: MCPClient,
+        mintToken: @escaping @Sendable () -> SessionToken = SessionToken.mint,
+        connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { c, u in try await c.connect(httpEndpoint: u) }
+    ) {
+        self.gitRemote = gitRemote
+        self.gitRef = gitRef
+        self.control = control
+        self.mcpClient = mcpClient
+        self.mintToken = mintToken
+        self.connect = connect
+    }
+
+    public var state: SiteRuntimeState { current }
+
+    public func observe() -> AsyncStream<SiteRuntimeState> {
+        let (stream, continuation) = AsyncStream<SiteRuntimeState>.makeStream(bufferingPolicy: .unbounded)
+        let id = UUID()
+        observers[id] = continuation
+        continuation.onTermination = { [weak self] _ in Task { await self?.removeObserver(id) } }
+        continuation.yield(current)
+        return stream
+    }
+
+    /// `siteDirectory` is unused on the remote path (no local files on iOS); the git remote + ref
+    /// come from `init`. Tears down any previous session, then settles to `.ready`/`.failed`.
+    public func start(siteID: String, siteDirectory: URL) async {
+        await teardown()
+        generation += 1
+        let gen = generation
+        setState(.starting(siteID: siteID))
+        do {
+            let session = try await control.start(
+                siteID: siteID, gitRemote: gitRemote, gitRef: gitRef, token: mintToken())
+            guard gen == generation else { return }
+            try await connect(mcpClient, session.mcpURL)
+            guard gen == generation else { return }
+            activeSiteID = siteID
+            setState(.ready(siteID: siteID, url: session.previewURL))
+        } catch {
+            guard gen == generation else { return }
+            setState(.failed(siteID: siteID, message: Self.friendlyMessage(for: error)))
+        }
+    }
+
+    public func stop() async {
+        generation += 1
+        await teardown()
+        setState(.idle)
+    }
+
+    // MARK: Internals
+
+    private func teardown() async {
+        await mcpClient.stop()
+        if let id = activeSiteID {
+            try? await control.stop(siteID: id)
+            activeSiteID = nil
+        }
+    }
+
+    private func setState(_ s: SiteRuntimeState) {
+        current = s
+        for c in observers.values { c.yield(s) }
+    }
+
+    private func removeObserver(_ id: UUID) { observers[id] = nil }
+
+    static func friendlyMessage(for error: Error) -> String {
+        switch error {
+        case SandboxControlError.notProvisioned: return "Connect a Cloudflare account to preview this site."
+        case SandboxControlError.unauthorized:   return "Cloudflare rejected the session. Reconnect your account."
+        case SandboxControlError.unreachable(let m): return "Couldn't reach Cloudflare: \(m)"
+        case SandboxControlError.startFailed(let m): return "Couldn't start the remote preview: \(m)"
+        default: return "Couldn't start the remote preview: \(error)"
+        }
+    }
+}

--- a/Sources/AnglesiteCore/SandboxControlClient.swift
+++ b/Sources/AnglesiteCore/SandboxControlClient.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// The two tunnel URLs a started remote session exposes: the preview (auth-proxy port) and the
+/// in-container MCP server. Both are `*.trycloudflare.com` quick-tunnel URLs.
+public struct SandboxSession: Sendable, Equatable {
+    public let previewURL: URL
+    public let mcpURL: URL
+    public init(previewURL: URL, mcpURL: URL) {
+        self.previewURL = previewURL
+        self.mcpURL = mcpURL
+    }
+}
+
+public enum SandboxControlError: Error, Equatable {
+    case notProvisioned          // no Control Worker / token on file → route to onboarding
+    case unauthorized            // token rejected by the Worker
+    case unreachable(String)     // network / DNS
+    case startFailed(String)     // Worker reported a boot/clone/hydrate failure
+}
+
+/// Typed wrapper over the user's Control Worker RPCs. The HTTPS impl (`HTTPSandboxControlClient`)
+/// is one conformer; tests use `FakeSandboxControlClient`. No Cloudflare types leak across this seam.
+public protocol SandboxControlClient: Sendable {
+    /// Boot (or resume) the sandbox for `siteID`, clone `gitRemote` at `gitRef`, start the in-guest
+    /// processes with `token` in their environment, and return the two tunnel URLs.
+    func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession
+    /// Stop the session (drop tunnels, let the sandbox sleep).
+    func stop(siteID: String) async throws
+}

--- a/Sources/AnglesiteCore/SessionToken.swift
+++ b/Sources/AnglesiteCore/SessionToken.swift
@@ -1,0 +1,19 @@
+import Foundation
+import CryptoKit
+
+/// A per-session bearer secret minted by the app and validated in-container (auth-proxy + MCP
+/// sidecar). Opaque; symmetric compare. The value is a secret — never log it (see `KeychainStore`).
+public struct SessionToken: Sendable, Equatable, CustomStringConvertible {
+    public let value: String
+
+    public init(value: String) { self.value = value }
+
+    /// 32 cryptographically-random bytes, hex-encoded (64 chars).
+    public static func mint() -> SessionToken {
+        let bytes = SymmetricKey(size: .bits256).withUnsafeBytes { Array($0) }
+        return SessionToken(value: bytes.map { String(format: "%02x", $0) }.joined())
+    }
+
+    /// Redacted — keeps the secret out of logs and crash dumps.
+    public var description: String { "SessionToken(redacted)" }
+}

--- a/Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift
+++ b/Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift
@@ -17,3 +17,46 @@ actor FakeSandboxControlClient: SandboxControlClient {
 
     func stop(siteID: String) async throws { stopped.append(siteID) }
 }
+
+/// A `SandboxControlClient` whose `start` suspends until `release()` is called.
+/// Use this to deterministically interleave a concurrent `stop()` or second `start()`
+/// while the first `start()` is parked inside `control.start(...)`.
+actor GatedFakeSandboxControlClient: SandboxControlClient {
+    private let result: Result<SandboxSession, SandboxControlError>
+    private(set) var stopped: [String] = []
+
+    // Signals when `start` is parked (test waits on this before acting).
+    private var parkedContinuation: CheckedContinuation<Void, Never>?
+    // Gate: `start` resumes when this is fulfilled.
+    private var gateContinuation: CheckedContinuation<Void, Never>?
+
+    init(result: Result<SandboxSession, SandboxControlError>) {
+        self.result = result
+    }
+
+    /// Suspend until `start` parks itself (i.e. the runtime is inside `control.start`).
+    func waitUntilParked() async {
+        await withCheckedContinuation { cont in
+            parkedContinuation = cont
+        }
+    }
+
+    /// Release the suspended `start` call so it returns its result.
+    func release() {
+        gateContinuation?.resume()
+        gateContinuation = nil
+    }
+
+    func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
+        // Signal to the test that we are now parked.
+        await withCheckedContinuation { cont in
+            parkedContinuation?.resume()
+            parkedContinuation = nil
+            // Park here until the test calls release().
+            gateContinuation = cont
+        }
+        return try result.get()
+    }
+
+    func stop(siteID: String) async throws { stopped.append(siteID) }
+}

--- a/Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift
+++ b/Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift
@@ -1,0 +1,19 @@
+import Foundation
+@testable import AnglesiteCore
+
+actor FakeSandboxControlClient: SandboxControlClient {
+    var startResult: Result<SandboxSession, SandboxControlError>
+    private(set) var stopped: [String] = []
+    private(set) var startedToken: SessionToken?
+
+    init(startResult: Result<SandboxSession, SandboxControlError>) {
+        self.startResult = startResult
+    }
+
+    func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
+        startedToken = token
+        return try startResult.get()
+    }
+
+    func stop(siteID: String) async throws { stopped.append(siteID) }
+}

--- a/Tests/AnglesiteCoreTests/HTTPSandboxControlClientTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPSandboxControlClientTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite(.serialized)
+struct HTTPSandboxControlClientTests {
+    private func session() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [SandboxStubURLProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    @Test("start posts and parses the two URLs")
+    func startParses() async throws {
+        SandboxStubURLProtocol.handler = { req in
+            #expect(req.url?.path == "/start")
+            #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer api-tok")
+            let body = #"{"previewURL":"https://p.trycloudflare.com","mcpURL":"https://m.trycloudflare.com/mcp"}"#
+            return (200, Data(body.utf8))
+        }
+        let client = HTTPSandboxControlClient(
+            workerBaseURL: URL(string: "https://worker.example.workers.dev")!,
+            apiToken: "api-tok", urlSession: session())
+        let s = try await client.start(
+            siteID: "s1", gitRemote: URL(string: "https://x/r.git")!,
+            gitRef: "main", token: SessionToken(value: "t"))
+        #expect(s.previewURL == URL(string: "https://p.trycloudflare.com")!)
+        #expect(s.mcpURL == URL(string: "https://m.trycloudflare.com/mcp")!)
+    }
+
+    @Test("401 maps to .unauthorized")
+    func unauthorized() async {
+        SandboxStubURLProtocol.handler = { _ in (401, Data()) }
+        let client = HTTPSandboxControlClient(
+            workerBaseURL: URL(string: "https://w.workers.dev")!, apiToken: "x", urlSession: session())
+        await #expect(throws: SandboxControlError.unauthorized) {
+            _ = try await client.start(
+                siteID: "s", gitRemote: URL(string: "https://x/r.git")!, gitRef: "main", token: SessionToken(value: "t"))
+        }
+    }
+}
+
+/// Minimal URLProtocol stub for offline HTTP-client tests (sandbox control client variant).
+/// Named `SandboxStubURLProtocol` to avoid redeclaration conflict with the queue-based
+/// `StubURLProtocol` already defined in `HTTPTransportTests.swift`.
+final class SandboxStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) -> (Int, Data))?
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        guard let handler = Self.handler else { client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse)); return }
+        let (status, data) = handler(request)
+        let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}

--- a/Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
@@ -67,7 +67,92 @@ struct RemoteSandboxSiteRuntimeTests {
         #expect(seen.contains(.starting(siteID: "s1")))
         #expect(seen.last == .ready(siteID: "s1", url: Self.ok.previewURL))
     }
+
+    // MARK: - Stale-generation guard
+
+    /// Verifies that if `stop()` bumps `generation` while `control.start(...)` is suspended,
+    /// the superseded first `start()` drops its result and does NOT overwrite `.idle`.
+    @Test("stop during suspended start: stale-generation guard drops the result")
+    func staleGenerationGuardDropsSupersededStart() async throws {
+        let gated = GatedFakeSandboxControlClient(result: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = RemoteSandboxSiteRuntime(
+            gitRemote: URL(string: "https://example.com/repo.git")!,
+            gitRef: "main",
+            control: gated,
+            mcpClient: mcp,
+            mintToken: { SessionToken(value: "fixedtoken") },
+            connect: { _, _ in })
+
+        // Begin start() in a background Task — it will park inside control.start().
+        let startTask = Task { await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused")) }
+
+        // Wait until the runtime is genuinely suspended inside control.start().
+        await gated.waitUntilParked()
+
+        // Now call stop() — this bumps generation and tears down.
+        await rt.stop()
+
+        // Release the gated control client so the first start() can resume.
+        await gated.release()
+        await startTask.value
+
+        // The stale-generation guard must have fired; state is .idle, not .ready.
+        #expect(await rt.state == .idle)
+    }
+
+    // MARK: - Live observe contract
+
+    /// Attaches the observer BEFORE start() runs, then drives start() through a
+    /// suspending control client so `.starting` is delivered to a live observer
+    /// (not drained from a buffer after the fact).
+    @Test("observe delivers .starting to a live observer while runtime is mid-start")
+    func observeDeliversStartingToLiveObserver() async throws {
+        let gated = GatedFakeSandboxControlClient(result: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = RemoteSandboxSiteRuntime(
+            gitRemote: URL(string: "https://example.com/repo.git")!,
+            gitRef: "main",
+            control: gated,
+            mcpClient: mcp,
+            mintToken: { SessionToken(value: "fixedtoken") },
+            connect: { _, _ in })
+
+        // Attach the observer BEFORE start().
+        let stream = await rt.observe()
+        let collector = StateCollector()
+
+        // Drain the stream in a side task so we can interleave with start().
+        let drainTask = Task {
+            for await s in stream {
+                await collector.append(s)
+                if case .ready = s { break }
+            }
+        }
+
+        // Begin start() — parks inside control.start(), emitting .starting en route.
+        let startTask = Task { await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused")) }
+
+        // Wait until parked (runtime has emitted .starting and is mid-start).
+        await gated.waitUntilParked()
+
+        // Release so start() completes to .ready.
+        await gated.release()
+        await startTask.value
+        await drainTask.value
+
+        // The stream must have delivered both transitions to the live observer.
+        let seen = await collector.states
+        #expect(seen.contains(.starting(siteID: "s1")))
+        #expect(seen.last == .ready(siteID: "s1", url: Self.ok.previewURL))
+    }
 }
 
 /// Test-only sink so the injected `connect` closure can record the URL it was handed.
 actor ConnectedURLBox { private(set) var url: URL?; func set(_ u: URL) { url = u } }
+
+/// Actor-isolated collector for `SiteRuntimeState` sequences (avoids Sendable warnings).
+actor StateCollector {
+    private(set) var states: [SiteRuntimeState] = []
+    func append(_ s: SiteRuntimeState) { states.append(s) }
+}

--- a/Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
@@ -101,6 +101,43 @@ struct RemoteSandboxSiteRuntimeTests {
         #expect(await rt.state == .idle)
     }
 
+    // MARK: - setState dedup guard
+
+    /// Verifies that `setState` does NOT re-emit when the new state equals the current
+    /// state. Driven by calling `stop()` on an already-idle runtime: the initial `.idle`
+    /// yield from `observe()` is the only delivery; the redundant `.idle` from `stop()`
+    /// must be swallowed.
+    @Test("setState dedup: stop() on an already-idle runtime emits .idle exactly once")
+    func setStateDedup() async {
+        let (rt, _) = makeRuntime(.success(Self.ok))
+        let stream = await rt.observe()
+        let collector = StateCollector()
+
+        // Drain the stream in a background Task. We break after we see two states OR after
+        // a limit so the task doesn't hang if the duplicate is correctly suppressed.
+        let drainTask = Task {
+            var count = 0
+            for await s in stream {
+                await collector.append(s)
+                count += 1
+                // Stop after 2 to catch a spurious duplicate; break after 1 in normal operation.
+                if count >= 2 { break }
+            }
+        }
+
+        // Call stop() on the already-idle runtime — this would produce a duplicate .idle
+        // if the dedup guard is absent.
+        await rt.stop()
+
+        // Give the drain task a moment to collect any spurious emission, then cancel.
+        drainTask.cancel()
+        _ = await drainTask.result
+
+        let seen = await collector.states
+        // The only delivery should be the initial `.idle` from observe().
+        #expect(seen == [.idle])
+    }
+
     // MARK: - Live observe contract
 
     /// Attaches the observer BEFORE start() runs, then drives start() through a

--- a/Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct RemoteSandboxSiteRuntimeTests {
+    private func makeRuntime(
+        _ result: Result<SandboxSession, SandboxControlError>,
+        connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { _, _ in }
+    ) -> (RemoteSandboxSiteRuntime, FakeSandboxControlClient) {
+        let fake = FakeSandboxControlClient(startResult: result)
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = RemoteSandboxSiteRuntime(
+            gitRemote: URL(string: "https://example.com/repo.git")!,
+            gitRef: "main",
+            control: fake,
+            mcpClient: mcp,
+            mintToken: { SessionToken(value: "fixedtoken") },
+            connect: connect)
+        return (rt, fake)
+    }
+
+    private static let ok = SandboxSession(
+        previewURL: URL(string: "https://preview.trycloudflare.com")!,
+        mcpURL: URL(string: "https://mcp.trycloudflare.com/mcp")!)
+
+    @Test("start settles to .ready with the preview URL")
+    func startReady() async {
+        let (rt, _) = makeRuntime(.success(Self.ok))
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        #expect(await rt.state == .ready(siteID: "s1", url: Self.ok.previewURL))
+    }
+
+    @Test("start connects the MCP client to the mcp tunnel URL")
+    func startConnectsMCP() async {
+        let box = ConnectedURLBox()
+        let (rt, _) = makeRuntime(.success(Self.ok), connect: { _, url in await box.set(url) })
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        #expect(await box.url == Self.ok.mcpURL)
+    }
+
+    @Test("control failure settles to .failed")
+    func startFailed() async {
+        let (rt, _) = makeRuntime(.failure(.startFailed("clone failed")))
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        if case .failed(let id, let msg) = await rt.state {
+            #expect(id == "s1")
+            #expect(msg.contains("clone failed"))
+        } else { Issue.record("expected .failed, got \(await rt.state)") }
+    }
+
+    @Test("stop calls the control client and returns to .idle")
+    func stop() async {
+        let (rt, fake) = makeRuntime(.success(Self.ok))
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        await rt.stop()
+        #expect(await rt.state == .idle)
+        #expect(await fake.stopped == ["s1"])
+    }
+
+    @Test("observe yields starting then ready")
+    func observeTransitions() async {
+        let (rt, _) = makeRuntime(.success(Self.ok))
+        let stream = await rt.observe()
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        var seen: [SiteRuntimeState] = []
+        for await s in stream { seen.append(s); if case .ready = s { break } }
+        #expect(seen.contains(.starting(siteID: "s1")))
+        #expect(seen.last == .ready(siteID: "s1", url: Self.ok.previewURL))
+    }
+}
+
+/// Test-only sink so the injected `connect` closure can record the URL it was handed.
+actor ConnectedURLBox { private(set) var url: URL?; func set(_ u: URL) { url = u } }

--- a/Tests/AnglesiteCoreTests/SandboxControlClientTests.swift
+++ b/Tests/AnglesiteCoreTests/SandboxControlClientTests.swift
@@ -1,0 +1,40 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SandboxControlClientTests {
+    @Test("fake returns the configured session and records the token")
+    func fakeStart() async throws {
+        let session = SandboxSession(
+            previewURL: URL(string: "https://preview.trycloudflare.com")!,
+            mcpURL: URL(string: "https://mcp.trycloudflare.com/mcp")!)
+        let fake = FakeSandboxControlClient(startResult: .success(session))
+        let token = SessionToken.mint()
+        let got = try await fake.start(
+            siteID: "site-1",
+            gitRemote: URL(string: "https://example.com/repo.git")!,
+            gitRef: "main",
+            token: token)
+        #expect(got == session)
+        #expect(await fake.startedToken == token)
+    }
+
+    @Test("fake propagates the configured error")
+    func fakeStartError() async {
+        let fake = FakeSandboxControlClient(startResult: .failure(.notProvisioned))
+        await #expect(throws: SandboxControlError.notProvisioned) {
+            _ = try await fake.start(
+                siteID: "s", gitRemote: URL(string: "https://x/r.git")!,
+                gitRef: "main", token: .mint())
+        }
+    }
+
+    @Test("fake records stop calls")
+    func fakeStop() async throws {
+        let fake = FakeSandboxControlClient(
+            startResult: .success(SandboxSession(
+                previewURL: URL(string: "https://p")!, mcpURL: URL(string: "https://m/mcp")!)))
+        try await fake.stop(siteID: "site-1")
+        #expect(await fake.stopped == ["site-1"])
+    }
+}

--- a/Tests/AnglesiteCoreTests/SessionTokenTests.swift
+++ b/Tests/AnglesiteCoreTests/SessionTokenTests.swift
@@ -1,0 +1,24 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SessionTokenTests {
+    @Test("mint produces a 64-char hex string")
+    func mintFormat() {
+        let t = SessionToken.mint()
+        #expect(t.value.count == 64)
+        #expect(t.value.allSatisfy { $0.isHexDigit })
+    }
+
+    @Test("two mints differ")
+    func mintUnique() {
+        #expect(SessionToken.mint() != SessionToken.mint())
+    }
+
+    @Test("description never leaks the value")
+    func redactedDescription() {
+        let t = SessionToken(value: "deadbeef")
+        #expect(!"\(t)".contains("deadbeef"))
+        #expect("\(t)".contains("SessionToken"))
+    }
+}

--- a/docs/superpowers/plans/2026-06-23-remote-sandbox-runtime-core.md
+++ b/docs/superpowers/plans/2026-06-23-remote-sandbox-runtime-core.md
@@ -1,0 +1,618 @@
+# RemoteSandboxSiteRuntime — AnglesiteCore layer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Swift `AnglesiteCore` layer of the iOS remote runtime — a `RemoteSandboxSiteRuntime` that conforms to the existing `SiteRuntime` protocol by driving a Cloudflare Sandbox through a typed control client, minting a per-session token, and pointing its `MCPClient` at the in-container MCP tunnel.
+
+**Architecture:** Mirror `LocalSiteRuntime`'s actor state machine (`current`/`observers`/`generation`/`setState`), but back it with a `SandboxControlClient` (protocol seam — faked in tests) instead of `AstroDevServer`+`ProcessSupervisor`. The runtime mints a `SessionToken`, asks the control client to `start` a session (returning preview + MCP tunnel URLs), connects its `MCPClient` over HTTP to the MCP URL, and settles to `.ready`/`.failed`.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Test`), `AnglesiteCore` SPM target, CryptoKit (token), `URLProtocol` stub (HTTP client tests). No Cloudflare in unit tests.
+
+## Global Constraints
+
+- Targets macOS 27+ / Swift 6.4; the `AnglesiteCore` package is **not** compiled with `ANGLESITE_MAS`, so no `#if ANGLESITE_MAS` guards here.
+- Process spawning is centralized in `ProcessSupervisor` — this layer spawns **nothing**; it only makes HTTPS calls and owns an `MCPClient`.
+- The session token is a secret: **never** log its value (consistent with `KeychainStore`).
+- `SiteRuntime` is fixed (#64, closed): `start(siteID:siteDirectory:) async`, `stop() async`, `observe() -> AsyncStream<SiteRuntimeState>`, `var mcpClient: MCPClient { get }`. Do not change it.
+- The remote path has no local files. `siteDirectory` (a `SiteRuntime` parameter) is **unused** on this runtime; the git remote + ref are supplied at `init` (the iOS onboarding constructs the runtime). Document this at the call site.
+- Tests live in `Tests/AnglesiteCoreTests/`, use Swift Testing, and must pass under `swift test --package-path .`.
+
+---
+
+### Task 1: `SessionToken`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SessionToken.swift`
+- Test: `Tests/AnglesiteCoreTests/SessionTokenTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `public struct SessionToken: Sendable, Equatable { public let value: String; public init(value: String); public static func mint() -> SessionToken }` — `value` is 32 random bytes hex-encoded (64 chars); `description` is redacted.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SessionTokenTests {
+    @Test("mint produces a 64-char hex string")
+    func mintFormat() {
+        let t = SessionToken.mint()
+        #expect(t.value.count == 64)
+        #expect(t.value.allSatisfy { $0.isHexDigit })
+    }
+
+    @Test("two mints differ")
+    func mintUnique() {
+        #expect(SessionToken.mint() != SessionToken.mint())
+    }
+
+    @Test("description never leaks the value")
+    func redactedDescription() {
+        let t = SessionToken(value: "deadbeef")
+        #expect(!"\(t)".contains("deadbeef"))
+        #expect("\(t)".contains("SessionToken"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter SessionTokenTests`
+Expected: FAIL — `cannot find 'SessionToken' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+import Foundation
+import CryptoKit
+
+/// A per-session bearer secret minted by the app and validated in-container (auth-proxy + MCP
+/// sidecar). Opaque; symmetric compare. The value is a secret — never log it (see `KeychainStore`).
+public struct SessionToken: Sendable, Equatable, CustomStringConvertible {
+    public let value: String
+
+    public init(value: String) { self.value = value }
+
+    /// 32 cryptographically-random bytes, hex-encoded (64 chars).
+    public static func mint() -> SessionToken {
+        let bytes = SymmetricKey(size: .bits256).withUnsafeBytes { Array($0) }
+        return SessionToken(value: bytes.map { String(format: "%02x", $0) }.joined())
+    }
+
+    /// Redacted — keeps the secret out of logs and crash dumps.
+    public var description: String { "SessionToken(redacted)" }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter SessionTokenTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SessionToken.swift Tests/AnglesiteCoreTests/SessionTokenTests.swift
+git commit -m "feat(#67): SessionToken — per-session bearer secret"
+```
+
+---
+
+### Task 2: `SandboxControlClient` seam + fake
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SandboxControlClient.swift`
+- Create: `Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift`
+- Test: `Tests/AnglesiteCoreTests/SandboxControlClientTests.swift`
+
+**Interfaces:**
+- Consumes: `SessionToken` (Task 1).
+- Produces:
+  - `public struct SandboxSession: Sendable, Equatable { public let previewURL: URL; public let mcpURL: URL }`
+  - `public enum SandboxControlError: Error, Equatable { case notProvisioned; case unauthorized; case unreachable(String); case startFailed(String) }`
+  - `public protocol SandboxControlClient: Sendable { func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession; func stop(siteID: String) async throws }`
+  - Test helper `actor FakeSandboxControlClient: SandboxControlClient` with `var startResult: Result<SandboxSession, SandboxControlError>`, `private(set) var stopped: [String]`, `private(set) var startedToken: SessionToken?`.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct SandboxControlClientTests {
+    @Test("fake returns the configured session and records the token")
+    func fakeStart() async throws {
+        let session = SandboxSession(
+            previewURL: URL(string: "https://preview.trycloudflare.com")!,
+            mcpURL: URL(string: "https://mcp.trycloudflare.com/mcp")!)
+        let fake = FakeSandboxControlClient(startResult: .success(session))
+        let token = SessionToken.mint()
+        let got = try await fake.start(
+            siteID: "site-1",
+            gitRemote: URL(string: "https://example.com/repo.git")!,
+            gitRef: "main",
+            token: token)
+        #expect(got == session)
+        #expect(await fake.startedToken == token)
+    }
+
+    @Test("fake propagates the configured error")
+    func fakeStartError() async {
+        let fake = FakeSandboxControlClient(startResult: .failure(.notProvisioned))
+        await #expect(throws: SandboxControlError.notProvisioned) {
+            _ = try await fake.start(
+                siteID: "s", gitRemote: URL(string: "https://x/r.git")!,
+                gitRef: "main", token: .mint())
+        }
+    }
+
+    @Test("fake records stop calls")
+    func fakeStop() async throws {
+        let fake = FakeSandboxControlClient(
+            startResult: .success(SandboxSession(
+                previewURL: URL(string: "https://p")!, mcpURL: URL(string: "https://m/mcp")!)))
+        try await fake.stop(siteID: "site-1")
+        #expect(await fake.stopped == ["site-1"])
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter SandboxControlClientTests`
+Expected: FAIL — `cannot find 'SandboxSession'` / `FakeSandboxControlClient`.
+
+- [ ] **Step 3: Write the seam**
+
+```swift
+// Sources/AnglesiteCore/SandboxControlClient.swift
+import Foundation
+
+/// The two tunnel URLs a started remote session exposes: the preview (auth-proxy port) and the
+/// in-container MCP server. Both are `*.trycloudflare.com` quick-tunnel URLs.
+public struct SandboxSession: Sendable, Equatable {
+    public let previewURL: URL
+    public let mcpURL: URL
+    public init(previewURL: URL, mcpURL: URL) {
+        self.previewURL = previewURL
+        self.mcpURL = mcpURL
+    }
+}
+
+public enum SandboxControlError: Error, Equatable {
+    case notProvisioned          // no Control Worker / token on file → route to onboarding
+    case unauthorized            // token rejected by the Worker
+    case unreachable(String)     // network / DNS
+    case startFailed(String)     // Worker reported a boot/clone/hydrate failure
+}
+
+/// Typed wrapper over the user's Control Worker RPCs. The HTTPS impl (`HTTPSandboxControlClient`)
+/// is one conformer; tests use `FakeSandboxControlClient`. No Cloudflare types leak across this seam.
+public protocol SandboxControlClient: Sendable {
+    /// Boot (or resume) the sandbox for `siteID`, clone `gitRemote` at `gitRef`, start the in-guest
+    /// processes with `token` in their environment, and return the two tunnel URLs.
+    func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession
+    /// Stop the session (drop tunnels, let the sandbox sleep).
+    func stop(siteID: String) async throws
+}
+```
+
+```swift
+// Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift
+import Foundation
+@testable import AnglesiteCore
+
+actor FakeSandboxControlClient: SandboxControlClient {
+    var startResult: Result<SandboxSession, SandboxControlError>
+    private(set) var stopped: [String] = []
+    private(set) var startedToken: SessionToken?
+
+    init(startResult: Result<SandboxSession, SandboxControlError>) {
+        self.startResult = startResult
+    }
+
+    func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
+        startedToken = token
+        return try startResult.get()
+    }
+
+    func stop(siteID: String) async throws { stopped.append(siteID) }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter SandboxControlClientTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SandboxControlClient.swift Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift Tests/AnglesiteCoreTests/SandboxControlClientTests.swift
+git commit -m "feat(#66): SandboxControlClient seam + test fake"
+```
+
+---
+
+### Task 3: `RemoteSandboxSiteRuntime`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift`
+- Test: `Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift`
+
+**Interfaces:**
+- Consumes: `SiteRuntime`, `SiteRuntimeState`, `MCPClient` (existing); `SessionToken` (Task 1); `SandboxControlClient`, `SandboxSession`, `SandboxControlError`, `FakeSandboxControlClient` (Task 2).
+- Produces: `public actor RemoteSandboxSiteRuntime: SiteRuntime` with
+  `public init(gitRemote: URL, gitRef: String, control: any SandboxControlClient, mcpClient: MCPClient, mintToken: @Sendable () -> SessionToken = SessionToken.mint, connect: @Sendable (MCPClient, URL) async throws -> Void = { c, u in try await c.connect(httpEndpoint: u) })`.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct RemoteSandboxSiteRuntimeTests {
+    private func makeRuntime(
+        _ result: Result<SandboxSession, SandboxControlError>,
+        connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { _, _ in }
+    ) -> (RemoteSandboxSiteRuntime, FakeSandboxControlClient) {
+        let fake = FakeSandboxControlClient(startResult: result)
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = RemoteSandboxSiteRuntime(
+            gitRemote: URL(string: "https://example.com/repo.git")!,
+            gitRef: "main",
+            control: fake,
+            mcpClient: mcp,
+            mintToken: { SessionToken(value: "fixedtoken") },
+            connect: connect)
+        return (rt, fake)
+    }
+
+    private static let ok = SandboxSession(
+        previewURL: URL(string: "https://preview.trycloudflare.com")!,
+        mcpURL: URL(string: "https://mcp.trycloudflare.com/mcp")!)
+
+    @Test("start settles to .ready with the preview URL")
+    func startReady() async {
+        let (rt, _) = makeRuntime(.success(Self.ok))
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        #expect(await rt.state == .ready(siteID: "s1", url: Self.ok.previewURL))
+    }
+
+    @Test("start connects the MCP client to the mcp tunnel URL")
+    func startConnectsMCP() async {
+        let box = ConnectedURLBox()
+        let (rt, _) = makeRuntime(.success(Self.ok), connect: { _, url in await box.set(url) })
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        #expect(await box.url == Self.ok.mcpURL)
+    }
+
+    @Test("control failure settles to .failed")
+    func startFailed() async {
+        let (rt, _) = makeRuntime(.failure(.startFailed("clone failed")))
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        if case .failed(let id, let msg) = await rt.state {
+            #expect(id == "s1")
+            #expect(msg.contains("clone failed"))
+        } else { Issue.record("expected .failed, got \(await rt.state)") }
+    }
+
+    @Test("stop calls the control client and returns to .idle")
+    func stop() async {
+        let (rt, fake) = makeRuntime(.success(Self.ok))
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        await rt.stop()
+        #expect(await rt.state == .idle)
+        #expect(await fake.stopped == ["s1"])
+    }
+
+    @Test("observe yields starting then ready")
+    func observeTransitions() async {
+        let (rt, _) = makeRuntime(.success(Self.ok))
+        let stream = await rt.observe()
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        var seen: [SiteRuntimeState] = []
+        for await s in stream { seen.append(s); if case .ready = s { break } }
+        #expect(seen.contains(.starting(siteID: "s1")))
+        #expect(seen.last == .ready(siteID: "s1", url: Self.ok.previewURL))
+    }
+}
+
+/// Test-only sink so the injected `connect` closure can record the URL it was handed.
+actor ConnectedURLBox { private(set) var url: URL?; func set(_ u: URL) { url = u } }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter RemoteSandboxSiteRuntimeTests`
+Expected: FAIL — `cannot find 'RemoteSandboxSiteRuntime' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+import Foundation
+
+/// `SiteRuntime` over a Cloudflare Sandbox (iOS-only; see design 2026-06-23). Mirrors
+/// `LocalSiteRuntime`'s state machine but drives a `SandboxControlClient` instead of a local
+/// subprocess: mint a token, start the session, connect the MCP client to the returned MCP tunnel,
+/// settle to `.ready`/`.failed`. Spawns nothing locally.
+public actor RemoteSandboxSiteRuntime: SiteRuntime {
+    private let gitRemote: URL
+    private let gitRef: String
+    private let control: any SandboxControlClient
+    public let mcpClient: MCPClient
+    private let mintToken: @Sendable () -> SessionToken
+    private let connect: @Sendable (MCPClient, URL) async throws -> Void
+
+    private var current: SiteRuntimeState = .idle
+    private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
+    private var generation = 0
+    private var activeSiteID: String?
+
+    public init(
+        gitRemote: URL,
+        gitRef: String,
+        control: any SandboxControlClient,
+        mcpClient: MCPClient,
+        mintToken: @escaping @Sendable () -> SessionToken = SessionToken.mint,
+        connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { c, u in try await c.connect(httpEndpoint: u) }
+    ) {
+        self.gitRemote = gitRemote
+        self.gitRef = gitRef
+        self.control = control
+        self.mcpClient = mcpClient
+        self.mintToken = mintToken
+        self.connect = connect
+    }
+
+    public var state: SiteRuntimeState { current }
+
+    public func observe() -> AsyncStream<SiteRuntimeState> {
+        let (stream, continuation) = AsyncStream<SiteRuntimeState>.makeStream(bufferingPolicy: .unbounded)
+        let id = UUID()
+        observers[id] = continuation
+        continuation.onTermination = { [weak self] _ in Task { await self?.removeObserver(id) } }
+        continuation.yield(current)
+        return stream
+    }
+
+    /// `siteDirectory` is unused on the remote path (no local files on iOS); the git remote + ref
+    /// come from `init`. Tears down any previous session, then settles to `.ready`/`.failed`.
+    public func start(siteID: String, siteDirectory: URL) async {
+        await teardown()
+        generation += 1
+        let gen = generation
+        setState(.starting(siteID: siteID))
+        do {
+            let session = try await control.start(
+                siteID: siteID, gitRemote: gitRemote, gitRef: gitRef, token: mintToken())
+            guard gen == generation else { return }
+            try await connect(mcpClient, session.mcpURL)
+            guard gen == generation else { return }
+            activeSiteID = siteID
+            setState(.ready(siteID: siteID, url: session.previewURL))
+        } catch {
+            guard gen == generation else { return }
+            setState(.failed(siteID: siteID, message: Self.friendlyMessage(for: error)))
+        }
+    }
+
+    public func stop() async {
+        generation += 1
+        await teardown()
+        setState(.idle)
+    }
+
+    // MARK: Internals
+
+    private func teardown() async {
+        await mcpClient.stop()
+        if let id = activeSiteID {
+            try? await control.stop(siteID: id)
+            activeSiteID = nil
+        }
+    }
+
+    private func setState(_ s: SiteRuntimeState) {
+        current = s
+        for c in observers.values { c.yield(s) }
+    }
+
+    private func removeObserver(_ id: UUID) { observers[id] = nil }
+
+    static func friendlyMessage(for error: Error) -> String {
+        switch error {
+        case SandboxControlError.notProvisioned: return "Connect a Cloudflare account to preview this site."
+        case SandboxControlError.unauthorized:   return "Cloudflare rejected the session. Reconnect your account."
+        case SandboxControlError.unreachable(let m): return "Couldn't reach Cloudflare: \(m)"
+        case SandboxControlError.startFailed(let m): return "Couldn't start the remote preview: \(m)"
+        default: return "Couldn't start the remote preview: \(error)"
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter RemoteSandboxSiteRuntimeTests`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
+git commit -m "feat(#66): RemoteSandboxSiteRuntime over SandboxControlClient"
+```
+
+---
+
+### Task 4: `HTTPSandboxControlClient` (real Worker calls)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/HTTPSandboxControlClient.swift`
+- Test: `Tests/AnglesiteCoreTests/HTTPSandboxControlClientTests.swift`
+
+**Interfaces:**
+- Consumes: `SandboxControlClient`, `SandboxSession`, `SandboxControlError`, `SessionToken`.
+- Produces: `public struct HTTPSandboxControlClient: SandboxControlClient` with
+  `public init(workerBaseURL: URL, apiToken: String, urlSession: URLSession = .shared)`.
+  Wire protocol: `POST {base}/start` JSON `{siteID,gitRemote,gitRef,token}` → 200 `{previewURL,mcpURL}`; `POST {base}/stop` JSON `{siteID}` → 200; `Authorization: Bearer {apiToken}`; 401 → `.unauthorized`; non-2xx → `.startFailed(body)`; transport error → `.unreachable(desc)`.
+
+- [ ] **Step 1: Write the failing test (URLProtocol stub)**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct HTTPSandboxControlClientTests {
+    private func session() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    @Test("start posts and parses the two URLs")
+    func startParses() async throws {
+        StubURLProtocol.handler = { req in
+            #expect(req.url?.path == "/start")
+            #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer api-tok")
+            let body = #"{"previewURL":"https://p.trycloudflare.com","mcpURL":"https://m.trycloudflare.com/mcp"}"#
+            return (200, Data(body.utf8))
+        }
+        let client = HTTPSandboxControlClient(
+            workerBaseURL: URL(string: "https://worker.example.workers.dev")!,
+            apiToken: "api-tok", urlSession: session())
+        let s = try await client.start(
+            siteID: "s1", gitRemote: URL(string: "https://x/r.git")!,
+            gitRef: "main", token: SessionToken(value: "t"))
+        #expect(s.previewURL == URL(string: "https://p.trycloudflare.com")!)
+        #expect(s.mcpURL == URL(string: "https://m.trycloudflare.com/mcp")!)
+    }
+
+    @Test("401 maps to .unauthorized")
+    func unauthorized() async {
+        StubURLProtocol.handler = { _ in (401, Data()) }
+        let client = HTTPSandboxControlClient(
+            workerBaseURL: URL(string: "https://w.workers.dev")!, apiToken: "x", urlSession: session())
+        await #expect(throws: SandboxControlError.unauthorized) {
+            _ = try await client.start(
+                siteID: "s", gitRemote: URL(string: "https://x/r.git")!, gitRef: "main", token: SessionToken(value: "t"))
+        }
+    }
+}
+
+/// Minimal URLProtocol stub for offline HTTP-client tests.
+final class StubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) -> (Int, Data))?
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        guard let handler = Self.handler else { client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse)); return }
+        let (status, data) = handler(request)
+        let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter HTTPSandboxControlClientTests`
+Expected: FAIL — `cannot find 'HTTPSandboxControlClient' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+import Foundation
+
+/// `SandboxControlClient` that calls the user's deployed Control Worker over HTTPS. No Cloudflare
+/// SDK — plain JSON. Used by the iOS app once onboarding has stored the Worker URL + API token.
+public struct HTTPSandboxControlClient: SandboxControlClient {
+    private let workerBaseURL: URL
+    private let apiToken: String
+    private let urlSession: URLSession
+
+    public init(workerBaseURL: URL, apiToken: String, urlSession: URLSession = .shared) {
+        self.workerBaseURL = workerBaseURL
+        self.apiToken = apiToken
+        self.urlSession = urlSession
+    }
+
+    private struct StartBody: Encodable { let siteID, gitRemote, gitRef, token: String }
+    private struct StartResponse: Decodable { let previewURL: URL; let mcpURL: URL }
+    private struct StopBody: Encodable { let siteID: String }
+
+    public func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
+        let body = StartBody(siteID: siteID, gitRemote: gitRemote.absoluteString, gitRef: gitRef, token: token.value)
+        let data = try await post("start", body: body)
+        do {
+            let r = try JSONDecoder().decode(StartResponse.self, from: data)
+            return SandboxSession(previewURL: r.previewURL, mcpURL: r.mcpURL)
+        } catch {
+            throw SandboxControlError.startFailed("bad response: \(error)")
+        }
+    }
+
+    public func stop(siteID: String) async throws {
+        _ = try await post("stop", body: StopBody(siteID: siteID))
+    }
+
+    private func post(_ path: String, body: some Encodable) async throws -> Data {
+        var req = URLRequest(url: workerBaseURL.appendingPathComponent(path))
+        req.httpMethod = "POST"
+        req.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONEncoder().encode(body)
+        let data: Data, resp: URLResponse
+        do { (data, resp) = try await urlSession.data(for: req) }
+        catch { throw SandboxControlError.unreachable(error.localizedDescription) }
+        let code = (resp as? HTTPURLResponse)?.statusCode ?? 0
+        switch code {
+        case 200...299: return data
+        case 401, 403: throw SandboxControlError.unauthorized
+        default: throw SandboxControlError.startFailed(String(data: data, encoding: .utf8) ?? "HTTP \(code)")
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter HTTPSandboxControlClientTests`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the whole Core suite + commit**
+
+Run: `swift test --package-path . --filter AnglesiteCoreTests`
+Expected: PASS (existing suite + the new tests; 0 failures).
+
+```bash
+git add Sources/AnglesiteCore/HTTPSandboxControlClient.swift Tests/AnglesiteCoreTests/HTTPSandboxControlClientTests.swift
+git commit -m "feat(#66): HTTPSandboxControlClient — Control Worker calls over HTTPS"
+```
+
+---
+
+## Deferred sub-plans (separate specs/plans — NOT in this plan)
+
+This plan delivers the unit-testable Swift core only. The other three subsystems each need their own plan (and #71 must exist before the iOS one can build):
+
+1. **Control Worker + amd64 image + in-guest auth-proxy** (TS/Docker, template repo) — implements the `/start` `/stop` `/status` RPCs this client calls, `tunnels.get(8080)`+`tunnels.get(4399)`, and the cookie-validating auth-proxy in front of `astro dev`.
+2. **MCP sidecar bearer check** (Node) — validate `Authorization: Bearer` on HTTP + WS upgrade.
+3. **iOS onboarding + WebView** (blocked on #71) — Deploy-to-Cloudflare flow, Keychain (Worker URL + API token), `WKWebView` via `UIViewRepresentable`, session-token cookie injection.
+4. **Live integration test** — boots a real sandbox; retires the #61 spike TBDs.
+
+## Self-Review
+
+- **Spec coverage (this subsystem):** SessionToken (Task 1) ✓ · control seam (Task 2) ✓ · runtime state machine + MCP connect + teardown (Task 3) ✓ · real Worker HTTPS calls (Task 4) ✓. Worker/image/auth-proxy, MCP-sidecar auth, iOS onboarding, live test → explicitly deferred above.
+- **Placeholder scan:** none — every step has real test + impl code and exact `swift test --filter` commands.
+- **Type consistency:** `SandboxSession{previewURL,mcpURL}`, `SandboxControlError` cases, and `SandboxControlClient.start(siteID:gitRemote:gitRef:token:)`/`stop(siteID:)` are used identically across Tasks 2–4 and the runtime. `RemoteSandboxSiteRuntime.init` matches its Interfaces block. `MCPClient.connect(httpEndpoint:)` matches `MCPClient.swift:161`. `SiteRuntime` conformance matches `SiteRuntime.swift` (`mcpClient` getter satisfied by `public let`).

--- a/docs/superpowers/specs/2026-06-23-remote-sandbox-runtime-ios-design.md
+++ b/docs/superpowers/specs/2026-06-23-remote-sandbox-runtime-ios-design.md
@@ -1,0 +1,169 @@
+# RemoteSandboxSiteRuntime + in-container security (iOS) — design
+
+**Date:** 2026-06-23
+**Issues:** #66 (`RemoteSandboxSiteRuntime` + control plane) + #67 (remote preview security) — designed as one slice. Part of epic #59. Consumed by #71 (iOS thin client).
+**Status:** Approved design; ready for implementation planning.
+
+## Scope correction (read first)
+
+This runtime is **iOS-only**. The earlier epic framing ("MAS takes the Cloudflare
+fallback") is superseded by the owner's decision (2026-06-23):
+
+- **macOS uses Apple Containerization** (`LocalContainerSiteRuntime`, #69) as *the*
+  runtime — including the MAS build, which means #69 must eventually run under the App
+  Sandbox (reopening #60's **Wall 3**: container networking without `vmnet`). That is a
+  **separate, next-up macOS blocker** and is out of scope here.
+- **The remote Cloudflare sandbox is only an option on iOS** (#71), which has no Apple
+  Containerization, no Node, and no subprocesses.
+
+So this design targets a device that can only make HTTPS calls and host a `WKWebView`.
+
+## Goal
+
+Let the iOS thin client open any Anglesite site, run its Astro dev server + the app-owned
+Node MCP sidecar in a **Cloudflare Sandbox** in the *user's own* Cloudflare account, show
+the live preview in a `WKWebView`, and drive edits over the in-container MCP server — with
+every session gated by an app-minted bearer token.
+
+## Locked decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Substrate | Cloudflare Sandbox (`@cloudflare/sandbox`) in the **user's account**; user bills | Matches epic "BYO token, remote bills the user"; zero Anglesite-operated infra |
+| Exposure | Per-port **quick tunnels** (`sandbox.tunnels.get(port)` → `*.trycloudflare.com`) | Zero-config, no custom domain / wildcard DNS; works on `.workers.dev` |
+| Authz home | **In-container** (auth-proxy for preview, bearer check in MCP sidecar) | Quick tunnels bypass the Worker, so the Worker can't validate — see "Exposure ⇄ auth" below |
+| Provisioning | One-time **Deploy-to-Cloudflare** flow against an Anglesite-maintained template repo | iOS can't build/push a container image or run wrangler; CF does it hosted |
+| Image | **amd64** OCI, built + pushed **Cloudflare-side** from the template repo | Cloudflare Containers require `linux/amd64`; iOS can't build images |
+| Source of truth | Git — sandbox `git clone`s `Source/`; cold re-hydrate on eviction | #72; survives `sleepAfter` disk loss |
+
+## Research findings that drive the design (Cloudflare docs, 2026-06)
+
+1. **Container architecture is amd64-only.** *"Your container image must be able to run on
+   the `linux/amd64` architecture"*
+   ([get-started](https://developers.cloudflare.com/containers/get-started/)). The local leg
+   (#69, Apple Silicon) is arm64, so the shared image is multi-arch overall, but the **remote
+   leg is amd64**, built Cloudflare-side here.
+2. **Exposure ⇄ auth tension.** `exposePort()` + `proxyToSandbox()` route every HTTP/WS
+   request through the Worker (so it *could* validate a token, via the SDK's
+   `validatePortToken()` / `wsConnect()`) **but require a custom domain with wildcard DNS**.
+   `sandbox.tunnels.get(port)` gives a zero-config `*.trycloudflare.com` URL but the traffic
+   goes cloudflared→client, **bypassing the Worker**
+   ([ports](https://developers.cloudflare.com/sandbox/api/ports/),
+   [tunnels changelog 2026-05-29](https://developers.cloudflare.com/changelog/post/2026-05-29-sandbox-named-tunnels/)).
+   We chose tunnels → **authz must live in-container.**
+3. **Container lifecycle.** `sleepAfter` idle-stops the instance; **container disk is lost on
+   sleep** (only Durable-Object `ctx.storage` persists). Snapshot/resume is **not documented
+   as reliable** → assume cold re-hydrate (Git clone + baked `node_modules`) on every cold
+   start ([containers](https://developers.cloudflare.com/containers/), get-started).
+4. **Instance types.** `lite` (1/16 vCPU, 256 MiB) … `standard-4` (4 vCPU, 12 GiB, 20 GB),
+   plus custom (GA)
+   ([limits](https://developers.cloudflare.com/containers/platform-details/limits/)).
+   `astro dev` + Node + sharp → floor is `standard-1`/`standard-2`; confirm under load.
+5. **Provisioning without wrangler.** Workers can be deployed via REST/JSON API or the
+   **Deploy-to-Cloudflare button** (`deploy.workers.cloudflare.com/?url=<template>`), which
+   provisions Worker + Durable Objects (and builds/pushes the container image) into the user's
+   account via browser OAuth
+   ([new Workers API](https://developers.cloudflare.com/changelog/post/2025-09-03-new-workers-api/)).
+
+## Architecture
+
+```
+ iOS thin client (#71)                       User's Cloudflare account
+ ┌─────────────────────────┐  Deploy-to-CF   ┌────────────────────────────────────┐
+ │ Onboarding              │──(browser OAuth)▶│ Control Worker + Sandbox DO         │
+ │  • store Worker URL+token│                 │  (from Anglesite template repo;     │
+ │                          │                 │   CF builds/pushes amd64 image)     │
+ │ RemoteSandboxSiteRuntime │   HTTPS control │  ┌──────────────────────────────┐  │
+ │   : SiteRuntime (#64)    │────start/stop──▶│  │ Container (amd64 OCI)         │  │
+ │   • mint sessionToken    │                 │  │  auth-proxy :8080 ◀─tunnel──┐ │  │ preview URL
+ │   • start/stop/observe    │                │  │    └─▶ astro dev :4321       │ │  │
+ │   • mcpEndpoint           │   tunnel URLs  │  │  MCP sidecar :4399 ◀─tunnel─┼─┘  │ mcp URL
+ │ WKWebView(UIViewRep.)     │◀──HTTPS/WS(cookie=token)─▶ auth-proxy (validates cookie)
+ │ MCPClient(Bearer token)   │◀──HTTPS/WS(Authorization: Bearer)─▶ MCP sidecar (validates)
+ └─────────────────────────┘                 └────────────────────────────────────┘
+```
+
+## Components (units, with one clear purpose each)
+
+1. **`RemoteSandboxSiteRuntime`** (AnglesiteCore) — implements `SiteRuntime` (#64). Owns the
+   session: mints the token, calls the Control Worker to start/stop, observes state, exposes
+   `mcpEndpoint`. Depends on a `SandboxControlClient` (below) and `SessionToken`.
+2. **`SandboxControlClient`** (AnglesiteCore, protocol + HTTPS impl) — thin typed wrapper over
+   the Control Worker's RPCs (`start`, `stop`, `status`). The protocol seam is what unit tests
+   fake — no Cloudflare in tests.
+3. **Control Worker** (new repo/dir: the Anglesite template) — `@cloudflare/sandbox` host:
+   the Sandbox Durable Object + `start`/`stop`/`status` routes. On `start`: `getSandbox(id =
+   user+site)`, `git clone` the `Source/` repo at `gitRef`, hydrate, `startProcess` the three
+   in-guest processes (token in env), then open two tunnels: **`tunnels.get(8080)` for the
+   preview (the auth-proxy port — *not* astro's 4321; tunneling 4321 directly would expose the
+   dev server unauthenticated)** and `tunnels.get(4399)` for MCP. Return the two URLs. Deployed
+   once per user via the Deploy button.
+4. **In-guest auth-proxy** (OCI image) — small reverse proxy in front of `astro dev` that
+   validates the session token (as a **cookie**, so HMR WebSocket upgrades and asset requests
+   from the `WKWebView` all carry it) and forwards. This is where #67's preview authz lives.
+5. **MCP sidecar bearer check** (app-owned Node sidecar, already HTTP per #63) — validates
+   `Authorization: Bearer <token>` on HTTP **and** WS upgrade; rejects otherwise.
+6. **`SessionToken`** (AnglesiteCore) — 256-bit opaque (CryptoKit random), minted per session,
+   passed into the sandbox as an env secret, never logged. Symmetric compare in-guest (no
+   asymmetric crypto needed).
+7. **Onboarding** (iOS) — Deploy-to-Cloudflare flow (open in `ASWebAuthenticationSession` /
+   in-app browser) + capture of the Worker URL and an API token (reuse #207's verify-then-
+   persist pattern; expanded token scope).
+
+## Data flow
+
+- **Provision (once):** user taps "Connect Cloudflare" → Deploy-to-CF button (template repo)
+  → CF builds/pushes the amd64 image + deploys the Worker+DO into their account → app stores
+  Worker URL + API token in the Keychain.
+- **Start session:** mint `SessionToken` → `SandboxControlClient.start(site, gitRef, token)` →
+  Worker boots the sandbox, hydrates from Git, starts the 3 processes, opens 2 tunnels,
+  returns `{previewURL, mcpURL}` → app injects the token as a cookie into the `WKWebView`
+  cookie store, loads `previewURL`; `MCPClient.connect(httpEndpoint: mcpURL)` with the bearer
+  header → state `.ready(url:)`.
+- **Edit:** unchanged app-side — `apply_edit`/`undo_edit` over the authenticated MCP tunnel.
+- **Teardown (Q-C — shared lifetime):** view/tab close → `SandboxControlClient.stop` (drop
+  tunnels, let the sandbox sleep) → discard the token. Idle → `sleepAfter` stops it; next open
+  is a cold re-hydrate with a fresh token + fresh tunnels.
+
+## Error handling & edge cases
+
+- **No token / not provisioned** → route to onboarding, don't attempt a session.
+- **Worker unreachable / token invalid** → surface a clear "reconnect Cloudflare" state;
+  never silently retry into a billing loop.
+- **Cold start slow / hydrate fallback** → `.starting` state drives a determinate-ish progress
+  UI; if baked `node_modules` doesn't match the lockfile, fall back to `npm ci` (slower; log
+  it, don't fail).
+- **Tunnel/auth mismatch** → a 401/403 from the auth-proxy or MCP sidecar tears the session
+  down rather than showing a half-authed preview.
+- **Sandbox evicted mid-session** → observe loss, re-hydrate transparently or prompt.
+
+## Testing
+
+- **`RemoteSandboxSiteRuntime`** against a **faked `SandboxControlClient`**: start/stop/observe
+  state machine, token minting, teardown ordering, error mapping. No Cloudflare. Runs under
+  `swift test` on CI.
+- **In-guest auth** (auth-proxy + MCP bearer): unit tests reject missing/wrong token on HTTP
+  **and** WS upgrade; accept valid; cookie vs header paths.
+- **One opt-in live integration test** (gated on a real account token, like the existing e2e
+  gates): boots a real sandbox, asserts preview loads, **HMR over the tunnel WebSocket**, and
+  an authenticated MCP round-trip. This finally retires the #61 spike's unmeasured TBDs.
+
+## Open items (verify during implementation; non-blocking)
+
+- Exact Cloudflare **token permission groups** for Containers + Durable Objects + Workers
+  Scripts (and image push for the deploy step — the Deploy button handles push). Manual-verify
+  like the #207 onboarding-URL gate.
+- **Instance-type floor** (`standard-1` vs `standard-2`) — measure RAM under `astro dev` +
+  sharp in the live test.
+- **Template repo** location + maintenance (the Control Worker + Dockerfile that the Deploy
+  button targets); how its image digest tracks the canonical image (#62).
+
+## Epic touchpoints
+
+- **#64 `SiteRuntime`** — this drops in as the second impl (alongside #69). `PreviewView` is
+  already `URL`-only, so it's portable.
+- **#63/#65 MCP-over-HTTP** — reused as-is; the sidecar gains the bearer check.
+- **#69 / #60 Wall 3** — the macOS local runtime is the separate next blocker (MAS App Sandbox
+  networking). Not addressed here.
+- **#71 iOS target** — this runtime ships *in* it; depends on the iOS shell existing.
+- **#70 host-Node retirement** — unaffected on iOS (no host Node there at all).


### PR DESCRIPTION
Part of the containerization epic **#59**. Lands the **AnglesiteCore Swift layer** of the iOS-only remote Cloudflare sandbox runtime, plus the design spec and implementation plan it was built from.

## Scope decision (important)
Per the 2026-06-23 direction: **macOS uses Apple Containerization (#69); the remote Cloudflare sandbox is an iOS-only option.** So this is the iOS path. The design (#66 runtime + control plane) and its security (#67 per-session token) were brainstormed and planned as one slice; this PR delivers the one subsystem that is **unit-testable today** — the Swift core. The Control Worker + amd64 image + in-guest auth-proxy, the MCP-sidecar bearer check, and the iOS onboarding/WebView are explicitly **deferred sub-plans** (the iOS UI one is blocked on #71).

## What's in this PR
**Docs**
- `docs/superpowers/specs/2026-06-23-remote-sandbox-runtime-ios-design.md` — design (grounded in current Cloudflare docs: amd64-only containers, quick-tunnel exposure bypasses the Worker → in-container auth, Deploy-to-Cloudflare provisioning).
- `docs/superpowers/plans/2026-06-23-remote-sandbox-runtime-core.md` — the TDD plan this PR executes.

**Code (`AnglesiteCore`)** — TDD, drops into the existing `SiteRuntime` protocol (#64, unchanged):
- `SessionToken` — 256-bit CryptoKit secret, redacted `description`, never logged.
- `SandboxControlClient` seam + `SandboxSession`/`SandboxControlError` (+ test fake).
- `RemoteSandboxSiteRuntime` actor — mirrors `LocalSiteRuntime`'s generation-guarded state machine; mints a token, drives the control client, connects its `MCPClient` to the MCP tunnel, settles `.ready`/`.failed`.
- `HTTPSandboxControlClient` — real Control-Worker HTTPS calls (URLProtocol-stubbed tests).

## Testing
16 new tests (incl. a deterministic gated-fake test proving the stale-generation guard, and a live-observer test). Full `AnglesiteCoreTests` suite: **797/797 green, build warning-free**. This layer spawns nothing locally — HTTPS + an owned `MCPClient` only.

## Review provenance
Built via subagent-driven development: per-task spec+quality review on each of the 4 tasks, then a whole-branch review (verdict: ready to merge). The one merge-blocker it raised (`setState` dedup guard, to match `LocalSiteRuntime`) is fixed in this branch.

### Known follow-ups (not merge-blocking; iOS path doesn't ship until #71)
- `teardown()` doesn't stop an in-flight `control.start` session if `stop()` races before `activeSiteID` is set (sandbox `sleepAfter` backstops the orphan).
- `.startFailed` reused for `/stop` errors (no `stopFailed` case yet); 403→`.unauthorized` and the start request-body contents are untested.
- The default `connect` closure carries no bearer token — production must supply a token-carrying closure once the in-guest sidecar bearer check lands.

Closes neither #66 nor #67 (their Worker/image/auth-proxy + onboarding remain) — see the design's deferred sub-plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)