### PR TITLE
feat(#309): add project impact analysis

### DIFF
--- a/Sources/AnglesiteCore/ProjectImpactAnalyzer.swift
+++ b/Sources/AnglesiteCore/ProjectImpactAnalyzer.swift
@@ -1,0 +1,324 @@
+import Foundation
+
+/// Best-effort, read-only impact analysis for a proposed project edit.
+///
+/// This intentionally does not try to be a full Astro compiler. It builds a conservative
+/// dependency graph from static relative imports and public image references, then maps the
+/// affected source files back to known routes/content entries.
+public enum ProjectImpactAnalyzer {
+    public struct Report: Sendable, Equatable {
+        public let targetPath: String
+        public let affectedPages: [AffectedPage]
+        public let directImporters: [String]
+        public let layoutImporters: [String]
+        public let referencedImages: [String]
+        public let contentCollections: [String]
+
+        public var affectedPageCount: Int { affectedPages.count }
+
+        public init(
+            targetPath: String,
+            affectedPages: [AffectedPage],
+            directImporters: [String],
+            layoutImporters: [String],
+            referencedImages: [String],
+            contentCollections: [String]
+        ) {
+            self.targetPath = targetPath
+            self.affectedPages = affectedPages
+            self.directImporters = directImporters
+            self.layoutImporters = layoutImporters
+            self.referencedImages = referencedImages
+            self.contentCollections = contentCollections
+        }
+
+        public var isEmpty: Bool {
+            affectedPages.isEmpty
+                && directImporters.isEmpty
+                && layoutImporters.isEmpty
+                && referencedImages.isEmpty
+                && contentCollections.isEmpty
+        }
+    }
+
+    public struct AffectedPage: Sendable, Equatable {
+        public let route: String
+        public let title: String?
+        public let filePath: String
+
+        public init(route: String, title: String?, filePath: String) {
+            self.route = route
+            self.title = title
+            self.filePath = filePath
+        }
+
+        public var displayName: String { title?.isEmpty == false ? title! : route }
+    }
+
+    private struct SourceFile {
+        let path: String
+        let url: URL
+        let text: String
+    }
+
+    private static let sourceExtensions: Set<String> = [
+        "astro", "md", "mdx", "mdoc", "markdown", "html",
+        "js", "jsx", "ts", "tsx", "mjs", "cjs",
+        "css", "scss", "sass", "json"
+    ]
+    private static let imageExtensions: Set<String> = ["jpg", "jpeg", "png", "webp", "gif", "svg", "avif"]
+    private static let resolvableExtensions = [
+        "astro", "md", "mdx", "mdoc", "markdown", "html",
+        "ts", "tsx", "js", "jsx", "mjs", "cjs",
+        "css", "json"
+    ]
+
+    private static let importRegexes: [NSRegularExpression] = [
+        try! NSRegularExpression(pattern: #"\bimport\s+(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]"#),
+        try! NSRegularExpression(pattern: #"\bexport\s+[^'"]+\s+from\s+['"]([^'"]+)['"]"#),
+        try! NSRegularExpression(pattern: #"\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)"#),
+        try! NSRegularExpression(pattern: #"@import\s+(?:url\()?['"]?([^'")\s]+)"#)
+    ]
+    private static let imageReferenceRegex = try! NSRegularExpression(
+        pattern: #"(?:"|')(/images/[^"']+\.(?:jpg|jpeg|png|webp|gif|svg|avif))(?:"|')"#,
+        options: [.caseInsensitive]
+    )
+
+    public static func analyze(
+        projectRoot: URL,
+        siteID: String,
+        changedPath: String,
+        graph: SiteContentGraph? = nil
+    ) async -> Report? {
+        let root = projectRoot.standardizedFileURL
+        let files = sourceFiles(in: root)
+        let knownPaths = Set(files.map(\.path))
+        var pages: [SiteContentGraph.Page] = []
+        var posts: [SiteContentGraph.Post] = []
+        var images: [SiteContentGraph.Image] = []
+        if let graph {
+            pages = await graph.pages(for: siteID)
+            posts = await graph.posts(for: siteID)
+            images = await graph.images(for: siteID)
+        }
+        if pages.isEmpty && posts.isEmpty && images.isEmpty {
+            let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+            pages = listing.pages
+            posts = listing.posts
+            images = listing.images
+        }
+
+        guard let target = resolveChangedPath(changedPath, pages: pages, knownPaths: knownPaths) else {
+            return nil
+        }
+
+        let importsByFile = Dictionary(uniqueKeysWithValues: files.map { file in
+            (file.path, resolvedImports(in: file, root: root, knownPaths: knownPaths))
+        })
+        let directImporters = importsByFile
+            .filter { $0.value.contains(target) }
+            .map(\.key)
+            .sorted()
+
+        let reverse = reverseIndex(importsByFile)
+        let affectedFiles = transitiveImporters(of: target, reverse: reverse).union([target])
+        let affectedPageFiles = Set(pages.map(\.filePath)).intersection(affectedFiles)
+        let affectedPages = pages
+            .filter { affectedPageFiles.contains($0.filePath) }
+            .sorted { normalizedRoute($0.route) < normalizedRoute($1.route) }
+            .map { AffectedPage(route: $0.route, title: $0.title, filePath: $0.filePath) }
+
+        let layoutImporters = directImporters
+            .filter { $0.hasPrefix("src/layouts/") || $0.contains("/layouts/") }
+            .sorted()
+
+        let contentCollections = Set(posts.compactMap { post -> String? in
+            affectedFiles.contains(post.filePath) ? post.collection : nil
+        }).sorted()
+
+        let referencedImages = imageReferences(
+            target: target,
+            files: files,
+            affectedFiles: affectedFiles,
+            knownImages: images.map(\.relativePath)
+        )
+
+        return Report(
+            targetPath: target,
+            affectedPages: affectedPages,
+            directImporters: directImporters,
+            layoutImporters: layoutImporters,
+            referencedImages: referencedImages,
+            contentCollections: contentCollections
+        )
+    }
+
+    public static func confirmationSummary(for report: Report?, routeLimit: Int = 5) -> String? {
+        guard let report, !report.isEmpty else { return nil }
+        var parts: [String] = []
+        if report.affectedPageCount == 1 {
+            parts.append("This change may affect 1 page")
+        } else if report.affectedPageCount > 1 {
+            parts.append("This change may affect \(report.affectedPageCount) pages")
+        }
+        if !report.directImporters.isEmpty {
+            parts.append("imported by \(report.directImporters.count) file\(report.directImporters.count == 1 ? "" : "s")")
+        }
+        if !report.layoutImporters.isEmpty {
+            parts.append("including \(report.layoutImporters.count) layout\(report.layoutImporters.count == 1 ? "" : "s")")
+        }
+        if !report.referencedImages.isEmpty {
+            parts.append("references \(report.referencedImages.count) image\(report.referencedImages.count == 1 ? "" : "s")")
+        }
+        if !report.contentCollections.isEmpty {
+            parts.append("included in \(report.contentCollections.count) content collection\(report.contentCollections.count == 1 ? "" : "s")")
+        }
+        guard !parts.isEmpty else { return nil }
+
+        let routes = report.affectedPages.prefix(routeLimit).map(\.displayName)
+        var summary = parts.joined(separator: "; ") + "."
+        if !routes.isEmpty {
+            summary += " Affected routes: " + routes.joined(separator: ", ")
+            if report.affectedPages.count > routeLimit {
+                summary += ", and \(report.affectedPages.count - routeLimit) more"
+            }
+            summary += "."
+        }
+        return summary
+    }
+
+    private static func sourceFiles(in root: URL) -> [SourceFile] {
+        walk(root)
+            .filter { sourceExtensions.contains($0.pathExtension.lowercased()) }
+            .compactMap { url in
+                guard let text = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+                return SourceFile(path: relativePosix(url, from: root), url: url, text: text)
+            }
+            .sorted { $0.path < $1.path }
+    }
+
+    private static func walk(_ dir: URL) -> [URL] {
+        let skippedDirectories = Set([".git", ".astro", "node_modules", "dist", ".vercel", ".netlify"])
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]
+        ) else { return [] }
+        var files: [URL] = []
+        for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            let isDir = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDir == true {
+                if skippedDirectories.contains(entry.lastPathComponent) { continue }
+                files.append(contentsOf: walk(entry))
+            } else {
+                files.append(entry)
+            }
+        }
+        return files
+    }
+
+    private static func resolvedImports(in file: SourceFile, root: URL, knownPaths: Set<String>) -> Set<String> {
+        var out = Set<String>()
+        for specifier in importSpecifiers(in: file.text) where specifier.hasPrefix(".") {
+            if let resolved = resolveImport(specifier, from: file.url, root: root, knownPaths: knownPaths) {
+                out.insert(resolved)
+            }
+        }
+        return out
+    }
+
+    private static func importSpecifiers(in text: String) -> [String] {
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return importRegexes.flatMap { regex in
+            regex.matches(in: text, range: range).compactMap { match in
+                guard let r = Range(match.range(at: 1), in: text) else { return nil }
+                return String(text[r])
+            }
+        }
+    }
+
+    private static func resolveImport(_ specifier: String, from fileURL: URL, root: URL, knownPaths: Set<String>) -> String? {
+        let base = fileURL.deletingLastPathComponent().appendingPathComponent(specifier).standardizedFileURL
+        let rel = relativePosix(base, from: root)
+        if knownPaths.contains(rel) { return rel }
+        if !base.pathExtension.isEmpty { return nil }
+        for ext in resolvableExtensions {
+            let candidate = rel + "." + ext
+            if knownPaths.contains(candidate) { return candidate }
+        }
+        for ext in resolvableExtensions {
+            let candidate = rel + "/index." + ext
+            if knownPaths.contains(candidate) { return candidate }
+        }
+        return nil
+    }
+
+    private static func reverseIndex(_ importsByFile: [String: Set<String>]) -> [String: Set<String>] {
+        var reverse: [String: Set<String>] = [:]
+        for (importer, imports) in importsByFile {
+            for imported in imports {
+                reverse[imported, default: []].insert(importer)
+            }
+        }
+        return reverse
+    }
+
+    private static func transitiveImporters(of target: String, reverse: [String: Set<String>]) -> Set<String> {
+        var seen = Set<String>()
+        var stack = Array(reverse[target] ?? [])
+        while let next = stack.popLast() {
+            if !seen.insert(next).inserted { continue }
+            stack.append(contentsOf: reverse[next] ?? [])
+        }
+        return seen
+    }
+
+    private static func imageReferences(
+        target: String,
+        files: [SourceFile],
+        affectedFiles: Set<String>,
+        knownImages: [String]
+    ) -> [String] {
+        let targetIsImage = imageExtensions.contains(URL(fileURLWithPath: target).pathExtension.lowercased())
+        if targetIsImage {
+            return knownImages.contains(target) ? [target] : []
+        }
+        let fileByPath = Dictionary(uniqueKeysWithValues: files.map { ($0.path, $0) })
+        let refs = affectedFiles.compactMap { fileByPath[$0]?.text }.flatMap(imageReferencePaths)
+        return Array(Set(refs)).sorted()
+    }
+
+    private static func imageReferencePaths(in text: String) -> [String] {
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return imageReferenceRegex.matches(in: text, range: range).compactMap { match in
+            guard let r = Range(match.range(at: 1), in: text) else { return nil }
+            return "public" + String(text[r])
+        }
+    }
+
+    private static func resolveChangedPath(_ changedPath: String, pages: [SiteContentGraph.Page], knownPaths: Set<String>) -> String? {
+        let trimmed = changedPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if knownPaths.contains(trimmed) { return trimmed }
+        let withoutLeadingSlash = trimmed.hasPrefix("/") ? String(trimmed.dropFirst()) : trimmed
+        if knownPaths.contains(withoutLeadingSlash) { return withoutLeadingSlash }
+        let route = normalizedRoute(trimmed)
+        if let page = pages.first(where: { normalizedRoute($0.route) == route }) {
+            return page.filePath
+        }
+        return nil
+    }
+
+    private static func normalizedRoute(_ route: String) -> String {
+        var value = route.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.isEmpty { return "/" }
+        if !value.hasPrefix("/") { value = "/" + value }
+        while value.count > 1 && value.hasSuffix("/") { value.removeLast() }
+        return value
+    }
+
+    private static func relativePosix(_ url: URL, from base: URL) -> String {
+        let urlComponents = url.standardizedFileURL.pathComponents
+        let baseComponents = base.standardizedFileURL.pathComponents
+        guard urlComponents.starts(with: baseComponents) else { return url.path }
+        return urlComponents.dropFirst(baseComponents.count).joined(separator: "/")
+    }
+}

--- a/Sources/AnglesiteCore/ProjectImpactAnalyzer.swift
+++ b/Sources/AnglesiteCore/ProjectImpactAnalyzer.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+private final class ProjectImpactContinuationBox<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Never>?
+
+    init(_ continuation: CheckedContinuation<T, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(_ value: T) {
+        lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(returning: value)
+    }
+}
+
 /// Best-effort, read-only impact analysis for a proposed project edit.
 ///
 /// This intentionally does not try to be a full Astro compiler. It builds a conservative
@@ -52,10 +69,13 @@ public enum ProjectImpactAnalyzer {
             self.filePath = filePath
         }
 
-        public var displayName: String { title?.isEmpty == false ? title! : route }
+        public var displayName: String {
+            if let title, !title.isEmpty { return title }
+            return route
+        }
     }
 
-    private struct SourceFile {
+    private struct SourceFile: Sendable {
         let path: String
         let url: URL
         let text: String
@@ -73,14 +93,18 @@ public enum ProjectImpactAnalyzer {
         "css", "json"
     ]
 
+    private static let maxSourceFileCount = 500
+    private static let analysisTimeoutNanoseconds: UInt64 = 2_000_000_000
+
     private static let importRegexes: [NSRegularExpression] = [
-        try! NSRegularExpression(pattern: #"\bimport\s+(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]"#),
-        try! NSRegularExpression(pattern: #"\bexport\s+[^'"]+\s+from\s+['"]([^'"]+)['"]"#),
-        try! NSRegularExpression(pattern: #"\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)"#),
-        try! NSRegularExpression(pattern: #"@import\s+(?:url\()?['"]?([^'")\s]+)"#)
+        makeRegex("static import", #"\bimport\s+(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]"#),
+        makeRegex("re-export", #"\bexport\s+[^'"]+\s+from\s+['"]([^'"]+)['"]"#),
+        makeRegex("dynamic import", #"\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)"#),
+        makeRegex("css import", #"@import\s+(?:url\()?['"]?([^'")\s]+)"#)
     ]
-    private static let imageReferenceRegex = try! NSRegularExpression(
-        pattern: #"(?:"|')(/images/[^"']+\.(?:jpg|jpeg|png|webp|gif|svg|avif))(?:"|')"#,
+    private static let imageReferenceRegex = makeRegex(
+        "image reference",
+        #"(?:"|')(/images/[^"']+\.(?:jpg|jpeg|png|webp|gif|svg|avif))(?:"|')"#,
         options: [.caseInsensitive]
     )
 
@@ -91,7 +115,7 @@ public enum ProjectImpactAnalyzer {
         graph: SiteContentGraph? = nil
     ) async -> Report? {
         let root = projectRoot.standardizedFileURL
-        let files = sourceFiles(in: root)
+        guard let files = await sourceFiles(in: root) else { return nil }
         let knownPaths = Set(files.map(\.path))
         var pages: [SiteContentGraph.Page] = []
         var posts: [SiteContentGraph.Post] = []
@@ -112,9 +136,12 @@ public enum ProjectImpactAnalyzer {
             return nil
         }
 
-        let importsByFile = Dictionary(uniqueKeysWithValues: files.map { file in
-            (file.path, resolvedImports(in: file, root: root, knownPaths: knownPaths))
-        })
+        let importsByFile = Dictionary(
+            files.map { file in
+                (file.path, resolvedImports(in: file, root: root, knownPaths: knownPaths))
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
         let directImporters = importsByFile
             .filter { $0.value.contains(target) }
             .map(\.key)
@@ -160,8 +187,14 @@ public enum ProjectImpactAnalyzer {
             parts.append("This change may affect 1 page")
         } else if report.affectedPageCount > 1 {
             parts.append("This change may affect \(report.affectedPageCount) pages")
+        } else if !report.directImporters.isEmpty {
+            parts.append("This change is imported by \(report.directImporters.count) file\(report.directImporters.count == 1 ? "" : "s")")
+        } else if !report.referencedImages.isEmpty {
+            parts.append("This change references \(report.referencedImages.count) image\(report.referencedImages.count == 1 ? "" : "s")")
+        } else if !report.contentCollections.isEmpty {
+            parts.append("This change is included in \(report.contentCollections.count) content collection\(report.contentCollections.count == 1 ? "" : "s")")
         }
-        if !report.directImporters.isEmpty {
+        if report.affectedPageCount > 0, !report.directImporters.isEmpty {
             parts.append("imported by \(report.directImporters.count) file\(report.directImporters.count == 1 ? "" : "s")")
         }
         if !report.layoutImporters.isEmpty {
@@ -187,18 +220,46 @@ public enum ProjectImpactAnalyzer {
         return summary
     }
 
-    private static func sourceFiles(in root: URL) -> [SourceFile] {
-        walk(root)
+    private static func sourceFiles(in root: URL) async -> [SourceFile]? {
+        await withCheckedContinuation { continuation in
+            let box = ProjectImpactContinuationBox(continuation)
+            Task.detached(priority: .utility) {
+                box.resume(Self.sourceFilesSync(in: root, maxFiles: Self.maxSourceFileCount))
+            }
+            Task {
+                try? await Task.sleep(nanoseconds: analysisTimeoutNanoseconds)
+                box.resume(nil)
+            }
+        }
+    }
+
+    private static func sourceFilesSync(in root: URL, maxFiles: Int) -> [SourceFile]? {
+        let urls = walk(root)
             .filter { sourceExtensions.contains($0.pathExtension.lowercased()) }
+        guard urls.count <= maxFiles else { return nil }
+        return urls
             .compactMap { url in
+                if Task.isCancelled { return nil }
                 guard let text = try? String(contentsOf: url, encoding: .utf8) else { return nil }
                 return SourceFile(path: relativePosix(url, from: root), url: url, text: text)
             }
             .sorted { $0.path < $1.path }
     }
 
+    private static func makeRegex(
+        _ name: String,
+        _ pattern: String,
+        options: NSRegularExpression.Options = []
+    ) -> NSRegularExpression {
+        do {
+            return try NSRegularExpression(pattern: pattern, options: options)
+        } catch {
+            preconditionFailure("Invalid ProjectImpactAnalyzer \(name) regex: \(error)")
+        }
+    }
+
     private static func walk(_ dir: URL) -> [URL] {
-        let skippedDirectories = Set([".git", ".astro", "node_modules", "dist", ".vercel", ".netlify"])
+        let skippedDirectories = Set(["node_modules", "dist"])
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
             at: dir, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]
@@ -282,7 +343,7 @@ public enum ProjectImpactAnalyzer {
         if targetIsImage {
             return knownImages.contains(target) ? [target] : []
         }
-        let fileByPath = Dictionary(uniqueKeysWithValues: files.map { ($0.path, $0) })
+        let fileByPath = Dictionary(files.map { ($0.path, $0) }, uniquingKeysWith: { first, _ in first })
         let refs = affectedFiles.compactMap { fileByPath[$0]?.text }.flatMap(imageReferencePaths)
         return Array(Set(refs)).sorted()
     }

--- a/Sources/AnglesiteIntents/EditContentIntent.swift
+++ b/Sources/AnglesiteIntents/EditContentIntent.swift
@@ -231,7 +231,8 @@ extension ContentDialogs {
             base = "Set \(edit.styleProperty ?? "style") to \(clip(edit.styleValue ?? "")) on \(pagePath)?"
         }
         guard let impactSummary, !impactSummary.isEmpty else { return base }
-        return "\(base) \(impactSummary)"
+        let question = base.hasSuffix("?") ? String(base.dropLast()) : base
+        return "\(question). \(impactSummary) Confirm?"
     }
 
     /// Dispatch on the reply status. Single entry point the intent's `perform()` uses.

--- a/Sources/AnglesiteIntents/EditContentIntent.swift
+++ b/Sources/AnglesiteIntents/EditContentIntent.swift
@@ -25,6 +25,7 @@ public struct EditContentIntent: AppIntent {
     ) public var instruction: String
     @Dependency private var bridge: IntentEditBridge
     @Dependency private var interpreter: any EditInterpreting
+    @Dependency private var graph: SiteContentGraph
 
     public init() {}
 
@@ -98,13 +99,27 @@ public struct EditContentIntent: AppIntent {
             }
             // .confirm falls through to apply
         } else {
+            let impactSummary: String?
+            if let siteDirectory {
+                let g = ContentGraphOverride.scoped ?? graph
+                let report = await ProjectImpactAnalyzer.analyze(
+                    projectRoot: siteDirectory,
+                    siteID: element.siteID,
+                    changedPath: element.pagePath,
+                    graph: g
+                )
+                impactSummary = ProjectImpactAnalyzer.confirmationSummary(for: report)
+            } else {
+                impactSummary = nil
+            }
             // Production: real Siri confirmation dialog showing a before/after diff.
             try await requestConfirmation(dialog: IntentDialog(stringLiteral:
                 ContentDialogs.editConfirmation(
                     edit: interpreted,
                     pagePath: element.pagePath,
                     before: preview.before,
-                    after: preview.after
+                    after: preview.after,
+                    impactSummary: impactSummary
                 )
             ))
         }
@@ -193,20 +208,30 @@ extension ContentDialogs {
 
     /// Before/after confirmation summary (#251). Spoken-friendly per kind; long fragments are
     /// truncated so Siri doesn't read paragraphs. Sourced from the plugin dry-run preview.
-    public static func editConfirmation(edit: InterpretedEdit, pagePath: String, before: String?, after: String?) -> String {
+    public static func editConfirmation(
+        edit: InterpretedEdit,
+        pagePath: String,
+        before: String?,
+        after: String?,
+        impactSummary: String? = nil
+    ) -> String {
         func clip(_ s: String, _ n: Int = 60) -> String { s.count <= n ? s : String(s.prefix(n)) + "\u{2026}" }
+        let base: String
         switch edit.kind {
         case .text:
             if let b = before, let a = after {
-                return "Change the text from \"\(clip(b))\" to \"\(clip(a))\" on \(pagePath)?"
+                base = "Change the text from \"\(clip(b))\" to \"\(clip(a))\" on \(pagePath)?"
+            } else {
+                base = "Change the text to \"\(clip(edit.newText ?? ""))\" on \(pagePath)?"
             }
-            return "Change the text to \"\(clip(edit.newText ?? ""))\" on \(pagePath)?"
         case .attribute:
             let name = edit.attributeName ?? "attribute"
-            return "Change \(name) to \"\(clip(edit.attributeValue ?? ""))\" on \(pagePath)?"
+            base = "Change \(name) to \"\(clip(edit.attributeValue ?? ""))\" on \(pagePath)?"
         case .style:
-            return "Set \(edit.styleProperty ?? "style") to \(clip(edit.styleValue ?? "")) on \(pagePath)?"
+            base = "Set \(edit.styleProperty ?? "style") to \(clip(edit.styleValue ?? "")) on \(pagePath)?"
         }
+        guard let impactSummary, !impactSummary.isEmpty else { return base }
+        return "\(base) \(impactSummary)"
     }
 
     /// Dispatch on the reply status. Single entry point the intent's `perform()` uses.

--- a/Tests/AnglesiteCoreTests/ProjectImpactAnalyzerTests.swift
+++ b/Tests/AnglesiteCoreTests/ProjectImpactAnalyzerTests.swift
@@ -94,6 +94,53 @@ import Callout from '../../components/Callout.astro'
         #expect(report?.contentCollections == ["posts"])
     }
 
+    @Test("static re-export dynamic and CSS imports are all resolved")
+    func importForms() async {
+        let root = makeSite([
+            "src/components/Shared.astro": "<p>Shared</p>",
+            "src/pages/static.astro": "import Shared from '../components/Shared.astro'",
+            "src/pages/reexport.astro": "export { default as Shared } from '../components/Shared.astro'",
+            "src/pages/dynamic.astro": "const Shared = await import('../components/Shared.astro')",
+            "src/pages/css.astro": #"""
+---
+import '../styles/site.css'
+---
+"""#,
+            "src/styles/site.css": #"@import "../components/Shared.astro";"#
+        ])
+
+        let report = await ProjectImpactAnalyzer.analyze(
+            projectRoot: root,
+            siteID: siteID,
+            changedPath: "src/components/Shared.astro"
+        )
+
+        #expect(report?.directImporters == [
+            "src/pages/dynamic.astro",
+            "src/pages/reexport.astro",
+            "src/pages/static.astro",
+            "src/styles/site.css",
+        ])
+        #expect(Set(report?.affectedPages.map(\.route) ?? []) == ["/css", "/dynamic", "/reexport", "/static"])
+    }
+
+    @Test("analysis bails out when source file count exceeds the bound")
+    func sourceFileLimit() async {
+        var files: [String: String] = ["src/components/Shared.astro": "<p>Shared</p>"]
+        for i in 0..<501 {
+            files["src/pages/page-\(i).astro"] = "<p>\(i)</p>"
+        }
+        let root = makeSite(files)
+
+        let report = await ProjectImpactAnalyzer.analyze(
+            projectRoot: root,
+            siteID: siteID,
+            changedPath: "src/components/Shared.astro"
+        )
+
+        #expect(report == nil)
+    }
+
     @Test("confirmation summary names page count and affected routes")
     func confirmationSummary() async {
         let root = makeSite([
@@ -112,5 +159,21 @@ import Callout from '../../components/Callout.astro'
         #expect(summary?.contains("may affect 2 pages") == true)
         #expect(summary?.contains("/") == true)
         #expect(summary?.contains("/contact") == true)
+    }
+
+    @Test("confirmation summary starts with a complete sentence when no pages are affected")
+    func confirmationSummaryWithoutPages() {
+        let report = ProjectImpactAnalyzer.Report(
+            targetPath: "src/utils/colors.ts",
+            affectedPages: [],
+            directImporters: ["src/utils/theme.ts", "src/utils/tokens.ts"],
+            layoutImporters: [],
+            referencedImages: [],
+            contentCollections: []
+        )
+
+        let summary = ProjectImpactAnalyzer.confirmationSummary(for: report)
+
+        #expect(summary?.hasPrefix("This change is imported by 2 files.") == true)
     }
 }

--- a/Tests/AnglesiteCoreTests/ProjectImpactAnalyzerTests.swift
+++ b/Tests/AnglesiteCoreTests/ProjectImpactAnalyzerTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("ProjectImpactAnalyzer")
+struct ProjectImpactAnalyzerTests {
+    private let siteID = "site-impact"
+
+    private func makeSite(_ files: [String: String]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("impact-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    @Test("component impact includes transitive routes, layout importers, and referenced images")
+    func componentImpact() async {
+        let root = makeSite([
+            "src/components/Hero.astro": #"<img src="/images/hero.png" alt="" />"#,
+            "src/layouts/Base.astro": #"""
+---
+import Hero from '../components/Hero.astro';
+---
+<Hero />
+<slot />
+"""#,
+            "src/pages/index.astro": #"""
+---
+import Base from '../layouts/Base.astro';
+---
+<Base title="Home" />
+"""#,
+            "src/pages/about.astro": #"""
+---
+import Base from '../layouts/Base.astro';
+---
+<Base title="About" />
+"""#,
+            "public/images/hero.png": "png"
+        ])
+
+        let report = await ProjectImpactAnalyzer.analyze(
+            projectRoot: root,
+            siteID: siteID,
+            changedPath: "src/components/Hero.astro"
+        )
+
+        #expect(report?.affectedPageCount == 2)
+        #expect(report?.affectedPages.map(\.route) == ["/", "/about"])
+        #expect(report?.directImporters == ["src/layouts/Base.astro"])
+        #expect(report?.layoutImporters == ["src/layouts/Base.astro"])
+        #expect(report?.referencedImages == ["public/images/hero.png"])
+    }
+
+    @Test("route input resolves to the backing page")
+    func routeInput() async {
+        let root = makeSite([
+            "src/pages/about.astro": "<h1>About</h1>"
+        ])
+
+        let report = await ProjectImpactAnalyzer.analyze(
+            projectRoot: root,
+            siteID: siteID,
+            changedPath: "/about/"
+        )
+
+        #expect(report?.targetPath == "src/pages/about.astro")
+        #expect(report?.affectedPages.map(\.route) == ["/about"])
+    }
+
+    @Test("content collection impact is reported for imported MDX entries")
+    func contentCollectionImpact() async {
+        let root = makeSite([
+            "src/components/Callout.astro": "<aside><slot /></aside>",
+            "src/content/posts/hello.mdx": #"""
+---
+title: Hello
+---
+import Callout from '../../components/Callout.astro'
+<Callout />
+"""#
+        ])
+
+        let report = await ProjectImpactAnalyzer.analyze(
+            projectRoot: root,
+            siteID: siteID,
+            changedPath: "src/components/Callout.astro"
+        )
+
+        #expect(report?.contentCollections == ["posts"])
+    }
+
+    @Test("confirmation summary names page count and affected routes")
+    func confirmationSummary() async {
+        let root = makeSite([
+            "src/components/Hero.astro": "<h1>Hero</h1>",
+            "src/pages/index.astro": "import Hero from '../components/Hero.astro'",
+            "src/pages/contact.astro": "import Hero from '../components/Hero.astro'"
+        ])
+
+        let report = await ProjectImpactAnalyzer.analyze(
+            projectRoot: root,
+            siteID: siteID,
+            changedPath: "src/components/Hero.astro"
+        )
+        let summary = ProjectImpactAnalyzer.confirmationSummary(for: report)
+
+        #expect(summary?.contains("may affect 2 pages") == true)
+        #expect(summary?.contains("/") == true)
+        #expect(summary?.contains("/contact") == true)
+    }
+}

--- a/Tests/AnglesiteIntentsTests/EditConfirmationDialogTests.swift
+++ b/Tests/AnglesiteIntentsTests/EditConfirmationDialogTests.swift
@@ -27,4 +27,18 @@ struct EditConfirmationDialogTests {
         #expect(s.contains("…"))
         #expect(s.count < 400)
     }
+
+    @Test("impact summary is appended to confirmation")
+    func impactSummary() {
+        let e = InterpretedEdit(kind: .text, newText: "new", attributeName: nil, attributeValue: nil, styleProperty: nil, styleValue: nil, summary: "s")
+        let s = ContentDialogs.editConfirmation(
+            edit: e,
+            pagePath: "/about/",
+            before: "old",
+            after: "new",
+            impactSummary: "This change may affect 3 pages."
+        )
+        #expect(s.contains("Change the text"))
+        #expect(s.contains("This change may affect 3 pages."))
+    }
 }

--- a/Tests/AnglesiteIntentsTests/EditConfirmationDialogTests.swift
+++ b/Tests/AnglesiteIntentsTests/EditConfirmationDialogTests.swift
@@ -40,5 +40,7 @@ struct EditConfirmationDialogTests {
         )
         #expect(s.contains("Change the text"))
         #expect(s.contains("This change may affect 3 pages."))
+        #expect(!s.contains("/about/? This change"))
+        #expect(s.hasSuffix("Confirm?"))
     }
 }


### PR DESCRIPTION
## Summary
- add a read-only ProjectImpactAnalyzer for static Astro/project impact analysis
- report affected routes, importers, layout importers, referenced images, and content collections
- include impact summaries in edit confirmation text before applying AI/Siri edits

## Verification
- env ANGLESITE_SKIP_CONTAINER=1 swift test --filter 'ProjectImpactAnalyzerTests|EditConfirmationDialogTests|EditContentIntentFlowTests'
- env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build

Closes #309