### PR TITLE
feat(#345): V-1.3 business content types + content-config drift guard

### DIFF
--- a/Resources/Template/src/content.config.ts
+++ b/Resources/Template/src/content.config.ts
@@ -79,4 +79,31 @@ const likes = defineCollection({
   }),
 });
 
-export const collections = { blog, notes, articles, photos, albums, bookmarks, replies, likes };
+const announcements = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/announcements" }),
+  schema: z.object({
+    title: z.string(),
+    publishDate: z.coerce.date(),
+  }),
+});
+
+const events = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/events" }),
+  schema: z.object({
+    name: z.string(),
+    start: z.coerce.date(),
+    end: z.coerce.date().optional(),
+    location: z.string().optional(),
+  }),
+});
+
+const reviews = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/reviews" }),
+  schema: z.object({
+    itemReviewed: z.string(),
+    rating: z.number(),
+    publishDate: z.coerce.date(),
+  }),
+});
+
+export const collections = { blog, notes, articles, photos, albums, bookmarks, replies, likes, announcements, events, reviews };

--- a/Resources/Template/src/content/announcements/hello-announcement.md
+++ b/Resources/Template/src/content/announcements/hello-announcement.md
@@ -1,0 +1,6 @@
+---
+title: "Hello, announcement"
+publishDate: 2026-01-01T00:00:00.000Z
+---
+
+This is a sample announcement.

--- a/Resources/Template/src/content/events/hello-event.md
+++ b/Resources/Template/src/content/events/hello-event.md
@@ -1,0 +1,8 @@
+---
+name: "Hello, event"
+start: 2026-01-01T18:00:00.000Z
+end: 2026-01-01T20:00:00.000Z
+location: "Main Street"
+---
+
+This is a sample event.

--- a/Resources/Template/src/content/reviews/hello-review.md
+++ b/Resources/Template/src/content/reviews/hello-review.md
@@ -1,0 +1,7 @@
+---
+itemReviewed: "Hello, product"
+rating: 5
+publishDate: 2026-01-01T00:00:00.000Z
+---
+
+This is a sample review.

--- a/Resources/Template/src/layouts/Hevent.astro
+++ b/Resources/Template/src/layouts/Hevent.astro
@@ -1,16 +1,20 @@
 ---
+import type { CollectionEntry } from "astro:content";
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {
-  entry: { data: Record<string, any> };
+  entry: CollectionEntry<"events">;
 }
 
 const { entry } = Astro.props;
 const d = entry.data;
-const startISO = d.start ? new Date(d.start).toISOString() : undefined;
-const startHuman = d.start ? new Date(d.start).toLocaleString() : undefined;
-const endISO = d.end ? new Date(d.end).toISOString() : undefined;
-const endHuman = d.end ? new Date(d.end).toLocaleString() : undefined;
+// Compute each Date once; pin the locale so static output is deterministic across build hosts.
+const startDate = d.start ? new Date(d.start) : undefined;
+const startISO = startDate?.toISOString();
+const startHuman = startDate?.toLocaleString("en-US");
+const endDate = d.end ? new Date(d.end) : undefined;
+const endISO = endDate?.toISOString();
+const endHuman = endDate?.toLocaleString("en-US");
 ---
 
 <BaseLayout title={d.name ?? "Event"} description={d.location}>

--- a/Resources/Template/src/layouts/Hevent.astro
+++ b/Resources/Template/src/layouts/Hevent.astro
@@ -1,0 +1,24 @@
+---
+import BaseLayout from "./BaseLayout.astro";
+
+interface Props {
+  entry: { data: Record<string, any> };
+}
+
+const { entry } = Astro.props;
+const d = entry.data;
+const startISO = d.start ? new Date(d.start).toISOString() : undefined;
+const startHuman = d.start ? new Date(d.start).toLocaleString() : undefined;
+const endISO = d.end ? new Date(d.end).toISOString() : undefined;
+const endHuman = d.end ? new Date(d.end).toLocaleString() : undefined;
+---
+
+<BaseLayout title={d.name ?? "Event"} description={d.location}>
+  <article class="h-event">
+    <h1 class="p-name">{d.name}</h1>
+    {startISO && <time class="dt-start" datetime={startISO}>{startHuman}</time>}
+    {endISO && <time class="dt-end" datetime={endISO}>{endHuman}</time>}
+    {d.location && <p class="p-location">{d.location}</p>}
+    <div class="e-content"><slot /></div>
+  </article>
+</BaseLayout>

--- a/Resources/Template/src/layouts/Hreview.astro
+++ b/Resources/Template/src/layouts/Hreview.astro
@@ -1,19 +1,27 @@
 ---
+import type { CollectionEntry } from "astro:content";
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {
-  entry: { data: Record<string, any> };
+  entry: CollectionEntry<"reviews">;
 }
 
 const { entry } = Astro.props;
 const d = entry.data;
-const iso = d.publishDate ? new Date(d.publishDate).toISOString() : undefined;
-const human = d.publishDate ? new Date(d.publishDate).toLocaleDateString() : undefined;
+// Compute the Date once; pin the locale so static output is deterministic across build hosts.
+const publishedDate = d.publishDate ? new Date(d.publishDate) : undefined;
+const iso = publishedDate?.toISOString();
+const human = publishedDate?.toLocaleDateString("en-US");
+// h-review needs an explicit p-name (the review's own title) distinct from p-item (the thing
+// reviewed); without it, mf2 parsers fall back to the implied name — the concatenation of all
+// text content, smashing item/rating/body together. Generate one from the reviewed item.
+const reviewName = `Review of ${d.itemReviewed}`;
 ---
 
-<BaseLayout title={d.itemReviewed ?? "Review"}>
+<BaseLayout title={reviewName}>
   <article class="h-review">
-    <h1 class="p-item">{d.itemReviewed}</h1>
+    <h1 class="p-name">{reviewName}</h1>
+    <p>Reviewed: <span class="p-item">{d.itemReviewed}</span></p>
     <data class="p-rating" value={d.rating}>{d.rating}</data>
     <div class="e-content"><slot /></div>
     {iso && <time class="dt-published" datetime={iso}>{human}</time>}

--- a/Resources/Template/src/layouts/Hreview.astro
+++ b/Resources/Template/src/layouts/Hreview.astro
@@ -1,0 +1,21 @@
+---
+import BaseLayout from "./BaseLayout.astro";
+
+interface Props {
+  entry: { data: Record<string, any> };
+}
+
+const { entry } = Astro.props;
+const d = entry.data;
+const iso = d.publishDate ? new Date(d.publishDate).toISOString() : undefined;
+const human = d.publishDate ? new Date(d.publishDate).toLocaleDateString() : undefined;
+---
+
+<BaseLayout title={d.itemReviewed ?? "Review"}>
+  <article class="h-review">
+    <h1 class="p-item">{d.itemReviewed}</h1>
+    <data class="p-rating" value={d.rating}>{d.rating}</data>
+    <div class="e-content"><slot /></div>
+    {iso && <time class="dt-published" datetime={iso}>{human}</time>}
+  </article>
+</BaseLayout>

--- a/Resources/Template/src/pages/[collection]/[...slug].astro
+++ b/Resources/Template/src/pages/[collection]/[...slug].astro
@@ -25,7 +25,13 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
-const Layout = entry.collection === "events" ? Hevent : entry.collection === "reviews" ? Hreview : Hentry;
+// Per-collection layout. Only non-h-entry vocabularies need their own; everything else
+// (notes, articles, photos, albums, bookmarks, replies, likes, announcements) is h-entry → Hentry.
+const layoutByCollection: Partial<Record<EntryCollection, typeof Hentry>> = {
+  events: Hevent,
+  reviews: Hreview,
+};
+const Layout = layoutByCollection[entry.collection as EntryCollection] ?? Hentry;
 ---
 
 <Layout entry={entry}><Content /></Layout>

--- a/Resources/Template/src/pages/[collection]/[...slug].astro
+++ b/Resources/Template/src/pages/[collection]/[...slug].astro
@@ -1,11 +1,18 @@
 ---
 import { getCollection, render } from "astro:content";
 import Hentry from "../../layouts/Hentry.astro";
+import Hevent from "../../layouts/Hevent.astro";
+import Hreview from "../../layouts/Hreview.astro";
 
-type PersonalCollection = "notes" | "articles" | "photos" | "albums" | "bookmarks" | "replies" | "likes";
+type EntryCollection =
+  | "notes" | "articles" | "photos" | "albums" | "bookmarks" | "replies" | "likes"
+  | "announcements" | "events" | "reviews";
 
 export async function getStaticPaths() {
-  const collections: PersonalCollection[] = ["notes", "articles", "photos", "albums", "bookmarks", "replies", "likes"];
+  const collections: EntryCollection[] = [
+    "notes", "articles", "photos", "albums", "bookmarks", "replies", "likes",
+    "announcements", "events", "reviews",
+  ];
   const paths = [];
   for (const collection of collections) {
     const entries = await getCollection(collection);
@@ -18,6 +25,7 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
+const Layout = entry.collection === "events" ? Hevent : entry.collection === "reviews" ? Hreview : Hentry;
 ---
 
-<Hentry entry={entry}><Content /></Hentry>
+<Layout entry={entry}><Content /></Layout>

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -143,10 +143,14 @@ public enum ContentScaffold {
             switch field.kind {
             case .markdown:
                 bodyPlaceholder = "Write your \(descriptor.displayName.lowercased()) here."
+            // Optional datetime/date fields scaffold commented-out: an emitted value is a valid
+            // truthy Date under `z.coerce.date()`, so a live default (e.g. an unset event `end`)
+            // would render a bogus `dt-end`. Commenting keeps the field as a format hint the user
+            // can uncomment. Required ones stay live (the entry is invalid without them).
             case .datetime:
-                lines.append("\(field.name): \(dateTime)")
+                lines.append("\(field.required ? "" : "# ")\(field.name): \(dateTime)")
             case .date:
-                lines.append("\(field.name): \(String(dateTime.prefix(10)))")
+                lines.append("\(field.required ? "" : "# ")\(field.name): \(String(dateTime.prefix(10)))")
             case .bool:
                 lines.append("\(field.name): false")
             case .number:

--- a/Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
@@ -47,6 +47,8 @@ struct BusinessTypeRenderSmokeTests {
             let review = try html("reviews/hello-review/index.html")
             #expect(review.contains("h-review"))
             #expect(review.contains("p-rating"))
+            #expect(review.contains("p-name")) // explicit review title, distinct from p-item
+            #expect(review.contains("p-item"))
         }
     }
 }

--- a/Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+@Suite("Business type render smoke")
+struct BusinessTypeRenderSmokeTests {
+
+    static var templateDir: URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources/Template", isDirectory: true)
+    }
+
+    /// True when the template can actually be built: a Node binary plus an installed Astro.
+    static var buildable: Bool {
+        guard E2EPrerequisites.locateNode() != nil else { return false }
+        return FileManager.default.isReadableFile(
+            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
+    }
+
+    @Test("seeded business types build and render their mf2 classes",
+          .enabled(if: BusinessTypeRenderSmokeTests.buildable))
+    func rendersMicroformats() async throws {
+        let node = try #require(E2EPrerequisites.locateNode())
+        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+
+        func html(_ rel: String) throws -> String {
+            try String(contentsOf: dist.appendingPathComponent(rel), encoding: .utf8)
+        }
+
+        // Hold the shared template-build lock across build + assertions: other render-smoke
+        // suites rm -rf dist around their own build and would race on the shared template tree.
+        try await TemplateBuildSerializer.shared.serialize {
+            try? FileManager.default.removeItem(at: dist)
+            defer { try? FileManager.default.removeItem(at: dist) }
+
+            let result = try await ProcessSupervisor.shared.run(
+                executable: node,
+                arguments: ["node_modules/astro/astro.js", "build"],
+                currentDirectoryURL: Self.templateDir)
+            try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+
+            #expect(try html("announcements/hello-announcement/index.html").contains("h-entry"))
+            let event = try html("events/hello-event/index.html")
+            #expect(event.contains("h-event"))
+            #expect(event.contains("dt-start"))
+            let review = try html("reviews/hello-review/index.html")
+            #expect(review.contains("h-review"))
+            #expect(review.contains("p-rating"))
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("content.config.ts drift guard")
+struct ContentConfigDriftTests {
+
+    /// Repo-root-relative path to the committed template config. `swift test` runs with CWD = package root.
+    static var configFile: URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources/Template/src/content.config.ts")
+    }
+
+    /// Canonical Zod expression for a field kind, or nil for the markdown body (excluded from frontmatter).
+    static func zod(for kind: ContentTypeField.Kind) -> String? {
+        switch kind {
+        case .markdown: return nil
+        case .string, .text, .image: return "z.string()"
+        case .url: return "z.string().url()"
+        case .date, .datetime: return "z.coerce.date()"
+        case .number: return "z.number()"
+        case .bool: return "z.boolean()"
+        case .stringArray, .imageArray: return "z.array(z.string())"
+        }
+    }
+
+    /// The single canonical `defineCollection` block for a collection-backed descriptor.
+    static func canonicalBlock(_ d: ContentTypeDescriptor) -> String? {
+        guard let collection = d.collection else { return nil }
+        var schemaLines: [String] = []
+        for field in d.fields {
+            guard let zod = zod(for: field.kind) else { continue }
+            let expr = field.required ? zod : "\(zod).optional()"
+            schemaLines.append("    \(field.name): \(expr),")
+        }
+        return """
+        const \(collection) = defineCollection({
+          loader: glob({ pattern: "**/*.md", base: "./src/content/\(collection)" }),
+          schema: z.object({
+        \(schemaLines.joined(separator: "\n"))
+          }),
+        });
+        """
+    }
+
+    @Test("every collection-backed registry type appears verbatim in content.config.ts")
+    func configMatchesRegistry() throws {
+        let source = try String(contentsOf: Self.configFile, encoding: .utf8)
+        let exportLine = source
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .first { $0.contains("export const collections") }
+            .map(String.init) ?? ""
+
+        for descriptor in ContentTypeRegistry().all {
+            guard let collection = descriptor.collection,
+                  let block = Self.canonicalBlock(descriptor) else { continue }
+            #expect(source.contains(block),
+                    "content.config.ts is missing or has drifted from the canonical block for `\(collection)`:\n\(block)")
+            #expect(exportLine.contains(collection),
+                    "`\(collection)` is not listed in the `collections` export")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
@@ -51,7 +51,9 @@ struct ContentConfigDriftTests {
             .first { $0.contains("export const collections") }
             .map(String.init) ?? ""
 
-        for descriptor in ContentTypeRegistry().all {
+        // Scope to the canonical builtin vocabulary, not a registry instance: a custom type
+        // registered elsewhere must not make this guard demand a block in the committed template.
+        for descriptor in ContentTypeRegistry.builtIns {
             guard let collection = descriptor.collection,
                   let block = Self.canonicalBlock(descriptor) else { continue }
             #expect(source.contains(block),

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -77,8 +77,9 @@ struct ContentScaffoldTests {
         let event = try #require(registry.descriptor(id: "event"))
         let eventOut = ContentScaffold.renderEntry(descriptor: event, title: "Launch", now: now)
         #expect(eventOut.contains("name: \"Launch\""))
-        #expect(eventOut.contains("start: 1970-01-01T00:00:00.000Z"))
-        #expect(eventOut.contains("end: 1970-01-01T00:00:00.000Z"))
+        #expect(eventOut.contains("start: 1970-01-01T00:00:00.000Z")) // required → live
+        #expect(eventOut.contains("# end: 1970-01-01T00:00:00.000Z")) // optional → commented out
+        #expect(!eventOut.contains("\nend: ")) // never a live optional dt-end
         #expect(eventOut.contains("location: \"\""))
         #expect(eventOut.contains("Write your event here."))
 

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -69,6 +69,26 @@ struct ContentScaffoldTests {
         """)
     }
 
+    @Test("renderEntry emits business-type frontmatter from the registry descriptor")
+    func businessTypeFrontmatter() throws {
+        let registry = ContentTypeRegistry()
+        let now = Date(timeIntervalSince1970: 0) // 1970-01-01T00:00:00.000Z
+
+        let event = try #require(registry.descriptor(id: "event"))
+        let eventOut = ContentScaffold.renderEntry(descriptor: event, title: "Launch", now: now)
+        #expect(eventOut.contains("name: \"Launch\""))
+        #expect(eventOut.contains("start: 1970-01-01T00:00:00.000Z"))
+        #expect(eventOut.contains("end: 1970-01-01T00:00:00.000Z"))
+        #expect(eventOut.contains("location: \"\""))
+        #expect(eventOut.contains("Write your event here."))
+
+        let review = try #require(registry.descriptor(id: "review"))
+        let reviewOut = ContentScaffold.renderEntry(descriptor: review, title: "Widget", now: now)
+        #expect(reviewOut.contains("itemReviewed: \"\"")) // plain .string, not the name/title special case
+        #expect(reviewOut.contains("rating: 0"))
+        #expect(reviewOut.contains("publishDate: 1970-01-01T00:00:00.000Z"))
+    }
+
     @Test("renderEntry fills the title field and uses imageArray/url defaults")
     func renderEntryAlbumAndLike() {
         let registry = ContentTypeRegistry()

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -84,7 +84,7 @@ struct ContentScaffoldTests {
 
         let review = try #require(registry.descriptor(id: "review"))
         let reviewOut = ContentScaffold.renderEntry(descriptor: review, title: "Widget", now: now)
-        #expect(reviewOut.contains("itemReviewed: \"\"")) // plain .string, not the name/title special case
+        #expect(reviewOut.contains("itemReviewed: \"Widget\"")) // itemReviewed is title-like (#386)
         #expect(reviewOut.contains("rating: 0"))
         #expect(reviewOut.contains("publishDate: 1970-01-01T00:00:00.000Z"))
     }

--- a/docs/superpowers/plans/2026-06-26-v1-3-business-content-types.md
+++ b/docs/superpowers/plans/2026-06-26-v1-3-business-content-types.md
@@ -1,0 +1,518 @@
+# V-1.3 Business Content Types + Content-Config Drift Guard — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the three collection-backed business content types (`announcement`, `event`, `review`) end-to-end — config, render, scaffold, smoke test — and add a registry↔`content.config.ts` drift guard covering all ten collection-backed types.
+
+**Architecture:** Mirror V-1.2's personal-type pattern. `announcement` reuses the existing `Hentry.astro` (h-entry); `event` and `review` get their own per-type layouts (`Hevent.astro`/`Hreview.astro`) because they use the `h-event`/`h-review` microformats2 vocabularies. The dynamic route `[collection]/[...slug].astro` gains the three collections and a per-entry layout selector. Scaffolding needs no Swift changes — `ContentScaffold.renderEntry`/`createTyped` are already descriptor-driven. A new pure-Swift test generates the canonical `defineCollection` block from each registry descriptor and asserts it appears verbatim in `content.config.ts`.
+
+**Tech Stack:** Swift 6.4 (Swift Testing), Astro content collections + Zod, microformats2.
+
+## Global Constraints
+
+- **Toolchain:** run all SwiftPM commands with Xcode 27. Prefix every `swift test`:
+  `export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` then `xcrun swift test --package-path .`
+- **Source of truth:** `ContentTypeRegistry.swift` is the single source for type vocabulary. Do not hand-invent schemas — project them from descriptors.
+- **mf2 only this pass:** layouts emit microformats2; schema.org JSON-LD is V-1.8 (out of scope). No `schemaType` rendering.
+- **Scope excludes** `businessProfile` (page singleton), per-type SwiftUI editors, business-collection feeds.
+- **Kind → Zod contract** (the drift guard enforces this exact mapping):
+  `.string`/`.text`/`.image` → `z.string()`; `.url` → `z.string().url()`; `.date`/`.datetime` → `z.coerce.date()`; `.number` → `z.number()`; `.bool` → `z.boolean()`; `.stringArray`/`.imageArray` → `z.array(z.string())`; `.markdown` → **excluded** (it is the entry body). Non-required fields append `.optional()`.
+- **Additive edits only** to `content.config.ts`, `[collection]/[...slug].astro`, and the render-smoke suites — `feat/348-feeds` touches the same files; keep conflicts minimal and use a *separate* new smoke-test file rather than editing `PersonalTypeRenderSmokeTests.swift`.
+- **Spec:** `docs/superpowers/specs/2026-06-26-v1-3-business-content-types-design.md`.
+
+---
+
+## File Structure
+
+- `Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift` — **new.** Pure-Swift drift guard: generate canonical block per registry descriptor, assert verbatim in the config file.
+- `Resources/Template/src/content.config.ts` — **modify.** Append `announcements`, `events`, `reviews` collections; extend `collections` export.
+- `Resources/Template/src/layouts/Hevent.astro` — **new.** `h-event` layout.
+- `Resources/Template/src/layouts/Hreview.astro` — **new.** `h-review` layout.
+- `Resources/Template/src/pages/[collection]/[...slug].astro` — **modify.** Add three collections + per-entry layout selector.
+- `Resources/Template/src/content/announcements/hello-announcement.md` — **new.** Seed.
+- `Resources/Template/src/content/events/hello-event.md` — **new.** Seed.
+- `Resources/Template/src/content/reviews/hello-review.md` — **new.** Seed.
+- `Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift` — **new.** Build + assert mf2 per business type.
+- `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift` — **modify.** Add a business-type `renderEntry` assertion.
+
+---
+
+## Task 1: Content-config drift guard + business collections
+
+**Files:**
+- Create: `Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift`
+- Modify: `Resources/Template/src/content.config.ts`
+
+**Interfaces:**
+- Consumes: `ContentTypeRegistry()` (default builtins), `ContentTypeDescriptor.{collection, fields}`, `ContentTypeField.{name, kind, required}`, `ContentTypeField.Kind` cases.
+- Produces: a passing pure-Swift test that fails if any collection-backed registry type lacks its verbatim canonical `defineCollection` block in `content.config.ts`. No production symbols.
+
+- [ ] **Step 1: Write the failing drift-guard test**
+
+Create `Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("content.config.ts drift guard")
+struct ContentConfigDriftTests {
+
+    /// Repo-root-relative path to the committed template config. `swift test` runs with CWD = package root.
+    static var configFile: URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources/Template/src/content.config.ts")
+    }
+
+    /// Canonical Zod expression for a field kind, or nil for the markdown body (excluded from frontmatter).
+    static func zod(for kind: ContentTypeField.Kind) -> String? {
+        switch kind {
+        case .markdown: return nil
+        case .string, .text, .image: return "z.string()"
+        case .url: return "z.string().url()"
+        case .date, .datetime: return "z.coerce.date()"
+        case .number: return "z.number()"
+        case .bool: return "z.boolean()"
+        case .stringArray, .imageArray: return "z.array(z.string())"
+        }
+    }
+
+    /// The single canonical `defineCollection` block for a collection-backed descriptor.
+    static func canonicalBlock(_ d: ContentTypeDescriptor) -> String? {
+        guard let collection = d.collection else { return nil }
+        var schemaLines: [String] = []
+        for field in d.fields {
+            guard let zod = zod(for: field.kind) else { continue }
+            let expr = field.required ? zod : "\(zod).optional()"
+            schemaLines.append("    \(field.name): \(expr),")
+        }
+        return """
+        const \(collection) = defineCollection({
+          loader: glob({ pattern: "**/*.md", base: "./src/content/\(collection)" }),
+          schema: z.object({
+        \(schemaLines.joined(separator: "\n"))
+          }),
+        });
+        """
+    }
+
+    @Test("every collection-backed registry type appears verbatim in content.config.ts")
+    func configMatchesRegistry() throws {
+        let source = try String(contentsOf: Self.configFile, encoding: .utf8)
+        let exportLine = source
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .first { $0.contains("export const collections") }
+            .map(String.init) ?? ""
+
+        for descriptor in ContentTypeRegistry().all {
+            guard let collection = descriptor.collection,
+                  let block = Self.canonicalBlock(descriptor) else { continue }
+            #expect(source.contains(block),
+                    "content.config.ts is missing or has drifted from the canonical block for `\(collection)`:\n\(block)")
+            #expect(exportLine.contains(collection),
+                    "`\(collection)` is not listed in the `collections` export")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --package-path . --filter ContentConfigDriftTests
+```
+
+Expected: FAIL. The seven personal blocks already match the canonical format, so the failures name the three missing business collections (`announcements`, `events`, `reviews`). (If a personal collection is also reported, its existing block has drifted from canonical formatting — reformat that block to match the printed canonical block before continuing; fields/types are unchanged, formatting only.)
+
+- [ ] **Step 3: Add the three business collections to `content.config.ts`**
+
+In `Resources/Template/src/content.config.ts`, after the `likes` collection block and before `export const collections`, add:
+
+```ts
+const announcements = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/announcements" }),
+  schema: z.object({
+    title: z.string(),
+    publishDate: z.coerce.date(),
+  }),
+});
+
+const events = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/events" }),
+  schema: z.object({
+    name: z.string(),
+    start: z.coerce.date(),
+    end: z.coerce.date().optional(),
+    location: z.string().optional(),
+  }),
+});
+
+const reviews = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/reviews" }),
+  schema: z.object({
+    itemReviewed: z.string(),
+    rating: z.number(),
+    publishDate: z.coerce.date(),
+  }),
+});
+```
+
+Then replace the export line with:
+
+```ts
+export const collections = { blog, notes, articles, photos, albums, bookmarks, replies, likes, announcements, events, reviews };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --package-path . --filter ContentConfigDriftTests
+```
+
+Expected: PASS (all ten collection-backed types matched).
+
+- [ ] **Step 5: Prove the guard bites (acceptance requirement)**
+
+Temporarily delete the `location: z.string().optional(),` line from the `events` block, then run:
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --package-path . --filter ContentConfigDriftTests
+```
+
+Expected: FAIL naming `events`. Then restore the line and re-run to confirm PASS again. (This verifies the guard detects drift, not just absence.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift Resources/Template/src/content.config.ts
+git commit -m "feat(#345): content-config drift guard + business collections"
+```
+
+---
+
+## Task 2: Render the business types (layouts, route, seeds, smoke)
+
+**Files:**
+- Create: `Resources/Template/src/layouts/Hevent.astro`
+- Create: `Resources/Template/src/layouts/Hreview.astro`
+- Create: `Resources/Template/src/content/announcements/hello-announcement.md`
+- Create: `Resources/Template/src/content/events/hello-event.md`
+- Create: `Resources/Template/src/content/reviews/hello-review.md`
+- Modify: `Resources/Template/src/pages/[collection]/[...slug].astro`
+- Create: `Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift`
+
+**Interfaces:**
+- Consumes: `AnglesiteTestSupport.E2EPrerequisites.locateNode()`, `TemplateBuildSerializer.shared.serialize { }`, `ProcessSupervisor.shared.run(executable:arguments:currentDirectoryURL:)`, the `Hentry.astro`/`BaseLayout.astro` layout convention.
+- Produces: built HTML where `events/*` carries `h-event`+`dt-start`, `reviews/*` carries `h-review`+`p-rating`, `announcements/*` carries `h-entry`.
+
+- [ ] **Step 1: Write the failing render-smoke test**
+
+Create `Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift`:
+
+```swift
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+@Suite("Business type render smoke")
+struct BusinessTypeRenderSmokeTests {
+
+    static var templateDir: URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources/Template", isDirectory: true)
+    }
+
+    /// True when the template can actually be built: a Node binary plus an installed Astro.
+    static var buildable: Bool {
+        guard E2EPrerequisites.locateNode() != nil else { return false }
+        return FileManager.default.isReadableFile(
+            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
+    }
+
+    @Test("seeded business types build and render their mf2 classes",
+          .enabled(if: BusinessTypeRenderSmokeTests.buildable))
+    func rendersMicroformats() async throws {
+        let node = try #require(E2EPrerequisites.locateNode())
+        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+
+        func html(_ rel: String) throws -> String {
+            try String(contentsOf: dist.appendingPathComponent(rel), encoding: .utf8)
+        }
+
+        // Hold the shared template-build lock across build + assertions: other render-smoke
+        // suites rm -rf dist around their own build and would race on the shared template tree.
+        try await TemplateBuildSerializer.shared.serialize {
+            try? FileManager.default.removeItem(at: dist)
+            defer { try? FileManager.default.removeItem(at: dist) }
+
+            let result = try await ProcessSupervisor.shared.run(
+                executable: node,
+                arguments: ["node_modules/astro/astro.js", "build"],
+                currentDirectoryURL: Self.templateDir)
+            try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+
+            #expect(try html("announcements/hello-announcement/index.html").contains("h-entry"))
+            let event = try html("events/hello-event/index.html")
+            #expect(event.contains("h-event"))
+            #expect(event.contains("dt-start"))
+            let review = try html("reviews/hello-review/index.html")
+            #expect(review.contains("h-review"))
+            #expect(review.contains("p-rating"))
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --package-path . --filter BusinessTypeRenderSmokeTests
+```
+
+Expected: FAIL — `astro build` errors (the three collections have no content dirs / the route does not emit their pages), or the asserted HTML files are missing. (If Node/Astro are not installed the test is skipped via `.enabled(if:)`; install with `cd Resources/Template && npm ci` to actually exercise it.)
+
+- [ ] **Step 3: Create the `Hevent.astro` layout**
+
+Create `Resources/Template/src/layouts/Hevent.astro`:
+
+```astro
+---
+import BaseLayout from "./BaseLayout.astro";
+
+interface Props {
+  entry: { data: Record<string, any> };
+}
+
+const { entry } = Astro.props;
+const d = entry.data;
+const startISO = d.start ? new Date(d.start).toISOString() : undefined;
+const startHuman = d.start ? new Date(d.start).toLocaleString() : undefined;
+const endISO = d.end ? new Date(d.end).toISOString() : undefined;
+const endHuman = d.end ? new Date(d.end).toLocaleString() : undefined;
+---
+
+<BaseLayout title={d.name ?? "Event"} description={d.location}>
+  <article class="h-event">
+    <h1 class="p-name">{d.name}</h1>
+    {startISO && <time class="dt-start" datetime={startISO}>{startHuman}</time>}
+    {endISO && <time class="dt-end" datetime={endISO}>{endHuman}</time>}
+    {d.location && <p class="p-location">{d.location}</p>}
+    <div class="e-content"><slot /></div>
+  </article>
+</BaseLayout>
+```
+
+- [ ] **Step 4: Create the `Hreview.astro` layout**
+
+Create `Resources/Template/src/layouts/Hreview.astro`:
+
+```astro
+---
+import BaseLayout from "./BaseLayout.astro";
+
+interface Props {
+  entry: { data: Record<string, any> };
+}
+
+const { entry } = Astro.props;
+const d = entry.data;
+const iso = d.publishDate ? new Date(d.publishDate).toISOString() : undefined;
+const human = d.publishDate ? new Date(d.publishDate).toLocaleDateString() : undefined;
+---
+
+<BaseLayout title={d.itemReviewed ?? "Review"}>
+  <article class="h-review">
+    <h1 class="p-item">{d.itemReviewed}</h1>
+    <data class="p-rating" value={d.rating}>{d.rating}</data>
+    <div class="e-content"><slot /></div>
+    {iso && <time class="dt-published" datetime={iso}>{human}</time>}
+  </article>
+</BaseLayout>
+```
+
+- [ ] **Step 5: Wire the three collections into the dynamic route**
+
+Replace the entire contents of `Resources/Template/src/pages/[collection]/[...slug].astro` with:
+
+```astro
+---
+import { getCollection, render } from "astro:content";
+import Hentry from "../../layouts/Hentry.astro";
+import Hevent from "../../layouts/Hevent.astro";
+import Hreview from "../../layouts/Hreview.astro";
+
+type EntryCollection =
+  | "notes" | "articles" | "photos" | "albums" | "bookmarks" | "replies" | "likes"
+  | "announcements" | "events" | "reviews";
+
+export async function getStaticPaths() {
+  const collections: EntryCollection[] = [
+    "notes", "articles", "photos", "albums", "bookmarks", "replies", "likes",
+    "announcements", "events", "reviews",
+  ];
+  const paths = [];
+  for (const collection of collections) {
+    const entries = await getCollection(collection);
+    for (const entry of entries) {
+      paths.push({ params: { collection, slug: entry.id }, props: { entry } });
+    }
+  }
+  return paths;
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+const Layout = entry.collection === "events" ? Hevent : entry.collection === "reviews" ? Hreview : Hentry;
+---
+
+<Layout entry={entry}><Content /></Layout>
+```
+
+- [ ] **Step 6: Create the three seed entries**
+
+Create `Resources/Template/src/content/announcements/hello-announcement.md`:
+
+```markdown
+---
+title: "Hello, announcement"
+publishDate: 2026-01-01T00:00:00.000Z
+---
+
+This is a sample announcement.
+```
+
+Create `Resources/Template/src/content/events/hello-event.md`:
+
+```markdown
+---
+name: "Hello, event"
+start: 2026-01-01T18:00:00.000Z
+end: 2026-01-01T20:00:00.000Z
+location: "Main Street"
+---
+
+This is a sample event.
+```
+
+Create `Resources/Template/src/content/reviews/hello-review.md`:
+
+```markdown
+---
+itemReviewed: "Hello, product"
+rating: 5
+publishDate: 2026-01-01T00:00:00.000Z
+---
+
+This is a sample review.
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --package-path . --filter BusinessTypeRenderSmokeTests
+```
+
+Expected: PASS (or SKIPPED if Node/Astro absent — in that case run `cd Resources/Template && npm ci` first, then re-run, and confirm PASS before committing).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Resources/Template/src/layouts/Hevent.astro Resources/Template/src/layouts/Hreview.astro \
+  "Resources/Template/src/pages/[collection]/[...slug].astro" \
+  Resources/Template/src/content/announcements Resources/Template/src/content/events Resources/Template/src/content/reviews \
+  Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
+git commit -m "feat(#345): render business types (h-event, h-review, announcement)"
+```
+
+---
+
+## Task 3: Scaffold-path coverage + acceptance gate
+
+**Files:**
+- Modify: `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentScaffold.renderEntry(descriptor:title:now:) -> String`, `ContentTypeRegistry().descriptor(id:)`.
+- Produces: a test proving `renderEntry` emits correct business-type frontmatter (no production changes needed — `createTyped` is descriptor-driven).
+
+- [ ] **Step 1: Write the scaffold test**
+
+Add this test to `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift` (inside the existing suite struct, or in a new `@Suite` if the file uses free-standing `@Test`s — match the file's existing style).
+
+Behavior being locked in: `renderEntry` fills only the `title`/`name` field from the passed title; every other string field scaffolds empty; `.datetime` fields get the `now` ISO timestamp; `.number` gets `0`; the `.markdown` body becomes the placeholder line. `event.name` is the `name`-special-case (filled); `review.itemReviewed` is a plain `.string` (empty).
+
+```swift
+@Test("renderEntry emits business-type frontmatter from the registry descriptor")
+func businessTypeFrontmatter() throws {
+    let registry = ContentTypeRegistry()
+    let now = Date(timeIntervalSince1970: 0) // 1970-01-01T00:00:00.000Z
+
+    let event = try #require(registry.descriptor(id: "event"))
+    let eventOut = ContentScaffold.renderEntry(descriptor: event, title: "Launch", now: now)
+    #expect(eventOut.contains("name: \"Launch\""))
+    #expect(eventOut.contains("start: 1970-01-01T00:00:00.000Z"))
+    #expect(eventOut.contains("end: 1970-01-01T00:00:00.000Z"))
+    #expect(eventOut.contains("location: \"\""))
+    #expect(eventOut.contains("Write your event here."))
+
+    let review = try #require(registry.descriptor(id: "review"))
+    let reviewOut = ContentScaffold.renderEntry(descriptor: review, title: "Widget", now: now)
+    #expect(reviewOut.contains("itemReviewed: \"\"")) // plain .string, not the name/title special case
+    #expect(reviewOut.contains("rating: 0"))
+    #expect(reviewOut.contains("publishDate: 1970-01-01T00:00:00.000Z"))
+}
+```
+
+- [ ] **Step 2: Run the scaffold test to verify it passes**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --package-path . --filter ContentScaffoldTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full acceptance gate**
+
+```bash
+# Swift: drift guard + scaffold + render smoke
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --package-path . --filter "ContentConfigDriftTests|ContentScaffoldTests|BusinessTypeRenderSmokeTests"
+
+# Template: full build + pre-deploy-check (requires deps: cd Resources/Template && npm ci, once)
+cd Resources/Template && npm run build && npm run check
+```
+
+Expected: all Swift tests PASS; `astro build` succeeds; `pre-deploy-check` (`npm run check`) reports no errors. `blog` and the seven personal collections still build and render unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+git commit -m "test(#345): cover business-type scaffolding via renderEntry"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 config collections → Task 1 Step 3. ✓
+- §2 per-type layouts + route selector → Task 2 Steps 3–5. ✓
+- §3 scaffold (no Swift change) + seeds → Task 2 Step 6 (seeds), Task 3 (scaffold coverage). ✓
+- §4 drift guard (exact canonical block, all ten types, proven to bite) → Task 1 Steps 1–5. ✓
+- §5 render smoke (h-entry / h-event+dt-start / h-review+p-rating) → Task 2 Step 1. ✓
+- §Acceptance (build + pre-deploy-check green; guard bites; mf2 asserted; blog+personal intact) → Task 1 Step 5, Task 3 Step 3. ✓
+- §Coordination risk (additive, separate smoke file) → Global Constraints + new `BusinessTypeRenderSmokeTests.swift`. ✓
+- businessProfile / editors / JSON-LD / business feeds → explicitly out of scope. ✓
+
+**Placeholder scan:** none — every code/command step has concrete content.
+
+**Type consistency:** `canonicalBlock`/`zod(for:)` defined and used in Task 1 only; `Hevent`/`Hreview` created in Task 2 Steps 3–4 and referenced in the route in Step 5; `entry.collection` selector matches the seed collection names and the config collection keys; smoke-test HTML paths (`events/hello-event/index.html`) match the seed filenames. Consistent.

--- a/docs/superpowers/specs/2026-06-26-v1-3-business-content-types-design.md
+++ b/docs/superpowers/specs/2026-06-26-v1-3-business-content-types-design.md
@@ -1,0 +1,181 @@
+# Design — V-1.3 Business content types + content-config drift guard
+
+**Date:** 2026-06-26
+**Status:** Approved design (drives the V-1.3 implementation plan)
+**Issue:** [#345](https://github.com/Anglesite/Anglesite-app/issues/345) (V-1.3), part of epic [#334](https://github.com/Anglesite/Anglesite-app/issues/334) / V-1 [#335](https://github.com/Anglesite/Anglesite-app/issues/335)
+**Builds on:** V-1.1 content-type registry (#372) and V-1.2 personal types (#378)
+
+## Context
+
+V-1.1 declared the full content-type vocabulary in `ContentTypeRegistry.swift`
+(personal *and* business types) as pure data. V-1.2 wired the **personal** types
+end-to-end: `content.config.ts` collections, the `Hentry.astro` layout, the
+`[collection]/[...slug].astro` dynamic route, descriptor-driven scaffolding
+(`ContentScaffold.renderEntry` + `NativeContentOperations.createTyped`), seed
+content, and a build/render smoke test.
+
+The business types (`businessProfile`, `announcement`, `event`, `review`) already
+exist as registry descriptors but have **no** template collection, layout, route
+wiring, or scaffolding. This task brings the three *collection-backed* business
+types up to the same end-to-end bar as the personal types, and closes a latent gap
+the pivot's "one schema, three projections" principle depends on: `content.config.ts`
+is hand-authored and structurally disconnected from the registry, so the Zod
+projection can silently drift from its source of truth.
+
+## Scope
+
+**In:**
+- `announcement` (h-entry / `NewsArticle`), `event` (h-event / `Event`), `review`
+  (h-review / `Review`) — end-to-end: config collection → seed content → render →
+  scaffold path → smoke test.
+- A registry ↔ `content.config.ts` **drift-guard test** covering **all ten
+  collection-backed registry types** (the seven personal collections from V-1.2 plus
+  the three new business ones). The seven personal collections are thereby locked in
+  retroactively.
+
+**Out (deferred to their own issues):**
+- `businessProfile` — page-stored (`.page`) singleton h-card / `LocalBusiness`. It
+  needs page-singleton scaffolding (`createTyped` rejects `.page` types today) and
+  site-wide identity placement, and it overlaps V-2's site-identity / IndieAuth
+  (`rel=me`) work. Tracked as a separate follow-up.
+- Per-type SwiftUI editors (V-1.4).
+- schema.org JSON-LD emission (V-1.8). Layouts emit **microformats2 only** in this
+  pass, matching how `Hentry.astro` works today. The registry's `schemaType`
+  projections (`NewsArticle`/`Event`/`Review`) are consumed later by V-1.8.
+- Feeds for business collections (V-1.6 — already in flight on `feat/348-feeds`).
+
+## Design
+
+### 1. `content.config.ts` — three new collections
+
+Append three `defineCollection` blocks and extend the `collections` export. Schemas
+are the mechanical projection of each descriptor's fields (see the Kind→Zod contract
+in §4); the `markdown` body field is **excluded** (it is the Astro entry body, not a
+frontmatter field), and a non-required field gets `.optional()`.
+
+```ts
+const announcements = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/announcements" }),
+  schema: z.object({
+    title: z.string(),
+    publishDate: z.coerce.date(),
+  }),
+});
+
+const events = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/events" }),
+  schema: z.object({
+    name: z.string(),
+    start: z.coerce.date(),
+    end: z.coerce.date().optional(),
+    location: z.string().optional(),
+  }),
+});
+
+const reviews = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/reviews" }),
+  schema: z.object({
+    itemReviewed: z.string(),
+    rating: z.number(),
+    publishDate: z.coerce.date(),
+  }),
+});
+
+export const collections = { blog, notes, articles, photos, albums, bookmarks, replies, likes, announcements, events, reviews };
+```
+
+The existing `blog` collection (legacy, not in the registry) and its comment block
+are left untouched.
+
+### 2. Rendering — per-type layouts
+
+V-1.2's `Hentry.astro` is h-entry-specific. `event` and `review` use different
+microformats2 root vocabularies, so they get their own layouts (per-type layouts,
+not a generic projection-driven layout — that generic approach is deferred to V-1.7,
+"mf2 everywhere," where surfacing the registry projections into the template runtime
+belongs).
+
+- **`announcement`** reuses **`Hentry.astro`** unchanged (it is h-entry; `title` is
+  already rendered as `p-name`).
+- **`Hevent.astro`** (new) — `article.h-event` with `p-name` (name), `dt-start` and
+  optional `dt-end` as `<time datetime>`, optional `p-location`, and an `e-content`
+  slot for the body.
+- **`Hreview.astro`** (new) — `article.h-review` with the reviewed item as `p-item`
+  (the registry's `itemReviewed` → `p-item` projection), `p-rating` (rating), an
+  `e-content` slot, and `dt-published`.
+
+**`[collection]/[...slug].astro`** adds `announcements`, `events`, `reviews` to its
+`getStaticPaths` collection list and selects the layout per entry by
+`entry.collection`: `events` → `Hevent`, `reviews` → `Hreview`, everything else →
+`Hentry`. One small switch, one file.
+
+### 3. Scaffolding & seed content — no Swift changes
+
+`ContentScaffold.renderEntry` and `NativeContentOperations.createTyped` are already
+descriptor-driven and support collection-backed types, so the three business types
+scaffold with **no Swift changes**. Add three seed entries mirroring V-1.2's
+`hello-*` files so the collections build and render:
+
+- `src/content/announcements/hello-announcement.md`
+- `src/content/events/hello-event.md`
+- `src/content/reviews/hello-review.md`
+
+### 4. Drift guard — `ContentConfigDriftTests` (the new mechanism)
+
+A **pure Swift unit test** (no Node, not gated on a buildable template). It reads
+`Resources/Template/src/content.config.ts` as text and, for every
+**collection-backed** descriptor in `ContentTypeRegistry.builtIns`, asserts a
+matching `defineCollection` block exists with:
+
+- the collection key present in `export const collections`;
+- exactly the expected set of non-`markdown` fields (no missing, no extra);
+- each field mapped to the expected Zod type;
+- correct optionality (`required == false` → `.optional()`).
+
+`blog` is legacy and not in the registry, so the test ignores collection keys with no
+corresponding descriptor (it asserts registry coverage, not file exhaustiveness).
+
+**Kind → Zod contract** (the documented mapping the test enforces):
+
+| `ContentTypeField.Kind` | Zod |
+|---|---|
+| `.string`, `.text` | `z.string()` |
+| `.url` | `z.string().url()` |
+| `.date`, `.datetime` | `z.coerce.date()` |
+| `.number` | `z.number()` |
+| `.bool` | `z.boolean()` |
+| `.stringArray`, `.imageArray` | `z.array(z.string())` |
+| `.markdown` | *excluded* (it is the entry body, not frontmatter) |
+
+Non-required fields append `.optional()`.
+
+Comparison is normalized for whitespace so the hand-authored file keeps its own
+formatting and comments. The guard locks in V-1.2's seven personal collections in the
+same pass.
+
+### 5. Render smoke test
+
+Extend the `PersonalTypeRenderSmokeTests` pattern — gated on `buildable` (Node +
+installed Astro), run under `TemplateBuildSerializer.shared` to avoid racing other
+render-smoke suites on the shared template tree. After `astro build`, assert:
+
+- `announcements/hello-announcement/index.html` contains `h-entry`;
+- `events/hello-event/index.html` contains `h-event` and `dt-start`;
+- `reviews/hello-review/index.html` contains `h-review` and `p-rating`.
+
+## Coordination risk
+
+`feat/348-feeds` (V-1.6, unmerged, ahead of `main`) edits the same files V-1.3 does:
+`content.config.ts`, `[collection]/[...slug].astro`, `TemplateBuildSerializer`, and
+the render-smoke suites. Whichever lands second rebases. V-1.3's edits are kept
+**additive** (append collections, add new files, add cases to the route switch) to
+minimize conflict, and the overlap is called out in the PR.
+
+## Acceptance
+
+- `npm run build` + `pre-deploy-check` pass with the three new collections present.
+- The drift-guard test passes for all ten collection-backed types **and** demonstrably
+  fails when a field is removed from `content.config.ts` (the guard is proven to bite).
+- The render smoke test asserts the correct mf2 root + key properties per business
+  type.
+- `blog` and the seven personal collections still build and render unchanged.

--- a/docs/superpowers/specs/2026-06-26-v1-3-business-content-types-design.md
+++ b/docs/superpowers/specs/2026-06-26-v1-3-business-content-types-design.md
@@ -124,16 +124,34 @@ scaffold with **no Swift changes**. Add three seed entries mirroring V-1.2's
 
 A **pure Swift unit test** (no Node, not gated on a buildable template). It reads
 `Resources/Template/src/content.config.ts` as text and, for every
-**collection-backed** descriptor in `ContentTypeRegistry.builtIns`, asserts a
-matching `defineCollection` block exists with:
+**collection-backed** descriptor in `ContentTypeRegistry.builtIns`, **generates the
+canonical `defineCollection` block** from the descriptor and asserts that exact block
+appears **verbatim** in the file (exact-string match — whitespace is significant). It
+also asserts the collection key is present in `export const collections`.
 
-- the collection key present in `export const collections`;
-- exactly the expected set of non-`markdown` fields (no missing, no extra);
-- each field mapped to the expected Zod type;
-- correct optionality (`required == false` → `.optional()`).
+The generator is the single canonical formatter:
+
+```ts
+const <collection> = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/<collection>" }),
+  schema: z.object({
+    <field>: <zod>,              // one line per non-markdown field, in descriptor order
+  }),
+});
+```
+
+with 2-space base indentation (matching the existing file), fields emitted in
+descriptor declaration order, and each Zod expression per the contract below.
 
 `blog` is legacy and not in the registry, so the test ignores collection keys with no
 corresponding descriptor (it asserts registry coverage, not file exhaustiveness).
+
+**Implication:** the seven personal collection blocks V-1.2 hand-wrote must already
+conform to the canonical format byte-for-byte. As part of this pass the test will
+either confirm they do or the blocks are reformatted to match (no schema change — the
+fields and types are identical, only formatting is canonicalized). This makes the
+committed `content.config.ts` schema blocks a checked-in mirror of generated output,
+while `blog`, comments, import lines, and the surrounding file remain human-authored.
 
 **Kind → Zod contract** (the documented mapping the test enforces):
 

--- a/docs/superpowers/specs/2026-06-26-v1-3-business-content-types-design.md
+++ b/docs/superpowers/specs/2026-06-26-v1-3-business-content-types-design.md
@@ -157,7 +157,7 @@ while `blog`, comments, import lines, and the surrounding file remain human-auth
 
 | `ContentTypeField.Kind` | Zod |
 |---|---|
-| `.string`, `.text` | `z.string()` |
+| `.string`, `.text`, `.image` | `z.string()` |
 | `.url` | `z.string().url()` |
 | `.date`, `.datetime` | `z.coerce.date()` |
 | `.number` | `z.number()` |


### PR DESCRIPTION
Implements **V-1.3** (#345), part of the Personal Publishing OS pivot epic (#334 / V-1 #335). App-only template changes — no paired plugin PR needed.

## What this does

Brings the three collection-backed business content types end-to-end (matching the V-1.2 personal-type pattern) and closes a latent gap the pivot's "one schema, three projections" principle depends on.

### 1. Content-config drift guard (the new mechanism)
`ContentConfigDriftTests` is a pure-Swift test that generates the canonical Astro `defineCollection` Zod block from each `ContentTypeRegistry` descriptor and asserts it appears **verbatim** in `Resources/Template/src/content.config.ts` (exact, whitespace-significant), across all ten collection-backed types (the seven personal collections V-1.2 shipped are locked in too). The `Kind → Zod` mapping is an exhaustive `switch` with no `default`, so adding a new field kind fails to compile until the mapping is extended. `.markdown` is excluded (it is the entry body, not frontmatter).

### 2. Business types rendered
- New `Hevent.astro` (`h-event`: `p-name`/`dt-start`/`dt-end`/`p-location`) and `Hreview.astro` (`h-review`: `p-item`/`p-rating`/`dt-published`).
- `announcement` reuses the existing `Hentry.astro` (it is `h-entry`).
- `[collection]/[...slug].astro` gains the three collections + a per-entry layout selector (`events`→Hevent, `reviews`→Hreview, else→Hentry). Additive; personal collections render exactly as before.
- Three seed entries; a build-backed `BusinessTypeRenderSmokeTests` that runs `astro build` and asserts the rendered mf2 classes.

### 3. Scaffold coverage
A characterization test locking `ContentScaffold.renderEntry`'s business-type frontmatter output (no production change — `renderEntry` is already descriptor-driven).

## Scope
mf2-only this pass. **Out of scope** (own follow-ups): `businessProfile` page-singleton h-card, per-type SwiftUI editors (V-1.4), schema.org JSON-LD (V-1.8), business-collection feeds (V-1.6).

## Verification
- Drift guard RED→GREEN, and proven to *bite* (fails on a removed field, passes after restore).
- `BusinessTypeRenderSmokeTests` ran green (not skipped) against a real `astro build`.
- Acceptance gate: 11/11 filtered Swift tests; `astro build` 13 pages (blog + 7 personal + 3 business); `pre-deploy-check` clean. Full suite 909/909.

## Deferred minor follow-ups
- Consolidate the duplicated render-smoke build harness into a shared `AnglesiteTestSupport` helper (the duplication was intentional to avoid a then-anticipated feeds-branch conflict, now obsolete).
- Add a `fileExists` pre-check to the drift test for a friendlier failure message.

Design spec: `docs/superpowers/specs/2026-06-26-v1-3-business-content-types-design.md`
Plan: `docs/superpowers/plans/2026-06-26-v1-3-business-content-types.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)