### PR TITLE
feat(#350): V-1.8 schema.org JSON-LD (astro-seo-schema + schema-dts)

### DIFF
--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -20,6 +20,8 @@ const { title, description } = Astro.props;
     <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml" />
     <link rel="alternate" type="application/atom+xml" title="Atom" href="/atom.xml" />
     <link rel="alternate" type="application/feed+json" title="JSON Feed" href="/feed.json" />
+    <!-- Per-page schema.org JSON-LD (V-1.8) is projected into this slot by the type layouts. -->
+    <slot name="head" />
   </head>
   <body>
     <slot />

--- a/Resources/Template/src/layouts/BlogPost.astro
+++ b/Resources/Template/src/layouts/BlogPost.astro
@@ -3,6 +3,8 @@
 // src/pages/blog/[...slug].astro renders through this layout; the Markdown body
 // fills the <slot/>, and the comments anchor in the <article> below is where the
 // giscus integration injects its widget when comments are set up.
+import { Schema } from "astro-seo-schema";
+import { blogPostingSchema } from "../lib/schema.ts";
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {
@@ -12,10 +14,13 @@ interface Props {
 }
 
 const { title, description, pubDate } = Astro.props;
+const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url).href;
+const jsonLd = blogPostingSchema({ title, description, pubDate }, { url: canonical, site: Astro.site });
 // anglesite:imports — integration component imports are injected here on setup
 ---
 
 <BaseLayout title={title} description={description}>
+  <Schema slot="head" item={jsonLd} />
   <article>
     <p><a href="/blog/">← All posts</a></p>
     <h1>{title}</h1>

--- a/Resources/Template/src/layouts/Hentry.astro
+++ b/Resources/Template/src/layouts/Hentry.astro
@@ -1,6 +1,8 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import { Schema } from "astro-seo-schema";
 import type { HentryCollection } from "../lib/collections.ts";
+import { entrySchema, type HentryData } from "../lib/schema.ts";
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {
@@ -28,9 +30,15 @@ const iso = d.publishDate ? new Date(d.publishDate).toISOString() : undefined;
 const human = d.publishDate ? new Date(d.publishDate).toLocaleDateString() : undefined;
 const images: string[] = Array.isArray(d.images) ? d.images : [];
 const tags: string[] = Array.isArray(d.tags) ? d.tags : [];
+
+// schema.org JSON-LD twin of the mf2 markup (V-1.8). `entry.collection` discriminates which
+// h-entry vocabulary this is; `entrySchema` returns null for likes (no rich-result type).
+const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url).href;
+const jsonLd = entrySchema(entry.collection, entry.data as HentryData, { url: canonical, site: Astro.site });
 ---
 
 <BaseLayout title={title ?? "Post"} description={d.summary}>
+  {jsonLd && <Schema slot="head" item={jsonLd} />}
   <article class="h-entry">
     {title && <h1 class="p-name">{title}</h1>}
     {d.image && <img class="u-photo" src={d.image} alt={d.caption ?? ""} />}

--- a/Resources/Template/src/layouts/Hevent.astro
+++ b/Resources/Template/src/layouts/Hevent.astro
@@ -1,5 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import { Schema } from "astro-seo-schema";
+import { entrySchema } from "../lib/schema.ts";
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {
@@ -8,6 +10,8 @@ interface Props {
 
 const { entry } = Astro.props;
 const d = entry.data;
+const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url).href;
+const jsonLd = entrySchema("events", entry.data, { url: canonical, site: Astro.site });
 // Compute each Date once; pin the locale so static output is deterministic across build hosts.
 const startDate = d.start ? new Date(d.start) : undefined;
 const startISO = startDate?.toISOString();
@@ -18,6 +22,7 @@ const endHuman = endDate?.toLocaleString("en-US");
 ---
 
 <BaseLayout title={d.name ?? "Event"} description={d.location}>
+  {jsonLd && <Schema slot="head" item={jsonLd} />}
   <article class="h-event">
     <h1 class="p-name">{d.name}</h1>
     {startISO && <time class="dt-start" datetime={startISO}>{startHuman}</time>}

--- a/Resources/Template/src/layouts/Hreview.astro
+++ b/Resources/Template/src/layouts/Hreview.astro
@@ -1,5 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import { Schema } from "astro-seo-schema";
+import { entrySchema } from "../lib/schema.ts";
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {
@@ -16,9 +18,12 @@ const human = publishedDate?.toLocaleDateString("en-US");
 // reviewed); without it, mf2 parsers fall back to the implied name — the concatenation of all
 // text content, smashing item/rating/body together. Generate one from the reviewed item.
 const reviewName = `Review of ${d.itemReviewed}`;
+const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url).href;
+const jsonLd = entrySchema("reviews", entry.data, { url: canonical, site: Astro.site });
 ---
 
 <BaseLayout title={reviewName}>
+  {jsonLd && <Schema slot="head" item={jsonLd} />}
   <article class="h-review">
     <h1 class="p-name">{reviewName}</h1>
     <p>Reviewed: <span class="p-item">{d.itemReviewed}</span></p>

--- a/Resources/Template/src/lib/schema.ts
+++ b/Resources/Template/src/lib/schema.ts
@@ -1,0 +1,239 @@
+/**
+ * schema.org JSON-LD projection for the routed content collections (V-1.8, #350).
+ *
+ * Each typed object already carries microformats2 classes in its layout (V-1.7); this is the
+ * machine-readable twin emitted as `<script type="application/ld+json">` for search engines.
+ * Keeping the mapping here — rather than inline in each layout — means the route, the layouts,
+ * and this projection can't drift from `content.config.ts`.
+ *
+ * Coverage mirrors the collections that exist today. `LocalBusiness` (the `businessProfile`
+ * singleton, #388) and `Recipe` (no V-1 content type) are intentionally absent — wire them in
+ * when those types land. `likes` emit no JSON-LD: a like is an interaction, not a CreativeWork
+ * with a meaningful schema.org rich-result type.
+ */
+import type {
+  WithContext,
+  Thing,
+  Article,
+  BlogPosting,
+  SocialMediaPosting,
+  ImageObject,
+  ImageGallery,
+  Event,
+  Review,
+  WebPage,
+  Comment,
+} from "schema-dts";
+import type { EntryCollection } from "./collections.ts";
+
+/** Page-level context the projection needs that isn't in the entry's frontmatter. */
+export interface SchemaContext {
+  /** Canonical absolute URL of the page being rendered (`Astro.url`). */
+  url: string;
+  /** Site origin (`Astro.site`), used to resolve root-relative asset paths to absolute URLs. */
+  site?: URL;
+}
+
+/** Flattened union of the h-entry collections' frontmatter — every field optional. */
+export interface HentryData {
+  title?: string;
+  summary?: string;
+  caption?: string;
+  publishDate?: Date;
+  updated?: Date;
+  image?: string;
+  images?: string[];
+  tags?: string[];
+  bookmarkOf?: string;
+  inReplyTo?: string;
+  likeOf?: string;
+}
+
+export interface EventData {
+  name?: string;
+  start?: Date;
+  end?: Date;
+  location?: string;
+}
+
+export interface ReviewData {
+  itemReviewed?: string;
+  rating?: number;
+  publishDate?: Date;
+}
+
+export interface BlogData {
+  title?: string;
+  description?: string;
+  pubDate?: Date;
+}
+
+function iso(d: Date | undefined): string | undefined {
+  return d ? new Date(d).toISOString() : undefined;
+}
+
+/** Resolve a possibly root-relative path against the site origin; pass full URLs through. */
+function abs(pathOrUrl: string | undefined, site: URL | undefined): string | undefined {
+  if (!pathOrUrl) return undefined;
+  try {
+    return new URL(pathOrUrl, site).href;
+  } catch {
+    return pathOrUrl;
+  }
+}
+
+/** Recursively drop `undefined` values (and emptied objects/arrays) so the JSON-LD stays tidy. */
+function clean<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(clean).filter((v) => v !== undefined) as unknown as T;
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const c = clean(v);
+      if (c !== undefined) out[k] = c;
+    }
+    return out as T;
+  }
+  return value;
+}
+
+const CONTEXT = "https://schema.org" as const;
+
+function keywordsOf(tags: string[] | undefined): string | undefined {
+  return tags && tags.length > 0 ? tags.join(", ") : undefined;
+}
+
+/** Map an h-entry collection's frontmatter to its schema.org type, or `null` when none applies. */
+function hentrySchema(
+  collection: EntryCollection,
+  d: HentryData,
+  ctx: SchemaContext,
+): WithContext<Thing> | null {
+  const datePublished = iso(d.publishDate);
+  const keywords = keywordsOf(d.tags);
+
+  switch (collection) {
+    case "articles":
+      return clean<WithContext<Article>>({
+        "@context": CONTEXT,
+        "@type": "Article",
+        headline: d.title,
+        description: d.summary,
+        datePublished,
+        dateModified: iso(d.updated),
+        keywords,
+        url: ctx.url,
+      });
+    case "announcements":
+      return clean<WithContext<Article>>({
+        "@context": CONTEXT,
+        "@type": "Article",
+        headline: d.title,
+        datePublished,
+        url: ctx.url,
+      });
+    case "notes":
+      return clean<WithContext<SocialMediaPosting>>({
+        "@context": CONTEXT,
+        "@type": "SocialMediaPosting",
+        datePublished,
+        keywords,
+        url: ctx.url,
+      });
+    case "photos":
+      return clean<WithContext<ImageObject>>({
+        "@context": CONTEXT,
+        "@type": "ImageObject",
+        contentUrl: abs(d.image, ctx.site),
+        caption: d.caption,
+        datePublished,
+        keywords,
+        url: ctx.url,
+      });
+    case "albums":
+      return clean<WithContext<ImageGallery>>({
+        "@context": CONTEXT,
+        "@type": "ImageGallery",
+        name: d.title,
+        datePublished,
+        keywords,
+        url: ctx.url,
+        image: (d.images ?? []).map((src) => abs(src, ctx.site)).filter((s): s is string => !!s),
+      });
+    case "bookmarks":
+      return clean<WithContext<WebPage>>({
+        "@context": CONTEXT,
+        "@type": "WebPage",
+        name: d.title,
+        datePublished,
+        keywords,
+        url: ctx.url,
+        relatedLink: d.bookmarkOf,
+      });
+    case "replies":
+      return clean<WithContext<Comment>>({
+        "@context": CONTEXT,
+        "@type": "Comment",
+        datePublished,
+        url: ctx.url,
+        about: d.inReplyTo ? { "@type": "WebPage", url: d.inReplyTo } : undefined,
+      });
+    case "likes":
+      return null;
+    default:
+      return null;
+  }
+}
+
+function eventSchema(d: EventData, ctx: SchemaContext): WithContext<Event> {
+  return clean<WithContext<Event>>({
+    "@context": CONTEXT,
+    "@type": "Event",
+    name: d.name,
+    startDate: iso(d.start),
+    endDate: iso(d.end),
+    location: d.location ? { "@type": "Place", name: d.location } : undefined,
+    url: ctx.url,
+  });
+}
+
+function reviewSchema(d: ReviewData, ctx: SchemaContext): WithContext<Review> {
+  return clean<WithContext<Review>>({
+    "@context": CONTEXT,
+    "@type": "Review",
+    name: d.itemReviewed ? `Review of ${d.itemReviewed}` : undefined,
+    itemReviewed: d.itemReviewed ? { "@type": "Thing", name: d.itemReviewed } : undefined,
+    reviewRating:
+      d.rating !== undefined ? { "@type": "Rating", ratingValue: d.rating } : undefined,
+    datePublished: iso(d.publishDate),
+    url: ctx.url,
+  });
+}
+
+/**
+ * Single entry point for the routed `[collection]/[...slug]` page. `events` and `reviews` have
+ * their own frontmatter shapes; everything else is an h-entry. Returns `null` when a type has no
+ * meaningful schema.org projection (e.g. likes), so the layout can skip emitting a script.
+ */
+export function entrySchema(
+  collection: EntryCollection,
+  data: HentryData & EventData & ReviewData,
+  ctx: SchemaContext,
+): WithContext<Thing> | null {
+  if (collection === "events") return eventSchema(data, ctx);
+  if (collection === "reviews") return reviewSchema(data, ctx);
+  return hentrySchema(collection, data, ctx);
+}
+
+/** Blog posts route through their own layout with bespoke props rather than a CollectionEntry. */
+export function blogPostingSchema(d: BlogData, ctx: SchemaContext): WithContext<BlogPosting> {
+  return clean<WithContext<BlogPosting>>({
+    "@context": CONTEXT,
+    "@type": "BlogPosting",
+    headline: d.title,
+    description: d.description,
+    datePublished: iso(d.pubDate),
+    url: ctx.url,
+  });
+}

--- a/Tests/AnglesiteCoreTests/JsonLdRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/JsonLdRenderSmokeTests.swift
@@ -1,0 +1,69 @@
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+/// V-1.8 (#350): the schema.org JSON-LD twin of the mf2 markup. Builds the committed template and
+/// asserts each routed type emits a `<script type="application/ld+json">` with the right `@type`,
+/// and that `likes` (an interaction, no rich-result type) emits none.
+@Suite("JSON-LD render smoke")
+struct JsonLdRenderSmokeTests {
+
+    static var templateDir: URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources/Template", isDirectory: true)
+    }
+
+    /// True when the template can actually be built: a Node binary plus an installed Astro.
+    static var buildable: Bool {
+        guard E2EPrerequisites.locateNode() != nil else { return false }
+        return FileManager.default.isReadableFile(
+            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
+    }
+
+    @Test("seeded types emit schema.org JSON-LD with the expected @type",
+          .enabled(if: JsonLdRenderSmokeTests.buildable))
+    func emitsJsonLd() async throws {
+        let node = try #require(E2EPrerequisites.locateNode())
+        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+
+        func html(_ rel: String) throws -> String {
+            try String(contentsOf: dist.appendingPathComponent(rel), encoding: .utf8)
+        }
+
+        // Hold the shared template-build lock across build + assertions: other render-smoke suites
+        // rm -rf dist around their own build and would race on the shared template tree.
+        try await TemplateBuildSerializer.shared.serialize {
+            try? FileManager.default.removeItem(at: dist)
+            defer { try? FileManager.default.removeItem(at: dist) }
+
+            let result = try await ProcessSupervisor.shared.run(
+                executable: node,
+                arguments: ["node_modules/astro/astro.js", "build"],
+                currentDirectoryURL: Self.templateDir)
+            try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+
+            let ldScript = "application/ld+json"
+
+            let article = try html("articles/hello-article/index.html")
+            #expect(article.contains(ldScript))
+            #expect(article.contains("\"@type\":\"Article\""))
+
+            let event = try html("events/hello-event/index.html")
+            #expect(event.contains("\"@type\":\"Event\""))
+            #expect(event.contains("\"startDate\""))
+
+            let review = try html("reviews/hello-review/index.html")
+            #expect(review.contains("\"@type\":\"Review\""))
+            #expect(review.contains("\"reviewRating\""))
+
+            #expect(try html("blog/welcome-to-your-blog/index.html").contains("\"@type\":\"BlogPosting\""))
+            #expect(try html("photos/hello-photo/index.html").contains("\"@type\":\"ImageObject\""))
+            #expect(try html("albums/hello-album/index.html").contains("\"@type\":\"ImageGallery\""))
+            #expect(try html("notes/hello-note/index.html").contains("\"@type\":\"SocialMediaPosting\""))
+
+            // A like is an interaction, not a CreativeWork — it gets no JSON-LD.
+            #expect(try !html("likes/hello-like/index.html").contains(ldScript))
+        }
+    }
+}


### PR DESCRIPTION
Closes #350 (V-1.8, part of #335).

Projects each routed content type to schema.org JSON-LD — the machine-readable twin of the V-1.7 microformats2 markup. A centralized `src/lib/schema.ts` maps each collection's frontmatter to a `schema-dts`-typed object (so the route, layouts, and projection can't drift from `content.config.ts`); layouts emit it into a new `head` slot on `BaseLayout` via `astro-seo-schema`'s `<Schema>`.

## Type mapping

| Collection | `@type` |
|---|---|
| articles / announcements | `Article` |
| blog | `BlogPosting` |
| notes | `SocialMediaPosting` |
| photos | `ImageObject` |
| albums | `ImageGallery` |
| bookmarks | `WebPage` |
| replies | `Comment` |
| events | `Event` |
| reviews | `Review` |
| likes | *(none — interaction, no rich-result type)* |

## Scope note

The issue's acceptance names Article / Event / **Recipe** / Review / **LocalBusiness**. Article, Event, Review are covered. Recipe and LocalBusiness are deferred:
- **Recipe** — no Recipe content type exists in V-1.
- **LocalBusiness** — depends on the `businessProfile` page-singleton being built in #388 (in-flight). The projection has a clear hook to add it once that type lands.

## Verification

- `npm run build` (incl. `astro check`) ✅
- `npm run check` (pre-deploy-check) ✅
- Built HTML emits correct JSON-LD in `<head>` for every covered type; `likes` emits none ✅
- New `JsonLdRenderSmokeTests` + existing mf2/feeds render-smoke suites all green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)