### PR TITLE
feat(#351): App-Intent entities for typed content (V-1.9)

### DIFF
--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -139,13 +139,16 @@ public struct ContentTypeRegistry: Sendable, Equatable {
     private mutating func insert(_ descriptor: ContentTypeDescriptor) {
         if byID[descriptor.id] == nil { order.append(descriptor.id) }
         // A replaced descriptor may have changed collection; drop any stale reverse entry first.
-        if let old = byID[descriptor.id]?.collection { collectionToID[old] = nil }
+        if let old = byID[descriptor.id]?.collection { collectionToID.removeValue(forKey: old) }
         byID[descriptor.id] = descriptor
         if let collection = descriptor.collection { collectionToID[collection] = descriptor.id }
     }
 
     /// Registers (or replaces) a content type. Replacing keeps the type's existing position in
-    /// `all`; a new type appends.
+    /// `all`; a new type appends. If two descriptors declare the *same* collection name (under
+    /// different ids), the later registration wins the `descriptor(forCollection:)` reverse lookup —
+    /// the same last-wins contract as duplicate ids. The built-in catalog has unique collection
+    /// names, so this only matters for custom types registered via this method.
     public mutating func register(_ descriptor: ContentTypeDescriptor) {
         insert(descriptor)
     }

--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -122,6 +122,9 @@ public struct ContentTypeDescriptor: Sendable, Equatable, Identifiable {
 public struct ContentTypeRegistry: Sendable, Equatable {
     private var byID: [String: ContentTypeDescriptor]
     private var order: [String]
+    /// collection name → type id, for `.collection`-stored types only. Built at insert time
+    /// so reverse lookups are O(1) and stay in sync with `byID`.
+    private var collectionToID: [String: String]
 
     /// Builds a registry from the given descriptors (default: the built-in catalog). Later
     /// descriptors with a duplicate `id` override earlier ones while keeping first-seen order —
@@ -129,12 +132,16 @@ public struct ContentTypeRegistry: Sendable, Equatable {
     public init(types: [ContentTypeDescriptor] = ContentTypeRegistry.builtIns) {
         byID = [:]
         order = []
+        collectionToID = [:]
         for descriptor in types { insert(descriptor) }
     }
 
     private mutating func insert(_ descriptor: ContentTypeDescriptor) {
         if byID[descriptor.id] == nil { order.append(descriptor.id) }
+        // A replaced descriptor may have changed collection; drop any stale reverse entry first.
+        if let old = byID[descriptor.id]?.collection { collectionToID[old] = nil }
         byID[descriptor.id] = descriptor
+        if let collection = descriptor.collection { collectionToID[collection] = descriptor.id }
     }
 
     /// Registers (or replaces) a content type. Replacing keeps the type's existing position in
@@ -146,6 +153,20 @@ public struct ContentTypeRegistry: Sendable, Equatable {
     public func descriptor(id: String) -> ContentTypeDescriptor? {
         byID[id]
     }
+
+    /// Reverse of `descriptor(id:)`: the `.collection`-stored type whose collection is `collection`.
+    public func descriptor(forCollection collection: String) -> ContentTypeDescriptor? {
+        guard let id = collectionToID[collection] else { return nil }
+        return byID[id]
+    }
+
+    /// Ids of the `.collection`-stored types, in registration order. Page-stored types are excluded.
+    public var collectionBackedTypeIDs: [String] {
+        order.compactMap { byID[$0] }.filter { $0.collection != nil }.map(\.id)
+    }
+
+    /// Shared built-in registry. Lets value-type consumers resolve types without rebuilding it.
+    public static let `default` = ContentTypeRegistry()
 
     /// All registered types in registration order.
     public var all: [ContentTypeDescriptor] {

--- a/Sources/AnglesiteIntents/ContentEntities.swift
+++ b/Sources/AnglesiteIntents/ContentEntities.swift
@@ -98,6 +98,7 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
     public let displayName: String   // title
     @Property(title: "Slug") public var slug: String
     @Property(title: "Collection") public var collection: String
+    @Property(title: "Type") public var contentType: String
     public let isDraft: Bool
     public let tags: [String]
     @Property(title: "Site") public var siteID: String
@@ -121,10 +122,15 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         self.slug = post.slug
         self.collection = post.collection
         self.siteID = post.siteID
+        // Typed dimension (#351): map the post's collection back to its content type's display
+        // name via the registry; fall back to the raw collection for custom/unknown collections.
+        self.contentType = ContentTypeRegistry.default.descriptor(forCollection: post.collection)?.displayName
+            ?? post.collection
     }
 
     public init(id: String, displayName: String, slug: String, collection: String,
-                siteID: String, isDraft: Bool = true, tags: [String] = []) {
+                siteID: String, isDraft: Bool = true, tags: [String] = [],
+                contentType: String = "") {
         self.id = id
         self.displayName = displayName
         self.isDraft = isDraft
@@ -132,6 +138,7 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         self.slug = slug
         self.collection = collection
         self.siteID = siteID
+        self.contentType = contentType
     }
 }
 

--- a/Sources/AnglesiteIntents/ContentEntities.swift
+++ b/Sources/AnglesiteIntents/ContentEntities.swift
@@ -114,6 +114,13 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
 
     public static let defaultQuery = PostEntityQuery()
 
+    /// Typed dimension (#351): map a post's collection back to its content type's display name via
+    /// the registry; fall back to the raw collection for custom/unknown collections. Shared by both
+    /// inits (and `AddPostIntent.createdPost`) so the derivation lives in exactly one place.
+    public static func contentTypeName(forCollection collection: String) -> String {
+        ContentTypeRegistry.default.descriptor(forCollection: collection)?.displayName ?? collection
+    }
+
     public init(_ post: SiteContentGraph.Post) {
         self.id = post.id
         self.displayName = post.title
@@ -122,10 +129,7 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         self.slug = post.slug
         self.collection = post.collection
         self.siteID = post.siteID
-        // Typed dimension (#351): map the post's collection back to its content type's display
-        // name via the registry; fall back to the raw collection for custom/unknown collections.
-        self.contentType = ContentTypeRegistry.default.descriptor(forCollection: post.collection)?.displayName
-            ?? post.collection
+        self.contentType = Self.contentTypeName(forCollection: post.collection)
     }
 
     public init(id: String, displayName: String, slug: String, collection: String,
@@ -138,7 +142,9 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         self.slug = slug
         self.collection = collection
         self.siteID = siteID
-        self.contentType = contentType
+        // A default-param can't reference `collection`, so derive when the caller omits it — this
+        // keeps the Spotlight "Type" attribute from being indexed blank.
+        self.contentType = contentType.isEmpty ? Self.contentTypeName(forCollection: collection) : contentType
     }
 }
 

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -101,11 +101,15 @@ public struct FindContentByTypeIntent: AppIntent {
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<[PostEntity]> {
         let g = ContentGraphOverride.scoped ?? graph
         let results = await Self.matches(graph: g, siteID: site.id, type: contentType)
-        let typeName = ContentTypeAppEnum.caseDisplayRepresentations[contentType]?.title ?? "content"
+        // Display name from the registry (same source as the enum's representations); fall back to
+        // the type's collection name rather than a generic "content" so a future case without a
+        // representation degrades to e.g. "events" instead of "contents".
+        let typeName = ContentTypeRegistry.default.descriptor(id: contentType.rawValue)?.displayName
+            ?? contentType.rawValue
         return .result(
             value: results,
             dialog: IntentDialog(stringLiteral: ContentDialogs.findByType(
-                typeName: String(localized: typeName), count: results.count))
+                typeName: typeName, count: results.count))
         )
     }
 
@@ -299,9 +303,10 @@ extension AddPostIntent {
         let coll = (collection?.isEmpty == false)
             ? collection!
             : ((filePath as NSString).deletingLastPathComponent as NSString).lastPathComponent
+        // `contentType` is omitted: the memberwise init derives it from `coll` (#351), so the
+        // collection→type-name mapping lives only in `PostEntity.contentTypeName(forCollection:)`.
         return PostEntity(id: "\(siteID):post:\(identifier)", displayName: title, slug: identifier,
-                          collection: coll, siteID: siteID,
-                          contentType: ContentTypeRegistry.default.descriptor(forCollection: coll)?.displayName ?? coll)
+                          collection: coll, siteID: siteID)
     }
 }
 
@@ -325,6 +330,8 @@ public enum ContentDialogs {
 
     /// Naive English pluralization sufficient for the built-in type display names
     /// (Note, Article, Photo, Album, Bookmark, Reply, Like, Announcement, Event, Review).
+    /// The `y → ies` rule is only correct for consonant+y endings — do NOT call with arbitrary
+    /// display names (e.g. "Essay" → "Essaies"). New built-in types must keep this invariant.
     private static func pluralize(_ noun: String, _ n: Int) -> String {
         let lower = noun.lowercased()
         if n == 1 { return lower }

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -299,7 +299,9 @@ extension AddPostIntent {
         let coll = (collection?.isEmpty == false)
             ? collection!
             : ((filePath as NSString).deletingLastPathComponent as NSString).lastPathComponent
-        return PostEntity(id: "\(siteID):post:\(identifier)", displayName: title, slug: identifier, collection: coll, siteID: siteID)
+        return PostEntity(id: "\(siteID):post:\(identifier)", displayName: title, slug: identifier,
+                          collection: coll, siteID: siteID,
+                          contentType: ContentTypeRegistry.default.descriptor(forCollection: coll)?.displayName ?? coll)
     }
 }
 

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -80,6 +80,46 @@ public struct SearchContentIntent: AppIntent {
     }
 }
 
+// MARK: - Find by type
+
+/// Lists a site's content of one type (#351). The typed counterpart to `SearchContentIntent`:
+/// resolves the type's collection from the registry and filters the graph's posts by it.
+public struct FindContentByTypeIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Find Content by Type"
+    public static let description = IntentDescription("List a site's content of a given type, e.g. events or reviews.")
+
+    @Parameter(title: "Site") public var site: SiteEntity
+    @Parameter(title: "Type") public var contentType: ContentTypeAppEnum
+    @Dependency private var graph: SiteContentGraph
+
+    public init() {}
+
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Find \(\.$contentType) in \(\.$site)")
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<[PostEntity]> {
+        let g = ContentGraphOverride.scoped ?? graph
+        let results = await Self.matches(graph: g, siteID: site.id, type: contentType)
+        let typeName = ContentTypeAppEnum.caseDisplayRepresentations[contentType]?.title ?? "content"
+        return .result(
+            value: results,
+            dialog: IntentDialog(stringLiteral: ContentDialogs.findByType(
+                typeName: String(localized: typeName), count: results.count))
+        )
+    }
+
+    /// Filter the site's posts to the type's collection, sorted (lastModified desc, id asc) — the
+    /// same comparator the entity queries use. Static + graph-injected for unit testability.
+    static func matches(graph: SiteContentGraph, siteID: String, type: ContentTypeAppEnum) async -> [PostEntity] {
+        guard let collection = type.collection else { return [] }
+        return await graph.posts(for: siteID)
+            .filter { $0.collection == collection }
+            .sorted { $0.lastModified != $1.lastModified ? $0.lastModified > $1.lastModified : $0.id < $1.id }
+            .map(PostEntity.init)
+    }
+}
+
 // MARK: - Status
 
 public struct SiteStatusIntent: AppIntent {
@@ -274,6 +314,21 @@ extension AddPostIntent: LongRunningIntent, CancellableIntent {}
 
 public enum ContentDialogs {
     public enum CreateKind: String, Sendable { case page, post }
+
+    public static func findByType(typeName: String, count: Int) -> String {
+        let plural = pluralize(typeName, count)
+        guard count > 0 else { return "No \(plural) found." }
+        return "Found \(count) \(plural)."
+    }
+
+    /// Naive English pluralization sufficient for the built-in type display names
+    /// (Note, Article, Photo, Album, Bookmark, Reply, Like, Announcement, Event, Review).
+    private static func pluralize(_ noun: String, _ n: Int) -> String {
+        let lower = noun.lowercased()
+        if n == 1 { return lower }
+        if lower.hasSuffix("y") { return lower.dropLast() + "ies" }  // reply → replies
+        return lower + "s"
+    }
 
     public static func search(query: String, pageCount: Int, postCount: Int, imageCount: Int) -> String {
         // #234: a blank query means "no term given", not "no results" — prompt instead of echoing `Nothing matched “”.`.

--- a/Sources/AnglesiteIntents/ContentTypeAppEnum.swift
+++ b/Sources/AnglesiteIntents/ContentTypeAppEnum.swift
@@ -1,0 +1,27 @@
+import AppIntents
+import AnglesiteCore
+
+/// The typed content kinds a user can filter by (the `.collection`-stored built-ins from
+/// `ContentTypeRegistry`). An `AppEnum` so it appears as a typed picker in Shortcuts and in the
+/// auto-derived MCP schema. `rawValue` is the registry id; kept in sync by a drift-guard test
+/// (`ContentTypeAppEnumTests`) — adding a built-in collection type fails that test until a case
+/// is added here. `businessProfile` (page singleton) is intentionally absent (#351 scope).
+public enum ContentTypeAppEnum: String, AppEnum, Sendable, CaseIterable {
+    case note, article, photo, album, bookmark, reply, like
+    case announcement, event, review
+
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Content Type" }
+
+    public static var caseDisplayRepresentations: [ContentTypeAppEnum: DisplayRepresentation] {
+        [
+            .note: "Note", .article: "Article", .photo: "Photo", .album: "Album",
+            .bookmark: "Bookmark", .reply: "Reply", .like: "Like",
+            .announcement: "Announcement", .event: "Event", .review: "Review",
+        ]
+    }
+
+    /// The Astro content collection backing this type (e.g. `.event` → "events"), via the registry.
+    public var collection: String? {
+        ContentTypeRegistry.default.descriptor(id: rawValue)?.collection
+    }
+}

--- a/Sources/AnglesiteIntents/ContentTypeAppEnum.swift
+++ b/Sources/AnglesiteIntents/ContentTypeAppEnum.swift
@@ -12,13 +12,11 @@ public enum ContentTypeAppEnum: String, AppEnum, Sendable, CaseIterable {
 
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Content Type" }
 
-    public static var caseDisplayRepresentations: [ContentTypeAppEnum: DisplayRepresentation] {
-        [
-            .note: "Note", .article: "Article", .photo: "Photo", .album: "Album",
-            .bookmark: "Bookmark", .reply: "Reply", .like: "Like",
-            .announcement: "Announcement", .event: "Event", .review: "Review",
-        ]
-    }
+    public static let caseDisplayRepresentations: [ContentTypeAppEnum: DisplayRepresentation] = [
+        .note: "Note", .article: "Article", .photo: "Photo", .album: "Album",
+        .bookmark: "Bookmark", .reply: "Reply", .like: "Like",
+        .announcement: "Announcement", .event: "Event", .review: "Review",
+    ]
 
     /// The Astro content collection backing this type (e.g. `.event` → "events"), via the registry.
     public var collection: String? {

--- a/Sources/AnglesiteIntents/OperationDescriptor.swift
+++ b/Sources/AnglesiteIntents/OperationDescriptor.swift
@@ -105,6 +105,12 @@ public enum AnglesiteOperations {
             resultShape: .none
         ),
         OperationDescriptor(
+            operationID: "find-content-by-type", displayName: "Find Content by Type",
+            intentTypeName: "FindContentByTypeIntent", sideEffect: .readOnly,
+            requiresConfirmation: false, isCancellable: false,
+            resultShape: .entities("PostEntity")
+        ),
+        OperationDescriptor(
             operationID: "preview-site", displayName: "Preview Site",
             intentTypeName: "PreviewSiteIntent", sideEffect: .readOnly,
             requiresConfirmation: false, isCancellable: false,

--- a/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
@@ -155,6 +155,28 @@ struct ContentTypeRegistryTests {
         #expect(like.projections.microformatProperties["likeOf"] == "u-like-of")
     }
 
+    // MARK: Reverse lookup
+
+    @Test("descriptor(forCollection:) maps a collection name back to its type")
+    func reverseLookupByCollection() {
+        let r = ContentTypeRegistry.default
+        #expect(r.descriptor(forCollection: "events")?.id == "event")
+        #expect(r.descriptor(forCollection: "reviews")?.id == "review")
+        #expect(r.descriptor(forCollection: "notes")?.id == "note")
+        // Unknown / custom collection has no descriptor.
+        #expect(r.descriptor(forCollection: "blog") == nil)
+        // Page-stored businessProfile has no collection, so it is never reverse-matched.
+        #expect(r.descriptor(forCollection: "") == nil)
+    }
+
+    @Test("collectionBackedTypeIDs lists exactly the .collection-stored built-ins, in order")
+    func collectionBackedIDs() {
+        #expect(ContentTypeRegistry.default.collectionBackedTypeIDs == [
+            "note", "article", "photo", "album", "bookmark", "reply", "like",
+            "announcement", "event", "review",
+        ])
+    }
+
     // MARK: Catalog invariants
 
     @Test("every built-in has a unique id, a microformat, and reachable mf2 fields")

--- a/Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
@@ -435,6 +435,18 @@ extension AppIntentsTests {
                 #expect(r.first?.siteID == AppIntentsTests.aSite)
             }
         }
+
+        @Test("PostEntity derives contentType display name from a known collection")
+        func postEntity_contentTypeFromKnownCollection() {
+            let entity = PostEntity(AppIntentsTests.gPost(collection: "events"))
+            #expect(entity.contentType == "Event")
+        }
+
+        @Test("PostEntity falls back to the raw collection for an unknown collection")
+        func postEntity_contentTypeUnknownCollectionFallsBack() {
+            let entity = PostEntity(AppIntentsTests.gPost(collection: "blog"))
+            #expect(entity.contentType == "blog")
+        }
     }
 
     @Suite("ImageEntityQuery")

--- a/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
@@ -261,6 +261,11 @@ extension AppIntentsTests {
             // Only this site's events, newest first.
             #expect(results.map(\.slug) == ["newer", "older"])
             #expect(results.allSatisfy { $0.contentType == "Event" })
+
+            // A type with posts of other types present but none of its own → empty (not all posts).
+            let none = await FindContentByTypeIntent.matches(
+                graph: graph, siteID: AppIntentsTests.aSite, type: .like)
+            #expect(none.isEmpty)
         }
     }
 }

--- a/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
@@ -227,5 +227,38 @@ extension AppIntentsTests {
             #expect(parsed?.collection == "notes")            // parsed from filePath
             #expect(AddPostIntent.createdPost(.failed(reason: "x"), siteID: AppIntentsTests.aSite, title: "Hello", collection: nil) == nil)
         }
+
+        @Test("findByType dialog: singular/plural and empty")
+        func findByTypeDialog() {
+            #expect(ContentDialogs.findByType(typeName: "Event", count: 0) == "No events found.")
+            #expect(ContentDialogs.findByType(typeName: "Event", count: 1) == "Found 1 event.")
+            #expect(ContentDialogs.findByType(typeName: "Review", count: 3) == "Found 3 reviews.")
+        }
+
+        @Test("FindContentByTypeIntent.matches filters by type's collection, sorted, scoped to site")
+        func findByTypeMatches() async {
+            let graph = SiteContentGraph()
+            await graph.load(
+                siteID: AppIntentsTests.aSite,
+                pages: [],
+                posts: [
+                    AppIntentsTests.gPost(slug: "older", title: "Older", collection: "events",
+                                          modified: AppIntentsTests.t0),
+                    AppIntentsTests.gPost(slug: "newer", title: "Newer", collection: "events",
+                                          modified: AppIntentsTests.t0.addingTimeInterval(60)),
+                    AppIntentsTests.gPost(slug: "a-review", title: "A Review", collection: "reviews"),
+                ],
+                images: []
+            )
+            // A post of the same type on another site must not leak in.
+            await graph.upsertPost(AppIntentsTests.gPost(site: AppIntentsTests.bSite, slug: "b-evt",
+                                                         collection: "events"))
+
+            let results = await FindContentByTypeIntent.matches(
+                graph: graph, siteID: AppIntentsTests.aSite, type: .event)
+            // Only this site's events, newest first.
+            #expect(results.map(\.slug) == ["newer", "older"])
+            #expect(results.allSatisfy { $0.contentType == "Event" })
+        }
     }
 }

--- a/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
@@ -223,8 +223,10 @@ extension AppIntentsTests {
             #expect(withInput?.id == "\(AppIntentsTests.aSite):post:hello")
             #expect(withInput?.slug == "hello")
             #expect(withInput?.collection == "blog")          // input wins
+            #expect(withInput?.contentType == "blog")         // unknown collection falls back to raw name
             let parsed = AddPostIntent.createdPost(ok, siteID: AppIntentsTests.aSite, title: "Hello", collection: nil)
             #expect(parsed?.collection == "notes")            // parsed from filePath
+            #expect(parsed?.contentType == "Note")            // registry maps "notes" → "Note"
             #expect(AddPostIntent.createdPost(.failed(reason: "x"), siteID: AppIntentsTests.aSite, title: "Hello", collection: nil) == nil)
         }
 

--- a/Tests/AnglesiteIntentsTests/ContentTypeAppEnumTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentTypeAppEnumTests.swift
@@ -1,0 +1,27 @@
+import Testing
+import AppIntents
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+extension AppIntentsTests {
+    @Suite("ContentTypeAppEnum")
+    struct ContentTypeAppEnumTests {
+
+        @Test("enum cases match the registry's collection-backed type ids exactly (drift guard)")
+        func driftGuard() {
+            let enumIDs = Set(ContentTypeAppEnum.allCases.map(\.rawValue))
+            let registryIDs = Set(ContentTypeRegistry.default.collectionBackedTypeIDs)
+            #expect(enumIDs == registryIDs)
+        }
+
+        @Test("every case has a non-empty display representation and resolves its collection")
+        func displayAndCollection() {
+            for kind in ContentTypeAppEnum.allCases {
+                let title = ContentTypeAppEnum.caseDisplayRepresentations[kind]?.title
+                #expect(title != nil)
+                #expect(kind.collection != nil)
+            }
+            #expect(ContentTypeAppEnum.event.collection == "events")
+        }
+    }
+}

--- a/Tests/AnglesiteIntentsTests/ContentTypeAppEnumTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentTypeAppEnumTests.swift
@@ -7,19 +7,19 @@ extension AppIntentsTests {
     @Suite("ContentTypeAppEnum")
     struct ContentTypeAppEnumTests {
 
-        @Test("enum cases match the registry's collection-backed type ids exactly (drift guard)")
+        @Test("enum cases match the registry's collection-backed type ids exactly, in order (drift guard)")
         func driftGuard() {
-            let enumIDs = Set(ContentTypeAppEnum.allCases.map(\.rawValue))
-            let registryIDs = Set(ContentTypeRegistry.default.collectionBackedTypeIDs)
-            #expect(enumIDs == registryIDs)
+            // Ordered equality, not just set equality: the Shortcuts picker shows cases in
+            // declaration order, so it must track the registry's registration order too.
+            #expect(ContentTypeAppEnum.allCases.map(\.rawValue) == ContentTypeRegistry.default.collectionBackedTypeIDs)
         }
 
-        @Test("every case has a non-empty display representation and resolves its collection")
+        @Test("every case has a non-empty display representation and resolves a non-empty collection")
         func displayAndCollection() {
             for kind in ContentTypeAppEnum.allCases {
                 let title = ContentTypeAppEnum.caseDisplayRepresentations[kind]?.title
                 #expect(title != nil)
-                #expect(kind.collection != nil)
+                #expect(kind.collection?.isEmpty == false)
             }
             #expect(ContentTypeAppEnum.event.collection == "events")
         }

--- a/Tests/AnglesiteIntentsTests/OperationDescriptorTests.swift
+++ b/Tests/AnglesiteIntentsTests/OperationDescriptorTests.swift
@@ -49,6 +49,7 @@ extension AppIntentsTests {
                 "open-site": .init(sideEffect: .readOnly, requiresConfirmation: false, isCancellable: false, resultShape: .none),
                 "search-content": .init(sideEffect: .readOnly, requiresConfirmation: false, isCancellable: false, resultShape: .entities("ContentMatchEntity")),
                 "site-status": .init(sideEffect: .readOnly, requiresConfirmation: false, isCancellable: false, resultShape: .none),
+                "find-content-by-type": .init(sideEffect: .readOnly, requiresConfirmation: false, isCancellable: false, resultShape: .entities("PostEntity")),
                 "preview-site": .init(sideEffect: .readOnly, requiresConfirmation: false, isCancellable: false, resultShape: .none),
                 "add-page": .init(sideEffect: .createsContent, requiresConfirmation: false, isCancellable: true, resultShape: .entity("PageEntity")),
                 "add-post": .init(sideEffect: .createsContent, requiresConfirmation: false, isCancellable: true, resultShape: .entity("PostEntity")),

--- a/Tests/AnglesiteIntentsTests/SmokeMatrixTests.swift
+++ b/Tests/AnglesiteIntentsTests/SmokeMatrixTests.swift
@@ -6,7 +6,7 @@ import Foundation
 /// Coverage anchor for the Siri AI smoke matrix (#237).
 ///
 /// `docs/specs/2026-06-20-siri-smoke-matrix.md` documents the product-level acceptance matrix —
-/// the eight supported Siri workflows, their phrases, app states, and expected outcomes. A doc
+/// the nine supported Siri workflows, their phrases, app states, and expected outcomes. A doc
 /// can silently drift from the code; this suite pins the *deterministic* claims of that doc to the
 /// shipped intent / operation registry so the matrix can't go stale unnoticed:
 ///
@@ -49,6 +49,7 @@ extension AppIntentsTests {
             Workflow(label: "Deploy with confirmation", operationID: "deploy-site", sideEffect: .publishes, confirmsAtRuntime: true),
             Workflow(label: "Search content", operationID: "search-content", sideEffect: .readOnly, confirmsAtRuntime: false),
             Workflow(label: "Site status", operationID: "site-status", sideEffect: .readOnly, confirmsAtRuntime: false),
+            Workflow(label: "Find content by type", operationID: "find-content-by-type", sideEffect: .readOnly, confirmsAtRuntime: false),
             Workflow(label: "Add page", operationID: "add-page", sideEffect: .createsContent, confirmsAtRuntime: false),
             Workflow(label: "Add post", operationID: "add-post", sideEffect: .createsContent, confirmsAtRuntime: false),
             Workflow(label: "Preview a page", operationID: "preview-site", sideEffect: .readOnly, confirmsAtRuntime: false),

--- a/docs/specs/2026-06-20-siri-smoke-matrix.md
+++ b/docs/specs/2026-06-20-siri-smoke-matrix.md
@@ -18,13 +18,14 @@ MAS build, anchored to automated fixtures so it can't silently drift.
 
 This **complements, not replaces**, the Phase C test-suite audit and the D.5 manual MCP smoke.
 
-## Scope — the eight supported workflows
+## Scope — the nine supported workflows
 
-Every row maps to a shipped intent in `Sources/AnglesiteIntents` with a curated Siri phrase in
-`AnglesiteShortcuts.appShortcuts`. Phrases below are verbatim from that provider; `Anglesite`
-is `\(.applicationName)` at runtime. (`OpenSiteIntent` ships but has **no** curated phrase — it
-is an `OpenIntent` reached from Spotlight result taps / Shortcuts chaining, so it is listed
-under "open" but is exercised via the entity-resolution path, not a spoken phrase.)
+Every row maps to a shipped intent in `Sources/AnglesiteIntents`. Most have a curated Siri phrase
+in `AnglesiteShortcuts.appShortcuts`; two exceptions ship without a curated phrase and are reached
+via Shortcuts / entity matching instead: `OpenSiteIntent` (an `OpenIntent` exercised via the
+entity-resolution path) and `FindContentByTypeIntent` (reached via Shortcuts / entity match — the
+10-phrase budget is full). Phrases below are verbatim from the shortcuts provider; `Anglesite`
+is `\(.applicationName)` at runtime.
 
 | # | Workflow | Intent | Curated Siri phrase(s) | Side effect | Confirms? | Returns |
 |---|---|---|---|---|---|---|
@@ -34,6 +35,7 @@ under "open" but is exercised via the entity-resolution path, not a spoken phras
 | 4 | Deploy with confirmation | `DeploySiteIntent` | "Deploy my site with Anglesite" | publishes | **yes** | `SiteEntity` |
 | 5 | Search content | `SearchContentIntent` | "What's on my site …" / "Search my site …" | read-only | no | `[ContentMatchEntity]` |
 | 5b | Site status | `SiteStatusIntent` | "How is my site doing …" / "My site status …" | read-only | no | — (dialog) |
+| 5c | Find content by type | `FindContentByTypeIntent` | *(no phrase — Shortcuts / entity match)* | read-only | no | `[PostEntity]` |
 | 6 | Add page / post | `AddPageIntent` / `AddPostIntent` | "Add a page …" / "Add a post …" | creates content | no | `PageEntity?` / `PostEntity?` |
 | 7 | Preview a page | `PreviewSiteIntent` | "Preview my site …" / "Open my site preview …" | read-only | no | — (opens UI) |
 | 8 | Edit visible content with confirmation | `EditContentIntent` | "Edit this with Anglesite" / "Change this with Anglesite" | modifies content | **yes** † | — (dialog) |
@@ -59,6 +61,7 @@ window is key; Preview = the WKWebView preview is focused (onscreen-awareness pa
 | Deploy | Launch; prompts; **confirm** | Prompts; confirm | Confirm; runs | n/a | runs after confirm | **fails closed** ‡ |
 | Search content | Launch; prompts | Prompts | Searches frontmost | n/a | reads | reads (graph is app-owned) |
 | Site status | Launch; prompts | Prompts | Status of frontmost | n/a | reads | reads |
+| Find content by type | Launch; prompts | Prompts | Searches frontmost | n/a | reads | reads (graph is app-owned) |
 | Add page/post | Launch; prompts | Prompts | Adds to frontmost | n/a | writes | **fails closed** ‡ |
 | Preview | Launch + open preview | Opens preview | Navigates preview | re-navigates current | opens | opens |
 | Edit visible content | n/a — needs onscreen element | n/a | n/a (no selection) | resolves `element`; **confirm**; writes | writes after confirm | **fails closed** ‡ |
@@ -101,7 +104,7 @@ checked by hand against a fixture site and recorded in the PR description, never
 The same matrix applies to both targets. Differences to watch on the MAS pass:
 
 - The "MAS grant present/missing" columns only apply to `AnglesiteMAS`; on DevID (sandbox off) writes work without the bookmark.
-- Chat / Sparkle / `gh` are compiled out of MAS, but none of the eight workflows depend on them, so the matrix is identical.
+- Chat / Sparkle / `gh` are compiled out of MAS, but none of the nine workflows depend on them, so the matrix is identical.
 - Run the manual pass once per target before tagging a release.
 
 ## How to run a pass

--- a/docs/superpowers/plans/2026-06-27-typed-content-app-intents.md
+++ b/docs/superpowers/plans/2026-06-27-typed-content-app-intents.md
@@ -1,0 +1,540 @@
+# Typed-content App-Intent entities (#351) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the ten collection-backed typed content objects matchable by Siri/Spotlight and add a typed filter intent (`FindContentByTypeIntent`).
+
+**Architecture:** Content-type identity is a pure function of `SiteContentGraph.Post.collection` via `ContentTypeRegistry` (no graph/scanner changes). Add a reverse lookup to the registry, surface a derived `contentType` `@Property` on `PostEntity` (auto-indexed by Spotlight), and add a typed `AppEnum` + filter intent in `AnglesiteIntents`.
+
+**Tech Stack:** Swift 6.4 / SwiftUI 27, AppIntents framework, Swift Testing (`@Test`/`#expect`), SwiftPM (`swift test`).
+
+## Global Constraints
+
+- ES modules / vanilla — N/A (Swift project).
+- **Worktree:** all work in `.claude/worktrees/351-typed-content-intents` (branch `feat/351-typed-content-intents`). `cd` there before any git/build op.
+- **Swift toolchain:** `swift test` needs `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` (default CommandLineTools swift is too old).
+- **No new third-party deps** — Apple frameworks only.
+- **Scope:** the ten `.collection(...)`-backed built-in types only. `businessProfile` / page singletons are OUT (→ #388). No `SiteContentGraph` / `ContentScanner` / MCP `list_content` changes. No new curated Siri `AppShortcut` phrases (10-phrase budget full).
+- **`FindContentByTypeIntent` returns `[PostEntity]`** (homogeneous), not `ContentMatchEntity`.
+- **Test invocation:** `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter <SuiteOrTest>` per commit; final task builds both Xcode schemes.
+- **Conventional commits**, footer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Registry reverse lookup (`AnglesiteCore`)
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ContentTypeRegistry.swift` (add to `ContentTypeRegistry` struct + a shared default)
+- Test: `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift`
+
+**Interfaces:**
+- Consumes: existing `ContentTypeDescriptor`, `ContentStorage`, `ContentTypeRegistry`.
+- Produces:
+  - `ContentTypeRegistry.descriptor(forCollection: String) -> ContentTypeDescriptor?`
+  - `static let ContentTypeRegistry.default: ContentTypeRegistry` (built-ins; O(1) reverse map)
+  - `ContentTypeRegistry.collectionBackedTypeIDs: [String]` (ordered ids of `.collection`-stored types)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift` (inside the existing suite/struct; match its `@Test` style):
+
+```swift
+@Test("descriptor(forCollection:) maps a collection name back to its type")
+func reverseLookupByCollection() {
+    let r = ContentTypeRegistry.default
+    #expect(r.descriptor(forCollection: "events")?.id == "event")
+    #expect(r.descriptor(forCollection: "reviews")?.id == "review")
+    #expect(r.descriptor(forCollection: "notes")?.id == "note")
+    // Unknown / custom collection has no descriptor.
+    #expect(r.descriptor(forCollection: "blog") == nil)
+    // Page-stored businessProfile has no collection, so it is never reverse-matched.
+    #expect(r.descriptor(forCollection: "") == nil)
+}
+
+@Test("collectionBackedTypeIDs lists exactly the .collection-stored built-ins, in order")
+func collectionBackedIDs() {
+    #expect(ContentTypeRegistry.default.collectionBackedTypeIDs == [
+        "note", "article", "photo", "album", "bookmark", "reply", "like",
+        "announcement", "event", "review",
+    ])
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ContentTypeRegistryTests`
+Expected: FAIL — `value of type 'ContentTypeRegistry' has no member 'descriptor(forCollection:)'` / no member `default` / `collectionBackedTypeIDs`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteCore/ContentTypeRegistry.swift`, add a stored reverse map to the struct and the accessors. Replace the struct's stored properties + `init` region so the reverse map is built alongside `byID`:
+
+```swift
+public struct ContentTypeRegistry: Sendable, Equatable {
+    private var byID: [String: ContentTypeDescriptor]
+    private var order: [String]
+    /// collection name → type id, for `.collection`-stored types only. Built at insert time
+    /// so reverse lookups are O(1) and stay in sync with `byID`.
+    private var collectionToID: [String: String]
+
+    public init(types: [ContentTypeDescriptor] = ContentTypeRegistry.builtIns) {
+        byID = [:]
+        order = []
+        collectionToID = [:]
+        for descriptor in types { insert(descriptor) }
+    }
+
+    private mutating func insert(_ descriptor: ContentTypeDescriptor) {
+        if byID[descriptor.id] == nil { order.append(descriptor.id) }
+        // A replaced descriptor may have changed collection; drop any stale reverse entry first.
+        if let old = byID[descriptor.id]?.collection { collectionToID[old] = nil }
+        byID[descriptor.id] = descriptor
+        if let collection = descriptor.collection { collectionToID[collection] = descriptor.id }
+    }
+```
+
+Keep the existing `register`, `descriptor(id:)`, `all`, `ids`. Then add (after `descriptor(id:)`):
+
+```swift
+    /// Reverse of `descriptor(id:)`: the `.collection`-stored type whose collection is `collection`.
+    public func descriptor(forCollection collection: String) -> ContentTypeDescriptor? {
+        guard let id = collectionToID[collection] else { return nil }
+        return byID[id]
+    }
+
+    /// Ids of the `.collection`-stored types, in registration order. Page-stored types are excluded.
+    public var collectionBackedTypeIDs: [String] {
+        order.compactMap { byID[$0] }.filter { $0.collection != nil }.map(\.id)
+    }
+
+    /// Shared built-in registry. Lets value-type consumers resolve types without rebuilding it.
+    public static let `default` = ContentTypeRegistry()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ContentTypeRegistryTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/351-typed-content-intents
+git add Sources/AnglesiteCore/ContentTypeRegistry.swift Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+git commit -m "feat(#351): registry reverse lookup (collection→type)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `PostEntity.contentType` derived property
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/ContentEntities.swift` (the `PostEntity` struct, ~lines 96–136)
+- Test: `Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentTypeRegistry.default.descriptor(forCollection:)` (Task 1); `SiteContentGraph.Post`.
+- Produces: `PostEntity.contentType: String` (`@Property(title: "Type")`); secondary `init` gains `contentType: String = ""` param. `init(_ post:)` derives it.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift` (inside the existing `PostEntityQuery` suite or a new `@Suite` next to it — match the file's style):
+
+```swift
+@Test("PostEntity derives contentType display name from a known collection")
+func postEntity_contentTypeFromKnownCollection() {
+    let entity = PostEntity(AppIntentsTests.gPost(collection: "events"))
+    #expect(entity.contentType == "Event")
+}
+
+@Test("PostEntity falls back to the raw collection for an unknown collection")
+func postEntity_contentTypeUnknownCollectionFallsBack() {
+    let entity = PostEntity(AppIntentsTests.gPost(collection: "blog"))
+    #expect(entity.contentType == "blog")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ContentEntitiesTests`
+Expected: FAIL — `value of type 'PostEntity' has no member 'contentType'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteIntents/ContentEntities.swift`, in `struct PostEntity`, add the property after `collection`:
+
+```swift
+    @Property(title: "Type") public var contentType: String
+```
+
+Update `init(_ post:)` to derive it (add this line alongside the other assignments):
+
+```swift
+        // Typed dimension (#351): map the post's collection back to its content type's display
+        // name via the registry; fall back to the raw collection for custom/unknown collections.
+        self.contentType = ContentTypeRegistry.default.descriptor(forCollection: post.collection)?.displayName
+            ?? post.collection
+```
+
+Update the secondary memberwise `init(id:displayName:slug:collection:siteID:isDraft:tags:)` to accept and assign `contentType`, defaulting so existing call sites are unaffected:
+
+```swift
+    public init(id: String, displayName: String, slug: String, collection: String,
+                siteID: String, isDraft: Bool = true, tags: [String] = [],
+                contentType: String = "") {
+        self.id = id
+        self.displayName = displayName
+        self.isDraft = isDraft
+        self.tags = tags
+        self.slug = slug
+        self.collection = collection
+        self.siteID = siteID
+        self.contentType = contentType
+    }
+```
+
+(`AnglesiteIntents` already `import AnglesiteCore`, so `ContentTypeRegistry` is in scope.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ContentEntitiesTests`
+Expected: PASS. (The existing `AddPostIntent.createdPost` call site still compiles — `contentType` defaults to `""`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/351-typed-content-intents
+git add Sources/AnglesiteIntents/ContentEntities.swift Tests/AnglesiteIntentsTests/ContentEntitiesTests.swift
+git commit -m "feat(#351): derive PostEntity.contentType for Spotlight/Siri matching
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `ContentTypeAppEnum` + drift guard
+
+**Files:**
+- Create: `Sources/AnglesiteIntents/ContentTypeAppEnum.swift`
+- Test: `Tests/AnglesiteIntentsTests/ContentTypeAppEnumTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentTypeRegistry.default` / `collectionBackedTypeIDs` (Task 1).
+- Produces:
+  - `enum ContentTypeAppEnum: String, AppEnum, Sendable` — one case per collection-backed type id; `rawValue == registry id`.
+  - `var collection: String?` — the type's collection name via the registry.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteIntentsTests/ContentTypeAppEnumTests.swift`:
+
+```swift
+import Testing
+import AppIntents
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+extension AppIntentsTests {
+    @Suite("ContentTypeAppEnum")
+    struct ContentTypeAppEnumTests {
+
+        @Test("enum cases match the registry's collection-backed type ids exactly (drift guard)")
+        func driftGuard() {
+            let enumIDs = Set(ContentTypeAppEnum.allCases.map(\.rawValue))
+            let registryIDs = Set(ContentTypeRegistry.default.collectionBackedTypeIDs)
+            #expect(enumIDs == registryIDs)
+        }
+
+        @Test("every case has a non-empty display representation and resolves its collection")
+        func displayAndCollection() {
+            for kind in ContentTypeAppEnum.allCases {
+                let title = ContentTypeAppEnum.caseDisplayRepresentations[kind]?.title
+                #expect(title != nil)
+                #expect(kind.collection != nil)
+            }
+            #expect(ContentTypeAppEnum.event.collection == "events")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ContentTypeAppEnumTests`
+Expected: FAIL — `cannot find 'ContentTypeAppEnum' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `Sources/AnglesiteIntents/ContentTypeAppEnum.swift`:
+
+```swift
+import AppIntents
+import AnglesiteCore
+
+/// The typed content kinds a user can filter by (the `.collection`-stored built-ins from
+/// `ContentTypeRegistry`). An `AppEnum` so it appears as a typed picker in Shortcuts and in the
+/// auto-derived MCP schema. `rawValue` is the registry id; kept in sync by a drift-guard test
+/// (`ContentTypeAppEnumTests`) — adding a built-in collection type fails that test until a case
+/// is added here. `businessProfile` (page singleton) is intentionally absent (#351 scope).
+public enum ContentTypeAppEnum: String, AppEnum, Sendable, CaseIterable {
+    case note, article, photo, album, bookmark, reply, like
+    case announcement, event, review
+
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Content Type" }
+
+    public static var caseDisplayRepresentations: [ContentTypeAppEnum: DisplayRepresentation] {
+        [
+            .note: "Note", .article: "Article", .photo: "Photo", .album: "Album",
+            .bookmark: "Bookmark", .reply: "Reply", .like: "Like",
+            .announcement: "Announcement", .event: "Event", .review: "Review",
+        ]
+    }
+
+    /// The Astro content collection backing this type (e.g. `.event` → "events"), via the registry.
+    public var collection: String? {
+        ContentTypeRegistry.default.descriptor(id: rawValue)?.collection
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ContentTypeAppEnumTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/351-typed-content-intents
+git add Sources/AnglesiteIntents/ContentTypeAppEnum.swift Tests/AnglesiteIntentsTests/ContentTypeAppEnumTests.swift
+git commit -m "feat(#351): ContentTypeAppEnum with registry drift guard
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `FindContentByTypeIntent` + dialog
+
+**Files:**
+- Modify: `Sources/AnglesiteIntents/ContentIntents.swift` (add the intent; add a `findByType` dialog to `ContentDialogs`)
+- Test: `Tests/AnglesiteIntentsTests/ContentIntentsTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentTypeAppEnum` (Task 3) + `.collection`; `PostEntity` (Task 2); `SiteContentGraph.posts(for:)`; `ContentGraphOverride.scoped`; `SiteEntity`.
+- Produces:
+  - `FindContentByTypeIntent` (params `site: SiteEntity`, `contentType: ContentTypeAppEnum`; returns `[PostEntity]`).
+  - `static FindContentByTypeIntent.matches(graph:siteID:type:) async -> [PostEntity]`.
+  - `ContentDialogs.findByType(typeName:count:) -> String`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteIntentsTests/ContentIntentsTests.swift` (inside the `ContentIntentsTests` struct):
+
+```swift
+@Test("findByType dialog: singular/plural and empty")
+func findByTypeDialog() {
+    #expect(ContentDialogs.findByType(typeName: "Event", count: 0) == "No events found.")
+    #expect(ContentDialogs.findByType(typeName: "Event", count: 1) == "Found 1 event.")
+    #expect(ContentDialogs.findByType(typeName: "Review", count: 3) == "Found 3 reviews.")
+}
+
+@Test("FindContentByTypeIntent.matches filters by type's collection, sorted, scoped to site")
+func findByTypeMatches() async {
+    let graph = SiteContentGraph()
+    await graph.load(
+        siteID: AppIntentsTests.aSite,
+        pages: [],
+        posts: [
+            AppIntentsTests.gPost(slug: "older", title: "Older", collection: "events",
+                                  modified: AppIntentsTests.t0),
+            AppIntentsTests.gPost(slug: "newer", title: "Newer", collection: "events",
+                                  modified: AppIntentsTests.t0.addingTimeInterval(60)),
+            AppIntentsTests.gPost(slug: "a-review", title: "A Review", collection: "reviews"),
+        ],
+        images: []
+    )
+    // A post of the same type on another site must not leak in.
+    await graph.upsertPost(AppIntentsTests.gPost(site: AppIntentsTests.bSite, slug: "b-evt",
+                                                 collection: "events"))
+
+    let results = await FindContentByTypeIntent.matches(
+        graph: graph, siteID: AppIntentsTests.aSite, type: .event)
+    // Only this site's events, newest first.
+    #expect(results.map(\.slug) == ["newer", "older"])
+    #expect(results.allSatisfy { $0.contentType == "Event" })
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ContentIntentsTests`
+Expected: FAIL — no `ContentDialogs.findByType` / no `FindContentByTypeIntent`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteIntents/ContentIntents.swift`, add the intent (after `SearchContentIntent`, before `SiteStatusIntent`):
+
+```swift
+// MARK: - Find by type
+
+/// Lists a site's content of one type (#351). The typed counterpart to `SearchContentIntent`:
+/// resolves the type's collection from the registry and filters the graph's posts by it.
+public struct FindContentByTypeIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Find Content by Type"
+    public static let description = IntentDescription("List a site's content of a given type, e.g. events or reviews.")
+
+    @Parameter(title: "Site") public var site: SiteEntity
+    @Parameter(title: "Type") public var contentType: ContentTypeAppEnum
+    @Dependency private var graph: SiteContentGraph
+
+    public init() {}
+
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Find \(\.$contentType) in \(\.$site)")
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<[PostEntity]> {
+        let g = ContentGraphOverride.scoped ?? graph
+        let results = await Self.matches(graph: g, siteID: site.id, type: contentType)
+        let typeName = ContentTypeAppEnum.caseDisplayRepresentations[contentType]?.title ?? "content"
+        return .result(
+            value: results,
+            dialog: IntentDialog(stringLiteral: ContentDialogs.findByType(
+                typeName: String(localized: typeName), count: results.count))
+        )
+    }
+
+    /// Filter the site's posts to the type's collection, sorted (lastModified desc, id asc) — the
+    /// same comparator the entity queries use. Static + graph-injected for unit testability.
+    static func matches(graph: SiteContentGraph, siteID: String, type: ContentTypeAppEnum) async -> [PostEntity] {
+        guard let collection = type.collection else { return [] }
+        return await graph.posts(for: siteID)
+            .filter { $0.collection == collection }
+            .sorted { $0.lastModified != $1.lastModified ? $0.lastModified > $1.lastModified : $0.id < $1.id }
+            .map(PostEntity.init)
+    }
+}
+```
+
+Add to the `ContentDialogs` enum (next to `search`):
+
+```swift
+    public static func findByType(typeName: String, count: Int) -> String {
+        let plural = pluralize(typeName, count)
+        guard count > 0 else { return "No \(plural) found." }
+        return "Found \(count) \(plural)."
+    }
+
+    /// Naive English pluralization sufficient for the built-in type display names
+    /// (Note, Article, Photo, Album, Bookmark, Reply, Like, Announcement, Event, Review).
+    private static func pluralize(_ noun: String, _ n: Int) -> String {
+        let lower = noun.lowercased()
+        if n == 1 { return lower }
+        if lower.hasSuffix("y") { return lower.dropLast() + "ies" }  // reply → replies
+        return lower + "s"
+    }
+```
+
+(`String(localized:)` converts the `DisplayRepresentation.title` `LocalizedStringResource` to a `String` for the dialog. `DisplayRepresentation.title` is a `LocalizedStringResource`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ContentIntentsTests`
+Expected: PASS — `findByTypeDialog` (note "reply"→"replies", "review"→"reviews") and `findByTypeMatches`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/351-typed-content-intents
+git add Sources/AnglesiteIntents/ContentIntents.swift Tests/AnglesiteIntentsTests/ContentIntentsTests.swift
+git commit -m "feat(#351): FindContentByTypeIntent + typed dialog
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Schema/smoke sweep + full verification
+
+**Files:**
+- Inspect: `Tests/AnglesiteIntentsTests/SchemaConformanceTests.swift`, `Tests/AnglesiteIntentsTests/SmokeMatrixTests.swift`, `Tests/AnglesiteIntentsTests/AnglesiteShortcutsTests.swift`
+- Modify: whichever of the above enumerate the intent/entity/enum surface (only if they do).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+- Produces: no new API — closes coverage and proves the whole suite + both app schemes build.
+
+- [ ] **Step 1: Check whether the sweep tests enumerate the surface**
+
+Run:
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/351-typed-content-intents
+grep -n "Intent\|AppEnum\|PostEntity\|allCases\|expectedIntents\|\.self" \
+  Tests/AnglesiteIntentsTests/SchemaConformanceTests.swift \
+  Tests/AnglesiteIntentsTests/SmokeMatrixTests.swift \
+  Tests/AnglesiteIntentsTests/AnglesiteShortcutsTests.swift
+```
+Expected: shows whether any test hard-codes a list of intents/entities. If a test asserts an exhaustive set (e.g. an `expectedIntents` array or an `AppShortcut` count), `FindContentByTypeIntent` / `ContentTypeAppEnum` must be added there. If they only conformance-check individual named types, no change is needed.
+
+- [ ] **Step 2: Apply the minimal additions the grep reveals**
+
+If (and only if) a test enumerates the surface, add `FindContentByTypeIntent` / `ContentTypeAppEnum` to that list in the same style the file already uses. If a schema-conformance test instantiates each intent, add:
+
+```swift
+_ = FindContentByTypeIntent()
+```
+
+in the same place the others are instantiated. If `AnglesiteShortcutsTests` asserts an exact curated-phrase count, **leave it unchanged** — the new intent is deliberately not a curated `AppShortcut` (10-phrase budget; see plan constraints). If nothing enumerates the surface, record that in the commit body and skip to Step 3.
+
+- [ ] **Step 3: Run the full intents + core suites**
+
+Run:
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
+  swift test --package-path . --filter AnglesiteIntentsTests
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
+  swift test --package-path . --filter ContentTypeRegistryTests
+```
+Expected: PASS, no regressions.
+
+- [ ] **Step 4: Build both app schemes (proves the `.app` targets link the new types)**
+
+`Anglesite.xcodeproj` is gitignored — generate it, populate the gitignored plugin resources, then build. Run:
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/351-typed-content-intents
+xcodegen generate
+ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite ./scripts/copy-plugin.sh
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build
+```
+Expected: both `BUILD SUCCEEDED`. (If `copy-plugin.sh` fails on a self-symlink under `Resources/plugin`, `rm` it and re-run — see project memory.)
+
+- [ ] **Step 5: Commit (only if Step 2 changed files)**
+
+```bash
+cd /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/351-typed-content-intents
+git add Tests/AnglesiteIntentsTests/
+git commit -m "test(#351): register typed-content intent/enum in schema/smoke sweep
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Registry reverse lookup → Task 1. ✓
+- `PostEntity.contentType` derived + Spotlight auto-index (no indexer change) → Task 2. ✓
+- `ContentTypeAppEnum` + drift guard → Task 3. ✓
+- `FindContentByTypeIntent` returns `[PostEntity]`, static testable helper, `ContentDialogs` entry, not a curated AppShortcut → Task 4. ✓
+- Schema/smoke sweep + both-scheme build → Task 5. ✓
+- Out-of-scope (businessProfile, per-type entities, graph/scanner changes) → enforced by constraints; no task touches them. ✓
+- Tests named in spec: `ContentEntitiesTests` (T2), `FindContentByTypeIntentTests`→folded into `ContentIntentsTests` (T4), `ContentTypeAppEnumTests` (T3), `ContentDialogsTests`→folded into `ContentIntentsTests`' dialog tests (T4). ✓ (Dialog/intent tests live in `ContentIntentsTests`, the established home for `ContentDialogs` + intent-helper tests.)
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; commands have expected output. ✓
+
+**Type consistency:** `descriptor(forCollection:)`, `collectionBackedTypeIDs`, `ContentTypeRegistry.default`, `ContentTypeAppEnum` (rawValue == id) + `.collection`, `PostEntity.contentType: String`, `FindContentByTypeIntent.matches(graph:siteID:type:) -> [PostEntity]`, `ContentDialogs.findByType(typeName:count:)` — names identical across tasks. ✓

--- a/docs/superpowers/plans/2026-06-27-typed-content-app-intents.md
+++ b/docs/superpowers/plans/2026-06-27-typed-content-app-intents.md
@@ -11,10 +11,10 @@
 ## Global Constraints
 
 - ES modules / vanilla — N/A (Swift project).
-- **Worktree:** all work in `.claude/worktrees/351-typed-content-intents` (branch `feat/351-typed-content-intents`). `cd` there before any git/build op.
+- **Worktree:** all work in `.claude/worktrees/351-typed-content-intents` (branch `feat/351-typed-content-intents`). `cd` there before any git/build op. The absolute `/Users/dwk/…` paths in the per-step commands below are machine-specific — substitute your own worktree root.
 - **Swift toolchain:** `swift test` needs `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` (default CommandLineTools swift is too old).
 - **No new third-party deps** — Apple frameworks only.
-- **Scope:** the ten `.collection(...)`-backed built-in types only. `businessProfile` / page singletons are OUT (→ #388). No `SiteContentGraph` / `ContentScanner` / MCP `list_content` changes. No new curated Siri `AppShortcut` phrases (10-phrase budget full).
+- **Scope:** the ten `.collection(...)`-backed built-in types only. `businessProfile` / page singletons are OUT (→ #388). No `SiteContentGraph` / `ContentScanner` / MCP `list_content` changes. No new curated Siri `AppShortcut` phrases (the last of the 10 slots is reserved for the queued Bucket-3 intents; `AnglesiteShortcuts` lists 9 today).
 - **`FindContentByTypeIntent` returns `[PostEntity]`** (homogeneous), not `ContentMatchEntity`.
 - **Test invocation:** `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter <SuiteOrTest>` per commit; final task builds both Xcode schemes.
 - **Conventional commits**, footer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.

--- a/docs/superpowers/specs/2026-06-27-typed-content-app-intents-design.md
+++ b/docs/superpowers/specs/2026-06-27-typed-content-app-intents-design.md
@@ -114,8 +114,10 @@ a new built-in collection type fails the test until the enum is updated.
   runtime via the `ContentGraphOverride.scoped` seam.
 - A spoken-result dialog string is added to `ContentDialogs`
   (pure/unit-testable, like the others).
-- **Not** registered as a curated `AppShortcut`: `AnglesiteShortcuts` is at its
-  10-phrase Siri budget. The intent is still discoverable in the Shortcuts app and
+- **Not** registered as a curated `AppShortcut`: `AppShortcutsProvider` allows at most
+  10 curated phrases; `AnglesiteShortcuts` already lists 9 and reserves the remaining
+  slot for the queued Bucket-3 integration intents (see the comment block in
+  `AnglesiteShortcuts.swift`). The intent is still discoverable in the Shortcuts app and
   via entity matching; voice/Spotlight matching of the typed content is carried by
   the `PostEntity.contentType` property.
 
@@ -154,4 +156,5 @@ SiteContentGraph.Post (collection)            ← unchanged; already populated
 - `businessProfile` / page-singleton entity surfacing → follows #388.
 - Per-type `AppEntity` types.
 - `SiteContentGraph` / `ContentScanner` / MCP `list_content` changes.
-- New curated Siri phrases (10-phrase budget is full).
+- New curated Siri phrases (the last of the 10 `AppShortcut` slots is reserved for the
+  queued Bucket-3 intents; `AnglesiteShortcuts` lists 9 today).

--- a/docs/superpowers/specs/2026-06-27-typed-content-app-intents-design.md
+++ b/docs/superpowers/specs/2026-06-27-typed-content-app-intents-design.md
@@ -1,0 +1,157 @@
+# V-1.9 / #351 — App-Intent entities for typed content
+
+**Status:** approved (2026-06-27)
+**Issue:** [#351](https://github.com/Anglesite/Anglesite-app/issues/351) — part of #335 (V-1), plan task 1.9.
+**Branch / worktree:** `feat/351-typed-content-intents` → `.claude/worktrees/351-typed-content-intents`
+
+## Goal
+
+Make the new typed content objects (V-1.2 personal types + V-1.3 business types)
+matchable by Siri/Spotlight, and add a typed filter intent so a user can ask for
+content *of a given type* (e.g. "find my events"). Acceptance from the issue: new
+types are matchable by voice/Spotlight; intent tests added.
+
+## Background / current state
+
+The typed content objects are declared once as `ContentTypeDescriptor`s in
+`AnglesiteCore/ContentTypeRegistry.swift` (V-1.1). Ten of them are
+`.collection(...)`-stored:
+
+| Type id | Collection | Type id | Collection |
+|---|---|---|---|
+| note | notes | bookmark | bookmarks |
+| article | articles | reply | replies |
+| photo | photos | like | likes |
+| album | albums | announcement | announcements |
+| | | event | events |
+| | | review | reviews |
+
+`businessProfile` is the one `.page`-stored type and is **out of scope** here.
+
+Two facts established during design that shape the approach:
+
+1. **The collection-backed types already flow through as `SiteContentGraph.Post`s.**
+   `ContentScanner` scans every built-in collection
+   (`ContentTypeRegistry.builtIns.compactMap(\.collection)`), so notes, articles,
+   events, reviews, … are already populated into the graph as `Post`s — already
+   resolvable as `PostEntity` and already Spotlight-indexed by
+   `ContentSpotlightIndexer` (via `indexPosts`).
+
+2. **What's missing is a typed dimension.** A `Post` carries its `collection`
+   ("events") but not its content *type* ("event"). Siri/Spotlight sees every
+   entry as a generic "Post", and `ContentMatchKind` only knows `page/post/image`.
+
+Because each type maps 1:1 to a collection, **content-type identity is a pure
+function of `Post.collection` via the registry** — no changes to
+`SiteContentGraph`, `ContentScanner`, the MCP `list_content` path, or the Spotlight
+indexer are required.
+
+## Approach (chosen)
+
+Enrich the existing post entity with a typed property and add a typed filter
+intent. Rejected alternatives:
+
+- **Per-type `AppEntity` (`NoteEntity`/`EventEntity`/…)** — ~10 near-identical
+  entity + query types, schema explosion, and the graph doesn't model per-type
+  fields. Boilerplate with no payoff. Rejected.
+- **Touching the graph / scanner to store `contentType`** — unnecessary; the value
+  derives from `collection`, and there are two population paths (native scanner +
+  MCP `list_content` DTO) that would both need it. Deriving keeps a single source
+  of truth. Rejected.
+
+## Components
+
+### 1. `AnglesiteCore` — registry reverse lookup (pure)
+
+Add to `ContentTypeRegistry`:
+
+- `func descriptor(forCollection collection: String) -> ContentTypeDescriptor?`
+  — reverse of the existing `descriptor(id:)`, backed by a precomputed
+  `[collection: id]` map so lookups are O(1).
+- A shared default instance (e.g. `static let `default` = ContentTypeRegistry()`)
+  so the entity layer can resolve types without rebuilding the registry per call.
+
+This is the only `AnglesiteCore` change — pure value data, no I/O, fully
+unit-testable.
+
+### 2. `PostEntity` — typed property (`AnglesiteIntents/ContentEntities.swift`)
+
+Add `@Property(title: "Type") public var contentType: String`, derived in
+`init(_ post:)` from `post.collection`:
+
+- known collection → the descriptor's `displayName` (e.g. "Event")
+- unknown / custom collection (e.g. a hand-rolled "blog") → fall back to the raw
+  collection string, so nothing is lost.
+
+Threaded through the secondary memberwise `init` as well (with a default so call
+sites that don't care are unaffected). `PostEntity` is already an `IndexedEntity`,
+so the new `@Property` flows into the Spotlight `CSSearchableItemAttributeSet`
+automatically **and** appears in the auto-derived Shortcuts/MCP schema — **no
+`ContentSpotlightIndexer` change required.**
+
+`ContentMatchEntity` is left unchanged (its `kind` remains the coarse
+storage-kind: page/post/image). The typed dimension lives on `PostEntity`.
+
+### 3. `ContentTypeAppEnum` (new file in `AnglesiteIntents`)
+
+An `AppEnum` whose cases mirror the ten collection-backed built-in type ids, each
+with a `DisplayRepresentation`. It is the typed parameter for the filter intent and
+maps to/from the registry id. Kept honest by a **drift-guard test** (see Testing) —
+the same convention V-1.3 used for the content-config drift guard — so introducing
+a new built-in collection type fails the test until the enum is updated.
+
+### 4. `FindContentByTypeIntent` (`AnglesiteIntents/ContentIntents.swift`)
+
+- Parameters: `site: SiteEntity`, `contentType: ContentTypeAppEnum`.
+- `perform()` resolves the type's collection from the registry, filters
+  `graph.posts(for: site.id)` by it, and returns `[PostEntity]` sorted by the
+  standard `(lastModified desc, id asc)` comparator the other queries use.
+- Returns `[PostEntity]` (homogeneous — every result is a post), not
+  `ContentMatchEntity`.
+- Logic in a static, graph-injected helper
+  `matches(graph:siteID:type:) -> [PostEntity]`, mirroring
+  `SearchContentIntent.matches`, so it's unit-testable without the AppIntents
+  runtime via the `ContentGraphOverride.scoped` seam.
+- A spoken-result dialog string is added to `ContentDialogs`
+  (pure/unit-testable, like the others).
+- **Not** registered as a curated `AppShortcut`: `AnglesiteShortcuts` is at its
+  10-phrase Siri budget. The intent is still discoverable in the Shortcuts app and
+  via entity matching; voice/Spotlight matching of the typed content is carried by
+  the `PostEntity.contentType` property.
+
+## Data flow
+
+```
+ContentTypeRegistry (id ↔ collection)         ← single source of truth
+        │  descriptor(forCollection:)
+        ▼
+SiteContentGraph.Post (collection)            ← unchanged; already populated
+        │
+        ├─ PostEntity.init(_:)  → contentType (display)   → Spotlight + Siri match
+        │
+        └─ FindContentByTypeIntent.matches(graph,site,type)
+               filter posts by registry collection(type)  → [PostEntity]
+```
+
+## Testing
+
+- **`ContentEntitiesTests`** — `PostEntity` derives `contentType` from a known
+  collection (display name); unknown collection falls back to the raw collection
+  string.
+- **`FindContentByTypeIntentTests`** (new) — type-filtered results contain only the
+  requested type; sort order is `(lastModified desc, id asc)`; empty result when no
+  posts of that type; exercised through `ContentGraphOverride.scoped`.
+- **`ContentTypeAppEnumTests`** (new) — drift guard: enum case ids equal the
+  registry's collection-backed type ids; every case has a non-empty
+  `DisplayRepresentation`.
+- **`ContentDialogsTests`** — the new filter dialog string (count phrasing, empty
+  case).
+- **Schema/smoke sweep** — update `SchemaConformanceTests` / `SmokeMatrixTests` if
+  they enumerate the intent/entity surface, so the new intent + enum are covered.
+
+## Out of scope
+
+- `businessProfile` / page-singleton entity surfacing → follows #388.
+- Per-type `AppEntity` types.
+- `SiteContentGraph` / `ContentScanner` / MCP `list_content` changes.
+- New curated Siri phrases (10-phrase budget is full).


### PR DESCRIPTION
Closes #351 (V-1.9, part of #335).

Makes the ten collection-backed typed content objects (note, article, photo, album, bookmark, reply, like, announcement, event, review) matchable by Siri/Spotlight, and adds a typed filter intent. `businessProfile` (page singleton) is out of scope — follows #388.

## Key insight
These types already flow through as `SiteContentGraph.Post`s (the scanner already scans every built-in collection), so they're already `PostEntity`-resolvable and Spotlight-indexed. What was missing is a **typed dimension** — a `Post` knew its `collection` ("events") but not its content type ("event"). Since type↔collection is 1:1 in the registry, this derives entirely from the existing `collection` field — **no `SiteContentGraph` / `ContentScanner` / MCP `list_content` changes**.

## Changes
- **`ContentTypeRegistry`** (AnglesiteCore, pure value data): `descriptor(forCollection:)` reverse lookup (O(1) precomputed map), `collectionBackedTypeIDs`, shared `static let default`.
- **`PostEntity.contentType`**: a derived `@Property(title: "Type")` (registry display name, raw-collection fallback) — auto-indexed into Spotlight via `IndexedEntity`, so no indexer change.
- **`ContentTypeAppEnum`**: typed `AppEnum` (one case per collection-backed type) + a **registry drift-guard test** (adding a built-in type without an enum case fails the test).
- **`FindContentByTypeIntent`**: site + type → `[PostEntity]`, sorted `(lastModified desc, id asc)`; static graph-injected `matches` helper for unit-testability; `ContentDialogs.findByType` dialog. Not a curated Siri `AppShortcut` (10-phrase budget full) — discoverable via Shortcuts + entity matching, like `OpenSiteIntent`.
- **Operation-descriptor registry**: registered the intent in `AnglesiteOperations` (system-MCP/Siri metadata source of truth) and synced `OperationDescriptorTests`, `SmokeMatrixTests`, and the smoke-matrix doc (now nine workflows).

## Testing
- New: registry reverse-lookup tests, `PostEntity.contentType` derivation (known + fallback), `ContentTypeAppEnum` drift guard, `FindContentByTypeIntent.matches` (type-filter, sort, cross-site isolation), `findByType` dialog (singular/plural incl. reply→replies).
- `AnglesiteIntentsTests` (228) + `ContentTypeRegistry`/`OperationDescriptor`/`SmokeMatrix` suites pass; both `Anglesite` and `AnglesiteMAS` schemes BUILD SUCCEEDED.
- Built via subagent-driven TDD (5 tasks) with per-task review + an opus whole-branch review (verdict: READY).

Design + plan: `docs/superpowers/specs/2026-06-27-typed-content-app-intents-design.md`, `docs/superpowers/plans/2026-06-27-typed-content-app-intents.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)