### PR TITLE
feat(#346): V-1.4 per-type SwiftUI form editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ Resources/Anglesite.help/**/*.helpindex
 
 # Playwright MCP browser-session artifacts
 .playwright-mcp/
+build-smoke/

--- a/Resources/Template/src/pages/about.md
+++ b/Resources/Template/src/pages/about.md
@@ -1,0 +1,19 @@
+---
+layout: ../layouts/BaseLayout.astro
+title: "About"
+type: businessProfile
+name: "Your Business Name"
+description: ""
+telephone: ""
+email: ""
+streetAddress: ""
+locality: ""
+region: ""
+postalCode: ""
+hours: []
+url: ""
+---
+
+# About
+
+Edit your business details in Anglesite (File ▸ open this page).

--- a/Sources/AnglesiteApp/InspectorContext.swift
+++ b/Sources/AnglesiteApp/InspectorContext.swift
@@ -20,6 +20,7 @@ protocol InspectorEditorModel: AnyObject {
 }
 
 /// What the right-hand inspector is editing for the current selection.
+@MainActor
 enum InspectorContext: Identifiable {
     case typed(TypedEntryEditorModel)
     case page(PageMetadataModel)

--- a/Sources/AnglesiteApp/InspectorContext.swift
+++ b/Sources/AnglesiteApp/InspectorContext.swift
@@ -1,0 +1,34 @@
+// Sources/AnglesiteApp/InspectorContext.swift
+import Foundation
+import AnglesiteCore
+
+/// Shared surface the inspector chrome (load/save/conflict/⌘S) drives, so one chrome wraps both the
+/// typed descriptor form and the plain page metadata form.
+@MainActor
+protocol InspectorEditorModel: AnyObject {
+    var file: FileRef { get }
+    var isDirty: Bool { get }
+    var loadError: String? { get }
+    var isLoading: Bool { get }
+    var conflictDiskContents: String? { get set }
+    func load() async
+    @discardableResult func save() async -> Bool
+    func flushBeforeLeaving() async -> Bool
+    func checkExternalChange() async
+    func keepMyChanges()
+    func reloadFromDisk() async
+}
+
+/// What the right-hand inspector is editing for the current selection.
+enum InspectorContext: Identifiable {
+    case typed(TypedEntryEditorModel)
+    case page(PageMetadataModel)
+
+    var model: any InspectorEditorModel {
+        switch self {
+        case .typed(let m): m
+        case .page(let m): m
+        }
+    }
+    var id: String { model.file.id }
+}

--- a/Sources/AnglesiteApp/PageInspectorView.swift
+++ b/Sources/AnglesiteApp/PageInspectorView.swift
@@ -1,0 +1,93 @@
+// Sources/AnglesiteApp/PageInspectorView.swift
+import SwiftUI
+import AnglesiteCore
+
+/// Right-hand inspector content for the selected page. Renders the typed descriptor form or the
+/// plain title/description form, wrapped in shared chrome (header + dirty/Save, off-main load,
+/// external-change conflict alert, ⌘S). Phase 1 has a single "Page" section; a tab picker for
+/// selection-level editing comes in Phase 3.
+struct PageInspectorView: View {
+    let context: InspectorContext
+
+    var body: some View {
+        switch context {
+        case .typed(let model):
+            InspectorChrome(model: model) { TypedEntryForm(model: model) }
+        case .page(let model):
+            InspectorChrome(model: model) { PageMetadataForm(model: model) }
+        }
+    }
+}
+
+/// The form for a plain (non-typed) frontmatter page: title + description.
+private struct PageMetadataForm: View {
+    @Bindable var model: PageMetadataModel
+
+    var body: some View {
+        Form {
+            TextField("Title", text: model.titleBinding())
+            VStack(alignment: .leading) {
+                Text("Description").font(.caption).foregroundStyle(.secondary)
+                TextField("", text: model.descriptionBinding(), axis: .vertical).lineLimit(2...6)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+/// Shared inspector chrome around any `InspectorEditorModel`. Generic over the concrete model so the
+/// form bodies keep their `@Bindable` two-way bindings.
+private struct InspectorChrome<M: InspectorEditorModel & Observable, Form: View>: View {
+    @Bindable var model: M
+    @ViewBuilder var form: () -> Form
+    @Environment(\.controlActiveState) private var controlActiveState
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            Group {
+                if let loadError = model.loadError {
+                    ContentUnavailableView {
+                        Label("Can't open \(model.file.name)", systemImage: "exclamationmark.triangle")
+                    } description: { Text(loadError) } actions: {
+                        Button("Reveal in Finder") { NSWorkspace.shared.activateFileViewerSelecting([model.file.url]) }
+                    }
+                } else if model.isLoading {
+                    ProgressView().controlSize(.small)
+                } else {
+                    form()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .task(id: model.file.id) { await model.load() }
+        .onChange(of: controlActiveState) { _, new in
+            if new == .key { Task { await model.checkExternalChange() } }
+        }
+        .background(Button("") { Task { await model.save() } }
+            .keyboardShortcut("s", modifiers: [.command]).hidden())
+        .alert("\(model.file.name) changed on disk", isPresented: conflictBinding) {
+            Button("Keep My Changes", role: .cancel) { model.keepMyChanges() }
+            Button("Reload from Disk") { Task { await model.reloadFromDisk() } }
+        } message: {
+            Text("Another tool edited this file while you had unsaved changes.")
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Label(model.file.name, systemImage: "doc.text").font(.headline)
+            if model.isDirty {
+                Circle().fill(.secondary).frame(width: 7, height: 7).help("Unsaved changes")
+            }
+            Spacer()
+            Button("Save") { Task { await model.save() } }.disabled(!model.isDirty)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
+    private var conflictBinding: Binding<Bool> {
+        Binding(get: { model.conflictDiskContents != nil }, set: { _ in })
+    }
+}

--- a/Sources/AnglesiteApp/PageMetadataModel.swift
+++ b/Sources/AnglesiteApp/PageMetadataModel.swift
@@ -18,6 +18,8 @@ final class PageMetadataModel: InspectorEditorModel {
     private var savedMetadata = PageMetadata(title: "", description: "")
     private var contents = ""
     private var lastModified: Date?
+    /// Guards against a concurrent second `save()` capturing a stale `contents` base.
+    private var isSaving = false
     private(set) var loadError: String?
     private(set) var isLoading = false
     var conflictDiskContents: String?
@@ -48,7 +50,9 @@ final class PageMetadataModel: InspectorEditorModel {
 
     @discardableResult
     func save() async -> Bool {
-        guard isDirty else { return true }
+        guard isDirty, !isSaving else { return true }
+        isSaving = true
+        defer { isSaving = false }
         let newContents = PageMetadataEditor.write(metadata, into: contents)
         let url = file.url
         do {
@@ -104,11 +108,15 @@ final class PageMetadataModel: InspectorEditorModel {
         conflictDiskContents = nil
     }
 
+    // `[weak self]` — see the note in TypedEntryEditorModel: view-lifetime bindings on a model that
+    // is replaced per selection.
     func titleBinding() -> Binding<String> {
-        Binding(get: { self.metadata.title }, set: { self.metadata.title = $0 })
+        Binding(get: { [weak self] in self?.metadata.title ?? "" },
+                set: { [weak self] in self?.metadata.title = $0 })
     }
     func descriptionBinding() -> Binding<String> {
-        Binding(get: { self.metadata.description }, set: { self.metadata.description = $0 })
+        Binding(get: { [weak self] in self?.metadata.description ?? "" },
+                set: { [weak self] in self?.metadata.description = $0 })
     }
 
     private func adopt(_ text: String) {

--- a/Sources/AnglesiteApp/PageMetadataModel.swift
+++ b/Sources/AnglesiteApp/PageMetadataModel.swift
@@ -86,11 +86,11 @@ final class PageMetadataModel: InspectorEditorModel {
             try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
         }.value
         switch change {
-        case .reloadable(let disk):
+        case .some(.reloadable(let disk)):
             adopt(disk); lastModified = await freshModificationDate()
-        case .conflict(let disk):
+        case .some(.conflict(let disk)):
             conflictDiskContents = disk
-        case .none, nil:
+        case .some(.none), nil:
             break
         }
     }

--- a/Sources/AnglesiteApp/PageMetadataModel.swift
+++ b/Sources/AnglesiteApp/PageMetadataModel.swift
@@ -1,0 +1,138 @@
+// Sources/AnglesiteApp/PageMetadataModel.swift
+import Foundation
+import SwiftUI
+import Observation
+import AnglesiteCore
+
+/// Editor state for a plain (non-typed) page's title + description. Parallels
+/// `TypedEntryEditorModel`: loads/saves through `FileDocumentIO`, writes via `PageMetadataEditor`
+/// (round-trip-safe), and commits each save. All disk IO runs off the main actor.
+@MainActor
+@Observable
+final class PageMetadataModel: InspectorEditorModel {
+    let file: FileRef
+    private let sourceDirectory: URL
+    private let gitCommit: NativeContentOperations.GitCommit
+
+    var metadata = PageMetadata(title: "", description: "")
+    private var savedMetadata = PageMetadata(title: "", description: "")
+    private var contents = ""
+    private var lastModified: Date?
+    private(set) var loadError: String?
+    private(set) var isLoading = false
+    var conflictDiskContents: String?
+
+    var isDirty: Bool { metadata != savedMetadata && loadError == nil && !isLoading }
+
+    init(file: FileRef,
+         sourceDirectory: URL,
+         gitCommit: @escaping NativeContentOperations.GitCommit = NativeContentOperations.processGitCommit) {
+        self.file = file
+        self.sourceDirectory = sourceDirectory
+        self.gitCommit = gitCommit
+    }
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        let url = file.url
+        do {
+            let loaded = try await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url) }.value
+            adopt(loaded.contents)
+            lastModified = loaded.modificationDate
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    @discardableResult
+    func save() async -> Bool {
+        guard isDirty else { return true }
+        let newContents = PageMetadataEditor.write(metadata, into: contents)
+        let url = file.url
+        do {
+            let mtime = try await Task.detached(priority: .userInitiated) {
+                try FileDocumentIO.save(newContents, to: url)
+            }.value
+            lastModified = mtime
+            contents = newContents
+            savedMetadata = metadata
+            await commit()
+            return true
+        } catch {
+            loadError = "Save failed: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    func flushBeforeLeaving() async -> Bool {
+        guard isDirty else { return true }
+        let url = file.url
+        let known = lastModified
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: true)
+        }.value
+        if case .conflict(let disk)? = change { conflictDiskContents = disk; return false }
+        return await save()
+    }
+
+    func checkExternalChange() async {
+        guard loadError == nil else { return }
+        let url = file.url
+        let known = lastModified
+        let dirty = isDirty
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
+        }.value
+        switch change {
+        case .reloadable(let disk):
+            adopt(disk); lastModified = await freshModificationDate()
+        case .conflict(let disk):
+            conflictDiskContents = disk
+        case .none, nil:
+            break
+        }
+    }
+
+    func keepMyChanges() { conflictDiskContents = nil }
+
+    func reloadFromDisk() async {
+        guard let disk = conflictDiskContents else { return }
+        adopt(disk)
+        lastModified = await freshModificationDate()
+        conflictDiskContents = nil
+    }
+
+    func titleBinding() -> Binding<String> {
+        Binding(get: { self.metadata.title }, set: { self.metadata.title = $0 })
+    }
+    func descriptionBinding() -> Binding<String> {
+        Binding(get: { self.metadata.description }, set: { self.metadata.description = $0 })
+    }
+
+    private func adopt(_ text: String) {
+        contents = text
+        let read = PageMetadataEditor.read(text)
+        metadata = read
+        savedMetadata = read
+    }
+
+    private func commit() async {
+        let rel = relativePath(of: file.url, under: sourceDirectory)
+        let slug = file.url.deletingPathExtension().lastPathComponent
+        _ = await gitCommit(sourceDirectory, rel, "anglesite: edit page \(slug)")
+    }
+
+    private func relativePath(of url: URL, under root: URL) -> String {
+        let u = url.standardizedFileURL.path(percentEncoded: false)
+        let r = root.standardizedFileURL.path(percentEncoded: false)
+        if u.hasPrefix(r) { return String(u.dropFirst(r.count)).drop(while: { $0 == "/" }).description }
+        return url.lastPathComponent
+    }
+
+    private func freshModificationDate() async -> Date? {
+        let url = file.url
+        return try? await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url).modificationDate }.value
+    }
+}

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -12,13 +12,11 @@ private enum MainPaneMode: Equatable {
 private enum ActiveEditor {
     case text(FileEditorModel)
     case plist(PlistEditorModel)
-    case typed(TypedEntryEditorModel)
 
     var file: FileRef {
         switch self {
         case .text(let model): model.file
         case .plist(let model): model.file
-        case .typed(let model): model.file
         }
     }
 }
@@ -114,6 +112,12 @@ struct SiteWindow: View {
     /// auto-save it and the Preview/Editor toggle keeps the buffer alive. Replaced when a different
     /// file opens; cleared on window close / site replay.
     @State private var activeEditor: ActiveEditor?
+    /// The right-hand inspector's current target (typed entry or plain page), or nil when the
+    /// selection has no editable metadata. Set by `applyNavigatorSelection`.
+    @State private var inspectorContext: InspectorContext?
+    /// Inspector visibility, persisted per window. Defaults to shown (auto-open); the toolbar toggle
+    /// flips it and the choice persists across selections.
+    @SceneStorage("siteInspector.shown") private var inspectorShown = true
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -145,6 +149,8 @@ struct SiteWindow: View {
             // Persist any unsaved edits before dropping the old site's editor on replay (#188 reuse).
             persistEditorBufferBestEffort()
             activeEditor = nil
+            if let model = inspectorContext?.model { Task { await model.flushBeforeLeaving() } }
+            inspectorContext = nil
             mainPaneMode = .preview
         }
         .onChange(of: preview.state) { _, newState in
@@ -178,6 +184,8 @@ struct SiteWindow: View {
             // on a flush return value — just write the buffer best-effort, off the main actor.
             persistEditorBufferBestEffort()
             activeEditor = nil
+            if let model = inspectorContext?.model { Task { await model.flushBeforeLeaving() } }
+            inspectorContext = nil
             #if ANGLESITE_MAS
             scopedURL?.stopAccessingSecurityScopedResource()
             scopedURL = nil
@@ -237,9 +245,28 @@ struct SiteWindow: View {
             }
         .animation(.easeInOut(duration: 0.18), value: deploy.drawerPresented)
         .animation(.easeInOut(duration: 0.18), value: backup.drawerPresented)
+        .inspector(isPresented: Binding(
+            get: { inspectorShown && inspectorContext != nil },
+            set: { inspectorShown = $0 }
+        )) {
+            if let inspectorContext {
+                PageInspectorView(context: inspectorContext)
+                    .inspectorColumnWidth(min: 260, ideal: 300, max: 420)
+            }
+        }
         .navigationTitle(site.name)
         .navigationSubtitle(preview.readyURL?.absoluteString ?? "")
         .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    inspectorShown.toggle()
+                } label: {
+                    Label("Inspector", systemImage: "sidebar.right")
+                }
+                .disabled(inspectorContext == nil)
+                .help("Show or hide the page inspector")
+            }
+
             // Backup — lowest priority, first to collapse into the native overflow chevron.
             ToolbarItem(placement: .primaryAction) {
                 Button {
@@ -487,7 +514,7 @@ struct SiteWindow: View {
         switch activeEditor {
         case .some(.text):
             return true
-        case .some(.plist), .some(.typed), .none:
+        case .some(.plist), .none:
             return false
         }
     }
@@ -518,11 +545,17 @@ struct SiteWindow: View {
             return await model.flushBeforeLeaving()
         case .plist(let model):
             return await model.flushBeforeLeaving()
-        case .typed(let model):
-            return await model.flushBeforeLeaving()
         case nil:
             return true
         }
+    }
+
+    /// Flush the inspector's editor before changing selection or tearing down — autosaves a dirty
+    /// buffer, returns false (and the model raises its conflict alert) on an external conflict so the
+    /// caller aborts the switch. Safe when no inspector is active.
+    private func leaveCurrentInspector() async -> Bool {
+        guard let model = inspectorContext?.model else { return true }
+        return await model.flushBeforeLeaving()
     }
 
     /// Best-effort off-main save of the open editor's buffer when the editor is torn down (window
@@ -540,9 +573,7 @@ struct SiteWindow: View {
                 let entries = model.entriesForSaving()
                 Task.detached(priority: .userInitiated) { try? PlistDocumentIO.save(entries, to: url) }
             }
-        case .typed(let model) where model.isDirty:
-            Task { await model.flushBeforeLeaving() }
-        case .text, .typed, nil:
+        case .text, nil:
             break
         }
     }
@@ -557,8 +588,6 @@ struct SiteWindow: View {
         case .editor:
             if case .text(let editorModel) = activeEditor {
                 MainPaneEditorView(model: editorModel)
-            } else if case .typed(let typedModel) = activeEditor {
-                TypedEntryEditorView(model: typedModel)
             } else if case .plist(let plistEditorModel) = activeEditor {
                 PlistEditorView(model: plistEditorModel) { title in
                     Task { await saveWebsiteTitle(title) }
@@ -666,26 +695,12 @@ struct SiteWindow: View {
         switch target {
         case .route(let route):
             Task {
-                guard await leaveCurrentEditor() else { return }   // abort if a conflict needs resolving
-                // Typed content (notes, articles, the business profile, …) is surfaced as a route
-                // in the navigator, but opens in its form editor rather than the preview. Plain
-                // pages (no content-type match) fall through to preview navigation.
-                if let source = site?.sourceDirectory,
-                   let typed = await typedEditorForContent(navigatorID: id, source: source) {
-                    if activeEditorFile?.id == typed.file.id {
-                        mainPaneMode = .editor(typed.file)   // re-show the open buffer intact
-                        return
-                    }
-                    activeEditor = .typed(typed)
-                    mainPaneMode = .editor(typed.file)
-                    return
-                }
+                guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+                // Content entry → preview in the center; its metadata in the inspector.
+                activeEditor = nil
                 mainPaneMode = .preview
-                if route.isEmpty || route == "/" {
-                    preview.clearRoute()
-                } else {
-                    preview.navigate(toRoute: route)
-                }
+                if route.isEmpty || route == "/" { preview.clearRoute() } else { preview.navigate(toRoute: route) }
+                inspectorContext = await makeInspectorContext(forNavigatorID: id)
             }
         case .file(let file):
             if activeEditorFile?.id == file.id {
@@ -693,23 +708,17 @@ struct SiteWindow: View {
                 return
             }
             Task {
-                guard await leaveCurrentEditor() else { return }   // flush the previous file first
-                if let source = site?.sourceDirectory,
-                   let descriptor = ContentTypeResolver.descriptor(
-                       forRelativePath: relativeProjectPath(of: file.url, under: source)) {
-                    activeEditor = .typed(TypedEntryEditorModel(
-                        file: file, descriptor: descriptor, sourceDirectory: source))
-                } else {
-                    switch EditorKind.resolve(for: file) {
-                    case .text:
-                        activeEditor = .text(FileEditorModel(file: file))
-                    case .plist:
-                        activeEditor = .plist(PlistEditorModel(
-                            file: file,
-                            websiteTitle: site?.name ?? file.name,
-                            sourceDirectory: site?.sourceDirectory ?? file.url.deletingLastPathComponent()
-                        ))
-                    }
+                guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+                inspectorContext = nil   // files (components/styles/metadata) have no page inspector
+                switch EditorKind.resolve(for: file) {
+                case .text:
+                    activeEditor = .text(FileEditorModel(file: file))
+                case .plist:
+                    activeEditor = .plist(PlistEditorModel(
+                        file: file,
+                        websiteTitle: site?.name ?? file.name,
+                        sourceDirectory: site?.sourceDirectory ?? file.url.deletingLastPathComponent()
+                    ))
                 }
                 mainPaneMode = .editor(file)
             }
@@ -724,26 +733,35 @@ struct SiteWindow: View {
         return String(u.dropFirst(r.count)).drop(while: { $0 == "/" }).description
     }
 
-    /// If a navigator id is a content page/post whose file resolves to a registered content type,
-    /// build its typed form editor. Returns `nil` for plain pages (which fall back to preview).
-    private func typedEditorForContent(navigatorID id: String, source: URL) async -> TypedEntryEditorModel? {
+    /// Build the inspector context for a content navigator id: the typed descriptor form when the
+    /// file resolves to a content type, the plain title/description form for a frontmatter-bearing
+    /// markdown page, or nil (plain `.astro`/other → preview only, no inspector).
+    private func makeInspectorContext(forNavigatorID id: String) async -> InspectorContext? {
+        guard let source = site?.sourceDirectory else { return nil }
         let relPath: String
         let group: FileGroup
         let displayName: String
         if let page = await contentGraph.page(id: id) {
-            relPath = page.filePath
-            group = .pages
-            displayName = page.title ?? page.route
+            relPath = page.filePath; group = .pages; displayName = page.title ?? page.route
         } else if let post = await contentGraph.post(id: id) {
-            relPath = post.filePath
-            group = .posts
-            displayName = post.title
+            relPath = post.filePath; group = .posts; displayName = post.title
         } else {
             return nil
         }
-        guard let descriptor = ContentTypeResolver.descriptor(forRelativePath: relPath) else { return nil }
-        let file = FileRef(url: source.appendingPathComponent(relPath), group: group, name: displayName)
-        return TypedEntryEditorModel(file: file, descriptor: descriptor, sourceDirectory: source)
+        let url = source.appendingPathComponent(relPath)
+        let file = FileRef(url: url, group: group, name: displayName)
+        if let descriptor = ContentTypeResolver.descriptor(forRelativePath: relPath) {
+            return .typed(TypedEntryEditorModel(file: file, descriptor: descriptor, sourceDirectory: source))
+        }
+        if isFrontmatterPage(relPath) {
+            return .page(PageMetadataModel(file: file, sourceDirectory: source))
+        }
+        return nil   // plain .astro / other → preview only
+    }
+
+    private func isFrontmatterPage(_ relPath: String) -> Bool {
+        let ext = (relPath as NSString).pathExtension.lowercased()
+        return ext == "md" || ext == "mdx" || ext == "markdown"
     }
 
     private var healthAssistantPrompt: String {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -725,14 +725,6 @@ struct SiteWindow: View {
         }
     }
 
-    /// Project-relative path of `url` under the site `Source/` directory, for content-type resolution.
-    private func relativeProjectPath(of url: URL, under root: URL) -> String {
-        let u = url.standardizedFileURL.path(percentEncoded: false)
-        let r = root.standardizedFileURL.path(percentEncoded: false)
-        guard u.hasPrefix(r) else { return url.lastPathComponent }
-        return String(u.dropFirst(r.count)).drop(while: { $0 == "/" }).description
-    }
-
     /// Build the inspector context for a content navigator id: the typed descriptor form when the
     /// file resolves to a content type, the plain title/description form for a frontmatter-bearing
     /// markdown page, or nil (plain `.astro`/other → preview only, no inspector).

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -12,11 +12,13 @@ private enum MainPaneMode: Equatable {
 private enum ActiveEditor {
     case text(FileEditorModel)
     case plist(PlistEditorModel)
+    case typed(TypedEntryEditorModel)
 
     var file: FileRef {
         switch self {
         case .text(let model): model.file
         case .plist(let model): model.file
+        case .typed(let model): model.file
         }
     }
 }
@@ -485,7 +487,7 @@ struct SiteWindow: View {
         switch activeEditor {
         case .some(.text):
             return true
-        case .some(.plist), .none:
+        case .some(.plist), .some(.typed), .none:
             return false
         }
     }
@@ -516,6 +518,8 @@ struct SiteWindow: View {
             return await model.flushBeforeLeaving()
         case .plist(let model):
             return await model.flushBeforeLeaving()
+        case .typed(let model):
+            return await model.flushBeforeLeaving()
         case nil:
             return true
         }
@@ -536,7 +540,9 @@ struct SiteWindow: View {
                 let entries = model.entriesForSaving()
                 Task.detached(priority: .userInitiated) { try? PlistDocumentIO.save(entries, to: url) }
             }
-        case .text, nil:
+        case .typed(let model) where model.isDirty:
+            Task { await model.flushBeforeLeaving() }
+        case .text, .typed, nil:
             break
         }
     }
@@ -551,6 +557,8 @@ struct SiteWindow: View {
         case .editor:
             if case .text(let editorModel) = activeEditor {
                 MainPaneEditorView(model: editorModel)
+            } else if case .typed(let typedModel) = activeEditor {
+                TypedEntryEditorView(model: typedModel)
             } else if case .plist(let plistEditorModel) = activeEditor {
                 PlistEditorView(model: plistEditorModel) { title in
                     Task { await saveWebsiteTitle(title) }
@@ -673,19 +681,34 @@ struct SiteWindow: View {
             }
             Task {
                 guard await leaveCurrentEditor() else { return }   // flush the previous file first
-                switch EditorKind.resolve(for: file) {
-                case .text:
-                    activeEditor = .text(FileEditorModel(file: file))
-                case .plist:
-                    activeEditor = .plist(PlistEditorModel(
-                        file: file,
-                        websiteTitle: site?.name ?? file.name,
-                        sourceDirectory: site?.sourceDirectory ?? file.url.deletingLastPathComponent()
-                    ))
+                if let source = site?.sourceDirectory,
+                   let descriptor = ContentTypeResolver.descriptor(
+                       forRelativePath: relativeProjectPath(of: file.url, under: source)) {
+                    activeEditor = .typed(TypedEntryEditorModel(
+                        file: file, descriptor: descriptor, sourceDirectory: source))
+                } else {
+                    switch EditorKind.resolve(for: file) {
+                    case .text:
+                        activeEditor = .text(FileEditorModel(file: file))
+                    case .plist:
+                        activeEditor = .plist(PlistEditorModel(
+                            file: file,
+                            websiteTitle: site?.name ?? file.name,
+                            sourceDirectory: site?.sourceDirectory ?? file.url.deletingLastPathComponent()
+                        ))
+                    }
                 }
                 mainPaneMode = .editor(file)
             }
         }
+    }
+
+    /// Project-relative path of `url` under the site `Source/` directory, for content-type resolution.
+    private func relativeProjectPath(of url: URL, under root: URL) -> String {
+        let u = url.standardizedFileURL.path(percentEncoded: false)
+        let r = root.standardizedFileURL.path(percentEncoded: false)
+        guard u.hasPrefix(r) else { return url.lastPathComponent }
+        return String(u.dropFirst(r.count)).drop(while: { $0 == "/" }).description
     }
 
     private var healthAssistantPrompt: String {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -149,7 +149,10 @@ struct SiteWindow: View {
             // Persist any unsaved edits before dropping the old site's editor on replay (#188 reuse).
             persistEditorBufferBestEffort()
             activeEditor = nil
-            if let model = inspectorContext?.model { Task { await model.flushBeforeLeaving() } }
+            // Overwrite unconditionally on teardown (save(), not flushBeforeLeaving): no conflict
+            // alert can be shown on a closing window, so a conflict-gated flush would silently drop
+            // the edits. Last-writer-wins, matching the .text/.plist teardown above.
+            if let model = inspectorContext?.model { Task { await model.save() } }
             inspectorContext = nil
             mainPaneMode = .preview
         }
@@ -184,7 +187,10 @@ struct SiteWindow: View {
             // on a flush return value — just write the buffer best-effort, off the main actor.
             persistEditorBufferBestEffort()
             activeEditor = nil
-            if let model = inspectorContext?.model { Task { await model.flushBeforeLeaving() } }
+            // Overwrite unconditionally on teardown (save(), not flushBeforeLeaving): no conflict
+            // alert can be shown on a closing window, so a conflict-gated flush would silently drop
+            // the edits. Last-writer-wins, matching the .text/.plist teardown above.
+            if let model = inspectorContext?.model { Task { await model.save() } }
             inspectorContext = nil
             #if ANGLESITE_MAS
             scopedURL?.stopAccessingSecurityScopedResource()

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -247,7 +247,12 @@ struct SiteWindow: View {
         .animation(.easeInOut(duration: 0.18), value: backup.drawerPresented)
         .inspector(isPresented: Binding(
             get: { inspectorShown && inspectorContext != nil },
-            set: { inspectorShown = $0 }
+            set: { newValue in
+                // Only persist an explicit show/hide while there is something to inspect.
+                // When inspectorContext is nil the panel is auto-hidden; ignore that write so
+                // it doesn't clobber the remembered preference (the bug: inspector never returns).
+                if inspectorContext != nil { inspectorShown = newValue }
+            }
         )) {
             if let inspectorContext {
                 PageInspectorView(context: inspectorContext)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -667,6 +667,19 @@ struct SiteWindow: View {
         case .route(let route):
             Task {
                 guard await leaveCurrentEditor() else { return }   // abort if a conflict needs resolving
+                // Typed content (notes, articles, the business profile, …) is surfaced as a route
+                // in the navigator, but opens in its form editor rather than the preview. Plain
+                // pages (no content-type match) fall through to preview navigation.
+                if let source = site?.sourceDirectory,
+                   let typed = await typedEditorForContent(navigatorID: id, source: source) {
+                    if activeEditorFile?.id == typed.file.id {
+                        mainPaneMode = .editor(typed.file)   // re-show the open buffer intact
+                        return
+                    }
+                    activeEditor = .typed(typed)
+                    mainPaneMode = .editor(typed.file)
+                    return
+                }
                 mainPaneMode = .preview
                 if route.isEmpty || route == "/" {
                     preview.clearRoute()
@@ -709,6 +722,28 @@ struct SiteWindow: View {
         let r = root.standardizedFileURL.path(percentEncoded: false)
         guard u.hasPrefix(r) else { return url.lastPathComponent }
         return String(u.dropFirst(r.count)).drop(while: { $0 == "/" }).description
+    }
+
+    /// If a navigator id is a content page/post whose file resolves to a registered content type,
+    /// build its typed form editor. Returns `nil` for plain pages (which fall back to preview).
+    private func typedEditorForContent(navigatorID id: String, source: URL) async -> TypedEntryEditorModel? {
+        let relPath: String
+        let group: FileGroup
+        let displayName: String
+        if let page = await contentGraph.page(id: id) {
+            relPath = page.filePath
+            group = .pages
+            displayName = page.title ?? page.route
+        } else if let post = await contentGraph.post(id: id) {
+            relPath = post.filePath
+            group = .posts
+            displayName = post.title
+        } else {
+            return nil
+        }
+        guard let descriptor = ContentTypeResolver.descriptor(forRelativePath: relPath) else { return nil }
+        let file = FileRef(url: source.appendingPathComponent(relPath), group: group, name: displayName)
+        return TypedEntryEditorModel(file: file, descriptor: descriptor, sourceDirectory: source)
     }
 
     private var healthAssistantPrompt: String {

--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -21,6 +21,7 @@ final class TypedEntryEditorModel {
     private var savedValues: TypedContentEditor.Values = .init()
     private var contents: String = ""               // last-loaded/saved file text (verbatim base)
     private var lastModified: Date?
+    private var numberDrafts: [String: String] = [:]
     private(set) var loadError: String?
     private(set) var isLoading = false
     var conflictDiskContents: String?
@@ -46,6 +47,7 @@ final class TypedEntryEditorModel {
             adopt(loaded.contents)
             lastModified = loaded.modificationDate
             loadError = nil
+            warnIfNoModificationDate(after: "load")
         } catch {
             loadError = error.localizedDescription
         }
@@ -66,6 +68,7 @@ final class TypedEntryEditorModel {
             lastModified = mtime
             contents = newContents
             savedValues = edited
+            warnIfNoModificationDate(after: "save")
             await commit()
             return true
         } catch {
@@ -128,9 +131,18 @@ final class TypedEntryEditorModel {
                 set: { self.values[name] = .date($0) })
     }
     func numberBinding(_ name: String) -> Binding<String> {
-        Binding(get: { if case .number(let n?)? = self.values[name] {
-                           return n.rounded() == n ? String(Int(n)) : String(n) }; return "" },
-                set: { self.values[name] = .number(Double($0)) })
+        Binding(
+            get: {
+                if let draft = self.numberDrafts[name] { return draft }
+                if case .number(let n?)? = self.values[name] { return Self.displayNumber(n) }
+                return ""
+            },
+            set: { raw in
+                self.numberDrafts[name] = raw
+                let trimmed = raw.trimmingCharacters(in: .whitespaces)
+                self.values[name] = .number(trimmed.isEmpty ? nil : Double(trimmed))
+            }
+        )
     }
     func listBinding(_ name: String) -> Binding<[String]> {
         Binding(get: { if case .list(let a)? = self.values[name] { return a }; return [] },
@@ -144,6 +156,28 @@ final class TypedEntryEditorModel {
         let read = TypedContentEditor.read(text, descriptor: descriptor)
         values = read
         savedValues = read
+        numberDrafts.removeAll()
+    }
+
+    /// Formats a number for the editor field: integral values render without a decimal point,
+    /// guarding the `Int(_:)` overflow trap for out-of-range magnitudes.
+    private static func displayNumber(_ n: Double) -> String {
+        if n == n.rounded(), abs(n) < 1e15 { return String(Int(n)) }
+        return String(n)
+    }
+
+    /// Surface (in the debug pane) when a file has no modification date after a successful load/save:
+    /// `FileDocumentIO.externalChange` keys on mtime, so a `nil` here silently disables external-change
+    /// detection for this file. "Logs are sacred" — make it visible rather than failing quietly.
+    private func warnIfNoModificationDate(after op: String) {
+        guard lastModified == nil else { return }
+        let path = file.url.path(percentEncoded: false)
+        Task {
+            await LogCenter.shared.append(
+                source: "editor", stream: .stderr,
+                text: "No modification date for \(path) after \(op); external-change detection is disabled for this file."
+            )
+        }
     }
 
     private func commit() async {

--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -93,13 +93,14 @@ final class TypedEntryEditorModel {
         let change = try? await Task.detached(priority: .userInitiated) {
             try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
         }.value
+        guard let change else { return }
         switch change {
+        case .none:
+            break
         case .reloadable(let disk):
             adopt(disk); lastModified = await freshModificationDate()
         case .conflict(let disk):
             conflictDiskContents = disk
-        case .none, nil:
-            break
         }
     }
 

--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -22,6 +22,9 @@ final class TypedEntryEditorModel: InspectorEditorModel {
     private var contents: String = ""               // last-loaded/saved file text (verbatim base)
     private var lastModified: Date?
     private var numberDrafts: [String: String] = [:]
+    /// Guards against a concurrent second `save()` capturing a stale `contents` base while an
+    /// earlier save is still in flight (e.g. ⌘S mash, or a teardown flush racing a save).
+    private var isSaving = false
     private(set) var loadError: String?
     private(set) var isLoading = false
     var conflictDiskContents: String?
@@ -55,7 +58,9 @@ final class TypedEntryEditorModel: InspectorEditorModel {
 
     @discardableResult
     func save() async -> Bool {
-        guard isDirty else { return true }
+        guard isDirty, !isSaving else { return true }
+        isSaving = true
+        defer { isSaving = false }
         let descriptor = self.descriptor
         let base = contents
         let edited = values
@@ -118,35 +123,46 @@ final class TypedEntryEditorModel: InspectorEditorModel {
 
     // MARK: Bindings used by the view
 
+    // Binding closures capture `self` weakly: SwiftUI holds a binding for the view's lifetime, and
+    // the model is replaced per selection — `[weak self]` avoids keeping a stale model alive and
+    // keeps the closures safe under Swift 6's non-isolated-closure checking.
     func textBinding(_ name: String) -> Binding<String> {
-        Binding(get: { if case .text(let s)? = self.values[name] { return s }; return "" },
-                set: { self.values[name] = .text($0) })
+        Binding(get: { [weak self] in if case .text(let s)? = self?.values[name] { return s }; return "" },
+                set: { [weak self] in self?.values[name] = .text($0) })
     }
     func boolBinding(_ name: String) -> Binding<Bool> {
-        Binding(get: { if case .flag(let b)? = self.values[name] { return b }; return false },
-                set: { self.values[name] = .flag($0) })
+        Binding(get: { [weak self] in if case .flag(let b)? = self?.values[name] { return b }; return false },
+                set: { [weak self] in self?.values[name] = .flag($0) })
     }
     func dateBinding(_ name: String) -> Binding<Date> {
-        Binding(get: { if case .date(let d?)? = self.values[name] { return d }; return Date(timeIntervalSince1970: 0) },
-                set: { self.values[name] = .date($0) })
+        Binding(get: { [weak self] in if case .date(let d?)? = self?.values[name] { return d }; return Date(timeIntervalSince1970: 0) },
+                set: { [weak self] in self?.values[name] = .date($0) })
     }
     func numberBinding(_ name: String) -> Binding<String> {
         Binding(
-            get: {
+            get: { [weak self] in
+                guard let self else { return "" }
                 if let draft = self.numberDrafts[name] { return draft }
                 if case .number(let n?)? = self.values[name] { return Self.displayNumber(n) }
                 return ""
             },
-            set: { raw in
+            set: { [weak self] raw in
+                guard let self else { return }
                 self.numberDrafts[name] = raw
                 let trimmed = raw.trimmingCharacters(in: .whitespaces)
-                self.values[name] = .number(trimmed.isEmpty ? nil : Double(trimmed))
+                // Only overwrite the stored value when the draft parses (or is cleared). A mid-edit
+                // unparseable draft like "3." must not clobber a previously valid number with nil.
+                if trimmed.isEmpty {
+                    self.values[name] = .number(nil)
+                } else if let parsed = Double(trimmed) {
+                    self.values[name] = .number(parsed)
+                }
             }
         )
     }
     func listBinding(_ name: String) -> Binding<[String]> {
-        Binding(get: { if case .list(let a)? = self.values[name] { return a }; return [] },
-                set: { self.values[name] = .list($0) })
+        Binding(get: { [weak self] in if case .list(let a)? = self?.values[name] { return a }; return [] },
+                set: { [weak self] in self?.values[name] = .list($0) })
     }
 
     // MARK: Private

--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -1,0 +1,165 @@
+// Sources/AnglesiteApp/TypedEntryEditorModel.swift
+import Foundation
+import SwiftUI
+import Observation
+import AnglesiteCore
+
+/// Editor state for one open *typed* content file. Parallels `FileEditorModel` but exposes the
+/// file as per-field `TypedContentEditor.Values` (bound by `TypedEntryEditorView`) and commits each
+/// save to git. The raw loaded `contents` is retained so writes go through
+/// `TypedContentEditor.write`, which preserves untouched keys, unknown keys, and the body verbatim.
+/// All disk IO runs off the main actor.
+@MainActor
+@Observable
+final class TypedEntryEditorModel {
+    let file: FileRef
+    let descriptor: ContentTypeDescriptor
+    private let sourceDirectory: URL
+    private let gitCommit: NativeContentOperations.GitCommit
+
+    var values: TypedContentEditor.Values = .init()
+    private var savedValues: TypedContentEditor.Values = .init()
+    private var contents: String = ""               // last-loaded/saved file text (verbatim base)
+    private var lastModified: Date?
+    private(set) var loadError: String?
+    private(set) var isLoading = false
+    var conflictDiskContents: String?
+
+    var isDirty: Bool { values != savedValues && loadError == nil && !isLoading }
+
+    init(file: FileRef,
+         descriptor: ContentTypeDescriptor,
+         sourceDirectory: URL,
+         gitCommit: @escaping NativeContentOperations.GitCommit = NativeContentOperations.processGitCommit) {
+        self.file = file
+        self.descriptor = descriptor
+        self.sourceDirectory = sourceDirectory
+        self.gitCommit = gitCommit
+    }
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        let url = file.url
+        do {
+            let loaded = try await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url) }.value
+            adopt(loaded.contents)
+            lastModified = loaded.modificationDate
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    @discardableResult
+    func save() async -> Bool {
+        guard isDirty else { return true }
+        let descriptor = self.descriptor
+        let base = contents
+        let edited = values
+        let newContents = TypedContentEditor.write(edited, into: base, descriptor: descriptor)
+        let url = file.url
+        do {
+            let mtime = try await Task.detached(priority: .userInitiated) {
+                try FileDocumentIO.save(newContents, to: url)
+            }.value
+            lastModified = mtime
+            contents = newContents
+            savedValues = edited
+            await commit()
+            return true
+        } catch {
+            loadError = "Save failed: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    func flushBeforeLeaving() async -> Bool {
+        guard isDirty else { return true }
+        let url = file.url
+        let known = lastModified
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: true)
+        }.value
+        if case .conflict(let disk)? = change { conflictDiskContents = disk; return false }
+        return await save()
+    }
+
+    func checkExternalChange() async {
+        guard loadError == nil else { return }
+        let url = file.url
+        let known = lastModified
+        let dirty = isDirty
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
+        }.value
+        switch change {
+        case .reloadable(let disk):
+            adopt(disk); lastModified = await freshModificationDate()
+        case .conflict(let disk):
+            conflictDiskContents = disk
+        case .none, nil:
+            break
+        }
+    }
+
+    func keepMyChanges() { conflictDiskContents = nil }
+
+    func reloadFromDisk() async {
+        guard let disk = conflictDiskContents else { return }
+        adopt(disk)
+        lastModified = await freshModificationDate()
+        conflictDiskContents = nil
+    }
+
+    // MARK: Bindings used by the view
+
+    func textBinding(_ name: String) -> Binding<String> {
+        Binding(get: { if case .text(let s)? = self.values[name] { return s }; return "" },
+                set: { self.values[name] = .text($0) })
+    }
+    func boolBinding(_ name: String) -> Binding<Bool> {
+        Binding(get: { if case .flag(let b)? = self.values[name] { return b }; return false },
+                set: { self.values[name] = .flag($0) })
+    }
+    func dateBinding(_ name: String) -> Binding<Date> {
+        Binding(get: { if case .date(let d?)? = self.values[name] { return d }; return Date(timeIntervalSince1970: 0) },
+                set: { self.values[name] = .date($0) })
+    }
+    func numberBinding(_ name: String) -> Binding<String> {
+        Binding(get: { if case .number(let n?)? = self.values[name] {
+                           return n.rounded() == n ? String(Int(n)) : String(n) }; return "" },
+                set: { self.values[name] = .number(Double($0)) })
+    }
+    func listBinding(_ name: String) -> Binding<[String]> {
+        Binding(get: { if case .list(let a)? = self.values[name] { return a }; return [] },
+                set: { self.values[name] = .list($0) })
+    }
+
+    // MARK: Private
+
+    private func adopt(_ text: String) {
+        contents = text
+        let read = TypedContentEditor.read(text, descriptor: descriptor)
+        values = read
+        savedValues = read
+    }
+
+    private func commit() async {
+        let rel = relativePath(of: file.url, under: sourceDirectory)
+        let slug = file.url.deletingPathExtension().lastPathComponent
+        _ = await gitCommit(sourceDirectory, rel, "anglesite: edit \(descriptor.id) \(slug)")
+    }
+
+    private func relativePath(of url: URL, under root: URL) -> String {
+        let u = url.standardizedFileURL.path(percentEncoded: false)
+        let r = root.standardizedFileURL.path(percentEncoded: false)
+        if u.hasPrefix(r) { return String(u.dropFirst(r.count)).drop(while: { $0 == "/" }).description }
+        return url.lastPathComponent
+    }
+
+    private func freshModificationDate() async -> Date? {
+        let url = file.url
+        return try? await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url).modificationDate }.value
+    }
+}

--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -11,7 +11,7 @@ import AnglesiteCore
 /// All disk IO runs off the main actor.
 @MainActor
 @Observable
-final class TypedEntryEditorModel {
+final class TypedEntryEditorModel: InspectorEditorModel {
     let file: FileRef
     let descriptor: ContentTypeDescriptor
     private let sourceDirectory: URL

--- a/Sources/AnglesiteApp/TypedEntryEditorView.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorView.swift
@@ -120,36 +120,62 @@ struct TypedEntryEditorView: View {
 }
 
 /// A minimal add/remove list editor for `stringArray` / `imageArray` fields (tags, hours, album
-/// images).
+/// images). Rows carry stable UUID identity so deleting a row never re-binds a surviving row's
+/// editor to the wrong item; `rows` mirrors the bound `items` two-way, re-syncing when `items` is
+/// replaced externally (e.g. reload-from-disk).
 private struct StringListEditor: View {
     let title: String
     @Binding var items: [String]
     var pickFile: Bool
 
+    private struct Row: Identifiable, Equatable {
+        let id = UUID()
+        var value: String
+    }
+    @State private var rows: [Row] = []
+
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(title).font(.caption).foregroundStyle(.secondary)
-            ForEach(items.indices, id: \.self) { i in
+            ForEach($rows) { $row in
                 HStack {
-                    TextField("", text: Binding(get: { items[i] }, set: { items[i] = $0 }))
-                    Button(role: .destructive) { items.remove(at: i) } label: { Image(systemName: "minus.circle") }
-                        .buttonStyle(.borderless)
+                    TextField("", text: $row.value)
+                    Button(role: .destructive) { rows.removeAll { $0.id == row.id } } label: {
+                        Image(systemName: "minus.circle")
+                    }
+                    .buttonStyle(.borderless)
                 }
             }
             HStack {
-                Button { items.append("") } label: { Label("Add", systemImage: "plus.circle") }
+                Button { rows.append(Row(value: "")) } label: { Label("Add", systemImage: "plus.circle") }
                     .buttonStyle(.borderless)
                 if pickFile {
                     Button("Choose…") { chooseFile() }
                 }
             }
         }
+        .onAppear { syncRowsFromItems() }
+        // External replacement of the bound array (e.g. reload-from-disk) rebuilds the rows;
+        // the value guard prevents a feedback loop with the rows→items write below.
+        .onChange(of: items) { _, new in
+            if new != rows.map(\.value) { rows = new.map(Row.init(value:)) }
+        }
+        // User edits/additions/deletions flow back to the bound array.
+        .onChange(of: rows) { _, new in
+            let mapped = new.map(\.value)
+            if mapped != items { items = mapped }
+        }
+    }
+
+    private func syncRowsFromItems() {
+        if items != rows.map(\.value) { rows = items.map(Row.init(value:)) }
     }
 
     private func chooseFile() {
         let panel = NSOpenPanel()
         panel.canChooseFiles = true
+        panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        if panel.runModal() == .OK, let url = panel.url { items.append(url.lastPathComponent) }
+        if panel.runModal() == .OK, let url = panel.url { rows.append(Row(value: url.lastPathComponent)) }
     }
 }

--- a/Sources/AnglesiteApp/TypedEntryEditorView.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorView.swift
@@ -75,7 +75,7 @@ struct TypedEntryEditorView: View {
         case .text:
             VStack(alignment: .leading) {
                 Text(label).font(.caption).foregroundStyle(.secondary)
-                TextField(label, text: model.textBinding(field.name), axis: .vertical).lineLimit(2...6)
+                TextField("", text: model.textBinding(field.name), axis: .vertical).lineLimit(2...6)
             }
         case .bool:
             Toggle(label, isOn: model.boolBinding(field.name))

--- a/Sources/AnglesiteApp/TypedEntryEditorView.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorView.swift
@@ -2,47 +2,13 @@
 import SwiftUI
 import AnglesiteCore
 
-/// Generic, schema-driven form editor for a typed content file. One control per field `Kind`,
-/// ordered by the descriptor. State lives in `TypedEntryEditorModel` (owned by `SiteWindow`) so
-/// navigating away auto-saves and the buffer survives the Preview/Editor toggle.
-struct TypedEntryEditorView: View {
+/// The schema-driven `Form` body for a typed content entry — one control per field `Kind`, ordered
+/// by the descriptor. Hosted inside `PageInspectorView`, which supplies the load/save/conflict
+/// chrome. (Previously a full-pane editor; the chrome moved to the inspector.)
+struct TypedEntryForm: View {
     @Bindable var model: TypedEntryEditorModel
-    @Environment(\.controlActiveState) private var controlActiveState
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-            Divider()
-            Group {
-                if let loadError = model.loadError {
-                    ContentUnavailableView {
-                        Label("Can't open \(model.file.name)", systemImage: "exclamationmark.triangle")
-                    } description: { Text(loadError) } actions: {
-                        Button("Reveal in Finder") { NSWorkspace.shared.activateFileViewerSelecting([model.file.url]) }
-                    }
-                } else if model.isLoading {
-                    ProgressView().controlSize(.small)
-                } else {
-                    form
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-        .task(id: model.file.id) { await model.load() }
-        .onChange(of: controlActiveState) { _, new in
-            if new == .key { Task { await model.checkExternalChange() } }
-        }
-        .background(Button("") { Task { await model.save() } }
-            .keyboardShortcut("s", modifiers: [.command]).hidden())
-        .alert("\(model.file.name) changed on disk", isPresented: conflictBinding) {
-            Button("Keep My Changes", role: .cancel) { model.keepMyChanges() }
-            Button("Reload from Disk") { Task { await model.reloadFromDisk() } }
-        } message: {
-            Text("Another tool edited this file while you had unsaved changes.")
-        }
-    }
-
-    private var form: some View {
         Form {
             ForEach(scalarFields, id: \.name) { field in
                 control(for: field)
@@ -101,22 +67,6 @@ struct TypedEntryEditorView: View {
             model.textBinding(name).wrappedValue = url.lastPathComponent
         }
     }
-
-    private var header: some View {
-        HStack {
-            Label(model.file.name, systemImage: "doc.text").font(.headline)
-            if model.isDirty {
-                Circle().fill(.secondary).frame(width: 7, height: 7).help("Unsaved changes")
-            }
-            Spacer()
-            Button("Save") { Task { await model.save() } }.disabled(!model.isDirty)
-        }
-        .padding(.horizontal, 12).padding(.vertical, 8)
-    }
-
-    private var conflictBinding: Binding<Bool> {
-        Binding(get: { model.conflictDiskContents != nil }, set: { _ in })
-    }
 }
 
 /// A minimal add/remove list editor for `stringArray` / `imageArray` fields (tags, hours, album
@@ -155,12 +105,9 @@ private struct StringListEditor: View {
             }
         }
         .onAppear { syncRowsFromItems() }
-        // External replacement of the bound array (e.g. reload-from-disk) rebuilds the rows;
-        // the value guard prevents a feedback loop with the rows→items write below.
         .onChange(of: items) { _, new in
             if new != rows.map(\.value) { rows = new.map(Row.init(value:)) }
         }
-        // User edits/additions/deletions flow back to the bound array.
         .onChange(of: rows) { _, new in
             let mapped = new.map(\.value)
             if mapped != items { items = mapped }

--- a/Sources/AnglesiteApp/TypedEntryEditorView.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorView.swift
@@ -1,0 +1,155 @@
+// Sources/AnglesiteApp/TypedEntryEditorView.swift
+import SwiftUI
+import AnglesiteCore
+
+/// Generic, schema-driven form editor for a typed content file. One control per field `Kind`,
+/// ordered by the descriptor. State lives in `TypedEntryEditorModel` (owned by `SiteWindow`) so
+/// navigating away auto-saves and the buffer survives the Preview/Editor toggle.
+struct TypedEntryEditorView: View {
+    @Bindable var model: TypedEntryEditorModel
+    @Environment(\.controlActiveState) private var controlActiveState
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            Group {
+                if let loadError = model.loadError {
+                    ContentUnavailableView {
+                        Label("Can't open \(model.file.name)", systemImage: "exclamationmark.triangle")
+                    } description: { Text(loadError) } actions: {
+                        Button("Reveal in Finder") { NSWorkspace.shared.activateFileViewerSelecting([model.file.url]) }
+                    }
+                } else if model.isLoading {
+                    ProgressView().controlSize(.small)
+                } else {
+                    form
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .task(id: model.file.id) { await model.load() }
+        .onChange(of: controlActiveState) { _, new in
+            if new == .key { Task { await model.checkExternalChange() } }
+        }
+        .background(Button("") { Task { await model.save() } }
+            .keyboardShortcut("s", modifiers: [.command]).hidden())
+        .alert("\(model.file.name) changed on disk", isPresented: conflictBinding) {
+            Button("Keep My Changes", role: .cancel) { model.keepMyChanges() }
+            Button("Reload from Disk") { Task { await model.reloadFromDisk() } }
+        } message: {
+            Text("Another tool edited this file while you had unsaved changes.")
+        }
+    }
+
+    private var form: some View {
+        Form {
+            ForEach(scalarFields, id: \.name) { field in
+                control(for: field)
+            }
+            if let body = bodyField {
+                Section("Body") {
+                    TextEditor(text: model.textBinding(body.name))
+                        .font(.system(.body, design: .monospaced))
+                        .frame(minHeight: 160)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private var scalarFields: [ContentTypeField] { model.descriptor.fields.filter { $0.kind != .markdown } }
+    private var bodyField: ContentTypeField? { model.descriptor.fields.first { $0.kind == .markdown } }
+
+    @ViewBuilder
+    private func control(for field: ContentTypeField) -> some View {
+        let label = field.name + (field.required ? " *" : "")
+        switch field.kind {
+        case .string, .url, .image:
+            HStack {
+                TextField(label, text: model.textBinding(field.name))
+                if field.kind == .image {
+                    Button("Choose…") { chooseFile(for: field.name) }
+                }
+            }
+        case .text:
+            VStack(alignment: .leading) {
+                Text(label).font(.caption).foregroundStyle(.secondary)
+                TextField(label, text: model.textBinding(field.name), axis: .vertical).lineLimit(2...6)
+            }
+        case .bool:
+            Toggle(label, isOn: model.boolBinding(field.name))
+        case .date, .datetime:
+            DatePicker(label, selection: model.dateBinding(field.name),
+                       displayedComponents: field.kind == .date ? [.date] : [.date, .hourAndMinute])
+        case .number:
+            TextField(label, text: model.numberBinding(field.name))
+        case .stringArray, .imageArray:
+            StringListEditor(title: label, items: model.listBinding(field.name),
+                             pickFile: field.kind == .imageArray)
+        case .markdown:
+            EmptyView()   // handled by the Body section
+        }
+    }
+
+    private func chooseFile(for name: String) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            model.textBinding(name).wrappedValue = url.lastPathComponent
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Label(model.file.name, systemImage: "doc.text").font(.headline)
+            if model.isDirty {
+                Circle().fill(.secondary).frame(width: 7, height: 7).help("Unsaved changes")
+            }
+            Spacer()
+            Button("Save") { Task { await model.save() } }.disabled(!model.isDirty)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
+    private var conflictBinding: Binding<Bool> {
+        Binding(get: { model.conflictDiskContents != nil }, set: { _ in })
+    }
+}
+
+/// A minimal add/remove list editor for `stringArray` / `imageArray` fields (tags, hours, album
+/// images).
+private struct StringListEditor: View {
+    let title: String
+    @Binding var items: [String]
+    var pickFile: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            ForEach(items.indices, id: \.self) { i in
+                HStack {
+                    TextField("", text: Binding(get: { items[i] }, set: { items[i] = $0 }))
+                    Button(role: .destructive) { items.remove(at: i) } label: { Image(systemName: "minus.circle") }
+                        .buttonStyle(.borderless)
+                }
+            }
+            HStack {
+                Button { items.append("") } label: { Label("Add", systemImage: "plus.circle") }
+                    .buttonStyle(.borderless)
+                if pickFile {
+                    Button("Choose…") { chooseFile() }
+                }
+            }
+        }
+    }
+
+    private func chooseFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url { items.append(url.lastPathComponent) }
+    }
+}

--- a/Sources/AnglesiteCore/ContentTypeResolver.swift
+++ b/Sources/AnglesiteCore/ContentTypeResolver.swift
@@ -4,9 +4,13 @@ import Foundation
 /// the form editor. Collection entries are matched by their `src/content/<collection>/` directory;
 /// page-stored singletons by a fixed path map. Pure, no I/O.
 public enum ContentTypeResolver {
-    /// Canonical singleton page paths for `.page`-stored types. `businessProfile` is shipped in the
-    /// template at `src/pages/about.md` (this PR; the editor-relevant slice of #388).
-    static let pagePaths: [String: String] = ["businessProfile": "src/pages/about.md"]
+    /// Canonical singleton paths for `.page`-stored types → their type id. Keyed by path (the lookup
+    /// direction) and lowercased for case-insensitive matching on case-insensitive APFS volumes.
+    /// `businessProfile` ships in the template at `src/pages/about.md` (the editor-relevant slice of
+    /// #388). NOTE: this resolves the singleton by *path*, so renaming `about.md` drops typed-editor
+    /// access — acceptable for a fixed singleton; revisit with a `type:` frontmatter marker if pages
+    /// become user-renamable.
+    static let pageTypesByPath: [String: String] = ["src/pages/about.md": "businessProfile"]
 
     public static func descriptor(
         forRelativePath path: String,
@@ -21,10 +25,8 @@ public enum ContentTypeResolver {
             if let match = registry.all.first(where: { $0.collection == collection }) { return match }
         }
 
-        // 2. Page singleton by exact path.
-        for (id, pagePath) in pagePaths where normalized == pagePath {
-            return registry.descriptor(id: id)
-        }
+        // 2. Page singleton by exact (case-insensitive) path.
+        if let id = pageTypesByPath[normalized] { return registry.descriptor(id: id) }
         return nil
     }
 
@@ -32,6 +34,8 @@ public enum ContentTypeResolver {
         var p = path.replacingOccurrences(of: "\\", with: "/")
         while p.hasPrefix("./") { p.removeFirst(2) }
         while p.hasPrefix("/") { p.removeFirst() }
-        return p
+        // Lowercase so a case-insensitive APFS volume returning `src/pages/About.md` still resolves.
+        // Collection names and the singleton paths are all lowercase by convention.
+        return p.lowercased()
     }
 }

--- a/Sources/AnglesiteCore/ContentTypeResolver.swift
+++ b/Sources/AnglesiteCore/ContentTypeResolver.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Resolves a project-relative file path to its content type, so the app can open typed files in
+/// the form editor. Collection entries are matched by their `src/content/<collection>/` directory;
+/// page-stored singletons by a fixed path map. Pure, no I/O.
+public enum ContentTypeResolver {
+    /// Canonical singleton page paths for `.page`-stored types. `businessProfile` is shipped in the
+    /// template at `src/pages/about.md` (this PR; the editor-relevant slice of #388).
+    static let pagePaths: [String: String] = ["businessProfile": "src/pages/about.md"]
+
+    public static func descriptor(
+        forRelativePath path: String,
+        registry: ContentTypeRegistry = ContentTypeRegistry()
+    ) -> ContentTypeDescriptor? {
+        let normalized = normalize(path)
+
+        // 1. Collection entry by directory.
+        let parts = normalized.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        if parts.count >= 4, parts[0] == "src", parts[1] == "content" {
+            let collection = parts[2]
+            if let match = registry.all.first(where: { $0.collection == collection }) { return match }
+        }
+
+        // 2. Page singleton by exact path.
+        for (id, pagePath) in pagePaths where normalized == pagePath {
+            return registry.descriptor(id: id)
+        }
+        return nil
+    }
+
+    private static func normalize(_ path: String) -> String {
+        var p = path.replacingOccurrences(of: "\\", with: "/")
+        while p.hasPrefix("./") { p.removeFirst(2) }
+        while p.hasPrefix("/") { p.removeFirst() }
+        return p
+    }
+}

--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -3,10 +3,16 @@ import Foundation
 /// A parsed frontmatter scalar/array value. Mirrors the `string | boolean | string[]` union the
 /// Node `parseFrontmatter` returns — the distinction matters to the scanner (`draft === true`
 /// wants a real boolean; `Array.isArray(tags)` wants a real array).
+///
+/// `.number` is a write-only case: `Frontmatter.parse` never produces it (a numeric scalar parses
+/// as `.string`), but the editor uses it via `FrontmatterDocument.set` so a `number`-kind field
+/// serializes **unquoted** (`rating: 4`, not `rating: "4"`). Quoting a number would make YAML read
+/// it as a string and fail a content collection's `z.number()` schema.
 public enum FrontmatterValue: Equatable, Sendable {
     case string(String)
     case bool(Bool)
     case array([String])
+    case number(Double)
 }
 
 /// Native port of `server/content-frontmatter.mjs` (Bucket 1, #275).

--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -78,7 +78,7 @@ public enum Frontmatter {
 
     /// Split `key: value` where key is `[A-Za-z0-9_-]+`. Value is right-trimmed of surrounding
     /// whitespace (`\s*(.*)` in the Node regex, then `.trim()`).
-    private static func splitKeyValue(_ line: String) -> (key: String, value: String)? {
+    static func splitKeyValue(_ line: String) -> (key: String, value: String)? {
         guard let colon = line.firstIndex(of: ":") else { return nil }
         let key = String(line[line.startIndex..<colon])
         guard !key.isEmpty, key.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" || $0 == "-" }) else {
@@ -89,7 +89,7 @@ public enum Frontmatter {
     }
 
     /// If `line` is a block-array item (`^\s*-\s+item`), return its trimmed item text.
-    private static func blockArrayItem(_ line: String) -> String? {
+    static func blockArrayItem(_ line: String) -> String? {
         let stripped = String(line.drop(while: { $0 == " " || $0 == "\t" }))
         guard stripped.hasPrefix("-") else { return nil }
         let afterDash = stripped.dropFirst()
@@ -98,7 +98,8 @@ public enum Frontmatter {
         return String(afterDash).trimmingCharacters(in: .whitespaces)
     }
 
-    private static func parseScalarOrArray(_ raw: String) -> FrontmatterValue {
+    /// Also consumed by `FrontmatterDocument` for consistent scalar/array parsing semantics.
+    static func parseScalarOrArray(_ raw: String) -> FrontmatterValue {
         if raw == "true" { return .bool(true) }
         if raw == "false" { return .bool(false) }
         if raw.hasPrefix("["), raw.hasSuffix("]") {
@@ -119,7 +120,7 @@ public enum Frontmatter {
     ///   `\t`→tab; unknown sequences keep both the backslash and the following character.
     /// - Single-quoted scalars: `''`→`'` (YAML single-quote doubling). No backslash processing.
     /// - Unquoted scalars: returned unchanged.
-    private static func unquote(_ s: String) -> String {
+    static func unquote(_ s: String) -> String {
         guard s.count >= 2 else { return s }
         if s.hasPrefix("\"") && s.hasSuffix("\"") {
             return decodeDoubleQuoted(String(s.dropFirst().dropLast()))
@@ -134,7 +135,7 @@ public enum Frontmatter {
     /// Single-pass YAML double-quoted escape decoder. Processes each character once so that
     /// `\\n` (two source chars) decodes to `\` + `n` (not newline), guarding the chained-replace
     /// pitfall.
-    private static func decodeDoubleQuoted(_ inner: String) -> String {
+    static func decodeDoubleQuoted(_ inner: String) -> String {
         var result = ""
         result.reserveCapacity(inner.unicodeScalars.count)
         var idx = inner.startIndex

--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -148,6 +148,7 @@ public enum Frontmatter {
                     case "\"": result.append("\"")
                     case "\\": result.append("\\")
                     case "n":  result.append("\n")
+                    case "r":  result.append("\r")
                     case "t":  result.append("\t")
                     default:
                         // Unknown escape: keep backslash + char unchanged.

--- a/Sources/AnglesiteCore/FrontmatterDocument.swift
+++ b/Sources/AnglesiteCore/FrontmatterDocument.swift
@@ -1,0 +1,152 @@
+// Sources/AnglesiteCore/FrontmatterDocument.swift
+import Foundation
+
+/// A read/write model of a content file's YAML frontmatter + body.
+///
+/// Unlike `Frontmatter.parse` (read-only, drops unknown keys, no serialization), this preserves
+/// **every** source segment — known keys, unknown keys, comments, and blank lines — in order, each
+/// with its verbatim source text. A key is re-rendered only when it is `set`. Consequences the
+/// editor relies on:
+///
+/// - An unedited `parse(...).serialized()` is the identity (modulo uniform line-ending
+///   normalization for mixed endings).
+/// - Editing one field never disturbs untouched keys or the body.
+/// - Form-only editing can never silently drop a hand-authored key or body content.
+///
+/// Scalar/array parsing reuses `Frontmatter`'s internal helpers, and values are the existing
+/// `FrontmatterValue`. Pure value type, no I/O.
+public struct FrontmatterDocument: Equatable, Sendable {
+    /// One ordered segment of the frontmatter block. A `key` segment is editable; a raw segment
+    /// (comment / blank / stray line) is opaque and always serialized verbatim.
+    private struct Segment: Equatable {
+        var key: String?               // nil ⟹ raw passthrough segment
+        var value: FrontmatterValue?   // logical value for key segments
+        var verbatim: [String]?        // original source lines; nil once a key segment is mutated
+    }
+
+    private var segments: [Segment]
+    /// Index into `segments` by key, for O(1) get/set. Only key segments are listed.
+    private var indexByKey: [String: Int]
+    /// Text after the closing `---` fence, verbatim (internally newline = "\n").
+    public var body: String
+    private let newline: String
+    private let hadFrontmatter: Bool
+
+    public var keys: [String] { segments.compactMap(\.key) }
+
+    public func value(for key: String) -> FrontmatterValue? {
+        guard let i = indexByKey[key] else { return nil }
+        return segments[i].value
+    }
+
+    public mutating func set(_ value: FrontmatterValue, for key: String) {
+        if let i = indexByKey[key] {
+            segments[i].value = value
+            segments[i].verbatim = nil   // force re-render
+        } else {
+            indexByKey[key] = segments.count
+            segments.append(Segment(key: key, value: value, verbatim: nil))
+        }
+    }
+
+    public func serialized() -> String {
+        guard hadFrontmatter else { return body.replacingOccurrences(of: "\n", with: newline) }
+        var lines: [String] = ["---"]
+        for seg in segments {
+            if let verbatim = seg.verbatim {
+                lines.append(contentsOf: verbatim)
+            } else if let key = seg.key, let value = seg.value {
+                lines.append(Self.render(key: key, value: value))
+            }
+        }
+        lines.append("---")
+        var out = lines.joined(separator: "\n")
+        if !body.isEmpty || hadFrontmatter { out += "\n" + body }
+        return out.replacingOccurrences(of: "\n", with: newline)
+    }
+
+    // MARK: Parse
+
+    public static func parse(_ source: String) -> FrontmatterDocument {
+        let newline = source.contains("\r\n") ? "\r\n" : "\n"
+        let normalized = source.replacingOccurrences(of: "\r\n", with: "\n")
+
+        guard normalized.hasPrefix("---\n") else {
+            return FrontmatterDocument(segments: [], indexByKey: [:], body: normalized,
+                                       newline: newline, hadFrontmatter: false)
+        }
+        let all = normalized.components(separatedBy: "\n")
+        // all[0] == "---"; find the closing fence.
+        var close = -1
+        var i = 1
+        while i < all.count { if all[i] == "---" { close = i; break }; i += 1 }
+        guard close >= 0 else {
+            return FrontmatterDocument(segments: [], indexByKey: [:], body: normalized,
+                                       newline: newline, hadFrontmatter: false)
+        }
+        let block = Array(all[1..<close])
+        // body = everything after the closing fence, rejoined (the leading separator after `---`
+        // is represented by the first element being "").
+        let body = Array(all[(close + 1)...]).joined(separator: "\n")
+
+        var segments: [Segment] = []
+        var indexByKey: [String: Int] = [:]
+        var j = 0
+        while j < block.count {
+            let line = block[j]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            // Comment / blank / stray-indent → raw passthrough.
+            let indented = (line.first == " " || line.first == "\t")
+            if trimmed.isEmpty || trimmed.hasPrefix("#") || indented {
+                segments.append(Segment(key: nil, value: nil, verbatim: [line]))
+                j += 1
+                continue
+            }
+            guard let (key, rawValue) = Frontmatter.splitKeyValue(line) else {
+                segments.append(Segment(key: nil, value: nil, verbatim: [line]))
+                j += 1
+                continue
+            }
+
+            var verbatim = [line]
+            let value: FrontmatterValue
+            if rawValue.isEmpty {
+                // Possible block array on following `- item` lines.
+                var items: [String] = []
+                var k = j + 1
+                while k < block.count, let item = Frontmatter.blockArrayItem(block[k]) {
+                    items.append(Frontmatter.unquote(item))
+                    verbatim.append(block[k])
+                    k += 1
+                }
+                value = items.isEmpty ? .string("") : .array(items)
+                j = k
+            } else {
+                value = Frontmatter.parseScalarOrArray(rawValue)
+                j += 1
+            }
+            indexByKey[key] = segments.count
+            segments.append(Segment(key: key, value: value, verbatim: verbatim))
+        }
+        return FrontmatterDocument(segments: segments, indexByKey: indexByKey, body: body,
+                                   newline: newline, hadFrontmatter: true)
+    }
+
+    // MARK: Render (mirrors ContentScaffold: double-quoted scalars, `[]` empty arrays, block lists)
+
+    private static func render(key: String, value: FrontmatterValue) -> String {
+        switch value {
+        case .string(let s):
+            return "\(key): \"\(escape(s))\""
+        case .bool(let b):
+            return "\(key): \(b)"
+        case .array(let items):
+            if items.isEmpty { return "\(key): []" }
+            return ([ "\(key):" ] + items.map { "  - \"\(escape($0))\"" }).joined(separator: "\n")
+        }
+    }
+
+    private static func escape(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/Sources/AnglesiteCore/FrontmatterDocument.swift
+++ b/Sources/AnglesiteCore/FrontmatterDocument.swift
@@ -156,6 +156,12 @@ public struct FrontmatterDocument: Equatable, Sendable {
             // but we intentionally normalize here (matching ContentScaffold) — an edited bool loses
             // a non-canonical original spelling. Verbatim is still preserved for *unedited* bools.
             return "\(key): \(b)"
+        case .number(let n):
+            // Numbers serialize unquoted so YAML reads them as numbers (a quoted "4" fails a
+            // collection's z.number() schema). Integral values drop the decimal point; the
+            // magnitude guard avoids the Int(_:) overflow trap.
+            let formatted = (n == n.rounded() && abs(n) < 1e15) ? String(Int(n)) : String(n)
+            return "\(key): \(formatted)"
         case .array(let items):
             if items.isEmpty { return "\(key): []" }
             return ([ "\(key):" ] + items.map { "  - \"\(escape($0))\"" }).joined(separator: "\n")

--- a/Sources/AnglesiteCore/FrontmatterDocument.swift
+++ b/Sources/AnglesiteCore/FrontmatterDocument.swift
@@ -26,11 +26,21 @@ public struct FrontmatterDocument: Equatable, Sendable {
 
     private var segments: [Segment]
     /// Index into `segments` by key, for O(1) get/set. Only key segments are listed.
+    ///
+    /// Known limitation: if a malformed source has the **same key twice**, `indexByKey` points at
+    /// the last occurrence (so get/set address it), but both segments remain in `segments`. An
+    /// unedited round-trip still reproduces the duplicate verbatim (identity holds); editing that
+    /// key re-renders only the last segment, leaving the first with its old value. Duplicate
+    /// top-level keys are already invalid YAML, so this is accepted rather than de-duplicated.
     private var indexByKey: [String: Int]
     /// Text after the closing `---` fence, verbatim (internally newline = "\n").
     public var body: String
     private let newline: String
     private let hadFrontmatter: Bool
+    /// Whether the source had anything (a body, or just a terminal newline) after the closing
+    /// `---` fence. Distinguishes `"---\n…\n---"` (no trailing newline) from `"---\n…\n---\n"`, so
+    /// `serialized()` doesn't inject a newline the source never had.
+    private let hasBodySection: Bool
 
     public var keys: [String] { segments.compactMap(\.key) }
 
@@ -61,7 +71,7 @@ public struct FrontmatterDocument: Equatable, Sendable {
         }
         lines.append("---")
         var out = lines.joined(separator: "\n")
-        if !body.isEmpty || hadFrontmatter { out += "\n" + body }
+        if hasBodySection { out += "\n" + body }
         return out.replacingOccurrences(of: "\n", with: newline)
     }
 
@@ -73,7 +83,7 @@ public struct FrontmatterDocument: Equatable, Sendable {
 
         guard normalized.hasPrefix("---\n") else {
             return FrontmatterDocument(segments: [], indexByKey: [:], body: normalized,
-                                       newline: newline, hadFrontmatter: false)
+                                       newline: newline, hadFrontmatter: false, hasBodySection: false)
         }
         let all = normalized.components(separatedBy: "\n")
         // all[0] == "---"; find the closing fence.
@@ -82,8 +92,11 @@ public struct FrontmatterDocument: Equatable, Sendable {
         while i < all.count { if all[i] == "---" { close = i; break }; i += 1 }
         guard close >= 0 else {
             return FrontmatterDocument(segments: [], indexByKey: [:], body: normalized,
-                                       newline: newline, hadFrontmatter: false)
+                                       newline: newline, hadFrontmatter: false, hasBodySection: false)
         }
+        // Anything after the closing fence (even just a terminal newline → one trailing "") means
+        // the source had a body section to reproduce.
+        let hasBodySection = (close + 1) < all.count
         let block = Array(all[1..<close])
         // body = everything after the closing fence, rejoined (the leading separator after `---`
         // is represented by the first element being "").
@@ -129,7 +142,7 @@ public struct FrontmatterDocument: Equatable, Sendable {
             segments.append(Segment(key: key, value: value, verbatim: verbatim))
         }
         return FrontmatterDocument(segments: segments, indexByKey: indexByKey, body: body,
-                                   newline: newline, hadFrontmatter: true)
+                                   newline: newline, hadFrontmatter: true, hasBodySection: hasBodySection)
     }
 
     // MARK: Render (mirrors ContentScaffold: double-quoted scalars, `[]` empty arrays, block lists)
@@ -139,6 +152,9 @@ public struct FrontmatterDocument: Equatable, Sendable {
         case .string(let s):
             return "\(key): \"\(escape(s))\""
         case .bool(let b):
+            // Bool fields canonicalize to true/false on write. YAML also accepts yes/no/on/off/1/0,
+            // but we intentionally normalize here (matching ContentScaffold) — an edited bool loses
+            // a non-canonical original spelling. Verbatim is still preserved for *unedited* bools.
             return "\(key): \(b)"
         case .array(let items):
             if items.isEmpty { return "\(key): []" }
@@ -146,7 +162,14 @@ public struct FrontmatterDocument: Equatable, Sendable {
         }
     }
 
+    /// Escapes a scalar for a double-quoted YAML value. Order matters: backslash first, then the
+    /// quote, then control characters — a literal newline in a `text`-kind field (e.g. a pasted
+    /// multi-line description) must become `\n`, or it would break `---` fence detection on
+    /// re-parse. `Frontmatter.unquote`'s decoder reverses each of these.
     private static func escape(_ s: String) -> String {
-        s.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+         .replacingOccurrences(of: "\"", with: "\\\"")
+         .replacingOccurrences(of: "\n", with: "\\n")
+         .replacingOccurrences(of: "\r", with: "\\r")
     }
 }

--- a/Sources/AnglesiteCore/PageMetadataEditor.swift
+++ b/Sources/AnglesiteCore/PageMetadataEditor.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// A page's editable metadata. Phase 1 covers title + description; the rendered `<title>` is
+/// composed from a site-level tokenized template (main site settings, out of scope here) with this
+/// per-page `title` substituted.
+public struct PageMetadata: Equatable, Sendable {
+    public var title: String
+    public var description: String
+    public init(title: String, description: String) {
+        self.title = title
+        self.description = description
+    }
+}
+
+/// Reads/writes `title` + `description` frontmatter for plain (non-typed) frontmatter pages.
+/// Goes through `FrontmatterDocument`, so unknown keys and the body survive verbatim and only a
+/// changed key is re-rendered. Pure, no I/O.
+public enum PageMetadataEditor {
+    public static func read(_ contents: String) -> PageMetadata {
+        let doc = FrontmatterDocument.parse(contents)
+        return PageMetadata(title: scalar(doc, "title"), description: scalar(doc, "description"))
+    }
+
+    public static func write(_ metadata: PageMetadata, into contents: String) -> String {
+        var doc = FrontmatterDocument.parse(contents)
+        let current = read(contents)
+        if metadata.title != current.title { doc.set(.string(metadata.title), for: "title") }
+        if metadata.description != current.description {
+            doc.set(.string(metadata.description), for: "description")
+        }
+        return doc.serialized()
+    }
+
+    private static func scalar(_ doc: FrontmatterDocument, _ key: String) -> String {
+        if case .string(let s)? = doc.value(for: key) { return s }
+        return ""
+    }
+}

--- a/Sources/AnglesiteCore/PageMetadataEditor.swift
+++ b/Sources/AnglesiteCore/PageMetadataEditor.swift
@@ -1,4 +1,3 @@
-import Foundation
 
 /// A page's editable metadata. Phase 1 covers title + description; the rendered `<title>` is
 /// composed from a site-level tokenized template (main site settings, out of scope here) with this

--- a/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
+++ b/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
@@ -311,6 +311,7 @@ public actor SiteKnowledgeIndex {
         case .string(let s): return s
         case .bool(let b): return b ? "true" : "false"
         case .array(let values): return values.joined(separator: " ")
+        case .number(let n): return n == n.rounded() && abs(n) < 1e15 ? String(Int(n)) : String(n)
         }
     }
 

--- a/Sources/AnglesiteCore/TypedContentEditor.swift
+++ b/Sources/AnglesiteCore/TypedContentEditor.swift
@@ -36,7 +36,12 @@ public enum TypedContentEditor {
     }
 
     public static func read(_ contents: String, descriptor: ContentTypeDescriptor) -> Values {
-        let doc = FrontmatterDocument.parse(contents)
+        read(from: FrontmatterDocument.parse(contents), descriptor: descriptor)
+    }
+
+    /// Reads field values from an already-parsed document. `write` reuses this to derive the current
+    /// values without re-parsing `contents` a second time.
+    private static func read(from doc: FrontmatterDocument, descriptor: ContentTypeDescriptor) -> Values {
         var out = Values()
         for field in descriptor.fields {
             if field.kind == .markdown {
@@ -54,7 +59,11 @@ public enum TypedContentEditor {
 
     public static func write(_ values: Values, into contents: String, descriptor: ContentTypeDescriptor) -> String {
         var doc = FrontmatterDocument.parse(contents)
-        let current = read(contents, descriptor: descriptor)
+        // Derive `current` from the already-parsed `doc` (no second parse). Comparison stays at the
+        // decoded `FieldValue` level on purpose: it preserves an unchanged field verbatim even when
+        // its on-disk form isn't canonical (e.g. a date-only or no-fractional-seconds `publishDate`),
+        // which a re-encoded string comparison would reformat.
+        let current = read(from: doc, descriptor: descriptor)
         for field in descriptor.fields {
             guard let newValue = values[field.name], newValue != current[field.name] else { continue }
             if field.kind == .markdown {

--- a/Sources/AnglesiteCore/TypedContentEditor.swift
+++ b/Sources/AnglesiteCore/TypedContentEditor.swift
@@ -124,6 +124,7 @@ public enum TypedContentEditor {
     }
 
     private static func formatNumber(_ n: Double) -> String {
-        n.rounded() == n ? String(Int(n)) : String(n)
+        if n == n.rounded(), abs(n) < 1e15 { return String(Int(n)) }
+        return String(n)
     }
 }

--- a/Sources/AnglesiteCore/TypedContentEditor.swift
+++ b/Sources/AnglesiteCore/TypedContentEditor.swift
@@ -104,7 +104,9 @@ public enum TypedContentEditor {
         case .text(let s): return .string(s)
         case .flag(let b): return .bool(b)
         case .date(let d): return .string(d.map { format($0, kind: kind) } ?? "")
-        case .number(let n): return .string(n.map { formatNumber($0) } ?? "")
+        // Numbers serialize unquoted (FrontmatterValue.number) so they satisfy a z.number() schema;
+        // a nil (cleared) number falls back to an empty quoted scalar.
+        case .number(let n): return n.map { .number($0) } ?? .string("")
         case .list(let a): return .array(a)
         }
     }
@@ -130,10 +132,5 @@ public enum TypedContentEditor {
         df.timeZone = TimeZone(identifier: "UTC")
         df.dateFormat = "yyyy-MM-dd"
         return df.date(from: s)
-    }
-
-    private static func formatNumber(_ n: Double) -> String {
-        if n == n.rounded(), abs(n) < 1e15 { return String(Int(n)) }
-        return String(n)
     }
 }

--- a/Sources/AnglesiteCore/TypedContentEditor.swift
+++ b/Sources/AnglesiteCore/TypedContentEditor.swift
@@ -1,0 +1,129 @@
+// Sources/AnglesiteCore/TypedContentEditor.swift
+import Foundation
+
+/// Bridges a content file to the typed, per-field values a form editor binds to, and back.
+///
+/// One `markdown` field per type (the `body`) maps to the document body; every other field maps to
+/// a frontmatter key. `write` applies only fields whose value actually changed, so
+/// `FrontmatterDocument`'s verbatim preservation keeps untouched keys and the body intact. Pure,
+/// no I/O.
+public enum TypedContentEditor {
+    public enum FieldValue: Equatable, Sendable {
+        case text(String)
+        case flag(Bool)
+        case date(Date?)
+        case number(Double?)
+        case list([String])
+    }
+
+    public struct Values: Equatable, Sendable {
+        private var dict: [String: FieldValue]
+        public init(_ dict: [String: FieldValue] = [:]) { self.dict = dict }
+        public subscript(_ name: String) -> FieldValue? {
+            get { dict[name] }
+            set { dict[name] = newValue }
+        }
+    }
+
+    public static func defaultValue(for kind: ContentTypeField.Kind) -> FieldValue {
+        switch kind {
+        case .string, .text, .markdown, .url, .image: return .text("")
+        case .bool: return .flag(false)
+        case .date, .datetime: return .date(nil)
+        case .number: return .number(nil)
+        case .stringArray, .imageArray: return .list([])
+        }
+    }
+
+    public static func read(_ contents: String, descriptor: ContentTypeDescriptor) -> Values {
+        let doc = FrontmatterDocument.parse(contents)
+        var out = Values()
+        for field in descriptor.fields {
+            if field.kind == .markdown {
+                out[field.name] = .text(doc.body)
+                continue
+            }
+            guard let raw = doc.value(for: field.name) else {
+                out[field.name] = defaultValue(for: field.kind)
+                continue
+            }
+            out[field.name] = decode(raw, kind: field.kind)
+        }
+        return out
+    }
+
+    public static func write(_ values: Values, into contents: String, descriptor: ContentTypeDescriptor) -> String {
+        var doc = FrontmatterDocument.parse(contents)
+        let current = read(contents, descriptor: descriptor)
+        for field in descriptor.fields {
+            guard let newValue = values[field.name], newValue != current[field.name] else { continue }
+            if field.kind == .markdown {
+                if case .text(let body) = newValue { doc.body = body }
+                continue
+            }
+            if let encoded = encode(newValue, kind: field.kind) { doc.set(encoded, for: field.name) }
+        }
+        return doc.serialized()
+    }
+
+    // MARK: Decode (frontmatter → field value)
+
+    private static func decode(_ value: FrontmatterValue, kind: ContentTypeField.Kind) -> FieldValue {
+        switch kind {
+        case .string, .text, .url, .image, .markdown:
+            if case .string(let s) = value { return .text(s) }
+            return .text("")
+        case .bool:
+            if case .bool(let b) = value { return .flag(b) }
+            return .flag(false)
+        case .date, .datetime:
+            if case .string(let s) = value { return .date(parseDate(s)) }
+            return .date(nil)
+        case .number:
+            if case .string(let s) = value { return .number(Double(s)) }
+            return .number(nil)
+        case .stringArray, .imageArray:
+            if case .array(let a) = value { return .list(a) }
+            return .list([])
+        }
+    }
+
+    // MARK: Encode (field value → frontmatter)
+
+    private static func encode(_ value: FieldValue, kind: ContentTypeField.Kind) -> FrontmatterValue? {
+        switch value {
+        case .text(let s): return .string(s)
+        case .flag(let b): return .bool(b)
+        case .date(let d): return .string(d.map { format($0, kind: kind) } ?? "")
+        case .number(let n): return .string(n.map { formatNumber($0) } ?? "")
+        case .list(let a): return .array(a)
+        }
+    }
+
+    // MARK: Date/number formatting (mirror ContentScaffold)
+
+    private static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static func format(_ date: Date, kind: ContentTypeField.Kind) -> String {
+        let full = iso.string(from: date)
+        return kind == .date ? String(full.prefix(10)) : full
+    }
+
+    private static func parseDate(_ s: String) -> Date? {
+        if let d = iso.date(from: s) { return d }
+        // date-only (yyyy-MM-dd) → midnight UTC
+        let df = DateFormatter()
+        df.calendar = Calendar(identifier: .iso8601)
+        df.timeZone = TimeZone(identifier: "UTC")
+        df.dateFormat = "yyyy-MM-dd"
+        return df.date(from: s)
+    }
+
+    private static func formatNumber(_ n: Double) -> String {
+        n.rounded() == n ? String(Int(n)) : String(n)
+    }
+}

--- a/Tests/AnglesiteCoreTests/ContentTypeResolverTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentTypeResolverTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite("ContentTypeResolver")
+struct ContentTypeResolverTests {
+    @Test("collection entry resolves by directory")
+    func collection() {
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "src/content/notes/hello.md")?.id == "note")
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "src/content/events/launch.md")?.id == "event")
+    }
+
+    @Test("businessProfile resolves by its singleton page path")
+    func businessProfile() {
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "src/pages/about.md")?.id == "businessProfile")
+    }
+
+    @Test("leading ./ and absolute-ish prefixes are tolerated")
+    func normalization() {
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "./src/content/articles/x.md")?.id == "article")
+    }
+
+    @Test("unrelated files resolve to nil (text fallback)")
+    func none() {
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "src/pages/index.astro") == nil)
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "src/styles/global.css") == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+++ b/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
@@ -1,0 +1,85 @@
+// Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("FrontmatterDocument")
+struct FrontmatterDocumentTests {
+
+    @Test("unedited round-trip is the identity")
+    func identity() {
+        let src = """
+        ---
+        title: "Hello"
+        draft: false
+        tags:
+          - a
+          - b
+        ---
+
+        Body text here.
+        """ + "\n"
+        #expect(FrontmatterDocument.parse(src).serialized() == src)
+    }
+
+    @Test("reads scalar, bool, and array values")
+    func reads() {
+        let doc = FrontmatterDocument.parse("---\ntitle: \"Hi\"\ndraft: true\ntags: [x, y]\n---\nB\n")
+        #expect(doc.value(for: "title") == .string("Hi"))
+        #expect(doc.value(for: "draft") == .bool(true))
+        #expect(doc.value(for: "tags") == .array(["x", "y"]))
+        #expect(doc.value(for: "missing") == nil)
+    }
+
+    @Test("editing one field leaves untouched keys and body verbatim")
+    func editPreserves() {
+        let src = "---\ntitle: \"Old\"\nweirdKey: keep-me-exactly\ndraft: false\n---\n\nBody.\n"
+        var doc = FrontmatterDocument.parse(src)
+        doc.set(.string("New"), for: "title")
+        let out = doc.serialized()
+        #expect(out.contains("title: \"New\""))
+        #expect(out.contains("weirdKey: keep-me-exactly"))   // unknown key preserved verbatim
+        #expect(out.contains("draft: false"))
+        #expect(out.hasSuffix("\n\nBody.\n"))                // body verbatim
+    }
+
+    @Test("setting a new key appends it")
+    func appendsNewKey() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\nB\n")
+        doc.set(.string("noreply@x.io"), for: "email")
+        #expect(doc.serialized().contains("email: \"noreply@x.io\""))
+        #expect(doc.value(for: "email") == .string("noreply@x.io"))
+    }
+
+    @Test("no-frontmatter source is all body")
+    func noFrontmatter() {
+        let doc = FrontmatterDocument.parse("# Heading\n\nbody\n")
+        #expect(doc.keys.isEmpty)
+        #expect(doc.body == "# Heading\n\nbody\n")
+        #expect(doc.serialized() == "# Heading\n\nbody\n")
+    }
+
+    @Test("editing the body leaves frontmatter verbatim")
+    func editBody() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\n\nold body\n")
+        doc.body = "\nnew body\n"
+        let out = doc.serialized()
+        #expect(out.contains("title: \"T\""))
+        #expect(out.hasSuffix("\nnew body\n"))
+    }
+
+    @Test("array set renders block form and round-trips")
+    func arraySet() {
+        var doc = FrontmatterDocument.parse("---\nhours: []\n---\n")
+        doc.set(.array(["Mon 9-5", "Tue 9-5"]), for: "hours")
+        let out = doc.serialized()
+        let reparsed = FrontmatterDocument.parse(out)
+        #expect(reparsed.value(for: "hours") == .array(["Mon 9-5", "Tue 9-5"]))
+    }
+
+    @Test("comments and blank lines inside frontmatter survive an unedited round-trip")
+    func commentsSurvive() {
+        let src = "---\ntitle: \"T\"\n# a comment\n\ndraft: false\n---\nB\n"
+        #expect(FrontmatterDocument.parse(src).serialized() == src)
+    }
+}

--- a/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+++ b/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
@@ -82,4 +82,50 @@ struct FrontmatterDocumentTests {
         let src = "---\ntitle: \"T\"\n# a comment\n\ndraft: false\n---\nB\n"
         #expect(FrontmatterDocument.parse(src).serialized() == src)
     }
+
+    @Test("frontmatter-only source with no trailing newline round-trips without injecting one")
+    func noTrailingNewlineIdentity() {
+        let src = "---\ntitle: \"T\"\n---"          // no body, no terminal newline
+        #expect(FrontmatterDocument.parse(src).serialized() == src)
+    }
+
+    @Test("frontmatter-only source with a trailing newline round-trips")
+    func trailingNewlineIdentity() {
+        let src = "---\ntitle: \"T\"\n---\n"        // terminal newline, still no body
+        #expect(FrontmatterDocument.parse(src).serialized() == src)
+    }
+
+    @Test("string value containing a double-quote round-trips")
+    func roundTripsDoubleQuote() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"x\"\n---\n")
+        doc.set(.string("a \"quoted\" b"), for: "title")
+        let out = doc.serialized()
+        #expect(FrontmatterDocument.parse(out).value(for: "title") == .string("a \"quoted\" b"))
+    }
+
+    @Test("string value containing a newline round-trips (escape)")
+    func roundTripsNewline() {
+        var doc = FrontmatterDocument.parse("---\ndescription: \"x\"\n---\n\nBody.\n")
+        doc.set(.string("line one\nline two"), for: "description")
+        let out = doc.serialized()
+        // The embedded newline must be escaped, not emitted literally (which would break the fence).
+        #expect(FrontmatterDocument.parse(out).value(for: "description") == .string("line one\nline two"))
+        #expect(out.contains("Body."))   // body intact, frontmatter still a single block
+    }
+
+    @Test("string value containing a bare colon round-trips (split on first colon only)")
+    func roundTripsBareColon() {
+        var doc = FrontmatterDocument.parse("---\nurl: \"x\"\n---\n")
+        doc.set(.string("https://example.com"), for: "url")
+        let out = doc.serialized()
+        #expect(FrontmatterDocument.parse(out).value(for: "url") == .string("https://example.com"))
+    }
+
+    @Test("duplicate top-level key survives an unedited round-trip verbatim")
+    func duplicateKeyIdentity() {
+        let src = "---\ntitle: \"A\"\ntitle: \"B\"\n---\nB\n"
+        let doc = FrontmatterDocument.parse(src)
+        #expect(doc.serialized() == src)                  // both occurrences preserved
+        #expect(doc.value(for: "title") == .string("B"))  // get addresses the last
+    }
 }

--- a/Tests/AnglesiteCoreTests/PageMetadataEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/PageMetadataEditorTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite("PageMetadataEditor")
+struct PageMetadataEditorTests {
+    @Test("reads title and description from frontmatter")
+    func reads() {
+        let src = "---\ntitle: \"Hello\"\ndescription: \"A page\"\n---\n\nBody.\n"
+        let m = PageMetadataEditor.read(src)
+        #expect(m.title == "Hello")
+        #expect(m.description == "A page")
+    }
+
+    @Test("missing fields default to empty")
+    func defaults() {
+        let m = PageMetadataEditor.read("---\ntitle: \"Only\"\n---\nB\n")
+        #expect(m.title == "Only")
+        #expect(m.description == "")
+    }
+
+    @Test("write changes only edited keys, preserving unknown keys and body")
+    func writeChangedOnly() {
+        let src = "---\ntitle: \"Old\"\ndescription: \"D\"\nweird: keep-me\n---\n\nBody.\n"
+        let out = PageMetadataEditor.write(PageMetadata(title: "New", description: "D"), into: src)
+        #expect(out.contains("title: \"New\""))
+        #expect(out.contains("description: \"D\""))   // unchanged
+        #expect(out.contains("weird: keep-me"))       // unknown key preserved
+        #expect(out.hasSuffix("\n\nBody.\n"))         // body preserved
+    }
+
+    @Test("write adds missing keys")
+    func writeAddsKeys() {
+        let out = PageMetadataEditor.write(PageMetadata(title: "T", description: "New desc"),
+                                           into: "---\ntitle: \"T\"\n---\nB\n")
+        #expect(out.contains("description: \"New desc\""))
+    }
+
+    @Test("unedited round-trip is the identity")
+    func identity() {
+        let src = "---\ntitle: \"T\"\ndescription: \"D\"\n---\n\nBody.\n"
+        let m = PageMetadataEditor.read(src)
+        #expect(PageMetadataEditor.write(m, into: src) == src)
+    }
+}

--- a/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
@@ -62,4 +62,30 @@ struct TypedContentEditorTests {
         #expect(TypedContentEditor.read(out, descriptor: profile)["hours"] == .list(["Mon 9-5", "Sat closed"]))
         #expect(out.contains("type: businessProfile"))   // unknown-to-schema key preserved
     }
+
+    @Test("template about.md reads as businessProfile with marker preserved")
+    func aboutPage() {
+        let profile = ContentTypeRegistry().descriptor(id: "businessProfile")!
+        let src = """
+        ---
+        layout: ../layouts/BaseLayout.astro
+        title: "About"
+        type: businessProfile
+        name: "Your Business Name"
+        hours: []
+        url: ""
+        ---
+
+        # About
+        """ + "\n"
+        let v = TypedContentEditor.read(src, descriptor: profile)
+        #expect(v["name"] == .text("Your Business Name"))
+        var dict = [String: TypedContentEditor.FieldValue]()
+        for f in profile.fields { dict[f.name] = v[f.name] }
+        dict["name"] = .text("Acme Co")
+        let out = TypedContentEditor.write(TypedContentEditor.Values(dict), into: src, descriptor: profile)
+        #expect(out.contains("name: \"Acme Co\""))
+        #expect(out.contains("type: businessProfile"))           // marker preserved
+        #expect(out.contains("layout: ../layouts/BaseLayout.astro")) // layout preserved
+    }
 }

--- a/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
@@ -8,6 +8,19 @@ struct TypedContentEditorTests {
     private var note: ContentTypeDescriptor { ContentTypeRegistry().descriptor(id: "note")! }
     private var event: ContentTypeDescriptor { ContentTypeRegistry().descriptor(id: "event")! }
     private var reply: ContentTypeDescriptor { ContentTypeRegistry().descriptor(id: "reply")! }
+    private var review: ContentTypeDescriptor { ContentTypeRegistry().descriptor(id: "review")! }
+
+    @Test("edited number field serializes unquoted (satisfies z.number())")
+    func numberWritesUnquoted() {
+        let src = "---\nitemReviewed: \"Widget\"\nrating: 5\npublishDate: 2026-01-01T00:00:00.000Z\n---\n\nReview.\n"
+        var v = TypedContentEditor.read(src, descriptor: review)
+        v["rating"] = .number(4)
+        let out = TypedContentEditor.write(v, into: src, descriptor: review)
+        #expect(out.contains("rating: 4"))        // unquoted
+        #expect(!out.contains("rating: \"4\""))   // not a quoted string
+        // round-trips back to a number
+        #expect(TypedContentEditor.read(out, descriptor: review)["rating"] == .number(4))
+    }
 
     @Test("reads markdown field from body and scalars from frontmatter")
     func reads() {

--- a/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
@@ -1,0 +1,65 @@
+// Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("TypedContentEditor")
+struct TypedContentEditorTests {
+    private var note: ContentTypeDescriptor { ContentTypeRegistry().descriptor(id: "note")! }
+    private var event: ContentTypeDescriptor { ContentTypeRegistry().descriptor(id: "event")! }
+    private var reply: ContentTypeDescriptor { ContentTypeRegistry().descriptor(id: "reply")! }
+
+    @Test("reads markdown field from body and scalars from frontmatter")
+    func reads() {
+        let src = "---\npublishDate: 2026-01-02T03:04:05.000Z\ntags: [a, b]\n---\n\nHello body.\n"
+        let v = TypedContentEditor.read(src, descriptor: note)
+        #expect(v["body"] == .text("\nHello body.\n"))           // markdown ⟷ body
+        #expect(v["tags"] == .list(["a", "b"]))
+        if case .date(let d?) = v["publishDate"] { #expect(d.timeIntervalSince1970 > 0) } else { Issue.record("no date") }
+    }
+
+    @Test("missing fields get empty defaults")
+    func defaults() {
+        let v = TypedContentEditor.read("---\n---\n", descriptor: reply)
+        #expect(v["inReplyTo"] == .text(""))
+        #expect(v["body"] == .text(""))
+    }
+
+    @Test("write applies only changed fields, leaving others verbatim")
+    func writeChangedOnly() {
+        let src = "---\ninReplyTo: \"https://a.example/x\"\npublishDate: 2026-01-02T03:04:05.000Z\n---\n\nold.\n"
+        var v = TypedContentEditor.read(src, descriptor: reply)
+        v = TypedContentEditor.Values([
+            "inReplyTo": .text("https://b.example/y"),      // changed
+            "publishDate": v["publishDate"]!,               // unchanged
+            "body": v["body"]!                              // unchanged
+        ])
+        let out = TypedContentEditor.write(v, into: src, descriptor: reply)
+        #expect(out.contains("inReplyTo: \"https://b.example/y\""))
+        #expect(out.contains("publishDate: 2026-01-02T03:04:05.000Z"))  // verbatim, not reformatted
+        #expect(out.hasSuffix("\nold.\n"))                              // body verbatim
+    }
+
+    @Test("write updates the markdown body")
+    func writeBody() {
+        let src = "---\npublishDate: 2026-01-02T03:04:05.000Z\n---\n\nold.\n"
+        var v = TypedContentEditor.read(src, descriptor: note)
+        v = TypedContentEditor.Values(["publishDate": v["publishDate"]!, "tags": v["tags"] ?? .list([]),
+                                       "body": .text("\nnew body.\n")])
+        let out = TypedContentEditor.write(v, into: src, descriptor: note)
+        #expect(out.hasSuffix("\nnew body.\n"))
+    }
+
+    @Test("write round-trips a list field into block YAML")
+    func writeList() {
+        let profile = ContentTypeRegistry().descriptor(id: "businessProfile")!
+        let src = "---\ntype: businessProfile\nname: \"Acme\"\nhours: []\n---\n"
+        var v = TypedContentEditor.read(src, descriptor: profile)
+        var dict = [String: TypedContentEditor.FieldValue]()
+        for f in profile.fields { dict[f.name] = v[f.name] }
+        dict["hours"] = .list(["Mon 9-5", "Sat closed"])
+        let out = TypedContentEditor.write(TypedContentEditor.Values(dict), into: src, descriptor: profile)
+        #expect(TypedContentEditor.read(out, descriptor: profile)["hours"] == .list(["Mon 9-5", "Sat closed"]))
+        #expect(out.contains("type: businessProfile"))   // unknown-to-schema key preserved
+    }
+}

--- a/docs/superpowers/plans/2026-06-27-inspector-phase1.md
+++ b/docs/superpowers/plans/2026-06-27-inspector-phase1.md
@@ -1,0 +1,976 @@
+# Inspector Phase 1 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the typed content form into a Pages/Xcode-style right-hand inspector with the live preview in the center, and add title/description editing for plain frontmatter pages.
+
+**Architecture:** A new `.inspector(isPresented:)` panel on the detail pane hosts a `PageInspectorView`, which renders either the existing typed descriptor form (#346) or a generic title/description form. Both editor models conform to a shared `InspectorEditorModel` protocol so one chrome (load/save/conflict/⌘S) wraps both. `SiteWindow`'s navigator routing is reworked: selecting a content entry navigates the preview (center) and sets the inspector context; the `.typed` main-pane editor path is removed.
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27+), Swift Testing, `git` via `NativeContentOperations.processGitCommit`.
+
+**Design spec:** [`docs/superpowers/specs/2026-06-27-inspector-phase1-design.md`](../specs/2026-06-27-inspector-phase1-design.md)
+
+## Global Constraints
+
+- **Apple-only frameworks** — no third-party Swift deps.
+- **Toolchain:** Xcode 27+ / Swift 6.4. Core tests: `swift test --package-path .`. App build: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`. Use `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` if the default `swift` is broken.
+- **Worktree:** `/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors`, branch `feat/346-typed-editors`. `cd` there before any git/build op. A fresh worktree app build needs `scripts/copy-plugin.sh` (with `ANGLESITE_PLUGIN_SRC` pointing at the real plugin checkout) and `xcodegen generate` first.
+- **App-target logic is not CI-testable** (hosted `.app` won't launch on CI). All testable logic lives in `AnglesiteCore`; `AnglesiteApp` is validated by `swift build`/`xcodebuild` + manual smoke.
+- **Pure Core types are I/O-free.**
+- **Round-trip safety:** all metadata writes go through `FrontmatterDocument` — unknown keys + body preserved verbatim; only changed keys re-rendered.
+- **Title model:** page title is the `title` frontmatter. The site-level tokenized title template is out of scope (main site settings, later). No `.astro` attribute editing.
+- **Swift Testing** (`import Testing`, `@Suite`/`@Test`/`#expect`), not XCTest, for new tests.
+
+---
+
+## File Structure
+
+New (AnglesiteCore — pure, tested):
+- `Sources/AnglesiteCore/PageMetadataEditor.swift` — read/write title+description via `FrontmatterDocument`.
+
+New (AnglesiteApp — build-validated):
+- `Sources/AnglesiteApp/PageMetadataModel.swift` — `@Observable` buffer for a plain page's title/description.
+- `Sources/AnglesiteApp/InspectorContext.swift` — `InspectorEditorModel` protocol + `InspectorContext` enum.
+- `Sources/AnglesiteApp/PageInspectorView.swift` — shared inspector chrome + typed form + page form.
+
+New (tests):
+- `Tests/AnglesiteCoreTests/PageMetadataEditorTests.swift`
+
+Modified:
+- `Sources/AnglesiteApp/TypedEntryEditorModel.swift` — conform to `InspectorEditorModel`.
+- `Sources/AnglesiteApp/TypedEntryEditorView.swift` — extract the form body as `TypedEntryForm` (drop the full-pane header/chrome; chrome moves to `PageInspectorView`).
+- `Sources/AnglesiteApp/SiteWindow.swift` — remove `.typed` main-pane editor path; add inspector shell, routing rework, toolbar toggle.
+
+---
+
+## Task 1: `PageMetadataEditor` — title/description frontmatter read/write (Core)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/PageMetadataEditor.swift`
+- Test: `Tests/AnglesiteCoreTests/PageMetadataEditorTests.swift`
+
+**Interfaces:**
+- Consumes: `FrontmatterDocument` / `FrontmatterValue` (existing).
+- Produces:
+  - `public struct PageMetadata: Equatable, Sendable { public var title: String; public var description: String; public init(title: String, description: String) }`
+  - `public enum PageMetadataEditor { public static func read(_ contents: String) -> PageMetadata; public static func write(_ metadata: PageMetadata, into contents: String) -> String }`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/PageMetadataEditorTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite("PageMetadataEditor")
+struct PageMetadataEditorTests {
+    @Test("reads title and description from frontmatter")
+    func reads() {
+        let src = "---\ntitle: \"Hello\"\ndescription: \"A page\"\n---\n\nBody.\n"
+        let m = PageMetadataEditor.read(src)
+        #expect(m.title == "Hello")
+        #expect(m.description == "A page")
+    }
+
+    @Test("missing fields default to empty")
+    func defaults() {
+        let m = PageMetadataEditor.read("---\ntitle: \"Only\"\n---\nB\n")
+        #expect(m.title == "Only")
+        #expect(m.description == "")
+    }
+
+    @Test("write changes only edited keys, preserving unknown keys and body")
+    func writeChangedOnly() {
+        let src = "---\ntitle: \"Old\"\ndescription: \"D\"\nweird: keep-me\n---\n\nBody.\n"
+        let out = PageMetadataEditor.write(PageMetadata(title: "New", description: "D"), into: src)
+        #expect(out.contains("title: \"New\""))
+        #expect(out.contains("description: \"D\""))   // unchanged
+        #expect(out.contains("weird: keep-me"))       // unknown key preserved
+        #expect(out.hasSuffix("\n\nBody.\n"))         // body preserved
+    }
+
+    @Test("write adds missing keys")
+    func writeAddsKeys() {
+        let out = PageMetadataEditor.write(PageMetadata(title: "T", description: "New desc"),
+                                           into: "---\ntitle: \"T\"\n---\nB\n")
+        #expect(out.contains("description: \"New desc\""))
+    }
+
+    @Test("unedited round-trip is the identity")
+    func identity() {
+        let src = "---\ntitle: \"T\"\ndescription: \"D\"\n---\n\nBody.\n"
+        let m = PageMetadataEditor.read(src)
+        #expect(PageMetadataEditor.write(m, into: src) == src)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors && swift test --package-path . --filter PageMetadataEditor 2>&1 | tail -20`
+Expected: FAIL — `cannot find 'PageMetadataEditor' in scope`.
+
+- [ ] **Step 3: Implement `PageMetadataEditor`**
+
+```swift
+// Sources/AnglesiteCore/PageMetadataEditor.swift
+import Foundation
+
+/// A page's editable metadata. Phase 1 covers title + description; the rendered `<title>` is
+/// composed from a site-level tokenized template (main site settings, out of scope here) with this
+/// per-page `title` substituted.
+public struct PageMetadata: Equatable, Sendable {
+    public var title: String
+    public var description: String
+    public init(title: String, description: String) {
+        self.title = title
+        self.description = description
+    }
+}
+
+/// Reads/writes `title` + `description` frontmatter for plain (non-typed) frontmatter pages.
+/// Goes through `FrontmatterDocument`, so unknown keys and the body survive verbatim and only a
+/// changed key is re-rendered. Pure, no I/O.
+public enum PageMetadataEditor {
+    public static func read(_ contents: String) -> PageMetadata {
+        let doc = FrontmatterDocument.parse(contents)
+        return PageMetadata(title: scalar(doc, "title"), description: scalar(doc, "description"))
+    }
+
+    public static func write(_ metadata: PageMetadata, into contents: String) -> String {
+        var doc = FrontmatterDocument.parse(contents)
+        let current = read(contents)
+        if metadata.title != current.title { doc.set(.string(metadata.title), for: "title") }
+        if metadata.description != current.description {
+            doc.set(.string(metadata.description), for: "description")
+        }
+        return doc.serialized()
+    }
+
+    private static func scalar(_ doc: FrontmatterDocument, _ key: String) -> String {
+        if case .string(let s)? = doc.value(for: key) { return s }
+        return ""
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `swift test --package-path . --filter PageMetadataEditor 2>&1 | tail -20`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Sources/AnglesiteCore/PageMetadataEditor.swift Tests/AnglesiteCoreTests/PageMetadataEditorTests.swift
+git commit -m "$(printf 'feat(#346): PageMetadataEditor reads/writes title+description frontmatter\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 2: `InspectorEditorModel` protocol + `PageMetadataModel` (App)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/InspectorContext.swift`
+- Create: `Sources/AnglesiteApp/PageMetadataModel.swift`
+- Modify: `Sources/AnglesiteApp/TypedEntryEditorModel.swift` (add protocol conformance)
+
+**Interfaces:**
+- Consumes: `PageMetadataEditor`/`PageMetadata` (Task 1), `FileDocumentIO`, `NativeContentOperations.GitCommit`, `FileRef`, `TypedEntryEditorModel` (#346).
+- Produces:
+  - `@MainActor protocol InspectorEditorModel: AnyObject` with: `var file: FileRef { get }`, `var isDirty: Bool { get }`, `var loadError: String? { get }`, `var isLoading: Bool { get }`, `var conflictDiskContents: String? { get set }`, `func load() async`, `@discardableResult func save() async -> Bool`, `func flushBeforeLeaving() async -> Bool`, `func checkExternalChange() async`, `func keepMyChanges()`, `func reloadFromDisk() async`.
+  - `enum InspectorContext: Identifiable` with `case typed(TypedEntryEditorModel)`, `case page(PageMetadataModel)`, `var model: any InspectorEditorModel`, `var id: String`.
+  - `@MainActor @Observable final class PageMetadataModel` with init `(file: FileRef, sourceDirectory: URL, gitCommit: @escaping NativeContentOperations.GitCommit = NativeContentOperations.processGitCommit)`, conforming to `InspectorEditorModel`, plus `func titleBinding() -> Binding<String>` and `func descriptionBinding() -> Binding<String>`.
+
+- [ ] **Step 1: Create the protocol + context**
+
+```swift
+// Sources/AnglesiteApp/InspectorContext.swift
+import Foundation
+import AnglesiteCore
+
+/// Shared surface the inspector chrome (load/save/conflict/⌘S) drives, so one chrome wraps both the
+/// typed descriptor form and the plain page metadata form.
+@MainActor
+protocol InspectorEditorModel: AnyObject {
+    var file: FileRef { get }
+    var isDirty: Bool { get }
+    var loadError: String? { get }
+    var isLoading: Bool { get }
+    var conflictDiskContents: String? { get set }
+    func load() async
+    @discardableResult func save() async -> Bool
+    func flushBeforeLeaving() async -> Bool
+    func checkExternalChange() async
+    func keepMyChanges()
+    func reloadFromDisk() async
+}
+
+/// What the right-hand inspector is editing for the current selection.
+enum InspectorContext: Identifiable {
+    case typed(TypedEntryEditorModel)
+    case page(PageMetadataModel)
+
+    var model: any InspectorEditorModel {
+        switch self {
+        case .typed(let m): m
+        case .page(let m): m
+        }
+    }
+    var id: String { model.file.id }
+}
+```
+
+- [ ] **Step 2: Conform `TypedEntryEditorModel` to the protocol**
+
+`TypedEntryEditorModel` already has every required member (from #346). Add the conformance. In `Sources/AnglesiteApp/TypedEntryEditorModel.swift`, change the class declaration line:
+
+```swift
+final class TypedEntryEditorModel {
+```
+to:
+```swift
+final class TypedEntryEditorModel: InspectorEditorModel {
+```
+
+- [ ] **Step 3: Implement `PageMetadataModel`**
+
+```swift
+// Sources/AnglesiteApp/PageMetadataModel.swift
+import Foundation
+import SwiftUI
+import Observation
+import AnglesiteCore
+
+/// Editor state for a plain (non-typed) page's title + description. Parallels
+/// `TypedEntryEditorModel`: loads/saves through `FileDocumentIO`, writes via `PageMetadataEditor`
+/// (round-trip-safe), and commits each save. All disk IO runs off the main actor.
+@MainActor
+@Observable
+final class PageMetadataModel: InspectorEditorModel {
+    let file: FileRef
+    private let sourceDirectory: URL
+    private let gitCommit: NativeContentOperations.GitCommit
+
+    var metadata = PageMetadata(title: "", description: "")
+    private var savedMetadata = PageMetadata(title: "", description: "")
+    private var contents = ""
+    private var lastModified: Date?
+    private(set) var loadError: String?
+    private(set) var isLoading = false
+    var conflictDiskContents: String?
+
+    var isDirty: Bool { metadata != savedMetadata && loadError == nil && !isLoading }
+
+    init(file: FileRef,
+         sourceDirectory: URL,
+         gitCommit: @escaping NativeContentOperations.GitCommit = NativeContentOperations.processGitCommit) {
+        self.file = file
+        self.sourceDirectory = sourceDirectory
+        self.gitCommit = gitCommit
+    }
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        let url = file.url
+        do {
+            let loaded = try await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url) }.value
+            adopt(loaded.contents)
+            lastModified = loaded.modificationDate
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    @discardableResult
+    func save() async -> Bool {
+        guard isDirty else { return true }
+        let newContents = PageMetadataEditor.write(metadata, into: contents)
+        let url = file.url
+        do {
+            let mtime = try await Task.detached(priority: .userInitiated) {
+                try FileDocumentIO.save(newContents, to: url)
+            }.value
+            lastModified = mtime
+            contents = newContents
+            savedMetadata = metadata
+            await commit()
+            return true
+        } catch {
+            loadError = "Save failed: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    func flushBeforeLeaving() async -> Bool {
+        guard isDirty else { return true }
+        let url = file.url
+        let known = lastModified
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: true)
+        }.value
+        if case .conflict(let disk)? = change { conflictDiskContents = disk; return false }
+        return await save()
+    }
+
+    func checkExternalChange() async {
+        guard loadError == nil else { return }
+        let url = file.url
+        let known = lastModified
+        let dirty = isDirty
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
+        }.value
+        switch change {
+        case .reloadable(let disk):
+            adopt(disk); lastModified = await freshModificationDate()
+        case .conflict(let disk):
+            conflictDiskContents = disk
+        case .none, nil:
+            break
+        }
+    }
+
+    func keepMyChanges() { conflictDiskContents = nil }
+
+    func reloadFromDisk() async {
+        guard let disk = conflictDiskContents else { return }
+        adopt(disk)
+        lastModified = await freshModificationDate()
+        conflictDiskContents = nil
+    }
+
+    func titleBinding() -> Binding<String> {
+        Binding(get: { self.metadata.title }, set: { self.metadata.title = $0 })
+    }
+    func descriptionBinding() -> Binding<String> {
+        Binding(get: { self.metadata.description }, set: { self.metadata.description = $0 })
+    }
+
+    private func adopt(_ text: String) {
+        contents = text
+        let read = PageMetadataEditor.read(text)
+        metadata = read
+        savedMetadata = read
+    }
+
+    private func commit() async {
+        let rel = relativePath(of: file.url, under: sourceDirectory)
+        let slug = file.url.deletingPathExtension().lastPathComponent
+        _ = await gitCommit(sourceDirectory, rel, "anglesite: edit page \(slug)")
+    }
+
+    private func relativePath(of url: URL, under root: URL) -> String {
+        let u = url.standardizedFileURL.path(percentEncoded: false)
+        let r = root.standardizedFileURL.path(percentEncoded: false)
+        if u.hasPrefix(r) { return String(u.dropFirst(r.count)).drop(while: { $0 == "/" }).description }
+        return url.lastPathComponent
+    }
+
+    private func freshModificationDate() async -> Date? {
+        let url = file.url
+        return try? await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url).modificationDate }.value
+    }
+}
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors && swift build --package-path . 2>&1 | tail -20`
+Expected: builds clean. (Fix any protocol-conformance mismatch on `TypedEntryEditorModel` — every member already exists, so conformance should be satisfied without new code.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Sources/AnglesiteApp/InspectorContext.swift Sources/AnglesiteApp/PageMetadataModel.swift Sources/AnglesiteApp/TypedEntryEditorModel.swift
+git commit -m "$(printf 'feat(#346): InspectorEditorModel protocol + PageMetadataModel\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 3: `PageInspectorView` — shared chrome + both forms (App)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/PageInspectorView.swift`
+- Modify: `Sources/AnglesiteApp/TypedEntryEditorView.swift` (extract `TypedEntryForm`, drop the full-pane chrome)
+
+**Interfaces:**
+- Consumes: `InspectorContext`/`InspectorEditorModel` (Task 2), `PageMetadataModel` (Task 2), `TypedEntryEditorModel` + the `control(for:)`/`StringListEditor` form internals (#346).
+- Produces: `struct PageInspectorView: View` taking `let context: InspectorContext`; `struct TypedEntryForm: View` taking `@Bindable var model: TypedEntryEditorModel`.
+
+- [ ] **Step 1: Extract the typed form body in `TypedEntryEditorView.swift`**
+
+Replace the whole file `Sources/AnglesiteApp/TypedEntryEditorView.swift` with the form extracted as `TypedEntryForm` (the header/`.task`/alert/⌘S chrome is removed — `PageInspectorView` supplies it). Keep `control(for:)`, `chooseFile`, and `StringListEditor` unchanged:
+
+```swift
+// Sources/AnglesiteApp/TypedEntryEditorView.swift
+import SwiftUI
+import AnglesiteCore
+
+/// The schema-driven `Form` body for a typed content entry — one control per field `Kind`, ordered
+/// by the descriptor. Hosted inside `PageInspectorView`, which supplies the load/save/conflict
+/// chrome. (Previously a full-pane editor; the chrome moved to the inspector.)
+struct TypedEntryForm: View {
+    @Bindable var model: TypedEntryEditorModel
+
+    var body: some View {
+        Form {
+            ForEach(scalarFields, id: \.name) { field in
+                control(for: field)
+            }
+            if let body = bodyField {
+                Section("Body") {
+                    TextEditor(text: model.textBinding(body.name))
+                        .font(.system(.body, design: .monospaced))
+                        .frame(minHeight: 160)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private var scalarFields: [ContentTypeField] { model.descriptor.fields.filter { $0.kind != .markdown } }
+    private var bodyField: ContentTypeField? { model.descriptor.fields.first { $0.kind == .markdown } }
+
+    @ViewBuilder
+    private func control(for field: ContentTypeField) -> some View {
+        let label = field.name + (field.required ? " *" : "")
+        switch field.kind {
+        case .string, .url, .image:
+            HStack {
+                TextField(label, text: model.textBinding(field.name))
+                if field.kind == .image {
+                    Button("Choose…") { chooseFile(for: field.name) }
+                }
+            }
+        case .text:
+            VStack(alignment: .leading) {
+                Text(label).font(.caption).foregroundStyle(.secondary)
+                TextField("", text: model.textBinding(field.name), axis: .vertical).lineLimit(2...6)
+            }
+        case .bool:
+            Toggle(label, isOn: model.boolBinding(field.name))
+        case .date, .datetime:
+            DatePicker(label, selection: model.dateBinding(field.name),
+                       displayedComponents: field.kind == .date ? [.date] : [.date, .hourAndMinute])
+        case .number:
+            TextField(label, text: model.numberBinding(field.name))
+        case .stringArray, .imageArray:
+            StringListEditor(title: label, items: model.listBinding(field.name),
+                             pickFile: field.kind == .imageArray)
+        case .markdown:
+            EmptyView()   // handled by the Body section
+        }
+    }
+
+    private func chooseFile(for name: String) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            model.textBinding(name).wrappedValue = url.lastPathComponent
+        }
+    }
+}
+
+/// A minimal add/remove list editor for `stringArray` / `imageArray` fields (tags, hours, album
+/// images). Rows carry stable UUID identity so deleting a row never re-binds a surviving row's
+/// editor to the wrong item; `rows` mirrors the bound `items` two-way, re-syncing when `items` is
+/// replaced externally (e.g. reload-from-disk).
+private struct StringListEditor: View {
+    let title: String
+    @Binding var items: [String]
+    var pickFile: Bool
+
+    private struct Row: Identifiable, Equatable {
+        let id = UUID()
+        var value: String
+    }
+    @State private var rows: [Row] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            ForEach($rows) { $row in
+                HStack {
+                    TextField("", text: $row.value)
+                    Button(role: .destructive) { rows.removeAll { $0.id == row.id } } label: {
+                        Image(systemName: "minus.circle")
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
+            HStack {
+                Button { rows.append(Row(value: "")) } label: { Label("Add", systemImage: "plus.circle") }
+                    .buttonStyle(.borderless)
+                if pickFile {
+                    Button("Choose…") { chooseFile() }
+                }
+            }
+        }
+        .onAppear { syncRowsFromItems() }
+        .onChange(of: items) { _, new in
+            if new != rows.map(\.value) { rows = new.map(Row.init(value:)) }
+        }
+        .onChange(of: rows) { _, new in
+            let mapped = new.map(\.value)
+            if mapped != items { items = mapped }
+        }
+    }
+
+    private func syncRowsFromItems() {
+        if items != rows.map(\.value) { rows = items.map(Row.init(value:)) }
+    }
+
+    private func chooseFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url { rows.append(Row(value: url.lastPathComponent)) }
+    }
+}
+```
+
+- [ ] **Step 2: Create `PageInspectorView` with shared chrome**
+
+```swift
+// Sources/AnglesiteApp/PageInspectorView.swift
+import SwiftUI
+import AnglesiteCore
+
+/// Right-hand inspector content for the selected page. Renders the typed descriptor form or the
+/// plain title/description form, wrapped in shared chrome (header + dirty/Save, off-main load,
+/// external-change conflict alert, ⌘S). Phase 1 has a single "Page" section; a tab picker for
+/// selection-level editing comes in Phase 3.
+struct PageInspectorView: View {
+    let context: InspectorContext
+
+    var body: some View {
+        switch context {
+        case .typed(let model):
+            InspectorChrome(model: model) { TypedEntryForm(model: model) }
+        case .page(let model):
+            InspectorChrome(model: model) { PageMetadataForm(model: model) }
+        }
+    }
+}
+
+/// The form for a plain (non-typed) frontmatter page: title + description.
+private struct PageMetadataForm: View {
+    @Bindable var model: PageMetadataModel
+
+    var body: some View {
+        Form {
+            TextField("Title", text: model.titleBinding())
+            VStack(alignment: .leading) {
+                Text("Description").font(.caption).foregroundStyle(.secondary)
+                TextField("", text: model.descriptionBinding(), axis: .vertical).lineLimit(2...6)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+/// Shared inspector chrome around any `InspectorEditorModel`. Generic over the concrete model so the
+/// form bodies keep their `@Bindable` two-way bindings.
+private struct InspectorChrome<M: InspectorEditorModel & Observable, Form: View>: View {
+    @Bindable var model: M
+    @ViewBuilder var form: () -> Form
+    @Environment(\.controlActiveState) private var controlActiveState
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            Group {
+                if let loadError = model.loadError {
+                    ContentUnavailableView {
+                        Label("Can't open \(model.file.name)", systemImage: "exclamationmark.triangle")
+                    } description: { Text(loadError) } actions: {
+                        Button("Reveal in Finder") { NSWorkspace.shared.activateFileViewerSelecting([model.file.url]) }
+                    }
+                } else if model.isLoading {
+                    ProgressView().controlSize(.small)
+                } else {
+                    form()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .task(id: model.file.id) { await model.load() }
+        .onChange(of: controlActiveState) { _, new in
+            if new == .key { Task { await model.checkExternalChange() } }
+        }
+        .background(Button("") { Task { await model.save() } }
+            .keyboardShortcut("s", modifiers: [.command]).hidden())
+        .alert("\(model.file.name) changed on disk", isPresented: conflictBinding) {
+            Button("Keep My Changes", role: .cancel) { model.keepMyChanges() }
+            Button("Reload from Disk") { Task { await model.reloadFromDisk() } }
+        } message: {
+            Text("Another tool edited this file while you had unsaved changes.")
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Label(model.file.name, systemImage: "doc.text").font(.headline)
+            if model.isDirty {
+                Circle().fill(.secondary).frame(width: 7, height: 7).help("Unsaved changes")
+            }
+            Spacer()
+            Button("Save") { Task { await model.save() } }.disabled(!model.isDirty)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
+    private var conflictBinding: Binding<Bool> {
+        Binding(get: { model.conflictDiskContents != nil }, set: { _ in })
+    }
+}
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors && swift build --package-path . 2>&1 | tail -25`
+Expected: builds clean. (At this point `TypedEntryEditorView` no longer exists as a type — Task 4 removes its last `SiteWindow` reference, so the package may still reference it; if `swift build` flags `cannot find 'TypedEntryEditorView'` in `SiteWindow.swift`, that reference is removed in Task 4 — proceed; the App module fully compiles after Task 4. To keep this task self-contained, you may temporarily expect the error to be confined to `SiteWindow.swift`'s `mainPaneContent`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Sources/AnglesiteApp/PageInspectorView.swift Sources/AnglesiteApp/TypedEntryEditorView.swift
+git commit -m "$(printf 'feat(#346): PageInspectorView — shared inspector chrome + page/typed forms\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 4: Wire the inspector into `SiteWindow`; remove the `.typed` main-pane path
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift`
+
+**Interfaces:**
+- Consumes: `InspectorContext` (Task 2), `PageInspectorView` (Task 3), `PageMetadataModel`/`TypedEntryEditorModel` (Task 2), `ContentTypeResolver` (#346), `contentGraph` (existing).
+
+This task removes the `.typed` main-pane editor and replaces it with the inspector. Do the edits in order.
+
+- [ ] **Step 1: Remove `.typed` from the `ActiveEditor` enum**
+
+Replace (around line 12):
+```swift
+private enum ActiveEditor {
+    case text(FileEditorModel)
+    case plist(PlistEditorModel)
+    case typed(TypedEntryEditorModel)
+
+    var file: FileRef {
+        switch self {
+        case .text(let model): model.file
+        case .plist(let model): model.file
+        case .typed(let model): model.file
+        }
+    }
+}
+```
+with:
+```swift
+private enum ActiveEditor {
+    case text(FileEditorModel)
+    case plist(PlistEditorModel)
+
+    var file: FileRef {
+        switch self {
+        case .text(let model): model.file
+        case .plist(let model): model.file
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add inspector state**
+
+After the `@State private var activeEditor: ActiveEditor?` line (around line 116), add:
+```swift
+    /// The right-hand inspector's current target (typed entry or plain page), or nil when the
+    /// selection has no editable metadata. Set by `applyNavigatorSelection`.
+    @State private var inspectorContext: InspectorContext?
+    /// Inspector visibility, persisted per window. Defaults to shown (auto-open); the toolbar toggle
+    /// flips it and the choice persists across selections.
+    @SceneStorage("siteInspector.shown") private var inspectorShown = true
+```
+
+- [ ] **Step 3: Attach `.inspector` to the detail content**
+
+In `siteUI(for:)`, the detail `ZStack` carries `.navigationTitle`/`.navigationSubtitle`/`.toolbar`. Add the inspector alongside them. Find (around line 240):
+```swift
+        .navigationTitle(site.name)
+        .navigationSubtitle(preview.readyURL?.absoluteString ?? "")
+        .toolbar {
+```
+and insert the `.inspector` modifier immediately before `.navigationTitle`:
+```swift
+        .inspector(isPresented: Binding(
+            get: { inspectorShown && inspectorContext != nil },
+            set: { inspectorShown = $0 }
+        )) {
+            if let inspectorContext {
+                PageInspectorView(context: inspectorContext)
+                    .inspectorColumnWidth(min: 260, ideal: 300, max: 420)
+            }
+        }
+        .navigationTitle(site.name)
+```
+
+- [ ] **Step 4: Add the toolbar toggle**
+
+Inside the `.toolbar { … }` block, add a toggle item (place it as the first `ToolbarItem` after the opening brace, before the Backup item):
+```swift
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    inspectorShown.toggle()
+                } label: {
+                    Label("Inspector", systemImage: "sidebar.right")
+                }
+                .disabled(inspectorContext == nil)
+                .help("Show or hide the page inspector")
+            }
+```
+
+- [ ] **Step 5: Remove the `.typed` main-pane render**
+
+Replace (around line 554):
+```swift
+        case .editor:
+            if case .text(let editorModel) = activeEditor {
+                MainPaneEditorView(model: editorModel)
+            } else if case .typed(let typedModel) = activeEditor {
+                TypedEntryEditorView(model: typedModel)
+            } else if case .plist(let plistEditorModel) = activeEditor {
+                PlistEditorView(model: plistEditorModel) { title in
+                    Task { await saveWebsiteTitle(title) }
+                }
+```
+with:
+```swift
+        case .editor:
+            if case .text(let editorModel) = activeEditor {
+                MainPaneEditorView(model: editorModel)
+            } else if case .plist(let plistEditorModel) = activeEditor {
+                PlistEditorView(model: plistEditorModel) { title in
+                    Task { await saveWebsiteTitle(title) }
+                }
+```
+
+- [ ] **Step 6: Remove the `.typed` cases from `showsPaneModePicker`, `leaveCurrentEditor`, `persistEditorBufferBestEffort`**
+
+In `showsPaneModePicker` (around line 490), replace:
+```swift
+        case .some(.plist), .some(.typed), .none:
+            return false
+```
+with:
+```swift
+        case .some(.plist), .none:
+            return false
+```
+
+In `leaveCurrentEditor` (around line 516), remove the `.typed` arm:
+```swift
+        case .typed(let model):
+            return await model.flushBeforeLeaving()
+```
+
+In `persistEditorBufferBestEffort` (around line 543), replace:
+```swift
+        case .typed(let model) where model.isDirty:
+            Task { await model.flushBeforeLeaving() }
+        case .text, .typed, nil:
+            break
+```
+with:
+```swift
+        case .text, nil:
+            break
+```
+
+- [ ] **Step 7: Add inspector-flush + teardown handling**
+
+Add a helper next to `leaveCurrentEditor` (after it, around line 526):
+```swift
+    /// Flush the inspector's editor before changing selection or tearing down — autosaves a dirty
+    /// buffer, returns false (and the model raises its conflict alert) on an external conflict so the
+    /// caller aborts the switch. Safe when no inspector is active.
+    private func leaveCurrentInspector() async -> Bool {
+        guard let model = inspectorContext?.model else { return true }
+        return await model.flushBeforeLeaving()
+    }
+```
+In the two teardown sites that already do `persistEditorBufferBestEffort(); activeEditor = nil; mainPaneMode = .preview` (around lines 146 and 179), add inspector teardown right after `activeEditor = nil`:
+```swift
+            if let model = inspectorContext?.model { Task { await model.flushBeforeLeaving() } }
+            inspectorContext = nil
+```
+
+- [ ] **Step 8: Rework `applyNavigatorSelection` routing**
+
+Replace the entire `.route`/`.file` switch body and the `typedEditorForContent` helper. Replace (around lines 666–747) the `switch target { … }` plus `typedEditorForContent(...)` with:
+
+```swift
+        switch target {
+        case .route(let route):
+            Task {
+                guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+                // Content entry → preview in the center; its metadata in the inspector.
+                activeEditor = nil
+                mainPaneMode = .preview
+                if route.isEmpty || route == "/" { preview.clearRoute() } else { preview.navigate(toRoute: route) }
+                inspectorContext = await makeInspectorContext(forNavigatorID: id)
+            }
+        case .file(let file):
+            if activeEditorFile?.id == file.id {
+                mainPaneMode = .editor(file)   // re-show the already-open file (buffer intact)
+                return
+            }
+            Task {
+                guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+                inspectorContext = nil   // files (components/styles/metadata) have no page inspector
+                switch EditorKind.resolve(for: file) {
+                case .text:
+                    activeEditor = .text(FileEditorModel(file: file))
+                case .plist:
+                    activeEditor = .plist(PlistEditorModel(
+                        file: file,
+                        websiteTitle: site?.name ?? file.name,
+                        sourceDirectory: site?.sourceDirectory ?? file.url.deletingLastPathComponent()
+                    ))
+                }
+                mainPaneMode = .editor(file)
+            }
+        }
+    }
+
+    /// Project-relative path of `url` under the site `Source/` directory, for content-type resolution.
+    private func relativeProjectPath(of url: URL, under root: URL) -> String {
+        let u = url.standardizedFileURL.path(percentEncoded: false)
+        let r = root.standardizedFileURL.path(percentEncoded: false)
+        guard u.hasPrefix(r) else { return url.lastPathComponent }
+        return String(u.dropFirst(r.count)).drop(while: { $0 == "/" }).description
+    }
+
+    /// Build the inspector context for a content navigator id: the typed descriptor form when the
+    /// file resolves to a content type, the plain title/description form for a frontmatter-bearing
+    /// markdown page, or nil (plain `.astro`/other → preview only, no inspector).
+    private func makeInspectorContext(forNavigatorID id: String) async -> InspectorContext? {
+        guard let source = site?.sourceDirectory else { return nil }
+        let relPath: String
+        let group: FileGroup
+        let displayName: String
+        if let page = await contentGraph.page(id: id) {
+            relPath = page.filePath; group = .pages; displayName = page.title ?? page.route
+        } else if let post = await contentGraph.post(id: id) {
+            relPath = post.filePath; group = .posts; displayName = post.title
+        } else {
+            return nil
+        }
+        let url = source.appendingPathComponent(relPath)
+        let file = FileRef(url: url, group: group, name: displayName)
+        if let descriptor = ContentTypeResolver.descriptor(forRelativePath: relPath) {
+            return .typed(TypedEntryEditorModel(file: file, descriptor: descriptor, sourceDirectory: source))
+        }
+        if isFrontmatterPage(relPath) {
+            return .page(PageMetadataModel(file: file, sourceDirectory: source))
+        }
+        return nil   // plain .astro / other → preview only
+    }
+
+    private func isFrontmatterPage(_ relPath: String) -> Bool {
+        let ext = (relPath as NSString).pathExtension.lowercased()
+        return ext == "md" || ext == "mdx" || ext == "markdown"
+    }
+```
+
+Note: the previous `relativeProjectPath` helper (used only by the removed `.file` typed-resolution) is retained above in case other call sites use it; if `swift build` reports it as unused, remove it.
+
+- [ ] **Step 9: Build the app target**
+
+Run:
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+export ANGLESITE_PLUGIN_SRC="$(cd ../../../../anglesite 2>/dev/null && pwd)"
+scripts/copy-plugin.sh 2>&1 | tail -2 || true
+xcodegen generate 2>&1 | tail -2
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -25
+```
+Expected: **BUILD SUCCEEDED**. Fix any leftover `.typed`/`TypedEntryEditorView` reference the steps missed (grep `grep -n "\.typed\|TypedEntryEditorView" Sources/AnglesiteApp/SiteWindow.swift` should return nothing).
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "$(printf 'feat(#346): host the editor in a right inspector; preview stays centered\n\nContent selection navigates the preview (center) and opens its metadata in\na .inspector panel (typed form or page title/description), with a toolbar\ntoggle. Removes the .typed main-pane editor path.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 5: Full verification + PR update
+
+**Files:** none (verification).
+
+- [ ] **Step 1: Core tests**
+
+Run: `cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors && swift test --package-path . 2>&1 | tail -25`
+Expected: all pass, including the new `PageMetadataEditor` suite and the unchanged `FrontmatterDocument`/`TypedContentEditor`/`ContentTypeResolver` suites. (Known env gap: the MCP/apply-edit e2e tests fail without `ANGLESITE_PLUGIN_PATH`/node — confirm only those fail.)
+
+- [ ] **Step 2: App build**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug -derivedDataPath ./build-smoke build 2>&1 | tail -6`
+Expected: **BUILD SUCCEEDED**.
+
+- [ ] **Step 3: In-app smoke**
+
+Launch `./build-smoke/Build/Products/Debug/Anglesite.app` against a site scaffolded from the current template (a `.anglesite` package whose `Source/` is the template, with `node_modules` symlinked so the runtime starts; register it in `~/Library/Application Support/Anglesite/recents.json`). Verify:
+1. Select a note → center shows the preview, the **right inspector** shows the typed form (publishDate/tags/Body). Edit a field → Save → file on disk updates + `git log -1` shows `anglesite: edit note <slug>`.
+2. Select `about.md` → inspector shows the Business Profile form; `type`/`layout`/`title` keys preserved on save.
+3. Select a plain markdown page (add one if the template has none) → inspector shows Title + Description.
+4. Select `index.astro` → preview only, **no** inspector. Select a component → main-pane text editor, no inspector.
+5. The toolbar `sidebar.right` button hides/shows the inspector; the choice persists when switching between content entries.
+
+Record results; clean up the throwaway site + recents entry afterward.
+
+- [ ] **Step 4: Push (updates the open PR #397)**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+rm -rf build-smoke
+git push 2>&1 | tail -3
+gh pr comment 397 --body "Phase 1 inspector landed: typed + page metadata now edit in a right-hand inspector with the preview centered. [smoke results …]"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Inspector shell via `.inspector` + toolbar toggle + remembered visibility → Task 4 (Steps 2–4). ✓
+- Center = live preview on content selection → Task 4 Step 8 (`.route` navigates preview). ✓
+- Typed entries via #346 core in the inspector → Tasks 2–3 (conformance + `TypedEntryForm` in `PageInspectorView`). ✓
+- Plain frontmatter pages get title/description → Tasks 1–3 (`PageMetadataEditor`/`Model`/`PageMetadataForm`). ✓
+- `.astro`/other → preview only, no inspector → Task 4 Step 8 (`inspectorContext` returns nil). ✓
+- Components/styles keep main-pane text editor → Task 4 Step 8 (`.file` branch unchanged; `inspectorContext = nil`). ✓
+- Remove `.typed` main-pane path → Task 4 Steps 1, 5, 6. ✓
+- Per-edit git commit → Task 2 (`PageMetadataModel.commit`) + existing `TypedEntryEditorModel`. ✓
+- Round-trip safety via `FrontmatterDocument` → Task 1. ✓
+- Flush-on-leave + teardown for the inspector model → Task 4 Step 7. ✓
+- Body stays in the typed form (Phase 1) → Task 3 (`TypedEntryForm` keeps the Body section). ✓
+- Title-template + social cards + selection-level + `.astro` editing all out of scope → not implemented. ✓
+
+**Placeholder scan:** No TBD/TODO. The two conditional notes (Task 3 Step 3 build-error confinement; Task 4 Step 8 `relativeProjectPath` possibly-unused) are bounded with exact grep/expected-error guidance, not open-ended work. ✓
+
+**Type consistency:** `InspectorEditorModel` members match what `TypedEntryEditorModel` (#346) and `PageMetadataModel` (Task 2) expose; `InspectorContext.model: any InspectorEditorModel`; `PageMetadataEditor.read/write` signatures match their uses in `PageMetadataModel`; `makeInspectorContext(forNavigatorID:)`/`leaveCurrentInspector()`/`isFrontmatterPage(_:)` are defined and called consistently in Task 4; `PageInspectorView(context:)` matches the `.inspector` call site. ✓

--- a/docs/superpowers/plans/2026-06-27-v1-4-typed-form-editors.md
+++ b/docs/superpowers/plans/2026-06-27-v1-4-typed-form-editors.md
@@ -1,0 +1,1417 @@
+# V-1.4 Per-type SwiftUI form editors — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every typed content object a schema-driven SwiftUI form editor that round-trips to YAML frontmatter without data loss and commits each save to git.
+
+**Architecture:** All round-trip and mapping logic lives in pure, unit-tested `AnglesiteCore` types (`FrontmatterDocument`, `TypedContentEditor`, `ContentTypeResolver`). The `AnglesiteApp` layer is a thin `@Observable` model + a generic SwiftUI `Form` that renders one control per field `Kind`, wired into `SiteWindow`'s existing navigator-selection routing. `businessProfile` (the only `.page`-stored type) gets a concrete home shipped in the template at `src/pages/about.md`.
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27+), Swift Testing (`@Test`/`#expect`), `git` via the existing `NativeContentOperations.processGitCommit`.
+
+**Design spec:** [`docs/superpowers/specs/2026-06-27-v1-4-typed-form-editors-design.md`](../specs/2026-06-27-v1-4-typed-form-editors-design.md)
+
+## Global Constraints
+
+- **ES/Apple-only frameworks** — no third-party Swift deps (CLAUDE.md).
+- **Toolchain:** Xcode 27+ / Swift 6.4. Tests run via `swift test --package-path .`. Set `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` if the default `swift` is the broken CommandLineTools one (see memory).
+- **Worktree:** all work happens in `/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors` on branch `feat/346-typed-editors`. `cd` there before any git/build op.
+- **App-target logic is not CI-testable** (hosted `.app` won't launch on CI runners). So all testable logic lives in `AnglesiteCore`; `AnglesiteApp` model/view code is validated by `swift build` + manual smoke only.
+- **Pure Core types are I/O-free** — `FrontmatterDocument`, `TypedContentEditor`, `ContentTypeResolver` take/return values; no `FileManager`, no `Process`.
+- **Round-trip safety is mandatory:** an unedited document serializes byte-identically (modulo uniform line-ending normalization); editing one field never alters untouched keys or the body.
+- **Swift Testing**, not XCTest, for all new tests (`import Testing`; `@Suite`/`@Test`/`#expect`).
+
+---
+
+## File Structure
+
+New (AnglesiteCore — pure, tested):
+- `Sources/AnglesiteCore/FrontmatterDocument.swift` — read/write frontmatter+body doc with per-key verbatim preservation.
+- `Sources/AnglesiteCore/TypedContentEditor.swift` — descriptor-aware bridge: file ⟷ typed field values; per-`Kind` parse/format; markdown field ⟷ body.
+- `Sources/AnglesiteCore/ContentTypeResolver.swift` — project-relative path → `ContentTypeDescriptor?`.
+
+New (AnglesiteApp — thin, build-validated):
+- `Sources/AnglesiteApp/TypedEntryEditorModel.swift` — `@MainActor @Observable` buffer over `TypedContentEditor` + `FileDocumentIO` + git commit.
+- `Sources/AnglesiteApp/TypedEntryEditorView.swift` — generic `Form` rendering controls per `Kind`.
+
+New (template):
+- `Resources/Template/src/pages/about.md` — `businessProfile` singleton page.
+
+New (tests):
+- `Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift`
+- `Tests/AnglesiteCoreTests/TypedContentEditorTests.swift`
+- `Tests/AnglesiteCoreTests/ContentTypeResolverTests.swift`
+
+Modified:
+- `Sources/AnglesiteApp/SiteWindow.swift` — add `.typed` editor case + resolution branch in `applyNavigatorSelection` and `mainPaneContent`.
+
+---
+
+## Task 1: `FrontmatterDocument` — round-trip-safe frontmatter+body model (Core)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/FrontmatterDocument.swift`
+- Test: `Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `public struct FrontmatterDocument: Equatable, Sendable`
+  - `public enum FrontmatterDocument.Value: Equatable, Sendable { case scalar(String); case bool(Bool); case array([String]) }`
+  - `public static func parse(_ source: String) -> FrontmatterDocument`
+  - `public func value(for key: String) -> Value?`
+  - `public mutating func set(_ value: Value, for key: String)` — updates an existing key in place (marking it for re-render) or appends a new key at the end.
+  - `public var body: String { get set }` — text after the closing `---` fence, verbatim; settable.
+  - `public func serialized() -> String`
+  - `public var keys: [String]` — frontmatter keys in source order (excludes synthetic raw segments).
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("FrontmatterDocument")
+struct FrontmatterDocumentTests {
+
+    @Test("unedited round-trip is the identity")
+    func identity() {
+        let src = """
+        ---
+        title: "Hello"
+        draft: false
+        tags:
+          - a
+          - b
+        ---
+
+        Body text here.
+        """ + "\n"
+        #expect(FrontmatterDocument.parse(src).serialized() == src)
+    }
+
+    @Test("reads scalar, bool, and array values")
+    func reads() {
+        let doc = FrontmatterDocument.parse("---\ntitle: \"Hi\"\ndraft: true\ntags: [x, y]\n---\nB\n")
+        #expect(doc.value(for: "title") == .scalar("Hi"))
+        #expect(doc.value(for: "draft") == .bool(true))
+        #expect(doc.value(for: "tags") == .array(["x", "y"]))
+        #expect(doc.value(for: "missing") == nil)
+    }
+
+    @Test("editing one field leaves untouched keys and body verbatim")
+    func editPreserves() {
+        let src = "---\ntitle: \"Old\"\nweirdKey: keep-me-exactly\ndraft: false\n---\n\nBody.\n"
+        var doc = FrontmatterDocument.parse(src)
+        doc.set(.scalar("New"), for: "title")
+        let out = doc.serialized()
+        #expect(out.contains("title: \"New\""))
+        #expect(out.contains("weirdKey: keep-me-exactly"))   // unknown key preserved verbatim
+        #expect(out.contains("draft: false"))
+        #expect(out.hasSuffix("\n\nBody.\n"))                // body verbatim
+    }
+
+    @Test("setting a new key appends it")
+    func appendsNewKey() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\nB\n")
+        doc.set(.scalar("noreply@x.io"), for: "email")
+        #expect(doc.serialized().contains("email: \"noreply@x.io\""))
+        #expect(doc.value(for: "email") == .scalar("noreply@x.io"))
+    }
+
+    @Test("no-frontmatter source is all body")
+    func noFrontmatter() {
+        let doc = FrontmatterDocument.parse("# Heading\n\nbody\n")
+        #expect(doc.keys.isEmpty)
+        #expect(doc.body == "# Heading\n\nbody\n")
+        #expect(doc.serialized() == "# Heading\n\nbody\n")
+    }
+
+    @Test("editing the body leaves frontmatter verbatim")
+    func editBody() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\n\nold body\n")
+        doc.body = "\nnew body\n"
+        let out = doc.serialized()
+        #expect(out.contains("title: \"T\""))
+        #expect(out.hasSuffix("\nnew body\n"))
+    }
+
+    @Test("array set renders block form and round-trips")
+    func arraySet() {
+        var doc = FrontmatterDocument.parse("---\nhours: []\n---\n")
+        doc.set(.array(["Mon 9-5", "Tue 9-5"]), for: "hours")
+        let out = doc.serialized()
+        let reparsed = FrontmatterDocument.parse(out)
+        #expect(reparsed.value(for: "hours") == .array(["Mon 9-5", "Tue 9-5"]))
+    }
+
+    @Test("comments and blank lines inside frontmatter survive an unedited round-trip")
+    func commentsSurvive() {
+        let src = "---\ntitle: \"T\"\n# a comment\n\ndraft: false\n---\nB\n"
+        #expect(FrontmatterDocument.parse(src).serialized() == src)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors && swift test --package-path . --filter FrontmatterDocument 2>&1 | tail -20`
+Expected: FAIL — `cannot find 'FrontmatterDocument' in scope`.
+
+- [ ] **Step 3: Implement `FrontmatterDocument`**
+
+```swift
+// Sources/AnglesiteCore/FrontmatterDocument.swift
+import Foundation
+
+/// A read/write model of a content file's YAML frontmatter + body.
+///
+/// Unlike `Frontmatter.parse` (read-only, top-level keys only, drops unknown keys, collapses
+/// value types), this preserves **every** source segment — known keys, unknown keys, comments,
+/// and blank lines — in order, each with its verbatim source text. A key is re-rendered only when
+/// it is `set`. Consequences the editor relies on:
+///
+/// - An unedited `parse(...).serialized()` is the identity (modulo uniform line-ending
+///   normalization for mixed endings).
+/// - Editing one field never disturbs untouched keys or the body.
+/// - Form-only editing can never silently drop a hand-authored key or body content.
+///
+/// Pure value type, no I/O.
+public struct FrontmatterDocument: Equatable, Sendable {
+    public enum Value: Equatable, Sendable {
+        case scalar(String)   // logical (unquoted/decoded) string
+        case bool(Bool)
+        case array([String])
+    }
+
+    /// One ordered segment of the frontmatter block. A `key` segment is editable; a `raw` segment
+    /// (comment / blank line) is opaque and always serialized verbatim.
+    private struct Segment: Equatable {
+        var key: String?            // nil ⟹ raw passthrough segment
+        var value: Value?           // logical value for key segments
+        var verbatim: [String]?     // original source lines; nil once a key segment is mutated
+    }
+
+    private var segments: [Segment]
+    /// Index into `segments` by key, for O(1) get/set. Only key segments are listed.
+    private var indexByKey: [String: Int]
+    /// Text after the closing `---` fence, verbatim (internally newline = "\n").
+    public var body: String
+    private let newline: String
+    private let hadFrontmatter: Bool
+
+    public var keys: [String] { segments.compactMap(\.key) }
+
+    public func value(for key: String) -> Value? {
+        guard let i = indexByKey[key] else { return nil }
+        return segments[i].value
+    }
+
+    public mutating func set(_ value: Value, for key: String) {
+        if let i = indexByKey[key] {
+            segments[i].value = value
+            segments[i].verbatim = nil   // force re-render
+        } else {
+            indexByKey[key] = segments.count
+            segments.append(Segment(key: key, value: value, verbatim: nil))
+        }
+    }
+
+    public func serialized() -> String {
+        guard hadFrontmatter else { return body.replacingOccurrences(of: "\n", with: newline) }
+        var lines: [String] = ["---"]
+        for seg in segments {
+            if let verbatim = seg.verbatim {
+                lines.append(contentsOf: verbatim)
+            } else if let key = seg.key, let value = seg.value {
+                lines.append(Self.render(key: key, value: value))
+            }
+        }
+        lines.append("---")
+        var out = lines.joined(separator: "\n")
+        if !body.isEmpty || hadFrontmatter { out += "\n" + body }
+        return out.replacingOccurrences(of: "\n", with: newline)
+    }
+
+    // MARK: Parse
+
+    public static func parse(_ source: String) -> FrontmatterDocument {
+        let newline = source.contains("\r\n") ? "\r\n" : "\n"
+        let normalized = source.replacingOccurrences(of: "\r\n", with: "\n")
+
+        guard normalized.hasPrefix("---\n") else {
+            return FrontmatterDocument(segments: [], indexByKey: [:], body: normalized,
+                                       newline: newline, hadFrontmatter: false)
+        }
+        var all = normalized.components(separatedBy: "\n")
+        // all[0] == "---"; find the closing fence.
+        var close = -1
+        var i = 1
+        while i < all.count { if all[i] == "---" { close = i; break }; i += 1 }
+        guard close >= 0 else {
+            return FrontmatterDocument(segments: [], indexByKey: [:], body: normalized,
+                                       newline: newline, hadFrontmatter: false)
+        }
+        let block = Array(all[1..<close])
+        // body = everything after the closing fence, rejoined (the leading separator after `---`
+        // is represented by the first element being "").
+        let body = Array(all[(close + 1)...]).joined(separator: "\n")
+
+        var segments: [Segment] = []
+        var indexByKey: [String: Int] = [:]
+        var j = 0
+        while j < block.count {
+            let line = block[j]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            // Comment / blank → raw passthrough.
+            if trimmed.isEmpty || trimmed.hasPrefix("#") {
+                segments.append(Segment(key: nil, value: nil, verbatim: [line]))
+                j += 1
+                continue
+            }
+            // A top-level `key: …` line (no leading whitespace).
+            if let first = line.first, first == " " || first == "\t" {
+                segments.append(Segment(key: nil, value: nil, verbatim: [line]))  // stray indent → passthrough
+                j += 1
+                continue
+            }
+            guard let colon = line.firstIndex(of: ":") else {
+                segments.append(Segment(key: nil, value: nil, verbatim: [line]))
+                j += 1
+                continue
+            }
+            let key = String(line[line.startIndex..<colon])
+            let rawValue = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+
+            var verbatim = [line]
+            let value: Value
+            if rawValue.isEmpty {
+                // Possible block array on following `- item` lines.
+                var items: [String] = []
+                var k = j + 1
+                while k < block.count, let item = blockArrayItem(block[k]) {
+                    items.append(unquote(item))
+                    verbatim.append(block[k])
+                    k += 1
+                }
+                value = items.isEmpty ? .scalar("") : .array(items)
+                j = k
+            } else {
+                value = parseScalarOrArray(rawValue)
+                j += 1
+            }
+            indexByKey[key] = segments.count
+            segments.append(Segment(key: key, value: value, verbatim: verbatim))
+        }
+        return FrontmatterDocument(segments: segments, indexByKey: indexByKey, body: body,
+                                   newline: newline, hadFrontmatter: true)
+    }
+
+    // MARK: Render (mirrors ContentScaffold conventions: double-quoted scalars, `[]` empty arrays)
+
+    private static func render(key: String, value: Value) -> String {
+        switch value {
+        case .scalar(let s):
+            return "\(key): \"\(escape(s))\""
+        case .bool(let b):
+            return "\(key): \(b)"
+        case .array(let items):
+            if items.isEmpty { return "\(key): []" }
+            return ([ "\(key):" ] + items.map { "  - \"\(escape($0))\"" }).joined(separator: "\n")
+        }
+    }
+
+    private static func escape(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    // MARK: Scalar/array parsing (matching Frontmatter.swift semantics)
+
+    private static func blockArrayItem(_ line: String) -> String? {
+        let stripped = String(line.drop(while: { $0 == " " || $0 == "\t" }))
+        guard stripped.hasPrefix("-") else { return nil }
+        let afterDash = stripped.dropFirst()
+        guard let f = afterDash.first, f == " " || f == "\t" else { return nil }
+        return String(afterDash).trimmingCharacters(in: .whitespaces)
+    }
+
+    private static func parseScalarOrArray(_ raw: String) -> Value {
+        if raw == "true" { return .bool(true) }
+        if raw == "false" { return .bool(false) }
+        if raw.hasPrefix("["), raw.hasSuffix("]") {
+            let inner = String(raw.dropFirst().dropLast()).trimmingCharacters(in: .whitespaces)
+            if inner.isEmpty { return .array([]) }
+            return .array(inner.split(separator: ",", omittingEmptySubsequences: false)
+                .map { unquote($0.trimmingCharacters(in: .whitespaces)) })
+        }
+        return .scalar(unquote(raw))
+    }
+
+    private static func unquote(_ s: String) -> String {
+        guard s.count >= 2 else { return s }
+        if s.hasPrefix("\"") && s.hasSuffix("\"") {
+            let inner = String(s.dropFirst().dropLast())
+            return inner
+                .replacingOccurrences(of: "\\\"", with: "\u{1}").replacingOccurrences(of: "\\\\", with: "\u{2}")
+                .replacingOccurrences(of: "\\n", with: "\n").replacingOccurrences(of: "\\t", with: "\t")
+                .replacingOccurrences(of: "\u{1}", with: "\"").replacingOccurrences(of: "\u{2}", with: "\\")
+        }
+        if s.hasPrefix("'") && s.hasSuffix("'") {
+            return String(s.dropFirst().dropLast()).replacingOccurrences(of: "''", with: "'")
+        }
+        return s
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `swift test --package-path . --filter FrontmatterDocument 2>&1 | tail -20`
+Expected: PASS (8 tests). If `identity`/`commentsSurvive` fail on a trailing-newline mismatch, check the `body` rejoin handles the final `""` element — fix the off-by-one in `serialized()`'s body concatenation before moving on.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Sources/AnglesiteCore/FrontmatterDocument.swift Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+git commit -m "$(printf 'feat(#346): FrontmatterDocument round-trip frontmatter+body model\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 2: `TypedContentEditor` — descriptor ⟷ typed field values (Core)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/TypedContentEditor.swift`
+- Test: `Tests/AnglesiteCoreTests/TypedContentEditorTests.swift`
+
+**Interfaces:**
+- Consumes: `FrontmatterDocument` (Task 1), `ContentTypeDescriptor`/`ContentTypeField.Kind` (existing).
+- Produces:
+  - `public enum TypedContentEditor.FieldValue: Equatable, Sendable { case text(String); case flag(Bool); case date(Date?); case number(Double?); case list([String]) }`
+  - `public struct TypedContentEditor.Values: Equatable, Sendable` with `public subscript(_ name: String) -> FieldValue?` and `public init(_ dict: [String: FieldValue])`.
+  - `public static func read(_ contents: String, descriptor: ContentTypeDescriptor) -> Values` — every field in `descriptor.fields` gets a value (empty default if absent). The single `markdown` field (if any) is read from the document **body**; all others from frontmatter.
+  - `public static func write(_ values: Values, into contents: String, descriptor: ContentTypeDescriptor) -> String` — applies only the fields whose value differs from what `contents` currently holds, so untouched fields stay verbatim (Task 1 guarantee). The markdown field writes to the body.
+  - `public static func defaultValue(for kind: ContentTypeField.Kind) -> FieldValue`
+
+Mapping `Kind` → `FieldValue`: `string`/`text`/`url`/`image`/`markdown` → `.text`; `bool` → `.flag`; `date`/`datetime` → `.date`; `number` → `.number`; `stringArray`/`imageArray` → `.list`.
+
+Date formatting (mirror `ContentScaffold.renderEntry`): `datetime` → ISO8601 `[.withInternetDateTime, .withFractionalSeconds]`; `date` → first 10 chars (`yyyy-MM-dd`).
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("TypedContentEditor")
+struct TypedContentEditorTests {
+    private var note: ContentTypeDescriptor { ContentTypeRegistry().descriptor(id: "note")! }
+    private var event: ContentTypeDescriptor { ContentTypeRegistry().descriptor(id: "event")! }
+    private var reply: ContentTypeDescriptor { ContentTypeRegistry().descriptor(id: "reply")! }
+
+    @Test("reads markdown field from body and scalars from frontmatter")
+    func reads() {
+        let src = "---\npublishDate: 2026-01-02T03:04:05.000Z\ntags: [a, b]\n---\n\nHello body.\n"
+        let v = TypedContentEditor.read(src, descriptor: note)
+        #expect(v["body"] == .text("\nHello body.\n"))           // markdown ⟷ body
+        #expect(v["tags"] == .list(["a", "b"]))
+        if case .date(let d?) = v["publishDate"] { #expect(d.timeIntervalSince1970 > 0) } else { Issue.record("no date") }
+    }
+
+    @Test("missing fields get empty defaults")
+    func defaults() {
+        let v = TypedContentEditor.read("---\n---\n", descriptor: reply)
+        #expect(v["inReplyTo"] == .text(""))
+        #expect(v["body"] == .text(""))
+    }
+
+    @Test("write applies only changed fields, leaving others verbatim")
+    func writeChangedOnly() {
+        let src = "---\ninReplyTo: \"https://a.example/x\"\npublishDate: 2026-01-02T03:04:05.000Z\n---\n\nold.\n"
+        var v = TypedContentEditor.read(src, descriptor: reply)
+        v = TypedContentEditor.Values([
+            "inReplyTo": .text("https://b.example/y"),      // changed
+            "publishDate": v["publishDate"]!,               // unchanged
+            "body": v["body"]!                              // unchanged
+        ])
+        let out = TypedContentEditor.write(v, into: src, descriptor: reply)
+        #expect(out.contains("inReplyTo: \"https://b.example/y\""))
+        #expect(out.contains("publishDate: 2026-01-02T03:04:05.000Z"))  // verbatim, not reformatted
+        #expect(out.hasSuffix("\nold.\n"))                              // body verbatim
+    }
+
+    @Test("write updates the markdown body")
+    func writeBody() {
+        let src = "---\npublishDate: 2026-01-02T03:04:05.000Z\n---\n\nold.\n"
+        var v = TypedContentEditor.read(src, descriptor: note)
+        v = TypedContentEditor.Values(["publishDate": v["publishDate"]!, "tags": v["tags"] ?? .list([]),
+                                       "body": .text("\nnew body.\n")])
+        let out = TypedContentEditor.write(v, into: src, descriptor: note)
+        #expect(out.hasSuffix("\nnew body.\n"))
+    }
+
+    @Test("write round-trips a list field into block YAML")
+    func writeList() {
+        let profile = ContentTypeRegistry().descriptor(id: "businessProfile")!
+        let src = "---\ntype: businessProfile\nname: \"Acme\"\nhours: []\n---\n"
+        var v = TypedContentEditor.read(src, descriptor: profile)
+        var dict = [String: TypedContentEditor.FieldValue]()
+        for f in profile.fields { dict[f.name] = v[f.name] }
+        dict["hours"] = .list(["Mon 9-5", "Sat closed"])
+        let out = TypedContentEditor.write(TypedContentEditor.Values(dict), into: src, descriptor: profile)
+        #expect(TypedContentEditor.read(out, descriptor: profile)["hours"] == .list(["Mon 9-5", "Sat closed"]))
+        #expect(out.contains("type: businessProfile"))   // unknown-to-schema key preserved
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `swift test --package-path . --filter TypedContentEditor 2>&1 | tail -20`
+Expected: FAIL — `cannot find 'TypedContentEditor' in scope`.
+
+- [ ] **Step 3: Implement `TypedContentEditor`**
+
+```swift
+// Sources/AnglesiteCore/TypedContentEditor.swift
+import Foundation
+
+/// Bridges a content file to the typed, per-field values a form editor binds to, and back.
+///
+/// One `markdown` field per type (the `body`) maps to the document body; every other field maps to
+/// a frontmatter key. `write` applies only fields whose value actually changed, so
+/// `FrontmatterDocument`'s verbatim preservation keeps untouched keys and the body intact. Pure,
+/// no I/O.
+public enum TypedContentEditor {
+    public enum FieldValue: Equatable, Sendable {
+        case text(String)
+        case flag(Bool)
+        case date(Date?)
+        case number(Double?)
+        case list([String])
+    }
+
+    public struct Values: Equatable, Sendable {
+        private var dict: [String: FieldValue]
+        public init(_ dict: [String: FieldValue] = [:]) { self.dict = dict }
+        public subscript(_ name: String) -> FieldValue? {
+            get { dict[name] }
+            set { dict[name] = newValue }
+        }
+    }
+
+    public static func defaultValue(for kind: ContentTypeField.Kind) -> FieldValue {
+        switch kind {
+        case .string, .text, .markdown, .url, .image: return .text("")
+        case .bool: return .flag(false)
+        case .date, .datetime: return .date(nil)
+        case .number: return .number(nil)
+        case .stringArray, .imageArray: return .list([])
+        }
+    }
+
+    public static func read(_ contents: String, descriptor: ContentTypeDescriptor) -> Values {
+        let doc = FrontmatterDocument.parse(contents)
+        var out = Values()
+        for field in descriptor.fields {
+            if field.kind == .markdown {
+                out[field.name] = .text(doc.body)
+                continue
+            }
+            guard let raw = doc.value(for: field.name) else {
+                out[field.name] = defaultValue(for: field.kind)
+                continue
+            }
+            out[field.name] = decode(raw, kind: field.kind)
+        }
+        return out
+    }
+
+    public static func write(_ values: Values, into contents: String, descriptor: ContentTypeDescriptor) -> String {
+        var doc = FrontmatterDocument.parse(contents)
+        let current = read(contents, descriptor: descriptor)
+        for field in descriptor.fields {
+            guard let newValue = values[field.name], newValue != current[field.name] else { continue }
+            if field.kind == .markdown {
+                if case .text(let body) = newValue { doc.body = body }
+                continue
+            }
+            if let encoded = encode(newValue, kind: field.kind) { doc.set(encoded, for: field.name) }
+        }
+        return doc.serialized()
+    }
+
+    // MARK: Decode (frontmatter → field value)
+
+    private static func decode(_ value: FrontmatterDocument.Value, kind: ContentTypeField.Kind) -> FieldValue {
+        switch kind {
+        case .string, .text, .url, .image, .markdown:
+            if case .scalar(let s) = value { return .text(s) }
+            return .text("")
+        case .bool:
+            if case .bool(let b) = value { return .flag(b) }
+            return .flag(false)
+        case .date, .datetime:
+            if case .scalar(let s) = value { return .date(parseDate(s)) }
+            return .date(nil)
+        case .number:
+            if case .scalar(let s) = value { return .number(Double(s)) }
+            return .number(nil)
+        case .stringArray, .imageArray:
+            if case .array(let a) = value { return .list(a) }
+            return .list([])
+        }
+    }
+
+    // MARK: Encode (field value → frontmatter)
+
+    private static func encode(_ value: FieldValue, kind: ContentTypeField.Kind) -> FrontmatterDocument.Value? {
+        switch value {
+        case .text(let s): return .scalar(s)
+        case .flag(let b): return .bool(b)
+        case .date(let d): return .scalar(d.map { format($0, kind: kind) } ?? "")
+        case .number(let n): return .scalar(n.map { formatNumber($0) } ?? "")
+        case .list(let a): return .array(a)
+        }
+    }
+
+    // MARK: Date/number formatting (mirror ContentScaffold)
+
+    private static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static func format(_ date: Date, kind: ContentTypeField.Kind) -> String {
+        let full = iso.string(from: date)
+        return kind == .date ? String(full.prefix(10)) : full
+    }
+
+    private static func parseDate(_ s: String) -> Date? {
+        if let d = iso.date(from: s) { return d }
+        // date-only (yyyy-MM-dd) → midnight UTC
+        let df = DateFormatter()
+        df.calendar = Calendar(identifier: .iso8601)
+        df.timeZone = TimeZone(identifier: "UTC")
+        df.dateFormat = "yyyy-MM-dd"
+        return df.date(from: s)
+    }
+
+    private static func formatNumber(_ n: Double) -> String {
+        n.rounded() == n ? String(Int(n)) : String(n)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `swift test --package-path . --filter TypedContentEditor 2>&1 | tail -20`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Sources/AnglesiteCore/TypedContentEditor.swift Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+git commit -m "$(printf 'feat(#346): TypedContentEditor maps descriptor fields to typed values\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 3: `ContentTypeResolver` — path → descriptor (Core)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ContentTypeResolver.swift`
+- Test: `Tests/AnglesiteCoreTests/ContentTypeResolverTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentTypeRegistry`/`ContentTypeDescriptor` (existing).
+- Produces: `public enum ContentTypeResolver { public static func descriptor(forRelativePath path: String, registry: ContentTypeRegistry = ContentTypeRegistry()) -> ContentTypeDescriptor? }`
+
+Rules (pure, no I/O):
+1. Collection types: if the normalized path contains the segment sequence `src/content/<collection>/…`, return the descriptor whose `collection == <collection>`.
+2. Page singletons: a fixed map of `descriptor.id → relative page path`; `businessProfile → "src/pages/about.md"`. Exact match → that descriptor.
+3. Otherwise `nil`.
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/ContentTypeResolverTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite("ContentTypeResolver")
+struct ContentTypeResolverTests {
+    @Test("collection entry resolves by directory")
+    func collection() {
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "src/content/notes/hello.md")?.id == "note")
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "src/content/events/launch.md")?.id == "event")
+    }
+
+    @Test("businessProfile resolves by its singleton page path")
+    func businessProfile() {
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "src/pages/about.md")?.id == "businessProfile")
+    }
+
+    @Test("leading ./ and absolute-ish prefixes are tolerated")
+    func normalization() {
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "./src/content/articles/x.md")?.id == "article")
+    }
+
+    @Test("unrelated files resolve to nil (text fallback)")
+    func none() {
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "src/pages/index.astro") == nil)
+        #expect(ContentTypeResolver.descriptor(forRelativePath: "src/styles/global.css") == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `swift test --package-path . --filter ContentTypeResolver 2>&1 | tail -20`
+Expected: FAIL — `cannot find 'ContentTypeResolver' in scope`.
+
+- [ ] **Step 3: Implement `ContentTypeResolver`**
+
+```swift
+// Sources/AnglesiteCore/ContentTypeResolver.swift
+import Foundation
+
+/// Resolves a project-relative file path to its content type, so the app can open typed files in
+/// the form editor. Collection entries are matched by their `src/content/<collection>/` directory;
+/// page-stored singletons by a fixed path map. Pure, no I/O.
+public enum ContentTypeResolver {
+    /// Canonical singleton page paths for `.page`-stored types. `businessProfile` is shipped in the
+    /// template at `src/pages/about.md` (this PR; the editor-relevant slice of #388).
+    static let pagePaths: [String: String] = ["businessProfile": "src/pages/about.md"]
+
+    public static func descriptor(
+        forRelativePath path: String,
+        registry: ContentTypeRegistry = ContentTypeRegistry()
+    ) -> ContentTypeDescriptor? {
+        let normalized = normalize(path)
+
+        // 1. Collection entry by directory.
+        let parts = normalized.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        if parts.count >= 4, parts[0] == "src", parts[1] == "content" {
+            let collection = parts[2]
+            if let match = registry.all.first(where: { $0.collection == collection }) { return match }
+        }
+
+        // 2. Page singleton by exact path.
+        for (id, pagePath) in pagePaths where normalized == pagePath {
+            return registry.descriptor(id: id)
+        }
+        return nil
+    }
+
+    private static func normalize(_ path: String) -> String {
+        var p = path.replacingOccurrences(of: "\\", with: "/")
+        while p.hasPrefix("./") { p.removeFirst(2) }
+        while p.hasPrefix("/") { p.removeFirst() }
+        return p
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `swift test --package-path . --filter ContentTypeResolver 2>&1 | tail -20`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Sources/AnglesiteCore/ContentTypeResolver.swift Tests/AnglesiteCoreTests/ContentTypeResolverTests.swift
+git commit -m "$(printf 'feat(#346): ContentTypeResolver maps project paths to content types\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 4: `businessProfile` singleton page in the template
+
+**Files:**
+- Create: `Resources/Template/src/pages/about.md`
+
+**Interfaces:** none (template asset). Consumed at runtime by `ContentTypeResolver` (Task 3) and the editor (Tasks 5–7).
+
+Rationale: `businessProfile` is the only `.page`-stored type and had no on-disk home. This ships one. It carries a `type: businessProfile` frontmatter marker (for downstream identification / #388 rendering and external tooling) plus the descriptor's fields. It uses `BaseLayout` + a `title` so the page builds and renders within the site shell today; the h-card / `LocalBusiness` JSON-LD **rendering** is deferred to #388. The `type`, `layout`, and `title` keys are not in the `businessProfile` schema and are preserved verbatim by the form editor (Task 1 guarantee), so editing business fields never disturbs them.
+
+- [ ] **Step 1: Create the page**
+
+```markdown
+---
+layout: ../layouts/BaseLayout.astro
+title: "About"
+type: businessProfile
+name: "Your Business Name"
+description: ""
+telephone: ""
+email: ""
+streetAddress: ""
+locality: ""
+region: ""
+postalCode: ""
+hours: []
+url: ""
+---
+
+# About
+
+Edit your business details in Anglesite (File ▸ open this page).
+```
+
+- [ ] **Step 2: Verify it parses as the businessProfile type (reuses Task 3)**
+
+Add a focused assertion to `ContentTypeResolverTests` is unnecessary (already covered). Instead verify the field read works end-to-end with a quick test addition:
+
+```swift
+// Append to TypedContentEditorTests.swift
+@Test("template about.md reads as businessProfile with marker preserved")
+func aboutPage() {
+    let profile = ContentTypeRegistry().descriptor(id: "businessProfile")!
+    let src = """
+    ---
+    layout: ../layouts/BaseLayout.astro
+    title: "About"
+    type: businessProfile
+    name: "Your Business Name"
+    hours: []
+    url: ""
+    ---
+
+    # About
+    """ + "\n"
+    let v = TypedContentEditor.read(src, descriptor: profile)
+    #expect(v["name"] == .text("Your Business Name"))
+    var dict = [String: TypedContentEditor.FieldValue]()
+    for f in profile.fields { dict[f.name] = v[f.name] }
+    dict["name"] = .text("Acme Co")
+    let out = TypedContentEditor.write(TypedContentEditor.Values(dict), into: src, descriptor: profile)
+    #expect(out.contains("name: \"Acme Co\""))
+    #expect(out.contains("type: businessProfile"))           // marker preserved
+    #expect(out.contains("layout: ../layouts/BaseLayout.astro")) // layout preserved
+}
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `swift test --package-path . --filter TypedContentEditor 2>&1 | tail -20`
+Expected: PASS (6 tests now).
+
+- [ ] **Step 4: (If node available) verify the template still builds**
+
+Run:
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors/Resources/Template
+[ -d node_modules ] && npx astro build 2>&1 | tail -15 || echo "SKIP: node_modules absent — build smoke skipped"
+```
+Expected: build succeeds (or SKIP). If `astro build` errors on `about.md`, confirm `BaseLayout.astro` tolerates extra frontmatter props (it should — Astro passes frontmatter through); do not add schema validation for pages.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Resources/Template/src/pages/about.md Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+git commit -m "$(printf 'feat(#346): ship businessProfile singleton page (src/pages/about.md)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 5: `TypedEntryEditorModel` — observable buffer (App)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/TypedEntryEditorModel.swift`
+
+**Interfaces:**
+- Consumes: `TypedContentEditor` (Task 2), `FileDocumentIO` (existing), `NativeContentOperations.processGitCommit` (existing), `FileRef`/`ContentTypeDescriptor` (existing).
+- Produces (used by Task 6/7):
+  - `@MainActor @Observable final class TypedEntryEditorModel`
+  - `init(file: FileRef, descriptor: ContentTypeDescriptor, sourceDirectory: URL, gitCommit: @escaping NativeContentOperations.GitCommit = NativeContentOperations.processGitCommit)`
+  - `let file: FileRef`, `let descriptor: ContentTypeDescriptor`
+  - `var values: TypedContentEditor.Values` (bound by the view)
+  - `var isDirty: Bool`, `var loadError: String?`, `var isLoading: Bool`, `var conflictDiskContents: String?`
+  - `func load() async`, `@discardableResult func save() async -> Bool`, `func flushBeforeLeaving() async -> Bool`, `func checkExternalChange() async`, `func keepMyChanges()`, `func reloadFromDisk() async`
+  - Binding helpers: `func textBinding(_ name: String) -> Binding<String>`, `func boolBinding(_ name: String) -> Binding<Bool>`, `func dateBinding(_ name: String) -> Binding<Date>`, `func numberBinding(_ name: String) -> Binding<String>`, `func listBinding(_ name: String) -> Binding<[String]>`.
+
+This mirrors `FileEditorModel` (Task reference: `Sources/AnglesiteApp/FileEditorModel.swift`) but holds typed `values` + the raw loaded `contents` (for verbatim writes) instead of a single `text` buffer, and commits after each save.
+
+- [ ] **Step 1: Implement the model**
+
+```swift
+// Sources/AnglesiteApp/TypedEntryEditorModel.swift
+import Foundation
+import SwiftUI
+import Observation
+import AnglesiteCore
+
+/// Editor state for one open *typed* content file. Parallels `FileEditorModel` but exposes the
+/// file as per-field `TypedContentEditor.Values` (bound by `TypedEntryEditorView`) and commits each
+/// save to git. The raw loaded `contents` is retained so writes go through
+/// `TypedContentEditor.write`, which preserves untouched keys, unknown keys, and the body verbatim.
+/// All disk IO runs off the main actor.
+@MainActor
+@Observable
+final class TypedEntryEditorModel {
+    let file: FileRef
+    let descriptor: ContentTypeDescriptor
+    private let sourceDirectory: URL
+    private let gitCommit: NativeContentOperations.GitCommit
+
+    var values: TypedContentEditor.Values = .init()
+    private var savedValues: TypedContentEditor.Values = .init()
+    private var contents: String = ""               // last-loaded/saved file text (verbatim base)
+    private var lastModified: Date?
+    private(set) var loadError: String?
+    private(set) var isLoading = false
+    var conflictDiskContents: String?
+
+    var isDirty: Bool { values != savedValues && loadError == nil && !isLoading }
+
+    init(file: FileRef,
+         descriptor: ContentTypeDescriptor,
+         sourceDirectory: URL,
+         gitCommit: @escaping NativeContentOperations.GitCommit = NativeContentOperations.processGitCommit) {
+        self.file = file
+        self.descriptor = descriptor
+        self.sourceDirectory = sourceDirectory
+        self.gitCommit = gitCommit
+    }
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        let url = file.url
+        do {
+            let loaded = try await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url) }.value
+            adopt(loaded.contents)
+            lastModified = loaded.modificationDate
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    @discardableResult
+    func save() async -> Bool {
+        guard isDirty else { return true }
+        let descriptor = self.descriptor
+        let base = contents
+        let edited = values
+        let newContents = TypedContentEditor.write(edited, into: base, descriptor: descriptor)
+        let url = file.url
+        do {
+            let mtime = try await Task.detached(priority: .userInitiated) {
+                try FileDocumentIO.save(newContents, to: url)
+            }.value
+            lastModified = mtime
+            contents = newContents
+            savedValues = edited
+            await commit()
+            return true
+        } catch {
+            loadError = "Save failed: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    func flushBeforeLeaving() async -> Bool {
+        guard isDirty else { return true }
+        let url = file.url
+        let known = lastModified
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: true)
+        }.value
+        if case .conflict(let disk)? = change { conflictDiskContents = disk; return false }
+        return await save()
+    }
+
+    func checkExternalChange() async {
+        guard loadError == nil else { return }
+        let url = file.url
+        let known = lastModified
+        let dirty = isDirty
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
+        }.value
+        switch change {
+        case .reloadable(let disk):
+            adopt(disk); lastModified = await freshModificationDate()
+        case .conflict(let disk):
+            conflictDiskContents = disk
+        case .none, nil:
+            break
+        }
+    }
+
+    func keepMyChanges() { conflictDiskContents = nil }
+
+    func reloadFromDisk() async {
+        guard let disk = conflictDiskContents else { return }
+        adopt(disk)
+        lastModified = await freshModificationDate()
+        conflictDiskContents = nil
+    }
+
+    // MARK: Bindings used by the view
+
+    func textBinding(_ name: String) -> Binding<String> {
+        Binding(get: { if case .text(let s)? = self.values[name] { return s }; return "" },
+                set: { self.values[name] = .text($0) })
+    }
+    func boolBinding(_ name: String) -> Binding<Bool> {
+        Binding(get: { if case .flag(let b)? = self.values[name] { return b }; return false },
+                set: { self.values[name] = .flag($0) })
+    }
+    func dateBinding(_ name: String) -> Binding<Date> {
+        Binding(get: { if case .date(let d?)? = self.values[name] { return d }; return Date(timeIntervalSince1970: 0) },
+                set: { self.values[name] = .date($0) })
+    }
+    func numberBinding(_ name: String) -> Binding<String> {
+        Binding(get: { if case .number(let n?)? = self.values[name] {
+                           return n.rounded() == n ? String(Int(n)) : String(n) }; return "" },
+                set: { self.values[name] = .number(Double($0)) })
+    }
+    func listBinding(_ name: String) -> Binding<[String]> {
+        Binding(get: { if case .list(let a)? = self.values[name] { return a }; return [] },
+                set: { self.values[name] = .list($0) })
+    }
+
+    // MARK: Private
+
+    private func adopt(_ text: String) {
+        contents = text
+        let read = TypedContentEditor.read(text, descriptor: descriptor)
+        values = read
+        savedValues = read
+    }
+
+    private func commit() async {
+        let rel = relativePath(of: file.url, under: sourceDirectory)
+        let slug = file.url.deletingPathExtension().lastPathComponent
+        _ = await gitCommit(sourceDirectory, rel, "anglesite: edit \(descriptor.id) \(slug)")
+    }
+
+    private func relativePath(of url: URL, under root: URL) -> String {
+        let u = url.standardizedFileURL.path(percentEncoded: false)
+        let r = root.standardizedFileURL.path(percentEncoded: false)
+        if u.hasPrefix(r) { return String(u.dropFirst(r.count)).drop(while: { $0 == "/" }).description }
+        return url.lastPathComponent
+    }
+
+    private func freshModificationDate() async -> Date? {
+        let url = file.url
+        return try? await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url).modificationDate }.value
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run:
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+swift build --package-path . 2>&1 | tail -20
+```
+Expected: builds clean (the SPM library builds `AnglesiteApp` sources). Fix any actor/`Sendable`/`Binding` errors before proceeding. (Note: `swift build` compiles the package; the full app bundle needs `xcodebuild`, deferred to Task 7's verification.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Sources/AnglesiteApp/TypedEntryEditorModel.swift
+git commit -m "$(printf 'feat(#346): TypedEntryEditorModel observable buffer over TypedContentEditor\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 6: `TypedEntryEditorView` — generic form (App)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/TypedEntryEditorView.swift`
+
+**Interfaces:**
+- Consumes: `TypedEntryEditorModel` (Task 5), `ContentTypeField.Kind` (existing).
+- Produces: `struct TypedEntryEditorView: View` taking `@Bindable var model: TypedEntryEditorModel`.
+
+Renders a `Form` iterating `model.descriptor.fields` in order, one control per `Kind`. Header + dirty dot + Save button + conflict alert mirror `MainPaneEditorView`. The single `markdown` field renders last as a full-width `TextEditor` labeled "Body".
+
+- [ ] **Step 1: Implement the view**
+
+```swift
+// Sources/AnglesiteApp/TypedEntryEditorView.swift
+import SwiftUI
+import AnglesiteCore
+
+/// Generic, schema-driven form editor for a typed content file. One control per field `Kind`,
+/// ordered by the descriptor. State lives in `TypedEntryEditorModel` (owned by `SiteWindow`) so
+/// navigating away auto-saves and the buffer survives the Preview/Editor toggle.
+struct TypedEntryEditorView: View {
+    @Bindable var model: TypedEntryEditorModel
+    @Environment(\.controlActiveState) private var controlActiveState
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            Group {
+                if let loadError = model.loadError {
+                    ContentUnavailableView {
+                        Label("Can't open \(model.file.name)", systemImage: "exclamationmark.triangle")
+                    } description: { Text(loadError) } actions: {
+                        Button("Reveal in Finder") { NSWorkspace.shared.activateFileViewerSelecting([model.file.url]) }
+                    }
+                } else if model.isLoading {
+                    ProgressView().controlSize(.small)
+                } else {
+                    form
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .task(id: model.file.id) { await model.load() }
+        .onChange(of: controlActiveState) { _, new in
+            if new == .key { Task { await model.checkExternalChange() } }
+        }
+        .background(Button("") { Task { await model.save() } }
+            .keyboardShortcut("s", modifiers: [.command]).hidden())
+        .alert("\(model.file.name) changed on disk", isPresented: conflictBinding) {
+            Button("Keep My Changes", role: .cancel) { model.keepMyChanges() }
+            Button("Reload from Disk") { Task { await model.reloadFromDisk() } }
+        } message: {
+            Text("Another tool edited this file while you had unsaved changes.")
+        }
+    }
+
+    private var form: some View {
+        Form {
+            ForEach(scalarFields, id: \.name) { field in
+                control(for: field)
+            }
+            if let body = bodyField {
+                Section("Body") {
+                    TextEditor(text: model.textBinding(body.name))
+                        .font(.system(.body, design: .monospaced))
+                        .frame(minHeight: 160)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private var scalarFields: [ContentTypeField] { model.descriptor.fields.filter { $0.kind != .markdown } }
+    private var bodyField: ContentTypeField? { model.descriptor.fields.first { $0.kind == .markdown } }
+
+    @ViewBuilder
+    private func control(for field: ContentTypeField) -> some View {
+        let label = field.name + (field.required ? " *" : "")
+        switch field.kind {
+        case .string, .url, .image:
+            HStack {
+                TextField(label, text: model.textBinding(field.name))
+                if field.kind == .image {
+                    Button("Choose…") { chooseFile(for: field.name) }
+                }
+            }
+        case .text:
+            VStack(alignment: .leading) {
+                Text(label).font(.caption).foregroundStyle(.secondary)
+                TextField(label, text: model.textBinding(field.name), axis: .vertical).lineLimit(2...6)
+            }
+        case .bool:
+            Toggle(label, isOn: model.boolBinding(field.name))
+        case .date, .datetime:
+            DatePicker(label, selection: model.dateBinding(field.name),
+                       displayedComponents: field.kind == .date ? [.date] : [.date, .hourAndMinute])
+        case .number:
+            TextField(label, text: model.numberBinding(field.name))
+        case .stringArray, .imageArray:
+            StringListEditor(title: label, items: model.listBinding(field.name),
+                             pickFile: field.kind == .imageArray)
+        case .markdown:
+            EmptyView()   // handled by the Body section
+        }
+    }
+
+    private func chooseFile(for name: String) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            model.textBinding(name).wrappedValue = url.lastPathComponent
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Label(model.file.name, systemImage: "doc.text").font(.headline)
+            if model.isDirty {
+                Circle().fill(.secondary).frame(width: 7, height: 7).help("Unsaved changes")
+            }
+            Spacer()
+            Button("Save") { Task { await model.save() } }.disabled(!model.isDirty)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
+    private var conflictBinding: Binding<Bool> {
+        Binding(get: { model.conflictDiskContents != nil }, set: { _ in })
+    }
+}
+
+/// A minimal add/remove list editor for `stringArray` / `imageArray` fields (tags, hours, album
+/// images).
+private struct StringListEditor: View {
+    let title: String
+    @Binding var items: [String]
+    var pickFile: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            ForEach(items.indices, id: \.self) { i in
+                HStack {
+                    TextField("", text: Binding(get: { items[i] }, set: { items[i] = $0 }))
+                    Button(role: .destructive) { items.remove(at: i) } label: { Image(systemName: "minus.circle") }
+                        .buttonStyle(.borderless)
+                }
+            }
+            HStack {
+                Button { items.append("") } label: { Label("Add", systemImage: "plus.circle") }
+                    .buttonStyle(.borderless)
+                if pickFile {
+                    Button("Choose…") { chooseFile() }
+                }
+            }
+        }
+    }
+
+    private func chooseFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url { items.append(url.lastPathComponent) }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors && swift build --package-path . 2>&1 | tail -20`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Sources/AnglesiteApp/TypedEntryEditorView.swift
+git commit -m "$(printf 'feat(#346): TypedEntryEditorView schema-driven form per field Kind\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 7: Wire typed editor into `SiteWindow` routing
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift`
+
+**Interfaces:**
+- Consumes: `ContentTypeResolver` (Task 3), `TypedEntryEditorModel` (Task 5), `TypedEntryEditorView` (Task 6).
+
+Add a `.typed` case to the private `ActiveEditor` enum, resolve the descriptor in `applyNavigatorSelection` before the existing `EditorKind` switch, and host `TypedEntryEditorView` in `mainPaneContent`. Resolution is by project-relative path (`ContentTypeResolver`), so it needs `site.sourceDirectory` — already in scope in these methods.
+
+- [ ] **Step 1: Add the `.typed` case to `ActiveEditor`**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, the `private enum ActiveEditor` (around line 12):
+
+```swift
+private enum ActiveEditor {
+    case text(FileEditorModel)
+    case plist(PlistEditorModel)
+    case typed(TypedEntryEditorModel)
+
+    var file: FileRef {
+        switch self {
+        case .text(let model): model.file
+        case .plist(let model): model.file
+        case .typed(let model): model.file
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Host the view in `mainPaneContent`**
+
+In `mainPaneContent(for:)` (around line 548), add a branch alongside `.text`/`.plist`:
+
+```swift
+case .editor:
+    if case .text(let editorModel) = activeEditor {
+        MainPaneEditorView(model: editorModel)
+    } else if case .typed(let typedModel) = activeEditor {
+        TypedEntryEditorView(model: typedModel)
+    } else if case .plist(let plistEditorModel) = activeEditor {
+        PlistEditorView(model: plistEditorModel) { title in
+            Task { await saveWebsiteTitle(title) }
+        }
+    } else {
+        previewPane(for: site)
+    }
+```
+
+- [ ] **Step 3: Resolve the descriptor in `applyNavigatorSelection`**
+
+In the `.file(let file)` branch (around line 669), before the `EditorKind.resolve` switch, attempt typed resolution. Replace the `switch EditorKind.resolve(for: file)` block with:
+
+```swift
+Task {
+    guard await leaveCurrentEditor() else { return }   // flush the previous file first
+    if let source = site?.sourceDirectory,
+       let descriptor = ContentTypeResolver.descriptor(
+           forRelativePath: relativeProjectPath(of: file.url, under: source)) {
+        activeEditor = .typed(TypedEntryEditorModel(
+            file: file, descriptor: descriptor, sourceDirectory: source))
+    } else {
+        switch EditorKind.resolve(for: file) {
+        case .text:
+            activeEditor = .text(FileEditorModel(file: file))
+        case .plist:
+            activeEditor = .plist(PlistEditorModel(
+                file: file,
+                websiteTitle: site?.name ?? file.name,
+                sourceDirectory: site?.sourceDirectory ?? file.url.deletingLastPathComponent()))
+        }
+    }
+    mainPaneMode = .editor(file)
+}
+```
+
+Add this private helper to `SiteWindow` (near the other private helpers, e.g. after `applyNavigatorSelection`):
+
+```swift
+/// Project-relative path of `url` under the site `Source/` directory, for content-type resolution.
+private func relativeProjectPath(of url: URL, under root: URL) -> String {
+    let u = url.standardizedFileURL.path(percentEncoded: false)
+    let r = root.standardizedFileURL.path(percentEncoded: false)
+    guard u.hasPrefix(r) else { return url.lastPathComponent }
+    return String(u.dropFirst(r.count)).drop(while: { $0 == "/" }).description
+}
+```
+
+- [ ] **Step 4: Verify `leaveCurrentEditor` flushes the typed editor**
+
+Find `leaveCurrentEditor` in `SiteWindow.swift` (search: `func leaveCurrentEditor`). It switches over `activeEditor` to call `flushBeforeLeaving()`. Add a `.typed` arm mirroring `.text`/`.plist`:
+
+```bash
+grep -n "func leaveCurrentEditor" -A 20 Sources/AnglesiteApp/SiteWindow.swift
+```
+If it switches on `activeEditor`, add:
+```swift
+case .typed(let model): return await model.flushBeforeLeaving()
+```
+If it instead pattern-matches only `.text`/`.plist` for conflict handling, mirror that exact structure for `.typed`. (Implementer: match the existing shape — do not restructure.)
+
+- [ ] **Step 5: Build the app target**
+
+Run:
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+# Worktree prep (memory: copy-plugin + xcodegen needed for a fresh worktree app build):
+export ANGLESITE_PLUGIN_SRC="$(cd ../../../anglesite 2>/dev/null && pwd)"
+scripts/copy-plugin.sh 2>&1 | tail -3 || true
+xcodegen generate 2>&1 | tail -3
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -25
+```
+Expected: **BUILD SUCCEEDED**. If `copy-plugin.sh` fails because `ANGLESITE_PLUGIN_SRC` is unset/wrong, point it at the real plugin checkout (`…/github.com/Anglesite/anglesite`). If the build hits the `Resources/plugin` self-symlink error, `rm` the self-pointing symlink and re-run `copy-plugin.sh` (memory).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git add Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "$(printf 'feat(#346): route typed content files to the form editor\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 8: Full verification + PR
+
+**Files:** none (verification + integration).
+
+- [ ] **Step 1: Run the full Core test suite**
+
+Run:
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+swift test --package-path . 2>&1 | tail -25
+```
+Expected: all tests pass, including the new `FrontmatterDocument`, `TypedContentEditor`, `ContentTypeResolver` suites. (If the MCP/apply-edit e2e tests fail for lack of `ANGLESITE_PLUGIN_PATH`/node, that is the known environment gap — confirm the *new* suites pass and the failures are only those e2e ones.)
+
+- [ ] **Step 2: Manual smoke (app)**
+
+Launch the built app, open a site, and:
+1. Select a note/article/event entry → confirm it opens in the form (not the text editor); edit a field + the body; Save; confirm the file on disk updated and `git log -1` in `Source/` shows the per-edit commit.
+2. Open `about.md` → confirm it opens as the Business Profile form; edit `name` + add an `hours` row; Save; confirm `type: businessProfile` and `layout:` keys are untouched in the file.
+3. Open a non-typed file (e.g. a CSS file) → confirm it still opens in the plain text editor.
+
+Record results in the PR description.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
+git push -u origin feat/346-typed-editors
+gh pr create --title "feat(#346): V-1.4 per-type SwiftUI form editors" --body "$(cat <<'EOF'
+Closes #346.
+
+Schema-driven form editor for all 11 typed content objects. Opening a typed content file shows a structured form (one control per field Kind) instead of raw markdown; edits round-trip to YAML frontmatter and commit per save.
+
+## What landed
+- `FrontmatterDocument` (Core): round-trip-safe frontmatter+body model — unedited round-trips are the identity; editing one field preserves untouched keys, unknown keys, comments, and the body verbatim.
+- `TypedContentEditor` (Core): maps descriptor fields ⟷ typed values; markdown field ⟷ body; writes only changed fields.
+- `ContentTypeResolver` (Core): project path → descriptor.
+- `TypedEntryEditorModel` + `TypedEntryEditorView` (App): observable buffer + generic SwiftUI form, wired into `SiteWindow` navigator routing.
+- `businessProfile` singleton shipped at `Resources/Template/src/pages/about.md` (settles the editor-relevant slice of #388 — *location only*, not h-card/JSON-LD rendering).
+
+## Out of scope
+- h-card / schema.org JSON-LD rendering (V-1.7 #349, V-1.8 #350, #388 rendering).
+- Form↔source toggle (form-only by design).
+- App-Intent entities (V-1.9 #351).
+
+## Testing
+- New Core unit suites: `FrontmatterDocument`, `TypedContentEditor`, `ContentTypeResolver` — all green under `swift test`.
+- App target builds (`xcodebuild -scheme Anglesite`).
+- Manual smoke: [fill in results from Task 8 Step 2].
+
+Design: `docs/superpowers/specs/2026-06-27-v1-4-typed-form-editors-design.md`
+Plan: `docs/superpowers/plans/2026-06-27-v1-4-typed-form-editors.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Schema-driven generic editor → Tasks 2, 6. ✓
+- Form-only (markdown body in form) → Task 6 Body section; `markdown`↔body in Task 2. ✓
+- All 11 types incl. businessProfile → Task 4 (location) + resolver Task 3 + generic engine. ✓
+- Round-trip-safe frontmatter serializer preserving unknown keys + body → Task 1. ✓
+- Type resolution (collection dir + businessProfile marker/path) → Task 3. (Note: design mentioned a frontmatter `type:` marker for robustness; the resolver uses the canonical **path** for the singleton, and the marker is still written into `about.md` for downstream/#388 use — equivalent for routing, no inline I/O. The marker's preservation is covered by Task 4's test.) ✓
+- Per-edit git commit → Task 5 `commit()` via `processGitCommit`. ✓
+- Wiring into SiteWindow mirroring `.plist` → Task 7. ✓
+- Error handling (load error, external-change conflict, malformed frontmatter → text fallback) → Task 5 + Task 7 (resolver returns nil ⟹ text editor). ✓
+- Testing strategy (logic in Core, app build-validated) → Tasks 1–4 tested; 5–7 built. ✓
+
+**Placeholder scan:** No TBD/TODO. The only deferred-to-implementer judgement is Task 7 Step 4 (match the existing `leaveCurrentEditor` shape) — bounded with an exact grep and explicit "mirror, don't restructure" instruction. ✓
+
+**Type consistency:** `FrontmatterDocument.Value`, `TypedContentEditor.FieldValue`/`.Values`, `ContentTypeResolver.descriptor(forRelativePath:registry:)`, `TypedEntryEditorModel` init signature, and the `NativeContentOperations.GitCommit` typealias are used identically across tasks. Binding helper names (`textBinding`/`boolBinding`/`dateBinding`/`numberBinding`/`listBinding`) match between Task 5 (definition) and Task 6 (use). ✓

--- a/docs/superpowers/plans/2026-06-27-v1-4-typed-form-editors.md
+++ b/docs/superpowers/plans/2026-06-27-v1-4-typed-form-editors.md
@@ -50,15 +50,17 @@ Modified:
 
 **Files:**
 - Create: `Sources/AnglesiteCore/FrontmatterDocument.swift`
+- Modify: `Sources/AnglesiteCore/Frontmatter.swift` — promote the shared YAML scalar/array helpers from `private` to `internal` (`splitKeyValue`, `blockArrayItem`, `parseScalarOrArray`, `unquote`, `decodeDoubleQuoted`) so `FrontmatterDocument` reuses them instead of duplicating. Leave `frontmatterBlock`/`frontmatterPattern` and `parse` untouched.
 - Test: `Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift`
+- Test (regression): `Tests/AnglesiteCoreTests/FrontmatterTests.swift` must still pass unchanged.
 
 **Interfaces:**
+- Reuses (existing): `FrontmatterValue` (`Sources/AnglesiteCore/Frontmatter.swift`) — `enum FrontmatterValue { case string(String); case bool(Bool); case array([String]) }`. `FrontmatterDocument` does **not** define its own value enum; it stores and returns `FrontmatterValue`.
 - Produces:
   - `public struct FrontmatterDocument: Equatable, Sendable`
-  - `public enum FrontmatterDocument.Value: Equatable, Sendable { case scalar(String); case bool(Bool); case array([String]) }`
   - `public static func parse(_ source: String) -> FrontmatterDocument`
-  - `public func value(for key: String) -> Value?`
-  - `public mutating func set(_ value: Value, for key: String)` — updates an existing key in place (marking it for re-render) or appends a new key at the end.
+  - `public func value(for key: String) -> FrontmatterValue?`
+  - `public mutating func set(_ value: FrontmatterValue, for key: String)` — updates an existing key in place (marking it for re-render) or appends a new key at the end.
   - `public var body: String { get set }` — text after the closing `---` fence, verbatim; settable.
   - `public func serialized() -> String`
   - `public var keys: [String]` — frontmatter keys in source order (excludes synthetic raw segments).
@@ -93,7 +95,7 @@ struct FrontmatterDocumentTests {
     @Test("reads scalar, bool, and array values")
     func reads() {
         let doc = FrontmatterDocument.parse("---\ntitle: \"Hi\"\ndraft: true\ntags: [x, y]\n---\nB\n")
-        #expect(doc.value(for: "title") == .scalar("Hi"))
+        #expect(doc.value(for: "title") == .string("Hi"))
         #expect(doc.value(for: "draft") == .bool(true))
         #expect(doc.value(for: "tags") == .array(["x", "y"]))
         #expect(doc.value(for: "missing") == nil)
@@ -103,7 +105,7 @@ struct FrontmatterDocumentTests {
     func editPreserves() {
         let src = "---\ntitle: \"Old\"\nweirdKey: keep-me-exactly\ndraft: false\n---\n\nBody.\n"
         var doc = FrontmatterDocument.parse(src)
-        doc.set(.scalar("New"), for: "title")
+        doc.set(.string("New"), for: "title")
         let out = doc.serialized()
         #expect(out.contains("title: \"New\""))
         #expect(out.contains("weirdKey: keep-me-exactly"))   // unknown key preserved verbatim
@@ -114,9 +116,9 @@ struct FrontmatterDocumentTests {
     @Test("setting a new key appends it")
     func appendsNewKey() {
         var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\nB\n")
-        doc.set(.scalar("noreply@x.io"), for: "email")
+        doc.set(.string("noreply@x.io"), for: "email")
         #expect(doc.serialized().contains("email: \"noreply@x.io\""))
-        #expect(doc.value(for: "email") == .scalar("noreply@x.io"))
+        #expect(doc.value(for: "email") == .string("noreply@x.io"))
     }
 
     @Test("no-frontmatter source is all body")
@@ -160,36 +162,35 @@ Expected: FAIL — `cannot find 'FrontmatterDocument' in scope`.
 
 - [ ] **Step 3: Implement `FrontmatterDocument`**
 
+First, in `Sources/AnglesiteCore/Frontmatter.swift`, promote the shared helpers from `private static func` to `internal static func` (drop the `private` keyword) on exactly these five: `splitKeyValue`, `blockArrayItem`, `parseScalarOrArray`, `unquote`, `decodeDoubleQuoted`. Add a one-line doc note on `parseScalarOrArray` that `FrontmatterDocument` also consumes it. Leave `parse`, `frontmatterBlock`, and `frontmatterPattern` exactly as they are. The existing `FrontmatterValue` enum (`case string`/`bool`/`array`) is reused as-is — do **not** add a new value enum.
+
+Then create `FrontmatterDocument`:
+
 ```swift
 // Sources/AnglesiteCore/FrontmatterDocument.swift
 import Foundation
 
 /// A read/write model of a content file's YAML frontmatter + body.
 ///
-/// Unlike `Frontmatter.parse` (read-only, top-level keys only, drops unknown keys, collapses
-/// value types), this preserves **every** source segment — known keys, unknown keys, comments,
-/// and blank lines — in order, each with its verbatim source text. A key is re-rendered only when
-/// it is `set`. Consequences the editor relies on:
+/// Unlike `Frontmatter.parse` (read-only, drops unknown keys, no serialization), this preserves
+/// **every** source segment — known keys, unknown keys, comments, and blank lines — in order, each
+/// with its verbatim source text. A key is re-rendered only when it is `set`. Consequences the
+/// editor relies on:
 ///
 /// - An unedited `parse(...).serialized()` is the identity (modulo uniform line-ending
 ///   normalization for mixed endings).
 /// - Editing one field never disturbs untouched keys or the body.
 /// - Form-only editing can never silently drop a hand-authored key or body content.
 ///
-/// Pure value type, no I/O.
+/// Scalar/array parsing reuses `Frontmatter`'s internal helpers, and values are the existing
+/// `FrontmatterValue`. Pure value type, no I/O.
 public struct FrontmatterDocument: Equatable, Sendable {
-    public enum Value: Equatable, Sendable {
-        case scalar(String)   // logical (unquoted/decoded) string
-        case bool(Bool)
-        case array([String])
-    }
-
-    /// One ordered segment of the frontmatter block. A `key` segment is editable; a `raw` segment
-    /// (comment / blank line) is opaque and always serialized verbatim.
+    /// One ordered segment of the frontmatter block. A `key` segment is editable; a raw segment
+    /// (comment / blank / stray line) is opaque and always serialized verbatim.
     private struct Segment: Equatable {
-        var key: String?            // nil ⟹ raw passthrough segment
-        var value: Value?           // logical value for key segments
-        var verbatim: [String]?     // original source lines; nil once a key segment is mutated
+        var key: String?               // nil ⟹ raw passthrough segment
+        var value: FrontmatterValue?   // logical value for key segments
+        var verbatim: [String]?        // original source lines; nil once a key segment is mutated
     }
 
     private var segments: [Segment]
@@ -202,12 +203,12 @@ public struct FrontmatterDocument: Equatable, Sendable {
 
     public var keys: [String] { segments.compactMap(\.key) }
 
-    public func value(for key: String) -> Value? {
+    public func value(for key: String) -> FrontmatterValue? {
         guard let i = indexByKey[key] else { return nil }
         return segments[i].value
     }
 
-    public mutating func set(_ value: Value, for key: String) {
+    public mutating func set(_ value: FrontmatterValue, for key: String) {
         if let i = indexByKey[key] {
             segments[i].value = value
             segments[i].verbatim = nil   // force re-render
@@ -243,7 +244,7 @@ public struct FrontmatterDocument: Equatable, Sendable {
             return FrontmatterDocument(segments: [], indexByKey: [:], body: normalized,
                                        newline: newline, hadFrontmatter: false)
         }
-        var all = normalized.components(separatedBy: "\n")
+        let all = normalized.components(separatedBy: "\n")
         // all[0] == "---"; find the closing fence.
         var close = -1
         var i = 1
@@ -263,41 +264,34 @@ public struct FrontmatterDocument: Equatable, Sendable {
         while j < block.count {
             let line = block[j]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            // Comment / blank → raw passthrough.
-            if trimmed.isEmpty || trimmed.hasPrefix("#") {
+            // Comment / blank / stray-indent → raw passthrough.
+            let indented = (line.first == " " || line.first == "\t")
+            if trimmed.isEmpty || trimmed.hasPrefix("#") || indented {
                 segments.append(Segment(key: nil, value: nil, verbatim: [line]))
                 j += 1
                 continue
             }
-            // A top-level `key: …` line (no leading whitespace).
-            if let first = line.first, first == " " || first == "\t" {
-                segments.append(Segment(key: nil, value: nil, verbatim: [line]))  // stray indent → passthrough
-                j += 1
-                continue
-            }
-            guard let colon = line.firstIndex(of: ":") else {
+            guard let (key, rawValue) = Frontmatter.splitKeyValue(line) else {
                 segments.append(Segment(key: nil, value: nil, verbatim: [line]))
                 j += 1
                 continue
             }
-            let key = String(line[line.startIndex..<colon])
-            let rawValue = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
 
             var verbatim = [line]
-            let value: Value
+            let value: FrontmatterValue
             if rawValue.isEmpty {
                 // Possible block array on following `- item` lines.
                 var items: [String] = []
                 var k = j + 1
-                while k < block.count, let item = blockArrayItem(block[k]) {
-                    items.append(unquote(item))
+                while k < block.count, let item = Frontmatter.blockArrayItem(block[k]) {
+                    items.append(Frontmatter.unquote(item))
                     verbatim.append(block[k])
                     k += 1
                 }
-                value = items.isEmpty ? .scalar("") : .array(items)
+                value = items.isEmpty ? .string("") : .array(items)
                 j = k
             } else {
-                value = parseScalarOrArray(rawValue)
+                value = Frontmatter.parseScalarOrArray(rawValue)
                 j += 1
             }
             indexByKey[key] = segments.count
@@ -307,11 +301,11 @@ public struct FrontmatterDocument: Equatable, Sendable {
                                    newline: newline, hadFrontmatter: true)
     }
 
-    // MARK: Render (mirrors ContentScaffold conventions: double-quoted scalars, `[]` empty arrays)
+    // MARK: Render (mirrors ContentScaffold: double-quoted scalars, `[]` empty arrays, block lists)
 
-    private static func render(key: String, value: Value) -> String {
+    private static func render(key: String, value: FrontmatterValue) -> String {
         switch value {
-        case .scalar(let s):
+        case .string(let s):
             return "\(key): \"\(escape(s))\""
         case .bool(let b):
             return "\(key): \(b)"
@@ -324,57 +318,26 @@ public struct FrontmatterDocument: Equatable, Sendable {
     private static func escape(_ s: String) -> String {
         s.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
     }
-
-    // MARK: Scalar/array parsing (matching Frontmatter.swift semantics)
-
-    private static func blockArrayItem(_ line: String) -> String? {
-        let stripped = String(line.drop(while: { $0 == " " || $0 == "\t" }))
-        guard stripped.hasPrefix("-") else { return nil }
-        let afterDash = stripped.dropFirst()
-        guard let f = afterDash.first, f == " " || f == "\t" else { return nil }
-        return String(afterDash).trimmingCharacters(in: .whitespaces)
-    }
-
-    private static func parseScalarOrArray(_ raw: String) -> Value {
-        if raw == "true" { return .bool(true) }
-        if raw == "false" { return .bool(false) }
-        if raw.hasPrefix("["), raw.hasSuffix("]") {
-            let inner = String(raw.dropFirst().dropLast()).trimmingCharacters(in: .whitespaces)
-            if inner.isEmpty { return .array([]) }
-            return .array(inner.split(separator: ",", omittingEmptySubsequences: false)
-                .map { unquote($0.trimmingCharacters(in: .whitespaces)) })
-        }
-        return .scalar(unquote(raw))
-    }
-
-    private static func unquote(_ s: String) -> String {
-        guard s.count >= 2 else { return s }
-        if s.hasPrefix("\"") && s.hasSuffix("\"") {
-            let inner = String(s.dropFirst().dropLast())
-            return inner
-                .replacingOccurrences(of: "\\\"", with: "\u{1}").replacingOccurrences(of: "\\\\", with: "\u{2}")
-                .replacingOccurrences(of: "\\n", with: "\n").replacingOccurrences(of: "\\t", with: "\t")
-                .replacingOccurrences(of: "\u{1}", with: "\"").replacingOccurrences(of: "\u{2}", with: "\\")
-        }
-        if s.hasPrefix("'") && s.hasSuffix("'") {
-            return String(s.dropFirst().dropLast()).replacingOccurrences(of: "''", with: "'")
-        }
-        return s
-    }
 }
 ```
+
+Note for the implementer: `Frontmatter.splitKeyValue` returns `(key: String, value: String)?` with the value already trimmed — use it directly. `Frontmatter.parseScalarOrArray`, `.blockArrayItem`, and `.unquote` are the same helpers `Frontmatter.parse` uses, so block-array and quoting semantics stay identical across both types.
 
 - [ ] **Step 4: Run tests, verify they pass**
 
 Run: `swift test --package-path . --filter FrontmatterDocument 2>&1 | tail -20`
 Expected: PASS (8 tests). If `identity`/`commentsSurvive` fail on a trailing-newline mismatch, check the `body` rejoin handles the final `""` element — fix the off-by-one in `serialized()`'s body concatenation before moving on.
 
+Also confirm the existing `Frontmatter` suite still passes after promoting its helpers to `internal`:
+Run: `swift test --package-path . --filter Frontmatter 2>&1 | tail -20`
+Expected: both `Frontmatter` and `FrontmatterDocument` suites PASS (no regression).
+
 - [ ] **Step 5: Commit**
 
 ```bash
 cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/346-typed-editors
-git add Sources/AnglesiteCore/FrontmatterDocument.swift Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
-git commit -m "$(printf 'feat(#346): FrontmatterDocument round-trip frontmatter+body model\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+git add Sources/AnglesiteCore/Frontmatter.swift Sources/AnglesiteCore/FrontmatterDocument.swift Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+git commit -m "$(printf 'feat(#346): FrontmatterDocument round-trip model reusing Frontmatter helpers\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
 ```
 
 ---
@@ -546,19 +509,19 @@ public enum TypedContentEditor {
 
     // MARK: Decode (frontmatter → field value)
 
-    private static func decode(_ value: FrontmatterDocument.Value, kind: ContentTypeField.Kind) -> FieldValue {
+    private static func decode(_ value: FrontmatterValue, kind: ContentTypeField.Kind) -> FieldValue {
         switch kind {
         case .string, .text, .url, .image, .markdown:
-            if case .scalar(let s) = value { return .text(s) }
+            if case .string(let s) = value { return .text(s) }
             return .text("")
         case .bool:
             if case .bool(let b) = value { return .flag(b) }
             return .flag(false)
         case .date, .datetime:
-            if case .scalar(let s) = value { return .date(parseDate(s)) }
+            if case .string(let s) = value { return .date(parseDate(s)) }
             return .date(nil)
         case .number:
-            if case .scalar(let s) = value { return .number(Double(s)) }
+            if case .string(let s) = value { return .number(Double(s)) }
             return .number(nil)
         case .stringArray, .imageArray:
             if case .array(let a) = value { return .list(a) }
@@ -568,12 +531,12 @@ public enum TypedContentEditor {
 
     // MARK: Encode (field value → frontmatter)
 
-    private static func encode(_ value: FieldValue, kind: ContentTypeField.Kind) -> FrontmatterDocument.Value? {
+    private static func encode(_ value: FieldValue, kind: ContentTypeField.Kind) -> FrontmatterValue? {
         switch value {
-        case .text(let s): return .scalar(s)
+        case .text(let s): return .string(s)
         case .flag(let b): return .bool(b)
-        case .date(let d): return .scalar(d.map { format($0, kind: kind) } ?? "")
-        case .number(let n): return .scalar(n.map { formatNumber($0) } ?? "")
+        case .date(let d): return .string(d.map { format($0, kind: kind) } ?? "")
+        case .number(let n): return .string(n.map { formatNumber($0) } ?? "")
         case .list(let a): return .array(a)
         }
     }
@@ -1414,4 +1377,4 @@ EOF
 
 **Placeholder scan:** No TBD/TODO. The only deferred-to-implementer judgement is Task 7 Step 4 (match the existing `leaveCurrentEditor` shape) — bounded with an exact grep and explicit "mirror, don't restructure" instruction. ✓
 
-**Type consistency:** `FrontmatterDocument.Value`, `TypedContentEditor.FieldValue`/`.Values`, `ContentTypeResolver.descriptor(forRelativePath:registry:)`, `TypedEntryEditorModel` init signature, and the `NativeContentOperations.GitCommit` typealias are used identically across tasks. Binding helper names (`textBinding`/`boolBinding`/`dateBinding`/`numberBinding`/`listBinding`) match between Task 5 (definition) and Task 6 (use). ✓
+**Type consistency:** `FrontmatterValue` (reused), `TypedContentEditor.FieldValue`/`.Values`, `ContentTypeResolver.descriptor(forRelativePath:registry:)`, `TypedEntryEditorModel` init signature, and the `NativeContentOperations.GitCommit` typealias are used identically across tasks. Binding helper names (`textBinding`/`boolBinding`/`dateBinding`/`numberBinding`/`listBinding`) match between Task 5 (definition) and Task 6 (use). ✓

--- a/docs/superpowers/specs/2026-06-27-inspector-phase1-design.md
+++ b/docs/superpowers/specs/2026-06-27-inspector-phase1-design.md
@@ -1,0 +1,167 @@
+# Inspector — Phase 1: shell + page-level metadata — design
+
+**Issue:** extends [#346](https://github.com/Anglesite/Anglesite-app/issues/346) (V-1.4). Reworks #346's presentation; first phase of a larger Inspector epic.
+**Date:** 2026-06-27
+**Status:** Approved (brainstorm)
+
+## Vision (the epic)
+
+Every page has metadata that isn't editable in the rendered preview — title,
+description, social cards, SEO. The app should expose a **context-sensitive
+right-hand Inspector**, like the Pages inspector: the center pane is the live
+preview (the canvas), the right inspector edits the metadata of the selected
+page and, eventually, the selected element.
+
+This is too large for one spec. It decomposes into three phases, each its own
+spec → plan → build:
+
+| Phase | Deliverable | Builds on |
+|---|---|---|
+| **1 (this spec)** | Inspector shell + page-level metadata (typed entries via #346 core; title/description for plain pages) | #346 core, `PageTitleEditor` |
+| 2 | Social-card / SEO model — new frontmatter fields + `<meta>` rendering + OG image, surfaced in the inspector | #350 (JSON-LD), og-images skill |
+| 3 | Selection-level inspector — overlay selection channel + per-element editing context | edit-overlay, apply-edit |
+
+Phase 1 is the foundation and delivers the immediate ask: every page gets
+editable metadata in a Pages-style inspector.
+
+## Goal (Phase 1)
+
+Move the typed content form (#346) from the main pane into a right-hand
+`.inspector` panel, restore preview-on-select in the center, and add
+title/description editing for plain (non-typed) pages — so selecting **any**
+Page or Post shows its metadata in the inspector while the preview renders in the
+center.
+
+## Decisions (locked in brainstorming)
+
+- **Center = live preview** for the selected entry (navigates to its route).
+- **Inspector auto-opens** on Page/Post selection; a toolbar toggle
+  (`sidebar.right`) shows/hides it; the choice is remembered across selections.
+- **Component/style files** keep the main-pane text editor; the inspector is
+  hidden for them.
+- **#346 reworked, not merged separately** — same branch/PR; the tested core
+  stays, the main-pane form presentation is replaced by the inspector. The
+  last-turn "form replaces main pane" routing is reverted to preview-on-select.
+- **Single "Page" section** in Phase 1 — no tabs yet, but the inspector view is
+  structured so a tab picker can be added for Phase 3's selection context.
+- **Body field stays in the inspector** for typed entries in Phase 1 (otherwise
+  a note's body would have no editor until Phase 3's overlay content editing).
+  The "metadata in inspector / body in canvas" split is a Phase 3 refinement.
+
+## Architecture
+
+### Inspector shell (`SiteWindow`)
+
+- Add `.inspector(isPresented: $inspectorShown)` to the detail pane.
+- New state:
+  - `inspectorContext: InspectorContext?` — `enum { case typed(TypedEntryEditorModel); case page(PageMetadataModel) }`.
+  - `inspectorShown: Bool` — remembered user preference; applied on each Page/Post selection (auto-open) and toggled by the toolbar button.
+- `applyNavigatorSelection` `.route` branch: resolve the navigator id via the
+  content graph → file path.
+  - If `ContentTypeResolver` matches a content type → `inspectorContext = .typed(TypedEntryEditorModel(...))`.
+  - Else (plain page) → `inspectorContext = .page(PageMetadataModel(...))`.
+  - Either way: navigate the preview to the entry's route (center = preview) and
+    set `inspectorShown = userPref`.
+- `.file` branch (components/styles/metadata): unchanged main-pane editor;
+  `inspectorContext = nil`, inspector hidden. (Revert the #346/last-turn typed
+  handling from this branch.)
+- Remove the `.typed` case from the main-pane `ActiveEditor` enum and its
+  `mainPaneContent`/`showsPaneModePicker` handling — the form is no longer a
+  main-pane editor.
+- Toolbar: a toggle `ToolbarItem` bound to `inspectorShown`, enabled only when
+  `inspectorContext != nil`.
+- ⌘S saves the active inspector model. Navigating away flushes it
+  (`flushBeforeLeaving`, autosave + conflict check); a conflict aborts the
+  switch, mirroring the existing `leaveCurrentEditor` contract.
+
+### Inspector content (`PageInspectorView`, App)
+
+Takes the `InspectorContext` and renders:
+- `.typed` → the descriptor form (the #346 `TypedEntryEditorView`, trimmed of its
+  full-pane header since the inspector supplies panel chrome; keeps a compact
+  dirty/Save affordance and the per-`Kind` controls).
+- `.page` → a small form with **Title** and **Description** fields bound to the
+  `PageMetadataModel`.
+
+### Generic page metadata (`PageMetadataEditor` Core, `PageMetadataModel` App)
+
+- **`PageMetadataEditor`** (Core, pure, no I/O): `read(_ contents: String, fileExtension: String) -> PageMetadata` and `write(_ metadata: PageMetadata, into contents: String, fileExtension: String) -> Result<String, Error>`, where `PageMetadata` carries `title: String` and `description: String`.
+  - **Markdown** (`.md`/`.mdx`/`.markdown`): read/write `title` + `description`
+    frontmatter via `FrontmatterDocument` (reused; round-trip-safe).
+  - **`.astro`/`.html`**: rewrite the first literal `title="…"` / `description="…"`
+    attribute via the existing `PageTitleEditor` pattern (extend it with a
+    description-attribute path). A dynamic (non-literal) attribute → report
+    "no editable location" for that field; the field renders disabled with an
+    explanatory caption.
+- **`PageMetadataModel`** (App, `@MainActor @Observable`): mirrors
+  `TypedEntryEditorModel` — `load()`/`save()`/`flushBeforeLeaving()`/
+  `checkExternalChange()` over `FileDocumentIO`, title/description bindings,
+  per-edit git commit (`anglesite: edit page <slug>`) via
+  `NativeContentOperations.processGitCommit`.
+
+## Data flow
+
+```
+select Page/Post in navigator
+  → applyNavigatorSelection(.route)
+  → look up content graph → filePath
+  → ContentTypeResolver: typed?  ┐
+       yes → inspectorContext = .typed(TypedEntryEditorModel)
+       no  → inspectorContext = .page(PageMetadataModel)
+  → preview.navigate(toRoute:)            // center = preview
+  → inspectorShown = userPref             // auto-open
+  → PageInspectorView renders the matching form
+  → edit field → Save → write file → git commit → preview HMR refresh
+```
+
+## Error handling
+
+- **Load failure / unreadable file:** surfaced via the model's load-error state,
+  same as `FileEditorModel`/`TypedEntryEditorModel`.
+- **External change while editing:** reuse the conflict path
+  (`checkExternalChange`, keep-mine / reload).
+- **Non-literal `.astro` title/description:** the field is shown disabled with a
+  caption ("This page's title isn't a literal value — edit it in the source");
+  no write is attempted.
+- **Round-trip safety:** markdown metadata writes go through `FrontmatterDocument`
+  (unknown keys + body preserved verbatim); `.astro` rewrites touch only the
+  matched attribute.
+- **Commit failure:** best-effort; the file is still written, matching
+  `processGitCommit` semantics.
+
+## Testing
+
+- **`PageMetadataEditor` (Core, unit):** markdown read/write of title +
+  description (round-trip, unknown keys preserved); `.astro` literal-attribute
+  rewrite for title and description; dynamic-attribute → no-edit result;
+  unaffected content preserved verbatim.
+- App-target inspector shell/views are not CI-testable (hosted app) → validated
+  by `swift build` + in-app smoke: select a note → typed form in the right
+  inspector with preview in the center; select a plain page → title/description
+  in the inspector; edit + save → disk + git commit + preview refresh; select a
+  component → main-pane text editor, inspector hidden; toolbar toggle hides/shows
+  the inspector and the choice persists across selections.
+
+## Files
+
+New:
+- `Sources/AnglesiteCore/PageMetadataEditor.swift`
+- `Sources/AnglesiteApp/PageMetadataModel.swift`
+- `Sources/AnglesiteApp/PageInspectorView.swift`
+- `Tests/AnglesiteCoreTests/PageMetadataEditorTests.swift`
+
+Modified:
+- `Sources/AnglesiteApp/SiteWindow.swift` — inspector shell, routing rework,
+  toolbar toggle, remove `.typed` main-pane case.
+- `Sources/AnglesiteApp/TypedEntryEditorView.swift` — trim full-pane header for
+  inspector hosting (becomes the typed branch of `PageInspectorView`).
+- `Sources/AnglesiteCore/PageTitleEditor.swift` — add the description-attribute
+  rewrite path (if not folded into `PageMetadataEditor`).
+
+## Scope discipline (out of scope)
+
+- Social-card / OG / SEO / canonical fields and their `<meta>` rendering (Phase 2).
+- Selection-level inspector + the overlay selection channel (Phase 3).
+- Inspector tabs / multiple sections (Phase 3).
+- Editing typed-entry body in the preview canvas (Phase 3) — body stays in the
+  inspector form for now.

--- a/docs/superpowers/specs/2026-06-27-inspector-phase1-design.md
+++ b/docs/superpowers/specs/2026-06-27-inspector-phase1-design.md
@@ -28,9 +28,19 @@ editable metadata in a Pages-style inspector.
 
 Move the typed content form (#346) from the main pane into a right-hand
 `.inspector` panel, restore preview-on-select in the center, and add
-title/description editing for plain (non-typed) pages — so selecting **any**
-Page or Post shows its metadata in the inspector while the preview renders in the
-center.
+title/description editing for plain (non-typed) **frontmatter** pages — so
+selecting a frontmatter-bearing Page or Post shows its metadata in the inspector
+while the preview renders in the center.
+
+## Title model (clarified)
+
+A page's **title is its `title` frontmatter** — the per-page token source. The
+rendered `<title>` is composed from a **site-level tokenized title template**
+(e.g. `{title} — {siteName}`) with the page's frontmatter title substituted. The
+inspector edits **only the per-page `title` frontmatter**; the tokenized template
+is a **main-site-settings** concern, edited there, **out of scope for the page
+inspector** (a separate feature, likely landing with Phase 2 SEO). There is no
+`.astro` `title="…"` attribute editing — titles are frontmatter, full stop.
 
 ## Decisions (locked in brainstorming)
 
@@ -57,11 +67,13 @@ center.
   - `inspectorContext: InspectorContext?` — `enum { case typed(TypedEntryEditorModel); case page(PageMetadataModel) }`.
   - `inspectorShown: Bool` — remembered user preference; applied on each Page/Post selection (auto-open) and toggled by the toolbar button.
 - `applyNavigatorSelection` `.route` branch: resolve the navigator id via the
-  content graph → file path.
-  - If `ContentTypeResolver` matches a content type → `inspectorContext = .typed(TypedEntryEditorModel(...))`.
-  - Else (plain page) → `inspectorContext = .page(PageMetadataModel(...))`.
-  - Either way: navigate the preview to the entry's route (center = preview) and
-    set `inspectorShown = userPref`.
+  content graph → file path. Navigate the preview to the route (center =
+  preview), then set the inspector context by file kind:
+  - `ContentTypeResolver` matches a content type → `inspectorContext = .typed(TypedEntryEditorModel(...))`, `inspectorShown = userPref`.
+  - else a **frontmatter-bearing markdown page** (`.md`/`.mdx`/`.markdown`) → `inspectorContext = .page(PageMetadataModel(...))`, `inspectorShown = userPref`.
+  - else (plain `.astro` template page, etc.) → `inspectorContext = nil`,
+    inspector hidden — preview only. Plain `.astro` pages are **out of scope**
+    for Phase 1 metadata editing (no YAML frontmatter to drive title).
 - `.file` branch (components/styles/metadata): unchanged main-pane editor;
   `inspectorContext = nil`, inspector hidden. (Revert the #346/last-turn typed
   handling from this branch.)
@@ -85,14 +97,16 @@ Takes the `InspectorContext` and renders:
 
 ### Generic page metadata (`PageMetadataEditor` Core, `PageMetadataModel` App)
 
-- **`PageMetadataEditor`** (Core, pure, no I/O): `read(_ contents: String, fileExtension: String) -> PageMetadata` and `write(_ metadata: PageMetadata, into contents: String, fileExtension: String) -> Result<String, Error>`, where `PageMetadata` carries `title: String` and `description: String`.
-  - **Markdown** (`.md`/`.mdx`/`.markdown`): read/write `title` + `description`
-    frontmatter via `FrontmatterDocument` (reused; round-trip-safe).
-  - **`.astro`/`.html`**: rewrite the first literal `title="…"` / `description="…"`
-    attribute via the existing `PageTitleEditor` pattern (extend it with a
-    description-attribute path). A dynamic (non-literal) attribute → report
-    "no editable location" for that field; the field renders disabled with an
-    explanatory caption.
+For frontmatter-bearing markdown pages that are **not** typed content (no
+`ContentTypeResolver` match) — title + description only.
+
+- **`PageMetadataEditor`** (Core, pure, no I/O): `read(_ contents: String) -> PageMetadata`
+  and `write(_ metadata: PageMetadata, into contents: String) -> String`, where
+  `PageMetadata` carries `title: String` and `description: String`. Both read and
+  write go through `FrontmatterDocument` (reused; round-trip-safe — unknown keys
+  and body preserved verbatim; only the `title`/`description` keys are touched, and
+  only when changed). No `.astro` attribute path — `.astro` pages are out of
+  scope (see routing above), so `PageTitleEditor` is **not** modified.
 - **`PageMetadataModel`** (App, `@MainActor @Observable`): mirrors
   `TypedEntryEditorModel` — `load()`/`save()`/`flushBeforeLeaving()`/
   `checkExternalChange()` over `FileDocumentIO`, title/description bindings,
@@ -105,11 +119,12 @@ Takes the `InspectorContext` and renders:
 select Page/Post in navigator
   → applyNavigatorSelection(.route)
   → look up content graph → filePath
-  → ContentTypeResolver: typed?  ┐
-       yes → inspectorContext = .typed(TypedEntryEditorModel)
-       no  → inspectorContext = .page(PageMetadataModel)
-  → preview.navigate(toRoute:)            // center = preview
-  → inspectorShown = userPref             // auto-open
+  → preview.navigate(toRoute:)                    // center = preview, always
+  → classify file:
+       ContentTypeResolver match  → .typed(TypedEntryEditorModel), show inspector
+       markdown page (no match)   → .page(PageMetadataModel),       show inspector
+       plain .astro / other       → inspectorContext = nil,         hide inspector
+  → inspectorShown = userPref (when context != nil)   // auto-open
   → PageInspectorView renders the matching form
   → edit field → Save → write file → git commit → preview HMR refresh
 ```
@@ -120,21 +135,17 @@ select Page/Post in navigator
   same as `FileEditorModel`/`TypedEntryEditorModel`.
 - **External change while editing:** reuse the conflict path
   (`checkExternalChange`, keep-mine / reload).
-- **Non-literal `.astro` title/description:** the field is shown disabled with a
-  caption ("This page's title isn't a literal value — edit it in the source");
-  no write is attempted.
-- **Round-trip safety:** markdown metadata writes go through `FrontmatterDocument`
-  (unknown keys + body preserved verbatim); `.astro` rewrites touch only the
-  matched attribute.
+- **Round-trip safety:** all metadata writes go through `FrontmatterDocument`
+  (unknown keys + body preserved verbatim; only changed keys re-rendered).
 - **Commit failure:** best-effort; the file is still written, matching
   `processGitCommit` semantics.
 
 ## Testing
 
-- **`PageMetadataEditor` (Core, unit):** markdown read/write of title +
-  description (round-trip, unknown keys preserved); `.astro` literal-attribute
-  rewrite for title and description; dynamic-attribute → no-edit result;
-  unaffected content preserved verbatim.
+- **`PageMetadataEditor` (Core, unit):** read title + description from
+  frontmatter; write changed title/description (round-trip identity when
+  unchanged, unknown keys + body preserved verbatim, only changed keys
+  re-rendered); empty/missing fields default to "".
 - App-target inspector shell/views are not CI-testable (hosted app) → validated
   by `swift build` + in-app smoke: select a note → typed form in the right
   inspector with preview in the center; select a plain page → title/description
@@ -155,11 +166,14 @@ Modified:
   toolbar toggle, remove `.typed` main-pane case.
 - `Sources/AnglesiteApp/TypedEntryEditorView.swift` — trim full-pane header for
   inspector hosting (becomes the typed branch of `PageInspectorView`).
-- `Sources/AnglesiteCore/PageTitleEditor.swift` — add the description-attribute
-  rewrite path (if not folded into `PageMetadataEditor`).
+
+`PageTitleEditor.swift` is **not** modified (no `.astro` attribute editing).
 
 ## Scope discipline (out of scope)
 
+- The **site-level tokenized title template** (e.g. `{title} — {siteName}`) and
+  its render-time substitution — a main-site-settings feature, likely Phase 2.
+- **Plain `.astro` template page** metadata editing (no frontmatter to drive it).
 - Social-card / OG / SEO / canonical fields and their `<meta>` rendering (Phase 2).
 - Selection-level inspector + the overlay selection channel (Phase 3).
 - Inspector tabs / multiple sections (Phase 3).

--- a/docs/superpowers/specs/2026-06-27-v1-4-typed-form-editors-design.md
+++ b/docs/superpowers/specs/2026-06-27-v1-4-typed-form-editors-design.md
@@ -1,0 +1,213 @@
+# V-1.4: Per-type SwiftUI form editors — design
+
+**Issue:** [#346](https://github.com/Anglesite/Anglesite-app/issues/346) (part of [#335](https://github.com/Anglesite/Anglesite-app/issues/335), V-1)
+**Date:** 2026-06-27
+**Status:** Approved (brainstorm)
+
+## Goal
+
+Give each typed content object a structured **form** editor in the app. Opening a
+typed content file (a note, article, photo, event, …, or the business profile)
+shows purpose-built form controls — date pickers, image pickers, in-reply-to URL
+fields, an hours list — instead of raw markdown. Edits round-trip to YAML
+frontmatter without data loss and produce a per-edit git commit, exactly like the
+existing text/MCP edit paths.
+
+**Acceptance (from #346):** each type has a form editor; round-trips to
+frontmatter; per-edit git commit preserved.
+
+## Approach
+
+The content-type registry (`ContentTypeRegistry`,
+`Sources/AnglesiteCore/ContentTypeRegistry.swift`) already encodes every type's
+fields and their `Kind` (`string`, `text`, `markdown`, `bool`, `date`,
+`datetime`, `url`, `image`, `number`, `stringArray`, `imageArray`). Every example
+in the issue maps onto an existing `Kind`:
+
+| Issue example | Kind |
+|---|---|
+| photo picker | `image` |
+| date + location for Event | `datetime` + `string` |
+| in-reply-to URL for Reply | `url` |
+| hours for Business Profile | `stringArray` |
+
+So a **single schema-driven editor** that renders one control per `Kind` covers
+all types from the registry. New types get an editor for free. No bespoke
+per-type views.
+
+Decisions locked during brainstorming:
+
+- **Schema-driven, not bespoke per-type.**
+- **Form-only for typed files.** No in-app form↔source toggle. Raw source stays
+  reachable on disk / external editor, consistent with "git is the source of
+  truth." This makes round-trip safety mandatory (below).
+- **All 11 types**, including `businessProfile` — whose on-disk location is
+  decided here (§3).
+
+## Components
+
+### 1. `FrontmatterDocument` (AnglesiteCore) — the keystone
+
+A new pure, I/O-free value type that models a content file as:
+
+- **ordered** frontmatter entries (key → raw value), and
+- the **body** text that follows the closing `---` fence.
+
+Responsibilities:
+
+- **Parse** a file string into ordered entries + body.
+- **Typed get/set** of a field's value, keyed by field name.
+- **Serialize** back to a string that **preserves key order, unknown keys not in
+  the type schema, and the body verbatim**, and preserves the original line
+  ending (LF/CRLF).
+
+Value representation preserves the raw scalar text per key (so untouched fields
+serialize byte-identically) plus arrays. The form layer converts to/from
+`Date`/`Bool`/number based on the field's `Kind`; only fields the user actually
+edits are rewritten.
+
+Why additive rather than reusing `Frontmatter.parse`: the existing parser is
+read-only, parses top-level keys only, drops unknown keys, and collapses values
+to `.string`/`.bool`/`.array`. That is lossy and unsafe for write-back. The
+existing parser stays for its current read-only consumers; `FrontmatterDocument`
+is the read/write path. It may share low-level scalar/array parsing helpers where
+practical, but owns serialization.
+
+### 2. Type resolution (FileRef → `ContentTypeDescriptor`)
+
+- **Collection types (10):** a file under `src/content/<collection>/` resolves to
+  the descriptor whose `collection` equals `<collection>`. Directory-based, zero
+  ambiguity, matches Astro's content-collection layout.
+- **`businessProfile` singleton:** resolved by a `type: businessProfile`
+  frontmatter marker — filename-independent and robust.
+
+Resolution is a pure function in AnglesiteCore taking the file's project-relative
+path and (for the singleton) parsed frontmatter, returning an optional
+descriptor.
+
+### 3. `businessProfile` on-disk location
+
+Ship a singleton markdown page in the template at **`Resources/Template/src/pages/about.md`**
+carrying `type: businessProfile` plus the business fields in YAML frontmatter.
+This:
+
+- satisfies the descriptor's `storage: .page`,
+- round-trips through `FrontmatterDocument` like any other typed file,
+- exists in the navigator for every newly scaffolded site,
+- gives #388's h-card / LocalBusiness **rendering** a stable file to build on
+  later — this PR settles *location only*, not rendering.
+
+This intentionally absorbs the editor-relevant slice of #388. The PR will say so.
+
+### 4. `TypedEntryEditorModel` (AnglesiteApp)
+
+`@MainActor`, `@Observable`, `final class`, paralleling `FileEditorModel`:
+
+- `init(file:descriptor:)`
+- `load()` — reads off-main via `FileDocumentIO.load`, parses into a
+  `FrontmatterDocument`, exposes field bindings + the body.
+- `save()` — applies edited values back into the document, serializes, writes
+  off-main via `FileDocumentIO.save`, then git-commits.
+- Reuses the existing dirty-tracking, `flushBeforeLeaving()`,
+  `checkExternalChange()`, and conflict-resolution machinery from the
+  `FileEditorModel` pattern (external edits to the same file must not be
+  clobbered).
+
+### 5. `TypedEntryEditorView` (AnglesiteApp)
+
+Renders a SwiftUI `Form` from `descriptor.fields`, one control per `Kind`:
+
+| Kind | Control |
+|---|---|
+| `string`, `url` | `TextField` |
+| `text` | multi-line `TextField` (`axis: .vertical`) |
+| `markdown` (`body`) | `TextEditor` |
+| `bool` | `Toggle` |
+| `date`, `datetime` | `DatePicker` |
+| `number` | `TextField` + number formatter |
+| `image` | path `TextField` + "Choose…" file picker |
+| `stringArray` (hours, tags) | editable add/remove row list |
+| `imageArray` (album) | editable list of image pickers |
+
+Required fields are marked; the body (`markdown`) renders last as a full-width
+editor. Field order follows the descriptor.
+
+### 6. Wiring
+
+`EditorKind.resolve(for:)` currently takes only a `FileRef` and returns
+`.text`/`.plist`. Typed-content detection needs project context (registry +
+project root), so the typed-form branch is selected where that context is
+available — in `SiteWindow.applyNavigatorSelection(_:)`, mirroring the existing
+`.plist` branch. When resolution returns a descriptor, the main pane hosts
+`TypedEntryEditorView`; otherwise it falls back to the existing
+`MainPaneEditorView` (`.text`).
+
+### 7. Per-edit git commit
+
+`save()` calls `NativeContentOperations.processGitCommit(projectRoot, relPath, message)`
+with message `anglesite: edit <type> <slug>`, reusing the exact stage/commit path
+used by content creation. Best-effort (returns the new HEAD SHA or nil), matching
+existing behavior.
+
+## Data flow
+
+```
+open typed file
+  → resolve descriptor (path for collections; frontmatter marker for businessProfile)
+  → TypedEntryEditorModel.load(): FileDocumentIO.load → FrontmatterDocument.parse
+  → TypedEntryEditorView renders Form from descriptor.fields
+  → user edits fields / body
+  → save(): apply edits → FrontmatterDocument.serialize (unknown keys + body preserved)
+           → FileDocumentIO.save → processGitCommit
+```
+
+## Error handling
+
+- **Load failure / unreadable file:** surface via the model's load-error state,
+  same as `FileEditorModel`.
+- **External change while editing:** reuse the conflict path
+  (`checkExternalChange`, keep-mine / reload-from-disk).
+- **Serialization safety:** untouched fields and unknown keys serialize
+  unchanged; the body is preserved verbatim. A round-trip of an unedited document
+  is the identity.
+- **Commit failure:** best-effort; a failed commit does not block the save (the
+  file is still written), matching `processGitCommit` semantics.
+- **Malformed frontmatter:** degrade gracefully — if a file can't be parsed into
+  a document, fall back to the text editor rather than risk data loss.
+
+## Testing
+
+- **`FrontmatterDocument` round-trip (unit):** identity on unedited documents;
+  unknown keys preserved across edits; body preserved verbatim; each `Kind`'s
+  value formatting; LF/CRLF preservation; key-order stability.
+- **Type resolution (unit):** collection path → descriptor; `businessProfile`
+  marker → descriptor; unrelated file → nil (text fallback).
+- **`TypedEntryEditorModel` (unit):** load → edit → save writes expected bytes;
+  commit invoked with expected relPath/message (injected git-commit closure);
+  external-change conflict handled.
+
+Logic lives in AnglesiteCore + the model so it is testable under `swift test`
+without a hosted app target (consistent with the repo's CI constraints).
+
+## Scope discipline (out of scope)
+
+- h-card / schema.org JSON-LD **rendering** of the business profile or any type —
+  that is V-1.7 (#349), V-1.8 (#350), and #388's rendering work. This PR ships
+  the editor and the businessProfile *file location* only.
+- Form ↔ raw-source toggle (form-only was chosen).
+- App-Intent entities for the new types — V-1.9 (#351).
+
+## Files (anticipated)
+
+New:
+- `Sources/AnglesiteCore/FrontmatterDocument.swift`
+- `Sources/AnglesiteCore/ContentTypeResolver.swift` (path/marker → descriptor)
+- `Sources/AnglesiteApp/TypedEntryEditorModel.swift`
+- `Sources/AnglesiteApp/TypedEntryEditorView.swift`
+- `Resources/Template/src/pages/about.md` (businessProfile singleton)
+- Tests under `Tests/AnglesiteCoreTests/` for document + resolver + model.
+
+Modified:
+- `Sources/AnglesiteApp/SiteWindow.swift` (editor routing branch)
+- possibly `Sources/AnglesiteCore/EditorKind.swift` (typed-form case, if it
+  improves the routing seam)


### PR DESCRIPTION
Closes #346.

Schema-driven form editor for all 11 typed content objects. Opening a typed content file shows a structured form (one control per field `Kind`) instead of raw markdown; edits round-trip to YAML frontmatter and commit per save.

## What landed
- **`FrontmatterDocument`** (AnglesiteCore): round-trip-safe frontmatter+body model — an unedited round-trip is the identity; editing one field preserves untouched keys, **unknown keys, comments, and the body** verbatim. Reuses `Frontmatter`'s scalar/array helpers (promoted `private`→`internal`) and the existing `FrontmatterValue` enum (no duplication).
- **`TypedContentEditor`** (AnglesiteCore): maps a descriptor's fields ⟷ typed values; the `markdown` field ⟷ document body; `write` re-renders **only changed fields**.
- **`ContentTypeResolver`** (AnglesiteCore): project-relative path → `ContentTypeDescriptor`.
- **`TypedEntryEditorModel` + `TypedEntryEditorView`** (AnglesiteApp): `@Observable` buffer + generic `Form`, wired into `SiteWindow` navigator routing (mirrors the existing `.plist` editor seam; falls back to text/plist for non-typed files).
- **`Resources/Template/src/pages/about.md`**: the `businessProfile` singleton page — settles the **editor-relevant slice of #388 (file location only)**, with a `type: businessProfile` marker preserved across edits.

## Out of scope (by design)
- h-card / schema.org JSON-LD **rendering** (V-1.7 #349, V-1.8 #350, #388 rendering).
- Form↔source toggle (form-only chosen).
- App-Intent entities for the new types (V-1.9 #351).

## Testing
- New AnglesiteCore Swift Testing suites: `FrontmatterDocument` (8), `TypedContentEditor` (6), `ContentTypeResolver` (4) — all green; full `swift test` passes with no regression to the existing `Frontmatter` suite.
- `xcodebuild -scheme Anglesite` (full app bundle) **BUILD SUCCEEDED**.
- `npx astro build` of the template **succeeded** → produces `dist/about/index.html` (businessProfile page builds).
- Still pending: manual in-app smoke (launch + edit an entry by hand) — needs the GUI.

## Reviews
Per-task spec+quality gates plus a final whole-branch review (no Critical findings; 2 Important + minors all fixed in `23c3446`): number-field in-progress input handling, external-change `LogCenter` diagnostic ("Logs are sacred"), safe number formatting, and a duplicate-label fix.

Design: `docs/superpowers/specs/2026-06-27-v1-4-typed-form-editors-design.md`
Plan: `docs/superpowers/plans/2026-06-27-v1-4-typed-form-editors.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)