### PR TITLE
Add opt-in Harden Cloudflare action (#407)

### DIFF
--- a/Sources/AnglesiteApp/HardenModel.swift
+++ b/Sources/AnglesiteApp/HardenModel.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+import AnglesiteCore
+
+@MainActor
+@Observable
+final class HardenModel {
+    enum Phase: Equatable {
+        case idle
+        case resolvingZone(domain: String)
+        case preview(plan: HardenPlan, domain: String, zoneID: String)
+        case applying(plan: HardenPlan, domain: String)
+        case succeeded(result: HardenResult)
+        case failed(reason: String)
+    }
+
+    struct HardenResult: Equatable {
+        let appliedCount: Int
+        let failedItems: [FailedItem]
+        let postAuditFindings: [AuditReport.Finding]
+        let auditError: String?
+
+        struct FailedItem: Equatable {
+            let description: String
+            let error: String
+        }
+    }
+
+    private(set) var phase: Phase = .idle
+    var sheetPresented: Bool = false
+    var domainInput: String = ""
+
+    private let reader: any CloudflareReading
+    private let writer: any CloudflareWriting
+    private let keychain: KeychainStore
+    private var inFlight: Task<Void, Never>?
+
+    init(
+        reader: any CloudflareReading = HTTPCloudflareClient(),
+        writer: any CloudflareWriting = HTTPCloudflareClient(),
+        keychain: KeychainStore = KeychainStore()
+    ) {
+        self.reader = reader
+        self.writer = writer
+        self.keychain = keychain
+    }
+
+    var isRunning: Bool {
+        switch phase {
+        case .resolvingZone, .applying: return true
+        default: return false
+        }
+    }
+
+    func harden() {
+        guard !isRunning else { return }
+        phase = .idle
+        domainInput = ""
+        sheetPresented = true
+    }
+
+    func resolveAndPlan() {
+        let domain = domainInput.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !domain.isEmpty else { return }
+        guard !isRunning else { return }
+
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runResolveAndPlan(domain: domain)
+        }
+    }
+
+    func apply() {
+        guard case .preview(let plan, let domain, let zoneID) = phase else { return }
+        guard !plan.isEmpty else { return }
+
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runApply(plan: plan, domain: domain, zoneID: zoneID)
+        }
+    }
+
+    func dismissSheet() {
+        sheetPresented = false
+        if !isRunning { phase = .idle }
+    }
+
+    // MARK: - Private
+
+    private func apiToken() -> String? {
+        if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
+            return env
+        }
+        return (try? keychain.readCloudflareToken()) ?? nil
+    }
+
+    private func runResolveAndPlan(domain: String) async {
+        guard let token = apiToken() else {
+            phase = .failed(reason: "No Cloudflare API token found. Add one in Settings → Credentials.")
+            return
+        }
+
+        phase = .resolvingZone(domain: domain)
+
+        do {
+            guard let zoneID = try await reader.resolveZoneID(domain: domain, apiToken: token) else {
+                phase = .failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission.")
+                return
+            }
+
+            let state = try await reader.zoneState(zoneID: zoneID, apiToken: token)
+            let plan = HardenPlanner.plan(from: state, domain: domain)
+            phase = .preview(plan: plan, domain: domain, zoneID: zoneID)
+        } catch let error as CloudflareError {
+            phase = .failed(reason: cloudflareErrorMessage(error, domain: domain))
+        } catch {
+            phase = .failed(reason: "Failed to read zone state: \(error.localizedDescription)")
+        }
+    }
+
+    private func runApply(plan: HardenPlan, domain: String, zoneID: String) async {
+        guard let token = apiToken() else {
+            phase = .failed(reason: "No Cloudflare API token found.")
+            return
+        }
+
+        phase = .applying(plan: plan, domain: domain)
+
+        let executor = HardenExecutor(reader: reader, writer: writer)
+        let result = await executor.execute(plan: plan, zoneID: zoneID, domain: domain, apiToken: token)
+
+        phase = .succeeded(result: HardenResult(
+            appliedCount: result.appliedCount,
+            failedItems: result.failedItems.map { .init(description: $0.item.description, error: $0.error) },
+            postAuditFindings: result.postAuditFindings,
+            auditError: result.auditError
+        ))
+    }
+
+    private func cloudflareErrorMessage(_ error: CloudflareError, domain: String) -> String {
+        switch error {
+        case .unauthorized:
+            return "API token is unauthorized. Check that it has Zone Read, DNS Read, and Zone Settings Read permissions."
+        case .http(let status):
+            return "Cloudflare API returned HTTP \(status)."
+        case .api(let message):
+            return "Cloudflare API error: \(message)"
+        case .malformedResponse:
+            return "Unexpected response from Cloudflare API."
+        case .zoneNotFound(let d):
+            return "Zone not found for \"\(d)\". Check the domain and token permissions."
+        }
+    }
+}

--- a/Sources/AnglesiteApp/HardenModel.swift
+++ b/Sources/AnglesiteApp/HardenModel.swift
@@ -51,10 +51,16 @@ final class HardenModel {
         }
     }
 
-    func harden() {
+    func openSheet() {
         guard !isRunning else { return }
         phase = .idle
         domainInput = ""
+        sheetPresented = true
+    }
+
+    func retryFromFailed() {
+        guard !isRunning else { return }
+        phase = .idle
         sheetPresented = true
     }
 
@@ -63,6 +69,7 @@ final class HardenModel {
         guard !domain.isEmpty else { return }
         guard !isRunning else { return }
 
+        inFlight?.cancel()
         inFlight = Task { @MainActor [weak self] in
             await self?.runResolveAndPlan(domain: domain)
         }
@@ -72,14 +79,17 @@ final class HardenModel {
         guard case .preview(let plan, let domain, let zoneID) = phase else { return }
         guard !plan.isEmpty else { return }
 
+        inFlight?.cancel()
         inFlight = Task { @MainActor [weak self] in
             await self?.runApply(plan: plan, domain: domain, zoneID: zoneID)
         }
     }
 
     func dismissSheet() {
+        inFlight?.cancel()
+        inFlight = nil
         sheetPresented = false
-        if !isRunning { phase = .idle }
+        phase = .idle
     }
 
     // MARK: - Private
@@ -88,7 +98,7 @@ final class HardenModel {
         if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
             return env
         }
-        return (try? keychain.readCloudflareToken()) ?? nil
+        return try? keychain.readCloudflareToken()
     }
 
     private func runResolveAndPlan(domain: String) async {

--- a/Sources/AnglesiteApp/HardenSheetView.swift
+++ b/Sources/AnglesiteApp/HardenSheetView.swift
@@ -1,0 +1,322 @@
+import SwiftUI
+import AnglesiteCore
+
+struct HardenSheetView: View {
+    @Bindable var model: HardenModel
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            footer
+        }
+        .frame(minWidth: 540, idealWidth: 620, minHeight: 380, idealHeight: 520)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            statusIcon
+            VStack(alignment: .leading, spacing: 1) {
+                Text(headerTitle).font(.headline)
+                if let subtitle = headerSubtitle {
+                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch model.phase {
+        case .idle:
+            Image(systemName: "shield.lefthalf.filled").font(.title3)
+        case .resolvingZone, .applying:
+            ProgressView().controlSize(.small)
+        case .preview(let plan, _, _):
+            Image(systemName: plan.isEmpty ? "checkmark.shield.fill" : "shield.lefthalf.filled")
+                .foregroundStyle(plan.isEmpty ? .green : .blue)
+                .font(.title3)
+        case .succeeded(let result):
+            Image(systemName: result.failedItems.isEmpty ? "checkmark.shield.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(result.failedItems.isEmpty ? .green : .yellow)
+                .font(.title3)
+        case .failed:
+            Image(systemName: "xmark.shield.fill")
+                .foregroundStyle(.red).font(.title3)
+        }
+    }
+
+    private var headerTitle: String {
+        switch model.phase {
+        case .idle:
+            return "Harden Cloudflare"
+        case .resolvingZone(let domain):
+            return "Reading zone state for \(domain)…"
+        case .preview(let plan, let domain, _):
+            if plan.isEmpty { return "\(domain) is fully hardened" }
+            return "\(plan.items.count) change\(plan.items.count == 1 ? "" : "s") for \(domain)"
+        case .applying(_, let domain):
+            return "Applying changes to \(domain)…"
+        case .succeeded(let result):
+            if result.failedItems.isEmpty {
+                return "\(result.appliedCount) change\(result.appliedCount == 1 ? "" : "s") applied"
+            }
+            return "\(result.appliedCount) applied, \(result.failedItems.count) failed"
+        case .failed:
+            return "Hardening failed"
+        }
+    }
+
+    private var headerSubtitle: String? {
+        switch model.phase {
+        case .preview(_, _, _):
+            return "Review the changes below, then click Apply to proceed."
+        case .succeeded(let result):
+            if let err = result.auditError {
+                return "Post-apply audit failed: \(err)"
+            }
+            let findings = result.postAuditFindings.count
+            if findings == 0 { return "Post-apply audit: no remaining issues." }
+            return "Post-apply audit: \(findings) remaining finding\(findings == 1 ? "" : "s")."
+        case .failed(let reason):
+            return reason
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .idle:
+            domainInputForm
+        case .resolvingZone:
+            VStack(spacing: 8) {
+                ProgressView()
+                Text("Resolving zone and reading current state…")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .preview(let plan, _, _):
+            planPreview(plan)
+        case .applying:
+            VStack(spacing: 8) {
+                ProgressView()
+                Text("Applying hardening changes…")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .succeeded(let result):
+            resultView(result)
+        case .failed(let reason):
+            VStack(spacing: 12) {
+                Image(systemName: "xmark.shield.fill")
+                    .foregroundStyle(.red).font(.largeTitle)
+                Text(reason)
+                    .font(.callout).foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 420)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var domainInputForm: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "shield.lefthalf.filled")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+            Text("Enter the domain to harden")
+                .font(.headline)
+            Text("The domain must be managed in Cloudflare. Your API token needs Zone DNS Edit, Zone Settings Edit, and WAF Edit permissions.")
+                .font(.callout).foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 400)
+            TextField("example.com", text: $model.domainInput)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: 300)
+                .onSubmit { model.resolveAndPlan() }
+            Spacer()
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private func planPreview(_ plan: HardenPlan) -> some View {
+        if plan.isEmpty {
+            VStack(spacing: 8) {
+                Image(systemName: "checkmark.shield.fill")
+                    .foregroundStyle(.green).font(.largeTitle)
+                Text("No changes needed.").font(.headline)
+                Text("This zone already has all recommended hardening settings.")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(Array(plan.items.enumerated()), id: \.offset) { _, item in
+                        planItemRow(item)
+                    }
+
+                    notIncludedSection
+                }
+                .padding(16)
+            }
+        }
+    }
+
+    private func planItemRow(_ item: HardenPlanItem) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "plus.circle.fill")
+                .foregroundStyle(.green)
+                .font(.callout)
+            Text(item.description)
+                .font(.callout.monospaced())
+                .textSelection(.enabled)
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(Color.green.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private var notIncludedSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Explicitly not included")
+                .font(.subheadline.weight(.semibold))
+                .padding(.top, 8)
+            ForEach(exclusions, id: \.self) { text in
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "xmark.circle")
+                        .foregroundStyle(.secondary)
+                        .font(.callout)
+                    Text(text)
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var exclusions: [String] {
+        [
+            "Rate limiting (broken on free plan)",
+            "Blanket user-agent blocking (breaks monitors, webhooks, RSS)",
+            "Outdated-browser sniffing / referrer-based challenges",
+        ]
+    }
+
+    @ViewBuilder
+    private func resultView(_ result: HardenModel.HardenResult) -> some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 14) {
+                if result.appliedCount > 0 {
+                    Section {
+                        Label("\(result.appliedCount) change\(result.appliedCount == 1 ? "" : "s") applied successfully.", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.callout)
+                    }
+                }
+
+                if !result.failedItems.isEmpty {
+                    Section {
+                        Text("Failed").font(.subheadline.weight(.semibold))
+                        ForEach(Array(result.failedItems.enumerated()), id: \.offset) { _, item in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(item.description).font(.callout.weight(.medium))
+                                Text(item.error).font(.caption).foregroundStyle(.red)
+                            }
+                            .padding(10)
+                            .background(Color.red.opacity(0.06))
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        }
+                    }
+                }
+
+                if !result.postAuditFindings.isEmpty {
+                    Section {
+                        Text("Remaining audit findings").font(.subheadline.weight(.semibold))
+                        ForEach(result.postAuditFindings) { finding in
+                            auditFindingRow(finding)
+                        }
+                    }
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private func auditFindingRow(_ finding: AuditReport.Finding) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            severityIcon(finding.severity)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(finding.title).font(.callout.weight(.medium))
+                Text(finding.detail).font(.callout).foregroundStyle(.primary)
+                if let remediation = finding.remediation {
+                    Text(remediation).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(Color.secondary.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    @ViewBuilder
+    private func severityIcon(_ severity: AuditReport.Finding.Severity) -> some View {
+        switch severity {
+        case .critical:
+            Image(systemName: "exclamationmark.octagon.fill").foregroundStyle(.red)
+        case .warning:
+            Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.yellow)
+        case .info:
+            Image(systemName: "info.circle.fill").foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            switch model.phase {
+            case .idle:
+                Button("Scan") { model.resolveAndPlan() }
+                    .disabled(model.domainInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .buttonStyle(.borderedProminent)
+            case .preview(let plan, _, _) where !plan.isEmpty:
+                Button("Apply \(plan.items.count) change\(plan.items.count == 1 ? "" : "s")") {
+                    model.apply()
+                }
+                .buttonStyle(.borderedProminent)
+            case .failed:
+                Button("Try again") {
+                    model.harden()
+                }
+            default:
+                EmptyView()
+            }
+            Spacer()
+            Button("Close") {
+                model.dismissSheet()
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}

--- a/Sources/AnglesiteApp/HardenSheetView.swift
+++ b/Sources/AnglesiteApp/HardenSheetView.swift
@@ -4,8 +4,6 @@ import AnglesiteCore
 struct HardenSheetView: View {
     @Bindable var model: HardenModel
 
-    @Environment(\.dismiss) private var dismiss
-
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -88,8 +86,8 @@ struct HardenSheetView: View {
             let findings = result.postAuditFindings.count
             if findings == 0 { return "Post-apply audit: no remaining issues." }
             return "Post-apply audit: \(findings) remaining finding\(findings == 1 ? "" : "s")."
-        case .failed(let reason):
-            return reason
+        case .failed:
+            return nil
         default:
             return nil
         }
@@ -168,7 +166,7 @@ struct HardenSheetView: View {
         } else {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 8) {
-                    ForEach(Array(plan.items.enumerated()), id: \.offset) { _, item in
+                    ForEach(plan.items, id: \.self) { item in
                         planItemRow(item)
                     }
 
@@ -199,7 +197,7 @@ struct HardenSheetView: View {
             Text("Explicitly not included")
                 .font(.subheadline.weight(.semibold))
                 .padding(.top, 8)
-            ForEach(exclusions, id: \.self) { text in
+            ForEach(Self.exclusions, id: \.self) { text in
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "xmark.circle")
                         .foregroundStyle(.secondary)
@@ -211,13 +209,11 @@ struct HardenSheetView: View {
         }
     }
 
-    private var exclusions: [String] {
-        [
+    private static let exclusions: [String] = [
             "Rate limiting (broken on free plan)",
             "Blanket user-agent blocking (breaks monitors, webhooks, RSS)",
-            "Outdated-browser sniffing / referrer-based challenges",
-        ]
-    }
+        "Outdated-browser sniffing / referrer-based challenges",
+    ]
 
     @ViewBuilder
     private func resultView(_ result: HardenModel.HardenResult) -> some View {
@@ -234,7 +230,7 @@ struct HardenSheetView: View {
                 if !result.failedItems.isEmpty {
                     Section {
                         Text("Failed").font(.subheadline.weight(.semibold))
-                        ForEach(Array(result.failedItems.enumerated()), id: \.offset) { _, item in
+                        ForEach(Array(result.failedItems.enumerated()), id: \.element.description) { _, item in
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(item.description).font(.callout.weight(.medium))
                                 Text(item.error).font(.caption).foregroundStyle(.red)
@@ -304,7 +300,7 @@ struct HardenSheetView: View {
                 .buttonStyle(.borderedProminent)
             case .failed:
                 Button("Try again") {
-                    model.harden()
+                    model.retryFromFailed()
                 }
             default:
                 EmptyView()
@@ -312,7 +308,6 @@ struct HardenSheetView: View {
             Spacer()
             Button("Close") {
                 model.dismissSheet()
-                dismiss()
             }
             .keyboardShortcut(.cancelAction)
         }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -90,6 +90,7 @@ struct SiteWindow: View {
     // the panel UI is target-agnostic.
     @State private var chat: ChatModel?
     @State private var chatPresented = false
+    @State private var harden = HardenModel()
     @State private var health = HealthModel(runner: DefaultHealthCheckRunner())
     /// Drives the determinate startup progress bar shown in `mainPane` while the dev server boots.
     @State private var startup = StartupProgressModel()
@@ -292,6 +293,24 @@ struct SiteWindow: View {
             }
             .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
 
+            // Harden — low priority, collapses alongside Audit/Backup.
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    harden.harden()
+                } label: {
+                    if harden.isRunning {
+                        Label("Hardening…", systemImage: "shield.lefthalf.filled")
+                    } else {
+                        Label("Harden", systemImage: "shield.lefthalf.filled")
+                    }
+                }
+                .disabled(harden.isRunning || !site.isValid)
+                .help(site.isValid
+                      ? "Preview and apply Cloudflare security hardening for this site"
+                      : "Site is missing required files")
+            }
+            .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
+
             // Audit — low priority, collapses before Chat.
             ToolbarItem(placement: .primaryAction) {
                 Button {
@@ -438,6 +457,9 @@ struct SiteWindow: View {
                 siteName: site.name,
                 onRunAgain: { audit.audit(siteID: site.id, siteDirectory: site.sourceDirectory) }
             )
+        }
+        .sheet(isPresented: $harden.sheetPresented) {
+            HardenSheetView(model: harden)
         }
         #if !ANGLESITE_MAS
         .sheet(isPresented: $publish.sheetPresented) {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -296,7 +296,7 @@ struct SiteWindow: View {
             // Harden — low priority, collapses alongside Audit/Backup.
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    harden.harden()
+                    harden.openSheet()
                 } label: {
                     if harden.isRunning {
                         Label("Hardening…", systemImage: "shield.lefthalf.filled")

--- a/Sources/AnglesiteCore/HardenPlan.swift
+++ b/Sources/AnglesiteCore/HardenPlan.swift
@@ -14,7 +14,7 @@ public struct HardenPlan: Sendable, Equatable {
 }
 
 /// A single hardening change to apply to a Cloudflare zone.
-public enum HardenPlanItem: Sendable, Equatable, CustomStringConvertible {
+public enum HardenPlanItem: Sendable, Hashable, CustomStringConvertible {
     case enableDNSSEC
     case addCAARecord(ca: String)
     case enableAlwaysUseHTTPS

--- a/docs/superpowers/plans/2026-06-28-c2-cloudflare-client-audit-406.md
+++ b/docs/superpowers/plans/2026-06-28-c2-cloudflare-client-audit-406.md
@@ -20,7 +20,7 @@ This plan is the **CI-testable core** of C2. Two pieces of the spec's C2 are del
 ## Global Constraints
 
 - **Swift 6, ES-equivalent module style** — `public` API in `AnglesiteCore`; `Sendable` everywhere; no third-party dependencies (Foundation `URLSession` only).
-- **Read-only** — every method is a GET. No write/PATCH/POST/PUT/DELETE anywhere in this plan. The documented token scope is read-only: Zone Read, DNS Read, Zone Settings Read.
+- **Read-only** — every method is a GET. No write/PATCH/POST/PUT/DELETE anywhere in this plan. The documented token scope for audit is read-only: Zone Read, DNS Read, Zone Settings Read. (C3 adds write scope: Zone DNS Edit, Zone Settings Edit, WAF Edit.)
 - **No Keychain, no SwiftUI in `AnglesiteCore`** — the API token is passed in as a `String` parameter (the caller reads `KeychainStore().readCloudflareToken()`; that wiring is the deferred UI plan). Mirror `CloudflareAPITokenVerifier`, which also takes the token as a parameter.
 - **Mirror existing patterns exactly:**
   - Seam: `public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)` with `static let defaultTransport` using `URLSession.shared.data(for:)` — copied from `Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift`.

--- a/docs/superpowers/specs/2026-06-27-security-story-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-27-security-story-hardening-design.md
@@ -114,7 +114,8 @@ Generate, mirroring the `csp.ts` pattern (pure function + writer + tests):
 
 - **`CloudflareClient`** (AnglesiteCore) — protocol abstracting the Cloudflare API; mockable in
   tests; centralizes MAS sandbox/token handling. Token in Keychain (existing `area:secrets`
-  pattern), minimal **read** scope (Zone DNS read, Zone settings read, WAF read), documented.
+  pattern). Token scope: **read** (Zone Read, DNS Read, Zone Settings Read) for audit;
+  **write** (Zone DNS Edit, Zone Settings Edit, WAF Edit) for the C3 Harden action.
   Read methods: DNSSEC status, CAA, SSL/Always-HTTPS/HSTS edge settings, MX/SPF/DMARC, Bot
   Fight Mode, custom-rule list.
 - **`SecurityAudit`** (pure, testable) — input: built `dist/` + account-state snapshot → graded


### PR DESCRIPTION
## Summary

- Wire the existing AnglesiteCore hardening infrastructure (`HardenPlanner`, `HardenExecutor`, `CloudflareWriting`) into a full app-layer UI with preview-and-consent flow
- Add `HardenModel` (orchestration: domain input → zone resolve → plan preview → apply on consent → post-audit results) and `HardenSheetView` (diff-style preview, result view with per-item failures and post-audit findings)
- Bump documented token scope in the security hardening design spec and C2 plan to reflect the write permissions (Zone DNS Edit, Zone Settings Edit, WAF Edit) the Harden action requires

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks).

> The Harden action talks directly to the Cloudflare v4 API via `HTTPCloudflareClient` — no MCP server involvement, so no paired plugin PR is needed.

## Test plan

- [ ] `swift test --package-path .`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build`
- [ ] Manual smoke: Open a site window → click "Harden" toolbar button → enter a Cloudflare-managed domain → verify the plan preview shows expected changes → click Apply → confirm changes applied and post-audit findings render

---
_Generated by [Claude Code](https://claude.ai/code/session_016joULqmAYCHMHJEzcHRuZe)_