### PR TITLE
feat(#407): opt-in Cloudflare hardening action (C3 core)

### DIFF
--- a/Sources/AnglesiteCore/CloudflareWriting.swift
+++ b/Sources/AnglesiteCore/CloudflareWriting.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Write-side Cloudflare API seam. The concrete `HTTPCloudflareClient` talks to the
+/// v4 REST API; tests provide a mock. Token is passed per call (no Keychain coupling).
+public protocol CloudflareWriting: Sendable {
+    func enableDNSSEC(zoneID: String, apiToken: String) async throws
+    func setAlwaysUseHTTPS(zoneID: String, enabled: Bool, apiToken: String) async throws
+    func setHSTS(zoneID: String, maxAge: Int, includeSubdomains: Bool, preload: Bool,
+                 apiToken: String) async throws
+    func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws
+    func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws
+    func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws
+}
+
+/// Payload for creating a DNS record via the Cloudflare API.
+public struct DNSRecordPayload: Sendable, Equatable, Encodable {
+    public let type: String
+    public let name: String
+    public let content: String
+    public let ttl: Int
+
+    public init(type: String, name: String, content: String, ttl: Int = 1) {
+        self.type = type
+        self.name = name
+        self.content = content
+        self.ttl = ttl
+    }
+}
+
+/// Payload for creating a custom WAF rule via the Cloudflare API.
+public struct WAFRulePayload: Sendable, Equatable {
+    public let description: String
+    public let expression: String
+    public let action: String
+
+    public init(description: String, expression: String, action: String) {
+        self.description = description
+        self.expression = expression
+        self.action = action
+    }
+}

--- a/Sources/AnglesiteCore/CloudflareWriting.swift
+++ b/Sources/AnglesiteCore/CloudflareWriting.swift
@@ -18,17 +18,19 @@ public struct DNSRecordPayload: Sendable, Equatable, Encodable {
     public let name: String
     public let content: String
     public let ttl: Int
+    public let priority: Int?
 
-    public init(type: String, name: String, content: String, ttl: Int = 1) {
+    public init(type: String, name: String, content: String, ttl: Int = 1, priority: Int? = nil) {
         self.type = type
         self.name = name
         self.content = content
         self.ttl = ttl
+        self.priority = priority
     }
 }
 
 /// Payload for creating a custom WAF rule via the Cloudflare API.
-public struct WAFRulePayload: Sendable, Equatable {
+public struct WAFRulePayload: Sendable, Equatable, Encodable {
     public let description: String
     public let expression: String
     public let action: String

--- a/Sources/AnglesiteCore/CloudflareZoneState.swift
+++ b/Sources/AnglesiteCore/CloudflareZoneState.swift
@@ -27,9 +27,26 @@ public struct CloudflareZoneState: Sendable, Equatable {
     public var spfRecords: [String]
     /// TXT records at `_dmarc.<zone>` whose content starts with `v=DMARC1`.
     public var dmarcRecords: [String]
+    /// Whether Bot Fight Mode is enabled (free-plan bot management).
+    public var botFightMode: Bool
+    /// Custom WAF rules in the `http_request_firewall_custom` phase.
+    public var wafCustomRules: [WAFCustomRule]
+
+    /// A single custom WAF rule from the zone's firewall ruleset.
+    public struct WAFCustomRule: Sendable, Equatable {
+        public var description: String
+        public var expression: String
+        public var action: String
+        public init(description: String, expression: String, action: String) {
+            self.description = description
+            self.expression = expression
+            self.action = action
+        }
+    }
 
     public init(dnssecActive: Bool, sslMode: String, alwaysUseHTTPS: Bool, hsts: HSTS?,
-                caaRecords: [String], mxRecords: [String], spfRecords: [String], dmarcRecords: [String]) {
+                caaRecords: [String], mxRecords: [String], spfRecords: [String], dmarcRecords: [String],
+                botFightMode: Bool = false, wafCustomRules: [WAFCustomRule] = []) {
         self.dnssecActive = dnssecActive
         self.sslMode = sslMode
         self.alwaysUseHTTPS = alwaysUseHTTPS
@@ -38,5 +55,7 @@ public struct CloudflareZoneState: Sendable, Equatable {
         self.mxRecords = mxRecords
         self.spfRecords = spfRecords
         self.dmarcRecords = dmarcRecords
+        self.botFightMode = botFightMode
+        self.wafCustomRules = wafCustomRules
     }
 }

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -8,6 +8,9 @@ private struct CFEnvelope<T: Decodable & Sendable>: Decodable, Sendable {
     let errors: [APIError]?
 }
 
+/// Placeholder for write responses where we only check `success`.
+private struct CFEmpty: Decodable, Sendable {}
+
 private struct CFZone: Decodable, Sendable {
     let id: String
     let name: String
@@ -165,10 +168,9 @@ public struct HTTPCloudflareClient: CloudflareReading {
         let (data, http) = try await transport(request)
         if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
         guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
-        struct Empty: Decodable {}
-        let env: CFEnvelope<Empty>
+        let env: CFEnvelope<CFEmpty>
         do {
-            env = try JSONDecoder().decode(CFEnvelope<Empty>.self, from: data)
+            env = try JSONDecoder().decode(CFEnvelope<CFEmpty>.self, from: data)
         } catch {
             throw CloudflareError.malformedResponse
         }

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -33,6 +33,20 @@ private struct CFDNSRecord: Decodable, Sendable {
     let name: String
     let content: String
 }
+private struct CFBotManagement: Decodable, Sendable {
+    let fight_mode: Bool?
+    let enable_js: Bool?
+}
+private struct CFRuleset: Decodable, Sendable {
+    let id: String
+    let phase: String?
+    let rules: [CFRulesetRule]?
+}
+private struct CFRulesetRule: Decodable, Sendable {
+    let description: String?
+    let expression: String
+    let action: String
+}
 
 /// Read-only Cloudflare v4 client. All methods are GETs.
 public struct HTTPCloudflareClient: CloudflareReading {
@@ -84,6 +98,16 @@ public struct HTTPCloudflareClient: CloudflareReading {
         let header = try await get("/zones/\(zoneID)/settings/security_header", apiToken: apiToken, as: CFSecurityHeader.self)
         let records = try await get("/zones/\(zoneID)/dns_records?per_page=100", apiToken: apiToken, as: [CFDNSRecord].self)
 
+        let botFight: Bool
+        do {
+            let bot = try await get("/zones/\(zoneID)/settings/bot_management", apiToken: apiToken, as: CFBotManagement.self)
+            botFight = bot.fight_mode ?? false
+        } catch {
+            botFight = false
+        }
+
+        let wafRules = await fetchWAFCustomRules(zoneID: zoneID, apiToken: apiToken)
+
         let sts = header.value.strict_transport_security
         let hsts: CloudflareZoneState.HSTS? = sts.enabled
             ? .init(maxAge: sts.max_age ?? 0, includeSubdomains: sts.include_subdomains ?? false, preload: sts.preload ?? false)
@@ -104,6 +128,128 @@ public struct HTTPCloudflareClient: CloudflareReading {
             caaRecords: contents(ofType: "CAA"),
             mxRecords: contents(ofType: "MX"),
             spfRecords: spf,
-            dmarcRecords: dmarc)
+            dmarcRecords: dmarc,
+            botFightMode: botFight,
+            wafCustomRules: wafRules)
+    }
+
+    private func fetchWAFCustomRules(zoneID: String, apiToken: String) async -> [CloudflareZoneState.WAFCustomRule] {
+        do {
+            let rulesets = try await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self)
+            guard let custom = rulesets.first(where: { $0.phase == "http_request_firewall_custom" }) else {
+                return []
+            }
+            let full = try await get("/zones/\(zoneID)/rulesets/\(custom.id)", apiToken: apiToken, as: CFRuleset.self)
+            return (full.rules ?? []).map {
+                .init(description: $0.description ?? "", expression: $0.expression, action: $0.action)
+            }
+        } catch {
+            return []
+        }
+    }
+
+    // MARK: - Write helpers
+
+    private func mutate<Body: Encodable & Sendable>(
+        method: String,
+        _ path: String,
+        body: Body,
+        apiToken: String
+    ) async throws {
+        guard let url = URL(string: Self.base + path) else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+        let (data, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        struct Empty: Decodable {}
+        let env: CFEnvelope<Empty>
+        do {
+            env = try JSONDecoder().decode(CFEnvelope<Empty>.self, from: data)
+        } catch {
+            throw CloudflareError.malformedResponse
+        }
+        if !env.success {
+            throw CloudflareError.api(message: env.errors?.first?.message ?? "request failed")
+        }
+    }
+}
+
+// MARK: - CloudflareWriting conformance
+
+extension HTTPCloudflareClient: CloudflareWriting {
+    public func enableDNSSEC(zoneID: String, apiToken: String) async throws {
+        try await mutate(method: "PUT", "/zones/\(zoneID)/dnssec",
+                         body: ["status": "active"], apiToken: apiToken)
+    }
+
+    public func setAlwaysUseHTTPS(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try await mutate(method: "PUT", "/zones/\(zoneID)/settings/always_use_https",
+                         body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
+    }
+
+    public func setHSTS(zoneID: String, maxAge: Int, includeSubdomains: Bool, preload: Bool,
+                         apiToken: String) async throws {
+        struct HSTSBody: Encodable, Sendable {
+            struct Value: Encodable, Sendable {
+                struct STS: Encodable, Sendable {
+                    let enabled: Bool
+                    let max_age: Int
+                    let include_subdomains: Bool
+                    let preload: Bool
+                }
+                let strict_transport_security: STS
+            }
+            let value: Value
+        }
+        let body = HSTSBody(value: .init(strict_transport_security: .init(
+            enabled: true, max_age: maxAge, include_subdomains: includeSubdomains, preload: preload)))
+        try await mutate(method: "PUT", "/zones/\(zoneID)/settings/security_header",
+                         body: body, apiToken: apiToken)
+    }
+
+    public func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws {
+        try await mutate(method: "POST", "/zones/\(zoneID)/dns_records",
+                         body: record, apiToken: apiToken)
+    }
+
+    public func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try await mutate(method: "PUT", "/zones/\(zoneID)/settings/bot_management",
+                         body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
+    }
+
+    public func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws {
+        let rulesets = try await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self)
+        let existing = rulesets.first(where: { $0.phase == "http_request_firewall_custom" })
+
+        struct RuleBody: Encodable, Sendable {
+            let description: String
+            let expression: String
+            let action: String
+        }
+        let ruleBody = RuleBody(description: rule.description, expression: rule.expression, action: rule.action)
+
+        if let rs = existing {
+            struct RulesAppend: Encodable, Sendable {
+                let rules: [RuleBody]
+            }
+            try await mutate(method: "POST", "/zones/\(zoneID)/rulesets/\(rs.id)/rules",
+                             body: ruleBody, apiToken: apiToken)
+        } else {
+            struct NewRuleset: Encodable, Sendable {
+                let name: String
+                let kind: String
+                let phase: String
+                let rules: [RuleBody]
+            }
+            try await mutate(method: "POST", "/zones/\(zoneID)/rulesets",
+                             body: NewRuleset(name: "Anglesite security rules",
+                                              kind: "zone", phase: "http_request_firewall_custom",
+                                              rules: [ruleBody]),
+                             apiToken: apiToken)
+        }
     }
 }

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -109,7 +109,7 @@ public struct HTTPCloudflareClient: CloudflareReading {
             botFight = false
         }
 
-        let wafRules = await fetchWAFCustomRules(zoneID: zoneID, apiToken: apiToken)
+        let wafRules = try await fetchWAFCustomRules(zoneID: zoneID, apiToken: apiToken)
 
         let sts = header.value.strict_transport_security
         let hsts: CloudflareZoneState.HSTS? = sts.enabled
@@ -136,18 +136,14 @@ public struct HTTPCloudflareClient: CloudflareReading {
             wafCustomRules: wafRules)
     }
 
-    private func fetchWAFCustomRules(zoneID: String, apiToken: String) async -> [CloudflareZoneState.WAFCustomRule] {
-        do {
-            let rulesets = try await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self)
-            guard let custom = rulesets.first(where: { $0.phase == "http_request_firewall_custom" }) else {
-                return []
-            }
-            let full = try await get("/zones/\(zoneID)/rulesets/\(custom.id)", apiToken: apiToken, as: CFRuleset.self)
-            return (full.rules ?? []).map {
-                .init(description: $0.description ?? "", expression: $0.expression, action: $0.action)
-            }
-        } catch {
+    private func fetchWAFCustomRules(zoneID: String, apiToken: String) async throws -> [CloudflareZoneState.WAFCustomRule] {
+        let rulesets = try await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self)
+        guard let custom = rulesets.first(where: { $0.phase == "http_request_firewall_custom" }) else {
             return []
+        }
+        let full = try await get("/zones/\(zoneID)/rulesets/\(custom.id)", apiToken: apiToken, as: CFRuleset.self)
+        return (full.rules ?? []).map {
+            .init(description: $0.description ?? "", expression: $0.expression, action: $0.action)
         }
     }
 
@@ -219,38 +215,28 @@ extension HTTPCloudflareClient: CloudflareWriting {
     }
 
     public func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws {
-        try await mutate(method: "PUT", "/zones/\(zoneID)/settings/bot_management",
-                         body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
+        try await mutate(method: "PATCH", "/zones/\(zoneID)/bot_management",
+                         body: ["fight_mode": enabled], apiToken: apiToken)
     }
 
     public func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws {
         let rulesets = try await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self)
         let existing = rulesets.first(where: { $0.phase == "http_request_firewall_custom" })
 
-        struct RuleBody: Encodable, Sendable {
-            let description: String
-            let expression: String
-            let action: String
-        }
-        let ruleBody = RuleBody(description: rule.description, expression: rule.expression, action: rule.action)
-
         if let rs = existing {
-            struct RulesAppend: Encodable, Sendable {
-                let rules: [RuleBody]
-            }
             try await mutate(method: "POST", "/zones/\(zoneID)/rulesets/\(rs.id)/rules",
-                             body: ruleBody, apiToken: apiToken)
+                             body: rule, apiToken: apiToken)
         } else {
             struct NewRuleset: Encodable, Sendable {
                 let name: String
                 let kind: String
                 let phase: String
-                let rules: [RuleBody]
+                let rules: [WAFRulePayload]
             }
             try await mutate(method: "POST", "/zones/\(zoneID)/rulesets",
                              body: NewRuleset(name: "Anglesite security rules",
                                               kind: "zone", phase: "http_request_firewall_custom",
-                                              rules: [ruleBody]),
+                                              rules: [rule]),
                              apiToken: apiToken)
         }
     }

--- a/Sources/AnglesiteCore/HardenExecutor.swift
+++ b/Sources/AnglesiteCore/HardenExecutor.swift
@@ -1,0 +1,105 @@
+/// Applies a `HardenPlan` via the Cloudflare write API, then re-reads state and re-audits.
+/// Per-item failures do not abort the remaining items.
+public struct HardenExecutor: Sendable {
+    private let reader: any CloudflareReading
+    private let writer: any CloudflareWriting
+
+    public init(reader: any CloudflareReading, writer: any CloudflareWriting) {
+        self.reader = reader
+        self.writer = writer
+    }
+
+    public struct ItemFailure: Sendable {
+        public let item: HardenPlanItem
+        public let error: String
+        public init(item: HardenPlanItem, error: String) {
+            self.item = item
+            self.error = error
+        }
+    }
+
+    public struct Result: Sendable {
+        public let appliedCount: Int
+        public let failedItems: [ItemFailure]
+        public let postAuditFindings: [AuditReport.Finding]
+
+        public init(appliedCount: Int, failedItems: [ItemFailure],
+                    postAuditFindings: [AuditReport.Finding]) {
+            self.appliedCount = appliedCount
+            self.failedItems = failedItems
+            self.postAuditFindings = postAuditFindings
+        }
+    }
+
+    public func execute(
+        plan: HardenPlan,
+        zoneID: String,
+        domain: String,
+        apiToken: String,
+        expectsMail: Bool
+    ) async -> Result {
+        var applied = 0
+        var failures: [ItemFailure] = []
+
+        for item in plan.items {
+            do {
+                try await apply(item, zoneID: zoneID, domain: domain, apiToken: apiToken)
+                applied += 1
+            } catch {
+                failures.append(.init(item: item, error: "\(error)"))
+            }
+        }
+
+        let findings: [AuditReport.Finding]
+        do {
+            let freshState = try await reader.zoneState(zoneID: zoneID, apiToken: apiToken)
+            findings = SecurityAudit.evaluate(freshState, expectsMail: expectsMail)
+        } catch {
+            findings = []
+        }
+
+        return Result(appliedCount: applied, failedItems: failures, postAuditFindings: findings)
+    }
+
+    private func apply(_ item: HardenPlanItem, zoneID: String, domain: String,
+                        apiToken: String) async throws {
+        switch item {
+        case .enableDNSSEC:
+            try await writer.enableDNSSEC(zoneID: zoneID, apiToken: apiToken)
+        case .addCAARecord(let ca):
+            try await writer.addDNSRecord(
+                zoneID: zoneID,
+                record: DNSRecordPayload(type: "CAA", name: domain,
+                                         content: "0 issue \"\(ca)\""),
+                apiToken: apiToken)
+        case .enableAlwaysUseHTTPS:
+            try await writer.setAlwaysUseHTTPS(zoneID: zoneID, enabled: true, apiToken: apiToken)
+        case .enableHSTS(let maxAge, let subs, let preload):
+            try await writer.setHSTS(zoneID: zoneID, maxAge: maxAge, includeSubdomains: subs,
+                                     preload: preload, apiToken: apiToken)
+        case .enableBotFightMode:
+            try await writer.setBotFightMode(zoneID: zoneID, enabled: true, apiToken: apiToken)
+        case .addNullMX:
+            try await writer.addDNSRecord(
+                zoneID: zoneID,
+                record: DNSRecordPayload(type: "MX", name: domain, content: "0 ."),
+                apiToken: apiToken)
+        case .addSPFRejectAll:
+            try await writer.addDNSRecord(
+                zoneID: zoneID,
+                record: DNSRecordPayload(type: "TXT", name: domain, content: "v=spf1 -all"),
+                apiToken: apiToken)
+        case .addDMARCReject:
+            try await writer.addDNSRecord(
+                zoneID: zoneID,
+                record: DNSRecordPayload(type: "TXT", name: "_dmarc.\(domain)",
+                                         content: "v=DMARC1; p=reject"),
+                apiToken: apiToken)
+        case .addWAFRule(let desc, let expr, let action):
+            try await writer.createWAFCustomRule(
+                zoneID: zoneID,
+                rule: WAFRulePayload(description: desc, expression: expr, action: action),
+                apiToken: apiToken)
+        }
+    }
+}

--- a/Sources/AnglesiteCore/HardenExecutor.swift
+++ b/Sources/AnglesiteCore/HardenExecutor.swift
@@ -22,12 +22,14 @@ public struct HardenExecutor: Sendable {
         public let appliedCount: Int
         public let failedItems: [ItemFailure]
         public let postAuditFindings: [AuditReport.Finding]
+        public let auditError: String?
 
         public init(appliedCount: Int, failedItems: [ItemFailure],
-                    postAuditFindings: [AuditReport.Finding]) {
+                    postAuditFindings: [AuditReport.Finding], auditError: String? = nil) {
             self.appliedCount = appliedCount
             self.failedItems = failedItems
             self.postAuditFindings = postAuditFindings
+            self.auditError = auditError
         }
     }
 
@@ -35,8 +37,7 @@ public struct HardenExecutor: Sendable {
         plan: HardenPlan,
         zoneID: String,
         domain: String,
-        apiToken: String,
-        expectsMail: Bool
+        apiToken: String
     ) async -> Result {
         var applied = 0
         var failures: [ItemFailure] = []
@@ -51,14 +52,19 @@ public struct HardenExecutor: Sendable {
         }
 
         let findings: [AuditReport.Finding]
+        var auditErr: String?
         do {
             let freshState = try await reader.zoneState(zoneID: zoneID, apiToken: apiToken)
+            let expectsMail = !freshState.mxRecords.isEmpty
+                && !freshState.mxRecords.allSatisfy({ $0.trimmingCharacters(in: .whitespaces) == "." || $0.hasPrefix("0 .") })
             findings = SecurityAudit.evaluate(freshState, expectsMail: expectsMail)
         } catch {
             findings = []
+            auditErr = "\(error)"
         }
 
-        return Result(appliedCount: applied, failedItems: failures, postAuditFindings: findings)
+        return Result(appliedCount: applied, failedItems: failures,
+                      postAuditFindings: findings, auditError: auditErr)
     }
 
     private func apply(_ item: HardenPlanItem, zoneID: String, domain: String,
@@ -82,7 +88,7 @@ public struct HardenExecutor: Sendable {
         case .addNullMX:
             try await writer.addDNSRecord(
                 zoneID: zoneID,
-                record: DNSRecordPayload(type: "MX", name: domain, content: "0 ."),
+                record: DNSRecordPayload(type: "MX", name: domain, content: ".", priority: 0),
                 apiToken: apiToken)
         case .addSPFRejectAll:
             try await writer.addDNSRecord(

--- a/Sources/AnglesiteCore/HardenPlan.swift
+++ b/Sources/AnglesiteCore/HardenPlan.swift
@@ -1,0 +1,53 @@
+/// A computed set of Cloudflare hardening changes, ready for preview and opt-in application.
+public struct HardenPlan: Sendable, Equatable {
+    public let items: [HardenPlanItem]
+    public var isEmpty: Bool { items.isEmpty }
+
+    public init(items: [HardenPlanItem]) {
+        self.items = items
+    }
+
+    public var summary: String {
+        if items.isEmpty { return "Zone is fully hardened. No changes needed." }
+        return items.map(\.description).joined(separator: "\n")
+    }
+}
+
+/// A single hardening change to apply to a Cloudflare zone.
+public enum HardenPlanItem: Sendable, Equatable, CustomStringConvertible {
+    case enableDNSSEC
+    case addCAARecord(ca: String)
+    case enableAlwaysUseHTTPS
+    case enableHSTS(maxAge: Int, includeSubdomains: Bool, preload: Bool)
+    case enableBotFightMode
+    case addNullMX
+    case addSPFRejectAll
+    case addDMARCReject
+    case addWAFRule(description: String, expression: String, action: String)
+
+    public var description: String {
+        switch self {
+        case .enableDNSSEC:
+            return "+ Enable DNSSEC"
+        case .addCAARecord(let ca):
+            return "+ Add CAA record: 0 issue \"\(ca)\""
+        case .enableAlwaysUseHTTPS:
+            return "+ Enable Always Use HTTPS"
+        case .enableHSTS(let maxAge, let subs, let preload):
+            var parts = "max-age=\(maxAge)"
+            if subs { parts += "; includeSubDomains" }
+            if preload { parts += "; preload" }
+            return "+ Enable HSTS (\(parts))"
+        case .enableBotFightMode:
+            return "+ Enable Bot Fight Mode"
+        case .addNullMX:
+            return "+ Add null MX record (0 .)"
+        case .addSPFRejectAll:
+            return "+ Add SPF record: v=spf1 -all"
+        case .addDMARCReject:
+            return "+ Add DMARC record: v=DMARC1; p=reject"
+        case .addWAFRule(let desc, _, let action):
+            return "+ Add WAF rule [\(action)]: \(desc)"
+        }
+    }
+}

--- a/Sources/AnglesiteCore/HardenPlanner.swift
+++ b/Sources/AnglesiteCore/HardenPlanner.swift
@@ -1,0 +1,97 @@
+/// Pure planner: computes what needs hardening given a zone's current state. No I/O.
+public enum HardenPlanner {
+    /// The three CAs that Cloudflare's free plan can rotate between for certificate issuance.
+    /// Pinning a single CA breaks renewal silently on the next rotation.
+    public static let freePlanCAs = ["letsencrypt.org", "digicert.com", "pki.goog"]
+
+    /// The curated WAF rule templates. Up to 5 rules on the free plan.
+    public static let curatedWAFRules: [(description: String, expression: String, action: String)] = [
+        (
+            "Block dotfile paths (except .well-known)",
+            """
+            (http.request.uri.path contains "/.") and \
+            not starts_with(http.request.uri.path, "/.well-known/")
+            """,
+            "block"
+        ),
+        (
+            "Block .env and .git access",
+            """
+            (http.request.uri.path contains "/.env") or \
+            (http.request.uri.path contains "/.git")
+            """,
+            "block"
+        ),
+        (
+            "Block path traversal attempts",
+            "(http.request.uri.path contains \"..\")",
+            "block"
+        ),
+        (
+            "Block common SQL injection patterns",
+            """
+            (http.request.uri.query contains "UNION SELECT") or \
+            (http.request.uri.query contains "OR 1=1") or \
+            (http.request.uri.query contains "'; DROP")
+            """,
+            "managed_challenge"
+        ),
+        (
+            "Block XSS patterns in query strings",
+            """
+            (http.request.uri.query contains "<script") or \
+            (http.request.uri.query contains "javascript:") or \
+            (http.request.uri.query contains "onerror=")
+            """,
+            "managed_challenge"
+        ),
+    ]
+
+    public static func plan(from state: CloudflareZoneState, domain: String) -> HardenPlan {
+        var items: [HardenPlanItem] = []
+
+        if !state.dnssecActive {
+            items.append(.enableDNSSEC)
+        }
+
+        for ca in freePlanCAs {
+            let alreadyAuthorized = state.caaRecords.contains { $0.lowercased().contains(ca.lowercased()) }
+            if !alreadyAuthorized {
+                items.append(.addCAARecord(ca: ca))
+            }
+        }
+
+        if !state.alwaysUseHTTPS {
+            items.append(.enableAlwaysUseHTTPS)
+        }
+
+        if state.hsts == nil || (state.hsts?.maxAge ?? 0) < 31_536_000 {
+            items.append(.enableHSTS(maxAge: 31_536_000, includeSubdomains: true, preload: false))
+        }
+
+        if !state.botFightMode {
+            items.append(.enableBotFightMode)
+        }
+
+        // Email hardening only for domains that don't send mail.
+        if state.mxRecords.isEmpty {
+            items.append(.addNullMX)
+            if !state.spfRecords.contains(where: { $0.lowercased().contains("-all") }) {
+                items.append(.addSPFRejectAll)
+            }
+            if !state.dmarcRecords.contains(where: { $0.lowercased().contains("p=reject") }) {
+                items.append(.addDMARCReject)
+            }
+        }
+
+        let existingDescriptions = Set(state.wafCustomRules.map { $0.description.lowercased() })
+        for rule in curatedWAFRules {
+            if !existingDescriptions.contains(rule.description.lowercased()) {
+                items.append(.addWAFRule(description: rule.description,
+                                        expression: rule.expression, action: rule.action))
+            }
+        }
+
+        return HardenPlan(items: items)
+    }
+}

--- a/Sources/AnglesiteCore/HardenPlanner.swift
+++ b/Sources/AnglesiteCore/HardenPlanner.swift
@@ -24,7 +24,7 @@ public enum HardenPlanner {
         ),
         (
             "Block path traversal attempts",
-            "(http.request.uri.path contains \"..\")",
+            "(http.request.uri.path contains \"/..\")",
             "block"
         ),
         (
@@ -34,7 +34,7 @@ public enum HardenPlanner {
             (http.request.uri.query contains "OR 1=1") or \
             (http.request.uri.query contains "'; DROP")
             """,
-            "managed_challenge"
+            "block"
         ),
         (
             "Block XSS patterns in query strings",
@@ -43,7 +43,7 @@ public enum HardenPlanner {
             (http.request.uri.query contains "javascript:") or \
             (http.request.uri.query contains "onerror=")
             """,
-            "managed_challenge"
+            "block"
         ),
     ]
 
@@ -76,10 +76,13 @@ public enum HardenPlanner {
         // Email hardening only for domains that don't send mail.
         if state.mxRecords.isEmpty {
             items.append(.addNullMX)
-            if !state.spfRecords.contains(where: { $0.lowercased().contains("-all") }) {
+            if state.spfRecords.isEmpty || !state.spfRecords.contains(where: { $0.lowercased().hasSuffix(" -all") }) {
                 items.append(.addSPFRejectAll)
             }
-            if !state.dmarcRecords.contains(where: { $0.lowercased().contains("p=reject") }) {
+            let hasDMARCReject = state.dmarcRecords.contains { record in
+                dmarcHasPolicy(record, policy: "reject")
+            }
+            if !hasDMARCReject {
                 items.append(.addDMARCReject)
             }
         }
@@ -94,4 +97,21 @@ public enum HardenPlanner {
 
         return HardenPlan(items: items)
     }
+}
+
+/// Checks whether a DMARC record contains `p=<policy>` (not `sp=<policy>`).
+func dmarcHasPolicy(_ record: String, policy: String) -> Bool {
+    let lower = record.lowercased()
+    let target = policy.lowercased()
+    var search = lower.startIndex
+    while let range = lower.range(of: "p=", range: search..<lower.endIndex) {
+        if range.lowerBound == lower.startIndex
+            || lower[lower.index(before: range.lowerBound)] == ";"
+            || lower[lower.index(before: range.lowerBound)] == " " {
+            let value = lower[range.upperBound...]
+            if value.hasPrefix(target) { return true }
+        }
+        search = range.upperBound
+    }
+    return false
 }

--- a/Sources/AnglesiteCore/SecurityAudit.swift
+++ b/Sources/AnglesiteCore/SecurityAudit.swift
@@ -44,12 +44,12 @@ public enum SecurityAudit {
                 "Add CAA records authorizing only your CA(s) to limit mis-issuance.")
         }
         if !expectsMail {
-            if !state.spfRecords.contains(where: { $0.lowercased().contains("-all") }) {
+            if state.spfRecords.isEmpty || !state.spfRecords.contains(where: { $0.lowercased().hasSuffix(" -all") }) {
                 add(.warning, "No strict SPF record",
                     "A domain that does not send mail should publish SPF \"v=spf1 -all\" to block spoofing.",
                     "Publish a TXT record: v=spf1 -all")
             }
-            if !state.dmarcRecords.contains(where: { $0.lowercased().contains("p=reject") }) {
+            if !state.dmarcRecords.contains(where: { dmarcHasPolicy($0, policy: "reject") }) {
                 add(.warning, "No DMARC reject policy",
                     "Without DMARC p=reject, spoofed mail claiming to be from this domain is not blocked.",
                     "Publish _dmarc TXT: v=DMARC1; p=reject")

--- a/Sources/AnglesiteCore/SecurityAudit.swift
+++ b/Sources/AnglesiteCore/SecurityAudit.swift
@@ -33,6 +33,11 @@ public enum SecurityAudit {
                 "An HSTS max-age under one year weakens downgrade protection.",
                 "Raise HSTS max-age to at least 31536000 (one year).")
         }
+        if !state.botFightMode {
+            add(.info, "Bot Fight Mode is off",
+                "Without Bot Fight Mode, automated threats are not challenged at the edge.",
+                "Enable Bot Fight Mode to challenge bots before they reach the site.")
+        }
         if state.caaRecords.isEmpty {
             add(.info, "No CAA records",
                 "Any certificate authority can issue certificates for this domain.",

--- a/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
@@ -138,7 +138,7 @@ func zoneStateAssembles() async throws {
     #expect(s.wafCustomRules.first?.description == "Block dotfiles")
 }
 
-@Test("HSTS disabled yields nil hsts; bot/WAF gracefully default on error")
+@Test("HSTS disabled yields nil hsts; bot fight mode gracefully defaults on error")
 func zoneStateHSTSDisabled() async throws {
     let env = { (r: String) in "{\"success\":true,\"errors\":[],\"messages\":[],\"result\":\(r)}" }
     let routes: [String: (Int, String)] = [
@@ -147,6 +147,7 @@ func zoneStateHSTSDisabled() async throws {
         "/settings/always_use_https": (200, env("{\"id\":\"always_use_https\",\"value\":\"off\"}")),
         "/settings/security_header": (200, env("{\"id\":\"security_header\",\"value\":{\"strict_transport_security\":{\"enabled\":false}}}")),
         "/dns_records": (200, env("[]")),
+        "/rulesets": (200, env("[]")),
     ]
     let client = HTTPCloudflareClient(transport: fakeTransport(routes))
     let s = try await client.zoneState(zoneID: "z", apiToken: "t")

--- a/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
@@ -16,10 +16,12 @@ struct CloudflareClientTests {
 }
 
 /// A fake transport that routes by URL substring to canned (Data, HTTPURLResponse).
+/// Routes are matched longest-needle-first so more specific paths win over prefixes.
 func fakeTransport(_ routes: [String: (Int, String)]) -> CloudflareTransport {
+    let sorted = routes.sorted { $0.key.count > $1.key.count }
     return { request in
         let url = request.url!.absoluteString
-        for (needle, pair) in routes where url.contains(needle) {
+        for (needle, pair) in sorted where url.contains(needle) {
             let resp = HTTPURLResponse(url: request.url!, statusCode: pair.0,
                                        httpVersion: nil, headerFields: nil)!
             return (Data(pair.1.utf8), resp)
@@ -48,11 +50,13 @@ final class TransportSpy: @unchecked Sendable {
 }
 
 /// A method-aware fake transport with optional spy for capturing requests.
+/// Routes are matched longest-needle-first so more specific paths win over prefixes.
 func spyTransport(_ routes: [String: (Int, String)], spy: TransportSpy? = nil) -> CloudflareTransport {
+    let sorted = routes.sorted { $0.key.count > $1.key.count }
     return { request in
         spy?.record(request)
         let url = request.url!.absoluteString
-        for (needle, pair) in routes where url.contains(needle) {
+        for (needle, pair) in sorted where url.contains(needle) {
             let resp = HTTPURLResponse(url: request.url!, statusCode: pair.0,
                                        httpVersion: nil, headerFields: nil)!
             return (Data(pair.1.utf8), resp)
@@ -116,7 +120,8 @@ func zoneStateAssembles() async throws {
         "/settings/security_header": (200, env("{\"id\":\"security_header\",\"value\":{\"strict_transport_security\":{\"enabled\":true,\"max_age\":31536000,\"include_subdomains\":true,\"preload\":false}}}")),
         "/dns_records": (200, env("[{\"type\":\"CAA\",\"name\":\"example.com\",\"content\":\"0 issue \\\"letsencrypt.org\\\"\"},{\"type\":\"TXT\",\"name\":\"example.com\",\"content\":\"v=spf1 -all\"},{\"type\":\"TXT\",\"name\":\"_dmarc.example.com\",\"content\":\"v=DMARC1; p=reject\"}]")),
         "/settings/bot_management": (200, env("{\"fight_mode\":true}")),
-        "/rulesets": (200, env("[{\"id\":\"rs1\",\"phase\":\"http_request_firewall_custom\",\"rules\":[{\"description\":\"Block dotfiles\",\"expression\":\"(x)\",\"action\":\"block\"}]}]")),
+        "/rulesets/rs1": (200, env("{\"id\":\"rs1\",\"phase\":\"http_request_firewall_custom\",\"rules\":[{\"description\":\"Block dotfiles\",\"expression\":\"(x)\",\"action\":\"block\"}]}")),
+        "/rulesets": (200, env("[{\"id\":\"rs1\",\"phase\":\"http_request_firewall_custom\"}]")),
     ]
     let client = HTTPCloudflareClient(transport: fakeTransport(routes))
     let s = try await client.zoneState(zoneID: "z", apiToken: "t")

--- a/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
@@ -29,6 +29,39 @@ func fakeTransport(_ routes: [String: (Int, String)]) -> CloudflareTransport {
     }
 }
 
+/// Thread-safe spy that records requests for write-method assertions.
+final class TransportSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _requests: [URLRequest] = []
+
+    var requests: [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _requests
+    }
+
+    func record(_ request: URLRequest) {
+        lock.lock()
+        defer { lock.unlock() }
+        _requests.append(request)
+    }
+}
+
+/// A method-aware fake transport with optional spy for capturing requests.
+func spyTransport(_ routes: [String: (Int, String)], spy: TransportSpy? = nil) -> CloudflareTransport {
+    return { request in
+        spy?.record(request)
+        let url = request.url!.absoluteString
+        for (needle, pair) in routes where url.contains(needle) {
+            let resp = HTTPURLResponse(url: request.url!, statusCode: pair.0,
+                                       httpVersion: nil, headerFields: nil)!
+            return (Data(pair.1.utf8), resp)
+        }
+        let resp = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (Data("{\"success\":true,\"errors\":[],\"result\":{}}".utf8), resp)
+    }
+}
+
 @Test("resolveZoneID returns the id of the matching active zone")
 func resolveZoneIDFound() async throws {
     let json = """
@@ -73,7 +106,7 @@ func unauthorizedMaps() async {
     }
 }
 
-@Test("zoneState assembles DNSSEC, settings, and DNS records")
+@Test("zoneState assembles DNSSEC, settings, DNS records, bot mode, and WAF rules")
 func zoneStateAssembles() async throws {
     let env = { (r: String) in "{\"success\":true,\"errors\":[],\"messages\":[],\"result\":\(r)}" }
     let routes: [String: (Int, String)] = [
@@ -82,6 +115,8 @@ func zoneStateAssembles() async throws {
         "/settings/always_use_https": (200, env("{\"id\":\"always_use_https\",\"value\":\"on\"}")),
         "/settings/security_header": (200, env("{\"id\":\"security_header\",\"value\":{\"strict_transport_security\":{\"enabled\":true,\"max_age\":31536000,\"include_subdomains\":true,\"preload\":false}}}")),
         "/dns_records": (200, env("[{\"type\":\"CAA\",\"name\":\"example.com\",\"content\":\"0 issue \\\"letsencrypt.org\\\"\"},{\"type\":\"TXT\",\"name\":\"example.com\",\"content\":\"v=spf1 -all\"},{\"type\":\"TXT\",\"name\":\"_dmarc.example.com\",\"content\":\"v=DMARC1; p=reject\"}]")),
+        "/settings/bot_management": (200, env("{\"fight_mode\":true}")),
+        "/rulesets": (200, env("[{\"id\":\"rs1\",\"phase\":\"http_request_firewall_custom\",\"rules\":[{\"description\":\"Block dotfiles\",\"expression\":\"(x)\",\"action\":\"block\"}]}]")),
     ]
     let client = HTTPCloudflareClient(transport: fakeTransport(routes))
     let s = try await client.zoneState(zoneID: "z", apiToken: "t")
@@ -93,9 +128,12 @@ func zoneStateAssembles() async throws {
     #expect(s.spfRecords == ["v=spf1 -all"])
     #expect(s.dmarcRecords == ["v=DMARC1; p=reject"])
     #expect(s.mxRecords.isEmpty)
+    #expect(s.botFightMode)
+    #expect(s.wafCustomRules.count == 1)
+    #expect(s.wafCustomRules.first?.description == "Block dotfiles")
 }
 
-@Test("HSTS disabled yields nil hsts")
+@Test("HSTS disabled yields nil hsts; bot/WAF gracefully default on error")
 func zoneStateHSTSDisabled() async throws {
     let env = { (r: String) in "{\"success\":true,\"errors\":[],\"messages\":[],\"result\":\(r)}" }
     let routes: [String: (Int, String)] = [
@@ -110,4 +148,6 @@ func zoneStateHSTSDisabled() async throws {
     #expect(!s.dnssecActive)
     #expect(s.hsts == nil)
     #expect(s.caaRecords.isEmpty)
+    #expect(!s.botFightMode)
+    #expect(s.wafCustomRules.isEmpty)
 }

--- a/Tests/AnglesiteCoreTests/CloudflareWritingTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareWritingTests.swift
@@ -57,14 +57,17 @@ struct CloudflareWritingTests {
         #expect(body["content"] as? String == "v=spf1 -all")
     }
 
-    @Test("setBotFightMode sends PUT to bot_management")
+    @Test("setBotFightMode sends PATCH to /bot_management with fight_mode")
     func setBotFightMode() async throws {
         let spy = TransportSpy()
         let client = HTTPCloudflareClient(transport: spyTransport([:], spy: spy))
         try await client.setBotFightMode(zoneID: zoneID, enabled: true, apiToken: token)
         let req = try #require(spy.requests.first)
-        #expect(req.httpMethod == "PUT")
-        #expect(req.url?.path.contains("/settings/bot_management") == true)
+        #expect(req.httpMethod == "PATCH")
+        #expect(req.url?.path.contains("/bot_management") == true)
+        #expect(req.url?.path.contains("/settings/") == false)
+        let body = try #require(req.httpBody.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        #expect(body["fight_mode"] as? Bool == true)
     }
 
     @Test("createWAFCustomRule sends POST to rulesets endpoint")

--- a/Tests/AnglesiteCoreTests/CloudflareWritingTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareWritingTests.swift
@@ -1,0 +1,99 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct CloudflareWritingTests {
+    private let zoneID = "zone123"
+    private let token = "test-token"
+
+    @Test("enableDNSSEC sends PUT to /zones/{id}/dnssec")
+    func enableDNSSEC() async throws {
+        let spy = TransportSpy()
+        let client = HTTPCloudflareClient(transport: spyTransport([:], spy: spy))
+        try await client.enableDNSSEC(zoneID: zoneID, apiToken: token)
+        let req = try #require(spy.requests.first)
+        #expect(req.httpMethod == "PUT")
+        #expect(req.url?.path.contains("/dnssec") == true)
+        let body = try #require(req.httpBody.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        #expect(body["status"] as? String == "active")
+    }
+
+    @Test("setAlwaysUseHTTPS sends PUT with correct value")
+    func setAlwaysUseHTTPS() async throws {
+        let spy = TransportSpy()
+        let client = HTTPCloudflareClient(transport: spyTransport([:], spy: spy))
+        try await client.setAlwaysUseHTTPS(zoneID: zoneID, enabled: true, apiToken: token)
+        let req = try #require(spy.requests.first)
+        #expect(req.httpMethod == "PUT" || req.httpMethod == "PATCH")
+        #expect(req.url?.path.contains("/settings/always_use_https") == true)
+        let body = try #require(req.httpBody.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        #expect(body["value"] as? String == "on")
+    }
+
+    @Test("setHSTS sends PUT with nested STS object")
+    func setHSTS() async throws {
+        let spy = TransportSpy()
+        let client = HTTPCloudflareClient(transport: spyTransport([:], spy: spy))
+        try await client.setHSTS(zoneID: zoneID, maxAge: 31_536_000,
+                                  includeSubdomains: true, preload: false, apiToken: token)
+        let req = try #require(spy.requests.first)
+        #expect(req.httpMethod == "PUT" || req.httpMethod == "PATCH")
+        #expect(req.url?.path.contains("/settings/security_header") == true)
+        #expect(req.httpBody != nil)
+    }
+
+    @Test("addDNSRecord sends POST with correct type/name/content")
+    func addDNSRecord() async throws {
+        let spy = TransportSpy()
+        let client = HTTPCloudflareClient(transport: spyTransport([:], spy: spy))
+        let payload = DNSRecordPayload(type: "TXT", name: "example.com", content: "v=spf1 -all")
+        try await client.addDNSRecord(zoneID: zoneID, record: payload, apiToken: token)
+        let req = try #require(spy.requests.first)
+        #expect(req.httpMethod == "POST")
+        #expect(req.url?.path.contains("/dns_records") == true)
+        let body = try #require(req.httpBody.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        #expect(body["type"] as? String == "TXT")
+        #expect(body["name"] as? String == "example.com")
+        #expect(body["content"] as? String == "v=spf1 -all")
+    }
+
+    @Test("setBotFightMode sends PUT to bot_management")
+    func setBotFightMode() async throws {
+        let spy = TransportSpy()
+        let client = HTTPCloudflareClient(transport: spyTransport([:], spy: spy))
+        try await client.setBotFightMode(zoneID: zoneID, enabled: true, apiToken: token)
+        let req = try #require(spy.requests.first)
+        #expect(req.httpMethod == "PUT")
+        #expect(req.url?.path.contains("/settings/bot_management") == true)
+    }
+
+    @Test("createWAFCustomRule sends POST to rulesets endpoint")
+    func createWAFCustomRule() async throws {
+        let spy = TransportSpy()
+        let rulesetJSON = """
+        {"success":true,"errors":[],"messages":[],"result":[{"id":"rs1","phase":"http_request_firewall_custom"}]}
+        """
+        let client = HTTPCloudflareClient(transport: spyTransport(["/rulesets": (200, rulesetJSON)], spy: spy))
+        let rule = WAFRulePayload(description: "Block dotfiles", expression: "(x)", action: "block")
+        try await client.createWAFCustomRule(zoneID: zoneID, rule: rule, apiToken: token)
+        let postReqs = spy.requests.filter { $0.httpMethod == "POST" }
+        #expect(!postReqs.isEmpty)
+    }
+
+    @Test("write methods include Authorization header")
+    func authorizationHeader() async throws {
+        let spy = TransportSpy()
+        let client = HTTPCloudflareClient(transport: spyTransport([:], spy: spy))
+        try await client.enableDNSSEC(zoneID: zoneID, apiToken: token)
+        let req = try #require(spy.requests.first)
+        #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)")
+    }
+
+    @Test("a 403 on a write surfaces as .unauthorized")
+    func writeUnauthorized() async {
+        let client = HTTPCloudflareClient(transport: fakeTransport(["/dnssec": (403, "{\"success\":false}")]))
+        await #expect(throws: CloudflareError.unauthorized) {
+            try await client.enableDNSSEC(zoneID: zoneID, apiToken: "bad")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
@@ -1,0 +1,158 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct HardenExecutorTests {
+    private func makeExecutor(
+        reader: MockCloudflareReader = MockCloudflareReader(),
+        writer: MockCloudflareWriter = MockCloudflareWriter()
+    ) -> (HardenExecutor, MockCloudflareWriter, MockCloudflareReader) {
+        let exec = HardenExecutor(reader: reader, writer: writer)
+        return (exec, writer, reader)
+    }
+
+    @Test("an empty plan produces zero applied, no failures, and re-audits")
+    func emptyPlanNoOps() async {
+        let (exec, writer, _) = makeExecutor()
+        let result = await exec.execute(
+            plan: HardenPlan(items: []),
+            zoneID: "z", domain: "example.com", apiToken: "t", expectsMail: false)
+        #expect(result.appliedCount == 0)
+        #expect(result.failedItems.isEmpty)
+        #expect(writer.calls.isEmpty)
+    }
+
+    @Test("each item type calls the correct writer method")
+    func itemsDispatchCorrectly() async {
+        let writer = MockCloudflareWriter()
+        let exec = HardenExecutor(reader: MockCloudflareReader(), writer: writer)
+        let plan = HardenPlan(items: [
+            .enableDNSSEC,
+            .addCAARecord(ca: "letsencrypt.org"),
+            .enableAlwaysUseHTTPS,
+            .enableHSTS(maxAge: 31_536_000, includeSubdomains: true, preload: false),
+            .enableBotFightMode,
+            .addNullMX,
+            .addSPFRejectAll,
+            .addDMARCReject,
+            .addWAFRule(description: "Block dotfiles", expression: "(x)", action: "block"),
+        ])
+        let result = await exec.execute(
+            plan: plan, zoneID: "z", domain: "example.com", apiToken: "t", expectsMail: false)
+        #expect(result.appliedCount == 9)
+        #expect(result.failedItems.isEmpty)
+        #expect(writer.calls.contains("enableDNSSEC"))
+        #expect(writer.calls.contains { $0.hasPrefix("addDNSRecord:CAA") })
+        #expect(writer.calls.contains("setAlwaysUseHTTPS"))
+        #expect(writer.calls.contains("setHSTS"))
+        #expect(writer.calls.contains("setBotFightMode"))
+        #expect(writer.calls.contains { $0.hasPrefix("addDNSRecord:MX") })
+        #expect(writer.calls.contains("addDNSRecord:TXT:v=spf1 -all"))
+        #expect(writer.calls.contains("addDNSRecord:TXT:v=DMARC1; p=reject"))
+        #expect(writer.calls.contains("createWAFCustomRule"))
+    }
+
+    @Test("a per-item failure does not abort remaining items")
+    func perItemFailureResilience() async {
+        let writer = MockCloudflareWriter()
+        writer.failOn = "enableDNSSEC"
+        let exec = HardenExecutor(reader: MockCloudflareReader(), writer: writer)
+        let plan = HardenPlan(items: [
+            .enableDNSSEC,
+            .enableAlwaysUseHTTPS,
+            .enableBotFightMode,
+        ])
+        let result = await exec.execute(
+            plan: plan, zoneID: "z", domain: "example.com", apiToken: "t", expectsMail: false)
+        #expect(result.appliedCount == 2)
+        #expect(result.failedItems.count == 1)
+        #expect(result.failedItems[0].item == .enableDNSSEC)
+    }
+
+    @Test("post-audit findings are populated from re-read state")
+    func postAuditFindings() async {
+        var state = CloudflareZoneState(
+            dnssecActive: false, sslMode: "flexible", alwaysUseHTTPS: false,
+            hsts: nil, caaRecords: [], mxRecords: [],
+            spfRecords: [], dmarcRecords: [])
+        let reader = MockCloudflareReader(state: state)
+        let exec = HardenExecutor(reader: reader, writer: MockCloudflareWriter())
+        let result = await exec.execute(
+            plan: HardenPlan(items: []),
+            zoneID: "z", domain: "example.com", apiToken: "t", expectsMail: false)
+        #expect(!result.postAuditFindings.isEmpty)
+        #expect(result.postAuditFindings.contains { $0.title.contains("DNSSEC") })
+    }
+
+    @Test("reader failure yields empty post-audit findings")
+    func readerFailureYieldsEmptyFindings() async {
+        let reader = MockCloudflareReader()
+        reader.shouldFail = true
+        let exec = HardenExecutor(reader: reader, writer: MockCloudflareWriter())
+        let result = await exec.execute(
+            plan: HardenPlan(items: [.enableDNSSEC]),
+            zoneID: "z", domain: "example.com", apiToken: "t", expectsMail: false)
+        #expect(result.appliedCount == 1)
+        #expect(result.postAuditFindings.isEmpty)
+    }
+}
+
+// MARK: - Mocks
+
+final class MockCloudflareReader: CloudflareReading, @unchecked Sendable {
+    private let state: CloudflareZoneState
+    var shouldFail = false
+
+    init(state: CloudflareZoneState = CloudflareZoneState(
+        dnssecActive: true, sslMode: "strict", alwaysUseHTTPS: true,
+        hsts: .init(maxAge: 31_536_000, includeSubdomains: true, preload: false),
+        caaRecords: [], mxRecords: [], spfRecords: ["v=spf1 -all"],
+        dmarcRecords: ["v=DMARC1; p=reject"], botFightMode: true)) {
+        self.state = state
+    }
+
+    func resolveZoneID(domain: String, apiToken: String) async throws -> String? { "z" }
+    func zoneState(zoneID: String, apiToken: String) async throws -> CloudflareZoneState {
+        if shouldFail { throw CloudflareError.malformedResponse }
+        return state
+    }
+}
+
+final class MockCloudflareWriter: CloudflareWriting, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls: [String] = []
+    var failOn: String?
+
+    var calls: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _calls
+    }
+
+    private func record(_ call: String) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if call == failOn { throw CloudflareError.apiError(errors: ["mock failure"]) }
+        _calls.append(call)
+    }
+
+    func enableDNSSEC(zoneID: String, apiToken: String) async throws {
+        try record("enableDNSSEC")
+    }
+    func setAlwaysUseHTTPS(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try record("setAlwaysUseHTTPS")
+    }
+    func setHSTS(zoneID: String, maxAge: Int, includeSubdomains: Bool, preload: Bool,
+                 apiToken: String) async throws {
+        try record("setHSTS")
+    }
+    func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws {
+        try self.record("addDNSRecord:\(record.type)\(record.content.isEmpty ? "" : ":\(record.content)")")
+    }
+    func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try record("setBotFightMode")
+    }
+    func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws {
+        try record("createWAFCustomRule")
+    }
+}

--- a/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
@@ -16,7 +16,7 @@ struct HardenExecutorTests {
         let (exec, writer, _) = makeExecutor()
         let result = await exec.execute(
             plan: HardenPlan(items: []),
-            zoneID: "z", domain: "example.com", apiToken: "t", expectsMail: false)
+            zoneID: "z", domain: "example.com", apiToken: "t")
         #expect(result.appliedCount == 0)
         #expect(result.failedItems.isEmpty)
         #expect(writer.calls.isEmpty)
@@ -38,7 +38,7 @@ struct HardenExecutorTests {
             .addWAFRule(description: "Block dotfiles", expression: "(x)", action: "block"),
         ])
         let result = await exec.execute(
-            plan: plan, zoneID: "z", domain: "example.com", apiToken: "t", expectsMail: false)
+            plan: plan, zoneID: "z", domain: "example.com", apiToken: "t")
         #expect(result.appliedCount == 9)
         #expect(result.failedItems.isEmpty)
         #expect(writer.calls.contains("enableDNSSEC"))
@@ -46,7 +46,7 @@ struct HardenExecutorTests {
         #expect(writer.calls.contains("setAlwaysUseHTTPS"))
         #expect(writer.calls.contains("setHSTS"))
         #expect(writer.calls.contains("setBotFightMode"))
-        #expect(writer.calls.contains { $0.hasPrefix("addDNSRecord:MX") })
+        #expect(writer.calls.contains("addDNSRecord:MX:."))
         #expect(writer.calls.contains("addDNSRecord:TXT:v=spf1 -all"))
         #expect(writer.calls.contains("addDNSRecord:TXT:v=DMARC1; p=reject"))
         #expect(writer.calls.contains("createWAFCustomRule"))
@@ -63,7 +63,7 @@ struct HardenExecutorTests {
             .enableBotFightMode,
         ])
         let result = await exec.execute(
-            plan: plan, zoneID: "z", domain: "example.com", apiToken: "t", expectsMail: false)
+            plan: plan, zoneID: "z", domain: "example.com", apiToken: "t")
         #expect(result.appliedCount == 2)
         #expect(result.failedItems.count == 1)
         #expect(result.failedItems[0].item == .enableDNSSEC)
@@ -71,7 +71,7 @@ struct HardenExecutorTests {
 
     @Test("post-audit findings are populated from re-read state")
     func postAuditFindings() async {
-        var state = CloudflareZoneState(
+        let state = CloudflareZoneState(
             dnssecActive: false, sslMode: "flexible", alwaysUseHTTPS: false,
             hsts: nil, caaRecords: [], mxRecords: [],
             spfRecords: [], dmarcRecords: [])
@@ -79,21 +79,22 @@ struct HardenExecutorTests {
         let exec = HardenExecutor(reader: reader, writer: MockCloudflareWriter())
         let result = await exec.execute(
             plan: HardenPlan(items: []),
-            zoneID: "z", domain: "example.com", apiToken: "t", expectsMail: false)
+            zoneID: "z", domain: "example.com", apiToken: "t")
         #expect(!result.postAuditFindings.isEmpty)
         #expect(result.postAuditFindings.contains { $0.title.contains("DNSSEC") })
     }
 
-    @Test("reader failure yields empty post-audit findings")
+    @Test("reader failure yields empty post-audit findings and populates auditError")
     func readerFailureYieldsEmptyFindings() async {
         let reader = MockCloudflareReader()
         reader.shouldFail = true
         let exec = HardenExecutor(reader: reader, writer: MockCloudflareWriter())
         let result = await exec.execute(
             plan: HardenPlan(items: [.enableDNSSEC]),
-            zoneID: "z", domain: "example.com", apiToken: "t", expectsMail: false)
+            zoneID: "z", domain: "example.com", apiToken: "t")
         #expect(result.appliedCount == 1)
         #expect(result.postAuditFindings.isEmpty)
+        #expect(result.auditError != nil)
     }
 }
 

--- a/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
@@ -132,7 +132,7 @@ final class MockCloudflareWriter: CloudflareWriting, @unchecked Sendable {
     private func record(_ call: String) throws {
         lock.lock()
         defer { lock.unlock() }
-        if call == failOn { throw CloudflareError.apiError(errors: ["mock failure"]) }
+        if call == failOn { throw CloudflareError.api(message: "mock failure") }
         _calls.append(call)
     }
 

--- a/Tests/AnglesiteCoreTests/HardenPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenPlannerTests.swift
@@ -1,0 +1,117 @@
+import Testing
+@testable import AnglesiteCore
+
+struct HardenPlannerTests {
+    private func hardened() -> CloudflareZoneState {
+        CloudflareZoneState(
+            dnssecActive: true, sslMode: "strict", alwaysUseHTTPS: true,
+            hsts: .init(maxAge: 31_536_000, includeSubdomains: true, preload: false),
+            caaRecords: [
+                "0 issue \"letsencrypt.org\"",
+                "0 issue \"digicert.com\"",
+                "0 issue \"pki.goog\"",
+            ],
+            mxRecords: [], spfRecords: ["v=spf1 -all"],
+            dmarcRecords: ["v=DMARC1; p=reject"],
+            botFightMode: true,
+            wafCustomRules: HardenPlanner.curatedWAFRules.map {
+                .init(description: $0.description, expression: $0.expression, action: $0.action)
+            })
+    }
+
+    private func bare() -> CloudflareZoneState {
+        CloudflareZoneState(
+            dnssecActive: false, sslMode: "flexible", alwaysUseHTTPS: false,
+            hsts: nil, caaRecords: [], mxRecords: [],
+            spfRecords: [], dmarcRecords: [])
+    }
+
+    @Test("a fully hardened zone produces an empty plan")
+    func fullyHardenedIsEmpty() {
+        let plan = HardenPlanner.plan(from: hardened(), domain: "example.com")
+        #expect(plan.isEmpty)
+        #expect(plan.summary.contains("No changes needed"))
+    }
+
+    @Test("a bare zone produces items for every hardening category")
+    func bareProducesAllItems() {
+        let plan = HardenPlanner.plan(from: bare(), domain: "example.com")
+        #expect(!plan.isEmpty)
+        #expect(plan.items.contains(.enableDNSSEC))
+        #expect(plan.items.contains(.enableAlwaysUseHTTPS))
+        #expect(plan.items.contains(.enableBotFightMode))
+        #expect(plan.items.contains(.addNullMX))
+        #expect(plan.items.contains(.addSPFRejectAll))
+        #expect(plan.items.contains(.addDMARCReject))
+        #expect(plan.items.contains(where: { if case .enableHSTS = $0 { return true }; return false }))
+        let caaItems = plan.items.filter { if case .addCAARecord = $0 { return true }; return false }
+        #expect(caaItems.count == 3)
+        let wafItems = plan.items.filter { if case .addWAFRule = $0 { return true }; return false }
+        #expect(wafItems.count == HardenPlanner.curatedWAFRules.count)
+    }
+
+    @Test("only missing CAA CAs are added")
+    func partialCAAOnlyAddsMissing() {
+        var s = hardened()
+        s.caaRecords = ["0 issue \"letsencrypt.org\""]
+        let plan = HardenPlanner.plan(from: s, domain: "example.com")
+        let cas = plan.items.compactMap { if case .addCAARecord(let ca) = $0 { return ca }; return nil }
+        #expect(cas.count == 2)
+        #expect(cas.contains("digicert.com"))
+        #expect(cas.contains("pki.goog"))
+        #expect(!cas.contains("letsencrypt.org"))
+    }
+
+    @Test("HSTS with short max-age triggers enableHSTS")
+    func shortHSTSTriggersItem() {
+        var s = hardened()
+        s.hsts = .init(maxAge: 3600, includeSubdomains: false, preload: false)
+        let plan = HardenPlanner.plan(from: s, domain: "example.com")
+        #expect(plan.items.contains(where: { if case .enableHSTS = $0 { return true }; return false }))
+    }
+
+    @Test("a mail-sending domain skips email hardening")
+    func mailDomainSkipsEmail() {
+        var s = bare()
+        s.mxRecords = ["10 mail.example.com"]
+        let plan = HardenPlanner.plan(from: s, domain: "example.com")
+        #expect(!plan.items.contains(.addNullMX))
+        #expect(!plan.items.contains(.addSPFRejectAll))
+        #expect(!plan.items.contains(.addDMARCReject))
+    }
+
+    @Test("existing WAF rules are not duplicated")
+    func wafRulesDeduped() {
+        var s = bare()
+        s.wafCustomRules = [.init(description: "Block path traversal attempts", expression: "x", action: "block")]
+        let plan = HardenPlanner.plan(from: s, domain: "example.com")
+        let wafDescs = plan.items.compactMap { if case .addWAFRule(let d, _, _) = $0 { return d }; return nil }
+        #expect(!wafDescs.contains("Block path traversal attempts"))
+        #expect(wafDescs.count == HardenPlanner.curatedWAFRules.count - 1)
+    }
+
+    @Test("WAF dedup is case-insensitive")
+    func wafDedupCaseInsensitive() {
+        var s = bare()
+        s.wafCustomRules = [.init(description: "BLOCK PATH TRAVERSAL ATTEMPTS", expression: "x", action: "block")]
+        let plan = HardenPlanner.plan(from: s, domain: "example.com")
+        let wafDescs = plan.items.compactMap { if case .addWAFRule(let d, _, _) = $0 { return d }; return nil }
+        #expect(!wafDescs.contains("Block path traversal attempts"))
+    }
+
+    @Test("plan summary is non-empty for a non-empty plan")
+    func summaryNonEmpty() {
+        let plan = HardenPlanner.plan(from: bare(), domain: "example.com")
+        #expect(!plan.summary.isEmpty)
+        #expect(plan.summary.contains("+"))
+    }
+
+    @Test("SPF with -all already present is not duplicated")
+    func existingSPFNotDuped() {
+        var s = bare()
+        s.spfRecords = ["v=spf1 -all"]
+        let plan = HardenPlanner.plan(from: s, domain: "example.com")
+        #expect(!plan.items.contains(.addSPFRejectAll))
+        #expect(plan.items.contains(.addNullMX))
+    }
+}

--- a/Tests/AnglesiteCoreTests/HardenPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenPlannerTests.swift
@@ -114,4 +114,28 @@ struct HardenPlannerTests {
         #expect(!plan.items.contains(.addSPFRejectAll))
         #expect(plan.items.contains(.addNullMX))
     }
+
+    @Test("SPF with ~all (softfail) still triggers addSPFRejectAll")
+    func softfailSPFTriggersHarden() {
+        var s = bare()
+        s.spfRecords = ["v=spf1 ~all"]
+        let plan = HardenPlanner.plan(from: s, domain: "example.com")
+        #expect(plan.items.contains(.addSPFRejectAll))
+    }
+
+    @Test("DMARC with sp=reject but no p=reject still triggers addDMARCReject")
+    func dmarcSubdomainPolicyNotConfused() {
+        var s = bare()
+        s.dmarcRecords = ["v=DMARC1; sp=reject"]
+        let plan = HardenPlanner.plan(from: s, domain: "example.com")
+        #expect(plan.items.contains(.addDMARCReject))
+    }
+
+    @Test("DMARC with p=reject is recognized regardless of position")
+    func dmarcPolicyRecognized() {
+        var s = bare()
+        s.dmarcRecords = ["v=DMARC1; sp=none; p=reject; rua=mailto:x@example.com"]
+        let plan = HardenPlanner.plan(from: s, domain: "example.com")
+        #expect(!plan.items.contains(.addDMARCReject))
+    }
 }

--- a/Tests/AnglesiteCoreTests/HardenPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenPlannerTests.swift
@@ -11,7 +11,7 @@ struct HardenPlannerTests {
                 "0 issue \"digicert.com\"",
                 "0 issue \"pki.goog\"",
             ],
-            mxRecords: [], spfRecords: ["v=spf1 -all"],
+            mxRecords: ["0 ."], spfRecords: ["v=spf1 -all"],
             dmarcRecords: ["v=DMARC1; p=reject"],
             botFightMode: true,
             wafCustomRules: HardenPlanner.curatedWAFRules.map {

--- a/Tests/AnglesiteCoreTests/SecurityAuditTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityAuditTests.swift
@@ -7,7 +7,8 @@ struct SecurityAuditTests {
             dnssecActive: true, sslMode: "strict", alwaysUseHTTPS: true,
             hsts: .init(maxAge: 31_536_000, includeSubdomains: true, preload: false),
             caaRecords: ["0 issue \"letsencrypt.org\""], mxRecords: [],
-            spfRecords: ["v=spf1 -all"], dmarcRecords: ["v=DMARC1; p=reject"])
+            spfRecords: ["v=spf1 -all"], dmarcRecords: ["v=DMARC1; p=reject"],
+            botFightMode: true)
     }
 
     @Test("a fully hardened non-mail zone yields no findings")
@@ -57,6 +58,13 @@ struct SecurityAuditTests {
         var s = clean(); s.spfRecords = []; s.dmarcRecords = []
         let f = SecurityAudit.evaluate(s, expectsMail: true)
         #expect(!f.contains { $0.title.contains("SPF") })
+    }
+
+    @Test("Bot Fight Mode off is an info finding")
+    func botFightModeInfo() {
+        var s = clean(); s.botFightMode = false
+        let f = SecurityAudit.evaluate(s, expectsMail: false)
+        #expect(f.contains { $0.severity == .info && $0.title.contains("Bot Fight Mode") })
     }
 
     @Test("every finding is in the security category")


### PR DESCRIPTION
## Summary

- Add the write side of the Cloudflare security hardening pipeline: `CloudflareWriting` protocol, `HardenPlan`/`HardenPlanItem` model, `HardenPlanner` (pure diff from zone state), and `HardenExecutor` (apply items + re-audit).
- Extend `CloudflareZoneState` with `botFightMode` and `wafCustomRules` fields, and `HTTPCloudflareClient` with bot-management/WAF reads and all 6 write methods.
- Seven hardening categories: DNSSEC, CAA (3 free-plan CAs), Always-Use-HTTPS, HSTS, Bot Fight Mode, email hardening (null MX + SPF + DMARC for non-mail domains), and 5 curated WAF rules (dotfiles, .env/.git, path traversal, SQLi, XSS).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.

## Test plan

- [ ] `swift test --package-path .`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECgZBY8quCTAuLFPKkW2qs

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECgZBY8quCTAuLFPKkW2qs)_