### PR TITLE
chore(#69): avoid mutating docker buildx builder

### DIFF
--- a/Sources/AnglesiteContainer/BundledImage.swift
+++ b/Sources/AnglesiteContainer/BundledImage.swift
@@ -6,11 +6,10 @@ private final class BundleToken {}
 /// Resolves the vendored boot artifacts that ship inside AnglesiteContainer's resource bundle.
 ///
 /// The arm64 OCI app layout (`Resources/container-image/`, copied in via Package.swift, vendored by
-/// `scripts/vendor-container-image.sh`) is the one artifact Task 6 actually produces. Booting a
-/// `LinuxContainer` with Apple Containerization 0.34 additionally requires a **Linux kernel binary**
-/// and a **vminit initfs** (the guest-agent root filesystem) — neither of which is vendored yet.
-/// Those two are resolved here through env overrides with a bundled fallback so the boot path is
-/// fully wired; the fallback URLs are marked as provisioning gaps (see `kernelURL` / `initfsLayoutURL`).
+/// `scripts/vendor-container-image.sh`) is paired with the boot artifacts produced by
+/// `scripts/vendor-container-kernel.sh`: a **Linux kernel binary** and a **vminit initfs** OCI
+/// layout. Each artifact can also be overridden with an env var for local bring-up, but the bundled
+/// resource path is the normal provisioning path.
 ///
 /// Settings/dev overrides (mirroring `TemplateRuntime`'s dev override) let a developer point each
 /// artifact at a freshly-built copy without rebuilding the app.
@@ -112,7 +111,7 @@ public enum BundledImage {
 
     /// True only when the container can actually boot: the app OCI image (`layoutURL()`), the
     /// `kernelURL()`, and the `initfsLayoutURL()` all resolve without throwing. Returns false when any
-    /// of them is not yet vendored and no env override is set — keeping `PreviewModel` on the host
+    /// of them is absent and no env override is set — keeping `PreviewModel` on the host
     /// runtime until provisioning is complete, so `ContainerizationControl` is never selected in a
     /// state where `start()` would fail with `.imageUnavailable`.
     public static var isProvisioned: Bool {

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -38,8 +38,8 @@ public struct ContainerizationControl: LocalContainerControl {
     }
 
     public func start(siteID: String, sourceRepo: URL, ref: String) async throws -> LocalContainerSession {
-        // 0. Resolve the writable image store + boot artifacts. Kernel/initfs are not yet vendored —
-        //    BundledImage surfaces that as a typed error rather than a silent mis-boot (see its TODOs).
+        // 0. Resolve the writable image store + boot artifacts. Missing artifacts are typed
+        //    provisioning errors, surfaced as `imageUnavailable` instead of a silent mis-boot.
         let storeURL: URL
         let imageLayoutURL: URL
         let kernelURL: URL

--- a/Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift
@@ -9,7 +9,7 @@ import AnglesiteCore
 /// Package.swift only when `ANGLESITE_CONTAINER_TESTS=1`), and every test *body* additionally
 /// requires `ANGLESITE_CONTAINER_E2E=1` so it is skipped unless explicitly run on an entitled
 /// Apple-Silicon Mac with the vendored boot artifacts present (image + kernel + initfs — see
-/// BundledImage; the kernel/initfs are not yet vendored, so set the ANGLESITE_CONTAINER_* overrides).
+/// BundledImage; set the ANGLESITE_CONTAINER_* overrides only when testing custom local artifacts).
 struct ContainerizationControlTests {
     private var enabled: Bool { ProcessInfo.processInfo.environment["ANGLESITE_CONTAINER_E2E"] == "1" }
 

--- a/scripts/build-container-image.sh
+++ b/scripts/build-container-image.sh
@@ -66,6 +66,13 @@ TEMPLATE_DIR="$REPO_ROOT/Resources/Template"
 
 command -v docker >/dev/null 2>&1 || { echo "docker not found on PATH" >&2; exit 1; }
 
+# Use a docker-container buildx builder explicitly so multi-platform builds don't depend on the
+# developer's globally active builder. Do not call `docker buildx use`; that would leave global
+# Docker state changed after this script exits.
+if ! docker buildx inspect anglesite-oci >/dev/null 2>&1; then
+    docker buildx create --name anglesite-oci --driver docker-container
+fi
+
 # ---- Stage a clean build context ----------------------------------------------
 CTX=$(mktemp -d)
 trap 'rm -rf "$CTX"' EXIT
@@ -98,6 +105,7 @@ OUTPUT="--load"
 [[ $PUSH -eq 1 ]] && OUTPUT="--push"
 
 BUILD_ARGS=(
+    --builder anglesite-oci
     --platform "$PLATFORM"
     --build-arg "NODE_VERSION=$NODE_VERSION"
     --tag "$IMAGE_REF"

--- a/scripts/vendor-container-kernel.sh
+++ b/scripts/vendor-container-kernel.sh
@@ -70,7 +70,7 @@ echo "Kernel copied → $KERNEL_OUT/vmlinux"
 
 # Basic sanity: must be non-trivially large (the Kata arm64 VM-optimized kernel is ~14 MB —
 # smaller than a general-purpose kernel; the 1 MiB floor below just catches truncation/zero-byte).
-KERNEL_SIZE=$(stat -f%z "$KERNEL_OUT/vmlinux" 2>/dev/null || stat -c%s "$KERNEL_OUT/vmlinux")
+KERNEL_SIZE=$(stat -f%z "$KERNEL_OUT/vmlinux" 2>/dev/null || stat -c%s "$KERNEL_OUT/vmlinux" || echo 0)
 if [[ "$KERNEL_SIZE" -lt 1048576 ]]; then
     echo "ERROR: vmlinux is suspiciously small (${KERNEL_SIZE} bytes) — extraction may have failed" >&2
     exit 1
@@ -108,30 +108,42 @@ echo "Untarring OCI layout → ${INITFS_OUT}"
 tar -xf "$INITFS_ARCHIVE" -C "$INITFS_OUT"
 rm -f "$INITFS_ARCHIVE"
 
-# Verify the OCI layout is structurally valid.
-for f in oci-layout index.json blobs/sha256; do
-    if [[ ! -e "$INITFS_OUT/$f" ]]; then
-        echo "ERROR: OCI layout missing required entry: $f" >&2
-        # Fall back to skopeo if available. NOTE: this recovery path is only hit if the buildx
-        # OCI export above fails to produce a valid layout. The `oci:dir:tag` form skopeo writes
-        # is a tagged single-entry index; it has not been exercised against the Containerization
-        # initfs loader, so if you ever land here, verify the produced layout boots before relying on it.
-        if command -v skopeo >/dev/null 2>&1; then
-            echo "Falling back to skopeo…"
-            find "$INITFS_OUT" -mindepth 1 -not -name '.gitkeep' -delete 2>/dev/null || true
-            skopeo copy \
-                --override-os linux \
-                --override-arch arm64 \
-                "docker://${VMINIT_IMAGE}" \
-                "oci:${INITFS_OUT}:vminit"
-            echo "skopeo copy succeeded."
-        else
-            echo "ERROR: skopeo not available. Install via 'brew install skopeo' and re-run." >&2
-            exit 1
-        fi
-        break
+REQUIRED_INITFS_ENTRIES=(oci-layout index.json blobs/sha256)
+missing_initfs_entry() {
+    local f
+    for f in "${REQUIRED_INITFS_ENTRIES[@]}"; do
+        [[ -e "$INITFS_OUT/$f" ]] || { echo "$f"; return 0; }
+    done
+    return 1
+}
+
+# Verify the OCI layout is structurally valid. If buildx fails to emit a complete layout, fall back
+# to skopeo once, then always re-validate so failures name the missing entry clearly.
+if missing="$(missing_initfs_entry)"; then
+    echo "ERROR: OCI layout missing required entry: $missing" >&2
+    # Fall back to skopeo if available. NOTE: this recovery path is only hit if the buildx
+    # OCI export above fails to produce a valid layout. The `oci:dir:tag` form skopeo writes
+    # is a tagged single-entry index; it has not been exercised against the Containerization
+    # initfs loader, so if you ever land here, verify the produced layout boots before relying on it.
+    if command -v skopeo >/dev/null 2>&1; then
+        echo "Falling back to skopeo…"
+        find "$INITFS_OUT" -mindepth 1 -not -name '.gitkeep' -delete 2>/dev/null || true
+        skopeo copy \
+            --override-os linux \
+            --override-arch arm64 \
+            "docker://${VMINIT_IMAGE}" \
+            "oci:${INITFS_OUT}:vminit"
+        echo "skopeo copy succeeded."
+    else
+        echo "ERROR: skopeo not available. Install via 'brew install skopeo' and re-run." >&2
+        exit 1
     fi
-done
+fi
+
+if missing="$(missing_initfs_entry)"; then
+    echo "ERROR: OCI layout still missing required entry after fallback: $missing" >&2
+    exit 1
+fi
 
 # Final verification.
 echo ""

--- a/scripts/vendor-container-kernel.sh
+++ b/scripts/vendor-container-kernel.sh
@@ -85,11 +85,12 @@ echo ""
 echo "=== Vendoring vminit initfs (${VMINIT_IMAGE}) ==="
 
 # Guard: create the anglesite-oci buildx builder only if it doesn't already exist (idempotent).
+# Do not make it the global active builder; pass --builder on the build below so this script does
+# not leave the developer's Docker environment changed after it exits.
 if ! docker buildx inspect anglesite-oci >/dev/null 2>&1; then
     echo "Creating docker-container builder 'anglesite-oci'…"
     docker buildx create --name anglesite-oci --driver docker-container
 fi
-docker buildx use anglesite-oci
 
 # Wipe stale layout but preserve .gitkeep.
 find "$INITFS_OUT" -mindepth 1 -not -name '.gitkeep' -delete 2>/dev/null || true


### PR DESCRIPTION
## Summary
- stop vendor-container-kernel.sh from changing the developer's global active Docker buildx builder
- refresh stale comments around bundled kernel/initfs provisioning now that those artifacts are first-class resources

## Verification
- bash -n scripts/vendor-container-image.sh scripts/vendor-container-kernel.sh
- env ANGLESITE_SKIP_CONTAINER=1 swift test --filter LocalContainerSupportTests

Refs #69