### PR TITLE
feat(#349): V-1.7 microformats2 markup + dist validation

### DIFF
--- a/Resources/Template/package-lock.json
+++ b/Resources/Template/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
         "@types/node": "^24.0.0",
+        "microformats-parser": "^2.0.4",
         "schema-dts": "^1.1.5",
         "tsx": "^4.0.0",
         "typescript": "^5.9.3"
@@ -4031,6 +4032,19 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/microformats-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/microformats-parser/-/microformats-parser-2.0.4.tgz",
+      "integrity": "sha512-DA2yt3uz2JjupBGoNvaG9ngBP5vSTI1ky2yhxBai/RnQrlzo+gEzuCdvwIIjj2nh3uVPDybTP5u7uua7pOa6LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/micromark": {
       "version": "4.0.2",

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "prebuild": "npx tsx scripts/csp.ts",
-    "build": "astro check && astro build",
+    "build": "astro check && astro build && npx tsx scripts/check-microformats.ts",
     "preview": "astro preview",
     "check": "npx tsx scripts/pre-deploy-check.ts"
   },

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@types/node": "^24.0.0",
+    "microformats-parser": "^2.0.4",
     "schema-dts": "^1.1.5",
     "tsx": "^4.0.0",
     "typescript": "^5.9.3"

--- a/Resources/Template/scripts/check-microformats.ts
+++ b/Resources/Template/scripts/check-microformats.ts
@@ -1,0 +1,11 @@
+import { validateDist } from "./microformats.ts";
+
+const distDir = process.argv[2] ?? "dist";
+const problems = validateDist(distDir);
+
+if (problems.length > 0) {
+  console.error(`✗ microformats validation failed (${problems.length} problem(s)):`);
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+console.log("✓ microformats validation passed");

--- a/Resources/Template/scripts/microformats.test.ts
+++ b/Resources/Template/scripts/microformats.test.ts
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { validateEntryHtml, findRoots } from "./microformats.ts";
+
+const GOOD_ENTRY = `<!doctype html><html><body>
+<article class="h-entry">
+  <h1 class="p-name">My Article</h1>
+  <p class="p-summary">Article summary text</p>
+  <a class="u-url" href="/articles/my-article/"><time class="dt-published" datetime="2026-06-27T12:00:00.000Z">Jun 27, 2026</time></a>
+  <div class="e-content"><p>Article body.</p></div>
+  <ul><li><a class="p-category" href="/tags/indieweb">indieweb</a></li></ul>
+</article></body></html>`;
+
+const GOOD_REVIEW = `<!doctype html><html><body>
+<article class="h-review">
+  <h1 class="p-name">Review of The Widget</h1>
+  <p>Reviewed: <span class="p-item">The Widget</span></p>
+  <data class="p-rating" value="4">4</data>
+  <a class="u-url" href="/reviews/the-widget/"><time class="dt-published" datetime="2026-06-27T12:00:00.000Z">Jun 27, 2026</time></a>
+  <div class="e-content"><p>Solid widget.</p></div>
+</article></body></html>`;
+
+const GOOD_EVENT = `<!doctype html><html><body>
+<article class="h-event">
+  <h1 class="p-name">Launch Party</h1>
+  <a class="u-url" href="/events/launch-party/"><time class="dt-start" datetime="2026-07-01T18:00:00.000Z">Jul 1, 2026</time></a>
+  <p class="p-location">Online</p>
+  <div class="e-content"><p>Join us.</p></div>
+</article></body></html>`;
+
+const NO_URL = `<!doctype html><html><body>
+<article class="h-entry">
+  <h1 class="p-name">No Permalink</h1>
+  <time class="dt-published" datetime="2026-06-27T12:00:00.000Z">Jun 27, 2026</time>
+  <div class="e-content"><p>Body.</p></div>
+</article></body></html>`;
+
+// h-review with NO explicit p-name: the parser implies a name from the full text,
+// smashing item/rating/body together — the pitfall Hreview.astro documents.
+const IMPLIED_REVIEW = `<!doctype html><html><body>
+<article class="h-review">
+  <p>Reviewed: <span class="p-item">The Widget</span></p>
+  <data class="p-rating" value="4">4</data>
+  <a class="u-url" href="/reviews/the-widget/"><time class="dt-published" datetime="2026-06-27T12:00:00.000Z">d</time></a>
+  <div class="e-content"><p>Solid widget.</p></div>
+</article></body></html>`;
+
+test("valid h-entry passes and exposes expected properties", () => {
+  assert.deepEqual(validateEntryHtml(GOOD_ENTRY, "good-entry"), []);
+  const [item] = findRoots(GOOD_ENTRY);
+  assert.deepEqual(item.properties.name, ["My Article"]);
+  assert.deepEqual(item.properties.summary, ["Article summary text"]);
+  assert.deepEqual(item.properties.category, ["indieweb"]);
+  assert.equal(item.properties.url[0], "https://example.com/articles/my-article/");
+  assert.ok(String(item.properties.published[0]).startsWith("2026-06-27"));
+});
+
+test("valid h-review passes with explicit name, item and rating", () => {
+  assert.deepEqual(validateEntryHtml(GOOD_REVIEW, "good-review"), []);
+  const [item] = findRoots(GOOD_REVIEW);
+  assert.deepEqual(item.properties.name, ["Review of The Widget"]);
+  assert.deepEqual(item.properties.item, ["The Widget"]);
+  assert.deepEqual(item.properties.rating, ["4"]);
+});
+
+test("valid h-event passes", () => {
+  assert.deepEqual(validateEntryHtml(GOOD_EVENT, "good-event"), []);
+  const [item] = findRoots(GOOD_EVENT);
+  assert.deepEqual(item.properties.name, ["Launch Party"]);
+  assert.deepEqual(item.properties.location, ["Online"]);
+  assert.ok(String(item.properties.start[0]).startsWith("2026-07-01"));
+});
+
+test("h-entry without u-url is flagged", () => {
+  const problems = validateEntryHtml(NO_URL, "no-url");
+  assert.ok(problems.some((p) => p.includes("missing u-url")), problems.join("; "));
+});
+
+test("h-review with implied (non-explicit) name is flagged", () => {
+  const problems = validateEntryHtml(IMPLIED_REVIEW, "implied-review");
+  assert.ok(problems.some((p) => p.includes("implied")), problems.join("; "));
+});
+
+// --- Deferred to #388 (site identity model) -------------------------------
+test("entries carry a p-author h-card", { skip: "#388 — site identity model" }, () => {
+  // When #388 lands the businessProfile h-card, assert the nested p-author here.
+});
+test("site-wide h-card is present", { skip: "#388 — site identity model" }, () => {
+  // #388 emits the businessProfile h-card in BaseLayout; assert a root h-card then.
+});

--- a/Resources/Template/scripts/microformats.test.ts
+++ b/Resources/Template/scripts/microformats.test.ts
@@ -35,6 +35,12 @@ const NO_URL = `<!doctype html><html><body>
   <div class="e-content"><p>Body.</p></div>
 </article></body></html>`;
 
+const NAMELESS_NOTE = `<!doctype html><html><body>
+<article class="h-entry">
+  <a class="u-url" href="/notes/hello-note/"><time class="dt-published" datetime="2026-06-27T12:00:00.000Z">Jun 27, 2026</time></a>
+  <div class="e-content"><p>Just a quick note.</p></div>
+</article></body></html>`;
+
 // h-review with NO explicit p-name: the parser implies a name from the full text,
 // smashing item/rating/body together — the pitfall Hreview.astro documents.
 const IMPLIED_REVIEW = `<!doctype html><html><body>
@@ -53,6 +59,10 @@ test("valid h-entry passes and exposes expected properties", () => {
   assert.deepEqual(item.properties.category, ["indieweb"]);
   assert.equal(item.properties.url[0], "https://example.com/articles/my-article/");
   assert.ok(String(item.properties.published[0]).startsWith("2026-06-27"));
+});
+
+test("nameless h-entry (note) passes — p-name is optional for entries", () => {
+  assert.deepEqual(validateEntryHtml(NAMELESS_NOTE, "note"), []);
 });
 
 test("valid h-review passes with explicit name, item and rating", () => {

--- a/Resources/Template/scripts/microformats.test.ts
+++ b/Resources/Template/scripts/microformats.test.ts
@@ -51,6 +51,17 @@ const IMPLIED_REVIEW = `<!doctype html><html><body>
   <div class="e-content"><p>Solid widget.</p></div>
 </article></body></html>`;
 
+// Implied-name review whose body has inline markup + irregular whitespace — the guard must
+// still flag it after whitespace normalization (proves it is not fitted to one fixture).
+const IMPLIED_REVIEW_MARKUP = `<!doctype html><html><body>
+<article class="h-review">
+  <p>Reviewed: <span class="p-item">The Widget</span></p>
+  <data class="p-rating" value="4">4</data>
+  <a class="u-url" href="/reviews/the-widget/"><time class="dt-published" datetime="2026-06-27T12:00:00.000Z">d</time></a>
+  <div class="e-content"><p>Solid   <strong>widget</strong>,
+  truly.</p></div>
+</article></body></html>`;
+
 test("valid h-entry passes and exposes expected properties", () => {
   assert.deepEqual(validateEntryHtml(GOOD_ENTRY, "good-entry"), []);
   const [item] = findRoots(GOOD_ENTRY);
@@ -88,6 +99,11 @@ test("h-entry without u-url is flagged", () => {
 
 test("h-review with implied (non-explicit) name is flagged", () => {
   const problems = validateEntryHtml(IMPLIED_REVIEW, "implied-review");
+  assert.ok(problems.some((p) => p.includes("implied")), problems.join("; "));
+});
+
+test("implied-name h-review with inline markup/whitespace is still flagged", () => {
+  const problems = validateEntryHtml(IMPLIED_REVIEW_MARKUP, "implied-markup");
   assert.ok(problems.some((p) => p.includes("implied")), problems.join("; "));
 });
 

--- a/Resources/Template/scripts/microformats.ts
+++ b/Resources/Template/scripts/microformats.ts
@@ -1,0 +1,119 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, extname } from "node:path";
+import { mf2 } from "microformats-parser";
+
+/** Base URL used to resolve relative u-* URLs during parsing. */
+const BASE_URL = "https://example.com";
+
+/** The mf2 root types our entry layouts may emit. */
+export const ENTRY_TYPES = ["h-entry", "h-review", "h-event"] as const;
+export type EntryType = (typeof ENTRY_TYPES)[number];
+
+/** Routed collection dirs whose built pages carry an entry microformat. */
+export const ENTRY_DIRS = [
+  "blog", "notes", "articles", "photos", "albums",
+  "bookmarks", "replies", "likes", "announcements", "events", "reviews",
+];
+
+type Mf2Item = { type: string[]; properties: Record<string, unknown[]> };
+
+const isEntryType = (t: string): t is EntryType =>
+  (ENTRY_TYPES as readonly string[]).includes(t);
+
+/** Parse HTML and return its root microformat items. */
+export function findRoots(html: string, baseUrl = BASE_URL): Mf2Item[] {
+  return mf2(html, { baseUrl }).items as Mf2Item[];
+}
+
+function has(item: Mf2Item, prop: string): boolean {
+  const v = item.properties[prop];
+  return Array.isArray(v) && v.length > 0;
+}
+
+/**
+ * Validate a single built entry page's microformats. Returns a list of human-readable
+ * problems; an empty list means the page is valid mf2 for our purposes.
+ */
+export function validateEntryHtml(html: string, label: string, baseUrl = BASE_URL): string[] {
+  const problems: string[] = [];
+  const roots = findRoots(html, baseUrl).filter((i) => i.type.some(isEntryType));
+
+  if (roots.length === 0) {
+    problems.push(`${label}: no h-entry/h-review/h-event root item found`);
+    return problems;
+  }
+  if (roots.length > 1) {
+    problems.push(`${label}: expected exactly one entry root, found ${roots.length}`);
+  }
+
+  const item = roots[0];
+  const type = item.type.find(isEntryType) as EntryType;
+
+  if (!has(item, "name")) problems.push(`${label}: ${type} missing p-name`);
+  if (!has(item, "url")) problems.push(`${label}: ${type} missing u-url`);
+  if (type === "h-event") {
+    if (!has(item, "start")) problems.push(`${label}: h-event missing dt-start`);
+  } else if (!has(item, "published")) {
+    problems.push(`${label}: ${type} missing dt-published`);
+  }
+  if (type === "h-review" && !has(item, "rating")) {
+    problems.push(`${label}: h-review missing p-rating`);
+  }
+
+  // Guard the implied-name pitfall: a valid entry's p-name is the explicit title, not the
+  // concatenation of all text (which the parser implies when no explicit p-name exists).
+  const name = String(item.properties.name?.[0] ?? "");
+  const content = String(
+    (item.properties.content?.[0] as { value?: string } | undefined)?.value ?? "",
+  ).trim();
+  if (name && content && name.includes(content)) {
+    problems.push(`${label}: ${type} p-name looks implied (contains the full content) — add an explicit p-name`);
+  }
+
+  return problems;
+}
+
+function walkHtml(dir: string): string[] {
+  const out: string[] = [];
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return out; // dir absent (collection had no built pages) — not an error here
+  }
+  for (const name of names) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...walkHtml(full));
+    else if (extname(full) === ".html") out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Validate every built entry page under `distDir` and assert vocabulary coverage:
+ * each of h-entry / h-review / h-event appears in at least one valid page.
+ */
+export function validateDist(distDir: string): string[] {
+  const problems: string[] = [];
+  const seen = new Set<string>();
+
+  for (const sub of ENTRY_DIRS) {
+    const base = join(distDir, sub);
+    for (const file of walkHtml(base)) {
+      const rel = file.slice(base.length + 1); // "welcome/index.html" or "index.html"
+      if (!rel.includes("/")) continue; // skip the collection's own list page (index.html)
+      const html = readFileSync(file, "utf8");
+      const label = file.slice(distDir.length + 1);
+      const pageProblems = validateEntryHtml(html, label);
+      problems.push(...pageProblems);
+      if (pageProblems.length === 0) {
+        for (const r of findRoots(html)) for (const t of r.type) if (isEntryType(t)) seen.add(t);
+      }
+    }
+  }
+
+  for (const t of ENTRY_TYPES) {
+    if (!seen.has(t)) problems.push(`coverage: no valid ${t} page found in ${distDir}`);
+  }
+  return problems;
+}

--- a/Resources/Template/scripts/microformats.ts
+++ b/Resources/Template/scripts/microformats.ts
@@ -71,14 +71,19 @@ export function validateEntryHtml(html: string, label: string, baseUrl = BASE_UR
     if (!has(item, "name")) {
       problems.push(`${label}: ${type} missing p-name`);
     } else {
-      // Guard the implied-name pitfall: the parsed name must be the explicit title, not
-      // the parser's concatenation of all text (implied when no explicit p-name exists).
-      const name = String(item.properties.name?.[0] ?? "");
-      const content = String(
-        (item.properties.content?.[0] as { value?: string } | undefined)?.value ?? "",
-      ).trim();
+      // Guard the implied-name pitfall (see Hreview.astro): when an h-review/h-event has
+      // no explicit p-name, the parser IMPLIES a name from the element's full text, which
+      // includes the e-content body. A valid explicit title never contains the whole body,
+      // so a name that (after whitespace normalization) contains the content body is the
+      // signal of an implied name. Normalizing both sides keeps the substring check robust
+      // to inline markup / whitespace differences between the two parsed values.
+      const collapse = (s: string) => s.replace(/\s+/g, " ").trim();
+      const name = collapse(String(item.properties.name?.[0] ?? ""));
+      const content = collapse(
+        String((item.properties.content?.[0] as { value?: string } | undefined)?.value ?? ""),
+      );
       if (name && content && name.includes(content)) {
-        problems.push(`${label}: ${type} p-name looks implied (contains the full content) — add an explicit p-name`);
+        problems.push(`${label}: ${type} p-name looks implied (contains the content body) — add an explicit p-name`);
       }
     }
   }

--- a/Resources/Template/scripts/microformats.ts
+++ b/Resources/Template/scripts/microformats.ts
@@ -30,13 +30,23 @@ function has(item: Mf2Item, prop: string): boolean {
   return Array.isArray(v) && v.length > 0;
 }
 
+/** The entry-microformat types found among a page's roots (deduped). */
+function entryTypesOf(roots: Mf2Item[]): EntryType[] {
+  return [...new Set(roots.flatMap((r) => r.type).filter(isEntryType))] as EntryType[];
+}
+
 /**
  * Validate a single built entry page's microformats. Returns a list of human-readable
  * problems; an empty list means the page is valid mf2 for our purposes.
  */
 export function validateEntryHtml(html: string, label: string, baseUrl = BASE_URL): string[] {
+  return validateRoots(findRoots(html, baseUrl), label);
+}
+
+/** Validate already-parsed roots — lets callers parse once and reuse the result. */
+function validateRoots(allRoots: Mf2Item[], label: string): string[] {
   const problems: string[] = [];
-  const roots = findRoots(html, baseUrl).filter((i) => i.type.some(isEntryType));
+  const roots = allRoots.filter((i) => i.type.some(isEntryType));
 
   if (roots.length === 0) {
     problems.push(`${label}: no h-entry/h-review/h-event root item found`);
@@ -113,25 +123,29 @@ function walkHtml(dir: string): string[] {
  */
 export function validateDist(distDir: string): string[] {
   const problems: string[] = [];
-  const seen = new Set<string>();
+  const seenAny = new Set<string>(); // type appeared on some page (valid or not)
+  const seenValid = new Set<string>(); // type appeared on a page with no problems
 
   for (const sub of ENTRY_DIRS) {
     const base = join(distDir, sub);
     for (const file of walkHtml(base)) {
       const rel = file.slice(base.length + 1); // "welcome/index.html" or "index.html"
       if (!rel.includes("/")) continue; // skip the collection's own list page (index.html)
-      const html = readFileSync(file, "utf8");
       const label = file.slice(distDir.length + 1);
-      const pageProblems = validateEntryHtml(html, label);
+      const roots = findRoots(readFileSync(file, "utf8")); // parse once; reuse below
+      const types = entryTypesOf(roots);
+      for (const t of types) seenAny.add(t);
+      const pageProblems = validateRoots(roots, label);
       problems.push(...pageProblems);
-      if (pageProblems.length === 0) {
-        for (const r of findRoots(html)) for (const t of r.type) if (isEntryType(t)) seen.add(t);
-      }
+      if (pageProblems.length === 0) for (const t of types) seenValid.add(t);
     }
   }
 
+  // Only report a coverage gap when a type is entirely absent. If pages of that type
+  // exist but all failed validation, the per-page problems above already explain it —
+  // a redundant "no valid …" line reads as a separate root cause.
   for (const t of ENTRY_TYPES) {
-    if (!seen.has(t)) problems.push(`coverage: no valid ${t} page found in ${distDir}`);
+    if (!seenAny.has(t)) problems.push(`coverage: no ${t} page found in ${distDir}`);
   }
   return problems;
 }

--- a/Resources/Template/scripts/microformats.ts
+++ b/Resources/Template/scripts/microformats.ts
@@ -49,25 +49,38 @@ export function validateEntryHtml(html: string, label: string, baseUrl = BASE_UR
   const item = roots[0];
   const type = item.type.find(isEntryType) as EntryType;
 
-  if (!has(item, "name")) problems.push(`${label}: ${type} missing p-name`);
+  // Every entry needs a permalink.
   if (!has(item, "url")) problems.push(`${label}: ${type} missing u-url`);
+
+  // Dates: events use dt-start; entries and reviews use dt-published.
   if (type === "h-event") {
     if (!has(item, "start")) problems.push(`${label}: h-event missing dt-start`);
   } else if (!has(item, "published")) {
     problems.push(`${label}: ${type} missing dt-published`);
   }
+
   if (type === "h-review" && !has(item, "rating")) {
     problems.push(`${label}: h-review missing p-rating`);
   }
 
-  // Guard the implied-name pitfall: a valid entry's p-name is the explicit title, not the
-  // concatenation of all text (which the parser implies when no explicit p-name exists).
-  const name = String(item.properties.name?.[0] ?? "");
-  const content = String(
-    (item.properties.content?.[0] as { value?: string } | undefined)?.value ?? "",
-  ).trim();
-  if (name && content && name.includes(content)) {
-    problems.push(`${label}: ${type} p-name looks implied (contains the full content) — add an explicit p-name`);
+  // p-name: required and explicit for h-review/h-event (both always carry a title).
+  // h-entry is intentionally name-OPTIONAL — notes, photos, replies and likes are
+  // legitimately nameless mf2 entries, so we neither require a name nor apply the
+  // implied-name guard to them.
+  if (type === "h-review" || type === "h-event") {
+    if (!has(item, "name")) {
+      problems.push(`${label}: ${type} missing p-name`);
+    } else {
+      // Guard the implied-name pitfall: the parsed name must be the explicit title, not
+      // the parser's concatenation of all text (implied when no explicit p-name exists).
+      const name = String(item.properties.name?.[0] ?? "");
+      const content = String(
+        (item.properties.content?.[0] as { value?: string } | undefined)?.value ?? "",
+      ).trim();
+      if (name && content && name.includes(content)) {
+        problems.push(`${label}: ${type} p-name looks implied (contains the full content) — add an explicit p-name`);
+      }
+    }
   }
 
   return problems;

--- a/Resources/Template/src/layouts/BlogPost.astro
+++ b/Resources/Template/src/layouts/BlogPost.astro
@@ -12,21 +12,25 @@ interface Props {
 }
 
 const { title, description, pubDate } = Astro.props;
+// Compute the Date once; pin the locale + UTC so static output is deterministic.
+const iso = pubDate ? new Date(pubDate).toISOString() : undefined;
+const human = pubDate
+  ? new Date(pubDate).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })
+  : undefined;
 // anglesite:imports — integration component imports are injected here on setup
 ---
 
 <BaseLayout title={title} description={description}>
-  <article>
-    <p><a href="/blog/">← All posts</a></p>
-    <h1>{title}</h1>
-    {
-      pubDate && (
-        <time datetime={pubDate.toISOString()}>
-          {pubDate.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })}
-        </time>
-      )
-    }
-    <slot />
+  <p><a href="/blog/">← All posts</a></p>
+  <article class="h-entry">
+    <h1 class="p-name">{title}</h1>
+    {description && <p class="p-summary">{description}</p>}
+    {iso && (
+      <a class="u-url" href={Astro.url.pathname}>
+        <time class="dt-published" datetime={iso}>{human}</time>
+      </a>
+    )}
+    <div class="e-content"><slot /></div>
     <!-- anglesite:comments -->
   </article>
 </BaseLayout>

--- a/Resources/Template/src/layouts/BlogPost.astro
+++ b/Resources/Template/src/layouts/BlogPost.astro
@@ -12,10 +12,10 @@ interface Props {
 }
 
 const { title, description, pubDate } = Astro.props;
-// Compute the Date once; pin the locale + UTC so static output is deterministic.
-const iso = pubDate ? new Date(pubDate).toISOString() : undefined;
+// pubDate is already a Date; pin the locale + UTC so static output is deterministic.
+const iso = pubDate ? pubDate.toISOString() : undefined;
 const human = pubDate
-  ? new Date(pubDate).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })
+  ? pubDate.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })
   : undefined;
 // anglesite:imports — integration component imports are injected here on setup
 ---
@@ -25,11 +25,10 @@ const human = pubDate
   <article class="h-entry">
     <h1 class="p-name">{title}</h1>
     {description && <p class="p-summary">{description}</p>}
-    {iso && (
-      <a class="u-url" href={Astro.url.pathname}>
-        <time class="dt-published" datetime={iso}>{human}</time>
-      </a>
-    )}
+    {/* The permalink (u-url) is unconditional; the dt-published time renders inside it when present. */}
+    <a class="u-url" href={Astro.url.pathname}>
+      {iso && <time class="dt-published" datetime={iso}>{human}</time>}
+    </a>
     <div class="e-content"><slot /></div>
     <!-- anglesite:comments -->
   </article>

--- a/Resources/Template/src/layouts/Hentry.astro
+++ b/Resources/Template/src/layouts/Hentry.astro
@@ -24,8 +24,10 @@ interface HentryFields {
 const { entry } = Astro.props;
 const d: HentryFields = entry.data;
 const title = d.title;
-const iso = d.publishDate ? new Date(d.publishDate).toISOString() : undefined;
-const human = d.publishDate ? new Date(d.publishDate).toLocaleDateString("en-US", { timeZone: "UTC" }) : undefined;
+const iso = d.publishDate ? d.publishDate.toISOString() : undefined;
+const human = d.publishDate
+  ? d.publishDate.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })
+  : undefined;
 const images: string[] = Array.isArray(d.images) ? d.images : [];
 const tags: string[] = Array.isArray(d.tags) ? d.tags : [];
 ---
@@ -40,11 +42,11 @@ const tags: string[] = Array.isArray(d.tags) ? d.tags : [];
     {d.likeOf && <a class="u-like-of" href={d.likeOf}>Liked this</a>}
     {(d.summary ?? d.caption) && <p class="p-summary">{d.summary ?? d.caption}</p>}
     <div class="e-content"><slot /></div>
-    {iso && (
-      <a class="u-url" href={Astro.url.pathname}>
-        <time class="dt-published" datetime={iso}>{human}</time>
-      </a>
-    )}
+    {/* The permalink (u-url) is unconditional — every entry has one regardless of whether
+        it carries a visible date; the dt-published time renders inside it when present. */}
+    <a class="u-url" href={Astro.url.pathname}>
+      {iso && <time class="dt-published" datetime={iso}>{human}</time>}
+    </a>
     {tags.length > 0 && (
       <ul class="tags">
         {tags.map((t) => <li><a class="p-category" href={`/tags/${t}`}>{t}</a></li>)}

--- a/Resources/Template/src/layouts/Hentry.astro
+++ b/Resources/Template/src/layouts/Hentry.astro
@@ -38,10 +38,13 @@ const tags: string[] = Array.isArray(d.tags) ? d.tags : [];
     {d.bookmarkOf && <a class="u-bookmark-of" href={d.bookmarkOf}>{d.bookmarkOf}</a>}
     {d.inReplyTo && <a class="u-in-reply-to" href={d.inReplyTo}>In reply to</a>}
     {d.likeOf && <a class="u-like-of" href={d.likeOf}>Liked this</a>}
-    {/* TODO(#349): article `summary` (registry p-summary) is not emitted here yet — only photo caption is. */}
-    {d.caption && <p class="p-summary">{d.caption}</p>}
+    {(d.summary ?? d.caption) && <p class="p-summary">{d.summary ?? d.caption}</p>}
     <div class="e-content"><slot /></div>
-    {iso && <time class="dt-published" datetime={iso}>{human}</time>}
+    {iso && (
+      <a class="u-url" href={Astro.url.pathname}>
+        <time class="dt-published" datetime={iso}>{human}</time>
+      </a>
+    )}
     {tags.length > 0 && (
       <ul class="tags">
         {tags.map((t) => <li><a class="p-category" href={`/tags/${t}`}>{t}</a></li>)}

--- a/Resources/Template/src/layouts/Hentry.astro
+++ b/Resources/Template/src/layouts/Hentry.astro
@@ -25,7 +25,7 @@ const { entry } = Astro.props;
 const d: HentryFields = entry.data;
 const title = d.title;
 const iso = d.publishDate ? new Date(d.publishDate).toISOString() : undefined;
-const human = d.publishDate ? new Date(d.publishDate).toLocaleDateString() : undefined;
+const human = d.publishDate ? new Date(d.publishDate).toLocaleDateString("en-US", { timeZone: "UTC" }) : undefined;
 const images: string[] = Array.isArray(d.images) ? d.images : [];
 const tags: string[] = Array.isArray(d.tags) ? d.tags : [];
 ---

--- a/Resources/Template/src/layouts/Hevent.astro
+++ b/Resources/Template/src/layouts/Hevent.astro
@@ -20,11 +20,10 @@ const endHuman = endDate?.toLocaleString("en-US");
 <BaseLayout title={d.name ?? "Event"} description={d.location}>
   <article class="h-event">
     <h1 class="p-name">{d.name}</h1>
-    {startISO && (
-      <a class="u-url" href={Astro.url.pathname}>
-        <time class="dt-start" datetime={startISO}>{startHuman}</time>
-      </a>
-    )}
+    {/* The permalink (u-url) is unconditional; the dt-start time renders inside it when present. */}
+    <a class="u-url" href={Astro.url.pathname}>
+      {startISO && <time class="dt-start" datetime={startISO}>{startHuman}</time>}
+    </a>
     {endISO && <time class="dt-end" datetime={endISO}>{endHuman}</time>}
     {d.location && <p class="p-location">{d.location}</p>}
     <div class="e-content"><slot /></div>

--- a/Resources/Template/src/layouts/Hevent.astro
+++ b/Resources/Template/src/layouts/Hevent.astro
@@ -20,7 +20,11 @@ const endHuman = endDate?.toLocaleString("en-US");
 <BaseLayout title={d.name ?? "Event"} description={d.location}>
   <article class="h-event">
     <h1 class="p-name">{d.name}</h1>
-    {startISO && <time class="dt-start" datetime={startISO}>{startHuman}</time>}
+    {startISO && (
+      <a class="u-url" href={Astro.url.pathname}>
+        <time class="dt-start" datetime={startISO}>{startHuman}</time>
+      </a>
+    )}
     {endISO && <time class="dt-end" datetime={endISO}>{endHuman}</time>}
     {d.location && <p class="p-location">{d.location}</p>}
     <div class="e-content"><slot /></div>

--- a/Resources/Template/src/layouts/Hreview.astro
+++ b/Resources/Template/src/layouts/Hreview.astro
@@ -24,6 +24,10 @@ const reviewName = `Review of ${d.itemReviewed}`;
     <p>Reviewed: <span class="p-item">{d.itemReviewed}</span></p>
     <data class="p-rating" value={d.rating}>{d.rating}</data>
     <div class="e-content"><slot /></div>
-    {iso && <time class="dt-published" datetime={iso}>{human}</time>}
+    {iso && (
+      <a class="u-url" href={Astro.url.pathname}>
+        <time class="dt-published" datetime={iso}>{human}</time>
+      </a>
+    )}
   </article>
 </BaseLayout>

--- a/Resources/Template/src/layouts/Hreview.astro
+++ b/Resources/Template/src/layouts/Hreview.astro
@@ -24,10 +24,9 @@ const reviewName = `Review of ${d.itemReviewed}`;
     <p>Reviewed: <span class="p-item">{d.itemReviewed}</span></p>
     <data class="p-rating" value={d.rating}>{d.rating}</data>
     <div class="e-content"><slot /></div>
-    {iso && (
-      <a class="u-url" href={Astro.url.pathname}>
-        <time class="dt-published" datetime={iso}>{human}</time>
-      </a>
-    )}
+    {/* The permalink (u-url) is unconditional; the dt-published time renders inside it when present. */}
+    <a class="u-url" href={Astro.url.pathname}>
+      {iso && <time class="dt-published" datetime={iso}>{human}</time>}
+    </a>
   </article>
 </BaseLayout>

--- a/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
@@ -65,8 +65,9 @@ import Foundation
     @Test func blogPostLayoutRendersTitleAndDate() throws {
         let root = templateRoot()
         let s = try String(contentsOf: root.appendingPathComponent("src/layouts/BlogPost.astro"), encoding: .utf8)
-        // visible heading + publication date in the article body
-        #expect(s.contains("<h1>{title}</h1>"), "post should render its title as an <h1>")
+        // visible heading + publication date in the article body. The heading carries the
+        // microformats2 `p-name` (V-1.7 / #349) — the post title is the h-entry's name.
+        #expect(s.contains("<h1 class=\"p-name\">{title}</h1>"), "post should render its title as an <h1 class=\"p-name\">")
         #expect(s.contains("pubDate"), "layout should accept/render pubDate")
         #expect(s.contains("<time"), "date should use a semantic <time> element")
         // render the date in UTC so a build machine behind UTC doesn't shift it a day

--- a/docs/superpowers/plans/2026-06-27-v1-7-microformats2-markup.md
+++ b/docs/superpowers/plans/2026-06-27-v1-7-microformats2-markup.md
@@ -10,7 +10,7 @@
 
 ## Global Constraints
 
-- **Work in the worktree:** `/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/349-microformats2`. All paths below are relative to its `Resources/Template/` directory; run commands from there.
+- **Work in the worktree:** `.claude/worktrees/349-microformats2` (repo-relative). All paths below are relative to its `Resources/Template/` directory; run commands from there.
 - **Run `npm install` once** in `Resources/Template/` before starting (the worktree has no `node_modules`). It is folded into Task 1, Step 1.
 - **ES modules only** — `import/export`, explicit `.ts` extensions on local imports (matches `astro.config.ts` importing `./scripts/config.ts`).
 - **Test runner is `node:test` via `tsx`** — no Vitest, no new test runner.

--- a/docs/superpowers/plans/2026-06-27-v1-7-microformats2-markup.md
+++ b/docs/superpowers/plans/2026-06-27-v1-7-microformats2-markup.md
@@ -1,0 +1,577 @@
+# V-1.7 microformats2 markup + validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete h-entry / h-review / h-event microformats2 markup in the entry-layer templates and add a parser-based validator that proves the built output is valid mf2.
+
+**Architecture:** Additive class/markup edits to four Astro layouts (no data-model changes), plus a pure validator module (`scripts/microformats.ts`) unit-tested with HTML fixtures on the existing `node:test` runner, exposed as a post-build CLI (`scripts/check-microformats.ts`) wired into the `build` script to validate the real `dist/` output.
+
+**Tech Stack:** Astro 5, TypeScript (ES modules), `node:test` + `tsx`, `microformats-parser`.
+
+## Global Constraints
+
+- **Work in the worktree:** `/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/349-microformats2`. All paths below are relative to its `Resources/Template/` directory; run commands from there.
+- **Run `npm install` once** in `Resources/Template/` before starting (the worktree has no `node_modules`). It is folded into Task 1, Step 1.
+- **ES modules only** — `import/export`, explicit `.ts` extensions on local imports (matches `astro.config.ts` importing `./scripts/config.ts`).
+- **Test runner is `node:test` via `tsx`** — no Vitest, no new test runner.
+- **Only new dependency:** `microformats-parser` (devDependency). Nothing else.
+- **Out of scope (→ #388):** author `p-author` h-card and the site-wide h-card. They appear in this plan only as `{ skip: ... }` placeholder tests.
+- **Determinism:** date formatting pins `"en-US"` + `timeZone: "UTC"` (existing convention).
+- Spec: `docs/superpowers/specs/2026-06-27-v1-7-microformats2-markup-design.md`.
+
+---
+
+### Task 1: Validator module, CLI, and unit tests
+
+**Files:**
+- Modify: `Resources/Template/package.json` (add `microformats-parser` devDependency)
+- Create: `Resources/Template/scripts/microformats.ts`
+- Create: `Resources/Template/scripts/check-microformats.ts`
+- Test: `Resources/Template/scripts/microformats.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `ENTRY_TYPES: readonly ["h-entry","h-review","h-event"]`
+  - `ENTRY_DIRS: string[]` — routed collection dir names under `dist/`
+  - `findRoots(html: string, baseUrl?: string): Mf2Item[]`
+  - `validateEntryHtml(html: string, label: string, baseUrl?: string): string[]` — empty array means valid
+  - `validateDist(distDir: string): string[]`
+- Consumes: nothing (first task).
+
+- [ ] **Step 1: Install deps and add the parser**
+
+Run (from `Resources/Template/`):
+
+```bash
+npm install
+npm install --save-dev microformats-parser
+```
+
+Expected: `package.json` `devDependencies` now lists `microformats-parser`; `node_modules` populated.
+
+- [ ] **Step 2: Write the failing unit test**
+
+Create `scripts/microformats.test.ts`:
+
+```ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { validateEntryHtml, findRoots } from "./microformats.ts";
+
+const GOOD_ENTRY = `<!doctype html><html><body>
+<article class="h-entry">
+  <h1 class="p-name">My Article</h1>
+  <p class="p-summary">Article summary text</p>
+  <a class="u-url" href="/articles/my-article/"><time class="dt-published" datetime="2026-06-27T12:00:00.000Z">Jun 27, 2026</time></a>
+  <div class="e-content"><p>Article body.</p></div>
+  <ul><li><a class="p-category" href="/tags/indieweb">indieweb</a></li></ul>
+</article></body></html>`;
+
+const GOOD_REVIEW = `<!doctype html><html><body>
+<article class="h-review">
+  <h1 class="p-name">Review of The Widget</h1>
+  <p>Reviewed: <span class="p-item">The Widget</span></p>
+  <data class="p-rating" value="4">4</data>
+  <a class="u-url" href="/reviews/the-widget/"><time class="dt-published" datetime="2026-06-27T12:00:00.000Z">Jun 27, 2026</time></a>
+  <div class="e-content"><p>Solid widget.</p></div>
+</article></body></html>`;
+
+const GOOD_EVENT = `<!doctype html><html><body>
+<article class="h-event">
+  <h1 class="p-name">Launch Party</h1>
+  <a class="u-url" href="/events/launch-party/"><time class="dt-start" datetime="2026-07-01T18:00:00.000Z">Jul 1, 2026</time></a>
+  <p class="p-location">Online</p>
+  <div class="e-content"><p>Join us.</p></div>
+</article></body></html>`;
+
+const NO_URL = `<!doctype html><html><body>
+<article class="h-entry">
+  <h1 class="p-name">No Permalink</h1>
+  <time class="dt-published" datetime="2026-06-27T12:00:00.000Z">Jun 27, 2026</time>
+  <div class="e-content"><p>Body.</p></div>
+</article></body></html>`;
+
+// h-review with NO explicit p-name: the parser implies a name from the full text,
+// smashing item/rating/body together — the pitfall Hreview.astro documents.
+const IMPLIED_REVIEW = `<!doctype html><html><body>
+<article class="h-review">
+  <p>Reviewed: <span class="p-item">The Widget</span></p>
+  <data class="p-rating" value="4">4</data>
+  <a class="u-url" href="/reviews/the-widget/"><time class="dt-published" datetime="2026-06-27T12:00:00.000Z">d</time></a>
+  <div class="e-content"><p>Solid widget.</p></div>
+</article></body></html>`;
+
+test("valid h-entry passes and exposes expected properties", () => {
+  assert.deepEqual(validateEntryHtml(GOOD_ENTRY, "good-entry"), []);
+  const [item] = findRoots(GOOD_ENTRY);
+  assert.deepEqual(item.properties.name, ["My Article"]);
+  assert.deepEqual(item.properties.summary, ["Article summary text"]);
+  assert.deepEqual(item.properties.category, ["indieweb"]);
+  assert.equal(item.properties.url[0], "https://example.com/articles/my-article/");
+  assert.ok(String(item.properties.published[0]).startsWith("2026-06-27"));
+});
+
+test("valid h-review passes with explicit name, item and rating", () => {
+  assert.deepEqual(validateEntryHtml(GOOD_REVIEW, "good-review"), []);
+  const [item] = findRoots(GOOD_REVIEW);
+  assert.deepEqual(item.properties.name, ["Review of The Widget"]);
+  assert.deepEqual(item.properties.item, ["The Widget"]);
+  assert.deepEqual(item.properties.rating, ["4"]);
+});
+
+test("valid h-event passes", () => {
+  assert.deepEqual(validateEntryHtml(GOOD_EVENT, "good-event"), []);
+  const [item] = findRoots(GOOD_EVENT);
+  assert.deepEqual(item.properties.name, ["Launch Party"]);
+  assert.deepEqual(item.properties.location, ["Online"]);
+  assert.ok(String(item.properties.start[0]).startsWith("2026-07-01"));
+});
+
+test("h-entry without u-url is flagged", () => {
+  const problems = validateEntryHtml(NO_URL, "no-url");
+  assert.ok(problems.some((p) => p.includes("missing u-url")), problems.join("; "));
+});
+
+test("h-review with implied (non-explicit) name is flagged", () => {
+  const problems = validateEntryHtml(IMPLIED_REVIEW, "implied-review");
+  assert.ok(problems.some((p) => p.includes("implied")), problems.join("; "));
+});
+
+// --- Deferred to #388 (site identity model) -------------------------------
+test("entries carry a p-author h-card", { skip: "#388 — site identity model" }, () => {
+  // When #388 lands the businessProfile h-card, assert the nested p-author here.
+});
+test("site-wide h-card is present", { skip: "#388 — site identity model" }, () => {
+  // #388 emits the businessProfile h-card in BaseLayout; assert a root h-card then.
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx tsx --test scripts/microformats.test.ts`
+Expected: FAIL — `Cannot find module './microformats.ts'` (the module does not exist yet).
+
+- [ ] **Step 4: Implement the validator module**
+
+Create `scripts/microformats.ts`:
+
+```ts
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, extname } from "node:path";
+import { mf2 } from "microformats-parser";
+
+/** Base URL used to resolve relative u-* URLs during parsing. */
+const BASE_URL = "https://example.com";
+
+/** The mf2 root types our entry layouts may emit. */
+export const ENTRY_TYPES = ["h-entry", "h-review", "h-event"] as const;
+export type EntryType = (typeof ENTRY_TYPES)[number];
+
+/** Routed collection dirs whose built pages carry an entry microformat. */
+export const ENTRY_DIRS = [
+  "blog", "notes", "articles", "photos", "albums",
+  "bookmarks", "replies", "likes", "announcements", "events", "reviews",
+];
+
+type Mf2Item = { type: string[]; properties: Record<string, unknown[]> };
+
+const isEntryType = (t: string): t is EntryType =>
+  (ENTRY_TYPES as readonly string[]).includes(t);
+
+/** Parse HTML and return its root microformat items. */
+export function findRoots(html: string, baseUrl = BASE_URL): Mf2Item[] {
+  return mf2(html, { baseUrl }).items as Mf2Item[];
+}
+
+function has(item: Mf2Item, prop: string): boolean {
+  const v = item.properties[prop];
+  return Array.isArray(v) && v.length > 0;
+}
+
+/**
+ * Validate a single built entry page's microformats. Returns a list of human-readable
+ * problems; an empty list means the page is valid mf2 for our purposes.
+ */
+export function validateEntryHtml(html: string, label: string, baseUrl = BASE_URL): string[] {
+  const problems: string[] = [];
+  const roots = findRoots(html, baseUrl).filter((i) => i.type.some(isEntryType));
+
+  if (roots.length === 0) {
+    problems.push(`${label}: no h-entry/h-review/h-event root item found`);
+    return problems;
+  }
+  if (roots.length > 1) {
+    problems.push(`${label}: expected exactly one entry root, found ${roots.length}`);
+  }
+
+  const item = roots[0];
+  const type = item.type.find(isEntryType) as EntryType;
+
+  if (!has(item, "name")) problems.push(`${label}: ${type} missing p-name`);
+  if (!has(item, "url")) problems.push(`${label}: ${type} missing u-url`);
+  if (type === "h-event") {
+    if (!has(item, "start")) problems.push(`${label}: h-event missing dt-start`);
+  } else if (!has(item, "published")) {
+    problems.push(`${label}: ${type} missing dt-published`);
+  }
+  if (type === "h-review" && !has(item, "rating")) {
+    problems.push(`${label}: h-review missing p-rating`);
+  }
+
+  // Guard the implied-name pitfall: a valid entry's p-name is the explicit title, not the
+  // concatenation of all text (which the parser implies when no explicit p-name exists).
+  const name = String(item.properties.name?.[0] ?? "");
+  const content = String(
+    (item.properties.content?.[0] as { value?: string } | undefined)?.value ?? "",
+  ).trim();
+  if (name && content && name.includes(content)) {
+    problems.push(`${label}: ${type} p-name looks implied (contains the full content) — add an explicit p-name`);
+  }
+
+  return problems;
+}
+
+function walkHtml(dir: string): string[] {
+  const out: string[] = [];
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return out; // dir absent (collection had no built pages) — not an error here
+  }
+  for (const name of names) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...walkHtml(full));
+    else if (extname(full) === ".html") out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Validate every built entry page under `distDir` and assert vocabulary coverage:
+ * each of h-entry / h-review / h-event appears in at least one valid page.
+ */
+export function validateDist(distDir: string): string[] {
+  const problems: string[] = [];
+  const seen = new Set<string>();
+
+  for (const sub of ENTRY_DIRS) {
+    const base = join(distDir, sub);
+    for (const file of walkHtml(base)) {
+      const rel = file.slice(base.length + 1); // "welcome/index.html" or "index.html"
+      if (!rel.includes("/")) continue; // skip the collection's own list page (index.html)
+      const html = readFileSync(file, "utf8");
+      const label = file.slice(distDir.length + 1);
+      const pageProblems = validateEntryHtml(html, label);
+      problems.push(...pageProblems);
+      if (pageProblems.length === 0) {
+        for (const r of findRoots(html)) for (const t of r.type) if (isEntryType(t)) seen.add(t);
+      }
+    }
+  }
+
+  for (const t of ENTRY_TYPES) {
+    if (!seen.has(t)) problems.push(`coverage: no valid ${t} page found in ${distDir}`);
+  }
+  return problems;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx tsx --test scripts/microformats.test.ts`
+Expected: PASS — 5 passing tests, 2 skipped (`# pass 5`, `# skipped 2`, `# fail 0`).
+
+- [ ] **Step 6: Add the post-build CLI**
+
+Create `scripts/check-microformats.ts`:
+
+```ts
+import { validateDist } from "./microformats.ts";
+
+const distDir = process.argv[2] ?? "dist";
+const problems = validateDist(distDir);
+
+if (problems.length > 0) {
+  console.error(`✗ microformats validation failed (${problems.length} problem(s)):`);
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+console.log("✓ microformats validation passed");
+```
+
+- [ ] **Step 7: Manually confirm the CLI flags the current (pre-fix) gaps**
+
+Run: `npx astro build && npx tsx scripts/check-microformats.ts`
+Expected: NON-ZERO exit — problems listed, including the blog page missing an entry root (BlogPost has no mf2 yet) and `missing u-url` on entry/review/event pages. This proves the guard detects real gaps before we fix the markup. (Do not wire it into `build` yet — that happens in Task 6.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Resources/Template/package.json Resources/Template/package-lock.json \
+  Resources/Template/scripts/microformats.ts \
+  Resources/Template/scripts/check-microformats.ts \
+  Resources/Template/scripts/microformats.test.ts
+git commit -m "feat(#349): mf2 validator module + post-build CLI"
+```
+
+---
+
+### Task 2: BlogPost.astro — add h-entry markup
+
+**Files:**
+- Modify: `Resources/Template/src/layouts/BlogPost.astro`
+
+**Interfaces:**
+- Consumes: `validateEntryHtml` / CLI from Task 1 (for verification).
+- Produces: a valid `h-entry` page at `dist/blog/<slug>/index.html`.
+
+- [ ] **Step 1: Replace the layout with h-entry markup**
+
+Replace the entire contents of `src/layouts/BlogPost.astro` with:
+
+```astro
+---
+// BlogPost.astro — layout for an individual blog post. The post route
+// src/pages/blog/[...slug].astro renders through this layout; the Markdown body
+// fills the <slot/>, and the comments anchor in the <article> below is where the
+// giscus integration injects its widget when comments are set up.
+import BaseLayout from "./BaseLayout.astro";
+
+interface Props {
+  title: string;
+  description?: string;
+  pubDate?: Date;
+}
+
+const { title, description, pubDate } = Astro.props;
+// Compute the Date once; pin the locale + UTC so static output is deterministic.
+const iso = pubDate ? new Date(pubDate).toISOString() : undefined;
+const human = pubDate
+  ? new Date(pubDate).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })
+  : undefined;
+// anglesite:imports — integration component imports are injected here on setup
+---
+
+<BaseLayout title={title} description={description}>
+  <p><a href="/blog/">← All posts</a></p>
+  <article class="h-entry">
+    <h1 class="p-name">{title}</h1>
+    {description && <p class="p-summary">{description}</p>}
+    {iso && (
+      <a class="u-url" href={Astro.url.pathname}>
+        <time class="dt-published" datetime={iso}>{human}</time>
+      </a>
+    )}
+    <div class="e-content"><slot /></div>
+    <!-- anglesite:comments -->
+  </article>
+</BaseLayout>
+```
+
+Note: the `← All posts` nav stays **outside** `h-entry`; the `<!-- anglesite:comments -->` anchor stays **outside** `e-content`.
+
+- [ ] **Step 2: Build and validate the blog page**
+
+Run: `npx astro build && npx tsx scripts/check-microformats.ts`
+Expected: NON-ZERO exit still (other layouts not yet fixed), BUT the problem list no longer contains any `blog/...: no h-entry/h-review/h-event root` entry — the blog page is now a valid h-entry. Remaining problems are `missing u-url` on `notes/articles/photos/albums/bookmarks/replies/likes/announcements`, `reviews`, and `events`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Resources/Template/src/layouts/BlogPost.astro
+git commit -m "feat(#349): h-entry markup for BlogPost layout"
+```
+
+---
+
+### Task 3: Hentry.astro — emit article p-summary and u-url
+
+**Files:**
+- Modify: `Resources/Template/src/layouts/Hentry.astro`
+
+**Interfaces:**
+- Consumes: CLI from Task 1.
+- Produces: valid h-entry pages for the eight h-entry collections, with `p-summary` for articles and `u-url` permalinks.
+
+- [ ] **Step 1: Update the article body markup**
+
+In `src/layouts/Hentry.astro`, replace this block (the TODO comment, the caption-only summary, and the bare published `<time>`):
+
+```astro
+    {/* TODO(#349): article `summary` (registry p-summary) is not emitted here yet — only photo caption is. */}
+    {d.caption && <p class="p-summary">{d.caption}</p>}
+    <div class="e-content"><slot /></div>
+    {iso && <time class="dt-published" datetime={iso}>{human}</time>}
+```
+
+with:
+
+```astro
+    {(d.summary ?? d.caption) && <p class="p-summary">{d.summary ?? d.caption}</p>}
+    <div class="e-content"><slot /></div>
+    {iso && (
+      <a class="u-url" href={Astro.url.pathname}>
+        <time class="dt-published" datetime={iso}>{human}</time>
+      </a>
+    )}
+```
+
+(An entry carries either a photo `caption` or an article `summary`, never both, so a single `p-summary` covers both.)
+
+- [ ] **Step 2: Build and validate**
+
+Run: `npx astro build && npx tsx scripts/check-microformats.ts`
+Expected: NON-ZERO exit still (reviews/events not yet fixed), BUT no remaining `missing u-url` problems for the h-entry collections (`notes/articles/photos/albums/bookmarks/replies/likes/announcements`). Remaining: `reviews` and `events` `missing u-url`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Resources/Template/src/layouts/Hentry.astro
+git commit -m "feat(#349): emit article p-summary and u-url in Hentry"
+```
+
+---
+
+### Task 4: Hreview.astro — add u-url
+
+**Files:**
+- Modify: `Resources/Template/src/layouts/Hreview.astro`
+
+**Interfaces:**
+- Consumes: CLI from Task 1.
+- Produces: valid h-review pages with `u-url`.
+
+- [ ] **Step 1: Wrap the published time in a u-url permalink**
+
+In `src/layouts/Hreview.astro`, replace:
+
+```astro
+    {iso && <time class="dt-published" datetime={iso}>{human}</time>}
+```
+
+with:
+
+```astro
+    {iso && (
+      <a class="u-url" href={Astro.url.pathname}>
+        <time class="dt-published" datetime={iso}>{human}</time>
+      </a>
+    )}
+```
+
+- [ ] **Step 2: Build and validate**
+
+Run: `npx astro build && npx tsx scripts/check-microformats.ts`
+Expected: NON-ZERO exit still (events not yet fixed), BUT no remaining `reviews/...: h-review missing u-url`. Only `events` `missing u-url` remains.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Resources/Template/src/layouts/Hreview.astro
+git commit -m "feat(#349): add u-url permalink to Hreview"
+```
+
+---
+
+### Task 5: Hevent.astro — add u-url
+
+**Files:**
+- Modify: `Resources/Template/src/layouts/Hevent.astro`
+
+**Interfaces:**
+- Consumes: CLI from Task 1.
+- Produces: valid h-event pages with `u-url`. After this task, `validateDist` returns zero problems.
+
+- [ ] **Step 1: Wrap the start time in a u-url permalink**
+
+In `src/layouts/Hevent.astro`, replace:
+
+```astro
+    {startISO && <time class="dt-start" datetime={startISO}>{startHuman}</time>}
+```
+
+with:
+
+```astro
+    {startISO && (
+      <a class="u-url" href={Astro.url.pathname}>
+        <time class="dt-start" datetime={startISO}>{startHuman}</time>
+      </a>
+    )}
+```
+
+(Leave the `dt-end` `<time>` unchanged — it is not the permalink.)
+
+- [ ] **Step 2: Build and validate — expect a clean pass now**
+
+Run: `npx astro build && npx tsx scripts/check-microformats.ts`
+Expected: ZERO exit — `✓ microformats validation passed`. All entry pages valid; h-entry/h-review/h-event coverage all satisfied.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Resources/Template/src/layouts/Hevent.astro
+git commit -m "feat(#349): add u-url permalink to Hevent"
+```
+
+---
+
+### Task 6: Wire the validator into the build and verify end-to-end
+
+**Files:**
+- Modify: `Resources/Template/package.json` (`build` script)
+
+**Interfaces:**
+- Consumes: `scripts/check-microformats.ts` (Task 1), all layout fixes (Tasks 2–5).
+- Produces: a `build` that fails if mf2 output regresses.
+
+- [ ] **Step 1: Add the post-build validation step**
+
+In `Resources/Template/package.json`, change the `build` script from:
+
+```json
+"build": "astro check && astro build",
+```
+
+to:
+
+```json
+"build": "astro check && astro build && npx tsx scripts/check-microformats.ts",
+```
+
+- [ ] **Step 2: Run the full build (gate must be green)**
+
+Run: `npm run build`
+Expected: PASS — `astro check` clean, `astro build` succeeds, and the final line is `✓ microformats validation passed`. Exit code 0.
+
+- [ ] **Step 3: Run the validator unit tests once more**
+
+Run: `npx tsx --test scripts/microformats.test.ts`
+Expected: PASS — `# pass 5`, `# skipped 2`, `# fail 0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Resources/Template/package.json
+git commit -m "feat(#349): gate build on microformats validation"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "Complete h-entry/h-review/h-event coverage in entry layouts" → Tasks 2–5 (BlogPost h-entry; Hentry p-summary + u-url; Hreview u-url; Hevent u-url). ✓
+- "Resolve the `TODO(#349)` p-summary" → Task 3. ✓
+- "u-url permalink on all entry layouts" → Tasks 2–5. ✓
+- "Validator module + CLI + unit tests on node:test" → Task 1. ✓
+- "Post-build dist validation wired into build" → Task 6. ✓
+- "site-wide h-card / p-author deferred to #388 with skipped placeholders" → Task 1, Step 2 (`{ skip }` tests). ✓
+- "Only new dep microformats-parser; no Vitest" → Task 1, Step 1; Global Constraints. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases" — every code step shows complete code. (The `TODO(#349)` string appears only as the text being *deleted* in Task 3.) ✓
+
+**Type consistency:** `findRoots`, `validateEntryHtml`, `validateDist`, `ENTRY_TYPES`, `ENTRY_DIRS`, `isEntryType` are defined in Task 1 and consumed consistently by the CLI and tests. Property names (`name`, `url`, `published`, `start`, `rating`, `item`, `summary`, `category`, `content`) match microformats-parser's output shape. ✓
+
+**Risk note for the implementer:** the implied-name guard in `validateEntryHtml` relies on `microformats-parser` populating `properties.name` with the concatenated text when no explicit `p-name` exists. If the parser version behaves differently for the `IMPLIED_REVIEW` fixture, keep the `missing u-url` assertion (deterministic) and adjust the implied-name heuristic to match observed parser output — do not weaken the explicit-`p-name` requirement in the real layouts.

--- a/docs/superpowers/specs/2026-06-27-v1-7-microformats2-markup-design.md
+++ b/docs/superpowers/specs/2026-06-27-v1-7-microformats2-markup-design.md
@@ -1,0 +1,136 @@
+# V-1.7: microformats2 markup in type templates — design
+
+**Issue:** #349 (part of V-1, epic #335 / #334)
+**Date:** 2026-06-27
+**Status:** approved, pre-implementation
+
+## Goal
+
+Complete microformats2 (mf2) property coverage in the **entry-layer** templates so
+every routed content type emits valid `h-entry` / `h-review` / `h-event`, and add a
+parser-based test that proves the rendered output is valid mf2.
+
+## Scope boundary with #388
+
+The issue's acceptance has two halves:
+
+1. **"output validates against an mf2 parser"** — owned by this issue (#349).
+2. **"site-wide h-card present"** — delegated to **#388** (the `businessProfile`
+   page-singleton). #388 *is* the site identity h-card / `LocalBusiness`, and it is in
+   active development on `feat/388-site-identity`.
+
+Therefore **author `p-author` h-card and the site-wide h-card are out of scope here.**
+Both need #388's identity data model as their source; building them in #349 would
+collide with active work and duplicate the data model. The harness ships with those
+assertions present but skipped, so #388 can switch them on when it lands its h-card.
+
+This keeps #349 small, dependency-clean, and collision-free, and hands #388 a
+ready-made mf2 validator to land its h-card against.
+
+## Current state (what already exists)
+
+mf2 is roughly 70% present in the three entry layouts:
+
+- `Hentry.astro` (8 collections: notes, articles, photos, albums, bookmarks, replies,
+  likes, announcements) emits `h-entry`, `p-name`, `u-photo`, `u-bookmark-of`,
+  `u-in-reply-to`, `u-like-of`, `e-content`, `dt-published`, `p-category`. It carries an
+  explicit `TODO(#349)` at line 41: article `summary` is not emitted as `p-summary`
+  (only photo `caption` is).
+- `Hreview.astro` emits `h-review`, `p-name`, `p-item`, `p-rating`, `e-content`,
+  `dt-published`. Already guards the implied-name pitfall (explicit `p-name` so the
+  parser doesn't smash item/rating/body into the name).
+- `Hevent.astro` emits `h-event`, `p-name`, `dt-start`, `dt-end`, `p-location`,
+  `e-content`.
+- `BlogPost.astro` (the flagship article type, routed separately via
+  `src/pages/blog/[...slug].astro`) emits **no mf2 at all** — plain `<article>`, `<h1>`,
+  `<time>`. This is the largest gap.
+
+Constraints discovered:
+
+- The template has **no author / site-identity data source**. The only config is
+  `.site-config` (`SITE_URL=…`) read via `scripts/config.ts` `readConfig()`. (This is
+  precisely why the site-wide h-card belongs to #388, which introduces the identity
+  model.)
+- Tests use **`node:test` + `node:assert/strict` run via `tsx`** (see
+  `src/lib/feeds.test.ts`, `scripts/config.test.ts`). No vitest. No mf2 parser dep yet.
+- `Astro.url` inside each layout is already the entry's permalink during render, so
+  `u-url` needs no prop threading.
+
+## Design
+
+### 1. Template changes (additive markup only — no data-model changes)
+
+**`BlogPost.astro`** — add full h-entry:
+
+- `<article class="h-entry">`
+- `<h1 class="p-name">{title}</h1>`
+- `description` → `<p class="p-summary">{description}</p>` (when present)
+- wrap `<slot/>` in `<div class="e-content">`
+- `pubDate` → `dt-published` (existing `<time>` gains the class)
+- `u-url` permalink (see pattern below)
+- The `← All posts` nav stays **outside** `<article class="h-entry">` so it cannot
+  pollute implied properties; the `<!-- anglesite:comments -->` anchor stays **outside**
+  `e-content` (comments are not part of the post content) — it may remain inside the
+  article, after the content div.
+
+**`Hentry.astro`** — resolve `TODO(#349)`:
+
+- Emit `p-summary` for article `summary`. An entry carries either a photo `caption` or an
+  article `summary` (not both), so emit whichever is present into a single `p-summary`.
+
+**All three entry layouts (`Hentry`, `Hreview`, `Hevent`)** — add `u-url`:
+
+- Use `Astro.url.pathname` (already the entry's URL). Pattern: wrap the existing
+  published/start `<time>` in `<a class="u-url" href={Astro.url.pathname}>…</a>`
+  (standard indieweb date-as-permalink). Every routed entry has a date field, so the
+  time element is always available as the permalink anchor.
+
+### 2. Validation harness
+
+- Add **`microformats-parser`** as a devDependency (maintained, pure-TS mf2 parser).
+- New test file `src/layouts/microformats.test.ts`, `node:test` + `tsx` style.
+- Render each real layout to an HTML string with **`experimental_AstroContainer`**
+  (`astro/container`), passing representative sample props + slot body. Parse the
+  rendered HTML with `microformats-parser`. Assert:
+  - exactly one root item of the expected type (`h-entry` / `h-review` / `h-event`)
+  - required properties present and correctly valued:
+    - h-entry: `name`, `published`, `content` (+ `summary` for the article fixture,
+      `category` for a tagged fixture)
+    - h-review: `name`, `item`, `rating`
+    - h-event: `name`, `start`
+  - `url` property present (the new `u-url`)
+  - a sanity assertion that `name` equals the explicit title, **not** the implied-name
+    concatenation (guards the pitfall `Hreview.astro` already documents)
+- Author / site-wide-h-card assertions are written as **`it.skip(...)` placeholders**
+  with a `// #388` note, so #388 can enable them when it ships the h-card.
+
+If the Container API needs a request URL for `Astro.url` to resolve `u-url`
+deterministically, set it via the container render options; this is an implementation
+detail, not a design risk.
+
+### 3. Testing & acceptance
+
+- `npx tsx --test src/layouts/microformats.test.ts` passes.
+- `astro check` remains clean (changes are type-neutral markup).
+- Acceptance "output validates against an mf2 parser" — met by the harness.
+- Acceptance "site-wide h-card present" — explicitly delegated to #388 (recorded on both
+  issues); the skipped assertions document the seam.
+
+## Out of scope (YAGNI)
+
+- Author `p-author` h-card and site-wide h-card → **#388**.
+- No `dist/` post-build mf2 guard in `pre-deploy-check.ts` (the Container-API unit test
+  covers validation without a full build; a build-time guard can be a later follow-up if
+  wanted).
+- No `p-best` / `p-worst` on reviews (mf2's default 1–5 scale is correct for the bare
+  `rating` number).
+- No nested `h-card` / `h-adr` for event location (text `p-location` is valid mf2).
+
+## Files touched
+
+- `Resources/Template/src/layouts/BlogPost.astro` (mf2 added)
+- `Resources/Template/src/layouts/Hentry.astro` (`p-summary` for article summary, `u-url`)
+- `Resources/Template/src/layouts/Hreview.astro` (`u-url`)
+- `Resources/Template/src/layouts/Hevent.astro` (`u-url`)
+- `Resources/Template/src/layouts/microformats.test.ts` (new)
+- `Resources/Template/package.json` (+ `microformats-parser` devDependency)

--- a/docs/superpowers/specs/2026-06-27-v1-7-microformats2-markup-design.md
+++ b/docs/superpowers/specs/2026-06-27-v1-7-microformats2-markup-design.md
@@ -87,41 +87,63 @@ Constraints discovered:
 
 ### 2. Validation harness
 
-- Add **`microformats-parser`** as a devDependency (maintained, pure-TS mf2 parser).
-- New test file `src/layouts/microformats.test.ts`, `node:test` + `tsx` style.
-- Render each real layout to an HTML string with **`experimental_AstroContainer`**
-  (`astro/container`), passing representative sample props + slot body. Parse the
-  rendered HTML with `microformats-parser`. Assert:
-  - exactly one root item of the expected type (`h-entry` / `h-review` / `h-event`)
-  - required properties present and correctly valued:
-    - h-entry: `name`, `published`, `content` (+ `summary` for the article fixture,
-      `category` for a tagged fixture)
-    - h-review: `name`, `item`, `rating`
-    - h-event: `name`, `start`
-  - `url` property present (the new `u-url`)
-  - a sanity assertion that `name` equals the explicit title, **not** the implied-name
-    concatenation (guards the pitfall `Hreview.astro` already documents)
-- Author / site-wide-h-card assertions are written as **`it.skip(...)` placeholders**
-  with a `// #388` note, so #388 can enable them when it ships the h-card.
+**Runner decision (corrected during planning):** the Astro **Container API cannot run
+on the template's `node:test`/`tsx` runner** — `tsx` cannot compile `.astro` imports
+(`ERR_UNKNOWN_FILE_EXTENSION ".astro"`, confirmed empirically), so it would require
+adding **Vitest** + `getViteConfig`. Instead — and because **the scaffold already ships
+exactly one sample entry in every collection** — the harness validates the **true built
+output**, which both avoids a second test runner and more literally satisfies "output
+validates against an mf2 parser."
 
-If the Container API needs a request URL for `Astro.url` to resolve `u-url`
-deterministically, set it via the container render options; this is an implementation
-detail, not a design risk.
+- Add **`microformats-parser`** as a devDependency (maintained, pure-TS mf2 parser;
+  `mf2(html, { baseUrl }) → { items, rels, "rel-urls" }`).
+- **Validator module** `scripts/microformats.ts` — pure, build-independent logic:
+  - `findRoots(html, baseUrl)` → root mf2 items via `microformats-parser`.
+  - `validateEntryHtml(html, baseUrl)` → returns `string[]` of problems for one page:
+    exactly one root item; its type is one of `h-entry`/`h-review`/`h-event`; required
+    properties present (`name`, `url`, and `published` for entry/review or `start` for
+    event; review also `rating`); `name` is the explicit title, **not** the implied-name
+    concatenation (guards the pitfall `Hreview.astro` documents).
+  - `validateDist(distDir)` → walks `dist/**/*.html` under the entry collection dirs
+    (`blog`, `notes`, `articles`, `photos`, `albums`, `bookmarks`, `replies`, `likes`,
+    `announcements`, `events`, `reviews`), runs `validateEntryHtml` on each, and asserts
+    **coverage**: each of the three vocab types (`h-entry`, `h-review`, `h-event`)
+    appears at least once. Returns aggregated problems.
+- **CLI** `scripts/check-microformats.ts` — runs `validateDist("dist")`, prints
+  problems, exits non-zero on failure. Wired into the `build` script *after*
+  `astro build` so every build guards mf2 validity (mirrors the existing
+  `pre-deploy-check.ts` guard philosophy).
+- **Unit test** `scripts/microformats.test.ts` — `node:test` + `tsx`, no build, no
+  `.astro`. Feeds `validateEntryHtml` representative **HTML fixture strings**:
+  - a good `h-entry` (article) → no problems; assert parsed `name`/`summary`/`published`/
+    `url`/`content`/`category`.
+  - a good `h-review` → no problems; assert `name`/`item`/`rating`/`url` and the explicit
+    name.
+  - a good `h-event` → no problems; assert `name`/`start`/`location`/`url`.
+  - a bad fixture (missing `u-url`, or an `h-review` with no explicit `p-name` so the
+    implied name smashes item/rating/body) → non-empty problems list.
+- Author / site-wide-h-card assertions are written as **`test(... , { skip: true })`
+  placeholders** with a `// #388` note, so #388 can enable them when it ships the h-card.
+
+This separates concerns cleanly: `microformats.test.ts` proves the validator logic with
+fast fixtures (the part that needs a review gate), and the post-build CLI proves the
+**real** site output passes (the part that needs a build).
 
 ### 3. Testing & acceptance
 
-- `npx tsx --test src/layouts/microformats.test.ts` passes.
+- `npx tsx --test scripts/microformats.test.ts` passes (validator-logic unit tests).
+- `npm run build` succeeds **and** the post-build `check-microformats` CLI passes against
+  the real `dist/` produced from the scaffold's seeded content — the literal "output
+  validates against an mf2 parser" acceptance.
 - `astro check` remains clean (changes are type-neutral markup).
-- Acceptance "output validates against an mf2 parser" — met by the harness.
 - Acceptance "site-wide h-card present" — explicitly delegated to #388 (recorded on both
-  issues); the skipped assertions document the seam.
+  issues); the skipped tests document the seam.
 
 ## Out of scope (YAGNI)
 
 - Author `p-author` h-card and site-wide h-card → **#388**.
-- No `dist/` post-build mf2 guard in `pre-deploy-check.ts` (the Container-API unit test
-  covers validation without a full build; a build-time guard can be a later follow-up if
-  wanted).
+- No Vitest / Container API (would add a second test runner; the post-build dist
+  validator covers the acceptance on the existing `node:test` runner).
 - No `p-best` / `p-worst` on reviews (mf2's default 1–5 scale is correct for the bare
   `rating` number).
 - No nested `h-card` / `h-adr` for event location (text `p-location` is valid mf2).
@@ -132,5 +154,8 @@ detail, not a design risk.
 - `Resources/Template/src/layouts/Hentry.astro` (`p-summary` for article summary, `u-url`)
 - `Resources/Template/src/layouts/Hreview.astro` (`u-url`)
 - `Resources/Template/src/layouts/Hevent.astro` (`u-url`)
-- `Resources/Template/src/layouts/microformats.test.ts` (new)
-- `Resources/Template/package.json` (+ `microformats-parser` devDependency)
+- `Resources/Template/scripts/microformats.ts` (new — validator module)
+- `Resources/Template/scripts/check-microformats.ts` (new — post-build CLI)
+- `Resources/Template/scripts/microformats.test.ts` (new — validator unit tests)
+- `Resources/Template/package.json` (+ `microformats-parser` devDependency; `build`
+  script gains the post-build validator)

--- a/docs/superpowers/specs/2026-06-27-v1-7-microformats2-markup-design.md
+++ b/docs/superpowers/specs/2026-06-27-v1-7-microformats2-markup-design.md
@@ -101,9 +101,12 @@ validates against an mf2 parser."
   - `findRoots(html, baseUrl)` → root mf2 items via `microformats-parser`.
   - `validateEntryHtml(html, baseUrl)` → returns `string[]` of problems for one page:
     exactly one root item; its type is one of `h-entry`/`h-review`/`h-event`; required
-    properties present (`name`, `url`, and `published` for entry/review or `start` for
-    event; review also `rating`); `name` is the explicit title, **not** the implied-name
-    concatenation (guards the pitfall `Hreview.astro` documents).
+    properties present — `url` (all); `published` for entry/review or `start` for event;
+    review also `rating`. **`p-name` is required and explicit only for `h-review` and
+    `h-event`** (both always carry a title); it is **optional for `h-entry`** because
+    notes, photos, replies, and likes are legitimately nameless mf2 entries. The
+    implied-name guard (`name` must be the explicit title, not the parser's concatenation —
+    the pitfall `Hreview.astro` documents) therefore applies only to `h-review`/`h-event`.
   - `validateDist(distDir)` → walks `dist/**/*.html` under the entry collection dirs
     (`blog`, `notes`, `articles`, `photos`, `albums`, `bookmarks`, `replies`, `likes`,
     `announcements`, `events`, `reviews`), runs `validateEntryHtml` on each, and asserts


### PR DESCRIPTION
Completes microformats2 (mf2) markup in the entry-layer templates and adds a parser-based validator that gates the build. Closes #349 (V-1.7, part of V-1 epic #335 / #334).

## What changed

**Markup completion** — the four entry layouts now emit valid mf2:
- `BlogPost.astro` — added full `h-entry` (`p-name`/`p-summary`/`dt-published`/`u-url`/`e-content`); was previously bare HTML.
- `Hentry.astro` — resolved the `TODO(#349)`: article `summary` now emits `p-summary` (was photo `caption` only); added `u-url`.
- `Hreview.astro` / `Hevent.astro` — added `u-url` permalinks (`Astro.url.pathname`).

**Validation harness** (the acceptance gate):
- New `scripts/microformats.ts` — validator over built `dist/**/*.html` using `microformats-parser` (the only new dep). Asserts one entry root per page, required properties, and vocabulary coverage (h-entry/h-review/h-event each appear in ≥1 valid page); skips collection list pages.
- New `scripts/check-microformats.ts` — post-build CLI, wired into `npm run build`.
- New `scripts/microformats.test.ts` — `node:test` unit tests (7 pass / 2 skipped), no new test runner.

## Scope boundary with #388
Author `p-author` h-card and the **site-wide h-card** are intentionally **out of scope** — they belong to #388 (the `businessProfile` site-identity model, in active development). They're represented here as two skipped tests so #388 can switch them on. So this PR satisfies the "validates against an mf2 parser" half of #349's acceptance; the "site-wide h-card present" half is delegated to #388.

## Design notes
- `p-name` is **optional** for `h-entry` (notes/photos/replies/likes are legitimately nameless mf2 entries) and **required + explicit** for `h-review`/`h-event`. The implied-name guard (preventing the parser from smashing item/rating/body into the name — the pitfall `Hreview.astro` documents) applies only to the latter, and normalizes whitespace so it isn't fixture-fitted.
- Runner choice: the validator runs over real built output on `node:test`/`tsx` rather than the Astro Container API, which would have required adding Vitest (`tsx` can't compile `.astro`). The scaffold ships one sample entry per collection, so the built `dist/` exercises every type.

## Verification
- `npm run build` → 13 pages, `✓ microformats validation passed` (exit 0)
- `npx tsx --test scripts/microformats.test.ts` → 7 pass / 2 skipped / 0 fail

Spec: `docs/superpowers/specs/2026-06-27-v1-7-microformats2-markup-design.md` · Plan: `docs/superpowers/plans/2026-06-27-v1-7-microformats2-markup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)