### PR TITLE
Add project knowledge indexing for assistant retrieval

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -22,6 +22,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `AnglesiteIntents.bootstrap` so it can be registered with `AppDependencyManager`;
     /// will also be threaded into `LocalSiteRuntime` in A.8 (#142).
     let contentGraph = SiteContentGraph()
+    /// Project-local retrieval index used by assistant tools for file-cited RAG context (#307).
+    let knowledgeIndex = SiteKnowledgeIndex()
     let contentIndexerStore = ContentIndexerStore()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -208,7 +210,12 @@ struct AnglesiteApp: App {
             // route to the launcher when restoration hands us a nil or unresolvable
             // id. If we short-circuit with `if let siteID` here the SiteWindow never
             // instantiates and an empty restored window strands the user.
-            SiteWindow(siteID: siteID, contentGraph: appDelegate.contentGraph, contentIndexerStore: appDelegate.contentIndexerStore)
+            SiteWindow(
+                siteID: siteID,
+                contentGraph: appDelegate.contentGraph,
+                knowledgeIndex: appDelegate.knowledgeIndex,
+                contentIndexerStore: appDelegate.contentIndexerStore
+            )
                 .frame(minWidth: 960, minHeight: 600)
         }
         .windowStyle(.titleBar)

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -106,7 +106,8 @@ final class PreviewModel {
             return LocalContainerSiteRuntime(
                 ref: "HEAD",
                 control: ContainerizationControl(),
-                mcpClient: MCPClient(supervisor: .shared)
+                mcpClient: MCPClient(supervisor: .shared),
+                knowledgeIndex: knowledgeIndex
             )
         }
         #endif

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -42,8 +42,12 @@ final class PreviewModel {
     /// `contentGraph` is the app-lifetime `SiteContentGraph` (held by `AppDelegate`); it's threaded
     /// into the default `LocalSiteRuntime` so opening this site populates the shared graph (A.8,
     /// #142). Tests inject an explicit `runtime` and leave the graph `nil`.
-    init(contentGraph: SiteContentGraph? = nil, runtime: (any SiteRuntime)? = nil) {
-        let runtime = runtime ?? Self.makeRuntime(contentGraph: contentGraph)
+    init(
+        contentGraph: SiteContentGraph? = nil,
+        knowledgeIndex: SiteKnowledgeIndex? = nil,
+        runtime: (any SiteRuntime)? = nil
+    ) {
+        let runtime = runtime ?? Self.makeRuntime(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex)
         self.runtime = runtime
         self.editRouter = MCPApplyEditRouter(mcpClient: { [weak runtime] in
             // `runtime` is the actor instance; reading `mcpClient` hops onto the actor.
@@ -93,7 +97,7 @@ final class PreviewModel {
     ///
     /// `sourceRepo` is NOT passed here — `LocalContainerSiteRuntime.init` doesn't take it; it
     /// receives it at `start(siteID:siteDirectory:)` time (forwarded from `open(siteID:siteDirectory:)`).
-    static func makeRuntime(contentGraph: SiteContentGraph?) -> any SiteRuntime {
+    static func makeRuntime(contentGraph: SiteContentGraph?, knowledgeIndex: SiteKnowledgeIndex?) -> any SiteRuntime {
         #if !ANGLESITE_MAS
         // Container runtime is DevID-only (MAS doesn't link AnglesiteContainer). On MAS this whole
         // branch compiles out and the host runtime below is always used.
@@ -106,7 +110,7 @@ final class PreviewModel {
             )
         }
         #endif
-        return LocalSiteRuntime(contentGraph: contentGraph)
+        return LocalSiteRuntime(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex)
     }
 
     func open(siteID: String, siteDirectory: URL) {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -25,17 +25,25 @@ struct SiteWindow: View {
     /// The app-lifetime content graph (held by `AppDelegate`), seeded into this window's
     /// `PreviewModel` so opening the site populates the shared graph (A.8, #142).
     private let contentGraph: SiteContentGraph
+    /// App-lifetime project knowledge index, rebuilt by the preview runtime and exposed to chat.
+    private let knowledgeIndex: SiteKnowledgeIndex
     /// Observed (not a bare optional) so the Siri AI Readiness button enables itself if `bootstrap`
     /// populates the indexer after this window was constructed — see `ContentIndexerStore`.
     private let contentIndexerStore: ContentIndexerStore
 
     private let integrationOps = IntegrationOperations.live()
 
-    init(siteID: String?, contentGraph: SiteContentGraph, contentIndexerStore: ContentIndexerStore) {
+    init(
+        siteID: String?,
+        contentGraph: SiteContentGraph,
+        knowledgeIndex: SiteKnowledgeIndex,
+        contentIndexerStore: ContentIndexerStore
+    ) {
         self.siteID = siteID
         self.contentGraph = contentGraph
+        self.knowledgeIndex = knowledgeIndex
         self.contentIndexerStore = contentIndexerStore
-        _preview = State(initialValue: PreviewModel(contentGraph: contentGraph))
+        _preview = State(initialValue: PreviewModel(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex))
     }
 
     @State private var site: SiteStore.Site?
@@ -707,6 +715,7 @@ struct SiteWindow: View {
                 tier: .onDevice,
                 editBridge: makeEditBridge(),
                 contentGraph: contentGraph,
+                knowledgeIndex: knowledgeIndex,
                 integrationService: integrationOps
             ),
             annotationFeed: feed,
@@ -740,6 +749,7 @@ struct SiteWindow: View {
                 tier: tier,
                 editBridge: makeEditBridge(),
                 contentGraph: contentGraph,
+                knowledgeIndex: knowledgeIndex,
                 integrationService: integrationOps
             )
         case .claude:

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -54,6 +54,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     private let tier: FoundationModelTier
     private let editBridge: IntentEditBridge?
     private let contentGraph: SiteContentGraph?
+    private let knowledgeIndex: SiteKnowledgeIndex?
     private let integrationService: (any IntegrationOperationsService)?
     private let logger = Logger(subsystem: "io.dwk.anglesite", category: "FoundationModelAssistant")
     /// The current conversational turn's consumer-facing ``TurnRelay``, retained so ``cancel()`` can
@@ -79,11 +80,13 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         tier: FoundationModelTier = .onDevice,
         editBridge: IntentEditBridge? = nil,
         contentGraph: SiteContentGraph? = nil,
+        knowledgeIndex: SiteKnowledgeIndex? = nil,
         integrationService: (any IntegrationOperationsService)? = nil
     ) {
         self.tier = tier
         self.editBridge = editBridge
         self.contentGraph = contentGraph
+        self.knowledgeIndex = knowledgeIndex
         self.integrationService = integrationService
         if tier == .privateCloudCompute {
             // v1 has no separate PCC session; fall back to on-device with a logged warning so the
@@ -280,6 +283,9 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         if editBridge != nil && contentGraph != nil {
             names += [ApplyEditTool.toolName, SearchContentTool.toolName]
         }
+        if knowledgeIndex != nil {
+            names.append(SearchKnowledgeTool.toolName)
+        }
         if integrationService != nil {
             names.append(SetupIntegrationTool.toolName)
         }
@@ -331,6 +337,9 @@ public actor FoundationModelAssistant: ConversationalAssistant {
                 contextSelector: context.selectedElementSelector
             ))
             tools.append(SearchContentTool(contentGraph: contentGraph, siteID: context.siteID))
+        }
+        if let knowledgeIndex {
+            tools.append(SearchKnowledgeTool(index: knowledgeIndex, siteID: context.siteID))
         }
         if let integrationService {
             tools.append(SetupIntegrationTool(service: integrationService, siteID: context.siteID))

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -9,22 +9,26 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     private let ref: String
     private let control: any LocalContainerControl
     public let mcpClient: MCPClient
+    private let knowledgeIndex: SiteKnowledgeIndex?
     private let connect: @Sendable (MCPClient, URL) async throws -> Void
 
     private var current: SiteRuntimeState = .idle
     private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
     private var generation = 0
     private var activeSiteID: String?
+    private var loadedKnowledgeSiteID: String?
 
     public init(
         ref: String,
         control: any LocalContainerControl,
         mcpClient: MCPClient,
+        knowledgeIndex: SiteKnowledgeIndex? = nil,
         connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { c, u in try await c.connect(httpEndpoint: u) }
     ) {
         self.ref = ref
         self.control = control
         self.mcpClient = mcpClient
+        self.knowledgeIndex = knowledgeIndex
         self.connect = connect
     }
 
@@ -51,6 +55,12 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             guard gen == generation else { return }
             try await connect(mcpClient, session.mcpURL)
             guard gen == generation else { return }
+            await knowledgeIndex?.rebuild(siteID: siteID, projectRoot: siteDirectory)
+            guard gen == generation else {
+                await knowledgeIndex?.unload(siteID: siteID)
+                return
+            }
+            loadedKnowledgeSiteID = siteID
             activeSiteID = siteID
             setState(.ready(siteID: siteID, url: session.previewURL))
         } catch {
@@ -72,6 +82,10 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
 
     private func teardown() async {
         await mcpClient.stop()
+        if let siteID = loadedKnowledgeSiteID {
+            await knowledgeIndex?.unload(siteID: siteID)
+            loadedKnowledgeSiteID = nil
+        }
         if let id = activeSiteID {
             try? await control.stop(siteID: id)
             activeSiteID = nil

--- a/Sources/AnglesiteCore/LocalSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalSiteRuntime.swift
@@ -34,6 +34,9 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
     /// `nil` in headless/test contexts that don't care about the graph — population is then a
     /// no-op. The App Intents entity queries (A.2 #137) and Spotlight indexer (A.3) read from it.
     private let contentGraph: SiteContentGraph?
+    /// App-lifetime local RAG index for project-aware assistant retrieval (#307). Rebuilt when a
+    /// site starts and unloaded with the content graph on close.
+    private let knowledgeIndex: SiteKnowledgeIndex?
     private let logCenter: LogCenter
     private let resolveCommand: CommandResolver
     private let resolveMCPCommand: MCPCommandResolver
@@ -44,7 +47,7 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
     private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
     /// Bumped on every `start(...)`; lets a slow `devServer.start` await know it was superseded.
     private var generation = 0
-    /// The siteID whose content this runtime last loaded into `contentGraph`, so `stop()` /
+    /// The siteID whose content this runtime last loaded into shared app indexes, so `stop()` /
     /// a site switch can evict exactly that site. `nil` when nothing is loaded.
     private var loadedGraphSiteID: String?
 
@@ -52,6 +55,7 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
         devServer: AstroDevServer? = nil,
         mcpClient: MCPClient? = nil,
         contentGraph: SiteContentGraph? = nil,
+        knowledgeIndex: SiteKnowledgeIndex? = nil,
         supervisor: ProcessSupervisor = .shared,
         logCenter: LogCenter = .shared,
         resolveCommand: @escaping CommandResolver = LocalSiteRuntime.resolveAstroCommand,
@@ -62,6 +66,7 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
         self.devServer = devServer ?? AstroDevServer(supervisor: supervisor, logCenter: logCenter)
         self.mcpClient = mcpClient ?? MCPClient(supervisor: supervisor, logCenter: logCenter)
         self.contentGraph = contentGraph
+        self.knowledgeIndex = knowledgeIndex
         self.logCenter = logCenter
         self.resolveCommand = resolveCommand
         self.resolveMCPCommand = resolveMCPCommand
@@ -151,6 +156,7 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
         await mcpClient.stop()
         if let siteID = loadedGraphSiteID {
             await contentGraph?.unload(siteID: siteID)
+            await knowledgeIndex?.unload(siteID: siteID)
             loadedGraphSiteID = nil
         }
     }
@@ -159,17 +165,19 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
     /// `ContentScanner` (Bucket 1, #275). A no-op when no graph is attached. The scan is read-only
     /// and total — an empty or partial site simply yields fewer entries; nothing throws.
     private func populateContentGraph(siteID: String, siteDirectory: URL, generation gen: Int) async {
-        guard let graph = contentGraph else { return }
         // Run the recursive filesystem scan off the actor so it doesn't block this runtime from
         // processing other messages (stop signals, state queries) for the scan's duration — the
         // old MCP path yielded the actor on every `await`, and this preserves that.
-        let listing = await Task.detached(priority: .utility) {
+        async let listingTask = Task.detached(priority: .utility) {
             ContentScanner.scan(projectRoot: siteDirectory, siteID: siteID)
         }.value
+        async let knowledgeTask: Void = knowledgeIndex?.rebuild(siteID: siteID, projectRoot: siteDirectory) ?? ()
+        let listing = await listingTask
+        await knowledgeTask
         // A newer start() may have superseded us during the scan — don't pollute the shared graph
         // with a site this window is no longer showing; that start() loads its own.
         guard gen == generation else { return }
-        await graph.load(siteID: siteID, pages: listing.pages, posts: listing.posts, images: listing.images)
+        await contentGraph?.load(siteID: siteID, pages: listing.pages, posts: listing.posts, images: listing.images)
         loadedGraphSiteID = siteID
     }
 

--- a/Sources/AnglesiteCore/LocalSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalSiteRuntime.swift
@@ -49,7 +49,7 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
     private var generation = 0
     /// The siteID whose content this runtime last loaded into shared app indexes, so `stop()` /
     /// a site switch can evict exactly that site. `nil` when nothing is loaded.
-    private var loadedGraphSiteID: String?
+    private var loadedSharedIndexSiteID: String?
 
     public init(
         devServer: AstroDevServer? = nil,
@@ -123,7 +123,7 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
                 // Populate the content graph with a native scan of the site's `Source/` directory
                 // (Bucket 1, #275). Replaces the `list_content` MCP round-trip — same projection,
                 // no subprocess hop. An empty/unscannable site just leaves the graph empty.
-                await populateContentGraph(siteID: siteID, siteDirectory: siteDirectory, generation: gen)
+                await populateSharedIndexes(siteID: siteID, siteDirectory: siteDirectory, generation: gen)
                 guard gen == generation else { return }
                 setState(.ready(siteID: siteID, url: url))
             } catch {
@@ -154,31 +154,38 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
     private func stopSubprocesses() async {
         await devServer.stop()
         await mcpClient.stop()
-        if let siteID = loadedGraphSiteID {
+        if let siteID = loadedSharedIndexSiteID {
             await contentGraph?.unload(siteID: siteID)
             await knowledgeIndex?.unload(siteID: siteID)
-            loadedGraphSiteID = nil
+            loadedSharedIndexSiteID = nil
         }
     }
 
-    /// Scan the site's `Source/` directory (`siteDirectory`) into `contentGraph` via the native
-    /// `ContentScanner` (Bucket 1, #275). A no-op when no graph is attached. The scan is read-only
-    /// and total — an empty or partial site simply yields fewer entries; nothing throws.
-    private func populateContentGraph(siteID: String, siteDirectory: URL, generation gen: Int) async {
+    /// Scan the site's `Source/` directory (`siteDirectory`) into the shared content and knowledge
+    /// indexes. The scan is read-only and total — an empty or partial site simply yields fewer
+    /// entries; nothing throws.
+    private func populateSharedIndexes(siteID: String, siteDirectory: URL, generation gen: Int) async {
         // Run the recursive filesystem scan off the actor so it doesn't block this runtime from
         // processing other messages (stop signals, state queries) for the scan's duration — the
         // old MCP path yielded the actor on every `await`, and this preserves that.
-        async let listingTask = Task.detached(priority: .utility) {
+        let listing = await Task.detached(priority: .utility) {
             ContentScanner.scan(projectRoot: siteDirectory, siteID: siteID)
         }.value
-        async let knowledgeTask: Void = knowledgeIndex?.rebuild(siteID: siteID, projectRoot: siteDirectory) ?? ()
-        let listing = await listingTask
-        await knowledgeTask
         // A newer start() may have superseded us during the scan — don't pollute the shared graph
         // with a site this window is no longer showing; that start() loads its own.
         guard gen == generation else { return }
         await contentGraph?.load(siteID: siteID, pages: listing.pages, posts: listing.posts, images: listing.images)
-        loadedGraphSiteID = siteID
+        guard gen == generation else {
+            await contentGraph?.unload(siteID: siteID)
+            return
+        }
+        await knowledgeIndex?.rebuild(siteID: siteID, projectRoot: siteDirectory)
+        guard gen == generation else {
+            await contentGraph?.unload(siteID: siteID)
+            await knowledgeIndex?.unload(siteID: siteID)
+            return
+        }
+        loadedSharedIndexSiteID = siteID
     }
 
     private func startMCPClient(siteID: String, siteDirectory: URL) async {

--- a/Sources/AnglesiteCore/SearchKnowledgeTool.swift
+++ b/Sources/AnglesiteCore/SearchKnowledgeTool.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+#if compiler(>=6.4)
+import FoundationModels
+
+/// FoundationModels tool for retrieving ranked excerpts from the current site's local knowledge
+/// index. Complements ``SearchContentTool``: content graph search finds known pages/posts by
+/// metadata, while this searches file contents across pages, components, layouts, config, and copy.
+public struct SearchKnowledgeTool: Tool, Sendable {
+    public static let toolName = "searchKnowledge"
+    public let name = SearchKnowledgeTool.toolName
+    public let description = "Search the current Astro project for relevant files and excerpts before answering or editing."
+
+    @Generable
+    public struct Arguments {
+        @Guide(description: "Natural-language query or keywords to search for in the current project.")
+        public var query: String
+    }
+
+    private let index: SiteKnowledgeIndex
+    private let siteID: String
+
+    public init(index: SiteKnowledgeIndex, siteID: String) {
+        self.index = index
+        self.siteID = siteID
+    }
+
+    public func call(arguments: Arguments) async throws -> String {
+        let query = arguments.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            return "Provide a project search query."
+        }
+        let results = await index.search(siteID: siteID, query: query, options: .init(limit: 6))
+        guard !results.isEmpty else { return "No matching project context." }
+
+        return results.map { result in
+            let lineLabel: String
+            if let range = result.lineRange {
+                lineLabel = ":\(range.lowerBound)"
+            } else {
+                lineLabel = ""
+            }
+            let title = result.document.title.map { " - \($0)" } ?? ""
+            return """
+            \(result.document.kind.rawValue.uppercased())  \(result.document.path)\(lineLabel)\(title)
+            \(result.excerpt)
+            """
+        }.joined(separator: "\n\n")
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
+++ b/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
@@ -1,0 +1,328 @@
+import Foundation
+
+/// Project-local retrieval index for an Astro site.
+///
+/// The index is intentionally lexical for v1: it reads the project's text files, extracts useful
+/// metadata (frontmatter, headings, internal links), and ranks file excerpts against a user query.
+/// That gives assistant features citation-ready project context without a network embedding service.
+public actor SiteKnowledgeIndex {
+    public struct Document: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let siteID: String
+        public let path: String
+        public let kind: Kind
+        public let title: String?
+        public let frontmatter: [String: FrontmatterValue]
+        public let headings: [String]
+        public let internalLinks: [String]
+        public let excerptText: String
+        public let lastModified: Date
+
+        public enum Kind: String, Sendable, Equatable, CaseIterable {
+            case page
+            case post
+            case component
+            case layout
+            case content
+            case config
+            case style
+            case script
+            case other
+        }
+    }
+
+    public struct SearchResult: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let document: Document
+        public let score: Double
+        public let excerpt: String
+        public let lineRange: ClosedRange<Int>?
+    }
+
+    public struct SearchOptions: Sendable, Equatable {
+        public let limit: Int
+        public let kinds: Set<Document.Kind>?
+
+        public init(limit: Int = 8, kinds: Set<Document.Kind>? = nil) {
+            self.limit = max(1, limit)
+            self.kinds = kinds
+        }
+    }
+
+    private var documentsBySite: [String: [String: Document]] = [:]
+
+    public init() {}
+
+    /// Rebuilds the site's index from disk. Missing directories and unreadable files are skipped.
+    public func rebuild(siteID: String, projectRoot: URL) async {
+        let documents = await Task.detached(priority: .utility) {
+            Self.scan(siteID: siteID, projectRoot: projectRoot)
+        }.value
+        documentsBySite[siteID] = Dictionary(uniqueKeysWithValues: documents.map { ($0.path, $0) })
+    }
+
+    public func unload(siteID: String) {
+        documentsBySite[siteID] = nil
+    }
+
+    public func documents(siteID: String) -> [Document] {
+        (documentsBySite[siteID] ?? [:]).values.sorted { $0.path < $1.path }
+    }
+
+    public func upsertFile(siteID: String, projectRoot: URL, relativePath: String) async {
+        let scanned = await Task.detached(priority: .utility) {
+            Self.document(siteID: siteID, projectRoot: projectRoot, relativePath: relativePath)
+        }.value
+        guard let document = scanned else {
+            documentsBySite[siteID]?[relativePath] = nil
+            return
+        }
+        var siteDocs = documentsBySite[siteID] ?? [:]
+        siteDocs[relativePath] = document
+        documentsBySite[siteID] = siteDocs
+    }
+
+    public func removeFile(siteID: String, relativePath: String) {
+        documentsBySite[siteID]?[relativePath] = nil
+    }
+
+    public func search(siteID: String, query: String, options: SearchOptions = .init()) -> [SearchResult] {
+        let terms = Self.queryTerms(query)
+        guard !terms.isEmpty else { return [] }
+        let phrase = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let siteDocuments = documentsBySite[siteID] else { return [] }
+        let allDocuments = siteDocuments.values
+        let scoped = allDocuments.filter { doc in
+            guard let kinds = options.kinds else { return true }
+            return kinds.contains(doc.kind)
+        }
+
+        return scoped.compactMap { document -> SearchResult? in
+            let score = Self.score(document: document, terms: terms, phrase: phrase)
+            guard score > 0 else { return nil }
+            let snippet = Self.excerpt(from: document.excerptText, terms: terms)
+            return SearchResult(
+                id: "\(document.id)#\(snippet.lineRange?.lowerBound ?? 0)",
+                document: document,
+                score: score,
+                excerpt: snippet.text,
+                lineRange: snippet.lineRange
+            )
+        }
+        .sorted {
+            if $0.score != $1.score { return $0.score > $1.score }
+            return $0.document.path < $1.document.path
+        }
+        .prefix(options.limit)
+        .map { $0 }
+    }
+
+    private static func scan(siteID: String, projectRoot: URL) -> [Document] {
+        walk(projectRoot).compactMap { abs in
+            let relativePath = relativePosix(abs, from: projectRoot)
+            return document(siteID: siteID, projectRoot: projectRoot, relativePath: relativePath)
+        }
+    }
+
+    private static func document(siteID: String, projectRoot: URL, relativePath: String) -> Document? {
+        guard shouldIndex(relativePath) else { return nil }
+        let url = projectRoot.appendingPathComponent(relativePath)
+        guard let size = fileSize(url), size <= 512_000 else { return nil }
+        guard let source = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        let frontmatter = Frontmatter.parse(source)
+        let title = title(in: source, frontmatter: frontmatter)
+        let headings = headings(in: source)
+        let links = internalLinks(in: source)
+        return Document(
+            id: "\(siteID):knowledge:\(relativePath)",
+            siteID: siteID,
+            path: relativePath,
+            kind: kind(for: relativePath),
+            title: title,
+            frontmatter: frontmatter,
+            headings: headings,
+            internalLinks: links,
+            excerptText: source,
+            lastModified: mtime(url)
+        )
+    }
+
+    private static func walk(_ dir: URL) -> [URL] {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey], options: [.skipsHiddenFiles]
+        ) else { return [] }
+        var files: [URL] = []
+        for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            if skippedDirectoryNames.contains(entry.lastPathComponent) { continue }
+            let values = try? entry.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            if values?.isSymbolicLink == true { continue }
+            if values?.isDirectory == true {
+                files.append(contentsOf: walk(entry))
+            } else {
+                files.append(entry)
+            }
+        }
+        return files
+    }
+
+    private static let skippedDirectoryNames: Set<String> = [
+        ".astro", ".git", ".netlify", ".vercel", "dist", "node_modules"
+    ]
+
+    private static let indexedExtensions: Set<String> = [
+        "astro", "md", "mdx", "mdoc", "markdown", "html", "css",
+        "js", "mjs", "cjs", "ts", "tsx", "jsx", "json", "yaml", "yml", "toml"
+    ]
+
+    private static func shouldIndex(_ relativePath: String) -> Bool {
+        if relativePath.split(separator: "/").contains(where: { skippedDirectoryNames.contains(String($0)) }) {
+            return false
+        }
+        let ext = URL(fileURLWithPath: relativePath).pathExtension.lowercased()
+        return indexedExtensions.contains(ext)
+    }
+
+    private static func kind(for path: String) -> Document.Kind {
+        let ext = URL(fileURLWithPath: path).pathExtension.lowercased()
+        if path.hasPrefix("src/pages/") { return .page }
+        if path.hasPrefix("src/content/posts/") || path.hasPrefix("src/content/notes/") { return .post }
+        if path.hasPrefix("src/content/") { return .content }
+        if path.hasPrefix("src/components/") { return .component }
+        if path.hasPrefix("src/layouts/") { return .layout }
+        if ext == "css" { return .style }
+        if ["js", "mjs", "cjs", "ts", "tsx", "jsx"].contains(ext) { return .script }
+        if path == "package.json" || path == "astro.config.mjs" || ["json", "yaml", "yml", "toml"].contains(ext) {
+            return .config
+        }
+        return .other
+    }
+
+    private static func title(in source: String, frontmatter: [String: FrontmatterValue]) -> String? {
+        if case let .string(value)? = frontmatter["title"], !value.isEmpty { return value }
+        return headings(in: source).first
+    }
+
+    private static let markdownHeadingRegex = try! NSRegularExpression(pattern: #"(?m)^\s{0,3}#{1,6}\s+(.+?)\s*$"#)
+    private static let htmlHeadingRegex = try! NSRegularExpression(pattern: #"<h[1-6][^>]*>(.*?)</h[1-6]>"#, options: [.caseInsensitive, .dotMatchesLineSeparators])
+
+    private static func headings(in source: String) -> [String] {
+        var out: [String] = []
+        for match in matches(markdownHeadingRegex, in: source, group: 1) {
+            out.append(cleanInlineMarkup(match))
+        }
+        for match in matches(htmlHeadingRegex, in: source, group: 1) {
+            out.append(cleanInlineMarkup(match))
+        }
+        return Array(out.prefix(12))
+    }
+
+    private static let linkRegex = try! NSRegularExpression(pattern: #"(?:href|src)=["']([^"']+)["']|\]\(([^)]+)\)"#, options: [.caseInsensitive])
+
+    private static func internalLinks(in source: String) -> [String] {
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        var links: [String] = []
+        for match in linkRegex.matches(in: source, range: range) {
+            for group in [1, 2] {
+                guard let r = Range(match.range(at: group), in: source) else { continue }
+                let value = String(source[r]).trimmingCharacters(in: .whitespacesAndNewlines)
+                if value.hasPrefix("/") || value.hasPrefix("./") || value.hasPrefix("../") {
+                    links.append(value)
+                }
+            }
+        }
+        return Array(Set(links)).sorted()
+    }
+
+    private static func matches(_ regex: NSRegularExpression, in source: String, group: Int) -> [String] {
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        return regex.matches(in: source, range: range).compactMap { match in
+            guard let r = Range(match.range(at: group), in: source) else { return nil }
+            return String(source[r])
+        }
+    }
+
+    private static func cleanInlineMarkup(_ raw: String) -> String {
+        raw.replacingOccurrences(of: #"<[^>]+>"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: "`", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func score(document: Document, terms: [String], phrase: String) -> Double {
+        let title = (document.title ?? "").lowercased()
+        let path = document.path.lowercased()
+        let headings = document.headings.joined(separator: " ").lowercased()
+        let frontmatter = document.frontmatter.values.map(Self.frontmatterText).joined(separator: " ").lowercased()
+        let links = document.internalLinks.joined(separator: " ").lowercased()
+        let body = document.excerptText.lowercased()
+        var score = 0.0
+
+        for term in terms {
+            if path.contains(term) { score += 6 }
+            if title.contains(term) { score += 7 }
+            if headings.contains(term) { score += 4 }
+            if frontmatter.contains(term) { score += 3 }
+            if links.contains(term) { score += 3 }
+            score += min(6, Double(body.components(separatedBy: term).count - 1))
+        }
+        if !phrase.isEmpty {
+            if path.contains(phrase) { score += 6 }
+            if title.contains(phrase) { score += 8 }
+            if body.contains(phrase) { score += 5 }
+        }
+        if score > 0, document.kind == .page || document.kind == .post { score += 1 }
+        return score
+    }
+
+    private static func frontmatterText(_ value: FrontmatterValue) -> String {
+        switch value {
+        case .string(let s): return s
+        case .bool(let b): return b ? "true" : "false"
+        case .array(let values): return values.joined(separator: " ")
+        }
+    }
+
+    private static func queryTerms(_ query: String) -> [String] {
+        let pieces = query.lowercased().split { !$0.isLetter && !$0.isNumber }
+        var seen: Set<String> = []
+        return pieces.compactMap { piece in
+            let term = String(piece)
+            guard term.count >= 2, !seen.contains(term) else { return nil }
+            seen.insert(term)
+            return term
+        }
+    }
+
+    private static func excerpt(from source: String, terms: [String]) -> (text: String, lineRange: ClosedRange<Int>?) {
+        let lines = source.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
+        let matchIndex = lines.firstIndex { line in
+            let lowered = line.lowercased()
+            return terms.contains { lowered.contains($0) }
+        } ?? 0
+        let lower = max(0, matchIndex - 1)
+        let upper = min(lines.count - 1, matchIndex + 2)
+        let excerpt = lines[lower...upper]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        let trimmed = excerpt.count > 700 ? String(excerpt.prefix(700)) + "..." : excerpt
+        return (trimmed, (lower + 1)...(upper + 1))
+    }
+
+    private static func relativePosix(_ url: URL, from base: URL) -> String {
+        let urlComponents = url.standardizedFileURL.pathComponents
+        let baseComponents = base.standardizedFileURL.pathComponents
+        guard urlComponents.starts(with: baseComponents) else { return url.path }
+        return urlComponents.dropFirst(baseComponents.count).joined(separator: "/")
+    }
+
+    private static func mtime(_ url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+            ?? Date(timeIntervalSince1970: 0)
+    }
+
+    private static func fileSize(_ url: URL) -> Int64? {
+        guard let value = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize else { return nil }
+        return Int64(value)
+    }
+}

--- a/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
+++ b/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
@@ -50,6 +50,7 @@ public actor SiteKnowledgeIndex {
     }
 
     private var documentsBySite: [String: [String: Document]] = [:]
+    private static let maxExcerptCharacters = 8_192
 
     public init() {}
 
@@ -130,9 +131,10 @@ public actor SiteKnowledgeIndex {
         guard let size = fileSize(url), size <= 512_000 else { return nil }
         guard let source = try? String(contentsOf: url, encoding: .utf8) else { return nil }
         let frontmatter = Frontmatter.parse(source)
-        let title = title(in: source, frontmatter: frontmatter)
-        let headings = headings(in: source)
-        let links = internalLinks(in: source)
+        let bodySource = bodyText(from: source)
+        let title = title(in: bodySource, frontmatter: frontmatter)
+        let headings = headings(in: bodySource)
+        let links = internalLinks(in: bodySource)
         return Document(
             id: "\(siteID):knowledge:\(relativePath)",
             siteID: siteID,
@@ -142,7 +144,7 @@ public actor SiteKnowledgeIndex {
             frontmatter: frontmatter,
             headings: headings,
             internalLinks: links,
-            excerptText: source,
+            excerptText: truncatedExcerpt(bodySource),
             lastModified: mtime(url)
         )
     }
@@ -254,7 +256,7 @@ public actor SiteKnowledgeIndex {
         let headings = document.headings.joined(separator: " ").lowercased()
         let frontmatter = document.frontmatter.values.map(Self.frontmatterText).joined(separator: " ").lowercased()
         let links = document.internalLinks.joined(separator: " ").lowercased()
-        let body = document.excerptText.lowercased()
+        let body = bodyText(from: document.excerptText).lowercased()
         var score = 0.0
 
         for term in terms {
@@ -282,6 +284,28 @@ public actor SiteKnowledgeIndex {
         }
     }
 
+    private static func truncatedExcerpt(_ source: String) -> String {
+        guard source.count > maxExcerptCharacters else { return source }
+        return String(source.prefix(maxExcerptCharacters))
+    }
+
+    private static func bodyText(from source: String) -> String {
+        let normalized = source.replacingOccurrences(of: "\r\n", with: "\n")
+        var lines = normalized.components(separatedBy: "\n")
+        guard lines.first?.trimmingCharacters(in: .whitespacesAndNewlines) == "---" else {
+            return normalized
+        }
+        guard let closing = lines.dropFirst().firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == "---"
+        }) else {
+            return normalized
+        }
+        for index in 0...closing {
+            lines[index] = ""
+        }
+        return lines.joined(separator: "\n")
+    }
+
     private static func queryTerms(_ query: String) -> [String] {
         let pieces = query.lowercased().split { !$0.isLetter && !$0.isNumber }
         var seen: Set<String> = []
@@ -294,7 +318,7 @@ public actor SiteKnowledgeIndex {
     }
 
     private static func excerpt(from source: String, terms: [String]) -> (text: String, lineRange: ClosedRange<Int>?) {
-        let lines = source.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
+        let lines = bodyText(from: source).replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
         let matchIndex = lines.firstIndex { line in
             let lowered = line.lowercased()
             return terms.contains { lowered.contains($0) }

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -238,6 +238,44 @@ struct SearchContentToolTests {
     }
 }
 
+@Suite("On-device tools: SearchKnowledgeTool")
+struct SearchKnowledgeToolTests {
+    private func makeSite(_ files: [String: String]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("knowledge-tool-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    @Test("formats cited project excerpts")
+    func formatsCitedProjectExcerpts() async throws {
+        let root = makeSite([
+            "src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nTeam plans mention annual billing.",
+        ])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site1", projectRoot: root)
+        let tool = SearchKnowledgeTool(index: index, siteID: "site1")
+
+        let out = try await tool.call(arguments: .init(query: "annual billing"))
+
+        #expect(out.contains("PAGE"))
+        #expect(out.contains("src/pages/pricing.astro"))
+        #expect(out.contains(":"))
+        #expect(out.contains("annual billing"))
+    }
+
+    @Test("empty query is rejected without dumping context")
+    func emptyQueryIsRejected() async throws {
+        let tool = SearchKnowledgeTool(index: SiteKnowledgeIndex(), siteID: "site1")
+        let out = try await tool.call(arguments: .init(query: "   "))
+        #expect(out == "Provide a project search query.")
+    }
+}
+
 @Suite("FoundationModelAssistant tool wiring")
 struct FoundationModelAssistantToolWiringTests {
 
@@ -247,7 +285,12 @@ struct FoundationModelAssistantToolWiringTests {
         let bridge = makeBridge(router)
         let graph = SiteContentGraph()
 
-        let withTools = FoundationModelAssistant(tier: .onDevice, editBridge: bridge, contentGraph: graph)
+        let withTools = FoundationModelAssistant(
+            tier: .onDevice,
+            editBridge: bridge,
+            contentGraph: graph,
+            knowledgeIndex: SiteKnowledgeIndex()
+        )
         #expect(withTools.capabilities.supportsTools == true)
 
         let withoutTools = FoundationModelAssistant(tier: .onDevice)
@@ -272,7 +315,8 @@ struct FoundationModelAssistantToolWiringTests {
         let assistant = FoundationModelAssistant(
             tier: .onDevice,
             editBridge: makeBridge(router),
-            contentGraph: SiteContentGraph()
+            contentGraph: SiteContentGraph(),
+            knowledgeIndex: SiteKnowledgeIndex()
         )
         let context = AssistantContext(siteID: "site-1", siteDirectory: URL(fileURLWithPath: "/tmp/site"))
 
@@ -284,7 +328,12 @@ struct FoundationModelAssistantToolWiringTests {
             }
         }
         // SpotlightSearchTool is unconditional; edit/search pair is conditional on both deps (C.8, #158)
-        #expect(startedToolNames == ["spotlightSearch", ApplyEditTool.toolName, SearchContentTool.toolName])
+        #expect(startedToolNames == [
+            "spotlightSearch",
+            ApplyEditTool.toolName,
+            SearchContentTool.toolName,
+            SearchKnowledgeTool.toolName,
+        ])
     }
 }
 #endif

--- a/Tests/AnglesiteCoreTests/SiteKnowledgeIndexTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteKnowledgeIndexTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SiteKnowledgeIndex")
+struct SiteKnowledgeIndexTests {
+    private func makeSite(_ files: [String: String]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("knowledge-index-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    @Test("rebuild indexes pages, components, layouts, config, and skips build artifacts")
+    func rebuildIndexesProjectKnowledge() async {
+        let root = makeSite([
+            "src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Plans\n<a href=\"/contact\">Talk to sales</a>",
+            "src/components/CTA.astro": "<button>Talk to sales</button>",
+            "src/layouts/BaseLayout.astro": "<slot />",
+            "astro.config.mjs": "export default {}",
+            "node_modules/pkg/index.js": "should not be indexed",
+            "dist/index.html": "built output",
+        ])
+        let index = SiteKnowledgeIndex()
+
+        await index.rebuild(siteID: "site-1", projectRoot: root)
+
+        let docs = await index.documents(siteID: "site-1")
+        #expect(docs.map(\.path) == [
+            "astro.config.mjs",
+            "src/components/CTA.astro",
+            "src/layouts/BaseLayout.astro",
+            "src/pages/pricing.astro",
+        ])
+        #expect(docs.first { $0.path == "src/pages/pricing.astro" }?.kind == .page)
+        #expect(docs.first { $0.path == "src/pages/pricing.astro" }?.title == "Pricing")
+        #expect(docs.first { $0.path == "src/pages/pricing.astro" }?.internalLinks == ["/contact"])
+    }
+
+    @Test("search ranks title and path matches above body-only matches")
+    func searchRanksUsefulMatches() async {
+        let root = makeSite([
+            "src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nSimple plans for teams.",
+            "src/components/Footer.astro": "<footer>See pricing for details.</footer>",
+            "src/pages/about.astro": "# About\nNothing relevant.",
+        ])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site-1", projectRoot: root)
+
+        let results = await index.search(siteID: "site-1", query: "pricing", options: .init(limit: 3))
+
+        #expect(results.first?.document.path == "src/pages/pricing.astro")
+        #expect(results.first?.excerpt.contains("Pricing") == true)
+        #expect(results.first?.lineRange?.lowerBound != nil)
+        #expect(results.map(\.document.path).contains("src/components/Footer.astro"))
+        #expect(!results.map(\.document.path).contains("src/pages/about.astro"))
+    }
+
+    @Test("upsert and remove update a single indexed file")
+    func upsertAndRemove() async {
+        let root = makeSite([
+            "src/pages/index.astro": "# Home",
+        ])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site-1", projectRoot: root)
+
+        let newFile = root.appendingPathComponent("src/components/Hero.astro")
+        try! FileManager.default.createDirectory(at: newFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try! Data("<section>Summer launch CTA</section>".utf8).write(to: newFile)
+        await index.upsertFile(siteID: "site-1", projectRoot: root, relativePath: "src/components/Hero.astro")
+
+        var results = await index.search(siteID: "site-1", query: "summer launch")
+        #expect(results.first?.document.path == "src/components/Hero.astro")
+
+        await index.removeFile(siteID: "site-1", relativePath: "src/components/Hero.astro")
+        results = await index.search(siteID: "site-1", query: "summer launch")
+        #expect(results.isEmpty)
+    }
+
+    @Test("unload removes only the requested site")
+    func unloadRemovesOnlyRequestedSite() async {
+        let rootA = makeSite(["src/pages/a.astro": "# Alpha"])
+        let rootB = makeSite(["src/pages/b.astro": "# Beta"])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "a", projectRoot: rootA)
+        await index.rebuild(siteID: "b", projectRoot: rootB)
+
+        await index.unload(siteID: "a")
+
+        #expect(await index.search(siteID: "a", query: "alpha").isEmpty)
+        #expect(await index.search(siteID: "b", query: "beta").count == 1)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteKnowledgeIndexTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteKnowledgeIndexTests.swift
@@ -81,6 +81,34 @@ struct SiteKnowledgeIndexTests {
         #expect(results.isEmpty)
     }
 
+    @Test("rebuild stores bounded excerpts instead of full source")
+    func rebuildStoresBoundedExcerpts() async {
+        let longBody = String(repeating: "a", count: 9_000)
+        let root = makeSite([
+            "src/pages/long.astro": "# Long\n\(longBody)",
+        ])
+        let index = SiteKnowledgeIndex()
+
+        await index.rebuild(siteID: "site-1", projectRoot: root)
+
+        let document = await index.documents(siteID: "site-1").first
+        #expect(document?.excerptText.count == 8_192)
+    }
+
+    @Test("search scores frontmatter separately from body text")
+    func searchDoesNotDoubleCountFrontmatter() async {
+        let root = makeSite([
+            "src/content/example.md": "---\nsummary: launchword\n---\nNo body match here.",
+        ])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site-1", projectRoot: root)
+
+        let result = await index.search(siteID: "site-1", query: "launchword").first
+
+        #expect(result?.score == 3)
+        #expect(result?.excerpt.contains("summary: launchword") == false)
+    }
+
     @Test("unload removes only the requested site")
     func unloadRemovesOnlyRequestedSite() async {
         let rootA = makeSite(["src/pages/a.astro": "# Alpha"])


### PR DESCRIPTION
## Summary
- Add a shared `SiteKnowledgeIndex` to rebuild and unload site-local file context alongside the content graph
- Wire the index through `PreviewModel`, `SiteWindow`, `LocalSiteRuntime`, and `FoundationModelAssistant`
- Introduce `SearchKnowledgeTool` for cited project excerpt retrieval and add unit coverage for tool formatting and wiring

## Testing
- Unit tests added for `SearchKnowledgeTool` output formatting and empty-query handling
- Unit tests updated to verify `FoundationModelAssistant` exposes and starts the knowledge search tool when indexed context is available