### PR TITLE
Refine New Page URL field

### DIFF
--- a/Sources/AnglesiteApp/FocusedSite.swift
+++ b/Sources/AnglesiteApp/FocusedSite.swift
@@ -37,11 +37,12 @@ struct NewContentCommands: Commands {
                     openWindow(id: "sites")
                     WindowRouter.shared.requestNewSite()
                 }
-                .keyboardShortcut("n")
+                .keyboardShortcut("n", modifiers: [.command, .shift])
 
                 Button("Page…") {
                     focusedActions?.newPage()
                 }
+                .keyboardShortcut("n")
                 .disabled(focusedActions == nil)
 
                 Button("Collection…") {

--- a/Sources/AnglesiteApp/NewContentSheets.swift
+++ b/Sources/AnglesiteApp/NewContentSheets.swift
@@ -2,11 +2,13 @@ import SwiftUI
 import AnglesiteCore
 
 struct NewPageSheet: View {
+    let baseURLPrefix: String
     let onCreate: (String, String?, ContentScaffold.PageTemplate) async -> ContentCreateResult
 
     @Environment(\.dismiss) private var dismiss
     @State private var title = ""
     @State private var route = ""
+    @State private var routeFollowsTitle = true
     @State private var template = ContentScaffold.PageTemplate.standard
     @State private var isCreating = false
     @State private var errorMessage: String?
@@ -16,7 +18,22 @@ struct NewPageSheet: View {
             Form {
                 Section("Page") {
                     TextField("Title", text: $title)
-                    TextField("Route", text: $route, prompt: Text("about/team"))
+                    HStack {
+                        Text("URL")
+                        Spacer(minLength: 16)
+                        HStack(spacing: 0) {
+                            Text(baseURLPrefix)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                            TextField("Route", text: $route, prompt: Text(routePrompt))
+                                .labelsHidden()
+                                .multilineTextAlignment(.trailing)
+                                .textFieldStyle(.plain)
+                                .frame(width: routeFieldWidth, alignment: .trailing)
+                            Text("/")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
                 Section("Template") {
                     Picker("Template", selection: $template) {
@@ -34,6 +51,14 @@ struct NewPageSheet: View {
             .formStyle(.grouped)
             .frame(minWidth: 420, minHeight: 250)
             .navigationTitle("New Page")
+            .onChange(of: title) { _, _ in
+                if routeFollowsTitle {
+                    route = defaultRoute
+                }
+            }
+            .onChange(of: route) { _, newValue in
+                routeFollowsTitle = newValue == defaultRoute
+            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -47,6 +72,25 @@ struct NewPageSheet: View {
                 }
             }
         }
+    }
+
+    private var defaultRoute: String {
+        ContentScaffold.slugify(title.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private var routePrompt: String {
+        defaultRoute.isEmpty ? "my-new-webpage" : defaultRoute
+    }
+
+    private var routeFieldWidth: CGFloat {
+        let characterWidth: CGFloat = 7.5
+        let padding: CGFloat = 2
+        let measured = CGFloat(max(routeTextForSizing.count, 1)) * characterWidth + padding
+        return min(max(measured, 40), 280)
+    }
+
+    private var routeTextForSizing: String {
+        route.isEmpty ? routePrompt : route
     }
 
     private func create() {

--- a/Sources/AnglesiteApp/NewContentSheets.swift
+++ b/Sources/AnglesiteApp/NewContentSheets.swift
@@ -1,14 +1,16 @@
+import AppKit
 import SwiftUI
 import AnglesiteCore
 
 struct NewPageSheet: View {
-    let baseURLPrefix: String
+    let site: SiteStore.Site?
     let onCreate: (String, String?, ContentScaffold.PageTemplate) async -> ContentCreateResult
 
     @Environment(\.dismiss) private var dismiss
     @State private var title = ""
     @State private var route = ""
     @State private var routeFollowsTitle = true
+    @State private var baseURLPrefix = "https://example.com/"
     @State private var template = ContentScaffold.PageTemplate.standard
     @State private var isCreating = false
     @State private var errorMessage: String?
@@ -25,7 +27,7 @@ struct NewPageSheet: View {
                             Text(baseURLPrefix)
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
-                            TextField("Route", text: $route, prompt: Text(routePrompt))
+                            TextField("Route", text: routeBinding, prompt: Text(routePrompt))
                                 .labelsHidden()
                                 .multilineTextAlignment(.trailing)
                                 .textFieldStyle(.plain)
@@ -56,8 +58,8 @@ struct NewPageSheet: View {
                     route = defaultRoute
                 }
             }
-            .onChange(of: route) { _, newValue in
-                routeFollowsTitle = newValue == defaultRoute
+            .task(id: site?.id) {
+                baseURLPrefix = await Self.resolveBaseURLPrefix(for: site)
             }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -74,6 +76,21 @@ struct NewPageSheet: View {
         }
     }
 
+    /// Editing the route through this binding detaches it from the title. Re-enabling
+    /// auto-follow requires an explicit gesture, not an incidental match against the
+    /// derived slug — so the setter only ever clears the flag, never restores it.
+    /// Programmatic updates from `onChange(of: title)` write `route` directly and so
+    /// bypass this setter, leaving auto-follow intact.
+    private var routeBinding: Binding<String> {
+        Binding(
+            get: { route },
+            set: { newValue in
+                route = newValue
+                routeFollowsTitle = false
+            }
+        )
+    }
+
     private var defaultRoute: String {
         ContentScaffold.slugify(title.trimmingCharacters(in: .whitespacesAndNewlines))
     }
@@ -83,14 +100,35 @@ struct NewPageSheet: View {
     }
 
     private var routeFieldWidth: CGFloat {
-        let characterWidth: CGFloat = 7.5
-        let padding: CGFloat = 2
-        let measured = CGFloat(max(routeTextForSizing.count, 1)) * characterWidth + padding
-        return min(max(measured, 40), 280)
+        let font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        let measured = (routeTextForSizing as NSString).size(withAttributes: [.font: font]).width
+        return min(max(ceil(measured) + 4, 40), 280)
     }
 
     private var routeTextForSizing: String {
         route.isEmpty ? routePrompt : route
+    }
+
+    /// Build the public-URL prefix for the page route, reading `.site-config` off the
+    /// main actor. Recomputed whenever the bound `site` changes, so a sheet opened
+    /// before the site finished loading still picks up the real host once it arrives.
+    private static func resolveBaseURLPrefix(for site: SiteStore.Site?) async -> String {
+        let fallbackHost = "example.com"
+        let config: String
+        if let site {
+            let directory = site.sourceDirectory
+            config = await Task.detached(priority: .utility) {
+                (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: directory)) ?? ""
+            }.value
+        } else {
+            config = ""
+        }
+        let host = WebsiteAnalyticsAsset.bestHost(from: config, fallback: fallbackHost)
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let absolute = trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://")
+            ? trimmed
+            : "https://\(trimmed.isEmpty ? fallbackHost : trimmed)"
+        return absolute.hasSuffix("/") ? absolute : absolute + "/"
     }
 
     private func create() {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -445,7 +445,7 @@ struct SiteWindow: View {
             }
         }
         .sheet(isPresented: $newPagePresented) {
-            NewPageSheet(baseURLPrefix: pageBaseURLPrefix(for: site)) { title, route, template in
+            NewPageSheet(site: site) { title, route, template in
                 await createPage(title: title, route: route, template: template)
             }
         }
@@ -493,19 +493,6 @@ struct SiteWindow: View {
     private var paneSelection: Int {
         if case .editor = mainPaneMode { return 1 }
         return 0
-    }
-
-    private func pageBaseURLPrefix(for site: SiteStore.Site?) -> String {
-        let fallbackHost = "example.com"
-        let config = site.flatMap {
-            try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: $0.sourceDirectory)
-        } ?? ""
-        let host = WebsiteAnalyticsAsset.bestHost(from: config, fallback: fallbackHost)
-        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
-        let absolute = trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://")
-            ? trimmed
-            : "https://\(trimmed.isEmpty ? fallbackHost : trimmed)"
-        return absolute.hasSuffix("/") ? absolute : absolute + "/"
     }
 
     private func setPaneSelection(_ value: Int) {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -445,7 +445,7 @@ struct SiteWindow: View {
             }
         }
         .sheet(isPresented: $newPagePresented) {
-            NewPageSheet { title, route, template in
+            NewPageSheet(baseURLPrefix: pageBaseURLPrefix(for: site)) { title, route, template in
                 await createPage(title: title, route: route, template: template)
             }
         }
@@ -493,6 +493,19 @@ struct SiteWindow: View {
     private var paneSelection: Int {
         if case .editor = mainPaneMode { return 1 }
         return 0
+    }
+
+    private func pageBaseURLPrefix(for site: SiteStore.Site?) -> String {
+        let fallbackHost = "example.com"
+        let config = site.flatMap {
+            try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: $0.sourceDirectory)
+        } ?? ""
+        let host = WebsiteAnalyticsAsset.bestHost(from: config, fallback: fallbackHost)
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let absolute = trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://")
+            ? trimmed
+            : "https://\(trimmed.isEmpty ? fallbackHost : trimmed)"
+        return absolute.hasSuffix("/") ? absolute : absolute + "/"
     }
 
     private func setPaneSelection(_ value: Int) {


### PR DESCRIPTION
## Summary
- show the New Page path as a public URL with configured-domain prefix and trailing slash
- auto-derive the URL path from the page title until the user edits it manually
- update shortcuts so Shift-Command-N creates a site and Command-N creates a page

## Verification
- env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build