### PR TITLE
feat(#70): native Cloudflare token verifier (Phase A4) — drop wrangler/Node

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -71,7 +71,7 @@ final class DeployModel {
         command: DeployCommand = DeployCommand(),
         logCenter: LogCenter = .shared,
         keychain: KeychainStore = KeychainStore(),
-        verifier: TokenVerifying = WranglerTokenVerifier(),
+        verifier: TokenVerifying = CloudflareAPITokenVerifier(),
         summarizer: any DeployFailureSummarizing = DeploySummarizerFactory.makeDefault()
     ) {
         self.command = command

--- a/Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift
+++ b/Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift
@@ -24,10 +24,17 @@ public struct CloudflareAPITokenVerifier: TokenVerifying {
         // `siteDirectory` is unused — verification is now a pure API call (kept for the protocol so
         // callers and the MAS sandbox grant path don't change).
         let data: Data
+        let http: HTTPURLResponse
         do {
-            (data, _) = try await get("user/tokens/verify", token: token)
+            (data, http) = try await get("user/tokens/verify", token: token)
         } catch {
             return .failure(.network)
+        }
+        // Rate-limit (429) / server errors (5xx) are transient outages, not a bad token — don't blame
+        // the user's token. A genuinely invalid token comes back as 401 with `success:false`, which
+        // falls through to the envelope check below and is correctly classified as `.invalidToken`.
+        if http.statusCode == 429 || http.statusCode >= 500 {
+            return .failure(.unavailable("Cloudflare is unavailable right now (HTTP \(http.statusCode)). Try again in a moment."))
         }
         guard let envelope = try? JSONDecoder().decode(VerifyEnvelope.self, from: data) else {
             return .failure(.unavailable("Cloudflare returned an unexpected response while checking the token."))

--- a/Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift
+++ b/Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Verifies a Cloudflare API token by calling the Cloudflare REST API directly — no Node, no
+/// wrangler. `GET /user/tokens/verify` confirms the token is valid and active; a best-effort
+/// `GET /accounts` supplies the account-name nicety. The HTTP step is injected (`Transport`) so the
+/// classification logic is unit-testable without real network — the same seam philosophy the old
+/// wrangler-based verifier used for its process step. Conforms to `TokenVerifying`.
+public struct CloudflareAPITokenVerifier: TokenVerifying {
+    /// Performs one authenticated GET and returns its body + response. Throws on connection failure.
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    private let baseURL: URL
+    private let transport: Transport
+
+    public init(
+        baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!,
+        transport: @escaping Transport = CloudflareAPITokenVerifier.defaultTransport
+    ) {
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    public func verify(token: String, siteDirectory: URL) async -> Result<CloudflareAccount, TokenVerifyError> {
+        // `siteDirectory` is unused — verification is now a pure API call (kept for the protocol so
+        // callers and the MAS sandbox grant path don't change).
+        let data: Data
+        do {
+            (data, _) = try await get("user/tokens/verify", token: token)
+        } catch {
+            return .failure(.network)
+        }
+        guard let envelope = try? JSONDecoder().decode(VerifyEnvelope.self, from: data) else {
+            return .failure(.unavailable("Cloudflare returned an unexpected response while checking the token."))
+        }
+        guard envelope.success, envelope.result?.status == "active" else {
+            return .failure(.invalidToken)
+        }
+        // Best-effort account name — never fails verification.
+        return .success(CloudflareAccount(name: await accountName(token: token), email: nil))
+    }
+
+    /// The first account's name, or `nil` if the lookup fails / returns nothing. A scoped token may
+    /// lack `account:read`, so this is strictly a nicety; a `nil` name still means "verified".
+    private func accountName(token: String) async -> String? {
+        guard let (data, http) = try? await get("accounts", token: token),
+              (200..<300).contains(http.statusCode),
+              let envelope = try? JSONDecoder().decode(AccountsEnvelope.self, from: data),
+              let name = envelope.result.first?.name,
+              !name.isEmpty
+        else {
+            return nil
+        }
+        return name
+    }
+
+    private func get(_ path: String, token: String) async throws -> (Data, HTTPURLResponse) {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return try await transport(request)
+    }
+
+    /// Production transport: a plain `URLSession` GET.
+    public static let defaultTransport: Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+
+    private struct VerifyEnvelope: Decodable {
+        let success: Bool
+        let result: TokenResult?
+        struct TokenResult: Decodable { let status: String }
+    }
+
+    private struct AccountsEnvelope: Decodable {
+        let result: [AccountInfo]
+        struct AccountInfo: Decodable { let name: String }
+    }
+}

--- a/Sources/AnglesiteCore/CloudflareTokenVerifier.swift
+++ b/Sources/AnglesiteCore/CloudflareTokenVerifier.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-/// A Cloudflare account as reported by `wrangler whoami`. Both fields are best-effort: the
-/// account `name` is `nil` when the whoami table can't be parsed (the token is still valid — the
-/// caller falls back to a generic "verified" message), and `email` is `nil` for token auth that
-/// isn't associated with a user email.
+/// A Cloudflare account surfaced after a token verifies. Both fields are best-effort: `name` is
+/// `nil` when the account lookup can't run or returns nothing (the token is still valid — the caller
+/// falls back to a generic "verified" message), and `email` is `nil` for token auth that isn't
+/// associated with a user email.
 public struct CloudflareAccount: Sendable, Equatable {
     public let name: String?
     public let email: String?
@@ -20,7 +20,7 @@ public enum TokenVerifyError: Error, Equatable, Sendable {
     case invalidToken
     /// We couldn't reach Cloudflare (DNS/connection failure).
     case network
-    /// We couldn't run wrangler at all (missing binary, spawn failure, etc.).
+    /// We couldn't check the token at all (unexpected response, etc.).
     case unavailable(String)
 
     public var userMessage: String {
@@ -36,126 +36,8 @@ public enum TokenVerifyError: Error, Equatable, Sendable {
 }
 
 /// Verifies a Cloudflare API token before it's persisted, so a bad token is caught at the point of
-/// entry instead of failing later inside `wrangler deploy`.
+/// entry instead of failing later inside a deploy. The production conformer is
+/// `CloudflareAPITokenVerifier` (a native REST call — no Node/wrangler).
 public protocol TokenVerifying: Sendable {
     func verify(token: String, siteDirectory: URL) async -> Result<CloudflareAccount, TokenVerifyError>
-}
-
-/// Verifies a token by running the site's own `wrangler whoami` with the token in the environment,
-/// through `ProcessSupervisor` — the same supervised spawn path the deploy uses, so it needs no new
-/// networking and inherits the MAS sandbox's per-site folder grant. The process step is injected
-/// (`Runner`) so the parsing/classification logic is unit-testable without spawning Node.
-public struct WranglerTokenVerifier: TokenVerifying {
-    /// Runs `wrangler whoami` for `siteDirectory` with `token` in the environment, returning its
-    /// captured output. Throws if the process can't be spawned.
-    public typealias Runner = @Sendable (_ token: String, _ siteDirectory: URL) async throws -> ProcessSupervisor.RunResult
-
-    private let run: Runner
-
-    public init(run: @escaping Runner = WranglerTokenVerifier.defaultRunner) {
-        self.run = run
-    }
-
-    public func verify(token: String, siteDirectory: URL) async -> Result<CloudflareAccount, TokenVerifyError> {
-        let result: ProcessSupervisor.RunResult
-        do {
-            result = try await run(token, siteDirectory)
-        } catch {
-            return .failure(.unavailable("Couldn’t run wrangler to check the token: \(error)"))
-        }
-
-        guard result.exitCode == 0 else {
-            return .failure(Self.classifyFailure(stdout: result.stdout, stderr: result.stderr))
-        }
-
-        // Exit 0 means the token is valid; the account name is a best-effort nicety.
-        return .success(Self.parseWhoami(result.stdout) ?? CloudflareAccount(name: nil, email: nil))
-    }
-
-    // MARK: Parsing
-
-    /// Extracts the account name (and email, if present) from `wrangler whoami` output. Returns
-    /// `nil` when no account table is recognizable, so the caller can still treat a zero-exit run
-    /// as verified.
-    static func parseWhoami(_ stdout: String) -> CloudflareAccount? {
-        let lines = stdout.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-
-        // Find the "Account Name | Account ID" header, then the first data row beneath it.
-        guard let headerIndex = lines.firstIndex(where: {
-            $0.contains("Account Name") && $0.contains("Account ID")
-        }) else {
-            return nil
-        }
-
-        let name = lines[(headerIndex + 1)...]
-            .lazy
-            .compactMap { Self.firstCell(in: $0) }
-            .first
-
-        guard let name, !name.isEmpty else { return nil }
-        return CloudflareAccount(name: name, email: Self.email(in: stdout))
-    }
-
-    /// Returns the trimmed first table cell of a box-drawing row (`│ a │ b │`), or `nil` for
-    /// separators (`├──┼──┤`) and non-table lines.
-    private static func firstCell(in line: String) -> String? {
-        guard line.contains("│") else { return nil }
-        // Separator rows are made of box-drawing line/junction characters only.
-        if line.contains("├") || line.contains("┼") || line.contains("┤") { return nil }
-        let cells = line
-            .split(separator: "│", omittingEmptySubsequences: true)
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-        return cells.first
-    }
-
-    /// Pulls the email out of "…associated with the email foo@bar.com." if present.
-    private static func email(in stdout: String) -> String? {
-        guard let range = stdout.range(of: #"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"#, options: .regularExpression) else {
-            return nil
-        }
-        return String(stdout[range])
-    }
-
-    // MARK: Failure classification
-
-    /// Maps a failed `wrangler whoami` run to a `TokenVerifyError` by sniffing its output for
-    /// network-level failures; anything else is treated as a rejected token.
-    static func classifyFailure(stdout: String, stderr: String) -> TokenVerifyError {
-        let combined = (stdout + "\n" + stderr).lowercased()
-        // Specific connectivity signatures only — the bare word "network" appears in auth/config
-        // errors too, and misclassifying those shows the wrong "check your connection" copy.
-        let networkMarkers = ["getaddrinfo", "enotfound", "econnrefused", "etimedout", "fetch failed", "socket hang up"]
-        if networkMarkers.contains(where: combined.contains) {
-            return .network
-        }
-        return .invalidToken
-    }
-
-    // MARK: Default runner
-
-    /// Production runner: resolves the site's `node_modules/.bin/wrangler` and runs `whoami` under
-    /// the vendored Node, with the token in the environment, through `ProcessSupervisor`.
-    public static let defaultRunner: Runner = { token, siteDirectory in
-        let wranglerBin = siteDirectory
-            .appendingPathComponent("node_modules", isDirectory: true)
-            .appendingPathComponent(".bin", isDirectory: true)
-            .appendingPathComponent("wrangler")
-        guard FileManager.default.isExecutableFile(atPath: wranglerBin.path) else {
-            throw TokenVerifyError.unavailable("wrangler isn’t installed — run `npm install` in this site")
-        }
-        guard let node = NodeRuntime.bundledExecutableURL else {
-            throw TokenVerifyError.unavailable("the embedded Node runtime isn’t bundled (rebuild the app)")
-        }
-
-        var environment = ProcessInfo.processInfo.environment
-        environment["CLOUDFLARE_API_TOKEN"] = token
-
-        return try await ProcessSupervisor.shared.run(
-            executable: node,
-            arguments: [wranglerBin.path, "whoami"],
-            environment: environment,
-            currentDirectoryURL: siteDirectory
-        )
-    }
 }

--- a/Tests/AnglesiteCoreTests/CloudflareAPITokenVerifierTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareAPITokenVerifierTests.swift
@@ -66,8 +66,22 @@ struct CloudflareAPITokenVerifierTests {
     func unparseableResponse() async {
         let verifier = CloudflareAPITokenVerifier(transport: Self.transport(verify: (200, "not json at all")))
         let result = await verifier.verify(token: "any", siteDirectory: Self.siteDir)
-        if case .failure(.unavailable) = result { } else {
+        guard case .failure(.unavailable) = result else {
             Issue.record("expected .unavailable, got \(result)")
+            return
+        }
+    }
+
+    @Test("a transient server error (5xx/429) maps to .unavailable, not .invalidToken")
+    func transientServerError() async {
+        // Cloudflare can return a `{"success":false}` body on a 503/429; that's an outage/rate-limit,
+        // not a bad token — it must not be misclassified as .invalidToken.
+        let verifier = CloudflareAPITokenVerifier(transport: Self.transport(
+            verify: (503, #"{"success":false,"errors":[{"code":10000,"message":"service unavailable"}]}"#)))
+        let result = await verifier.verify(token: "valid-but-cf-is-down", siteDirectory: Self.siteDir)
+        guard case .failure(.unavailable) = result else {
+            Issue.record("expected .unavailable, got \(result)")
+            return
         }
     }
 

--- a/Tests/AnglesiteCoreTests/CloudflareAPITokenVerifierTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareAPITokenVerifierTests.swift
@@ -1,0 +1,97 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for the native (Node-free) Cloudflare token verifier. The HTTP step is injected, so the
+/// classification logic is exercised without real network: the fake transport dispatches by request
+/// path — `…/user/tokens/verify` vs `…/accounts` — and returns canned envelopes.
+struct CloudflareAPITokenVerifierTests {
+    private static let siteDir = URL(fileURLWithPath: "/unused")
+
+    /// Build a transport that returns `(status, json)` per request, chosen by URL path suffix.
+    private static func transport(
+        verify: (Int, String),
+        accounts: (Int, String) = (200, #"{"success":true,"result":[]}"#)
+    ) -> CloudflareAPITokenVerifier.Transport {
+        { request in
+            let path = request.url?.path ?? ""
+            let (status, json): (Int, String) = path.hasSuffix("tokens/verify") ? verify : accounts
+            let http = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(json.utf8), http)
+        }
+    }
+
+    @Test("a valid active token verifies and surfaces the account name")
+    func validActiveTokenWithAccount() async {
+        let verifier = CloudflareAPITokenVerifier(transport: Self.transport(
+            verify: (200, #"{"success":true,"result":{"id":"abc","status":"active"}}"#),
+            accounts: (200, #"{"success":true,"result":[{"id":"a1","name":"Acme Corp"}]}"#)))
+        let result = await verifier.verify(token: "good", siteDirectory: Self.siteDir)
+        #expect(result == .success(CloudflareAccount(name: "Acme Corp", email: nil)))
+    }
+
+    @Test("a rejected token maps to .invalidToken")
+    func invalidToken() async {
+        let verifier = CloudflareAPITokenVerifier(transport: Self.transport(
+            verify: (401, #"{"success":false,"result":null,"errors":[{"code":1000,"message":"Invalid API Token"}]}"#)))
+        let result = await verifier.verify(token: "bad", siteDirectory: Self.siteDir)
+        #expect(result == .failure(.invalidToken))
+    }
+
+    @Test("a non-active token status maps to .invalidToken")
+    func inactiveTokenStatus() async {
+        let verifier = CloudflareAPITokenVerifier(transport: Self.transport(
+            verify: (200, #"{"success":true,"result":{"id":"abc","status":"disabled"}}"#)))
+        let result = await verifier.verify(token: "expired", siteDirectory: Self.siteDir)
+        #expect(result == .failure(.invalidToken))
+    }
+
+    @Test("a connection failure maps to .network")
+    func networkFailure() async {
+        let verifier = CloudflareAPITokenVerifier(transport: { _ in throw URLError(.notConnectedToInternet) })
+        let result = await verifier.verify(token: "any", siteDirectory: Self.siteDir)
+        #expect(result == .failure(.network))
+    }
+
+    @Test("a valid token still verifies when the best-effort accounts lookup fails")
+    func validTokenButAccountsLookupFails() async {
+        let verifier = CloudflareAPITokenVerifier(transport: Self.transport(
+            verify: (200, #"{"success":true,"result":{"id":"abc","status":"active"}}"#),
+            accounts: (403, #"{"success":false,"errors":[{"code":9109,"message":"Unauthorized"}]}"#)))
+        let result = await verifier.verify(token: "good", siteDirectory: Self.siteDir)
+        #expect(result == .success(CloudflareAccount(name: nil, email: nil)))
+    }
+
+    @Test("an unparseable verify response maps to .unavailable (not a bad-token claim)")
+    func unparseableResponse() async {
+        let verifier = CloudflareAPITokenVerifier(transport: Self.transport(verify: (200, "not json at all")))
+        let result = await verifier.verify(token: "any", siteDirectory: Self.siteDir)
+        if case .failure(.unavailable) = result { } else {
+            Issue.record("expected .unavailable, got \(result)")
+        }
+    }
+
+    @Test("the request carries the bearer token and hits the verify endpoint")
+    func sendsBearerTokenToVerifyEndpoint() async {
+        let captured = CapturedRequest()
+        let verifier = CloudflareAPITokenVerifier(transport: { request in
+            await captured.record(request)
+            let http = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (Data(#"{"success":true,"result":{"id":"x","status":"active"}}"#.utf8), http)
+        })
+        _ = await verifier.verify(token: "secret-token", siteDirectory: Self.siteDir)
+        #expect(await captured.authHeader == "Bearer secret-token")
+        #expect(await captured.firstPath?.hasSuffix("user/tokens/verify") == true)
+    }
+
+    private actor CapturedRequest {
+        private(set) var authHeader: String?
+        private(set) var firstPath: String?
+        func record(_ request: URLRequest) {
+            if firstPath == nil {
+                firstPath = request.url?.path
+                authHeader = request.value(forHTTPHeaderField: "Authorization")
+            }
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/CloudflareTokenVerifierTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareTokenVerifierTests.swift
@@ -2,92 +2,9 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
-/// Unit tests for the pure pieces of `WranglerTokenVerifier`: the `wrangler whoami` stdout parser,
-/// the exit/output → error classification, the user-facing error copy, and the verify orchestration
-/// (driven by an injected runner so no Node is spawned).
+/// Tests for the user-facing copy of `TokenVerifyError`. The verifier behavior itself lives in
+/// `CloudflareAPITokenVerifierTests` (the native, Node-free conformer).
 struct CloudflareTokenVerifierTests {
-
-    // MARK: whoami parsing
-
-    /// A representative `wrangler whoami` success with the account table and an email line.
-    private static let whoamiWithEmail = """
-     ⛅️ wrangler 4.20.0
-    ───────────────────
-    Getting User settings...
-    👋 You are logged in with an API Token, associated with the email jane@example.com.
-    ┌──────────────────────────┬──────────────────────────────────┐
-    │ Account Name             │ Account ID                       │
-    ├──────────────────────────┼──────────────────────────────────┤
-    │ Acme Co.                 │ 0123456789abcdef0123456789abcdef │
-    └──────────────────────────┴──────────────────────────────────┘
-    🔓 Token Permissions: ...
-    """
-
-    /// A token-auth `wrangler whoami` with no email associated.
-    private static let whoamiNoEmail = """
-     ⛅️ wrangler 4.20.0
-    ───────────────────
-    Getting User settings...
-    👋 You are logged in with an API Token.
-    ┌─────────────────┬──────────────────────────────────┐
-    │ Account Name    │ Account ID                       │
-    ├─────────────────┼──────────────────────────────────┤
-    │ Jane's Stuff    │ abcdef0123456789abcdef0123456789 │
-    └─────────────────┴──────────────────────────────────┘
-    """
-
-    @Test("Parses the account name and email from a standard whoami table")
-    func parsesNameAndEmail() {
-        let account = WranglerTokenVerifier.parseWhoami(Self.whoamiWithEmail)
-        #expect(account?.name == "Acme Co.")
-        #expect(account?.email == "jane@example.com")
-    }
-
-    @Test("Parses the account name when no email is associated with the token")
-    func parsesNameWithoutEmail() {
-        let account = WranglerTokenVerifier.parseWhoami(Self.whoamiNoEmail)
-        #expect(account?.name == "Jane's Stuff")
-        #expect(account?.email == nil)
-    }
-
-    @Test("Returns nil when the output has no recognizable account table")
-    func unparsableReturnsNil() {
-        #expect(WranglerTokenVerifier.parseWhoami("total gibberish\nno table here") == nil)
-    }
-
-    // MARK: failure classification
-
-    @Test("Classifies an auth failure as invalidToken")
-    func classifiesAuthFailure() {
-        let err = WranglerTokenVerifier.classifyFailure(
-            stdout: "",
-            stderr: "Authentication error [code: 10000]\nUnable to authenticate request"
-        )
-        #expect(err == .invalidToken)
-    }
-
-    @Test("Classifies a DNS/connection failure as network")
-    func classifiesNetworkFailure() {
-        let err = WranglerTokenVerifier.classifyFailure(
-            stdout: "",
-            stderr: "request to https://api.cloudflare.com failed, reason: getaddrinfo ENOTFOUND api.cloudflare.com"
-        )
-        #expect(err == .network)
-    }
-
-    @Test("An error merely mentioning 'network' is not misclassified as a connectivity failure")
-    func ambiguousNetworkWordIsNotNetworkFailure() {
-        // The bare word "network" appears in auth/config errors that aren't connectivity failures;
-        // those must fall through to the safer .invalidToken default, not show "check your connection".
-        let err = WranglerTokenVerifier.classifyFailure(
-            stdout: "",
-            stderr: "Authentication error [code: 10000]: your Workers network configuration is invalid"
-        )
-        #expect(err == .invalidToken)
-    }
-
-    // MARK: user-facing copy
-
     @Test("Invalid-token error names the Edit Cloudflare Workers template")
     func invalidTokenCopyNamesTemplate() {
         #expect(TokenVerifyError.invalidToken.userMessage.contains("Edit Cloudflare Workers"))
@@ -96,47 +13,5 @@ struct CloudflareTokenVerifierTests {
     @Test("Network error tells the user to check their connection")
     func networkCopyMentionsConnection() {
         #expect(TokenVerifyError.network.userMessage.localizedCaseInsensitiveContains("connection"))
-    }
-
-    // MARK: verify orchestration (injected runner — no Node spawned)
-
-    private let siteDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-
-    @Test("A zero-exit whoami yields the parsed account")
-    func verifySuccessReturnsAccount() async {
-        let verifier = WranglerTokenVerifier { _, _ in
-            ProcessSupervisor.RunResult(stdout: Self.whoamiWithEmail, stderr: "", exitCode: 0)
-        }
-        let result = await verifier.verify(token: "tok", siteDirectory: siteDir)
-        #expect(result == .success(CloudflareAccount(name: "Acme Co.", email: "jane@example.com")))
-    }
-
-    @Test("A zero-exit but unparsable whoami still succeeds, with no account name")
-    func verifySuccessFallsBackWhenUnparsable() async {
-        let verifier = WranglerTokenVerifier { _, _ in
-            ProcessSupervisor.RunResult(stdout: "logged in, somehow", stderr: "", exitCode: 0)
-        }
-        let result = await verifier.verify(token: "tok", siteDirectory: siteDir)
-        #expect(result == .success(CloudflareAccount(name: nil, email: nil)))
-    }
-
-    @Test("A non-zero exit with an auth error fails as invalidToken")
-    func verifyAuthFailure() async {
-        let verifier = WranglerTokenVerifier { _, _ in
-            ProcessSupervisor.RunResult(stdout: "", stderr: "Unable to authenticate request", exitCode: 1)
-        }
-        let result = await verifier.verify(token: "bad", siteDirectory: siteDir)
-        #expect(result == .failure(.invalidToken))
-    }
-
-    @Test("A thrown runner error surfaces as an unavailable failure")
-    func verifySpawnFailure() async {
-        struct Boom: Error {}
-        let verifier = WranglerTokenVerifier { _, _ in throw Boom() }
-        let result = await verifier.verify(token: "tok", siteDirectory: siteDir)
-        guard case .failure(.unavailable) = result else {
-            Issue.record("expected .unavailable, got \(result)")
-            return
-        }
     }
 }


### PR DESCRIPTION
First **Phase A** step of the #70 (embedded-Node removal) plan — migrates `CloudflareTokenVerifier` off `wrangler whoami`/embedded Node to a native Cloudflare REST call. Standalone, no container needed.

### What changed
- **New `CloudflareAPITokenVerifier`** (`TokenVerifying`): `GET /user/tokens/verify` to confirm the token is valid + `status == "active"`, plus a best-effort `GET /accounts` for the account-name nicety. HTTP step is an injectable `Transport` (mirrors the old `Runner` seam), so classification is unit-tested with no network — built test-first (7 tests: valid/active, rejected, non-active status, network failure, accounts-lookup-fails-still-verifies, unparseable→`.unavailable`, bearer-header/endpoint).
- **`DeployModel`** default verifier switches to it.
- **Removed `WranglerTokenVerifier`** (the embedded-Node consumer) + its whoami-parsing/classification tests; the `TokenVerifyError` user-copy tests stay.

### Verification
- `swift test --filter 'CloudflareAPITokenVerifier|CloudflareTokenVerifier|TokenOnboarding'` → 14/14.
- DevID app `xcodebuild … BUILD SUCCEEDED` (DeployModel compiles with the new default).
- `git grep WranglerTokenVerifier` → empty; the verifier path no longer references `NodeRuntime`.

Mirrors the existing native `CloudflareWebAnalyticsClient` idiom (Bearer auth + envelope decoding). The protocol/`CloudflareAccount`/`TokenVerifyError` types are unchanged, so `TokenOnboarding`/Settings callers are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
