### PR TITLE
Provision per-site social Worker resources

### DIFF
--- a/Resources/Template/worker/wrangler.toml.template
+++ b/Resources/Template/worker/wrangler.toml.template
@@ -2,8 +2,9 @@
 # Static-only sites omit the `main` entry and deploy dist/ directly.
 # Social features (V-2+) set `main = "worker/worker.ts"` and add bindings below.
 #
-# Do not edit the [[d1_databases]] / [[r2_buckets]] blocks manually — Anglesite's
-# provisioning flow (#353) fills the database_id and bucket_name from the CF API.
+# Do not edit the [[d1_databases]] / [[kv_namespaces]] / [[r2_buckets]] blocks
+# manually — Anglesite's provisioning flow (#353) fills the resource ids from
+# the CF API.
 
 name = "{{SITE_NAME}}"
 compatibility_date = "2025-01-01"
@@ -17,6 +18,10 @@ directory = "dist"
 # binding = "DB"
 # database_name = "{{SITE_NAME}}-social"
 # database_id = ""
+#
+# [[kv_namespaces]]
+# binding = "SOCIAL_KV"
+# id = ""
 #
 # [[r2_buckets]]
 # binding = "MEDIA"

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -1,16 +1,19 @@
 import Foundation
 
-/// Provisions and deploys the per-site Cloudflare Worker used by the V-2 social layer.
+/// Provisions the per-site Cloudflare Worker resources used by the V-2 social layer, then
+/// publishes through ``DeployCommand`` so build and pre-deploy security checks stay in path.
 ///
 /// This is the app-side integration seam for `@dwk/workers`: it creates the backing Cloudflare
-/// resources with wrangler, writes a concrete `wrangler.toml`, then deploys the composed Worker.
+/// resources with wrangler, writes a concrete `wrangler.toml`, then asks the existing deploy
+/// pipeline to build, scan, and deploy the composed Worker.
 /// The Worker source itself stays in the template's `worker/worker.ts`; when the upstream
 /// `@dwk/*` packages are stable, that file is the only protocol-specific piece that needs to
 /// grow imports and route handlers.
 public actor SocialWorkerProvisionCommand {
     public enum Result: Sendable, Equatable {
         case succeeded(url: URL, resources: WorkerComposition.ProvisionedResources, duration: TimeInterval)
-        case failed(reason: String, exitCode: Int32?)
+        case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning], resources: WorkerComposition.ProvisionedResources)
+        case failed(reason: String, exitCode: Int32?, resources: WorkerComposition.ProvisionedResources)
     }
 
     public typealias TokenSource = DeployCommand.TokenSource
@@ -20,16 +23,24 @@ public actor SocialWorkerProvisionCommand {
         _ environment: [String: String],
         _ source: String
     ) async throws -> ProcessSupervisor.RunResult
+    public typealias Deployer = @Sendable (
+        _ token: String,
+        _ siteID: String,
+        _ siteDirectory: URL
+    ) async -> DeployCommand.Result
 
     public nonisolated let tokenSource: TokenSource
     private let runner: CommandRunner
+    private let deployer: Deployer
 
     public init(
         tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
-        runner: @escaping CommandRunner = SocialWorkerProvisionCommand.defaultRunner
+        runner: @escaping CommandRunner = SocialWorkerProvisionCommand.defaultRunner,
+        deployer: @escaping Deployer = SocialWorkerProvisionCommand.defaultDeployer
     ) {
         self.tokenSource = tokenSource
         self.runner = runner
+        self.deployer = deployer
     }
 
     public func provision(
@@ -42,16 +53,18 @@ public actor SocialWorkerProvisionCommand {
         do {
             token = try await tokenSource()
         } catch {
-            return .failed(reason: "couldn't read Cloudflare API token: \(error)", exitCode: nil)
+            return .failed(reason: "couldn't read Cloudflare API token: \(error)", exitCode: nil, resources: .init())
         }
         guard let token, !token.isEmpty else {
-            return .failed(reason: "no CLOUDFLARE_API_TOKEN — add it in Settings → Advanced → Credentials, or set the env var", exitCode: nil)
+            return .failed(
+                reason: "no CLOUDFLARE_API_TOKEN — add it in Settings → Advanced → Credentials, or set the env var",
+                exitCode: nil,
+                resources: .init()
+            )
         }
 
-        do {
-            _ = try WorkerComposition.generateWranglerToml(siteName: siteName, features: features)
-        } catch {
-            return .failed(reason: "invalid Worker name: \(siteName)", exitCode: nil)
+        guard WorkerComposition.isValidSiteName(siteName) else {
+            return .failed(reason: "invalid Worker name: \(siteName)", exitCode: nil, resources: .init())
         }
 
         var environment = DeployCommand.hostDeployEnvironment()
@@ -59,50 +72,130 @@ public actor SocialWorkerProvisionCommand {
         let source = "worker-provision:\(siteID)"
         let started = Date()
 
-        var resources = WorkerComposition.ProvisionedResources()
+        var resources = Self.readPersistedResources(from: siteDirectory)
 
         if features.contains(where: { $0.needsD1 }) {
-            let name = "\(siteName)-social"
-            let result = await runWrangler(
-                siteDirectory: siteDirectory,
-                arguments: ["d1", "create", name, "--json"],
-                environment: environment,
-                source: source
-            )
-            guard case .success(let output) = result else { return result.failure! }
-            guard let id = Self.extractResourceID(from: output) else {
-                return .failed(reason: "wrangler created D1 database \(name) but no database id was found", exitCode: 0)
+            if resources.d1DatabaseID == nil {
+                let name = "\(siteName)-social"
+                let result = await runWrangler(
+                    siteDirectory: siteDirectory,
+                    arguments: ["d1", "create", name, "--json"],
+                    environment: environment,
+                    source: source,
+                    resources: resources
+                )
+                let output: String
+                switch result {
+                case .success(let value):
+                    output = value
+                case .failure(let failure):
+                    return failure
+                }
+                guard let id = Self.extractResourceID(from: output) else {
+                    return .failed(reason: "wrangler created D1 database \(name) but no database id was found", exitCode: 0, resources: resources)
+                }
+                resources.d1DatabaseID = id
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, resources: resources) {
+                    return failure
+                }
             }
-            resources.d1DatabaseID = id
         }
 
         if features.contains(where: { $0.needsKV }) {
-            let name = "\(siteName)-social"
-            let result = await runWrangler(
-                siteDirectory: siteDirectory,
-                arguments: ["kv", "namespace", "create", name, "--json"],
-                environment: environment,
-                source: source
-            )
-            guard case .success(let output) = result else { return result.failure! }
-            guard let id = Self.extractResourceID(from: output) else {
-                return .failed(reason: "wrangler created KV namespace \(name) but no namespace id was found", exitCode: 0)
+            if resources.kvNamespaceID == nil {
+                let name = "\(siteName)-social"
+                let result = await runWrangler(
+                    siteDirectory: siteDirectory,
+                    arguments: ["kv", "namespace", "create", name, "--json"],
+                    environment: environment,
+                    source: source,
+                    resources: resources
+                )
+                let output: String
+                switch result {
+                case .success(let value):
+                    output = value
+                case .failure(let failure):
+                    return failure
+                }
+                guard let id = Self.extractResourceID(from: output) else {
+                    return .failed(reason: "wrangler created KV namespace \(name) but no namespace id was found", exitCode: 0, resources: resources)
+                }
+                resources.kvNamespaceID = id
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, resources: resources) {
+                    return failure
+                }
             }
-            resources.kvNamespaceID = id
         }
 
         if features.contains(where: { $0.needsR2 }) {
-            let name = "\(siteName)-media"
-            let result = await runWrangler(
-                siteDirectory: siteDirectory,
-                arguments: ["r2", "bucket", "create", name],
-                environment: environment,
-                source: source
-            )
-            guard case .success = result else { return result.failure! }
-            resources.r2BucketName = name
+            if resources.r2BucketName == nil {
+                let name = "\(siteName)-media"
+                let result = await runWrangler(
+                    siteDirectory: siteDirectory,
+                    arguments: ["r2", "bucket", "create", name],
+                    environment: environment,
+                    source: source,
+                    resources: resources
+                )
+                if case .failure(let failure) = result {
+                    return failure
+                }
+                resources.r2BucketName = name
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, resources: resources) {
+                    return failure
+                }
+            }
         }
 
+        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, resources: resources) {
+            return failure
+        }
+
+        switch await deployer(token, siteID, siteDirectory) {
+        case .succeeded(let url, _):
+            return .succeeded(url: url, resources: resources, duration: Date().timeIntervalSince(started))
+        case .blocked(let failures, let warnings):
+            return .blocked(failures: failures, warnings: warnings, resources: resources)
+        case .failed(let reason, let exitCode):
+            return .failed(reason: reason, exitCode: exitCode, resources: resources)
+        }
+    }
+
+    private enum StepResult {
+        case success(String)
+        case failure(Result)
+    }
+
+    private func runWrangler(
+        siteDirectory: URL,
+        arguments: [String],
+        environment: [String: String],
+        source: String,
+        resources: WorkerComposition.ProvisionedResources
+    ) async -> StepResult {
+        do {
+            let result = try await runner(siteDirectory, arguments, environment, source)
+            let output = result.stdout.isEmpty ? result.stderr : result.stdout
+            guard result.exitCode == 0 else {
+                return .failure(.failed(
+                    reason: output.isEmpty ? "wrangler exited with code \(result.exitCode)" : output,
+                    exitCode: result.exitCode,
+                    resources: resources
+                ))
+            }
+            return .success(output)
+        } catch {
+            return .failure(.failed(reason: "wrangler could not run: \(error)", exitCode: nil, resources: resources))
+        }
+    }
+
+    private func persistConfig(
+        siteDirectory: URL,
+        siteName: String,
+        features: [WorkerComposition.Feature],
+        resources: WorkerComposition.ProvisionedResources
+    ) -> Result? {
         do {
             let toml = try WorkerComposition.generateWranglerToml(
                 siteName: siteName,
@@ -114,52 +207,25 @@ public actor SocialWorkerProvisionCommand {
                 atomically: true,
                 encoding: .utf8
             )
+            return nil
         } catch {
-            return .failed(reason: "couldn't write wrangler.toml: \(error)", exitCode: nil)
+            return .failed(reason: "couldn't write wrangler.toml: \(error)", exitCode: nil, resources: resources)
         }
+    }
 
-        let deploy = await runWrangler(
-            siteDirectory: siteDirectory,
-            arguments: ["deploy"],
-            environment: environment,
-            source: source
+    static func readPersistedResources(from siteDirectory: URL) -> WorkerComposition.ProvisionedResources {
+        let url = siteDirectory.appendingPathComponent("wrangler.toml")
+        guard let toml = try? String(contentsOf: url, encoding: .utf8) else {
+            return .init()
+        }
+        return .init(
+            d1DatabaseID: extractTomlString(named: "database_id", from: toml),
+            kvNamespaceID: extractTomlString(named: "id", from: toml),
+            r2BucketName: extractTomlString(named: "bucket_name", from: toml)
         )
-        guard case .success(let output) = deploy else { return deploy.failure! }
-        guard let url = DeployCommand.extractDeployedURL(from: output) else {
-            return .failed(reason: "wrangler exited cleanly but no deployed URL was found in its output", exitCode: 0)
-        }
-
-        return .succeeded(url: url, resources: resources, duration: Date().timeIntervalSince(started))
     }
 
-    private enum StepResult {
-        case success(String)
-        case failure(Result)
-
-        var failure: Result? {
-            if case .failure(let result) = self { result } else { nil }
-        }
-    }
-
-    private func runWrangler(
-        siteDirectory: URL,
-        arguments: [String],
-        environment: [String: String],
-        source: String
-    ) async -> StepResult {
-        do {
-            let result = try await runner(siteDirectory, arguments, environment, source)
-            let output = result.stdout.isEmpty ? result.stderr : result.stdout
-            guard result.exitCode == 0 else {
-                return .failure(.failed(reason: output.isEmpty ? "wrangler exited with code \(result.exitCode)" : output, exitCode: result.exitCode))
-            }
-            return .success(output)
-        } catch {
-            return .failure(.failed(reason: "wrangler could not run: \(error)", exitCode: nil))
-        }
-    }
-
-    public static func extractResourceID(from output: String) -> String? {
+    static func extractResourceID(from output: String) -> String? {
         if let data = output.data(using: .utf8),
            let json = try? JSONSerialization.jsonObject(with: data),
            let id = findID(in: json) {
@@ -173,6 +239,19 @@ public actor SocialWorkerProvisionCommand {
             return String(output[range])
         }
         return nil
+    }
+
+    private static func extractTomlString(named key: String, from toml: String) -> String? {
+        let escaped = NSRegularExpression.escapedPattern(for: key)
+        let pattern = #"(?m)^\s*#(KEY)\s*=\s*"([^"]+)""#.replacingOccurrences(of: "#(KEY)", with: escaped)
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: toml, range: NSRange(toml.startIndex..., in: toml)),
+              match.numberOfRanges > 1,
+              let range = Range(match.range(at: 1), in: toml) else {
+            return nil
+        }
+        let value = String(toml[range])
+        return value.isEmpty ? nil : value
     }
 
     private static func findID(in value: Any) -> String? {
@@ -227,6 +306,10 @@ public actor SocialWorkerProvisionCommand {
         await append(result.stdout, source: source, stream: .stdout)
         await append(result.stderr, source: source, stream: .stderr)
         return result
+    }
+
+    public static let defaultDeployer: Deployer = { token, siteID, siteDirectory in
+        await DeployCommand(tokenSource: { token }).deploy(siteID: siteID, siteDirectory: siteDirectory)
     }
 
     private static func append(_ text: String, source: String, stream: LogCenter.Stream) async {

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+/// Provisions and deploys the per-site Cloudflare Worker used by the V-2 social layer.
+///
+/// This is the app-side integration seam for `@dwk/workers`: it creates the backing Cloudflare
+/// resources with wrangler, writes a concrete `wrangler.toml`, then deploys the composed Worker.
+/// The Worker source itself stays in the template's `worker/worker.ts`; when the upstream
+/// `@dwk/*` packages are stable, that file is the only protocol-specific piece that needs to
+/// grow imports and route handlers.
+public actor SocialWorkerProvisionCommand {
+    public enum Result: Sendable, Equatable {
+        case succeeded(url: URL, resources: WorkerComposition.ProvisionedResources, duration: TimeInterval)
+        case failed(reason: String, exitCode: Int32?)
+    }
+
+    public typealias TokenSource = DeployCommand.TokenSource
+    public typealias CommandRunner = @Sendable (
+        _ siteDirectory: URL,
+        _ arguments: [String],
+        _ environment: [String: String],
+        _ source: String
+    ) async throws -> ProcessSupervisor.RunResult
+
+    public nonisolated let tokenSource: TokenSource
+    private let runner: CommandRunner
+
+    public init(
+        tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
+        runner: @escaping CommandRunner = SocialWorkerProvisionCommand.defaultRunner
+    ) {
+        self.tokenSource = tokenSource
+        self.runner = runner
+    }
+
+    public func provision(
+        siteID: String,
+        siteDirectory: URL,
+        siteName: String,
+        features: [WorkerComposition.Feature] = WorkerComposition.Feature.v2
+    ) async -> Result {
+        let token: String?
+        do {
+            token = try await tokenSource()
+        } catch {
+            return .failed(reason: "couldn't read Cloudflare API token: \(error)", exitCode: nil)
+        }
+        guard let token, !token.isEmpty else {
+            return .failed(reason: "no CLOUDFLARE_API_TOKEN — add it in Settings → Advanced → Credentials, or set the env var", exitCode: nil)
+        }
+
+        do {
+            _ = try WorkerComposition.generateWranglerToml(siteName: siteName, features: features)
+        } catch {
+            return .failed(reason: "invalid Worker name: \(siteName)", exitCode: nil)
+        }
+
+        var environment = DeployCommand.hostDeployEnvironment()
+        environment["CLOUDFLARE_API_TOKEN"] = token
+        let source = "worker-provision:\(siteID)"
+        let started = Date()
+
+        var resources = WorkerComposition.ProvisionedResources()
+
+        if features.contains(where: { $0.needsD1 }) {
+            let name = "\(siteName)-social"
+            let result = await runWrangler(
+                siteDirectory: siteDirectory,
+                arguments: ["d1", "create", name, "--json"],
+                environment: environment,
+                source: source
+            )
+            guard case .success(let output) = result else { return result.failure! }
+            guard let id = Self.extractResourceID(from: output) else {
+                return .failed(reason: "wrangler created D1 database \(name) but no database id was found", exitCode: 0)
+            }
+            resources.d1DatabaseID = id
+        }
+
+        if features.contains(where: { $0.needsKV }) {
+            let name = "\(siteName)-social"
+            let result = await runWrangler(
+                siteDirectory: siteDirectory,
+                arguments: ["kv", "namespace", "create", name, "--json"],
+                environment: environment,
+                source: source
+            )
+            guard case .success(let output) = result else { return result.failure! }
+            guard let id = Self.extractResourceID(from: output) else {
+                return .failed(reason: "wrangler created KV namespace \(name) but no namespace id was found", exitCode: 0)
+            }
+            resources.kvNamespaceID = id
+        }
+
+        if features.contains(where: { $0.needsR2 }) {
+            let name = "\(siteName)-media"
+            let result = await runWrangler(
+                siteDirectory: siteDirectory,
+                arguments: ["r2", "bucket", "create", name],
+                environment: environment,
+                source: source
+            )
+            guard case .success = result else { return result.failure! }
+            resources.r2BucketName = name
+        }
+
+        do {
+            let toml = try WorkerComposition.generateWranglerToml(
+                siteName: siteName,
+                features: features,
+                resources: resources
+            )
+            try toml.write(
+                to: siteDirectory.appendingPathComponent("wrangler.toml"),
+                atomically: true,
+                encoding: .utf8
+            )
+        } catch {
+            return .failed(reason: "couldn't write wrangler.toml: \(error)", exitCode: nil)
+        }
+
+        let deploy = await runWrangler(
+            siteDirectory: siteDirectory,
+            arguments: ["deploy"],
+            environment: environment,
+            source: source
+        )
+        guard case .success(let output) = deploy else { return deploy.failure! }
+        guard let url = DeployCommand.extractDeployedURL(from: output) else {
+            return .failed(reason: "wrangler exited cleanly but no deployed URL was found in its output", exitCode: 0)
+        }
+
+        return .succeeded(url: url, resources: resources, duration: Date().timeIntervalSince(started))
+    }
+
+    private enum StepResult {
+        case success(String)
+        case failure(Result)
+
+        var failure: Result? {
+            if case .failure(let result) = self { result } else { nil }
+        }
+    }
+
+    private func runWrangler(
+        siteDirectory: URL,
+        arguments: [String],
+        environment: [String: String],
+        source: String
+    ) async -> StepResult {
+        do {
+            let result = try await runner(siteDirectory, arguments, environment, source)
+            let output = result.stdout.isEmpty ? result.stderr : result.stdout
+            guard result.exitCode == 0 else {
+                return .failure(.failed(reason: output.isEmpty ? "wrangler exited with code \(result.exitCode)" : output, exitCode: result.exitCode))
+            }
+            return .success(output)
+        } catch {
+            return .failure(.failed(reason: "wrangler could not run: \(error)", exitCode: nil))
+        }
+    }
+
+    public static func extractResourceID(from output: String) -> String? {
+        if let data = output.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data),
+           let id = findID(in: json) {
+            return id
+        }
+        let pattern = #""?(?:id|uuid|database_id|namespace_id)"?\s*[:=]\s*"([^"]+)""#
+        if let regex = try? NSRegularExpression(pattern: pattern),
+           let match = regex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
+           match.numberOfRanges > 1,
+           let range = Range(match.range(at: 1), in: output) {
+            return String(output[range])
+        }
+        return nil
+    }
+
+    private static func findID(in value: Any) -> String? {
+        if let dict = value as? [String: Any] {
+            for key in ["id", "uuid", "database_id", "namespace_id"] {
+                if let id = dict[key] as? String, !id.isEmpty {
+                    return id
+                }
+            }
+            for child in dict.values {
+                if let id = findID(in: child) {
+                    return id
+                }
+            }
+        }
+        if let array = value as? [Any] {
+            for child in array {
+                if let id = findID(in: child) {
+                    return id
+                }
+            }
+        }
+        return nil
+    }
+
+    public static let defaultRunner: CommandRunner = { siteDirectory, arguments, environment, source in
+        let wranglerBin = siteDirectory
+            .appendingPathComponent("node_modules", isDirectory: true)
+            .appendingPathComponent(".bin", isDirectory: true)
+            .appendingPathComponent("wrangler")
+        guard FileManager.default.isExecutableFile(atPath: wranglerBin.path) else {
+            return ProcessSupervisor.RunResult(
+                stdout: "wrangler not installed — run `npm install` in this site",
+                stderr: "",
+                exitCode: 127
+            )
+        }
+        guard let node = NodeRuntime.bundledExecutableURL else {
+            return ProcessSupervisor.RunResult(
+                stdout: "the embedded Node runtime isn't bundled (rebuild the app)",
+                stderr: "",
+                exitCode: 127
+            )
+        }
+
+        let result = try await ProcessSupervisor.shared.run(
+            executable: node,
+            arguments: [wranglerBin.path] + arguments,
+            environment: environment,
+            currentDirectoryURL: siteDirectory
+        )
+        await append(result.stdout, source: source, stream: .stdout)
+        await append(result.stderr, source: source, stream: .stderr)
+        return result
+    }
+
+    private static func append(_ text: String, source: String, stream: LogCenter.Stream) async {
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
+            await LogCenter.shared.append(source: source, stream: stream, text: String(line))
+        }
+    }
+}

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -57,6 +57,10 @@ public enum WorkerComposition {
         case invalidSiteName(String)
     }
 
+    private static let validNameCharacters = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
+    )
+
     public struct ProvisionedResources: Sendable, Equatable {
         public var d1DatabaseID: String?
         public var kvNamespaceID: String?
@@ -132,13 +136,8 @@ public enum WorkerComposition {
         return lines.joined(separator: "\n")
     }
 
-    private static func isValidSiteName(_ siteName: String) -> Bool {
+    static func isValidSiteName(_ siteName: String) -> Bool {
         guard !siteName.isEmpty else { return false }
-        return siteName.unicodeScalars.allSatisfy { scalar in
-            scalar.value == 45 || scalar.value == 95 ||
-                (48...57).contains(scalar.value) ||
-                (65...90).contains(scalar.value) ||
-                (97...122).contains(scalar.value)
-        }
+        return siteName.unicodeScalars.allSatisfy { validNameCharacters.contains($0) }
     }
 }

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -5,8 +5,8 @@ import Foundation
 ///
 /// Today's deploy is static-only (`wrangler deploy` with `[assets]`). The social layer (V-2+)
 /// adds a Worker script that mounts `@dwk/indieauth`, `@dwk/webmention`, etc. under path
-/// prefixes. This type generates the configuration; actual CF resource provisioning (D1/R2
-/// creation) is a V-2.1 task (#353).
+/// prefixes. This type generates the configuration; `SocialWorkerProvisionCommand` fills the
+/// Cloudflare resource identifiers once provisioning has created the backing stores.
 public enum WorkerComposition {
     /// A social feature that can be composed into the per-site Worker.
     public enum Feature: String, CaseIterable, Sendable {
@@ -34,6 +34,15 @@ public enum WorkerComposition {
             }
         }
 
+        var needsKV: Bool {
+            switch self {
+            case .webmention, .micropub, .indieauth, .websub, .microsub, .activitypub:
+                return true
+            case .webfinger:
+                return false
+            }
+        }
+
         var needsR2: Bool {
             switch self {
             case .micropub:
@@ -48,7 +57,17 @@ public enum WorkerComposition {
         case invalidSiteName(String)
     }
 
-    private static let validNamePattern = #/^[A-Za-z0-9_-]+$/#
+    public struct ProvisionedResources: Sendable, Equatable {
+        public var d1DatabaseID: String?
+        public var kvNamespaceID: String?
+        public var r2BucketName: String?
+
+        public init(d1DatabaseID: String? = nil, kvNamespaceID: String? = nil, r2BucketName: String? = nil) {
+            self.d1DatabaseID = d1DatabaseID
+            self.kvNamespaceID = kvNamespaceID
+            self.r2BucketName = r2BucketName
+        }
+    }
 
     /// Generates a wrangler.toml for a site with the given features enabled.
     ///
@@ -61,9 +80,10 @@ public enum WorkerComposition {
     ///   characters outside `[A-Za-z0-9_-]`.
     public static func generateWranglerToml(
         siteName: String,
-        features: [Feature]
+        features: [Feature],
+        resources: ProvisionedResources = .init()
     ) throws -> String {
-        guard siteName.wholeMatch(of: validNamePattern) != nil else {
+        guard isValidSiteName(siteName) else {
             throw ConfigError.invalidSiteName(siteName)
         }
         var lines: [String] = []
@@ -83,17 +103,42 @@ public enum WorkerComposition {
             lines.append("[[d1_databases]]")
             lines.append("binding = \"DB\"")
             lines.append("database_name = \"\(siteName)-social\"")
-            lines.append("database_id = \"\"  # filled by provisioning")
+            if let id = resources.d1DatabaseID, !id.isEmpty {
+                lines.append("database_id = \"\(id)\"")
+            } else {
+                lines.append("database_id = \"\"  # filled by provisioning")
+            }
+        }
+
+        if features.contains(where: { $0.needsKV }) {
+            lines.append("")
+            lines.append("[[kv_namespaces]]")
+            lines.append("binding = \"SOCIAL_KV\"")
+            if let id = resources.kvNamespaceID, !id.isEmpty {
+                lines.append("id = \"\(id)\"")
+            } else {
+                lines.append("id = \"\"  # filled by provisioning")
+            }
         }
 
         if features.contains(where: { $0.needsR2 }) {
             lines.append("")
             lines.append("[[r2_buckets]]")
             lines.append("binding = \"MEDIA\"")
-            lines.append("bucket_name = \"\(siteName)-media\"")
+            lines.append("bucket_name = \"\(resources.r2BucketName ?? "\(siteName)-media")\"")
         }
 
         lines.append("")
         return lines.joined(separator: "\n")
+    }
+
+    private static func isValidSiteName(_ siteName: String) -> Bool {
+        guard !siteName.isEmpty else { return false }
+        return siteName.unicodeScalars.allSatisfy { scalar in
+            scalar.value == 45 || scalar.value == 95 ||
+                (48...57).contains(scalar.value) ||
+                (65...90).contains(scalar.value) ||
+                (97...122).contains(scalar.value)
+        }
     }
 }

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SocialWorkerProvisionCommand")
+struct SocialWorkerProvisionCommandTests {
+    @Test("provisions V-2 D1 and KV, writes wrangler.toml, then deploys")
+    func provisionsV2Worker() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
+            ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"id":"kv-id"}}"#, stderr: "", exitCode: 0),
+            ["deploy"]: .init(stdout: "Published my-site (1.23 sec)\n  https://my-site.example.workers.dev", stderr: "", exitCode: 0),
+        ])
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner)
+
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+
+        guard case .succeeded(let url, let resources, _) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(url == URL(string: "https://my-site.example.workers.dev"))
+        #expect(resources.d1DatabaseID == "d1-id")
+        #expect(resources.kvNamespaceID == "kv-id")
+        #expect(resources.r2BucketName == nil)
+        #expect(await recorder.arguments == [
+            ["d1", "create", "my-site-social", "--json"],
+            ["kv", "namespace", "create", "my-site-social", "--json"],
+            ["deploy"],
+        ])
+        #expect(await recorder.environments.allSatisfy { $0["CLOUDFLARE_API_TOKEN"] == "token" })
+
+        let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains("main = \"worker/worker.ts\""))
+        #expect(toml.contains("database_id = \"d1-id\""))
+        #expect(toml.contains("id = \"kv-id\""))
+        #expect(!toml.contains("[[r2_buckets]]"))
+    }
+
+    @Test("provisions R2 only when a selected feature needs media")
+    func provisionsR2ForMicropub() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"uuid":"d1-id"}"#, stderr: "", exitCode: 0),
+            ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"id":"kv-id"}"#, stderr: "", exitCode: 0),
+            ["r2", "bucket", "create", "my-site-media"]: .init(stdout: "Created bucket my-site-media", stderr: "", exitCode: 0),
+            ["deploy"]: .init(stdout: "Published my-site\nhttps://my-site.example.workers.dev", stderr: "", exitCode: 0),
+        ])
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner)
+
+        let result = await command.provision(
+            siteID: "site-1",
+            siteDirectory: site,
+            siteName: "my-site",
+            features: WorkerComposition.Feature.v3
+        )
+
+        guard case .succeeded(_, let resources, _) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(resources.r2BucketName == "my-site-media")
+
+        let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains("[[r2_buckets]]"))
+        #expect(toml.contains("bucket_name = \"my-site-media\""))
+    }
+
+    @Test("fails before running wrangler when no token is available")
+    func missingToken() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([:])
+        let command = SocialWorkerProvisionCommand(tokenSource: { nil }, runner: recorder.runner)
+
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+
+        guard case .failed(let reason, nil) = result else {
+            Issue.record("expected token failure, got \(result)")
+            return
+        }
+        #expect(reason.contains("no CLOUDFLARE_API_TOKEN"))
+        #expect(await recorder.arguments.isEmpty)
+    }
+
+    @Test("extracts resource ids from common wrangler JSON shapes")
+    func resourceIDExtraction() {
+        #expect(SocialWorkerProvisionCommand.extractResourceID(from: #"{"result":{"uuid":"d1-id"}}"#) == "d1-id")
+        #expect(SocialWorkerProvisionCommand.extractResourceID(from: #"{"id":"kv-id"}"#) == "kv-id")
+        #expect(SocialWorkerProvisionCommand.extractResourceID(from: #"{"result":[{"database_id":"db-id"}]}"#) == "db-id")
+        #expect(SocialWorkerProvisionCommand.extractResourceID(from: #"binding = "SOCIAL_KV"\nid = "text-id""#) == "text-id")
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SocialWorkerProvisionCommandTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}
+
+private actor WranglerRecorder {
+    private let responses: [[String]: ProcessSupervisor.RunResult]
+    private var seenArguments: [[String]] = []
+    private var seenEnvironments: [[String: String]] = []
+
+    init(_ responses: [[String]: ProcessSupervisor.RunResult]) {
+        self.responses = responses
+    }
+
+    var arguments: [[String]] { seenArguments }
+    var environments: [[String: String]] { seenEnvironments }
+
+    nonisolated var runner: SocialWorkerProvisionCommand.CommandRunner {
+        { siteDirectory, arguments, environment, source in
+            _ = siteDirectory
+            _ = source
+            return await self.run(arguments: arguments, environment: environment)
+        }
+    }
+
+    private func run(arguments: [String], environment: [String: String]) -> ProcessSupervisor.RunResult {
+        seenArguments.append(arguments)
+        seenEnvironments.append(environment)
+        return responses[arguments] ?? .init(stdout: "unexpected arguments \(arguments)", stderr: "", exitCode: 127)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -4,15 +4,15 @@ import Testing
 
 @Suite("SocialWorkerProvisionCommand")
 struct SocialWorkerProvisionCommandTests {
-    @Test("provisions V-2 D1 and KV, writes wrangler.toml, then deploys")
+    @Test("provisions V-2 D1 and KV, writes wrangler.toml, then deploys through DeployCommand seam")
     func provisionsV2Worker() async throws {
         let site = try temporaryDirectory()
         let recorder = WranglerRecorder([
             ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
             ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"id":"kv-id"}}"#, stderr: "", exitCode: 0),
-            ["deploy"]: .init(stdout: "Published my-site (1.23 sec)\n  https://my-site.example.workers.dev", stderr: "", exitCode: 0),
         ])
-        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner)
+        let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
 
         let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
 
@@ -27,9 +27,9 @@ struct SocialWorkerProvisionCommandTests {
         #expect(await recorder.arguments == [
             ["d1", "create", "my-site-social", "--json"],
             ["kv", "namespace", "create", "my-site-social", "--json"],
-            ["deploy"],
         ])
         #expect(await recorder.environments.allSatisfy { $0["CLOUDFLARE_API_TOKEN"] == "token" })
+        #expect(await deployer.calls == [.init(token: "token", siteID: "site-1", siteDirectory: site)])
 
         let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
         #expect(toml.contains("main = \"worker/worker.ts\""))
@@ -45,9 +45,12 @@ struct SocialWorkerProvisionCommandTests {
             ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"uuid":"d1-id"}"#, stderr: "", exitCode: 0),
             ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"id":"kv-id"}"#, stderr: "", exitCode: 0),
             ["r2", "bucket", "create", "my-site-media"]: .init(stdout: "Created bucket my-site-media", stderr: "", exitCode: 0),
-            ["deploy"]: .init(stdout: "Published my-site\nhttps://my-site.example.workers.dev", stderr: "", exitCode: 0),
         ])
-        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner)
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: recorder.runner,
+            deployer: DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1)).deployer
+        )
 
         let result = await command.provision(
             siteID: "site-1",
@@ -75,12 +78,101 @@ struct SocialWorkerProvisionCommandTests {
 
         let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
 
-        guard case .failed(let reason, nil) = result else {
+        guard case .failed(let reason, nil, let resources) = result else {
             Issue.record("expected token failure, got \(result)")
             return
         }
         #expect(reason.contains("no CLOUDFLARE_API_TOKEN"))
+        #expect(resources == .init())
         #expect(await recorder.arguments.isEmpty)
+    }
+
+    @Test("reuses persisted resource ids and does not recreate Cloudflare backing stores")
+    func reusesPersistedResources() async throws {
+        let site = try temporaryDirectory()
+        let existing = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            features: WorkerComposition.Feature.v3,
+            resources: .init(d1DatabaseID: "d1-existing", kvNamespaceID: "kv-existing", r2BucketName: "media-existing")
+        )
+        try existing.write(to: site.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+
+        let recorder = WranglerRecorder([:])
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: recorder.runner,
+            deployer: DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1)).deployer
+        )
+
+        let result = await command.provision(
+            siteID: "site-1",
+            siteDirectory: site,
+            siteName: "my-site",
+            features: WorkerComposition.Feature.v3
+        )
+
+        guard case .succeeded(_, let resources, _) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(resources.d1DatabaseID == "d1-existing")
+        #expect(resources.kvNamespaceID == "kv-existing")
+        #expect(resources.r2BucketName == "media-existing")
+        #expect(await recorder.arguments.isEmpty)
+    }
+
+    @Test("persists partial D1 resources and reports them when KV creation fails")
+    func partialFailureReportsResources() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"uuid":"d1-id"}"#, stderr: "", exitCode: 0),
+            ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: "KV failed", stderr: "", exitCode: 1),
+        ])
+        let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
+
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+
+        guard case .failed(let reason, let exitCode, let resources) = result else {
+            Issue.record("expected failure, got \(result)")
+            return
+        }
+        #expect(reason == "KV failed")
+        #expect(exitCode == 1)
+        #expect(resources.d1DatabaseID == "d1-id")
+        #expect(resources.kvNamespaceID == nil)
+        #expect(await deployer.calls.isEmpty)
+
+        let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains("database_id = \"d1-id\""))
+    }
+
+    @Test("keeps provisioned resources when DeployCommand fails after config is written")
+    func deployFailureReportsResources() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"uuid":"d1-id"}"#, stderr: "", exitCode: 0),
+            ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"id":"kv-id"}"#, stderr: "", exitCode: 0),
+        ])
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: recorder.runner,
+            deployer: DeployRecorder(result: .failed(reason: "pre-deploy scan could not run", exitCode: nil)).deployer
+        )
+
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+
+        guard case .failed(let reason, nil, let resources) = result else {
+            Issue.record("expected deploy failure, got \(result)")
+            return
+        }
+        #expect(reason == "pre-deploy scan could not run")
+        #expect(resources.d1DatabaseID == "d1-id")
+        #expect(resources.kvNamespaceID == "kv-id")
+
+        let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains("database_id = \"d1-id\""))
+        #expect(toml.contains("id = \"kv-id\""))
     }
 
     @Test("extracts resource ids from common wrangler JSON shapes")
@@ -91,11 +183,61 @@ struct SocialWorkerProvisionCommandTests {
         #expect(SocialWorkerProvisionCommand.extractResourceID(from: #"binding = "SOCIAL_KV"\nid = "text-id""#) == "text-id")
     }
 
+    @Test("reads persisted resource ids from active wrangler.toml bindings only")
+    func persistedResourceParsing() throws {
+        let site = try temporaryDirectory()
+        let toml = """
+        # id = "commented-kv"
+        name = "my-site"
+        [[d1_databases]]
+        database_id = "d1-id"
+        [[kv_namespaces]]
+        id = "kv-id"
+        [[r2_buckets]]
+        bucket_name = "media-bucket"
+        """
+        try toml.write(to: site.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+
+        let resources = SocialWorkerProvisionCommand.readPersistedResources(from: site)
+
+        #expect(resources.d1DatabaseID == "d1-id")
+        #expect(resources.kvNamespaceID == "kv-id")
+        #expect(resources.r2BucketName == "media-bucket")
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("SocialWorkerProvisionCommandTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+}
+
+private struct DeployCall: Sendable, Equatable {
+    let token: String
+    let siteID: String
+    let siteDirectory: URL
+}
+
+private actor DeployRecorder {
+    private let result: DeployCommand.Result
+    private var seenCalls: [DeployCall] = []
+
+    init(result: DeployCommand.Result) {
+        self.result = result
+    }
+
+    var calls: [DeployCall] { seenCalls }
+
+    nonisolated var deployer: SocialWorkerProvisionCommand.Deployer {
+        { token, siteID, siteDirectory in
+            await self.deploy(token: token, siteID: siteID, siteDirectory: siteDirectory)
+        }
+    }
+
+    private func deploy(token: String, siteID: String, siteDirectory: URL) -> DeployCommand.Result {
+        seenCalls.append(DeployCall(token: token, siteID: siteID, siteDirectory: siteDirectory))
+        return result
     }
 }
 

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -16,7 +16,7 @@ struct WorkerCompositionTests {
         #expect(!toml.contains("[[d1_databases]]"))
     }
 
-    @Test("generates wrangler.toml with webmention + indieauth (D1 yes, R2 no)")
+    @Test("generates wrangler.toml with webmention + indieauth (D1 + KV yes, R2 no)")
     func withSocialFeatures() throws {
         let toml = try WorkerComposition.generateWranglerToml(
             siteName: "my-site",
@@ -26,6 +26,8 @@ struct WorkerCompositionTests {
         #expect(toml.contains("[assets]"))
         #expect(toml.contains("[[d1_databases]]"))
         #expect(toml.contains("binding = \"DB\""))
+        #expect(toml.contains("[[kv_namespaces]]"))
+        #expect(toml.contains("binding = \"SOCIAL_KV\""))
         #expect(!toml.contains("[[r2_buckets]]"))
     }
 
@@ -36,6 +38,7 @@ struct WorkerCompositionTests {
             features: WorkerComposition.Feature.v2
         )
         #expect(toml.contains("[[d1_databases]]"))
+        #expect(toml.contains("[[kv_namespaces]]"))
         #expect(!toml.contains("[[r2_buckets]]"))
     }
 
@@ -46,8 +49,22 @@ struct WorkerCompositionTests {
             features: WorkerComposition.Feature.v3
         )
         #expect(toml.contains("[[d1_databases]]"))
+        #expect(toml.contains("[[kv_namespaces]]"))
         #expect(toml.contains("[[r2_buckets]]"))
         #expect(toml.contains("binding = \"MEDIA\""))
+    }
+
+    @Test("writes provisioned Cloudflare resource ids into wrangler.toml")
+    func provisionedResources() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            features: WorkerComposition.Feature.v3,
+            resources: .init(d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: "custom-media")
+        )
+
+        #expect(toml.contains("database_id = \"d1-id\""))
+        #expect(toml.contains("id = \"kv-id\""))
+        #expect(toml.contains("bucket_name = \"custom-media\""))
     }
 
     @Test("rejects site names containing TOML-unsafe characters")


### PR DESCRIPTION
## Summary
- add SocialWorkerProvisionCommand to create D1/KV/R2 resources via wrangler and deploy the composed per-site Worker
- teach WorkerComposition to emit provisioned D1, KV, and R2 bindings
- update the template wrangler comments and add focused provisioning/composition tests

Refs #336
Closes #353

## Tests
- swift test --package-path . --filter 'WorkerComposition|SocialWorkerProvisionCommand'