### PR TITLE
feat(#70): in-container deploy — run build/scan/wrangler in the container guest

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -65,7 +65,13 @@ final class DeployModel {
     private let summarizer: any DeployFailureSummarizing
     private var inFlight: Task<Void, Never>?
     /// Site to retry once the user pastes a token. `nil` outside the prompt flow.
-    private var pendingDeploy: (siteID: String, siteDirectory: URL)?
+    /// Carries the container control (if any) so the parked-then-retried deploy
+    /// uses the same executor as the original dispatch.
+    private var pendingDeploy: (
+        siteID: String,
+        siteDirectory: URL,
+        containerControl: (siteID: String, control: any LocalContainerControl)?
+    )?
 
     init(
         command: DeployCommand = DeployCommand(),
@@ -93,20 +99,29 @@ final class DeployModel {
 
     /// Kicks off a deploy. No-op if one is already running.
     ///
+    /// When `containerControl` is non-nil the deploy runs inside the already-started container
+    /// via `ContainerDeployExecutor`; otherwise it runs on the host via `HostDeployExecutor`
+    /// (today's default behavior). The container control is threaded through the pending-deploy
+    /// flow so a token-prompt retry uses the same executor as the original dispatch.
+    ///
     /// First checks whether a Cloudflare token is available (env > Keychain). If neither has one,
     /// the token-prompt sheet is presented and the deploy is parked until the user pastes and
     /// verifies a token via `verifyAndSaveToken(_:)` — at which point the parked site is dispatched
     /// without the user having to click Deploy again.
-    func deploy(siteID: String, siteDirectory: URL) {
+    func deploy(
+        siteID: String,
+        siteDirectory: URL,
+        containerControl: (siteID: String, control: any LocalContainerControl)? = nil
+    ) {
         guard !isRunning else { return }
         if !hasUsableToken() {
-            pendingDeploy = (siteID, siteDirectory)
+            pendingDeploy = (siteID, siteDirectory, containerControl)
             tokenVerification = .idle
             tokenPromptPresented = true
             return
         }
         inFlight = Task { @MainActor [weak self] in
-            await self?.runDeploy(siteID: siteID, siteDirectory: siteDirectory)
+            await self?.runDeploy(siteID: siteID, siteDirectory: siteDirectory, containerControl: containerControl)
         }
     }
 
@@ -141,7 +156,7 @@ final class DeployModel {
             pendingDeploy = nil
             tokenPromptPresented = false
             tokenVerification = .idle
-            deploy(siteID: pending.siteID, siteDirectory: pending.siteDirectory)
+            deploy(siteID: pending.siteID, siteDirectory: pending.siteDirectory, containerControl: pending.containerControl)
         case .stay(let message):
             tokenVerification = .failed(message: message)
         case .abort:
@@ -176,7 +191,11 @@ final class DeployModel {
         return false
     }
 
-    private func runDeploy(siteID: String, siteDirectory: URL) async {
+    private func runDeploy(
+        siteID: String,
+        siteDirectory: URL,
+        containerControl: (siteID: String, control: any LocalContainerControl)? = nil
+    ) async {
         phase = .running(siteID: siteID, since: Date())
         logLines = []
         currentMilestone = nil
@@ -195,7 +214,25 @@ final class DeployModel {
             }
         }
 
-        let result = await command.deploy(
+        // Select the executor: in-container when the runtime is a started container;
+        // host (embedded Node) otherwise. The token source always comes from the
+        // injected `command` so the test-injection path (a fully pre-built
+        // `DeployCommand`) continues to work unmodified.
+        let activeCommand: DeployCommand
+        if let cc = containerControl {
+            activeCommand = DeployCommand(
+                tokenSource: DeployCommand.keychainTokenSource,
+                executor: ContainerDeployExecutor(
+                    control: cc.control,
+                    siteID: cc.siteID,
+                    logCenter: logCenter
+                )
+            )
+        } else {
+            activeCommand = command
+        }
+
+        let result = await activeCommand.deploy(
             siteID: siteID,
             siteDirectory: siteDirectory,
             onPreflight: { [weak self] outcome in

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -221,7 +221,7 @@ final class DeployModel {
         let activeCommand: DeployCommand
         if let cc = containerControl {
             activeCommand = DeployCommand(
-                tokenSource: DeployCommand.keychainTokenSource,
+                tokenSource: command.tokenSource,
                 executor: ContainerDeployExecutor(
                     control: cc.control,
                     siteID: cc.siteID,

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -184,12 +184,23 @@ final class PreviewModel {
     ///
     /// Uses only `AnglesiteCore` types (`LocalContainerControl`, `LocalContainerSiteRuntime`)
     /// — no `AnglesiteContainer` import needed, so this compiles on both targets.
+    ///
+    /// Reads both fields in a single actor hop via `containerSnapshot()` to avoid a
+    /// theoretical TOCTOU window between two separate `await` reads.
     func activeContainerControl() async -> (siteID: String, control: any LocalContainerControl)? {
         guard let containerRuntime = runtime as? LocalContainerSiteRuntime else { return nil }
-        guard
-            let control = await containerRuntime.containerControl,
-            let siteID = await containerRuntime.containerActiveSiteID
-        else { return nil }
-        return (siteID: siteID, control: control)
+        guard let snapshot = await containerRuntime.containerSnapshot() else { return nil }
+        return (siteID: snapshot.siteID, control: snapshot.control)
+    }
+
+    /// True when the preview runtime is ready — used to gate the Deploy button so a user
+    /// deploying before the container (or dev server) is up sees a coherent error rather than
+    /// a silent `ContainerDeployExecutor` "container isn't running" failure.
+    ///
+    /// On the host path the runtime becomes `.ready` almost immediately (the dev server
+    /// starts in the background), so this gate is mostly relevant for the container path.
+    var canDeploy: Bool {
+        if case .ready = state { return true }
+        return false
     }
 }

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -173,4 +173,23 @@ final class PreviewModel {
     func mcpClient() async -> MCPClient? {
         await runtime.mcpClient
     }
+
+    /// Returns the active container control and site ID when the runtime is a
+    /// `LocalContainerSiteRuntime` that has successfully started a container.
+    ///
+    /// Returns `nil`:
+    ///   - on MAS (container runtime is not linked; `runtime` is always a `LocalSiteRuntime`)
+    ///   - on DevID when the container capability gate chose the host runtime
+    ///   - when the runtime is a container runtime but `start()` hasn't completed yet
+    ///
+    /// Uses only `AnglesiteCore` types (`LocalContainerControl`, `LocalContainerSiteRuntime`)
+    /// — no `AnglesiteContainer` import needed, so this compiles on both targets.
+    func activeContainerControl() async -> (siteID: String, control: any LocalContainerControl)? {
+        guard let containerRuntime = runtime as? LocalContainerSiteRuntime else { return nil }
+        guard
+            let control = await containerRuntime.containerControl,
+            let siteID = await containerRuntime.containerActiveSiteID
+        else { return nil }
+        return (siteID: siteID, control: control)
+    }
 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -348,10 +348,12 @@ struct SiteWindow: View {
                     Label("Deploy", systemImage: "paperplane.fill")
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(deploy.isRunning || backup.isRunning || audit.isRunning || !site.isValid)
-                .help(site.isValid
+                .disabled(deploy.isRunning || backup.isRunning || audit.isRunning || !site.isValid || !preview.canDeploy)
+                .help(site.isValid && preview.canDeploy
                       ? "Build, scan, and run wrangler deploy on this site"
-                      : "Site is missing required files")
+                      : site.isValid
+                        ? "Open the preview first to start the runtime before deploying"
+                        : "Site is missing required files")
             }
             .visibilityPriority(.high)
 

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -333,7 +333,17 @@ struct SiteWindow: View {
             // Declared LAST so it renders at the trailing edge (macOS primary-action position).
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    deploy.deploy(siteID: site.id, siteDirectory: site.sourceDirectory)
+                    // Resolve the container control asynchronously before dispatching:
+                    // `activeContainerControl()` hops to the container runtime actor and
+                    // returns the control + siteID if a container is running, else nil.
+                    // `deploy.deploy(...)` is synchronous (schedules its own Task), so we
+                    // wrap only the async resolution here.
+                    let siteID = site.id
+                    let siteDirectory = site.sourceDirectory
+                    Task { @MainActor in
+                        let cc = await preview.activeContainerControl()
+                        deploy.deploy(siteID: siteID, siteDirectory: siteDirectory, containerControl: cc)
+                    }
                 } label: {
                     Label("Deploy", systemImage: "paperplane.fill")
                 }

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -207,6 +207,25 @@ public struct ContainerizationControl: LocalContainerControl {
         await live.teardown(siteID: siteID)
     }
 
+    /// Run `argv` inside the named container, streaming stdout lines to `onOutput` and returning
+    /// the captured result. Full streaming I/O and environment-variable forwarding are wired in
+    /// Task 8 (the `InContainerDeployOperation` integration). This stub satisfies the seam so
+    /// AnglesiteContainer compiles; it runs the process and captures its exit code but does not
+    /// yet pipe stdout or forward environment.
+    public func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @Sendable (String) -> Void
+    ) async throws -> ContainerExecResult {
+        guard let container = await live.container(for: siteID) else {
+            throw LocalContainerError.bootFailed("exec: no live container for siteID '\(siteID)'")
+        }
+        try await runToCompletion(container, id: siteID + "-exec", argv)
+        return ContainerExecResult(exitCode: 0, stdout: "", stderr: "")
+    }
+
     // MARK: - Helpers
 
     /// Import an OCI layout into the store, tolerating a prior import (idempotent): if `load` fails
@@ -293,6 +312,8 @@ actor LiveContainers {
     private var proxies: [String: [VsockTCPProxy]] = [:]
     /// Per-site ext4 files (rootfs + initfs) to delete on teardown so disk doesn't grow per start/stop.
     private var ext4Artifacts: [String: [URL]] = [:]
+
+    func container(for siteID: String) -> LinuxContainer? { containers[siteID] }
 
     func store(siteID: String, container: LinuxContainer, proxies ps: [VsockTCPProxy], ext4Artifacts artifacts: [URL]) {
         containers[siteID] = container

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -208,16 +208,21 @@ public struct ContainerizationControl: LocalContainerControl {
     }
 
     /// Run `argv` inside the named container as a one-shot guest exec, forwarding `environment`
-    /// and `workingDirectory`, streaming each stdout line to `onOutput` as it arrives, capturing
-    /// the full stdout + stderr, and returning the real guest exit code (it does NOT throw on a
-    /// non-zero exit — the caller maps the code). Mirrors `runToCompletion`'s lifecycle
-    /// (`exec` -> `start` -> `wait` -> `delete`) but installs capturing/streaming `Writer`s.
+    /// and `workingDirectory`, streaming each stdout AND stderr line to `onOutput` as it arrives
+    /// (many tools, incl. `wrangler`, write progress to stderr), capturing the full stdout + stderr,
+    /// and returning the real guest exit code (it does NOT throw on a non-zero exit — the caller maps
+    /// the code). Honors task cancellation: a cancelled deploy SIGTERMs the guest process, mirroring
+    /// the host path. Mirrors `runToCompletion`'s lifecycle (`exec` -> `start` -> `wait` -> `delete`)
+    /// but installs capturing/streaming `Writer`s.
     ///
     /// Env/cwd are set via the real 0.34 `LinuxProcessConfiguration` fields — `arguments`,
     /// `environmentVariables`, `workingDirectory` (`LinuxProcessConfiguration.swift:366-370`) — so
     /// there is no shell wrapping and therefore no shell-metacharacter injection surface: each
     /// `K=V` pair and each argv element is passed literally to the guest agent (no `sh -lc`, no
-    /// `env` binary). The default `PATH` is preserved so the resolver still finds `git`/`node`/etc.
+    /// `env` binary). NOTE: `LinuxContainer.exec` builds a FRESH config, so the image-baked env is
+    /// NOT inherited — only the default `PATH` (which covers `/usr/local/bin` for `node:22`, so
+    /// `node`/`npm`/`npx`/`wrangler` resolve) plus the caller's `environment` are set. Anything the
+    /// deploy toolchain needs beyond PATH must be passed in `environment`.
     public func exec(
         siteID: String,
         argv: [String],
@@ -235,10 +240,11 @@ public struct ContainerizationControl: LocalContainerControl {
         // (`LinuxProcess.waitIoComplete`, LinuxProcess.swift:372) and `flush()` runs synchronously
         // right after — so the escaping copy never outlives this function call.
         return try await withoutActuallyEscaping(onOutput) { onOutput in
-            // Streaming line-splitter for stdout (forwards each completed line to `onOutput` and
-            // accumulates the raw text); a plain accumulator for stderr.
+            // Streaming line-splitter for BOTH stdout and stderr — forward each completed line to
+            // `onOutput` live (so the deploy drawer shows progress, incl. wrangler's stderr) while
+            // accumulating each stream's raw text separately (the caller parses stdout for the URL).
             let stdoutSink = LineStreamingWriter(onLine: onOutput)
-            let stderrSink = AccumulatingWriter()
+            let stderrSink = LineStreamingWriter(onLine: onOutput)
 
             let proc = try await container.exec(siteID + "-exec") { config in
                 config.arguments = argv
@@ -252,12 +258,20 @@ public struct ContainerizationControl: LocalContainerControl {
                 config.stderr = stderrSink
             }
             try await proc.start()
-            let status = try await proc.wait()
+            // Honor task cancellation for parity with the host deploy path (which SIGTERMs a
+            // cancelled deploy): if the deploy task is cancelled mid-`wait()`, signal the guest
+            // process so a hung/long `npm install` / `wrangler deploy` can actually be aborted.
+            let status = try await withTaskCancellationHandler {
+                try await proc.wait()
+            } onCancel: {
+                Task { try? await proc.kill(.term) }
+            }
             try? await proc.delete()
 
             // `wait()` returns only after the IO streams have drained, so the sinks hold the full
-            // output here. Flush any trailing partial (unterminated) stdout line.
+            // output here. Flush any trailing partial (unterminated) line on each stream.
             stdoutSink.flush()
+            stderrSink.flush()
             return ContainerExecResult(
                 exitCode: status.exitCode,
                 stdout: stdoutSink.text,
@@ -372,22 +386,6 @@ actor LiveContainers {
         }
         ext4Artifacts[siteID] = nil
     }
-}
-
-/// A Containerization `Writer` that accumulates the raw guest stream into a UTF-8 string.
-/// Used for stderr capture in `exec`. The library invokes `write` from a single `FileHandle`
-/// readability handler, so the buffer is not touched concurrently (`@unchecked Sendable`, mirroring
-/// the upstream `BufferWriter` test helper in `ContainerTests.swift:83`).
-final class AccumulatingWriter: @unchecked Sendable, Writer {
-    private var buffer = Data()
-
-    var text: String { String(decoding: buffer, as: UTF8.self) }
-
-    func write(_ data: Data) throws {
-        buffer.append(data)
-    }
-
-    func close() throws {}
 }
 
 /// A Containerization `Writer` that splits the guest stream into newline-delimited lines, forwarding

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -207,11 +207,17 @@ public struct ContainerizationControl: LocalContainerControl {
         await live.teardown(siteID: siteID)
     }
 
-    /// Run `argv` inside the named container, streaming stdout lines to `onOutput` and returning
-    /// the captured result. Full streaming I/O and environment-variable forwarding are wired in
-    /// Task 8 (the `InContainerDeployOperation` integration). This stub satisfies the seam so
-    /// AnglesiteContainer compiles; it runs the process and captures its exit code but does not
-    /// yet pipe stdout or forward environment.
+    /// Run `argv` inside the named container as a one-shot guest exec, forwarding `environment`
+    /// and `workingDirectory`, streaming each stdout line to `onOutput` as it arrives, capturing
+    /// the full stdout + stderr, and returning the real guest exit code (it does NOT throw on a
+    /// non-zero exit — the caller maps the code). Mirrors `runToCompletion`'s lifecycle
+    /// (`exec` -> `start` -> `wait` -> `delete`) but installs capturing/streaming `Writer`s.
+    ///
+    /// Env/cwd are set via the real 0.34 `LinuxProcessConfiguration` fields — `arguments`,
+    /// `environmentVariables`, `workingDirectory` (`LinuxProcessConfiguration.swift:366-370`) — so
+    /// there is no shell wrapping and therefore no shell-metacharacter injection surface: each
+    /// `K=V` pair and each argv element is passed literally to the guest agent (no `sh -lc`, no
+    /// `env` binary). The default `PATH` is preserved so the resolver still finds `git`/`node`/etc.
     public func exec(
         siteID: String,
         argv: [String],
@@ -222,8 +228,42 @@ public struct ContainerizationControl: LocalContainerControl {
         guard let container = await live.container(for: siteID) else {
             throw LocalContainerError.bootFailed("exec: no live container for siteID '\(siteID)'")
         }
-        try await runToCompletion(container, id: siteID + "-exec", argv)
-        return ContainerExecResult(exitCode: 0, stdout: "", stderr: "")
+
+        // The seam's `onOutput` is non-escaping, but the `Writer` we install must close over it.
+        // `withoutActuallyEscaping` is sound here: every `write`/`flush` invocation that calls
+        // `onOutput` happens *before* `proc.wait()` returns — `wait()` drains the IO streams
+        // (`LinuxProcess.waitIoComplete`, LinuxProcess.swift:372) and `flush()` runs synchronously
+        // right after — so the escaping copy never outlives this function call.
+        return try await withoutActuallyEscaping(onOutput) { onOutput in
+            // Streaming line-splitter for stdout (forwards each completed line to `onOutput` and
+            // accumulates the raw text); a plain accumulator for stderr.
+            let stdoutSink = LineStreamingWriter(onLine: onOutput)
+            let stderrSink = AccumulatingWriter()
+
+            let proc = try await container.exec(siteID + "-exec") { config in
+                config.arguments = argv
+                // Preserve the default PATH (so argv[0] resolves) and append the caller's env as
+                // literal `K=V` argv-style entries — no shell parsing, no escaping bugs, no injection.
+                config.environmentVariables =
+                    ["PATH=\(LinuxProcessConfiguration.defaultPath)"]
+                    + environment.map { "\($0.key)=\($0.value)" }
+                config.workingDirectory = workingDirectory
+                config.stdout = stdoutSink
+                config.stderr = stderrSink
+            }
+            try await proc.start()
+            let status = try await proc.wait()
+            try? await proc.delete()
+
+            // `wait()` returns only after the IO streams have drained, so the sinks hold the full
+            // output here. Flush any trailing partial (unterminated) stdout line.
+            stdoutSink.flush()
+            return ContainerExecResult(
+                exitCode: status.exitCode,
+                stdout: stdoutSink.text,
+                stderr: stderrSink.text
+            )
+        }
     }
 
     // MARK: - Helpers
@@ -331,5 +371,61 @@ actor LiveContainers {
             try? FileManager.default.removeItem(at: url)
         }
         ext4Artifacts[siteID] = nil
+    }
+}
+
+/// A Containerization `Writer` that accumulates the raw guest stream into a UTF-8 string.
+/// Used for stderr capture in `exec`. The library invokes `write` from a single `FileHandle`
+/// readability handler, so the buffer is not touched concurrently (`@unchecked Sendable`, mirroring
+/// the upstream `BufferWriter` test helper in `ContainerTests.swift:83`).
+final class AccumulatingWriter: @unchecked Sendable, Writer {
+    private var buffer = Data()
+
+    var text: String { String(decoding: buffer, as: UTF8.self) }
+
+    func write(_ data: Data) throws {
+        buffer.append(data)
+    }
+
+    func close() throws {}
+}
+
+/// A Containerization `Writer` that splits the guest stream into newline-delimited lines, forwarding
+/// each completed line to `onLine` as it arrives (live streaming) while also accumulating the full
+/// raw text. Bytes are buffered until a `\n` is seen so a chunk that splits mid-line doesn't emit a
+/// partial line; `flush()` (called after `wait()`) emits any trailing unterminated line.
+///
+/// Single-handler invocation (one `FileHandle` readability handler) means no concurrent access, so
+/// `@unchecked Sendable` is safe here exactly as for the upstream test `BufferWriter`.
+final class LineStreamingWriter: @unchecked Sendable, Writer {
+    private let onLine: @Sendable (String) -> Void
+    private var pending = Data()   // bytes after the last emitted newline
+    private var full = Data()      // entire raw stream, for `text`
+
+    init(onLine: @escaping @Sendable (String) -> Void) {
+        self.onLine = onLine
+    }
+
+    var text: String { String(decoding: full, as: UTF8.self) }
+
+    func write(_ data: Data) throws {
+        guard !data.isEmpty else { return }
+        full.append(data)
+        pending.append(data)
+        let newline = UInt8(ascii: "\n")
+        while let idx = pending.firstIndex(of: newline) {
+            let lineData = pending[pending.startIndex..<idx]
+            onLine(String(decoding: lineData, as: UTF8.self))
+            pending = Data(pending[pending.index(after: idx)...])
+        }
+    }
+
+    func close() throws {}
+
+    /// Emit any buffered bytes that were never newline-terminated as a final line.
+    func flush() {
+        guard !pending.isEmpty else { return }
+        onLine(String(decoding: pending, as: UTF8.self))
+        pending.removeAll()
     }
 }

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -228,55 +228,76 @@ public struct ContainerizationControl: LocalContainerControl {
         argv: [String],
         environment: [String: String],
         workingDirectory: String,
-        onOutput: @Sendable (String) -> Void
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> ContainerExecResult {
         guard let container = await live.container(for: siteID) else {
             throw LocalContainerError.bootFailed("exec: no live container for siteID '\(siteID)'")
         }
 
-        // The seam's `onOutput` is non-escaping, but the `Writer` we install must close over it.
-        // `withoutActuallyEscaping` is sound here: every `write`/`flush` invocation that calls
-        // `onOutput` happens *before* `proc.wait()` returns — `wait()` drains the IO streams
-        // (`LinuxProcess.waitIoComplete`, LinuxProcess.swift:372) and `flush()` runs synchronously
-        // right after — so the escaping copy never outlives this function call.
-        return try await withoutActuallyEscaping(onOutput) { onOutput in
-            // Streaming line-splitter for BOTH stdout and stderr — forward each completed line to
-            // `onOutput` live (so the deploy drawer shows progress, incl. wrangler's stderr) while
-            // accumulating each stream's raw text separately (the caller parses stdout for the URL).
-            let stdoutSink = LineStreamingWriter(onLine: onOutput)
-            let stderrSink = LineStreamingWriter(onLine: onOutput)
+        // `onOutput` is `@escaping` (the seam declares it so): the `Writer` sinks below close over it
+        // and may legitimately fire it after this function returns (e.g. a kill-triggered final line
+        // on cancellation). No `withoutActuallyEscaping` — that wrapper would be UNSOUND here.
+        //
+        // Two line-splitters, one per stream, each tagging its lines with the stream it owns so the
+        // caller can label wrangler's stderr progress correctly (and parse stdout for the URL).
+        let stdoutSink = LineStreamingWriter(stream: .stdout, onLine: onOutput)
+        let stderrSink = LineStreamingWriter(stream: .stderr, onLine: onOutput)
 
-            let proc = try await container.exec(siteID + "-exec") { config in
-                config.arguments = argv
-                // Preserve the default PATH (so argv[0] resolves) and append the caller's env as
-                // literal `K=V` argv-style entries — no shell parsing, no escaping bugs, no injection.
-                config.environmentVariables =
-                    ["PATH=\(LinuxProcessConfiguration.defaultPath)"]
-                    + environment.map { "\($0.key)=\($0.value)" }
-                config.workingDirectory = workingDirectory
-                config.stdout = stdoutSink
-                config.stderr = stderrSink
-            }
-            try await proc.start()
-            // Honor task cancellation for parity with the host deploy path (which SIGTERMs a
-            // cancelled deploy): if the deploy task is cancelled mid-`wait()`, signal the guest
-            // process so a hung/long `npm install` / `wrangler deploy` can actually be aborted.
-            let status = try await withTaskCancellationHandler {
-                try await proc.wait()
-            } onCancel: {
-                Task { try? await proc.kill(.term) }
-            }
-            try? await proc.delete()
+        // Unique exec id per call so build/preflight/wrangler don't collide on the same vended
+        // process name. The label maps each step's argv to a distinct, readable suffix; a short
+        // uniquifier guarantees distinctness even if two calls share a label (e.g. two `npx` steps).
+        let label = Self.execLabel(for: argv)
+        let proc = try await container.exec("\(siteID)-exec-\(label)-\(UUID().uuidString.prefix(8))") { config in
+            config.arguments = argv
+            // Preserve the default PATH (so argv[0] resolves) and append the caller's env as
+            // literal `K=V` argv-style entries — no shell parsing, no escaping bugs, no injection.
+            config.environmentVariables =
+                ["PATH=\(LinuxProcessConfiguration.defaultPath)"]
+                + environment.map { "\($0.key)=\($0.value)" }
+            config.workingDirectory = workingDirectory
+            config.stdout = stdoutSink
+            config.stderr = stderrSink
+        }
+        try await proc.start()
+        // Honor task cancellation for parity with the host deploy path (which SIGTERMs a
+        // cancelled deploy): if the deploy task is cancelled mid-`wait()`, signal the guest
+        // process so a hung/long `npm install` / `wrangler deploy` can actually be aborted.
+        let status = try await withTaskCancellationHandler {
+            try await proc.wait()
+        } onCancel: {
+            // Fire-and-forget SIGTERM. This may land AFTER `proc.delete()` runs below (the cancel
+            // handler and the main flow race once `wait()` resumes). That's tolerated: `kill` and
+            // `delete` are independent async ops on `LinuxProcess` with no shared guard —
+            // `LinuxProcess.kill` (LinuxProcess.swift:307-321) just calls `agent.signalProcess` and
+            // *throws* a wrapped `ContainerizationError` if the process is already gone, and our
+            // `try?` swallows that throw. Best-effort by construction — we never need the kill to
+            // succeed once the process has exited or been deleted.
+            Task { try? await proc.kill(.term) }
+        }
+        try? await proc.delete()
 
-            // `wait()` returns only after the IO streams have drained, so the sinks hold the full
-            // output here. Flush any trailing partial (unterminated) line on each stream.
-            stdoutSink.flush()
-            stderrSink.flush()
-            return ContainerExecResult(
-                exitCode: status.exitCode,
-                stdout: stdoutSink.text,
-                stderr: stderrSink.text
-            )
+        // `wait()` returns only after the IO streams have drained, so the sinks hold the full
+        // output here. Flush any trailing partial (unterminated) line on each stream.
+        stdoutSink.flush()
+        stderrSink.flush()
+        return ContainerExecResult(
+            exitCode: status.exitCode,
+            stdout: stdoutSink.text,
+            stderr: stderrSink.text
+        )
+    }
+
+    /// Maps a step's argv to a short, distinct, readable exec-id label. `npm run build` → `build`,
+    /// `npx tsx …pre-deploy-check…` → `preflight`, `npx wrangler deploy` → `wrangler`; anything else
+    /// falls back to argv[0]. Both `npx` steps would otherwise collapse to the same prefix.
+    private static func execLabel(for argv: [String]) -> String {
+        switch argv.first {
+        case "npm": return "build"
+        case "npx":
+            if argv.contains("wrangler") { return "wrangler" }
+            if argv.contains(where: { $0.contains("pre-deploy-check") }) { return "preflight" }
+            return "npx"
+        default: return argv.first ?? "cmd"
         }
     }
 
@@ -396,11 +417,13 @@ actor LiveContainers {
 /// Single-handler invocation (one `FileHandle` readability handler) means no concurrent access, so
 /// `@unchecked Sendable` is safe here exactly as for the upstream test `BufferWriter`.
 final class LineStreamingWriter: @unchecked Sendable, Writer {
-    private let onLine: @Sendable (String) -> Void
+    private let stream: LogCenter.Stream
+    private let onLine: @Sendable (String, LogCenter.Stream) -> Void
     private var pending = Data()   // bytes after the last emitted newline
     private var full = Data()      // entire raw stream, for `text`
 
-    init(onLine: @escaping @Sendable (String) -> Void) {
+    init(stream: LogCenter.Stream, onLine: @escaping @Sendable (String, LogCenter.Stream) -> Void) {
+        self.stream = stream
         self.onLine = onLine
     }
 
@@ -413,7 +436,7 @@ final class LineStreamingWriter: @unchecked Sendable, Writer {
         let newline = UInt8(ascii: "\n")
         while let idx = pending.firstIndex(of: newline) {
             let lineData = pending[pending.startIndex..<idx]
-            onLine(String(decoding: lineData, as: UTF8.self))
+            onLine(String(decoding: lineData, as: UTF8.self), stream)
             pending = Data(pending[pending.index(after: idx)...])
         }
     }
@@ -423,7 +446,7 @@ final class LineStreamingWriter: @unchecked Sendable, Writer {
     /// Emit any buffered bytes that were never newline-terminated as a final line.
     func flush() {
         guard !pending.isEmpty else { return }
-        onLine(String(decoding: pending, as: UTF8.self))
+        onLine(String(decoding: pending, as: UTF8.self), stream)
         pending.removeAll()
     }
 }

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -2,22 +2,28 @@ import Foundation
 
 /// One-shot orchestrator for `wrangler deploy`.
 ///
-/// A deploy is a single foreground action with three real steps and one resolver step:
+/// A deploy is a single foreground action with a pre-spawn token gate and three real steps,
+/// each run through the injected `DeployExecutor` seam (default `HostDeployExecutor`, which
+/// preserves the embedded-Node host behavior; `ContainerDeployExecutor` runs the same steps
+/// in a guest):
 ///   1. Resolve / read the Cloudflare API token (pre-spawn; no token → `.failed`).
-///   2. Run `npm run build` so `dist/` is fresh (streamed to `LogCenter` via `supervisor.launch`).
-///   3. Run the bundled plugin's pre-deploy scan; `.blocked` short-circuits with no override
-///      (per CLAUDE.md, the app cannot bypass plugin security hooks).
-///   4. Run `wrangler deploy` (also streamed to `LogCenter`); parse the deployed URL out of the
-///      success block on exit 0.
+///   2. `executor.run(step: .build, …)` so `dist/` is fresh.
+///   3. `executor.run(step: .preflight, …)` — the bundled plugin's pre-deploy scan; its captured
+///      stdout is parsed into a `PreDeployCheck.Outcome`. `.blocked` short-circuits with no
+///      override (per CLAUDE.md, the app cannot bypass plugin security hooks).
+///   4. `executor.run(step: .wrangler, …)` — parse the deployed URL out of the captured output.
 ///
-/// Both subprocesses go through `ProcessSupervisor.launch(...)`, not `.run(...)`, so their stdout
-/// and stderr flow into `LogCenter` line-by-line as wrangler produces them. The deploy drawer
-/// (#22) and Debug pane both consume this stream while the deploy is in flight; the URL extractor
-/// re-reads the captured stdout via a `LogCenter` subscription opened before launch.
+/// On the host path the executor streams each step's stdout+stderr into `LogCenter` line-by-line
+/// (under the caller-supplied source) and returns the accumulated stdout in `DeployStepResult.output`,
+/// so the URL/scan parsing here re-reads the captured stdout rather than re-snapshotting `LogCenter`.
 ///
-/// Note: the supervisor's pipe pump dispatches each line via an untracked `Task { await
-/// logCenter.append(...) }`, so the subscription needs a brief grace period after `waitForExit`
-/// before it's safe to cancel — see the call site for details.
+/// **Environment contract** (matches today's host behavior):
+///   - `.build` and `.preflight` get `ProcessInfo.processInfo.environment` *without* the token.
+///   - `.wrangler` gets that environment *plus* `CLOUDFLARE_API_TOKEN`.
+///
+/// **Cancellation**: cancelling the deploy task propagates through `executor.run` (the host
+/// executor wraps its `waitForExit` in a cancellation handler that SIGTERMs the in-flight
+/// subprocess), so a cancelled build/wrangler is actually killed rather than orphaned.
 public actor DeployCommand {
     public enum Result: Sendable, Equatable {
         case succeeded(url: URL, duration: TimeInterval)
@@ -51,27 +57,15 @@ public actor DeployCommand {
     /// cases where deploy() returns .failed afterwards.
     public typealias PreflightObserver = @Sendable (PreDeployCheck.Outcome) -> Void
 
-    private let supervisor: ProcessSupervisor
-    private let logCenter: LogCenter
-    private let resolveCommand: CommandResolver
-    private let resolveBuildCommand: CommandResolver
     private let tokenSource: TokenSource
-    private let preflight: PreflightChecker
+    private let executor: any DeployExecutor
 
     public init(
-        supervisor: ProcessSupervisor = .shared,
-        logCenter: LogCenter = .shared,
-        resolveCommand: @escaping CommandResolver = DeployCommand.resolveWranglerCommand,
-        resolveBuildCommand: @escaping CommandResolver = DeployCommand.resolveBuildCommand,
         tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
-        preflight: @escaping PreflightChecker = DeployCommand.defaultPreflight
+        executor: any DeployExecutor = HostDeployExecutor()
     ) {
-        self.supervisor = supervisor
-        self.logCenter = logCenter
-        self.resolveCommand = resolveCommand
-        self.resolveBuildCommand = resolveBuildCommand
         self.tokenSource = tokenSource
-        self.preflight = preflight
+        self.executor = executor
     }
 
     /// Run a deploy for `siteID`. Returns once wrangler has exited (or before, if pre-spawn
@@ -95,22 +89,44 @@ public actor DeployCommand {
             return .failed(reason: "no CLOUDFLARE_API_TOKEN — add it in Settings → Advanced → Credentials, or set the env var", exitCode: nil)
         }
 
-        // Build dist/ before the scan needs it. Streams to LogCenter via launch().
+        // Environment for the non-secret steps: the process env WITHOUT the token. The build and
+        // preflight steps rely on the executor's default Node-on-PATH env; the token is added only
+        // for the wrangler step below.
+        let baseEnvironment = ProcessInfo.processInfo.environment
+
+        // Build dist/ before the scan needs it. Streams to LogCenter via the executor.
         onProgress?(.deployBuilding)
-        switch await runBuild(siteID: siteID, siteDirectory: siteDirectory) {
-        case .success:
-            break
-        case .failure(let result):
-            return result
+        let buildResult = await executor.run(
+            step: .build,
+            siteDirectory: siteDirectory,
+            environment: baseEnvironment,
+            source: "deploy:\(siteID):build"
+        )
+        guard buildResult.exitCode == 0 else {
+            if let code = buildResult.exitCode {
+                return .failed(reason: "npm run build failed (exit \(code))", exitCode: code)
+            }
+            // nil exit code → unavailable resolver, spawn failure, or termination (cancellation).
+            if Task.isCancelled {
+                return .failed(reason: "build was terminated", exitCode: nil)
+            }
+            // The executor put the reason (unavailable/spawn) in `output`.
+            return .failed(reason: buildResult.output.isEmpty ? "build was terminated" : buildResult.output, exitCode: nil)
         }
 
-        // Pre-deploy scan runs after the build (so dist/ exists) and before wrangler is
-        // resolved. If the bundled plugin's checks find PII, exposed tokens, unauthorized
-        // third-party scripts, or Keystatic admin routes in dist/, the deploy is blocked —
-        // per the durable rule in CLAUDE.md, the app cannot bypass plugin security hooks;
-        // the UI sheet for `.blocked` has no override.
+        // Pre-deploy scan runs after the build (so dist/ exists) and before wrangler. If the
+        // bundled plugin's checks find PII, exposed tokens, unauthorized third-party scripts, or
+        // Keystatic admin routes in dist/, the deploy is blocked — per the durable rule in
+        // CLAUDE.md, the app cannot bypass plugin security hooks; the UI sheet for `.blocked` has
+        // no override.
         onProgress?(.deployPreflight)
-        let preflightOutcome = await preflight(siteDirectory)
+        let preflightResult = await executor.run(
+            step: .preflight,
+            siteDirectory: siteDirectory,
+            environment: baseEnvironment,
+            source: "deploy:\(siteID):preflight"
+        )
+        let preflightOutcome = Self.parseScanReport(output: preflightResult.output, exitCode: preflightResult.exitCode)
         onPreflight?(preflightOutcome)
         switch preflightOutcome {
         case .passed:
@@ -121,123 +137,70 @@ public actor DeployCommand {
             return .failed(reason: "pre-deploy scan could not run: \(reason)", exitCode: nil)
         }
 
-        let plan = resolveCommand(siteDirectory)
-        let executable: URL
-        let arguments: [String]
-        switch plan {
-        case .unavailable(let reason):
-            return .failed(reason: reason, exitCode: nil)
-        case .run(let exe, let args):
-            executable = exe
-            arguments = args
-        }
-
-        let source = "deploy:\(siteID)"
-        var environment = ProcessInfo.processInfo.environment
-        environment["CLOUDFLARE_API_TOKEN"] = token
+        // Wrangler step: process env PLUS the Cloudflare token.
+        var wranglerEnvironment = baseEnvironment
+        wranglerEnvironment["CLOUDFLARE_API_TOKEN"] = token
 
         let started = Date()
         onProgress?(.deployDeploying)
-        let handle: ProcessSupervisor.Handle
-        do {
-            handle = try await supervisor.launch(
-                source: source,
-                executable: executable,
-                arguments: arguments,
-                environment: environment,
-                currentDirectoryURL: siteDirectory,
-                logCenter: logCenter
-            )
-        } catch {
-            return .failed(reason: "couldn't spawn wrangler: \(error)", exitCode: nil)
-        }
-
-        let reason = await withTaskCancellationHandler {
-            await supervisor.waitForExit(handle)
-        } onCancel: {
-            // The deploy was cancelled (e.g. a Shortcuts/Siri CancellableIntent). The backend
-            // resumes our wait as `.terminated`, but the OS process would otherwise keep running —
-            // actually SIGTERM it so the build/wrangler doesn't finish (and, for wrangler, doesn't
-            // keep publishing to production) after we've reported cancellation.
-            Task { await supervisor.terminate(handle) }
-        }
+        let wranglerResult = await executor.run(
+            step: .wrangler,
+            siteDirectory: siteDirectory,
+            environment: wranglerEnvironment,
+            source: "deploy:\(siteID)"
+        )
         let duration = Date().timeIntervalSince(started)
 
-        // `waitForExit` only resumes after the supervisor's per-pipe drain Tasks have
-        // finished — every byte wrangler wrote to stdout/stderr is in `LogCenter` by
-        // the time we get here, so the snapshot can't miss the `Published` line.
         if !Task.isCancelled { onProgress?(.deployFinalizing) }
-        let snapshot = await logCenter.snapshot()
-        let stdout = snapshot
-            .filter { $0.source == source && $0.stream == .stdout }
-            .map(\.text)
-            .joined(separator: "\n")
 
-        switch reason {
-        case .exited(let code):
-            if code == 0 {
-                if let url = Self.extractDeployedURL(from: stdout) {
-                    return .succeeded(url: url, duration: duration)
-                }
-                return .failed(reason: "wrangler exited cleanly but no deployed URL was found in its output", exitCode: 0)
+        guard let code = wranglerResult.exitCode else {
+            // nil exit code → unavailable resolver, spawn failure, or termination (e.g. cancellation).
+            // The cancellation path must say "terminated" (the cancellation test asserts on it);
+            // for the unavailable/spawn-failure cases the executor surfaces the reason in `output`.
+            if Task.isCancelled {
+                return .failed(reason: "wrangler was terminated", exitCode: nil)
             }
-            return .failed(reason: "wrangler exited with code \(code)", exitCode: code)
-        case .terminated:
-            return .failed(reason: "wrangler was terminated", exitCode: nil)
-        case .retriesExhausted(let lastCode):
-            return .failed(reason: "wrangler retries exhausted (exit \(lastCode))", exitCode: lastCode)
+            return .failed(reason: wranglerResult.output.isEmpty ? "wrangler was terminated" : wranglerResult.output, exitCode: nil)
         }
+        if code == 0 {
+            if let url = Self.extractDeployedURL(from: wranglerResult.output) {
+                return .succeeded(url: url, duration: duration)
+            }
+            return .failed(reason: "wrangler exited cleanly but no deployed URL was found in its output", exitCode: 0)
+        }
+        return .failed(reason: "wrangler exited with code \(code)", exitCode: code)
     }
 
-    // MARK: Build step
+    // MARK: Scan report parsing
 
-    private enum BuildOutcome { case success; case failure(Result) }
-
-    private func runBuild(siteID: String, siteDirectory: URL) async -> BuildOutcome {
-        let plan = resolveBuildCommand(siteDirectory)
-        let executable: URL
-        let arguments: [String]
-        switch plan {
-        case .unavailable(let reason):
-            return .failure(.failed(reason: reason, exitCode: nil))
-        case .run(let exe, let args):
-            executable = exe
-            arguments = args
+    /// Parses the captured stdout of the pre-deploy scan (`scripts/pre-deploy-check.ts --json`)
+    /// into a `PreDeployCheck.Outcome`. Mirrors the JSON contract owned by the plugin; a
+    /// non-decodable payload maps to `.error` with an exit-code-aware remediation (this is the
+    /// decoding that previously lived inside `PreDeployCheck.check` / `defaultPreflight`).
+    public static func parseScanReport(output: String, exitCode: Int32?) -> PreDeployCheck.Outcome {
+        struct RawReport: Decodable {
+            let ok: Bool
+            let failures: [PreDeployCheck.ScanFailure]
+            let warnings: [PreDeployCheck.ScanWarning]
         }
 
-        let source = "deploy:\(siteID):build"
-        let handle: ProcessSupervisor.Handle
+        let report: RawReport
         do {
-            handle = try await supervisor.launch(
-                source: source,
-                executable: executable,
-                arguments: arguments,
-                currentDirectoryURL: siteDirectory,
-                logCenter: logCenter
-            )
+            report = try JSONDecoder().decode(RawReport.self, from: Data(output.utf8))
         } catch {
-            return .failure(.failed(reason: "couldn't spawn build: \(error)", exitCode: nil))
+            // No parseable JSON — the script most likely errored out (missing dist/, missing tsx,
+            // or an outdated script that predates `--json`). Exit 0 with no JSON is distinct from a
+            // non-zero exit so the remediation can be specific.
+            let exit = exitCode ?? -1
+            return .error(reason: exit == 0
+                ? "pre-deploy scan emitted no JSON (exit 0) — is the site's scripts/pre-deploy-check.ts up to date?"
+                : "pre-deploy scan failed (exit \(exit)) — run `npm run build` and try again, or run `/anglesite:update` if the script is outdated")
         }
 
-        let reason = await withTaskCancellationHandler {
-            await supervisor.waitForExit(handle)
-        } onCancel: {
-            // The deploy was cancelled (e.g. a Shortcuts/Siri CancellableIntent). The backend
-            // resumes our wait as `.terminated`, but the OS process would otherwise keep running —
-            // actually SIGTERM it so the build/wrangler doesn't finish (and, for wrangler, doesn't
-            // keep publishing to production) after we've reported cancellation.
-            Task { await supervisor.terminate(handle) }
+        if report.ok {
+            return .passed(warnings: report.warnings)
         }
-        switch reason {
-        case .exited(let code) where code == 0:
-            return .success
-        case .exited(let code):
-            return .failure(.failed(reason: "npm run build failed (exit \(code))", exitCode: code))
-        case .terminated:
-            return .failure(.failed(reason: "build was terminated", exitCode: nil))
-        case .retriesExhausted(let lastCode):
-            return .failure(.failed(reason: "build retries exhausted (exit \(lastCode))", exitCode: lastCode))
-        }
+        return .blocked(failures: report.failures, warnings: report.warnings)
     }
 
     // MARK: URL extraction
@@ -294,6 +257,9 @@ public actor DeployCommand {
     /// plugin's template, so every Anglesite site already has it; outdated sites that
     /// predate the `--json` mode surface as `.error` outcomes, which `deploy` maps to
     /// `.failed` with a "run `/anglesite:update`" remediation.
+    ///
+    /// Retained for non-deploy consumers (`DefaultHealthCheckRunner`) and parity; the deploy flow
+    /// itself now runs preflight through the `DeployExecutor` seam and parses with `parseScanReport`.
     public static let defaultPreflight: PreflightChecker = { siteDirectory in
         let check = PreDeployCheck(invoke: { siteDir in
             let scriptPath = siteDir.appendingPathComponent("scripts/pre-deploy-check.ts").path

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -57,7 +57,7 @@ public actor DeployCommand {
     /// cases where deploy() returns .failed afterwards.
     public typealias PreflightObserver = @Sendable (PreDeployCheck.Outcome) -> Void
 
-    private let tokenSource: TokenSource
+    public nonisolated let tokenSource: TokenSource
     private let executor: any DeployExecutor
 
     public init(

--- a/Sources/AnglesiteCore/DeployExecutor.swift
+++ b/Sources/AnglesiteCore/DeployExecutor.swift
@@ -100,7 +100,7 @@ public struct ContainerDeployExecutor: DeployExecutor {
             result = try await control.exec(
                 siteID: siteID,
                 argv: argv,
-                environment: environment,
+                environment: Self.guestEnvironment(from: environment),
                 workingDirectory: "/workspace/site",
                 onOutput: { line in continuation.yield(line) }
             )
@@ -112,6 +112,18 @@ public struct ContainerDeployExecutor: DeployExecutor {
         continuation.finish()
         await drained
         return DeployStepResult(exitCode: result.exitCode, output: result.stdout)
+    }
+
+    /// `DeployCommand` hands every step the full HOST (macOS) environment; almost none of it is valid
+    /// in the Linux guest. We must NOT forward it wholesale: the host `PATH` (`/opt/homebrew/bin:…`)
+    /// would shadow the guest's Linux PATH and break `node`/`npm`/`wrangler` resolution, and
+    /// `HOME`/`TMPDIR`/`XPC_*`/`__CF*` are host-only noise. The guest provides its own PATH/HOME; the
+    /// only host-originated value the deploy needs across the boundary is the Cloudflare token. Keep
+    /// this allowlist tight — add a key only when a deploy step demonstrably needs it in-guest.
+    private static let guestEnvAllowlist: Set<String> = ["CLOUDFLARE_API_TOKEN"]
+
+    private static func guestEnvironment(from hostEnvironment: [String: String]) -> [String: String] {
+        hostEnvironment.filter { guestEnvAllowlist.contains($0.key) }
     }
 
     // MARK: argv mapping

--- a/Sources/AnglesiteCore/DeployExecutor.swift
+++ b/Sources/AnglesiteCore/DeployExecutor.swift
@@ -82,19 +82,25 @@ public struct ContainerDeployExecutor: DeployExecutor {
     ) async -> DeployStepResult {
         // `siteDirectory` is the HOST path — the guest always uses /workspace/site.
         let argv = guestArgv(for: step)
-        // Stream guest output to LogCenter LIVE (matching the host path): the sync `onOutput`
-        // callback yields each line into an AsyncStream (`yield` is nonisolated + Sendable, so it's
-        // safe from the @Sendable closure), and a structured `async let` drains it concurrently,
-        // appending to the actor-isolated LogCenter. The `continuation.finish()` + `await drained`
-        // before returning guarantees no trailing line is lost — the same contract
-        // `InProcessBackend` uses for the host streaming.
+        // Stream guest output to LogCenter LIVE (matching the host path): the `@escaping @Sendable`
+        // `onOutput` callback yields each (line, stream) into an AsyncStream (`yield` is nonisolated
+        // + Sendable, so it's safe from the closure even when fired after `exec` returns), and a
+        // DETACHED task drains it, appending to the actor-isolated LogCenter under the line's own
+        // stream (so wrangler's stderr progress is labelled `.stderr`, not mislabelled `.stdout`).
+        //
+        // The drain is `Task.detached`, NOT `async let`: a structured child is cancelled the instant
+        // this task is cancelled — *before* it consumes the buffered lines — which would silently
+        // drop the kill-triggered final log lines. A detached task is independent of structured
+        // cancellation, so it drains exactly what was yielded. We `continuation.finish()` then
+        // `await drain.value` on EVERY exit path, so no line leaks and the drain always completes.
         // Never log the environment dict — CLOUDFLARE_API_TOKEN stays off disk and out of logs.
-        let (lines, continuation) = AsyncStream<String>.makeStream(bufferingPolicy: .unbounded)
-        async let drained: Void = {
-            for await line in lines {
-                await logCenter.append(source: source, stream: .stdout, text: line)
+        let (lines, continuation) = AsyncStream<(String, LogCenter.Stream)>.makeStream(bufferingPolicy: .unbounded)
+        let logCenter = self.logCenter
+        let drain = Task.detached(priority: .utility) {
+            for await (line, stream) in lines {
+                await logCenter.append(source: source, stream: stream, text: line)
             }
-        }()
+        }
         let result: ContainerExecResult
         do {
             result = try await control.exec(
@@ -102,15 +108,35 @@ public struct ContainerDeployExecutor: DeployExecutor {
                 argv: argv,
                 environment: Self.guestEnvironment(from: environment),
                 workingDirectory: "/workspace/site",
-                onOutput: { line in continuation.yield(line) }
+                onOutput: { line, stream in continuation.yield((line, stream)) }
             )
-        } catch {
+        } catch is CancellationError {
+            // A cancelled deploy: drain whatever the kill-triggered output produced, then surface a
+            // termination (nil exitCode, empty output). `DeployCommand` checks `Task.isCancelled`
+            // and renders "terminated" — we must NOT bury cancellation under a generic exec-error
+            // string. (The `DeployExecutor` seam is non-throwing, so we signal termination via the
+            // nil/empty result rather than re-throwing; `Task.isCancelled` carries the intent.)
             continuation.finish()
-            await drained
+            _ = await drain.value
+            return DeployStepResult(exitCode: nil, output: "")
+        } catch let error as LocalContainerError {
+            continuation.finish()
+            _ = await drain.value
+            // A dead/never-booted container surfaces as `.bootFailed`; give the user an actionable
+            // message instead of the raw error (the Deploy-button gating half lives app-side).
+            if case .bootFailed = error {
+                return DeployStepResult(
+                    exitCode: nil,
+                    output: "Container isn't running — open/start the site's preview first.")
+            }
+            return DeployStepResult(exitCode: nil, output: "couldn't exec in the container: \(error)")
+        } catch let error {
+            continuation.finish()
+            _ = await drain.value
             return DeployStepResult(exitCode: nil, output: "couldn't exec in the container: \(error)")
         }
         continuation.finish()
-        await drained
+        _ = await drain.value
         return DeployStepResult(exitCode: result.exitCode, output: result.stdout)
     }
 

--- a/Sources/AnglesiteCore/DeployExecutor.swift
+++ b/Sources/AnglesiteCore/DeployExecutor.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+// MARK: - Types
+
+/// Identifies one logical step in the deploy sequence.
+public enum DeployStep: Sendable {
+    /// `npm run build` — produces `dist/`.
+    case build
+    /// `npx tsx scripts/pre-deploy-check.ts --json` — the bundled plugin's security scan.
+    case preflight
+    /// `wrangler deploy` — publishes the built site to Cloudflare Workers.
+    case wrangler
+}
+
+/// The result of running a single deploy step.
+///
+/// - `exitCode`: the process exit code, or `nil` for pre-spawn failures (resolver reported
+///   `.unavailable`, or the process could not be spawned at all). Mirrors the `exitCode`
+///   convention in `DeployCommand.Result.failed`.
+/// - `output`: captured stdout, used for URL/scan parsing by the caller. Also streamed
+///   line-by-line to `LogCenter` under the caller-supplied source during execution.
+public struct DeployStepResult: Sendable, Equatable {
+    public let exitCode: Int32?
+    public let output: String
+
+    public init(exitCode: Int32?, output: String) {
+        self.exitCode = exitCode
+        self.output = output
+    }
+}
+
+// MARK: - Protocol
+
+/// Abstraction over the execution substrate for one deploy step.
+///
+/// `HostDeployExecutor` is the concrete implementation for the embedded-Node (host) path.
+/// A future `ContainerDeployExecutor` will implement this for the in-container path.
+///
+/// The `source` parameter is the `LogCenter` source tag (e.g. `"deploy:<id>:build"`,
+/// `"deploy:<id>"`). Callers supply it so the right log row receives the output.
+public protocol DeployExecutor: Sendable {
+    func run(
+        step: DeployStep,
+        siteDirectory: URL,
+        environment: [String: String],
+        source: String
+    ) async -> DeployStepResult
+}
+
+// MARK: - HostDeployExecutor
+
+/// Runs deploy steps on the host using the embedded Node runtime, mirroring `DeployCommand`'s
+/// existing inline spawn logic.
+///
+/// Injecting a custom `resolveCommand` lets tests drive arbitrary shell fixtures without
+/// requiring the vendored Node bundle to be present (same pattern as `DeployCommand`'s
+/// `CommandResolver`/`PreflightChecker` injection).
+///
+/// Normally (i.e. not in tests) the default resolver chooses the host command per step:
+///   - `.build`    → `node npm run build`  (vendored npm)
+///   - `.preflight`→ `/usr/bin/env npx tsx scripts/pre-deploy-check.ts --json`
+///   - `.wrangler` → `node node_modules/.bin/wrangler deploy`
+///
+/// Output is streamed line-by-line to `logCenter` under `source` *and* accumulated into
+/// `DeployStepResult.output` so callers can parse the deployed URL or scan JSON.
+public struct HostDeployExecutor: DeployExecutor {
+    private let supervisor: ProcessSupervisor
+    private let logCenter: LogCenter
+    /// Injectable per-step command resolver. Defaults to `HostDeployExecutor.defaultResolver`.
+    private let resolveCommand: @Sendable (DeployStep) -> DeployCommand.CommandResolver
+
+    public init(
+        supervisor: ProcessSupervisor = .shared,
+        logCenter: LogCenter = .shared,
+        resolveCommand: @escaping @Sendable (DeployStep) -> DeployCommand.CommandResolver =
+            HostDeployExecutor.defaultResolver
+    ) {
+        self.supervisor = supervisor
+        self.logCenter = logCenter
+        self.resolveCommand = resolveCommand
+    }
+
+    // MARK: DeployExecutor
+
+    public func run(
+        step: DeployStep,
+        siteDirectory: URL,
+        environment: [String: String],
+        source: String
+    ) async -> DeployStepResult {
+        let resolver = resolveCommand(step)
+        let plan = resolver(siteDirectory)
+
+        switch plan {
+        case .unavailable(let reason):
+            return DeployStepResult(exitCode: nil, output: reason)
+        case .run(let executable, let arguments):
+            return await spawn(
+                executable: executable,
+                arguments: arguments,
+                environment: environment,
+                siteDirectory: siteDirectory,
+                source: source
+            )
+        }
+    }
+
+    // MARK: Spawn helpers
+
+    private func spawn(
+        executable: URL,
+        arguments: [String],
+        environment: [String: String],
+        siteDirectory: URL,
+        source: String
+    ) async -> DeployStepResult {
+        let handle: ProcessSupervisor.Handle
+        do {
+            handle = try await supervisor.launch(
+                source: source,
+                executable: executable,
+                arguments: arguments,
+                environment: environment,
+                currentDirectoryURL: siteDirectory,
+                logCenter: logCenter
+            )
+        } catch {
+            return DeployStepResult(exitCode: nil, output: "couldn't spawn process: \(error)")
+        }
+
+        let reason = await withTaskCancellationHandler {
+            await supervisor.waitForExit(handle)
+        } onCancel: {
+            Task { await supervisor.terminate(handle) }
+        }
+
+        // Snapshot stdout from LogCenter — identical to DeployCommand's approach.
+        let snapshot = await logCenter.snapshot()
+        let output = snapshot
+            .filter { $0.source == source && $0.stream == .stdout }
+            .map(\.text)
+            .joined(separator: "\n")
+
+        switch reason {
+        case .exited(let code):
+            return DeployStepResult(exitCode: code, output: output)
+        case .terminated:
+            return DeployStepResult(exitCode: nil, output: output)
+        case .retriesExhausted(let lastCode):
+            return DeployStepResult(exitCode: lastCode, output: output)
+        }
+    }
+
+    // MARK: Default command resolvers
+
+    /// Returns the appropriate `CommandResolver` for each step, mirroring `DeployCommand`'s
+    /// static resolvers exactly.
+    public static let defaultResolver: @Sendable (DeployStep) -> DeployCommand.CommandResolver = { step in
+        switch step {
+        case .build:
+            return DeployCommand.resolveBuildCommand
+        case .preflight:
+            return preflightResolver
+        case .wrangler:
+            return DeployCommand.resolveWranglerCommand
+        }
+    }
+
+    /// Resolves the preflight command: `/usr/bin/env npx tsx scripts/pre-deploy-check.ts --json`.
+    /// Mirrors the inline resolve inside `DeployCommand.defaultPreflight`.
+    public static let preflightResolver: DeployCommand.CommandResolver = { siteDirectory in
+        let scriptPath = siteDirectory
+            .appendingPathComponent("scripts/pre-deploy-check.ts")
+            .path
+        return .run(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["npx", "tsx", scriptPath, "--json"]
+        )
+    }
+}

--- a/Sources/AnglesiteCore/DeployExecutor.swift
+++ b/Sources/AnglesiteCore/DeployExecutor.swift
@@ -82,11 +82,19 @@ public struct ContainerDeployExecutor: DeployExecutor {
     ) async -> DeployStepResult {
         // `siteDirectory` is the HOST path — the guest always uses /workspace/site.
         let argv = guestArgv(for: step)
-        // Collect lines synchronously during exec (the onOutput callback is nonisolated/sync),
-        // then batch-append them to LogCenter after exec returns (where we have await).
-        // This avoids unstructured Tasks and keeps log ordering deterministic.
+        // Stream guest output to LogCenter LIVE (matching the host path): the sync `onOutput`
+        // callback yields each line into an AsyncStream (`yield` is nonisolated + Sendable, so it's
+        // safe from the @Sendable closure), and a structured `async let` drains it concurrently,
+        // appending to the actor-isolated LogCenter. The `continuation.finish()` + `await drained`
+        // before returning guarantees no trailing line is lost — the same contract
+        // `InProcessBackend` uses for the host streaming.
         // Never log the environment dict — CLOUDFLARE_API_TOKEN stays off disk and out of logs.
-        let collectedLines: _CollectedLines = .init()
+        let (lines, continuation) = AsyncStream<String>.makeStream(bufferingPolicy: .unbounded)
+        async let drained: Void = {
+            for await line in lines {
+                await logCenter.append(source: source, stream: .stdout, text: line)
+            }
+        }()
         let result: ContainerExecResult
         do {
             result = try await control.exec(
@@ -94,14 +102,15 @@ public struct ContainerDeployExecutor: DeployExecutor {
                 argv: argv,
                 environment: environment,
                 workingDirectory: "/workspace/site",
-                onOutput: { line in collectedLines.append(line) }
+                onOutput: { line in continuation.yield(line) }
             )
         } catch {
+            continuation.finish()
+            await drained
             return DeployStepResult(exitCode: nil, output: "couldn't exec in the container: \(error)")
         }
-        for line in collectedLines.lines {
-            await logCenter.append(source: source, stream: .stdout, text: line)
-        }
+        continuation.finish()
+        await drained
         return DeployStepResult(exitCode: result.exitCode, output: result.stdout)
     }
 
@@ -117,18 +126,6 @@ public struct ContainerDeployExecutor: DeployExecutor {
             return ["npx", "wrangler", "deploy"]
         }
     }
-}
-
-// MARK: - _CollectedLines
-
-/// A Sendable accumulator for `onOutput` callbacks from `LocalContainerControl.exec`.
-///
-/// The callback is guaranteed to be called sequentially (one line at a time) from the
-/// exec implementation, so no locking is needed — but the class must be `@unchecked Sendable`
-/// because its `var lines` is mutated from inside the `@Sendable` closure.
-private final class _CollectedLines: @unchecked Sendable {
-    var lines: [String] = []
-    func append(_ line: String) { lines.append(line) }
 }
 
 // MARK: - HostDeployExecutor

--- a/Sources/AnglesiteCore/DeployExecutor.swift
+++ b/Sources/AnglesiteCore/DeployExecutor.swift
@@ -47,6 +47,90 @@ public protocol DeployExecutor: Sendable {
     ) async -> DeployStepResult
 }
 
+// MARK: - ContainerDeployExecutor
+
+/// Runs deploy steps inside a running container via `LocalContainerControl.exec`.
+///
+/// The site is cloned to `/workspace/site` in the guest at boot time; Node 22 and the
+/// site's `node_modules` are already installed there. Each step is mapped to an in-guest
+/// argv and executed at that working directory.
+///
+/// `CLOUDFLARE_API_TOKEN` is forwarded through the `environment` dict that the caller
+/// supplies — it is never added here and never written to logs.
+public struct ContainerDeployExecutor: DeployExecutor {
+    private let control: any LocalContainerControl
+    private let siteID: String
+    private let logCenter: LogCenter
+
+    public init(
+        control: any LocalContainerControl,
+        siteID: String,
+        logCenter: LogCenter = .shared
+    ) {
+        self.control = control
+        self.siteID = siteID
+        self.logCenter = logCenter
+    }
+
+    // MARK: DeployExecutor
+
+    public func run(
+        step: DeployStep,
+        siteDirectory: URL,
+        environment: [String: String],
+        source: String
+    ) async -> DeployStepResult {
+        // `siteDirectory` is the HOST path — the guest always uses /workspace/site.
+        let argv = guestArgv(for: step)
+        // Collect lines synchronously during exec (the onOutput callback is nonisolated/sync),
+        // then batch-append them to LogCenter after exec returns (where we have await).
+        // This avoids unstructured Tasks and keeps log ordering deterministic.
+        // Never log the environment dict — CLOUDFLARE_API_TOKEN stays off disk and out of logs.
+        let collectedLines: _CollectedLines = .init()
+        let result: ContainerExecResult
+        do {
+            result = try await control.exec(
+                siteID: siteID,
+                argv: argv,
+                environment: environment,
+                workingDirectory: "/workspace/site",
+                onOutput: { line in collectedLines.append(line) }
+            )
+        } catch {
+            return DeployStepResult(exitCode: nil, output: "couldn't exec in the container: \(error)")
+        }
+        for line in collectedLines.lines {
+            await logCenter.append(source: source, stream: .stdout, text: line)
+        }
+        return DeployStepResult(exitCode: result.exitCode, output: result.stdout)
+    }
+
+    // MARK: argv mapping
+
+    private func guestArgv(for step: DeployStep) -> [String] {
+        switch step {
+        case .build:
+            return ["npm", "run", "build"]
+        case .preflight:
+            return ["npx", "tsx", "scripts/pre-deploy-check.ts", "--json"]
+        case .wrangler:
+            return ["npx", "wrangler", "deploy"]
+        }
+    }
+}
+
+// MARK: - _CollectedLines
+
+/// A Sendable accumulator for `onOutput` callbacks from `LocalContainerControl.exec`.
+///
+/// The callback is guaranteed to be called sequentially (one line at a time) from the
+/// exec implementation, so no locking is needed — but the class must be `@unchecked Sendable`
+/// because its `var lines` is mutated from inside the `@Sendable` closure.
+private final class _CollectedLines: @unchecked Sendable {
+    var lines: [String] = []
+    func append(_ line: String) { lines.append(line) }
+}
+
 // MARK: - HostDeployExecutor
 
 /// Runs deploy steps on the host using the embedded Node runtime, mirroring `DeployCommand`'s

--- a/Sources/AnglesiteCore/LocalContainerControl.swift
+++ b/Sources/AnglesiteCore/LocalContainerControl.swift
@@ -18,6 +18,19 @@ public enum LocalContainerError: Error, Equatable {
     case cloneFailed(String)            // git clone of Source/ into the guest failed
 }
 
+/// The captured output of a guest `exec` call. No `Containerization`/`Virtualization` types cross
+/// this boundary — only `String` and `Int32`.
+public struct ContainerExecResult: Sendable, Equatable {
+    public let exitCode: Int32
+    public let stdout: String
+    public let stderr: String
+    public init(exitCode: Int32, stdout: String, stderr: String) {
+        self.exitCode = exitCode
+        self.stdout = stdout
+        self.stderr = stderr
+    }
+}
+
 /// Typed wrapper over "boot a container, hydrate it from a repo, start the guest processes, and
 /// return host-reachable endpoints." `ContainerizationControl` (in AnglesiteContainer) is the
 /// production conformer; `FakeLocalContainerControl` backs the tests. Mirrors `SandboxControlClient`.
@@ -25,4 +38,15 @@ public enum LocalContainerError: Error, Equatable {
 public protocol LocalContainerControl: Sendable {
     func start(siteID: String, sourceRepo: URL, ref: String) async throws -> LocalContainerSession
     func stop(siteID: String) async throws
+
+    /// Run `argv` inside the named container's guest environment, streaming each output line to
+    /// `onOutput` as it arrives, and returning the captured result when the process exits.
+    /// No `Containerization`/`Virtualization` types cross this seam.
+    func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @Sendable (String) -> Void
+    ) async throws -> ContainerExecResult
 }

--- a/Sources/AnglesiteCore/LocalContainerControl.swift
+++ b/Sources/AnglesiteCore/LocalContainerControl.swift
@@ -40,13 +40,19 @@ public protocol LocalContainerControl: Sendable {
     func stop(siteID: String) async throws
 
     /// Run `argv` inside the named container's guest environment, streaming each output line to
-    /// `onOutput` as it arrives, and returning the captured result when the process exits.
-    /// No `Containerization`/`Virtualization` types cross this seam.
+    /// `onOutput` (tagged with the stream it came from — `.stdout`/`.stderr`) as it arrives, and
+    /// returning the captured result when the process exits. No `Containerization`/`Virtualization`
+    /// types cross this seam.
+    ///
+    /// `onOutput` is `@escaping`: the production conformer hands it to the guest process's `Writer`
+    /// sinks, which can legitimately fire it *after* `exec` returns (e.g. a kill-triggered final
+    /// line on cancellation). The signature is honest about that — callers must not assume the
+    /// closure is dead once `exec` resolves.
     func exec(
         siteID: String,
         argv: [String],
         environment: [String: String],
         workingDirectory: String,
-        onOutput: @Sendable (String) -> Void
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> ContainerExecResult
 }

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -48,6 +48,17 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     /// Parallel to `containerControl` — callers need both to build a `ContainerDeployExecutor`.
     public var containerActiveSiteID: String? { activeSiteID }
 
+    /// Returns the control and active site ID atomically in a single actor hop, so the
+    /// caller (e.g. `PreviewModel.activeContainerControl()`) cannot observe a torn state
+    /// where one field is set and the other is not.
+    ///
+    /// Returns `nil` when no container is started (i.e. `activeSiteID` is nil — before
+    /// `start()` completes successfully and after `stop()`).
+    public func containerSnapshot() -> (control: any LocalContainerControl, siteID: String)? {
+        guard let id = activeSiteID else { return nil }
+        return (control: control, siteID: id)
+    }
+
     public func observe() -> AsyncStream<SiteRuntimeState> {
         let (stream, continuation) = AsyncStream<SiteRuntimeState>.makeStream(bufferingPolicy: .unbounded)
         let id = UUID()

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -34,6 +34,20 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
 
     public var state: SiteRuntimeState { current }
 
+    /// The `LocalContainerControl` held by this runtime, or `nil` if no site is currently
+    /// started. Callers (e.g. `PreviewModel`) read this to build a `ContainerDeployExecutor`
+    /// for the in-container deploy path (Task 5).
+    ///
+    /// Returns `nil` before `start()` completes successfully and after `stop()`.
+    public var containerControl: (any LocalContainerControl)? {
+        guard activeSiteID != nil else { return nil }
+        return control
+    }
+
+    /// The site ID of the currently-running container, or `nil` if none is started.
+    /// Parallel to `containerControl` — callers need both to build a `ContainerDeployExecutor`.
+    public var containerActiveSiteID: String? { activeSiteID }
+
     public func observe() -> AsyncStream<SiteRuntimeState> {
         let (stream, continuation) = AsyncStream<SiteRuntimeState>.makeStream(bufferingPolicy: .unbounded)
         let id = UUID()

--- a/Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift
@@ -102,6 +102,31 @@ struct ContainerDeployExecutorTests {
         #expect(calls[0].env["CLOUDFLARE_API_TOKEN"] == "supersecret")
     }
 
+    @Test("host-only env (PATH/HOME/Apple vars) is NOT forwarded into the Linux guest")
+    func curatesHostEnvOutOfGuest() async {
+        // DeployCommand passes the full host (macOS) environment; the guest must not receive it —
+        // a macOS PATH would shadow the guest's Linux PATH and break node/wrangler resolution, and
+        // HOME/__CF* are host-only noise. Only deploy-relevant vars (the token) should cross.
+        let fake = fakePassing()
+        let executor = makeExecutor(fake: fake)
+        _ = await executor.run(
+            step: .wrangler,
+            siteDirectory: URL(fileURLWithPath: "/host/irrelevant"),
+            environment: [
+                "CLOUDFLARE_API_TOKEN": "tok",
+                "PATH": "/opt/homebrew/bin:/usr/bin",
+                "HOME": "/Users/dev",
+                "__CFBundleIdentifier": "com.apple.dt.Xcode"
+            ],
+            source: "deploy:site-abc"
+        )
+        let env = await fake.execCalls[0].env
+        #expect(env["CLOUDFLARE_API_TOKEN"] == "tok")
+        #expect(env["PATH"] == nil)
+        #expect(env["HOME"] == nil)
+        #expect(env["__CFBundleIdentifier"] == nil)
+    }
+
     @Test("token does not appear in log output")
     func tokenNotLogged() async {
         let logCenter = LogCenter()

--- a/Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift
@@ -225,6 +225,34 @@ struct ContainerDeployExecutorTests {
         #expect(result.output.contains("couldn't exec in the container"))
     }
 
+    // MARK: - cancellation does not hang and surfaces termination
+
+    @Test("a cancelled exec resolves (does not hang) and surfaces termination, not an exec error")
+    func cancelledExecTerminates() async {
+        // The fake's `exec` parks until the running Task is cancelled (then throws CancellationError),
+        // mirroring a real long-running guest process that the deploy cancels mid-flight. The deploy
+        // task must resolve promptly with a nil exitCode + empty output (the "terminated" signal),
+        // NOT hang and NOT bury cancellation under a "couldn't exec" string.
+        let fake = CancelParkingFakeContainerControl()
+        let executor = ContainerDeployExecutor(control: fake, siteID: "s", logCenter: LogCenter())
+
+        let task = Task {
+            await executor.run(
+                step: .wrangler,
+                siteDirectory: URL(fileURLWithPath: "/host"),
+                environment: ["CLOUDFLARE_API_TOKEN": "tok"],
+                source: "deploy:s"
+            )
+        }
+        // Let `exec` reach its park point, then cancel.
+        await fake.waitUntilParked()
+        task.cancel()
+
+        let result = await task.value
+        #expect(result.exitCode == nil)
+        #expect(result.output.isEmpty, "cancellation must not surface a generic exec-error string")
+    }
+
     // MARK: - siteID forwarded to exec
 
     @Test("siteID is forwarded to exec")
@@ -260,8 +288,47 @@ private actor ThrowingFakeLocalContainerControl: LocalContainerControl {
         argv: [String],
         environment: [String: String],
         workingDirectory: String,
-        onOutput: @Sendable (String) -> Void
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> ContainerExecResult {
         throw ExecError.boom
+    }
+}
+
+// MARK: - CancelParkingFakeContainerControl
+
+/// A `LocalContainerControl` whose `exec` suspends until the calling Task is cancelled, then throws
+/// `CancellationError` — modelling a long-running guest process that the deploy aborts mid-flight.
+/// `waitUntilParked()` lets the test rendezvous with the park point before cancelling, so the test
+/// is deterministic (no sleeps) and proves the deploy resolves rather than hanging.
+private actor CancelParkingFakeContainerControl: LocalContainerControl {
+    private var parkedContinuation: CheckedContinuation<Void, Never>?
+
+    /// Resolves once `exec` has reached its suspension point.
+    func waitUntilParked() async {
+        await withCheckedContinuation { cont in parkedContinuation = cont }
+    }
+
+    func start(siteID: String, sourceRepo: URL, ref: String) async throws -> LocalContainerSession {
+        throw LocalContainerError.virtualizationUnavailable
+    }
+    func stop(siteID: String) async throws {}
+
+    func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> ContainerExecResult {
+        // Signal we've parked, then sleep "forever" — `Task.sleep` throws `CancellationError` the
+        // instant the Task is cancelled, which is exactly the abort path we want to exercise.
+        signalParked()
+        try await Task.sleep(for: .seconds(3600))
+        return ContainerExecResult(exitCode: 0, stdout: "", stderr: "")
+    }
+
+    private func signalParked() {
+        parkedContinuation?.resume()
+        parkedContinuation = nil
     }
 }

--- a/Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift
@@ -1,0 +1,242 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContainerDeployExecutor")
+struct ContainerDeployExecutorTests {
+
+    // MARK: Helpers
+
+    private func makeExecutor(
+        fake: FakeLocalContainerControl,
+        siteID: String = "site-abc",
+        logCenter: LogCenter = LogCenter()
+    ) -> ContainerDeployExecutor {
+        ContainerDeployExecutor(control: fake, siteID: siteID, logCenter: logCenter)
+    }
+
+    private func fakePassing(lines: [String] = []) -> FakeLocalContainerControl {
+        FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: "ok", stderr: ""),
+            execStdoutLines: lines
+        )
+    }
+
+    // MARK: - argv mapping
+
+    @Test("wrangler step sends correct argv")
+    func wranglerArgv() async {
+        let fake = fakePassing()
+        let executor = makeExecutor(fake: fake)
+        _ = await executor.run(
+            step: .wrangler,
+            siteDirectory: URL(fileURLWithPath: "/host/irrelevant"),
+            environment: ["CLOUDFLARE_API_TOKEN": "tok123"],
+            source: "deploy:site-abc"
+        )
+        let calls = await fake.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].argv == ["npx", "wrangler", "deploy"])
+    }
+
+    @Test("build step sends correct argv")
+    func buildArgv() async {
+        let fake = fakePassing()
+        let executor = makeExecutor(fake: fake)
+        _ = await executor.run(
+            step: .build,
+            siteDirectory: URL(fileURLWithPath: "/host/irrelevant"),
+            environment: [:],
+            source: "deploy:site-abc:build"
+        )
+        let calls = await fake.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].argv == ["npm", "run", "build"])
+    }
+
+    @Test("preflight step sends correct argv")
+    func preflightArgv() async {
+        let fake = fakePassing()
+        let executor = makeExecutor(fake: fake)
+        _ = await executor.run(
+            step: .preflight,
+            siteDirectory: URL(fileURLWithPath: "/host/irrelevant"),
+            environment: [:],
+            source: "deploy:site-abc:preflight"
+        )
+        let calls = await fake.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].argv == ["npx", "tsx", "scripts/pre-deploy-check.ts", "--json"])
+    }
+
+    // MARK: - cwd is always /workspace/site
+
+    @Test("exec always uses /workspace/site as working directory")
+    func workingDirectory() async {
+        let fake = fakePassing()
+        let executor = makeExecutor(fake: fake)
+        _ = await executor.run(
+            step: .build,
+            siteDirectory: URL(fileURLWithPath: "/host/totally/different"),
+            environment: [:],
+            source: "src"
+        )
+        let calls = await fake.execCalls
+        #expect(calls[0].cwd == "/workspace/site")
+    }
+
+    // MARK: - CLOUDFLARE_API_TOKEN forwarded, not logged
+
+    @Test("wrangler forwards CLOUDFLARE_API_TOKEN in env")
+    func wranglerForwardsToken() async {
+        let fake = fakePassing()
+        let executor = makeExecutor(fake: fake)
+        _ = await executor.run(
+            step: .wrangler,
+            siteDirectory: URL(fileURLWithPath: "/host/irrelevant"),
+            environment: ["CLOUDFLARE_API_TOKEN": "supersecret"],
+            source: "deploy:site-abc"
+        )
+        let calls = await fake.execCalls
+        #expect(calls[0].env["CLOUDFLARE_API_TOKEN"] == "supersecret")
+    }
+
+    @Test("token does not appear in log output")
+    func tokenNotLogged() async {
+        let logCenter = LogCenter()
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: "done", stderr: ""),
+            execStdoutLines: ["build complete"]
+        )
+        let executor = makeExecutor(fake: fake, logCenter: logCenter)
+        _ = await executor.run(
+            step: .wrangler,
+            siteDirectory: URL(fileURLWithPath: "/host/irrelevant"),
+            environment: ["CLOUDFLARE_API_TOKEN": "mysecrettoken"],
+            source: "deploy:site-abc"
+        )
+        let snapshot = await logCenter.snapshot()
+        for line in snapshot {
+            #expect(!line.text.contains("mysecrettoken"))
+        }
+    }
+
+    // MARK: - stdout lines reach LogCenter
+
+    @Test("stdout lines from exec are appended to LogCenter under source")
+    func stdoutToLogCenter() async {
+        let logCenter = LogCenter()
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: "full", stderr: ""),
+            execStdoutLines: ["line one", "line two"]
+        )
+        let executor = makeExecutor(fake: fake, logCenter: logCenter)
+        _ = await executor.run(
+            step: .build,
+            siteDirectory: URL(fileURLWithPath: "/host"),
+            environment: [:],
+            source: "deploy:site-abc:build"
+        )
+        let snapshot = await logCenter.snapshot()
+        let texts = snapshot
+            .filter { $0.source == "deploy:site-abc:build" }
+            .map(\.text)
+        #expect(texts.contains("line one"))
+        #expect(texts.contains("line two"))
+    }
+
+    // MARK: - exit code surfaced
+
+    @Test("non-zero exit code surfaces in DeployStepResult")
+    func nonZeroExitCode() async {
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 127, stdout: "not found", stderr: ""),
+            execStdoutLines: []
+        )
+        let executor = makeExecutor(fake: fake)
+        let result = await executor.run(
+            step: .build,
+            siteDirectory: URL(fileURLWithPath: "/host"),
+            environment: [:],
+            source: "src"
+        )
+        #expect(result.exitCode == 127)
+    }
+
+    @Test("zero exit code surfaces in DeployStepResult")
+    func zeroExitCode() async {
+        let fake = fakePassing()
+        let executor = makeExecutor(fake: fake)
+        let result = await executor.run(
+            step: .build,
+            siteDirectory: URL(fileURLWithPath: "/host"),
+            environment: [:],
+            source: "src"
+        )
+        #expect(result.exitCode == 0)
+    }
+
+    // MARK: - thrown exec surfaces as nil exitCode
+
+    @Test("thrown exec returns nil exitCode and error message")
+    func thrownExecReturnsNilExitCode() async {
+        let fake = ThrowingFakeLocalContainerControl()
+        let executor = ContainerDeployExecutor(
+            control: fake,
+            siteID: "site-abc",
+            logCenter: LogCenter()
+        )
+        let result = await executor.run(
+            step: .build,
+            siteDirectory: URL(fileURLWithPath: "/host"),
+            environment: [:],
+            source: "src"
+        )
+        #expect(result.exitCode == nil)
+        #expect(result.output.contains("couldn't exec in the container"))
+    }
+
+    // MARK: - siteID forwarded to exec
+
+    @Test("siteID is forwarded to exec")
+    func siteIDForwarded() async {
+        let fake = fakePassing()
+        let executor = ContainerDeployExecutor(
+            control: fake,
+            siteID: "my-special-site",
+            logCenter: LogCenter()
+        )
+        _ = await executor.run(
+            step: .build,
+            siteDirectory: URL(fileURLWithPath: "/host"),
+            environment: [:],
+            source: "src"
+        )
+        let calls = await fake.execCalls
+        #expect(calls[0].siteID == "my-special-site")
+    }
+}
+
+// MARK: - ThrowingFakeLocalContainerControl
+
+private actor ThrowingFakeLocalContainerControl: LocalContainerControl {
+    enum ExecError: Error { case boom }
+
+    func start(siteID: String, sourceRepo: URL, ref: String) async throws -> LocalContainerSession {
+        throw ExecError.boom
+    }
+    func stop(siteID: String) async throws {}
+    func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @Sendable (String) -> Void
+    ) async throws -> ContainerExecResult {
+        throw ExecError.boom
+    }
+}

--- a/Tests/AnglesiteCoreTests/DeployCommandProgressTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandProgressTests.swift
@@ -8,18 +8,27 @@ struct DeployCommandProgressTests {
     @Test("a blocked deploy still emits building then preflight milestones")
     func milestonesUpToBlock() async {
         let recorder = ProgressRecorder()
-        // Build resolves to `/usr/bin/true` (exit 0); preflight returns .blocked so we stop early
-        // without needing wrangler.
-        let cmd = DeployCommand(
-            resolveCommand: { _ in .unavailable(reason: "no wrangler in test") },
-            resolveBuildCommand: { _ in .run(executable: URL(fileURLWithPath: "/usr/bin/true"), arguments: []) },
-            tokenSource: { "token" },
-            preflight: { _ in .blocked(failures: [], warnings: []) }
-        )
+        // Build succeeds (exit 0); preflight JSON blocks so we stop early without reaching wrangler.
+        let exec = BlockingPreflightExecutor()
+        let cmd = DeployCommand(tokenSource: { "token" }, executor: exec)
         _ = await cmd.deploy(siteID: "s", siteDirectory: URL(fileURLWithPath: NSTemporaryDirectory()),
                              onProgress: { recorder.record($0) })
         let phases = recorder.phases()
         #expect(phases.prefix(2) == ["building", "preflightScan"])
+    }
+}
+
+/// Fake executor: build passes, preflight emits a `ok:false` blocking report, wrangler never runs.
+private struct BlockingPreflightExecutor: DeployExecutor {
+    func run(step: DeployStep, siteDirectory: URL, environment: [String: String], source: String) async -> DeployStepResult {
+        switch step {
+        case .build:
+            return DeployStepResult(exitCode: 0, output: "")
+        case .preflight:
+            return DeployStepResult(exitCode: 0, output: #"{"ok":false,"failures":[],"warnings":[]}"#)
+        case .wrangler:
+            return DeployStepResult(exitCode: 0, output: "")
+        }
     }
 }
 

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -3,34 +3,336 @@ import Foundation
 @testable import AnglesiteCore
 
 struct DeployCommandTests {
-    /// A real, existing directory — the supervisor `cd`s into the site dir before spawning, so a
+    /// A real, existing directory — the host executor `cd`s into the site dir before spawning, so a
     /// nonexistent path would fail `process.run()` before our fixture script even runs.
     private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
 
-    private func makeCommand(
-        resolve: @escaping DeployCommand.CommandResolver,
-        token: @escaping DeployCommand.TokenSource,
-        preflight: @escaping DeployCommand.PreflightChecker = { _ in .passed(warnings: []) },
-        build: @escaping DeployCommand.CommandResolver = { _ in .run(executable: URL(fileURLWithPath: "/usr/bin/true"), arguments: []) }
-    ) -> (DeployCommand, ProcessSupervisor, LogCenter) {
-        let supervisor = ProcessSupervisor()
+    // MARK: Fake executor
+
+    /// A `DeployExecutor` that returns canned `DeployStepResult`s per step, records the
+    /// environment it was handed per step, and counts how many times each step ran. Lets the
+    /// flow tests drive build→preflight→wrangler without a subprocess.
+    private final class FakeExecutor: DeployExecutor, @unchecked Sendable {
+        struct Call: Sendable { let step: DeployStep; let environment: [String: String]; let source: String }
+
+        private let lock = NSLock()
+        private var byStep: [String: DeployStepResult] = [:]
+        private(set) var calls: [Call] = []
+        /// Optional hook fired (inside `run`) when a given step runs — used to assert a step is
+        /// NOT reached (the parallel to the old `confirmation(expectedCount: 0)` resolver guards).
+        private var onRun: [String: @Sendable () -> Void] = [:]
+
+        init() {}
+
+        private func key(_ step: DeployStep) -> String {
+            switch step {
+            case .build: return "build"
+            case .preflight: return "preflight"
+            case .wrangler: return "wrangler"
+            }
+        }
+
+        @discardableResult
+        func set(_ step: DeployStep, exitCode: Int32?, output: String) -> FakeExecutor {
+            lock.lock(); byStep[key(step)] = DeployStepResult(exitCode: exitCode, output: output); lock.unlock()
+            return self
+        }
+
+        @discardableResult
+        func onRun(_ step: DeployStep, _ body: @escaping @Sendable () -> Void) -> FakeExecutor {
+            lock.lock(); onRun[key(step)] = body; lock.unlock()
+            return self
+        }
+
+        func ran(_ step: DeployStep) -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            return calls.contains { key($0.step) == key(step) }
+        }
+
+        func environment(for step: DeployStep) -> [String: String]? {
+            lock.lock(); defer { lock.unlock() }
+            return calls.first { key($0.step) == key(step) }?.environment
+        }
+
+        func run(step: DeployStep, siteDirectory: URL, environment: [String: String], source: String) async -> DeployStepResult {
+            lock.lock()
+            calls.append(Call(step: step, environment: environment, source: source))
+            let hook = onRun[key(step)]
+            let result = byStep[key(step)] ?? DeployStepResult(exitCode: 0, output: "")
+            lock.unlock()
+            hook?()
+            return result
+        }
+    }
+
+    /// Build the JSON payload the plugin's `pre-deploy-check.ts --json` emits.
+    private func scanJSON(ok: Bool) -> String {
+        ok ? #"{"ok":true,"failures":[],"warnings":[]}"#
+           : #"{"ok":false,"failures":[{"category":"pii-email","file":"dist/index.html","detail":"email","remediation":"wrap it"}],"warnings":[]}"#
+    }
+
+    // MARK: Full flow through the fake executor
+
+    @Test("Drives build → preflight → wrangler and succeeds with the extracted URL")
+    func fullFlowSucceeds() async {
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "building…")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published angle-app (1.23 sec)\n  https://angle-app.example.workers.dev")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "s", siteDirectory: tmpDir)
+        guard case .succeeded(let url, let duration) = result else {
+            Issue.record("expected .succeeded, got \(result)"); return
+        }
+        #expect(url == URL(string: "https://angle-app.example.workers.dev")!)
+        #expect(duration >= 0)
+        #expect(exec.ran(.build) && exec.ran(.preflight) && exec.ran(.wrangler))
+    }
+
+    @Test("Environment contract: build/preflight get no token, wrangler gets CLOUDFLARE_API_TOKEN")
+    func environmentContractPerStep() async {
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(tokenSource: { "secret-tok" }, executor: exec)
+        _ = await cmd.deploy(siteID: "s", siteDirectory: tmpDir)
+        #expect(exec.environment(for: .build)?["CLOUDFLARE_API_TOKEN"] == nil)
+        #expect(exec.environment(for: .preflight)?["CLOUDFLARE_API_TOKEN"] == nil)
+        #expect(exec.environment(for: .wrangler)?["CLOUDFLARE_API_TOKEN"] == "secret-tok")
+    }
+
+    // MARK: Pre-spawn refusal (no work wasted)
+
+    @Test("Refuses before any step when token source returns nil")
+    func refusesBeforeStepsWhenTokenNil() async {
+        let exec = FakeExecutor().onRun(.build, { Issue.record("build must not run when token is missing") })
+        let cmd = DeployCommand(tokenSource: { nil }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else {
+            Issue.record("expected .failed, got \(result)"); return
+        }
+        #expect(reason.contains("CLOUDFLARE_API_TOKEN"))
+        #expect(exit == nil)
+        #expect(!exec.ran(.build))
+    }
+
+    @Test("Refuses before any step when token source returns empty string")
+    func refusesBeforeStepsWhenTokenEmpty() async {
+        let exec = FakeExecutor()
+        let cmd = DeployCommand(tokenSource: { "" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, _) = result else {
+            Issue.record("expected .failed, got \(result)"); return
+        }
+        #expect(reason.contains("CLOUDFLARE_API_TOKEN"))
+        #expect(!exec.ran(.build))
+    }
+
+    // MARK: Build step
+
+    @Test("Fails when build exits non-zero, and does not run preflight or wrangler")
+    func failsWhenBuildExitsNonZero() async {
+        let exec = FakeExecutor().set(.build, exitCode: 2, output: "astro: type error")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else {
+            Issue.record("expected .failed, got \(result)"); return
+        }
+        #expect(exit == 2)
+        #expect(reason.contains("build") && reason.contains("2"))
+        #expect(!exec.ran(.preflight) && !exec.ran(.wrangler))
+    }
+
+    @Test("Fails with the executor's reason when build is unavailable (nil exit)")
+    func failsWhenBuildUnavailable() async {
+        let exec = FakeExecutor().set(.build, exitCode: nil, output: "vendored npm not found — rebuild the app")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, _) = result else {
+            Issue.record("expected .failed, got \(result)"); return
+        }
+        #expect(reason.contains("vendored npm"))
+    }
+
+    // MARK: Preflight step
+
+    @Test("Returns blocked and does not run wrangler when preflight JSON blocks")
+    func blockedPreflightShortCircuits() async {
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: false))
+            .onRun(.wrangler, { Issue.record("wrangler must not run when preflight blocks") })
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .blocked(let failures, _) = result else {
+            Issue.record("expected .blocked, got \(result)"); return
+        }
+        #expect(failures.count == 1)
+        #expect(failures[0].category == .piiEmail)
+        #expect(failures[0].file == "dist/index.html")
+        #expect(!exec.ran(.wrangler))
+    }
+
+    @Test("Fails when preflight output is not parseable JSON (and does not run wrangler)")
+    func failsWhenPreflightErrors() async {
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 1, output: "Error: tsx not installed")
+            .onRun(.wrangler, { Issue.record("wrangler must not run when preflight errored") })
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, _) = result else {
+            Issue.record("expected .failed, got \(result)"); return
+        }
+        #expect(reason.lowercased().contains("pre-deploy scan"))
+        #expect(!exec.ran(.wrangler))
+    }
+
+    @Test("Fires onPreflight with the resolved outcome")
+    func firesOnPreflight() async {
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: #"{"ok":true,"failures":[],"warnings":[{"category":"missing-og-image","detail":"no og image","remediation":"add one"}]}"#)
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let observed = Mutex<PreDeployCheck.Outcome?>(nil)
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        _ = await cmd.deploy(siteID: "t", siteDirectory: tmpDir, onPreflight: { observed.set($0) })
+        guard case .passed(let warnings) = observed.get() else {
+            Issue.record("expected .passed outcome observed"); return
+        }
+        #expect(warnings.first?.category == .missingOgImage)
+    }
+
+    // MARK: Wrangler failure surfacing
+
+    @Test("Fails when wrangler exits non-zero")
+    func failsWhenWranglerExitsNonZero() async {
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 10, output: "Error: authentication failed")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else {
+            Issue.record("expected .failed, got \(result)"); return
+        }
+        #expect(exit == 10)
+        #expect(reason.contains("10"))
+    }
+
+    @Test("Fails semantically when wrangler exits 0 but no published URL")
+    func failsWhenZeroExitButNoURL() async {
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Did some thing.\nNo anchor here.")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit) = result else {
+            Issue.record("expected .failed, got \(result)"); return
+        }
+        #expect(exit == 0)
+        #expect(reason.lowercased().contains("url"))
+    }
+
+    @Test("Ignores URLs before the published anchor")
+    func ignoresURLsBeforeAnchor() async {
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "See https://developers.cloudflare.com/workers for help.\nPublished angle-app (1.23 sec)\n  https://angle-app.example.workers.dev")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .succeeded(let url, _) = result else {
+            Issue.record("expected .succeeded, got \(result)"); return
+        }
+        #expect(url.host == "angle-app.example.workers.dev")
+    }
+
+    // MARK: Scan report parsing helper
+
+    @Test("parseScanReport maps ok/blocked/error correctly")
+    func parseScanReport() {
+        if case .passed(let w) = DeployCommand.parseScanReport(output: scanJSON(ok: true), exitCode: 0) {
+            #expect(w.isEmpty)
+        } else { Issue.record("expected .passed") }
+
+        if case .blocked(let f, _) = DeployCommand.parseScanReport(output: scanJSON(ok: false), exitCode: 0) {
+            #expect(f.first?.category == .piiEmail)
+        } else { Issue.record("expected .blocked") }
+
+        if case .error(let reason) = DeployCommand.parseScanReport(output: "not json", exitCode: 1) {
+            #expect(reason.contains("exit 1"))
+        } else { Issue.record("expected .error for non-JSON exit 1") }
+
+        if case .error(let reason) = DeployCommand.parseScanReport(output: "not json", exitCode: 0) {
+            #expect(reason.contains("no JSON"))
+        } else { Issue.record("expected .error for non-JSON exit 0") }
+    }
+
+    // MARK: Host-executor parity (real subprocess via HostDeployExecutor)
+
+    /// One end-to-end test that runs the REAL `HostDeployExecutor` against `/bin/sh` fixtures so the
+    /// host spawn/snapshot/parse path stays covered. Per-step resolvers are injected so no vendored
+    /// Node bundle is required.
+    @Test("Host executor parity: real build + preflight + wrangler sh fixtures → succeeded")
+    func hostExecutorParity() async {
         let center = LogCenter()
-        let cmd = DeployCommand(
-            supervisor: supervisor,
+        let exec = HostDeployExecutor(
+            supervisor: ProcessSupervisor(),
             logCenter: center,
-            resolveCommand: resolve,
-            resolveBuildCommand: build,
-            tokenSource: token,
-            preflight: preflight
+            resolveCommand: { step in
+                { _ in
+                    switch step {
+                    case .build:
+                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", "echo building; exit 0"])
+                    case .preflight:
+                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", #"echo '{"ok":true,"failures":[],"warnings":[]}'; exit 0"#])
+                    case .wrangler:
+                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", "echo 'Published angle-app (1.23 sec)'; echo '  https://angle-app.example.workers.dev'; exit 0"])
+                    }
+                }
+            }
         )
-        return (cmd, supervisor, center)
+        let cmd = DeployCommand(tokenSource: { "fake-token" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .succeeded(let url, _) = result else {
+            Issue.record("expected .succeeded, got \(result)"); return
+        }
+        #expect(url == URL(string: "https://angle-app.example.workers.dev")!)
+        // Build output reached LogCenter under the build source.
+        let lines = await center.snapshot()
+        #expect(lines.contains { $0.source == "deploy:mysite:build" && $0.text == "building" })
     }
 
-    private func shFixture(_ script: String, _ args: String...) -> DeployCommand.LaunchPlan {
-        .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", script] + args)
+    @Test("Host executor parity: wrangler step sees CLOUDFLARE_API_TOKEN in its environment")
+    func hostExecutorPassesToken() async {
+        let center = LogCenter()
+        let exec = HostDeployExecutor(
+            supervisor: ProcessSupervisor(),
+            logCenter: center,
+            resolveCommand: { step in
+                { _ in
+                    switch step {
+                    case .build:
+                        return .run(executable: URL(fileURLWithPath: "/usr/bin/true"), arguments: [])
+                    case .preflight:
+                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", #"echo '{"ok":true,"failures":[],"warnings":[]}'"#])
+                    case .wrangler:
+                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", "echo \"TOKEN=$CLOUDFLARE_API_TOKEN\"; echo 'Published x (0.1 sec)'; echo '  https://x.workers.dev'"])
+                    }
+                }
+            }
+        )
+        let cmd = DeployCommand(tokenSource: { "secret-token-abc" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+        let lines = await center.snapshot()
+        #expect(lines.first(where: { $0.text.contains("TOKEN=") })?.text == "TOKEN=secret-token-abc")
     }
 
-    // MARK: Cancellation
+    // MARK: Cancellation (real HostDeployExecutor → SIGTERM)
 
     /// Poll `center` for a marker line up to `timeout`. Returns true once it appears.
     private func waitForMarker(_ marker: String, in center: LogCenter, timeout: Duration = .seconds(3)) async -> Bool {
@@ -42,341 +344,44 @@ struct DeployCommandTests {
         return false
     }
 
-    /// Budget for observing an asynchronous side-effect (a subprocess marker reaching `LogCenter`).
-    /// Generous on purpose: cancellation resumes `waitForExit` with `.terminated` *immediately*, so
-    /// `task.value` returns before the kill even happens. The marker only lands after a chain of
-    /// fire-and-forget tasks + libdispatch + actor hops (cancel → `Task{terminate}` → SIGTERM → the
-    /// fixture's trap echo → pipe drain → `LogCenter.append`). The line is never dropped — `finalize`
-    /// in InProcessBackend awaits the drain before settling — but under 294 Swift Tests running in
-    /// parallel on a loaded CI runner the cooperative pool can starve those tasks for several seconds
-    /// (this is what made the suite flake at the old 10s budget). Normal completion is ~100ms, so a
-    /// 30s ceiling still surfaces a genuine hang quickly while no longer false-positiving under load.
+    /// Generous budget — see the original note: cancellation resumes `waitForExit` immediately, so
+    /// the marker only lands after a chain of fire-and-forget tasks under parallel-test load.
     private static let markerObservationTimeout: Duration = .seconds(30)
 
     @Test("Cancelling the task actually SIGTERMs the in-flight wrangler subprocess")
     func cancellationTerminatesWrangler() async {
         // Token + build (/usr/bin/true) + preflight pass quickly, then wrangler blocks. Cancelling
-        // the deploy must kill wrangler (not orphan it mid-publish): `.failed(terminated)` AND the
-        // process reports the SIGTERM trap. The fixture sets the trap, then echoes __STARTED__ so
-        // we cancel exactly once wrangler is running (no fixed-delay race — `__STARTED__` is unique
-        // to wrangler since the build step is silent /usr/bin/true).
-        let (cmd, _, center) = makeCommand(
-            resolve: { _ in self.shFixture("trap 'echo __SIGTERM__; exit 143' TERM; echo __STARTED__; sleep 20; echo __COMPLETED__") },
-            token: { "tok" }
+        // the deploy must kill wrangler: `.failed(terminated)` AND the process reports the SIGTERM
+        // trap. The fixture sets the trap, then echoes __STARTED__ so we cancel exactly once
+        // wrangler is running.
+        let center = LogCenter()
+        let exec = HostDeployExecutor(
+            supervisor: ProcessSupervisor(),
+            logCenter: center,
+            resolveCommand: { step in
+                { _ in
+                    switch step {
+                    case .build:
+                        return .run(executable: URL(fileURLWithPath: "/usr/bin/true"), arguments: [])
+                    case .preflight:
+                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", #"echo '{"ok":true,"failures":[],"warnings":[]}'"#])
+                    case .wrangler:
+                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", "trap 'echo __SIGTERM__; exit 143' TERM; echo __STARTED__; sleep 20; echo __COMPLETED__"])
+                    }
+                }
+            }
         )
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
         let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         let task = Task { await cmd.deploy(siteID: "site", siteDirectory: dir) }
         #expect(await waitForMarker("__STARTED__", in: center, timeout: Self.markerObservationTimeout), "wrangler never started")
         task.cancel()
         let result = await task.value
         guard case .failed(let reason, _) = result else {
-            Issue.record("expected .failed(terminated), got \(result)")
-            return
+            Issue.record("expected .failed(terminated), got \(result)"); return
         }
         #expect(reason.contains("terminated"))
         #expect(await waitForMarker("__SIGTERM__", in: center, timeout: Self.markerObservationTimeout), "wrangler subprocess was not actually SIGTERM'd")
-    }
-
-    // MARK: Pre-spawn refusal (no work wasted)
-
-    @Test("Refuses before spawn when token source returns nil") func refusesBeforeSpawnWhenTokenSourceReturnsNil() async {
-        // The resolver must never be consulted when the token is missing.
-        await confirmation("resolver should not be consulted when token is missing", expectedCount: 0) { resolverCalled in
-            let (cmd, _, _) = makeCommand(
-                resolve: { _ in
-                    resolverCalled()
-                    return self.shFixture("exit 0")
-                },
-                token: { nil }
-            )
-            let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-            guard case .failed(let reason, let exit) = result else {
-                Issue.record("expected .failed, got \(result)")
-                return
-            }
-            #expect(reason.contains("CLOUDFLARE_API_TOKEN"), "reason should name the env var the caller should set: \(reason)")
-            #expect(exit == nil)
-        }
-    }
-
-    @Test("Refuses before spawn when token source returns empty string") func refusesBeforeSpawnWhenTokenSourceReturnsEmptyString() async {
-        let (cmd, _, _) = makeCommand(
-            resolve: { _ in self.shFixture("exit 0") },
-            token: { "" }
-        )
-        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-        guard case .failed(let reason, _) = result else {
-            Issue.record("expected .failed, got \(result)")
-            return
-        }
-        #expect(reason.contains("CLOUDFLARE_API_TOKEN"), "\(reason)")
-    }
-
-    @Test("Fails when resolver reports unavailable") func failsWhenResolverReportsUnavailable() async {
-        let (cmd, _, _) = makeCommand(
-            resolve: { _ in .unavailable(reason: "wrangler not installed — run `npm install`") },
-            token: { "fake-token" }
-        )
-        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-        guard case .failed(let reason, let exit) = result else {
-            Issue.record("expected .failed, got \(result)")
-            return
-        }
-        #expect(reason == "wrangler not installed — run `npm install`")
-        #expect(exit == nil)
-    }
-
-    // MARK: Happy path — URL extraction
-
-    @Test("Succeeds and extracts URL from published line") func succeedsAndExtractsURLFromPublishedLine() async {
-        // Synthetic wrangler output: a blank line, the `Published ...` summary, indented URL, exit 0.
-        let script = """
-        echo ''
-        echo '⛅️ wrangler 3.50.0'
-        echo 'Total Upload: 4.20 KiB'
-        echo 'Published angle-app (1.23 sec)'
-        echo '  https://angle-app.example.workers.dev'
-        echo '  Current Deployment ID: abc-123'
-        exit 0
-        """
-        let (cmd, _, _) = makeCommand(
-            resolve: { _ in self.shFixture(script) },
-            token: { "fake-token" }
-        )
-        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-        guard case .succeeded(let url, let duration) = result else {
-            Issue.record("expected .succeeded, got \(result)")
-            return
-        }
-        #expect(url == URL(string: "https://angle-app.example.workers.dev")!)
-        #expect(duration >= 0)
-    }
-
-    @Test("Ignores URLs that appear before the published anchor") func ignoresURLsThatAppearBeforeThePublishedAnchor() async {
-        // A help-text URL in wrangler's output must NOT be reported as the deployed URL.
-        let script = """
-        echo 'See https://developers.cloudflare.com/workers for help.'
-        echo 'Published angle-app (1.23 sec)'
-        echo '  https://angle-app.example.workers.dev'
-        exit 0
-        """
-        let (cmd, _, _) = makeCommand(
-            resolve: { _ in self.shFixture(script) },
-            token: { "fake-token" }
-        )
-        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-        guard case .succeeded(let url, _) = result else {
-            Issue.record("expected .succeeded, got \(result)")
-            return
-        }
-        #expect(url.host == "angle-app.example.workers.dev")
-    }
-
-    // MARK: Failure surfacing
-
-    @Test("Fails when wrangler exits non-zero") func failsWhenWranglerExitsNonZero() async {
-        let script = """
-        echo 'Error: authentication failed' 1>&2
-        exit 10
-        """
-        let (cmd, _, _) = makeCommand(
-            resolve: { _ in self.shFixture(script) },
-            token: { "fake-token" }
-        )
-        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-        guard case .failed(let reason, let exit) = result else {
-            Issue.record("expected .failed, got \(result)")
-            return
-        }
-        #expect(exit == 10)
-        #expect(reason.contains("10"), "reason should mention the exit code: \(reason)")
-    }
-
-    @Test("Fails semantically when zero exit but no published URL") func failsSemanticallyWhenZeroExitButNoPublishedURL() async {
-        // A wrangler bug or unexpected output shape: process exits 0 but our anchor never matched.
-        // We surface this as a clear failure rather than silently returning a bogus URL.
-        let script = """
-        echo 'Did some thing.'
-        echo 'No anchor here.'
-        exit 0
-        """
-        let (cmd, _, _) = makeCommand(
-            resolve: { _ in self.shFixture(script) },
-            token: { "fake-token" }
-        )
-        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-        guard case .failed(let reason, let exit) = result else {
-            Issue.record("expected .failed, got \(result)")
-            return
-        }
-        #expect(exit == 0)
-        #expect(reason.lowercased().contains("url"), "reason should explain the URL was missing: \(reason)")
-    }
-
-    // MARK: Token propagation
-
-    @Test("Passes Cloudflare token as environment variable to subprocess") func passesCloudflareTokenAsEnvironmentVariableToSubprocess() async {
-        // Fixture echoes the value of $CLOUDFLARE_API_TOKEN, then prints a fake Published URL so
-        // the deploy reaches `.succeeded`. We can then read what was echoed via the LogCenter.
-        let script = """
-        echo "TOKEN_SEEN_BY_WRANGLER=$CLOUDFLARE_API_TOKEN"
-        echo 'Published angle-app (0.42 sec)'
-        echo '  https://t.example.workers.dev'
-        exit 0
-        """
-        let (cmd, _, center) = makeCommand(
-            resolve: { _ in self.shFixture(script) },
-            token: { "secret-token-abc" }
-        )
-        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-        guard case .succeeded = result else {
-            Issue.record("expected .succeeded, got \(result)")
-            return
-        }
-        let lines = await center.snapshot()
-        let tokenLine = lines.first(where: { $0.text.contains("TOKEN_SEEN_BY_WRANGLER=") })
-        #expect(tokenLine?.text == "TOKEN_SEEN_BY_WRANGLER=secret-token-abc")
-    }
-
-    // MARK: Build step
-
-    @Test("Fails when build exits non-zero") func failsWhenBuildExitsNonZero() async {
-        // preflight and wrangler must not run when build fails.
-        await confirmation("neither preflight nor wrangler runs when build fails", expectedCount: 0) { neitherCalled in
-            let (cmd, _, _) = makeCommand(
-                resolve: { _ in
-                    neitherCalled()
-                    return self.shFixture("exit 0")
-                },
-                token: { "fake-token" },
-                preflight: { _ in
-                    neitherCalled()
-                    return .passed(warnings: [])
-                },
-                build: { _ in
-                    self.shFixture("echo 'astro: oops, type error' 1>&2; exit 2")
-                }
-            )
-            let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-            guard case .failed(let reason, let exit) = result else {
-                Issue.record("expected .failed, got \(result)")
-                return
-            }
-            #expect(exit == 2)
-            #expect(reason.contains("build") && reason.contains("2"), "reason should name the build and the exit code: \(reason)")
-        }
-    }
-
-    @Test("Fails when build resolver reports unavailable") func failsWhenBuildResolverReportsUnavailable() async {
-        let (cmd, _, _) = makeCommand(
-            resolve: { _ in self.shFixture("exit 0") },
-            token: { "fake-token" },
-            build: { _ in .unavailable(reason: "vendored npm not found — rebuild the app") }
-        )
-        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-        guard case .failed(let reason, _) = result else {
-            Issue.record("expected .failed, got \(result)")
-            return
-        }
-        #expect(reason.contains("vendored npm"), "\(reason)")
-    }
-
-    @Test("Build output appears in LogCenter under build source") func buildOutputAppearsInLogCenterUnderBuildSource() async {
-        let (cmd, _, center) = makeCommand(
-            resolve: { _ in
-                self.shFixture("echo 'Published angle-app (0.42 sec)'; echo '  https://t.example.workers.dev'; exit 0")
-            },
-            token: { "fake-token" },
-            build: { _ in self.shFixture("echo 'building dist…'; exit 0") }
-        )
-        _ = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-        let lines = await center.snapshot()
-        #expect(
-            lines.contains { $0.source == "deploy:mysite:build" && $0.text == "building dist…" },
-            "build line should appear under deploy:<site>:build source"
-        )
-    }
-
-    // MARK: Pre-deploy preflight
-
-    @Test("Returns blocked and does not spawn wrangler when preflight blocks") func returnsBlockedAndDoesNotSpawnWranglerWhenPreflightBlocks() async {
-        let blockedOutcome = PreDeployCheck.Outcome.blocked(
-            failures: [
-                .init(
-                    category: .piiEmail,
-                    file: "dist/index.html",
-                    detail: "Possible email address: jane@yourbusiness.com",
-                    remediation: "Wrap the address in a `mailto:` link or add it to PII_EMAIL_ALLOW in .site-config."
-                )
-            ],
-            warnings: []
-        )
-        // wrangler must not run when the pre-deploy scan blocks the deploy.
-        await confirmation("wrangler must not run when the pre-deploy scan blocks the deploy", expectedCount: 0) { wranglerSpawned in
-            let (cmd, _, _) = makeCommand(
-                resolve: { _ in
-                    wranglerSpawned()
-                    return self.shFixture("exit 0")
-                },
-                token: { "fake-token" },
-                preflight: { _ in blockedOutcome }
-            )
-
-            let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-
-            guard case .blocked(let failures, _) = result else {
-                Issue.record("expected .blocked, got \(result)")
-                return
-            }
-            #expect(failures.count == 1)
-            #expect(failures[0].category == .piiEmail)
-            #expect(failures[0].file == "dist/index.html")
-        }
-    }
-
-    @Test("Fails when preflight errors") func failsWhenPreflightErrors() async {
-        // wrangler must not run when preflight could not run at all.
-        await confirmation("wrangler must not run when preflight could not run at all", expectedCount: 0) { wranglerSpawned in
-            let (cmd, _, _) = makeCommand(
-                resolve: { _ in
-                    wranglerSpawned()
-                    return self.shFixture("exit 0")
-                },
-                token: { "fake-token" },
-                preflight: { _ in .error(reason: "tsx not installed in this site") }
-            )
-
-            let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
-
-            guard case .failed(let reason, _) = result else {
-                Issue.record("expected .failed, got \(result)")
-                return
-            }
-            #expect(reason.contains("tsx"), "reason should surface the preflight error: \(reason)")
-        }
-    }
-
-    // MARK: onPreflight callback
-
-    @Test("Deploy fires onPreflight with resolved outcome") func deployFiresOnPreflightWithResolvedOutcome() async {
-        let expectedOutcome = PreDeployCheck.Outcome.passed(warnings: [
-            .init(category: .missingOgImage, detail: "no og image", remediation: "add one")
-        ])
-        let observed = Mutex<PreDeployCheck.Outcome?>(nil)
-
-        let (cmd, _, _) = makeCommand(
-            resolve: { _ in self.shFixture("exit 0") },
-            token: { "fake-token" },
-            preflight: { _ in expectedOutcome }
-        )
-
-        _ = await cmd.deploy(
-            siteID: "test",
-            siteDirectory: tmpDir,
-            onPreflight: { outcome in observed.set(outcome) }
-        )
-
-        #expect(observed.get() == expectedOutcome)
     }
 }
 

--- a/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
@@ -29,16 +29,6 @@ struct DeployExecutorSelectionTests {
             execResult: ContainerExecResult(exitCode: 0, stdout: scanOK, stderr: ""),
             execStdoutLines: []
         )
-        // ContainerDeployExecutor calls control.exec for every step.
-        // Build: exit 0 / Preflight: exit 0 + scan JSON / Wrangler: exit 0 + URL
-        let fakeWithURL = FakeLocalContainerControl(
-            startResult: .failure(.virtualizationUnavailable),
-            execResult: ContainerExecResult(exitCode: 0, stdout: wranglerOut, stderr: ""),
-            execStdoutLines: []
-        )
-        // For a multi-step flow we need different outputs per step; use the per-step override on
-        // the executor rather than the control (the control always returns the same execResult).
-        // Simplest approach: run with a single-step check — just assert exec was called at all.
         let executor = ContainerDeployExecutor(
             control: fake,
             siteID: "site-1",
@@ -48,10 +38,9 @@ struct DeployExecutorSelectionTests {
             tokenSource: { "tok" },
             executor: executor
         )
-        // Run only a partial flow: `build` exits 0, `preflight` returns the scan JSON with exit 0,
-        // but the execResult is the same for every call, so the wrangler step also gets scanOK
-        // (not a URL). That's fine — we're testing executor selection, not the full deploy flow.
-        // Use a custom step-aware fake that returns appropriate payloads per step.
+        // The fake returns the same execResult for every step, so this asserts routing (exec is
+        // reached on the container control), not the full flow — step ordering is covered by
+        // `allStepsRouteViaContainer`.
         _ = await cmd.deploy(siteID: "site-1", siteDirectory: tmpDir)
         let calls = await fake.execCalls
         // The container executor must have forwarded at least the build step through exec().

--- a/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
@@ -172,6 +172,39 @@ struct LocalContainerSiteRuntimeControlExposureTests {
         let siteID = await rt.containerActiveSiteID
         #expect(siteID == nil)
     }
+
+    // MARK: - containerSnapshot() — single-hop accessor
+
+    @Test("containerSnapshot returns nil before start()")
+    func snapshotNilBeforeStart() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+        let snap = await rt.containerSnapshot()
+        #expect(snap == nil)
+    }
+
+    @Test("containerSnapshot returns control and siteID after start() succeeds")
+    func snapshotPresentAfterStart() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+        await rt.start(siteID: "snap-site", siteDirectory: URL(fileURLWithPath: "/unused"))
+        let snap = await rt.containerSnapshot()
+        #expect(snap != nil)
+        #expect(snap?.siteID == "snap-site")
+    }
+
+    @Test("containerSnapshot returns nil after stop()")
+    func snapshotNilAfterStop() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        await rt.stop()
+        let snap = await rt.containerSnapshot()
+        #expect(snap == nil)
+    }
 }
 
 // MARK: - StepAwareFakeContainerControl

--- a/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
@@ -1,0 +1,225 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for Task 5: when a `LocalContainerControl` is supplied to `DeployCommand`, the
+/// deploy routes through `ContainerDeployExecutor`; when absent it uses the host path.
+///
+/// The selection is exercised at the `DeployCommand` level because `DeployModel` (App target)
+/// isn't unit-testable here. The observable signal is whether `FakeLocalContainerControl.execCalls`
+/// is non-empty: the container executor calls `control.exec(...)` for every step, the host
+/// executor never does.
+///
+/// Also tests the `LocalContainerSiteRuntime.containerControl` / `containerActiveSiteID`
+/// accessors added for Task 5's "expose control" step.
+@Suite("DeployExecutor selection (Task 5)")
+struct DeployExecutorSelectionTests {
+
+    // A successful scan JSON so the full build→preflight→wrangler flow runs without blocking.
+    private let scanOK = #"{"ok":true,"failures":[],"warnings":[]}"#
+    private let wranglerOut = "Published site (1s)\n  https://site.example.workers.dev"
+    private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+    // MARK: - Container path
+
+    @Test("when a container control is supplied, exec() is called on it for every step")
+    func containerControlRoutesExecToContainer() async {
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: scanOK, stderr: ""),
+            execStdoutLines: []
+        )
+        // ContainerDeployExecutor calls control.exec for every step.
+        // Build: exit 0 / Preflight: exit 0 + scan JSON / Wrangler: exit 0 + URL
+        let fakeWithURL = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: wranglerOut, stderr: ""),
+            execStdoutLines: []
+        )
+        // For a multi-step flow we need different outputs per step; use the per-step override on
+        // the executor rather than the control (the control always returns the same execResult).
+        // Simplest approach: run with a single-step check — just assert exec was called at all.
+        let executor = ContainerDeployExecutor(
+            control: fake,
+            siteID: "site-1",
+            logCenter: LogCenter()
+        )
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            executor: executor
+        )
+        // Run only a partial flow: `build` exits 0, `preflight` returns the scan JSON with exit 0,
+        // but the execResult is the same for every call, so the wrangler step also gets scanOK
+        // (not a URL). That's fine — we're testing executor selection, not the full deploy flow.
+        // Use a custom step-aware fake that returns appropriate payloads per step.
+        _ = await cmd.deploy(siteID: "site-1", siteDirectory: tmpDir)
+        let calls = await fake.execCalls
+        // The container executor must have forwarded at least the build step through exec().
+        #expect(calls.count >= 1, "container control.exec() must be called at least once when container executor is used")
+        #expect(calls[0].siteID == "site-1")
+    }
+
+    @Test("when container control is supplied, exec siteID matches the deploy siteID")
+    func containerSiteIDForwarded() async {
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: scanOK, stderr: ""),
+            execStdoutLines: []
+        )
+        let executor = ContainerDeployExecutor(control: fake, siteID: "my-site", logCenter: LogCenter())
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: executor)
+        _ = await cmd.deploy(siteID: "my-site", siteDirectory: tmpDir)
+        let calls = await fake.execCalls
+        for call in calls {
+            #expect(call.siteID == "my-site")
+        }
+    }
+
+    // MARK: - Host path (nil control → no exec calls on any container control)
+
+    @Test("when no container control is supplied, container control exec() is never called")
+    func hostPathDoesNotCallContainerExec() async {
+        // Track calls via a FakeLocalContainerControl that should NOT be called.
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: "", stderr: ""),
+            execStdoutLines: []
+        )
+        // HostDeployExecutor with an unavailable resolver — simulates the host path being chosen.
+        let hostExecutor = HostDeployExecutor(
+            supervisor: ProcessSupervisor(),
+            logCenter: LogCenter(),
+            resolveCommand: { _ in { _ in .unavailable(reason: "host path chosen") } }
+        )
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: hostExecutor)
+        _ = await cmd.deploy(siteID: "site-1", siteDirectory: tmpDir)
+        let calls = await fake.execCalls
+        #expect(calls.isEmpty, "container control.exec() must NOT be called when the host executor is used")
+    }
+
+    // MARK: - Step routing for full container deploy
+
+    @Test("all three steps route through the container executor in order")
+    func allStepsRouteViaContainer() async {
+        // Use a step-aware fake: intercept exec calls in order and return the right payload.
+        let stepAware = StepAwareFakeContainerControl()
+        let executor = ContainerDeployExecutor(control: stepAware, siteID: "s", logCenter: LogCenter())
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: executor)
+        _ = await cmd.deploy(siteID: "s", siteDirectory: tmpDir)
+        let calls = await stepAware.calls
+        let argvs = calls.map(\.argv)
+        #expect(argvs.count == 3)
+        #expect(argvs[0] == ["npm", "run", "build"])
+        #expect(argvs[1] == ["npx", "tsx", "scripts/pre-deploy-check.ts", "--json"])
+        #expect(argvs[2] == ["npx", "wrangler", "deploy"])
+    }
+}
+
+// MARK: - LocalContainerSiteRuntime.containerControl exposure (Task 5)
+
+@Suite("LocalContainerSiteRuntime containerControl exposure")
+struct LocalContainerSiteRuntimeControlExposureTests {
+    private static let ok = LocalContainerSession(
+        previewURL: URL(string: "http://127.0.0.1:51001")!,
+        mcpURL: URL(string: "http://127.0.0.1:51002/mcp")!
+    )
+
+    @Test("containerControl returns nil before start()")
+    func containerControlNilBeforeStart() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+        let control = await rt.containerControl
+        #expect(control == nil)
+    }
+
+    @Test("containerControl returns the held control after start() succeeds")
+    func containerControlPresentAfterStart() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        let control = await rt.containerControl
+        #expect(control != nil)
+    }
+
+    @Test("containerActiveSiteID returns nil before start()")
+    func activeSiteIDNilBeforeStart() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+        let siteID = await rt.containerActiveSiteID
+        #expect(siteID == nil)
+    }
+
+    @Test("containerActiveSiteID returns the started siteID after start() succeeds")
+    func activeSiteIDAfterStart() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+        await rt.start(siteID: "my-site", siteDirectory: URL(fileURLWithPath: "/unused"))
+        let siteID = await rt.containerActiveSiteID
+        #expect(siteID == "my-site")
+    }
+
+    @Test("containerControl returns nil after stop()")
+    func containerControlNilAfterStop() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        await rt.stop()
+        let control = await rt.containerControl
+        #expect(control == nil)
+    }
+
+    @Test("containerActiveSiteID returns nil after stop()")
+    func activeSiteIDNilAfterStop() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        await rt.stop()
+        let siteID = await rt.containerActiveSiteID
+        #expect(siteID == nil)
+    }
+}
+
+// MARK: - StepAwareFakeContainerControl
+
+/// A `LocalContainerControl` whose `exec` returns the appropriate payload for each step
+/// in sequence (build → preflight → wrangler), so the full three-step flow completes
+/// without the wrong step output short-circuiting the run.
+private actor StepAwareFakeContainerControl: LocalContainerControl {
+    private(set) var calls: [(siteID: String, argv: [String])] = []
+    private var callCount = 0
+
+    private let scanOK = #"{"ok":true,"failures":[],"warnings":[]}"#
+    private let wranglerOut = "Published site (1s)\n  https://site.example.workers.dev"
+
+    func start(siteID: String, sourceRepo: URL, ref: String) async throws -> LocalContainerSession {
+        throw LocalContainerError.virtualizationUnavailable
+    }
+
+    func stop(siteID: String) async throws {}
+
+    func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @Sendable (String) -> Void
+    ) async throws -> ContainerExecResult {
+        calls.append((siteID: siteID, argv: argv))
+        let n = callCount
+        callCount += 1
+        // Step 0 = build (exit 0, empty stdout)
+        // Step 1 = preflight (exit 0, scan JSON)
+        // Step 2 = wrangler (exit 0, URL output)
+        switch n {
+        case 0: return ContainerExecResult(exitCode: 0, stdout: "", stderr: "")
+        case 1: return ContainerExecResult(exitCode: 0, stdout: scanOK, stderr: "")
+        default: return ContainerExecResult(exitCode: 0, stdout: wranglerOut, stderr: "")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
@@ -38,14 +38,14 @@ struct DeployExecutorSelectionTests {
             tokenSource: { "tok" },
             executor: executor
         )
-        // The fake returns the same execResult for every step, so this asserts routing (exec is
-        // reached on the container control), not the full flow — step ordering is covered by
-        // `allStepsRouteViaContainer`.
+        // The fake returns exit-0 + valid scan JSON for every step, so the full
+        // build→preflight→wrangler flow reaches all three exec() calls (wrangler then fails on the
+        // missing URL, but only AFTER routing). Asserting `== 3` proves every step routes through
+        // the container; step-argv ordering is covered by `allStepsRouteViaContainer`.
         _ = await cmd.deploy(siteID: "site-1", siteDirectory: tmpDir)
         let calls = await fake.execCalls
-        // The container executor must have forwarded at least the build step through exec().
-        #expect(calls.count >= 1, "container control.exec() must be called at least once when container executor is used")
-        #expect(calls[0].siteID == "site-1")
+        #expect(calls.count == 3, "all three deploy steps must route through container control.exec()")
+        #expect(calls.allSatisfy { $0.siteID == "site-1" })
     }
 
     @Test("when container control is supplied, exec siteID matches the deploy siteID")
@@ -197,7 +197,7 @@ private actor StepAwareFakeContainerControl: LocalContainerControl {
         argv: [String],
         environment: [String: String],
         workingDirectory: String,
-        onOutput: @Sendable (String) -> Void
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> ContainerExecResult {
         calls.append((siteID: siteID, argv: argv))
         let n = callCount

--- a/Tests/AnglesiteCoreTests/DeployExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorTests.swift
@@ -1,0 +1,140 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct DeployExecutorTests {
+    /// A real, existing directory — the supervisor `cd`s into the site dir before spawning.
+    private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+    /// Builds a `HostDeployExecutor` with a single injected resolver and isolated supervision.
+    private func makeExecutor(
+        resolveCommand: @escaping @Sendable (URL) -> DeployCommand.LaunchPlan
+    ) -> (HostDeployExecutor, ProcessSupervisor, LogCenter) {
+        let supervisor = ProcessSupervisor()
+        let center = LogCenter()
+        let executor = HostDeployExecutor(
+            supervisor: supervisor,
+            logCenter: center,
+            resolveCommand: { _ in { dir in resolveCommand(dir) } }
+        )
+        return (executor, supervisor, center)
+    }
+
+    /// Mirrors `DeployCommandTests.shFixture`.
+    private func shPlan(_ script: String) -> DeployCommand.LaunchPlan {
+        .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", script])
+    }
+
+    // MARK: - build step
+
+    @Test("HostDeployExecutor build: exit 0 and stdout captured")
+    func buildStepReturnsExitCodeAndOutput() async {
+        let (executor, _, center) = makeExecutor(resolveCommand: { _ in
+            self.shPlan("echo 'build output line'; exit 0")
+        })
+
+        let result = await executor.run(
+            step: .build,
+            siteDirectory: tmpDir,
+            environment: ProcessInfo.processInfo.environment,
+            source: "test:build"
+        )
+
+        #expect(result.exitCode == 0)
+        #expect(result.output.contains("build output line"))
+        // The line must also appear in LogCenter under the given source.
+        let lines = await center.snapshot()
+        #expect(
+            lines.contains { $0.source == "test:build" && $0.text == "build output line" },
+            "build output should be streamed to LogCenter under the supplied source"
+        )
+    }
+
+    @Test("HostDeployExecutor build: non-zero exit code is preserved")
+    func buildStepNonZeroExitCode() async {
+        let (executor, _, _) = makeExecutor(resolveCommand: { _ in self.shPlan("exit 42") })
+        let result = await executor.run(
+            step: .build,
+            siteDirectory: tmpDir,
+            environment: ProcessInfo.processInfo.environment,
+            source: "test:build"
+        )
+        #expect(result.exitCode == 42)
+    }
+
+    @Test("HostDeployExecutor build: unavailable plan returns nil exitCode with reason")
+    func buildStepUnavailableReturnsNilExitCode() async {
+        let (executor, _, _) = makeExecutor(resolveCommand: { _ in
+            .unavailable(reason: "node not bundled — test")
+        })
+        let result = await executor.run(
+            step: .build,
+            siteDirectory: tmpDir,
+            environment: ProcessInfo.processInfo.environment,
+            source: "test:build"
+        )
+        #expect(result.exitCode == nil)
+        #expect(result.output.contains("node not bundled"))
+    }
+
+    // MARK: - wrangler step
+
+    @Test("HostDeployExecutor wrangler: stdout captured for URL parsing")
+    func wranglerStepStdoutCaptured() async {
+        let (executor, _, _) = makeExecutor(resolveCommand: { _ in
+            self.shPlan(
+                """
+                echo 'Published site (0.42 sec)'
+                echo '  https://site.example.workers.dev'
+                exit 0
+                """
+            )
+        })
+        let result = await executor.run(
+            step: .wrangler,
+            siteDirectory: tmpDir,
+            environment: ProcessInfo.processInfo.environment,
+            source: "test:wrangler"
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.output.contains("Published"))
+        #expect(result.output.contains("https://site.example.workers.dev"))
+    }
+
+    // MARK: - preflight step
+
+    @Test("HostDeployExecutor preflight: stdout captured")
+    func preflightStepStdoutCaptured() async {
+        let (executor, _, _) = makeExecutor(resolveCommand: { _ in
+            self.shPlan(#"echo '{"status":"pass"}'; exit 0"#)
+        })
+        let result = await executor.run(
+            step: .preflight,
+            siteDirectory: tmpDir,
+            environment: ProcessInfo.processInfo.environment,
+            source: "test:preflight"
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.output.contains("pass"))
+    }
+
+    // MARK: - DeployStepResult equatability
+
+    @Test("DeployStepResult is Equatable")
+    func deployStepResultEquatable() {
+        let a = DeployStepResult(exitCode: 0, output: "hello")
+        let b = DeployStepResult(exitCode: 0, output: "hello")
+        let c = DeployStepResult(exitCode: 1, output: "hello")
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    @Test("DeployStepResult with nil exitCode is Equatable")
+    func deployStepResultNilExitCodeEquatable() {
+        let a = DeployStepResult(exitCode: nil, output: "unavailable")
+        let b = DeployStepResult(exitCode: nil, output: "unavailable")
+        let c = DeployStepResult(exitCode: 0, output: "unavailable")
+        #expect(a == b)
+        #expect(a != c)
+    }
+}

--- a/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
+++ b/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
@@ -35,10 +35,10 @@ actor FakeLocalContainerControl: LocalContainerControl {
         argv: [String],
         environment: [String: String],
         workingDirectory: String,
-        onOutput: @Sendable (String) -> Void
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> ContainerExecResult {
         execCalls.append((siteID: siteID, argv: argv, env: environment, cwd: workingDirectory))
-        for line in execStdoutLines { onOutput(line) }
+        for line in execStdoutLines { onOutput(line, .stdout) }
         return execResult
     }
 }
@@ -78,7 +78,7 @@ actor GatedFakeLocalContainerControl: LocalContainerControl {
         argv: [String],
         environment: [String: String],
         workingDirectory: String,
-        onOutput: @Sendable (String) -> Void
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> ContainerExecResult {
         ContainerExecResult(exitCode: 0, stdout: "", stderr: "")
     }

--- a/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
+++ b/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
@@ -6,8 +6,21 @@ actor FakeLocalContainerControl: LocalContainerControl {
     private(set) var stopped: [String] = []
     private(set) var startedRepos: [(siteID: String, repo: URL, ref: String)] = []
 
-    init(startResult: Result<LocalContainerSession, LocalContainerError>) {
+    /// Canned result returned by `exec`. Defaults to a successful empty run.
+    var execResult: ContainerExecResult
+    /// Lines replayed to `onOutput` in order before `exec` returns.
+    var execStdoutLines: [String]
+    /// All `exec` invocations recorded for assertion.
+    private(set) var execCalls: [(siteID: String, argv: [String], env: [String: String], cwd: String)] = []
+
+    init(
+        startResult: Result<LocalContainerSession, LocalContainerError>,
+        execResult: ContainerExecResult = ContainerExecResult(exitCode: 0, stdout: "", stderr: ""),
+        execStdoutLines: [String] = []
+    ) {
         self.startResult = startResult
+        self.execResult = execResult
+        self.execStdoutLines = execStdoutLines
     }
 
     func start(siteID: String, sourceRepo: URL, ref: String) async throws -> LocalContainerSession {
@@ -16,6 +29,18 @@ actor FakeLocalContainerControl: LocalContainerControl {
     }
 
     func stop(siteID: String) async throws { stopped.append(siteID) }
+
+    func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @Sendable (String) -> Void
+    ) async throws -> ContainerExecResult {
+        execCalls.append((siteID: siteID, argv: argv, env: environment, cwd: workingDirectory))
+        for line in execStdoutLines { onOutput(line) }
+        return execResult
+    }
 }
 
 /// A `LocalContainerControl` whose `start` suspends until `release()` is called — for
@@ -47,4 +72,14 @@ actor GatedFakeLocalContainerControl: LocalContainerControl {
         return try result.get()
     }
     func stop(siteID: String) async throws { stopped.append(siteID) }
+
+    func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @Sendable (String) -> Void
+    ) async throws -> ContainerExecResult {
+        ContainerExecResult(exitCode: 0, stdout: "", stderr: "")
+    }
 }

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -185,7 +185,7 @@ struct FakeLocalContainerControlExecTests {
             argv: ["wrangler", "deploy"],
             environment: ["NODE_ENV": "production"],
             workingDirectory: "/workspace/Source",
-            onOutput: { _ in })
+            onOutput: { _, _ in })
 
         let calls = await fake.execCalls
         #expect(calls.count == 1)
@@ -207,7 +207,7 @@ struct FakeLocalContainerControlExecTests {
             argv: ["cmd"],
             environment: [:],
             workingDirectory: "/",
-            onOutput: { _ in })
+            onOutput: { _, _ in })
 
         #expect(result == expected)
     }
@@ -219,14 +219,32 @@ struct FakeLocalContainerControlExecTests {
             execResult: Self.defaultResult,
             execStdoutLines: ["line1", "line2", "line3"])
 
-        var received: [String] = []
+        // `onOutput` is `@escaping @Sendable`; collect through a thread-safe box and assert the
+        // fake replays each line tagged `.stdout`.
+        let collector = LineCollector()
         _ = try await fake.exec(
             siteID: "s",
             argv: ["build"],
             environment: [:],
             workingDirectory: "/",
-            onOutput: { received.append($0) })
+            onOutput: { line, stream in collector.append(line, stream) })
 
-        #expect(received == ["line1", "line2", "line3"])
+        #expect(collector.lines == ["line1", "line2", "line3"])
+        #expect(collector.streams.allSatisfy { $0 == .stdout })
     }
+}
+
+/// Thread-safe sink for `onOutput` lines in tests (the seam's closure is `@escaping @Sendable`).
+private final class LineCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _lines: [String] = []
+    private var _streams: [LogCenter.Stream] = []
+
+    func append(_ line: String, _ stream: LogCenter.Stream) {
+        lock.lock(); defer { lock.unlock() }
+        _lines.append(line)
+        _streams.append(stream)
+    }
+    var lines: [String] { lock.lock(); defer { lock.unlock() }; return _lines }
+    var streams: [LogCenter.Stream] { lock.lock(); defer { lock.unlock() }; return _streams }
 }

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -163,3 +163,70 @@ struct LocalContainerSiteRuntimeTests {
         #expect(seen.last == .ready(siteID: "s1", url: Self.ok.previewURL))
     }
 }
+
+// MARK: - FakeLocalContainerControl exec tests
+
+struct FakeLocalContainerControlExecTests {
+    private static let defaultResult = ContainerExecResult(
+        exitCode: 0, stdout: "built successfully", stderr: "")
+
+    private static let session = LocalContainerSession(
+        previewURL: URL(string: "http://127.0.0.1:1")!,
+        mcpURL: URL(string: "http://127.0.0.1:2")!)
+
+    @Test("exec records the call with siteID, argv, env, and cwd")
+    func execRecordsCall() async throws {
+        let fake = FakeLocalContainerControl(
+            startResult: .success(Self.session),
+            execResult: Self.defaultResult)
+
+        _ = try await fake.exec(
+            siteID: "site-abc",
+            argv: ["wrangler", "deploy"],
+            environment: ["NODE_ENV": "production"],
+            workingDirectory: "/workspace/Source",
+            onOutput: { _ in })
+
+        let calls = await fake.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].siteID == "site-abc")
+        #expect(calls[0].argv == ["wrangler", "deploy"])
+        #expect(calls[0].env == ["NODE_ENV": "production"])
+        #expect(calls[0].cwd == "/workspace/Source")
+    }
+
+    @Test("exec returns the injected execResult")
+    func execReturnsResult() async throws {
+        let expected = ContainerExecResult(exitCode: 1, stdout: "out", stderr: "err")
+        let fake = FakeLocalContainerControl(
+            startResult: .success(Self.session),
+            execResult: expected)
+
+        let result = try await fake.exec(
+            siteID: "s",
+            argv: ["cmd"],
+            environment: [:],
+            workingDirectory: "/",
+            onOutput: { _ in })
+
+        #expect(result == expected)
+    }
+
+    @Test("exec replays execStdoutLines via onOutput in order")
+    func execReplaysStoLines() async throws {
+        let fake = FakeLocalContainerControl(
+            startResult: .success(Self.session),
+            execResult: Self.defaultResult,
+            execStdoutLines: ["line1", "line2", "line3"])
+
+        var received: [String] = []
+        _ = try await fake.exec(
+            siteID: "s",
+            argv: ["build"],
+            environment: [:],
+            workingDirectory: "/",
+            onOutput: { received.append($0) })
+
+        #expect(received == ["line1", "line2", "line3"])
+    }
+}


### PR DESCRIPTION
Implements the **in-container deploy** capability — the prerequisite #70 **A1** needs before host-side deploy Node can be removed (A1's operations — Astro build, the plugin pre-deploy scan, `wrangler deploy` — are all Node-required with no native path, so the only migration is into the container). Plan: `docs/superpowers/plans/2026-06-26-in-container-deploy.md`.

When a site runs in a `LocalContainerSiteRuntime` (#69), deploy now runs build + pre-deploy scan + `wrangler deploy` **inside that container** (where Node already lives) instead of host embedded Node.

### Design (9 commits, subagent-driven + reviewed per task)
- **`exec` on the `LocalContainerControl` seam** + fake (captured/streamed) — AnglesiteCore.
- **`DeployExecutor`** abstraction: `HostDeployExecutor` (today's path, extracted unchanged) + `ContainerDeployExecutor` (build/scan/wrangler via `control.exec` at `/workspace/site`, **live** LogCenter streaming of stdout+stderr).
- **`DeployCommand`** driven by the executor — flow/observers/retries/**cancellation→SIGTERM** preserved (behavior-equivalent for the host path).
- **Host-vs-container selection** in `DeployModel`/`SiteWindow` via `PreviewModel.activeContainerControl()`.
- **Real `ContainerizationControl.exec`** against `apple/containerization` 0.34 (`environmentVariables`/`workingDirectory`/`Writer` streaming/`kill(.term)` on cancel) — `AnglesiteContainer`, never CI-compiled.

### Guarantees (per the final whole-branch review — "Ready to merge: Yes")
- **Additive + inert:** the host deploy path is unchanged and the default; the container path is selected only on an entitled, provisioned, non-MAS build where the site already runs in a container. **Merging changes nothing for current users.**
- **CI boundary:** only `ContainerizationControl.exec` is non-CI (gated by `ANGLESITE_SKIP_CONTAINER`); everything else is fake-tested. Full CI-mode suite = **888 tests pass**; both schemes build.
- **Token safety:** the Cloudflare token crosses only via the guest exec env (literal `K=V`, no shell, never logged). The guest env is **curated to a tight allowlist** (token only) — the full host macOS env is NOT forwarded (its `PATH` would shadow the guest's Linux PATH).

### Author follow-up — Task 7 (entitled Apple-Silicon Mac, boot-gated)
The live build→scan→`wrangler deploy`→URL round-trip can only run on your machine. Verify: deploy runs in-guest (no host Node), streams to the drawer, the deployed URL is parsed, a blocked scan short-circuits, an invalid token fails before wrangler, and a non-container build still deploys (host regression). One thing to confirm: wrangler's "Published" URL lands on **stdout** in-guest (the parser reads stdout; stderr is streamed but not parsed).

### Tracked follow-up (non-blocking)
`DeployCommand.parseScanReport` duplicates the scan-JSON decode in `PreDeployCheck.check` (different consumers) — consolidate to one decoder in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
