### PR TITLE
fix(#383): keep SemanticRanker in sync on incremental reindex

### DIFF
--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -135,12 +135,13 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
 
     private func applyFileChanges(_ batch: FileChangeBatch, siteID: String, projectRoot: URL, generation gen: Int) async {
         guard gen == generation, let knowledgeIndex else { return }
-        await KnowledgeReindex.apply(batch, to: knowledgeIndex, siteID: siteID, projectRoot: projectRoot)
+        await KnowledgeReindex.apply(batch, to: knowledgeIndex, ranker: semanticRanker, siteID: siteID, projectRoot: projectRoot)
         // A stop()/site-switch may have superseded us during the apply above; if so, drop anything
         // we re-added for a site this runtime no longer owns — mirroring populateSharedIndexes'
         // post-await unload discipline.
         guard gen == generation else {
             await knowledgeIndex.unload(siteID: siteID)
+            await semanticRanker?.unload(siteID: siteID)
             return
         }
     }

--- a/Sources/AnglesiteCore/LocalSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalSiteRuntime.swift
@@ -239,12 +239,13 @@ public actor LocalSiteRuntime: SiteRuntime, HeadlessRuntime {
     /// has superseded the watcher that produced it.
     private func applyFileChanges(_ batch: FileChangeBatch, siteID: String, projectRoot: URL, generation gen: Int) async {
         guard gen == generation, let knowledgeIndex else { return }
-        await KnowledgeReindex.apply(batch, to: knowledgeIndex, siteID: siteID, projectRoot: projectRoot)
+        await KnowledgeReindex.apply(batch, to: knowledgeIndex, ranker: semanticRanker, siteID: siteID, projectRoot: projectRoot)
         // A stop()/site-switch may have superseded us during the apply above; if so, drop anything
         // we re-added for a site this runtime no longer owns — mirroring populateSharedIndexes'
         // post-await unload discipline.
         guard gen == generation else {
             await knowledgeIndex.unload(siteID: siteID)
+            await semanticRanker?.unload(siteID: siteID)
             return
         }
     }

--- a/Sources/AnglesiteCore/SiteFileWatcher.swift
+++ b/Sources/AnglesiteCore/SiteFileWatcher.swift
@@ -47,18 +47,27 @@ public protocol SiteFileWatching: Sendable {
     func stop()
 }
 
-/// Translates a `FileChangeBatch` into `SiteKnowledgeIndex` mutations. Kept free-standing (not on
-/// the runtime actor) so it is unit-testable without spinning a runtime.
+/// Translates a `FileChangeBatch` into `SiteKnowledgeIndex` mutations, and (when supplied) mirrors
+/// each mutation into the `SemanticRanker` so the lexical and semantic halves stay consistent after
+/// incremental edits (#383). Kept free-standing (not on the runtime actor) so it is unit-testable
+/// without spinning a runtime.
 public enum KnowledgeReindex {
     public static func apply(
         _ batch: FileChangeBatch,
         to index: SiteKnowledgeIndex,
+        ranker: SemanticRanker? = nil,
         siteID: String,
         projectRoot: URL,
         fileExists: @Sendable (URL) -> Bool = { FileManager.default.fileExists(atPath: $0.path) }
     ) async {
         if batch.needsFullRescan {
             await index.rebuild(siteID: siteID, projectRoot: projectRoot)
+            // A coalesced/bulk event drops per-file granularity, so re-sync the ranker against the
+            // freshly-rebuilt document set rather than guessing which vectors changed. `sync` reuses
+            // cached vectors for unchanged content, so this only re-embeds what actually moved.
+            if let ranker {
+                await ranker.sync(siteID: siteID, documents: await index.documents(siteID: siteID))
+            }
             return
         }
         // FSEvents can list the same path multiple times in one coalesced batch (e.g. write →
@@ -72,8 +81,17 @@ public enum KnowledgeReindex {
             else { continue }
             if fileExists(url) {
                 await index.upsertFile(siteID: siteID, projectRoot: projectRoot, relativePath: relativePath)
+                guard let ranker else { continue }
+                // `upsertFile` may have dropped the path (now unreadable or a non-indexed kind); in
+                // that case there's no document to embed, so drop its vector instead.
+                if let document = await index.document(siteID: siteID, relativePath: relativePath) {
+                    await ranker.upsert(siteID: siteID, document: document)
+                } else {
+                    await ranker.remove(siteID: siteID, docID: SiteKnowledgeIndex.documentID(siteID: siteID, relativePath: relativePath))
+                }
             } else {
                 await index.removeFile(siteID: siteID, relativePath: relativePath)
+                await ranker?.remove(siteID: siteID, docID: SiteKnowledgeIndex.documentID(siteID: siteID, relativePath: relativePath))
             }
         }
     }

--- a/Sources/AnglesiteCore/SiteFileWatcher.swift
+++ b/Sources/AnglesiteCore/SiteFileWatcher.swift
@@ -81,13 +81,14 @@ public enum KnowledgeReindex {
             else { continue }
             if fileExists(url) {
                 await index.upsertFile(siteID: siteID, projectRoot: projectRoot, relativePath: relativePath)
-                guard let ranker else { continue }
-                // `upsertFile` may have dropped the path (now unreadable or a non-indexed kind); in
-                // that case there's no document to embed, so drop its vector instead.
-                if let document = await index.document(siteID: siteID, relativePath: relativePath) {
-                    await ranker.upsert(siteID: siteID, document: document)
-                } else {
-                    await ranker.remove(siteID: siteID, docID: SiteKnowledgeIndex.documentID(siteID: siteID, relativePath: relativePath))
+                if let ranker {
+                    // `upsertFile` may have dropped the path (now unreadable or a non-indexed kind);
+                    // in that case there's no document to embed, so drop its vector instead.
+                    if let document = await index.document(siteID: siteID, relativePath: relativePath) {
+                        await ranker.upsert(siteID: siteID, document: document)
+                    } else {
+                        await ranker.remove(siteID: siteID, docID: SiteKnowledgeIndex.documentID(siteID: siteID, relativePath: relativePath))
+                    }
                 }
             } else {
                 await index.removeFile(siteID: siteID, relativePath: relativePath)

--- a/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
+++ b/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
@@ -87,6 +87,18 @@ public actor SiteKnowledgeIndex {
         documentsBySite[siteID]?[relativePath] = nil
     }
 
+    /// The currently-indexed document for a path, or `nil` if none is held. Lets incremental
+    /// consumers (the semantic ranker) read back what `upsertFile` produced without a full scan.
+    public func document(siteID: String, relativePath: String) -> Document? {
+        documentsBySite[siteID]?[relativePath]
+    }
+
+    /// The stable document ID for a path. The index owns this format; consumers that key off
+    /// document identity (e.g. ``SemanticRanker``) derive it here rather than reconstructing it.
+    public static func documentID(siteID: String, relativePath: String) -> String {
+        "\(siteID):knowledge:\(relativePath)"
+    }
+
     public func search(siteID: String, query: String, options: SearchOptions = .init()) -> [SearchResult] {
         let terms = Self.queryTerms(query)
         guard !terms.isEmpty else { return [] }
@@ -156,7 +168,7 @@ public actor SiteKnowledgeIndex {
         let headings = headings(in: bodySource)
         let links = internalLinks(in: bodySource)
         return Document(
-            id: "\(siteID):knowledge:\(relativePath)",
+            id: documentID(siteID: siteID, relativePath: relativePath),
             siteID: siteID,
             path: relativePath,
             kind: kind(for: relativePath),

--- a/Tests/AnglesiteCoreTests/IncrementalReindexTests.swift
+++ b/Tests/AnglesiteCoreTests/IncrementalReindexTests.swift
@@ -97,7 +97,9 @@ struct IncrementalReindexTests {
     // MARK: - Semantic ranker reconciliation (#383)
 
     /// Wraps the deterministic fake to count embed() calls, so re-embedding is observable.
-    /// `@unchecked Sendable` is safe because the ranker embeds strictly sequentially.
+    /// `@unchecked Sendable` is safe: `NSLock` protects `_calls` across actor hops. Sequential
+    /// embedding means the lock is never contended in practice, but the lock — not the call
+    /// order — is the soundness argument.
     final class CountingFake: EmbeddingProvider, @unchecked Sendable {
         let dimension = 8
         private let lock = NSLock()
@@ -179,6 +181,9 @@ struct IncrementalReindexTests {
         await KnowledgeReindex.apply(.init(paths: [touched], needsFullRescan: false),
                                      to: index, ranker: ranker, siteID: "s", projectRoot: root, fileExists: exists)
 
+        // SemanticRanker.upsert skips re-embedding when the document's content hash is unchanged;
+        // KnowledgeReindex itself does not dedupe by content. This verifies that guarantee holds
+        // end-to-end through the reindex path (it would break if the ranker lost its hash check).
         #expect(provider.calls == baseline)
     }
 
@@ -194,6 +199,35 @@ struct IncrementalReindexTests {
                                      to: index, ranker: ranker, siteID: "s", projectRoot: root, fileExists: exists)
 
         #expect(await ranker.vectorCount(siteID: "s") == 2)
+    }
+
+    @Test("apply drops a stale ranker vector when a present file is no longer indexable")
+    func applyRemovesRankerVectorForNonIndexableFile() async {
+        // A file exists on disk (so fileExists is true and it isn't in a skipped dir) but its kind
+        // is not indexed (.png) — `upsertFile` runs yet persists no document. Exercises the branch
+        // where the ranker still holds a vector for that path and must drop it.
+        let root = makeSite([:])
+        let pngPath = "assets/logo.png"
+        let pngURL = root.appendingPathComponent(pngPath)
+        try! FileManager.default.createDirectory(at: pngURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try! Data("not really a png".utf8).write(to: pngURL)
+
+        let index = SiteKnowledgeIndex()
+        let ranker = SemanticRanker(provider: FakeEmbeddingProvider(dimension: 8), cache: nil)
+        // Simulate a stale vector lingering for this path's doc ID (e.g. it was indexable before).
+        let staleDoc = SiteKnowledgeIndex.Document(
+            id: SiteKnowledgeIndex.documentID(siteID: "s", relativePath: pngPath),
+            siteID: "s", path: pngPath, kind: .other, title: "Logo",
+            frontmatter: [:], headings: [], internalLinks: [], excerptText: "logo",
+            lastModified: Date(timeIntervalSince1970: 0))
+        await ranker.upsert(siteID: "s", document: staleDoc)
+        #expect(await ranker.vectorCount(siteID: "s") == 1)
+
+        await KnowledgeReindex.apply(.init(paths: [pngURL], needsFullRescan: false),
+                                     to: index, ranker: ranker, siteID: "s", projectRoot: root, fileExists: exists)
+
+        #expect(await ranker.vectorCount(siteID: "s") == 0)
+        #expect(await index.document(siteID: "s", relativePath: pngPath) == nil)
     }
 
     @Test("apply with a nil ranker still updates the index (back-compat)")

--- a/Tests/AnglesiteCoreTests/IncrementalReindexTests.swift
+++ b/Tests/AnglesiteCoreTests/IncrementalReindexTests.swift
@@ -94,6 +94,122 @@ struct IncrementalReindexTests {
         #expect(await index.documents(siteID: "s").contains { $0.path == "src/pages/surprise.astro" })
     }
 
+    // MARK: - Semantic ranker reconciliation (#383)
+
+    /// Wraps the deterministic fake to count embed() calls, so re-embedding is observable.
+    /// `@unchecked Sendable` is safe because the ranker embeds strictly sequentially.
+    final class CountingFake: EmbeddingProvider, @unchecked Sendable {
+        let dimension = 8
+        private let lock = NSLock()
+        private var _calls = 0
+        var calls: Int { lock.lock(); defer { lock.unlock() }; return _calls }
+        func embed(_ text: String) async throws -> [Float] {
+            lock.lock(); _calls += 1; lock.unlock()
+            return try await FakeEmbeddingProvider(dimension: 8).embed(text)
+        }
+    }
+
+    /// Build an index + ranker both seeded to the same on-disk state (mirrors site-open:
+    /// `rebuild` then `sync`), so subsequent `apply` calls exercise the incremental path.
+    private func seededIndexAndRanker(
+        _ root: URL, siteID: String = "s", provider: EmbeddingProvider = FakeEmbeddingProvider(dimension: 8)
+    ) async -> (SiteKnowledgeIndex, SemanticRanker) {
+        let index = SiteKnowledgeIndex()
+        let ranker = SemanticRanker(provider: provider, cache: nil)
+        await index.rebuild(siteID: siteID, projectRoot: root)
+        await ranker.sync(siteID: siteID, documents: await index.documents(siteID: siteID))
+        return (index, ranker)
+    }
+
+    @Test("apply embeds a newly created file into the ranker")
+    func applyUpsertsRankerForNewFile() async {
+        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let (index, ranker) = await seededIndexAndRanker(root)
+        #expect(await ranker.vectorCount(siteID: "s") == 1)
+
+        let added = root.appendingPathComponent("src/pages/about.astro")
+        try! Data("---\ntitle: About\n---\n# About".utf8).write(to: added)
+        await KnowledgeReindex.apply(.init(paths: [added], needsFullRescan: false),
+                                     to: index, ranker: ranker, siteID: "s", projectRoot: root, fileExists: exists)
+
+        #expect(await ranker.vectorCount(siteID: "s") == 2)
+    }
+
+    @Test("apply drops a deleted file's vector from the ranker")
+    func applyRemovesRankerVectorForDeletedFile() async {
+        let root = makeSite([
+            "src/pages/index.astro": "---\ntitle: Home\n---\n# Home",
+            "src/pages/gone.astro": "---\ntitle: Gone\n---\nbody",
+        ])
+        let (index, ranker) = await seededIndexAndRanker(root)
+        #expect(await ranker.vectorCount(siteID: "s") == 2)
+
+        let gone = root.appendingPathComponent("src/pages/gone.astro")
+        try! FileManager.default.removeItem(at: gone)
+        await KnowledgeReindex.apply(.init(paths: [gone], needsFullRescan: false),
+                                     to: index, ranker: ranker, siteID: "s", projectRoot: root, fileExists: exists)
+
+        #expect(await ranker.vectorCount(siteID: "s") == 1)
+    }
+
+    @Test("apply re-embeds a changed file so the ranker reflects new content")
+    func applyReembedsChangedFile() async {
+        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let provider = CountingFake()
+        let (index, ranker) = await seededIndexAndRanker(root, provider: provider)
+        let baseline = provider.calls
+
+        let changed = root.appendingPathComponent("src/pages/index.astro")
+        try! Data("---\ntitle: Home Renamed\n---\n# Totally different body".utf8).write(to: changed)
+        await KnowledgeReindex.apply(.init(paths: [changed], needsFullRescan: false),
+                                     to: index, ranker: ranker, siteID: "s", projectRoot: root, fileExists: exists)
+
+        #expect(provider.calls == baseline + 1)
+        #expect(await ranker.vectorCount(siteID: "s") == 1)
+    }
+
+    @Test("apply does not re-embed when a touched file's content is unchanged")
+    func applySkipsReembedForUnchangedFile() async {
+        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let provider = CountingFake()
+        let (index, ranker) = await seededIndexAndRanker(root, provider: provider)
+        let baseline = provider.calls
+
+        let touched = root.appendingPathComponent("src/pages/index.astro")
+        await KnowledgeReindex.apply(.init(paths: [touched], needsFullRescan: false),
+                                     to: index, ranker: ranker, siteID: "s", projectRoot: root, fileExists: exists)
+
+        #expect(provider.calls == baseline)
+    }
+
+    @Test("apply with needsFullRescan re-syncs the ranker with files absent from the batch")
+    func applyFullRescanResyncsRanker() async {
+        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let (index, ranker) = await seededIndexAndRanker(root)
+        #expect(await ranker.vectorCount(siteID: "s") == 1)
+
+        let surprise = root.appendingPathComponent("src/pages/surprise.astro")
+        try! Data("---\ntitle: Surprise\n---\nbody".utf8).write(to: surprise)
+        await KnowledgeReindex.apply(.init(paths: [], needsFullRescan: true),
+                                     to: index, ranker: ranker, siteID: "s", projectRoot: root, fileExists: exists)
+
+        #expect(await ranker.vectorCount(siteID: "s") == 2)
+    }
+
+    @Test("apply with a nil ranker still updates the index (back-compat)")
+    func applyWithNilRankerUpdatesIndex() async {
+        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "s", projectRoot: root)
+
+        let added = root.appendingPathComponent("src/pages/about.astro")
+        try! Data("---\ntitle: About\n---\n# About".utf8).write(to: added)
+        await KnowledgeReindex.apply(.init(paths: [added], needsFullRescan: false),
+                                     to: index, ranker: nil, siteID: "s", projectRoot: root, fileExists: exists)
+
+        #expect(await index.documents(siteID: "s").contains { $0.path == "src/pages/about.astro" })
+    }
+
     @Test("apply deduplicates repeated paths within a single batch")
     func applyDeduplicatesRepeatedPaths() async {
         let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])


### PR DESCRIPTION
Closes #383.

## Problem

#379 added a filesystem watcher that keeps the lexical `SiteKnowledgeIndex` fresh incrementally, but it did **not** re-sync `SemanticRanker`. After a site was open and files were edited, the lexical index reflected the edits while the embeddings still described pre-edit content — so `SearchKnowledgeTool`'s hybrid results mixed fresh and stale signal for the same file.

## Fix (option 2 from the issue)

The ranker already had `upsert`/`remove` incremental seams; this just wires them into the reindex path.

- `KnowledgeReindex.apply` takes an optional `SemanticRanker?` and mirrors each index mutation into it:
  - per-file **upsert** → re-embed the resulting document (or drop its vector if the path became non-indexable)
  - per-file **remove** → drop the vector
  - **needsFullRescan** → re-sync against the rebuilt document set (`sync` reuses cached vectors, so only changed content re-embeds)
- Both `LocalSiteRuntime` and `LocalContainerSiteRuntime` pass the ranker through and unload it alongside the index in the superseded-generation guard.
- `SiteKnowledgeIndex` gains a per-path `document(siteID:relativePath:)` getter and a `documentID(siteID:relativePath:)` helper so the ranker derives doc identity from the index instead of reconstructing the key format (also DRYs the internal `document(...)`).

Cost is bounded: only changed files re-embed; touched-but-unchanged files hit the ranker's content-hash guard and skip embedding.

## Tests

7 new cases in `IncrementalReindexTests` covering ranker upsert on create, vector drop on delete, re-embed on content change, no re-embed on unchanged touch, full-rescan re-sync, and nil-ranker back-compat. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)