### PR TITLE
fix(#346): serialize date fields unquoted (match ContentScaffold)

### DIFF
--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -4,15 +4,19 @@ import Foundation
 /// Node `parseFrontmatter` returns — the distinction matters to the scanner (`draft === true`
 /// wants a real boolean; `Array.isArray(tags)` wants a real array).
 ///
-/// `.number` is a write-only case: `Frontmatter.parse` never produces it (a numeric scalar parses
-/// as `.string`), but the editor uses it via `FrontmatterDocument.set` so a `number`-kind field
-/// serializes **unquoted** (`rating: 4`, not `rating: "4"`). Quoting a number would make YAML read
-/// it as a string and fail a content collection's `z.number()` schema.
+/// `.number` and `.date` are write-only cases: `Frontmatter.parse` never produces them (a numeric
+/// or date scalar parses as `.string`), but the editor uses them via `FrontmatterDocument.set` so
+/// those fields serialize **unquoted** — `rating: 4` (not `rating: "4"`) and
+/// `publishDate: 2026-01-01T00:00:00.000Z` (not `…: "…"`). Quoting would make YAML read the value
+/// as a string and fail a content collection's `z.number()`/non-coercing date schema. `.date`
+/// carries an already-formatted scalar (the editor decides date-only vs. full ISO by field kind),
+/// emitted verbatim, matching `ContentScaffold`'s unquoted dates.
 public enum FrontmatterValue: Equatable, Sendable {
     case string(String)
     case bool(Bool)
     case array([String])
     case number(Double)
+    case date(String)
 }
 
 /// Native port of `server/content-frontmatter.mjs` (Bucket 1, #275).

--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -16,6 +16,10 @@ public enum FrontmatterValue: Equatable, Sendable {
     case bool(Bool)
     case array([String])
     case number(Double)
+    /// A preformatted date scalar emitted **unquoted**. `s` must be a safe bare YAML scalar — no
+    /// newlines, no `: ` (colon-space) sequences — because `FrontmatterDocument.render` emits it
+    /// verbatim, unescaped. It is always produced by `TypedContentEditor.format()`
+    /// (`ISO8601DateFormatter` output or its 10-char date-only prefix), which satisfies that.
     case date(String)
 }
 

--- a/Sources/AnglesiteCore/FrontmatterDocument.swift
+++ b/Sources/AnglesiteCore/FrontmatterDocument.swift
@@ -162,6 +162,10 @@ public struct FrontmatterDocument: Equatable, Sendable {
             // magnitude guard avoids the Int(_:) overflow trap.
             let formatted = (n == n.rounded() && abs(n) < 1e15) ? String(Int(n)) : String(n)
             return "\(key): \(formatted)"
+        case .date(let s):
+            // Already-formatted date scalar, emitted unquoted (matching ContentScaffold) so YAML
+            // reads it as a date — a quoted scalar fails a non-coercing date schema.
+            return "\(key): \(s)"
         case .array(let items):
             if items.isEmpty { return "\(key): []" }
             return ([ "\(key):" ] + items.map { "  - \"\(escape($0))\"" }).joined(separator: "\n")

--- a/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
+++ b/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
@@ -312,6 +312,7 @@ public actor SiteKnowledgeIndex {
         case .bool(let b): return b ? "true" : "false"
         case .array(let values): return values.joined(separator: " ")
         case .number(let n): return n == n.rounded() && abs(n) < 1e15 ? String(Int(n)) : String(n)
+        case .date(let s): return s
         }
     }
 

--- a/Sources/AnglesiteCore/TypedContentEditor.swift
+++ b/Sources/AnglesiteCore/TypedContentEditor.swift
@@ -103,7 +103,10 @@ public enum TypedContentEditor {
         switch value {
         case .text(let s): return .string(s)
         case .flag(let b): return .bool(b)
-        case .date(let d): return .string(d.map { format($0, kind: kind) } ?? "")
+        // Dates serialize unquoted (FrontmatterValue.date) so they satisfy a non-coercing date
+        // schema and stay consistent with ContentScaffold; a nil (cleared) date falls back to an
+        // empty quoted scalar.
+        case .date(let d): return d.map { .date(format($0, kind: kind)) } ?? .string("")
         // Numbers serialize unquoted (FrontmatterValue.number) so they satisfy a z.number() schema;
         // a nil (cleared) number falls back to an empty quoted scalar.
         case .number(let n): return n.map { .number($0) } ?? .string("")

--- a/Sources/AnglesiteCore/TypedContentEditor.swift
+++ b/Sources/AnglesiteCore/TypedContentEditor.swift
@@ -86,6 +86,10 @@ public enum TypedContentEditor {
             if case .bool(let b) = value { return .flag(b) }
             return .flag(false)
         case .date, .datetime:
+            // `FrontmatterValue.date` is write-only — `Frontmatter.parse` only ever yields a date
+            // scalar as `.string`, so matching `.string` here is exhaustive in practice. If that
+            // invariant is ever relaxed, add a `.date` arm: the `.date(nil)` fallback would
+            // otherwise silently drop a valid date.
             if case .string(let s) = value { return .date(parseDate(s)) }
             return .date(nil)
         case .number:

--- a/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
@@ -44,6 +44,29 @@ struct TypedContentEditorTests {
         #expect(out2.contains("publishDate: 2026-01-01T00:00:00.000Z"))    // verbatim, still unquoted
     }
 
+    @Test("edited date-only (.date kind) field serializes as a bare yyyy-MM-dd scalar")
+    func dateOnlyWritesUnquoted() {
+        // No built-in type uses .date kind, so exercise the `kind == .date` branch in format() with
+        // a custom descriptor.
+        let dated = ContentTypeDescriptor(
+            id: "dated", displayName: "Dated", storage: .collection("dated"),
+            fields: [ContentTypeField("start", .date, required: true), ContentTypeField("body", .markdown)],
+            projections: ContentTypeProjections(microformat: "h-entry", microformatProperties: [:], schemaType: nil))
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let newDate = iso.date(from: "2027-03-04T00:00:00.000Z")!   // midnight UTC ⟷ yyyy-MM-dd
+
+        let src = "---\nstart: 2026-01-01\n---\n\nEntry.\n"
+        var v = TypedContentEditor.read(src, descriptor: dated)
+        v["start"] = .date(newDate)
+        let out = TypedContentEditor.write(v, into: src, descriptor: dated)
+        #expect(out.contains("start: 2027-03-04"))       // bare date, unquoted
+        #expect(!out.contains("start: 2027-03-04T"))      // not the full datetime
+        #expect(!out.contains("start: \"2027-03-04\""))   // not a quoted string
+        #expect(TypedContentEditor.read(out, descriptor: dated)["start"] == .date(newDate))
+    }
+
     @Test("reads markdown field from body and scalars from frontmatter")
     func reads() {
         let src = "---\npublishDate: 2026-01-02T03:04:05.000Z\ntags: [a, b]\n---\n\nHello body.\n"

--- a/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
@@ -22,6 +22,28 @@ struct TypedContentEditorTests {
         #expect(TypedContentEditor.read(out, descriptor: review)["rating"] == .number(4))
     }
 
+    @Test("edited date field serializes unquoted and round-trips to the same Date")
+    func dateWritesUnquoted() {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let newDate = iso.date(from: "2027-03-04T05:06:07.000Z")!
+
+        // datetime kind (review.publishDate) → full ISO, unquoted
+        let src = "---\nitemReviewed: \"Widget\"\nrating: 5\npublishDate: 2026-01-01T00:00:00.000Z\n---\n\nReview.\n"
+        var v = TypedContentEditor.read(src, descriptor: review)
+        v["publishDate"] = .date(newDate)
+        let out = TypedContentEditor.write(v, into: src, descriptor: review)
+        #expect(out.contains("publishDate: 2027-03-04T05:06:07.000Z"))     // unquoted
+        #expect(!out.contains("publishDate: \"2027-03-04T05:06:07.000Z\"")) // not a quoted string
+        #expect(TypedContentEditor.read(out, descriptor: review)["publishDate"] == .date(newDate))
+
+        // an unedited date stays byte-for-byte (verbatim), never re-rendered
+        var v2 = TypedContentEditor.read(src, descriptor: review)
+        v2["rating"] = .number(4)
+        let out2 = TypedContentEditor.write(v2, into: src, descriptor: review)
+        #expect(out2.contains("publishDate: 2026-01-01T00:00:00.000Z"))    // verbatim, still unquoted
+    }
+
     @Test("reads markdown field from body and scalars from frontmatter")
     func reads() {
         let src = "---\npublishDate: 2026-01-02T03:04:05.000Z\ntags: [a, b]\n---\n\nHello body.\n"


### PR DESCRIPTION
## Summary

- Date/datetime frontmatter fields written by the typed editor now serialize **unquoted** — `publishDate: 2026-01-01T00:00:00.000Z`, not `publishDate: "…"`.
- Fixes the same class of bug already fixed for numbers in c70ee27: a quoted scalar works today only because every date field's content-collection schema uses `z.coerce.date()`; a stricter/non-coercing date schema would reject it. Also brings the editor in line with `ContentScaffold`, which already emits dates unquoted.

### How
Mirrors the number fix: adds a write-only `FrontmatterValue.date` case rendered as a bare scalar (`FrontmatterDocument.render`); `TypedContentEditor.encode` maps `.date`/`.datetime` to it (a cleared/nil date still falls back to an empty quoted scalar). The one exhaustive `FrontmatterValue` switch (`SiteKnowledgeIndex.frontmatterText`) is updated. Parse still reads dates as `.string`, so `decode` and the unchanged-field verbatim path are untouched — **an unedited date stays byte-for-byte; only an edited date re-renders, now unquoted.**

New `dateWritesUnquoted` test (mirrors `numberWritesUnquoted`): an edited `publishDate` serializes unquoted, round-trips back to the same `Date`, and an unedited date is preserved verbatim.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite)

## Test plan

- [x] `swift test --package-path .` — 1208 tests, 0 failures
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build` — not run (no MAS-specific code touched)
- [ ] Manual smoke — n/a (no UI changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
