### PR TITLE
feat(#308): add visual site graph explorer

### DIFF
--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+@MainActor
+@Observable
+final class SiteGraphExplorerModel {
+    private(set) var snapshot = SiteGraphExplorerSnapshot(nodes: [], edges: [])
+    var selectedNodeID: String?
+    var searchText = ""
+    var enabledKinds = Set(SiteGraphNodeKind.allCases)
+
+    private let graph: SiteContentGraph
+    private var observeTask: Task<Void, Never>?
+    private var siteID: String?
+    private var sourceDirectory: URL?
+
+    init(graph: SiteContentGraph) {
+        self.graph = graph
+    }
+
+    var filteredNodes: [SiteGraphNode] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return snapshot.nodes.filter { node in
+            guard enabledKinds.contains(node.kind) else { return false }
+            guard !query.isEmpty else { return true }
+            return node.title.lowercased().contains(query)
+                || node.detail?.lowercased().contains(query) == true
+                || node.filePath?.lowercased().contains(query) == true
+        }
+    }
+
+    var filteredEdges: [SiteGraphEdge] {
+        let visible = Set(filteredNodes.map(\.id))
+        return snapshot.edges.filter { visible.contains($0.sourceID) && visible.contains($0.targetID) }
+    }
+
+    var selectedNode: SiteGraphNode? {
+        guard let selectedNodeID else { return nil }
+        return snapshot.nodes.first { $0.id == selectedNodeID }
+    }
+
+    var selectedIncoming: [SiteGraphEdge] {
+        guard let selectedNodeID else { return [] }
+        return snapshot.edges.filter { $0.targetID == selectedNodeID }
+    }
+
+    var selectedOutgoing: [SiteGraphEdge] {
+        guard let selectedNodeID else { return [] }
+        return snapshot.edges.filter { $0.sourceID == selectedNodeID }
+    }
+
+    func start(siteID: String, sourceDirectory: URL) {
+        self.siteID = siteID
+        self.sourceDirectory = sourceDirectory
+        observeTask?.cancel()
+        observeTask = Task { [weak self, graph, siteID, sourceDirectory] in
+            let stream = await graph.changeStream()
+            await self?.refresh(siteID: siteID, sourceDirectory: sourceDirectory)
+            for await changedSiteID in stream {
+                if Task.isCancelled { break }
+                if changedSiteID == siteID {
+                    await self?.refresh(siteID: siteID, sourceDirectory: sourceDirectory)
+                }
+            }
+        }
+    }
+
+    func stop() {
+        observeTask?.cancel()
+        observeTask = nil
+    }
+
+    func setKind(_ kind: SiteGraphNodeKind, enabled: Bool) {
+        if enabled {
+            enabledKinds.insert(kind)
+        } else {
+            enabledKinds.remove(kind)
+        }
+        if let selectedNodeID, !filteredNodes.contains(where: { $0.id == selectedNodeID }) {
+            self.selectedNodeID = nil
+        }
+    }
+
+    func node(id: String) -> SiteGraphNode? {
+        snapshot.nodes.first { $0.id == id }
+    }
+
+    private func refresh(siteID: String, sourceDirectory: URL) async {
+        let pages = await graph.pages(for: siteID)
+        if Task.isCancelled { return }
+        let posts = await graph.posts(for: siteID)
+        if Task.isCancelled { return }
+        let images = await graph.images(for: siteID)
+        if Task.isCancelled { return }
+        let next = await Task.detached(priority: .userInitiated) {
+            SiteGraphExplorer.build(
+                projectRoot: sourceDirectory,
+                siteID: siteID,
+                pages: pages,
+                posts: posts,
+                images: images
+            )
+        }.value
+        if Task.isCancelled { return }
+        snapshot = next
+        if let selectedNodeID, !next.nodes.contains(where: { $0.id == selectedNodeID }) {
+            self.selectedNodeID = nil
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -42,12 +42,12 @@ final class SiteGraphExplorerModel {
 
     var selectedIncoming: [SiteGraphEdge] {
         guard let selectedNodeID else { return [] }
-        return snapshot.edges.filter { $0.targetID == selectedNodeID }
+        return filteredEdges.filter { $0.targetID == selectedNodeID }
     }
 
     var selectedOutgoing: [SiteGraphEdge] {
         guard let selectedNodeID else { return [] }
-        return snapshot.edges.filter { $0.sourceID == selectedNodeID }
+        return filteredEdges.filter { $0.sourceID == selectedNodeID }
     }
 
     func start(siteID: String, sourceDirectory: URL) {

--- a/Sources/AnglesiteApp/SiteGraphExplorerView.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerView.swift
@@ -1,0 +1,338 @@
+import SwiftUI
+import AnglesiteCore
+
+struct SiteGraphExplorerView: View {
+    @Bindable var model: SiteGraphExplorerModel
+    let onOpenFile: (SiteGraphNode) -> Void
+
+    var body: some View {
+        HSplitView {
+            VStack(spacing: 0) {
+                SiteGraphToolbar(model: model)
+                Divider()
+                SiteGraphCanvas(
+                    nodes: model.filteredNodes,
+                    edges: model.filteredEdges,
+                    selectedNodeID: model.selectedNodeID,
+                    node: model.node(id:),
+                    onSelect: { model.selectedNodeID = $0 }
+                )
+            }
+            .frame(minWidth: 520)
+
+            SiteGraphInspector(
+                model: model,
+                onOpenFile: onOpenFile
+            )
+            .frame(minWidth: 280, idealWidth: 320, maxWidth: 420)
+        }
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+}
+
+private struct SiteGraphToolbar: View {
+    @Bindable var model: SiteGraphExplorerModel
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                Label("Site Graph", systemImage: "point.3.connected.trianglepath.dotted")
+                    .font(.headline)
+                Spacer()
+                TextField("Search graph", text: $model.searchText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 220)
+            }
+            ScrollView(.horizontal) {
+                HStack(spacing: 8) {
+                    ForEach(SiteGraphNodeKind.allCases) { kind in
+                        Toggle(isOn: Binding(
+                            get: { model.enabledKinds.contains(kind) },
+                            set: { model.setKind(kind, enabled: $0) }
+                        )) {
+                            Label(kind.title, systemImage: kind.systemImage)
+                        }
+                        .toggleStyle(.button)
+                        .controlSize(.small)
+                        .help("Show or hide \(kind.title.lowercased())")
+                    }
+                }
+            }
+            .scrollIndicators(.hidden)
+        }
+        .padding(12)
+    }
+}
+
+private struct SiteGraphCanvas: View {
+    let nodes: [SiteGraphNode]
+    let edges: [SiteGraphEdge]
+    let selectedNodeID: String?
+    let node: (String) -> SiteGraphNode?
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        GeometryReader { proxy in
+            let positions = SiteGraphLayout.positions(for: nodes, in: proxy.size)
+            ZStack {
+                Canvas { context, _ in
+                    for edge in edges {
+                        guard let start = positions[edge.sourceID], let end = positions[edge.targetID] else { continue }
+                        var path = Path()
+                        path.move(to: start)
+                        let controlOffset = max(40, abs(end.x - start.x) * 0.35)
+                        path.addCurve(
+                            to: end,
+                            control1: CGPoint(x: start.x + controlOffset, y: start.y),
+                            control2: CGPoint(x: end.x - controlOffset, y: end.y)
+                        )
+                        context.stroke(
+                            path,
+                            with: .color(edgeColor(edge, selectedNodeID: selectedNodeID)),
+                            lineWidth: highlighted(edge, selectedNodeID: selectedNodeID) ? 2 : 1
+                        )
+                    }
+                }
+                ForEach(nodes) { node in
+                    if let point = positions[node.id] {
+                        SiteGraphNodeButton(
+                            node: node,
+                            selected: node.id == selectedNodeID,
+                            related: isRelated(node.id, selectedNodeID: selectedNodeID)
+                        ) {
+                            onSelect(node.id)
+                        }
+                        .position(point)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay {
+                if nodes.isEmpty {
+                    ContentUnavailableView("No matching graph nodes", systemImage: "point.3.connected.trianglepath.dotted")
+                }
+            }
+        }
+    }
+
+    private func highlighted(_ edge: SiteGraphEdge, selectedNodeID: String?) -> Bool {
+        guard let selectedNodeID else { return false }
+        return edge.sourceID == selectedNodeID || edge.targetID == selectedNodeID
+    }
+
+    private func isRelated(_ nodeID: String, selectedNodeID: String?) -> Bool {
+        guard let selectedNodeID, nodeID != selectedNodeID else { return false }
+        return edges.contains {
+            ($0.sourceID == selectedNodeID && $0.targetID == nodeID)
+                || ($0.targetID == selectedNodeID && $0.sourceID == nodeID)
+        }
+    }
+
+    private func edgeColor(_ edge: SiteGraphEdge, selectedNodeID: String?) -> Color {
+        if highlighted(edge, selectedNodeID: selectedNodeID) { return .accentColor }
+        switch edge.kind {
+        case .imports: return .secondary.opacity(0.45)
+        case .usesLayout: return .blue.opacity(0.55)
+        case .referencesAsset: return .green.opacity(0.5)
+        case .contains: return .orange.opacity(0.45)
+        }
+    }
+}
+
+private struct SiteGraphNodeButton: View {
+    let node: SiteGraphNode
+    let selected: Bool
+    let related: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 4) {
+                Image(systemName: node.kind.systemImage)
+                    .font(.headline)
+                Text(node.title)
+                    .font(.caption)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .frame(width: 112)
+                if node.referencedByCount > 0 {
+                    Text("\(node.referencedByCount) refs")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 7)
+            .frame(width: 132)
+            .frame(minHeight: 76)
+            .background(node.kind.tint.opacity(selected ? 0.24 : related ? 0.16 : 0.1))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(selected ? Color.accentColor : node.kind.tint.opacity(0.35), lineWidth: selected ? 2 : 1)
+            }
+            .clipShape(.rect(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(node.kind.title), \(node.title)")
+        .help(node.detail ?? node.title)
+    }
+}
+
+private struct SiteGraphInspector: View {
+    @Bindable var model: SiteGraphExplorerModel
+    let onOpenFile: (SiteGraphNode) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let node = model.selectedNode {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 14) {
+                        Label(node.kind.title, systemImage: node.kind.systemImage)
+                            .font(.headline)
+                        Text(node.title)
+                            .font(.title3)
+                            .fontWeight(.semibold)
+                            .textSelection(.enabled)
+                        if let detail = node.detail {
+                            Text(detail)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        }
+                        if node.filePath != nil {
+                            Button("Open File", systemImage: "doc.text.magnifyingglass") {
+                                onOpenFile(node)
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                        Divider()
+                        SiteGraphEdgeList(
+                            title: "Depends On",
+                            edges: model.selectedOutgoing,
+                            endpoint: \.targetID,
+                            model: model
+                        )
+                        SiteGraphEdgeList(
+                            title: "Referenced By",
+                            edges: model.selectedIncoming,
+                            endpoint: \.sourceID,
+                            model: model
+                        )
+                    }
+                    .padding()
+                }
+            } else {
+                ContentUnavailableView("Select a node", systemImage: "cursorarrow.click")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .background(Color(NSColor.controlBackgroundColor))
+    }
+}
+
+private struct SiteGraphEdgeList: View {
+    let title: String
+    let edges: [SiteGraphEdge]
+    let endpoint: KeyPath<SiteGraphEdge, String>
+    @Bindable var model: SiteGraphExplorerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            if edges.isEmpty {
+                Text("None")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(edges) { edge in
+                    if let node = model.node(id: edge[keyPath: endpoint]) {
+                        Button {
+                            model.selectedNodeID = node.id
+                        } label: {
+                            HStack {
+                                Label(node.title, systemImage: node.kind.systemImage)
+                                Spacer()
+                                Text(edge.kind.title)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private enum SiteGraphLayout {
+    static func positions(for nodes: [SiteGraphNode], in size: CGSize) -> [String: CGPoint] {
+        guard !nodes.isEmpty else { return [:] }
+        let grouped = Dictionary(grouping: nodes, by: \.kind)
+        let kinds = SiteGraphNodeKind.allCases.filter { grouped[$0]?.isEmpty == false }
+        let columnWidth = max(170, size.width / CGFloat(max(kinds.count, 1)))
+        var output: [String: CGPoint] = [:]
+        for (column, kind) in kinds.enumerated() {
+            let columnNodes = (grouped[kind] ?? []).sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+            let rowHeight = max(96, (size.height - 60) / CGFloat(max(columnNodes.count, 1)))
+            for (row, node) in columnNodes.enumerated() {
+                output[node.id] = CGPoint(
+                    x: min(size.width - 76, max(76, CGFloat(column) * columnWidth + columnWidth / 2)),
+                    y: min(size.height - 50, max(50, CGFloat(row) * rowHeight + rowHeight / 2 + 24))
+                )
+            }
+        }
+        return output
+    }
+}
+
+private extension SiteGraphNodeKind {
+    var title: String {
+        switch self {
+        case .page: return "Pages"
+        case .layout: return "Layouts"
+        case .component: return "Components"
+        case .collection: return "Collections"
+        case .contentEntry: return "Entries"
+        case .asset: return "Assets"
+        case .style: return "Styles"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .page: return "doc.richtext"
+        case .layout: return "rectangle.split.3x1"
+        case .component: return "square.stack.3d.up"
+        case .collection: return "tray.full"
+        case .contentEntry: return "text.document"
+        case .asset: return "photo"
+        case .style: return "paintbrush"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .page: return .blue
+        case .layout: return .indigo
+        case .component: return .teal
+        case .collection: return .orange
+        case .contentEntry: return .pink
+        case .asset: return .green
+        case .style: return .purple
+        }
+    }
+}
+
+private extension SiteGraphEdgeKind {
+    var title: String {
+        switch self {
+        case .imports: return "imports"
+        case .usesLayout: return "layout"
+        case .referencesAsset: return "asset"
+        case .contains: return "contains"
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteGraphExplorerView.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerView.swift
@@ -14,7 +14,6 @@ struct SiteGraphExplorerView: View {
                     nodes: model.filteredNodes,
                     edges: model.filteredEdges,
                     selectedNodeID: model.selectedNodeID,
-                    node: model.node(id:),
                     onSelect: { model.selectedNodeID = $0 }
                 )
             }
@@ -68,7 +67,6 @@ private struct SiteGraphCanvas: View {
     let nodes: [SiteGraphNode]
     let edges: [SiteGraphEdge]
     let selectedNodeID: String?
-    let node: (String) -> SiteGraphNode?
     let onSelect: (String) -> Void
 
     var body: some View {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -780,15 +780,19 @@ struct SiteWindow: View {
     @MainActor
     private func openGraphNode(_ node: SiteGraphNode, site: SiteStore.Site) {
         guard let filePath = node.filePath else { return }
-        if node.kind == .asset {
+        let group: FileGroup
+        switch node.kind {
+        case .page:
+            group = .pages
+        case .collection, .contentEntry:
+            group = .posts
+        case .layout, .component:
+            group = .components
+        case .style:
+            group = .styles
+        case .asset:
             NSWorkspace.shared.activateFileViewerSelecting([site.sourceDirectory.appendingPathComponent(filePath)])
             return
-        }
-        let group: FileGroup = switch node.kind {
-        case .page: .pages
-        case .collection, .contentEntry: .posts
-        case .layout, .component: .components
-        case .asset, .style: .styles
         }
         let url = site.sourceDirectory.appendingPathComponent(filePath)
         openFile(FileRef(url: url, group: group, name: node.title))

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -7,6 +7,7 @@ import AnglesiteIntents
 private enum MainPaneMode: Equatable {
     case preview
     case editor(FileRef)
+    case graph
 }
 
 private enum ActiveEditor {
@@ -63,6 +64,7 @@ struct SiteWindow: View {
         self.semanticRanker = semanticRanker
         self.contentIndexerStore = contentIndexerStore
         _preview = State(initialValue: PreviewModel(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex, semanticRanker: semanticRanker))
+        _graphExplorer = State(initialValue: SiteGraphExplorerModel(graph: contentGraph))
     }
 
     @State private var site: SiteStore.Site?
@@ -105,6 +107,7 @@ struct SiteWindow: View {
     @State private var newPagePresented = false
     @State private var newCollectionPresented = false
     @State private var navigator: SiteNavigatorModel?
+    @State private var graphExplorer: SiteGraphExplorerModel
     @State private var mainPaneMode: MainPaneMode = .preview
     /// Sidebar visibility persisted per scene (window), per the design spec. Column WIDTH is restored
     /// automatically by `NavigationSplitView`'s own scene state, so only explicit visibility is wired.
@@ -183,6 +186,7 @@ struct SiteWindow: View {
             chat = nil
             navigator?.stop()
             navigator = nil
+            graphExplorer.stop()
             // Window closing: persist unsaved edits unconditionally (consistent with
             // auto-save-on-leave). No conflict dialog is possible during teardown, so we don't gate
             // on a flush return value — just write the buffer best-effort, off the main actor.
@@ -269,6 +273,20 @@ struct SiteWindow: View {
         .navigationTitle(site.name)
         .navigationSubtitle(preview.readyURL?.absoluteString ?? "")
         .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    Task {
+                        if await leaveCurrentEditor(), await leaveCurrentInspector() {
+                            inspectorContext = nil
+                            mainPaneMode = .graph
+                        }
+                    }
+                } label: {
+                    Label("Site Graph", systemImage: "point.3.connected.trianglepath.dotted")
+                }
+                .help("Explore pages, layouts, components, collections, and assets")
+            }
+
             ToolbarItem(placement: .primaryAction) {
                 Button {
                     inspectorShown.toggle()
@@ -543,11 +561,12 @@ struct SiteWindow: View {
                     set: { setPaneSelection($0) }
                 )) {
                     Text("Preview").tag(0)
-                    Text("Editor").tag(1)
+                    if activeEditorFile != nil { Text("Editor").tag(1) }
+                    Text("Graph").tag(2)
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
-                .frame(width: 180)
+                .frame(width: activeEditorFile == nil ? 220 : 270)
                 .padding(6)
                 Divider()
             }
@@ -556,16 +575,12 @@ struct SiteWindow: View {
     }
 
     private var showsPaneModePicker: Bool {
-        switch activeEditor {
-        case .some(.text):
-            return true
-        case .some(.plist), .none:
-            return false
-        }
+        true
     }
 
     private var paneSelection: Int {
         if case .editor = mainPaneMode { return 1 }
+        if case .graph = mainPaneMode { return 2 }
         return 0
     }
 
@@ -576,6 +591,12 @@ struct SiteWindow: View {
             Task { if await leaveCurrentEditor() { mainPaneMode = .preview } }
         } else if value == 1, let file = activeEditorFile {
             mainPaneMode = .editor(file)
+        } else if value == 2 {
+            Task {
+                guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+                inspectorContext = nil
+                mainPaneMode = .graph
+            }
         }
     }
 
@@ -639,6 +660,10 @@ struct SiteWindow: View {
                 }
             } else {
                 previewPane(for: site)
+            }
+        case .graph:
+            SiteGraphExplorerView(model: graphExplorer) { node in
+                openGraphNode(node, site: site)
             }
         case .preview:
             previewPane(for: site)
@@ -748,25 +773,47 @@ struct SiteWindow: View {
                 inspectorContext = await makeInspectorContext(forNavigatorID: id)
             }
         case .file(let file):
-            if activeEditorFile?.id == file.id {
-                mainPaneMode = .editor(file)   // re-show the already-open file (buffer intact)
-                return
+            openFile(file)
+        }
+    }
+
+    @MainActor
+    private func openGraphNode(_ node: SiteGraphNode, site: SiteStore.Site) {
+        guard let filePath = node.filePath else { return }
+        if node.kind == .asset {
+            NSWorkspace.shared.activateFileViewerSelecting([site.sourceDirectory.appendingPathComponent(filePath)])
+            return
+        }
+        let group: FileGroup = switch node.kind {
+        case .page: .pages
+        case .collection, .contentEntry: .posts
+        case .layout, .component: .components
+        case .asset, .style: .styles
+        }
+        let url = site.sourceDirectory.appendingPathComponent(filePath)
+        openFile(FileRef(url: url, group: group, name: node.title))
+    }
+
+    @MainActor
+    private func openFile(_ file: FileRef) {
+        if activeEditorFile?.id == file.id {
+            mainPaneMode = .editor(file)
+            return
+        }
+        Task {
+            guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+            inspectorContext = nil
+            switch EditorKind.resolve(for: file) {
+            case .text:
+                activeEditor = .text(FileEditorModel(file: file))
+            case .plist:
+                activeEditor = .plist(PlistEditorModel(
+                    file: file,
+                    websiteTitle: site?.name ?? file.name,
+                    sourceDirectory: site?.sourceDirectory ?? file.url.deletingLastPathComponent()
+                ))
             }
-            Task {
-                guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
-                inspectorContext = nil   // files (components/styles/metadata) have no page inspector
-                switch EditorKind.resolve(for: file) {
-                case .text:
-                    activeEditor = .text(FileEditorModel(file: file))
-                case .plist:
-                    activeEditor = .plist(PlistEditorModel(
-                        file: file,
-                        websiteTitle: site?.name ?? file.name,
-                        sourceDirectory: site?.sourceDirectory ?? file.url.deletingLastPathComponent()
-                    ))
-                }
-                mainPaneMode = .editor(file)
-            }
+            mainPaneMode = .editor(file)
         }
     }
 
@@ -940,6 +987,7 @@ struct SiteWindow: View {
             websiteTitle: resolved.name
         )
         navigator = navModel
+        graphExplorer.start(siteID: resolved.id, sourceDirectory: resolved.sourceDirectory)
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
         applyPendingNavigation(for: resolved.id)

--- a/Sources/AnglesiteCore/SiteGraphExplorer.swift
+++ b/Sources/AnglesiteCore/SiteGraphExplorer.swift
@@ -77,9 +77,6 @@ public enum SiteGraphExplorer {
     private static let sourceExtensions: Set<String> = [
         ".astro", ".md", ".mdx", ".markdown", ".js", ".jsx", ".ts", ".tsx", ".css"
     ]
-    private static let assetExtensions: Set<String> = [
-        ".jpg", ".jpeg", ".png", ".webp", ".gif", ".svg", ".avif"
-    ]
     private static let dynamicImportRegex = try! NSRegularExpression(
         pattern: #"import\(\s*['"]([^'"]+)['"]\s*\)"#
     )
@@ -139,6 +136,11 @@ public enum SiteGraphExplorer {
             ))
         }
         for post in posts {
+            let edge = SiteGraphEdge(
+                sourceID: "\(siteID):collection:\(post.collection)",
+                targetID: post.id,
+                kind: .contains
+            )
             addNode(SiteGraphNode(
                 id: post.id,
                 kind: .contentEntry,
@@ -147,11 +149,7 @@ public enum SiteGraphExplorer {
                 filePath: post.filePath,
                 route: postRoute(for: post)
             ))
-            edgesByID[SiteGraphEdge(
-                sourceID: "\(siteID):collection:\(post.collection)",
-                targetID: post.id,
-                kind: .contains
-            ).id] = SiteGraphEdge(sourceID: "\(siteID):collection:\(post.collection)", targetID: post.id, kind: .contains)
+            edgesByID[edge.id] = edge
         }
 
         for image in images {
@@ -169,11 +167,10 @@ public enum SiteGraphExplorer {
             let relativePath = relativePosix(file, from: projectRoot)
             guard sourceExtensions.contains(fileExtension(file)) else { continue }
             guard nodesByID[nodeIDByRelativePath[relativePath] ?? ""] == nil else { continue }
-            let kind = kind(for: relativePath)
-            guard kind != nil else { continue }
+            guard let kind = kind(for: relativePath) else { continue }
             addNode(SiteGraphNode(
                 id: "\(siteID):file:\(relativePath)",
-                kind: kind!,
+                kind: kind,
                 title: file.lastPathComponent,
                 detail: relativePath,
                 filePath: relativePath,
@@ -223,11 +220,15 @@ public enum SiteGraphExplorer {
         }
         return SiteGraphExplorerSnapshot(
             nodes: nodes.sorted { lhs, rhs in
-                if lhs.kind.rawValue == rhs.kind.rawValue { return lhs.title.localizedStandardCompare(rhs.title) == .orderedAscending }
-                return lhs.kind.rawValue < rhs.kind.rawValue
+                if lhs.kind == rhs.kind { return lhs.title.localizedStandardCompare(rhs.title) == .orderedAscending }
+                return kindRank(lhs.kind) < kindRank(rhs.kind)
             },
             edges: edgesByID.values.sorted { $0.id < $1.id }
         )
+    }
+
+    private static func kindRank(_ kind: SiteGraphNodeKind) -> Int {
+        SiteGraphNodeKind.allCases.firstIndex(of: kind) ?? Int.max
     }
 
     private static func kind(for relativePath: String) -> SiteGraphNodeKind? {

--- a/Sources/AnglesiteCore/SiteGraphExplorer.swift
+++ b/Sources/AnglesiteCore/SiteGraphExplorer.swift
@@ -1,0 +1,371 @@
+import Foundation
+
+public enum SiteGraphNodeKind: String, Sendable, CaseIterable, Identifiable {
+    case page
+    case layout
+    case component
+    case collection
+    case contentEntry
+    case asset
+    case style
+
+    public var id: String { rawValue }
+}
+
+public enum SiteGraphEdgeKind: String, Sendable, CaseIterable, Identifiable {
+    case imports
+    case usesLayout
+    case referencesAsset
+    case contains
+
+    public var id: String { rawValue }
+}
+
+public struct SiteGraphNode: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let kind: SiteGraphNodeKind
+    public let title: String
+    public let detail: String?
+    public let filePath: String?
+    public let route: String?
+    public let referencedByCount: Int
+
+    public init(
+        id: String,
+        kind: SiteGraphNodeKind,
+        title: String,
+        detail: String?,
+        filePath: String?,
+        route: String?,
+        referencedByCount: Int = 0
+    ) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+        self.detail = detail
+        self.filePath = filePath
+        self.route = route
+        self.referencedByCount = referencedByCount
+    }
+}
+
+public struct SiteGraphEdge: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let sourceID: String
+    public let targetID: String
+    public let kind: SiteGraphEdgeKind
+
+    public init(sourceID: String, targetID: String, kind: SiteGraphEdgeKind) {
+        self.sourceID = sourceID
+        self.targetID = targetID
+        self.kind = kind
+        self.id = "\(sourceID)->\(targetID):\(kind.rawValue)"
+    }
+}
+
+public struct SiteGraphExplorerSnapshot: Sendable, Equatable {
+    public let nodes: [SiteGraphNode]
+    public let edges: [SiteGraphEdge]
+
+    public init(nodes: [SiteGraphNode], edges: [SiteGraphEdge]) {
+        self.nodes = nodes
+        self.edges = edges
+    }
+}
+
+public enum SiteGraphExplorer {
+    private static let sourceExtensions: Set<String> = [
+        ".astro", ".md", ".mdx", ".markdown", ".js", ".jsx", ".ts", ".tsx", ".css"
+    ]
+    private static let assetExtensions: Set<String> = [
+        ".jpg", ".jpeg", ".png", ".webp", ".gif", ".svg", ".avif"
+    ]
+    private static let dynamicImportRegex = try! NSRegularExpression(
+        pattern: #"import\(\s*['"]([^'"]+)['"]\s*\)"#
+    )
+    private static let srcHrefRegex = try! NSRegularExpression(
+        pattern: #"\b(?:src|href)\s*=\s*["']([^"']+\.(?:jpg|jpeg|png|webp|gif|svg|avif))["']"#,
+        options: [.caseInsensitive]
+    )
+    private static let urlAssetRegex = try! NSRegularExpression(
+        pattern: #"url\(\s*['"]?([^'")]+\.(?:jpg|jpeg|png|webp|gif|svg|avif))['"]?\s*\)"#,
+        options: [.caseInsensitive]
+    )
+
+    public static func build(
+        projectRoot: URL,
+        siteID: String,
+        pages: [SiteContentGraph.Page],
+        posts: [SiteContentGraph.Post],
+        images: [SiteContentGraph.Image],
+        fileManager: FileManager = .default
+    ) -> SiteGraphExplorerSnapshot {
+        var nodesByID: [String: SiteGraphNode] = [:]
+        var edgesByID: [String: SiteGraphEdge] = [:]
+        var nodeIDByRelativePath: [String: String] = [:]
+        var nodeIDByPublicPath: [String: String] = [:]
+
+        func addNode(_ node: SiteGraphNode) {
+            nodesByID[node.id] = node
+            if let filePath = node.filePath {
+                nodeIDByRelativePath[filePath] = node.id
+                if filePath.hasPrefix("public/") {
+                    nodeIDByPublicPath["/" + String(filePath.dropFirst("public".count + 1))] = node.id
+                }
+            }
+        }
+
+        for page in pages {
+            addNode(SiteGraphNode(
+                id: page.id,
+                kind: .page,
+                title: page.title ?? page.route,
+                detail: page.route,
+                filePath: page.filePath,
+                route: page.route
+            ))
+        }
+
+        let collections = Dictionary(grouping: posts, by: \.collection)
+        for collection in collections.keys.sorted() {
+            let collectionID = "\(siteID):collection:\(collection)"
+            addNode(SiteGraphNode(
+                id: collectionID,
+                kind: .collection,
+                title: collection,
+                detail: "src/content/\(collection)",
+                filePath: nil,
+                route: nil
+            ))
+        }
+        for post in posts {
+            addNode(SiteGraphNode(
+                id: post.id,
+                kind: .contentEntry,
+                title: post.title,
+                detail: "\(post.collection)/\(post.slug)",
+                filePath: post.filePath,
+                route: postRoute(for: post)
+            ))
+            edgesByID[SiteGraphEdge(
+                sourceID: "\(siteID):collection:\(post.collection)",
+                targetID: post.id,
+                kind: .contains
+            ).id] = SiteGraphEdge(sourceID: "\(siteID):collection:\(post.collection)", targetID: post.id, kind: .contains)
+        }
+
+        for image in images {
+            addNode(SiteGraphNode(
+                id: image.id,
+                kind: .asset,
+                title: image.fileName,
+                detail: image.relativePath,
+                filePath: image.relativePath,
+                route: nil
+            ))
+        }
+
+        for file in walk(projectRoot, fileManager: fileManager) {
+            let relativePath = relativePosix(file, from: projectRoot)
+            guard sourceExtensions.contains(fileExtension(file)) else { continue }
+            guard nodesByID[nodeIDByRelativePath[relativePath] ?? ""] == nil else { continue }
+            let kind = kind(for: relativePath)
+            guard kind != nil else { continue }
+            addNode(SiteGraphNode(
+                id: "\(siteID):file:\(relativePath)",
+                kind: kind!,
+                title: file.lastPathComponent,
+                detail: relativePath,
+                filePath: relativePath,
+                route: nil
+            ))
+        }
+
+        let sourceNodes = nodesByID.values
+            .filter { $0.filePath != nil && $0.kind != .asset && $0.kind != .collection }
+        for node in sourceNodes {
+            guard let filePath = node.filePath else { continue }
+            let fileURL = projectRoot.appendingPathComponent(filePath)
+            guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
+            for specifier in importSpecifiers(in: text) {
+                guard let targetID = resolveImport(
+                    specifier,
+                    from: filePath,
+                    projectRoot: projectRoot,
+                    nodeIDByRelativePath: nodeIDByRelativePath,
+                    nodeIDByPublicPath: nodeIDByPublicPath,
+                    fileManager: fileManager
+                ) else { continue }
+                let targetKind = nodesByID[targetID]?.kind
+                let edgeKind: SiteGraphEdgeKind = targetKind == .layout ? .usesLayout : .imports
+                let edge = SiteGraphEdge(sourceID: node.id, targetID: targetID, kind: edgeKind)
+                edgesByID[edge.id] = edge
+            }
+            for assetPath in assetReferences(in: text) {
+                guard let targetID = nodeIDByPublicPath[assetPath] else { continue }
+                let edge = SiteGraphEdge(sourceID: node.id, targetID: targetID, kind: .referencesAsset)
+                edgesByID[edge.id] = edge
+            }
+        }
+
+        let incomingCounts = Dictionary(grouping: edgesByID.values, by: \.targetID)
+            .mapValues(\.count)
+        let nodes = nodesByID.values.map { node in
+            SiteGraphNode(
+                id: node.id,
+                kind: node.kind,
+                title: node.title,
+                detail: node.detail,
+                filePath: node.filePath,
+                route: node.route,
+                referencedByCount: incomingCounts[node.id, default: 0]
+            )
+        }
+        return SiteGraphExplorerSnapshot(
+            nodes: nodes.sorted { lhs, rhs in
+                if lhs.kind.rawValue == rhs.kind.rawValue { return lhs.title.localizedStandardCompare(rhs.title) == .orderedAscending }
+                return lhs.kind.rawValue < rhs.kind.rawValue
+            },
+            edges: edgesByID.values.sorted { $0.id < $1.id }
+        )
+    }
+
+    private static func kind(for relativePath: String) -> SiteGraphNodeKind? {
+        if relativePath.hasPrefix("src/layouts/") { return .layout }
+        if relativePath.hasPrefix("src/components/") { return .component }
+        if relativePath.hasPrefix("src/styles/") { return .style }
+        return nil
+    }
+
+    private static func importSpecifiers(in text: String) -> [String] {
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let staticImports = text.split(separator: "\n").compactMap(staticImportSpecifier)
+        let dynamicImports = dynamicImportRegex.matches(in: text, range: range).compactMap { match in
+            Range(match.range(at: 1), in: text).map { String(text[$0]) }
+        }
+        return staticImports + dynamicImports
+    }
+
+    private static func staticImportSpecifier(in line: Substring) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("import ") || trimmed.hasPrefix("export ") else { return nil }
+        let searchStart: String.SubSequence
+        if let fromRange = trimmed.range(of: " from ") {
+            searchStart = trimmed[fromRange.upperBound...]
+        } else {
+            searchStart = trimmed[trimmed.startIndex...]
+        }
+        guard let quote = searchStart.first(where: { $0 == "\"" || $0 == "'" }) else { return nil }
+        guard let open = searchStart.firstIndex(of: quote) else { return nil }
+        let afterOpen = searchStart.index(after: open)
+        guard let close = searchStart[afterOpen...].firstIndex(of: quote) else { return nil }
+        return String(searchStart[afterOpen..<close])
+    }
+
+    private static func assetReferences(in text: String) -> [String] {
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let regexes = [srcHrefRegex, urlAssetRegex]
+        return regexes.flatMap { regex in
+            regex.matches(in: text, range: range).compactMap { match in
+                guard let found = Range(match.range(at: 1), in: text) else { return nil }
+                let value = String(text[found])
+                if value.hasPrefix("/") { return value }
+                if value.hasPrefix("public/") { return "/" + String(value.dropFirst("public".count + 1)) }
+                return nil
+            }
+        }
+    }
+
+    private static func resolveImport(
+        _ specifier: String,
+        from relativePath: String,
+        projectRoot: URL,
+        nodeIDByRelativePath: [String: String],
+        nodeIDByPublicPath: [String: String],
+        fileManager: FileManager
+    ) -> String? {
+        if specifier.hasPrefix("/") {
+            return nodeIDByPublicPath[specifier]
+        }
+        var candidate: String
+        if specifier.hasPrefix("@/") {
+            candidate = "src/" + String(specifier.dropFirst(2))
+        } else if specifier.hasPrefix("./") || specifier.hasPrefix("../") {
+            let base = (relativePath as NSString).deletingLastPathComponent
+            candidate = normalizeRelativePath((base as NSString).appendingPathComponent(specifier))
+        } else {
+            return nil
+        }
+        for path in candidatePaths(candidate, projectRoot: projectRoot, fileManager: fileManager) {
+            if let id = nodeIDByRelativePath[path] { return id }
+        }
+        return nil
+    }
+
+    private static func normalizeRelativePath(_ path: String) -> String {
+        var output: [String] = []
+        for component in path.split(separator: "/", omittingEmptySubsequences: false) {
+            switch component {
+            case "", ".":
+                continue
+            case "..":
+                if !output.isEmpty { output.removeLast() }
+            default:
+                output.append(String(component))
+            }
+        }
+        return output.joined(separator: "/")
+    }
+
+    private static func candidatePaths(
+        _ path: String,
+        projectRoot: URL,
+        fileManager: FileManager
+    ) -> [String] {
+        if !fileExtension(path).isEmpty { return [path] }
+        let extensions = [".astro", ".md", ".mdx", ".js", ".jsx", ".ts", ".tsx", ".css"]
+        var candidates = extensions.map { path + $0 }
+        candidates += extensions.map { path + "/index" + $0 }
+        return candidates.filter {
+            fileManager.fileExists(atPath: projectRoot.appendingPathComponent($0).path(percentEncoded: false))
+        }
+    }
+
+    private static func walk(_ dir: URL, fileManager: FileManager) -> [URL] {
+        guard let enumerator = fileManager.enumerator(
+            at: dir,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        var files: [URL] = []
+        for case let url as URL in enumerator {
+            let name = url.lastPathComponent
+            let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            if values?.isSymbolicLink == true { continue }
+            if values?.isDirectory == true {
+                if ["node_modules", "dist", ".astro", ".git"].contains(name) {
+                    enumerator.skipDescendants()
+                }
+                continue
+            }
+            files.append(url)
+        }
+        return files
+    }
+
+    private static func relativePosix(_ url: URL, from base: URL) -> String {
+        let urlComponents = url.standardizedFileURL.pathComponents
+        let baseComponents = base.standardizedFileURL.pathComponents
+        guard urlComponents.starts(with: baseComponents) else { return url.path }
+        return urlComponents.dropFirst(baseComponents.count).joined(separator: "/")
+    }
+
+    private static func fileExtension(_ path: String) -> String {
+        let ext = (path as NSString).pathExtension
+        return ext.isEmpty ? "" : "." + ext.lowercased()
+    }
+
+    private static func fileExtension(_ url: URL) -> String {
+        fileExtension(url.path)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
@@ -26,6 +26,7 @@ struct SiteGraphExplorerTests {
             "src/content/posts/hello.md": "---\ntitle: Hello\n---\nBody",
             "public/images/unused.png": "PNG",
         ])
+        defer { try? FileManager.default.removeItem(at: root) }
         let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
         let graph = SiteGraphExplorer.build(
             projectRoot: root,
@@ -50,6 +51,7 @@ struct SiteGraphExplorerTests {
             "src/layouts/Base.astro": "---\nimport Nav from '../components/Nav.astro';\n---\n<Nav />",
             "src/components/Nav.astro": "<nav />",
         ])
+        defer { try? FileManager.default.removeItem(at: root) }
         let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
         let graph = SiteGraphExplorer.build(
             projectRoot: root,
@@ -76,6 +78,7 @@ struct SiteGraphExplorerTests {
         let root = makeSite([
             "src/content/posts/hello.md": "---\ntitle: Hello\n---\nBody",
         ])
+        defer { try? FileManager.default.removeItem(at: root) }
         let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
         let graph = SiteGraphExplorer.build(
             projectRoot: root,
@@ -98,6 +101,7 @@ struct SiteGraphExplorerTests {
             "public/images/hero.png": "PNG",
             "public/images/unused.png": "PNG",
         ])
+        defer { try? FileManager.default.removeItem(at: root) }
         let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
         let graph = SiteGraphExplorer.build(
             projectRoot: root,
@@ -114,5 +118,69 @@ struct SiteGraphExplorerTests {
             $0.sourceID == page.id && $0.targetID == hero.id && $0.kind == .referencesAsset
         })
         #expect(unused.referencedByCount == 0)
+    }
+
+    @Test("@ alias imports resolve to src-relative nodes")
+    func aliasImports() throws {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nimport Nav from '@/components/Nav.astro';\n---\n<Nav />",
+            "src/components/Nav.astro": "<nav />",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let page = try #require(graph.nodes.first { $0.kind == .page })
+        let component = try #require(graph.nodes.first { $0.kind == .component })
+
+        #expect(graph.edges.contains {
+            $0.sourceID == page.id && $0.targetID == component.id && $0.kind == .imports
+        })
+    }
+
+    @Test("dynamic imports create dependency edges")
+    func dynamicImports() throws {
+        let root = makeSite([
+            "src/pages/index.astro": "<script>const Card = await import('../components/Card.astro')</script>",
+            "src/components/Card.astro": "<article />",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let page = try #require(graph.nodes.first { $0.kind == .page })
+        let component = try #require(graph.nodes.first { $0.kind == .component })
+
+        #expect(graph.edges.contains {
+            $0.sourceID == page.id && $0.targetID == component.id && $0.kind == .imports
+        })
+    }
+
+    @Test("src styles files become style nodes")
+    func styleNodes() {
+        let root = makeSite([
+            "src/styles/global.css": "body { color: black; }",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+
+        #expect(graph.nodes.contains { $0.kind == .style && $0.filePath == "src/styles/global.css" })
     }
 }

--- a/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
@@ -1,0 +1,118 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("SiteGraphExplorer")
+struct SiteGraphExplorerTests {
+    private let siteID = "site-graph"
+
+    private func makeSite(_ files: [String: String]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("site-graph-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    @Test("pages, layouts, components, collections, entries, and assets become graph nodes")
+    func nodeKinds() {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nimport Base from '../layouts/Base.astro';\n---\n<Base />",
+            "src/layouts/Base.astro": "---\nimport Nav from '../components/Nav.astro';\n---\n<Nav />",
+            "src/components/Nav.astro": "<nav />",
+            "src/content/posts/hello.md": "---\ntitle: Hello\n---\nBody",
+            "public/images/unused.png": "PNG",
+        ])
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+
+        #expect(graph.nodes.contains { $0.kind == .page && $0.title == "/" })
+        #expect(graph.nodes.contains { $0.kind == .layout && $0.filePath == "src/layouts/Base.astro" })
+        #expect(graph.nodes.contains { $0.kind == .component && $0.filePath == "src/components/Nav.astro" })
+        #expect(graph.nodes.contains { $0.kind == .collection && $0.title == "posts" })
+        #expect(graph.nodes.contains { $0.kind == .contentEntry && $0.title == "Hello" })
+        #expect(graph.nodes.contains { $0.kind == .asset && $0.filePath == "public/images/unused.png" })
+    }
+
+    @Test("imports create layout and component dependency edges")
+    func importEdges() throws {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nimport Base from '../layouts/Base.astro';\n---\n<Base />",
+            "src/layouts/Base.astro": "---\nimport Nav from '../components/Nav.astro';\n---\n<Nav />",
+            "src/components/Nav.astro": "<nav />",
+        ])
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let page = try #require(graph.nodes.first { $0.kind == .page })
+        let layout = try #require(graph.nodes.first { $0.kind == .layout })
+        let component = try #require(graph.nodes.first { $0.kind == .component })
+
+        #expect(graph.edges.contains {
+            $0.sourceID == page.id && $0.targetID == layout.id && $0.kind == .usesLayout
+        })
+        #expect(graph.edges.contains {
+            $0.sourceID == layout.id && $0.targetID == component.id && $0.kind == .imports
+        })
+        #expect(graph.nodes.first { $0.id == layout.id }?.referencedByCount == 1)
+    }
+
+    @Test("content collections contain their entries")
+    func collectionEdges() throws {
+        let root = makeSite([
+            "src/content/posts/hello.md": "---\ntitle: Hello\n---\nBody",
+        ])
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let collection = try #require(graph.nodes.first { $0.kind == .collection })
+        let entry = try #require(graph.nodes.first { $0.kind == .contentEntry })
+        #expect(graph.edges.contains {
+            $0.sourceID == collection.id && $0.targetID == entry.id && $0.kind == .contains
+        })
+    }
+
+    @Test("public image src references create asset edges while unused images remain visible")
+    func assetEdgesAndUnusedAssets() throws {
+        let root = makeSite([
+            "src/pages/index.astro": "<img src=\"/images/hero.png\" />",
+            "public/images/hero.png": "PNG",
+            "public/images/unused.png": "PNG",
+        ])
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let page = try #require(graph.nodes.first { $0.kind == .page })
+        let hero = try #require(graph.nodes.first { $0.filePath == "public/images/hero.png" })
+        let unused = try #require(graph.nodes.first { $0.filePath == "public/images/unused.png" })
+
+        #expect(graph.edges.contains {
+            $0.sourceID == page.id && $0.targetID == hero.id && $0.kind == .referencesAsset
+        })
+        #expect(unused.referencedByCount == 0)
+    }
+}


### PR DESCRIPTION
## Summary
- add a core site graph explorer projection for pages, layouts, components, collections, entries, assets, styles, and dependency/reference edges
- add a native SwiftUI graph explorer with filters, search, selection highlighting, inspector details, and file open/reveal actions
- wire the graph explorer into the site window toolbar and main pane

## Verification
- env ANGLESITE_SKIP_CONTAINER=1 swift test --filter SiteGraphExplorerTests
- env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build