### PR TITLE
feat(#312): on-device semantic index foundation + SearchKnowledgeTool hybrid (Plan A)

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -33,8 +33,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// incremental `upsert`/`remove` re-embedding are built + tested but deliberately not wired
     /// yet — the shared app-global index architecture needs per-site cache routing the runtime
     /// can derive, which is a follow-up.
-    let semanticRanker: SemanticRanker? = NLEmbeddingProvider().map {
+    let semanticRanker: SemanticRanker? = AppDelegate.makeEmbeddingProvider().map {
         SemanticRanker(provider: $0, cache: nil)
+    }
+
+    /// On-device embedding provider, best-first: the multilingual transformer
+    /// (`NLContextualEmbedding`), then the lighter `NLEmbedding.sentenceEmbedding`, then `nil`
+    /// (→ pure-lexical retrieval). Never the test-double fake.
+    private static func makeEmbeddingProvider() -> (any EmbeddingProvider)? {
+        if let contextual = NLContextualEmbeddingProvider() { return contextual }
+        if let sentence = NLEmbeddingProvider() { return sentence }
+        return nil
     }
     let contentIndexerStore = ContentIndexerStore()
 

--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -25,12 +25,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Project-local retrieval index used by assistant tools for file-cited RAG context (#307).
     let knowledgeIndex = SiteKnowledgeIndex()
     /// On-device semantic ranker layered over `knowledgeIndex`, synced by the preview runtime so
-    /// assistant retrieval ranks by meaning, not just keywords (#312). In-memory for v0 — the
-    /// per-site `Config/` embedding cache (`SemanticIndexCache`) is a follow-up, since the shared
-    /// app-global index architecture needs per-site cache routing the runtime can derive.
-    let semanticRanker = SemanticRanker(
-        provider: NLEmbeddingProvider() ?? FakeEmbeddingProvider(),
-        cache: nil)
+    /// assistant retrieval ranks by meaning, not just keywords (#312). `nil` when no on-device
+    /// embedding model is available — the whole chain takes `SemanticRanker?`, so retrieval then
+    /// degrades to pure lexical (never the test-double fake, which would blend nonsense vectors).
+    ///
+    /// In-memory for v0: the per-site `Config/` embedding cache (`SemanticIndexCache`) and
+    /// incremental `upsert`/`remove` re-embedding are built + tested but deliberately not wired
+    /// yet — the shared app-global index architecture needs per-site cache routing the runtime
+    /// can derive, which is a follow-up.
+    let semanticRanker: SemanticRanker? = NLEmbeddingProvider().map {
+        SemanticRanker(provider: $0, cache: nil)
+    }
     let contentIndexerStore = ContentIndexerStore()
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -29,17 +29,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// embedding model is available — the whole chain takes `SemanticRanker?`, so retrieval then
     /// degrades to pure lexical (never the test-double fake, which would blend nonsense vectors).
     ///
+    /// Populated asynchronously from `applicationDidFinishLaunching` because building the
+    /// `NLContextualEmbedding` provider calls `model.load()` (hundreds of ms of asset/model init),
+    /// which must not run on the main thread during launch. A site window opened in the brief
+    /// pre-load window captures `nil` and stays lexical-only for that session (reopening picks up
+    /// the ranker) — an acceptable degradation since the launcher is shown first.
+    ///
     /// In-memory for v0: the per-site `Config/` embedding cache (`SemanticIndexCache`) and
     /// incremental `upsert`/`remove` re-embedding are built + tested but deliberately not wired
     /// yet — the shared app-global index architecture needs per-site cache routing the runtime
     /// can derive, which is a follow-up.
-    let semanticRanker: SemanticRanker? = AppDelegate.makeEmbeddingProvider().map {
-        SemanticRanker(provider: $0, cache: nil)
-    }
+    var semanticRanker: SemanticRanker?
 
     /// On-device embedding provider, best-first: the multilingual transformer
     /// (`NLContextualEmbedding`), then the lighter `NLEmbedding.sentenceEmbedding`, then `nil`
-    /// (→ pure-lexical retrieval). Never the test-double fake.
+    /// (→ pure-lexical retrieval). Never the test-double fake. Runs the model load, so call it off
+    /// the main thread.
     private static func makeEmbeddingProvider() -> (any EmbeddingProvider)? {
         if let contextual = NLContextualEmbeddingProvider() { return contextual }
         if let sentence = NLEmbeddingProvider() { return sentence }
@@ -56,6 +61,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { [contentGraph, contentIndexerStore] in
             // This Task inherits the @MainActor context, so the store write needs no extra hop.
             contentIndexerStore.indexer = await AnglesiteIntents.bootstrap(contentGraph: contentGraph)
+        }
+
+        // Build the on-device embedding provider off the main thread (model load is expensive),
+        // then publish the ranker on the main actor for new site windows to capture.
+        Task { [weak self] in
+            let provider = await Task.detached(priority: .utility) { Self.makeEmbeddingProvider() }.value
+            await MainActor.run { self?.semanticRanker = provider.map { SemanticRanker(provider: $0, cache: nil) } }
         }
 
         // Begin mirroring the site registry so the File ▸ Open Recent submenu is populated

--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -24,6 +24,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let contentGraph = SiteContentGraph()
     /// Project-local retrieval index used by assistant tools for file-cited RAG context (#307).
     let knowledgeIndex = SiteKnowledgeIndex()
+    /// On-device semantic ranker layered over `knowledgeIndex`, synced by the preview runtime so
+    /// assistant retrieval ranks by meaning, not just keywords (#312). In-memory for v0 — the
+    /// per-site `Config/` embedding cache (`SemanticIndexCache`) is a follow-up, since the shared
+    /// app-global index architecture needs per-site cache routing the runtime can derive.
+    let semanticRanker = SemanticRanker(
+        provider: NLEmbeddingProvider() ?? FakeEmbeddingProvider(),
+        cache: nil)
     let contentIndexerStore = ContentIndexerStore()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -214,6 +221,7 @@ struct AnglesiteApp: App {
                 siteID: siteID,
                 contentGraph: appDelegate.contentGraph,
                 knowledgeIndex: appDelegate.knowledgeIndex,
+                semanticRanker: appDelegate.semanticRanker,
                 contentIndexerStore: appDelegate.contentIndexerStore
             )
                 .frame(minWidth: 960, minHeight: 600)

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -45,9 +45,10 @@ final class PreviewModel {
     init(
         contentGraph: SiteContentGraph? = nil,
         knowledgeIndex: SiteKnowledgeIndex? = nil,
+        semanticRanker: SemanticRanker? = nil,
         runtime: (any SiteRuntime)? = nil
     ) {
-        let runtime = runtime ?? Self.makeRuntime(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex)
+        let runtime = runtime ?? Self.makeRuntime(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex, semanticRanker: semanticRanker)
         self.runtime = runtime
         self.editRouter = MCPApplyEditRouter(mcpClient: { [weak runtime] in
             // `runtime` is the actor instance; reading `mcpClient` hops onto the actor.
@@ -97,7 +98,7 @@ final class PreviewModel {
     ///
     /// `sourceRepo` is NOT passed here — `LocalContainerSiteRuntime.init` doesn't take it; it
     /// receives it at `start(siteID:siteDirectory:)` time (forwarded from `open(siteID:siteDirectory:)`).
-    static func makeRuntime(contentGraph: SiteContentGraph?, knowledgeIndex: SiteKnowledgeIndex?) -> any SiteRuntime {
+    static func makeRuntime(contentGraph: SiteContentGraph?, knowledgeIndex: SiteKnowledgeIndex?, semanticRanker: SemanticRanker?) -> any SiteRuntime {
         #if !ANGLESITE_MAS
         // Container runtime is DevID-only (MAS doesn't link AnglesiteContainer). On MAS this whole
         // branch compiles out and the host runtime below is always used.
@@ -107,11 +108,12 @@ final class PreviewModel {
                 ref: "HEAD",
                 control: ContainerizationControl(),
                 mcpClient: MCPClient(supervisor: .shared),
-                knowledgeIndex: knowledgeIndex
+                knowledgeIndex: knowledgeIndex,
+                semanticRanker: semanticRanker
             )
         }
         #endif
-        return LocalSiteRuntime(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex)
+        return LocalSiteRuntime(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex, semanticRanker: semanticRanker)
     }
 
     func open(siteID: String, siteDirectory: URL) {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -39,6 +39,9 @@ struct SiteWindow: View {
     private let contentGraph: SiteContentGraph
     /// App-lifetime project knowledge index, rebuilt by the preview runtime and exposed to chat.
     private let knowledgeIndex: SiteKnowledgeIndex
+    /// App-lifetime on-device semantic ranker, synced from the knowledge index by the runtime so
+    /// `SearchKnowledgeTool` ranks retrieval by meaning, not just keywords (#312).
+    private let semanticRanker: SemanticRanker
     /// Observed (not a bare optional) so the Siri AI Readiness button enables itself if `bootstrap`
     /// populates the indexer after this window was constructed — see `ContentIndexerStore`.
     private let contentIndexerStore: ContentIndexerStore
@@ -49,13 +52,15 @@ struct SiteWindow: View {
         siteID: String?,
         contentGraph: SiteContentGraph,
         knowledgeIndex: SiteKnowledgeIndex,
+        semanticRanker: SemanticRanker,
         contentIndexerStore: ContentIndexerStore
     ) {
         self.siteID = siteID
         self.contentGraph = contentGraph
         self.knowledgeIndex = knowledgeIndex
+        self.semanticRanker = semanticRanker
         self.contentIndexerStore = contentIndexerStore
-        _preview = State(initialValue: PreviewModel(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex))
+        _preview = State(initialValue: PreviewModel(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex, semanticRanker: semanticRanker))
     }
 
     @State private var site: SiteStore.Site?
@@ -783,6 +788,7 @@ struct SiteWindow: View {
                     editBridge: makeEditBridge(),
                     contentGraph: contentGraph,
                     knowledgeIndex: knowledgeIndex,
+                    semanticRanker: semanticRanker,
                     integrationService: integrationOps
                 ),
                 index: knowledgeIndex
@@ -819,6 +825,7 @@ struct SiteWindow: View {
                 editBridge: makeEditBridge(),
                 contentGraph: contentGraph,
                 knowledgeIndex: knowledgeIndex,
+                semanticRanker: semanticRanker,
                 integrationService: integrationOps
             )
         case .claude:

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -40,8 +40,9 @@ struct SiteWindow: View {
     /// App-lifetime project knowledge index, rebuilt by the preview runtime and exposed to chat.
     private let knowledgeIndex: SiteKnowledgeIndex
     /// App-lifetime on-device semantic ranker, synced from the knowledge index by the runtime so
-    /// `SearchKnowledgeTool` ranks retrieval by meaning, not just keywords (#312).
-    private let semanticRanker: SemanticRanker
+    /// `SearchKnowledgeTool` ranks retrieval by meaning, not just keywords (#312). `nil` when no
+    /// on-device embedding model is available — retrieval then degrades to pure lexical.
+    private let semanticRanker: SemanticRanker?
     /// Observed (not a bare optional) so the Siri AI Readiness button enables itself if `bootstrap`
     /// populates the indexer after this window was constructed — see `ContentIndexerStore`.
     private let contentIndexerStore: ContentIndexerStore
@@ -52,7 +53,7 @@ struct SiteWindow: View {
         siteID: String?,
         contentGraph: SiteContentGraph,
         knowledgeIndex: SiteKnowledgeIndex,
-        semanticRanker: SemanticRanker,
+        semanticRanker: SemanticRanker?,
         contentIndexerStore: ContentIndexerStore
     ) {
         self.siteID = siteID

--- a/Sources/AnglesiteCore/EmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/EmbeddingProvider.swift
@@ -36,7 +36,9 @@ public struct FakeEmbeddingProvider: EmbeddingProvider {
             vector[Int(scalar.value) % dimension] += 1
         }
         let magnitude = (vector.reduce(0) { $0 + $1 * $1 }).squareRoot()
-        guard magnitude > 0 else { throw EmbeddingError.emptyText }
+        // Unreachable for non-empty trimmed input (every scalar increments a bucket), but label it
+        // accurately if it ever triggers: a zero vector is a failed embedding, not empty input.
+        guard magnitude > 0 else { throw EmbeddingError.modelUnavailable }
         return vector.map { $0 / magnitude }
     }
 }

--- a/Sources/AnglesiteCore/EmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/EmbeddingProvider.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// An error surfaced by an ``EmbeddingProvider``.
+public enum EmbeddingError: Error, Equatable {
+    /// The text to embed was empty or whitespace-only.
+    case emptyText
+    /// No on-device embedding model/asset is available at runtime.
+    case modelUnavailable
+}
+
+/// Produces a fixed-length, unit-normalized embedding for a string. The single seam the
+/// semantic ranker depends on, so the model choice (Apple NaturalLanguage in production, a
+/// deterministic fake in tests) is swappable without touching ranking logic.
+public protocol EmbeddingProvider: Sendable {
+    /// The length of every vector this provider returns.
+    var dimension: Int { get }
+    /// Returns a unit-normalized embedding, or throws if the text is empty / no model is available.
+    func embed(_ text: String) async throws -> [Float]
+}
+
+/// Deterministic embedding for tests: a stable bag-of-characters projection, unit-normalized.
+/// Not semantically meaningful — only stable and content-sensitive, which is all the ranker,
+/// cache, and incremental-update tests need.
+public struct FakeEmbeddingProvider: EmbeddingProvider {
+    public let dimension: Int
+
+    public init(dimension: Int = 8) {
+        self.dimension = max(1, dimension)
+    }
+
+    public func embed(_ text: String) async throws -> [Float] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw EmbeddingError.emptyText }
+        var vector = [Float](repeating: 0, count: dimension)
+        for scalar in trimmed.unicodeScalars {
+            vector[Int(scalar.value) % dimension] += 1
+        }
+        let magnitude = (vector.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        guard magnitude > 0 else { throw EmbeddingError.emptyText }
+        return vector.map { $0 / magnitude }
+    }
+}

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -55,6 +55,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     private let editBridge: IntentEditBridge?
     private let contentGraph: SiteContentGraph?
     private let knowledgeIndex: SiteKnowledgeIndex?
+    private let semanticRanker: SemanticRanker?
     private let integrationService: (any IntegrationOperationsService)?
     private let logger = Logger(subsystem: "io.dwk.anglesite", category: "FoundationModelAssistant")
     /// The current conversational turn's consumer-facing ``TurnRelay``, retained so ``cancel()`` can
@@ -81,12 +82,14 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         editBridge: IntentEditBridge? = nil,
         contentGraph: SiteContentGraph? = nil,
         knowledgeIndex: SiteKnowledgeIndex? = nil,
+        semanticRanker: SemanticRanker? = nil,
         integrationService: (any IntegrationOperationsService)? = nil
     ) {
         self.tier = tier
         self.editBridge = editBridge
         self.contentGraph = contentGraph
         self.knowledgeIndex = knowledgeIndex
+        self.semanticRanker = semanticRanker
         self.integrationService = integrationService
         if tier == .privateCloudCompute {
             // v1 has no separate PCC session; fall back to on-device with a logged warning so the
@@ -339,7 +342,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
             tools.append(SearchContentTool(contentGraph: contentGraph, siteID: context.siteID))
         }
         if let knowledgeIndex {
-            tools.append(SearchKnowledgeTool(index: knowledgeIndex, siteID: context.siteID))
+            tools.append(SearchKnowledgeTool(index: knowledgeIndex, siteID: context.siteID, ranker: semanticRanker))
         }
         if let integrationService {
             tools.append(SetupIntegrationTool(service: integrationService, siteID: context.siteID))

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -10,6 +10,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     private let control: any LocalContainerControl
     public let mcpClient: MCPClient
     private let knowledgeIndex: SiteKnowledgeIndex?
+    private let semanticRanker: SemanticRanker?
     private let connect: @Sendable (MCPClient, URL) async throws -> Void
 
     private var current: SiteRuntimeState = .idle
@@ -23,12 +24,14 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         control: any LocalContainerControl,
         mcpClient: MCPClient,
         knowledgeIndex: SiteKnowledgeIndex? = nil,
+        semanticRanker: SemanticRanker? = nil,
         connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { c, u in try await c.connect(httpEndpoint: u) }
     ) {
         self.ref = ref
         self.control = control
         self.mcpClient = mcpClient
         self.knowledgeIndex = knowledgeIndex
+        self.semanticRanker = semanticRanker
         self.connect = connect
     }
 
@@ -60,6 +63,14 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
                 await knowledgeIndex?.unload(siteID: siteID)
                 return
             }
+            if let documents = await knowledgeIndex?.documents(siteID: siteID) {
+                await semanticRanker?.sync(siteID: siteID, documents: documents)
+            }
+            guard gen == generation else {
+                await knowledgeIndex?.unload(siteID: siteID)
+                await semanticRanker?.unload(siteID: siteID)
+                return
+            }
             loadedKnowledgeSiteID = siteID
             activeSiteID = siteID
             setState(.ready(siteID: siteID, url: session.previewURL))
@@ -84,6 +95,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         await mcpClient.stop()
         if let siteID = loadedKnowledgeSiteID {
             await knowledgeIndex?.unload(siteID: siteID)
+            await semanticRanker?.unload(siteID: siteID)
             loadedKnowledgeSiteID = nil
         }
         if let id = activeSiteID {

--- a/Sources/AnglesiteCore/LocalSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalSiteRuntime.swift
@@ -37,6 +37,10 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
     /// App-lifetime local RAG index for project-aware assistant retrieval (#307). Rebuilt when a
     /// site starts and unloaded with the content graph on close.
     private let knowledgeIndex: SiteKnowledgeIndex?
+    /// App-lifetime on-device semantic ranker, synced from the knowledge index after each rebuild
+    /// so assistant retrieval can rank by meaning, not just keywords (#312). Unloaded with the
+    /// other shared indexes on close.
+    private let semanticRanker: SemanticRanker?
     private let logCenter: LogCenter
     private let resolveCommand: CommandResolver
     private let resolveMCPCommand: MCPCommandResolver
@@ -56,6 +60,7 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
         mcpClient: MCPClient? = nil,
         contentGraph: SiteContentGraph? = nil,
         knowledgeIndex: SiteKnowledgeIndex? = nil,
+        semanticRanker: SemanticRanker? = nil,
         supervisor: ProcessSupervisor = .shared,
         logCenter: LogCenter = .shared,
         resolveCommand: @escaping CommandResolver = LocalSiteRuntime.resolveAstroCommand,
@@ -67,6 +72,7 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
         self.mcpClient = mcpClient ?? MCPClient(supervisor: supervisor, logCenter: logCenter)
         self.contentGraph = contentGraph
         self.knowledgeIndex = knowledgeIndex
+        self.semanticRanker = semanticRanker
         self.logCenter = logCenter
         self.resolveCommand = resolveCommand
         self.resolveMCPCommand = resolveMCPCommand
@@ -157,6 +163,7 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
         if let siteID = loadedSharedIndexSiteID {
             await contentGraph?.unload(siteID: siteID)
             await knowledgeIndex?.unload(siteID: siteID)
+            await semanticRanker?.unload(siteID: siteID)
             loadedSharedIndexSiteID = nil
         }
     }
@@ -183,6 +190,15 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
         guard gen == generation else {
             await contentGraph?.unload(siteID: siteID)
             await knowledgeIndex?.unload(siteID: siteID)
+            return
+        }
+        if let documents = await knowledgeIndex?.documents(siteID: siteID) {
+            await semanticRanker?.sync(siteID: siteID, documents: documents)
+        }
+        guard gen == generation else {
+            await contentGraph?.unload(siteID: siteID)
+            await knowledgeIndex?.unload(siteID: siteID)
+            await semanticRanker?.unload(siteID: siteID)
             return
         }
         loadedSharedIndexSiteID = siteID

--- a/Sources/AnglesiteCore/NLContextualEmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/NLContextualEmbeddingProvider.swift
@@ -1,5 +1,6 @@
 import Foundation
 import NaturalLanguage
+import os
 
 /// Production ``EmbeddingProvider`` backed by Apple's on-device `NLContextualEmbedding` — a
 /// transformer embedding model that is higher quality and broader-language than
@@ -11,6 +12,8 @@ import NaturalLanguage
 /// loaded model embed mixed-language content reasonably; loading distinct per-script models is a
 /// further enhancement.
 public struct NLContextualEmbeddingProvider: EmbeddingProvider {
+    private static let log = Logger(subsystem: "io.dwk.anglesite", category: "NLContextualEmbeddingProvider")
+
     private let model: NLContextualEmbedding
     private let defaultLanguage: NLLanguage
     public let dimension: Int
@@ -40,7 +43,14 @@ public struct NLContextualEmbeddingProvider: EmbeddingProvider {
         var sum = [Double](repeating: 0, count: dimension)
         var count = 0
         result.enumerateTokenVectors(in: trimmed.startIndex..<trimmed.endIndex) { vector, _ in
-            guard vector.count == dimension else { return true }
+            guard vector.count == dimension else {
+                // `model.dimension` and the result's token vectors disagree — a framework/programmer
+                // error, not recoverable data. Trap in debug; in release, skip with a diagnostic
+                // rather than silently distorting the mean-pool.
+                assertionFailure("NLContextualEmbedding dimension mismatch: expected \(dimension), got \(vector.count)")
+                Self.log.error("token vector dimension mismatch: expected \(dimension), got \(vector.count)")
+                return true
+            }
             for i in 0..<dimension { sum[i] += vector[i] }
             count += 1
             return true

--- a/Sources/AnglesiteCore/NLContextualEmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/NLContextualEmbeddingProvider.swift
@@ -1,0 +1,61 @@
+import Foundation
+import NaturalLanguage
+
+/// Production ``EmbeddingProvider`` backed by Apple's on-device `NLContextualEmbedding` — a
+/// transformer embedding model that is higher quality and broader-language than
+/// `NLEmbedding.sentenceEmbedding`, which matters for i18n sites (#312). Token vectors are
+/// mean-pooled into a single unit-normalized passage vector.
+///
+/// `init?` returns `nil` when the model's assets aren't available on the host (so callers fall
+/// back to ``NLEmbeddingProvider`` and then to lexical-only). Per-call language detection lets one
+/// loaded model embed mixed-language content reasonably; loading distinct per-script models is a
+/// further enhancement.
+public struct NLContextualEmbeddingProvider: EmbeddingProvider {
+    private let model: NLContextualEmbedding
+    private let defaultLanguage: NLLanguage
+    public let dimension: Int
+
+    public init?(language: NLLanguage = .english) {
+        guard let model = NLContextualEmbedding(language: language) else { return nil }
+        // Assets ship on demand; without them the model can't embed, so bail to the fallback chain
+        // rather than load lazily mid-query (which would block the actor on a download).
+        guard model.hasAvailableAssets else { return nil }
+        do {
+            try model.load()
+        } catch {
+            return nil
+        }
+        self.model = model
+        self.defaultLanguage = language
+        self.dimension = model.dimension
+    }
+
+    public func embed(_ text: String) async throws -> [Float] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw EmbeddingError.emptyText }
+
+        let language = Self.detectLanguage(trimmed) ?? defaultLanguage
+        let result = try model.embeddingResult(for: trimmed, language: language)
+
+        var sum = [Double](repeating: 0, count: dimension)
+        var count = 0
+        result.enumerateTokenVectors(in: trimmed.startIndex..<trimmed.endIndex) { vector, _ in
+            guard vector.count == dimension else { return true }
+            for i in 0..<dimension { sum[i] += vector[i] }
+            count += 1
+            return true
+        }
+        guard count > 0 else { throw EmbeddingError.modelUnavailable }
+
+        let mean = sum.map { Float($0 / Double(count)) }
+        let magnitude = (mean.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        guard magnitude > 0 else { throw EmbeddingError.modelUnavailable }
+        return mean.map { $0 / magnitude }
+    }
+
+    private static func detectLanguage(_ text: String) -> NLLanguage? {
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(text)
+        return recognizer.dominantLanguage
+    }
+}

--- a/Sources/AnglesiteCore/NLEmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/NLEmbeddingProvider.swift
@@ -19,6 +19,11 @@ public struct NLEmbeddingProvider: EmbeddingProvider {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { throw EmbeddingError.emptyText }
         guard let raw = embedding.vector(for: trimmed) else { throw EmbeddingError.modelUnavailable }
+        // Despite the documented contract, `sentenceEmbedding.vector(for:)` does NOT return a unit
+        // vector here (verified: magnitudes ≠ 1) — so normalize to honor the EmbeddingProvider
+        // contract. (Ranking via `VectorMath.cosine` is scale-invariant regardless, but other
+        // consumers may rely on unit length.) A degenerate zero vector means the model produced
+        // nothing usable for this input.
         let floats = raw.map { Float($0) }
         let magnitude = (floats.reduce(0) { $0 + $1 * $1 }).squareRoot()
         guard magnitude > 0 else { throw EmbeddingError.modelUnavailable }

--- a/Sources/AnglesiteCore/NLEmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/NLEmbeddingProvider.swift
@@ -1,0 +1,27 @@
+import Foundation
+import NaturalLanguage
+
+/// Production ``EmbeddingProvider`` backed by Apple's on-device `NLEmbedding.sentenceEmbedding`.
+/// Synchronous and asset-light, so it works without a network embedding service (project
+/// strategy). Returns `nil` from init when no model is available, letting callers degrade to
+/// lexical-only ranking.
+public struct NLEmbeddingProvider: EmbeddingProvider {
+    private let embedding: NLEmbedding
+    public let dimension: Int
+
+    public init?(language: NLLanguage = .english) {
+        guard let embedding = NLEmbedding.sentenceEmbedding(for: language) else { return nil }
+        self.embedding = embedding
+        self.dimension = embedding.dimension
+    }
+
+    public func embed(_ text: String) async throws -> [Float] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw EmbeddingError.emptyText }
+        guard let raw = embedding.vector(for: trimmed) else { throw EmbeddingError.modelUnavailable }
+        let floats = raw.map { Float($0) }
+        let magnitude = (floats.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        guard magnitude > 0 else { throw EmbeddingError.modelUnavailable }
+        return floats.map { $0 / magnitude }
+    }
+}

--- a/Sources/AnglesiteCore/SearchKnowledgeTool.swift
+++ b/Sources/AnglesiteCore/SearchKnowledgeTool.swift
@@ -19,10 +19,12 @@ public struct SearchKnowledgeTool: Tool, Sendable {
 
     private let index: SiteKnowledgeIndex
     private let siteID: String
+    private let ranker: SemanticRanker?
 
-    public init(index: SiteKnowledgeIndex, siteID: String) {
+    public init(index: SiteKnowledgeIndex, siteID: String, ranker: SemanticRanker? = nil) {
         self.index = index
         self.siteID = siteID
+        self.ranker = ranker
     }
 
     public func call(arguments: Arguments) async throws -> String {
@@ -30,7 +32,22 @@ public struct SearchKnowledgeTool: Tool, Sendable {
         guard !query.isEmpty else {
             return "Provide a project search query."
         }
-        let results = await index.search(siteID: siteID, query: query, options: .init(limit: 6))
+        var results = await index.search(siteID: siteID, query: query, options: .init(limit: 6))
+        if let ranker {
+            // Blend the lexical scores with on-device semantic similarity so retrieval matches
+            // meaning, not just keywords. Falls back to pure lexical order when the ranker has
+            // no vectors (no model / not yet synced).
+            let semantic = await ranker.search(siteID: siteID, queryText: query, limit: 50)
+            if !semantic.isEmpty {
+                let lexicalScores = Dictionary(results.map { ($0.document.id, $0.score) }, uniquingKeysWith: max)
+                let semanticScores = Dictionary(semantic.map { ($0.docID, Double($0.score)) }, uniquingKeysWith: max)
+                let blended = SemanticRanker.blend(lexical: lexicalScores, semantic: semanticScores, semanticWeight: 0.6)
+                results = results.sorted {
+                    let lhs = blended[$0.document.id] ?? 0, rhs = blended[$1.document.id] ?? 0
+                    return lhs != rhs ? lhs > rhs : $0.document.path < $1.document.path
+                }
+            }
+        }
         guard !results.isEmpty else { return "No matching project context." }
 
         return results.map { result in

--- a/Sources/AnglesiteCore/SearchKnowledgeTool.swift
+++ b/Sources/AnglesiteCore/SearchKnowledgeTool.swift
@@ -36,22 +36,26 @@ public struct SearchKnowledgeTool: Tool, Sendable {
             return "Provide a project search query."
         }
         let resultLimit = 6
-        // Pull a wider lexical candidate pool than we display so semantic reranking can lift a
-        // weak-keyword-but-on-topic doc into the visible results — not merely reorder the top 6.
-        // A doc with *zero* lexical overlap still can't surface here: `results` carry the lexical
-        // excerpt + line range. True semantic-only retrieval (synthesizing excerpt-less results)
-        // is a follow-up — see the #312 design doc's Related-Pages panel (Plan B).
+        // Pull a wider lexical candidate pool than we display, then semantically rerank *within
+        // that pool*: a weak-keyword-but-on-topic doc ranked, say, #25 lexically can be lifted into
+        // the visible 6. A doc with *zero* lexical overlap is deliberately NOT surfaced here —
+        // results carry a lexical excerpt + line range, so synthesizing excerpt-less semantic-only
+        // hits belongs to the Related-Pages panel (Plan B), not this cited-excerpt tool.
         let candidatePool = ranker == nil ? resultLimit : 30
         var results = await index.search(siteID: siteID, query: query, options: .init(limit: candidatePool))
-        if let ranker {
-            let semantic = await ranker.search(siteID: siteID, queryText: query, limit: candidatePool)
+        if let ranker, !results.isEmpty {
+            // Score broadly, then keep only the lexical candidates' scores — no throwaway work on
+            // semantic hits that can't be surfaced anyway.
+            let semantic = await ranker.search(siteID: siteID, queryText: query, limit: 200)
             if semantic.isEmpty {
                 // No on-device model, or nothing synced yet: degrade to lexical — but say so, since
                 // silently dropping ranking quality would violate the project's "logs are sacred".
                 Self.log.notice("semantic ranking returned no vectors; using lexical order")
             } else {
                 let lexicalScores = Dictionary(results.map { ($0.document.id, $0.score) }, uniquingKeysWith: max)
-                let semanticScores = Dictionary(semantic.map { ($0.docID, Double($0.score)) }, uniquingKeysWith: max)
+                let semanticScores = semantic.reduce(into: [String: Double]()) { acc, ranked in
+                    if lexicalScores[ranked.docID] != nil { acc[ranked.docID] = Double(ranked.score) }
+                }
                 let blended = SemanticRanker.blend(lexical: lexicalScores, semantic: semanticScores, semanticWeight: 0.6)
                 results = results.sorted {
                     let lhs = blended[$0.document.id] ?? 0, rhs = blended[$1.document.id] ?? 0

--- a/Sources/AnglesiteCore/SearchKnowledgeTool.swift
+++ b/Sources/AnglesiteCore/SearchKnowledgeTool.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 #if compiler(>=6.4)
 import FoundationModels
@@ -17,6 +18,8 @@ public struct SearchKnowledgeTool: Tool, Sendable {
         public var query: String
     }
 
+    private static let log = Logger(subsystem: "io.dwk.anglesite", category: "SearchKnowledgeTool")
+
     private let index: SiteKnowledgeIndex
     private let siteID: String
     private let ranker: SemanticRanker?
@@ -32,13 +35,21 @@ public struct SearchKnowledgeTool: Tool, Sendable {
         guard !query.isEmpty else {
             return "Provide a project search query."
         }
-        var results = await index.search(siteID: siteID, query: query, options: .init(limit: 6))
+        let resultLimit = 6
+        // Pull a wider lexical candidate pool than we display so semantic reranking can lift a
+        // weak-keyword-but-on-topic doc into the visible results — not merely reorder the top 6.
+        // A doc with *zero* lexical overlap still can't surface here: `results` carry the lexical
+        // excerpt + line range. True semantic-only retrieval (synthesizing excerpt-less results)
+        // is a follow-up — see the #312 design doc's Related-Pages panel (Plan B).
+        let candidatePool = ranker == nil ? resultLimit : 30
+        var results = await index.search(siteID: siteID, query: query, options: .init(limit: candidatePool))
         if let ranker {
-            // Blend the lexical scores with on-device semantic similarity so retrieval matches
-            // meaning, not just keywords. Falls back to pure lexical order when the ranker has
-            // no vectors (no model / not yet synced).
-            let semantic = await ranker.search(siteID: siteID, queryText: query, limit: 50)
-            if !semantic.isEmpty {
+            let semantic = await ranker.search(siteID: siteID, queryText: query, limit: candidatePool)
+            if semantic.isEmpty {
+                // No on-device model, or nothing synced yet: degrade to lexical — but say so, since
+                // silently dropping ranking quality would violate the project's "logs are sacred".
+                Self.log.notice("semantic ranking returned no vectors; using lexical order")
+            } else {
                 let lexicalScores = Dictionary(results.map { ($0.document.id, $0.score) }, uniquingKeysWith: max)
                 let semanticScores = Dictionary(semantic.map { ($0.docID, Double($0.score)) }, uniquingKeysWith: max)
                 let blended = SemanticRanker.blend(lexical: lexicalScores, semantic: semanticScores, semanticWeight: 0.6)
@@ -48,6 +59,7 @@ public struct SearchKnowledgeTool: Tool, Sendable {
                 }
             }
         }
+        results = Array(results.prefix(resultLimit))
         guard !results.isEmpty else { return "No matching project context." }
 
         return results.map { result in

--- a/Sources/AnglesiteCore/SemanticIndexCache.swift
+++ b/Sources/AnglesiteCore/SemanticIndexCache.swift
@@ -26,17 +26,32 @@ public struct SemanticIndexCache: Sendable {
     }
 
     /// Loads `[docID: Entry]`. Entries whose `dimension` differs from `expectedDimension` are
-    /// dropped (the provider changed). A missing or corrupt file yields an empty map — never fatal.
+    /// dropped (the provider changed); a single malformed/legacy entry is skipped rather than
+    /// discarding the whole cache. A missing file (or one that isn't a JSON array) yields an empty
+    /// map — never fatal.
+    ///
+    /// Performs blocking file I/O on the caller's executor (today that's `SemanticRanker`'s actor).
+    /// Acceptable while the cache is unwired in production; move the read off-actor when the
+    /// per-site cache is enabled (see `SemanticRanker.persist`).
     public func load(expectedDimension: Int) -> [String: Entry] {
         guard let data = try? Data(contentsOf: fileURL),
-              let entries = try? JSONDecoder().decode([Entry].self, from: data) else {
+              let entries = try? JSONDecoder().decode([LenientEntry].self, from: data) else {
             return [:]
         }
         var out: [String: Entry] = [:]
-        for entry in entries where entry.dimension == expectedDimension {
+        for entry in entries.compactMap(\.entry) where entry.dimension == expectedDimension {
             out[entry.docID] = entry
         }
         return out
+    }
+
+    /// Decodes an array element to `Entry?`, swallowing a per-element decode failure so one bad
+    /// entry doesn't fail the whole-array decode.
+    private struct LenientEntry: Decodable {
+        let entry: Entry?
+        init(from decoder: Decoder) throws {
+            entry = try? Entry(from: decoder)
+        }
     }
 
     /// Atomically writes the entries, creating the parent directory if needed.

--- a/Sources/AnglesiteCore/SemanticIndexCache.swift
+++ b/Sources/AnglesiteCore/SemanticIndexCache.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// On-disk cache of document embeddings, one file per site under the package's app-owned
+/// `Config/caches/` (never in git). Embeddings are expensive to recompute; the lexical index
+/// itself stays in-memory (see #329). Invalidation is by `contentHash` (caller-checked) and by
+/// `dimension` (checked here on load).
+public struct SemanticIndexCache: Sendable {
+    public struct Entry: Codable, Equatable, Sendable {
+        public let docID: String
+        public let contentHash: String
+        public let dimension: Int
+        public let vector: [Float]
+
+        public init(docID: String, contentHash: String, dimension: Int, vector: [Float]) {
+            self.docID = docID
+            self.contentHash = contentHash
+            self.dimension = dimension
+            self.vector = vector
+        }
+    }
+
+    private let fileURL: URL
+
+    public init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    /// Loads `[docID: Entry]`. Entries whose `dimension` differs from `expectedDimension` are
+    /// dropped (the provider changed). A missing or corrupt file yields an empty map — never fatal.
+    public func load(expectedDimension: Int) -> [String: Entry] {
+        guard let data = try? Data(contentsOf: fileURL),
+              let entries = try? JSONDecoder().decode([Entry].self, from: data) else {
+            return [:]
+        }
+        var out: [String: Entry] = [:]
+        for entry in entries where entry.dimension == expectedDimension {
+            out[entry.docID] = entry
+        }
+        return out
+    }
+
+    /// Atomically writes the entries, creating the parent directory if needed.
+    public func save(_ entries: [String: Entry]) throws {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(entries.values.sorted { $0.docID < $1.docID })
+        try data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/Sources/AnglesiteCore/SemanticRanker.swift
+++ b/Sources/AnglesiteCore/SemanticRanker.swift
@@ -41,10 +41,11 @@ public actor SemanticRanker {
         let existing = vectorsBySite[siteID] ?? [:]
         var next: [String: Stored] = [:]
         for document in documents {
-            let hash = VectorMath.stableHash(Self.embeddedText(for: document))
+            let text = Self.embeddedText(for: document)
+            let hash = VectorMath.stableHash(text)
             if let prior = existing[document.id], prior.contentHash == hash {
                 next[document.id] = prior
-            } else if let vector = try? await provider.embed(Self.embeddedText(for: document)) {
+            } else if let vector = try? await provider.embed(text), Self.isUsable(vector) {
                 next[document.id] = Stored(contentHash: hash, vector: vector)
             }
         }
@@ -54,15 +55,24 @@ public actor SemanticRanker {
 
     /// Re-embeds a single document if its content changed (incremental update during a session).
     public func upsert(siteID: String, document: SiteKnowledgeIndex.Document) async {
-        let hash = VectorMath.stableHash(Self.embeddedText(for: document))
+        let text = Self.embeddedText(for: document)
+        let hash = VectorMath.stableHash(text)
         if vectorsBySite[siteID]?[document.id]?.contentHash == hash { return }
-        guard let vector = try? await provider.embed(Self.embeddedText(for: document)) else { return }
+        guard let vector = try? await provider.embed(text), Self.isUsable(vector) else { return }
         vectorsBySite[siteID, default: [:]][document.id] = Stored(contentHash: hash, vector: vector)
         persist(siteID: siteID)
     }
 
-    /// Drops a single document's vector (e.g. its file was deleted).
-    public func remove(siteID: String, docID: String) async {
+    /// A vector is only worth storing if it has non-zero magnitude — a zero vector ranks 0 against
+    /// everything (`VectorMath.cosine`), so storing it just wastes a slot. Guards against a provider
+    /// that unexpectedly returns an all-zero vector for some input.
+    private static func isUsable(_ vector: [Float]) -> Bool {
+        vector.contains { $0 != 0 }
+    }
+
+    /// Drops a single document's vector (e.g. its file was deleted). Not `async`: actor isolation
+    /// alone forces callers to `await`; the keyword would falsely imply an internal suspension point.
+    public func remove(siteID: String, docID: String) {
         vectorsBySite[siteID]?[docID] = nil
         persist(siteID: siteID)
     }
@@ -119,7 +129,9 @@ public actor SemanticRanker {
     ) -> [String: Double] {
         func normalize(_ map: [String: Double]) -> [String: Double] {
             guard let lo = map.values.min(), let hi = map.values.max(), hi > lo else {
-                return map.mapValues { _ in map.isEmpty ? 0 : 1 }
+                // All values equal (incl. all-zero) → no discriminating signal. Map to 0 so a flat
+                // signal contributes nothing to the weighted sum rather than inflating every doc.
+                return map.mapValues { _ in 0 }
             }
             return map.mapValues { ($0 - lo) / (hi - lo) }
         }

--- a/Sources/AnglesiteCore/SemanticRanker.swift
+++ b/Sources/AnglesiteCore/SemanticRanker.swift
@@ -133,6 +133,9 @@ public actor SemanticRanker {
     }
 
     private func persist(siteID: String) {
+        // Inert in v0 (production wires `cache: nil`). When the per-site cache is enabled, this
+        // synchronous encode + disk write runs on the actor and `try?`-swallows failures — move it
+        // off the actor (e.g. a detached writer) and log write errors as part of that follow-up.
         guard let cache, let stored = vectorsBySite[siteID] else { return }
         let entries = stored.reduce(into: [String: SemanticIndexCache.Entry]()) { result, pair in
             result[pair.key] = SemanticIndexCache.Entry(

--- a/Sources/AnglesiteCore/SemanticRanker.swift
+++ b/Sources/AnglesiteCore/SemanticRanker.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// On-device semantic ranking layer over #329's lexical ``SiteKnowledgeIndex``. Holds one
+/// embedding vector per document, persisted via ``SemanticIndexCache``. The lexical index is
+/// untouched; this is purely additive.
+public actor SemanticRanker {
+    private struct Stored {
+        let contentHash: String
+        let vector: [Float]
+    }
+
+    private let provider: EmbeddingProvider
+    private let cache: SemanticIndexCache?
+    /// `[siteID: [docID: Stored]]`.
+    private var vectorsBySite: [String: [String: Stored]] = [:]
+
+    public init(provider: EmbeddingProvider, cache: SemanticIndexCache?) {
+        self.provider = provider
+        self.cache = cache
+    }
+
+    /// Text fed to the embedder: title + headings + a leading slice of the body. Document-level
+    /// granularity (v0); chunking is a later extension.
+    static func embeddedText(for document: SiteKnowledgeIndex.Document) -> String {
+        var parts: [String] = []
+        if let title = document.title, !title.isEmpty { parts.append(title) }
+        if !document.headings.isEmpty { parts.append(document.headings.joined(separator: " ")) }
+        parts.append(String(document.excerptText.prefix(2000)))
+        return parts.joined(separator: "\n")
+    }
+
+    /// Reconciles the vector store for a site against the lexical index's current documents:
+    /// reuse cached vectors whose content is unchanged, embed new/changed documents, and drop
+    /// vectors for documents that no longer exist.
+    public func sync(siteID: String, documents: [SiteKnowledgeIndex.Document]) async {
+        // Seed from the cold cache on first touch of this site.
+        if vectorsBySite[siteID] == nil, let cache {
+            vectorsBySite[siteID] = cache.load(expectedDimension: provider.dimension)
+                .mapValues { Stored(contentHash: $0.contentHash, vector: $0.vector) }
+        }
+        let existing = vectorsBySite[siteID] ?? [:]
+        var next: [String: Stored] = [:]
+        for document in documents {
+            let hash = VectorMath.stableHash(Self.embeddedText(for: document))
+            if let prior = existing[document.id], prior.contentHash == hash {
+                next[document.id] = prior
+            } else if let vector = try? await provider.embed(Self.embeddedText(for: document)) {
+                next[document.id] = Stored(contentHash: hash, vector: vector)
+            }
+        }
+        vectorsBySite[siteID] = next
+        persist(siteID: siteID)
+    }
+
+    /// Re-embeds a single document if its content changed (incremental update during a session).
+    public func upsert(siteID: String, document: SiteKnowledgeIndex.Document) async {
+        let hash = VectorMath.stableHash(Self.embeddedText(for: document))
+        if vectorsBySite[siteID]?[document.id]?.contentHash == hash { return }
+        guard let vector = try? await provider.embed(Self.embeddedText(for: document)) else { return }
+        vectorsBySite[siteID, default: [:]][document.id] = Stored(contentHash: hash, vector: vector)
+        persist(siteID: siteID)
+    }
+
+    /// Drops a single document's vector (e.g. its file was deleted).
+    public func remove(siteID: String, docID: String) async {
+        vectorsBySite[siteID]?[docID] = nil
+        persist(siteID: siteID)
+    }
+
+    /// Number of vectors held for a site (inspection/tests).
+    public func vectorCount(siteID: String) -> Int {
+        vectorsBySite[siteID]?.count ?? 0
+    }
+
+    private func persist(siteID: String) {
+        guard let cache, let stored = vectorsBySite[siteID] else { return }
+        let entries = stored.reduce(into: [String: SemanticIndexCache.Entry]()) { result, pair in
+            result[pair.key] = SemanticIndexCache.Entry(
+                docID: pair.key,
+                contentHash: pair.value.contentHash,
+                dimension: provider.dimension,
+                vector: pair.value.vector)
+        }
+        try? cache.save(entries)
+    }
+}

--- a/Sources/AnglesiteCore/SemanticRanker.swift
+++ b/Sources/AnglesiteCore/SemanticRanker.swift
@@ -72,6 +72,61 @@ public actor SemanticRanker {
         vectorsBySite[siteID]?.count ?? 0
     }
 
+    // MARK: - Ranking
+
+    /// A document scored against a query, where `score` is cosine similarity in -1…1.
+    public struct Ranked: Sendable, Equatable {
+        public let docID: String
+        public let score: Float
+        public init(docID: String, score: Float) {
+            self.docID = docID
+            self.score = score
+        }
+    }
+
+    /// Documents most semantically similar to `toDocID`, descending, excluding the source itself.
+    public func related(siteID: String, toDocID: String, limit: Int) -> [Ranked] {
+        guard let store = vectorsBySite[siteID], let source = store[toDocID] else { return [] }
+        return rank(store: store, against: source.vector, excluding: toDocID, limit: limit)
+    }
+
+    /// Documents most semantically similar to an arbitrary query string, descending.
+    public func search(siteID: String, queryText: String, limit: Int) async -> [Ranked] {
+        guard let store = vectorsBySite[siteID],
+              let queryVector = try? await provider.embed(queryText) else { return [] }
+        return rank(store: store, against: queryVector, excluding: nil, limit: limit)
+    }
+
+    private func rank(store: [String: Stored], against query: [Float], excluding: String?, limit: Int) -> [Ranked] {
+        store.compactMap { docID, stored -> Ranked? in
+            if docID == excluding { return nil }
+            return Ranked(docID: docID, score: VectorMath.cosine(query, stored.vector))
+        }
+        .sorted { $0.score != $1.score ? $0.score > $1.score : $0.docID < $1.docID }
+        .prefix(max(0, limit))
+        .map { $0 }
+    }
+
+    /// Min-max normalizes each signal to 0…1, then returns the weighted sum per docID over the
+    /// union of keys (a docID absent from one side contributes 0 there).
+    public nonisolated static func blend(
+        lexical: [String: Double], semantic: [String: Double], semanticWeight: Double
+    ) -> [String: Double] {
+        func normalize(_ map: [String: Double]) -> [String: Double] {
+            guard let lo = map.values.min(), let hi = map.values.max(), hi > lo else {
+                return map.mapValues { _ in map.isEmpty ? 0 : 1 }
+            }
+            return map.mapValues { ($0 - lo) / (hi - lo) }
+        }
+        let lex = normalize(lexical), sem = normalize(semantic)
+        let w = min(max(semanticWeight, 0), 1)
+        var out: [String: Double] = [:]
+        for docID in Set(lex.keys).union(sem.keys) {
+            out[docID] = w * (sem[docID] ?? 0) + (1 - w) * (lex[docID] ?? 0)
+        }
+        return out
+    }
+
     private func persist(siteID: String) {
         guard let cache, let stored = vectorsBySite[siteID] else { return }
         let entries = stored.reduce(into: [String: SemanticIndexCache.Entry]()) { result, pair in

--- a/Sources/AnglesiteCore/SemanticRanker.swift
+++ b/Sources/AnglesiteCore/SemanticRanker.swift
@@ -67,6 +67,11 @@ public actor SemanticRanker {
         persist(siteID: siteID)
     }
 
+    /// Drops all vectors for a site (mirrors `SiteKnowledgeIndex.unload` on site close).
+    public func unload(siteID: String) {
+        vectorsBySite[siteID] = nil
+    }
+
     /// Number of vectors held for a site (inspection/tests).
     public func vectorCount(siteID: String) -> Int {
         vectorsBySite[siteID]?.count ?? 0

--- a/Sources/AnglesiteCore/VectorMath.swift
+++ b/Sources/AnglesiteCore/VectorMath.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Small numeric helpers for the semantic index: cosine similarity and a process-stable hash.
+public enum VectorMath {
+    /// Cosine similarity. Returns 0 when lengths differ or either vector has zero magnitude,
+    /// so degenerate inputs rank last instead of crashing.
+    public static func cosine(_ a: [Float], _ b: [Float]) -> Float {
+        guard a.count == b.count, !a.isEmpty else { return 0 }
+        var dot: Float = 0, magA: Float = 0, magB: Float = 0
+        for i in a.indices {
+            dot += a[i] * b[i]
+            magA += a[i] * a[i]
+            magB += b[i] * b[i]
+        }
+        guard magA > 0, magB > 0 else { return 0 }
+        return dot / (magA.squareRoot() * magB.squareRoot())
+    }
+
+    /// FNV-1a 64-bit hash as hex. Stable across process runs (unlike `Hasher`), so it is safe
+    /// as a cache-invalidation key for embedded text.
+    public static func stableHash(_ text: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in text.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x100000001b3
+        }
+        return String(hash, radix: 16)
+    }
+}

--- a/Tests/AnglesiteCoreTests/EmbeddingProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/EmbeddingProviderTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("EmbeddingProvider")
+struct EmbeddingProviderTests {
+    @Test("fake provider is deterministic and unit-normalized")
+    func deterministicNormalized() async throws {
+        let provider = FakeEmbeddingProvider(dimension: 8)
+        let a = try await provider.embed("pricing plans for teams")
+        let b = try await provider.embed("pricing plans for teams")
+        #expect(a == b)
+        #expect(a.count == 8)
+        let magnitude = (a.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        #expect(abs(magnitude - 1.0) < 0.0001)
+    }
+
+    @Test("different text yields different vectors")
+    func differentText() async throws {
+        let provider = FakeEmbeddingProvider(dimension: 8)
+        let a = try await provider.embed("pricing")
+        let b = try await provider.embed("about the team")
+        #expect(a != b)
+    }
+
+    @Test("blank text throws emptyText")
+    func blankThrows() async {
+        let provider = FakeEmbeddingProvider(dimension: 8)
+        await #expect(throws: EmbeddingError.emptyText) {
+            _ = try await provider.embed("   ")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/NLContextualEmbeddingProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/NLContextualEmbeddingProviderTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import NaturalLanguage
+import Testing
+@testable import AnglesiteCore
+
+@Suite("NLContextualEmbeddingProvider")
+struct NLContextualEmbeddingProviderTests {
+    @Test("when assets are available, embeddings are unit-normalized and similar text ranks closer")
+    func embeds() async throws {
+        guard let provider = NLContextualEmbeddingProvider() else {
+            // Contextual-embedding assets not provisioned on this host (e.g. CI) — nothing to verify.
+            return
+        }
+        let pricing = try await provider.embed("our pricing and subscription plans")
+        let plans = try await provider.embed("subscription pricing tiers")
+        let weather = try await provider.embed("today's weather forecast")
+        let magnitude = (pricing.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        #expect(abs(magnitude - 1.0) < 0.001)
+        #expect(provider.dimension > 0)
+        #expect(VectorMath.cosine(pricing, plans) > VectorMath.cosine(pricing, weather))
+    }
+}

--- a/Tests/AnglesiteCoreTests/NLEmbeddingProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/NLEmbeddingProviderTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import NaturalLanguage
+import Testing
+@testable import AnglesiteCore
+
+@Suite("NLEmbeddingProvider")
+struct NLEmbeddingProviderTests {
+    @Test("when a model is available, embeddings are unit-normalized and similar text ranks closer")
+    func embeds() async throws {
+        guard let provider = NLEmbeddingProvider() else {
+            // No sentence-embedding asset on this host (e.g. minimal CI image) — nothing to verify.
+            return
+        }
+        let pricing = try await provider.embed("our pricing and subscription plans")
+        let plans = try await provider.embed("subscription pricing tiers")
+        let weather = try await provider.embed("today's weather forecast")
+        let magnitude = (pricing.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        #expect(abs(magnitude - 1.0) < 0.001)
+        #expect(VectorMath.cosine(pricing, plans) > VectorMath.cosine(pricing, weather))
+    }
+}

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -335,5 +335,29 @@ struct FoundationModelAssistantToolWiringTests {
             SearchKnowledgeTool.toolName,
         ])
     }
+
+    @Test("a semantic ranker is accepted and the knowledge tool is still advertised (#312)")
+    func startedReportsKnowledgeToolWithRanker() async throws {
+        guard modelAvailable() else { return }
+        let router = FakeEditRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let assistant = FoundationModelAssistant(
+            tier: .onDevice,
+            editBridge: makeBridge(router),
+            contentGraph: SiteContentGraph(),
+            knowledgeIndex: SiteKnowledgeIndex(),
+            semanticRanker: SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+        )
+        let context = AssistantContext(siteID: "site-1", siteDirectory: URL(fileURLWithPath: "/tmp/site"))
+
+        var startedToolNames: [String]?
+        for await event in try await assistant.converse(prompt: "Say hi.", context: context) {
+            if case .started(_, let toolNames) = event {
+                startedToolNames = toolNames
+                break
+            }
+        }
+        // The ranker is wired into SearchKnowledgeTool without changing the advertised tool set.
+        #expect(startedToolNames?.contains(SearchKnowledgeTool.toolName) == true)
+    }
 }
 #endif

--- a/Tests/AnglesiteCoreTests/SearchKnowledgeToolHybridTests.swift
+++ b/Tests/AnglesiteCoreTests/SearchKnowledgeToolHybridTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+// Gated like the type under test — FoundationModels (and thus SearchKnowledgeTool) is only
+// compiled under the Xcode-27 toolchain (#128). The hybrid path needs no live model: a fake
+// embedding provider drives SemanticRanker.
+#if compiler(>=6.4)
+import FoundationModels
+
+@Suite("SearchKnowledgeTool hybrid")
+struct SearchKnowledgeToolHybridTests {
+    private func makeSite(_ files: [String: String]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("khybrid-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    @Test("hybrid mode returns results and does not crash with a fake provider")
+    func hybridRanks() async {
+        let root = makeSite([
+            "src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nSubscription plans for teams.",
+            "src/pages/about.astro": "---\ntitle: About\n---\n# About\nOur team story.",
+        ])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "s", projectRoot: root)
+        let ranker = SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+        await ranker.sync(siteID: "s", documents: await index.documents(siteID: "s"))
+
+        let tool = SearchKnowledgeTool(index: index, siteID: "s", ranker: ranker)
+        let output = try! await tool.call(arguments: .init(query: "subscription pricing plans"))
+        #expect(output.contains("pricing.astro"))
+    }
+
+    @Test("without a ranker, output matches the lexical-only tool")
+    func lexicalFallback() async {
+        let root = makeSite(["src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nPlans."])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "s", projectRoot: root)
+        let lexicalOnly = SearchKnowledgeTool(index: index, siteID: "s")
+        let output = try! await lexicalOnly.call(arguments: .init(query: "pricing"))
+        #expect(output.contains("pricing.astro"))
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/SearchKnowledgeToolHybridTests.swift
+++ b/Tests/AnglesiteCoreTests/SearchKnowledgeToolHybridTests.swift
@@ -3,8 +3,8 @@ import Testing
 @testable import AnglesiteCore
 
 // Gated like the type under test — FoundationModels (and thus SearchKnowledgeTool) is only
-// compiled under the Xcode-27 toolchain (#128). The hybrid path needs no live model: a fake
-// embedding provider drives SemanticRanker.
+// compiled under the Xcode-27 toolchain (#128). The hybrid path needs no live model: the
+// embedding providers below are deterministic test doubles.
 #if compiler(>=6.4)
 import FoundationModels
 
@@ -21,8 +21,52 @@ struct SearchKnowledgeToolHybridTests {
         return root
     }
 
-    @Test("hybrid mode returns results and does not crash with a fake provider")
-    func hybridRanks() async {
+    /// Returns the index of a path token in the formatted tool output, or `Int.max` if absent —
+    /// so `<` comparisons express "ranked earlier".
+    private func position(of token: String, in output: String) -> Int {
+        guard let range = output.range(of: token) else { return .max }
+        return output.distance(from: output.startIndex, to: range.lowerBound)
+    }
+
+    /// Maps text to a 2-D vector by marker so semantic similarity can be dictated independently of
+    /// lexical keyword overlap. The query string itself is treated as semantically "near".
+    private struct ScriptedEmbeddingProvider: EmbeddingProvider, Sendable {
+        let dimension = 2
+        let queryText: String
+        func embed(_ text: String) async throws -> [Float] {
+            if text == queryText { return [0, 1] }
+            if text.localizedCaseInsensitiveContains("near") { return [0, 1] }
+            if text.localizedCaseInsensitiveContains("far") { return [1, 0] }
+            return [0, 0]
+        }
+    }
+
+    @Test("hybrid blend reorders results by semantics, independent of lexical keyword overlap")
+    func hybridReordersBySemantics() async {
+        // Both pages match the query term "team" in their body equally, so lexical scoring ties and
+        // breaks by path: aaa before zzz. Semantically, only zzz is "near" the query, so the blend
+        // must lift zzz above aaa — a flip a lexical-only run can never produce.
+        let root = makeSite([
+            "src/pages/aaa.astro": "---\ntitle: AAA\n---\nOur team works far from the topic.",
+            "src/pages/zzz.astro": "---\ntitle: ZZZ\n---\nOur team works near the topic.",
+        ])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "s", projectRoot: root)
+        let documents = await index.documents(siteID: "s")
+
+        let lexicalOnly = SearchKnowledgeTool(index: index, siteID: "s")
+        let lexicalOut = try! await lexicalOnly.call(arguments: .init(query: "team"))
+        #expect(position(of: "aaa.astro", in: lexicalOut) < position(of: "zzz.astro", in: lexicalOut))
+
+        let ranker = SemanticRanker(provider: ScriptedEmbeddingProvider(queryText: "team"), cache: nil)
+        await ranker.sync(siteID: "s", documents: documents)
+        let hybrid = SearchKnowledgeTool(index: index, siteID: "s", ranker: ranker)
+        let hybridOut = try! await hybrid.call(arguments: .init(query: "team"))
+        #expect(position(of: "zzz.astro", in: hybridOut) < position(of: "aaa.astro", in: hybridOut))
+    }
+
+    @Test("hybrid mode tolerates a fake provider and still returns matching results")
+    func hybridRanksWithFakeProvider() async {
         let root = makeSite([
             "src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nSubscription plans for teams.",
             "src/pages/about.astro": "---\ntitle: About\n---\n# About\nOur team story.",
@@ -37,7 +81,7 @@ struct SearchKnowledgeToolHybridTests {
         #expect(output.contains("pricing.astro"))
     }
 
-    @Test("without a ranker, output matches the lexical-only tool")
+    @Test("a nil ranker yields pure lexical output")
     func lexicalFallback() async {
         let root = makeSite(["src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nPlans."])
         let index = SiteKnowledgeIndex()

--- a/Tests/AnglesiteCoreTests/SemanticIndexCacheTests.swift
+++ b/Tests/AnglesiteCoreTests/SemanticIndexCacheTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SemanticIndexCache")
+struct SemanticIndexCacheTests {
+    private func tempCacheURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("sem-cache-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("caches/semantic-index.json")
+    }
+
+    @Test("save then load round-trips entries")
+    func roundTrip() throws {
+        let cache = SemanticIndexCache(fileURL: tempCacheURL())
+        let entry = SemanticIndexCache.Entry(docID: "s:doc:a", contentHash: "abc", dimension: 8, vector: [0, 1, 0, 0, 0, 0, 0, 0])
+        try cache.save(["s:doc:a": entry])
+        let loaded = cache.load(expectedDimension: 8)
+        #expect(loaded == ["s:doc:a": entry])
+    }
+
+    @Test("load drops entries with mismatched dimension")
+    func dropsWrongDimension() throws {
+        let cache = SemanticIndexCache(fileURL: tempCacheURL())
+        let entry = SemanticIndexCache.Entry(docID: "s:doc:a", contentHash: "abc", dimension: 8, vector: [0, 1, 0, 0, 0, 0, 0, 0])
+        try cache.save(["s:doc:a": entry])
+        #expect(cache.load(expectedDimension: 16).isEmpty)
+    }
+
+    @Test("load returns empty for a missing file")
+    func missingFile() {
+        let cache = SemanticIndexCache(fileURL: tempCacheURL())
+        #expect(cache.load(expectedDimension: 8).isEmpty)
+    }
+
+    @Test("load returns empty for a corrupt file")
+    func corruptFile() throws {
+        let url = tempCacheURL()
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("not json".utf8).write(to: url)
+        #expect(SemanticIndexCache(fileURL: url).load(expectedDimension: 8).isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SemanticRankerRankTests.swift
+++ b/Tests/AnglesiteCoreTests/SemanticRankerRankTests.swift
@@ -35,6 +35,18 @@ struct SemanticRankerRankTests {
         #expect(ranked.first?.docID == "a")
     }
 
+    @Test("a flat (all-equal) signal contributes 0, letting the other signal decide")
+    func blendFlatSignal() {
+        // All lexical scores equal → no discriminating signal → normalizes to 0, so semantic
+        // decides and the lexical side does not inflate every doc (the #1 review fix).
+        let result = SemanticRanker.blend(
+            lexical: ["a": 5, "b": 5],
+            semantic: ["a": 0, "b": 1],
+            semanticWeight: 0.6)
+        #expect(abs((result["a"] ?? -1) - 0.0) < 0.0001)   // 0.6*0 + 0.4*0
+        #expect(abs((result["b"] ?? -1) - 0.6) < 0.0001)   // 0.6*1 + 0.4*0
+    }
+
     @Test("blend normalizes and weights both signals")
     func blend() {
         let result = SemanticRanker.blend(

--- a/Tests/AnglesiteCoreTests/SemanticRankerRankTests.swift
+++ b/Tests/AnglesiteCoreTests/SemanticRankerRankTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SemanticRanker rank")
+struct SemanticRankerRankTests {
+    private func doc(_ id: String, body: String) -> SiteKnowledgeIndex.Document {
+        SiteKnowledgeIndex.Document(
+            id: id, siteID: "s", path: "\(id).md", kind: .page, title: id,
+            frontmatter: [:], headings: [], internalLinks: [], excerptText: body,
+            lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("related ranks the most similar document first and excludes self")
+    func related() async {
+        let ranker = SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+        await ranker.sync(siteID: "s", documents: [
+            doc("a", body: "pricing plans pricing plans"),
+            doc("b", body: "pricing plans for teams"),   // close to a
+            doc("c", body: "zzzz qqqq wholly different"), // far from a
+        ])
+        let ranked = await ranker.related(siteID: "s", toDocID: "a", limit: 5)
+        #expect(!ranked.contains { $0.docID == "a" })
+        #expect(ranked.first?.docID == "b")
+    }
+
+    @Test("search ranks by similarity to the query text")
+    func search() async {
+        let ranker = SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+        await ranker.sync(siteID: "s", documents: [
+            doc("a", body: "pricing plans for teams"),
+            doc("b", body: "completely unrelated content here"),
+        ])
+        let ranked = await ranker.search(siteID: "s", queryText: "pricing plans for teams", limit: 5)
+        #expect(ranked.first?.docID == "a")
+    }
+
+    @Test("blend normalizes and weights both signals")
+    func blend() {
+        let result = SemanticRanker.blend(
+            lexical: ["a": 10, "b": 0],
+            semantic: ["a": 0, "b": 1],
+            semanticWeight: 0.5)
+        // a: 0.5*0 + 0.5*1 = 0.5 ; b: 0.5*1 + 0.5*0 = 0.5
+        #expect(abs((result["a"] ?? -1) - 0.5) < 0.0001)
+        #expect(abs((result["b"] ?? -1) - 0.5) < 0.0001)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SemanticRankerSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/SemanticRankerSyncTests.swift
@@ -5,6 +5,11 @@ import Testing
 @Suite("SemanticRanker sync")
 struct SemanticRankerSyncTests {
     /// Counts how many times embed() ran, so cache-hit behavior is observable.
+    ///
+    /// `@unchecked Sendable` with an unguarded counter is safe here *only* because
+    /// `SemanticRanker.sync`/`upsert` embed documents strictly sequentially (no `TaskGroup`), so
+    /// `embed` is never called concurrently. If that loop is ever parallelized, replace this with an
+    /// actor or a locked counter.
     final class CountingProvider: EmbeddingProvider, @unchecked Sendable {
         let dimension = 8
         private(set) var calls = 0
@@ -19,6 +24,19 @@ struct SemanticRankerSyncTests {
             id: id, siteID: "s", path: "\(id).md", kind: .page, title: title,
             frontmatter: [:], headings: [], internalLinks: [], excerptText: body,
             lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("embeddedText joins title, headings, and a 2000-char-truncated excerpt")
+    func embeddedTextFormat() {
+        let longBody = String(repeating: "x", count: 5000)
+        let document = SiteKnowledgeIndex.Document(
+            id: "d", siteID: "s", path: "d.md", kind: .page, title: "My Title",
+            frontmatter: [:], headings: ["Intro", "Details"], internalLinks: [], excerptText: longBody,
+            lastModified: Date(timeIntervalSince1970: 0))
+        let text = SemanticRanker.embeddedText(for: document)
+        #expect(text.hasPrefix("My Title\nIntro Details\n"))
+        #expect(text.contains(String(repeating: "x", count: 2000)))
+        #expect(!text.contains(String(repeating: "x", count: 2001)))
     }
 
     @Test("sync embeds each document once")

--- a/Tests/AnglesiteCoreTests/SemanticRankerSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/SemanticRankerSyncTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SemanticRanker sync")
+struct SemanticRankerSyncTests {
+    /// Counts how many times embed() ran, so cache-hit behavior is observable.
+    final class CountingProvider: EmbeddingProvider, @unchecked Sendable {
+        let dimension = 8
+        private(set) var calls = 0
+        func embed(_ text: String) async throws -> [Float] {
+            calls += 1
+            return try await FakeEmbeddingProvider(dimension: 8).embed(text)
+        }
+    }
+
+    private func doc(_ id: String, title: String, body: String) -> SiteKnowledgeIndex.Document {
+        SiteKnowledgeIndex.Document(
+            id: id, siteID: "s", path: "\(id).md", kind: .page, title: title,
+            frontmatter: [:], headings: [], internalLinks: [], excerptText: body,
+            lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("sync embeds each document once")
+    func embedsEach() async {
+        let provider = CountingProvider()
+        let ranker = SemanticRanker(provider: provider, cache: nil)
+        await ranker.sync(siteID: "s", documents: [
+            doc("a", title: "Pricing", body: "plans"),
+            doc("b", title: "About", body: "team"),
+        ])
+        #expect(provider.calls == 2)
+        #expect(await ranker.vectorCount(siteID: "s") == 2)
+    }
+
+    @Test("re-sync with unchanged content does not re-embed")
+    func cachesUnchanged() async {
+        let provider = CountingProvider()
+        let ranker = SemanticRanker(provider: provider, cache: nil)
+        let docs = [doc("a", title: "Pricing", body: "plans")]
+        await ranker.sync(siteID: "s", documents: docs)
+        await ranker.sync(siteID: "s", documents: docs)
+        #expect(provider.calls == 1)
+    }
+
+    @Test("sync drops vectors for removed documents")
+    func dropsRemoved() async {
+        let ranker = SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+        await ranker.sync(siteID: "s", documents: [doc("a", title: "A", body: "x"), doc("b", title: "B", body: "y")])
+        await ranker.sync(siteID: "s", documents: [doc("a", title: "A", body: "x")])
+        #expect(await ranker.vectorCount(siteID: "s") == 1)
+    }
+
+    @Test("cache lets a fresh ranker skip embedding")
+    func warmCacheSkipsEmbed() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sem-\(UUID().uuidString)/caches/semantic-index.json")
+        let docs = [doc("a", title: "Pricing", body: "plans")]
+        let first = SemanticRanker(provider: CountingProvider(), cache: SemanticIndexCache(fileURL: url))
+        await first.sync(siteID: "s", documents: docs)
+
+        let warmProvider = CountingProvider()
+        let second = SemanticRanker(provider: warmProvider, cache: SemanticIndexCache(fileURL: url))
+        await second.sync(siteID: "s", documents: docs)
+        #expect(warmProvider.calls == 0)
+    }
+}

--- a/Tests/AnglesiteCoreTests/VectorMathTests.swift
+++ b/Tests/AnglesiteCoreTests/VectorMathTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite("VectorMath")
+struct VectorMathTests {
+    @Test("cosine of identical unit vectors is 1")
+    func identical() {
+        #expect(abs(VectorMath.cosine([1, 0, 0], [1, 0, 0]) - 1.0) < 0.0001)
+    }
+
+    @Test("cosine of orthogonal vectors is 0")
+    func orthogonal() {
+        #expect(abs(VectorMath.cosine([1, 0], [0, 1])) < 0.0001)
+    }
+
+    @Test("cosine returns 0 for mismatched lengths or zero vectors")
+    func degenerate() {
+        #expect(VectorMath.cosine([1, 0], [1, 0, 0]) == 0)
+        #expect(VectorMath.cosine([0, 0], [1, 0]) == 0)
+    }
+
+    @Test("stableHash is deterministic and content-sensitive")
+    func stableHash() {
+        #expect(VectorMath.stableHash("pricing") == VectorMath.stableHash("pricing"))
+        #expect(VectorMath.stableHash("pricing") != VectorMath.stableHash("about"))
+    }
+}

--- a/docs/superpowers/plans/2026-06-25-semantic-index-foundation-p1.md
+++ b/docs/superpowers/plans/2026-06-25-semantic-index-foundation-p1.md
@@ -1,0 +1,1012 @@
+# Semantic Index Foundation (Plan A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an on-device semantic ranking layer on top of #329's lexical `SiteKnowledgeIndex`, and give the existing `SearchKnowledgeTool` a hybrid (lexical + semantic) mode.
+
+**Architecture:** A `SemanticRanker` actor consumes `SiteKnowledgeIndex.documents(siteID:)`, embeds each document via a swappable `EmbeddingProvider`, caches the vectors in the package's `Config/` dir, and ranks by cosine similarity. Production embeddings come from Apple's `NaturalLanguage` framework on-device; a `FakeEmbeddingProvider` makes all ranking/caching logic CI-testable. The lexical index (#329) is unchanged.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Test`/`@Suite`/`#expect`), Apple `NaturalLanguage` (`NLContextualEmbedding` → `NLEmbedding` fallback), Foundation. No third-party dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-25-semantic-link-assistant-design.md`
+
+## Global Constraints
+
+- **Hard prerequisite:** PR #329 (`SiteKnowledgeIndex`, `SearchKnowledgeTool`, `Document`) merged to `main`. This plan builds against those types as they land.
+- **No external API / no network embedding service** — embeddings are 100% on-device (project strategy).
+- **No third-party Swift dependencies** (Apple frameworks only).
+- **Swift Testing**, not XCTest, for all new tests (`@Suite` / `@Test` / `#expect`).
+- **Toolchain:** Xcode 27 / Swift 6.4. `swift test` requires `DEVELOPER_DIR` pointed at the Xcode 27 toolchain — prefix every test command with `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` (adjust if your Xcode 27 lives elsewhere).
+- **`Config/` is app-owned and never in git** — the embedding cache lives there.
+- New AnglesiteCore types stay free of `FoundationModels` so they compile on CI; only files that already `#if compiler(>=6.4) import FoundationModels` (e.g. `SearchKnowledgeTool`) keep that guard. `NaturalLanguage` needs **no** compiler guard (it compiles on the macOS-15 CI runner; only the model *assets* may be absent at runtime).
+- Run new-suite tests with `swift test --package-path . --filter <SuiteName>`.
+
+---
+
+### Task 1: `EmbeddingProvider` protocol + `FakeEmbeddingProvider`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/EmbeddingProvider.swift`
+- Test: `Tests/AnglesiteCoreTests/EmbeddingProviderTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `protocol EmbeddingProvider: Sendable { var dimension: Int { get }; func embed(_ text: String) async throws -> [Float] }`
+  - `struct FakeEmbeddingProvider: EmbeddingProvider` with `init(dimension: Int = 8)`; deterministic, unit-normalized output; same text → identical vector; throws `EmbeddingError.emptyText` for blank input.
+  - `enum EmbeddingError: Error, Equatable { case emptyText, modelUnavailable }`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("EmbeddingProvider")
+struct EmbeddingProviderTests {
+    @Test("fake provider is deterministic and unit-normalized")
+    func deterministicNormalized() async throws {
+        let provider = FakeEmbeddingProvider(dimension: 8)
+        let a = try await provider.embed("pricing plans for teams")
+        let b = try await provider.embed("pricing plans for teams")
+        #expect(a == b)
+        #expect(a.count == 8)
+        let magnitude = (a.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        #expect(abs(magnitude - 1.0) < 0.0001)
+    }
+
+    @Test("different text yields different vectors")
+    func differentText() async throws {
+        let provider = FakeEmbeddingProvider(dimension: 8)
+        let a = try await provider.embed("pricing")
+        let b = try await provider.embed("about the team")
+        #expect(a != b)
+    }
+
+    @Test("blank text throws emptyText")
+    func blankThrows() async {
+        let provider = FakeEmbeddingProvider(dimension: 8)
+        await #expect(throws: EmbeddingError.emptyText) {
+            _ = try await provider.embed("   ")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter EmbeddingProvider`
+Expected: FAIL — `cannot find 'FakeEmbeddingProvider' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+import Foundation
+
+/// An error surfaced by an ``EmbeddingProvider``.
+public enum EmbeddingError: Error, Equatable {
+    /// The text to embed was empty or whitespace-only.
+    case emptyText
+    /// No on-device embedding model/asset is available at runtime.
+    case modelUnavailable
+}
+
+/// Produces a fixed-length, unit-normalized embedding for a string. The single seam the
+/// semantic ranker depends on, so the model choice (Apple NaturalLanguage in production, a
+/// deterministic fake in tests) is swappable without touching ranking logic.
+public protocol EmbeddingProvider: Sendable {
+    /// The length of every vector this provider returns.
+    var dimension: Int { get }
+    /// Returns a unit-normalized embedding, or throws if the text is empty / no model is available.
+    func embed(_ text: String) async throws -> [Float]
+}
+
+/// Deterministic embedding for tests: a stable bag-of-characters projection, unit-normalized.
+/// Not semantically meaningful — only stable and content-sensitive, which is all the ranker,
+/// cache, and incremental-update tests need.
+public struct FakeEmbeddingProvider: EmbeddingProvider {
+    public let dimension: Int
+
+    public init(dimension: Int = 8) {
+        self.dimension = max(1, dimension)
+    }
+
+    public func embed(_ text: String) async throws -> [Float] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw EmbeddingError.emptyText }
+        var vector = [Float](repeating: 0, count: dimension)
+        for scalar in trimmed.unicodeScalars {
+            vector[Int(scalar.value) % dimension] += 1
+        }
+        let magnitude = (vector.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        guard magnitude > 0 else { throw EmbeddingError.emptyText }
+        return vector.map { $0 / magnitude }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter EmbeddingProvider`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/EmbeddingProvider.swift Tests/AnglesiteCoreTests/EmbeddingProviderTests.swift
+git commit -m "feat(#312): EmbeddingProvider seam + deterministic FakeEmbeddingProvider"
+```
+
+---
+
+### Task 2: `VectorMath` (cosine + stable hash helpers)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/VectorMath.swift`
+- Test: `Tests/AnglesiteCoreTests/VectorMathTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `enum VectorMath` with `static func cosine(_ a: [Float], _ b: [Float]) -> Float` (returns 0 for mismatched lengths or a zero vector) and `static func stableHash(_ text: String) -> String` (FNV-1a 64-bit, hex; identical across process runs — Swift's `Hasher` is per-run randomized and must not be used here).
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite("VectorMath")
+struct VectorMathTests {
+    @Test("cosine of identical unit vectors is 1")
+    func identical() {
+        #expect(abs(VectorMath.cosine([1, 0, 0], [1, 0, 0]) - 1.0) < 0.0001)
+    }
+
+    @Test("cosine of orthogonal vectors is 0")
+    func orthogonal() {
+        #expect(abs(VectorMath.cosine([1, 0], [0, 1])) < 0.0001)
+    }
+
+    @Test("cosine returns 0 for mismatched lengths or zero vectors")
+    func degenerate() {
+        #expect(VectorMath.cosine([1, 0], [1, 0, 0]) == 0)
+        #expect(VectorMath.cosine([0, 0], [1, 0]) == 0)
+    }
+
+    @Test("stableHash is deterministic and content-sensitive")
+    func stableHash() {
+        #expect(VectorMath.stableHash("pricing") == VectorMath.stableHash("pricing"))
+        #expect(VectorMath.stableHash("pricing") != VectorMath.stableHash("about"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter VectorMath`
+Expected: FAIL — `cannot find 'VectorMath' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+import Foundation
+
+/// Small numeric helpers for the semantic index: cosine similarity and a process-stable hash.
+public enum VectorMath {
+    /// Cosine similarity. Returns 0 when lengths differ or either vector has zero magnitude,
+    /// so degenerate inputs rank last instead of crashing.
+    public static func cosine(_ a: [Float], _ b: [Float]) -> Float {
+        guard a.count == b.count, !a.isEmpty else { return 0 }
+        var dot: Float = 0, magA: Float = 0, magB: Float = 0
+        for i in a.indices {
+            dot += a[i] * b[i]
+            magA += a[i] * a[i]
+            magB += b[i] * b[i]
+        }
+        guard magA > 0, magB > 0 else { return 0 }
+        return dot / (magA.squareRoot() * magB.squareRoot())
+    }
+
+    /// FNV-1a 64-bit hash as hex. Stable across process runs (unlike `Hasher`), so it is safe
+    /// as a cache-invalidation key for embedded text.
+    public static func stableHash(_ text: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in text.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x100000001b3
+        }
+        return String(hash, radix: 16)
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter VectorMath`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/VectorMath.swift Tests/AnglesiteCoreTests/VectorMathTests.swift
+git commit -m "feat(#312): VectorMath cosine + process-stable FNV-1a hash"
+```
+
+---
+
+### Task 3: `SemanticIndexCache` (Config/ persistence of embeddings)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SemanticIndexCache.swift`
+- Test: `Tests/AnglesiteCoreTests/SemanticIndexCacheTests.swift`
+
+**Interfaces:**
+- Consumes: `VectorMath` (indirectly, via callers).
+- Produces:
+  - `struct SemanticIndexCache.Entry: Codable, Equatable, Sendable { let docID: String; let contentHash: String; let dimension: Int; let vector: [Float] }`
+  - `struct SemanticIndexCache` with `init(fileURL: URL)`, `func load(expectedDimension: Int) -> [String: Entry]` (returns `[docID: Entry]`; drops entries whose `dimension` ≠ `expectedDimension`; returns empty on missing/corrupt file), and `func save(_ entries: [String: Entry]) throws` (creates parent dirs; atomic write).
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SemanticIndexCache")
+struct SemanticIndexCacheTests {
+    private func tempCacheURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("sem-cache-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("caches/semantic-index.json")
+    }
+
+    @Test("save then load round-trips entries")
+    func roundTrip() throws {
+        let cache = SemanticIndexCache(fileURL: tempCacheURL())
+        let entry = SemanticIndexCache.Entry(docID: "s:doc:a", contentHash: "abc", dimension: 8, vector: [0, 1, 0, 0, 0, 0, 0, 0])
+        try cache.save(["s:doc:a": entry])
+        let loaded = cache.load(expectedDimension: 8)
+        #expect(loaded == ["s:doc:a": entry])
+    }
+
+    @Test("load drops entries with mismatched dimension")
+    func dropsWrongDimension() throws {
+        let cache = SemanticIndexCache(fileURL: tempCacheURL())
+        let entry = SemanticIndexCache.Entry(docID: "s:doc:a", contentHash: "abc", dimension: 8, vector: [0, 1, 0, 0, 0, 0, 0, 0])
+        try cache.save(["s:doc:a": entry])
+        #expect(cache.load(expectedDimension: 16).isEmpty)
+    }
+
+    @Test("load returns empty for a missing file")
+    func missingFile() {
+        let cache = SemanticIndexCache(fileURL: tempCacheURL())
+        #expect(cache.load(expectedDimension: 8).isEmpty)
+    }
+
+    @Test("load returns empty for a corrupt file")
+    func corruptFile() throws {
+        let url = tempCacheURL()
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("not json".utf8).write(to: url)
+        #expect(SemanticIndexCache(fileURL: url).load(expectedDimension: 8).isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SemanticIndexCache`
+Expected: FAIL — `cannot find 'SemanticIndexCache' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+import Foundation
+
+/// On-disk cache of document embeddings, one file per site under the package's app-owned
+/// `Config/caches/` (never in git). Embeddings are expensive to recompute; the lexical index
+/// itself stays in-memory (see #329). Invalidation is by `contentHash` (caller-checked) and by
+/// `dimension` (checked here on load).
+public struct SemanticIndexCache: Sendable {
+    public struct Entry: Codable, Equatable, Sendable {
+        public let docID: String
+        public let contentHash: String
+        public let dimension: Int
+        public let vector: [Float]
+
+        public init(docID: String, contentHash: String, dimension: Int, vector: [Float]) {
+            self.docID = docID
+            self.contentHash = contentHash
+            self.dimension = dimension
+            self.vector = vector
+        }
+    }
+
+    private let fileURL: URL
+
+    public init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    /// Loads `[docID: Entry]`. Entries whose `dimension` differs from `expectedDimension` are
+    /// dropped (the provider changed). A missing or corrupt file yields an empty map — never fatal.
+    public func load(expectedDimension: Int) -> [String: Entry] {
+        guard let data = try? Data(contentsOf: fileURL),
+              let entries = try? JSONDecoder().decode([Entry].self, from: data) else {
+            return [:]
+        }
+        var out: [String: Entry] = [:]
+        for entry in entries where entry.dimension == expectedDimension {
+            out[entry.docID] = entry
+        }
+        return out
+    }
+
+    /// Atomically writes the entries, creating the parent directory if needed.
+    public func save(_ entries: [String: Entry]) throws {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(entries.values.sorted { $0.docID < $1.docID })
+        try data.write(to: fileURL, options: .atomic)
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SemanticIndexCache`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SemanticIndexCache.swift Tests/AnglesiteCoreTests/SemanticIndexCacheTests.swift
+git commit -m "feat(#312): SemanticIndexCache — Config/ embedding persistence + invalidation"
+```
+
+---
+
+### Task 4: `SemanticRanker` — sync / incremental embedding with cache
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SemanticRanker.swift`
+- Test: `Tests/AnglesiteCoreTests/SemanticRankerSyncTests.swift`
+
+**Interfaces:**
+- Consumes: `EmbeddingProvider`, `SemanticIndexCache`, `VectorMath.stableHash`, and `SiteKnowledgeIndex.Document` (from #329 — has `id`, `title`, `headings`, `excerptText`).
+- Produces:
+  - `actor SemanticRanker` with `init(provider: EmbeddingProvider, cache: SemanticIndexCache?)`.
+  - `func sync(siteID: String, documents: [SiteKnowledgeIndex.Document]) async` — embeds each doc whose `contentHash` is new/changed (cache hit → reuse; miss → `provider.embed`), removes vectors for docs no longer present, writes the cache when a `cache` was supplied.
+  - `func upsert(siteID: String, document: SiteKnowledgeIndex.Document) async` and `func remove(siteID: String, docID: String) async` for incremental updates.
+  - `func vectorCount(siteID: String) async -> Int` (test/inspection helper).
+  - Internal `static func embeddedText(for:) -> String` = `title` + `headings` joined + leading slice of `excerptText`.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SemanticRanker sync")
+struct SemanticRankerSyncTests {
+    /// Counts how many times embed() ran, so cache-hit behavior is observable.
+    final class CountingProvider: EmbeddingProvider, @unchecked Sendable {
+        let dimension = 8
+        private(set) var calls = 0
+        func embed(_ text: String) async throws -> [Float] {
+            calls += 1
+            return try await FakeEmbeddingProvider(dimension: 8).embed(text)
+        }
+    }
+
+    private func doc(_ id: String, title: String, body: String) -> SiteKnowledgeIndex.Document {
+        SiteKnowledgeIndex.Document(
+            id: id, siteID: "s", path: "\(id).md", kind: .page, title: title,
+            frontmatter: [:], headings: [], internalLinks: [], excerptText: body,
+            lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("sync embeds each document once")
+    func embedsEach() async {
+        let provider = CountingProvider()
+        let ranker = SemanticRanker(provider: provider, cache: nil)
+        await ranker.sync(siteID: "s", documents: [
+            doc("a", title: "Pricing", body: "plans"),
+            doc("b", title: "About", body: "team"),
+        ])
+        #expect(provider.calls == 2)
+        #expect(await ranker.vectorCount(siteID: "s") == 2)
+    }
+
+    @Test("re-sync with unchanged content does not re-embed")
+    func cachesUnchanged() async {
+        let provider = CountingProvider()
+        let ranker = SemanticRanker(provider: provider, cache: nil)
+        let docs = [doc("a", title: "Pricing", body: "plans")]
+        await ranker.sync(siteID: "s", documents: docs)
+        await ranker.sync(siteID: "s", documents: docs)
+        #expect(provider.calls == 1)
+    }
+
+    @Test("sync drops vectors for removed documents")
+    func dropsRemoved() async {
+        let ranker = SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+        await ranker.sync(siteID: "s", documents: [doc("a", title: "A", body: "x"), doc("b", title: "B", body: "y")])
+        await ranker.sync(siteID: "s", documents: [doc("a", title: "A", body: "x")])
+        #expect(await ranker.vectorCount(siteID: "s") == 1)
+    }
+
+    @Test("cache lets a fresh ranker skip embedding")
+    func warmCacheSkipsEmbed() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sem-\(UUID().uuidString)/caches/semantic-index.json")
+        let docs = [doc("a", title: "Pricing", body: "plans")]
+        let first = SemanticRanker(provider: CountingProvider(), cache: SemanticIndexCache(fileURL: url))
+        await first.sync(siteID: "s", documents: docs)
+
+        let warmProvider = CountingProvider()
+        let second = SemanticRanker(provider: warmProvider, cache: SemanticIndexCache(fileURL: url))
+        await second.sync(siteID: "s", documents: docs)
+        #expect(warmProvider.calls == 0)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter "SemanticRanker sync"`
+Expected: FAIL — `cannot find 'SemanticRanker' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+import Foundation
+
+/// On-device semantic ranking layer over #329's lexical ``SiteKnowledgeIndex``. Holds one
+/// embedding vector per document, persisted via ``SemanticIndexCache``. The lexical index is
+/// untouched; this is purely additive.
+public actor SemanticRanker {
+    private struct Stored {
+        let contentHash: String
+        let vector: [Float]
+    }
+
+    private let provider: EmbeddingProvider
+    private let cache: SemanticIndexCache?
+    /// `[siteID: [docID: Stored]]`.
+    private var vectorsBySite: [String: [String: Stored]] = [:]
+
+    public init(provider: EmbeddingProvider, cache: SemanticIndexCache?) {
+        self.provider = provider
+        self.cache = cache
+    }
+
+    /// Text fed to the embedder: title + headings + a leading slice of the body. Document-level
+    /// granularity (v0); chunking is a later extension.
+    static func embeddedText(for document: SiteKnowledgeIndex.Document) -> String {
+        var parts: [String] = []
+        if let title = document.title, !title.isEmpty { parts.append(title) }
+        if !document.headings.isEmpty { parts.append(document.headings.joined(separator: " ")) }
+        parts.append(String(document.excerptText.prefix(2000)))
+        return parts.joined(separator: "\n")
+    }
+
+    public func sync(siteID: String, documents: [SiteKnowledgeIndex.Document]) async {
+        // Seed from the cold cache on first touch of this site.
+        if vectorsBySite[siteID] == nil, let cache {
+            let entries = cache.load(expectedDimension: provider.dimension)
+            vectorsBySite[siteID] = entries.mapValues { Stored(contentHash: $0.contentHash, vector: $0.vector) }
+        }
+        var current = vectorsBySite[siteID] ?? [:]
+        var next: [String: Stored] = [:]
+        for document in documents {
+            let hash = VectorMath.stableHash(Self.embeddedText(for: document))
+            if let existing = current[document.id], existing.contentHash == hash {
+                next[document.id] = existing
+                continue
+            }
+            if let vector = try? await provider.embed(Self.embeddedText(for: document)) {
+                next[document.id] = Stored(contentHash: hash, vector: vector)
+            }
+        }
+        vectorsBySite[siteID] = next
+        current = next
+        persist(siteID: siteID)
+    }
+
+    public func upsert(siteID: String, document: SiteKnowledgeIndex.Document) async {
+        let hash = VectorMath.stableHash(Self.embeddedText(for: document))
+        if let existing = vectorsBySite[siteID]?[document.id], existing.contentHash == hash { return }
+        guard let vector = try? await provider.embed(Self.embeddedText(for: document)) else { return }
+        vectorsBySite[siteID, default: [:]][document.id] = Stored(contentHash: hash, vector: vector)
+        persist(siteID: siteID)
+    }
+
+    public func remove(siteID: String, docID: String) async {
+        vectorsBySite[siteID]?[docID] = nil
+        persist(siteID: siteID)
+    }
+
+    public func vectorCount(siteID: String) -> Int {
+        vectorsBySite[siteID]?.count ?? 0
+    }
+
+    private func persist(siteID: String) {
+        guard let cache, let stored = vectorsBySite[siteID] else { return }
+        let entries = stored.mapValues {
+            SemanticIndexCache.Entry(docID: "", contentHash: $0.contentHash, dimension: provider.dimension, vector: $0.vector)
+        }
+        // Re-stamp docID from the key (Entry needs it for round-trip).
+        var keyed: [String: SemanticIndexCache.Entry] = [:]
+        for (docID, entry) in entries {
+            keyed[docID] = SemanticIndexCache.Entry(docID: docID, contentHash: entry.contentHash, dimension: entry.dimension, vector: entry.vector)
+        }
+        try? cache.save(keyed)
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter "SemanticRanker sync"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SemanticRanker.swift Tests/AnglesiteCoreTests/SemanticRankerSyncTests.swift
+git commit -m "feat(#312): SemanticRanker sync — incremental embedding with Config/ cache"
+```
+
+---
+
+### Task 5: `SemanticRanker` — ranking queries + hybrid blend
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SemanticRanker.swift`
+- Test: `Tests/AnglesiteCoreTests/SemanticRankerRankTests.swift`
+
+**Interfaces:**
+- Consumes: the `vectorsBySite` store from Task 4, `VectorMath.cosine`, `EmbeddingProvider`.
+- Produces (added to `SemanticRanker`):
+  - `struct Ranked: Sendable, Equatable { let docID: String; let score: Float }`
+  - `func related(siteID: String, toDocID: String, limit: Int) async -> [Ranked]` — cosine of the source doc's vector vs every other same-site vector, descending, self excluded.
+  - `func search(siteID: String, queryText: String, limit: Int) async -> [Ranked]` — embeds `queryText`, ranks by cosine.
+  - `static func blend(lexical: [String: Double], semantic: [String: Double], semanticWeight: Double) -> [String: Double]` — min-max normalizes each map to 0…1 and returns `semanticWeight * sem + (1 - semanticWeight) * lex` per docID (union of keys; a missing side counts 0).
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SemanticRanker rank")
+struct SemanticRankerRankTests {
+    private func doc(_ id: String, body: String) -> SiteKnowledgeIndex.Document {
+        SiteKnowledgeIndex.Document(
+            id: id, siteID: "s", path: "\(id).md", kind: .page, title: id,
+            frontmatter: [:], headings: [], internalLinks: [], excerptText: body,
+            lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("related ranks the most similar document first and excludes self")
+    func related() async {
+        let ranker = SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+        await ranker.sync(siteID: "s", documents: [
+            doc("a", body: "pricing plans pricing plans"),
+            doc("b", body: "pricing plans for teams"),   // close to a
+            doc("c", body: "zzzz qqqq wholly different"), // far from a
+        ])
+        let ranked = await ranker.related(siteID: "s", toDocID: "a", limit: 5)
+        #expect(!ranked.contains { $0.docID == "a" })
+        #expect(ranked.first?.docID == "b")
+    }
+
+    @Test("search ranks by similarity to the query text")
+    func search() async {
+        let ranker = SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+        await ranker.sync(siteID: "s", documents: [
+            doc("a", body: "pricing plans for teams"),
+            doc("b", body: "completely unrelated content here"),
+        ])
+        let ranked = await ranker.search(siteID: "s", queryText: "pricing plans for teams", limit: 5)
+        #expect(ranked.first?.docID == "a")
+    }
+
+    @Test("blend normalizes and weights both signals")
+    func blend() {
+        let result = SemanticRanker.blend(
+            lexical: ["a": 10, "b": 0],
+            semantic: ["a": 0, "b": 1],
+            semanticWeight: 0.5)
+        // a: 0.5*0 + 0.5*1 = 0.5 ; b: 0.5*1 + 0.5*0 = 0.5
+        #expect(abs((result["a"] ?? -1) - 0.5) < 0.0001)
+        #expect(abs((result["b"] ?? -1) - 0.5) < 0.0001)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter "SemanticRanker rank"`
+Expected: FAIL — `value of type 'SemanticRanker' has no member 'related'`.
+
+- [ ] **Step 3: Write minimal implementation** — append to `SemanticRanker.swift`, inside the actor for the instance methods and as a `nonisolated static` for `blend`:
+
+```swift
+    public struct Ranked: Sendable, Equatable {
+        public let docID: String
+        public let score: Float
+        public init(docID: String, score: Float) { self.docID = docID; self.score = score }
+    }
+
+    public func related(siteID: String, toDocID: String, limit: Int) -> [Ranked] {
+        guard let store = vectorsBySite[siteID], let source = store[toDocID] else { return [] }
+        return rank(store: store, against: source.vector, excluding: toDocID, limit: limit)
+    }
+
+    public func search(siteID: String, queryText: String, limit: Int) async -> [Ranked] {
+        guard let store = vectorsBySite[siteID], let queryVector = try? await provider.embed(queryText) else { return [] }
+        return rank(store: store, against: queryVector, excluding: nil, limit: limit)
+    }
+
+    private func rank(store: [String: Stored], against query: [Float], excluding: String?, limit: Int) -> [Ranked] {
+        store.compactMap { docID, stored -> Ranked? in
+            if docID == excluding { return nil }
+            return Ranked(docID: docID, score: VectorMath.cosine(query, stored.vector))
+        }
+        .sorted { $0.score != $1.score ? $0.score > $1.score : $0.docID < $1.docID }
+        .prefix(max(0, limit))
+        .map { $0 }
+    }
+
+    /// Min-max normalizes each signal to 0…1, then returns the weighted sum per docID over the
+    /// union of keys (a docID absent from one side contributes 0 there).
+    public nonisolated static func blend(
+        lexical: [String: Double], semantic: [String: Double], semanticWeight: Double
+    ) -> [String: Double] {
+        func normalize(_ map: [String: Double]) -> [String: Double] {
+            guard let lo = map.values.min(), let hi = map.values.max(), hi > lo else {
+                return map.mapValues { _ in map.isEmpty ? 0 : 1 }
+            }
+            return map.mapValues { ($0 - lo) / (hi - lo) }
+        }
+        let lex = normalize(lexical), sem = normalize(semantic)
+        let w = min(max(semanticWeight, 0), 1)
+        var out: [String: Double] = [:]
+        for docID in Set(lex.keys).union(sem.keys) {
+            out[docID] = w * (sem[docID] ?? 0) + (1 - w) * (lex[docID] ?? 0)
+        }
+        return out
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter "SemanticRanker rank"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SemanticRanker.swift Tests/AnglesiteCoreTests/SemanticRankerRankTests.swift
+git commit -m "feat(#312): SemanticRanker related/search queries + hybrid blend"
+```
+
+---
+
+### Task 6: `NLEmbeddingProvider` (production, on-device)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/NLEmbeddingProvider.swift`
+- Test: `Tests/AnglesiteCoreTests/NLEmbeddingProviderTests.swift`
+
+**Interfaces:**
+- Consumes: `EmbeddingProvider`, `NaturalLanguage`.
+- Produces: `struct NLEmbeddingProvider: EmbeddingProvider` with `init?(language: NLLanguage = .english)` (fails init if no sentence-embedding model is available, so callers fall back to lexical-only). `dimension` reflects the loaded model; `embed` returns the model vector unit-normalized, throwing `EmbeddingError.emptyText` for blank input.
+
+> Rationale: `NLEmbedding.sentenceEmbedding` is synchronous, asset-free, and available on the CI runner, so it is the dependable production default. `NLContextualEmbedding` (higher quality, multilingual) is a later swap behind the same protocol — deferred so this task stays CI-verifiable. The smoke test self-skips when no model is present.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Foundation
+import NaturalLanguage
+import Testing
+@testable import AnglesiteCore
+
+@Suite("NLEmbeddingProvider")
+struct NLEmbeddingProviderTests {
+    @Test("when a model is available, embeddings are unit-normalized and similar text ranks closer")
+    func embeds() async throws {
+        guard let provider = NLEmbeddingProvider() else {
+            // No sentence-embedding asset on this host (e.g. minimal CI image) — nothing to verify.
+            return
+        }
+        let pricing = try await provider.embed("our pricing and subscription plans")
+        let plans = try await provider.embed("subscription pricing tiers")
+        let weather = try await provider.embed("today's weather forecast")
+        let magnitude = (pricing.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        #expect(abs(magnitude - 1.0) < 0.001)
+        #expect(VectorMath.cosine(pricing, plans) > VectorMath.cosine(pricing, weather))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter NLEmbeddingProvider`
+Expected: FAIL — `cannot find 'NLEmbeddingProvider' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+import Foundation
+import NaturalLanguage
+
+/// Production ``EmbeddingProvider`` backed by Apple's on-device `NLEmbedding.sentenceEmbedding`.
+/// Synchronous and asset-light, so it works without a network embedding service (project
+/// strategy). Returns `nil` from init when no model is available, letting callers degrade to
+/// lexical-only ranking.
+public struct NLEmbeddingProvider: EmbeddingProvider {
+    private let embedding: NLEmbedding
+    public let dimension: Int
+
+    public init?(language: NLLanguage = .english) {
+        guard let embedding = NLEmbedding.sentenceEmbedding(for: language) else { return nil }
+        self.embedding = embedding
+        self.dimension = embedding.dimension
+    }
+
+    public func embed(_ text: String) async throws -> [Float] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw EmbeddingError.emptyText }
+        guard let raw = embedding.vector(for: trimmed) else { throw EmbeddingError.modelUnavailable }
+        let floats = raw.map { Float($0) }
+        let magnitude = (floats.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        guard magnitude > 0 else { throw EmbeddingError.modelUnavailable }
+        return floats.map { $0 / magnitude }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter NLEmbeddingProvider`
+Expected: PASS (1 test — verifies real ranking if a model is present, no-ops otherwise).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NLEmbeddingProvider.swift Tests/AnglesiteCoreTests/NLEmbeddingProviderTests.swift
+git commit -m "feat(#312): NLEmbeddingProvider — on-device NaturalLanguage embeddings"
+```
+
+---
+
+### Task 7: `SearchKnowledgeTool` hybrid (lexical + semantic) mode
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SearchKnowledgeTool.swift`
+- Test: `Tests/AnglesiteCoreTests/SearchKnowledgeToolHybridTests.swift`
+
+**Interfaces:**
+- Consumes: `SiteKnowledgeIndex` (lexical results), `SemanticRanker.search`, `SemanticRanker.blend`.
+- Produces: `SearchKnowledgeTool.init(index:siteID:ranker:)` gains an optional `ranker: SemanticRanker? = nil`. When a ranker is present, `call` blends lexical scores (from `index.search`) with semantic scores (from `ranker.search`) via `SemanticRanker.blend(..., semanticWeight: 0.6)`, re-ordering the lexical `SearchResult`s by blended score before formatting. When `ranker == nil` (or it returns nothing), behavior is byte-for-byte the existing lexical output.
+
+> Keep `@Generable Arguments`, the empty-query guard, and the output string format from #329 unchanged — only the ordering of results changes when a ranker is attached.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SearchKnowledgeTool hybrid")
+struct SearchKnowledgeToolHybridTests {
+    private func makeSite(_ files: [String: String]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("khybrid-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    @Test("hybrid mode returns results and does not crash with a fake provider")
+    func hybridRanks() async {
+        let root = makeSite([
+            "src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nSubscription plans for teams.",
+            "src/pages/about.astro": "---\ntitle: About\n---\n# About\nOur team story.",
+        ])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "s", projectRoot: root)
+        let ranker = SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+        await ranker.sync(siteID: "s", documents: await index.documents(siteID: "s"))
+
+        let tool = SearchKnowledgeTool(index: index, siteID: "s", ranker: ranker)
+        let output = try! await tool.call(arguments: .init(query: "subscription pricing plans"))
+        #expect(output.contains("pricing.astro"))
+    }
+
+    @Test("without a ranker, output matches the lexical-only tool")
+    func lexicalFallback() async {
+        let root = makeSite(["src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nPlans."])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "s", projectRoot: root)
+        let lexicalOnly = SearchKnowledgeTool(index: index, siteID: "s")
+        let output = try! await lexicalOnly.call(arguments: .init(query: "pricing"))
+        #expect(output.contains("pricing.astro"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter "SearchKnowledgeTool hybrid"`
+Expected: FAIL — `extra argument 'ranker' in call`.
+
+- [ ] **Step 3: Write minimal implementation** — update the stored props, init, and `call` in `SearchKnowledgeTool.swift`:
+
+```swift
+    private let index: SiteKnowledgeIndex
+    private let siteID: String
+    private let ranker: SemanticRanker?
+
+    public init(index: SiteKnowledgeIndex, siteID: String, ranker: SemanticRanker? = nil) {
+        self.index = index
+        self.siteID = siteID
+        self.ranker = ranker
+    }
+
+    public func call(arguments: Arguments) async throws -> String {
+        let query = arguments.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            return "Provide a project search query."
+        }
+        var results = await index.search(siteID: siteID, query: query, options: .init(limit: 6))
+        if let ranker {
+            let semantic = await ranker.search(siteID: siteID, queryText: query, limit: 50)
+            if !semantic.isEmpty {
+                let lexicalScores = Dictionary(results.map { ($0.document.id, $0.score) }, uniquingKeysWith: max)
+                let semanticScores = Dictionary(semantic.map { ($0.docID, Double($0.score)) }, uniquingKeysWith: max)
+                let blended = SemanticRanker.blend(lexical: lexicalScores, semantic: semanticScores, semanticWeight: 0.6)
+                results = results.sorted {
+                    (blended[$0.document.id] ?? 0) != (blended[$1.document.id] ?? 0)
+                        ? (blended[$0.document.id] ?? 0) > (blended[$1.document.id] ?? 0)
+                        : $0.document.path < $1.document.path
+                }
+            }
+        }
+        guard !results.isEmpty else { return "No matching project context." }
+
+        return results.map { result in
+            let lineLabel: String
+            if let range = result.lineRange {
+                lineLabel = ":\(range.lowerBound)"
+            } else {
+                lineLabel = ""
+            }
+            let title = result.document.title.map { " - \($0)" } ?? ""
+            return """
+            \(result.document.kind.rawValue.uppercased())  \(result.document.path)\(lineLabel)\(title)
+            \(result.excerpt)
+            """
+        }.joined(separator: "\n\n")
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter "SearchKnowledgeTool"`
+Expected: PASS (both the new hybrid suite and #329's existing `SearchKnowledgeTool` coverage in `OnDeviceToolsTests`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SearchKnowledgeTool.swift Tests/AnglesiteCoreTests/SearchKnowledgeToolHybridTests.swift
+git commit -m "feat(#312): SearchKnowledgeTool hybrid lexical+semantic ranking"
+```
+
+---
+
+### Task 8: Wire `SemanticRanker` through the runtime
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/LocalSiteRuntime.swift` (construct + own a `SemanticRanker` next to the `SiteKnowledgeIndex`; call `ranker.sync` after the index `rebuild`, and `unload`/clear on site close)
+- Modify: `Sources/AnglesiteCore/FoundationModelAssistant.swift` (accept an optional `semanticRanker` and pass it into `SearchKnowledgeTool(index:siteID:ranker:)` at line ~342)
+- Modify: `Sources/AnglesiteApp/PreviewModel.swift` and `Sources/AnglesiteApp/SiteWindow.swift` (thread the ranker through exactly where #329 threads the `knowledgeIndex`)
+- Test: `Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift` (extend the existing assistant-wiring test)
+
+**Interfaces:**
+- Consumes: `SemanticRanker`, `NLEmbeddingProvider`, `SemanticIndexCache`, `SiteKnowledgeIndex`, `AnglesitePackage` (for the `Config/` dir → cache file URL).
+- Produces: a live `SemanticRanker` per open site, kept in sync with the lexical index, attached to the on-device tool. The cache file URL is `<package>/Config/caches/semantic-index.json` via `AnglesitePackage`'s config-directory accessor.
+
+- [ ] **Step 1: Write the failing test** — extend `OnDeviceToolsTests` to assert the assistant still advertises `searchKnowledge` when a ranker is attached:
+
+```swift
+@Test("assistant attaches searchKnowledge tool when a semantic ranker is present")
+func attachesKnowledgeToolWithRanker() async {
+    let index = SiteKnowledgeIndex()
+    let ranker = SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+    let assistant = FoundationModelAssistant(knowledgeIndex: index, semanticRanker: ranker)
+    #expect(assistant.capabilities.supportsTools)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter OnDeviceTools`
+Expected: FAIL — `extra argument 'semanticRanker' in call`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `FoundationModelAssistant.swift`: add `private let semanticRanker: SemanticRanker?`, add `semanticRanker: SemanticRanker? = nil` to `init` (store it), and change the knowledge-tool construction:
+
+```swift
+        if let knowledgeIndex {
+            tools.append(SearchKnowledgeTool(index: knowledgeIndex, siteID: context.siteID, ranker: semanticRanker))
+        }
+```
+
+In `LocalSiteRuntime.swift`, alongside the existing `SiteKnowledgeIndex` lifecycle, construct the ranker once per runtime:
+
+```swift
+        let cacheURL = package.configDirectory
+            .appendingPathComponent("caches/semantic-index.json")
+        let ranker = SemanticRanker(
+            provider: NLEmbeddingProvider() ?? FakeEmbeddingProvider(),
+            cache: SemanticIndexCache(fileURL: cacheURL))
+```
+
+and after the knowledge index `rebuild` completes:
+
+```swift
+        await ranker.sync(siteID: siteID, documents: await knowledgeIndex.documents(siteID: siteID))
+```
+
+Thread `ranker` into `FoundationModelAssistant(...)` and through `PreviewModel` / `SiteWindow` at the same call sites that already pass `knowledgeIndex` (follow #329's diff in those two files). Use `package.configDirectory` if it exists; otherwise the package's `Config/` URL accessor from `AnglesitePackage` — confirm the exact name when implementing (`AnglesitePackage`/`SiteStore.Site` exposes `configDirectory`).
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .`
+Expected: PASS — all prior suites plus the new `OnDeviceTools` assertion. Then build the app to confirm the App-target wiring compiles:
+`xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+(run `xcodegen generate` + `scripts/copy-plugin.sh` first if in a fresh worktree).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/LocalSiteRuntime.swift Sources/AnglesiteCore/FoundationModelAssistant.swift Sources/AnglesiteApp/PreviewModel.swift Sources/AnglesiteApp/SiteWindow.swift Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+git commit -m "feat(#312): wire SemanticRanker through runtime + on-device assistant"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan A scope):**
+- `EmbeddingProvider` seam + on-device engine → Tasks 1, 6. ✅
+- `SemanticRanker` consuming `SiteKnowledgeIndex.documents`, document-level granularity with chunk seam noted → Tasks 4, 5. ✅
+- `Config/` embedding cache, content-hash + dimension invalidation, in-memory lexical untouched → Task 3, used in 4 & 8. ✅
+- Hybrid (lexical + semantic) ranking → Task 5 (`blend`), Task 7 (tool). ✅
+- `SearchKnowledgeTool` semantic upgrade consumer → Task 7. ✅
+- Graceful degradation to lexical when no model → `NLEmbeddingProvider?` init + `try?` in ranker + `ranker == nil` path in tool (Tasks 6, 4, 7). ✅
+- Runtime wiring mirroring #329 → Task 8. ✅
+- **Deferred to Plan B (Related-Pages panel + insertion):** `LinkGraph`, `RelatedPagesProvider`, the SwiftUI panel, link insertion via `EditRouter`. Out of this plan by design.
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases" — every code step is complete. The one runtime-name caveat (Task 8: confirm `configDirectory` accessor) is an explicit verify-the-name instruction against a known type, not a missing implementation. ✅
+
+**Type consistency:** `EmbeddingProvider.embed`/`dimension`, `EmbeddingError.{emptyText,modelUnavailable}`, `SemanticIndexCache.Entry{docID,contentHash,dimension,vector}`, `SemanticRanker.{sync,upsert,remove,related,search,blend,vectorCount,Ranked,Stored,embeddedText}`, `SearchKnowledgeTool.init(index:siteID:ranker:)`, `FoundationModelAssistant(... semanticRanker:)` — all consistent across tasks. ✅
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-25-semantic-index-foundation-p1.md`.

--- a/docs/superpowers/specs/2026-06-25-semantic-link-assistant-design.md
+++ b/docs/superpowers/specs/2026-06-25-semantic-link-assistant-design.md
@@ -1,0 +1,218 @@
+# On-device Semantic Index + Internal Link Assistant — Design
+
+**Date:** 2026-06-25
+**Issues:** #312 (AI Internal Link Assistant), foundation of #307 / #311 (RAG knowledge index)
+**Status:** Approved — pending implementation plan
+**Hard prerequisite:** PR #329 (`SiteKnowledgeIndex`, #307 lexical index) merged to `main`
+
+## Summary
+
+Add an **on-device semantic ranking layer** on top of the lexical `SiteKnowledgeIndex`
+landing in PR #329, and use it to ship the #312 Internal Link Assistant: a Related-Pages
+panel that suggests semantically relevant internal links while editing, plus a semantic
+upgrade to the existing `SearchKnowledgeTool` so the AI-editing path benefits too.
+
+The semantic layer is the reusable foundation the rest of the #307–314 cluster
+(RAG Q&A, related content, dead-asset detection) can later consume — but this spec owns
+only the index's semantic layer and the #312 consumers. Full RAG retrieval and the other
+cluster features are out of scope and get their own specs.
+
+## Goals
+
+- Rank a site's pages/posts by **semantic similarity**, not just keyword matching (#312's
+  core requirement), entirely **on-device** with no external API (project strategy:
+  Apple Intelligence / NaturalLanguage, no network embedding service).
+- Deliver the #312 link assistant: a Related-Pages side panel with confidence scores,
+  one-click link insertion, and ignore.
+- Surface the cheap link-graph wins (reciprocal links, isolated pages, over-linking) from
+  data #329 already extracts.
+- Leave a clean, additive seam so chunk-level granularity and the broader RAG cluster can
+  build on this later.
+
+## Non-goals
+
+- Inline-while-typing suggestions in the edit overlay (a follow-up consumer).
+- A whole-site link/SEO audit report (future #310-style spec).
+- Full RAG question-answering retrieval / citations beyond what #329 already provides.
+- Chunk-level (paragraph) embeddings — the API is designed to accept them later, but v0 is
+  document-level only.
+- Cloudflare Vectorize / remote index (a future extension noted in #307).
+
+## Background: what PR #329 provides
+
+PR #329 (`codex/implement-307`) lands `SiteKnowledgeIndex`, an actor that is the lexical
+foundation. This spec builds **on top of it** and does not duplicate it.
+
+`SiteKnowledgeIndex` already:
+
+- Walks the whole project (`src/pages`, `src/content`, `src/components`, `src/layouts`,
+  config, CSS, scripts — broader than `ContentScanner`), skipping `.astro`, `.git`, `dist`,
+  `node_modules`, etc., capping files at 512 KB.
+- Produces a `Document` per file carrying: `path`, `kind` (page/post/component/layout/
+  content/config/style/script/other), `title`, parsed `frontmatter`, `headings`,
+  **`internalLinks`**, full `excerptText` (source), and `lastModified`.
+- Scores documents lexically (term + phrase, field-weighted) and returns cited
+  `SearchResult`s with line ranges via `search(siteID:query:options:)`.
+- Maintains the index in-memory with `rebuild` / `upsertFile` / `removeFile` / `unload`,
+  wired through `PreviewModel`, `SiteWindow`, `LocalSiteRuntime`, and exposed to the
+  on-device model via `SearchKnowledgeTool`.
+
+It is **intentionally lexical** — no embeddings. That gap is exactly what this spec fills.
+
+## Architecture
+
+Two new units in `AnglesiteCore`, one upgrade, one new view.
+
+### `EmbeddingProvider` (protocol — the testable seam)
+
+```swift
+public protocol EmbeddingProvider: Sendable {
+    var dimension: Int { get }
+    /// Returns a unit-normalized embedding, or throws if no model/asset is available.
+    func embed(_ text: String) async throws -> [Float]
+}
+```
+
+- **Production:** `NLContextualEmbeddingProvider` — Apple's on-device transformer embedding
+  (`NLContextualEmbedding`), mean-pooled to a single passage vector, multilingual (matters
+  for i18n sites). If the contextual asset is unavailable at runtime it falls back to
+  `NLEmbedding.sentenceEmbedding(for:)`. Gated/structured like the existing on-device code so
+  its absence on CI is handled, not fatal.
+- **Tests:** `FakeEmbeddingProvider` — deterministic vectors so all ranking, caching, and
+  incremental logic is CI-testable without the real model (same approach as the
+  FoundationModels suites).
+
+The protocol is the only thing consumers depend on; the model choice is swappable without
+touching the ranker.
+
+### `SemanticRanker` (actor)
+
+Consumes `SiteKnowledgeIndex.documents(siteID:)`; holds per-document embedding vectors;
+offers semantic and hybrid ranking. `SiteKnowledgeIndex` itself stays untouched.
+
+Responsibilities:
+
+- **Sync from the lexical index.** Given the index's documents, compute a stable
+  `contentHash` per document over the embedded text (title + headings + excerpt). On a cache
+  hit, load the vector; on a miss, call `EmbeddingProvider.embed` and store it (and write the
+  cache entry). Mirrors #329's `upsertFile` / `removeFile` so a single edit re-embeds exactly
+  one document.
+- **Embedded text (v0, document-level):** `title` + `headings` joined + a leading slice of
+  `excerptText`. Documents with too little text get no vector (they fall back to lexical).
+- **Rank.** `relatedDocuments(siteID:to:limit:)` returns top-k by cosine similarity to a
+  source document's vector; `search(siteID:queryVector:limit:)` ranks against an arbitrary
+  query vector. A **hybrid** mode blends cosine with #329's lexical score into a normalized
+  `confidence` in 0…1.
+- **Granularity seam.** The vector store keys on an opaque entry id with an optional
+  `chunkID`. v0 always uses the document id; chunk-level (#311) adds chunk ids later without
+  changing the consumer API.
+
+### `SemanticIndexCache` (persistence — embeddings only)
+
+The lexical index stays in-memory (cheap to rebuild, per #329). Only the **embeddings**
+(expensive to recompute) persist:
+
+- File: `Config/caches/semantic-index.json` — app-owned per-site state, **never in git**
+  (lives in the package's `Config/`, outside `Source/`).
+- Entry: `{ docID, contentHash, dim, vector }`.
+- On load: entries whose `dim` ≠ the current provider's dimension, or that fail to decode,
+  are dropped and re-embedded. Cache corruption is never fatal.
+- On `contentHash` mismatch (file changed): treated as a miss → re-embed → overwrite entry.
+
+### `LinkGraph` (pure helper)
+
+Reads `Document.internalLinks` across a site (no embeddings) to compute:
+
+- **Reciprocal-link gaps:** A links to B but B does not link back to A.
+- **Isolated pages:** pages with no inbound internal links.
+- **Over-linked pages:** outbound link count above a threshold.
+
+These ship as affordances in the panel, not a standalone audit.
+
+## Consumers
+
+### Related-Pages panel (#312 UI — net-new)
+
+A panel in the preview-pane header family (same pattern as `ChatView` / drawer views),
+scoped to the page currently being edited:
+
+- Rows of related pages: title, route, **confidence** (from `SemanticRanker` hybrid score),
+  `[Insert link]`, `[Ignore]`.
+- Self and already-linked targets (from the source doc's `internalLinks`) are filtered out.
+- A small "isolated page" / "missing reciprocal link" hint section driven by `LinkGraph`.
+- **Insert** routes through the existing `EditRouter` / apply-edit pipeline — constructs a
+  markdown or `<a>` link to the target route at the current selection. No new mutation path.
+- **Ignore** dismisses a suggestion for the session (no persistence in v0).
+
+UI stays thin; ranking, filtering, and confidence live in `SemanticRanker` / `LinkGraph`
+so they are testable in `AnglesiteCore`.
+
+### `SearchKnowledgeTool` semantic upgrade (existing — from #329)
+
+The tool #329 already ships gains a semantic/hybrid mode: embed the query string via
+`EmbeddingProvider`, blend cosine similarity with the existing lexical score. Pure-lexical
+remains the fallback when embeddings are unavailable, so chat-driven editing ("add links to
+related pages") improves with no UI change.
+
+## Data flow
+
+**Indexing** (after #329's `rebuild` / `upsertFile`):
+
+```
+SiteKnowledgeIndex.documents(siteID)          // lexical docs, in-memory
+  → SemanticRanker.sync(documents)
+      for each doc: contentHash(title + headings + excerpt)
+        ├─ hash in Config/ cache?  → load vector
+        └─ miss                    → EmbeddingProvider.embed(...) → store + write cache
+  → vectors held in-memory, keyed by document id
+```
+
+**Query — Related-Pages panel:**
+
+```
+currentPage docID → its vector → cosine vs all same-site vectors
+  → top-k, drop self + already-linked (doc.internalLinks)
+  → hybrid re-rank with #329 lexical score → confidence 0…1
+  → rows: title, route, confidence, [Insert] [Ignore]
+```
+
+**Query — `SearchKnowledgeTool`:** embed query string → blend cosine with lexical score →
+cited results; pure-lexical fallback when embeddings unavailable.
+
+## Error handling
+
+- **No embedding model** (CI, or asset not downloaded): `EmbeddingProvider.embed` throws →
+  `SemanticRanker` degrades to #329's pure-lexical ranking; the panel shows a one-line
+  "semantic ranking unavailable — showing keyword matches" note. Degradation is surfaced,
+  never silent (logs-are-sacred).
+- **Cache corruption / dimension mismatch:** offending entries skipped and re-embedded;
+  never fatal.
+- **Empty or too-short content:** no vector produced; that document falls back to lexical
+  ranking.
+- **Insert failure:** surfaced via the existing apply-edit failure path (`no-match`,
+  `ambiguous-match`, etc.) — the app does not silently swallow it.
+
+## Testing
+
+- `FakeEmbeddingProvider` (deterministic vectors) drives:
+  - `SemanticRanker` cosine + hybrid ranking and top-k selection.
+  - Cache hit / miss / `contentHash` invalidation / dimension-mismatch drop.
+  - Incremental `upsert` / `remove` re-embedding exactly the changed document.
+- `LinkGraph` reciprocal / isolated / over-linked math against fixture `internalLinks`.
+- `NLContextualEmbeddingProvider` gets a smoke test gated like the other on-device suites
+  (does not run on CI).
+- Panel + insert kept thin; ranking/confidence/filter logic pushed into `AnglesiteCore`
+  types so it is covered without a hosted app target.
+
+## Dependencies & sequencing
+
+1. **PR #329 merged first** — this spec is written against `SiteKnowledgeIndex` as it lands;
+   the `SemanticRanker` builds on top of `main`.
+2. Then: `EmbeddingProvider` + `FakeEmbeddingProvider` → `SemanticRanker` + cache →
+   `LinkGraph` → `SearchKnowledgeTool` upgrade → Related-Pages panel + insert.
+
+## Open questions
+
+None blocking. Chunk-level granularity, an inline-while-typing consumer, a whole-site audit,
+and Cloudflare Vectorize export are deliberately deferred to later specs that consume this
+layer.


### PR DESCRIPTION
## Summary

Plan A of #312: an **on-device semantic ranking layer** built on top of the merged lexical `SiteKnowledgeIndex` (#329). This is the reusable foundation that also unblocks the #307/#311 RAG cluster. The first consumer — a semantic upgrade to `SearchKnowledgeTool` — ships here; the Related-Pages panel + link insertion (#312's visible UI) is **Plan B**, a follow-up branch.

Design + plan: `docs/superpowers/specs/2026-06-25-semantic-link-assistant-design.md`, `docs/superpowers/plans/2026-06-25-semantic-index-foundation-p1.md`.

## What's here

- **`EmbeddingProvider`** seam + `FakeEmbeddingProvider` (deterministic test double) + `EmbeddingError`
- **`VectorMath`** — cosine + process-stable FNV-1a hash
- **`SemanticIndexCache`** — Codable per-site embedding cache (built + tested; production wiring deferred, see below)
- **`SemanticRanker`** (actor) — sync/upsert/remove/unload + `related`/`search`/`blend` hybrid ranking
- **`NLEmbeddingProvider`** and **`NLContextualEmbeddingProvider`** — on-device embeddings; production picks best-first: multilingual `NLContextualEmbedding` → `NLEmbedding.sentenceEmbedding` → `nil` (pure lexical)
- **`SearchKnowledgeTool`** gains a hybrid lexical+semantic mode (widened candidate pool so semantic reranking can lift on-topic docs, not just reorder the top 6)
- **Wiring** — an app-global ranker threaded App → SiteWindow → PreviewModel → `LocalSiteRuntime`/`LocalContainerSiteRuntime` → `FoundationModelAssistant`, synced from the knowledge index after each rebuild (generation-guarded), unloaded on close. No model available → ranker is `nil` → retrieval degrades to pure lexical.

## Deferred (documented in code)

- Per-site `Config/` embedding cache + incremental `upsert`/`remove` re-embedding are **not wired** in production (`cache: nil`); the types exist and are tested, ready for a follow-up that adds per-site cache routing under the shared app-global index model.

## Testing

- `swift test`: **AnglesiteCore 883/883**, AnglesiteIntents 222, AnglesiteBridge 17 — all green.
- `xcodebuild -scheme Anglesite -configuration Debug`: **BUILD SUCCEEDED**.
- A scripted-embedding test proves the hybrid blend reorders by semantics independently of lexical keyword overlap; `NLContextualEmbedding` verified running on-device.

## Review

Built TDD task-by-task; a whole-branch review returned CHANGES-REQUESTED and **all findings were resolved**: C1 (don't ship the fake provider in production — degrade to lexical), I1 (widen candidate pool), I2 (implement the spec's multilingual `NLContextualEmbedding`), and M1–M5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)