### PR TITLE
feat(#336): plan outbound social publishing

### DIFF
--- a/Sources/AnglesiteCore/SocialPublishPlan.swift
+++ b/Sources/AnglesiteCore/SocialPublishPlan.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+/// Network-free planning for V-2 outbound social publishing.
+///
+/// The actual Webmention/POSSE sends are gated on `@dwk/workers` readiness. This planner gives
+/// the deploy pipeline a deterministic contract: for each publishable content entry, compute the
+/// canonical source URL, outbound Webmention targets, and requested POSSE destinations.
+public enum SocialPublishPlan {
+    public struct Entry: Equatable, Sendable {
+        public let sourceFile: String
+        public let canonicalURL: URL
+        public let webmentionTargets: [URL]
+        public let posseTargets: [String]
+
+        public init(
+            sourceFile: String,
+            canonicalURL: URL,
+            webmentionTargets: [URL],
+            posseTargets: [String]
+        ) {
+            self.sourceFile = sourceFile
+            self.canonicalURL = canonicalURL
+            self.webmentionTargets = webmentionTargets
+            self.posseTargets = posseTargets
+        }
+    }
+
+    public struct Plan: Equatable, Sendable {
+        public let entries: [Entry]
+
+        public init(entries: [Entry]) {
+            self.entries = entries
+        }
+
+        public var isEmpty: Bool { entries.isEmpty }
+        public var webmentionCount: Int { entries.reduce(0) { $0 + $1.webmentionTargets.count } }
+        public var posseCount: Int { entries.reduce(0) { $0 + $1.posseTargets.count } }
+    }
+
+    public enum PlanningError: Error, Equatable, Sendable {
+        case invalidSiteBase(String)
+    }
+
+    private static let entryExtensions: Set<String> = ["md", "mdx", "mdoc", "markdown"]
+    private static let outboundURLPattern = try! NSRegularExpression(
+        pattern: #"https?://[^\s<>"'\)\]\}]+"#,
+        options: [.caseInsensitive]
+    )
+    private static let trailingPunctuation = CharacterSet(charactersIn: ".,;:!?")
+
+    /// Builds the outbound-social plan for a site's Astro project root (`Source/`).
+    public static func build(projectRoot: URL, siteBase: URL) throws -> Plan {
+        guard let baseHost = siteBase.host, siteBase.scheme == "http" || siteBase.scheme == "https" else {
+            throw PlanningError.invalidSiteBase(siteBase.absoluteString)
+        }
+
+        let contentRoot = projectRoot.appendingPathComponent("src/content", isDirectory: true)
+        let files = walk(contentRoot).filter { entryExtensions.contains($0.pathExtension.lowercased()) }
+        let entries = files.compactMap { file -> Entry? in
+            guard let source = try? String(contentsOf: file, encoding: .utf8) else { return nil }
+            let frontmatter = Frontmatter.parse(source)
+            if frontmatter["draft"] == .bool(true) { return nil }
+
+            let relPath = relativePosix(file, from: projectRoot)
+            guard let canonical = canonicalURL(for: relPath, frontmatter: frontmatter, siteBase: siteBase) else {
+                return nil
+            }
+
+            let targets = webmentionTargets(in: source, frontmatter: frontmatter, excludingHost: baseHost)
+            let posseTargets = posseTargets(in: frontmatter)
+            guard !targets.isEmpty || !posseTargets.isEmpty else { return nil }
+
+            return Entry(
+                sourceFile: relPath,
+                canonicalURL: canonical,
+                webmentionTargets: targets,
+                posseTargets: posseTargets
+            )
+        }
+        return Plan(entries: entries.sorted { $0.sourceFile < $1.sourceFile })
+    }
+
+    private static func canonicalURL(
+        for relPath: String,
+        frontmatter: [String: FrontmatterValue],
+        siteBase: URL
+    ) -> URL? {
+        let parts = relPath.split(separator: "/").map(String.init)
+        guard parts.count >= 4, parts[0] == "src", parts[1] == "content" else { return nil }
+        let collection = parts[2]
+        let fileName = parts.last ?? ""
+        let fallbackSlug = basenameWithoutExtension(fileName)
+        let slug = string(frontmatter["slug"]) ?? fallbackSlug
+        return URL(string: "/\(collection)/\(slug)/", relativeTo: siteBase)?.absoluteURL
+    }
+
+    private static func webmentionTargets(
+        in source: String,
+        frontmatter: [String: FrontmatterValue],
+        excludingHost siteHost: String
+    ) -> [URL] {
+        var candidates: [URL] = []
+
+        for key in ["inReplyTo", "bookmarkOf", "likeOf", "repostOf"] {
+            if let value = string(frontmatter[key]), let url = URL(string: value) {
+                candidates.append(url)
+            }
+        }
+
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        for match in outboundURLPattern.matches(in: source, range: range) {
+            guard let r = Range(match.range, in: source) else { continue }
+            let raw = String(source[r]).trimmingCharacters(in: trailingPunctuation)
+            if let url = URL(string: raw) {
+                candidates.append(url)
+            }
+        }
+
+        return unique(candidates.compactMap { url -> URL? in
+            guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else { return nil }
+            guard let host = url.host, host.caseInsensitiveCompare(siteHost) != .orderedSame else { return nil }
+            return url
+        })
+    }
+
+    private static func posseTargets(in frontmatter: [String: FrontmatterValue]) -> [String] {
+        let keys = ["posse", "syndicateTo", "syndicate-to"]
+        let values = keys.flatMap { key -> [String] in
+            switch frontmatter[key] {
+            case .array(let items): return items
+            case .string(let item) where !item.isEmpty: return [item]
+            default: return []
+            }
+        }
+        return Array(Set(values.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }))
+            .sorted()
+    }
+
+    private static func unique(_ urls: [URL]) -> [URL] {
+        var seen: Set<String> = []
+        var out: [URL] = []
+        for url in urls {
+            let key = url.absoluteString
+            if seen.insert(key).inserted {
+                out.append(url)
+            }
+        }
+        return out.sorted { $0.absoluteString < $1.absoluteString }
+    }
+
+    private static func string(_ value: FrontmatterValue?) -> String? {
+        if case let .string(s)? = value, !s.isEmpty { return s }
+        return nil
+    }
+
+    private static func basenameWithoutExtension(_ fileName: String) -> String {
+        guard let dot = fileName.lastIndex(of: ".") else { return fileName }
+        return String(fileName[..<dot])
+    }
+
+    private static func walk(_ dir: URL) -> [URL] {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.isDirectoryKey], options: []
+        ) else { return [] }
+        var files: [URL] = []
+        for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            let isDir = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDir {
+                files.append(contentsOf: walk(entry))
+            } else {
+                files.append(entry)
+            }
+        }
+        return files
+    }
+
+    private static func relativePosix(_ url: URL, from base: URL) -> String {
+        let urlComponents = url.standardizedFileURL.pathComponents
+        let baseComponents = base.standardizedFileURL.pathComponents
+        guard urlComponents.starts(with: baseComponents) else { return url.path }
+        return urlComponents.dropFirst(baseComponents.count).joined(separator: "/")
+    }
+}

--- a/Sources/AnglesiteCore/SocialPublishPlan.swift
+++ b/Sources/AnglesiteCore/SocialPublishPlan.swift
@@ -42,14 +42,24 @@ public enum SocialPublishPlan {
     }
 
     private static let entryExtensions: Set<String> = ["md", "mdx", "mdoc", "markdown"]
-    private static let outboundURLPattern = try! NSRegularExpression(
-        pattern: #"https?://[^\s<>"'\)\]\}]+"#,
-        options: [.caseInsensitive]
-    )
+    private static let outboundURLPattern: NSRegularExpression = {
+        do {
+            return try NSRegularExpression(
+                pattern: #"https?://[^\s<>"'\)\]\}]+"#,
+                options: [.caseInsensitive]
+            )
+        } catch {
+            fatalError("Invalid outbound social URL regex: \(error)")
+        }
+    }()
     private static let trailingPunctuation = CharacterSet(charactersIn: ".,;:!?")
 
     /// Builds the outbound-social plan for a site's Astro project root (`Source/`).
-    public static func build(projectRoot: URL, siteBase: URL) throws -> Plan {
+    public static func build(
+        projectRoot: URL,
+        siteBase: URL,
+        referenceDate: Date = Date()
+    ) throws -> Plan {
         guard let baseHost = siteBase.host, siteBase.scheme == "http" || siteBase.scheme == "https" else {
             throw PlanningError.invalidSiteBase(siteBase.absoluteString)
         }
@@ -59,7 +69,7 @@ public enum SocialPublishPlan {
         let entries = files.compactMap { file -> Entry? in
             guard let source = try? String(contentsOf: file, encoding: .utf8) else { return nil }
             let frontmatter = Frontmatter.parse(source)
-            if frontmatter["draft"] == .bool(true) { return nil }
+            if isDraft(frontmatter["draft"]) || isFutureDated(frontmatter, after: referenceDate) { return nil }
 
             let relPath = relativePosix(file, from: projectRoot)
             guard let canonical = canonicalURL(for: relPath, frontmatter: frontmatter, siteBase: siteBase) else {
@@ -88,8 +98,10 @@ public enum SocialPublishPlan {
         let parts = relPath.split(separator: "/").map(String.init)
         guard parts.count >= 4, parts[0] == "src", parts[1] == "content" else { return nil }
         let collection = parts[2]
-        let fileName = parts.last ?? ""
-        let fallbackSlug = basenameWithoutExtension(fileName)
+        let collectionRelParts = Array(parts.dropFirst(3))
+        guard let lastPart = collectionRelParts.last else { return nil }
+        let fallbackSlug = (collectionRelParts.dropLast() + [basenameWithoutExtension(lastPart)])
+            .joined(separator: "/")
         let slug = string(frontmatter["slug"]) ?? fallbackSlug
         return URL(string: "/\(collection)/\(slug)/", relativeTo: siteBase)?.absoluteURL
     }
@@ -107,10 +119,11 @@ public enum SocialPublishPlan {
             }
         }
 
-        let range = NSRange(source.startIndex..<source.endIndex, in: source)
-        for match in outboundURLPattern.matches(in: source, range: range) {
-            guard let r = Range(match.range, in: source) else { continue }
-            let raw = String(source[r]).trimmingCharacters(in: trailingPunctuation)
+        let body = FrontmatterDocument.parse(source).body
+        let range = NSRange(body.startIndex..<body.endIndex, in: body)
+        for match in outboundURLPattern.matches(in: body, range: range) {
+            guard let r = Range(match.range, in: body) else { continue }
+            let raw = String(body[r]).trimmingCharacters(in: trailingPunctuation)
             if let url = URL(string: raw) {
                 candidates.append(url)
             }
@@ -132,8 +145,7 @@ public enum SocialPublishPlan {
             default: return []
             }
         }
-        return Array(Set(values.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }))
-            .sorted()
+        return uniqueStrings(values.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty })
     }
 
     private static func unique(_ urls: [URL]) -> [URL] {
@@ -146,6 +158,51 @@ public enum SocialPublishPlan {
             }
         }
         return out.sorted { $0.absoluteString < $1.absoluteString }
+    }
+
+    private static func uniqueStrings(_ values: [String]) -> [String] {
+        var seen: Set<String> = []
+        var out: [String] = []
+        for value in values {
+            if seen.insert(value).inserted {
+                out.append(value)
+            }
+        }
+        return out
+    }
+
+    private static func isDraft(_ value: FrontmatterValue?) -> Bool {
+        switch value {
+        case .bool(true):
+            return true
+        case .string(let raw):
+            return ["true", "yes", "1"].contains(raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
+        default:
+            return false
+        }
+    }
+
+    private static func isFutureDated(_ frontmatter: [String: FrontmatterValue], after referenceDate: Date) -> Bool {
+        guard let publishDate = parseDate(string(frontmatter["publishDate"]) ?? string(frontmatter["date"])) else {
+            return false
+        }
+        return publishDate > referenceDate
+    }
+
+    private static func parseDate(_ raw: String?) -> Date? {
+        guard let raw, !raw.isEmpty else { return nil }
+        if let date = ISO8601DateFormatter().date(from: raw) {
+            return date
+        }
+        let parts = raw.split(separator: "-")
+        guard parts.count == 3,
+              let year = Int(parts[0]),
+              let month = Int(parts[1]),
+              let day = Int(parts[2])
+        else { return nil }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        return calendar.date(from: DateComponents(year: year, month: month, day: day))
     }
 
     private static func string(_ value: FrontmatterValue?) -> String? {

--- a/Tests/AnglesiteCoreTests/SocialPublishPlanTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialPublishPlanTests.swift
@@ -4,23 +4,25 @@ import Testing
 
 @Suite("SocialPublishPlan")
 struct SocialPublishPlanTests {
-    private func makeSite(_ files: [String: String]) -> URL {
+    private let referenceDate = Date(timeIntervalSince1970: 1_782_777_600) // 2026-06-30T00:00:00Z
+
+    private func makeSite(_ files: [String: String]) throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("social-plan-\(UUID().uuidString)", isDirectory: true)
         for (rel, contents) in files {
             let url = root.appendingPathComponent(rel)
-            try! FileManager.default.createDirectory(
+            try FileManager.default.createDirectory(
                 at: url.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
-            try! Data(contents.utf8).write(to: url)
+            try Data(contents.utf8).write(to: url)
         }
         return root
     }
 
     @Test("collects webmention targets from mf2 frontmatter and body links")
     func webmentionTargets() throws {
-        let root = makeSite([
+        let root = try makeSite([
             "src/content/replies/hello.md": """
             ---
             slug: reply-to-someone
@@ -31,10 +33,12 @@ struct SocialPublishPlanTests {
             Internal links like https://mysite.test/about are not webmention targets.
             """
         ])
+        defer { try? FileManager.default.removeItem(at: root) }
 
         let plan = try SocialPublishPlan.build(
             projectRoot: root,
-            siteBase: URL(string: "https://mysite.test")!
+            siteBase: URL(string: "https://mysite.test")!,
+            referenceDate: referenceDate
         )
 
         #expect(plan.entries.count == 1)
@@ -48,7 +52,7 @@ struct SocialPublishPlanTests {
 
     @Test("collects requested POSSE destinations without requiring outbound links")
     func posseTargets() throws {
-        let root = makeSite([
+        let root = try makeSite([
             "src/content/notes/today.md": """
             ---
             publishDate: 2026-06-29
@@ -57,25 +61,27 @@ struct SocialPublishPlanTests {
             Short note.
             """
         ])
+        defer { try? FileManager.default.removeItem(at: root) }
 
         let plan = try SocialPublishPlan.build(
             projectRoot: root,
-            siteBase: URL(string: "https://mysite.test/")!
+            siteBase: URL(string: "https://mysite.test/")!,
+            referenceDate: referenceDate
         )
 
         #expect(plan.entries.count == 1)
         #expect(plan.entries[0].canonicalURL.absoluteString == "https://mysite.test/notes/today/")
         #expect(plan.entries[0].webmentionTargets.isEmpty)
-        #expect(plan.entries[0].posseTargets == ["bluesky", "mastodon"])
+        #expect(plan.entries[0].posseTargets == ["mastodon", "bluesky"])
         #expect(plan.posseCount == 2)
     }
 
     @Test("skips drafts and entries with no outbound social work")
     func skipsNonPublishableEntries() throws {
-        let root = makeSite([
+        let root = try makeSite([
             "src/content/notes/draft.md": """
             ---
-            draft: true
+            draft: "yes"
             inReplyTo: "https://example.com/post"
             ---
             Draft.
@@ -87,13 +93,84 @@ struct SocialPublishPlanTests {
             Only links to https://mysite.test/elsewhere.
             """
         ])
+        defer { try? FileManager.default.removeItem(at: root) }
 
         let plan = try SocialPublishPlan.build(
             projectRoot: root,
-            siteBase: URL(string: "https://mysite.test")!
+            siteBase: URL(string: "https://mysite.test")!,
+            referenceDate: referenceDate
         )
 
         #expect(plan.isEmpty)
         #expect(plan.webmentionCount == 0)
+    }
+
+    @Test("nested content paths keep their collection-relative slug")
+    func nestedContentPathSlug() throws {
+        let root = try makeSite([
+            "src/content/notes/2026/june/hello.md": """
+            ---
+            publishDate: 2026-06-29
+            ---
+            See https://example.com/nested.
+            """
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let plan = try SocialPublishPlan.build(
+            projectRoot: root,
+            siteBase: URL(string: "https://mysite.test")!,
+            referenceDate: referenceDate
+        )
+
+        #expect(plan.entries.first?.canonicalURL.absoluteString == "https://mysite.test/notes/2026/june/hello/")
+    }
+
+    @Test("body URL scan ignores unrelated frontmatter URLs")
+    func ignoresUnrelatedFrontmatterURLs() throws {
+        let root = try makeSite([
+            "src/content/articles/photo-credit.md": """
+            ---
+            publishDate: 2026-06-29
+            image: "https://cdn.example.test/photo.jpg"
+            inReplyTo: "https://example.com/reply-target"
+            ---
+            Body links to https://elsewhere.test/body-link.
+            """
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let plan = try SocialPublishPlan.build(
+            projectRoot: root,
+            siteBase: URL(string: "https://mysite.test")!,
+            referenceDate: referenceDate
+        )
+
+        #expect(plan.entries.first?.webmentionTargets.map(\.absoluteString) == [
+            "https://elsewhere.test/body-link",
+            "https://example.com/reply-target",
+        ])
+    }
+
+    @Test("skips future-dated content")
+    func skipsFutureDatedContent() throws {
+        let root = try makeSite([
+            "src/content/notes/tomorrow.md": """
+            ---
+            publishDate: 2026-07-01
+            inReplyTo: "https://example.com/future"
+            ---
+            Scheduled.
+            """
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let plan = try SocialPublishPlan.build(
+            projectRoot: root,
+            siteBase: URL(string: "https://mysite.test")!,
+            referenceDate: referenceDate
+        )
+
+        #expect(plan.isEmpty)
     }
 }

--- a/Tests/AnglesiteCoreTests/SocialPublishPlanTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialPublishPlanTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SocialPublishPlan")
+struct SocialPublishPlanTests {
+    private func makeSite(_ files: [String: String]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("social-plan-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try! FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try! Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    @Test("collects webmention targets from mf2 frontmatter and body links")
+    func webmentionTargets() throws {
+        let root = makeSite([
+            "src/content/replies/hello.md": """
+            ---
+            slug: reply-to-someone
+            inReplyTo: "https://example.com/post"
+            publishDate: 2026-06-29
+            ---
+            Body links to https://elsewhere.test/page, and repeats https://example.com/post.
+            Internal links like https://mysite.test/about are not webmention targets.
+            """
+        ])
+
+        let plan = try SocialPublishPlan.build(
+            projectRoot: root,
+            siteBase: URL(string: "https://mysite.test")!
+        )
+
+        #expect(plan.entries.count == 1)
+        #expect(plan.entries[0].sourceFile == "src/content/replies/hello.md")
+        #expect(plan.entries[0].canonicalURL.absoluteString == "https://mysite.test/replies/reply-to-someone/")
+        #expect(plan.entries[0].webmentionTargets.map(\.absoluteString) == [
+            "https://elsewhere.test/page",
+            "https://example.com/post",
+        ])
+    }
+
+    @Test("collects requested POSSE destinations without requiring outbound links")
+    func posseTargets() throws {
+        let root = makeSite([
+            "src/content/notes/today.md": """
+            ---
+            publishDate: 2026-06-29
+            posse: [mastodon, bluesky, mastodon]
+            ---
+            Short note.
+            """
+        ])
+
+        let plan = try SocialPublishPlan.build(
+            projectRoot: root,
+            siteBase: URL(string: "https://mysite.test/")!
+        )
+
+        #expect(plan.entries.count == 1)
+        #expect(plan.entries[0].canonicalURL.absoluteString == "https://mysite.test/notes/today/")
+        #expect(plan.entries[0].webmentionTargets.isEmpty)
+        #expect(plan.entries[0].posseTargets == ["bluesky", "mastodon"])
+        #expect(plan.posseCount == 2)
+    }
+
+    @Test("skips drafts and entries with no outbound social work")
+    func skipsNonPublishableEntries() throws {
+        let root = makeSite([
+            "src/content/notes/draft.md": """
+            ---
+            draft: true
+            inReplyTo: "https://example.com/post"
+            ---
+            Draft.
+            """,
+            "src/content/notes/local.md": """
+            ---
+            publishDate: 2026-06-29
+            ---
+            Only links to https://mysite.test/elsewhere.
+            """
+        ])
+
+        let plan = try SocialPublishPlan.build(
+            projectRoot: root,
+            siteBase: URL(string: "https://mysite.test")!
+        )
+
+        #expect(plan.isEmpty)
+        #expect(plan.webmentionCount == 0)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a network-free SocialPublishPlan for V-2 outbound publishing
- Compute canonical content URLs, external Webmention targets, and POSSE destinations from frontmatter/body content
- Cover Webmention extraction, POSSE-only entries, and draft/no-op skips

## Tests
- swift test --package-path . --filter SocialPublishPlanTests