### PR TITLE
Add site knowledge retrieval to assistant prompts

### DIFF
--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -117,7 +117,11 @@ final class ChatModel {
     init(siteID: String, siteDirectory: URL, configDirectory: URL, annotationFeed: AnnotationFeed? = nil, annotationResolver: AnnotationResolver? = nil, undoCommand: UndoCommand? = nil) {
         self.siteID = siteID
         self.siteDirectory = siteDirectory
-        let assistant = ClaudeAssistant(siteID: siteID, siteDirectory: siteDirectory)
+        let claude = ClaudeAssistant(siteID: siteID, siteDirectory: siteDirectory)
+        let assistant = KnowledgeAugmentedAssistant(
+            base: claude,
+            index: SiteKnowledgeIndex(siteDirectory: siteDirectory)
+        )
         self.assistant = assistant
         self.transcript = ConversationTranscript(providerName: assistant.capabilities.providerName)
         self.history = ChatHistoryStore(configDirectory: configDirectory)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -694,6 +694,7 @@ struct SiteWindow: View {
         }
         #if ANGLESITE_MAS
         assistantChoice = .foundationModel(.onDevice)
+        let knowledgeIndex = SiteKnowledgeIndex(siteDirectory: resolved.sourceDirectory)
         // Sandboxed App Store build: there's no `claude` CLI to shell out to, so chat is backed by
         // the on-device `FoundationModelAssistant` (#159). This is the MAS build's first chat pane.
         // The per-site `editBridge` + app-lifetime `contentGraph` attach `ApplyEditTool` +
@@ -703,11 +704,14 @@ struct SiteWindow: View {
             siteID: resolved.id,
             siteDirectory: resolved.sourceDirectory,
             configDirectory: resolved.configDirectory,
-            assistant: FoundationModelAssistant(
-                tier: .onDevice,
-                editBridge: makeEditBridge(),
-                contentGraph: contentGraph,
-                integrationService: integrationOps
+            assistant: KnowledgeAugmentedAssistant(
+                base: FoundationModelAssistant(
+                    tier: .onDevice,
+                    editBridge: makeEditBridge(),
+                    contentGraph: contentGraph,
+                    integrationService: integrationOps
+                ),
+                index: knowledgeIndex
             ),
             annotationFeed: feed,
             annotationResolver: annotationResolver,
@@ -732,6 +736,7 @@ struct SiteWindow: View {
         // construction stays here because it needs App-owned deps (the edit bridge, content graph).
         // `makeEditBridge()` is only called in the on-device arm — the Claude path does no bridge work.
         let assistant: any ConversationalAssistant
+        let knowledgeIndex = SiteKnowledgeIndex(siteDirectory: resolved.sourceDirectory)
         let choice = resolveAssistantChoice(preferFoundationModels: settings.preferFoundationModels, tier: settings.foundationModelTier)
         assistantChoice = choice
         switch choice {
@@ -745,7 +750,15 @@ struct SiteWindow: View {
         case .claude:
             assistant = ClaudeAssistant(siteID: resolved.id, siteDirectory: resolved.sourceDirectory)
         }
-        chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.sourceDirectory, configDirectory: resolved.configDirectory, assistant: assistant, annotationFeed: feed, annotationResolver: annotationResolver, undoCommand: undoCommand)
+        chat = ChatModel(
+            siteID: resolved.id,
+            siteDirectory: resolved.sourceDirectory,
+            configDirectory: resolved.configDirectory,
+            assistant: KnowledgeAugmentedAssistant(base: assistant, index: knowledgeIndex),
+            annotationFeed: feed,
+            annotationResolver: annotationResolver,
+            undoCommand: undoCommand
+        )
         #endif
         // Auto alt-text (C.7 / #157): after a successful image drop, generate alt text on-device and
         // apply it to the `<img>`. Target-agnostic — the on-device vision model runs on both builds.

--- a/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+/// Decorates any assistant backend with project-local retrieval context before each turn.
+public actor KnowledgeAugmentedAssistant: ConversationalAssistant {
+    private let base: any ConversationalAssistant
+    private let index: SiteKnowledgeIndex
+
+    public init(base: any ConversationalAssistant, index: SiteKnowledgeIndex) {
+        self.base = base
+        self.index = index
+    }
+
+    public nonisolated var capabilities: AssistantCapabilities {
+        base.capabilities
+    }
+
+    public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        let enriched = await enrichedPrompt(prompt, context: context)
+        return try await base.converse(prompt: enriched, context: context)
+    }
+
+    public func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        let enriched = await enrichedPrompt(prompt, context: context)
+        return try await base.generate(prompt: enriched, context: context)
+    }
+
+    #if compiler(>=6.4)
+    public func generateStructured<T: Generable & Sendable>(
+        prompt: String,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        let enriched = await enrichedPrompt(prompt, context: context)
+        return try await base.generateStructured(
+            prompt: enriched,
+            context: context,
+            resultType: resultType
+        )
+    }
+    #endif
+
+    public func cancel() async {
+        await base.cancel()
+    }
+
+    public func resetSession() async {
+        await base.resetSession()
+    }
+
+    private func enrichedPrompt(_ prompt: String, context: AssistantContext) async -> String {
+        guard let retrieved = await index.formattedContext(for: prompt) else { return prompt }
+        return """
+        \(retrieved)
+
+        User request:
+        \(prompt)
+        """
+    }
+}

--- a/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
+++ b/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
@@ -1,0 +1,251 @@
+import Foundation
+
+/// A project-local lexical retrieval index for an Astro site.
+///
+/// The index is intentionally lightweight: it scans source-like files under the active site
+/// directory, skips generated/dependency folders, caches file metadata, and returns bounded
+/// excerpts ranked by query-term overlap. It gives every assistant backend the same local context
+/// without requiring a network embedding service or a provider-specific tool.
+public actor SiteKnowledgeIndex {
+    public struct Match: Sendable, Equatable {
+        public let relativePath: String
+        public let lineRange: ClosedRange<Int>
+        public let score: Int
+        public let excerpt: String
+
+        public init(relativePath: String, lineRange: ClosedRange<Int>, score: Int, excerpt: String) {
+            self.relativePath = relativePath
+            self.lineRange = lineRange
+            self.score = score
+            self.excerpt = excerpt
+        }
+    }
+
+    public struct Options: Sendable, Equatable {
+        public let maxFileBytes: UInt64
+        public let maxResults: Int
+        public let excerptRadius: Int
+        public let maxExcerptCharacters: Int
+
+        public init(
+            maxFileBytes: UInt64 = 256 * 1024,
+            maxResults: Int = 6,
+            excerptRadius: Int = 3,
+            maxExcerptCharacters: Int = 1_200
+        ) {
+            self.maxFileBytes = maxFileBytes
+            self.maxResults = maxResults
+            self.excerptRadius = excerptRadius
+            self.maxExcerptCharacters = maxExcerptCharacters
+        }
+    }
+
+    private struct IndexedFile: Sendable, Equatable {
+        let relativePath: String
+        let modifiedAt: Date
+        let byteSize: UInt64
+        let content: String
+        let tokens: Set<String>
+    }
+
+    private let siteDirectory: URL
+    private let options: Options
+    private var files: [String: IndexedFile] = [:]
+    private var lastRefresh: Date?
+
+    private static let indexedExtensions: Set<String> = [
+        "astro", "md", "mdx", "html", "css", "scss",
+        "js", "jsx", "ts", "tsx", "json", "jsonc", "yaml", "yml", "toml",
+    ]
+
+    private static let skippedDirectoryNames: Set<String> = [
+        ".astro", ".git", ".netlify", ".wrangler", ".vercel",
+        "build", "coverage", "dist", "node_modules", "out",
+    ]
+
+    public init(siteDirectory: URL, options: Options = Options()) {
+        self.siteDirectory = siteDirectory.standardizedFileURL
+        self.options = options
+    }
+
+    /// Refreshes the cache from disk. This is cheap for unchanged files: only metadata is checked
+    /// before preserving an existing `IndexedFile`.
+    public func refresh() {
+        let discovered = discoverIndexableFiles()
+        var next: [String: IndexedFile] = [:]
+
+        for url in discovered {
+            guard let relativePath = relativePath(for: url),
+                  let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+                  let byteSize = (attributes[.size] as? NSNumber)?.uint64Value,
+                  byteSize <= options.maxFileBytes
+            else { continue }
+            let modifiedAt = (attributes[.modificationDate] as? Date) ?? .distantPast
+
+            if let existing = files[relativePath],
+               existing.modifiedAt == modifiedAt,
+               existing.byteSize == byteSize {
+                next[relativePath] = existing
+                continue
+            }
+
+            guard let data = try? Data(contentsOf: url),
+                  let content = String(data: data, encoding: .utf8)
+            else { continue }
+            next[relativePath] = IndexedFile(
+                relativePath: relativePath,
+                modifiedAt: modifiedAt,
+                byteSize: byteSize,
+                content: content,
+                tokens: Self.tokens(in: relativePath + "\n" + content)
+            )
+        }
+
+        files = next
+        lastRefresh = Date()
+    }
+
+    /// Retrieves project context for a user request. Calls `refresh()` first so disk edits made by
+    /// the app, MCP, or another editor are visible on the next assistant turn.
+    public func search(_ query: String) -> [Match] {
+        refresh()
+        let queryTokens = Self.tokens(in: query)
+        guard !queryTokens.isEmpty else { return [] }
+
+        return files.values.compactMap { file -> Match? in
+            let overlap = file.tokens.intersection(queryTokens)
+            guard !overlap.isEmpty else { return nil }
+            let lineMatch = bestLineMatch(in: file.content, queryTokens: queryTokens)
+            let score = overlap.count * 10 + lineMatch.score
+            return Match(
+                relativePath: file.relativePath,
+                lineRange: lineMatch.range,
+                score: score,
+                excerpt: excerpt(from: file.content, around: lineMatch.range)
+            )
+        }
+        .sorted {
+            if $0.score != $1.score { return $0.score > $1.score }
+            return $0.relativePath < $1.relativePath
+        }
+        .prefix(options.maxResults)
+        .map { $0 }
+    }
+
+    public func formattedContext(for query: String) -> String? {
+        let matches = search(query)
+        guard !matches.isEmpty else { return nil }
+        var lines = [
+            "Relevant project context retrieved from this Astro site:",
+            "Use this context when it is relevant. Cite file paths when answering.",
+        ]
+        for match in matches {
+            let lineLabel = match.lineRange.lowerBound == match.lineRange.upperBound
+                ? "line \(match.lineRange.lowerBound)"
+                : "lines \(match.lineRange.lowerBound)-\(match.lineRange.upperBound)"
+            lines.append("\n[\(match.relativePath):\(lineLabel)]")
+            lines.append(match.excerpt)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func discoverIndexableFiles() -> [URL] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: siteDirectory,
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        var urls: [URL] = []
+        for case let url as URL in enumerator {
+            if isSkippedDirectory(url) {
+                enumerator.skipDescendants()
+                continue
+            }
+            guard isIndexableFile(url) else { continue }
+            urls.append(url)
+        }
+        return urls
+    }
+
+    private func isSkippedDirectory(_ url: URL) -> Bool {
+        guard (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else {
+            return false
+        }
+        return Self.skippedDirectoryNames.contains(url.lastPathComponent)
+    }
+
+    private func isIndexableFile(_ url: URL) -> Bool {
+        guard (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true else {
+            return false
+        }
+        return Self.indexedExtensions.contains(url.pathExtension.lowercased())
+    }
+
+    private func relativePath(for url: URL) -> String? {
+        let base = siteDirectory.path
+        let path = url.standardizedFileURL.path
+        guard path == base || path.hasPrefix(base + "/") else { return nil }
+        return String(path.dropFirst(base.count + 1))
+    }
+
+    private func bestLineMatch(in content: String, queryTokens: Set<String>) -> (range: ClosedRange<Int>, score: Int) {
+        let lines = content.components(separatedBy: .newlines)
+        var bestLine = 1
+        var bestScore = 0
+
+        for (index, line) in lines.enumerated() {
+            let lineTokens = Self.tokens(in: line)
+            let score = lineTokens.intersection(queryTokens).count
+            if score > bestScore {
+                bestScore = score
+                bestLine = index + 1
+            }
+        }
+
+        let start = max(1, bestLine - options.excerptRadius)
+        let end = min(max(1, lines.count), bestLine + options.excerptRadius)
+        return (start...end, bestScore)
+    }
+
+    private func excerpt(from content: String, around range: ClosedRange<Int>) -> String {
+        let lines = content.components(separatedBy: .newlines)
+        let excerpt = range.compactMap { lineNumber -> String? in
+            guard lines.indices.contains(lineNumber - 1) else { return nil }
+            return "\(lineNumber): \(lines[lineNumber - 1])"
+        }.joined(separator: "\n")
+        guard excerpt.count > options.maxExcerptCharacters else { return excerpt }
+        let end = excerpt.index(excerpt.startIndex, offsetBy: options.maxExcerptCharacters)
+        return String(excerpt[..<end]) + "\n..."
+    }
+
+    private static func tokens(in text: String) -> Set<String> {
+        let normalized = splitCamelCase(in: text).lowercased()
+        let parts = normalized.split { character in
+            !character.isLetter && !character.isNumber
+        }
+        let tokens = parts.map(String.init).filter { $0.count >= 2 && !stopWords.contains($0) }
+        return Set(tokens)
+    }
+
+    private static func splitCamelCase(in text: String) -> String {
+        var output = ""
+        var previousWasLowercaseOrNumber = false
+        for scalar in text.unicodeScalars {
+            let character = Character(scalar)
+            if previousWasLowercaseOrNumber && CharacterSet.uppercaseLetters.contains(scalar) {
+                output.append(" ")
+            }
+            output.append(character)
+            previousWasLowercaseOrNumber = CharacterSet.lowercaseLetters.contains(scalar)
+                || CharacterSet.decimalDigits.contains(scalar)
+        }
+        return output
+    }
+
+    private static let stopWords: Set<String> = [
+        "a", "an", "and", "are", "as", "at", "be", "by", "for", "from",
+        "how", "in", "is", "it", "my", "of", "on", "or", "that", "the",
+        "this", "to", "use", "what", "where", "why", "with", "your",
+    ]
+}

--- a/Tests/AnglesiteCoreTests/KnowledgeAugmentedAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/KnowledgeAugmentedAssistantTests.swift
@@ -1,0 +1,120 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+private actor CapturingConversationalAssistant: ConversationalAssistant {
+    private(set) var prompts: [String] = []
+
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(
+            supportsStreaming: true,
+            supportsStructuredOutput: false,
+            supportsVision: false,
+            supportsTools: false,
+            maxContextTokens: nil,
+            providerName: "Capture"
+        )
+    }
+
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        prompts.append(prompt)
+        return AsyncStream { continuation in
+            continuation.yield(.started(model: "Capture", toolNames: []))
+            continuation.yield(.textDelta("ok"))
+            continuation.yield(.turnComplete(nil))
+            continuation.finish()
+        }
+    }
+
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        prompts.append(prompt)
+        return AsyncThrowingStream { continuation in
+            continuation.yield("ok")
+            continuation.finish()
+        }
+    }
+
+    #if compiler(>=6.4)
+    func generateStructured<T: Generable & Sendable>(
+        prompt: String,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        prompts.append(prompt)
+        throw AssistantError.unsupported("capture assistant does not generate structured values")
+    }
+    #endif
+
+    func cancel() async {}
+    func resetSession() async {}
+}
+
+@Suite("KnowledgeAugmentedAssistant")
+struct KnowledgeAugmentedAssistantTests {
+    @Test("converse enriches prompts with retrieved project context")
+    func converseEnrichesPrompt() async throws {
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "export const CTA = 'Book a consultation';\n".write(
+            to: root.appendingPathComponent("src/components/CTA.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let base = CapturingConversationalAssistant()
+        let assistant = KnowledgeAugmentedAssistant(
+            base: base,
+            index: SiteKnowledgeIndex(siteDirectory: root)
+        )
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        for await _ in try await assistant.converse(prompt: "Find every place this CTA appears.", context: context) {}
+
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Relevant project context retrieved") == true)
+        #expect(prompt?.contains("src/components/CTA.astro") == true)
+        #expect(prompt?.contains("User request:\nFind every place this CTA appears.") == true)
+    }
+
+    @Test("generate leaves unrelated prompts untouched")
+    func generateLeavesUnmatchedPromptUntouched() async throws {
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "# About\n".write(
+            to: root.appendingPathComponent("src/pages/about.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let base = CapturingConversationalAssistant()
+        let assistant = KnowledgeAugmentedAssistant(
+            base: base,
+            index: SiteKnowledgeIndex(siteDirectory: root)
+        )
+        let prompt = "Explain lunar geology."
+        for try await _ in try await assistant.generate(
+            prompt: prompt,
+            context: AssistantContext(siteID: "site", siteDirectory: root)
+        ) {}
+
+        #expect(await base.prompts.first == prompt)
+    }
+
+    private func makeSite() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("knowledge-assistant-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("src/components"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("src/pages"),
+            withIntermediateDirectories: true
+        )
+        return root
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteKnowledgeIndexTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteKnowledgeIndexTests.swift
@@ -1,0 +1,87 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("SiteKnowledgeIndex")
+struct SiteKnowledgeIndexTests {
+    @Test("retrieves bounded excerpts from relevant Astro site files")
+    func retrievesRelevantExcerpts() async throws {
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try write(
+            """
+            ---
+            title: Pricing
+            ---
+            <section>
+              <h1>Simple pricing</h1>
+              <PricingTable tiers={tiers} />
+            </section>
+            """,
+            to: root.appendingPathComponent("src/pages/pricing.astro")
+        )
+        try write(
+            """
+            export const tiers = [
+              { name: 'Starter', cta: 'Start free' },
+              { name: 'Pro', cta: 'Talk to sales' }
+            ];
+            """,
+            to: root.appendingPathComponent("src/components/PricingTable.astro")
+        )
+        try write("pricing should not come from built output", to: root.appendingPathComponent("dist/pricing.html"))
+
+        let index = SiteKnowledgeIndex(
+            siteDirectory: root,
+            options: .init(maxResults: 4, excerptRadius: 1, maxExcerptCharacters: 400)
+        )
+
+        let matches = await index.search("Where is the pricing table defined?")
+
+        #expect(matches.map(\.relativePath).contains("src/pages/pricing.astro"))
+        #expect(matches.map(\.relativePath).contains("src/components/PricingTable.astro"))
+        #expect(!matches.map(\.relativePath).contains("dist/pricing.html"))
+        #expect(matches.allSatisfy { $0.excerpt.count <= 404 })
+    }
+
+    @Test("formatted context includes file citations and line numbers")
+    func formattedContextIncludesCitations() async throws {
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try write("# About\n\nOur docs explain the launch checklist.", to: root.appendingPathComponent("src/content/docs/about.md"))
+
+        let index = SiteKnowledgeIndex(siteDirectory: root)
+        let context = await index.formattedContext(for: "launch checklist docs")
+
+        #expect(context?.contains("Relevant project context") == true)
+        #expect(context?.contains("[src/content/docs/about.md:") == true)
+        #expect(context?.contains("launch checklist") == true)
+    }
+
+    private func makeSite() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("knowledge-index-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("src/pages"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("src/components"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("src/content/docs"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("dist"),
+            withIntermediateDirectories: true
+        )
+        return root
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap chat assistants with a site-local knowledge index so prompts include relevant project excerpts before each turn
- Apply retrieval augmentation in both regular and MAS chat flows
- Add coverage for retrieval ranking, citations, and prompt enrichment

## Testing
- Unit tests added for `SiteKnowledgeIndex`
- Unit tests added for `KnowledgeAugmentedAssistant`