### PR TITLE
feat(#377): MCP-backed createTyped parity (consume plugin #389)

### DIFF
--- a/Sources/AnglesiteCore/ContentOperations.swift
+++ b/Sources/AnglesiteCore/ContentOperations.swift
@@ -31,9 +31,16 @@ public struct ContentOperations: ContentOperationsService {
     }
 
     public func createTyped(siteID: String, typeID: String, title: String, onProgress: ProgressHandler? = nil) async -> ContentCreateResult {
-        var args: [String: JSONValue] = ["type": .string(typeID)]
+        // Cheap empty guard so an obviously-invalid type doesn't cost an MCP round-trip. An unknown
+        // but non-empty typeID is left to the plugin's `create_content` schema (a `z.enum` over the
+        // registry ids) — the native path validates the same thing locally via `ContentTypeRegistry`.
+        let cleanType = typeID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanType.isEmpty else { return .failed(reason: "createTyped requires a non-empty typeID") }
+        // Always send `title` (consistent with createPost). An empty title is valid: the plugin —
+        // like NativeContentOperations — derives the slug from the type's id and leaves the title
+        // field blank, so there's nothing to guard against here.
         let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !cleanTitle.isEmpty { args["title"] = .string(cleanTitle) }
+        let args: [String: JSONValue] = ["type": .string(cleanType), "title": .string(cleanTitle)]
         return await create(siteID: siteID, tool: "create_content", arguments: args, identifierKey: "slug", onProgress: onProgress)
     }
 

--- a/Sources/AnglesiteCore/ContentOperations.swift
+++ b/Sources/AnglesiteCore/ContentOperations.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// Production `ContentOperationsService`: resolves the site's directory, gets an MCP client from a
 /// `HeadlessRuntimePool` (spawning one headlessly when no window is open), and calls the plugin's
-/// `create_page` / `create_post` tools (A.5/#139, backed by A.4 #138 and the plugin tools #140).
+/// `create_page` / `create_post` / `create_content` tools (A.5/#139, backed by A.4 #138 and the
+/// plugin tools #140; typed scaffolding parity #377/plugin #389).
 public struct ContentOperations: ContentOperationsService {
     private let pool: HeadlessRuntimePool
     /// Maps a siteID to its on-disk directory (wired to `SiteStore` in bootstrap). `nil` → unknown site.
@@ -27,6 +28,13 @@ public struct ContentOperations: ContentOperationsService {
         if let collection, !collection.isEmpty { args["collection"] = .string(collection) }
         if let slug, !slug.isEmpty { args["slug"] = .string(slug) }
         return await create(siteID: siteID, tool: "create_post", arguments: args, identifierKey: "slug", onProgress: onProgress)
+    }
+
+    public func createTyped(siteID: String, typeID: String, title: String, onProgress: ProgressHandler? = nil) async -> ContentCreateResult {
+        var args: [String: JSONValue] = ["type": .string(typeID)]
+        let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !cleanTitle.isEmpty { args["title"] = .string(cleanTitle) }
+        return await create(siteID: siteID, tool: "create_content", arguments: args, identifierKey: "slug", onProgress: onProgress)
     }
 
     private func create(

--- a/Sources/AnglesiteCore/ContentOperationsService.swift
+++ b/Sources/AnglesiteCore/ContentOperationsService.swift
@@ -7,6 +7,10 @@ import Foundation
 public protocol ContentOperationsService: Sendable {
     func createPage(siteID: String, name: String, route: String?, onProgress: ProgressHandler?) async -> ContentCreateResult
     func createPost(siteID: String, title: String, collection: String?, slug: String?, onProgress: ProgressHandler?) async -> ContentCreateResult
+    /// Scaffold a typed entry (V-1.2 personal/business content types) from the content-type registry.
+    /// `typeID` is a registry id (`note`, `article`, …); `title` seeds the name/title field and the
+    /// slug. Collection-stored types only — page-stored types (e.g. `businessProfile`) report `.failed`.
+    func createTyped(siteID: String, typeID: String, title: String, onProgress: ProgressHandler?) async -> ContentCreateResult
 }
 
 public extension ContentOperationsService {
@@ -16,11 +20,14 @@ public extension ContentOperationsService {
     func createPost(siteID: String, title: String, collection: String?, slug: String?) async -> ContentCreateResult {
         await createPost(siteID: siteID, title: title, collection: collection, slug: slug, onProgress: nil)
     }
+    func createTyped(siteID: String, typeID: String, title: String) async -> ContentCreateResult {
+        await createTyped(siteID: siteID, typeID: typeID, title: title, onProgress: nil)
+    }
 }
 
-/// Outcome of a `create_page` / `create_post` call.
+/// Outcome of a `create_page` / `create_post` / `create_content` call.
 public enum ContentCreateResult: Sendable, Equatable {
-    /// `identifier` is the route (page) or slug (post). `filePath` is relative to the site root.
+    /// `identifier` is the route (page) or slug (post / typed entry). `filePath` is relative to the site root.
     case created(filePath: String, identifier: String)
     /// The site id didn't resolve to a known site directory.
     case siteNotFound

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -104,15 +104,22 @@ public struct NativeContentOperations: ContentOperationsService {
         return .created(filePath: relPath, identifier: finalSlug)
     }
 
+    /// `ContentOperationsService` witness: derive the slug from `title` alone. Mirrors the plugin's
+    /// `create_content` MCP tool, which takes only `{ type, title }`.
+    public func createTyped(siteID: String, typeID: String, title: String, onProgress: ProgressHandler? = nil) async -> ContentCreateResult {
+        await createTyped(siteID: siteID, typeID: typeID, title: title, slug: nil, onProgress: onProgress)
+    }
+
     /// Create a typed content entry (V-1.2). Looks the type up in `registry`, derives a slug from
-    /// `title`, renders frontmatter via `ContentScaffold.renderEntry`, writes it, and commits —
+    /// `slug ?? title`, renders frontmatter via `ContentScaffold.renderEntry`, writes it, and commits —
     /// the same write/commit path as `createPost`. Collection-stored types only; page-stored types
-    /// (e.g. `businessProfile`) are #345.
+    /// (e.g. `businessProfile`) are #345. The explicit-`slug` overload is the native path's superset
+    /// over the MCP witness (SiteWindow's per-type editor passes a caller-chosen slug).
     public func createTyped(
         siteID: String,
         typeID: String,
         title: String,
-        slug: String? = nil,
+        slug: String?,
         registry: ContentTypeRegistry = ContentTypeRegistry(),
         onProgress: ProgressHandler? = nil
     ) async -> ContentCreateResult {

--- a/Tests/AnglesiteCoreTests/ContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentOperationsTests.swift
@@ -38,7 +38,11 @@ struct ContentOperationsTests {
                 resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":body}],"isError":False}}
             elif name == "create_content":
                 args = (msg.get("params") or {}).get("arguments") or {}
-                if args.get("type") == "businessProfile":
+                if "title" not in args:
+                    # Mirrors the always-send-title contract: createTyped must include the key even
+                    # when the title is empty, so a missing key is a client bug, not a valid call.
+                    resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":"create_content expected a title key"}],"isError":True}}
+                elif args.get("type") == "businessProfile":
                     resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":"Page-stored type businessProfile is not supported by createTyped yet"}],"isError":True}}
                 else:
                     body = json.dumps({"filePath":"src/content/notes/hello-note.md","slug":"hello-note","collection":"notes","type":args.get("type"),"commit":None})
@@ -108,6 +112,23 @@ struct ContentOperationsTests {
         let ops = ContentOperations(pool: HeadlessRuntimePool(), siteDirectory: { _ in nil })
         let result = await ops.createTyped(siteID: "s1", typeID: "note", title: "Hello")
         #expect(result == .siteNotFound)
+    }
+
+    @Test("createTyped rejects an empty typeID before any MCP round-trip")
+    func createTypedEmptyTypeID() async {
+        // Site resolves fine; the cheap typeID guard short-circuits before the pool is touched.
+        let ops = ContentOperations(pool: HeadlessRuntimePool(), siteDirectory: { _ in self.dir })
+        let result = await ops.createTyped(siteID: "s1", typeID: "   ", title: "Hello")
+        #expect(result == .failed(reason: "createTyped requires a non-empty typeID"))
+    }
+
+    @Test("createTyped always sends the title key, even when the title is empty", .enabled(if: pythonAvailable))
+    func createTypedSendsEmptyTitle() async {
+        // The fake server errors when the `title` key is absent — so a green result proves we send
+        // it rather than omitting it (Option A; consistent with createPost).
+        let ops = ContentOperations(pool: poolWithFakeServer(), siteDirectory: { _ in self.dir })
+        let result = await ops.createTyped(siteID: "site-typed-empty", typeID: "note", title: "   ")
+        #expect(result == .created(filePath: "src/content/notes/hello-note.md", identifier: "hello-note"))
     }
 
     @Test("createTyped drives the pool → create_content → parse and returns the created entry", .enabled(if: pythonAvailable))

--- a/Tests/AnglesiteCoreTests/ContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentOperationsTests.swift
@@ -36,6 +36,13 @@ struct ContentOperationsTests {
             elif name == "create_post":
                 body = json.dumps({"filePath":"src/content/posts/hello.md","slug":"hello","collection":"posts","commit":None})
                 resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":body}],"isError":False}}
+            elif name == "create_content":
+                args = (msg.get("params") or {}).get("arguments") or {}
+                if args.get("type") == "businessProfile":
+                    resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":"Page-stored type businessProfile is not supported by createTyped yet"}],"isError":True}}
+                else:
+                    body = json.dumps({"filePath":"src/content/notes/hello-note.md","slug":"hello-note","collection":"notes","type":args.get("type"),"commit":None})
+                    resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":body}],"isError":False}}
             else:
                 resp = {"jsonrpc":"2.0","id":rid,"error":{"code":-32601,"message":"unknown tool"}}
         else:
@@ -94,5 +101,26 @@ struct ContentOperationsTests {
         let ops = ContentOperations(pool: poolWithFakeServer(), siteDirectory: { _ in self.dir })
         let result = await ops.createPost(siteID: "site-post", title: "Hello", collection: nil, slug: nil)
         #expect(result == .created(filePath: "src/content/posts/hello.md", identifier: "hello"))
+    }
+
+    @Test("createTyped returns siteNotFound when the site directory can't be resolved")
+    func createTypedSiteNotFound() async {
+        let ops = ContentOperations(pool: HeadlessRuntimePool(), siteDirectory: { _ in nil })
+        let result = await ops.createTyped(siteID: "s1", typeID: "note", title: "Hello")
+        #expect(result == .siteNotFound)
+    }
+
+    @Test("createTyped drives the pool → create_content → parse and returns the created entry", .enabled(if: pythonAvailable))
+    func createTypedThroughPool() async {
+        let ops = ContentOperations(pool: poolWithFakeServer(), siteDirectory: { _ in self.dir })
+        let result = await ops.createTyped(siteID: "site-typed", typeID: "note", title: "Hello Note")
+        #expect(result == .created(filePath: "src/content/notes/hello-note.md", identifier: "hello-note"))
+    }
+
+    @Test("createTyped surfaces the plugin's error for a page-stored type", .enabled(if: pythonAvailable))
+    func createTypedPageStoredError() async {
+        let ops = ContentOperations(pool: poolWithFakeServer(), siteDirectory: { _ in self.dir })
+        let result = await ops.createTyped(siteID: "site-typed-err", typeID: "businessProfile", title: "Acme")
+        #expect(result == .failed(reason: "Page-stored type businessProfile is not supported by createTyped yet"))
     }
 }

--- a/Tests/AnglesiteCoreTests/CreateContentEndToEndTests.swift
+++ b/Tests/AnglesiteCoreTests/CreateContentEndToEndTests.swift
@@ -23,6 +23,14 @@ final class CreateContentEndToEndTests {
 
     deinit { try? FileManager.default.removeItem(at: tmpSite) }
 
+    /// Resolve the plugin's Node binary + MCP server entry point once. The `.enabled(if:)` trait
+    /// guarantees both are present, so `#require` never trips when the test body actually runs.
+    private func resolvePlugin() throws -> (node: URL, serverPath: URL) {
+        let pluginRoot = try #require(E2EPrerequisites.locateSiblingPlugin())
+        let node = try #require(E2EPrerequisites.locateNode())
+        return (node, pluginRoot.appendingPathComponent("server/index.mjs"))
+    }
+
     /// A pool whose runtime spawns the real plugin server scoped to `tmpSite` (LocalSiteRuntime
     /// passes the site directory as `ANGLESITE_PROJECT_ROOT`, so the plugin writes into our temp site).
     private func poolWithRealPlugin(node: URL, serverPath: URL) -> HeadlessRuntimePool {
@@ -42,9 +50,7 @@ final class CreateContentEndToEndTests {
         )
     )
     func createTypedNoteEndToEnd() async throws {
-        let pluginRoot = try #require(E2EPrerequisites.locateSiblingPlugin())
-        let node = try #require(E2EPrerequisites.locateNode())
-        let serverPath = pluginRoot.appendingPathComponent("server/index.mjs")
+        let (node, serverPath) = try resolvePlugin()
 
         let site = tmpSite
         let ops = ContentOperations(
@@ -73,9 +79,7 @@ final class CreateContentEndToEndTests {
         )
     )
     func createTypedPageStoredRefusedEndToEnd() async throws {
-        let pluginRoot = try #require(E2EPrerequisites.locateSiblingPlugin())
-        let node = try #require(E2EPrerequisites.locateNode())
-        let serverPath = pluginRoot.appendingPathComponent("server/index.mjs")
+        let (node, serverPath) = try resolvePlugin()
 
         let site = tmpSite
         let ops = ContentOperations(

--- a/Tests/AnglesiteCoreTests/CreateContentEndToEndTests.swift
+++ b/Tests/AnglesiteCoreTests/CreateContentEndToEndTests.swift
@@ -1,0 +1,94 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+import AnglesiteTestSupport
+
+/// End-to-end: drive the app's MCP-backed `ContentOperations.createTyped` through a real
+/// `HeadlessRuntimePool` spawning the *real* plugin MCP server (`create_content`, #377/#389),
+/// and assert a typed entry lands on disk with the registry-driven frontmatter — the app's
+/// "consume" record for the plugin's typed-scaffolding parity.
+///
+/// Skipped (via `.enabled(if:)`) when the sibling plugin checkout, its `node_modules`, or a Node
+/// binary aren't present — CI provides them via `ANGLESITE_PLUGIN_PATH`; local dev relies on the
+/// `../anglesite` sibling layout. Serialized: spawns a real Node subprocess.
+@Suite(.serialized)
+final class CreateContentEndToEndTests {
+    private let tmpSite: URL
+
+    init() throws {
+        tmpSite = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("anglesite-create-e2e-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpSite, withIntermediateDirectories: true)
+    }
+
+    deinit { try? FileManager.default.removeItem(at: tmpSite) }
+
+    /// A pool whose runtime spawns the real plugin server scoped to `tmpSite` (LocalSiteRuntime
+    /// passes the site directory as `ANGLESITE_PROJECT_ROOT`, so the plugin writes into our temp site).
+    private func poolWithRealPlugin(node: URL, serverPath: URL) -> HeadlessRuntimePool {
+        HeadlessRuntimePool(makeRuntime: {
+            LocalSiteRuntime(
+                supervisor: ProcessSupervisor(),
+                resolveMCPCommand: { .run(executable: node, arguments: [serverPath.path]) }
+            )
+        })
+    }
+
+    @Test(
+        "createTyped scaffolds a note end-to-end through the real plugin's create_content",
+        .enabled(
+            if: E2EPrerequisites.prerequisitesMet,
+            "requires the sibling Anglesite plugin checkout with a complete install (ANGLESITE_PLUGIN_PATH, or ../anglesite — run `npm install`) and a Node binary"
+        )
+    )
+    func createTypedNoteEndToEnd() async throws {
+        let pluginRoot = try #require(E2EPrerequisites.locateSiblingPlugin())
+        let node = try #require(E2EPrerequisites.locateNode())
+        let serverPath = pluginRoot.appendingPathComponent("server/index.mjs")
+
+        let site = tmpSite
+        let ops = ContentOperations(
+            pool: poolWithRealPlugin(node: node, serverPath: serverPath),
+            siteDirectory: { _ in site }
+        )
+
+        let result = await ops.createTyped(siteID: "e2e", typeID: "note", title: "Hello E2E")
+        #expect(
+            result == .created(filePath: "src/content/notes/hello-e2e.md", identifier: "hello-e2e"),
+            "expected a created note; got \(result)"
+        )
+
+        // The file actually exists on disk with the registry-driven h-entry frontmatter.
+        let entry = tmpSite.appendingPathComponent("src/content/notes/hello-e2e.md")
+        let contents = try String(contentsOf: entry, encoding: .utf8)
+        #expect(contents.contains("publishDate:"), "note frontmatter should carry publishDate: \(contents)")
+        #expect(!contents.contains("pubDate:"), "should use the registry field name, not the legacy pubDate")
+    }
+
+    @Test(
+        "createTyped surfaces the plugin's refusal for a page-stored type",
+        .enabled(
+            if: E2EPrerequisites.prerequisitesMet,
+            "requires the sibling Anglesite plugin checkout with a complete install and a Node binary"
+        )
+    )
+    func createTypedPageStoredRefusedEndToEnd() async throws {
+        let pluginRoot = try #require(E2EPrerequisites.locateSiblingPlugin())
+        let node = try #require(E2EPrerequisites.locateNode())
+        let serverPath = pluginRoot.appendingPathComponent("server/index.mjs")
+
+        let site = tmpSite
+        let ops = ContentOperations(
+            pool: poolWithRealPlugin(node: node, serverPath: serverPath),
+            siteDirectory: { _ in site }
+        )
+
+        // `businessProfile` is page-stored; the plugin's create_content schema only advertises
+        // collection-stored types, but a direct call should still refuse cleanly rather than write.
+        let result = await ops.createTyped(siteID: "e2e", typeID: "businessProfile", title: "Acme")
+        guard case .failed = result else {
+            Issue.record("expected .failed for a page-stored type; got \(result)")
+            return
+        }
+    }
+}

--- a/Tests/AnglesiteIntentsTests/Support/FakeContentOps.swift
+++ b/Tests/AnglesiteIntentsTests/Support/FakeContentOps.swift
@@ -32,6 +32,9 @@ final class FakeContentOps: ContentOperationsService, @unchecked Sendable {
         return postResult
     }
 
+    // TODO(#351): no App Intent drives createTyped yet, so `typedCalls` is recorded but unasserted.
+    // The typed-content intent entities land in #351 — its intent tests will exercise this, matching
+    // how the page/post intent tests assert pageCalls/postCalls.
     func createTyped(siteID: String, typeID: String, title: String, onProgress: ProgressHandler?) async -> ContentCreateResult {
         typedCalls.append((siteID, typeID, title))
         return typedResult

--- a/Tests/AnglesiteIntentsTests/Support/FakeContentOps.swift
+++ b/Tests/AnglesiteIntentsTests/Support/FakeContentOps.swift
@@ -17,8 +17,10 @@ import Foundation
 final class FakeContentOps: ContentOperationsService, @unchecked Sendable {
     var pageResult: ContentCreateResult = .created(filePath: "src/pages/x.astro", identifier: "/x")
     var postResult: ContentCreateResult = .created(filePath: "src/content/posts/x.md", identifier: "x")
+    var typedResult: ContentCreateResult = .created(filePath: "src/content/notes/x.md", identifier: "x")
     private(set) var pageCalls: [(siteID: String, name: String, route: String?)] = []
     private(set) var postCalls: [(siteID: String, title: String, collection: String?, slug: String?)] = []
+    private(set) var typedCalls: [(siteID: String, typeID: String, title: String)] = []
 
     func createPage(siteID: String, name: String, route: String?, onProgress: ProgressHandler?) async -> ContentCreateResult {
         pageCalls.append((siteID, name, route))
@@ -28,5 +30,10 @@ final class FakeContentOps: ContentOperationsService, @unchecked Sendable {
     func createPost(siteID: String, title: String, collection: String?, slug: String?, onProgress: ProgressHandler?) async -> ContentCreateResult {
         postCalls.append((siteID, title, collection, slug))
         return postResult
+    }
+
+    func createTyped(siteID: String, typeID: String, title: String, onProgress: ProgressHandler?) async -> ContentCreateResult {
+        typedCalls.append((siteID, typeID, title))
+        return typedResult
     }
 }


### PR DESCRIPTION
Closes #377.

The plugin half of #377 ([anglesite#389](https://github.com/Anglesite/anglesite/pull/389), merged to plugin `main` at `ebf29c3`) mirrored the native V-1.2 typed-content scaffolding into the Node MCP sidecar and registered a new `create_content` tool. This is the app-side consumer: it brings the MCP-backed create path to parity with the native one and exercises the new tool end-to-end against the real plugin.

## What changed

- **`ContentOperationsService`** — `createTyped(siteID:typeID:title:)` is now a protocol requirement (plus a no-`onProgress` convenience overload), so both backends are interchangeable behind the seam.
- **`ContentOperations`** (MCP-backed) — implements `createTyped` by calling the plugin's new `create_content` tool (`{ type, title }`), parsing `{ filePath, slug }` like `create_post`.
- **`NativeContentOperations`** — split a protocol-witness `createTyped` (title → slug) from the richer explicit-`slug` overload `SiteWindow`'s per-type editor uses. Making `slug` required on the richer overload removes the call-site ambiguity the witness would otherwise introduce. Behavior is unchanged.
- **`FakeContentOps`** — records `createTyped` calls.

## Tests

- 3 new unit cases through the fake MCP server (siteNotFound, created entry, page-stored refusal).
- 2 new **real-plugin e2e** cases (`CreateContentEndToEndTests`) driving `ContentOperations.createTyped` through the live `create_content` tool — gated on the sibling plugin checkout + Node (skip cleanly when absent, like the apply-edit e2e).
- Full suite green (`swift test`); DevID app target builds clean (`xcodebuild -scheme Anglesite`).

## Bundled plugin

`Resources/plugin/` is gitignored and regenerated by `copy-plugin.sh` from the sibling checkout, so consuming the merged plugin needs no committed pointer bump — the next build stamps `ebf29c3`. Verified: a worktree build bundled the new `create_content` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)