### PR TITLE
fix(#418): curate host deploy environment for build/preflight

### DIFF
--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -17,9 +17,10 @@ import Foundation
 /// (under the caller-supplied source) and returns the accumulated stdout in `DeployStepResult.output`,
 /// so the URL/scan parsing here re-reads the captured stdout rather than re-snapshotting `LogCenter`.
 ///
-/// **Environment contract** (matches today's host behavior):
-///   - `.build` and `.preflight` get `ProcessInfo.processInfo.environment` *without* the token.
-///   - `.wrangler` gets that environment *plus* `CLOUDFLARE_API_TOKEN`.
+/// **Environment contract:**
+///   - `.build` and `.preflight` get a curated subset of the host environment (see
+///     `hostDeployEnvironment()`) — safe shell/locale/proxy/Node vars only, no unrelated secrets.
+///   - `.wrangler` gets that curated environment *plus* `CLOUDFLARE_API_TOKEN`.
 ///
 /// **Cancellation**: cancelling the deploy task propagates through `executor.run` (the host
 /// executor wraps its `waitForExit` in a cancellation handler that SIGTERMs the in-flight
@@ -89,10 +90,10 @@ public actor DeployCommand {
             return .failed(reason: "no CLOUDFLARE_API_TOKEN — add it in Settings → Advanced → Credentials, or set the env var", exitCode: nil)
         }
 
-        // Environment for the non-secret steps: the process env WITHOUT the token. The build and
-        // preflight steps rely on the executor's default Node-on-PATH env; the token is added only
+        // Curated environment for the non-secret steps: a safe subset of the host process env,
+        // stripping unrelated secrets the developer's shell may carry. The token is added only
         // for the wrangler step below.
-        let baseEnvironment = ProcessInfo.processInfo.environment
+        let baseEnvironment = Self.hostDeployEnvironment()
 
         // Build dist/ before the scan needs it. Streams to LogCenter via the executor.
         onProgress?(.deployBuilding)
@@ -230,6 +231,46 @@ public actor DeployCommand {
             }
         }
         return nil
+    }
+
+    // MARK: Host environment curation
+
+    /// Keys that a host-path build or preflight step legitimately needs. The allowlist is
+    /// intentionally conservative — add a key only when a build script demonstrably requires it.
+    /// Mirrors the tight `guestEnvAllowlist` in `ContainerDeployExecutor`, adapted for the host
+    /// where Node/npm/Astro rely on the user's shell plumbing.
+    private static let hostEnvAllowlist: Set<String> = [
+        // Shell / process fundamentals
+        "PATH", "HOME", "USER", "LOGNAME", "SHELL",
+        // Temp directories — Node/npm/Astro write to these
+        "TMPDIR", "TEMP", "TMP",
+        // Locale — affects sorting, date formatting in build output
+        "LANG", "LC_ALL", "LC_COLLATE", "LC_CTYPE", "LC_MESSAGES", "LC_MONETARY",
+        "LC_NUMERIC", "LC_TIME",
+        // Proxy — corporate/VPN environments need these for npm registry + API fetches
+        "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+        "http_proxy", "https_proxy", "no_proxy",
+        // Node-specific
+        "NODE_ENV", "NODE_OPTIONS", "NODE_PATH", "NODE_EXTRA_CA_CERTS", "NPM_CONFIG_CACHE",
+        // XDG — npm/pnpm/yarn respect these for cache and config paths
+        "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+        // Terminal — some build tools check these for color/width
+        "TERM", "COLORTERM", "COLUMNS",
+    ]
+
+    /// Returns a curated subset of the current process environment safe for host-path build and
+    /// preflight steps. Strips unrelated secrets (`AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, …)
+    /// that the developer's shell may carry. `CLOUDFLARE_API_TOKEN` is explicitly excluded here;
+    /// `deploy()` adds it only to the `.wrangler` step's environment.
+    static func hostDeployEnvironment() -> [String: String] {
+        var result: [String: String] = [:]
+        let env = ProcessInfo.processInfo.environment
+        for (key, value) in env {
+            if hostEnvAllowlist.contains(key) {
+                result[key] = value
+            }
+        }
+        return result
     }
 
     // MARK: Default seams

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -244,6 +244,8 @@ public actor DeployCommand {
         "PATH", "HOME", "USER", "LOGNAME", "SHELL",
         // Temp directories — Node/npm/Astro write to these
         "TMPDIR", "TEMP", "TMP",
+        // CI — Astro, Vite, and many post-install scripts check this to suppress interactive prompts
+        "CI",
         // Locale — affects sorting, date formatting in build output
         "LANG", "LC_ALL", "LC_COLLATE", "LC_CTYPE", "LC_MESSAGES", "LC_MONETARY",
         "LC_NUMERIC", "LC_TIME",
@@ -258,19 +260,27 @@ public actor DeployCommand {
         "TERM", "COLORTERM", "COLUMNS",
     ]
 
-    /// Returns a curated subset of the current process environment safe for host-path build and
-    /// preflight steps. Strips unrelated secrets (`AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, …)
-    /// that the developer's shell may carry. `CLOUDFLARE_API_TOKEN` is explicitly excluded here;
-    /// `deploy()` adds it only to the `.wrangler` step's environment.
-    static func hostDeployEnvironment() -> [String: String] {
-        var result: [String: String] = [:]
-        let env = ProcessInfo.processInfo.environment
-        for (key, value) in env {
-            if hostEnvAllowlist.contains(key) {
-                result[key] = value
-            }
+    /// Key prefixes that Astro/Vite projects use for build-time environment variables. These are
+    /// standard conventions for variables inlined into client-side output (`PUBLIC_*`) or consumed
+    /// by Vite's pipeline (`VITE_*`). Users set them in their shell and expect them to flow through
+    /// to `astro build`. `ASTRO_` covers Astro's own config overrides (e.g. `ASTRO_TELEMETRY_DISABLED`).
+    private static let hostEnvPrefixes: [String] = ["PUBLIC_", "VITE_", "ASTRO_"]
+
+    /// Returns a curated subset of the given environment safe for host-path build and preflight
+    /// steps. Strips unrelated secrets (`AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, …) that the
+    /// developer's shell may carry. `CLOUDFLARE_API_TOKEN` is explicitly excluded here; `deploy()`
+    /// adds it only to the `.wrangler` step's environment.
+    ///
+    /// The `env` parameter defaults to the current process environment; tests inject a literal
+    /// dictionary instead (avoiding `setenv`/`unsetenv` races and the `ProcessInfo` launch-time
+    /// snapshot issue).
+    static func hostDeployEnvironment(
+        _ env: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        env.filter { key, _ in
+            hostEnvAllowlist.contains(key) ||
+            hostEnvPrefixes.contains(where: { key.hasPrefix($0) })
         }
-        return result
     }
 
     // MARK: Default seams

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -104,57 +104,64 @@ struct DeployCommandTests {
 
     // MARK: Host environment curation
 
-    @Test("hostDeployEnvironment retains PATH and HOME")
+    @Test("hostDeployEnvironment retains PATH, HOME, and CI")
     func hostEnvRetainsEssentials() {
-        let env = DeployCommand.hostDeployEnvironment()
-        #expect(env["PATH"] != nil, "PATH must be retained for Node/npm/Astro resolution")
-        #expect(env["HOME"] != nil, "HOME must be retained for npm cache and config paths")
+        let env = DeployCommand.hostDeployEnvironment([
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/Users/dev",
+            "CI": "true",
+            "UNRELATED_SECRET": "leaked",
+        ])
+        #expect(env["PATH"] == "/usr/bin:/bin")
+        #expect(env["HOME"] == "/Users/dev")
+        #expect(env["CI"] == "true")
+        #expect(env["UNRELATED_SECRET"] == nil)
     }
 
     @Test("hostDeployEnvironment excludes unrelated secrets")
     func hostEnvExcludesSecrets() {
-        let planted: [(String, String)] = [
-            ("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
-            ("GITHUB_TOKEN", "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
-            ("NPM_TOKEN", "npm_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
-            ("DATABASE_URL", "postgres://user:pass@host/db"),
-        ]
-        // Plant secrets in the current process environment for this test.
-        for (key, value) in planted { setenv(key, value, 1) }
-        defer { for (key, _) in planted { unsetenv(key) } }
-
-        let env = DeployCommand.hostDeployEnvironment()
-        for (key, _) in planted {
-            #expect(env[key] == nil, "\(key) must not leak into build/preflight environment")
-        }
+        let env = DeployCommand.hostDeployEnvironment([
+            "PATH": "/usr/bin",
+            "HOME": "/tmp",
+            "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "GITHUB_TOKEN": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "NPM_TOKEN": "npm_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "DATABASE_URL": "postgres://user:pass@host/db",
+        ])
+        #expect(env["AWS_SECRET_ACCESS_KEY"] == nil, "AWS key must not leak into build/preflight")
+        #expect(env["GITHUB_TOKEN"] == nil, "GitHub token must not leak into build/preflight")
+        #expect(env["NPM_TOKEN"] == nil, "npm token must not leak into build/preflight")
+        #expect(env["DATABASE_URL"] == nil, "database URL must not leak into build/preflight")
+        #expect(env["PATH"] == "/usr/bin", "PATH must be retained")
+        #expect(env["HOME"] == "/tmp", "HOME must be retained")
     }
 
     @Test("hostDeployEnvironment excludes CLOUDFLARE_API_TOKEN")
     func hostEnvExcludesCloudflareToken() {
-        setenv("CLOUDFLARE_API_TOKEN", "test-cf-token", 1)
-        defer { unsetenv("CLOUDFLARE_API_TOKEN") }
-
-        let env = DeployCommand.hostDeployEnvironment()
+        let env = DeployCommand.hostDeployEnvironment([
+            "PATH": "/usr/bin",
+            "CLOUDFLARE_API_TOKEN": "cf-secret-token",
+        ])
         #expect(env["CLOUDFLARE_API_TOKEN"] == nil,
                 "CLOUDFLARE_API_TOKEN must not reach build/preflight — it's added only to the wrangler step")
+        #expect(env["PATH"] == "/usr/bin")
     }
 
-    @Test("Build/preflight steps receive curated environment excluding planted secrets")
-    func buildPreflightExcludePlantedSecrets() async {
-        setenv("AWS_SECRET_ACCESS_KEY", "planted-secret", 1)
-        defer { unsetenv("AWS_SECRET_ACCESS_KEY") }
-
-        let exec = FakeExecutor()
-            .set(.build, exitCode: 0, output: "")
-            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
-            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
-        _ = await cmd.deploy(siteID: "s", siteDirectory: tmpDir)
-
-        #expect(exec.environment(for: .build)?["AWS_SECRET_ACCESS_KEY"] == nil)
-        #expect(exec.environment(for: .preflight)?["AWS_SECRET_ACCESS_KEY"] == nil)
-        #expect(exec.environment(for: .build)?["PATH"] != nil)
-        #expect(exec.environment(for: .preflight)?["PATH"] != nil)
+    @Test("hostDeployEnvironment passes through PUBLIC_*, VITE_*, and ASTRO_* prefixed vars")
+    func hostEnvPassesThroughBuildPrefixes() {
+        let env = DeployCommand.hostDeployEnvironment([
+            "PATH": "/usr/bin",
+            "PUBLIC_API_URL": "https://api.example.com",
+            "PUBLIC_SITE_NAME": "My Site",
+            "VITE_APP_TITLE": "Title",
+            "ASTRO_TELEMETRY_DISABLED": "1",
+            "SECRET_KEY": "should-be-stripped",
+        ])
+        #expect(env["PUBLIC_API_URL"] == "https://api.example.com")
+        #expect(env["PUBLIC_SITE_NAME"] == "My Site")
+        #expect(env["VITE_APP_TITLE"] == "Title")
+        #expect(env["ASTRO_TELEMETRY_DISABLED"] == "1")
+        #expect(env["SECRET_KEY"] == nil)
     }
 
     // MARK: Pre-spawn refusal (no work wasted)

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -102,6 +102,61 @@ struct DeployCommandTests {
         #expect(exec.environment(for: .wrangler)?["CLOUDFLARE_API_TOKEN"] == "secret-tok")
     }
 
+    // MARK: Host environment curation
+
+    @Test("hostDeployEnvironment retains PATH and HOME")
+    func hostEnvRetainsEssentials() {
+        let env = DeployCommand.hostDeployEnvironment()
+        #expect(env["PATH"] != nil, "PATH must be retained for Node/npm/Astro resolution")
+        #expect(env["HOME"] != nil, "HOME must be retained for npm cache and config paths")
+    }
+
+    @Test("hostDeployEnvironment excludes unrelated secrets")
+    func hostEnvExcludesSecrets() {
+        let planted: [(String, String)] = [
+            ("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+            ("GITHUB_TOKEN", "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
+            ("NPM_TOKEN", "npm_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
+            ("DATABASE_URL", "postgres://user:pass@host/db"),
+        ]
+        // Plant secrets in the current process environment for this test.
+        for (key, value) in planted { setenv(key, value, 1) }
+        defer { for (key, _) in planted { unsetenv(key) } }
+
+        let env = DeployCommand.hostDeployEnvironment()
+        for (key, _) in planted {
+            #expect(env[key] == nil, "\(key) must not leak into build/preflight environment")
+        }
+    }
+
+    @Test("hostDeployEnvironment excludes CLOUDFLARE_API_TOKEN")
+    func hostEnvExcludesCloudflareToken() {
+        setenv("CLOUDFLARE_API_TOKEN", "test-cf-token", 1)
+        defer { unsetenv("CLOUDFLARE_API_TOKEN") }
+
+        let env = DeployCommand.hostDeployEnvironment()
+        #expect(env["CLOUDFLARE_API_TOKEN"] == nil,
+                "CLOUDFLARE_API_TOKEN must not reach build/preflight — it's added only to the wrangler step")
+    }
+
+    @Test("Build/preflight steps receive curated environment excluding planted secrets")
+    func buildPreflightExcludePlantedSecrets() async {
+        setenv("AWS_SECRET_ACCESS_KEY", "planted-secret", 1)
+        defer { unsetenv("AWS_SECRET_ACCESS_KEY") }
+
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        _ = await cmd.deploy(siteID: "s", siteDirectory: tmpDir)
+
+        #expect(exec.environment(for: .build)?["AWS_SECRET_ACCESS_KEY"] == nil)
+        #expect(exec.environment(for: .preflight)?["AWS_SECRET_ACCESS_KEY"] == nil)
+        #expect(exec.environment(for: .build)?["PATH"] != nil)
+        #expect(exec.environment(for: .preflight)?["PATH"] != nil)
+    }
+
     // MARK: Pre-spawn refusal (no work wasted)
 
     @Test("Refuses before any step when token source returns nil")


### PR DESCRIPTION
## Summary

- Add `hostDeployEnvironment()` allowlist to `DeployCommand` that filters the host process environment to only the vars Node/npm/Astro legitimately need (PATH, HOME, TMPDIR, locale, proxy, Node-specific, XDG, terminal) — stripping unrelated secrets (`AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `NPM_TOKEN`, etc.) that a developer's shell may carry.
- Replace the raw `ProcessInfo.processInfo.environment` forwarding in `deploy()` with the curated environment for `.build` and `.preflight` steps. `.wrangler` continues to receive the curated env plus `CLOUDFLARE_API_TOKEN`.
- Mirrors the tight `guestEnvAllowlist` pattern already used by `ContainerDeployExecutor`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite)

## Test plan

- [ ] `swift test --package-path .`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build`

Four new tests added to `DeployCommandTests`:
- `hostEnvRetainsEssentials` — PATH and HOME are retained
- `hostEnvExcludesSecrets` — planted AWS/GitHub/NPM/DB secrets are stripped
- `hostEnvExcludesCloudflareToken` — CLOUDFLARE_API_TOKEN excluded from build/preflight (added only to wrangler)
- `buildPreflightExcludePlantedSecrets` — end-to-end through the fake executor: build/preflight steps don't see planted secrets but do see PATH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjbKUxrSTdUjx9B1Qr6k7Y)_