### PR TITLE
docs(#402): security story hardening design

### DIFF
--- a/docs/superpowers/plans/2026-06-27-pre-deploy-audit-extensions-404.md
+++ b/docs/superpowers/plans/2026-06-27-pre-deploy-audit-extensions-404.md
@@ -1,0 +1,440 @@
+# Pre-Deploy Audit Extensions (Layer B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the pre-deploy security scan with four content/artifact checks — mixed content, missing SRI, unsafe `target="_blank"` links, and presence of `robots.txt` / `security.txt`.
+
+**Architecture:** Mirror the existing `checkHeaders` pattern in `Resources/Template/scripts/pre-deploy-check.ts`: each new check is an **exported pure function** unit-tested in isolation, then wired into the `scan()` file walk. No change to the `Issue` model or the error/warning exit semantics.
+
+**Tech Stack:** TypeScript (ES modules), `tsx`, `node:test`. Tests run with `npx tsx --test scripts/pre-deploy-check.test.ts` from `Resources/Template/`.
+
+**Issue:** [#404](https://github.com/Anglesite/Anglesite-app/issues/404) — sub-issue B of epic [#402](https://github.com/Anglesite/Anglesite-app/issues/402). Spec: [`docs/superpowers/specs/2026-06-27-security-story-hardening-design.md`](../specs/2026-06-27-security-story-hardening-design.md) §"B — Pre-deploy checks".
+
+## Global Constraints
+
+- **ES Modules only** — `import`/`export`, never CommonJS.
+- **Template-only change** — files live under `Resources/Template/`; no `AnglesiteCore`/Swift changes.
+- **Follow the existing pattern** — new checks are exported pure functions in `pre-deploy-check.ts` with the signature `(content: string, file: string): Issue[]` (or `(relPaths: string[]): Issue[]` for the presence check), unit-tested like `checkHeaders`. `scan()` integration is untested (consistent with the existing code, which has no `scan()` test).
+- **Severity rules:**
+  - Mixed content → **warning** (not error). Rationale: slice A added `upgrade-insecure-requests` to the CSP, which auto-upgrades insecure subresources at runtime, so this is advisory, not deploy-blocking. *(This deliberately refines the spec's "error".)*
+  - Missing SRI → **warning**.
+  - `target="_blank"` without `rel="noopener"` → **warning**.
+  - Missing `robots.txt` / `security.txt` → **warning** (the generators land in slice C1; until then this is informational).
+- **No new dependencies** — checks are regex/string-based, like the existing `BLOCKED_SCRIPTS` checks. Heuristic regex HTML matching is acceptable here and consistent with the file.
+- **Out of scope for this plan:** the dependency/lockfile vulnerability audit mentioned in spec §B — it needs a different mechanism (an `npm audit` subprocess + advisory data) and is tracked as a separate follow-up, not part of these four checks.
+- **Work in a git worktree** branched off `main`; do not commit on the main checkout.
+- **One issue per file per check** — a check returns at most one `Issue` per file (matching how `BLOCKED_SCRIPTS` reports), so a file with three insecure refs yields one warning, not three.
+
+---
+
+### Task 1: Mixed-content check
+
+**Files:**
+- Modify: `Resources/Template/scripts/pre-deploy-check.ts` (add `checkMixedContent`; call it in the `scan()` per-file loop for `.html`/`.css`)
+- Test: `Resources/Template/scripts/pre-deploy-check.test.ts`
+
+**Interfaces:**
+- Consumes: the `Issue` interface (already defined in `pre-deploy-check.ts`).
+- Produces: `export function checkMixedContent(content: string, file: string): Issue[]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `scripts/pre-deploy-check.test.ts` (and extend the import on line 3 to include `checkMixedContent`):
+
+```typescript
+import { checkHeaders, checkMixedContent } from "./pre-deploy-check";
+
+test("checkMixedContent: flags an insecure src", () => {
+  const issues = checkMixedContent('<img src="http://example.com/a.png">', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.match(issues[0].message, /mixed content/i);
+  assert.equal(issues[0].file, "dist/index.html");
+});
+
+test("checkMixedContent: flags an insecure url() in CSS", () => {
+  const issues = checkMixedContent("body { background: url(http://x.com/bg.png); }", "dist/a.css");
+  assert.equal(issues.length, 1);
+});
+
+test("checkMixedContent: https and relative refs are clean", () => {
+  const ok = '<img src="https://x.com/a.png"><script src="/local.js"></script>';
+  assert.deepEqual(checkMixedContent(ok, "dist/index.html"), []);
+});
+
+test("checkMixedContent: svg xmlns http URL is not flagged", () => {
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+  assert.deepEqual(checkMixedContent(svg, "dist/index.html"), []);
+});
+
+test("checkMixedContent: at most one issue per file", () => {
+  const two = '<img src="http://a.com/1.png"><img src="http://b.com/2.png">';
+  assert.equal(checkMixedContent(two, "dist/index.html").length, 1);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: FAIL — `checkMixedContent` is not exported (import error / undefined).
+
+- [ ] **Step 3: Implement `checkMixedContent`**
+
+In `scripts/pre-deploy-check.ts`, add after `checkHeaders` (before `scan`):
+
+```typescript
+/**
+ * Insecure (http://) subresource references in built HTML/CSS. Targets resource
+ * attributes (`src`) and CSS `url(...)` only — NOT `href` — so anchor links and
+ * `xmlns="http://..."` declarations do not false-positive. Advisory: slice A's
+ * `upgrade-insecure-requests` auto-upgrades these at runtime. One issue per file.
+ */
+export function checkMixedContent(content: string, file: string): Issue[] {
+  const patterns = [/\bsrc\s*=\s*["']http:\/\//i, /url\(\s*["']?http:\/\//i];
+  for (const pattern of patterns) {
+    if (pattern.test(content)) {
+      return [{ severity: "warning", message: "Mixed content: insecure http:// resource reference", file }];
+    }
+  }
+  return [];
+}
+```
+
+- [ ] **Step 4: Wire it into `scan()`**
+
+In `scripts/pre-deploy-check.ts`, inside the `for await (const file of walk(DIST_DIR))` loop, after the `SECRET_PATTERNS` block and before the `if (/\.html?$/i.test(file))` block, add:
+
+```typescript
+    if (/\.(html?|css)$/i.test(file)) {
+      issues.push(...checkMixedContent(content, rel));
+    }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: PASS — all tests pass (existing `checkHeaders` tests plus the 5 new ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Template/scripts/pre-deploy-check.ts Resources/Template/scripts/pre-deploy-check.test.ts
+git commit -m "feat(#404): add mixed-content pre-deploy check
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Subresource-integrity (SRI) check
+
+**Files:**
+- Modify: `Resources/Template/scripts/pre-deploy-check.ts` (add `checkSRI`; call it in `scan()` for `.html`)
+- Test: `Resources/Template/scripts/pre-deploy-check.test.ts`
+
+**Interfaces:**
+- Consumes: `Issue`.
+- Produces: `export function checkSRI(content: string, file: string): Issue[]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the test file (extend the import to include `checkSRI`):
+
+```typescript
+test("checkSRI: external script without integrity is a warning", () => {
+  const issues = checkSRI('<script src="https://cdn.x.com/a.js"></script>', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.match(issues[0].message, /integrity/i);
+});
+
+test("checkSRI: external script WITH integrity is clean", () => {
+  const ok = '<script src="https://cdn.x.com/a.js" integrity="sha384-abc"></script>';
+  assert.deepEqual(checkSRI(ok, "dist/index.html"), []);
+});
+
+test("checkSRI: relative script is clean", () => {
+  assert.deepEqual(checkSRI('<script src="/local.js"></script>', "dist/index.html"), []);
+});
+
+test("checkSRI: external stylesheet link without integrity is a warning", () => {
+  const issues = checkSRI('<link rel="stylesheet" href="https://cdn.x.com/a.css">', "dist/index.html");
+  assert.equal(issues.length, 1);
+});
+
+test("checkSRI: non-stylesheet link is ignored", () => {
+  assert.deepEqual(checkSRI('<link rel="preconnect" href="https://x.com">', "dist/index.html"), []);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: FAIL — `checkSRI` is not exported.
+
+- [ ] **Step 3: Implement `checkSRI`**
+
+In `scripts/pre-deploy-check.ts`, add after `checkMixedContent`:
+
+```typescript
+/**
+ * External (absolute or protocol-relative) <script> and stylesheet <link> tags
+ * that lack an `integrity` attribute. Heuristic tag-level regex match. One issue
+ * per offending tag.
+ */
+export function checkSRI(content: string, file: string): Issue[] {
+  const issues: Issue[] = [];
+  const tagPattern = /<(script|link)\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = tagPattern.exec(content)) !== null) {
+    const tag = m[0];
+    const isScript = m[1].toLowerCase() === "script";
+    const urlAttr = isScript
+      ? /\bsrc\s*=\s*["'](?:https?:)?\/\//i
+      : /\bhref\s*=\s*["'](?:https?:)?\/\//i;
+    if (!urlAttr.test(tag)) continue;
+    if (!isScript && !/\brel\s*=\s*["'][^"']*stylesheet/i.test(tag)) continue;
+    if (!/\bintegrity\s*=/i.test(tag)) {
+      issues.push({
+        severity: "warning",
+        message: `External ${isScript ? "script" : "stylesheet"} without subresource integrity (SRI)`,
+        file,
+      });
+    }
+  }
+  return issues;
+}
+```
+
+- [ ] **Step 4: Wire it into `scan()`**
+
+In `scripts/pre-deploy-check.ts`, inside the existing `if (/\.html?$/i.test(file))` block (alongside the `BLOCKED_SCRIPTS` / `BLOCKED_ROUTES` loops), add:
+
+```typescript
+      issues.push(...checkSRI(content, rel));
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: PASS — all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Template/scripts/pre-deploy-check.ts Resources/Template/scripts/pre-deploy-check.test.ts
+git commit -m "feat(#404): add subresource-integrity (SRI) pre-deploy check
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Unsafe `target="_blank"` link check
+
+**Files:**
+- Modify: `Resources/Template/scripts/pre-deploy-check.ts` (add `checkExternalLinkRel`; call it in `scan()` for `.html`)
+- Test: `Resources/Template/scripts/pre-deploy-check.test.ts`
+
+**Interfaces:**
+- Consumes: `Issue`.
+- Produces: `export function checkExternalLinkRel(content: string, file: string): Issue[]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the test file (extend the import to include `checkExternalLinkRel`):
+
+```typescript
+test("checkExternalLinkRel: target=_blank without rel=noopener is a warning", () => {
+  const issues = checkExternalLinkRel('<a href="https://x.com" target="_blank">x</a>', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.match(issues[0].message, /noopener/i);
+});
+
+test("checkExternalLinkRel: rel=noopener is clean", () => {
+  const ok = '<a href="https://x.com" target="_blank" rel="noopener">x</a>';
+  assert.deepEqual(checkExternalLinkRel(ok, "dist/index.html"), []);
+});
+
+test("checkExternalLinkRel: rel with noopener among others is clean", () => {
+  const ok = '<a href="https://x.com" target="_blank" rel="noopener noreferrer">x</a>';
+  assert.deepEqual(checkExternalLinkRel(ok, "dist/index.html"), []);
+});
+
+test("checkExternalLinkRel: link without target=_blank is ignored", () => {
+  assert.deepEqual(checkExternalLinkRel('<a href="https://x.com">x</a>', "dist/index.html"), []);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: FAIL — `checkExternalLinkRel` is not exported.
+
+- [ ] **Step 3: Implement `checkExternalLinkRel`**
+
+In `scripts/pre-deploy-check.ts`, add after `checkSRI`:
+
+```typescript
+/**
+ * Anchors that open a new tab (`target="_blank"`) without `rel="noopener"`,
+ * which can expose `window.opener`. Advisory — modern browsers imply noopener,
+ * but explicit is safer. One issue per offending anchor.
+ */
+export function checkExternalLinkRel(content: string, file: string): Issue[] {
+  const issues: Issue[] = [];
+  const anchorPattern = /<a\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = anchorPattern.exec(content)) !== null) {
+    const tag = m[0];
+    if (!/\btarget\s*=\s*["']_blank["']/i.test(tag)) continue;
+    const relMatch = tag.match(/\brel\s*=\s*["']([^"']*)["']/i);
+    const rel = relMatch ? relMatch[1].toLowerCase() : "";
+    if (!/\bnoopener\b/.test(rel)) {
+      issues.push({ severity: "warning", message: 'Link with target="_blank" missing rel="noopener"', file });
+    }
+  }
+  return issues;
+}
+```
+
+- [ ] **Step 4: Wire it into `scan()`**
+
+In `scripts/pre-deploy-check.ts`, inside the same `if (/\.html?$/i.test(file))` block, add:
+
+```typescript
+      issues.push(...checkExternalLinkRel(content, rel));
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: PASS — all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Template/scripts/pre-deploy-check.ts Resources/Template/scripts/pre-deploy-check.test.ts
+git commit -m "feat(#404): warn on target=_blank links missing rel=noopener
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Security-artifact presence check
+
+**Files:**
+- Modify: `Resources/Template/scripts/pre-deploy-check.ts` (add `checkArtifactPresence`; collect relative paths during the walk and call it after the loop)
+- Test: `Resources/Template/scripts/pre-deploy-check.test.ts`
+
+**Interfaces:**
+- Consumes: `Issue`.
+- Produces: `export function checkArtifactPresence(relPaths: string[]): Issue[]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the test file (extend the import to include `checkArtifactPresence`):
+
+```typescript
+test("checkArtifactPresence: both present is clean", () => {
+  const paths = ["dist/index.html", "dist/robots.txt", "dist/.well-known/security.txt"];
+  assert.deepEqual(checkArtifactPresence(paths), []);
+});
+
+test("checkArtifactPresence: missing robots.txt is a warning", () => {
+  const issues = checkArtifactPresence(["dist/index.html", "dist/.well-known/security.txt"]);
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.match(issues[0].message, /robots\.txt/);
+});
+
+test("checkArtifactPresence: missing both yields two warnings", () => {
+  const issues = checkArtifactPresence(["dist/index.html"]);
+  assert.equal(issues.length, 2);
+});
+
+test("checkArtifactPresence: backslash paths are normalized", () => {
+  const paths = ["dist\\robots.txt", "dist\\.well-known\\security.txt"];
+  assert.deepEqual(checkArtifactPresence(paths), []);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: FAIL — `checkArtifactPresence` is not exported.
+
+- [ ] **Step 3: Implement `checkArtifactPresence`**
+
+In `scripts/pre-deploy-check.ts`, add after `checkExternalLinkRel`:
+
+```typescript
+/**
+ * Warn when expected security artifacts are absent from the built output.
+ * Generators for these land in slice C1 (#405); until then this is informational.
+ */
+export function checkArtifactPresence(relPaths: string[]): Issue[] {
+  const set = new Set(relPaths.map((p) => p.replace(/\\/g, "/")));
+  const required = ["dist/robots.txt", "dist/.well-known/security.txt"];
+  const issues: Issue[] = [];
+  for (const path of required) {
+    if (!set.has(path)) {
+      issues.push({ severity: "warning", message: `Missing security artifact: ${path.replace(/^dist\//, "")}`, file: path });
+    }
+  }
+  return issues;
+}
+```
+
+- [ ] **Step 4: Wire it into `scan()`**
+
+In `scripts/pre-deploy-check.ts`, collect the relative paths during the walk and run the check after the loop. Declare a collector before the loop:
+
+```typescript
+  const relPaths: string[] = [];
+```
+
+Inside the `for await (const file of walk(DIST_DIR))` loop, immediately after `const rel = relative(process.cwd(), file);`, add:
+
+```typescript
+    relPaths.push(rel);
+```
+
+After the `for await` loop closes (before `return issues;`), add:
+
+```typescript
+  issues.push(...checkArtifactPresence(relPaths));
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: PASS — all tests pass.
+
+- [ ] **Step 6: Final verification — generator + scan still run clean**
+
+Run: `cd Resources/Template && npx tsx scripts/pre-deploy-check.ts --json`
+Expected: exits without throwing and prints a JSON array (it will report "No dist/ directory found" as a single warning when run in the template, which is expected — there is no built `dist/` in the template).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Resources/Template/scripts/pre-deploy-check.ts Resources/Template/scripts/pre-deploy-check.test.ts
+git commit -m "feat(#404): warn on missing robots.txt / security.txt in built output
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (spec §B): SRI ✅ Task 2; mixed content ✅ Task 1 (severity refined to warning, flagged in Global Constraints); `rel=noopener` ✅ Task 3; `security.txt`/`robots.txt` presence ✅ Task 4; dependency/lockfile audit — explicitly deferred to a follow-up in Global Constraints (different mechanism), **not** silently dropped.
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code; every run step states the command and expected result.
+
+**Type consistency:** all four new functions return `Issue[]` using the existing `Issue` interface. Content checks share the `(content: string, file: string)` signature; `checkArtifactPresence(relPaths: string[])` is the documented exception. The `scan()` wiring references each function by the exact exported name. The `relPaths` collector declared in Task 4 is the only new local in `scan()`.
+
+**Ordering note:** Tasks 1–3 each append to the per-file loop / the `.html` block; Task 4 adds a pre-loop declaration and a post-loop call. None conflict; each leaves the test suite green at commit.

--- a/docs/superpowers/plans/2026-06-27-security-headers-hardening-403.md
+++ b/docs/superpowers/plans/2026-06-27-security-headers-hardening-403.md
@@ -10,6 +10,13 @@
 
 **Issue:** [#403](https://github.com/Anglesite/Anglesite-app/issues/403) — sub-issue A of epic [#402](https://github.com/Anglesite/Anglesite-app/issues/402). Spec: [`docs/superpowers/specs/2026-06-27-security-story-hardening-design.md`](../specs/2026-06-27-security-story-hardening-design.md) §"A — Response headers / CSP".
 
+> **Post-review update (after PR #410 review):** two settled deviations from the task text below.
+> (1) **COOP/CORP final values** are `Cross-Origin-Opener-Policy: same-origin-allow-popups` and
+> `Cross-Origin-Resource-Policy: same-site` (the Task 2 snippets show the original `same-origin`
+> values) — see the spec §A for the rationale (popup/auth flows; same-site subdomain assets).
+> (2) **Verification is JS-only** (see the Pre-push guard below): `swift test` was *not* required for
+> this template-only change.
+
 ## Global Constraints
 
 - **ES Modules only** — `import`/`export`, never CommonJS.
@@ -19,7 +26,7 @@
 - **COEP stays off** — would break third-party embeds; out of scope for this plan.
 - **Work in a git worktree** — create it via the `superpowers:using-git-worktrees` skill before starting; do not commit on the main checkout. Branch off `main` (the spec/plan PR #409 is docs-only and independent).
 - **HSTS preload is opt-in** — only emitted when `.site-config` has `HSTS_PRELOAD=true`; never in the baseline.
-- **Pre-push guard** — `grep` shows no Swift test currently asserts header content, but per project guidance run `swift test --package-path .` before pushing template changes regardless, in case a smoke test couples later.
+- **Pre-push guard** — the JS gate is authoritative for this template-only change: `npx tsx --test scripts/csp.test.ts` plus the generator round-trip (`npx tsx scripts/csp.ts && git diff --exit-code public/_headers`). `grep` shows no Swift test asserts header content, so `swift test` is **not required** here. If you do run it, set `ANGLESITE_PLUGIN_PATH` to the plugin checkout (or `--filter` out the e2e suites) — the MCP e2e tests (`AppliesEditEndToEndTests`, `MCPClientHTTPEndToEndTests`) **fail** (not skip) when the plugin checkout is absent, and `swift test` needs `DEVELOPER_DIR` set per project memory.
 
 ---
 
@@ -262,13 +269,12 @@ In `Resources/Template/public/_headers`, add the HSTS line after `Cross-Origin-R
 Run: `cd Resources/Template && npx tsx --test scripts/csp.test.ts`
 Expected: PASS — all tests pass.
 
-- [ ] **Step 7: Verify the generator round-trips and Swift tests still pass**
+- [ ] **Step 7: Verify the generator round-trips (JS-only gate)**
 
 Run: `cd Resources/Template && npx tsx scripts/csp.ts && git diff --exit-code public/_headers`
 Expected: exits 0 — running the generator regenerates a `public/_headers` identical to the committed one.
 
-Run: `swift test --package-path .`
-Expected: PASS — no template-coupled Swift smoke test regressed. (Set `DEVELOPER_DIR` per project memory if `swift test` reports a toolchain error.)
+(`swift test` is **not required** for this template-only change — see the Pre-push guard in Global Constraints for the `ANGLESITE_PLUGIN_PATH`/`DEVELOPER_DIR` caveats if you choose to run it anyway.)
 
 - [ ] **Step 8: Commit**
 

--- a/docs/superpowers/plans/2026-06-27-security-headers-hardening-403.md
+++ b/docs/superpowers/plans/2026-06-27-security-headers-hardening-403.md
@@ -1,0 +1,290 @@
+# Security Header Hardening (Layer A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the response headers current OWASP/Mozilla guidance recommends (HSTS, COOP, CORP, `upgrade-insecure-requests`) to Anglesite's build-time `_headers` generator.
+
+**Architecture:** Extend the existing build-time CSP generator (`Resources/Template/scripts/csp.ts`). `buildCSP()` gains the valueless `upgrade-insecure-requests` directive; `buildHeaders()` gains three static/conditional header lines. The committed `public/_headers` is the no-config baseline and must stay byte-identical to `buildHeaders("")` — a test enforces this, so every output change updates both the code and the committed file in the same commit.
+
+**Tech Stack:** TypeScript (ES modules), `tsx`, `node:test`. Tests run with `npx tsx --test <file>` from `Resources/Template/`.
+
+**Issue:** [#403](https://github.com/Anglesite/Anglesite-app/issues/403) — sub-issue A of epic [#402](https://github.com/Anglesite/Anglesite-app/issues/402). Spec: [`docs/superpowers/specs/2026-06-27-security-story-hardening-design.md`](../specs/2026-06-27-security-story-hardening-design.md) §"A — Response headers / CSP".
+
+## Global Constraints
+
+- **ES Modules only** — `import`/`export`, never CommonJS.
+- **Template-only change** — files live under `Resources/Template/`; no `AnglesiteCore`/Swift changes.
+- **Byte-identical invariant** — `buildHeaders("")` must exactly equal the committed `Resources/Template/public/_headers`. Any change to generator output updates `public/_headers` in the same commit.
+- **`X-XSS-Protection` stays absent** — deprecated/harmful; do not add it.
+- **COEP stays off** — would break third-party embeds; out of scope for this plan.
+- **Work in a git worktree** — create it via the `superpowers:using-git-worktrees` skill before starting; do not commit on the main checkout. Branch off `main` (the spec/plan PR #409 is docs-only and independent).
+- **HSTS preload is opt-in** — only emitted when `.site-config` has `HSTS_PRELOAD=true`; never in the baseline.
+- **Pre-push guard** — `grep` shows no Swift test currently asserts header content, but per project guidance run `swift test --package-path .` before pushing template changes regardless, in case a smoke test couples later.
+
+---
+
+### Task 1: Add `upgrade-insecure-requests` to the CSP
+
+**Files:**
+- Modify: `Resources/Template/scripts/csp.ts` (the `BASE` map, `DIRECTIVE_ORDER`, and the `buildCSP` emit line)
+- Modify: `Resources/Template/public/_headers` (the `Content-Security-Policy` line)
+- Test: `Resources/Template/scripts/csp.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `buildCSP(configContent: string): string` now ends its output with `; upgrade-insecure-requests`. `buildHeaders` output likewise gains it (via `buildCSP`).
+
+- [ ] **Step 1: Update the failing test for the new baseline CSP**
+
+In `scripts/csp.test.ts`, change the `buildCSP: baseline when no integrations configured` assertion to expect the trailing directive:
+
+```typescript
+test("buildCSP: baseline when no integrations configured", () => {
+  assert.equal(
+    buildCSP(""),
+    "default-src 'self'; script-src 'self' static.cloudflareinsights.com; " +
+      "style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; " +
+      "connect-src 'self' cloudflareinsights.com; frame-src 'self'; object-src 'none'; " +
+      "frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests",
+  );
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd Resources/Template && npx tsx --test scripts/csp.test.ts`
+Expected: FAIL — `buildCSP: baseline …` shows actual output ending at `form-action 'self'` (no `upgrade-insecure-requests`). The byte-identical test still passes for now.
+
+- [ ] **Step 3: Add the directive to the generator**
+
+In `scripts/csp.ts`, add `upgrade-insecure-requests` with an empty value array to `BASE` (after `form-action`):
+
+```typescript
+  "form-action": ["'self'"],
+  "upgrade-insecure-requests": [],
+```
+
+Add it to the end of `DIRECTIVE_ORDER`:
+
+```typescript
+const DIRECTIVE_ORDER = [
+  "default-src", "script-src", "style-src", "img-src", "font-src",
+  "connect-src", "frame-src", "object-src", "frame-ancestors", "base-uri", "form-action",
+  "upgrade-insecure-requests",
+];
+```
+
+Update the emit line in `buildCSP` so a valueless directive emits its name with no trailing space:
+
+```typescript
+  return DIRECTIVE_ORDER.map((name) =>
+    directives[name].length ? `${name} ${directives[name].join(" ")}` : name,
+  ).join("; ");
+```
+
+- [ ] **Step 4: Run the test to verify the baseline passes and byte-identical now fails**
+
+Run: `cd Resources/Template && npx tsx --test scripts/csp.test.ts`
+Expected: `buildCSP: baseline …` now PASSES; `committed public/_headers is byte-identical …` now FAILS (the committed file lacks the new directive).
+
+- [ ] **Step 5: Update the committed `public/_headers`**
+
+In `Resources/Template/public/_headers`, append `; upgrade-insecure-requests` to the end of the `Content-Security-Policy:` line so it reads:
+
+```
+  Content-Security-Policy: default-src 'self'; script-src 'self' static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' cloudflareinsights.com; frame-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+```
+
+- [ ] **Step 6: Run the full file to verify all green**
+
+Run: `cd Resources/Template && npx tsx --test scripts/csp.test.ts`
+Expected: PASS — all 6 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Resources/Template/scripts/csp.ts Resources/Template/scripts/csp.test.ts Resources/Template/public/_headers
+git commit -m "feat(#403): add upgrade-insecure-requests to generated CSP
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add Cross-Origin-Opener-Policy and Cross-Origin-Resource-Policy
+
+**Files:**
+- Modify: `Resources/Template/scripts/csp.ts` (the `buildHeaders` template literal)
+- Modify: `Resources/Template/public/_headers`
+- Test: `Resources/Template/scripts/csp.test.ts`
+
+**Interfaces:**
+- Consumes: `buildCSP` from Task 1.
+- Produces: `buildHeaders` output now contains `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Resource-Policy: same-origin` lines.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `scripts/csp.test.ts`:
+
+```typescript
+test("buildHeaders: includes cross-origin isolation headers", () => {
+  const out = buildHeaders("");
+  assert.match(out, /Cross-Origin-Opener-Policy: same-origin/);
+  assert.match(out, /Cross-Origin-Resource-Policy: same-origin/);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd Resources/Template && npx tsx --test scripts/csp.test.ts`
+Expected: FAIL — `buildHeaders: includes cross-origin isolation headers` fails (headers not present).
+
+- [ ] **Step 3: Add the headers to `buildHeaders`**
+
+In `scripts/csp.ts`, insert the two lines after the `Permissions-Policy` line in the `buildHeaders` template literal:
+
+```typescript
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Resource-Policy: same-origin
+  Content-Security-Policy: ${csp}
+```
+
+- [ ] **Step 4: Run the test to verify the new test passes and byte-identical now fails**
+
+Run: `cd Resources/Template && npx tsx --test scripts/csp.test.ts`
+Expected: `buildHeaders: includes cross-origin isolation headers` PASSES; `committed public/_headers is byte-identical …` FAILS.
+
+- [ ] **Step 5: Update the committed `public/_headers`**
+
+In `Resources/Template/public/_headers`, insert the two lines after the `Permissions-Policy:` line:
+
+```
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Resource-Policy: same-origin
+  Content-Security-Policy: default-src 'self'; script-src 'self' static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' cloudflareinsights.com; frame-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+```
+
+- [ ] **Step 6: Run the full file to verify all green**
+
+Run: `cd Resources/Template && npx tsx --test scripts/csp.test.ts`
+Expected: PASS — all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Resources/Template/scripts/csp.ts Resources/Template/scripts/csp.test.ts Resources/Template/public/_headers
+git commit -m "feat(#403): add COOP and CORP response headers
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add Strict-Transport-Security with opt-in preload
+
+**Files:**
+- Modify: `Resources/Template/scripts/csp.ts` (the `buildHeaders` function body + template literal)
+- Modify: `Resources/Template/public/_headers`
+- Test: `Resources/Template/scripts/csp.test.ts`
+
+**Interfaces:**
+- Consumes: `readConfigFromString` (already imported in `csp.ts`).
+- Produces: `buildHeaders("")` emits `Strict-Transport-Security: max-age=31536000; includeSubDomains` (no `preload`). `buildHeaders("HSTS_PRELOAD=true")` appends `; preload`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests to `scripts/csp.test.ts`:
+
+```typescript
+test("buildHeaders: HSTS present without preload by default", () => {
+  const out = buildHeaders("");
+  assert.match(out, /Strict-Transport-Security: max-age=31536000; includeSubDomains\n/);
+  assert.ok(!/Strict-Transport-Security:[^\n]*preload/.test(out));
+});
+
+test("buildHeaders: HSTS_PRELOAD=true appends preload", () => {
+  const out = buildHeaders("HSTS_PRELOAD=true");
+  assert.match(out, /Strict-Transport-Security: max-age=31536000; includeSubDomains; preload\n/);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd Resources/Template && npx tsx --test scripts/csp.test.ts`
+Expected: FAIL — both new tests fail (no `Strict-Transport-Security` line emitted).
+
+- [ ] **Step 3: Add HSTS to `buildHeaders`**
+
+In `scripts/csp.ts`, at the top of `buildHeaders`, compute the value, then add the line after the `Cross-Origin-Resource-Policy` line:
+
+```typescript
+export function buildHeaders(configContent: string): string {
+  const csp = buildCSP(configContent);
+  const hstsPreload =
+    (readConfigFromString(configContent, "HSTS_PRELOAD") ?? "").trim().toLowerCase() === "true";
+  const hsts = `max-age=31536000; includeSubDomains${hstsPreload ? "; preload" : ""}`;
+  return `/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Resource-Policy: same-origin
+  Strict-Transport-Security: ${hsts}
+  Content-Security-Policy: ${csp}
+  Cache-Control: public, max-age=0, must-revalidate
+
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+`;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass and byte-identical now fails**
+
+Run: `cd Resources/Template && npx tsx --test scripts/csp.test.ts`
+Expected: both HSTS tests PASS; `committed public/_headers is byte-identical …` FAILS.
+
+- [ ] **Step 5: Update the committed `public/_headers`**
+
+In `Resources/Template/public/_headers`, add the HSTS line after `Cross-Origin-Resource-Policy:`:
+
+```
+  Cross-Origin-Resource-Policy: same-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Content-Security-Policy: default-src 'self'; script-src 'self' static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' cloudflareinsights.com; frame-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+```
+
+- [ ] **Step 6: Run the full file to verify all green**
+
+Run: `cd Resources/Template && npx tsx --test scripts/csp.test.ts`
+Expected: PASS — all tests pass.
+
+- [ ] **Step 7: Verify the generator round-trips and Swift tests still pass**
+
+Run: `cd Resources/Template && npx tsx scripts/csp.ts && git diff --exit-code public/_headers`
+Expected: exits 0 — running the generator regenerates a `public/_headers` identical to the committed one.
+
+Run: `swift test --package-path .`
+Expected: PASS — no template-coupled Swift smoke test regressed. (Set `DEVELOPER_DIR` per project memory if `swift test` reports a toolchain error.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Resources/Template/scripts/csp.ts Resources/Template/scripts/csp.test.ts Resources/Template/public/_headers
+git commit -m "feat(#403): add HSTS header with opt-in HSTS_PRELOAD
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (spec §A): HSTS ✅ Task 3; `HSTS_PRELOAD` opt-in ✅ Task 3; COOP ✅ Task 2; CORP ✅ Task 2; `upgrade-insecure-requests` ✅ Task 1; `X-XSS-Protection` absent ✅ Global Constraints (never added); COEP off ✅ Global Constraints (out of scope); nonce/hash inline scripts — explicitly a phase-2 stretch in the spec, intentionally **not** in this plan.
+
+**Placeholder scan:** no TBD/TODO/"handle edge cases"; every code step shows complete code; every run step states the exact command and expected result.
+
+**Type consistency:** `buildCSP(configContent: string): string`, `buildHeaders(configContent: string): string`, and `readConfigFromString(content, key): string | undefined` match their existing definitions throughout. The valueless-directive emit handles the empty-array case introduced in Task 1 and relied on by later tasks.

--- a/docs/superpowers/specs/2026-06-27-security-story-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-27-security-story-hardening-design.md
@@ -1,0 +1,168 @@
+# Security story hardening — design (#402)
+
+**Date:** 2026-06-27
+**Epic:** [#402](https://github.com/Anglesite/Anglesite-app/issues/402) — Security story hardening (tracking)
+**Sub-issues:** [#403](https://github.com/Anglesite/Anglesite-app/issues/403) (A), [#404](https://github.com/Anglesite/Anglesite-app/issues/404) (B), [#405](https://github.com/Anglesite/Anglesite-app/issues/405) (C1), [#406](https://github.com/Anglesite/Anglesite-app/issues/406) (C2), [#407](https://github.com/Anglesite/Anglesite-app/issues/407) (C3), [#408](https://github.com/Anglesite/Anglesite-app/issues/408) (C4)
+**Scope:** template (`Resources/Template/`) for layers A/B/C1; `AnglesiteCore` + app for C2/C3; C3 may be `cross-repo` (paired plugin PR)
+
+## Problem
+
+A community Cloudflare config we evaluated ([buybitart/cloudflare-security-art](https://github.com/buybitart/cloudflare-security-art))
+prompted a review of Anglesite's security posture. The generated-site baseline already beats
+that guide — build-time CSP from `.site-config` (`scripts/csp.ts`), a modern `public/_headers`,
+and a `pre-deploy-check.ts` that validates the CSP and scans for leaked secrets.
+
+The gaps are elsewhere:
+
+- A few **response headers** current OWASP/Mozilla guidance recommends are missing (HSTS,
+  COOP/CORP, `upgrade-insecure-requests`).
+- The **pre-deploy check** doesn't cover SRI, mixed content, or unsafe external links.
+- The **Cloudflare edge/account/DNS layer is not addressed at all** — DNSSEC, CAA, email
+  authentication, Bot Fight Mode. This is the largest gap and the highest-leverage one for
+  our audience.
+
+## Threat model (scoped)
+
+Anglesite hosts **static** marketing/portfolio/creator/small-business sites on Cloudflare
+Pages — no server, no database, no app backend. That narrows what matters.
+
+**High-likelihood threats:** secret/credential leakage committed to the repo; deploy-token
+compromise → defacement; **dangling DNS / subdomain takeover**; **email spoofing** (phishing
+in the owner's name from an unprotected domain); TLS cert mis-issuance; clickjacking; mixed
+content; supply chain via third-party embeds.
+
+**Low value for this audience:** elaborate WAF rule-writing and rate limiting. There is no
+dynamic attack surface, and Cloudflare's auto-on Free Managed Ruleset already absorbs DDoS.
+This is why we prioritize **DNS + email + headers** over WAF gymnastics — and why the linked
+guide's "2 requests / 10s" rate limit is both broken (blocks normal visitors) and unavailable
+(rate-limiting rules are effectively a paid feature).
+
+## Cloudflare free-plan reality
+
+The delivery model must respect what's actually available to a free-plan user:
+
+- ✅ free / zero-config: DDoS L3–7, Free Managed Ruleset (auto-on), Bot Fight Mode (toggle),
+  Always-Use-HTTPS, DNSSEC, CAA, all email-auth DNS records.
+- ⚠️ **5 custom WAF rules** maximum on free.
+- ❌ rate-limiting rules — effectively paid.
+
+## Decisions
+
+Settled during brainstorming:
+
+1. **Holistic scope across four layers** (A: headers, B: pre-deploy checks, C: edge/account/DNS,
+   D: supply chain), decomposed into per-layer sub-issues rather than one monolithic change.
+
+2. **Hybrid delivery model.** Anglesite auto-applies only **repo-owned artifacts** (the
+   headers/CSP it already generates, plus `security.txt`/`robots.txt`). Account/edge/DNS
+   changes are **opt-in**: a "Harden" action computes a change plan, previews an **exact diff**,
+   and applies only on explicit consent, then re-runs the audit. Never silent — it surfaces
+   failures rather than overriding, consistent with `pre-deploy-check`. A standing **read-only
+   Security audit** reports a graded scorecard and drift.
+
+3. **AI-crawler blocking is opt-in, off by default.** Blocking `gptbot`/`claudebot`/etc. trades
+   away AI-search discoverability — a real cost for creator/business sites — and is
+   philosophically odd to default-on in a Claude-powered app.
+
+4. **Config split.** Repo-artifact prefs (`HSTS_PRELOAD`, `SECURITY_CONTACT`, `BLOCK_AI`, …) live
+   in `.site-config` (`Source/`, template-owned). The Cloudflare API token and edge prefs live
+   in `Config/` (app-owned, never git). Token scope is minimal and documented.
+
+## Layers
+
+### A — Response headers / CSP (#403)
+
+Extend `scripts/csp.ts` `buildHeaders()`. Add to the generated `public/_headers`:
+
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains`
+- `preload` directive **behind opt-in `.site-config` `HSTS_PRELOAD`** — hard to reverse, never default-on
+- `Cross-Origin-Opener-Policy: same-origin`
+- `Cross-Origin-Resource-Policy: same-origin`
+- `upgrade-insecure-requests` in the CSP
+
+Explicitly **not** doing: `X-XSS-Protection` stays absent (deprecated/harmful); COEP stays off
+by default (breaks embeds), opt-in only. Stretch (phase 2): nonce/hash inline scripts to drop
+inline-script trust; `'unsafe-inline'` on `style-src` remains an accepted tradeoff for now.
+
+### B — Pre-deploy checks (#404)
+
+Extend `scripts/pre-deploy-check.ts` (keep CSP validation + secret scanning), reusing the
+`Issue { severity, message, file }` model. Add: SRI on external `<script>`/`<link>` (warn),
+mixed-content scan (error), `target="_blank"` without `rel="noopener"` (warn), presence of
+`.well-known/security.txt` and `robots.txt` (warn), and a dependency/lockfile vuln surface (warn).
+
+### C1 — Repo-owned edge artifacts (#405)
+
+Generate, mirroring the `csp.ts` pattern (pure function + writer + tests):
+
+- `public/.well-known/security.txt` — `Contact:` + `Expires:` (RFC 9116), from `SECURITY_CONTACT`
+- `public/robots.txt` — allow legitimate crawlers; AI-crawler directives gated behind C4
+
+### C2 — CloudflareClient seam + read-only audit (#406)
+
+- **`CloudflareClient`** (AnglesiteCore) — protocol abstracting the Cloudflare API; mockable in
+  tests; centralizes MAS sandbox/token handling. Token in Keychain (existing `area:secrets`
+  pattern), minimal **read** scope (Zone DNS read, Zone settings read, WAF read), documented.
+  Read methods: DNSSEC status, CAA, SSL/Always-HTTPS/HSTS edge settings, MX/SPF/DMARC, Bot
+  Fight Mode, custom-rule list.
+- **`SecurityAudit`** (pure, testable) — input: built `dist/` + account-state snapshot → graded
+  findings (mirror the pre-deploy `Issue` model). Surfaced as a scorecard in the debug/Settings
+  panel; reports drift; never auto-fixes.
+
+Keep app-target logic thin; push testable logic into `AnglesiteCore` so it runs under
+`swift test` on CI (hosted app tests don't run there).
+
+### C3 — Opt-in "Harden Cloudflare" action (#407)
+
+Compute a change plan → preview exact diff → apply on consent → re-run the C2 audit.
+Dry-runnable, never silent. Changes (all preview-gated):
+
+- Enable **DNSSEC**
+- Add **CAA** records pinned to the site's CA
+- **Always-Use-HTTPS** + edge **HSTS**
+- **Bot Fight Mode** on
+- For non-mail domains: **null-MX + `SPF -all` + `DMARC p=reject`** (detect mail-sending first)
+- Up to **5 curated WAF custom rules** — only durable parts: block `.env`/`.git`/dotfile paths,
+  path traversal, obvious SQLi/XSS query-string patterns
+
+Explicitly **not** included: the 2-req/10s rate limit; blanket `curl`/`wget`/`python-requests`
+blocking (breaks monitors, webhooks, RSS); outdated-browser sniffing / referrer challenges.
+
+Needs `CloudflareClient` **write** scope (Zone DNS edit, Zone settings edit, WAF edit) — bump
+the documented token scope. If any of this routes through the plugin MCP server, it lands as a
+paired plugin + app PR (`cross-repo`).
+
+### C4 — Optional AI-crawler toggle (#408)
+
+Off by default. `.site-config` `BLOCK_AI` → `robots.txt` directives, optional edge toggle via
+the Harden action, clear UI copy on the discoverability tradeoff. Lowest priority.
+
+## Sequencing
+
+A + B are app-only and low-risk — ship first. Then C1. C2 → C3 is the substantive new build.
+C4 last.
+
+1. A (#403) → 2. B (#404) → 3. C1 (#405) → 4. C2 (#406) → 5. C3 (#407) → 6. C4 (#408)
+
+## Testing
+
+- A/B/C1: extend `csp.test.ts`, `pre-deploy-check.test.ts`, and new artifact-generator tests.
+  Run `swift test` before pushing — string-match/smoke tests are coupled to template
+  markup/headers.
+- C2/C3: unit-test `SecurityAudit` and the change-plan/diff computation against a mocked
+  `CloudflareClient`. No live-account calls in tests.
+
+## Out of scope
+
+- Rate limiting (broken for this use case; paid).
+- Blanket automation/user-agent blocking.
+- Non-Cloudflare hosting targets.
+- App-binary signing/notarization (tracked separately under Phase 10.1).
+
+## Sources
+
+- [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/)
+- [Cloudflare Pages `_headers`](https://developers.cloudflare.com/pages/configuration/headers/)
+- [Cloudflare WAF custom rules](https://developers.cloudflare.com/waf/custom-rules/)
+- [Cloudflare — stop malicious bots (Free/Pro/Business)](https://developers.cloudflare.com/use-cases/solutions/stop-malicious-bots/)
+- [EasyDMARC — DMARC best practices 2026](https://easydmarc.com/blog/dmarc-best-practices/)

--- a/docs/superpowers/specs/2026-06-27-security-story-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-27-security-story-hardening-design.md
@@ -76,9 +76,16 @@ Extend `scripts/csp.ts` `buildHeaders()`. Add to the generated `public/_headers`
 
 - `Strict-Transport-Security: max-age=31536000; includeSubDomains`
 - `preload` directive **behind opt-in `.site-config` `HSTS_PRELOAD`** — hard to reverse, never default-on
-- `Cross-Origin-Opener-Policy: same-origin`
-- `Cross-Origin-Resource-Policy: same-origin`
+- `Cross-Origin-Opener-Policy: same-origin-allow-popups` — *not* bare `same-origin`, which severs
+  `window.opener` for popups the site itself opens (OAuth sign-in, Stripe/PayPal checkout — common
+  for this audience); `-allow-popups` keeps those working while still isolating attacker-opened windows.
+- `Cross-Origin-Resource-Policy: same-site` — *not* `same-origin`, so same-site subdomains can still
+  load shared assets (e.g. a logo on `blog.example.com`); cross-*site* isolation is retained.
 - `upgrade-insecure-requests` in the CSP
+
+Already shipped as always-on defaults (predating this work, no tradeoff for static sites; keep them):
+`X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`,
+`Referrer-Policy: strict-origin-when-cross-origin`, and the locked-down `Permissions-Policy`.
 
 Explicitly **not** doing: `X-XSS-Protection` stays absent (deprecated/harmful); COEP stays off
 by default (breaks embeds), opt-in only. Stretch (phase 2): nonce/hash inline scripts to drop
@@ -87,18 +94,23 @@ inline-script trust; `'unsafe-inline'` on `style-src` remains an accepted tradeo
 ### B — Pre-deploy checks (#404)
 
 Extend `scripts/pre-deploy-check.ts` (keep CSP validation + secret scanning), reusing the
-`Issue { severity, message, file }` model. Add: SRI on external `<script>`/`<link>` (warn),
-mixed-content scan (error), `target="_blank"` without `rel="noopener"` (warn), presence of
-`.well-known/security.txt` and `robots.txt` (warn), and a dependency/lockfile vuln surface (warn).
+`Issue { severity, message, file }` model. Add: SRI on external `<script>`/`<link>` (warn —
+including a separate warning for `integrity` present but `crossorigin` missing, which fails CORS),
+mixed-content scan (**warn** — advisory; layer A's `upgrade-insecure-requests` auto-upgrades these
+at runtime, so it does not block deploy), `target="_blank"` without `rel="noopener"` or
+`rel="noreferrer"` (warn; `noreferrer` implies `noopener`), presence of `.well-known/security.txt`
+and `robots.txt` (warn), and a dependency/lockfile vuln surface (warn — deferred to a follow-up).
 
 ### C1 — Repo-owned edge artifacts (#405)
 
 Generate, mirroring the `csp.ts` pattern (pure function + writer + tests):
 
-- `public/.well-known/security.txt` — `Contact:` + `Expires:` (RFC 9116), from `SECURITY_CONTACT`
+- `public/.well-known/security.txt` — `Contact:` + `Expires:` (RFC 9116), from `SECURITY_CONTACT`.
+  **`Expires` is regenerated with a fresh future date (+1 year) on every build/deploy** (the same
+  pipeline that runs `csp.ts`), so it never silently lapses — no user action and no warning path needed.
 - `public/robots.txt` — allow legitimate crawlers; AI-crawler directives gated behind C4
 
-### C2 — CloudflareClient seam + read-only audit (#406)
+### C2 — `CloudflareClient` seam + read-only audit (#406)
 
 - **`CloudflareClient`** (AnglesiteCore) — protocol abstracting the Cloudflare API; mockable in
   tests; centralizes MAS sandbox/token handling. Token in Keychain (existing `area:secrets`
@@ -118,12 +130,19 @@ Compute a change plan → preview exact diff → apply on consent → re-run the
 Dry-runnable, never silent. Changes (all preview-gated):
 
 - Enable **DNSSEC**
-- Add **CAA** records pinned to the site's CA
+- Add **CAA** records authorizing **all CAs Cloudflare's free plan can rotate between** — Let's Encrypt
+  (`letsencrypt.org`), DigiCert (`digicert.com`), and Google Trust Services (`pki.goog`) — or, more
+  precisely, read the zone's current issuer via the SSL API (`GET /zones/{id}/ssl/certificate_packs`)
+  and authorize that plus `letsencrypt.org` as fallback. **Pinning a single CA breaks cert renewal
+  silently on the next rotation**, so the rule template must enumerate all three by default.
 - **Always-Use-HTTPS** + edge **HSTS**
 - **Bot Fight Mode** on
 - For non-mail domains: **null-MX + `SPF -all` + `DMARC p=reject`** (detect mail-sending first)
 - Up to **5 curated WAF custom rules** — only durable parts: block `.env`/`.git`/dotfile paths,
-  path traversal, obvious SQLi/XSS query-string patterns
+  path traversal, obvious SQLi/XSS query-string patterns. **The dotfile rule must carve out
+  `/.well-known/`** (negative match `starts_with(http.request.uri.path, "/.well-known/")` *before*
+  the dotfile block) so it never blocks `/.well-known/security.txt` (C1) or
+  `/.well-known/acme-challenge/` (Cloudflare-managed cert issuance).
 
 Explicitly **not** included: the 2-req/10s rate limit; blanket `curl`/`wget`/`python-requests`
 blocking (breaks monitors, webhooks, RSS); outdated-browser sniffing / referrer challenges.


### PR DESCRIPTION
Design doc for the security-story-hardening epic (#402).

Covers:
- **Threat model** scoped to static Cloudflare-hosted marketing/portfolio/creator sites — prioritizes DNS/email/headers over WAF/rate-limiting (no dynamic attack surface).
- **Cloudflare free-plan reality** (5 custom rules, no rate limiting, auto Managed Ruleset) and why the linked community guide's centerpiece doesn't fit.
- **Hybrid delivery model**: auto-apply repo-owned artifacts; account/edge/DNS changes are opt-in, diff-previewed, consent-gated; a standing read-only audit reports drift.
- **A/B/C1–C4 decomposition** mapping 1:1 to #403–#408 with sequencing.

Doc-only; no code changes. First implementation slice is #403 (header hardening).

Related: #402 (epic), #403, #404, #405, #406, #407, #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)