### PR TITLE
Fix #432: Inject SiteRuntime factory

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -243,6 +243,7 @@ struct AnglesiteApp: App {
                 contentGraph: appDelegate.contentGraph,
                 knowledgeIndex: appDelegate.knowledgeIndex,
                 semanticRanker: appDelegate.semanticRanker,
+                runtimeFactory: LiveSiteRuntimeFactory(),
                 contentIndexerStore: appDelegate.contentIndexerStore
             )
                 .frame(minWidth: 960, minHeight: 600)

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -1,12 +1,6 @@
 import SwiftUI
 import WebKit
 import AnglesiteCore
-// AnglesiteContainer (the local-container runtime + entitlement probe) links into the DevID app only;
-// the MAS target does not link it (container distribution is deferred). Guard so the shared
-// PreviewModel still compiles for AnglesiteMAS, which always uses the host LocalSiteRuntime.
-#if !ANGLESITE_MAS
-import AnglesiteContainer
-#endif
 
 /// SwiftUI-facing wrapper over a `SiteRuntime` actor: mirrors the runtime's `SiteRuntimeState` into
 /// an observable property and exposes `open(...)` / `close()` for the view layer.
@@ -40,15 +34,22 @@ final class PreviewModel {
     private(set) var editRouter: EditRouter
 
     /// `contentGraph` is the app-lifetime `SiteContentGraph` (held by `AppDelegate`); it's threaded
-    /// into the default `LocalSiteRuntime` so opening this site populates the shared graph (A.8,
-    /// #142). Tests inject an explicit `runtime` and leave the graph `nil`.
-    init(
+    /// into the live runtime factory so opening this site populates the shared graph (A.8,
+    /// #142). Tests can inject an explicit `runtime` and leave the graph `nil`.
+    convenience init(
         contentGraph: SiteContentGraph? = nil,
         knowledgeIndex: SiteKnowledgeIndex? = nil,
         semanticRanker: SemanticRanker? = nil,
-        runtime: (any SiteRuntime)? = nil
+        runtimeFactory: any SiteRuntimeFactory
     ) {
-        let runtime = runtime ?? Self.makeRuntime(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex, semanticRanker: semanticRanker)
+        self.init(runtime: runtimeFactory.makeRuntime(
+            contentGraph: contentGraph,
+            knowledgeIndex: knowledgeIndex,
+            semanticRanker: semanticRanker
+        ))
+    }
+
+    init(runtime: any SiteRuntime) {
         self.runtime = runtime
         self.editRouter = MCPApplyEditRouter(mcpClient: { [weak runtime] in
             // `runtime` is the actor instance; reading `mcpClient` hops onto the actor.
@@ -90,30 +91,6 @@ final class PreviewModel {
             let current = self.editRouter
             Task { await EditRouterRegistry.shared.register(current, for: siteID) }
         }
-    }
-
-    /// Pick the runtime by capability (no feature flag): a local Apple-Containerization VM when the
-    /// build is entitled + the kernel/initfs are provisioned; otherwise the existing host-subprocess
-    /// runtime.
-    ///
-    /// `sourceRepo` is NOT passed here — `LocalContainerSiteRuntime.init` doesn't take it; it
-    /// receives it at `start(siteID:siteDirectory:)` time (forwarded from `open(siteID:siteDirectory:)`).
-    static func makeRuntime(contentGraph: SiteContentGraph?, knowledgeIndex: SiteKnowledgeIndex?, semanticRanker: SemanticRanker?) -> any SiteRuntime {
-        #if !ANGLESITE_MAS
-        // Container runtime is DevID-only (MAS doesn't link AnglesiteContainer). On MAS this whole
-        // branch compiles out and the host runtime below is always used.
-        if LocalContainerSupport.isAvailable(hasVirtualizationEntitlement: VirtualizationEntitlement.isPresent)
-            && BundledImage.isProvisioned {
-            return LocalContainerSiteRuntime(
-                ref: "HEAD",
-                control: ContainerizationControl(),
-                mcpClient: MCPClient(supervisor: .shared),
-                knowledgeIndex: knowledgeIndex,
-                semanticRanker: semanticRanker
-            )
-        }
-        #endif
-        return LocalSiteRuntime(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex, semanticRanker: semanticRanker)
     }
 
     func open(siteID: String, siteDirectory: URL) {

--- a/Sources/AnglesiteApp/SiteRuntimeFactory.swift
+++ b/Sources/AnglesiteApp/SiteRuntimeFactory.swift
@@ -1,0 +1,43 @@
+import AnglesiteCore
+
+// AnglesiteContainer links into the DevID app only; the MAS target intentionally
+// falls back to the host subprocess runtime.
+#if !ANGLESITE_MAS
+import AnglesiteContainer
+#endif
+
+protocol SiteRuntimeFactory: Sendable {
+    func makeRuntime(
+        contentGraph: SiteContentGraph?,
+        knowledgeIndex: SiteKnowledgeIndex?,
+        semanticRanker: SemanticRanker?
+    ) -> any SiteRuntime
+}
+
+struct LiveSiteRuntimeFactory: SiteRuntimeFactory {
+    /// Pick the runtime by capability (no feature flag): a local Apple-Containerization VM when the
+    /// build is entitled + the kernel/initfs are provisioned; otherwise the existing host-subprocess
+    /// runtime.
+    ///
+    /// `sourceRepo` is not passed here. Container runtimes receive it at
+    /// `start(siteID:siteDirectory:)` time.
+    func makeRuntime(
+        contentGraph: SiteContentGraph?,
+        knowledgeIndex: SiteKnowledgeIndex?,
+        semanticRanker: SemanticRanker?
+    ) -> any SiteRuntime {
+        #if !ANGLESITE_MAS
+        if LocalContainerSupport.isAvailable(hasVirtualizationEntitlement: VirtualizationEntitlement.isPresent)
+            && BundledImage.isProvisioned {
+            return LocalContainerSiteRuntime(
+                ref: "HEAD",
+                control: ContainerizationControl(),
+                mcpClient: MCPClient(supervisor: .shared),
+                knowledgeIndex: knowledgeIndex,
+                semanticRanker: semanticRanker
+            )
+        }
+        #endif
+        return LocalSiteRuntime(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex, semanticRanker: semanticRanker)
+    }
+}

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -56,6 +56,7 @@ struct SiteWindow: View {
         contentGraph: SiteContentGraph,
         knowledgeIndex: SiteKnowledgeIndex,
         semanticRanker: SemanticRanker?,
+        runtimeFactory: any SiteRuntimeFactory,
         contentIndexerStore: ContentIndexerStore
     ) {
         self.siteID = siteID
@@ -63,7 +64,12 @@ struct SiteWindow: View {
         self.knowledgeIndex = knowledgeIndex
         self.semanticRanker = semanticRanker
         self.contentIndexerStore = contentIndexerStore
-        _preview = State(initialValue: PreviewModel(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex, semanticRanker: semanticRanker))
+        _preview = State(initialValue: PreviewModel(
+            contentGraph: contentGraph,
+            knowledgeIndex: knowledgeIndex,
+            semanticRanker: semanticRanker,
+            runtimeFactory: runtimeFactory
+        ))
         _graphExplorer = State(initialValue: SiteGraphExplorerModel(graph: contentGraph))
         _relatedPages = State(initialValue: RelatedPagesModel(index: knowledgeIndex, ranker: semanticRanker))
     }


### PR DESCRIPTION
## Summary
- add a SiteRuntimeFactory seam and live factory for host/container runtime selection
- remove AnglesiteContainer import and runtime selection policy from PreviewModel
- inject the live factory from app/window bootstrap while preserving direct runtime injection for tests

## Verification
- xcodegen generate
- xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
- xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMAS -configuration Debug build

Fixes #432