### PR TITLE
feat(#406): Cloudflare read seam + SecurityAudit (C2 core)

### DIFF
--- a/Sources/AnglesiteCore/CloudflareReading.swift
+++ b/Sources/AnglesiteCore/CloudflareReading.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Errors surfaced by the Cloudflare read client.
+public enum CloudflareError: Error, Equatable, Sendable {
+    case unauthorized
+    case http(status: Int)
+    case api(message: String)
+    case malformedResponse
+    case zoneNotFound(domain: String)
+}
+
+/// Read-only Cloudflare API seam. The concrete `HTTPCloudflareClient` talks to the
+/// v4 REST API; tests provide a fake. Token is passed per call (no Keychain coupling).
+public protocol CloudflareReading: Sendable {
+    /// Resolve a zone's id from its apex domain, or nil if the token can't see it.
+    func resolveZoneID(domain: String, apiToken: String) async throws -> String?
+    /// Fetch the security-relevant state for a zone.
+    func zoneState(zoneID: String, apiToken: String) async throws -> CloudflareZoneState
+}
+
+/// Injectable HTTP boundary — identical shape to `CloudflareAPITokenVerifier.Transport`.
+public typealias CloudflareTransport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)

--- a/Sources/AnglesiteCore/CloudflareZoneState.swift
+++ b/Sources/AnglesiteCore/CloudflareZoneState.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// A read-only snapshot of a Cloudflare zone's security-relevant edge/DNS state.
+/// Assembled by `HTTPCloudflareClient.zoneState` and graded by `SecurityAudit`.
+public struct CloudflareZoneState: Sendable, Equatable {
+    /// HSTS edge setting (Zone Settings → security_header). `nil` when disabled.
+    public struct HSTS: Sendable, Equatable {
+        public var maxAge: Int
+        public var includeSubdomains: Bool
+        public var preload: Bool
+        public init(maxAge: Int, includeSubdomains: Bool, preload: Bool) {
+            self.maxAge = maxAge
+            self.includeSubdomains = includeSubdomains
+            self.preload = preload
+        }
+    }
+
+    public var dnssecActive: Bool
+    /// SSL/TLS encryption mode: "off" | "flexible" | "full" | "strict".
+    public var sslMode: String
+    public var alwaysUseHTTPS: Bool
+    public var hsts: HSTS?
+    /// Raw record contents (`content` field) for the relevant DNS types.
+    public var caaRecords: [String]
+    public var mxRecords: [String]
+    /// TXT records whose content starts with `v=spf1`.
+    public var spfRecords: [String]
+    /// TXT records at `_dmarc.<zone>` whose content starts with `v=DMARC1`.
+    public var dmarcRecords: [String]
+
+    public init(dnssecActive: Bool, sslMode: String, alwaysUseHTTPS: Bool, hsts: HSTS?,
+                caaRecords: [String], mxRecords: [String], spfRecords: [String], dmarcRecords: [String]) {
+        self.dnssecActive = dnssecActive
+        self.sslMode = sslMode
+        self.alwaysUseHTTPS = alwaysUseHTTPS
+        self.hsts = hsts
+        self.caaRecords = caaRecords
+        self.mxRecords = mxRecords
+        self.spfRecords = spfRecords
+        self.dmarcRecords = dmarcRecords
+    }
+}

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Standard Cloudflare v4 response envelope.
+private struct CFEnvelope<T: Decodable & Sendable>: Decodable, Sendable {
+    let success: Bool
+    let result: T?
+    struct APIError: Decodable, Sendable { let message: String }
+    let errors: [APIError]?
+}
+
+private struct CFZone: Decodable, Sendable {
+    let id: String
+    let name: String
+    let status: String
+}
+
+/// Read-only Cloudflare v4 client. All methods are GETs.
+public struct HTTPCloudflareClient: CloudflareReading {
+    private static let base = "https://api.cloudflare.com/client/v4"
+    private let transport: CloudflareTransport
+
+    public init(transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport) {
+        self.transport = transport
+    }
+
+    public static let defaultTransport: CloudflareTransport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw CloudflareError.malformedResponse }
+        return (data, http)
+    }
+
+    /// GET `path`, decode `CFEnvelope<T>`, return `result` or throw a mapped error.
+    private func get<T: Decodable & Sendable>(_ path: String, apiToken: String, as: T.Type) async throws -> T {
+        guard let url = URL(string: Self.base + path) else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let (data, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        let env = try JSONDecoder().decode(CFEnvelope<T>.self, from: data)
+        guard env.success, let result = env.result else {
+            throw CloudflareError.api(message: env.errors?.first?.message ?? "request failed")
+        }
+        return result
+    }
+
+    public func resolveZoneID(domain: String, apiToken: String) async throws -> String? {
+        let escaped = domain.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? domain
+        let zones = try await get("/zones?name=\(escaped)&status=active", apiToken: apiToken, as: [CFZone].self)
+        return zones.first(where: { $0.name == domain })?.id
+    }
+
+    // Implemented in Task 3.
+    public func zoneState(zoneID: String, apiToken: String) async throws -> CloudflareZoneState {
+        fatalError("zoneState not yet implemented — Task 3")
+    }
+}

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -59,7 +59,12 @@ public struct HTTPCloudflareClient: CloudflareReading {
         let (data, http) = try await transport(request)
         if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
         guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
-        let env = try JSONDecoder().decode(CFEnvelope<T>.self, from: data)
+        let env: CFEnvelope<T>
+        do {
+            env = try JSONDecoder().decode(CFEnvelope<T>.self, from: data)
+        } catch {
+            throw CloudflareError.malformedResponse
+        }
         guard env.success, let result = env.result else {
             throw CloudflareError.api(message: env.errors?.first?.message ?? "request failed")
         }
@@ -69,7 +74,7 @@ public struct HTTPCloudflareClient: CloudflareReading {
     public func resolveZoneID(domain: String, apiToken: String) async throws -> String? {
         let escaped = domain.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? domain
         let zones = try await get("/zones?name=\(escaped)&status=active", apiToken: apiToken, as: [CFZone].self)
-        return zones.first(where: { $0.name == domain })?.id
+        return zones.first(where: { $0.name.lowercased() == domain.lowercased() })?.id
     }
 
     public func zoneState(zoneID: String, apiToken: String) async throws -> CloudflareZoneState {

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -14,6 +14,26 @@ private struct CFZone: Decodable, Sendable {
     let status: String
 }
 
+private struct CFDNSSEC: Decodable, Sendable { let status: String }
+private struct CFStringSetting: Decodable, Sendable { let value: String }
+private struct CFSecurityHeader: Decodable, Sendable {
+    struct Value: Decodable, Sendable {
+        struct STS: Decodable, Sendable {
+            let enabled: Bool
+            let max_age: Int?
+            let include_subdomains: Bool?
+            let preload: Bool?
+        }
+        let strict_transport_security: STS
+    }
+    let value: Value
+}
+private struct CFDNSRecord: Decodable, Sendable {
+    let type: String
+    let name: String
+    let content: String
+}
+
 /// Read-only Cloudflare v4 client. All methods are GETs.
 public struct HTTPCloudflareClient: CloudflareReading {
     private static let base = "https://api.cloudflare.com/client/v4"
@@ -52,8 +72,33 @@ public struct HTTPCloudflareClient: CloudflareReading {
         return zones.first(where: { $0.name == domain })?.id
     }
 
-    // Implemented in Task 3.
     public func zoneState(zoneID: String, apiToken: String) async throws -> CloudflareZoneState {
-        fatalError("zoneState not yet implemented — Task 3")
+        let dnssec = try await get("/zones/\(zoneID)/dnssec", apiToken: apiToken, as: CFDNSSEC.self)
+        let ssl = try await get("/zones/\(zoneID)/settings/ssl", apiToken: apiToken, as: CFStringSetting.self)
+        let https = try await get("/zones/\(zoneID)/settings/always_use_https", apiToken: apiToken, as: CFStringSetting.self)
+        let header = try await get("/zones/\(zoneID)/settings/security_header", apiToken: apiToken, as: CFSecurityHeader.self)
+        let records = try await get("/zones/\(zoneID)/dns_records?per_page=100", apiToken: apiToken, as: [CFDNSRecord].self)
+
+        let sts = header.value.strict_transport_security
+        let hsts: CloudflareZoneState.HSTS? = sts.enabled
+            ? .init(maxAge: sts.max_age ?? 0, includeSubdomains: sts.include_subdomains ?? false, preload: sts.preload ?? false)
+            : nil
+
+        func contents(ofType t: String) -> [String] {
+            records.filter { $0.type.uppercased() == t }.map(\.content)
+        }
+        let txt = records.filter { $0.type.uppercased() == "TXT" }
+        let spf = txt.filter { $0.content.lowercased().hasPrefix("v=spf1") }.map(\.content)
+        let dmarc = txt.filter { $0.name.lowercased().hasPrefix("_dmarc.") && $0.content.lowercased().hasPrefix("v=dmarc1") }.map(\.content)
+
+        return CloudflareZoneState(
+            dnssecActive: dnssec.status.lowercased() == "active",
+            sslMode: ssl.value,
+            alwaysUseHTTPS: https.value.lowercased() == "on",
+            hsts: hsts,
+            caaRecords: contents(ofType: "CAA"),
+            mxRecords: contents(ofType: "MX"),
+            spfRecords: spf,
+            dmarcRecords: dmarc)
     }
 }

--- a/Sources/AnglesiteCore/SecurityAudit.swift
+++ b/Sources/AnglesiteCore/SecurityAudit.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Pure evaluator: grades a `CloudflareZoneState` into security findings. Read-only,
+/// no I/O — it never fixes anything. Findings reuse the shared `AuditReport.Finding`
+/// model (`category: .security`).
+public enum SecurityAudit {
+    public static func evaluate(_ state: CloudflareZoneState, expectsMail: Bool) -> [AuditReport.Finding] {
+        var findings: [AuditReport.Finding] = []
+        func add(_ severity: AuditReport.Finding.Severity, _ title: String, _ detail: String, _ remediation: String) {
+            findings.append(.init(category: .security, severity: severity, title: title,
+                                  detail: detail, remediation: remediation, location: nil))
+        }
+
+        if !state.dnssecActive {
+            add(.warning, "DNSSEC is not active",
+                "DNSSEC is disabled, leaving DNS responses unauthenticated.",
+                "Enable DNSSEC for the zone and publish the DS record at your registrar.")
+        }
+        if !["full", "strict"].contains(state.sslMode.lowercased()) {
+            add(.critical, "Weak SSL/TLS mode (\(state.sslMode))",
+                "SSL mode \"\(state.sslMode)\" allows unencrypted or unauthenticated origin connections.",
+                "Set the zone's SSL/TLS mode to Full (strict).")
+        }
+        if !state.alwaysUseHTTPS {
+            add(.warning, "Always Use HTTPS is off",
+                "Visitors can reach the site over plaintext HTTP.",
+                "Enable Always Use HTTPS so HTTP requests are redirected to HTTPS.")
+        }
+        if state.hsts == nil {
+            add(.warning, "HSTS is not enabled",
+                "Without HSTS, browsers may downgrade to HTTP on the first visit.",
+                "Enable HTTP Strict Transport Security (max-age ≥ 1 year, includeSubDomains).")
+        } else if let h = state.hsts, h.maxAge < 31_536_000 {
+            add(.warning, "HSTS max-age is short (\(h.maxAge)s)",
+                "An HSTS max-age under one year weakens downgrade protection.",
+                "Raise HSTS max-age to at least 31536000 (one year).")
+        }
+        if state.caaRecords.isEmpty {
+            add(.info, "No CAA records",
+                "Any certificate authority can issue certificates for this domain.",
+                "Add CAA records authorizing only your CA(s) to limit mis-issuance.")
+        }
+        if !expectsMail {
+            if !state.spfRecords.contains(where: { $0.lowercased().contains("-all") }) {
+                add(.warning, "No strict SPF record",
+                    "A domain that does not send mail should publish SPF \"v=spf1 -all\" to block spoofing.",
+                    "Publish a TXT record: v=spf1 -all")
+            }
+            if !state.dmarcRecords.contains(where: { $0.lowercased().contains("p=reject") }) {
+                add(.warning, "No DMARC reject policy",
+                    "Without DMARC p=reject, spoofed mail claiming to be from this domain is not blocked.",
+                    "Publish _dmarc TXT: v=DMARC1; p=reject")
+            }
+        }
+        return findings
+    }
+}

--- a/Sources/AnglesiteCore/SecurityAudit.swift
+++ b/Sources/AnglesiteCore/SecurityAudit.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Pure evaluator: grades a `CloudflareZoneState` into security findings. Read-only,
 /// no I/O — it never fixes anything. Findings reuse the shared `AuditReport.Finding`
 /// model (`category: .security`).

--- a/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
@@ -54,3 +54,42 @@ func unauthorizedMaps() async {
         _ = try await client.resolveZoneID(domain: "example.com", apiToken: "bad")
     }
 }
+
+@Test("zoneState assembles DNSSEC, settings, and DNS records")
+func zoneStateAssembles() async throws {
+    let env = { (r: String) in "{\"success\":true,\"errors\":[],\"messages\":[],\"result\":\(r)}" }
+    let routes: [String: (Int, String)] = [
+        "/dnssec": (200, env("{\"status\":\"active\"}")),
+        "/settings/ssl": (200, env("{\"id\":\"ssl\",\"value\":\"strict\"}")),
+        "/settings/always_use_https": (200, env("{\"id\":\"always_use_https\",\"value\":\"on\"}")),
+        "/settings/security_header": (200, env("{\"id\":\"security_header\",\"value\":{\"strict_transport_security\":{\"enabled\":true,\"max_age\":31536000,\"include_subdomains\":true,\"preload\":false}}}")),
+        "/dns_records": (200, env("[{\"type\":\"CAA\",\"name\":\"example.com\",\"content\":\"0 issue \\\"letsencrypt.org\\\"\"},{\"type\":\"TXT\",\"name\":\"example.com\",\"content\":\"v=spf1 -all\"},{\"type\":\"TXT\",\"name\":\"_dmarc.example.com\",\"content\":\"v=DMARC1; p=reject\"}]")),
+    ]
+    let client = HTTPCloudflareClient(transport: fakeTransport(routes))
+    let s = try await client.zoneState(zoneID: "z", apiToken: "t")
+    #expect(s.dnssecActive)
+    #expect(s.sslMode == "strict")
+    #expect(s.alwaysUseHTTPS)
+    #expect(s.hsts == CloudflareZoneState.HSTS(maxAge: 31536000, includeSubdomains: true, preload: false))
+    #expect(s.caaRecords == ["0 issue \"letsencrypt.org\""])
+    #expect(s.spfRecords == ["v=spf1 -all"])
+    #expect(s.dmarcRecords == ["v=DMARC1; p=reject"])
+    #expect(s.mxRecords.isEmpty)
+}
+
+@Test("HSTS disabled yields nil hsts")
+func zoneStateHSTSDisabled() async throws {
+    let env = { (r: String) in "{\"success\":true,\"errors\":[],\"messages\":[],\"result\":\(r)}" }
+    let routes: [String: (Int, String)] = [
+        "/dnssec": (200, env("{\"status\":\"disabled\"}")),
+        "/settings/ssl": (200, env("{\"id\":\"ssl\",\"value\":\"full\"}")),
+        "/settings/always_use_https": (200, env("{\"id\":\"always_use_https\",\"value\":\"off\"}")),
+        "/settings/security_header": (200, env("{\"id\":\"security_header\",\"value\":{\"strict_transport_security\":{\"enabled\":false}}}")),
+        "/dns_records": (200, env("[]")),
+    ]
+    let client = HTTPCloudflareClient(transport: fakeTransport(routes))
+    let s = try await client.zoneState(zoneID: "z", apiToken: "t")
+    #expect(!s.dnssecActive)
+    #expect(s.hsts == nil)
+    #expect(s.caaRecords.isEmpty)
+}

--- a/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
@@ -1,0 +1,16 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct CloudflareClientTests {
+    @Test("CloudflareZoneState is value-equal by field")
+    func zoneStateEquatable() {
+        let a = CloudflareZoneState(
+            dnssecActive: true, sslMode: "strict", alwaysUseHTTPS: true,
+            hsts: .init(maxAge: 31_536_000, includeSubdomains: true, preload: false),
+            caaRecords: ["0 issue \"letsencrypt.org\""], mxRecords: [],
+            spfRecords: ["v=spf1 -all"], dmarcRecords: ["v=DMARC1; p=reject"])
+        let b = a
+        #expect(a == b)
+    }
+}

--- a/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
@@ -47,6 +47,24 @@ func resolveZoneIDMissing() async throws {
     #expect(id == nil)
 }
 
+@Test("resolveZoneID matches case-insensitively on the zone name")
+func resolveZoneIDCaseInsensitive() async throws {
+    let json = """
+    {"success":true,"errors":[],"messages":[],"result":[{"id":"zone123","name":"example.com","status":"active"}]}
+    """
+    let client = HTTPCloudflareClient(transport: fakeTransport(["/zones?": (200, json)]))
+    let id = try await client.resolveZoneID(domain: "Example.COM", apiToken: "t")
+    #expect(id == "zone123")
+}
+
+@Test("a malformed JSON body surfaces as .malformedResponse")
+func malformedBodyMaps() async {
+    let client = HTTPCloudflareClient(transport: fakeTransport(["/zones?": (200, "not json")]))
+    await #expect(throws: CloudflareError.malformedResponse) {
+        _ = try await client.resolveZoneID(domain: "example.com", apiToken: "t")
+    }
+}
+
 @Test("a 403 surfaces as .unauthorized")
 func unauthorizedMaps() async {
     let client = HTTPCloudflareClient(transport: fakeTransport(["/zones?": (403, "{\"success\":false}")]))

--- a/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
@@ -14,3 +14,43 @@ struct CloudflareClientTests {
         #expect(a == b)
     }
 }
+
+/// A fake transport that routes by URL substring to canned (Data, HTTPURLResponse).
+func fakeTransport(_ routes: [String: (Int, String)]) -> CloudflareTransport {
+    return { request in
+        let url = request.url!.absoluteString
+        for (needle, pair) in routes where url.contains(needle) {
+            let resp = HTTPURLResponse(url: request.url!, statusCode: pair.0,
+                                       httpVersion: nil, headerFields: nil)!
+            return (Data(pair.1.utf8), resp)
+        }
+        let resp = HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+        return (Data("{\"success\":false}".utf8), resp)
+    }
+}
+
+@Test("resolveZoneID returns the id of the matching active zone")
+func resolveZoneIDFound() async throws {
+    let json = """
+    {"success":true,"errors":[],"messages":[],"result":[{"id":"zone123","name":"example.com","status":"active"}]}
+    """
+    let client = HTTPCloudflareClient(transport: fakeTransport(["/zones?": (200, json)]))
+    let id = try await client.resolveZoneID(domain: "example.com", apiToken: "t")
+    #expect(id == "zone123")
+}
+
+@Test("resolveZoneID returns nil when no zone matches")
+func resolveZoneIDMissing() async throws {
+    let json = "{\"success\":true,\"errors\":[],\"messages\":[],\"result\":[]}"
+    let client = HTTPCloudflareClient(transport: fakeTransport(["/zones?": (200, json)]))
+    let id = try await client.resolveZoneID(domain: "absent.com", apiToken: "t")
+    #expect(id == nil)
+}
+
+@Test("a 403 surfaces as .unauthorized")
+func unauthorizedMaps() async {
+    let client = HTTPCloudflareClient(transport: fakeTransport(["/zones?": (403, "{\"success\":false}")]))
+    await #expect(throws: CloudflareError.unauthorized) {
+        _ = try await client.resolveZoneID(domain: "example.com", apiToken: "bad")
+    }
+}

--- a/Tests/AnglesiteCoreTests/SecurityAuditTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityAuditTests.swift
@@ -1,0 +1,67 @@
+import Testing
+@testable import AnglesiteCore
+
+struct SecurityAuditTests {
+    private func clean() -> CloudflareZoneState {
+        CloudflareZoneState(
+            dnssecActive: true, sslMode: "strict", alwaysUseHTTPS: true,
+            hsts: .init(maxAge: 31_536_000, includeSubdomains: true, preload: false),
+            caaRecords: ["0 issue \"letsencrypt.org\""], mxRecords: [],
+            spfRecords: ["v=spf1 -all"], dmarcRecords: ["v=DMARC1; p=reject"])
+    }
+
+    @Test("a fully hardened non-mail zone yields no findings")
+    func cleanZoneNoFindings() {
+        #expect(SecurityAudit.evaluate(clean(), expectsMail: false).isEmpty)
+    }
+
+    @Test("DNSSEC disabled is a warning")
+    func dnssecWarning() {
+        var s = clean(); s.dnssecActive = false
+        let f = SecurityAudit.evaluate(s, expectsMail: false)
+        #expect(f.contains { $0.severity == .warning && $0.title.contains("DNSSEC") })
+    }
+
+    @Test("weak SSL mode is critical")
+    func sslCritical() {
+        var s = clean(); s.sslMode = "flexible"
+        let f = SecurityAudit.evaluate(s, expectsMail: false)
+        #expect(f.contains { $0.severity == .critical && $0.title.contains("SSL") })
+    }
+
+    @Test("missing HSTS and Always-Use-HTTPS each warn")
+    func httpsWarnings() {
+        var s = clean(); s.hsts = nil; s.alwaysUseHTTPS = false
+        let f = SecurityAudit.evaluate(s, expectsMail: false)
+        #expect(f.contains { $0.title.contains("HSTS") })
+        #expect(f.contains { $0.title.contains("HTTPS") })
+    }
+
+    @Test("missing CAA is an info finding")
+    func caaInfo() {
+        var s = clean(); s.caaRecords = []
+        let f = SecurityAudit.evaluate(s, expectsMail: false)
+        #expect(f.contains { $0.severity == .info && $0.title.contains("CAA") })
+    }
+
+    @Test("non-mail zone without SPF -all / DMARC reject warns on spoofing")
+    func emailWarnings() {
+        var s = clean(); s.spfRecords = []; s.dmarcRecords = []
+        let f = SecurityAudit.evaluate(s, expectsMail: false)
+        #expect(f.contains { $0.title.contains("SPF") })
+        #expect(f.contains { $0.title.contains("DMARC") })
+    }
+
+    @Test("a mail-sending zone is not warned for absent SPF/DMARC by this audit")
+    func mailZoneSkipsEmailHardening() {
+        var s = clean(); s.spfRecords = []; s.dmarcRecords = []
+        let f = SecurityAudit.evaluate(s, expectsMail: true)
+        #expect(!f.contains { $0.title.contains("SPF") })
+    }
+
+    @Test("every finding is in the security category")
+    func allSecurityCategory() {
+        var s = clean(); s.dnssecActive = false; s.sslMode = "off"
+        #expect(SecurityAudit.evaluate(s, expectsMail: false).allSatisfy { $0.category == .security })
+    }
+}


### PR DESCRIPTION
Layer C2 **core** of the security epic (#402) — the CI-testable data + audit layer, all in `AnglesiteCore`. No UI, no Keychain coupling, no account writes.

## What's here (5 commits, 16 tests across 2 suites)
- **`CloudflareZoneState`** — Sendable/Equatable snapshot (DNSSEC, SSL mode, Always-Use-HTTPS, HSTS, CAA/MX/SPF/DMARC).
- **`CloudflareReading`** seam + `CloudflareError` + `CloudflareTransport` (injectable `@Sendable` closure — mirrors `CloudflareAPITokenVerifier`).
- **`HTTPCloudflareClient`** — generic `CFEnvelope<T>`/`get<T>` helper (Bearer auth; 401/403→`.unauthorized`, other non-2xx→`.http`, `success:false`→`.api`, decode failure→`.malformedResponse`), `resolveZoneID` (case-insensitive), and `zoneState` reading 5 GET endpoints. **Read-only — every request is a GET.**
- **`SecurityAudit.evaluate(_:expectsMail:)`** — pure mapping to the existing `AuditReport.Finding` model (`category: .security`); never fixes anything. `expectsMail` gates the email-spoofing findings.

Tests use a fake `Transport` with canned JSON fixtures — no live calls.

## Reviewed
TDD per task, per-task reviewed, whole-branch reviewed (merge-ready), then a review-polish commit: total error mapping, case-insensitive zone match, dropped a genuinely-unused import (verified by recompile).

## Deferred to follow-ups (flagged in the plan, not dropped)
- **Bot Fight Mode read + WAF custom-rules listing** (free-plan/rulesets uncertainty; pairs with C3).
- **Scorecard SwiftUI surface + drift reporting** (thin app-target work on the `AuditModel`/`AuditSheetView` precedent).

## Caveat
Cloudflare v4 JSON field names in the decode structs are authored from documented shapes; the fixtures pin the contract but the **first live run** is where any field-name mismatch would surface. Verify against a real response when wiring the UI follow-up.

Spec: `docs/superpowers/specs/2026-06-27-security-story-hardening-design.md` §C2 · Plan: [#414](https://github.com/Anglesite/Anglesite-app/pull/414).

Part of #402. Implements the core of #406 (Bot Fight Mode / WAF listing + UI tracked as follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)