### PR TITLE
docs(#341): rename Bucket 5 `syndicate` → `repurpose`

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ flowchart TB
     end
 
     subgraph pcc["Private Cloud Compute — Apple cloud, no external APIs"]
-        pccgen["Bucket 5 heavy generation<br/>copy-edit · design-interview · social · syndicate"]
+        pccgen["Bucket 5 heavy generation<br/>copy-edit · design-interview · social · repurpose"]
     end
 
     subgraph container["Site container — per-site runtime<br/>(Apple Containerization local · Cloudflare Sandbox fallback)"]
@@ -85,7 +85,7 @@ flowchart TB
 |---|---|---|
 | **Apple device (host)** | The Swift app: front-doors (GUI / Siri / chat), the `FoundationModelAssistant` orchestrator, deterministic Swift (Bucket 1 hot-paths + Bucket 3 wizards), the native `pre-deploy-check` gate, `MCPClient`, and the `WKWebView` preview. | User input; in-process Apple Intelligence API; `MCPClient` to the container. |
 | **Apple Intelligence (on-device)** | The ~3B on-device Foundation Models + vision, with the registered FM `Tool`s (`ApplyEditTool`, `SearchContentTool`, Spotlight). | Called in-process by the FM brain; never leaves the device. |
-| **Private Cloud Compute** | Heavy generation that exceeds the on-device ceiling (Bucket 5: copy-edit, design-interview, social, syndicate). Apple-operated; **no external LLM APIs ever**. | The FM brain escalates to the PCC tier over Apple's attested, encrypted channel. |
+| **Private Cloud Compute** | Heavy generation that exceeds the on-device ceiling (Bucket 5: copy-edit, design-interview, social, repurpose). Apple-operated; **no external LLM APIs ever**. | The FM brain escalates to the PCC tier over Apple's attested, encrypted channel. |
 | **Site container (per-site)** | **All JavaScript**: the Node MCP server and everything it drives in-guest — `apply_edit`/`undo_edit` (HTML/Astro patcher), the Astro dev server + build, Sharp, Satori, Pagefind, Keystatic. Apple Containerization locally; Cloudflare Sandbox as the fallback on MAS / iOS / non-Apple-Silicon. | The host reaches it only over the in-container **MCP HTTP/WS transport** (#64) — not by host-spawning Node. |
 | **Site `Source/` (git repo)** | The filesystem source of truth — the clonable, externally-editable unit. | Mounted into the container; written by the in-guest JS and by Swift Bucket-1 hot-paths; read by `WKWebView` via the dev server. |
 | **Cloudflare (deploy target)** | The published site (Workers). | Deploy runs only after the native `pre-deploy-check` gate passes. |

--- a/docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md
@@ -148,7 +148,7 @@ Compute. Escalation is a runtime tier choice; the front-door is unchanged.
 
 - `copy-edit` (whole-site critique + rewrites)
 - `design-interview` (multi-turn brand conversation + palette/typography)
-- `social-media` (strategy + brand-voice posts), `repurpose` (per-platform variants; renamed from `syndicate` to free that term for POSSE syndication — #341)
+- `social-media` (strategy + brand-voice posts), `repurpose` (per-platform variants)
 - `reputation` (review-response drafts)
 - `animate` (motion-design direction; CSS syntax itself is deterministic)
 - `i18n` content translation

--- a/docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md
@@ -148,7 +148,7 @@ Compute. Escalation is a runtime tier choice; the front-door is unchanged.
 
 - `copy-edit` (whole-site critique + rewrites)
 - `design-interview` (multi-turn brand conversation + palette/typography)
-- `social-media` (strategy + brand-voice posts), `syndicate` (per-platform variants)
+- `social-media` (strategy + brand-voice posts), `repurpose` (per-platform variants; renamed from `syndicate` to free that term for POSSE syndication — #341)
 - `reputation` (review-response drafts)
 - `animate` (motion-design direction; CSS syntax itself is deterministic)
 - `i18n` content translation
@@ -185,7 +185,7 @@ Proposed slice order (each independently shippable):
 4. **Deploy** — Bucket 3 `deploy` flow + the security gate change (§7) + Bucket 4 deploy
    summary (already done).
 5. **Theme / design** — Bucket 3 `themes` apply + Bucket 5 `design-interview` on PCC.
-6. **Content help** — Bucket 5 `copy-edit`, `social-media`, `syndicate`.
+6. **Content help** — Bucket 5 `copy-edit`, `social-media`, `repurpose`.
 7. **Cleanup** — retire Bucket 6 skills, delete `ClaudeAgent`, remove `--plugin-dir`
    wiring and the `claude` binary expectation, convert the plugin repo (§9).
 


### PR DESCRIPTION
Closes #341 (app-repo slice).

The integration-wizard / Claude-removal roadmap used `syndicate` for AI-generated **copy variants**, colliding with POSSE **syndication** (the real protocol feature in the pivot — publish once, cross-post, backfeed). This renames the Bucket 5 entry → `repurpose` in the app-owned docs so the two stop being conflated; `syndicate`/`syndication` is now reserved for POSSE.

**Changed:**
- `docs/architecture.md` — Bucket 5 PCC diagram + table row
- `docs/superpowers/specs/2026-06-20-claude-code-removal-roadmap-design.md` — bucket listing + content-help step

Left intentionally untouched: pivot-analysis/pivot-plan references that either carry the POSSE meaning or are the recommendation text describing this rename.

**Paired follow-up (plugin repo):** the actual `/anglesite:syndicate` skill + its `copy-edit`/`social-media` SKILL.md references live in `Anglesite/anglesite` and need the same rename — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)