### PR TITLE
Add website settings editor

### DIFF
--- a/Sources/AnglesiteApp/HTMLSnippetEditor.swift
+++ b/Sources/AnglesiteApp/HTMLSnippetEditor.swift
@@ -1,0 +1,92 @@
+import AppKit
+import SwiftUI
+
+struct HTMLSnippetEditor: NSViewRepresentable {
+    @Binding var text: String
+    var onEditingEnded: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, onEditingEnded: onEditingEnded)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+
+        let textView = NSTextView()
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+        textView.backgroundColor = .textBackgroundColor
+        textView.textContainerInset = NSSize(width: 6, height: 6)
+        textView.delegate = context.coordinator
+        textView.string = text
+        context.coordinator.applyHighlighting(to: textView)
+
+        scrollView.documentView = textView
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+        if textView.string != text {
+            textView.string = text
+            context.coordinator.applyHighlighting(to: textView)
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        private var text: Binding<String>
+        private let onEditingEnded: () -> Void
+        private var isHighlighting = false
+
+        init(text: Binding<String>, onEditingEnded: @escaping () -> Void) {
+            self.text = text
+            self.onEditingEnded = onEditingEnded
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            text.wrappedValue = textView.string
+            applyHighlighting(to: textView)
+        }
+
+        func textDidEndEditing(_ notification: Notification) {
+            onEditingEnded()
+        }
+
+        func applyHighlighting(to textView: NSTextView) {
+            guard !isHighlighting else { return }
+            isHighlighting = true
+            defer { isHighlighting = false }
+
+            let selectedRanges = textView.selectedRanges
+            let source = textView.string as NSString
+            let fullRange = NSRange(location: 0, length: source.length)
+            let storage = textView.textStorage
+            storage?.beginEditing()
+            storage?.setAttributes([
+                .font: NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular),
+                .foregroundColor: NSColor.labelColor
+            ], range: fullRange)
+
+            highlight(pattern: #"</?[\w:-]+|/?>"#, color: .systemBlue, in: source, storage: storage)
+            highlight(pattern: #"[\w:-]+(?=\=)"#, color: .systemPurple, in: source, storage: storage)
+            highlight(pattern: #""[^"]*"|'[^']*'"#, color: .systemGreen, in: source, storage: storage)
+            highlight(pattern: #"<!--[\s\S]*?-->"#, color: .secondaryLabelColor, in: source, storage: storage)
+
+            storage?.endEditing()
+            textView.selectedRanges = selectedRanges
+        }
+
+        private func highlight(pattern: String, color: NSColor, in source: NSString, storage: NSTextStorage?) {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { return }
+            let range = NSRange(location: 0, length: source.length)
+            for match in regex.matches(in: source as String, range: range) {
+                storage?.addAttribute(.foregroundColor, value: color, range: match.range)
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteApp/MainPaneEditorView.swift
+++ b/Sources/AnglesiteApp/MainPaneEditorView.swift
@@ -26,7 +26,7 @@ struct MainPaneEditorView: View {
                     ProgressView().controlSize(.small)
                 } else {
                     switch EditorKind.resolve(for: model.file) {
-                    case .text:
+                    case .text, .plist:
                         TextEditor(text: $model.text)
                             .font(.system(.body, design: .monospaced))
                             .scrollContentBackground(.hidden)

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -1,0 +1,270 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+@MainActor
+@Observable
+final class PlistEditorModel {
+    let file: FileRef
+    let sourceDirectory: URL
+    private let initialWebsiteTitle: String
+    private let analyticsProvider: any CloudflareWebAnalyticsProviding
+    private let customAnalyticsValidator: any CustomAnalyticsHTMLValidating
+    private let keychain: KeychainStore
+    var entries: [PlistDocumentIO.PlistEntry] = []
+    private(set) var savedEntries: [PlistDocumentIO.PlistEntry] = []
+    private var allEntries: [PlistDocumentIO.PlistEntry] = []
+    private(set) var lastModified: Date?
+    private(set) var loadError: String?
+    private(set) var iconError: String?
+    private(set) var analyticsError: String?
+    private(set) var isLoading = false
+    private(set) var isInstallingIcons = false
+    private(set) var isSavingAnalytics = false
+    private(set) var isConfiguringCloudflareAnalytics = false
+    private(set) var hasWebsiteIcons = false
+    var analyticsSettings = WebsiteAnalyticsAsset.Settings()
+    private(set) var savedAnalyticsSettings = WebsiteAnalyticsAsset.Settings()
+    var conflictDiskContents: String?
+
+    var isDirty: Bool { entries != savedEntries && loadError == nil && !isLoading }
+    var isAnalyticsDirty: Bool { analyticsSettings != savedAnalyticsSettings && loadError == nil && !isLoading }
+    var cloudflareAnalyticsEnabled: Bool { !analyticsSettings.cloudflareToken.isEmpty }
+    var customAnalyticsValidationMessage: String? {
+        WebsiteAnalyticsAsset.customHeadTagValidationMessage(analyticsSettings.customHeadTag)
+    }
+
+    var validationMessage: String? {
+        for entry in entries {
+            if case .unsupported(let description) = entry.value {
+                return "\(entry.key) is a \(description.lowercased()) value, which this editor can't save yet."
+            }
+        }
+        return nil
+    }
+
+    var websiteTitle: String {
+        get {
+            guard let entry = entries.first, case .string(let title) = entry.value else { return "" }
+            return title
+        }
+        set {
+            guard let index = entries.firstIndex(where: Self.isWebsiteTitleEntry) else { return }
+            entries[index].value = .string(newValue)
+        }
+    }
+
+    init(file: FileRef, websiteTitle: String, sourceDirectory: URL,
+         analyticsProvider: any CloudflareWebAnalyticsProviding = CloudflareWebAnalyticsClient(),
+         customAnalyticsValidator: any CustomAnalyticsHTMLValidating = AstroHTMLValidator(),
+         keychain: KeychainStore = KeychainStore()) {
+        self.file = file
+        self.initialWebsiteTitle = websiteTitle
+        self.sourceDirectory = sourceDirectory
+        self.analyticsProvider = analyticsProvider
+        self.customAnalyticsValidator = customAnalyticsValidator
+        self.keychain = keychain
+        self.hasWebsiteIcons = WebsiteIconInstaller.hasInstalledIcons(in: sourceDirectory)
+    }
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        let url = file.url
+        do {
+            let loaded = try await Task.detached(priority: .userInitiated) {
+                try PlistDocumentIO.load(url)
+            }.value
+            var visibleEntries = loaded.entries.filter(Self.isWebsiteTitleEntry)
+            if let index = visibleEntries.firstIndex(where: Self.isWebsiteTitleEntry) {
+                visibleEntries[index].value = .string(initialWebsiteTitle)
+            }
+            allEntries = loaded.entries
+            entries = visibleEntries
+            savedEntries = visibleEntries
+            lastModified = loaded.modificationDate
+            loadError = nil
+            hasWebsiteIcons = WebsiteIconInstaller.hasInstalledIcons(in: sourceDirectory)
+            let analytics = try Self.loadAnalyticsSettings(sourceDirectory: sourceDirectory)
+            analyticsSettings = analytics
+            savedAnalyticsSettings = analytics
+            analyticsError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    @discardableResult
+    func save() async -> Bool {
+        guard isDirty else { return true }
+        guard validationMessage == nil else { return false }
+        let url = file.url
+        let entries = entriesForSaving()
+        do {
+            let mtime = try await Task.detached(priority: .userInitiated) {
+                try PlistDocumentIO.save(entries, to: url)
+            }.value
+            lastModified = mtime
+            allEntries = entries
+            savedEntries = self.entries
+            return true
+        } catch {
+            loadError = "Save failed: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    func flushBeforeLeaving() async -> Bool {
+        if isDirty {
+            let url = file.url
+            let known = lastModified
+            let change = try? await Task.detached(priority: .userInitiated) {
+                try PlistDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: true)
+            }.value
+            if case .conflict(let disk)? = change {
+                conflictDiskContents = disk
+                return false
+            }
+            guard await save() else { return false }
+        }
+        if isAnalyticsDirty {
+            return await saveAnalytics()
+        }
+        return true
+    }
+
+    func checkExternalChange() async {
+        guard loadError == nil else { return }
+        let url = file.url
+        let known = lastModified
+        let dirty = isDirty
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try PlistDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
+        }.value
+        guard let change else { return }
+        switch change {
+        case .none:
+            break
+        case .reloadable:
+            await load()
+        case .conflict(let disk):
+            conflictDiskContents = disk
+        }
+    }
+
+    func keepMyChanges() { conflictDiskContents = nil }
+
+    func reloadFromDisk() async {
+        conflictDiskContents = nil
+        await load()
+    }
+
+    func installWebsiteIcons(from imageURL: URL) async {
+        guard !isInstallingIcons else { return }
+        isInstallingIcons = true
+        iconError = nil
+        defer { isInstallingIcons = false }
+
+        let siteName = websiteTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? initialWebsiteTitle
+            : websiteTitle
+        let sourceDirectory = sourceDirectory
+        do {
+            _ = try await Task.detached(priority: .userInitiated) {
+                try WebsiteIconInstaller.install(from: imageURL, siteName: siteName, siteDirectory: sourceDirectory)
+            }.value
+            hasWebsiteIcons = true
+        } catch {
+            iconError = error.localizedDescription
+        }
+    }
+
+    @discardableResult
+    func saveAnalytics() async -> Bool {
+        guard isAnalyticsDirty else { return true }
+        guard !isSavingAnalytics else { return false }
+        let sourceDirectory = sourceDirectory
+        let settings = analyticsSettings
+        if let validationMessage = await customAnalyticsValidator.validationMessage(
+            for: settings.customHeadTag,
+            siteDirectory: sourceDirectory
+        ) ?? customAnalyticsValidationMessage {
+            analyticsError = validationMessage
+            return false
+        }
+        isSavingAnalytics = true
+        analyticsError = nil
+        defer { isSavingAnalytics = false }
+
+        do {
+            try await Task.detached(priority: .userInitiated) {
+                try WebsiteAnalyticsAsset.install(settings, siteDirectory: sourceDirectory)
+            }.value
+            savedAnalyticsSettings = settings
+            return true
+        } catch {
+            analyticsError = error.localizedDescription
+            return false
+        }
+    }
+
+    func setCloudflareAnalyticsEnabled(_ enabled: Bool) async {
+        if !enabled {
+            analyticsSettings.cloudflareToken = ""
+            _ = await saveAnalytics()
+            return
+        }
+        guard !isConfiguringCloudflareAnalytics else { return }
+        isConfiguringCloudflareAnalytics = true
+        analyticsError = nil
+        defer { isConfiguringCloudflareAnalytics = false }
+
+        do {
+            guard let token = try cloudflareToken(), !token.isEmpty else {
+                analyticsError = CloudflareWebAnalyticsError.missingToken.localizedDescription
+                return
+            }
+            let config = try WebsiteAnalyticsAsset.loadConfig(siteDirectory: sourceDirectory)
+            let fallbackHost = "\(SiteSlug.derive(from: initialWebsiteTitle)).pages.dev"
+            let host = WebsiteAnalyticsAsset.bestHost(from: config, fallback: fallbackHost)
+            let siteTag = try await analyticsProvider.siteTag(for: host, apiToken: token)
+            analyticsSettings.cloudflareToken = siteTag
+            _ = await saveAnalytics()
+        } catch {
+            analyticsError = error.localizedDescription
+        }
+    }
+
+    private static func loadAnalyticsSettings(sourceDirectory: URL) throws -> WebsiteAnalyticsAsset.Settings {
+        let layoutURL = sourceDirectory.appendingPathComponent(WebsiteAnalyticsAsset.layoutRelativePath)
+        let config = try WebsiteAnalyticsAsset.loadConfig(siteDirectory: sourceDirectory)
+        guard FileManager.default.fileExists(atPath: layoutURL.path) else {
+            return WebsiteAnalyticsAsset.parseMigratingLegacySettings(layoutSource: "", config: config)
+        }
+        let source = try String(contentsOf: layoutURL, encoding: .utf8)
+        return WebsiteAnalyticsAsset.parseMigratingLegacySettings(layoutSource: source, config: config)
+    }
+
+    private func cloudflareToken() throws -> String? {
+        if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
+            return env
+        }
+        return try keychain.readCloudflareToken()
+    }
+
+    private static func isWebsiteTitleEntry(_ entry: PlistDocumentIO.PlistEntry) -> Bool {
+        entry.key == "AnglesiteDisplayName" || entry.key == "displayName"
+    }
+
+    func entriesForSaving() -> [PlistDocumentIO.PlistEntry] {
+        var merged = allEntries
+        for entry in entries {
+            if let index = merged.firstIndex(where: { $0.key == entry.key }) {
+                merged[index] = entry
+            } else {
+                merged.append(entry)
+            }
+        }
+        return merged
+    }
+}

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -23,7 +23,13 @@ final class PlistEditorModel {
     private(set) var isSavingAnalytics = false
     private(set) var isConfiguringCloudflareAnalytics = false
     private(set) var hasWebsiteIcons = false
-    var analyticsSettings = WebsiteAnalyticsAsset.Settings()
+    var analyticsSettings = WebsiteAnalyticsAsset.Settings() {
+        didSet {
+            if oldValue.customHeadTag != analyticsSettings.customHeadTag {
+                analyticsError = nil
+            }
+        }
+    }
     private(set) var savedAnalyticsSettings = WebsiteAnalyticsAsset.Settings()
     var conflictDiskContents: String?
 
@@ -220,7 +226,7 @@ final class PlistEditorModel {
         defer { isConfiguringCloudflareAnalytics = false }
 
         do {
-            guard let token = try cloudflareToken(), !token.isEmpty else {
+            guard let token = try await cloudflareToken(), !token.isEmpty else {
                 analyticsError = CloudflareWebAnalyticsError.missingToken.localizedDescription
                 return
             }
@@ -245,11 +251,37 @@ final class PlistEditorModel {
         return WebsiteAnalyticsAsset.parseMigratingLegacySettings(layoutSource: source, config: config)
     }
 
-    private func cloudflareToken() throws -> String? {
-        if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
+    private func cloudflareToken() async throws -> String? {
+        do {
+            if let token = try keychain.readCloudflareToken(), !token.isEmpty {
+                return token
+            }
+        } catch {
+            if cloudflareEnvironmentToken() == nil {
+                throw error
+            }
+            await LogCenter.shared.append(
+                source: "analytics",
+                stream: .stderr,
+                text: "Could not read Cloudflare API token from Keychain; falling back to CLOUDFLARE_API_TOKEN."
+            )
+        }
+        if let env = cloudflareEnvironmentToken() {
+            await LogCenter.shared.append(
+                source: "analytics",
+                stream: .stderr,
+                text: "Using CLOUDFLARE_API_TOKEN environment fallback for Cloudflare Analytics."
+            )
             return env
         }
-        return try keychain.readCloudflareToken()
+        return nil
+    }
+
+    private func cloudflareEnvironmentToken() -> String? {
+        let token = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let token, !token.isEmpty else { return nil }
+        return token
     }
 
     private static func isWebsiteTitleEntry(_ entry: PlistDocumentIO.PlistEntry) -> Bool {
@@ -257,14 +289,8 @@ final class PlistEditorModel {
     }
 
     func entriesForSaving() -> [PlistDocumentIO.PlistEntry] {
-        var merged = allEntries
-        for entry in entries {
-            if let index = merged.firstIndex(where: { $0.key == entry.key }) {
-                merged[index] = entry
-            } else {
-                merged.append(entry)
-            }
-        }
+        var merged = allEntries.filter { !Self.isWebsiteTitleEntry($0) }
+        merged.append(contentsOf: entries)
         return merged
     }
 }

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -31,11 +31,7 @@ struct PlistEditorView: View {
         }
         .onChange(of: selectedTab) { oldValue, _ in
             if oldValue == .analytics {
-                Task {
-                    if await model.saveAnalytics() == false {
-                        selectedTab = .analytics
-                    }
-                }
+                Task { await model.saveAnalytics() }
             }
         }
         .onChange(of: controlActiveState) { _, new in
@@ -94,6 +90,11 @@ struct PlistEditorView: View {
 
                     if let validationMessage = model.validationMessage {
                         Label(validationMessage, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .font(.callout)
+                    }
+                    if selectedTab != .analytics, let analyticsError = model.analyticsError {
+                        Label(analyticsError, systemImage: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
                             .font(.callout)
                     }
@@ -232,7 +233,7 @@ struct PlistEditorView: View {
     }
 
     private var customAnalyticsMessage: String? {
-        model.customAnalyticsValidationMessage ?? model.analyticsError
+        model.analyticsError ?? model.customAnalyticsValidationMessage
     }
 
     private func saveWebsiteTitle() async {

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -1,0 +1,264 @@
+import AppKit
+import SwiftUI
+import AnglesiteCore
+
+struct PlistEditorView: View {
+    @Bindable var model: PlistEditorModel
+    let onWebsiteTitleSaved: (String) -> Void
+
+    private enum SettingsTab: String, CaseIterable, Identifiable {
+        case website = "Website"
+        case analytics = "Analytics"
+        var id: Self { self }
+    }
+
+    @Environment(\.controlActiveState) private var controlActiveState
+    @State private var selectedTab: SettingsTab = .website
+    @State private var showingCustomAnalyticsHelp = false
+    @FocusState private var titleFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .task(id: model.file.id) { await model.load() }
+        .onChange(of: titleFocused) { wasFocused, isFocused in
+            if wasFocused && !isFocused {
+                Task { await saveWebsiteTitle() }
+            }
+        }
+        .onChange(of: selectedTab) { oldValue, _ in
+            if oldValue == .analytics {
+                Task {
+                    if await model.saveAnalytics() == false {
+                        selectedTab = .analytics
+                    }
+                }
+            }
+        }
+        .onChange(of: controlActiveState) { _, new in
+            if new == .key { Task { await model.checkExternalChange() } }
+        }
+        .alert("Website details changed on disk", isPresented: conflictBinding) {
+            Button("Keep My Changes", role: .cancel) { model.keepMyChanges() }
+            Button("Reload from Disk") { Task { await model.reloadFromDisk() } }
+        } message: {
+            Text("Another tool edited the website details while you had unsaved changes.")
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Label("Settings", systemImage: "gearshape")
+                .font(.headline)
+            if model.isDirty || model.isAnalyticsDirty {
+                Circle().fill(.secondary).frame(width: 7, height: 7)
+                    .help("Unsaved changes")
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let loadError = model.loadError {
+            ContentUnavailableView {
+                Label("Can't open website details", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(loadError)
+            }
+        } else if model.isLoading {
+            ProgressView().controlSize(.small)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if model.entries.isEmpty {
+            ContentUnavailableView {
+                Label("No website details", systemImage: "globe")
+            } description: {
+                Text("There are no editable website details.")
+            }
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    Picker("Settings", selection: $selectedTab) {
+                        ForEach(SettingsTab.allCases) { tab in
+                            Text(tab.rawValue).tag(tab)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(maxWidth: 260)
+
+                    if let validationMessage = model.validationMessage {
+                        Label(validationMessage, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .font(.callout)
+                    }
+
+                    switch selectedTab {
+                    case .website:
+                        websiteTab
+                    case .analytics:
+                        analyticsTab
+                    }
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+        }
+    }
+
+    private var websiteTab: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 8) {
+                GridRow {
+                    Text("Title")
+                        .frame(minWidth: 160, alignment: .leading)
+                    TextField("Title", text: $model.websiteTitle)
+                        .focused($titleFocused)
+                        .onSubmit { Task { await saveWebsiteTitle() } }
+                        .frame(minWidth: 220)
+                }
+                GridRow {
+                    Text("Icons")
+                        .frame(minWidth: 160, alignment: .leading)
+                    HStack(spacing: 8) {
+                        Image(systemName: model.hasWebsiteIcons ? "checkmark.circle.fill" : "globe")
+                            .foregroundStyle(model.hasWebsiteIcons ? .green : .secondary)
+                            .frame(width: 18)
+                        Text(model.hasWebsiteIcons ? "Installed" : "Not Set")
+                            .foregroundStyle(.secondary)
+                            .frame(minWidth: 72, alignment: .leading)
+                        Button {
+                            chooseWebsiteIcon()
+                        } label: {
+                            Label(model.hasWebsiteIcons ? "Change Image" : "Choose Image",
+                                  systemImage: "photo.badge.plus")
+                        }
+                        .disabled(model.isInstallingIcons)
+                        if model.isInstallingIcons {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
+                }
+            }
+            .textFieldStyle(.roundedBorder)
+            if let iconError = model.iconError {
+                Label(iconError, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.callout)
+            }
+        }
+    }
+
+    private var analyticsTab: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 8) {
+                GridRow {
+                    Text("Cloudflare")
+                        .frame(minWidth: 160, alignment: .leading)
+                    HStack(spacing: 8) {
+                        Toggle("Cloudflare", isOn: cloudflareAnalyticsBinding)
+                            .toggleStyle(.switch)
+                            .labelsHidden()
+                            .disabled(model.isConfiguringCloudflareAnalytics)
+                        Text(model.cloudflareAnalyticsEnabled ? "On" : "Off")
+                            .foregroundStyle(.secondary)
+                            .frame(minWidth: 28, alignment: .leading)
+                        if model.isConfiguringCloudflareAnalytics {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Link(destination: WebsiteAnalyticsAsset.dashboardURL) {
+                            Label("Open Dashboard", systemImage: "arrow.up.right.square")
+                        }
+                    }
+                }
+                GridRow(alignment: .top) {
+                    HStack(spacing: 6) {
+                        Text("Custom")
+                        Button {
+                            showingCustomAnalyticsHelp = true
+                        } label: {
+                            Image(systemName: "questionmark.circle")
+                        }
+                        .buttonStyle(.plain)
+                        .help("About custom analytics")
+                    }
+                    .frame(minWidth: 160, alignment: .leading)
+                    .padding(.top, 4)
+                    HTMLSnippetEditor(text: $model.analyticsSettings.customHeadTag) {
+                        Task { await model.saveAnalytics() }
+                    }
+                        .frame(minWidth: 360, minHeight: 90)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(customAnalyticsMessage == nil ? Color.secondary.opacity(0.25) : Color.orange)
+                        }
+                }
+            }
+            .textFieldStyle(.roundedBorder)
+            HStack(spacing: 8) {
+                if model.isSavingAnalytics {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                if let customAnalyticsMessage {
+                    Label(customAnalyticsMessage, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.callout)
+                }
+            }
+        }
+        .popover(isPresented: $showingCustomAnalyticsHelp, arrowEdge: .trailing) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Custom Analytics")
+                    .font(.headline)
+                Text("Paste the HTML code from another analytics provider here, such as Google Analytics, Plausible, Fathom, or a conversion tag.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 280, alignment: .leading)
+            }
+            .padding()
+        }
+    }
+
+    private var conflictBinding: Binding<Bool> {
+        Binding(get: { model.conflictDiskContents != nil }, set: { _ in })
+    }
+
+    private var customAnalyticsMessage: String? {
+        model.customAnalyticsValidationMessage ?? model.analyticsError
+    }
+
+    private func saveWebsiteTitle() async {
+        guard model.validationMessage == nil else { return }
+        if await model.save() {
+            onWebsiteTitleSaved(model.websiteTitle)
+        }
+    }
+
+    private var cloudflareAnalyticsBinding: Binding<Bool> {
+        Binding(
+            get: { model.cloudflareAnalyticsEnabled },
+            set: { enabled in
+                Task { await model.setCloudflareAnalyticsEnabled(enabled) }
+            }
+        )
+    }
+
+    private func chooseWebsiteIcon() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = WebsiteIconInstaller.allowedContentTypes
+        panel.prompt = model.hasWebsiteIcons ? "Change" : "Choose"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task { await model.installWebsiteIcons(from: url) }
+    }
+}

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -68,7 +68,8 @@ final class SiteNavigatorModel {
                 id: section.id,
                 title: section.title,
                 items: section.items.map {
-                    NavigatorItem(id: $0.id, title: title, target: $0.target)
+                    guard case .file(let file) = $0.target, file.name == "Info.plist" else { return $0 }
+                    return NavigatorItem(id: $0.id, title: title, target: $0.target)
                 }
             )
         }

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -18,6 +18,7 @@ final class SiteNavigatorModel {
     var renameError: String?
 
     private var sourceDirectory: URL?
+    private var websiteTitle: String?
     private let renameService = NavigatorRenameService()
 
     private let graph: SiteContentGraph
@@ -27,8 +28,9 @@ final class SiteNavigatorModel {
         self.graph = graph
     }
 
-    func start(siteID: String, siteRoot: URL, sourceDirectory: URL) {
+    func start(siteID: String, siteRoot: URL, sourceDirectory: URL, websiteTitle: String) {
         self.sourceDirectory = sourceDirectory
+        self.websiteTitle = websiteTitle
         // Cancel any prior observer (window reuse: SwiftUI can replay a different site into the
         // same window) BEFORE starting the new one, so a stale refresh can't overwrite the new
         // site's sections. The initial load runs as the new task's first step, so it is tracked
@@ -56,6 +58,20 @@ final class SiteNavigatorModel {
             if let item = section.items.first(where: { $0.id == id }) { return item.target }
         }
         return nil
+    }
+
+    func updateWebsiteTitle(_ title: String) {
+        websiteTitle = title
+        sections = sections.map { section in
+            guard section.id == .metadata else { return section }
+            return NavigatorSection(
+                id: section.id,
+                title: section.title,
+                items: section.items.map {
+                    NavigatorItem(id: $0.id, title: title, target: $0.target)
+                }
+            )
+        }
     }
 
     /// A row is renamable iff it is a page or post (route target). File rows (components/styles/
@@ -150,6 +166,11 @@ final class SiteNavigatorModel {
             SiteFileTree.scan(siteRoot: siteRoot)
         }.value
         if Task.isCancelled { return }
-        sections = buildNavigatorTree(pages: pages, posts: posts, fileGroups: fileGroups)
+        sections = buildNavigatorTree(
+            pages: pages,
+            posts: posts,
+            fileGroups: fileGroups,
+            websiteTitle: websiteTitle
+        )
     }
 }

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -10,15 +10,15 @@ struct SiteNavigatorView: View {
     var body: some View {
         List(selection: $model.selection) {
             ForEach(model.sections) { section in
-                if section.title.isEmpty {
-                    ForEach(section.items) { item in
-                        row(for: item, in: section)
-                    }
-                } else {
-                    Section(section.title) {
+                if let title = section.title {
+                    Section(title) {
                         ForEach(section.items) { item in
                             row(for: item, in: section)
                         }
+                    }
+                } else {
+                    ForEach(section.items) { item in
+                        row(for: item, in: section)
                     }
                 }
             }

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -10,9 +10,15 @@ struct SiteNavigatorView: View {
     var body: some View {
         List(selection: $model.selection) {
             ForEach(model.sections) { section in
-                Section(section.title) {
+                if section.title.isEmpty {
                     ForEach(section.items) { item in
                         row(for: item, in: section)
+                    }
+                } else {
+                    Section(section.title) {
+                        ForEach(section.items) { item in
+                            row(for: item, in: section)
+                        }
                     }
                 }
             }
@@ -89,7 +95,7 @@ struct SiteNavigatorView: View {
         case .posts: return "text.document"
         case .components: return "square.stack.3d.up"
         case .styles: return "paintbrush"
-        case .metadata: return "gearshape"
+        case .metadata: return "globe"
         }
     }
 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -85,6 +85,7 @@ struct SiteWindow: View {
     /// auto-save it and the Preview/Editor toggle keeps the buffer alive. Replaced when a different
     /// file opens; cleared on window close / site replay.
     @State private var editorModel: FileEditorModel?
+    @State private var plistEditorModel: PlistEditorModel?
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -116,6 +117,7 @@ struct SiteWindow: View {
             // Persist any unsaved edits before dropping the old site's editor on replay (#188 reuse).
             persistEditorBufferBestEffort()
             editorModel = nil
+            plistEditorModel = nil
             mainPaneMode = .preview
         }
         .onChange(of: preview.state) { _, newState in
@@ -145,6 +147,7 @@ struct SiteWindow: View {
             // on a flush return value — just write the buffer best-effort, off the main actor.
             persistEditorBufferBestEffort()
             editorModel = nil
+            plistEditorModel = nil
             #if ANGLESITE_MAS
             scopedURL?.stopAccessingSecurityScopedResource()
             scopedURL = nil
@@ -426,7 +429,7 @@ struct SiteWindow: View {
     @ViewBuilder
     private func mainPane(for site: SiteStore.Site) -> some View {
         VStack(spacing: 0) {
-            if editorModel != nil {
+            if activeEditorFile != nil {
                 Picker("", selection: Binding(
                     get: { paneSelection },
                     set: { setPaneSelection($0) }
@@ -454,8 +457,8 @@ struct SiteWindow: View {
             // Switching to Preview auto-saves the open editor (abort on an unresolved conflict).
             // The flush is async (off-main IO), so do it in a Task and only switch on success.
             Task { if await leaveCurrentEditor() { mainPaneMode = .preview } }
-        } else if value == 1, let model = editorModel {
-            mainPaneMode = .editor(model.file)
+        } else if value == 1, let file = activeEditorFile {
+            mainPaneMode = .editor(file)
         }
     }
 
@@ -464,18 +467,41 @@ struct SiteWindow: View {
     /// switch instead of clobbering the other tool's edit. Safe to call when not editing. Async
     /// because the save/check IO runs off the main actor.
     private func leaveCurrentEditor() async -> Bool {
-        guard case .editor = mainPaneMode, let model = editorModel else { return true }
-        return await model.flushBeforeLeaving()
+        guard case .editor = mainPaneMode else { return true }
+        if let model = editorModel {
+            return await model.flushBeforeLeaving()
+        }
+        if let model = plistEditorModel {
+            return await model.flushBeforeLeaving()
+        }
+        return true
     }
 
     /// Best-effort off-main save of the open editor's buffer when the editor is torn down (window
     /// close or site replay), where no conflict dialog can be shown. Consistent with the
     /// auto-save-on-leave model; last-writer-wins on the rare teardown-time external conflict.
     private func persistEditorBufferBestEffort() {
-        guard let model = editorModel, model.isDirty else { return }
-        let url = model.file.url
-        let contents = model.text
-        Task.detached(priority: .userInitiated) { try? FileDocumentIO.save(contents, to: url) }
+        if let model = editorModel, model.isDirty {
+            let url = model.file.url
+            let contents = model.text
+            Task.detached(priority: .userInitiated) { try? FileDocumentIO.save(contents, to: url) }
+        }
+        if let model = plistEditorModel, model.isDirty, model.validationMessage == nil {
+            let url = model.file.url
+            let entries = model.entriesForSaving()
+            Task.detached(priority: .userInitiated) { try? PlistDocumentIO.save(entries, to: url) }
+        }
+        if let model = plistEditorModel, model.isAnalyticsDirty {
+            let sourceDirectory = model.sourceDirectory
+            let settings = model.analyticsSettings
+            Task.detached(priority: .userInitiated) {
+                try? WebsiteAnalyticsAsset.install(settings, siteDirectory: sourceDirectory)
+            }
+        }
+    }
+
+    private var activeEditorFile: FileRef? {
+        editorModel?.file ?? plistEditorModel?.file
     }
 
     @ViewBuilder
@@ -484,6 +510,10 @@ struct SiteWindow: View {
         case .editor:
             if let editorModel {
                 MainPaneEditorView(model: editorModel)
+            } else if let plistEditorModel {
+                PlistEditorView(model: plistEditorModel) { title in
+                    Task { await saveWebsiteTitle(title) }
+                }
             } else {
                 previewPane(for: site)
             }
@@ -558,6 +588,7 @@ struct SiteWindow: View {
             }
             if entry.name != site?.name {
                 site?.name = entry.name
+                navigator?.updateWebsiteTitle(entry.name)
             }
         }
     }
@@ -595,13 +626,24 @@ struct SiteWindow: View {
                 }
             }
         case .file(let file):
-            if editorModel?.file.id == file.id {
+            if activeEditorFile?.id == file.id {
                 mainPaneMode = .editor(file)   // re-show the already-open file (buffer intact)
                 return
             }
             Task {
                 guard await leaveCurrentEditor() else { return }   // flush the previous file first
-                editorModel = FileEditorModel(file: file)
+                switch EditorKind.resolve(for: file) {
+                case .text:
+                    editorModel = FileEditorModel(file: file)
+                    plistEditorModel = nil
+                case .plist:
+                    plistEditorModel = PlistEditorModel(
+                        file: file,
+                        websiteTitle: site?.name ?? file.name,
+                        sourceDirectory: site?.sourceDirectory ?? file.url.deletingLastPathComponent()
+                    )
+                    editorModel = nil
+                }
                 mainPaneMode = .editor(file)
             }
         }
@@ -613,6 +655,20 @@ struct SiteWindow: View {
             return "/anglesite:check"
         case .foundationModel:
             return "Audit this site for issues and suggest improvements to make it deploy-ready. Review the available site content and call out concrete files or sections when relevant."
+        }
+    }
+
+    private func saveWebsiteTitle(_ title: String) async {
+        guard let id = site?.id else { return }
+        do {
+            guard let updated = try await SiteStore.shared.setDisplayName(title, for: id) else { return }
+            site = updated
+            navigator?.updateWebsiteTitle(updated.name)
+        } catch {
+            await LogCenter.shared.append(
+                source: "editor", stream: .stderr,
+                text: "Saving website title failed: \(error.localizedDescription)"
+            )
         }
     }
 
@@ -671,7 +727,12 @@ struct SiteWindow: View {
         // this creation and stop the freshly-made navigator instead.
         navigator?.stop()
         let navModel = SiteNavigatorModel(graph: contentGraph)
-        navModel.start(siteID: resolved.id, siteRoot: resolved.packageURL, sourceDirectory: resolved.sourceDirectory)
+        navModel.start(
+            siteID: resolved.id,
+            siteRoot: resolved.packageURL,
+            sourceDirectory: resolved.sourceDirectory,
+            websiteTitle: resolved.name
+        )
         navigator = navModel
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -9,6 +9,18 @@ private enum MainPaneMode: Equatable {
     case editor(FileRef)
 }
 
+private enum ActiveEditor {
+    case text(FileEditorModel)
+    case plist(PlistEditorModel)
+
+    var file: FileRef {
+        switch self {
+        case .text(let model): model.file
+        case .plist(let model): model.file
+        }
+    }
+}
+
 /// Root view for a single per-site window. Owns the site's `PreviewModel`,
 /// `DeployModel`, and `ChatModel` as `@State` — lifecycle is bound to the window:
 /// when the window opens we resolve the `siteID` to a `SiteStore.Site` and start
@@ -84,8 +96,7 @@ struct SiteWindow: View {
     /// The open file's editor state. Owned here (not in `MainPaneEditorView`) so navigating away can
     /// auto-save it and the Preview/Editor toggle keeps the buffer alive. Replaced when a different
     /// file opens; cleared on window close / site replay.
-    @State private var editorModel: FileEditorModel?
-    @State private var plistEditorModel: PlistEditorModel?
+    @State private var activeEditor: ActiveEditor?
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -116,8 +127,7 @@ struct SiteWindow: View {
             siriReadinessModel = nil
             // Persist any unsaved edits before dropping the old site's editor on replay (#188 reuse).
             persistEditorBufferBestEffort()
-            editorModel = nil
-            plistEditorModel = nil
+            activeEditor = nil
             mainPaneMode = .preview
         }
         .onChange(of: preview.state) { _, newState in
@@ -146,8 +156,7 @@ struct SiteWindow: View {
             // auto-save-on-leave). No conflict dialog is possible during teardown, so we don't gate
             // on a flush return value — just write the buffer best-effort, off the main actor.
             persistEditorBufferBestEffort()
-            editorModel = nil
-            plistEditorModel = nil
+            activeEditor = nil
             #if ANGLESITE_MAS
             scopedURL?.stopAccessingSecurityScopedResource()
             scopedURL = nil
@@ -468,49 +477,47 @@ struct SiteWindow: View {
     /// because the save/check IO runs off the main actor.
     private func leaveCurrentEditor() async -> Bool {
         guard case .editor = mainPaneMode else { return true }
-        if let model = editorModel {
+        switch activeEditor {
+        case .text(let model):
             return await model.flushBeforeLeaving()
-        }
-        if let model = plistEditorModel {
+        case .plist(let model):
             return await model.flushBeforeLeaving()
+        case nil:
+            return true
         }
-        return true
     }
 
     /// Best-effort off-main save of the open editor's buffer when the editor is torn down (window
     /// close or site replay), where no conflict dialog can be shown. Consistent with the
     /// auto-save-on-leave model; last-writer-wins on the rare teardown-time external conflict.
     private func persistEditorBufferBestEffort() {
-        if let model = editorModel, model.isDirty {
+        switch activeEditor {
+        case .text(let model) where model.isDirty:
             let url = model.file.url
             let contents = model.text
             Task.detached(priority: .userInitiated) { try? FileDocumentIO.save(contents, to: url) }
-        }
-        if let model = plistEditorModel, model.isDirty, model.validationMessage == nil {
-            let url = model.file.url
-            let entries = model.entriesForSaving()
-            Task.detached(priority: .userInitiated) { try? PlistDocumentIO.save(entries, to: url) }
-        }
-        if let model = plistEditorModel, model.isAnalyticsDirty {
-            let sourceDirectory = model.sourceDirectory
-            let settings = model.analyticsSettings
-            Task.detached(priority: .userInitiated) {
-                try? WebsiteAnalyticsAsset.install(settings, siteDirectory: sourceDirectory)
+        case .plist(let model):
+            if model.isDirty, model.validationMessage == nil {
+                let url = model.file.url
+                let entries = model.entriesForSaving()
+                Task.detached(priority: .userInitiated) { try? PlistDocumentIO.save(entries, to: url) }
             }
+        case .text, nil:
+            break
         }
     }
 
     private var activeEditorFile: FileRef? {
-        editorModel?.file ?? plistEditorModel?.file
+        activeEditor?.file
     }
 
     @ViewBuilder
     private func mainPaneContent(for site: SiteStore.Site) -> some View {
         switch mainPaneMode {
         case .editor:
-            if let editorModel {
+            if case .text(let editorModel) = activeEditor {
                 MainPaneEditorView(model: editorModel)
-            } else if let plistEditorModel {
+            } else if case .plist(let plistEditorModel) = activeEditor {
                 PlistEditorView(model: plistEditorModel) { title in
                     Task { await saveWebsiteTitle(title) }
                 }
@@ -634,15 +641,13 @@ struct SiteWindow: View {
                 guard await leaveCurrentEditor() else { return }   // flush the previous file first
                 switch EditorKind.resolve(for: file) {
                 case .text:
-                    editorModel = FileEditorModel(file: file)
-                    plistEditorModel = nil
+                    activeEditor = .text(FileEditorModel(file: file))
                 case .plist:
-                    plistEditorModel = PlistEditorModel(
+                    activeEditor = .plist(PlistEditorModel(
                         file: file,
                         websiteTitle: site?.name ?? file.name,
                         sourceDirectory: site?.sourceDirectory ?? file.url.deletingLastPathComponent()
-                    )
-                    editorModel = nil
+                    ))
                 }
                 mainPaneMode = .editor(file)
             }

--- a/Sources/AnglesiteApp/WebsiteIconInstaller.swift
+++ b/Sources/AnglesiteApp/WebsiteIconInstaller.swift
@@ -1,0 +1,148 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+import AnglesiteCore
+
+enum WebsiteIconInstaller {
+    static let allowedContentTypes: [UTType] = [.image]
+
+    struct Result: Equatable {
+        let wroteIconCount: Int
+        let patchedLayout: Bool
+    }
+
+    enum InstallError: LocalizedError {
+        case unreadableImage(URL)
+        case pngEncodingFailed(Int)
+        case icoTooLarge(Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .unreadableImage(let url):
+                "Could not read the selected image at \(url.lastPathComponent)."
+            case .pngEncodingFailed(let size):
+                "Could not create the \(size)x\(size) website icon."
+            case .icoTooLarge(let byteCount):
+                "The generated favicon is too large (\(byteCount) bytes)."
+            }
+        }
+    }
+
+    static func install(from imageURL: URL, siteName: String, siteDirectory: URL,
+                        fileManager: FileManager = .default) throws -> Result {
+        guard let image = NSImage(contentsOf: imageURL), image.isValid else {
+            throw InstallError.unreadableImage(imageURL)
+        }
+
+        let publicDir = siteDirectory.appendingPathComponent(WebsiteIconAsset.publicDirectoryRelativePath, isDirectory: true)
+        try fileManager.createDirectory(at: publicDir, withIntermediateDirectories: true)
+
+        let faviconPNG = try pngData(from: image, sideLength: 32)
+        let generated: [(String, Data)] = [
+            (WebsiteIconAsset.faviconICOName, try icoData(pngData: faviconPNG)),
+            (WebsiteIconAsset.faviconPNGName, faviconPNG),
+            (WebsiteIconAsset.appleTouchIconName, try pngData(from: image, sideLength: 180)),
+            (WebsiteIconAsset.icon192Name, try pngData(from: image, sideLength: 192)),
+            (WebsiteIconAsset.icon512Name, try pngData(from: image, sideLength: 512)),
+            (WebsiteIconAsset.manifestName, try WebsiteIconAsset.manifestData(siteName: siteName))
+        ]
+
+        for (name, data) in generated {
+            try data.write(to: publicDir.appendingPathComponent(name), options: .atomic)
+        }
+
+        let layoutURL = siteDirectory.appendingPathComponent(WebsiteIconAsset.layoutRelativePath)
+        let before = try? String(contentsOf: layoutURL, encoding: .utf8)
+        try WebsiteIconAsset.patchLayout(in: siteDirectory, fileManager: fileManager)
+        let after = try? String(contentsOf: layoutURL, encoding: .utf8)
+
+        return Result(wroteIconCount: generated.count, patchedLayout: before != after)
+    }
+
+    static func hasInstalledIcons(in siteDirectory: URL, fileManager: FileManager = .default) -> Bool {
+        WebsiteIconAsset.hasInstalledIcons(in: siteDirectory, fileManager: fileManager)
+    }
+
+    private static func pngData(from image: NSImage, sideLength: Int) throws -> Data {
+        let side = CGFloat(sideLength)
+        let size = NSSize(width: side, height: side)
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: sideLength,
+            pixelsHigh: sideLength,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            throw InstallError.pngEncodingFailed(sideLength)
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        let context = NSGraphicsContext(bitmapImageRep: rep)
+        NSGraphicsContext.current = context
+        NSColor.clear.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        image.draw(in: fittedRect(for: image.size, inside: size),
+                   from: NSRect(origin: .zero, size: image.size),
+                   operation: .sourceOver,
+                   fraction: 1)
+        context?.flushGraphics()
+        NSGraphicsContext.restoreGraphicsState()
+
+        guard let data = rep.representation(using: .png, properties: [:]) else {
+            throw InstallError.pngEncodingFailed(sideLength)
+        }
+        return data
+    }
+
+    private static func fittedRect(for sourceSize: NSSize, inside targetSize: NSSize) -> NSRect {
+        guard sourceSize.width > 0, sourceSize.height > 0 else {
+            return NSRect(origin: .zero, size: targetSize)
+        }
+        let scale = min(targetSize.width / sourceSize.width, targetSize.height / sourceSize.height)
+        let fitted = NSSize(width: sourceSize.width * scale, height: sourceSize.height * scale)
+        return NSRect(
+            x: (targetSize.width - fitted.width) / 2,
+            y: (targetSize.height - fitted.height) / 2,
+            width: fitted.width,
+            height: fitted.height
+        )
+    }
+
+    private static func icoData(pngData: Data) throws -> Data {
+        guard pngData.count <= Int(UInt32.max) else {
+            throw InstallError.icoTooLarge(pngData.count)
+        }
+
+        var data = Data()
+        appendUInt16(0, to: &data)      // reserved
+        appendUInt16(1, to: &data)      // image type: icon
+        appendUInt16(1, to: &data)      // image count
+        data.append(32)                 // width
+        data.append(32)                 // height
+        data.append(0)                  // color count
+        data.append(0)                  // reserved
+        appendUInt16(1, to: &data)      // color planes
+        appendUInt16(32, to: &data)     // bits per pixel
+        appendUInt32(UInt32(pngData.count), to: &data)
+        appendUInt32(22, to: &data)     // header + one directory entry
+        data.append(pngData)
+        return data
+    }
+
+    private static func appendUInt16(_ value: UInt16, to data: inout Data) {
+        data.append(UInt8(value & 0xff))
+        data.append(UInt8((value >> 8) & 0xff))
+    }
+
+    private static func appendUInt32(_ value: UInt32, to data: inout Data) {
+        data.append(UInt8(value & 0xff))
+        data.append(UInt8((value >> 8) & 0xff))
+        data.append(UInt8((value >> 16) & 0xff))
+        data.append(UInt8((value >> 24) & 0xff))
+    }
+}

--- a/Sources/AnglesiteApp/WebsiteIconInstaller.swift
+++ b/Sources/AnglesiteApp/WebsiteIconInstaller.swift
@@ -30,7 +30,11 @@ enum WebsiteIconInstaller {
 
     static func install(from imageURL: URL, siteName: String, siteDirectory: URL,
                         fileManager: FileManager = .default) throws -> Result {
-        guard let image = NSImage(contentsOf: imageURL), image.isValid else {
+        guard let image = NSImage(contentsOf: imageURL),
+              image.isValid,
+              image.size.width > 0,
+              image.size.height > 0
+        else {
             throw InstallError.unreadableImage(imageURL)
         }
 

--- a/Sources/AnglesiteCore/AstroHTMLValidator.swift
+++ b/Sources/AnglesiteCore/AstroHTMLValidator.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+public protocol CustomAnalyticsHTMLValidating: Sendable {
+    func validationMessage(for html: String, siteDirectory: URL) async -> String?
+}
+
+public struct AstroHTMLValidator: CustomAnalyticsHTMLValidating, Sendable {
+    public typealias CommandRunner = @Sendable (_ executable: URL, _ arguments: [String], _ cwd: URL?) async throws -> ProcessSupervisor.RunResult
+
+    private let nodeExecutable: @Sendable () -> URL?
+    private let run: CommandRunner
+
+    public init(
+        nodeExecutable: @escaping @Sendable () -> URL? = { NodeRuntime.bundledExecutableURL },
+        run: @escaping CommandRunner = { executable, arguments, cwd in
+            try await ProcessSupervisor.shared.run(
+                executable: executable,
+                arguments: arguments,
+                currentDirectoryURL: cwd
+            )
+        }
+    ) {
+        self.nodeExecutable = nodeExecutable
+        self.run = run
+    }
+
+    public func validationMessage(for html: String, siteDirectory: URL) async -> String? {
+        let snippet = html.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !snippet.isEmpty else { return nil }
+
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: siteDirectory.appendingPathComponent("node_modules/@astrojs/compiler/package.json").path) else {
+            return "Custom analytics HTML couldn't be validated because Astro dependencies are missing. Run npm install in this site and try again."
+        }
+        guard let node = nodeExecutable() else {
+            return "Custom analytics HTML couldn't be validated because the embedded Node runtime isn't available. Rebuild Anglesite and try again."
+        }
+
+        do {
+            let workDirectory = fileManager.temporaryDirectory
+                .appendingPathComponent("anglesite-astro-html-validation-\(UUID().uuidString)", isDirectory: true)
+            try fileManager.createDirectory(at: workDirectory, withIntermediateDirectories: true)
+            defer { try? fileManager.removeItem(at: workDirectory) }
+
+            let snippetURL = workDirectory.appendingPathComponent("custom-analytics.html")
+            let scriptURL = workDirectory.appendingPathComponent("validate-custom-analytics.mjs")
+            try snippet.write(to: snippetURL, atomically: true, encoding: .utf8)
+            try Self.validationScript.write(to: scriptURL, atomically: true, encoding: .utf8)
+
+            let result = try await run(
+                node,
+                [scriptURL.path, siteDirectory.path, snippetURL.path],
+                siteDirectory
+            )
+            guard result.exitCode != 0 else { return nil }
+            let message = [result.stderr, result.stdout]
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .first { !$0.isEmpty }
+            return "Custom analytics HTML is invalid: \(Self.friendlyMessage(message))"
+        } catch {
+            return "Custom analytics HTML couldn't be validated: \(error.localizedDescription)"
+        }
+    }
+
+    private static func friendlyMessage(_ message: String?) -> String {
+        guard let message, !message.isEmpty else {
+            return "Astro couldn't parse the snippet."
+        }
+        if message.contains("Cannot read properties of undefined")
+            || message.contains("index out of range") {
+            return "Astro couldn't parse the snippet. Check for incomplete tags or script blocks."
+        }
+        return message
+    }
+
+    private static let validationScript = #"""
+    import { createRequire } from 'node:module';
+    import { readFileSync } from 'node:fs';
+    import { pathToFileURL } from 'node:url';
+    import { join } from 'node:path';
+
+    const siteDirectory = process.argv[2];
+    const snippetPath = process.argv[3];
+    const require = createRequire(pathToFileURL(join(siteDirectory, 'package.json')));
+    const { convertToTSX } = require('@astrojs/compiler/sync');
+    const snippet = readFileSync(snippetPath, 'utf8');
+    const source = `---
+    ---
+    <html>
+      <head>
+    ${snippet}
+      </head>
+      <body></body>
+    </html>
+    `;
+
+    try {
+      const result = convertToTSX(source, {
+        filename: 'AnglesiteCustomAnalytics.astro',
+        includeScripts: true,
+        includeStyles: true,
+      });
+      const diagnostic = (result.diagnostics || []).find((item) => item.severity === 1);
+      if (diagnostic) {
+        const location = diagnostic.location
+          ? `${diagnostic.location.line}:${diagnostic.location.column}: `
+          : '';
+        console.error(`${location}${diagnostic.text || 'Astro reported invalid HTML.'}`);
+        process.exit(1);
+      }
+    } catch (error) {
+      console.error(error?.message || String(error));
+      process.exit(1);
+    }
+    """#
+}

--- a/Sources/AnglesiteCore/AstroHTMLValidator.swift
+++ b/Sources/AnglesiteCore/AstroHTMLValidator.swift
@@ -36,27 +36,34 @@ public struct AstroHTMLValidator: CustomAnalyticsHTMLValidating, Sendable {
             return "Custom analytics HTML couldn't be validated because the embedded Node runtime isn't available. Rebuild Anglesite and try again."
         }
 
+        let workDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("anglesite-astro-html-validation-\(UUID().uuidString)", isDirectory: true)
+        let cleanup: @Sendable () -> Void = {
+            try? FileManager.default.removeItem(at: workDirectory)
+        }
         do {
-            let workDirectory = fileManager.temporaryDirectory
-                .appendingPathComponent("anglesite-astro-html-validation-\(UUID().uuidString)", isDirectory: true)
-            try fileManager.createDirectory(at: workDirectory, withIntermediateDirectories: true)
-            defer { try? fileManager.removeItem(at: workDirectory) }
+            return try await withTaskCancellationHandler {
+                try fileManager.createDirectory(at: workDirectory, withIntermediateDirectories: true)
+                defer { cleanup() }
 
-            let snippetURL = workDirectory.appendingPathComponent("custom-analytics.html")
-            let scriptURL = workDirectory.appendingPathComponent("validate-custom-analytics.mjs")
-            try snippet.write(to: snippetURL, atomically: true, encoding: .utf8)
-            try Self.validationScript.write(to: scriptURL, atomically: true, encoding: .utf8)
+                let snippetURL = workDirectory.appendingPathComponent("custom-analytics.html")
+                let scriptURL = workDirectory.appendingPathComponent("validate-custom-analytics.mjs")
+                try snippet.write(to: snippetURL, atomically: true, encoding: .utf8)
+                try Self.validationScript.write(to: scriptURL, atomically: true, encoding: .utf8)
 
-            let result = try await run(
-                node,
-                [scriptURL.path, siteDirectory.path, snippetURL.path],
-                siteDirectory
-            )
-            guard result.exitCode != 0 else { return nil }
-            let message = [result.stderr, result.stdout]
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .first { !$0.isEmpty }
-            return "Custom analytics HTML is invalid: \(Self.friendlyMessage(message))"
+                let result = try await run(
+                    node,
+                    [scriptURL.path, siteDirectory.path, snippetURL.path],
+                    siteDirectory
+                )
+                guard result.exitCode != 0 else { return nil }
+                let message = [result.stderr, result.stdout]
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .first { !$0.isEmpty }
+                return "Custom analytics HTML is invalid: \(Self.friendlyMessage(message))"
+            } onCancel: {
+                cleanup()
+            }
         } catch {
             return "Custom analytics HTML couldn't be validated: \(error.localizedDescription)"
         }

--- a/Sources/AnglesiteCore/CloudflareWebAnalyticsClient.swift
+++ b/Sources/AnglesiteCore/CloudflareWebAnalyticsClient.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+public struct CloudflareWebAnalyticsSite: Sendable, Equatable {
+    public let host: String
+    public let siteTag: String
+
+    public init(host: String, siteTag: String) {
+        self.host = host
+        self.siteTag = siteTag
+    }
+}
+
+public enum CloudflareWebAnalyticsError: Error, LocalizedError, Sendable, Equatable {
+    case missingToken
+    case noAccount
+    case noMatchingSite(String)
+    case invalidResponse
+    case api(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingToken:
+            return "Cloudflare API token is not configured."
+        case .noAccount:
+            return "No Cloudflare account was available for this token."
+        case .noMatchingSite(let host):
+            return "Cloudflare Web Analytics is not enabled for \(host)."
+        case .invalidResponse:
+            return "Cloudflare returned an unexpected Web Analytics response."
+        case .api(let message):
+            return message
+        }
+    }
+}
+
+public protocol CloudflareWebAnalyticsProviding: Sendable {
+    func siteTag(for host: String, apiToken: String) async throws -> String
+}
+
+public struct CloudflareWebAnalyticsClient: CloudflareWebAnalyticsProviding {
+    private let baseURL: URL
+    private let urlSession: URLSession
+
+    public init(baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!,
+                urlSession: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.urlSession = urlSession
+    }
+
+    public func siteTag(for host: String, apiToken: String) async throws -> String {
+        let accounts = try await accounts(apiToken: apiToken)
+        guard let accountID = accounts.first?.id else { throw CloudflareWebAnalyticsError.noAccount }
+        let sites = try await webAnalyticsSites(accountID: accountID, apiToken: apiToken)
+        guard let site = Self.matchingSite(for: host, in: sites) else {
+            throw CloudflareWebAnalyticsError.noMatchingSite(host)
+        }
+        return site.siteTag
+    }
+
+    public static func matchingSite(for host: String, in sites: [CloudflareWebAnalyticsSite]) -> CloudflareWebAnalyticsSite? {
+        let normalized = normalizeHost(host)
+        return sites.first { normalizeHost($0.host) == normalized }
+    }
+
+    private func accounts(apiToken: String) async throws -> [Account] {
+        let envelope: Envelope<[Account]> = try await get("accounts", apiToken: apiToken)
+        return envelope.result
+    }
+
+    private func webAnalyticsSites(accountID: String, apiToken: String) async throws -> [CloudflareWebAnalyticsSite] {
+        let envelope: Envelope<[SiteInfo]> = try await get("accounts/\(accountID)/rum/site_info/list", apiToken: apiToken)
+        return envelope.result.map { CloudflareWebAnalyticsSite(host: $0.host, siteTag: $0.siteTag) }
+    }
+
+    private func get<T: Decodable>(_ path: String, apiToken: String) async throws -> T {
+        let url = baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let (data, response) = try await urlSession.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            let message = (try? JSONDecoder().decode(ErrorEnvelope.self, from: data).errors.first?.message)
+                ?? "Cloudflare API request failed with HTTP \(http.statusCode)."
+            throw CloudflareWebAnalyticsError.api(message)
+        }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw CloudflareWebAnalyticsError.invalidResponse
+        }
+    }
+
+    private static func normalizeHost(_ host: String) -> String {
+        host.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: #"^https?://"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: #"/.*$"#, with: "", options: .regularExpression)
+    }
+
+    private struct Envelope<Result: Decodable>: Decodable {
+        let result: Result
+    }
+
+    private struct ErrorEnvelope: Decodable {
+        let errors: [APIError]
+    }
+
+    private struct APIError: Decodable {
+        let message: String
+    }
+
+    private struct Account: Decodable {
+        let id: String
+    }
+
+    private struct SiteInfo: Decodable {
+        let host: String
+        let siteTag: String
+
+        enum CodingKeys: String, CodingKey {
+            case host
+            case siteTag = "site_tag"
+        }
+    }
+}

--- a/Sources/AnglesiteCore/EditorKind.swift
+++ b/Sources/AnglesiteCore/EditorKind.swift
@@ -1,15 +1,16 @@
 import Foundation
 
-/// Which editor surface a navigator file opens in. v1 ships only `.text`; future cases
-/// (`.metadataForm`, etc.) slot in by extending this enum and the `resolve(for:)` mapping —
-/// call sites switch on the kind and need no change beyond adding the new view.
+/// Which editor surface a navigator file opens in.
 public enum EditorKind: Sendable, Equatable {
     case text
-    // future: case metadataForm
+    case plist
 
     /// Resolves the editor for a file. A single decision point so the routing rule lives in one
     /// tested place; kept on the enum to keep the public API surface tidy.
     public static func resolve(for file: FileRef) -> EditorKind {
-        .text
+        if file.group == .metadata, file.url.pathExtension.lowercased() == "plist" {
+            return .plist
+        }
+        return .text
     }
 }

--- a/Sources/AnglesiteCore/NavigatorTree.swift
+++ b/Sources/AnglesiteCore/NavigatorTree.swift
@@ -17,9 +17,9 @@ public struct NavigatorItem: Sendable, Equatable, Identifiable {
 
 public struct NavigatorSection: Sendable, Equatable, Identifiable {
     public let id: FileGroup
-    public let title: String
+    public let title: String?
     public let items: [NavigatorItem]
-    public init(id: FileGroup, title: String, items: [NavigatorItem]) {
+    public init(id: FileGroup, title: String?, items: [NavigatorItem]) {
         self.id = id; self.title = title; self.items = items
     }
 }
@@ -34,8 +34,8 @@ public func postRoute(for post: SiteContentGraph.Post) -> String {
 }
 
 /// Display titles for the five groups, in canonical sidebar order.
-private let groupTitles: [(FileGroup, String)] = [
-    (.metadata, ""), (.pages, "Pages"), (.posts, "Posts"),
+private let groupTitles: [(FileGroup, String?)] = [
+    (.metadata, nil), (.pages, "Pages"), (.posts, "Posts"),
     (.components, "Components"), (.styles, "Styles"),
 ]
 

--- a/Sources/AnglesiteCore/NavigatorTree.swift
+++ b/Sources/AnglesiteCore/NavigatorTree.swift
@@ -35,15 +35,16 @@ public func postRoute(for post: SiteContentGraph.Post) -> String {
 
 /// Display titles for the five groups, in canonical sidebar order.
 private let groupTitles: [(FileGroup, String)] = [
-    (.pages, "Pages"), (.posts, "Posts"),
-    (.components, "Components"), (.styles, "Styles"), (.metadata, "Metadata"),
+    (.metadata, ""), (.pages, "Pages"), (.posts, "Posts"),
+    (.components, "Components"), (.styles, "Styles"),
 ]
 
 /// Merges content-graph pages/posts with the filesystem scan into ordered, non-empty sections.
 public func buildNavigatorTree(
     pages: [SiteContentGraph.Page],
     posts: [SiteContentGraph.Post],
-    fileGroups: [FileGroup: [FileRef]]
+    fileGroups: [FileGroup: [FileRef]],
+    websiteTitle: String? = nil
 ) -> [NavigatorSection] {
     let pageItems = pages
         .sorted { $0.route < $1.route }
@@ -58,6 +59,8 @@ public func buildNavigatorTree(
         switch group {
         case .pages: items = pageItems
         case .posts: items = postItems
+        case .metadata:
+            items = siteMetadataItems(from: fileGroups[group] ?? [], websiteTitle: websiteTitle)
         default:
             items = (fileGroups[group] ?? []).map {
                 NavigatorItem(id: $0.id, title: $0.name, target: .file($0))
@@ -66,4 +69,16 @@ public func buildNavigatorTree(
         if !items.isEmpty { sections.append(NavigatorSection(id: group, title: title, items: items)) }
     }
     return sections
+}
+
+private func siteMetadataItems(from refs: [FileRef], websiteTitle: String?) -> [NavigatorItem] {
+    guard let infoPlist = refs.first(where: { $0.name == "Info.plist" }) else { return [] }
+    let title = websiteTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return [
+        NavigatorItem(
+            id: infoPlist.id,
+            title: title.flatMap { $0.isEmpty ? nil : $0 } ?? "Website",
+            target: .file(infoPlist)
+        )
+    ]
 }

--- a/Sources/AnglesiteCore/PlistDocumentIO.swift
+++ b/Sources/AnglesiteCore/PlistDocumentIO.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// Stateless IO for small property-list metadata files shown in the navigator.
+/// The first GUI editor version intentionally supports root dictionaries with scalar values,
+/// which covers package `Info.plist` and `Config/settings.plist`.
+public enum PlistDocumentIO {
+    public struct Loaded: Sendable, Equatable {
+        public let entries: [PlistEntry]
+        public let modificationDate: Date?
+    }
+
+    public struct PlistEntry: Sendable, Equatable, Identifiable {
+        public var id: String { key }
+        public var key: String
+        public var value: PlistValue
+
+        public init(key: String, value: PlistValue) {
+            self.key = key
+            self.value = value
+        }
+    }
+
+    public enum PlistValue: Sendable, Equatable {
+        case string(String)
+        case bool(Bool)
+        case integer(Int)
+        case double(Double)
+        case date(Date)
+        case unsupported(String)
+
+        public var kind: PlistValueKind {
+            switch self {
+            case .string: return .string
+            case .bool: return .bool
+            case .integer: return .integer
+            case .double: return .double
+            case .date: return .date
+            case .unsupported: return .unsupported
+            }
+        }
+    }
+
+    public enum PlistValueKind: String, Sendable, CaseIterable, Identifiable {
+        case string
+        case bool
+        case integer
+        case double
+        case date
+        case unsupported
+
+        public var id: String { rawValue }
+    }
+
+    public enum PlistError: Error, Sendable, Equatable {
+        case rootNotDictionary
+        case duplicateKey(String)
+        case blankKey
+        case unsupportedValue(key: String, description: String)
+    }
+
+    public static func load(_ url: URL, fileManager: FileManager = .default) throws -> Loaded {
+        let data = try Data(contentsOf: url)
+        let object = try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+        guard let dictionary = object as? [String: Any] else {
+            throw PlistError.rootNotDictionary
+        }
+        let entries = dictionary.keys.sorted().map { key in
+            PlistEntry(key: key, value: value(from: dictionary[key] as Any))
+        }
+        return Loaded(entries: entries, modificationDate: try modificationDate(of: url, fileManager: fileManager))
+    }
+
+    @discardableResult
+    public static func save(_ entries: [PlistEntry], to url: URL, fileManager: FileManager = .default) throws -> Date? {
+        var dictionary: [String: Any] = [:]
+        for entry in entries {
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { throw PlistError.blankKey }
+            guard dictionary[key] == nil else { throw PlistError.duplicateKey(key) }
+            dictionary[key] = try serializedValue(entry.value, key: key)
+        }
+        let data = try PropertyListSerialization.data(fromPropertyList: dictionary, format: .xml, options: 0)
+        try data.write(to: url, options: [.atomic])
+        return try modificationDate(of: url, fileManager: fileManager)
+    }
+
+    public static func externalChange(
+        at url: URL,
+        lastKnownModificationDate: Date?,
+        bufferIsDirty: Bool,
+        fileManager: FileManager = .default
+    ) throws -> FileDocumentIO.ExternalChange {
+        let current = try modificationDate(of: url, fileManager: fileManager)
+        guard let current, let last = lastKnownModificationDate, current > last else {
+            return .none
+        }
+        let diskContents = try String(contentsOf: url, encoding: .utf8)
+        return bufferIsDirty ? .conflict(diskContents) : .reloadable(diskContents)
+    }
+
+    private static func value(from object: Any) -> PlistValue {
+        switch object {
+        case let value as String:
+            return .string(value)
+        case let value as Date:
+            return .date(value)
+        case let value as NSNumber:
+            if CFGetTypeID(value) == CFBooleanGetTypeID() {
+                return .bool(value.boolValue)
+            }
+            let type = String(cString: value.objCType)
+            if ["f", "d"].contains(type) {
+                return .double(value.doubleValue)
+            }
+            return .integer(value.intValue)
+        case is [Any]:
+            return .unsupported("Array")
+        case is [String: Any]:
+            return .unsupported("Dictionary")
+        case is Data:
+            return .unsupported("Data")
+        default:
+            return .unsupported(String(describing: type(of: object)))
+        }
+    }
+
+    private static func serializedValue(_ value: PlistValue, key: String) throws -> Any {
+        switch value {
+        case .string(let string):
+            return string
+        case .bool(let bool):
+            return bool
+        case .integer(let int):
+            return int
+        case .double(let double):
+            return double
+        case .date(let date):
+            return date
+        case .unsupported(let description):
+            throw PlistError.unsupportedValue(key: key, description: description)
+        }
+    }
+
+    private static func modificationDate(of url: URL, fileManager: FileManager) throws -> Date? {
+        try fileManager.attributesOfItem(atPath: url.path(percentEncoded: false))[.modificationDate] as? Date
+    }
+}
+
+extension PlistDocumentIO.PlistError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .rootNotDictionary:
+            return "Only dictionary property lists can be edited here."
+        case .duplicateKey(let key):
+            return "The key \(key) appears more than once."
+        case .blankKey:
+            return "Keys can't be blank."
+        case .unsupportedValue(let key, let description):
+            return "\(key) is a \(description.lowercased()) value, which this editor can't save yet."
+        }
+    }
+}

--- a/Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift
+++ b/Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift
@@ -1,0 +1,300 @@
+import Foundation
+
+public enum WebsiteAnalyticsAsset {
+    public struct Settings: Sendable, Equatable {
+        public var cloudflareToken: String
+        public var customHeadTag: String
+
+        public init(cloudflareToken: String = "", customHeadTag: String = "") {
+            self.cloudflareToken = cloudflareToken
+            self.customHeadTag = customHeadTag
+        }
+
+        public var isEmpty: Bool {
+            cloudflareToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && customHeadTag.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    public enum InstallError: LocalizedError, Sendable {
+        case layoutNotFound(URL)
+        case headCloseTagNotFound(URL)
+        case invalidCustomHTML(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .layoutNotFound(let url):
+                return "Website layout not found at \(url.path)."
+            case .headCloseTagNotFound(let url):
+                return "Website layout is missing a closing head tag at \(url.path)."
+            case .invalidCustomHTML(let reason):
+                return reason
+            }
+        }
+    }
+
+    public static let layoutRelativePath = "src/layouts/BaseLayout.astro"
+    public static let configRelativePath = ".site-config"
+    public static let dashboardURL = URL(string: "https://dash.cloudflare.com/?to=/:account/web-analytics")!
+
+    private static let blockStart = "<!-- anglesite:analytics-start -->"
+    private static let blockEnd = "<!-- anglesite:analytics-end -->"
+    private static let customStart = "<!-- anglesite:custom-analytics-start -->"
+    private static let customEnd = "<!-- anglesite:custom-analytics-end -->"
+
+    public static func parseSettings(from source: String) -> Settings {
+        Settings(
+            cloudflareToken: firstCapture(in: source, pattern: #"data-cf-beacon=['"]\{"token":"([^"]+)"\}['"]"#) ?? "",
+            customHeadTag: customTag(in: source) ?? ""
+        )
+    }
+
+    public static func apply(_ settings: Settings, to source: String) -> String {
+        let block = renderBlock(settings)
+        if let existing = analyticsBlockRange(in: source) {
+            var patched = source
+            if block.isEmpty {
+                patched.replaceSubrange(existing, with: "")
+            } else {
+                patched.replaceSubrange(existing, with: block)
+            }
+            return patched
+        }
+        guard !block.isEmpty, let headEnd = source.range(of: "</head>") else { return source }
+        var patched = source
+        patched.insert(contentsOf: block + "\n", at: headEnd.lowerBound)
+        return patched
+    }
+
+    public static func install(_ settings: Settings, siteDirectory: URL, fileManager: FileManager = .default) throws {
+        if let validationMessage = customHeadTagValidationMessage(settings.customHeadTag) {
+            throw InstallError.invalidCustomHTML(validationMessage)
+        }
+
+        let layoutURL = siteDirectory.appendingPathComponent(layoutRelativePath)
+        guard fileManager.fileExists(atPath: layoutURL.path) else {
+            throw InstallError.layoutNotFound(layoutURL)
+        }
+        let source = try String(contentsOf: layoutURL, encoding: .utf8)
+        let patched = applyMigratingLegacy(settings, to: source)
+        if patched == source && !settings.isEmpty && source.range(of: "</head>") == nil {
+            throw InstallError.headCloseTagNotFound(layoutURL)
+        }
+        if patched != source {
+            try patched.write(to: layoutURL, atomically: true, encoding: .utf8)
+        }
+
+        let configURL = siteDirectory.appendingPathComponent(configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        var updatedConfig = SiteConfigFile.upsert([
+            ("CF_WEB_ANALYTICS_TOKEN", settings.cloudflareToken.trimmingCharacters(in: .whitespacesAndNewlines))
+        ], into: config)
+        let customDomains = customScriptDomains(from: settings.customHeadTag)
+        if !customDomains.isEmpty {
+            updatedConfig = SiteConfigFile.addCSPDomains(customDomains, into: updatedConfig)
+        }
+        if updatedConfig != config {
+            try updatedConfig.write(to: configURL, atomically: true, encoding: .utf8)
+        }
+    }
+
+    public static func bestHost(from config: String, fallback: String) -> String {
+        let domain = configValue("DOMAIN", in: config)
+            ?? configValue("SITE_DOMAIN", in: config)
+            ?? fallback
+        return domain.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public static func customScriptDomains(from html: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: #"<script[^>]+src=["']https?://([^/"']+)"#, options: [.caseInsensitive]) else {
+            return []
+        }
+        let range = NSRange(html.startIndex..<html.endIndex, in: html)
+        let domains = regex.matches(in: html, range: range).compactMap { match -> String? in
+            guard match.numberOfRanges > 1, let capture = Range(match.range(at: 1), in: html) else { return nil }
+            return String(html[capture]).lowercased()
+        }
+        return Array(Set(domains)).sorted()
+    }
+
+    public static func customHeadTagValidationMessage(_ html: String) -> String? {
+        let snippet = html.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !snippet.isEmpty else { return nil }
+
+        if snippet.contains(blockStart) || snippet.contains(blockEnd)
+            || snippet.contains(customStart) || snippet.contains(customEnd) {
+            return "Custom analytics HTML can't include Anglesite's managed analytics comments."
+        }
+
+        if hasDanglingHTMLComment(in: snippet) {
+            return "Custom analytics HTML has an unfinished comment."
+        }
+
+        if hasDanglingTag(in: snippet) {
+            return "Custom analytics HTML has an unfinished tag."
+        }
+
+        if hasUnclosedScriptTag(in: snippet) {
+            return "Custom analytics script tags must include a closing </script> tag."
+        }
+
+        return nil
+    }
+
+    public static func configValue(_ key: String, in config: String) -> String? {
+        for line in config.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("\(key)=") else { continue }
+            return String(trimmed.dropFirst(key.count + 1))
+        }
+        return nil
+    }
+
+    public static func loadConfig(siteDirectory: URL, fileManager: FileManager = .default) throws -> String {
+        let configURL = siteDirectory.appendingPathComponent(configRelativePath)
+        guard fileManager.fileExists(atPath: configURL.path) else { return "" }
+        return try String(contentsOf: configURL, encoding: .utf8)
+    }
+
+    public static func parseSettings(layoutSource: String, config: String) -> Settings {
+        var settings = parseSettings(from: layoutSource)
+        if settings.cloudflareToken.isEmpty, let token = configValue("CF_WEB_ANALYTICS_TOKEN", in: config) {
+            settings.cloudflareToken = token
+        }
+        return settings
+    }
+
+    public static func setCloudflareToken(_ token: String, in settings: inout Settings) {
+        settings.cloudflareToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func legacyGoogleTag(in source: String) -> String? {
+        guard let id = firstCapture(in: source, pattern: #"googletagmanager\.com/gtag/js\?id=([^"'&<\s]+)"#) else {
+            return nil
+        }
+        return """
+        <script async src="https://www.googletagmanager.com/gtag/js?id=\(attr(id))"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '\(attr(id))');
+        </script>
+        """
+    }
+
+    private static func migrateLegacyGoogle(from source: String, into settings: inout Settings) {
+        if settings.customHeadTag.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           let tag = legacyGoogleTag(in: source) {
+            settings.customHeadTag = tag
+        }
+    }
+
+    public static func parseMigratingLegacySettings(layoutSource: String, config: String) -> Settings {
+        var settings = parseSettings(layoutSource: layoutSource, config: config)
+        migrateLegacyGoogle(from: layoutSource, into: &settings)
+        return settings
+    }
+
+    public static func stripLegacyGoogle(from source: String) -> String {
+        var output = source
+        if let asyncRange = output.range(of: #"\n?\s*<script async src="https://www\.googletagmanager\.com/gtag/js\?id=[^"]+"></script>"#, options: .regularExpression) {
+            output.removeSubrange(asyncRange)
+        }
+        if let blockRange = output.range(of: #"\n?\s*<script>\s*window\.dataLayer = window\.dataLayer \|\| \[\];\s*function gtag\(\)\{dataLayer\.push\(arguments\);\}\s*gtag\('js', new Date\(\)\);\s*gtag\('config', '[^']+'\);\s*</script>"#, options: .regularExpression) {
+            output.removeSubrange(blockRange)
+        }
+        return output
+    }
+
+    public static func applyMigratingLegacy(_ settings: Settings, to source: String) -> String {
+        apply(settings, to: stripLegacyGoogle(from: source))
+    }
+
+    private static func renderBlock(_ settings: Settings) -> String {
+        var lines: [String] = []
+        let cloudflareToken = settings.cloudflareToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        let customTag = settings.customHeadTag.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !cloudflareToken.isEmpty {
+            lines.append(#"<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"\#(attr(cloudflareToken))"}'></script>"#)
+        }
+        if !customTag.isEmpty {
+            lines.append(customStart)
+            lines.append(customTag)
+            lines.append(customEnd)
+        }
+        guard !lines.isEmpty else { return "" }
+        return ([blockStart] + lines + [blockEnd]).joined(separator: "\n")
+    }
+
+    private static func analyticsBlockRange(in source: String) -> Range<String.Index>? {
+        guard let start = source.range(of: blockStart),
+              let end = source.range(of: blockEnd, range: start.upperBound..<source.endIndex)
+        else { return nil }
+        var upper = end.upperBound
+        if upper < source.endIndex, source[upper] == "\n" {
+            upper = source.index(after: upper)
+        }
+        return start.lowerBound..<upper
+    }
+
+    private static func customTag(in source: String) -> String? {
+        guard let start = source.range(of: customStart),
+              let end = source.range(of: customEnd, range: start.upperBound..<source.endIndex)
+        else { return nil }
+        return source[start.upperBound..<end.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func firstCapture(in source: String, pattern: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        guard let match = regex.firstMatch(in: source, range: range),
+              match.numberOfRanges > 1,
+              let capture = Range(match.range(at: 1), in: source)
+        else { return nil }
+        return String(source[capture])
+    }
+
+    private static func hasDanglingHTMLComment(in snippet: String) -> Bool {
+        var searchStart = snippet.startIndex
+        while let start = snippet.range(of: "<!--", range: searchStart..<snippet.endIndex) {
+            guard let end = snippet.range(of: "-->", range: start.upperBound..<snippet.endIndex) else {
+                return true
+            }
+            searchStart = end.upperBound
+        }
+        return false
+    }
+
+    private static func hasDanglingTag(in snippet: String) -> Bool {
+        guard let lastOpen = snippet.lastIndex(of: "<") else { return false }
+        guard let lastClose = snippet.lastIndex(of: ">") else { return true }
+        return lastOpen > lastClose
+    }
+
+    private static func hasUnclosedScriptTag(in snippet: String) -> Bool {
+        let lowercased = snippet.lowercased()
+        var searchStart = lowercased.startIndex
+        while let openStart = lowercased.range(of: "<script", range: searchStart..<lowercased.endIndex) {
+            guard let openEnd = lowercased.range(of: ">", range: openStart.upperBound..<lowercased.endIndex) else {
+                return true
+            }
+            guard let close = lowercased.range(of: "</script", range: openEnd.upperBound..<lowercased.endIndex),
+                  lowercased.range(of: ">", range: close.upperBound..<lowercased.endIndex) != nil
+            else {
+                return true
+            }
+            searchStart = close.upperBound
+        }
+        return false
+    }
+
+    private static func attr(_ value: String) -> String {
+        value.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+}

--- a/Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift
+++ b/Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift
@@ -44,7 +44,7 @@ public enum WebsiteAnalyticsAsset {
 
     public static func parseSettings(from source: String) -> Settings {
         Settings(
-            cloudflareToken: firstCapture(in: source, pattern: #"data-cf-beacon=['"]\{"token":"([^"]+)"\}['"]"#) ?? "",
+            cloudflareToken: cloudflareToken(in: source) ?? "",
             customHeadTag: customTag(in: source) ?? ""
         )
     }
@@ -217,7 +217,8 @@ public enum WebsiteAnalyticsAsset {
         let customTag = settings.customHeadTag.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if !cloudflareToken.isEmpty {
-            lines.append(#"<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"\#(attr(cloudflareToken))"}'></script>"#)
+            let beacon = cloudflareBeaconAttributeValue(token: cloudflareToken)
+            lines.append(#"<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='\#(beacon)'></script>"#)
         }
         if !customTag.isEmpty {
             lines.append(customStart)
@@ -251,10 +252,13 @@ public enum WebsiteAnalyticsAsset {
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
         let range = NSRange(source.startIndex..<source.endIndex, in: source)
         guard let match = regex.firstMatch(in: source, range: range),
-              match.numberOfRanges > 1,
-              let capture = Range(match.range(at: 1), in: source)
+              match.numberOfRanges > 1
         else { return nil }
-        return String(source[capture])
+        for index in 1..<match.numberOfRanges {
+            guard let capture = Range(match.range(at: index), in: source) else { continue }
+            return String(source[capture])
+        }
+        return nil
     }
 
     private static func hasDanglingHTMLComment(in snippet: String) -> Bool {
@@ -293,8 +297,44 @@ public enum WebsiteAnalyticsAsset {
 
     private static func attr(_ value: String) -> String {
         value.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "'", with: "&#39;")
             .replacingOccurrences(of: "\"", with: "&quot;")
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    private static func cloudflareBeaconAttributeValue(token: String) -> String {
+        let object = ["token": token]
+        let data = (try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]))
+            ?? Data(#"{"token":""}"#.utf8)
+        return singleQuotedAttr(String(decoding: data, as: UTF8.self))
+    }
+
+    private static func singleQuotedAttr(_ value: String) -> String {
+        value.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    private static func cloudflareToken(in source: String) -> String? {
+        guard let json = firstCapture(in: source, pattern: #"data-cf-beacon=(?:"([^"]+)"|'([^']+)')"#) else {
+            return nil
+        }
+        let decoded = htmlAttributeDecode(json)
+        guard let data = decoded.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let token = object["token"] as? String
+        else { return nil }
+        return token
+    }
+
+    private static func htmlAttributeDecode(_ value: String) -> String {
+        value.replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&apos;", with: "'")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&amp;", with: "&")
     }
 }

--- a/Sources/AnglesiteCore/WebsiteIconAsset.swift
+++ b/Sources/AnglesiteCore/WebsiteIconAsset.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Deterministic website icon links and metadata for an Anglesite site's public assets.
+public enum WebsiteIconAsset {
+    public static let publicDirectoryRelativePath = "public"
+    public static let layoutRelativePath = "src/layouts/BaseLayout.astro"
+    public static let faviconICOName = "favicon.ico"
+    public static let faviconPNGName = "favicon.png"
+    public static let appleTouchIconName = "apple-touch-icon.png"
+    public static let icon192Name = "icon-192.png"
+    public static let icon512Name = "icon-512.png"
+    public static let manifestName = "site.webmanifest"
+
+    public enum InstallError: Error, Sendable {
+        case layoutNotFound(URL)
+    }
+
+    public static let headLinks = """
+        <link rel="icon" href="/favicon.ico" sizes="any" />
+        <link rel="icon" type="image/png" href="/favicon.png" />
+        <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+        <link rel="manifest" href="/site.webmanifest" />
+    """
+
+    public static func insertHeadLinks(into source: String) -> String {
+        guard !source.contains(#"href="/favicon.ico""#),
+              !source.contains(#"href="/site.webmanifest""#) else {
+            return source
+        }
+        guard let headRange = source.range(of: "<head>") else { return source }
+        let insertion = "\n" + headLinks
+        var patched = source
+        patched.insert(contentsOf: insertion, at: headRange.upperBound)
+        return patched
+    }
+
+    public static func patchLayout(in siteDirectory: URL, fileManager: FileManager = .default) throws {
+        let layoutURL = siteDirectory.appendingPathComponent(layoutRelativePath)
+        guard fileManager.fileExists(atPath: layoutURL.path) else {
+            throw InstallError.layoutNotFound(layoutURL)
+        }
+        let source = try String(contentsOf: layoutURL, encoding: .utf8)
+        let patched = insertHeadLinks(into: source)
+        if patched != source {
+            try patched.write(to: layoutURL, atomically: true, encoding: .utf8)
+        }
+    }
+
+    public static func manifestData(siteName: String) throws -> Data {
+        let manifest: [String: Any] = [
+            "name": siteName,
+            "short_name": siteName,
+            "icons": [
+                [
+                    "src": "/icon-192.png",
+                    "sizes": "192x192",
+                    "type": "image/png"
+                ],
+                [
+                    "src": "/icon-512.png",
+                    "sizes": "512x512",
+                    "type": "image/png"
+                ]
+            ],
+            "display": "standalone"
+        ]
+        return try JSONSerialization.data(withJSONObject: manifest, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    public static func installedIconURLs(in siteDirectory: URL) -> [URL] {
+        let publicDir = siteDirectory.appendingPathComponent(publicDirectoryRelativePath, isDirectory: true)
+        return [
+            faviconICOName,
+            faviconPNGName,
+            appleTouchIconName,
+            icon192Name,
+            icon512Name,
+            manifestName
+        ].map { publicDir.appendingPathComponent($0) }
+    }
+
+    public static func hasInstalledIcons(in siteDirectory: URL, fileManager: FileManager = .default) -> Bool {
+        installedIconURLs(in: siteDirectory).contains { fileManager.fileExists(atPath: $0.path) }
+    }
+}

--- a/Tests/AnglesiteCoreTests/AstroHTMLValidatorTests.swift
+++ b/Tests/AnglesiteCoreTests/AstroHTMLValidatorTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("AstroHTMLValidator")
+struct AstroHTMLValidatorTests {
+    @Test("empty custom analytics HTML is valid without spawning Node")
+    func emptyHTMLDoesNotSpawnNode() async {
+        let validator = AstroHTMLValidator(
+            nodeExecutable: { URL(fileURLWithPath: "/usr/bin/node") },
+            run: { _, _, _ in
+                Issue.record("Empty HTML should not run Astro validation")
+                return ProcessSupervisor.RunResult(stdout: "", stderr: "", exitCode: 1)
+            }
+        )
+
+        let message = await validator.validationMessage(for: "   \n", siteDirectory: URL(fileURLWithPath: "/tmp/site"))
+
+        #expect(message == nil)
+    }
+
+    @Test("missing Astro compiler reports dependency error")
+    func missingAstroCompiler() async throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let validator = AstroHTMLValidator(nodeExecutable: { URL(fileURLWithPath: "/usr/bin/node") })
+
+        let message = await validator.validationMessage(for: "<script></script>", siteDirectory: root)
+
+        #expect(message?.contains("Astro dependencies are missing") == true)
+    }
+
+    @Test("runner failure is returned as invalid custom analytics HTML")
+    func runnerFailure() async throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(
+            at: root.appendingPathComponent("node_modules/@astrojs/compiler", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try "{}".write(
+            to: root.appendingPathComponent("node_modules/@astrojs/compiler/package.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        defer { try? fm.removeItem(at: root) }
+
+        let validator = AstroHTMLValidator(
+            nodeExecutable: { URL(fileURLWithPath: "/usr/bin/node") },
+            run: { _, arguments, cwd in
+                #expect(arguments.count == 3)
+                #expect(cwd == root)
+                #expect((try? String(contentsOf: URL(fileURLWithPath: arguments[2]), encoding: .utf8)) == "<script></")
+                return ProcessSupervisor.RunResult(
+                    stdout: "",
+                    stderr: "Cannot read properties of undefined (reading 'map')",
+                    exitCode: 1
+                )
+            }
+        )
+
+        let message = await validator.validationMessage(for: "<script></", siteDirectory: root)
+
+        #expect(message == "Custom analytics HTML is invalid: Astro couldn't parse the snippet. Check for incomplete tags or script blocks.")
+    }
+}

--- a/Tests/AnglesiteCoreTests/CloudflareWebAnalyticsClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareWebAnalyticsClientTests.swift
@@ -1,0 +1,17 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite("CloudflareWebAnalyticsClient")
+struct CloudflareWebAnalyticsClientTests {
+    @Test("matchingSite normalizes host URLs")
+    func matchingSiteNormalizesHostURLs() {
+        let sites = [
+            CloudflareWebAnalyticsSite(host: "example.com", siteTag: "tag-1"),
+            CloudflareWebAnalyticsSite(host: "other.example", siteTag: "tag-2")
+        ]
+
+        #expect(CloudflareWebAnalyticsClient.matchingSite(for: "https://example.com/", in: sites)?.siteTag == "tag-1")
+        #expect(CloudflareWebAnalyticsClient.matchingSite(for: "OTHER.EXAMPLE/path", in: sites)?.siteTag == "tag-2")
+        #expect(CloudflareWebAnalyticsClient.matchingSite(for: "missing.example", in: sites) == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/EditorKindTests.swift
+++ b/Tests/AnglesiteCoreTests/EditorKindTests.swift
@@ -3,8 +3,20 @@ import Foundation
 @testable import AnglesiteCore
 
 struct EditorKindTests {
-    @Test("v1 routes every file group to the text editor")
-    func everythingIsText() {
+    @Test("metadata plist files route to the plist editor")
+    func metadataPlistUsesPlistEditor() {
+        let ref = FileRef(url: URL(fileURLWithPath: "/tmp/Info.plist"), group: .metadata, name: "Info.plist")
+        #expect(EditorKind.resolve(for: ref) == .plist)
+    }
+
+    @Test("non-metadata plist files remain text editable")
+    func sourcePlistUsesTextEditor() {
+        let ref = FileRef(url: URL(fileURLWithPath: "/tmp/Config.plist"), group: .components, name: "Config.plist")
+        #expect(EditorKind.resolve(for: ref) == .text)
+    }
+
+    @Test("non-plist files route to the text editor")
+    func nonPlistFilesAreText() {
         for group in FileGroup.allCases {
             let ref = FileRef(url: URL(fileURLWithPath: "/tmp/x"), group: group, name: "x")
             #expect(EditorKind.resolve(for: ref) == .text)

--- a/Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
+++ b/Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
@@ -47,4 +47,23 @@ struct NavigatorTreeTests {
         #expect(item.title == "Base.astro")
         #expect(item.target == .file(ref))
     }
+
+    @Test("package Info.plist appears as the headerless first website item")
+    func packageMetadataAppearsAsWebsiteItem() throws {
+        let info = FileRef(url: URL(fileURLWithPath: "/tmp/Site.anglesite/Info.plist"), group: .metadata, name: "Info.plist")
+        let settings = FileRef(url: URL(fileURLWithPath: "/tmp/Site.anglesite/Config/settings.plist"), group: .metadata, name: "settings.plist")
+
+        let sections = buildNavigatorTree(
+            pages: [page("/about/", title: "About")],
+            posts: [],
+            fileGroups: [.metadata: [settings, info]],
+            websiteTitle: "Acme"
+        )
+
+        let site = try #require(sections.first)
+        #expect(site.id == .metadata)
+        #expect(site.title == "")
+        #expect(site.items.map(\.title) == ["Acme"])
+        #expect(site.items.first?.target == .file(info))
+    }
 }

--- a/Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
+++ b/Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
@@ -62,7 +62,7 @@ struct NavigatorTreeTests {
 
         let site = try #require(sections.first)
         #expect(site.id == .metadata)
-        #expect(site.title == "")
+        #expect(site.title == nil)
         #expect(site.items.map(\.title) == ["Acme"])
         #expect(site.items.first?.target == .file(info))
     }

--- a/Tests/AnglesiteCoreTests/PlistDocumentIOTests.swift
+++ b/Tests/AnglesiteCoreTests/PlistDocumentIOTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct PlistDocumentIOTests {
+    private func makeTempFile(named name: String = "Info.plist") throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("anglesite-plist-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent(name)
+    }
+
+    @Test("load reads scalar dictionary plist entries")
+    func loadScalarDictionary() throws {
+        let url = try makeTempFile()
+        let date = Date(timeIntervalSinceReferenceDate: 42)
+        let plist: [String: Any] = [
+            "Name": "Acme",
+            "Enabled": true,
+            "Count": 3,
+            "Ratio": 1.5,
+            "Created": date
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: url)
+
+        let loaded = try PlistDocumentIO.load(url)
+
+        #expect(loaded.entries.contains(.init(key: "Name", value: .string("Acme"))))
+        #expect(loaded.entries.contains(.init(key: "Enabled", value: .bool(true))))
+        #expect(loaded.entries.contains(.init(key: "Count", value: .integer(3))))
+        #expect(loaded.entries.contains(.init(key: "Ratio", value: .double(1.5))))
+        #expect(loaded.entries.contains(.init(key: "Created", value: .date(date))))
+        #expect(loaded.modificationDate != nil)
+    }
+
+    @Test("save writes scalar dictionary plist entries")
+    func saveScalarDictionary() throws {
+        let url = try makeTempFile()
+        try PlistDocumentIO.save([
+            .init(key: "Name", value: .string("Acme")),
+            .init(key: "Enabled", value: .bool(false)),
+            .init(key: "Count", value: .integer(4))
+        ], to: url)
+
+        let loaded = try PlistDocumentIO.load(url)
+
+        #expect(loaded.entries.contains(.init(key: "Name", value: .string("Acme"))))
+        #expect(loaded.entries.contains(.init(key: "Enabled", value: .bool(false))))
+        #expect(loaded.entries.contains(.init(key: "Count", value: .integer(4))))
+    }
+
+    @Test("save rejects blank and duplicate keys")
+    func saveValidatesKeys() throws {
+        let url = try makeTempFile()
+        #expect(throws: PlistDocumentIO.PlistError.blankKey) {
+            try PlistDocumentIO.save([.init(key: " ", value: .string(""))], to: url)
+        }
+        #expect(throws: PlistDocumentIO.PlistError.duplicateKey("Name")) {
+            try PlistDocumentIO.save([
+                .init(key: "Name", value: .string("A")),
+                .init(key: "Name", value: .string("B"))
+            ], to: url)
+        }
+    }
+
+    @Test("load rejects non-dictionary plist roots")
+    func loadRejectsNonDictionaryRoot() throws {
+        let url = try makeTempFile()
+        let data = try PropertyListSerialization.data(fromPropertyList: ["x", "y"], format: .xml, options: 0)
+        try data.write(to: url)
+
+        #expect(throws: PlistDocumentIO.PlistError.rootNotDictionary) {
+            try PlistDocumentIO.load(url)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/WebsiteAnalyticsAssetTests.swift
+++ b/Tests/AnglesiteCoreTests/WebsiteAnalyticsAssetTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("WebsiteAnalyticsAsset")
+struct WebsiteAnalyticsAssetTests {
+    private let layout = """
+    <html>
+      <head>
+        <title>Acme</title>
+      </head>
+    </html>
+    """
+
+    @Test("apply inserts configured analytics before the closing head tag")
+    func applyInsertsAnalyticsBlock() {
+        let settings = WebsiteAnalyticsAsset.Settings(
+            cloudflareToken: "cf-token",
+            customHeadTag: #"<script async src="https://www.googletagmanager.com/gtag/js?id=G-1234567890"></script>"#
+        )
+
+        let patched = WebsiteAnalyticsAsset.apply(settings, to: layout)
+
+        #expect(patched.contains("static.cloudflareinsights.com/beacon.min.js"))
+        #expect(patched.contains("www.googletagmanager.com/gtag/js?id=G-1234567890"))
+        #expect(patched.range(of: "<!-- anglesite:analytics-start -->")!.lowerBound <
+                patched.range(of: "</head>")!.lowerBound)
+    }
+
+    @Test("apply replaces an existing managed analytics block")
+    func applyReplacesManagedBlock() {
+        let first = WebsiteAnalyticsAsset.apply(
+            WebsiteAnalyticsAsset.Settings(cloudflareToken: "old"),
+            to: layout
+        )
+
+        let second = WebsiteAnalyticsAsset.apply(
+            WebsiteAnalyticsAsset.Settings(customHeadTag: #"<script src="https://example.com/new.js"></script>"#),
+            to: first
+        )
+
+        #expect(!second.contains("old"))
+        #expect(second.contains("https://example.com/new.js"))
+        #expect(second.components(separatedBy: "<!-- anglesite:analytics-start -->").count == 2)
+    }
+
+    @Test("empty settings remove the managed analytics block")
+    func applyRemovesBlock() {
+        let withAnalytics = WebsiteAnalyticsAsset.apply(
+            WebsiteAnalyticsAsset.Settings(cloudflareToken: "cf-token"),
+            to: layout
+        )
+
+        let removed = WebsiteAnalyticsAsset.apply(WebsiteAnalyticsAsset.Settings(), to: withAnalytics)
+
+        #expect(!removed.contains("anglesite:analytics"))
+    }
+
+    @Test("parseSettings reads managed analytics values")
+    func parseSettings() {
+        let settings = WebsiteAnalyticsAsset.Settings(
+            cloudflareToken: "cf-token",
+            customHeadTag: #"<meta name="x" content="y">"#
+        )
+        let source = WebsiteAnalyticsAsset.apply(settings, to: layout)
+
+        #expect(WebsiteAnalyticsAsset.parseSettings(from: source) == settings)
+    }
+
+    @Test("install writes layout and adds custom script CSP domains")
+    func installPatchesLayoutAndConfig() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let siteDir = root.appendingPathComponent("Source")
+        let layoutDir = siteDir.appendingPathComponent("src/layouts")
+        try fm.createDirectory(at: layoutDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        try layout.write(to: layoutDir.appendingPathComponent("BaseLayout.astro"), atomically: true, encoding: .utf8)
+        try "SITE_NAME=Acme\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        try WebsiteAnalyticsAsset.install(
+            WebsiteAnalyticsAsset.Settings(customHeadTag: #"<script async src="https://www.googletagmanager.com/gtag/js?id=G-ABCDEF1234"></script>"#),
+            siteDirectory: siteDir,
+            fileManager: fm
+        )
+
+        let patched = try String(contentsOf: layoutDir.appendingPathComponent("BaseLayout.astro"), encoding: .utf8)
+        let config = try String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(patched.contains("G-ABCDEF1234"))
+        #expect(config.contains("www.googletagmanager.com"))
+    }
+
+    @Test("install rejects incomplete custom analytics HTML without changing the layout")
+    func installRejectsIncompleteCustomHTML() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let siteDir = root.appendingPathComponent("Source")
+        let layoutDir = siteDir.appendingPathComponent("src/layouts")
+        let layoutURL = layoutDir.appendingPathComponent("BaseLayout.astro")
+        try fm.createDirectory(at: layoutDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        try layout.write(to: layoutURL, atomically: true, encoding: .utf8)
+
+        #expect(throws: WebsiteAnalyticsAsset.InstallError.self) {
+            try WebsiteAnalyticsAsset.install(
+                WebsiteAnalyticsAsset.Settings(customHeadTag: "<script></"),
+                siteDirectory: siteDir,
+                fileManager: fm
+            )
+        }
+
+        let unchanged = try String(contentsOf: layoutURL, encoding: .utf8)
+        #expect(unchanged == layout)
+    }
+
+    @Test("custom analytics validation accepts complete snippets and rejects broken snippets")
+    func customAnalyticsValidation() {
+        #expect(WebsiteAnalyticsAsset.customHeadTagValidationMessage("") == nil)
+        #expect(WebsiteAnalyticsAsset.customHeadTagValidationMessage(#"<meta name="test" content="ok">"#) == nil)
+        #expect(WebsiteAnalyticsAsset.customHeadTagValidationMessage("<script>window.test = true;</script>") == nil)
+        #expect(WebsiteAnalyticsAsset.customHeadTagValidationMessage("<script></") != nil)
+        #expect(WebsiteAnalyticsAsset.customHeadTagValidationMessage("<!-- unfinished") != nil)
+    }
+
+    @Test("bestHost prefers configured domains")
+    func bestHost() {
+        #expect(WebsiteAnalyticsAsset.bestHost(from: "SITE_DOMAIN=example.com\n", fallback: "fallback.pages.dev") == "example.com")
+        #expect(WebsiteAnalyticsAsset.bestHost(from: "DOMAIN=example.org\n", fallback: "fallback.pages.dev") == "example.org")
+        #expect(WebsiteAnalyticsAsset.bestHost(from: "", fallback: "fallback.pages.dev") == "fallback.pages.dev")
+    }
+
+    @Test("customScriptDomains extracts external script hosts")
+    func customScriptDomains() {
+        let html = #"<script src="https://www.googletagmanager.com/gtag/js?id=G-X"></script><script src='https://cdn.example.com/a.js'></script>"#
+        #expect(WebsiteAnalyticsAsset.customScriptDomains(from: html) == ["cdn.example.com", "www.googletagmanager.com"])
+    }
+}

--- a/Tests/AnglesiteCoreTests/WebsiteAnalyticsAssetTests.swift
+++ b/Tests/AnglesiteCoreTests/WebsiteAnalyticsAssetTests.swift
@@ -67,6 +67,17 @@ struct WebsiteAnalyticsAssetTests {
         #expect(WebsiteAnalyticsAsset.parseSettings(from: source) == settings)
     }
 
+    @Test("Cloudflare beacon token is JSON encoded and round trips")
+    func cloudflareBeaconTokenIsJSONEncoded() {
+        let token = #"cf'token\with"quotes&chars"#
+        let settings = WebsiteAnalyticsAsset.Settings(cloudflareToken: token)
+
+        let source = WebsiteAnalyticsAsset.apply(settings, to: layout)
+
+        #expect(source.contains(#"data-cf-beacon='{"token":"cf&#39;token\\with\"quotes&amp;chars"}'"#))
+        #expect(WebsiteAnalyticsAsset.parseSettings(from: source).cloudflareToken == token)
+    }
+
     @Test("install writes layout and adds custom script CSP domains")
     func installPatchesLayoutAndConfig() throws {
         let fm = FileManager.default

--- a/Tests/AnglesiteCoreTests/WebsiteIconAssetTests.swift
+++ b/Tests/AnglesiteCoreTests/WebsiteIconAssetTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("WebsiteIconAsset")
+struct WebsiteIconAssetTests {
+    @Test("insertHeadLinks adds standard website icon links after the head tag")
+    func insertHeadLinks() {
+        let source = """
+        <html>
+          <head>
+            <title>Acme</title>
+          </head>
+        </html>
+        """
+
+        let patched = WebsiteIconAsset.insertHeadLinks(into: source)
+
+        #expect(patched.contains(#"<link rel="icon" href="/favicon.ico" sizes="any" />"#))
+        #expect(patched.contains(#"<link rel="apple-touch-icon" href="/apple-touch-icon.png" />"#))
+        #expect(patched.contains(#"<link rel="manifest" href="/site.webmanifest" />"#))
+        #expect(patched.range(of: #"<link rel="icon" href="/favicon.ico""#)!.lowerBound <
+                patched.range(of: "<title>Acme</title>")!.lowerBound)
+    }
+
+    @Test("insertHeadLinks is idempotent")
+    func insertHeadLinksIsIdempotent() {
+        let source = """
+        <html>
+          <head>
+        \(WebsiteIconAsset.headLinks)
+            <title>Acme</title>
+          </head>
+        </html>
+        """
+
+        #expect(WebsiteIconAsset.insertHeadLinks(into: source) == source)
+    }
+
+    @Test("patchLayout updates an Astro layout file")
+    func patchLayout() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let siteDir = root.appendingPathComponent("Source")
+        let layoutDir = siteDir.appendingPathComponent("src/layouts")
+        try fm.createDirectory(at: layoutDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let layoutURL = layoutDir.appendingPathComponent("BaseLayout.astro")
+        try "<html><head><title>{title}</title></head></html>".write(to: layoutURL, atomically: true, encoding: .utf8)
+
+        try WebsiteIconAsset.patchLayout(in: siteDir, fileManager: fm)
+
+        let patched = try String(contentsOf: layoutURL, encoding: .utf8)
+        #expect(patched.contains(#"href="/favicon.ico""#))
+    }
+
+    @Test("manifestData writes web app icon metadata")
+    func manifestData() throws {
+        let data = try WebsiteIconAsset.manifestData(siteName: #"A "Site""#)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let icons = object?["icons"] as? [[String: String]]
+
+        #expect(object?["name"] as? String == #"A "Site""#)
+        #expect(object?["short_name"] as? String == #"A "Site""#)
+        #expect(object?["display"] as? String == "standalone")
+        #expect(icons?.map { $0["src"] } == ["/icon-192.png", "/icon-512.png"])
+    }
+}


### PR DESCRIPTION
## Summary
- Add a first-class Website settings editor as the first sidebar item, exposing only the website title while hiding plist details from the user.
- Add website icon generation/installation and managed layout patching for favicon, PNG, Apple touch icon, and web manifest assets.
- Add Analytics settings with Cloudflare Web Analytics lookup, a single custom analytics HTML field, syntax highlighting, and Astro-backed validation that refuses invalid snippets before saving.

## Verification
- swift test --package-path . --filter 'NavigatorTreeTests|EditorKindTests|PlistDocumentIOTests|WebsiteIconAssetTests|WebsiteAnalyticsAssetTests|CloudflareWebAnalyticsClientTests|SiteConfigFileTests'
- swift test --package-path . --filter 'AstroHTMLValidatorTests|WebsiteAnalyticsAssetTests'
- env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
- npm run build (in /Users/dwk/Sites/anglesite-test.anglesite/Source)