### PR TITLE
feat(#388): site identity h-card singleton (personal + business)

### DIFF
--- a/Resources/Template/src/components/Hcard.astro
+++ b/Resources/Template/src/components/Hcard.astro
@@ -1,0 +1,33 @@
+---
+// Site representative h-card (#388). Optional: renders only when src/data/profile.json exists.
+// The glob returns {} when the file is absent, so an unconfigured site shows no footer identity.
+// microformats2 only — the Person vs LocalBusiness schema.org @type is V-1.8.
+const mods = import.meta.glob<{ default: Record<string, any> }>("../data/profile.json", { eager: true });
+const profile = Object.values(mods)[0]?.default;
+const hasAddress = profile && (profile.streetAddress || profile.locality || profile.region || profile.postalCode);
+const hours: string[] = Array.isArray(profile?.hours) ? profile.hours : [];
+---
+
+{profile && (
+  <footer class="site-identity">
+    <div class="h-card">
+      {profile.name && <p class="p-name">{profile.name}</p>}
+      {profile.description && <p class="p-note">{profile.description}</p>}
+      {profile.photo && <img class="u-photo" src={profile.photo} alt={profile.name ?? ""} />}
+      {profile.telephone && <a class="p-tel" href={`tel:${profile.telephone}`}>{profile.telephone}</a>}
+      {profile.email && <a class="u-email" href={`mailto:${profile.email}`}>{profile.email}</a>}
+      {hasAddress && (
+        <p class="p-adr h-adr">
+          {profile.streetAddress && <span class="p-street-address">{profile.streetAddress}</span>}
+          {profile.locality && <span class="p-locality">{profile.locality}</span>}
+          {profile.region && <span class="p-region">{profile.region}</span>}
+          {profile.postalCode && <span class="p-postal-code">{profile.postalCode}</span>}
+        </p>
+      )}
+      {profile.url && <a class="u-url" href={profile.url}>{profile.url}</a>}
+      {hours.length > 0 && (
+        <ul class="hours">{hours.map((h) => <li>{h}</li>)}</ul>
+      )}
+    </div>
+  </footer>
+)}

--- a/Resources/Template/src/components/Hcard.astro
+++ b/Resources/Template/src/components/Hcard.astro
@@ -9,6 +9,9 @@ const hours: string[] = Array.isArray(profile?.hours) ? profile.hours : [];
 ---
 
 {profile && (
+  // This is the site's contentinfo landmark. A theme that renders its own <footer>
+  // should coordinate with this so the page has a single landmark footer (HTML allows
+  // multiple <footer> elements, but duplicate contentinfo landmarks confuse a11y trees).
   <footer class="site-identity">
     <div class="h-card">
       {profile.name && <p class="p-name">{profile.name}</p>}

--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ interface Props {
 }
 
 const { title, description } = Astro.props;
+import Hcard from "../components/Hcard.astro";
 // anglesite:imports — integration component imports are injected here on setup
 ---
 
@@ -23,6 +24,7 @@ const { title, description } = Astro.props;
   </head>
   <body>
     <slot />
+    <Hcard />
     <!-- anglesite:body-end -->
   </body>
 </html>

--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -1,12 +1,13 @@
 ---
+import Hcard from "../components/Hcard.astro";
+// anglesite:imports — integration component imports are injected here on setup
+
 interface Props {
   title: string;
   description?: string;
 }
 
 const { title, description } = Astro.props;
-import Hcard from "../components/Hcard.astro";
-// anglesite:imports — integration component imports are injected here on setup
 ---
 
 <!doctype html>

--- a/Sources/AnglesiteCore/ContentOperationsService.swift
+++ b/Sources/AnglesiteCore/ContentOperationsService.swift
@@ -9,7 +9,8 @@ public protocol ContentOperationsService: Sendable {
     func createPost(siteID: String, title: String, collection: String?, slug: String?, onProgress: ProgressHandler?) async -> ContentCreateResult
     /// Scaffold a typed entry (V-1.2 personal/business content types) from the content-type registry.
     /// `typeID` is a registry id (`note`, `article`, …); `title` seeds the name/title field and the
-    /// slug. Collection-stored types only — page-stored types (e.g. `businessProfile`) report `.failed`.
+    /// slug. Collection-stored types only — non-collection types (e.g. the `profile` identity singleton)
+    /// report `.failed` — use `createTypedSingleton`.
     func createTyped(siteID: String, typeID: String, title: String, onProgress: ProgressHandler?) async -> ContentCreateResult
 }
 

--- a/Sources/AnglesiteCore/ContentOperationsService.swift
+++ b/Sources/AnglesiteCore/ContentOperationsService.swift
@@ -12,6 +12,8 @@ public protocol ContentOperationsService: Sendable {
     /// slug. Collection-stored types only — non-collection types (e.g. the `profile` identity singleton)
     /// report `.failed` — use `createTypedSingleton`.
     func createTyped(siteID: String, typeID: String, title: String, onProgress: ProgressHandler?) async -> ContentCreateResult
+    // TODO: add `createTypedSingleton` here when remote runtimes land (#66/#69). It lives only on the
+    // concrete `NativeContentOperations` today; protocol-typed call sites can't create singletons yet.
 }
 
 public extension ContentOperationsService {

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -50,6 +50,10 @@ public enum ContentScaffold {
         "src/content/\(collection)/\(slug).md"
     }
 
+    public static func singletonRelativePath(slot: String) -> String {
+        "src/data/\(slot).json"
+    }
+
     /// `/about` → `../layouts/BaseLayout.astro`; `/a/b` → `../../layouts/BaseLayout.astro`.
     public static func layoutImport(normalizedRoute: String) -> String {
         let trimmed = normalizedRoute.hasPrefix("/") ? String(normalizedRoute.dropFirst()) : normalizedRoute
@@ -171,6 +175,32 @@ public enum ContentScaffold {
         return output
     }
 
+    /// Render a per-site singleton (e.g. the representative h-card) as a JSON data module:
+    /// `"type"` first, then one key per non-`markdown` field in descriptor order, with empty/zero
+    /// defaults and the name-like field filled from `name`. Pure; hand-rendered for deterministic
+    /// key order (unlike `JSONEncoder`). The template imports this file to render the identity.
+    public static func renderSingleton(descriptor: ContentTypeDescriptor, name: String?) -> String {
+        var entries: [String] = ["\"type\": \"\(escapeJSON(descriptor.id))\""]
+        for field in descriptor.fields {
+            let value: String
+            switch field.kind {
+            case .markdown:
+                continue // a data record has no body
+            case .bool:
+                value = "false"
+            case .number:
+                value = "0"
+            case .stringArray, .imageArray:
+                value = "[]"
+            case .string, .text, .url, .image, .date, .datetime:
+                let filled = titleLikeFieldNames.contains(field.name) ? (name ?? "") : ""
+                value = "\"\(escapeJSON(filled))\""
+            }
+            entries.append("\"\(field.name)\": \(value)")
+        }
+        return "{\n" + entries.map { "  \($0)" }.joined(separator: ",\n") + "\n}\n"
+    }
+
     // MARK: - Escaping (order matters: `&` first)
 
     static func escapeAttr(_ s: String) -> String {
@@ -187,6 +217,14 @@ public enum ContentScaffold {
     static func escapeYAML(_ s: String) -> String {
         s.replacingOccurrences(of: "\\", with: "\\\\")
          .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    static func escapeJSON(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+         .replacingOccurrences(of: "\"", with: "\\\"")
+         .replacingOccurrences(of: "\n", with: "\\n")
+         .replacingOccurrences(of: "\r", with: "\\r")
+         .replacingOccurrences(of: "\t", with: "\\t")
     }
 
     private static let titleLikeFieldNames: Set<String> = ["title", "name", "itemReviewed"]

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -220,9 +220,11 @@ public enum ContentScaffold {
     }
 
     /// Escape a string for use as a JSON string value. Covers `\` and `"`, the named control
-    /// escapes, and — critically — every remaining C0 control character as `\uXXXX`. The rendered
+    /// escapes, every remaining C0 control character as `\uXXXX`, and U+2028/U+2029. The rendered
     /// file is imported as a JS module, so an unescaped control char would be invalid JSON and
-    /// hard-fail the whole site build; the full C0 range is handled, not just the common few.
+    /// hard-fail the whole site build. U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are
+    /// valid in standalone JSON but break JS parsers if the data is ever inlined into a `<script>`
+    /// (e.g. V-1.8 JSON-LD), so they are escaped pre-emptively.
     static func escapeJSON(_ s: String) -> String {
         var out = ""
         out.reserveCapacity(s.count)
@@ -235,6 +237,8 @@ public enum ContentScaffold {
             case "\t": out += "\\t"
             case "\u{08}": out += "\\b"
             case "\u{0C}": out += "\\f"
+            case "\u{2028}": out += "\\u2028"
+            case "\u{2029}": out += "\\u2029"
             case let c where c.value < 0x20:
                 out += String(format: "\\u%04x", c.value)
             default:

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -219,12 +219,29 @@ public enum ContentScaffold {
          .replacingOccurrences(of: "\"", with: "\\\"")
     }
 
+    /// Escape a string for use as a JSON string value. Covers `\` and `"`, the named control
+    /// escapes, and — critically — every remaining C0 control character as `\uXXXX`. The rendered
+    /// file is imported as a JS module, so an unescaped control char would be invalid JSON and
+    /// hard-fail the whole site build; the full C0 range is handled, not just the common few.
     static func escapeJSON(_ s: String) -> String {
-        s.replacingOccurrences(of: "\\", with: "\\\\")
-         .replacingOccurrences(of: "\"", with: "\\\"")
-         .replacingOccurrences(of: "\n", with: "\\n")
-         .replacingOccurrences(of: "\r", with: "\\r")
-         .replacingOccurrences(of: "\t", with: "\\t")
+        var out = ""
+        out.reserveCapacity(s.count)
+        for scalar in s.unicodeScalars {
+            switch scalar {
+            case "\\": out += "\\\\"
+            case "\"": out += "\\\""
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            case "\t": out += "\\t"
+            case "\u{08}": out += "\\b"
+            case "\u{0C}": out += "\\f"
+            case let c where c.value < 0x20:
+                out += String(format: "\\u%04x", c.value)
+            default:
+                out.unicodeScalars.append(scalar)
+            }
+        }
+        return out
     }
 
     private static let titleLikeFieldNames: Set<String> = ["title", "name", "itemReviewed"]

--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -82,6 +82,10 @@ public struct ContentTypeProjections: Sendable, Equatable {
 public enum ContentStorage: Sendable, Equatable {
     case page
     case collection(String)
+    /// One record per site, stored as a data module (not a route, not a collection). The
+    /// associated value is the shared slot name; descriptors that share a slot are mutually
+    /// exclusive (one identity file per site).
+    case singleton(String)
 }
 
 /// A registered content type — pure declarative data, no behavior.
@@ -112,6 +116,12 @@ public struct ContentTypeDescriptor: Sendable, Equatable, Identifiable {
     /// The default collection name for `.collection`-stored types; `nil` for pages.
     public var collection: String? {
         if case let .collection(name) = storage { return name }
+        return nil
+    }
+
+    /// The shared slot name for `.singleton`-stored types; `nil` otherwise.
+    public var singletonSlot: String? {
+        if case let .singleton(name) = storage { return name }
         return nil
     }
 }
@@ -161,7 +171,7 @@ extension ContentTypeRegistry {
     /// The built-in content types: the personal IndieWeb post types (#344) and the small-business
     /// types (#345), declared as data here in V-1.1. Templates and editors for them land in their
     /// own tasks; this is the shared vocabulary they consume.
-    public static let builtIns: [ContentTypeDescriptor] = personalTypes + businessTypes
+    public static let builtIns: [ContentTypeDescriptor] = personalTypes + identityTypes + businessTypes
 
     // MARK: Personal (h-entry family)
 
@@ -321,14 +331,16 @@ extension ContentTypeRegistry {
         )
     )
 
-    // MARK: Business (#345 / §4.1)
+    // MARK: Site identity (h-card singletons, #388)
 
-    static let businessTypes: [ContentTypeDescriptor] = [businessProfile, announcement, event, review]
+    /// The two representative-h-card types. They share the `"profile"` slot, so a site has at most
+    /// one identity — personal or business — enforced at scaffold time by the single slot file.
+    static let identityTypes: [ContentTypeDescriptor] = [businessProfile, personalProfile]
 
     static let businessProfile = ContentTypeDescriptor(
         id: "businessProfile",
         displayName: "Business Profile",
-        storage: .page,
+        storage: .singleton("profile"),
         fields: [
             ContentTypeField("name", .string, required: true),
             ContentTypeField("description", .text),
@@ -359,6 +371,34 @@ extension ContentTypeRegistry {
             schemaType: "LocalBusiness"
         )
     )
+
+    static let personalProfile = ContentTypeDescriptor(
+        id: "personalProfile",
+        displayName: "Personal Profile",
+        storage: .singleton("profile"),
+        fields: [
+            ContentTypeField("name", .string, required: true),
+            ContentTypeField("description", .text),
+            ContentTypeField("email", .string),
+            ContentTypeField("url", .url),
+            ContentTypeField("photo", .image),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-card",
+            microformatProperties: [
+                "name": "p-name",
+                "description": "p-note",
+                "email": "u-email",
+                "url": "u-url",
+                "photo": "u-photo",
+            ],
+            schemaType: "Person"
+        )
+    )
+
+    // MARK: Business (collection types, #345 / §4.1)
+
+    static let businessTypes: [ContentTypeDescriptor] = [announcement, event, review]
 
     static let announcement = ContentTypeDescriptor(
         id: "announcement",

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -112,9 +112,10 @@ public struct NativeContentOperations: ContentOperationsService {
 
     /// Create a typed content entry (V-1.2). Looks the type up in `registry`, derives a slug from
     /// `slug ?? title`, renders frontmatter via `ContentScaffold.renderEntry`, writes it, and commits —
-    /// the same write/commit path as `createPost`. Collection-stored types only; page-stored types
-    /// (e.g. `businessProfile`) are #345. The explicit-`slug` overload is the native path's superset
-    /// over the MCP witness (SiteWindow's per-type editor passes a caller-chosen slug).
+    /// the same write/commit path as `createPost`. Collection-stored types only; singleton-stored types
+    /// (e.g. the `profile` identity) go through `createTypedSingleton`. The explicit-`slug` overload
+    /// is the native path's superset over the MCP witness (SiteWindow's per-type editor passes a
+    /// caller-chosen slug).
     public func createTyped(
         siteID: String,
         typeID: String,
@@ -129,7 +130,7 @@ public struct NativeContentOperations: ContentOperationsService {
             return .failed(reason: "Unknown content type: \(typeID)")
         }
         guard let collection = descriptor.collection else {
-            return .failed(reason: "Page-stored type \(typeID) is not supported by createTyped yet")
+            return .failed(reason: "\(typeID) is not a collection type; use createTypedSingleton")
         }
 
         let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -153,6 +154,44 @@ public struct NativeContentOperations: ContentOperationsService {
         onProgress?(.createFinalizing)
         _ = await gitCommit(root, relPath, "anglesite: add \(collection) \(finalSlug)")
         return .created(filePath: relPath, identifier: finalSlug)
+    }
+
+    /// Create a per-site singleton (V-1.3 follow-up, #388) — e.g. the representative h-card.
+    /// Looks the type up, resolves its `singletonSlot`, renders the JSON data module via
+    /// `ContentScaffold.renderSingleton`, and writes it — refusing if the slot file already exists,
+    /// which enforces one identity per site across both `businessProfile` and `personalProfile`
+    /// (they share the `"profile"` slot). Same write/commit path as `createTyped`.
+    public func createTypedSingleton(
+        siteID: String,
+        typeID: String,
+        name: String,
+        registry: ContentTypeRegistry = ContentTypeRegistry(),
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+        onProgress?(.createResolvingRuntime)
+        guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+        guard let descriptor = registry.descriptor(id: typeID) else {
+            return .failed(reason: "Unknown content type: \(typeID)")
+        }
+        guard let slot = descriptor.singletonSlot else {
+            return .failed(reason: "\(typeID) is not a singleton type")
+        }
+
+        let relPath = ContentScaffold.singletonRelativePath(slot: slot)
+        let abs = root.appendingPathComponent(relPath)
+        if fileManager.fileExists(atPath: abs.path) {
+            return .failed(reason: "A site identity already exists at \(relPath)")
+        }
+
+        let cleanName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let contents = ContentScaffold.renderSingleton(
+            descriptor: descriptor, name: cleanName.isEmpty ? nil : cleanName)
+        do { try write(contents, to: abs) }
+        catch { return .failed(reason: "\(error)") }
+
+        onProgress?(.createFinalizing)
+        _ = await gitCommit(root, relPath, "anglesite: add \(descriptor.id)")
+        return .created(filePath: relPath, identifier: slot)
     }
 
     private func write(_ contents: String, to abs: URL) throws {

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -161,6 +161,10 @@ public struct NativeContentOperations: ContentOperationsService {
     /// `ContentScaffold.renderSingleton`, and writes it — refusing if the slot file already exists,
     /// which enforces one identity per site across both `businessProfile` and `personalProfile`
     /// (they share the `"profile"` slot). Same write/commit path as `createTyped`.
+    ///
+    /// TODO: add to the `ContentOperationsService` protocol when remote runtimes land
+    /// (`RemoteSandboxSiteRuntime` #66, `LocalContainerSiteRuntime` #69) — they implement the
+    /// protocol and currently have no path to create singletons.
     public func createTypedSingleton(
         siteID: String,
         typeID: String,
@@ -179,6 +183,10 @@ public struct NativeContentOperations: ContentOperationsService {
 
         let relPath = ContentScaffold.singletonRelativePath(slot: slot)
         let abs = root.appendingPathComponent(relPath)
+        // The exists-check → write below is a TOCTOU window (as it is in the sibling create*
+        // methods). Acceptable here: the app is single-user and the create path is serialized, so
+        // two concurrent calls for the same site don't occur in practice. If that assumption ever
+        // changes, make this atomic with an O_CREAT|O_EXCL create rather than this check.
         if fileManager.fileExists(atPath: abs.path) {
             return .failed(reason: "A site identity already exists at \(relPath)")
         }

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -122,4 +122,42 @@ struct ContentScaffoldTests {
         #expect(!out.contains("\ntitle:"))
         #expect(!out.contains("\ndraft:"))
     }
+
+    @Test("singletonRelativePath maps a slot to a data-module json path")
+    func singletonPath() {
+        #expect(ContentScaffold.singletonRelativePath(slot: "profile") == "src/data/profile.json")
+    }
+
+    @Test("renderSingleton emits a business profile with type, filled name, and empty defaults")
+    func renderSingletonBusiness() throws {
+        let biz = try #require(ContentTypeRegistry().descriptor(id: "businessProfile"))
+        let out = ContentScaffold.renderSingleton(descriptor: biz, name: "Acme \"Co\"")
+        #expect(out == """
+        {
+          "type": "businessProfile",
+          "name": "Acme \\"Co\\"",
+          "description": "",
+          "telephone": "",
+          "email": "",
+          "streetAddress": "",
+          "locality": "",
+          "region": "",
+          "postalCode": "",
+          "hours": [],
+          "url": ""
+        }
+        """ + "\n")
+    }
+
+    @Test("renderSingleton for a personal profile omits business-only keys")
+    func renderSingletonPersonal() throws {
+        let person = try #require(ContentTypeRegistry().descriptor(id: "personalProfile"))
+        let out = ContentScaffold.renderSingleton(descriptor: person, name: "Ada")
+        #expect(out.contains("\"type\": \"personalProfile\""))
+        #expect(out.contains("\"name\": \"Ada\""))
+        #expect(out.contains("\"photo\": \"\""))
+        #expect(!out.contains("streetAddress"))
+        #expect(!out.contains("hours"))
+        #expect(out.hasSuffix("}\n"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -164,11 +164,15 @@ struct ContentScaffoldTests {
     @Test("renderSingleton emits valid JSON even when the name carries control characters")
     func renderSingletonEscapesControlChars() throws {
         let person = try #require(ContentTypeRegistry().descriptor(id: "personalProfile"))
-        // NUL, SOH, backspace, form-feed — all below U+0020, must be \u/named-escaped.
-        let out = ContentScaffold.renderSingleton(descriptor: person, name: "A\u{0}\u{1}\u{8}\u{C}B")
+        // NUL, SOH, backspace, form-feed (C0) plus U+2028/U+2029 (the JS-in-<script> landmine).
+        let tricky = "A\u{0}\u{1}\u{8}\u{C}\u{2028}\u{2029}B"
+        let out = ContentScaffold.renderSingleton(descriptor: person, name: tricky)
+        // U+2028/U+2029 must be emitted as \u escapes, not raw, so inline-<script> embedding is safe.
+        #expect(!out.unicodeScalars.contains("\u{2028}"))
+        #expect(!out.unicodeScalars.contains("\u{2029}"))
         let data = try #require(out.data(using: .utf8))
         let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         #expect(obj?["type"] as? String == "personalProfile")
-        #expect(obj?["name"] as? String == "A\u{0}\u{1}\u{8}\u{C}B") // round-trips losslessly
+        #expect(obj?["name"] as? String == tricky) // round-trips losslessly
     }
 }

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -160,4 +160,15 @@ struct ContentScaffoldTests {
         #expect(!out.contains("hours"))
         #expect(out.hasSuffix("}\n"))
     }
+
+    @Test("renderSingleton emits valid JSON even when the name carries control characters")
+    func renderSingletonEscapesControlChars() throws {
+        let person = try #require(ContentTypeRegistry().descriptor(id: "personalProfile"))
+        // NUL, SOH, backspace, form-feed — all below U+0020, must be \u/named-escaped.
+        let out = ContentScaffold.renderSingleton(descriptor: person, name: "A\u{0}\u{1}\u{8}\u{C}B")
+        let data = try #require(out.data(using: .utf8))
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(obj?["type"] as? String == "personalProfile")
+        #expect(obj?["name"] as? String == "A\u{0}\u{1}\u{8}\u{C}B") // round-trips losslessly
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
@@ -111,14 +111,28 @@ struct ContentTypeRegistryTests {
         #expect(review.fields.first { $0.name == "rating" }?.required == true)
     }
 
-    @Test("Business Profile is a page projecting h-card + LocalBusiness")
+    @Test("Business Profile is an h-card / LocalBusiness singleton")
     func businessProfileType() throws {
         let profile = try #require(ContentTypeRegistry().descriptor(id: "businessProfile"))
-        #expect(profile.storage == .page)
+        #expect(profile.storage == .singleton("profile"))
+        #expect(profile.singletonSlot == "profile")
         #expect(profile.collection == nil)
         #expect(profile.projections.microformat == "h-card")
         #expect(profile.projections.schemaType == "LocalBusiness")
         #expect(profile.projections.microformatProperties["telephone"] == "p-tel")
+    }
+
+    @Test("Personal Profile is an h-card / Person singleton sharing the profile slot")
+    func personalProfileType() throws {
+        let profile = try #require(ContentTypeRegistry().descriptor(id: "personalProfile"))
+        #expect(profile.storage == .singleton("profile"))
+        #expect(profile.singletonSlot == "profile")
+        #expect(profile.collection == nil)
+        #expect(profile.projections.microformat == "h-card")
+        #expect(profile.projections.schemaType == "Person")
+        #expect(profile.projections.microformatProperties["email"] == "u-email")
+        #expect(profile.fields.first?.name == "name")
+        #expect(profile.fields.first?.required == true)
     }
 
     @Test("personalTypes include album and like in canonical order")

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -121,11 +121,43 @@ struct NativeContentOperationsTests {
         #expect(result == .failed(reason: "Unknown content type: nope"))
     }
 
-    @Test("createTyped refuses page-stored types")
-    func createTypedPageStored() async {
+    @Test("createTyped rejects singleton types with a pointer to createTypedSingleton")
+    func createTypedRejectsSingleton() async {
         let (ops, _, _) = makeOps()
         let result = await ops.createTyped(siteID: "s1", typeID: "businessProfile", title: "x")
-        #expect(result == .failed(reason: "Page-stored type businessProfile is not supported by createTyped yet"))
+        #expect(result == .failed(reason: "businessProfile is not a collection type; use createTypedSingleton"))
+    }
+
+    @Test("createTypedSingleton writes the slot data file and commits")
+    func createTypedSingletonWrites() async throws {
+        let (ops, root, spy) = makeOps()
+        let result = await ops.createTypedSingleton(siteID: "s1", typeID: "businessProfile", name: "Acme")
+        #expect(result == .created(filePath: "src/data/profile.json", identifier: "profile"))
+        let written = try String(
+            contentsOf: root.appendingPathComponent("src/data/profile.json"), encoding: .utf8)
+        #expect(written.contains("\"type\": \"businessProfile\""))
+        #expect(written.contains("\"name\": \"Acme\""))
+        let calls = await spy.calls
+        #expect(calls.count == 1)
+        #expect(calls.first?.1 == "src/data/profile.json")
+        #expect(calls.first?.2 == "anglesite: add businessProfile")
+    }
+
+    @Test("createTypedSingleton enforces one identity per site across kinds")
+    func createTypedSingletonMutuallyExclusive() async {
+        let (ops, _, _) = makeOps()
+        _ = await ops.createTypedSingleton(siteID: "s1", typeID: "businessProfile", name: "Acme")
+        let second = await ops.createTypedSingleton(siteID: "s1", typeID: "personalProfile", name: "Ada")
+        #expect(second == .failed(reason: "A site identity already exists at src/data/profile.json"))
+    }
+
+    @Test("createTypedSingleton rejects collection types and unknown ids")
+    func createTypedSingletonRejectsCollection() async {
+        let (ops, _, _) = makeOps()
+        let coll = await ops.createTypedSingleton(siteID: "s1", typeID: "note", name: "x")
+        #expect(coll == .failed(reason: "note is not a singleton type"))
+        let unknown = await ops.createTypedSingleton(siteID: "s1", typeID: "nope", name: "x")
+        #expect(unknown == .failed(reason: "Unknown content type: nope"))
     }
 
     @Test("processGitCommit returns a SHA in a real repo, nil outside one")

--- a/Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+@Suite("Site identity h-card render smoke")
+struct SiteIdentityRenderSmokeTests {
+
+    static var templateDir: URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources/Template", isDirectory: true)
+    }
+
+    /// True when the template can actually be built: a Node binary plus an installed Astro.
+    static var buildable: Bool {
+        guard E2EPrerequisites.locateNode() != nil else { return false }
+        return FileManager.default.isReadableFile(
+            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
+    }
+
+    @Test("footer h-card renders per profile kind, and nothing when unconfigured",
+          .enabled(if: SiteIdentityRenderSmokeTests.buildable))
+    func rendersFooterHcard() async throws {
+        let node = try #require(E2EPrerequisites.locateNode())
+        let dataDir = Self.templateDir.appendingPathComponent("src/data", isDirectory: true)
+        let profile = dataDir.appendingPathComponent("profile.json")
+        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+
+        func build() async throws {
+            try? FileManager.default.removeItem(at: dist)
+            let result = try await ProcessSupervisor.shared.run(
+                executable: node,
+                arguments: ["node_modules/astro/astro.js", "build"],
+                currentDirectoryURL: Self.templateDir)
+            try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+        }
+        func indexHTML() throws -> String {
+            try String(contentsOf: dist.appendingPathComponent("index.html"), encoding: .utf8)
+        }
+        func writeProfile(_ json: String) throws {
+            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+            try json.write(to: profile, atomically: true, encoding: .utf8)
+        }
+
+        try await TemplateBuildSerializer.shared.serialize {
+            // Keep the template ship-empty no matter how this test exits.
+            defer {
+                try? FileManager.default.removeItem(at: dataDir)
+                try? FileManager.default.removeItem(at: dist)
+            }
+
+            // 1. Unconfigured: no profile.json → no h-card in the footer.
+            try? FileManager.default.removeItem(at: dataDir)
+            try await build()
+            #expect(!(try indexHTML().contains("h-card")))
+
+            // 2. Business profile → h-card with contact + address mf2.
+            try writeProfile("""
+            {"type":"businessProfile","name":"Acme Co","telephone":"+1-555-0100",\
+            "email":"hi@acme.test","streetAddress":"1 Main St","locality":"Springfield",\
+            "region":"IL","postalCode":"62701","hours":["Mon-Fri 9-5"],"url":"https://acme.test"}
+            """)
+            try await build()
+            let biz = try indexHTML()
+            #expect(biz.contains("h-card"))
+            #expect(biz.contains("p-name"))
+            #expect(biz.contains("p-tel"))
+            #expect(biz.contains("p-street-address"))
+
+            // 3. Personal profile → h-card without business-only address mf2.
+            try writeProfile("""
+            {"type":"personalProfile","name":"Ada Lovelace","description":"Mathematician",\
+            "email":"ada@example.test","url":"https://ada.example.test"}
+            """)
+            try await build()
+            let person = try indexHTML()
+            #expect(person.contains("h-card"))
+            #expect(person.contains("p-name"))
+            #expect(person.contains("u-email"))
+            #expect(!person.contains("p-street-address"))
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-06-27-site-identity-hcard.md
+++ b/docs/superpowers/plans/2026-06-27-site-identity-hcard.md
@@ -1,0 +1,669 @@
+# Site identity h-card (personal + business) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a single per-site representative h-card — personal (`Person`) or business (`LocalBusiness`), mutually exclusive — that renders in a site-wide footer, on a general singleton storage mechanism.
+
+**Architecture:** A new `ContentStorage.singleton(slot)` registry case backs two descriptors (`businessProfile`, `personalProfile`) that share one slot (`"profile"`). `AnglesiteCore` gains a pure JSON renderer (`ContentScaffold.renderSingleton`) and a writer (`NativeContentOperations.createTypedSingleton`) that enforces one-per-site by refusing to overwrite the slot file `src/data/profile.json`. The template gains an `Hcard.astro` footer partial that optionally imports that JSON and renders `h-card` mf2 (or nothing when absent).
+
+**Tech Stack:** Swift 6.4 / Swift Testing (`@Test`), Astro (template), microformats2.
+
+## Global Constraints
+
+- ES modules / vanilla — no new dependencies. macOS 27+, Swift 6.4.
+- **mf2 only** this pass. No schema.org JSON-LD (V-1.8), no `rel=me`/IndieAuth (V-2), no SwiftUI/app-target code, no UI.
+- **Template ships empty:** `src/data/profile.json` is never committed. Any test that writes it must `defer`-remove it.
+- Tests are Swift Testing (`@Test`/`#expect`/`#require`), run with `swift test --package-path .` from the worktree root.
+- `swift test` needs `DEVELOPER_DIR` pointed at the Xcode-beta toolchain (Xcode 27 / Swift 6.4); the default CommandLineTools `swift` is too old.
+- Work entirely in the worktree `.claude/worktrees/388-site-identity/` on branch `feat/388-site-identity`. Spec: `docs/superpowers/specs/2026-06-27-site-identity-hcard-design.md`.
+
+---
+
+### Task 1: Registry — singleton storage + `personalProfile`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ContentTypeRegistry.swift` (the `ContentStorage` enum ~L82-85, the `collection` computed property ~L113-116, the built-in catalog ~L164 and the Business section ~L324-361)
+- Test: `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift` (the `businessProfileType` test ~L114-122)
+
+**Interfaces:**
+- Produces: `ContentStorage.singleton(String)`; `ContentTypeDescriptor.singletonSlot -> String?`; `ContentTypeRegistry.identityTypes: [ContentTypeDescriptor]`; descriptors `businessProfile` (now `.singleton("profile")`) and `personalProfile` (`.singleton("profile")`, `h-card`/`Person`, fields `name`/`description`/`email`/`url`/`photo`).
+
+- [ ] **Step 1: Update the existing registry test to the singleton expectation**
+
+In `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift`, replace the `businessProfileType` test (currently asserting `.page`) with:
+
+```swift
+    @Test("Business Profile is an h-card / LocalBusiness singleton")
+    func businessProfileType() throws {
+        let profile = try #require(ContentTypeRegistry().descriptor(id: "businessProfile"))
+        #expect(profile.storage == .singleton("profile"))
+        #expect(profile.singletonSlot == "profile")
+        #expect(profile.collection == nil)
+        #expect(profile.projections.microformat == "h-card")
+        #expect(profile.projections.schemaType == "LocalBusiness")
+        #expect(profile.projections.microformatProperties["telephone"] == "p-tel")
+    }
+
+    @Test("Personal Profile is an h-card / Person singleton sharing the profile slot")
+    func personalProfileType() throws {
+        let profile = try #require(ContentTypeRegistry().descriptor(id: "personalProfile"))
+        #expect(profile.storage == .singleton("profile"))
+        #expect(profile.singletonSlot == "profile")
+        #expect(profile.collection == nil)
+        #expect(profile.projections.microformat == "h-card")
+        #expect(profile.projections.schemaType == "Person")
+        #expect(profile.projections.microformatProperties["email"] == "u-email")
+        #expect(profile.fields.first?.name == "name")
+        #expect(profile.fields.first?.required == true)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter "ContentTypeRegistryTests"`
+Expected: FAIL — `.singleton` is not a member of `ContentStorage`; `singletonSlot` and `personalProfile` do not exist (compile errors).
+
+- [ ] **Step 3: Add the `.singleton` storage case and `singletonSlot`**
+
+In `Sources/AnglesiteCore/ContentTypeRegistry.swift`, extend the enum:
+
+```swift
+public enum ContentStorage: Sendable, Equatable {
+    case page
+    case collection(String)
+    /// One record per site, stored as a data module (not a route, not a collection). The
+    /// associated value is the shared slot name; descriptors that share a slot are mutually
+    /// exclusive (one identity file per site).
+    case singleton(String)
+}
+```
+
+Add the computed property next to `collection` (after the existing `collection` var, ~L116):
+
+```swift
+    /// The shared slot name for `.singleton`-stored types; `nil` otherwise.
+    public var singletonSlot: String? {
+        if case let .singleton(name) = storage { return name }
+        return nil
+    }
+```
+
+- [ ] **Step 4: Add `personalProfile`, flip `businessProfile` to a singleton, and regroup**
+
+In `Sources/AnglesiteCore/ContentTypeRegistry.swift`, change the catalog aggregate (~L164):
+
+```swift
+    public static let builtIns: [ContentTypeDescriptor] = personalTypes + identityTypes + businessTypes
+```
+
+Replace the `// MARK: Business (#345 / §4.1)` section header + `businessTypes` line + the `businessProfile` declaration so the section reads:
+
+```swift
+    // MARK: Site identity (h-card singletons, #388)
+
+    /// The two representative-h-card types. They share the `"profile"` slot, so a site has at most
+    /// one identity — personal or business — enforced at scaffold time by the single slot file.
+    static let identityTypes: [ContentTypeDescriptor] = [businessProfile, personalProfile]
+
+    static let businessProfile = ContentTypeDescriptor(
+        id: "businessProfile",
+        displayName: "Business Profile",
+        storage: .singleton("profile"),
+        fields: [
+            ContentTypeField("name", .string, required: true),
+            ContentTypeField("description", .text),
+            ContentTypeField("telephone", .string),
+            ContentTypeField("email", .string),
+            ContentTypeField("streetAddress", .string),
+            ContentTypeField("locality", .string),
+            ContentTypeField("region", .string),
+            ContentTypeField("postalCode", .string),
+            ContentTypeField("hours", .stringArray),
+            ContentTypeField("url", .url),
+        ],
+        // `hours` is intentionally unmapped: h-card has no normative opening-hours property, so
+        // hours are carried by schema.org (`LocalBusiness.openingHours`) only, not microformats2.
+        projections: ContentTypeProjections(
+            microformat: "h-card",
+            microformatProperties: [
+                "name": "p-name",
+                "description": "p-note",
+                "telephone": "p-tel",
+                "email": "u-email",
+                "streetAddress": "p-street-address",
+                "locality": "p-locality",
+                "region": "p-region",
+                "postalCode": "p-postal-code",
+                "url": "u-url",
+            ],
+            schemaType: "LocalBusiness"
+        )
+    )
+
+    static let personalProfile = ContentTypeDescriptor(
+        id: "personalProfile",
+        displayName: "Personal Profile",
+        storage: .singleton("profile"),
+        fields: [
+            ContentTypeField("name", .string, required: true),
+            ContentTypeField("description", .text),
+            ContentTypeField("email", .string),
+            ContentTypeField("url", .url),
+            ContentTypeField("photo", .image),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-card",
+            microformatProperties: [
+                "name": "p-name",
+                "description": "p-note",
+                "email": "u-email",
+                "url": "u-url",
+                "photo": "u-photo",
+            ],
+            schemaType: "Person"
+        )
+    )
+
+    // MARK: Business (collection types, #345 / §4.1)
+
+    static let businessTypes: [ContentTypeDescriptor] = [announcement, event, review]
+```
+
+(The `announcement`, `event`, `review` declarations stay exactly where they are, below this.)
+
+- [ ] **Step 5: Run the full registry suite to verify it passes**
+
+Run: `swift test --package-path . --filter "ContentTypeRegistryTests"`
+Expected: PASS — including `builtInInvariants` (validates `personalProfile`: `h-card` prefix, all mapped fields exist, singleton skipped by the `.collection` switch) and `defaultRegistry` (tautological id checks).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentTypeRegistry.swift Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+git commit -m "feat(#388): singleton storage + personalProfile h-card descriptor"
+```
+
+---
+
+### Task 2: Scaffold — `renderSingleton` + path + JSON escaping
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ContentScaffold.swift` (add path builder near `postRelativePath` ~L49-51, add `renderSingleton` after `renderEntry` ~L172, add `escapeJSON` near the other escapers ~L174-190)
+- Test: `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentTypeDescriptor`, `ContentTypeField.Kind` (Task 1).
+- Produces: `ContentScaffold.singletonRelativePath(slot: String) -> String` → `"src/data/<slot>.json"`; `ContentScaffold.renderSingleton(descriptor: ContentTypeDescriptor, name: String?) -> String` → a JSON object string, `"type"` first, one key per non-`markdown` field in descriptor order, deterministic, trailing newline.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift` (inside the `ContentScaffoldTests` struct):
+
+```swift
+    @Test("singletonRelativePath maps a slot to a data-module json path")
+    func singletonPath() {
+        #expect(ContentScaffold.singletonRelativePath(slot: "profile") == "src/data/profile.json")
+    }
+
+    @Test("renderSingleton emits a business profile with type, filled name, and empty defaults")
+    func renderSingletonBusiness() throws {
+        let biz = try #require(ContentTypeRegistry().descriptor(id: "businessProfile"))
+        let out = ContentScaffold.renderSingleton(descriptor: biz, name: "Acme \"Co\"")
+        #expect(out == """
+        {
+          "type": "businessProfile",
+          "name": "Acme \\"Co\\"",
+          "description": "",
+          "telephone": "",
+          "email": "",
+          "streetAddress": "",
+          "locality": "",
+          "region": "",
+          "postalCode": "",
+          "hours": [],
+          "url": ""
+        }
+        """ + "\n")
+    }
+
+    @Test("renderSingleton for a personal profile omits business-only keys")
+    func renderSingletonPersonal() throws {
+        let person = try #require(ContentTypeRegistry().descriptor(id: "personalProfile"))
+        let out = ContentScaffold.renderSingleton(descriptor: person, name: "Ada")
+        #expect(out.contains("\"type\": \"personalProfile\""))
+        #expect(out.contains("\"name\": \"Ada\""))
+        #expect(out.contains("\"photo\": \"\""))
+        #expect(!out.contains("streetAddress"))
+        #expect(!out.contains("hours"))
+        #expect(out.hasSuffix("}\n"))
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter "ContentScaffold"`
+Expected: FAIL — `singletonRelativePath` and `renderSingleton` are undefined.
+
+- [ ] **Step 3: Implement the path builder, JSON escaper, and renderer**
+
+In `Sources/AnglesiteCore/ContentScaffold.swift`, add the path builder next to `postRelativePath`:
+
+```swift
+    public static func singletonRelativePath(slot: String) -> String {
+        "src/data/\(slot).json"
+    }
+```
+
+Add `escapeJSON` next to the other escapers (after `escapeYAML`):
+
+```swift
+    static func escapeJSON(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+         .replacingOccurrences(of: "\"", with: "\\\"")
+         .replacingOccurrences(of: "\n", with: "\\n")
+         .replacingOccurrences(of: "\r", with: "\\r")
+         .replacingOccurrences(of: "\t", with: "\\t")
+    }
+```
+
+Add the renderer after `renderEntry`:
+
+```swift
+    /// Render a per-site singleton (e.g. the representative h-card) as a JSON data module:
+    /// `"type"` first, then one key per non-`markdown` field in descriptor order, with empty/zero
+    /// defaults and the name-like field filled from `name`. Pure; hand-rendered for deterministic
+    /// key order (unlike `JSONEncoder`). The template imports this file to render the identity.
+    public static func renderSingleton(descriptor: ContentTypeDescriptor, name: String?) -> String {
+        var entries: [String] = ["\"type\": \"\(escapeJSON(descriptor.id))\""]
+        for field in descriptor.fields {
+            let value: String
+            switch field.kind {
+            case .markdown:
+                continue // a data record has no body
+            case .bool:
+                value = "false"
+            case .number:
+                value = "0"
+            case .stringArray, .imageArray:
+                value = "[]"
+            case .string, .text, .url, .image, .date, .datetime:
+                let filled = titleLikeFieldNames.contains(field.name) ? (name ?? "") : ""
+                value = "\"\(escapeJSON(filled))\""
+            }
+            entries.append("\"\(field.name)\": \(value)")
+        }
+        return "{\n" + entries.map { "  \($0)" }.joined(separator: ",\n") + "\n}\n"
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter "ContentScaffold"`
+Expected: PASS (all three new tests plus the existing scaffold tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentScaffold.swift Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+git commit -m "feat(#388): ContentScaffold.renderSingleton + singleton path"
+```
+
+---
+
+### Task 3: Operations — `createTypedSingleton` + generalized `createTyped` rejection
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/NativeContentOperations.swift` (the `createTyped` guard ~L124-126 and its doc comment ~L107-116; add `createTypedSingleton` after `createTyped` ~L149)
+- Modify: `Sources/AnglesiteCore/ContentOperationsService.swift` (doc comment ~L12 referencing "page-stored types (e.g. `businessProfile`)")
+- Test: `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift` (replace `createTypedPageStored` ~L124-129; add new tests)
+
+**Interfaces:**
+- Consumes: `ContentTypeDescriptor.singletonSlot`, `ContentScaffold.singletonRelativePath`, `ContentScaffold.renderSingleton` (Tasks 1-2); the existing private `write(_:to:)` and `gitCommit` closure.
+- Produces: `NativeContentOperations.createTypedSingleton(siteID:typeID:name:registry:onProgress:) async -> ContentCreateResult`. On success: `.created(filePath: "src/data/<slot>.json", identifier: <slot>)`. Refuses a second identity with `.failed(reason: "A site identity already exists at src/data/<slot>.json")`.
+
+- [ ] **Step 1: Update the obsolete test and add the new behavior tests**
+
+In `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift`, replace the `createTypedPageStored` test with:
+
+```swift
+    @Test("createTyped rejects singleton types with a pointer to createTypedSingleton")
+    func createTypedRejectsSingleton() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createTyped(siteID: "s1", typeID: "businessProfile", title: "x")
+        #expect(result == .failed(reason: "businessProfile is not a collection type; use createTypedSingleton"))
+    }
+
+    @Test("createTypedSingleton writes the slot data file and commits")
+    func createTypedSingletonWrites() async throws {
+        let (ops, root, spy) = makeOps()
+        let result = await ops.createTypedSingleton(siteID: "s1", typeID: "businessProfile", name: "Acme")
+        #expect(result == .created(filePath: "src/data/profile.json", identifier: "profile"))
+        let written = try String(
+            contentsOf: root.appendingPathComponent("src/data/profile.json"), encoding: .utf8)
+        #expect(written.contains("\"type\": \"businessProfile\""))
+        #expect(written.contains("\"name\": \"Acme\""))
+        let calls = await spy.calls
+        #expect(calls.count == 1)
+        #expect(calls.first?.1 == "src/data/profile.json")
+        #expect(calls.first?.2 == "anglesite: add businessProfile")
+    }
+
+    @Test("createTypedSingleton enforces one identity per site across kinds")
+    func createTypedSingletonMutuallyExclusive() async {
+        let (ops, _, _) = makeOps()
+        _ = await ops.createTypedSingleton(siteID: "s1", typeID: "businessProfile", name: "Acme")
+        let second = await ops.createTypedSingleton(siteID: "s1", typeID: "personalProfile", name: "Ada")
+        #expect(second == .failed(reason: "A site identity already exists at src/data/profile.json"))
+    }
+
+    @Test("createTypedSingleton rejects collection types and unknown ids")
+    func createTypedSingletonRejectsCollection() async {
+        let (ops, _, _) = makeOps()
+        let coll = await ops.createTypedSingleton(siteID: "s1", typeID: "note", name: "x")
+        #expect(coll == .failed(reason: "note is not a singleton type"))
+        let unknown = await ops.createTypedSingleton(siteID: "s1", typeID: "nope", name: "x")
+        #expect(unknown == .failed(reason: "Unknown content type: nope"))
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter "NativeContentOperations"`
+Expected: FAIL — `createTypedSingleton` is undefined; `createTyped` still returns the old "Page-stored type…" message.
+
+- [ ] **Step 3: Generalize the `createTyped` rejection and add `createTypedSingleton`**
+
+In `Sources/AnglesiteCore/NativeContentOperations.swift`, change the `createTyped` guard (currently returns the "Page-stored type … is not supported by createTyped yet" message):
+
+```swift
+        guard let collection = descriptor.collection else {
+            return .failed(reason: "\(typeID) is not a collection type; use createTypedSingleton")
+        }
+```
+
+Update the `createTyped` doc comment's last sentence from "page-stored types (e.g. `businessProfile`) are #345." to: "Singleton-stored types (e.g. the `profile` identity) go through `createTypedSingleton`."
+
+Add the new method immediately after `createTyped`:
+
+```swift
+    /// Create a per-site singleton (V-1.3 follow-up, #388) — e.g. the representative h-card.
+    /// Looks the type up, resolves its `singletonSlot`, renders the JSON data module via
+    /// `ContentScaffold.renderSingleton`, and writes it — refusing if the slot file already exists,
+    /// which enforces one identity per site across both `businessProfile` and `personalProfile`
+    /// (they share the `"profile"` slot). Same write/commit path as `createTyped`.
+    public func createTypedSingleton(
+        siteID: String,
+        typeID: String,
+        name: String,
+        registry: ContentTypeRegistry = ContentTypeRegistry(),
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+        onProgress?(.createResolvingRuntime)
+        guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+        guard let descriptor = registry.descriptor(id: typeID) else {
+            return .failed(reason: "Unknown content type: \(typeID)")
+        }
+        guard let slot = descriptor.singletonSlot else {
+            return .failed(reason: "\(typeID) is not a singleton type")
+        }
+
+        let relPath = ContentScaffold.singletonRelativePath(slot: slot)
+        let abs = root.appendingPathComponent(relPath)
+        if fileManager.fileExists(atPath: abs.path) {
+            return .failed(reason: "A site identity already exists at \(relPath)")
+        }
+
+        let cleanName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let contents = ContentScaffold.renderSingleton(
+            descriptor: descriptor, name: cleanName.isEmpty ? nil : cleanName)
+        do { try write(contents, to: abs) }
+        catch { return .failed(reason: "\(error)") }
+
+        onProgress?(.createFinalizing)
+        _ = await gitCommit(root, relPath, "anglesite: add \(descriptor.id)")
+        return .created(filePath: relPath, identifier: slot)
+    }
+```
+
+In `Sources/AnglesiteCore/ContentOperationsService.swift`, update the `createTyped` doc comment (~L12) from "page-stored types (e.g. `businessProfile`) report `.failed`." to "non-collection types (e.g. the `profile` identity singleton) report `.failed` — use `createTypedSingleton`."
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter "NativeContentOperations"`
+Expected: PASS (the four new/updated tests plus the existing operation tests).
+
+- [ ] **Step 5: Confirm the MCP-path tests are unaffected**
+
+The MCP-routed tests (`ContentOperationsTests`, `CreateContentEndToEndTests`) assert the *plugin's* "Page-stored type businessProfile…" message via a mock/real plugin that is **not** modified in this repo, so they must still pass unchanged.
+
+Run: `swift test --package-path . --filter "ContentOperationsTests"`
+Expected: PASS (no changes needed). If `CreateContentEndToEndTests` is enabled in your env (needs `ANGLESITE_PLUGIN_PATH` + node), it also passes unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NativeContentOperations.swift Sources/AnglesiteCore/ContentOperationsService.swift Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+git commit -m "feat(#388): NativeContentOperations.createTypedSingleton with one-per-site gate"
+```
+
+---
+
+### Task 4: Template — footer `Hcard.astro` + render smoke test
+
+**Files:**
+- Create: `Resources/Template/src/components/Hcard.astro`
+- Modify: `Resources/Template/src/layouts/BaseLayout.astro` (add the import in frontmatter ~L8 and `<Hcard />` after the `<slot />` ~L25)
+- Create: `Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift`
+
+**Interfaces:**
+- Consumes: nothing from Swift at runtime — the partial reads `src/data/profile.json` itself. The smoke test writes fixture JSON shaped like `ContentScaffold.renderSingleton` output but with **populated** values (the scaffold writes empty placeholders; the renderer only emits fields that are non-empty, so a populated fixture is required to assert address/contact mf2).
+
+- [ ] **Step 1: Ensure the worktree template can build**
+
+The worktree has no `node_modules` (gitignored). Install Astro so the smoke test runs instead of skipping:
+
+Run: `npm install --prefix Resources/Template`
+Expected: completes; `Resources/Template/node_modules/astro/astro.js` now exists.
+
+- [ ] **Step 2: Write the failing render smoke test**
+
+Create `Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift`:
+
+```swift
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+@Suite("Site identity h-card render smoke")
+struct SiteIdentityRenderSmokeTests {
+
+    static var templateDir: URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources/Template", isDirectory: true)
+    }
+
+    /// True when the template can actually be built: a Node binary plus an installed Astro.
+    static var buildable: Bool {
+        guard E2EPrerequisites.locateNode() != nil else { return false }
+        return FileManager.default.isReadableFile(
+            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
+    }
+
+    @Test("footer h-card renders per profile kind, and nothing when unconfigured",
+          .enabled(if: SiteIdentityRenderSmokeTests.buildable))
+    func rendersFooterHcard() async throws {
+        let node = try #require(E2EPrerequisites.locateNode())
+        let dataDir = Self.templateDir.appendingPathComponent("src/data", isDirectory: true)
+        let profile = dataDir.appendingPathComponent("profile.json")
+        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+
+        func build() async throws {
+            try? FileManager.default.removeItem(at: dist)
+            let result = try await ProcessSupervisor.shared.run(
+                executable: node,
+                arguments: ["node_modules/astro/astro.js", "build"],
+                currentDirectoryURL: Self.templateDir)
+            try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+        }
+        func indexHTML() throws -> String {
+            try String(contentsOf: dist.appendingPathComponent("index.html"), encoding: .utf8)
+        }
+        func writeProfile(_ json: String) throws {
+            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+            try json.write(to: profile, atomically: true, encoding: .utf8)
+        }
+
+        try await TemplateBuildSerializer.shared.serialize {
+            // Keep the template ship-empty no matter how this test exits.
+            defer {
+                try? FileManager.default.removeItem(at: dataDir)
+                try? FileManager.default.removeItem(at: dist)
+            }
+
+            // 1. Unconfigured: no profile.json → no h-card in the footer.
+            try? FileManager.default.removeItem(at: dataDir)
+            try await build()
+            #expect(!(try indexHTML().contains("h-card")))
+
+            // 2. Business profile → h-card with contact + address mf2.
+            try writeProfile("""
+            {"type":"businessProfile","name":"Acme Co","telephone":"+1-555-0100",\
+            "email":"hi@acme.test","streetAddress":"1 Main St","locality":"Springfield",\
+            "region":"IL","postalCode":"62701","hours":["Mon-Fri 9-5"],"url":"https://acme.test"}
+            """)
+            try await build()
+            let biz = try indexHTML()
+            #expect(biz.contains("h-card"))
+            #expect(biz.contains("p-name"))
+            #expect(biz.contains("p-tel"))
+            #expect(biz.contains("p-street-address"))
+
+            // 3. Personal profile → h-card without business-only address mf2.
+            try writeProfile("""
+            {"type":"personalProfile","name":"Ada Lovelace","description":"Mathematician",\
+            "email":"ada@example.test","url":"https://ada.example.test"}
+            """)
+            try await build()
+            let person = try indexHTML()
+            #expect(person.contains("h-card"))
+            #expect(person.contains("p-name"))
+            #expect(person.contains("u-email"))
+            #expect(!person.contains("p-street-address"))
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `swift test --package-path . --filter "SiteIdentityRenderSmokeTests"`
+Expected: FAIL — the build succeeds but no `h-card` is emitted (no `Hcard.astro`, no footer wiring), so the business/personal `#expect`s fail. (If it reports *skipped*, Step 1 did not install Astro — fix that first; a skipped test is not a passing test.)
+
+- [ ] **Step 4: Create the `Hcard.astro` footer partial**
+
+Create `Resources/Template/src/components/Hcard.astro`:
+
+```astro
+---
+// Site representative h-card (#388). Optional: renders only when src/data/profile.json exists.
+// The glob returns {} when the file is absent, so an unconfigured site shows no footer identity.
+// microformats2 only — the Person vs LocalBusiness schema.org @type is V-1.8.
+const mods = import.meta.glob<{ default: Record<string, any> }>("../data/profile.json", { eager: true });
+const profile = Object.values(mods)[0]?.default;
+const hasAddress = profile && (profile.streetAddress || profile.locality || profile.region || profile.postalCode);
+const hours: string[] = Array.isArray(profile?.hours) ? profile.hours : [];
+---
+
+{profile && (
+  <footer class="site-identity">
+    <div class="h-card">
+      {profile.name && <p class="p-name">{profile.name}</p>}
+      {profile.description && <p class="p-note">{profile.description}</p>}
+      {profile.photo && <img class="u-photo" src={profile.photo} alt={profile.name ?? ""} />}
+      {profile.telephone && <a class="p-tel" href={`tel:${profile.telephone}`}>{profile.telephone}</a>}
+      {profile.email && <a class="u-email" href={`mailto:${profile.email}`}>{profile.email}</a>}
+      {hasAddress && (
+        <p class="p-adr h-adr">
+          {profile.streetAddress && <span class="p-street-address">{profile.streetAddress}</span>}
+          {profile.locality && <span class="p-locality">{profile.locality}</span>}
+          {profile.region && <span class="p-region">{profile.region}</span>}
+          {profile.postalCode && <span class="p-postal-code">{profile.postalCode}</span>}
+        </p>
+      )}
+      {profile.url && <a class="u-url" href={profile.url}>{profile.url}</a>}
+      {hours.length > 0 && (
+        <ul class="hours">{hours.map((h) => <li>{h}</li>)}</ul>
+      )}
+    </div>
+  </footer>
+)}
+```
+
+- [ ] **Step 5: Wire the partial into the site-wide layout**
+
+In `Resources/Template/src/layouts/BaseLayout.astro`, add the import in the frontmatter (above the `// anglesite:imports` comment):
+
+```astro
+import Hcard from "../components/Hcard.astro";
+```
+
+And render it after the `<slot />` in the body:
+
+```astro
+  <body>
+    <slot />
+    <Hcard />
+    <!-- anglesite:body-end -->
+  </body>
+```
+
+- [ ] **Step 6: Run the render smoke test to verify it passes**
+
+Run: `swift test --package-path . --filter "SiteIdentityRenderSmokeTests"`
+Expected: PASS — unconfigured build has no `h-card`; business build has `p-tel` + `p-street-address`; personal build has `u-email` and no `p-street-address`.
+
+- [ ] **Step 7: Confirm the template is still ship-empty**
+
+Run: `git status --short Resources/Template/src/data`
+Expected: no output (the test's `defer` removed `src/data`; nothing staged or untracked there).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Resources/Template/src/components/Hcard.astro Resources/Template/src/layouts/BaseLayout.astro Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift
+git commit -m "feat(#388): site-wide footer h-card partial + render smoke"
+```
+
+---
+
+### Task 5: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole AnglesiteCore suite**
+
+Run: `swift test --package-path .`
+Expected: PASS — all suites green, including `ContentConfigDriftTests` (unchanged — both singletons have `collection == nil` and are skipped), `BusinessTypeRenderSmokeTests`, and the new `SiteIdentityRenderSmokeTests`. No suite regressed.
+
+- [ ] **Step 2: Confirm the working tree is clean and ship-empty**
+
+Run: `git status --short`
+Expected: clean (all task commits made; no stray `Resources/Template/src/data/profile.json`, no `dist/`).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Singleton storage kind + `personalProfile` + shared slot → Task 1. ✓
+- `renderSingleton` (pure JSON) + path → Task 2. ✓
+- `createTypedSingleton` with one-per-site gate + generalized `createTyped` → Task 3. ✓
+- Footer `Hcard.astro` (optional import, mf2, hours unmapped) + `BaseLayout` wiring → Task 4. ✓
+- All five test groups in the spec (registry, scaffold, operations, render smoke incl. empty state, drift untouched) → Tasks 1-5. ✓
+- Decisions: one-per-site (Task 3 gate), footer-only data module (Task 4), ship-empty (Task 4 Steps 7 + test `defer`), no UI (no app-target files touched). ✓
+- Coordination risk (no exhaustive `ContentStorage` switch) verified pre-plan; computed properties only. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code; every command has expected output. ✓
+
+**Type consistency:** `singletonSlot` (Task 1) ← `createTypedSingleton`/tests (Task 3); `singletonRelativePath`/`renderSingleton` signatures (Task 2) ← consumed verbatim in Task 3; `.created(filePath:identifier:)` matches existing `ContentCreateResult`; fixture JSON shape matches `Hcard.astro` field reads (Task 4). ✓

--- a/docs/superpowers/specs/2026-06-27-site-identity-hcard-design.md
+++ b/docs/superpowers/specs/2026-06-27-site-identity-hcard-design.md
@@ -1,0 +1,160 @@
+# Design — Site identity h-card (personal + business)
+
+**Date:** 2026-06-27
+**Status:** Approved design (drives the implementation plan)
+**Issue:** [#388](https://github.com/Anglesite/Anglesite-app/issues/388) — V-1.3 follow-up: `businessProfile` page-singleton (h-card / LocalBusiness), part of V-1 ([#335](https://github.com/Anglesite/Anglesite-app/issues/335)) / epic [#334](https://github.com/Anglesite/Anglesite-app/issues/334)
+**Builds on:** V-1.1 content-type registry (#372), V-1.2 personal types (#378), V-1.3 business collection types (#387)
+
+## Context
+
+V-1.3 ([#387](https://github.com/Anglesite/Anglesite-app/issues/387)) shipped the three *collection-backed* business types (announcement / event / review) end-to-end and deferred `businessProfile`, which is structurally different: it is the site's single identity card, not a feed entry. #388 picks that up.
+
+During design we widened the scope by one deliberate step. `businessProfile` is really one half of a more general concept: the IndieWeb **representative h-card** — the single identity that "owns" a site, the anchor for `rel=me` / IndieAuth. That representative h-card is not business-specific; the same `h-card` vocabulary represents *either* a person *or* an organization. The registry today is lopsided: the seven personal types are all `h-entry` *posts*, with no person identity card, while `businessProfile` is the only `h-card`. So this pass builds **both** flavors — personal and business — on one shared singleton mechanism.
+
+## Decisions
+
+These were settled with the owner during brainstorming:
+
+1. **One representative h-card per site (mutually exclusive).** A site has *either* a personal (`Person`) *or* a business (`LocalBusiness`) identity, never both. The "I'm a solo business" case is handled by picking the face the site leads with. Mutual exclusivity is enforced at scaffold time, not in the type model.
+2. **Footer-only placement.** The identity renders as a compact h-card in a site-wide footer. No dedicated identity page, no route. This makes it a *representative* h-card (site-wide) and means the profile must be importable everywhere → it lives in a **data module**, not a page's frontmatter. This is a deliberate departure from #388's original "`.page`-stored" framing, which assumed a route under `src/pages`.
+3. **Ship empty.** The template does **not** commit a profile, so a fresh, unconfigured site shows no placeholder identity in its footer. The footer partial renders nothing until a profile exists.
+4. **Mechanism + template + tests only — no UI.** Creation is exercised through the `AnglesiteCore` API and tests; field-level editing is file-based. No `File ▸ New` command and no per-type SwiftUI editor in this pass.
+
+## Scope
+
+**In:**
+- A general **singleton** storage kind in the content-type registry, plus a `personalProfile` descriptor (`h-card` / `Person`) alongside the existing `businessProfile` (`h-card` / `LocalBusiness`), both sharing one identity slot.
+- Singleton scaffolding in `AnglesiteCore`: `ContentScaffold.renderSingleton` (pure JSON renderer) and `NativeContentOperations.createTypedSingleton` (write + one-per-site gate + commit).
+- A site-wide footer `h-card` partial in the template, rendering whichever profile is configured (or nothing).
+- Tests across all of the above, including a build-backed render smoke test for both flavors.
+
+**Out (own follow-ups):**
+- Per-type SwiftUI editor — V-1.4 ([#346](https://github.com/Anglesite/Anglesite-app/issues/346)).
+- schema.org `LocalBusiness` / `Person` JSON-LD — V-1.8 ([#350](https://github.com/Anglesite/Anglesite-app/issues/350)). This pass emits **microformats2 only**.
+- `rel=me` / IndieAuth site-identity wiring — V-2.
+- Any UI affordance to create or edit the identity.
+
+## Design
+
+### 1. Registry — a third storage kind and a new descriptor
+
+A representative h-card is neither a route page nor a collection, so `ContentStorage` gains a third case:
+
+```swift
+public enum ContentStorage: Sendable, Equatable {
+    case page
+    case collection(String)
+    case singleton(String)   // one record per site; the String is the shared slot name
+}
+```
+
+with a `singletonSlot` computed property mirroring the existing `collection`:
+
+```swift
+public var singletonSlot: String? {
+    if case let .singleton(name) = storage { return name }
+    return nil
+}
+```
+
+- `businessProfile.storage` changes from `.page` to `.singleton("profile")`; the rest of that descriptor is unchanged.
+- A new `personalProfile` descriptor is added to `businessTypes`' sibling set (it is a site-identity type, declared next to `businessProfile`):
+
+```swift
+static let personalProfile = ContentTypeDescriptor(
+    id: "personalProfile",
+    displayName: "Personal Profile",
+    storage: .singleton("profile"),
+    fields: [
+        ContentTypeField("name", .string, required: true),
+        ContentTypeField("description", .text),
+        ContentTypeField("email", .string),
+        ContentTypeField("url", .url),
+        ContentTypeField("photo", .image),
+    ],
+    projections: ContentTypeProjections(
+        microformat: "h-card",
+        microformatProperties: [
+            "name": "p-name",
+            "description": "p-note",
+            "email": "u-email",
+            "url": "u-url",
+            "photo": "u-photo",
+        ],
+        schemaType: "Person"
+    )
+)
+```
+
+Both profiles use the **same slot** (`"profile"`), which is what makes them mutually exclusive: there is one identity file per site, and whichever type wrote it owns the slot.
+
+**Why mf2 rendering stays uniform.** In microformats2, a person and a business are both just `h-card`; the only difference is *which properties appear* (a business has `p-adr`/`p-tel`; a person does not). The `Person` vs `LocalBusiness` distinction is a schema.org `@type` concern, which is V-1.8. So in this pass the two descriptors differ only in their **fields** and their (forward-looking) `schemaType` — the renderer treats them identically.
+
+### 2. Storage format — one JSON data module
+
+The profile is a single JSON file at **`src/data/profile.json`** (the shared slot). Shape:
+
+```json
+{
+  "type": "businessProfile",
+  "name": "",
+  "description": "",
+  "telephone": "",
+  "email": "",
+  "streetAddress": "",
+  "locality": "",
+  "region": "",
+  "postalCode": "",
+  "hours": [],
+  "url": ""
+}
+```
+
+- `"type"` records the originating descriptor id. Everything downstream — the schema.org `@type` in V-1.8 — is derivable from it via the registry, so no other discriminator is stored.
+- Keys follow descriptor field order; the `markdown` body field (a data record has none) is excluded.
+- **Not committed to the template.** The template ships without `src/data/profile.json` (decision 3).
+
+### 3. Rendering — a site-wide footer h-card
+
+- **New `src/components/Hcard.astro`.** Optionally loads the profile with the standard Vite "optional import" idiom:
+
+  ```ts
+  const mods = import.meta.glob<{ default: Record<string, any> }>(
+    "../data/profile.json", { eager: true });
+  const profile = Object.values(mods)[0]?.default;
+  ```
+
+  When the file is absent the glob returns `{}` and the component renders nothing (decision 3). When present it renders a `div.h-card` emitting, for whatever fields exist: `p-name`, `p-note` (description), `p-tel` (telephone), `u-email`, a nested `p-adr h-adr` block (`p-street-address` / `p-locality` / `p-region` / `p-postal-code`), `u-url`, and `u-photo`. `hours` renders as a plain `<ul>` with **no** mf2 class — h-card has no opening-hours property, so per the descriptor's existing comment hours are carried by schema.org (V-1.8) only.
+
+- **`BaseLayout.astro`** gains a `<footer>` that renders `<Hcard />`, so the identity appears site-wide on every page that uses the base layout.
+
+### 4. Scaffolding — `AnglesiteCore`, no UI
+
+- **`ContentScaffold.renderSingleton(descriptor:name:)` → `String`.** Pure, deterministic JSON: `"type"` first, then one key per non-`markdown` field in descriptor order, with empty/`0`/`false`/`[]` defaults and the `name`-like field filled from the passed name. Two-space indentation, trailing newline. A new `ContentScaffold.singletonRelativePath(slot:)` returns `src/data/<slot>.json`.
+
+- **`NativeContentOperations.createTypedSingleton(siteID:typeID:name:registry:)`.** Resolves the descriptor's `singletonSlot` (failing for non-singleton types), computes `src/data/<slot>.json`, **refuses if that file already exists** ("A site identity already exists" — the mutual-exclusivity gate, which fires across both kinds because they share the slot), renders via `renderSingleton`, writes it, and commits best-effort through the same git closure as `createTyped`.
+
+- **`createTyped`** continues to handle only collection-backed types; its rejection message generalizes from the `.page`-specific wording to "… is not a collection type; use createTypedSingleton". The existing `createTypedPageStored` test updates to the new message and the `.singleton` storage.
+
+### 5. Tests
+
+- **Registry** (`ContentTypeRegistryTests`): `personalProfile` is present; both profiles report `.singleton("profile")` and `h-card`; `schemaType`s are `Person` / `LocalBusiness`; `singletonSlot` works.
+- **Scaffold** (`ContentScaffoldTests`): `renderSingleton` for `businessProfile` (address keys + `"hours": []`, `name` filled) and for `personalProfile` (no address keys); output is deterministic and ends in one newline.
+- **Operations** (`NativeContentOperationsTests`): `createTypedSingleton` writes `src/data/profile.json` and commits; a **second** create (business then person) is refused with the identity-exists message; it rejects collection types; `createTyped` rejects singleton types with the generalized message.
+- **Render smoke** (new `SiteIdentityRenderSmokeTests`, gated on `buildable`, serialized under `TemplateBuildSerializer.shared`): write a business `profile.json` fixture into the template → `astro build` → a built page's footer HTML contains `h-card` / `p-name` / `p-tel` / `p-street-address`; swap the fixture to a person profile → rebuild → footer contains `h-card` / `p-name` / `u-email` and **no** `p-street-address`. The fixture is `defer`-removed so the template stays ship-empty. Optionally assert the absent-file → no-`h-card` empty state before writing any fixture.
+
+### 6. Unchanged / non-goals
+
+- **Drift guard untouched.** `ContentConfigDriftTests` iterates collection-backed types only (it skips any descriptor whose `collection` is `nil`). Both singletons have `collection == nil`, so they are skipped and the guard still passes with no change. The data module is not a Zod collection and is intentionally outside the guard's remit, per #388's note.
+- **No new public surface beyond the registry case and the two `AnglesiteCore` methods.** No protocol change to `ContentOperationsService` (the new method lives on the concrete `NativeContentOperations`); no app-target / SwiftUI code.
+
+## Coordination risk
+
+`businessProfile`'s storage changes from `.page` to `.singleton("profile")`. Adding a `ContentStorage` case is a public-enum change: any exhaustive `switch` over `ContentStorage` elsewhere would fail to compile until it handles `.singleton`. The implementation must grep for such switches first (the known consumers — `descriptor.collection`, the `New Collection` sheet's `collection != nil` filter — use the computed property, not a raw switch, so they are unaffected, but this must be verified, not assumed).
+
+## Acceptance
+
+- `personalProfile` and `businessProfile` are both `.singleton("profile")` / `h-card` registry types.
+- `createTypedSingleton` writes `src/data/profile.json`, commits, and refuses a second identity of either kind.
+- A configured business profile renders an h-card footer with `p-tel` + `p-adr`; a configured personal profile renders an h-card footer without address properties; an unconfigured site renders no footer h-card. Proven by a real `astro build` in the render smoke test.
+- The drift guard and the seven personal + three business collection types still build and render unchanged; full `swift test` is green.


### PR DESCRIPTION
Implements [#388](https://github.com/Anglesite/Anglesite-app/issues/388) (V-1.3 follow-up), part of V-1 (#335) / epic #334. App-only template + AnglesiteCore changes — no paired plugin PR needed.

## What this does

Adds a single per-site **representative h-card** — personal (`Person`) or business (`LocalBusiness`), mutually exclusive — rendered site-wide in the footer, on a new generic singleton storage mechanism. Widened from #388's business-only framing during design: the representative h-card is the IndieWeb site-identity anchor (the `rel=me` target), not a business-only thing, so both flavors ship on one mechanism.

### 1. Registry — `ContentStorage.singleton(slot)`
A third storage kind alongside `.page`/`.collection`, with a `singletonSlot` computed property. `businessProfile` moves from `.page` to `.singleton(\"profile\")`; a new `personalProfile` (`h-card` / `Person`: name/description/email/url/photo) shares the same `\"profile\"` slot — so a site has at most one identity, of either kind.

### 2. Scaffold — `ContentScaffold.renderSingleton`
Pure, deterministic JSON renderer (`\"type\"` first, descriptor field order, empty defaults, name filled), plus `singletonRelativePath(slot:)` → `src/data/<slot>.json`. JSON escaping covers the full C0 control range (the file is imported as a JS module, so invalid JSON would hard-fail the build).

### 3. Operations — `NativeContentOperations.createTypedSingleton`
Writes `src/data/profile.json` and commits, **refusing if the slot file already exists** — the one-identity-per-site gate, which fires across both kinds since they share the slot. `createTyped`'s non-collection rejection generalizes to point at the singleton path.

### 4. Template — site-wide footer h-card
New `src/components/Hcard.astro` optionally imports the profile via `import.meta.glob(..., { eager: true })` (renders **nothing** when absent — the template ships empty, no committed `profile.json`) and emits `h-card` mf2: `p-name`/`p-note`/`p-tel`/`u-email`/nested `p-adr h-adr`/`u-url`/`u-photo`. `hours` renders as a plain list with no mf2 class (h-card has no opening-hours property — schema.org carries it in V-1.8). Wired into `BaseLayout`.

## Scope

mf2-only this pass. **Out of scope** (forward hooks in place — the `\"type\"` field + registry `schemaType`): schema.org JSON-LD (V-1.8 #350), `rel=me`/IndieAuth (V-2), per-type SwiftUI editor (V-1.4 #346), any UI to create/edit the identity.

## Verification

- Full `swift test`: **1167 passing, 0 failures** (incl. the new `SiteIdentityRenderSmokeTests` running 3 real \`astro build\`s — empty→no h-card, business→p-tel+p-street-address, personal→u-email+no address).
- Drift guard untouched (singletons have `collection == nil`, skipped by design); MCP-path tests unchanged and green.
- Template confirmed ship-empty (`src/data` never committed; render test \`defer\`-cleans).

Design spec: \`docs/superpowers/specs/2026-06-27-site-identity-hcard-design.md\`
Plan: \`docs/superpowers/plans/2026-06-27-site-identity-hcard.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)