### PR TITLE
feat(#307): citation UX + kind-filtered RAG retrieval

### DIFF
--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -92,7 +92,7 @@ final class ChatModel {
     // MARK: Dependencies
 
     private let siteID: String
-    private let siteDirectory: URL
+    let siteDirectory: URL
     private let assistant: any ConversationalAssistant
     private let history: ChatHistoryStore
     /// Sticky-note source. Wired to the per-site `SiteRuntime.mcpClient` in production so
@@ -200,7 +200,7 @@ final class ChatModel {
 
     /// Sends a user prompt to the agent and consumes the resulting event stream. No-op while
     /// a turn is in flight.
-    func send(_ prompt: String) {
+    func send(_ prompt: String, searchOptions: SiteKnowledgeIndex.SearchOptions = .init()) {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !isStreaming else { return }
 
@@ -213,7 +213,7 @@ final class ChatModel {
 
         isStreaming = true
         streamTask = Task { @MainActor [weak self] in
-            await self?.consumeAssistantStream(prompt: trimmed)
+            await self?.consumeAssistantStream(prompt: trimmed, searchOptions: searchOptions)
         }
     }
 
@@ -303,10 +303,10 @@ final class ChatModel {
 
     // MARK: Event consumption
 
-    private func consumeAssistantStream(prompt: String) async {
+    private func consumeAssistantStream(prompt: String, searchOptions: SiteKnowledgeIndex.SearchOptions = .init()) async {
         let stream: AsyncStream<AssistantEvent>
         do {
-            let context = AssistantContext(siteID: siteID, siteDirectory: siteDirectory)
+            let context = AssistantContext(siteID: siteID, siteDirectory: siteDirectory, searchOptions: searchOptions)
             stream = try await assistant.converse(prompt: prompt, context: context)
         } catch {
             transcript.endTurn()
@@ -350,15 +350,17 @@ final class ChatModel {
     // MARK: Helpers
 
     private func persist(_ message: Message) {
+        // Citations are ephemeral per-session (re-computed on each turn), like annotations.
+        guard message.role != .citation else { return }
         let role: ChatHistoryStore.Role = {
             switch message.role {
             case .user: return .user
             case .assistant: return .assistant
-            // `.system`/`.error`/`.annotation` are never routed through `persist` — they're
-            // appended directly. Annotations in particular are reloaded fresh from MCP each
-            // session via `loadAnnotations()`, so they're intentionally non-persisted. This
-            // arm only keeps the switch exhaustive.
-            case .system, .error, .annotation: return .assistant
+            // `.system`/`.error`/`.annotation`/`.citation` are never routed through `persist` —
+            // they're appended directly or guarded above. Annotations are reloaded fresh from
+            // MCP each session via `loadAnnotations()`, and citations are re-computed per turn.
+            // This arm only keeps the switch exhaustive.
+            case .system, .error, .annotation, .citation: return .assistant
             case .edit: return .edit
             }
         }()

--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -92,7 +92,9 @@ final class ChatModel {
     // MARK: Dependencies
 
     private let siteID: String
-    let siteDirectory: URL
+    private let siteDirectory: URL
+    /// The site's source directory, exposed read-only for CitationRowView's click-to-open.
+    var siteDirectoryURL: URL { siteDirectory }
     private let assistant: any ConversationalAssistant
     private let history: ChatHistoryStore
     /// Sticky-note source. Wired to the per-site `SiteRuntime.mcpClient` in production so

--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -217,6 +217,7 @@ struct ChatView: View {
         let prompt = draft
         let options = activeKinds.map { SiteKnowledgeIndex.SearchOptions(kinds: $0) } ?? .init()
         model.send(prompt, searchOptions: options)
+        // Clear input only after a successful start (model.isStreaming flipped to true).
         if !model.isStreaming { return }
         draft = ""
         inputFocused = true
@@ -254,7 +255,7 @@ private struct MessageRow: View {
             AnnotationRowView(message: message, model: model)
         } else if message.role == .citation {
             if let meta = message.citationMetadata {
-                CitationRowView(citations: meta.citations, siteDirectory: model.siteDirectory)
+                CitationRowView(citations: meta.citations, siteDirectory: model.siteDirectoryURL)
             }
         } else {
             HStack {
@@ -341,7 +342,8 @@ private struct MessageRow: View {
         case .assistant: return "Assistant said: \(message.content)"
         case .error:     return "Error: \(message.content)"
         case .system:    return "System: \(message.content)"
-        case .edit, .annotation, .citation: return message.content  // rendered by their own rows
+        case .edit, .annotation: return message.content
+        case .citation: return "Retrieved context"
         }
     }
 

--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -19,6 +19,7 @@ struct ChatView: View {
     /// Binds the prompt input. Lives in the view (not the model) because it's pure transient
     /// UI state; the model only sees the final string when the user hits Send.
     @State private var draft: String = ""
+    @State private var activeKinds: Set<SiteKnowledgeIndex.Document.Kind>?
     @FocusState private var inputFocused: Bool
     var body: some View {
         VStack(spacing: 0) {
@@ -144,6 +145,7 @@ struct ChatView: View {
 
     private var inputBar: some View {
         HStack(alignment: .bottom, spacing: 8) {
+            kindFilterMenu
             TextField("Ask the assistant…", text: $draft, axis: .vertical)
                 .textFieldStyle(.roundedBorder)
                 .lineLimit(1...6)
@@ -173,11 +175,49 @@ struct ChatView: View {
         .padding(.vertical, 10)
     }
 
+    private var kindFilterMenu: some View {
+        Menu {
+            ForEach(SiteKnowledgeIndex.Document.Kind.allCases, id: \.self) { kind in
+                Toggle(kind.rawValue.capitalized, isOn: kindBinding(for: kind))
+            }
+            Divider()
+            Button("Clear filter") { activeKinds = nil }
+                .disabled(activeKinds == nil)
+        } label: {
+            Image(systemName: activeKinds != nil
+                  ? "line.3.horizontal.decrease.circle.fill"
+                  : "line.3.horizontal.decrease.circle")
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help(activeKinds.map { "Filtering: \($0.map { $0.rawValue }.sorted().joined(separator: ", "))" }
+              ?? "Filter retrieval by content type")
+        .accessibilityLabel("Content type filter")
+        .accessibilityValue(activeKinds.map { "\($0.count) selected" } ?? "All types")
+    }
+
+    private func kindBinding(for kind: SiteKnowledgeIndex.Document.Kind) -> Binding<Bool> {
+        Binding(
+            get: { activeKinds?.contains(kind) ?? false },
+            set: { isOn in
+                if isOn {
+                    var kinds = activeKinds ?? []
+                    kinds.insert(kind)
+                    activeKinds = kinds
+                } else {
+                    activeKinds?.remove(kind)
+                    if activeKinds?.isEmpty == true { activeKinds = nil }
+                }
+            }
+        )
+    }
+
     private func submitIfReady() {
         let prompt = draft
-        model.send(prompt)
+        let options = activeKinds.map { SiteKnowledgeIndex.SearchOptions(kinds: $0) } ?? .init()
+        model.send(prompt, searchOptions: options)
         if !model.isStreaming { return }
-        // Clear input only after a successful start (model.isStreaming flipped to true).
         draft = ""
         inputFocused = true
     }
@@ -212,6 +252,10 @@ private struct MessageRow: View {
             editRow
         } else if message.role == .annotation {
             AnnotationRowView(message: message, model: model)
+        } else if message.role == .citation {
+            if let meta = message.citationMetadata {
+                CitationRowView(citations: meta.citations, siteDirectory: model.siteDirectory)
+            }
         } else {
             HStack {
                 if message.role == .user { Spacer(minLength: 32) }
@@ -297,7 +341,7 @@ private struct MessageRow: View {
         case .assistant: return "Assistant said: \(message.content)"
         case .error:     return "Error: \(message.content)"
         case .system:    return "System: \(message.content)"
-        case .edit, .annotation: return message.content  // rendered by their own rows
+        case .edit, .annotation, .citation: return message.content  // rendered by their own rows
         }
     }
 
@@ -316,6 +360,7 @@ private struct MessageRow: View {
         case .error: return Color.red.opacity(0.15)
         case .edit: return Color.secondary.opacity(0.06)  // editRow handles .edit rendering; this is unreachable
         case .annotation: return Color.secondary.opacity(0.12)
+        case .citation: return Color.secondary.opacity(0.06)  // citationRow handles rendering; unreachable
         }
     }
 

--- a/Sources/AnglesiteApp/CitationRowView.swift
+++ b/Sources/AnglesiteApp/CitationRowView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Renders retrieved RAG citations as a horizontal strip of clickable chips below an assistant
+/// response. Each chip shows a kind badge and the file's last path component; clicking opens
+/// the file in the default editor.
+struct CitationRowView: View {
+    let citations: [RetrievedCitation]
+    let siteDirectory: URL
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Sources")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+            FlowLayout(spacing: 6) {
+                ForEach(citations) { citation in
+                    CitationChip(citation: citation) {
+                        let url = siteDirectory.appendingPathComponent(citation.path)
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Retrieved context from \(citations.count) file\(citations.count == 1 ? "" : "s")")
+    }
+}
+
+private struct CitationChip: View {
+    let citation: RetrievedCitation
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Text(citation.kind.rawValue.uppercased())
+                    .font(.system(.caption2, design: .rounded, weight: .semibold))
+                    .foregroundStyle(kindColor)
+                Text(fileName)
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.secondary.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help(citation.path)
+        .accessibilityLabel("\(citation.kind.rawValue) \(fileName)")
+        .accessibilityHint("Opens \(citation.path) in the default editor")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var fileName: String {
+        (citation.path as NSString).lastPathComponent
+    }
+
+    private var kindColor: Color {
+        switch citation.kind {
+        case .page: return .blue
+        case .post: return .purple
+        case .component: return .orange
+        case .layout: return .teal
+        case .content: return .indigo
+        case .config: return .gray
+        case .style: return .pink
+        case .script: return .yellow
+        case .other: return .secondary
+        }
+    }
+}
+
+/// A simple wrapping flow layout for citation chips. Uses a horizontal layout that wraps to
+/// the next line when chips exceed the available width.
+private struct FlowLayout: Layout {
+    var spacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        guard !rows.isEmpty else { return .zero }
+        let height = rows.reduce(CGFloat(0)) { sum, row in
+            sum + row.height + (sum > 0 ? spacing : 0)
+        }
+        let width = rows.map(\.width).max() ?? 0
+        return CGSize(width: width, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        var y = bounds.minY
+        var subviewIndex = 0
+        for row in rows {
+            var x = bounds.minX
+            for _ in 0..<row.count {
+                let size = subviews[subviewIndex].sizeThatFits(.unspecified)
+                subviews[subviewIndex].place(at: CGPoint(x: x, y: y), proposal: .unspecified)
+                x += size.width + spacing
+                subviewIndex += 1
+            }
+            y += row.height + spacing
+        }
+    }
+
+    private struct Row {
+        var count: Int
+        var width: CGFloat
+        var height: CGFloat
+    }
+
+    private func computeRows(proposal: ProposedViewSize, subviews: Subviews) -> [Row] {
+        let maxWidth = proposal.width ?? .infinity
+        var rows: [Row] = []
+        var currentRow = Row(count: 0, width: 0, height: 0)
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            let newWidth = currentRow.width + (currentRow.count > 0 ? spacing : 0) + size.width
+            if currentRow.count > 0 && newWidth > maxWidth {
+                rows.append(currentRow)
+                currentRow = Row(count: 1, width: size.width, height: size.height)
+            } else {
+                currentRow.count += 1
+                currentRow.width = newWidth
+                currentRow.height = max(currentRow.height, size.height)
+            }
+        }
+        if currentRow.count > 0 { rows.append(currentRow) }
+        return rows
+    }
+}

--- a/Sources/AnglesiteApp/CitationRowView.swift
+++ b/Sources/AnglesiteApp/CitationRowView.swift
@@ -80,8 +80,16 @@ private struct CitationChip: View {
 private struct FlowLayout: Layout {
     var spacing: CGFloat
 
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let rows = computeRows(proposal: proposal, subviews: subviews)
+    struct Cache {
+        var sizes: [CGSize]
+    }
+
+    func makeCache(subviews: Subviews) -> Cache {
+        Cache(sizes: subviews.map { $0.sizeThatFits(.unspecified) })
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Cache) -> CGSize {
+        let rows = computeRows(proposal: proposal, sizes: cache.sizes)
         guard !rows.isEmpty else { return .zero }
         let height = rows.reduce(CGFloat(0)) { sum, row in
             sum + row.height + (sum > 0 ? spacing : 0)
@@ -90,14 +98,14 @@ private struct FlowLayout: Layout {
         return CGSize(width: width, height: height)
     }
 
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        let rows = computeRows(proposal: proposal, subviews: subviews)
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Cache) {
+        let rows = computeRows(proposal: proposal, sizes: cache.sizes)
         var y = bounds.minY
         var subviewIndex = 0
         for row in rows {
             var x = bounds.minX
             for _ in 0..<row.count {
-                let size = subviews[subviewIndex].sizeThatFits(.unspecified)
+                let size = cache.sizes[subviewIndex]
                 subviews[subviewIndex].place(at: CGPoint(x: x, y: y), proposal: .unspecified)
                 x += size.width + spacing
                 subviewIndex += 1
@@ -112,12 +120,11 @@ private struct FlowLayout: Layout {
         var height: CGFloat
     }
 
-    private func computeRows(proposal: ProposedViewSize, subviews: Subviews) -> [Row] {
+    private func computeRows(proposal: ProposedViewSize, sizes: [CGSize]) -> [Row] {
         let maxWidth = proposal.width ?? .infinity
         var rows: [Row] = []
         var currentRow = Row(count: 0, width: 0, height: 0)
-        for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
+        for size in sizes {
             let newWidth = currentRow.width + (currentRow.count > 0 ? spacing : 0) + size.width
             if currentRow.count > 0 && newWidth > maxWidth {
                 rows.append(currentRow)

--- a/Sources/AnglesiteCore/ContentAssistant.swift
+++ b/Sources/AnglesiteCore/ContentAssistant.swift
@@ -64,6 +64,9 @@ public struct AssistantContext: Sendable {
     public let selectedElementSelector: JSONValue?
     /// Prior turns, oldest first.
     public let conversationHistory: [AssistantMessage]
+    /// Optional kind filter for RAG retrieval. When non-nil, only documents matching these kinds
+    /// are considered during the pre-prompt enrichment search.
+    public let searchOptions: SiteKnowledgeIndex.SearchOptions
 
     public init(
         siteID: String,
@@ -71,7 +74,8 @@ public struct AssistantContext: Sendable {
         currentPageRoute: String? = nil,
         currentPageContent: String? = nil,
         selectedElementSelector: JSONValue? = nil,
-        conversationHistory: [AssistantMessage] = []
+        conversationHistory: [AssistantMessage] = [],
+        searchOptions: SiteKnowledgeIndex.SearchOptions = .init()
     ) {
         self.siteID = siteID
         self.siteDirectory = siteDirectory
@@ -79,6 +83,7 @@ public struct AssistantContext: Sendable {
         self.currentPageContent = currentPageContent
         self.selectedElementSelector = selectedElementSelector
         self.conversationHistory = conversationHistory
+        self.searchOptions = searchOptions
     }
 }
 

--- a/Sources/AnglesiteCore/ConversationTranscript.swift
+++ b/Sources/AnglesiteCore/ConversationTranscript.swift
@@ -6,7 +6,7 @@ import Foundation
 /// these rows can be unit-tested in `AnglesiteCore` without the App shell (#161). `ChatModel`
 /// re-exports this as `ChatModel.Message` via a typealias, so its SwiftUI views are unaffected.
 public struct ChatMessage: Identifiable, Equatable, Sendable {
-    public enum Role: Equatable, Sendable { case user, assistant, system, error, edit, annotation }
+    public enum Role: Equatable, Sendable { case user, assistant, system, error, edit, annotation, citation }
 
     public let id: UUID
     public let role: Role
@@ -17,6 +17,8 @@ public struct ChatMessage: Identifiable, Equatable, Sendable {
     public var editMetadata: ChatEditMetadata?
     /// Only set on `role: .annotation` rows. Carries the backing annotation id.
     public var annotationMetadata: ChatAnnotationMetadata?
+    /// Only set on `role: .citation` rows. Carries the retrieved files for this turn.
+    public var citationMetadata: ChatCitationMetadata?
 
     public init(
         id: UUID = UUID(),
@@ -25,7 +27,8 @@ public struct ChatMessage: Identifiable, Equatable, Sendable {
         toolCalls: [ChatToolCall] = [],
         timestamp: Date = Date(),
         editMetadata: ChatEditMetadata? = nil,
-        annotationMetadata: ChatAnnotationMetadata? = nil
+        annotationMetadata: ChatAnnotationMetadata? = nil,
+        citationMetadata: ChatCitationMetadata? = nil
     ) {
         self.id = id
         self.role = role
@@ -34,6 +37,7 @@ public struct ChatMessage: Identifiable, Equatable, Sendable {
         self.timestamp = timestamp
         self.editMetadata = editMetadata
         self.annotationMetadata = annotationMetadata
+        self.citationMetadata = citationMetadata
     }
 }
 
@@ -68,6 +72,11 @@ public struct ChatEditMetadata: Equatable, Sendable {
 public struct ChatAnnotationMetadata: Equatable, Sendable {
     public let annotationID: String
     public init(annotationID: String) { self.annotationID = annotationID }
+}
+
+public struct ChatCitationMetadata: Equatable, Sendable {
+    public let citations: [RetrievedCitation]
+    public init(citations: [RetrievedCitation]) { self.citations = citations }
 }
 
 /// The provider-agnostic reducer that turns a stream of ``AssistantEvent`` values into chat rows.
@@ -203,6 +212,14 @@ public struct ConversationTranscript: Equatable, Sendable {
                 lastError = note
                 messages.append(ChatMessage(role: .error, content: note))
             }
+
+        case .citations(let items):
+            guard !items.isEmpty else { break }
+            messages.append(ChatMessage(
+                role: .citation,
+                content: "",
+                citationMetadata: ChatCitationMetadata(citations: items)
+            ))
         }
     }
 

--- a/Sources/AnglesiteCore/ConversationalAssistant.swift
+++ b/Sources/AnglesiteCore/ConversationalAssistant.swift
@@ -25,6 +25,9 @@ public enum AssistantEvent: Sendable, Equatable {
     case cancelled
     /// The backing process/session exited with this OS code (`0` is clean).
     case backendExited(code: Int32)
+    /// Files retrieved as RAG context for this turn. The chat panel surfaces these as clickable
+    /// citation chips below the assistant's response.
+    case citations([RetrievedCitation])
 }
 
 /// Token/cost telemetry for one completed turn.

--- a/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
@@ -23,14 +23,14 @@ public actor KnowledgeAugmentedAssistant: ConversationalAssistant {
         let baseStream = try await base.converse(prompt: enriched, context: context)
         guard !citations.isEmpty else { return baseStream }
         return AsyncStream { continuation in
-            let citationItems = citations
-            Task {
-                continuation.yield(.citations(citationItems))
+            let task = Task {
+                continuation.yield(.citations(citations))
                 for await event in baseStream {
                     continuation.yield(event)
                 }
                 continuation.finish()
             }
+            continuation.onTermination = { _ in task.cancel() }
         }
     }
 

--- a/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
@@ -19,12 +19,23 @@ public actor KnowledgeAugmentedAssistant: ConversationalAssistant {
     }
 
     public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
-        let enriched = await enrichedPrompt(prompt, context: context)
-        return try await base.converse(prompt: enriched, context: context)
+        let (enriched, citations) = await enrichedContext(prompt, context: context)
+        let baseStream = try await base.converse(prompt: enriched, context: context)
+        guard !citations.isEmpty else { return baseStream }
+        return AsyncStream { continuation in
+            let citationItems = citations
+            Task {
+                continuation.yield(.citations(citationItems))
+                for await event in baseStream {
+                    continuation.yield(event)
+                }
+                continuation.finish()
+            }
+        }
     }
 
     public func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
-        let enriched = await enrichedPrompt(prompt, context: context)
+        let (enriched, _) = await enrichedContext(prompt, context: context)
         return try await base.generate(prompt: enriched, context: context)
     }
 
@@ -34,7 +45,7 @@ public actor KnowledgeAugmentedAssistant: ConversationalAssistant {
         context: AssistantContext,
         resultType: T.Type
     ) async throws -> T {
-        let enriched = await enrichedPrompt(prompt, context: context)
+        let (enriched, _) = await enrichedContext(prompt, context: context)
         return try await base.generateStructured(
             prompt: enriched,
             context: context,
@@ -51,13 +62,38 @@ public actor KnowledgeAugmentedAssistant: ConversationalAssistant {
         await base.resetSession()
     }
 
-    private func enrichedPrompt(_ prompt: String, context: AssistantContext) async -> String {
-        guard let retrieved = await index.formattedContext(siteID: context.siteID, query: prompt) else { return prompt }
-        return """
-        \(retrieved)
+    private func enrichedContext(_ prompt: String, context: AssistantContext) async -> (prompt: String, citations: [RetrievedCitation]) {
+        let results = await index.search(
+            siteID: context.siteID,
+            query: prompt,
+            options: context.searchOptions
+        )
+        guard !results.isEmpty else { return (prompt, []) }
+        let formatted = Self.formatContext(results)
+        let enriched = """
+        \(formatted)
 
         User request:
         \(prompt)
         """
+        return (enriched, results.map(RetrievedCitation.init))
+    }
+
+    private static func formatContext(_ results: [SiteKnowledgeIndex.SearchResult]) -> String {
+        var lines = [
+            "Relevant project context retrieved from this Astro site:",
+            "Use this context when it is relevant. Cite file paths when answering.",
+        ]
+        for result in results {
+            let lineLabel = result.lineRange.map { range in
+                range.lowerBound == range.upperBound
+                    ? "line \(range.lowerBound)"
+                    : "lines \(range.lowerBound)-\(range.upperBound)"
+            } ?? "excerpt"
+            let title = result.document.title.map { " - \($0)" } ?? ""
+            lines.append("\n[\(result.document.path):\(lineLabel)]\(title)")
+            lines.append(result.excerpt)
+        }
+        return lines.joined(separator: "\n")
     }
 }

--- a/Sources/AnglesiteCore/RetrievedCitation.swift
+++ b/Sources/AnglesiteCore/RetrievedCitation.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A lightweight value type representing one file cited during RAG retrieval. Carries enough
+/// for the chat UI to render a chip and navigate to the file without reaching back into the index.
+public struct RetrievedCitation: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let path: String
+    public let kind: SiteKnowledgeIndex.Document.Kind
+    public let title: String?
+    public let lineRange: ClosedRange<Int>?
+    public let score: Double
+
+    public init(id: String, path: String, kind: SiteKnowledgeIndex.Document.Kind, title: String?, lineRange: ClosedRange<Int>?, score: Double) {
+        self.id = id
+        self.path = path
+        self.kind = kind
+        self.title = title
+        self.lineRange = lineRange
+        self.score = score
+    }
+
+    public init(_ result: SiteKnowledgeIndex.SearchResult) {
+        self.init(
+            id: result.document.id,
+            path: result.document.path,
+            kind: result.document.kind,
+            title: result.document.title,
+            lineRange: result.lineRange,
+            score: result.score
+        )
+    }
+}

--- a/Tests/AnglesiteCoreTests/ConversationTranscriptTests.swift
+++ b/Tests/AnglesiteCoreTests/ConversationTranscriptTests.swift
@@ -300,6 +300,37 @@ struct ConversationTranscriptAppendTests {
         #expect(t.messages.first?.role == .user)
     }
 
+    @Test(".citations event appends a .citation row with metadata")
+    func citationsEventAppendsCitationRow() {
+        var t = ConversationTranscript()
+        t.beginTurn(userPrompt: "tell me about the CTA")
+        let citations = [
+            RetrievedCitation(
+                id: "src/components/CTA.astro:1-5",
+                path: "src/components/CTA.astro",
+                kind: .component,
+                title: "CTA",
+                lineRange: 1...5,
+                score: 0.9
+            ),
+        ]
+        t.apply(.citations(citations))
+        let citationRow = t.messages.first { $0.role == .citation }
+        #expect(citationRow != nil)
+        #expect(citationRow?.citationMetadata?.citations.count == 1)
+        #expect(citationRow?.citationMetadata?.citations.first?.path == "src/components/CTA.astro")
+        #expect(citationRow?.content == "")
+    }
+
+    @Test(".citations with empty array is a no-op")
+    func citationsEmptyArrayIsNoOp() {
+        var t = ConversationTranscript()
+        t.beginTurn(userPrompt: "hi")
+        let before = t.messages.count
+        t.apply(.citations([]))
+        #expect(t.messages.count == before)
+    }
+
     @Test("inserting a row before the in-flight assistant keeps deltas on the assistant")
     func insertBeforeInFlightKeepsDeltasOnAssistant() {
         var t = ConversationTranscript()

--- a/Tests/AnglesiteCoreTests/KnowledgeAugmentedAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/KnowledgeAugmentedAssistantTests.swift
@@ -82,6 +82,61 @@ struct KnowledgeAugmentedAssistantTests {
         #expect(prompt?.contains("User request:\nFind every place this CTA appears.") == true)
     }
 
+    @Test("converse emits .citations event before the base stream")
+    func converseEmitsCitationsEvent() async throws {
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "export const CTA = 'Book a consultation';\n".write(
+            to: root.appendingPathComponent("src/components/CTA.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let base = CapturingConversationalAssistant()
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+        let assistant = KnowledgeAugmentedAssistant(base: base, index: index)
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "CTA", context: context) {
+            events.append(event)
+        }
+
+        guard case .citations(let citations) = events.first else {
+            Issue.record("Expected first event to be .citations, got \(events.first.debugDescription)")
+            return
+        }
+        #expect(citations.count >= 1)
+        #expect(citations.first?.path == "src/components/CTA.astro")
+        #expect(citations.first?.kind == .component)
+    }
+
+    @Test("converse with no matching results skips .citations event")
+    func converseNoMatchSkipsCitations() async throws {
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "# About\n".write(
+            to: root.appendingPathComponent("src/pages/about.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let base = CapturingConversationalAssistant()
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+        let assistant = KnowledgeAugmentedAssistant(base: base, index: index)
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "Explain quantum entanglement", context: context) {
+            events.append(event)
+        }
+
+        let hasCitations = events.contains { if case .citations = $0 { return true } else { return false } }
+        #expect(!hasCitations)
+    }
+
     @Test("generate leaves unrelated prompts untouched")
     func generateLeavesUnmatchedPromptUntouched() async throws {
         let root = try makeSite()


### PR DESCRIPTION
## Summary

- **Citation chips** — retrieved RAG context surfaces as a row of clickable chips below each assistant response. Each chip shows a color-coded kind badge and filename; clicking opens the file in the default editor via `NSWorkspace`.
- **Kind filter menu** — a new toggle menu in the chat input bar lets users filter retrieval by document kind (page, post, component, layout, etc.), threading `SearchOptions.kinds` through `ChatModel` → `AssistantContext` → `KnowledgeAugmentedAssistant`.
- **`.citations` event pipeline** — `KnowledgeAugmentedAssistant` emits a new `.citations([RetrievedCitation])` event before the base stream when context is found, which `ConversationTranscript` reduces into an ephemeral `.citation` row (skipped in persistence).

Closes #307 gaps 3 (Citation UX) and 4 (Type-filtered retrieval). Gap 5 (Cloudflare Vectorize) is deferred to #66.

## Files

| Area | Files |
|------|-------|
| Core types | `RetrievedCitation.swift`, `ConversationalAssistant.swift` (new event case), `ConversationTranscript.swift` (citation role + reducer), `ContentAssistant.swift` (searchOptions on AssistantContext) |
| RAG decorator | `KnowledgeAugmentedAssistant.swift` (enrichedContext → citations emission) |
| App UI | `CitationRowView.swift` (new), `ChatView.swift` (kind filter menu + citation row routing), `ChatModel.swift` (searchOptions plumbing + citation persistence skip) |
| Tests | `ConversationTranscriptTests.swift` (+2), `KnowledgeAugmentedAssistantTests.swift` (+2) |

## Test plan

- [x] All 1,313 tests pass (1067 AnglesiteCore + 228 AnglesiteIntents + 18 AnglesiteBridge)
- [x] `xcodebuild -scheme Anglesite` builds clean
- [ ] Manual: open a site, chat with RAG-indexed content, verify citation chips appear and open files on click
- [ ] Manual: toggle kind filters in the input bar menu, verify retrieval narrows accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)