### PR TITLE
feat(#348): V-1.6 feeds (RSS/Atom/JSON)

### DIFF
--- a/Resources/Template/astro.config.mjs
+++ b/Resources/Template/astro.config.mjs
@@ -1,3 +1,0 @@
-import { defineConfig } from "astro/config";
-
-export default defineConfig({});

--- a/Resources/Template/astro.config.ts
+++ b/Resources/Template/astro.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "astro/config";
+import { readConfig } from "./scripts/config.ts";
+
+// The deploy step writes the real domain into `.site-config` (SITE_URL=…) before build.
+// Absent that, feeds carry a placeholder host — fine for a not-yet-deployed scaffold.
+const site = readConfig("SITE_URL") ?? "https://example.com";
+
+export default defineConfig({ site });

--- a/Resources/Template/package-lock.json
+++ b/Resources/Template/package-lock.json
@@ -8,6 +8,7 @@
       "name": "anglesite-site",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/rss": "^4.0.0",
         "astro": "^5.0.0"
       },
       "devDependencies": {
@@ -65,6 +66,26 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/rss/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1089,6 +1110,18 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -1724,6 +1757,18 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2424,6 +2469,45 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2791,6 +2875,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
@@ -3882,6 +3978,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -4419,6 +4530,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/svgo": {
@@ -5936,6 +6062,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -10,7 +10,8 @@
     "check": "npx tsx scripts/pre-deploy-check.ts"
   },
   "dependencies": {
-    "astro": "^5.0.0"
+    "astro": "^5.0.0",
+    "@astrojs/rss": "^4.0.0"
   },
   "devDependencies": {
     "tsx": "^4.0.0"

--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -17,6 +17,9 @@ const { title, description } = Astro.props;
     {description && <meta name="description" content={description} />}
     <title>{title}</title>
     <link rel="stylesheet" href="/src/styles/global.css" />
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml" />
+    <link rel="alternate" type="application/atom+xml" title="Atom" href="/atom.xml" />
+    <link rel="alternate" type="application/feed+json" title="JSON Feed" href="/feed.json" />
   </head>
   <body>
     <slot />

--- a/Resources/Template/src/lib/feed-data.ts
+++ b/Resources/Template/src/lib/feed-data.ts
@@ -1,20 +1,30 @@
 import { getCollection } from "astro:content";
 import { FEED_COLLECTIONS, toFeedItem, sortAndLimit, type FeedItem } from "./feeds.ts";
 
+const PER_COLLECTION_LIMIT = 50;
 const COMBINED_LIMIT = 50;
 
-export async function getCollectionItems(collection: string, site: string): Promise<FeedItem[]> {
+/// Map a collection's entries to feed items *without* sorting — callers that immediately re-sort
+/// (the combined feed) skip the wasted per-collection sort.
+async function mapCollection(collection: string, site: string): Promise<FeedItem[]> {
   const entries = await getCollection(collection as any);
-  const items = entries.map((e: any) =>
+  return entries.map((e: any) =>
     toFeedItem(collection, { id: e.id, collection, data: e.data, body: e.body }, site),
   );
-  return sortAndLimit(items);
+}
+
+export async function getCollectionItems(
+  collection: string,
+  site: string,
+  limit = PER_COLLECTION_LIMIT,
+): Promise<FeedItem[]> {
+  return sortAndLimit(await mapCollection(collection, site), limit);
 }
 
 export async function getCombinedItems(site: string, limit = COMBINED_LIMIT): Promise<FeedItem[]> {
   const all: FeedItem[] = [];
   for (const collection of Object.keys(FEED_COLLECTIONS)) {
-    all.push(...(await getCollectionItems(collection, site)));
+    all.push(...(await mapCollection(collection, site)));
   }
   return sortAndLimit(all, limit);
 }

--- a/Resources/Template/src/lib/feed-data.ts
+++ b/Resources/Template/src/lib/feed-data.ts
@@ -1,0 +1,20 @@
+import { getCollection } from "astro:content";
+import { FEED_COLLECTIONS, toFeedItem, sortAndLimit, type FeedItem } from "./feeds.ts";
+
+const COMBINED_LIMIT = 50;
+
+export async function getCollectionItems(collection: string, site: string): Promise<FeedItem[]> {
+  const entries = await getCollection(collection as any);
+  const items = entries.map((e: any) =>
+    toFeedItem(collection, { id: e.id, collection, data: e.data, body: e.body }, site),
+  );
+  return sortAndLimit(items);
+}
+
+export async function getCombinedItems(site: string, limit = COMBINED_LIMIT): Promise<FeedItem[]> {
+  const all: FeedItem[] = [];
+  for (const collection of Object.keys(FEED_COLLECTIONS)) {
+    all.push(...(await getCollectionItems(collection, site)));
+  }
+  return sortAndLimit(all, limit);
+}

--- a/Resources/Template/src/lib/feeds.test.ts
+++ b/Resources/Template/src/lib/feeds.test.ts
@@ -1,0 +1,92 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FEED_COLLECTIONS,
+  toFeedItem,
+  sortAndLimit,
+  renderRss,
+  renderAtom,
+  renderJsonFeed,
+  type FeedEntry,
+} from "./feeds.ts";
+
+const SITE = "https://example.com";
+
+function entry(collection: string, data: Record<string, any>, body = ""): FeedEntry {
+  return { id: "hello", collection, data, body };
+}
+
+test("config covers all eight collections", () => {
+  assert.deepEqual(
+    Object.keys(FEED_COLLECTIONS).sort(),
+    ["albums", "articles", "blog", "bookmarks", "likes", "notes", "photos", "replies"],
+  );
+});
+
+test("toFeedItem uses pubDate for blog and an absolute link", () => {
+  const item = toFeedItem("blog", entry("blog", { title: "Hi", pubDate: "2026-01-02" }), SITE);
+  assert.equal(item.title, "Hi");
+  assert.equal(item.link, "https://example.com/blog/hello/");
+  assert.equal(item.date.getUTCFullYear(), 2026);
+});
+
+test("toFeedItem derives a title for a title-less note from its body", () => {
+  const item = toFeedItem(
+    "notes",
+    entry("notes", { publishDate: "2026-01-02" }, "Just a quick thought about feeds."),
+    SITE,
+  );
+  assert.ok(item.title.length > 0);
+  assert.ok(item.title.startsWith("Just a quick"));
+});
+
+test("toFeedItem derives a title from the link host for a like", () => {
+  const item = toFeedItem(
+    "likes",
+    entry("likes", { likeOf: "https://indieweb.org/post", publishDate: "2026-01-02" }),
+    SITE,
+  );
+  assert.equal(item.title, "Liked indieweb.org");
+});
+
+test("sortAndLimit sorts newest first and caps", () => {
+  const mk = (iso: string): any => ({ title: iso, link: "/", date: new Date(iso), summary: "" });
+  const out = sortAndLimit([mk("2026-01-01"), mk("2026-03-01"), mk("2026-02-01")], 2);
+  assert.deepEqual(out.map((i) => i.title), ["2026-03-01", "2026-02-01"]);
+});
+
+test("renderRss produces RSS XML with the item and escapes specials", async () => {
+  const res = await renderRss({
+    title: "All",
+    description: "Everything",
+    site: SITE,
+    items: [{ title: "A & B", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi" }],
+  });
+  const xml = await res.text();
+  assert.match(xml, /<rss/);
+  assert.match(xml, /A &(amp|#38);? ?B|A &amp; B/);
+  assert.match(xml, /example\.com\/blog\/a\//);
+});
+
+test("renderAtom produces a feed with entry and self link", () => {
+  const res = renderAtom({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/atom.xml`,
+    items: [{ title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi" }],
+  });
+  assert.equal(res.headers.get("content-type"), "application/atom+xml; charset=utf-8");
+});
+
+test("renderJsonFeed produces valid JSON Feed 1.1", async () => {
+  const res = renderJsonFeed({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/feed.json`,
+    items: [{ title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi" }],
+  });
+  const feed = JSON.parse(await res.text());
+  assert.equal(feed.version, "https://jsonfeed.org/version/1.1");
+  assert.equal(feed.feed_url, `${SITE}/feed.json`);
+  assert.equal(feed.items[0].url, `${SITE}/blog/a/`);
+});

--- a/Resources/Template/src/lib/feeds.test.ts
+++ b/Resources/Template/src/lib/feeds.test.ts
@@ -4,6 +4,7 @@ import {
   FEED_COLLECTIONS,
   toFeedItem,
   sortAndLimit,
+  siteFrom,
   renderRss,
   renderAtom,
   renderJsonFeed,
@@ -47,6 +48,22 @@ test("toFeedItem derives a title from the link host for a like", () => {
     SITE,
   );
   assert.equal(item.title, "Liked indieweb.org");
+});
+
+test("toFeedItem throws on a missing or invalid date field", () => {
+  assert.throws(
+    () => toFeedItem("notes", entry("notes", {}), SITE),
+    /missing or invalid publishDate/,
+  );
+  assert.throws(
+    () => toFeedItem("notes", entry("notes", { publishDate: "not-a-date" }), SITE),
+    /missing or invalid publishDate/,
+  );
+});
+
+test("siteFrom returns the href or throws a clear error when site is unset", () => {
+  assert.equal(siteFrom({ site: new URL("https://x.test/") }), "https://x.test/");
+  assert.throws(() => siteFrom({}), /not configured/);
 });
 
 test("sortAndLimit sorts newest first and caps", () => {

--- a/Resources/Template/src/lib/feeds.ts
+++ b/Resources/Template/src/lib/feeds.ts
@@ -1,0 +1,166 @@
+import rss from "@astrojs/rss";
+
+export interface FeedItem {
+  title: string;
+  link: string; // absolute
+  date: Date;
+  summary: string;
+}
+
+export type FeedEntry = {
+  id: string;
+  collection: string;
+  data: Record<string, any>;
+  body?: string;
+};
+
+export interface FeedCollectionConfig {
+  title: string;
+  dateField: string;
+  deriveTitle(entry: FeedEntry): string;
+}
+
+function host(url: unknown): string {
+  try {
+    return new URL(String(url)).host;
+  } catch {
+    return String(url ?? "");
+  }
+}
+
+function excerpt(body: string | undefined, max = 80): string {
+  const text = (body ?? "").replace(/\s+/g, " ").trim();
+  if (text.length <= max) return text || "Untitled";
+  return text.slice(0, max).trimEnd() + "…";
+}
+
+export const FEED_COLLECTIONS: Record<string, FeedCollectionConfig> = {
+  blog: { title: "Blog", dateField: "pubDate", deriveTitle: (e) => e.data.title },
+  notes: { title: "Notes", dateField: "publishDate", deriveTitle: (e) => excerpt(e.body) },
+  articles: { title: "Articles", dateField: "publishDate", deriveTitle: (e) => e.data.title },
+  photos: {
+    title: "Photos",
+    dateField: "publishDate",
+    deriveTitle: (e) => e.data.caption ?? "Photo",
+  },
+  albums: { title: "Albums", dateField: "publishDate", deriveTitle: (e) => e.data.title },
+  bookmarks: {
+    title: "Bookmarks",
+    dateField: "publishDate",
+    deriveTitle: (e) => e.data.title ?? host(e.data.bookmarkOf),
+  },
+  replies: {
+    title: "Replies",
+    dateField: "publishDate",
+    deriveTitle: (e) => "Re: " + host(e.data.inReplyTo),
+  },
+  likes: {
+    title: "Likes",
+    dateField: "publishDate",
+    deriveTitle: (e) => "Liked " + host(e.data.likeOf),
+  },
+};
+
+export function toFeedItem(collection: string, entry: FeedEntry, site: string): FeedItem {
+  const cfg = FEED_COLLECTIONS[collection];
+  if (!cfg) throw new Error(`No feed config for collection "${collection}"`);
+  const rawDate = entry.data[cfg.dateField];
+  const date = rawDate instanceof Date ? rawDate : new Date(rawDate);
+  const summary = (entry.data.summary ?? entry.data.caption ?? excerpt(entry.body, 280)) || "";
+  return {
+    title: cfg.deriveTitle(entry) || "Untitled",
+    link: new URL(`/${collection}/${entry.id}/`, site).href,
+    date,
+    summary: String(summary),
+  };
+}
+
+export function sortAndLimit(items: FeedItem[], limit?: number): FeedItem[] {
+  const sorted = [...items].sort((a, b) => b.date.valueOf() - a.date.valueOf());
+  return typeof limit === "number" ? sorted.slice(0, limit) : sorted;
+}
+
+export function renderRss(o: {
+  title: string;
+  description: string;
+  site: string;
+  items: FeedItem[];
+}): Promise<Response> {
+  return rss({
+    title: o.title,
+    description: o.description,
+    site: o.site,
+    items: o.items.map((i) => ({
+      title: i.title,
+      link: i.link,
+      pubDate: i.date,
+      description: i.summary,
+    })),
+  });
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function renderAtom(o: {
+  title: string;
+  site: string;
+  feedUrl: string;
+  items: FeedItem[];
+}): Response {
+  const updated = o.items[0]?.date ?? new Date(0);
+  const entries = o.items
+    .map(
+      (i) => `  <entry>
+    <title>${escapeXml(i.title)}</title>
+    <link href="${escapeXml(i.link)}"/>
+    <id>${escapeXml(i.link)}</id>
+    <updated>${i.date.toISOString()}</updated>
+    <summary>${escapeXml(i.summary)}</summary>
+  </entry>`,
+    )
+    .join("\n");
+  const xml = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>${escapeXml(o.title)}</title>
+  <id>${escapeXml(o.site)}</id>
+  <link href="${escapeXml(o.site)}"/>
+  <link rel="self" href="${escapeXml(o.feedUrl)}"/>
+  <updated>${updated.toISOString()}</updated>
+${entries}
+</feed>
+`;
+  return new Response(xml, {
+    headers: { "Content-Type": "application/atom+xml; charset=utf-8" },
+  });
+}
+
+export function renderJsonFeed(o: {
+  title: string;
+  site: string;
+  feedUrl: string;
+  items: FeedItem[];
+}): Response {
+  const feed = {
+    version: "https://jsonfeed.org/version/1.1",
+    title: o.title,
+    home_page_url: o.site,
+    feed_url: o.feedUrl,
+    items: o.items.map((i) => ({
+      id: i.link,
+      url: i.link,
+      title: i.title,
+      summary: i.summary,
+      date_published: i.date.toISOString(),
+    })),
+  };
+  return new Response(JSON.stringify(feed, null, 2), {
+    headers: { "Content-Type": "application/feed+json; charset=utf-8" },
+  });
+}

--- a/Resources/Template/src/lib/feeds.ts
+++ b/Resources/Template/src/lib/feeds.ts
@@ -61,11 +61,29 @@ export const FEED_COLLECTIONS: Record<string, FeedCollectionConfig> = {
   },
 };
 
+/// Resolve the absolute site base URL from an Astro endpoint context, failing loudly when
+/// `site` is unset. `astro.config.ts` always provides a fallback, so in practice this never
+/// throws — but an `Invalid`/undefined site would otherwise surface as an opaque TypeError in
+/// all 27 feed routes, so we give one clear message instead.
+export function siteFrom(context: { site?: URL }): string {
+  if (!context.site) {
+    throw new Error(
+      "[feeds] Astro `site` is not configured — set SITE_URL in .site-config so feeds can emit absolute URLs.",
+    );
+  }
+  return context.site.href;
+}
+
 export function toFeedItem(collection: string, entry: FeedEntry, site: string): FeedItem {
   const cfg = FEED_COLLECTIONS[collection];
   if (!cfg) throw new Error(`No feed config for collection "${collection}"`);
   const rawDate = entry.data[cfg.dateField];
   const date = rawDate instanceof Date ? rawDate : new Date(rawDate);
+  // An invalid/missing date would make `sortAndLimit` non-deterministic and crash
+  // `renderAtom`/`renderJsonFeed` at `date.toISOString()` (RangeError). Fail at build instead.
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`[feeds] entry "${entry.id}" has a missing or invalid ${cfg.dateField}`);
+  }
   const summary = (entry.data.summary ?? entry.data.caption ?? excerpt(entry.body, 280)) || "";
   return {
     title: cfg.deriveTitle(entry) || "Untitled",
@@ -117,6 +135,9 @@ export function renderAtom(o: {
   const updated = o.items[0]?.date ?? new Date(0);
   const entries = o.items
     .map(
+      // Known limitation: <id> uses the permalink rather than a permanent tag: IRI (RFC 4287
+      // §4.2.6). Renaming a slug therefore reads as a new entry in readers that saw the old URL.
+      // This matches most simple RSS libraries; a stable tag: URI is a future improvement.
       (i) => `  <entry>
     <title>${escapeXml(i.title)}</title>
     <link href="${escapeXml(i.link)}"/>

--- a/Resources/Template/src/pages/albums/atom.xml.ts
+++ b/Resources/Template/src/pages/albums/atom.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "albums";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/albums/atom.xml.ts
+++ b/Resources/Template/src/pages/albums/atom.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "albums";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderAtom({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/albums/feed.json.ts
+++ b/Resources/Template/src/pages/albums/feed.json.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "albums";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderJsonFeed({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/albums/feed.json.ts
+++ b/Resources/Template/src/pages/albums/feed.json.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "albums";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/albums/rss.xml.ts
+++ b/Resources/Template/src/pages/albums/rss.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "albums";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
+    site,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/albums/rss.xml.ts
+++ b/Resources/Template/src/pages/albums/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "albums";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderRss({
     title: FEED_COLLECTIONS[COLLECTION].title,
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,

--- a/Resources/Template/src/pages/articles/atom.xml.ts
+++ b/Resources/Template/src/pages/articles/atom.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "articles";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderAtom({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/articles/atom.xml.ts
+++ b/Resources/Template/src/pages/articles/atom.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "articles";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/articles/feed.json.ts
+++ b/Resources/Template/src/pages/articles/feed.json.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "articles";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderJsonFeed({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/articles/feed.json.ts
+++ b/Resources/Template/src/pages/articles/feed.json.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "articles";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/articles/rss.xml.ts
+++ b/Resources/Template/src/pages/articles/rss.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "articles";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
+    site,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/articles/rss.xml.ts
+++ b/Resources/Template/src/pages/articles/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "articles";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderRss({
     title: FEED_COLLECTIONS[COLLECTION].title,
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,

--- a/Resources/Template/src/pages/atom.xml.ts
+++ b/Resources/Template/src/pages/atom.xml.ts
@@ -1,0 +1,13 @@
+import type { APIContext } from "astro";
+import { getCombinedItems } from "../lib/feed-data.ts";
+import { renderAtom } from "../lib/feeds.ts";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: "All posts",
+    site,
+    feedUrl: new URL("/atom.xml", site).href,
+    items: await getCombinedItems(site),
+  });
+}

--- a/Resources/Template/src/pages/atom.xml.ts
+++ b/Resources/Template/src/pages/atom.xml.ts
@@ -1,9 +1,9 @@
 import type { APIContext } from "astro";
 import { getCombinedItems } from "../lib/feed-data.ts";
-import { renderAtom } from "../lib/feeds.ts";
+import { renderAtom, siteFrom } from "../lib/feeds.ts";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderAtom({
     title: "All posts",
     site,

--- a/Resources/Template/src/pages/blog/atom.xml.ts
+++ b/Resources/Template/src/pages/blog/atom.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "blog";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderAtom({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/blog/atom.xml.ts
+++ b/Resources/Template/src/pages/blog/atom.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "blog";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/blog/feed.json.ts
+++ b/Resources/Template/src/pages/blog/feed.json.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "blog";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/blog/feed.json.ts
+++ b/Resources/Template/src/pages/blog/feed.json.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "blog";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderJsonFeed({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/blog/index.astro
+++ b/Resources/Template/src/pages/blog/index.astro
@@ -10,6 +10,7 @@ const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
 <BaseLayout title="Blog" description="Read the latest posts and updates.">
   <main>
     <h1>Blog</h1>
+    <p><a href="/blog/rss.xml">Subscribe (RSS)</a></p>
     {
       posts.length === 0 ? (
         <p>No posts yet. Add a Markdown file in <code>src/content/blog/</code> to get started.</p>

--- a/Resources/Template/src/pages/blog/rss.xml.ts
+++ b/Resources/Template/src/pages/blog/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "blog";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderRss({
     title: FEED_COLLECTIONS[COLLECTION].title,
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,

--- a/Resources/Template/src/pages/blog/rss.xml.ts
+++ b/Resources/Template/src/pages/blog/rss.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "blog";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
+    site,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/bookmarks/atom.xml.ts
+++ b/Resources/Template/src/pages/bookmarks/atom.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "bookmarks";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderAtom({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/bookmarks/atom.xml.ts
+++ b/Resources/Template/src/pages/bookmarks/atom.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "bookmarks";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/bookmarks/feed.json.ts
+++ b/Resources/Template/src/pages/bookmarks/feed.json.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "bookmarks";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/bookmarks/feed.json.ts
+++ b/Resources/Template/src/pages/bookmarks/feed.json.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "bookmarks";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderJsonFeed({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/bookmarks/rss.xml.ts
+++ b/Resources/Template/src/pages/bookmarks/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "bookmarks";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderRss({
     title: FEED_COLLECTIONS[COLLECTION].title,
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,

--- a/Resources/Template/src/pages/bookmarks/rss.xml.ts
+++ b/Resources/Template/src/pages/bookmarks/rss.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "bookmarks";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
+    site,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/feed.json.ts
+++ b/Resources/Template/src/pages/feed.json.ts
@@ -1,0 +1,13 @@
+import type { APIContext } from "astro";
+import { getCombinedItems } from "../lib/feed-data.ts";
+import { renderJsonFeed } from "../lib/feeds.ts";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: "All posts",
+    site,
+    feedUrl: new URL("/feed.json", site).href,
+    items: await getCombinedItems(site),
+  });
+}

--- a/Resources/Template/src/pages/feed.json.ts
+++ b/Resources/Template/src/pages/feed.json.ts
@@ -1,9 +1,9 @@
 import type { APIContext } from "astro";
 import { getCombinedItems } from "../lib/feed-data.ts";
-import { renderJsonFeed } from "../lib/feeds.ts";
+import { renderJsonFeed, siteFrom } from "../lib/feeds.ts";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderJsonFeed({
     title: "All posts",
     site,

--- a/Resources/Template/src/pages/likes/atom.xml.ts
+++ b/Resources/Template/src/pages/likes/atom.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "likes";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderAtom({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/likes/atom.xml.ts
+++ b/Resources/Template/src/pages/likes/atom.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "likes";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/likes/feed.json.ts
+++ b/Resources/Template/src/pages/likes/feed.json.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "likes";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/likes/feed.json.ts
+++ b/Resources/Template/src/pages/likes/feed.json.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "likes";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderJsonFeed({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/likes/rss.xml.ts
+++ b/Resources/Template/src/pages/likes/rss.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "likes";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
+    site,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/likes/rss.xml.ts
+++ b/Resources/Template/src/pages/likes/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "likes";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderRss({
     title: FEED_COLLECTIONS[COLLECTION].title,
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,

--- a/Resources/Template/src/pages/notes/atom.xml.ts
+++ b/Resources/Template/src/pages/notes/atom.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "notes";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderAtom({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/notes/atom.xml.ts
+++ b/Resources/Template/src/pages/notes/atom.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "notes";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/notes/feed.json.ts
+++ b/Resources/Template/src/pages/notes/feed.json.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "notes";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/notes/feed.json.ts
+++ b/Resources/Template/src/pages/notes/feed.json.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "notes";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderJsonFeed({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/notes/rss.xml.ts
+++ b/Resources/Template/src/pages/notes/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "notes";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderRss({
     title: FEED_COLLECTIONS[COLLECTION].title,
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,

--- a/Resources/Template/src/pages/notes/rss.xml.ts
+++ b/Resources/Template/src/pages/notes/rss.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "notes";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
+    site,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/photos/atom.xml.ts
+++ b/Resources/Template/src/pages/photos/atom.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "photos";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/photos/atom.xml.ts
+++ b/Resources/Template/src/pages/photos/atom.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "photos";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderAtom({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/photos/feed.json.ts
+++ b/Resources/Template/src/pages/photos/feed.json.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "photos";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/photos/feed.json.ts
+++ b/Resources/Template/src/pages/photos/feed.json.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "photos";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderJsonFeed({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/photos/rss.xml.ts
+++ b/Resources/Template/src/pages/photos/rss.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "photos";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
+    site,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/photos/rss.xml.ts
+++ b/Resources/Template/src/pages/photos/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "photos";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderRss({
     title: FEED_COLLECTIONS[COLLECTION].title,
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,

--- a/Resources/Template/src/pages/replies/atom.xml.ts
+++ b/Resources/Template/src/pages/replies/atom.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "replies";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/replies/atom.xml.ts
+++ b/Resources/Template/src/pages/replies/atom.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "replies";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderAtom({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/replies/feed.json.ts
+++ b/Resources/Template/src/pages/replies/feed.json.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "replies";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/replies/feed.json.ts
+++ b/Resources/Template/src/pages/replies/feed.json.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "replies";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderJsonFeed({
     title: FEED_COLLECTIONS[COLLECTION].title,
     site,

--- a/Resources/Template/src/pages/replies/rss.xml.ts
+++ b/Resources/Template/src/pages/replies/rss.xml.ts
@@ -1,0 +1,15 @@
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "replies";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
+    site,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}

--- a/Resources/Template/src/pages/replies/rss.xml.ts
+++ b/Resources/Template/src/pages/replies/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIContext } from "astro";
 import { getCollectionItems } from "../../lib/feed-data.ts";
-import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "replies";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderRss({
     title: FEED_COLLECTIONS[COLLECTION].title,
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,

--- a/Resources/Template/src/pages/rss.xml.ts
+++ b/Resources/Template/src/pages/rss.xml.ts
@@ -1,0 +1,13 @@
+import type { APIContext } from "astro";
+import { getCombinedItems } from "../lib/feed-data.ts";
+import { renderRss } from "../lib/feeds.ts";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: "All posts",
+    description: "Everything published on this site.",
+    site,
+    items: await getCombinedItems(site),
+  });
+}

--- a/Resources/Template/src/pages/rss.xml.ts
+++ b/Resources/Template/src/pages/rss.xml.ts
@@ -1,9 +1,9 @@
 import type { APIContext } from "astro";
 import { getCombinedItems } from "../lib/feed-data.ts";
-import { renderRss } from "../lib/feeds.ts";
+import { renderRss, siteFrom } from "../lib/feeds.ts";
 
 export async function GET(context: APIContext) {
-  const site = context.site!.href;
+  const site = siteFrom(context);
   return renderRss({
     title: "All posts",
     description: "Everything published on this site.",

--- a/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
@@ -24,14 +24,6 @@ struct FeedsRenderSmokeTests {
     func rendersFeeds() async throws {
         let node = try #require(E2EPrerequisites.locateNode())
         let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
-        try? FileManager.default.removeItem(at: dist)
-        defer { try? FileManager.default.removeItem(at: dist) }
-
-        let result = try await ProcessSupervisor.shared.run(
-            executable: node,
-            arguments: ["node_modules/astro/astro.js", "build"],
-            currentDirectoryURL: Self.templateDir)
-        try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
 
         func exists(_ rel: String) -> Bool {
             FileManager.default.fileExists(atPath: dist.appendingPathComponent(rel).path)
@@ -40,28 +32,42 @@ struct FeedsRenderSmokeTests {
             try String(contentsOf: dist.appendingPathComponent(rel), encoding: .utf8)
         }
 
-        // Combined feeds at the root.
-        #expect(exists("rss.xml"))
-        #expect(exists("atom.xml"))
-        #expect(exists("feed.json"))
+        // Hold the shared template-build lock across the build *and* the assertions: other
+        // render-smoke suites `rm -rf dist` around their own build, so reading `dist` after
+        // releasing the lock would race against them.
+        try await TemplateBuildSerializer.shared.serialize {
+            try? FileManager.default.removeItem(at: dist)
+            defer { try? FileManager.default.removeItem(at: dist) }
 
-        // Per-collection feeds for every collection, all three formats.
-        for c in ["blog", "notes", "articles", "photos", "albums", "bookmarks", "replies", "likes"] {
-            #expect(exists("\(c)/rss.xml"), "missing \(c)/rss.xml")
-            #expect(exists("\(c)/atom.xml"), "missing \(c)/atom.xml")
-            #expect(exists("\(c)/feed.json"), "missing \(c)/feed.json")
+            let result = try await ProcessSupervisor.shared.run(
+                executable: node,
+                arguments: ["node_modules/astro/astro.js", "build"],
+                currentDirectoryURL: Self.templateDir)
+            try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+
+            // Combined feeds at the root.
+            #expect(exists("rss.xml"))
+            #expect(exists("atom.xml"))
+            #expect(exists("feed.json"))
+
+            // Per-collection feeds for every collection, all three formats.
+            for c in ["blog", "notes", "articles", "photos", "albums", "bookmarks", "replies", "likes"] {
+                #expect(exists("\(c)/rss.xml"), "missing \(c)/rss.xml")
+                #expect(exists("\(c)/atom.xml"), "missing \(c)/atom.xml")
+                #expect(exists("\(c)/feed.json"), "missing \(c)/feed.json")
+            }
+
+            // The dynamic [collection] entry route still renders (feed routes don't shadow it).
+            #expect(exists("notes/hello-note/index.html"))
+
+            // Feeds carry absolute URLs from `site`.
+            #expect(try text("feed.json").contains("https://example.com/"))
+            #expect(try text("blog/rss.xml").contains("<rss"))
+
+            // A title-less type (likes) still produces a non-empty title.
+            let likesJson = try text("likes/feed.json")
+            #expect(likesJson.contains("\"title\""))
+            #expect(!likesJson.contains("\"title\": \"\""))
         }
-
-        // The dynamic [collection] entry route still renders (feed routes don't shadow it).
-        #expect(exists("notes/hello-note/index.html"))
-
-        // Feeds carry absolute URLs from `site`.
-        #expect(try text("feed.json").contains("https://example.com/"))
-        #expect(try text("blog/rss.xml").contains("<rss"))
-
-        // A title-less type (likes) still produces a non-empty title.
-        let likesJson = try text("likes/feed.json")
-        #expect(likesJson.contains("\"title\""))
-        #expect(!likesJson.contains("\"title\": \"\""))
     }
 }

--- a/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+@Suite("Feeds render smoke")
+struct FeedsRenderSmokeTests {
+
+    /// Repo-root-relative path to the committed template. `swift test` runs with CWD = package root.
+    static var templateDir: URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources/Template", isDirectory: true)
+    }
+
+    /// True when the template can actually be built: a Node binary plus an installed Astro.
+    static var buildable: Bool {
+        guard E2EPrerequisites.locateNode() != nil else { return false }
+        return FileManager.default.isReadableFile(
+            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
+    }
+
+    @Test("collections emit RSS/Atom/JSON and a combined feed",
+          .enabled(if: FeedsRenderSmokeTests.buildable))
+    func rendersFeeds() async throws {
+        let node = try #require(E2EPrerequisites.locateNode())
+        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+        try? FileManager.default.removeItem(at: dist)
+        defer { try? FileManager.default.removeItem(at: dist) }
+
+        let result = try await ProcessSupervisor.shared.run(
+            executable: node,
+            arguments: ["node_modules/astro/astro.js", "build"],
+            currentDirectoryURL: Self.templateDir)
+        try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+
+        func exists(_ rel: String) -> Bool {
+            FileManager.default.fileExists(atPath: dist.appendingPathComponent(rel).path)
+        }
+        func text(_ rel: String) throws -> String {
+            try String(contentsOf: dist.appendingPathComponent(rel), encoding: .utf8)
+        }
+
+        // Combined feeds at the root.
+        #expect(exists("rss.xml"))
+        #expect(exists("atom.xml"))
+        #expect(exists("feed.json"))
+
+        // Per-collection feeds for every collection, all three formats.
+        for c in ["blog", "notes", "articles", "photos", "albums", "bookmarks", "replies", "likes"] {
+            #expect(exists("\(c)/rss.xml"), "missing \(c)/rss.xml")
+            #expect(exists("\(c)/atom.xml"), "missing \(c)/atom.xml")
+            #expect(exists("\(c)/feed.json"), "missing \(c)/feed.json")
+        }
+
+        // The dynamic [collection] entry route still renders (feed routes don't shadow it).
+        #expect(exists("notes/hello-note/index.html"))
+
+        // Feeds carry absolute URLs from `site`.
+        #expect(try text("feed.json").contains("https://example.com/"))
+        #expect(try text("blog/rss.xml").contains("<rss"))
+
+        // A title-less type (likes) still produces a non-empty title.
+        let likesJson = try text("likes/feed.json")
+        #expect(likesJson.contains("\"title\""))
+        #expect(!likesJson.contains("\"title\": \"\""))
+    }
+}

--- a/Tests/AnglesiteCoreTests/PersonalTypeRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/PersonalTypeRenderSmokeTests.swift
@@ -24,26 +24,33 @@ struct PersonalTypeRenderSmokeTests {
     func rendersMicroformats() async throws {
         let node = try #require(E2EPrerequisites.locateNode())
         let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
-        try? FileManager.default.removeItem(at: dist)
-        defer { try? FileManager.default.removeItem(at: dist) }
-
-        let result = try await ProcessSupervisor.shared.run(
-            executable: node,
-            arguments: ["node_modules/astro/astro.js", "build"],
-            currentDirectoryURL: Self.templateDir)
-        try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
 
         func html(_ rel: String) throws -> String {
             try String(contentsOf: dist.appendingPathComponent(rel), encoding: .utf8)
         }
-        let noteHTML = try html("notes/hello-note/index.html")
-        #expect(noteHTML.contains("h-entry"))
-        #expect(noteHTML.contains("dt-published"))
-        #expect(try html("articles/hello-article/index.html").contains("p-name"))
-        #expect(try html("photos/hello-photo/index.html").contains("u-photo"))
-        #expect(try html("albums/hello-album/index.html").contains("u-photo"))
-        #expect(try html("bookmarks/hello-bookmark/index.html").contains("u-bookmark-of"))
-        #expect(try html("replies/hello-reply/index.html").contains("u-in-reply-to"))
-        #expect(try html("likes/hello-like/index.html").contains("u-like-of"))
+
+        // Hold the shared template-build lock across the build *and* the assertions: other
+        // render-smoke suites (e.g. FeedsRenderSmokeTests) `rm -rf dist` around their own build,
+        // so a concurrent build/read would race against this one on the shared template tree.
+        try await TemplateBuildSerializer.shared.serialize {
+            try? FileManager.default.removeItem(at: dist)
+            defer { try? FileManager.default.removeItem(at: dist) }
+
+            let result = try await ProcessSupervisor.shared.run(
+                executable: node,
+                arguments: ["node_modules/astro/astro.js", "build"],
+                currentDirectoryURL: Self.templateDir)
+            try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+
+            let noteHTML = try html("notes/hello-note/index.html")
+            #expect(noteHTML.contains("h-entry"))
+            #expect(noteHTML.contains("dt-published"))
+            #expect(try html("articles/hello-article/index.html").contains("p-name"))
+            #expect(try html("photos/hello-photo/index.html").contains("u-photo"))
+            #expect(try html("albums/hello-album/index.html").contains("u-photo"))
+            #expect(try html("bookmarks/hello-bookmark/index.html").contains("u-bookmark-of"))
+            #expect(try html("replies/hello-reply/index.html").contains("u-in-reply-to"))
+            #expect(try html("likes/hello-like/index.html").contains("u-like-of"))
+        }
     }
 }

--- a/Tests/AnglesiteTestSupport/TemplateBuildSerializer.swift
+++ b/Tests/AnglesiteTestSupport/TemplateBuildSerializer.swift
@@ -10,33 +10,65 @@ import Foundation
 ///
 /// It is a genuine async lock (not just an actor method — actor reentrancy would let calls
 /// interleave at the build's `await`), implemented with a one-slot gate and a FIFO waiter queue.
+/// A waiter whose task is cancelled drains itself from the queue and throws `CancellationError`,
+/// so a cancelled/timed-out test never wedges the lock for the suites behind it.
 public actor TemplateBuildSerializer {
     public static let shared = TemplateBuildSerializer()
 
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
     private var locked = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [Waiter] = []
 
     public init() {}
 
-    private func lock() async {
+    private func lock() async throws {
         if !locked {
             locked = true
             return
         }
-        await withCheckedContinuation { waiters.append($0) }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await self.enqueue(id: id)
+        } onCancel: {
+            Task { await self.drainCancelled(id) }
+        }
+    }
+
+    /// Park the caller until granted the lock (resumed by `unlock`) or cancelled (resumed by
+    /// `drainCancelled`). Resumes immediately if cancellation already happened — the `onCancel`
+    /// handler runs only after this synchronous append, so it could otherwise miss the waiter.
+    private func enqueue(id: UUID) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            if Task.isCancelled {
+                continuation.resume(throwing: CancellationError())
+                return
+            }
+            waiters.append(Waiter(id: id, continuation: continuation))
+        }
+    }
+
+    private func drainCancelled(_ id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
     }
 
     private func unlock() {
         if waiters.isEmpty {
             locked = false
         } else {
-            waiters.removeFirst().resume()
+            waiters.removeFirst().continuation.resume()
         }
     }
 
     /// Run `body` while holding the shared template-build lock; other callers wait their turn.
-    public func serialize<T>(_ body: () async throws -> T) async rethrows -> T {
-        await lock()
+    /// Throws `CancellationError` (without running `body`) if the task is cancelled while waiting.
+    public func serialize<T>(_ body: () async throws -> T) async throws -> T {
+        try await lock()
         defer { unlock() }
         return try await body()
     }

--- a/Tests/AnglesiteTestSupport/TemplateBuildSerializer.swift
+++ b/Tests/AnglesiteTestSupport/TemplateBuildSerializer.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Serializes `astro build` runs against the shared `Resources/Template/` working tree.
+///
+/// Multiple render-smoke suites (`PersonalTypeRenderSmokeTests`, `FeedsRenderSmokeTests`, …)
+/// each build the *same* template directory and `rm -rf dist` around their build. Swift Testing
+/// runs suites in parallel, so without coordination one suite's `rm -rf dist` deletes another's
+/// in-flight output and that build fails. This actor gives those builds mutual exclusion: each
+/// wraps its build in `TemplateBuildSerializer.shared.serialize { … }` so only one runs at a time.
+///
+/// It is a genuine async lock (not just an actor method — actor reentrancy would let calls
+/// interleave at the build's `await`), implemented with a one-slot gate and a FIFO waiter queue.
+public actor TemplateBuildSerializer {
+    public static let shared = TemplateBuildSerializer()
+
+    private var locked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    public init() {}
+
+    private func lock() async {
+        if !locked {
+            locked = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    private func unlock() {
+        if waiters.isEmpty {
+            locked = false
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+
+    /// Run `body` while holding the shared template-build lock; other callers wait their turn.
+    public func serialize<T>(_ body: () async throws -> T) async rethrows -> T {
+        await lock()
+        defer { unlock() }
+        return try await body()
+    }
+}

--- a/docs/superpowers/plans/2026-06-26-feeds-rss-atom-json.md
+++ b/docs/superpowers/plans/2026-06-26-feeds-rss-atom-json.md
@@ -707,6 +707,13 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 **Gating:** `.enabled(if:)` on Node located **and** `Resources/Template/node_modules/astro/astro.js` present — skips (never fails) when deps aren't installed, matching `PersonalTypeRenderSmokeTests`.
 
+> **Illustrative sample — see the committed test for the real shape.** Swift Testing runs suites
+> in parallel, so this smoke and `PersonalTypeRenderSmokeTests` build the *same* `Resources/Template`
+> tree concurrently and `rm -rf dist` around it, racing. The shipped implementation wraps the build
+> **and its assertions** in `TemplateBuildSerializer.shared.serialize { … }`
+> (`Tests/AnglesiteTestSupport/TemplateBuildSerializer.swift`), and `PersonalTypeRenderSmokeTests`
+> does the same. The sample below omits that wrapper for brevity — do not copy it verbatim.
+
 - [ ] **Step 1: Write the gated smoke test**
 
 `Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift`:

--- a/docs/superpowers/plans/2026-06-26-feeds-rss-atom-json.md
+++ b/docs/superpowers/plans/2026-06-26-feeds-rss-atom-json.md
@@ -1,0 +1,854 @@
+# V-1.6 Feeds (RSS / Atom / JSON) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every content collection in `Resources/Template/` publishes RSS 2.0, Atom 1.0, and JSON Feed 1.1 — co-located inside the collection — plus a site-wide combined feed, all valid at build and green through `pre-deploy-check`.
+
+**Architecture:** Pure feed logic (config table + item mapping + three serializers) lives in `src/lib/feeds.ts` and is unit-tested without an Astro runtime. A thin astro-coupled `src/lib/feed-data.ts` loads collections via `astro:content`. Per-collection route files (`src/pages/<collection>/{rss.xml,atom.xml,feed.json}.ts`) and root combined routes are 1–2 line delegators. A node-gated Swift smoke test builds the template and asserts the rendered feeds.
+
+**Tech Stack:** Astro 5, `@astrojs/rss`, TypeScript (tsx for node tests), Swift 6 (Swift Testing) for the gated build smoke.
+
+## ⚠️ Prerequisite — gated on #344
+
+This plan references the personal-type collections (`notes`, `articles`, `photos`, `albums`, `bookmarks`, `replies`, `likes`) created by V-1.2 ([#344](https://github.com/Anglesite/Anglesite-app/issues/344)). **Do not begin until #344 has merged to `main`.** First step at execution time:
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/348-feeds
+git fetch origin && git rebase origin/main
+# confirm the typed collections now exist:
+ls src/content/{notes,articles,photos,albums,bookmarks,replies,likes} 2>/dev/null   # from Resources/Template
+```
+
+If those collection dirs are absent, stop — #344 has not landed yet.
+
+One-time local setup (for the build steps and the gated test):
+
+```bash
+cd Resources/Template && npm install && cd ../..
+```
+
+## Global Constraints
+
+- **App-only, template-only.** No plugin PR, no `Resources/plugin` change. Work lands under `Resources/Template/` plus one Swift test in `Tests/AnglesiteCoreTests/`.
+- **ES Modules**, vanilla. Only one new dependency: `@astrojs/rss`.
+- **Registry-named fields, verbatim.** `blog` dates are `pubDate`; every typed collection dates are `publishDate`. The per-collection config table in `feeds.ts` is the only place this difference is encoded — never hard-code `pubDate` elsewhere.
+- **Pure core / coupled edge split.** `src/lib/feeds.ts` must NOT import `astro:content` (so it unit-tests under plain node). All `getCollection` calls live in `src/lib/feed-data.ts` and route files.
+- **Swift Testing** (`@Test`/`#expect`), gated `.enabled(if:)` to skip — not fail — when Node or the installed Astro is absent.
+- **Conventional commits**, each ending with the trailer:
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
+- Run Swift tests with `swift test --package-path .` (set `DEVELOPER_DIR` to the Xcode-beta toolchain if the default `swift` is too old).
+- Run template node tests from `Resources/Template/` with `npx tsx --test <file>`.
+
+## Collection feed config (the single source of truth)
+
+| Collection | Date field | Title derivation |
+|---|---|---|
+| `blog` | `pubDate` | `data.title` |
+| `notes` | `publishDate` | first ~80 chars of body text |
+| `articles` | `publishDate` | `data.title` |
+| `photos` | `publishDate` | `data.caption ?? "Photo"` |
+| `albums` | `publishDate` | `data.title` |
+| `bookmarks` | `publishDate` | `data.title ?? host(data.bookmarkOf)` |
+| `replies` | `publishDate` | `"Re: " + host(data.inReplyTo)` |
+| `likes` | `publishDate` | `"Liked " + host(data.likeOf)` |
+
+---
+
+### Task 1: `feeds.ts` pure core + node unit tests
+
+**Files:**
+- Create: `Resources/Template/src/lib/feeds.ts`
+- Create: `Resources/Template/src/lib/feeds.test.ts`
+- Modify: `Resources/Template/package.json` (add `@astrojs/rss`)
+
+**Interfaces:**
+- Consumes: `@astrojs/rss`'s `rss()` (returns `Promise<Response>`); global `URL`, `Response` (Node 20+).
+- Produces:
+  - `interface FeedItem { title: string; link: string; date: Date; summary: string }`
+  - `interface FeedCollectionConfig { title: string; dateField: string; deriveTitle(entry: FeedEntry): string }`
+  - `const FEED_COLLECTIONS: Record<string, FeedCollectionConfig>` (the 8 entries above)
+  - `type FeedEntry = { id: string; collection: string; data: Record<string, any>; body?: string }`
+  - `function toFeedItem(collection: string, entry: FeedEntry, site: string): FeedItem`
+  - `function sortAndLimit(items: FeedItem[], limit?: number): FeedItem[]`
+  - `function renderRss(o: { title: string; description: string; site: string; items: FeedItem[] }): Promise<Response>`
+  - `function renderAtom(o: { title: string; site: string; feedUrl: string; items: FeedItem[] }): Response`
+  - `function renderJsonFeed(o: { title: string; site: string; feedUrl: string; items: FeedItem[] }): Response`
+
+- [ ] **Step 1: Add the dependency**
+
+In `Resources/Template/package.json`, add to `dependencies` (keep `astro`):
+
+```json
+  "dependencies": {
+    "astro": "^5.0.0",
+    "@astrojs/rss": "^4.0.0"
+  },
+```
+
+Then install: `cd Resources/Template && npm install && cd ../..`
+
+- [ ] **Step 2: Write the failing unit tests**
+
+`Resources/Template/src/lib/feeds.test.ts`:
+
+```ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FEED_COLLECTIONS,
+  toFeedItem,
+  sortAndLimit,
+  renderRss,
+  renderAtom,
+  renderJsonFeed,
+  type FeedEntry,
+} from "./feeds.ts";
+
+const SITE = "https://example.com";
+
+function entry(collection: string, data: Record<string, any>, body = ""): FeedEntry {
+  return { id: "hello", collection, data, body };
+}
+
+test("config covers all eight collections", () => {
+  assert.deepEqual(
+    Object.keys(FEED_COLLECTIONS).sort(),
+    ["albums", "articles", "blog", "bookmarks", "likes", "notes", "photos", "replies"],
+  );
+});
+
+test("toFeedItem uses pubDate for blog and an absolute link", () => {
+  const item = toFeedItem("blog", entry("blog", { title: "Hi", pubDate: "2026-01-02" }), SITE);
+  assert.equal(item.title, "Hi");
+  assert.equal(item.link, "https://example.com/blog/hello/");
+  assert.equal(item.date.getUTCFullYear(), 2026);
+});
+
+test("toFeedItem derives a title for a title-less note from its body", () => {
+  const item = toFeedItem(
+    "notes",
+    entry("notes", { publishDate: "2026-01-02" }, "Just a quick thought about feeds."),
+    SITE,
+  );
+  assert.ok(item.title.length > 0);
+  assert.ok(item.title.startsWith("Just a quick"));
+});
+
+test("toFeedItem derives a title from the link host for a like", () => {
+  const item = toFeedItem(
+    "likes",
+    entry("likes", { likeOf: "https://indieweb.org/post", publishDate: "2026-01-02" }),
+    SITE,
+  );
+  assert.equal(item.title, "Liked indieweb.org");
+});
+
+test("sortAndLimit sorts newest first and caps", () => {
+  const mk = (iso: string): any => ({ title: iso, link: "/", date: new Date(iso), summary: "" });
+  const out = sortAndLimit([mk("2026-01-01"), mk("2026-03-01"), mk("2026-02-01")], 2);
+  assert.deepEqual(out.map((i) => i.title), ["2026-03-01", "2026-02-01"]);
+});
+
+test("renderRss produces RSS XML with the item and escapes specials", async () => {
+  const res = await renderRss({
+    title: "All",
+    description: "Everything",
+    site: SITE,
+    items: [{ title: "A & B", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi" }],
+  });
+  const xml = await res.text();
+  assert.match(xml, /<rss/);
+  assert.match(xml, /A &(amp|#38);? ?B|A &amp; B/);
+  assert.match(xml, /example\.com\/blog\/a\//);
+});
+
+test("renderAtom produces a feed with entry and self link", () => {
+  const res = renderAtom({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/atom.xml`,
+    items: [{ title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi" }],
+  });
+  assert.equal(res.headers.get("content-type"), "application/atom+xml; charset=utf-8");
+});
+
+test("renderJsonFeed produces valid JSON Feed 1.1", async () => {
+  const res = renderJsonFeed({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/feed.json`,
+    items: [{ title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi" }],
+  });
+  const feed = JSON.parse(await res.text());
+  assert.equal(feed.version, "https://jsonfeed.org/version/1.1");
+  assert.equal(feed.feed_url, `${SITE}/feed.json`);
+  assert.equal(feed.items[0].url, `${SITE}/blog/a/`);
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cd Resources/Template && npx tsx --test src/lib/feeds.test.ts; cd ../..`
+Expected: FAIL — `./feeds.ts` cannot be resolved (module not yet created).
+
+- [ ] **Step 4: Implement `feeds.ts`**
+
+`Resources/Template/src/lib/feeds.ts`:
+
+```ts
+import rss from "@astrojs/rss";
+
+export interface FeedItem {
+  title: string;
+  link: string; // absolute
+  date: Date;
+  summary: string;
+}
+
+export type FeedEntry = {
+  id: string;
+  collection: string;
+  data: Record<string, any>;
+  body?: string;
+};
+
+export interface FeedCollectionConfig {
+  title: string;
+  dateField: string;
+  deriveTitle(entry: FeedEntry): string;
+}
+
+function host(url: unknown): string {
+  try {
+    return new URL(String(url)).host;
+  } catch {
+    return String(url ?? "");
+  }
+}
+
+function excerpt(body: string | undefined, max = 80): string {
+  const text = (body ?? "").replace(/\s+/g, " ").trim();
+  if (text.length <= max) return text || "Untitled";
+  return text.slice(0, max).trimEnd() + "…";
+}
+
+export const FEED_COLLECTIONS: Record<string, FeedCollectionConfig> = {
+  blog: { title: "Blog", dateField: "pubDate", deriveTitle: (e) => e.data.title },
+  notes: { title: "Notes", dateField: "publishDate", deriveTitle: (e) => excerpt(e.body) },
+  articles: { title: "Articles", dateField: "publishDate", deriveTitle: (e) => e.data.title },
+  photos: {
+    title: "Photos",
+    dateField: "publishDate",
+    deriveTitle: (e) => e.data.caption ?? "Photo",
+  },
+  albums: { title: "Albums", dateField: "publishDate", deriveTitle: (e) => e.data.title },
+  bookmarks: {
+    title: "Bookmarks",
+    dateField: "publishDate",
+    deriveTitle: (e) => e.data.title ?? host(e.data.bookmarkOf),
+  },
+  replies: {
+    title: "Replies",
+    dateField: "publishDate",
+    deriveTitle: (e) => "Re: " + host(e.data.inReplyTo),
+  },
+  likes: {
+    title: "Likes",
+    dateField: "publishDate",
+    deriveTitle: (e) => "Liked " + host(e.data.likeOf),
+  },
+};
+
+export function toFeedItem(collection: string, entry: FeedEntry, site: string): FeedItem {
+  const cfg = FEED_COLLECTIONS[collection];
+  if (!cfg) throw new Error(`No feed config for collection "${collection}"`);
+  const rawDate = entry.data[cfg.dateField];
+  const date = rawDate instanceof Date ? rawDate : new Date(rawDate);
+  const summary = (entry.data.summary ?? entry.data.caption ?? excerpt(entry.body, 280)) || "";
+  return {
+    title: cfg.deriveTitle(entry) || "Untitled",
+    link: new URL(`/${collection}/${entry.id}/`, site).href,
+    date,
+    summary: String(summary),
+  };
+}
+
+export function sortAndLimit(items: FeedItem[], limit?: number): FeedItem[] {
+  const sorted = [...items].sort((a, b) => b.date.valueOf() - a.date.valueOf());
+  return typeof limit === "number" ? sorted.slice(0, limit) : sorted;
+}
+
+export function renderRss(o: {
+  title: string;
+  description: string;
+  site: string;
+  items: FeedItem[];
+}): Promise<Response> {
+  return rss({
+    title: o.title,
+    description: o.description,
+    site: o.site,
+    items: o.items.map((i) => ({
+      title: i.title,
+      link: i.link,
+      pubDate: i.date,
+      description: i.summary,
+    })),
+  });
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function renderAtom(o: {
+  title: string;
+  site: string;
+  feedUrl: string;
+  items: FeedItem[];
+}): Response {
+  const updated = o.items[0]?.date ?? new Date(0);
+  const entries = o.items
+    .map(
+      (i) => `  <entry>
+    <title>${escapeXml(i.title)}</title>
+    <link href="${escapeXml(i.link)}"/>
+    <id>${escapeXml(i.link)}</id>
+    <updated>${i.date.toISOString()}</updated>
+    <summary>${escapeXml(i.summary)}</summary>
+  </entry>`,
+    )
+    .join("\n");
+  const xml = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>${escapeXml(o.title)}</title>
+  <id>${escapeXml(o.site)}</id>
+  <link href="${escapeXml(o.site)}"/>
+  <link rel="self" href="${escapeXml(o.feedUrl)}"/>
+  <updated>${updated.toISOString()}</updated>
+${entries}
+</feed>
+`;
+  return new Response(xml, {
+    headers: { "Content-Type": "application/atom+xml; charset=utf-8" },
+  });
+}
+
+export function renderJsonFeed(o: {
+  title: string;
+  site: string;
+  feedUrl: string;
+  items: FeedItem[];
+}): Response {
+  const feed = {
+    version: "https://jsonfeed.org/version/1.1",
+    title: o.title,
+    home_page_url: o.site,
+    feed_url: o.feedUrl,
+    items: o.items.map((i) => ({
+      id: i.link,
+      url: i.link,
+      title: i.title,
+      summary: i.summary,
+      date_published: i.date.toISOString(),
+    })),
+  };
+  return new Response(JSON.stringify(feed, null, 2), {
+    headers: { "Content-Type": "application/feed+json; charset=utf-8" },
+  });
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd Resources/Template && npx tsx --test src/lib/feeds.test.ts; cd ../..`
+Expected: PASS (all 8 tests).
+
+> If the RSS escaping assertion fails, print the actual `xml` once and align the regex to `@astrojs/rss`'s exact entity output — do not loosen to a bare `contains("A")`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Template/package.json Resources/Template/package-lock.json \
+        Resources/Template/src/lib/feeds.ts Resources/Template/src/lib/feeds.test.ts
+git commit -m "feat(#348): pure feed core (config, item mapping, RSS/Atom/JSON serializers)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Site URL from `.site-config`
+
+**Files:**
+- Delete + Create (rename): `Resources/Template/astro.config.mjs` → `Resources/Template/astro.config.ts`
+
+**Interfaces:**
+- Consumes: `readConfig` from `Resources/Template/scripts/config.ts` (`readConfig(key: string): string | undefined`, defaults to reading `<cwd>/.site-config`).
+- Produces: an Astro config whose `site` is `readConfig("SITE_URL") ?? "https://example.com"`. `context.site` (used by every feed route) derives from this.
+
+> No unit test — this is build configuration. Verified by the Task 3/5 builds, which assert feeds carry absolute URLs built from `site`.
+
+- [ ] **Step 1: Replace the config file**
+
+Remove `astro.config.mjs` and create `Resources/Template/astro.config.ts`:
+
+```ts
+import { defineConfig } from "astro/config";
+import { readConfig } from "./scripts/config.ts";
+
+// The deploy step writes the real domain into `.site-config` (SITE_URL=…) before build.
+// Absent that, feeds carry a placeholder host — fine for a not-yet-deployed scaffold.
+const site = readConfig("SITE_URL") ?? "https://example.com";
+
+export default defineConfig({ site });
+```
+
+```bash
+git rm Resources/Template/astro.config.mjs
+```
+
+- [ ] **Step 2: Verify the template still builds**
+
+Run: `cd Resources/Template && node node_modules/astro/astro.js build && cd ../..`
+Expected: build succeeds (existing pages still emit). Then clean: `rm -rf Resources/Template/dist`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Resources/Template/astro.config.ts
+git commit -m "feat(#348): set Astro site from SITE_URL in .site-config
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `feed-data.ts` + root combined feeds
+
+**Files:**
+- Create: `Resources/Template/src/lib/feed-data.ts`
+- Create: `Resources/Template/src/pages/rss.xml.ts`
+- Create: `Resources/Template/src/pages/atom.xml.ts`
+- Create: `Resources/Template/src/pages/feed.json.ts`
+
+**Interfaces:**
+- Consumes: `getCollection` from `astro:content`; `FEED_COLLECTIONS`, `toFeedItem`, `sortAndLimit`, `renderRss`, `renderAtom`, `renderJsonFeed`, `FeedItem` from `../lib/feeds.ts` (Task 1); `context.site` (Task 2).
+- Produces:
+  - `getCollectionItems(collection: string, site: string): Promise<FeedItem[]>`
+  - `getCombinedItems(site: string, limit?: number): Promise<FeedItem[]>`
+  - Endpoint routes `GET` at `/rss.xml`, `/atom.xml`, `/feed.json`.
+
+> Astro-coupled; verified by build (`getCollection` only resolves during `astro build`). No node unit test.
+
+- [ ] **Step 1: Implement the data loader**
+
+`Resources/Template/src/lib/feed-data.ts`:
+
+```ts
+import { getCollection } from "astro:content";
+import { FEED_COLLECTIONS, toFeedItem, sortAndLimit, type FeedItem } from "./feeds.ts";
+
+const COMBINED_LIMIT = 50;
+
+export async function getCollectionItems(collection: string, site: string): Promise<FeedItem[]> {
+  const entries = await getCollection(collection as any);
+  const items = entries.map((e: any) =>
+    toFeedItem(collection, { id: e.id, collection, data: e.data, body: e.body }, site),
+  );
+  return sortAndLimit(items);
+}
+
+export async function getCombinedItems(site: string, limit = COMBINED_LIMIT): Promise<FeedItem[]> {
+  const all: FeedItem[] = [];
+  for (const collection of Object.keys(FEED_COLLECTIONS)) {
+    all.push(...(await getCollectionItems(collection, site)));
+  }
+  return sortAndLimit(all, limit);
+}
+```
+
+- [ ] **Step 2: Create the three combined routes**
+
+`Resources/Template/src/pages/rss.xml.ts`:
+
+```ts
+import type { APIContext } from "astro";
+import { getCombinedItems } from "../lib/feed-data.ts";
+import { renderRss } from "../lib/feeds.ts";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: "All posts",
+    description: "Everything published on this site.",
+    site,
+    items: await getCombinedItems(site),
+  });
+}
+```
+
+`Resources/Template/src/pages/atom.xml.ts`:
+
+```ts
+import type { APIContext } from "astro";
+import { getCombinedItems } from "../lib/feed-data.ts";
+import { renderAtom } from "../lib/feeds.ts";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: "All posts",
+    site,
+    feedUrl: new URL("/atom.xml", site).href,
+    items: await getCombinedItems(site),
+  });
+}
+```
+
+`Resources/Template/src/pages/feed.json.ts`:
+
+```ts
+import type { APIContext } from "astro";
+import { getCombinedItems } from "../lib/feed-data.ts";
+import { renderJsonFeed } from "../lib/feeds.ts";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: "All posts",
+    site,
+    feedUrl: new URL("/feed.json", site).href,
+    items: await getCombinedItems(site),
+  });
+}
+```
+
+- [ ] **Step 3: Build and verify the combined feeds**
+
+Run:
+```bash
+cd Resources/Template && node node_modules/astro/astro.js build && cd ../..
+```
+Expected: build succeeds; `dist/rss.xml`, `dist/atom.xml`, `dist/feed.json` exist. Spot-check:
+```bash
+cd Resources/Template
+grep -o '<rss' dist/rss.xml
+grep -o 'application/atom' dist/atom.xml || head -2 dist/atom.xml
+grep -o 'jsonfeed.org/version/1.1' dist/feed.json
+grep -o 'https://example.com/' dist/feed.json | head -1
+rm -rf dist && cd ../..
+```
+Expected: each prints its marker, and the JSON feed contains the absolute `https://example.com/` base.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Resources/Template/src/lib/feed-data.ts Resources/Template/src/pages/rss.xml.ts \
+        Resources/Template/src/pages/atom.xml.ts Resources/Template/src/pages/feed.json.ts
+git commit -m "feat(#348): site-wide combined RSS/Atom/JSON feeds
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Per-collection feed routes + autodiscovery
+
+**Files:**
+- Create: `Resources/Template/src/pages/<collection>/{rss.xml.ts,atom.xml.ts,feed.json.ts}` for all 8 collections (24 files)
+- Modify: `Resources/Template/src/layouts/BaseLayout.astro` (autodiscovery links)
+- Modify: `Resources/Template/src/pages/blog/index.astro` (blog's own feed link)
+
+**Interfaces:**
+- Consumes: `getCollectionItems` from `../../lib/feed-data.ts`; `renderRss`/`renderAtom`/`renderJsonFeed`, `FEED_COLLECTIONS` from `../../lib/feeds.ts`; `context.site`.
+- Produces: endpoints at `/<collection>/rss.xml`, `/<collection>/atom.xml`, `/<collection>/feed.json` for every collection.
+
+- [ ] **Step 1: Create the three blog feed routes (the template for all collections)**
+
+`Resources/Template/src/pages/blog/rss.xml.ts`:
+
+```ts
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderRss, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "blog";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderRss({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
+    site,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}
+```
+
+`Resources/Template/src/pages/blog/atom.xml.ts`:
+
+```ts
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderAtom, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "blog";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderAtom({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}
+```
+
+`Resources/Template/src/pages/blog/feed.json.ts`:
+
+```ts
+import type { APIContext } from "astro";
+import { getCollectionItems } from "../../lib/feed-data.ts";
+import { renderJsonFeed, FEED_COLLECTIONS } from "../../lib/feeds.ts";
+
+const COLLECTION = "blog";
+
+export async function GET(context: APIContext) {
+  const site = context.site!.href;
+  return renderJsonFeed({
+    title: FEED_COLLECTIONS[COLLECTION].title,
+    site,
+    feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
+    items: await getCollectionItems(COLLECTION, site),
+  });
+}
+```
+
+- [ ] **Step 2: Replicate for the other seven collections**
+
+For each collection in `notes, articles, photos, albums, bookmarks, replies, likes`, copy the three `blog/*` files into that collection's page directory and change **only** the `const COLLECTION = "blog";` line to the matching name. The import paths (`../../lib/...`) are identical because every collection dir is one level under `pages/`. Resulting files:
+
+```
+src/pages/notes/{rss.xml.ts,atom.xml.ts,feed.json.ts}
+src/pages/articles/{rss.xml.ts,atom.xml.ts,feed.json.ts}
+src/pages/photos/{rss.xml.ts,atom.xml.ts,feed.json.ts}
+src/pages/albums/{rss.xml.ts,atom.xml.ts,feed.json.ts}
+src/pages/bookmarks/{rss.xml.ts,atom.xml.ts,feed.json.ts}
+src/pages/replies/{rss.xml.ts,atom.xml.ts,feed.json.ts}
+src/pages/likes/{rss.xml.ts,atom.xml.ts,feed.json.ts}
+```
+
+- [ ] **Step 3: Add combined-feed autodiscovery to BaseLayout**
+
+In `Resources/Template/src/layouts/BaseLayout.astro`, add three `<link rel="alternate">` lines inside `<head>`, immediately after the existing stylesheet `<link>`:
+
+```astro
+    <link rel="stylesheet" href="/src/styles/global.css" />
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml" />
+    <link rel="alternate" type="application/atom+xml" title="Atom" href="/atom.xml" />
+    <link rel="alternate" type="application/feed+json" title="JSON Feed" href="/feed.json" />
+```
+
+- [ ] **Step 4: Link the blog index to its own feed**
+
+In `Resources/Template/src/pages/blog/index.astro`, the page uses `BaseLayout`. Add a visible feed link inside `<main>`, after the `<h1>Blog</h1>`:
+
+```astro
+    <h1>Blog</h1>
+    <p><a href="/blog/rss.xml">Subscribe (RSS)</a></p>
+```
+
+- [ ] **Step 5: Build and verify every feed + route precedence**
+
+Run:
+```bash
+cd Resources/Template && node node_modules/astro/astro.js build
+```
+Expected: build succeeds. Verify per-collection feeds and that `/blog/rss.xml` is the feed (not a slug page):
+```bash
+for c in blog notes articles photos albums bookmarks replies likes; do
+  for f in rss.xml atom.xml feed.json; do
+    test -f "dist/$c/$f" && echo "ok  $c/$f" || echo "MISSING $c/$f"
+  done
+done
+grep -o '<rss' dist/blog/rss.xml            # blog/rss.xml is a feed
+grep -o 'jsonfeed' dist/likes/feed.json      # title-less type still produced a feed
+grep -o 'application/rss' dist/index.html    # BaseLayout autodiscovery present
+rm -rf dist && cd ../..
+```
+Expected: 24 `ok` lines, the three greps print their markers.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Template/src/pages Resources/Template/src/layouts/BaseLayout.astro
+git commit -m "feat(#348): per-collection feeds + feed autodiscovery links
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Node-gated mf2/feed render smoke test
+
+**Files:**
+- Create: `Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift`
+
+**Interfaces:**
+- Consumes: `E2EPrerequisites.locateNode()` (`Tests/AnglesiteTestSupport/E2EPrerequisites.swift`, returns `URL?`); `ProcessSupervisor.shared.run(executable:arguments:currentDirectoryURL:)` → `RunResult { stdout, stderr, exitCode }`; the template at `Resources/Template/`.
+- Produces: one gated `@Test` asserting the built feeds exist and a title-less feed item is non-empty. No production code.
+
+**Gating:** `.enabled(if:)` on Node located **and** `Resources/Template/node_modules/astro/astro.js` present — skips (never fails) when deps aren't installed, matching `PersonalTypeRenderSmokeTests`.
+
+- [ ] **Step 1: Write the gated smoke test**
+
+`Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift`:
+
+```swift
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+@Suite("Feeds render smoke")
+struct FeedsRenderSmokeTests {
+
+    /// Repo-root-relative path to the committed template. `swift test` runs with CWD = package root.
+    static var templateDir: URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources/Template", isDirectory: true)
+    }
+
+    /// True when the template can actually be built: a Node binary plus an installed Astro.
+    static var buildable: Bool {
+        guard E2EPrerequisites.locateNode() != nil else { return false }
+        return FileManager.default.isReadableFile(
+            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
+    }
+
+    @Test("collections emit RSS/Atom/JSON and a combined feed",
+          .enabled(if: FeedsRenderSmokeTests.buildable))
+    func rendersFeeds() async throws {
+        let node = try #require(E2EPrerequisites.locateNode())
+        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+        try? FileManager.default.removeItem(at: dist)
+        defer { try? FileManager.default.removeItem(at: dist) }
+
+        let result = try await ProcessSupervisor.shared.run(
+            executable: node,
+            arguments: ["node_modules/astro/astro.js", "build"],
+            currentDirectoryURL: Self.templateDir)
+        #expect(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+
+        func exists(_ rel: String) -> Bool {
+            FileManager.default.fileExists(atPath: dist.appendingPathComponent(rel).path)
+        }
+        func text(_ rel: String) throws -> String {
+            try String(contentsOf: dist.appendingPathComponent(rel), encoding: .utf8)
+        }
+
+        // Combined feeds at the root.
+        #expect(exists("rss.xml"))
+        #expect(exists("atom.xml"))
+        #expect(exists("feed.json"))
+
+        // Per-collection feeds for every collection, all three formats.
+        for c in ["blog", "notes", "articles", "photos", "albums", "bookmarks", "replies", "likes"] {
+            #expect(exists("\(c)/rss.xml"), "missing \(c)/rss.xml")
+            #expect(exists("\(c)/atom.xml"), "missing \(c)/atom.xml")
+            #expect(exists("\(c)/feed.json"), "missing \(c)/feed.json")
+        }
+
+        // Feeds carry absolute URLs from `site`.
+        #expect(try text("feed.json").contains("https://example.com/"))
+        #expect(try text("blog/rss.xml").contains("<rss"))
+
+        // A title-less type (likes) still produces a non-empty <title>.
+        let likesJson = try text("likes/feed.json")
+        #expect(likesJson.contains("\"title\""))
+        #expect(!likesJson.contains("\"title\": \"\""))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Prerequisite (local): `cd Resources/Template && npm install && cd ../..`
+Run: `swift test --package-path . --filter FeedsRenderSmokeTests`
+Expected: PASS where deps are installed; SKIPPED (not failed) where they aren't.
+
+> If `RunResult` field names differ from `.exitCode`/`.stdout`/`.stderr`, reconcile against `ProcessSupervisor.RunResult` (it is `{ stdout, stderr, exitCode }`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
+git commit -m "test(#348): node-gated RSS/Atom/JSON feed render smoke
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full verification + pre-deploy-check + push
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the feed node unit tests + the full AnglesiteCore suite**
+
+Run:
+```bash
+cd Resources/Template && npx tsx --test src/lib/feeds.test.ts && cd ../..
+swift test --package-path . --filter AnglesiteCoreTests
+```
+Expected: node tests PASS; Swift suite PASS (feed smoke passes or skips), no regressions.
+
+- [ ] **Step 2: Confirm the template still passes pre-deploy-check**
+
+Run: `cd Resources/Template && npm run check && cd ../..`
+Expected: pre-deploy-check passes with the new feed routes and config.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feat/348-feeds
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat(#348): V-1.6 feeds (RSS/Atom/JSON)" \
+  --body "Closes #348. Per-collection RSS 2.0 / Atom 1.0 / JSON Feed 1.1 co-located in each collection, plus a site-wide combined feed. Pure feed core in \`src/lib/feeds.ts\` (node-unit-tested); astro-coupled loading in \`feed-data.ts\`; node-gated Swift build smoke. Site URL from \`SITE_URL\` in \`.site-config\`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- RSS + Atom + JSON, all three formats → Task 1 serializers ✓
+- One feed per collection → Task 4 (24 routes) ✓
+- Combined feed → Task 3 ✓
+- Self-contained collections (co-located routes, shared logic) → `feeds.ts`/`feed-data.ts` + per-collection routes ✓
+- `pubDate` vs `publishDate` via config table → Task 1 `FEED_COLLECTIONS` ✓
+- Title-less type derivation → Task 1 `deriveTitle` + tests ✓
+- SITE_URL from `.site-config`, placeholder fallback → Task 2 ✓
+- Autodiscovery → Task 4 Steps 3–4 ✓
+- Node-gated build smoke, skips when absent → Task 5 ✓
+- pre-deploy-check stays green → Task 6 Step 2 ✓
+- Gated on #344 (typed collections) → Prerequisite section ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full content; commands list expected output.
+
+**Type consistency:** `FeedItem { title, link, date, summary }` defined in Task 1, consumed identically in Tasks 3–5. `toFeedItem(collection, entry, site)`, `sortAndLimit(items, limit?)`, `renderRss/renderAtom/renderJsonFeed` signatures match across `feed-data.ts` and route files. `getCollectionItems(collection, site)` / `getCombinedItems(site, limit?)` defined in Task 3, consumed in Task 4. `FEED_COLLECTIONS` keys (8 collections) consistent across config, routes, build greps, and the Swift smoke. `RunResult { stdout, stderr, exitCode }` matches `ProcessSupervisor`.
+
+**Out of scope (untouched):** full-content (markdown→HTML) feed bodies; feed pagination/`rel=next`; WebSub (#361); Zod hardening (#347); mf2 (#349).

--- a/docs/superpowers/specs/2026-06-26-feeds-rss-atom-json-design.md
+++ b/docs/superpowers/specs/2026-06-26-feeds-rss-atom-json-design.md
@@ -1,0 +1,136 @@
+# V-1.6 Feeds (RSS / Atom / JSON) — Design
+
+> Issue: [#348](https://github.com/Anglesite/Anglesite-app/issues/348) — part of the V-1 typed-content epic [#335](https://github.com/Anglesite/Anglesite-app/issues/335).
+
+**Goal:** Every content collection in `Resources/Template/` publishes a syndication feed in three formats — RSS 2.0, Atom 1.0, and JSON Feed 1.1 — co-located inside the collection, plus a site-wide combined feed. Feeds are valid at build time and survive `pre-deploy-check`.
+
+## Dependency — gated on #344
+
+The feed set covers **all** content collections, but only `blog` exists on `main` today. The personal-type collections (`notes`, `articles`, `photos`, `albums`, `bookmarks`, `replies`, `likes`) are being created by V-1.2 ([#344](https://github.com/Anglesite/Anglesite-app/issues/344)). **This implementation must not start until #344 has merged to `main`** — the per-collection feed routes and the combined aggregator reference those collections by name and will not compile without them.
+
+The design and the implementation plan are written now (against #344's committed schema) so execution can begin the moment #344 lands. Field names and collection names below are taken verbatim from #344's plan to stay in lockstep.
+
+## Global Constraints
+
+- **App-only, template-only.** No plugin PR, no `Resources/plugin` change. All work lands under `Resources/Template/` plus one node-gated Swift smoke test.
+- **ES Modules**, vanilla — Astro 5 + `@astrojs/rss` only. No other new dependencies.
+- **Registry-named fields.** Feed code reads the field names each collection actually uses — `blog` uses `pubDate`; the typed collections use `publishDate`. The per-collection feed config table is the single place this difference is declared.
+- **Swift Testing** (`@Test`/`#expect`) for the smoke test, gated to skip (not fail) when template deps are absent — mirroring `PersonalTypeRenderSmokeTests` from #344.
+- **Conventional commits.**
+
+## Collections in scope
+
+| Collection | Title field | Date field | Notes |
+|---|---|---|---|
+| `blog` | `title` | `pubDate` | existing; legacy date field name |
+| `notes` | — (none) | `publishDate` | title-less → derive from body |
+| `articles` | `title` | `publishDate` | has `summary` |
+| `photos` | — (`caption`) | `publishDate` | caption as summary |
+| `albums` | `title` | `publishDate` | |
+| `bookmarks` | `title?` | `publishDate` | title optional → fall back to `bookmarkOf` host |
+| `replies` | — (none) | `publishDate` | title-less → derive from body |
+| `likes` | — (none) | `publishDate` | title-less → derive from `likeOf` |
+
+## Architecture
+
+Feed **logic** lives in exactly one module; each collection owns thin **route** files that delegate to it. This keeps every collection self-contained (its feed endpoints sit beside its pages) without duplicating serialization.
+
+### 1. `src/lib/feeds.ts` — the shared module
+
+- **`FEED_COLLECTIONS`** — an ordered config table, one entry per collection:
+  ```ts
+  interface FeedCollection {
+    name: string;            // collection name, e.g. "blog"
+    title: string;          // human feed title, e.g. "Blog"
+    dateField: string;      // "pubDate" | "publishDate"
+    toItem(entry): FeedItem; // maps a collection entry to a normalized item
+  }
+  ```
+  `toItem` produces a normalized `FeedItem { title, link, date, summary, content }`. Title-less types derive a title from the first ~80 chars of body text (`note`, `reply`), from the link host (`like`, untitled `bookmark`), or from `caption` (`photo`). `link` is the entry's canonical permalink (`/<collection>/<id>/`), resolved to absolute against `site`.
+- **`getFeedItems(collectionName, limit?)`** — loads the collection via `getCollection`, drops drafts where applicable, sorts by the configured date field descending, maps through `toItem`, applies an optional `limit`.
+- **`getCombinedItems(limit = 50)`** — concatenates all collections' items, sorts by date descending, caps at `limit`.
+- **Three serializers:**
+  - `buildRss(context, collectionName?)` — wraps `@astrojs/rss`'s `rss()`; `collectionName` omitted → combined.
+  - `buildAtom(context, collectionName?)` — returns a `Response` with hand-written Atom 1.0 XML (`<feed>`/`<entry>`, `id`, `updated`, `link rel="self"`).
+  - `buildJsonFeed(context, collectionName?)` — returns a `Response` with a JSON Feed 1.1 object (`version`, `title`, `home_page_url`, `feed_url`, `items[]`).
+  All three pull the absolute base from `context.site` (Astro injects it from `astro.config`'s `site`). XML/JSON values are escaped; dates are emitted as RFC-822 (RSS) / RFC-3339 (Atom, JSON).
+
+### 2. Per-collection route files (co-located)
+
+Inside each collection's page directory, three thin endpoints:
+
+```
+src/pages/<collection>/rss.xml.ts     export const GET = (ctx) => buildRss(ctx, "<collection>")
+src/pages/<collection>/atom.xml.ts    export const GET = (ctx) => buildAtom(ctx, "<collection>")
+src/pages/<collection>/feed.json.ts   export const GET = (ctx) => buildJsonFeed(ctx, "<collection>")
+```
+
+Routing: `/<collection>/rss.xml` resolves to the endpoint, **not** the collection's `[...slug].astro` — Astro ranks named/static routes above `[...spread]` params, so the two coexist. The build smoke verifies this.
+
+### 3. Site-wide combined feed (root)
+
+```
+src/pages/rss.xml.ts    export const GET = (ctx) => buildRss(ctx)
+src/pages/atom.xml.ts   export const GET = (ctx) => buildAtom(ctx)
+src/pages/feed.json.ts  export const GET = (ctx) => buildJsonFeed(ctx)
+```
+
+### 4. `astro.config.mjs` — site URL
+
+Reads `SITE_URL` from `.site-config` (the existing `scripts/config.ts` `readConfig` pattern; same file CSP reads `SCRIPT_ALLOW` from), falling back to `https://example.com` when unset:
+
+```js
+import { readConfig } from "./scripts/config.ts";
+const site = readConfig("SITE_URL") ?? "https://example.com";
+export default defineConfig({ site });
+```
+
+The deploy step is responsible for writing the real `SITE_URL` into `.site-config` before build; absent that, feeds carry the placeholder host (acceptable for a not-yet-deployed scaffold).
+
+### 5. Autodiscovery
+
+`BaseLayout.astro` `<head>` gains `<link rel="alternate">` tags for the three **combined** feeds (`application/rss+xml`, `application/atom+xml`, `application/feed+json`). Each collection's `index.astro` adds an alternate link to its own RSS feed so readers on a collection page discover that collection's feed.
+
+## Data flow
+
+```
+.site-config (SITE_URL) ──► astro.config site ──► context.site
+                                                      │
+getCollection(<name>) ──► sort by dateField ──► toItem() ──► FeedItem[]
+                                                      │
+              buildRss / buildAtom / buildJsonFeed ──► Response (xml/json)
+```
+
+## Error handling
+
+- A missing/empty collection yields a valid empty feed (channel metadata, zero items) — never a build error.
+- `toItem` always produces a non-empty `title` and `content`/`summary` (the derivation fallbacks guarantee this), so title-less types never emit an empty `<title>`.
+- `astro.config` never throws on a missing `.site-config`; it falls back to the placeholder.
+
+## Testing
+
+1. **Node-gated build smoke** — `Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift`, `.enabled(if:)` on Node + installed Astro (same gate as `PersonalTypeRenderSmokeTests`). Builds the template and asserts, in `dist/`:
+   - each collection emits `rss.xml`, `atom.xml`, `feed.json`;
+   - the root combined `rss.xml` / `atom.xml` / `feed.json` exist;
+   - a title-less `notes` feed item still carries a non-empty `<title>` and content;
+   - feeds contain absolute URLs built from `site`.
+2. **`pre-deploy-check`** stays green with the new endpoint routes (run `npm run check`).
+3. Optional, fast: a Node unit test for `feeds.ts` `toItem` derivations (title-less fallbacks, date-field selection) if the build smoke proves too coarse — decided during planning.
+
+## Out of scope
+
+- Per-format autodiscovery for every collection beyond RSS (combined gets all three; collection indexes link RSS only).
+- Feed pagination / `rel="next"`; the combined feed simply caps at 50.
+- WebSub/hub advertisement (that's V-3.3, [#361](https://github.com/Anglesite/Anglesite-app/issues/361)).
+- Full Zod hardening of schemas ([#347](https://github.com/Anglesite/Anglesite-app/issues/347)) and mf2 markup ([#349](https://github.com/Anglesite/Anglesite-app/issues/349)).
+
+## Self-review
+
+- Formats: RSS + Atom + JSON — all three, per issue title. ✓
+- Site URL: `SITE_URL` in `.site-config`, placeholder fallback. ✓
+- Scope: all collections; **gated on #344**, design written now. ✓
+- Self-contained collections: feed routes co-located per collection; shared logic in `src/lib/feeds.ts`. ✓
+- Combined feed at root. ✓
+- Date-field divergence (`pubDate` vs `publishDate`) handled by the per-collection config table. ✓
+- Title-less types handled by `toItem` derivations. ✓
+- Testing: node-gated smoke + pre-deploy-check. ✓


### PR DESCRIPTION
Closes #348. Part of the V-1 typed-content epic (#335 / #334).

## What's here
Per-collection **RSS 2.0 / Atom 1.0 / JSON Feed 1.1** co-located inside each collection, plus a site-wide combined feed.

- **Pure core** (`src/lib/feeds.ts`) — a per-collection config table (handles the `blog` `pubDate` vs typed-collection `publishDate` divergence and title-less types like note/like/reply), item mapping, and the three serializers. No `astro:content` import, so it's covered by fast Node unit tests (`feeds.test.ts`, 8 tests).
- **Astro-coupled loader** (`src/lib/feed-data.ts`) — `getCollection` lives here; combined feed merges all collections, sorts desc, caps at 50.
- **Routes** — `src/pages/<collection>/{rss.xml,atom.xml,feed.json}.ts` for all 8 collections (24 thin delegators) + root `src/pages/{rss.xml,atom.xml,feed.json}.ts`. The 7 typed collections are served by #344's dynamic `[collection]/[...slug].astro`; the feed endpoints are sibling static routes (static wins over `[...slug]`, verified in the smoke test).
- **Site URL** — `astro.config.ts` reads `SITE_URL` from `.site-config` (the existing config pattern), placeholder fallback.
- **Autodiscovery** — `<link rel="alternate">` for the three combined feeds in `BaseLayout`; a Subscribe link on the blog index.

## Tests
- `feeds.test.ts` (Node) — 8 passing.
- `FeedsRenderSmokeTests` (node-gated Swift) — builds the template, asserts all 24 per-collection feeds + 3 combined feeds, route precedence, absolute URLs, and a non-empty title for title-less types. Skips cleanly when Node/template deps are absent.
- Added `TemplateBuildSerializer` (async lock in `AnglesiteTestSupport`) so this smoke and #344's `PersonalTypeRenderSmokeTests` don't race on the shared `dist/`.
- `swift test --filter AnglesiteCoreTests` → 904 passing; template `pre-deploy-check` passes.

## Out of scope (tracked)
Full-content (markdown→HTML) feed bodies; feed pagination; WebSub (#361); Zod hardening (#347); mf2 (#349).

🤖 Generated with [Claude Code](https://claude.com/claude-code)