### PR TITLE
feat(#343): content-type registry foundation (V-1.1)

### DIFF
--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -1,0 +1,375 @@
+// Sources/AnglesiteCore/ContentTypeRegistry.swift
+import Foundation
+
+/// The registry of typed content objects (V-1.1, epic #334 / #343).
+///
+/// A content type is declared **once** as a `ContentTypeDescriptor` and projects three ways —
+/// its frontmatter schema (what the editor and Astro content collection see), its microformats2
+/// mapping (what Webmention/federation consume), and its schema.org mapping (what search
+/// rich-results consume). This is the "one schema, three projections" principle from the pivot
+/// plan: there is a single source of truth per type, and downstream consumers read from it.
+///
+/// This file is **pure value data with no I/O** — it is the vocabulary, not the machinery.
+/// Scaffolding (`ContentScaffold`), the content graph (`SiteContentGraph`), per-type editors,
+/// and template generation are layered on top in later V-1 tasks (#344–#352); each reads
+/// descriptors from here rather than hard-coding type knowledge.
+
+/// One field in a content type's frontmatter schema.
+public struct ContentTypeField: Sendable, Equatable {
+    /// The shape of a field's value. Maps to an editor control and to a Zod type at the
+    /// template layer (#351); kept deliberately small.
+    public enum Kind: String, Sendable, Equatable {
+        case string        // single-line text
+        case text          // multi-line plain text
+        case markdown      // multi-line rich body
+        case bool
+        case date
+        case url
+        case image         // a site-relative media path
+        case number
+        case stringArray   // e.g. tags
+    }
+
+    public let name: String
+    public let kind: Kind
+    public let required: Bool
+
+    public init(_ name: String, _ kind: Kind, required: Bool = false) {
+        self.name = name
+        self.kind = kind
+        self.required = required
+    }
+}
+
+/// How a content type projects to microformats2 and schema.org. Field-name keys reference
+/// `ContentTypeField.name` values on the same descriptor.
+public struct ContentTypeProjections: Sendable, Equatable {
+    /// The root microformats2 class for instances of this type (e.g. `h-entry`, `h-event`,
+    /// `h-review`, `h-card`).
+    public let microformat: String
+
+    /// Maps a frontmatter field name → its microformats2 property (e.g. `"title"` → `"p-name"`,
+    /// `"publishDate"` → `"dt-published"`, `"body"` → `"e-content"`). Fields absent from this map
+    /// carry no mf2 property.
+    public let microformatProperties: [String: String]
+
+    /// The schema.org `@type` emitted as JSON-LD (e.g. `Article`, `Event`, `Review`,
+    /// `LocalBusiness`). `nil` means this type emits no schema.org node.
+    public let schemaType: String?
+
+    public init(
+        microformat: String,
+        microformatProperties: [String: String],
+        schemaType: String?
+    ) {
+        self.microformat = microformat
+        self.microformatProperties = microformatProperties
+        self.schemaType = schemaType
+    }
+}
+
+/// Where instances of a content type live on disk, mirroring the Astro layout `ContentScaffold`
+/// already uses: route-addressed pages under `src/pages`, or slug-addressed entries in a content
+/// collection under `src/content/<collection>`.
+public enum ContentStorage: Sendable, Equatable {
+    case page
+    case collection(String)
+}
+
+/// A registered content type — pure declarative data, no behavior.
+public struct ContentTypeDescriptor: Sendable, Equatable, Identifiable {
+    /// Stable lowerCamelCase key (e.g. `note`, `article`, `businessProfile`). The registry's key
+    /// and the identity used by editors/intents; never localized.
+    public let id: String
+    /// Human-facing label (e.g. `Business Profile`).
+    public let displayName: String
+    public let storage: ContentStorage
+    public let fields: [ContentTypeField]
+    public let projections: ContentTypeProjections
+
+    public init(
+        id: String,
+        displayName: String,
+        storage: ContentStorage,
+        fields: [ContentTypeField],
+        projections: ContentTypeProjections
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.storage = storage
+        self.fields = fields
+        self.projections = projections
+    }
+
+    /// The default collection name for `.collection`-stored types; `nil` for pages.
+    public var collection: String? {
+        if case let .collection(name) = storage { return name }
+        return nil
+    }
+}
+
+/// An ordered, lookup-by-id catalog of content types. Value type so it composes cleanly into the
+/// (actor-isolated) graph and the app's environment; built-ins are registered at init and custom
+/// types can be added with `register(_:)`.
+public struct ContentTypeRegistry: Sendable, Equatable {
+    private var byID: [String: ContentTypeDescriptor]
+    private var order: [String]
+
+    /// Builds a registry from the given descriptors (default: the built-in catalog). Later
+    /// descriptors with a duplicate `id` override earlier ones while keeping first-seen order —
+    /// the same last-wins/stable-order contract as `register(_:)`.
+    public init(types: [ContentTypeDescriptor] = ContentTypeRegistry.builtIns) {
+        byID = [:]
+        order = []
+        for type in types { insert(type) }
+    }
+
+    private mutating func insert(_ descriptor: ContentTypeDescriptor) {
+        if byID[descriptor.id] == nil { order.append(descriptor.id) }
+        byID[descriptor.id] = descriptor
+    }
+
+    /// Registers (or replaces) a content type. Replacing keeps the type's existing position in
+    /// `all`; a new type appends.
+    public mutating func register(_ descriptor: ContentTypeDescriptor) {
+        insert(descriptor)
+    }
+
+    public func descriptor(id: String) -> ContentTypeDescriptor? {
+        byID[id]
+    }
+
+    /// All registered types in registration order.
+    public var all: [ContentTypeDescriptor] {
+        order.compactMap { byID[$0] }
+    }
+
+    public var ids: [String] { order }
+}
+
+// MARK: - Built-in catalog
+
+extension ContentTypeRegistry {
+    /// The built-in content types: the personal IndieWeb post types (#344) and the small-business
+    /// types (#345), declared as data here in V-1.1. Templates and editors for them land in their
+    /// own tasks; this is the shared vocabulary they consume.
+    public static let builtIns: [ContentTypeDescriptor] = personalTypes + businessTypes
+
+    // MARK: Personal (h-entry family)
+
+    static let personalTypes: [ContentTypeDescriptor] = [note, article, photo, bookmark, reply]
+
+    static let note = ContentTypeDescriptor(
+        id: "note",
+        displayName: "Note",
+        storage: .collection("notes"),
+        fields: [
+            ContentTypeField("body", .markdown, required: true),
+            ContentTypeField("publishDate", .date, required: true),
+            ContentTypeField("tags", .stringArray),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-entry",
+            microformatProperties: [
+                "body": "e-content",
+                "publishDate": "dt-published",
+                "tags": "p-category",
+            ],
+            schemaType: "SocialMediaPosting"
+        )
+    )
+
+    static let article = ContentTypeDescriptor(
+        id: "article",
+        displayName: "Article",
+        storage: .collection("articles"),
+        fields: [
+            ContentTypeField("title", .string, required: true),
+            ContentTypeField("summary", .text),
+            ContentTypeField("body", .markdown, required: true),
+            ContentTypeField("publishDate", .date, required: true),
+            ContentTypeField("updated", .date),
+            ContentTypeField("tags", .stringArray),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-entry",
+            microformatProperties: [
+                "title": "p-name",
+                "summary": "p-summary",
+                "body": "e-content",
+                "publishDate": "dt-published",
+                "updated": "dt-updated",
+                "tags": "p-category",
+            ],
+            schemaType: "Article"
+        )
+    )
+
+    static let photo = ContentTypeDescriptor(
+        id: "photo",
+        displayName: "Photo",
+        storage: .collection("photos"),
+        fields: [
+            ContentTypeField("image", .image, required: true),
+            ContentTypeField("caption", .text),
+            ContentTypeField("publishDate", .date, required: true),
+            ContentTypeField("tags", .stringArray),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-entry",
+            microformatProperties: [
+                "image": "u-photo",
+                "caption": "p-summary",
+                "publishDate": "dt-published",
+                "tags": "p-category",
+            ],
+            schemaType: "Photograph"
+        )
+    )
+
+    static let bookmark = ContentTypeDescriptor(
+        id: "bookmark",
+        displayName: "Bookmark",
+        storage: .collection("bookmarks"),
+        fields: [
+            ContentTypeField("bookmarkOf", .url, required: true),
+            ContentTypeField("title", .string),
+            ContentTypeField("body", .markdown),
+            ContentTypeField("publishDate", .date, required: true),
+            ContentTypeField("tags", .stringArray),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-entry",
+            microformatProperties: [
+                "bookmarkOf": "u-bookmark-of",
+                "title": "p-name",
+                "body": "e-content",
+                "publishDate": "dt-published",
+                "tags": "p-category",
+            ],
+            schemaType: nil
+        )
+    )
+
+    static let reply = ContentTypeDescriptor(
+        id: "reply",
+        displayName: "Reply",
+        storage: .collection("replies"),
+        fields: [
+            ContentTypeField("inReplyTo", .url, required: true),
+            ContentTypeField("body", .markdown, required: true),
+            ContentTypeField("publishDate", .date, required: true),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-entry",
+            microformatProperties: [
+                "inReplyTo": "u-in-reply-to",
+                "body": "e-content",
+                "publishDate": "dt-published",
+            ],
+            schemaType: "Comment"
+        )
+    )
+
+    // MARK: Business (#345 / §4.1)
+
+    static let businessTypes: [ContentTypeDescriptor] = [businessProfile, announcement, event, review]
+
+    static let businessProfile = ContentTypeDescriptor(
+        id: "businessProfile",
+        displayName: "Business Profile",
+        storage: .page,
+        fields: [
+            ContentTypeField("name", .string, required: true),
+            ContentTypeField("description", .text),
+            ContentTypeField("telephone", .string),
+            ContentTypeField("email", .string),
+            ContentTypeField("streetAddress", .string),
+            ContentTypeField("locality", .string),
+            ContentTypeField("region", .string),
+            ContentTypeField("postalCode", .string),
+            ContentTypeField("hours", .stringArray),
+            ContentTypeField("url", .url),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-card",
+            microformatProperties: [
+                "name": "p-name",
+                "telephone": "p-tel",
+                "email": "u-email",
+                "streetAddress": "p-street-address",
+                "locality": "p-locality",
+                "region": "p-region",
+                "postalCode": "p-postal-code",
+                "url": "u-url",
+            ],
+            schemaType: "LocalBusiness"
+        )
+    )
+
+    static let announcement = ContentTypeDescriptor(
+        id: "announcement",
+        displayName: "Announcement",
+        storage: .collection("announcements"),
+        fields: [
+            ContentTypeField("title", .string, required: true),
+            ContentTypeField("body", .markdown, required: true),
+            ContentTypeField("publishDate", .date, required: true),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-entry",
+            microformatProperties: [
+                "title": "p-name",
+                "body": "e-content",
+                "publishDate": "dt-published",
+            ],
+            schemaType: "SpecialAnnouncement"
+        )
+    )
+
+    static let event = ContentTypeDescriptor(
+        id: "event",
+        displayName: "Event",
+        storage: .collection("events"),
+        fields: [
+            ContentTypeField("name", .string, required: true),
+            ContentTypeField("body", .markdown),
+            ContentTypeField("start", .date, required: true),
+            ContentTypeField("end", .date),
+            ContentTypeField("location", .string),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-event",
+            microformatProperties: [
+                "name": "p-name",
+                "body": "e-content",
+                "start": "dt-start",
+                "end": "dt-end",
+                "location": "p-location",
+            ],
+            schemaType: "Event"
+        )
+    )
+
+    static let review = ContentTypeDescriptor(
+        id: "review",
+        displayName: "Review",
+        storage: .collection("reviews"),
+        fields: [
+            ContentTypeField("itemReviewed", .string, required: true),
+            ContentTypeField("rating", .number, required: true),
+            ContentTypeField("body", .markdown),
+            ContentTypeField("publishDate", .date, required: true),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-review",
+            microformatProperties: [
+                "itemReviewed": "p-item",
+                "rating": "p-rating",
+                "body": "e-content",
+                "publishDate": "dt-published",
+            ],
+            schemaType: "Review"
+        )
+    )
+}

--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -23,7 +23,8 @@ public struct ContentTypeField: Sendable, Equatable {
         case text          // multi-line plain text
         case markdown      // multi-line rich body
         case bool
-        case date
+        case date          // calendar date, no time
+        case datetime      // ISO 8601 date-time with time + timezone (mf2 `dt-*` properties)
         case url
         case image         // a site-relative media path
         case number
@@ -55,6 +56,12 @@ public struct ContentTypeProjections: Sendable, Equatable {
 
     /// The schema.org `@type` emitted as JSON-LD (e.g. `Article`, `Event`, `Review`,
     /// `LocalBusiness`). `nil` means this type emits no schema.org node.
+    ///
+    /// **Object-valued property contract.** Some schema.org properties expect a nested `Thing`
+    /// rather than a literal (e.g. `Review.itemReviewed`). A string-typed field mapped to such a
+    /// property is emitted by the JSON-LD layer (#347–#351) as a minimal node
+    /// `{ "@type": "Thing", "name": <value> }`. This is the settled vocabulary-level contract so
+    /// the template layer never has to guess; richer typing can be added per-field later.
     public let schemaType: String?
 
     public init(
@@ -121,7 +128,7 @@ public struct ContentTypeRegistry: Sendable, Equatable {
     public init(types: [ContentTypeDescriptor] = ContentTypeRegistry.builtIns) {
         byID = [:]
         order = []
-        for type in types { insert(type) }
+        for descriptor in types { insert(descriptor) }
     }
 
     private mutating func insert(_ descriptor: ContentTypeDescriptor) {
@@ -165,7 +172,7 @@ extension ContentTypeRegistry {
         storage: .collection("notes"),
         fields: [
             ContentTypeField("body", .markdown, required: true),
-            ContentTypeField("publishDate", .date, required: true),
+            ContentTypeField("publishDate", .datetime, required: true),
             ContentTypeField("tags", .stringArray),
         ],
         projections: ContentTypeProjections(
@@ -187,8 +194,8 @@ extension ContentTypeRegistry {
             ContentTypeField("title", .string, required: true),
             ContentTypeField("summary", .text),
             ContentTypeField("body", .markdown, required: true),
-            ContentTypeField("publishDate", .date, required: true),
-            ContentTypeField("updated", .date),
+            ContentTypeField("publishDate", .datetime, required: true),
+            ContentTypeField("updated", .datetime),
             ContentTypeField("tags", .stringArray),
         ],
         projections: ContentTypeProjections(
@@ -212,7 +219,7 @@ extension ContentTypeRegistry {
         fields: [
             ContentTypeField("image", .image, required: true),
             ContentTypeField("caption", .text),
-            ContentTypeField("publishDate", .date, required: true),
+            ContentTypeField("publishDate", .datetime, required: true),
             ContentTypeField("tags", .stringArray),
         ],
         projections: ContentTypeProjections(
@@ -235,7 +242,7 @@ extension ContentTypeRegistry {
             ContentTypeField("bookmarkOf", .url, required: true),
             ContentTypeField("title", .string),
             ContentTypeField("body", .markdown),
-            ContentTypeField("publishDate", .date, required: true),
+            ContentTypeField("publishDate", .datetime, required: true),
             ContentTypeField("tags", .stringArray),
         ],
         projections: ContentTypeProjections(
@@ -258,7 +265,7 @@ extension ContentTypeRegistry {
         fields: [
             ContentTypeField("inReplyTo", .url, required: true),
             ContentTypeField("body", .markdown, required: true),
-            ContentTypeField("publishDate", .date, required: true),
+            ContentTypeField("publishDate", .datetime, required: true),
         ],
         projections: ContentTypeProjections(
             microformat: "h-entry",
@@ -291,10 +298,13 @@ extension ContentTypeRegistry {
             ContentTypeField("hours", .stringArray),
             ContentTypeField("url", .url),
         ],
+        // `hours` is intentionally unmapped: h-card has no normative opening-hours property, so
+        // hours are carried by schema.org (`LocalBusiness.openingHours`) only, not microformats2.
         projections: ContentTypeProjections(
             microformat: "h-card",
             microformatProperties: [
                 "name": "p-name",
+                "description": "p-note",
                 "telephone": "p-tel",
                 "email": "u-email",
                 "streetAddress": "p-street-address",
@@ -314,7 +324,7 @@ extension ContentTypeRegistry {
         fields: [
             ContentTypeField("title", .string, required: true),
             ContentTypeField("body", .markdown, required: true),
-            ContentTypeField("publishDate", .date, required: true),
+            ContentTypeField("publishDate", .datetime, required: true),
         ],
         projections: ContentTypeProjections(
             microformat: "h-entry",
@@ -323,7 +333,9 @@ extension ContentTypeRegistry {
                 "body": "e-content",
                 "publishDate": "dt-published",
             ],
-            schemaType: "SpecialAnnouncement"
+            // Not schema.org `SpecialAnnouncement` — that is a COVID-era crisis type requiring
+            // crisis-specific properties. A general business announcement is editorial news.
+            schemaType: "NewsArticle"
         )
     )
 
@@ -334,8 +346,8 @@ extension ContentTypeRegistry {
         fields: [
             ContentTypeField("name", .string, required: true),
             ContentTypeField("body", .markdown),
-            ContentTypeField("start", .date, required: true),
-            ContentTypeField("end", .date),
+            ContentTypeField("start", .datetime, required: true),
+            ContentTypeField("end", .datetime),
             ContentTypeField("location", .string),
         ],
         projections: ContentTypeProjections(
@@ -356,10 +368,13 @@ extension ContentTypeRegistry {
         displayName: "Review",
         storage: .collection("reviews"),
         fields: [
+            // String name of the item; the JSON-LD layer wraps it as a `{@type: Thing, name}` node
+            // for schema.org `Review.itemReviewed` per the object-valued-property contract on
+            // `ContentTypeProjections.schemaType`.
             ContentTypeField("itemReviewed", .string, required: true),
             ContentTypeField("rating", .number, required: true),
             ContentTypeField("body", .markdown),
-            ContentTypeField("publishDate", .date, required: true),
+            ContentTypeField("publishDate", .datetime, required: true),
         ],
         projections: ContentTypeProjections(
             microformat: "h-review",

--- a/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
@@ -1,0 +1,146 @@
+// Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContentTypeRegistry")
+struct ContentTypeRegistryTests {
+
+    // MARK: Registry mechanics
+
+    @Test("default registry exposes the built-in catalog in order, looked up by id")
+    func defaultRegistry() {
+        let registry = ContentTypeRegistry()
+        #expect(registry.all.map(\.id) == registry.ids)
+        #expect(registry.ids == ContentTypeRegistry.builtIns.map(\.id))
+        #expect(registry.descriptor(id: "note") != nil)
+        #expect(registry.descriptor(id: "businessProfile") != nil)
+        #expect(registry.descriptor(id: "nope") == nil)
+    }
+
+    @Test("registering a new type appends; the registry surfaces it by id")
+    func registerAppends() {
+        var registry = ContentTypeRegistry(types: [])
+        #expect(registry.all.isEmpty)
+        let custom = ContentTypeDescriptor(
+            id: "recipe",
+            displayName: "Recipe",
+            storage: .collection("recipes"),
+            fields: [ContentTypeField("title", .string, required: true)],
+            projections: ContentTypeProjections(
+                microformat: "h-recipe",
+                microformatProperties: ["title": "p-name"],
+                schemaType: "Recipe"
+            )
+        )
+        registry.register(custom)
+        #expect(registry.ids == ["recipe"])
+        #expect(registry.descriptor(id: "recipe") == custom)
+    }
+
+    @Test("re-registering an id replaces in place and keeps its position")
+    func registerReplacesInPlace() {
+        var registry = ContentTypeRegistry()  // built-ins
+        let originalOrder = registry.ids
+        let position = originalOrder.firstIndex(of: "article")
+        let overridden = ContentTypeDescriptor(
+            id: "article",
+            displayName: "Long-form Article",
+            storage: .collection("articles"),
+            fields: [ContentTypeField("title", .string, required: true)],
+            projections: ContentTypeProjections(
+                microformat: "h-entry",
+                microformatProperties: ["title": "p-name"],
+                schemaType: "Article"
+            )
+        )
+        registry.register(overridden)
+        #expect(registry.ids == originalOrder)                       // order unchanged
+        #expect(registry.ids.firstIndex(of: "article") == position)  // same slot
+        #expect(registry.descriptor(id: "article")?.displayName == "Long-form Article")
+    }
+
+    @Test("init de-dupes by id, last-wins, first-seen order")
+    func initDeDupes() {
+        let a1 = ContentTypeDescriptor(
+            id: "x", displayName: "First", storage: .page, fields: [],
+            projections: ContentTypeProjections(microformat: "h-entry", microformatProperties: [:], schemaType: nil))
+        let a2 = ContentTypeDescriptor(
+            id: "x", displayName: "Second", storage: .page, fields: [],
+            projections: ContentTypeProjections(microformat: "h-entry", microformatProperties: [:], schemaType: nil))
+        let registry = ContentTypeRegistry(types: [a1, a2])
+        #expect(registry.ids == ["x"])
+        #expect(registry.descriptor(id: "x")?.displayName == "Second")
+    }
+
+    // MARK: Per-type declarations (≥3 types, distinct microformats + schema.org)
+
+    @Test("Article projects h-entry + schema.org Article, with required body and date")
+    func articleType() throws {
+        let article = try #require(ContentTypeRegistry().descriptor(id: "article"))
+        #expect(article.storage == .collection("articles"))
+        #expect(article.collection == "articles")
+        #expect(article.projections.microformat == "h-entry")
+        #expect(article.projections.schemaType == "Article")
+        #expect(article.projections.microformatProperties["title"] == "p-name")
+        #expect(article.projections.microformatProperties["body"] == "e-content")
+        #expect(article.projections.microformatProperties["publishDate"] == "dt-published")
+        let required = Set(article.fields.filter(\.required).map(\.name))
+        #expect(required == ["title", "body", "publishDate"])
+    }
+
+    @Test("Event projects h-event + schema.org Event with dt-start/dt-end")
+    func eventType() throws {
+        let event = try #require(ContentTypeRegistry().descriptor(id: "event"))
+        #expect(event.projections.microformat == "h-event")
+        #expect(event.projections.schemaType == "Event")
+        #expect(event.projections.microformatProperties["start"] == "dt-start")
+        #expect(event.projections.microformatProperties["end"] == "dt-end")
+        #expect(event.fields.first { $0.name == "start" }?.kind == .date)
+    }
+
+    @Test("Review projects h-review + schema.org Review with a numeric rating")
+    func reviewType() throws {
+        let review = try #require(ContentTypeRegistry().descriptor(id: "review"))
+        #expect(review.projections.microformat == "h-review")
+        #expect(review.projections.schemaType == "Review")
+        #expect(review.projections.microformatProperties["rating"] == "p-rating")
+        #expect(review.fields.first { $0.name == "rating" }?.kind == .number)
+        #expect(review.fields.first { $0.name == "rating" }?.required == true)
+    }
+
+    @Test("Business Profile is a page projecting h-card + LocalBusiness")
+    func businessProfileType() throws {
+        let profile = try #require(ContentTypeRegistry().descriptor(id: "businessProfile"))
+        #expect(profile.storage == .page)
+        #expect(profile.collection == nil)
+        #expect(profile.projections.microformat == "h-card")
+        #expect(profile.projections.schemaType == "LocalBusiness")
+        #expect(profile.projections.microformatProperties["telephone"] == "p-tel")
+    }
+
+    // MARK: Catalog invariants
+
+    @Test("every built-in has a unique id, a microformat, and reachable mf2 fields")
+    func builtInInvariants() {
+        let registry = ContentTypeRegistry()
+        let ids = registry.ids
+        #expect(Set(ids).count == ids.count)  // ids unique
+
+        for type in registry.all {
+            #expect(!type.displayName.isEmpty)
+            #expect(type.projections.microformat.hasPrefix("h-"))
+            // Every field referenced by an mf2 mapping must exist on the type.
+            let fieldNames = Set(type.fields.map(\.name))
+            for mappedField in type.projections.microformatProperties.keys {
+                #expect(fieldNames.contains(mappedField),
+                        "\(type.id): mf2 maps unknown field '\(mappedField)'")
+            }
+            // A collection type must carry a non-empty collection name.
+            if case let .collection(name) = type.storage {
+                #expect(!name.isEmpty)
+                #expect(type.collection == name)
+            }
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
@@ -39,10 +39,10 @@ struct ContentTypeRegistryTests {
     }
 
     @Test("re-registering an id replaces in place and keeps its position")
-    func registerReplacesInPlace() {
+    func registerReplacesInPlace() throws {
         var registry = ContentTypeRegistry()  // built-ins
         let originalOrder = registry.ids
-        let position = originalOrder.firstIndex(of: "article")
+        let position = try #require(originalOrder.firstIndex(of: "article"))
         let overridden = ContentTypeDescriptor(
             id: "article",
             displayName: "Long-form Article",
@@ -96,7 +96,9 @@ struct ContentTypeRegistryTests {
         #expect(event.projections.schemaType == "Event")
         #expect(event.projections.microformatProperties["start"] == "dt-start")
         #expect(event.projections.microformatProperties["end"] == "dt-end")
-        #expect(event.fields.first { $0.name == "start" }?.kind == .date)
+        // h-event dt-start/dt-end are datetimes (ISO 8601 with time + timezone), not bare dates.
+        #expect(event.fields.first { $0.name == "start" }?.kind == .datetime)
+        #expect(event.fields.first { $0.name == "end" }?.kind == .datetime)
     }
 
     @Test("Review projects h-review + schema.org Review with a numeric rating")
@@ -127,19 +129,19 @@ struct ContentTypeRegistryTests {
         let ids = registry.ids
         #expect(Set(ids).count == ids.count)  // ids unique
 
-        for type in registry.all {
-            #expect(!type.displayName.isEmpty)
-            #expect(type.projections.microformat.hasPrefix("h-"))
+        for descriptor in registry.all {
+            #expect(!descriptor.displayName.isEmpty)
+            #expect(descriptor.projections.microformat.hasPrefix("h-"))
             // Every field referenced by an mf2 mapping must exist on the type.
-            let fieldNames = Set(type.fields.map(\.name))
-            for mappedField in type.projections.microformatProperties.keys {
+            let fieldNames = Set(descriptor.fields.map(\.name))
+            for mappedField in descriptor.projections.microformatProperties.keys {
                 #expect(fieldNames.contains(mappedField),
-                        "\(type.id): mf2 maps unknown field '\(mappedField)'")
+                        "\(descriptor.id): mf2 maps unknown field '\(mappedField)'")
             }
             // A collection type must carry a non-empty collection name.
-            if case let .collection(name) = type.storage {
+            if case let .collection(name) = descriptor.storage {
                 #expect(!name.isEmpty)
-                #expect(type.collection == name)
+                #expect(descriptor.collection == name)
             }
         }
     }


### PR DESCRIPTION
Kicks off the pivot epic (#334) with its first ungated task.

Closes #343. Part of #335 (V-1).

## What

Adds the typed-content **vocabulary** as pure, `Sendable` value data in `AnglesiteCore` — the foundation the rest of V-1 builds on. No I/O, no macOS-27 symbols (CI-runnable on the older runners).

- **`ContentTypeField` / `ContentTypeProjections` / `ContentStorage` / `ContentTypeDescriptor`** — a content type is declared **once** (its frontmatter schema) and projects three ways: Astro/editing, microformats2, and schema.org JSON-LD. This is the "one schema, three projections" principle from the pivot plan.
- **`ContentTypeRegistry`** — ordered, lookup-by-id catalog; built-ins at init, custom types via `register(_:)` (last-wins, stable order).
- **Built-in catalog** — personal h-entry types (`note`, `article`, `photo`, `bookmark`, `reply`) + business types (`businessProfile` → `h-card`/`LocalBusiness`, `announcement`, `event` → `h-event`, `review` → `h-review`) per §4.1.
- **Tests** — registry mechanics (append / replace-in-place / de-dupe) + per-type projections across ≥3 distinct microformats and the catalog invariants (unique ids; mf2 maps reference only fields that exist on the type).

## Scope boundary

This is V-1.1 only — the **registry + catalog**. Deliberately *not* in this PR (their own sub-issues under #335):
- Astro templates per type (#344/#345)
- Per-type SwiftUI editors (#346)
- Content-collection Zod schemas, feeds, mf2/JSON-LD emission in templates (#347–#351)
- Wiring typed entries into `SiteContentGraph` / `ContentScaffold` (follow-on) — today the graph still models `Page`/`Post`/`Image`; this PR adds the type system those will be expressed in.

## Verification

Built and reasoned locally; the Swift toolchain isn't available in this environment, so **CI is the build/test gate** (per the repo's `swift test` CI). New tests live in `ContentTypeRegistryTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBdXeZ7ZGXJZmcjFZ5UTht)_