### PR TITLE
feat(#404): extend pre-deploy audit (mixed content, SRI, target=_blank, artifact presence)

### DIFF
--- a/Resources/Template/scripts/pre-deploy-check.test.ts
+++ b/Resources/Template/scripts/pre-deploy-check.test.ts
@@ -84,9 +84,15 @@ test("checkSRI: external script without integrity is a warning", () => {
   assert.match(issues[0].message, /integrity/i);
 });
 
-test("checkSRI: external script WITH integrity is clean", () => {
-  const ok = '<script src="https://cdn.x.com/a.js" integrity="sha384-abc"></script>';
+test("checkSRI: external script with integrity AND crossorigin is clean", () => {
+  const ok = '<script src="https://cdn.x.com/a.js" integrity="sha384-abc" crossorigin="anonymous"></script>';
   assert.deepEqual(checkSRI(ok, "dist/index.html"), []);
+});
+
+test("checkSRI: integrity without crossorigin is a warning (CORS would block it)", () => {
+  const issues = checkSRI('<script src="https://cdn.x.com/a.js" integrity="sha384-abc"></script>', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.match(issues[0].message, /crossorigin/i);
 });
 
 test("checkSRI: relative script is clean", () => {
@@ -116,6 +122,11 @@ test("checkExternalLinkRel: rel=noopener is clean", () => {
 
 test("checkExternalLinkRel: rel with noopener among others is clean", () => {
   const ok = '<a href="https://x.com" target="_blank" rel="noopener noreferrer">x</a>';
+  assert.deepEqual(checkExternalLinkRel(ok, "dist/index.html"), []);
+});
+
+test("checkExternalLinkRel: rel=noreferrer alone is clean (implies noopener)", () => {
+  const ok = '<a href="https://x.com" target="_blank" rel="noreferrer">x</a>';
   assert.deepEqual(checkExternalLinkRel(ok, "dist/index.html"), []);
 });
 

--- a/Resources/Template/scripts/pre-deploy-check.test.ts
+++ b/Resources/Template/scripts/pre-deploy-check.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { checkHeaders } from "./pre-deploy-check";
+import { checkHeaders, checkMixedContent } from "./pre-deploy-check";
 
 const GOOD = `/*
   Content-Security-Policy: default-src 'self'; frame-src 'self' js.stripe.com
@@ -47,4 +47,32 @@ test("substring of an allowed domain does not satisfy coverage", () => {
   assert.equal(issues.length, 1);
   assert.equal(issues[0].severity, "error");
   assert.match(issues[0].message, /cal\.com/);
+});
+
+test("checkMixedContent: flags an insecure src", () => {
+  const issues = checkMixedContent('<img src="http://example.com/a.png">', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.match(issues[0].message, /mixed content/i);
+  assert.equal(issues[0].file, "dist/index.html");
+});
+
+test("checkMixedContent: flags an insecure url() in CSS", () => {
+  const issues = checkMixedContent("body { background: url(http://x.com/bg.png); }", "dist/a.css");
+  assert.equal(issues.length, 1);
+});
+
+test("checkMixedContent: https and relative refs are clean", () => {
+  const ok = '<img src="https://x.com/a.png"><script src="/local.js"></script>';
+  assert.deepEqual(checkMixedContent(ok, "dist/index.html"), []);
+});
+
+test("checkMixedContent: svg xmlns http URL is not flagged", () => {
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+  assert.deepEqual(checkMixedContent(svg, "dist/index.html"), []);
+});
+
+test("checkMixedContent: at most one issue per file", () => {
+  const two = '<img src="http://a.com/1.png"><img src="http://b.com/2.png">';
+  assert.equal(checkMixedContent(two, "dist/index.html").length, 1);
 });

--- a/Resources/Template/scripts/pre-deploy-check.test.ts
+++ b/Resources/Template/scripts/pre-deploy-check.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { checkHeaders, checkMixedContent, checkSRI, checkExternalLinkRel } from "./pre-deploy-check";
+import { checkHeaders, checkMixedContent, checkSRI, checkExternalLinkRel, checkArtifactPresence } from "./pre-deploy-check";
 
 const GOOD = `/*
   Content-Security-Policy: default-src 'self'; frame-src 'self' js.stripe.com
@@ -121,4 +121,26 @@ test("checkExternalLinkRel: rel with noopener among others is clean", () => {
 
 test("checkExternalLinkRel: link without target=_blank is ignored", () => {
   assert.deepEqual(checkExternalLinkRel('<a href="https://x.com">x</a>', "dist/index.html"), []);
+});
+
+test("checkArtifactPresence: both present is clean", () => {
+  const paths = ["dist/index.html", "dist/robots.txt", "dist/.well-known/security.txt"];
+  assert.deepEqual(checkArtifactPresence(paths), []);
+});
+
+test("checkArtifactPresence: missing robots.txt is a warning", () => {
+  const issues = checkArtifactPresence(["dist/index.html", "dist/.well-known/security.txt"]);
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.match(issues[0].message, /robots\.txt/);
+});
+
+test("checkArtifactPresence: missing both yields two warnings", () => {
+  const issues = checkArtifactPresence(["dist/index.html"]);
+  assert.equal(issues.length, 2);
+});
+
+test("checkArtifactPresence: backslash paths are normalized", () => {
+  const paths = ["dist\\robots.txt", "dist\\.well-known\\security.txt"];
+  assert.deepEqual(checkArtifactPresence(paths), []);
 });

--- a/Resources/Template/scripts/pre-deploy-check.test.ts
+++ b/Resources/Template/scripts/pre-deploy-check.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { checkHeaders, checkMixedContent, checkSRI } from "./pre-deploy-check";
+import { checkHeaders, checkMixedContent, checkSRI, checkExternalLinkRel } from "./pre-deploy-check";
 
 const GOOD = `/*
   Content-Security-Policy: default-src 'self'; frame-src 'self' js.stripe.com
@@ -100,4 +100,25 @@ test("checkSRI: external stylesheet link without integrity is a warning", () => 
 
 test("checkSRI: non-stylesheet link is ignored", () => {
   assert.deepEqual(checkSRI('<link rel="preconnect" href="https://x.com">', "dist/index.html"), []);
+});
+
+test("checkExternalLinkRel: target=_blank without rel=noopener is a warning", () => {
+  const issues = checkExternalLinkRel('<a href="https://x.com" target="_blank">x</a>', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.match(issues[0].message, /noopener/i);
+});
+
+test("checkExternalLinkRel: rel=noopener is clean", () => {
+  const ok = '<a href="https://x.com" target="_blank" rel="noopener">x</a>';
+  assert.deepEqual(checkExternalLinkRel(ok, "dist/index.html"), []);
+});
+
+test("checkExternalLinkRel: rel with noopener among others is clean", () => {
+  const ok = '<a href="https://x.com" target="_blank" rel="noopener noreferrer">x</a>';
+  assert.deepEqual(checkExternalLinkRel(ok, "dist/index.html"), []);
+});
+
+test("checkExternalLinkRel: link without target=_blank is ignored", () => {
+  assert.deepEqual(checkExternalLinkRel('<a href="https://x.com">x</a>', "dist/index.html"), []);
 });

--- a/Resources/Template/scripts/pre-deploy-check.test.ts
+++ b/Resources/Template/scripts/pre-deploy-check.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { checkHeaders, checkMixedContent } from "./pre-deploy-check";
+import { checkHeaders, checkMixedContent, checkSRI } from "./pre-deploy-check";
 
 const GOOD = `/*
   Content-Security-Policy: default-src 'self'; frame-src 'self' js.stripe.com
@@ -75,4 +75,29 @@ test("checkMixedContent: svg xmlns http URL is not flagged", () => {
 test("checkMixedContent: at most one issue per file", () => {
   const two = '<img src="http://a.com/1.png"><img src="http://b.com/2.png">';
   assert.equal(checkMixedContent(two, "dist/index.html").length, 1);
+});
+
+test("checkSRI: external script without integrity is a warning", () => {
+  const issues = checkSRI('<script src="https://cdn.x.com/a.js"></script>', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.match(issues[0].message, /integrity/i);
+});
+
+test("checkSRI: external script WITH integrity is clean", () => {
+  const ok = '<script src="https://cdn.x.com/a.js" integrity="sha384-abc"></script>';
+  assert.deepEqual(checkSRI(ok, "dist/index.html"), []);
+});
+
+test("checkSRI: relative script is clean", () => {
+  assert.deepEqual(checkSRI('<script src="/local.js"></script>', "dist/index.html"), []);
+});
+
+test("checkSRI: external stylesheet link without integrity is a warning", () => {
+  const issues = checkSRI('<link rel="stylesheet" href="https://cdn.x.com/a.css">', "dist/index.html");
+  assert.equal(issues.length, 1);
+});
+
+test("checkSRI: non-stylesheet link is ignored", () => {
+  assert.deepEqual(checkSRI('<link rel="preconnect" href="https://x.com">', "dist/index.html"), []);
 });

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -116,8 +116,11 @@ export function checkMixedContent(content: string, file: string): Issue[] {
 
 /**
  * External (absolute or protocol-relative) <script> and stylesheet <link> tags
- * that lack an `integrity` attribute. Heuristic tag-level regex match. One issue
- * per offending tag.
+ * with a subresource-integrity problem: either missing `integrity`, or carrying
+ * `integrity` without the `crossorigin` attribute it requires — the browser
+ * blocks the response on CORS before integrity is evaluated, so the resource
+ * silently fails to load. Heuristic tag-level regex match; multi-line tag
+ * attributes are not matched. One issue per offending tag.
  */
 export function checkSRI(content: string, file: string): Issue[] {
   const issues: Issue[] = [];
@@ -131,10 +134,13 @@ export function checkSRI(content: string, file: string): Issue[] {
       : /\bhref\s*=\s*["'](?:https?:)?\/\//i;
     if (!urlAttr.test(tag)) continue;
     if (!isScript && !/\brel\s*=\s*["'][^"']*stylesheet/i.test(tag)) continue;
+    const kind = isScript ? "script" : "stylesheet";
     if (!/\bintegrity\s*=/i.test(tag)) {
+      issues.push({ severity: "warning", message: `External ${kind} without subresource integrity (SRI)`, file });
+    } else if (!/\scrossorigin\b/i.test(tag)) {
       issues.push({
         severity: "warning",
-        message: `External ${isScript ? "script" : "stylesheet"} without subresource integrity (SRI)`,
+        message: `External ${kind} has integrity but is missing crossorigin (will fail CORS)`,
         file,
       });
     }
@@ -144,8 +150,10 @@ export function checkSRI(content: string, file: string): Issue[] {
 
 /**
  * Anchors that open a new tab (`target="_blank"`) without `rel="noopener"`,
- * which can expose `window.opener`. Advisory — modern browsers imply noopener,
- * but explicit is safer. One issue per offending anchor.
+ * which can expose `window.opener`. `rel="noreferrer"` also implies noopener
+ * (per the HTML spec and all modern browsers), so either token is accepted.
+ * Advisory — modern browsers imply noopener, but explicit is safer. One issue
+ * per offending anchor.
  */
 export function checkExternalLinkRel(content: string, file: string): Issue[] {
   const issues: Issue[] = [];
@@ -156,7 +164,7 @@ export function checkExternalLinkRel(content: string, file: string): Issue[] {
     if (!/\btarget\s*=\s*["']_blank["']/i.test(tag)) continue;
     const relMatch = tag.match(/\brel\s*=\s*["']([^"']*)["']/i);
     const rel = relMatch ? relMatch[1].toLowerCase() : "";
-    if (!/\bnoopener\b/.test(rel)) {
+    if (!/\bnoopener\b|\bnoreferrer\b/.test(rel)) {
       issues.push({ severity: "warning", message: 'Link with target="_blank" missing rel="noopener"', file });
     }
   }

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -98,6 +98,22 @@ export function checkHeaders(headersContent: string | null, configContent: strin
   return issues;
 }
 
+/**
+ * Insecure (http://) subresource references in built HTML/CSS. Targets resource
+ * attributes (`src`) and CSS `url(...)` only — NOT `href` — so anchor links and
+ * `xmlns="http://..."` declarations do not false-positive. Advisory: slice A's
+ * `upgrade-insecure-requests` auto-upgrades these at runtime. One issue per file.
+ */
+export function checkMixedContent(content: string, file: string): Issue[] {
+  const patterns = [/\bsrc\s*=\s*["']http:\/\//i, /url\(\s*["']?http:\/\//i];
+  for (const pattern of patterns) {
+    if (pattern.test(content)) {
+      return [{ severity: "warning", message: "Mixed content: insecure http:// resource reference", file }];
+    }
+  }
+  return [];
+}
+
 async function scan(): Promise<Issue[]> {
   const issues: Issue[] = [];
 
@@ -133,6 +149,10 @@ async function scan(): Promise<Issue[]> {
       if (pattern.test(content)) {
         issues.push({ severity: "error", message: `Possible ${name} exposed`, file: rel });
       }
+    }
+
+    if (/\.(html?|css)$/i.test(file)) {
+      issues.push(...checkMixedContent(content, rel));
     }
 
     if (/\.html?$/i.test(file)) {

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -114,6 +114,34 @@ export function checkMixedContent(content: string, file: string): Issue[] {
   return [];
 }
 
+/**
+ * External (absolute or protocol-relative) <script> and stylesheet <link> tags
+ * that lack an `integrity` attribute. Heuristic tag-level regex match. One issue
+ * per offending tag.
+ */
+export function checkSRI(content: string, file: string): Issue[] {
+  const issues: Issue[] = [];
+  const tagPattern = /<(script|link)\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = tagPattern.exec(content)) !== null) {
+    const tag = m[0];
+    const isScript = m[1].toLowerCase() === "script";
+    const urlAttr = isScript
+      ? /\bsrc\s*=\s*["'](?:https?:)?\/\//i
+      : /\bhref\s*=\s*["'](?:https?:)?\/\//i;
+    if (!urlAttr.test(tag)) continue;
+    if (!isScript && !/\brel\s*=\s*["'][^"']*stylesheet/i.test(tag)) continue;
+    if (!/\bintegrity\s*=/i.test(tag)) {
+      issues.push({
+        severity: "warning",
+        message: `External ${isScript ? "script" : "stylesheet"} without subresource integrity (SRI)`,
+        file,
+      });
+    }
+  }
+  return issues;
+}
+
 async function scan(): Promise<Issue[]> {
   const issues: Issue[] = [];
 
@@ -175,6 +203,8 @@ async function scan(): Promise<Issue[]> {
           });
         }
       }
+
+      issues.push(...checkSRI(content, rel));
     }
   }
 

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -163,6 +163,22 @@ export function checkExternalLinkRel(content: string, file: string): Issue[] {
   return issues;
 }
 
+/**
+ * Warn when expected security artifacts are absent from the built output.
+ * Generators for these land in slice C1 (#405); until then this is informational.
+ */
+export function checkArtifactPresence(relPaths: string[]): Issue[] {
+  const set = new Set(relPaths.map((p) => p.replace(/\\/g, "/")));
+  const required = ["dist/robots.txt", "dist/.well-known/security.txt"];
+  const issues: Issue[] = [];
+  for (const path of required) {
+    if (!set.has(path)) {
+      issues.push({ severity: "warning", message: `Missing security artifact: ${path.replace(/^dist\//, "")}`, file: path });
+    }
+  }
+  return issues;
+}
+
 async function scan(): Promise<Issue[]> {
   const issues: Issue[] = [];
 
@@ -181,10 +197,13 @@ async function scan(): Promise<Issue[]> {
   );
   issues.push(...checkHeaders(headersContent, configContent));
 
+  const relPaths: string[] = [];
+
   for await (const file of walk(DIST_DIR)) {
     if (!/\.(html?|js|css|json|xml|txt)$/i.test(file)) continue;
     const content = await readFile(file, "utf-8");
     const rel = relative(process.cwd(), file);
+    relPaths.push(rel);
 
     for (const { name, pattern } of PII_PATTERNS) {
       pattern.lastIndex = 0;
@@ -229,6 +248,8 @@ async function scan(): Promise<Issue[]> {
       issues.push(...checkExternalLinkRel(content, rel));
     }
   }
+
+  issues.push(...checkArtifactPresence(relPaths));
 
   return issues;
 }

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -142,6 +142,27 @@ export function checkSRI(content: string, file: string): Issue[] {
   return issues;
 }
 
+/**
+ * Anchors that open a new tab (`target="_blank"`) without `rel="noopener"`,
+ * which can expose `window.opener`. Advisory — modern browsers imply noopener,
+ * but explicit is safer. One issue per offending anchor.
+ */
+export function checkExternalLinkRel(content: string, file: string): Issue[] {
+  const issues: Issue[] = [];
+  const anchorPattern = /<a\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = anchorPattern.exec(content)) !== null) {
+    const tag = m[0];
+    if (!/\btarget\s*=\s*["']_blank["']/i.test(tag)) continue;
+    const relMatch = tag.match(/\brel\s*=\s*["']([^"']*)["']/i);
+    const rel = relMatch ? relMatch[1].toLowerCase() : "";
+    if (!/\bnoopener\b/.test(rel)) {
+      issues.push({ severity: "warning", message: 'Link with target="_blank" missing rel="noopener"', file });
+    }
+  }
+  return issues;
+}
+
 async function scan(): Promise<Issue[]> {
   const issues: Issue[] = [];
 
@@ -205,6 +226,7 @@ async function scan(): Promise<Issue[]> {
       }
 
       issues.push(...checkSRI(content, rel));
+      issues.push(...checkExternalLinkRel(content, rel));
     }
   }
 


### PR DESCRIPTION
Layer B of the security-story-hardening epic (#402). Extends the pre-deploy security scan (`Resources/Template/scripts/pre-deploy-check.ts`) with four new exported pure checks, each wired into `scan()` and mirroring the existing `checkHeaders` pattern.

## New checks (all advisory — `warning`, never deploy-blocking)
- **`checkMixedContent`** — insecure `http://` refs in `src=` / CSS `url()` (scoped to avoid `href`/`xmlns` false positives).
- **`checkSRI`** — external `<script>` / stylesheet `<link>` missing an `integrity` attribute.
- **`checkExternalLinkRel`** — `<a target="_blank">` without `rel="noopener"`.
- **`checkArtifactPresence`** — missing `robots.txt` / `.well-known/security.txt` in built output (generators land in C1/#405).

## Decisions (flagged in the plan)
- **Mixed content is a `warning`, not the spec's `error`** — slice A's `upgrade-insecure-requests` (#403) auto-upgrades insecure subresources at runtime, so a hard block would be redundant and surprising.
- **Dependency/lockfile audit deferred** — needs an `npm audit`-style mechanism; tracked as a separate follow-up rather than dropped.

## Testing
- `npx tsx --test scripts/pre-deploy-check.test.ts` → **25/25 pass** (7 pre-existing + 18 new).
- `--json` smoke run clean. Template-only; no Swift touched.

Built TDD across four commits (each green at commit), task-reviewed per commit, and passed a final whole-branch review (no Critical/Important). Two Minor heuristic gaps noted for optional follow-up: `srcset` and `modulepreload` are not matched (within the plan's accepted heuristic scope).

Spec: `docs/superpowers/specs/2026-06-27-security-story-hardening-design.md` §B · Plan: `docs/superpowers/plans/2026-06-27-pre-deploy-audit-extensions-404.md`

Closes #404. Part of #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)