### PR TITLE
Move build info into About panel

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -114,8 +114,12 @@ struct AnglesiteApp: App {
     }
 
     private func showAboutPanel() {
+        // Credits carries the build info the standard fields don't: the dev phase and the
+        // host OS. App name and version come from the bundle via .applicationName and the
+        // default .applicationVersion (CFBundleShortVersionString) — passing "Phase X" there
+        // would clobber the real version and render as "Version Phase X".
         let credits = NSAttributedString(
-            string: BuildInfo.summary,
+            string: "Phase \(BuildInfo.phase) · macOS \(ProcessInfo.processInfo.operatingSystemVersionString)",
             attributes: [
                 .font: NSFont.monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular),
                 .foregroundColor: NSColor.secondaryLabelColor
@@ -123,7 +127,6 @@ struct AnglesiteApp: App {
         )
         NSApplication.shared.orderFrontStandardAboutPanel(options: [
             .applicationName: BuildInfo.appName,
-            .applicationVersion: "Phase \(BuildInfo.phase)",
             .credits: credits
         ])
     }

--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -113,6 +113,21 @@ struct AnglesiteApp: App {
         }
     }
 
+    private func showAboutPanel() {
+        let credits = NSAttributedString(
+            string: BuildInfo.summary,
+            attributes: [
+                .font: NSFont.monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular),
+                .foregroundColor: NSColor.secondaryLabelColor
+            ]
+        )
+        NSApplication.shared.orderFrontStandardAboutPanel(options: [
+            .applicationName: BuildInfo.appName,
+            .applicationVersion: "Phase \(BuildInfo.phase)",
+            .credits: credits
+        ])
+    }
+
     var body: some Scene {
         // The launcher is the first scene so it's the default window at launch (used when
         // SwiftUI has nothing to restore). It autoopens the most-recently-used site from its
@@ -141,6 +156,10 @@ struct AnglesiteApp: App {
         }
         .windowResizability(.contentSize)
         .commands {
+            CommandGroup(replacing: .appInfo) {
+                Button("About Anglesite") { showAboutPanel() }
+            }
+
             CommandGroup(replacing: .newItem) {
                 Button("New Site") {
                     // Ensure the launcher exists to host the wizard sheet, then ask it to open.

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -192,23 +192,17 @@ struct SiteWindow: View {
                 VStack(spacing: 0) {
                     HStack(spacing: 0) {
                         mainPane(for: site)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    if chatPresented, let chat {
-                        Divider()
-                        ChatView(model: chat)
-                            .frame(width: 420)
-                            .transition(reduceMotion
-                                ? .opacity
-                                : .move(edge: .trailing).combined(with: .opacity))
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        if chatPresented, let chat {
+                            Divider()
+                            ChatView(model: chat)
+                                .frame(width: 420)
+                                .transition(reduceMotion
+                                    ? .opacity
+                                    : .move(edge: .trailing).combined(with: .opacity))
+                        }
                     }
-                }
-                .animation(.easeInOut(duration: 0.18), value: chatPresented)
-                Divider()
-                Text(BuildInfo.summary)
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.tertiary)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 6)
+                    .animation(.easeInOut(duration: 0.18), value: chatPresented)
             }
             if deploy.drawerPresented {
                 DeployDrawerView(model: deploy, siteName: site.name)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -203,25 +203,25 @@ struct SiteWindow: View {
                         }
                     }
                     .animation(.easeInOut(duration: 0.18), value: chatPresented)
+                }
+                if deploy.drawerPresented {
+                    DeployDrawerView(model: deploy, siteName: site.name)
+                        .transition(reduceMotion
+                            ? .opacity
+                            : .move(edge: .bottom).combined(with: .opacity))
+                        .shadow(radius: 8, y: -2)
+                } else if backup.drawerPresented {
+                    // Backup and deploy can't both run at once (each disables the other's
+                    // button while running), but a stale completed-deploy drawer might still
+                    // be on screen when a backup finishes. Deploy wins the z-order — its
+                    // drawer carries the more critical "your deploy URL" payload.
+                    BackupDrawerView(model: backup, siteName: site.name)
+                        .transition(reduceMotion
+                            ? .opacity
+                            : .move(edge: .bottom).combined(with: .opacity))
+                        .shadow(radius: 8, y: -2)
+                }
             }
-            if deploy.drawerPresented {
-                DeployDrawerView(model: deploy, siteName: site.name)
-                    .transition(reduceMotion
-                        ? .opacity
-                        : .move(edge: .bottom).combined(with: .opacity))
-                    .shadow(radius: 8, y: -2)
-            } else if backup.drawerPresented {
-                // Backup and deploy can't both run at once (each disables the other's
-                // button while running), but a stale completed-deploy drawer might still
-                // be on screen when a backup finishes. Deploy wins the z-order — its
-                // drawer carries the more critical "your deploy URL" payload.
-                BackupDrawerView(model: backup, siteName: site.name)
-                    .transition(reduceMotion
-                        ? .opacity
-                        : .move(edge: .bottom).combined(with: .opacity))
-                    .shadow(radius: 8, y: -2)
-            }
-        }
         .animation(.easeInOut(duration: 0.18), value: deploy.drawerPresented)
         .animation(.easeInOut(duration: 0.18), value: backup.drawerPresented)
         .navigationTitle(site.name)

--- a/Sources/AnglesiteCore/BuildInfo.swift
+++ b/Sources/AnglesiteCore/BuildInfo.swift
@@ -2,7 +2,8 @@ import Foundation
 
 public enum BuildInfo {
     public static let appName = "Anglesite"
-    public static let phase = "9"
+    // Bump manually at each phase milestone (tracked in docs/build-plan.md).
+    public static let phase = "10"
 
     public static var summary: String {
         "\(appName) · phase \(phase) · macOS \(ProcessInfo.processInfo.operatingSystemVersionString)"


### PR DESCRIPTION
## Summary
- remove the build-info footer from the main site editor/preview window
- show the same build summary in the native About Anglesite panel

## Testing
- xcodegen generate
- env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build