### PR TITLE
Hide pane mode picker for website settings

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -446,7 +446,7 @@ struct SiteWindow: View {
     @ViewBuilder
     private func mainPane(for site: SiteStore.Site) -> some View {
         VStack(spacing: 0) {
-            if activeEditorFile != nil {
+            if showsPaneModePicker {
                 Picker("", selection: Binding(
                     get: { paneSelection },
                     set: { setPaneSelection($0) }
@@ -462,6 +462,11 @@ struct SiteWindow: View {
             }
             mainPaneContent(for: site)
         }
+    }
+
+    private var showsPaneModePicker: Bool {
+        if case .text = activeEditor { return true }
+        return false
     }
 
     private var paneSelection: Int {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -465,8 +465,12 @@ struct SiteWindow: View {
     }
 
     private var showsPaneModePicker: Bool {
-        if case .text = activeEditor { return true }
-        return false
+        switch activeEditor {
+        case .some(.text):
+            return true
+        case .some(.plist), .none:
+            return false
+        }
     }
 
     private var paneSelection: Int {


### PR DESCRIPTION
## Summary
- hide the Preview/Editor segmented control when the active editor is the plist-backed website settings surface
- keep the mode picker for normal text-file editors

## Verification
- env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build

Note: the build still emits pre-existing HTMLSnippetEditor.swift actor-isolation warnings.