### PR TITLE
Expose social worker provisioning through SiteOperations

### DIFF
--- a/Sources/AnglesiteCore/CommandFactory.swift
+++ b/Sources/AnglesiteCore/CommandFactory.swift
@@ -7,6 +7,7 @@ public protocol CommandFactory: Sendable {
     func deploy() -> DeployCommand
     func backup() -> BackupCommand
     func audit() -> AuditCommand
+    func socialWorkerProvision() -> SocialWorkerProvisionCommand
 }
 
 public struct LiveCommandFactory: CommandFactory {
@@ -14,4 +15,5 @@ public struct LiveCommandFactory: CommandFactory {
     public func deploy() -> DeployCommand { DeployCommand() }
     public func backup() -> BackupCommand { BackupCommand() }
     public func audit() -> AuditCommand { AuditCommand() }
+    public func socialWorkerProvision() -> SocialWorkerProvisionCommand { SocialWorkerProvisionCommand() }
 }

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -7,12 +7,30 @@ import Foundation
 /// A missing security-scoped grant (MAS) or a not-found site is mapped onto each command's
 /// own `.failed` case so callers handle exactly one Result type per operation.
 public struct SiteOperations: Sendable {
+    typealias SocialWorkerAccess = @Sendable (
+        _ site: SiteStore.Site,
+        _ store: SiteStore,
+        _ body: @Sendable @escaping (URL) async -> SocialWorkerProvisionCommand.Result
+    ) async throws -> SocialWorkerProvisionCommand.Result
+
     private let factory: CommandFactory
     private let store: SiteStore
+    private let socialWorkerAccess: SocialWorkerAccess
 
     public init(factory: CommandFactory = LiveCommandFactory(), store: SiteStore = .shared) {
+        self.init(
+            factory: factory,
+            store: store,
+            socialWorkerAccess: { site, store, body in
+                try await SiteAccess.withScopedAccess(to: site, in: store, body)
+            }
+        )
+    }
+
+    init(factory: CommandFactory, store: SiteStore, socialWorkerAccess: @escaping SocialWorkerAccess) {
         self.factory = factory
         self.store = store
+        self.socialWorkerAccess = socialWorkerAccess
     }
 
     /// Resolve a site id (as carried by `SiteEntity`) to the registry's `Site`.
@@ -60,7 +78,7 @@ public struct SiteOperations: Sendable {
 
     public func provisionSocialWorker(site: SiteStore.Site) async -> SocialWorkerProvisionCommand.Result {
         do {
-            return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
+            return try await socialWorkerAccess(site, store) { url in
                 await factory.socialWorkerProvision().provision(
                     siteID: site.id,
                     siteDirectory: url,

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -58,6 +58,22 @@ public struct SiteOperations: Sendable {
         }
     }
 
+    public func provisionSocialWorker(site: SiteStore.Site) async -> SocialWorkerProvisionCommand.Result {
+        do {
+            return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
+                await factory.socialWorkerProvision().provision(
+                    siteID: site.id,
+                    siteDirectory: url,
+                    siteName: SiteSlug.derive(from: site.name)
+                )
+            }
+        } catch let SiteAccess.AccessError.noGrant(message) {
+            return .failed(reason: message, exitCode: nil, resources: .init())
+        } catch {
+            return .failed(reason: error.localizedDescription, exitCode: nil, resources: .init())
+        }
+    }
+
     // MARK: Dialog mapping (pure)
 
     public static func dialog(forDeploy result: DeployCommand.Result) -> String {
@@ -96,9 +112,31 @@ public struct SiteOperations: Sendable {
         }
     }
 
+    public static func dialog(forSocialWorkerProvision result: SocialWorkerProvisionCommand.Result) -> String {
+        switch result {
+        case .succeeded(let url, let resources, _):
+            return "Social Worker provisioned at \(url.absoluteString).\(resourceSuffix(resources))"
+        case .blocked(let failures, _, let resources):
+            let count = failures.count
+            let noun = count == 1 ? "issue" : "issues"
+            return "Social Worker provisioning blocked by the pre-deploy security scan (\(count) \(noun)).\(resourceSuffix(resources))"
+        case .failed(let reason, _, let resources):
+            return "Social Worker provisioning failed: \(reason).\(resourceSuffix(resources))"
+        }
+    }
+
     /// Friendly dialog for a Siri/Shortcuts cancellation, mapped from `Task.isCancelled` at the
     /// intent boundary (the command actor SIGTERMs the underlying subprocess on cancel).
     public static func canceledDialog(operation: String, siteName: String) -> String {
         "Canceled the \(operation) of \(siteName)."
+    }
+
+    private static func resourceSuffix(_ resources: WorkerComposition.ProvisionedResources) -> String {
+        var labels: [String] = []
+        if resources.d1DatabaseID != nil { labels.append("D1") }
+        if resources.kvNamespaceID != nil { labels.append("KV") }
+        if resources.r2BucketName != nil { labels.append("R2") }
+        guard !labels.isEmpty else { return "" }
+        return " Provisioned resources: \(labels.joined(separator: ", "))."
     }
 }

--- a/Sources/AnglesiteCore/SiteOperationsService.swift
+++ b/Sources/AnglesiteCore/SiteOperationsService.swift
@@ -11,6 +11,7 @@ public protocol SiteOperationsService: Sendable {
     func deploy(site: SiteStore.Site, onProgress: ProgressHandler?) async -> DeployCommand.Result
     func backup(site: SiteStore.Site, onProgress: ProgressHandler?) async -> BackupCommand.Result
     func audit(site: SiteStore.Site, onProgress: ProgressHandler?) async -> AuditCommand.Result
+    func provisionSocialWorker(site: SiteStore.Site) async -> SocialWorkerProvisionCommand.Result
 }
 
 public extension SiteOperationsService {

--- a/Tests/AnglesiteCoreTests/SiteOperationsProgressSeamTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsProgressSeamTests.swift
@@ -26,4 +26,5 @@ private struct NoopCommandFactory: CommandFactory {
     func deploy() -> DeployCommand { DeployCommand(tokenSource: { nil }) }
     func backup() -> BackupCommand { BackupCommand(runner: { _, _ in .init(stdout: "", stderr: "", exitCode: 1) }, streamer: { _, _, _ in (1, "") }) }
     func audit() -> AuditCommand { AuditCommand(resolveBuildCommand: { _ in .unavailable(reason: "noop") }, runners: []) }
+    func socialWorkerProvision() -> SocialWorkerProvisionCommand { SocialWorkerProvisionCommand(tokenSource: { nil }) }
 }

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -130,9 +130,10 @@ struct SiteOperationsTests {
         #expect(dialog == "Deploy failed: network down")
     }
 
-    @Test("social Worker provisioning runs through SiteOperations and slugifies the worker name")
+    @Test("social worker provisioning runs through SiteOperations and slugifies the worker name")
     func socialWorkerProvisionOperation() async throws {
         let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
         let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
         let recorder = SocialWorkerRecorder()
         let ops = SiteOperations(factory: SocialWorkerFactory(recorder: recorder), store: throwawayStore())
@@ -153,7 +154,39 @@ struct SiteOperationsTests {
         ])
     }
 
-    @Test("social Worker provisioning dialog reports success and resources")
+    @Test("social worker provisioning maps missing folder grants to failed results")
+    func socialWorkerProvisionNoGrant() async {
+        let site = makeSite()
+        let ops = SiteOperations(
+            factory: SocialWorkerFactory(recorder: SocialWorkerRecorder()),
+            store: throwawayStore(),
+            socialWorkerAccess: { _, _, _ in
+                throw SiteAccess.AccessError.noGrant("Portfolio has no folder grant.")
+            }
+        )
+
+        let result = await ops.provisionSocialWorker(site: site)
+
+        #expect(result == .failed(reason: "Portfolio has no folder grant.", exitCode: nil, resources: .init()))
+    }
+
+    @Test("social worker provisioning maps unexpected access errors to failed results")
+    func socialWorkerProvisionGenericAccessError() async {
+        let site = makeSite()
+        let ops = SiteOperations(
+            factory: SocialWorkerFactory(recorder: SocialWorkerRecorder()),
+            store: throwawayStore(),
+            socialWorkerAccess: { _, _, _ in
+                throw TestAccessError()
+            }
+        )
+
+        let result = await ops.provisionSocialWorker(site: site)
+
+        #expect(result == .failed(reason: "could not resolve site access", exitCode: nil, resources: .init()))
+    }
+
+    @Test("social worker provisioning dialog reports success and resources")
     func socialWorkerProvisionSuccessDialog() {
         let result = SocialWorkerProvisionCommand.Result.succeeded(
             url: URL(string: "https://site.example.workers.dev")!,
@@ -166,7 +199,7 @@ struct SiteOperationsTests {
         )
     }
 
-    @Test("social Worker provisioning blocked dialog preserves security gate wording")
+    @Test("social worker provisioning blocked dialog preserves security gate wording")
     func socialWorkerProvisionBlockedDialog() {
         let failure = PreDeployCheck.ScanFailure(
             category: .exposedToken,
@@ -185,7 +218,7 @@ struct SiteOperationsTests {
         #expect(!dialog.lowercased().contains("override"))
     }
 
-    @Test("social Worker provisioning failure dialog includes partial resources")
+    @Test("social worker provisioning failure dialog includes partial resources")
     func socialWorkerProvisionFailureDialog() {
         let result = SocialWorkerProvisionCommand.Result.failed(
             reason: "KV failed",
@@ -240,6 +273,10 @@ private struct DeployCall: Sendable, Equatable {
     let token: String
     let siteID: String
     let siteDirectory: URL
+}
+
+private struct TestAccessError: LocalizedError, Sendable {
+    var errorDescription: String? { "could not resolve site access" }
 }
 
 private struct SocialWorkerFactory: CommandFactory {

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -12,6 +12,9 @@ struct SiteOperationsTests {
     private struct FakeFactory: CommandFactory {
         func deploy() -> DeployCommand { DeployCommand() }
         func audit() -> AuditCommand { AuditCommand() }
+        func socialWorkerProvision() -> SocialWorkerProvisionCommand {
+            SocialWorkerProvisionCommand(tokenSource: { nil })
+        }
         func backup() -> BackupCommand {
             BackupCommand(
                 runner: { _, args in
@@ -46,6 +49,26 @@ struct SiteOperationsTests {
             isValid: true,
             missingSentinels: []
         )
+    }
+
+    private func makeSite(name: String, packageURL: URL) -> SiteStore.Site {
+        SiteStore.Site(
+            id: "s1",
+            name: name,
+            packageURL: packageURL,
+            isValid: true,
+            missingSentinels: []
+        )
+    }
+
+    private func temporaryPackage() throws -> URL {
+        let package = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SiteOperationsTests-\(UUID().uuidString).anglesite", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: package.appendingPathComponent("Source", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        return package
     }
 
     private func finding(_ severity: AuditReport.Finding.Severity) -> AuditReport.Finding {
@@ -107,6 +130,74 @@ struct SiteOperationsTests {
         #expect(dialog == "Deploy failed: network down")
     }
 
+    @Test("social Worker provisioning runs through SiteOperations and slugifies the worker name")
+    func socialWorkerProvisionOperation() async throws {
+        let package = try temporaryPackage()
+        let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
+        let recorder = SocialWorkerRecorder()
+        let ops = SiteOperations(factory: SocialWorkerFactory(recorder: recorder), store: throwawayStore())
+
+        let result = await ops.provisionSocialWorker(site: site)
+
+        guard case .succeeded(let url, _, _) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(url == URL(string: "https://blue-bottle-cafe.example.workers.dev"))
+        #expect(await recorder.arguments == [
+            ["d1", "create", "blue-bottle-cafe-social", "--json"],
+            ["kv", "namespace", "create", "blue-bottle-cafe-social", "--json"],
+        ])
+        #expect(await recorder.deployCalls == [
+            .init(token: "token", siteID: "s1", siteDirectory: package.appendingPathComponent("Source", isDirectory: true))
+        ])
+    }
+
+    @Test("social Worker provisioning dialog reports success and resources")
+    func socialWorkerProvisionSuccessDialog() {
+        let result = SocialWorkerProvisionCommand.Result.succeeded(
+            url: URL(string: "https://site.example.workers.dev")!,
+            resources: .init(d1DatabaseID: "d1", kvNamespaceID: "kv"),
+            duration: 1
+        )
+        #expect(
+            SiteOperations.dialog(forSocialWorkerProvision: result)
+                == "Social Worker provisioned at https://site.example.workers.dev. Provisioned resources: D1, KV."
+        )
+    }
+
+    @Test("social Worker provisioning blocked dialog preserves security gate wording")
+    func socialWorkerProvisionBlockedDialog() {
+        let failure = PreDeployCheck.ScanFailure(
+            category: .exposedToken,
+            file: "dist/index.html",
+            detail: "API key committed",
+            remediation: "Remove it"
+        )
+        let result = SocialWorkerProvisionCommand.Result.blocked(
+            failures: [failure],
+            warnings: [],
+            resources: .init(d1DatabaseID: "d1", kvNamespaceID: "kv", r2BucketName: "media")
+        )
+        let dialog = SiteOperations.dialog(forSocialWorkerProvision: result)
+        #expect(dialog == "Social Worker provisioning blocked by the pre-deploy security scan (1 issue). Provisioned resources: D1, KV, R2.")
+        #expect(!dialog.lowercased().contains("force"))
+        #expect(!dialog.lowercased().contains("override"))
+    }
+
+    @Test("social Worker provisioning failure dialog includes partial resources")
+    func socialWorkerProvisionFailureDialog() {
+        let result = SocialWorkerProvisionCommand.Result.failed(
+            reason: "KV failed",
+            exitCode: 1,
+            resources: .init(d1DatabaseID: "d1")
+        )
+        #expect(
+            SiteOperations.dialog(forSocialWorkerProvision: result)
+                == "Social Worker provisioning failed: KV failed. Provisioned resources: D1."
+        )
+    }
+
     @Test("backup failure dialog surfaces the reason")
     func backupFailureDialog() {
         let dialog = SiteOperations.dialog(forBackup: .failed(reason: "push rejected", exitCode: 1))
@@ -117,5 +208,51 @@ struct SiteOperationsTests {
     func auditFailureDialog() {
         let dialog = SiteOperations.dialog(forAudit: .failed(reason: "config missing", exitCode: 1, logTail: []))
         #expect(dialog == "Audit failed: config missing")
+    }
+}
+
+private actor SocialWorkerRecorder {
+    private var seenArguments: [[String]] = []
+    private var seenDeployCalls: [DeployCall] = []
+
+    var arguments: [[String]] { seenArguments }
+    var deployCalls: [DeployCall] { seenDeployCalls }
+
+    func run(arguments: [String]) -> ProcessSupervisor.RunResult {
+        seenArguments.append(arguments)
+        switch arguments.first {
+        case "d1":
+            return .init(stdout: #"{"uuid":"d1-id"}"#, stderr: "", exitCode: 0)
+        case "kv":
+            return .init(stdout: #"{"id":"kv-id"}"#, stderr: "", exitCode: 0)
+        default:
+            return .init(stdout: "unexpected arguments \(arguments)", stderr: "", exitCode: 127)
+        }
+    }
+
+    func deploy(token: String, siteID: String, siteDirectory: URL) -> DeployCommand.Result {
+        seenDeployCalls.append(.init(token: token, siteID: siteID, siteDirectory: siteDirectory))
+        return .succeeded(url: URL(string: "https://blue-bottle-cafe.example.workers.dev")!, duration: 1)
+    }
+}
+
+private struct DeployCall: Sendable, Equatable {
+    let token: String
+    let siteID: String
+    let siteDirectory: URL
+}
+
+private struct SocialWorkerFactory: CommandFactory {
+    let recorder: SocialWorkerRecorder
+
+    func deploy() -> DeployCommand { DeployCommand() }
+    func backup() -> BackupCommand { BackupCommand(runner: { _, _ in .init(stdout: "", stderr: "", exitCode: 1) }, streamer: { _, _, _ in (1, "") }) }
+    func audit() -> AuditCommand { AuditCommand(resolveBuildCommand: { _ in .unavailable(reason: "noop") }, runners: []) }
+    func socialWorkerProvision() -> SocialWorkerProvisionCommand {
+        SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: { _, arguments, _, _ in await recorder.run(arguments: arguments) },
+            deployer: { token, siteID, siteDirectory in await recorder.deploy(token: token, siteID: siteID, siteDirectory: siteDirectory) }
+        )
     }
 }

--- a/Tests/AnglesiteIntentsTests/Support/FakeOperations.swift
+++ b/Tests/AnglesiteIntentsTests/Support/FakeOperations.swift
@@ -18,11 +18,13 @@ final class FakeOperations: SiteOperationsService, @unchecked Sendable {
     var deployResult: DeployCommand.Result = .failed(reason: "unstubbed deploy", exitCode: nil)
     var backupResult: BackupCommand.Result = .failed(reason: "unstubbed backup", exitCode: nil)
     var auditResult: AuditCommand.Result = .failed(reason: "unstubbed audit", exitCode: nil, logTail: [])
+    var socialWorkerProvisionResult: SocialWorkerProvisionCommand.Result = .failed(reason: "unstubbed social Worker provisioning", exitCode: nil, resources: .init())
 
     private(set) var siteCalls: [String] = []
     private(set) var deployCalls: [SiteStore.Site] = []
     private(set) var backupCalls: [SiteStore.Site] = []
     private(set) var auditCalls: [SiteStore.Site] = []
+    private(set) var socialWorkerProvisionCalls: [SiteStore.Site] = []
     private(set) var lastDeployProgress: ProgressHandler?
     private(set) var lastBackupProgress: ProgressHandler?
     private(set) var lastAuditProgress: ProgressHandler?
@@ -48,5 +50,10 @@ final class FakeOperations: SiteOperationsService, @unchecked Sendable {
         auditCalls.append(site)
         lastAuditProgress = onProgress
         return auditResult
+    }
+
+    func provisionSocialWorker(site: SiteStore.Site) async -> SocialWorkerProvisionCommand.Result {
+        socialWorkerProvisionCalls.append(site)
+        return socialWorkerProvisionResult
     }
 }

--- a/Tests/AnglesiteIntentsTests/Support/FakeOperations.swift
+++ b/Tests/AnglesiteIntentsTests/Support/FakeOperations.swift
@@ -18,7 +18,7 @@ final class FakeOperations: SiteOperationsService, @unchecked Sendable {
     var deployResult: DeployCommand.Result = .failed(reason: "unstubbed deploy", exitCode: nil)
     var backupResult: BackupCommand.Result = .failed(reason: "unstubbed backup", exitCode: nil)
     var auditResult: AuditCommand.Result = .failed(reason: "unstubbed audit", exitCode: nil, logTail: [])
-    var socialWorkerProvisionResult: SocialWorkerProvisionCommand.Result = .failed(reason: "unstubbed social Worker provisioning", exitCode: nil, resources: .init())
+    var socialWorkerProvisionResult: SocialWorkerProvisionCommand.Result = .failed(reason: "unstubbed social worker provisioning", exitCode: nil, resources: .init())
 
     private(set) var siteCalls: [String] = []
     private(set) var deployCalls: [SiteStore.Site] = []


### PR DESCRIPTION
## Summary
- add SocialWorkerProvisionCommand to CommandFactory and SiteOperations
- derive stable worker names from site display names via SiteSlug
- add user-facing dialog mapping for success, blocked scans, and partial-resource failures
- update SiteOperationsService fakes/tests for the new operation seam

Follow-up to #430.

## Tests
- swift test --package-path . --filter 'SiteOperations|SocialWorkerProvisionCommand|WorkerComposition'