### PR TITLE
Extract site assistant session wiring

### DIFF
--- a/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
+++ b/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
@@ -1,0 +1,150 @@
+import Foundation
+import AnglesiteCore
+
+/// The per-site assistant/edit bundle that `SiteWindow` installs into the preview session.
+@MainActor
+struct SiteAssistantSession {
+    let chat: ChatModel
+    let editObserver: MCPApplyEditRouter.EditObserver
+    let editPostProcessor: MCPApplyEditRouter.PostProcessor?
+}
+
+/// Builds the cross-cutting assistant surface for one open site: chat, annotations, undo,
+/// edit-recording, and best-effort alt-text post-processing.
+@MainActor
+enum SiteAssistantSessionFactory {
+    typealias MCPClientProvider = @Sendable () async -> MCPClient?
+    typealias EditRouterProvider = @Sendable (_ siteID: String) async -> (any EditRouter)?
+    typealias AssistantBuilder = @Sendable (
+        _ editBridge: IntentEditBridge,
+        _ contentGraph: SiteContentGraph,
+        _ knowledgeIndex: SiteKnowledgeIndex,
+        _ semanticRanker: SemanticRanker?,
+        _ integrationService: any IntegrationOperationsService
+    ) -> any ConversationalAssistant
+
+    struct Dependencies {
+        var annotationFeed: @Sendable (_ sourceDirectory: URL) -> AnnotationFeed
+        var resolveAnnotation: @Sendable (_ sourceDirectory: URL, _ id: String) async throws -> Void
+        var undoCommand: @Sendable (_ mcpClient: @escaping MCPClientProvider) -> UndoCommand
+        var editRouterProvider: EditRouterProvider
+        var assistant: AssistantBuilder
+        var altTextGenerator: @Sendable (
+            _ siteID: String,
+            _ sourceDirectory: URL,
+            _ mcpClient: @escaping MCPClientProvider
+        ) -> AltTextGenerator
+
+        static let live: Dependencies = {
+            let annotationFeed: @Sendable (URL) -> AnnotationFeed = { sourceDirectory in
+                AnnotationFeedFactory.native(directory: sourceDirectory)
+            }
+            let resolveAnnotation: @Sendable (URL, String) async throws -> Void = { sourceDirectory, id in
+                try AnnotationStore.resolve(in: sourceDirectory, id: id)
+            }
+            let undoCommand: @Sendable (@escaping MCPClientProvider) -> UndoCommand = { mcpClient in
+                UndoCommand(mcpClient: mcpClient)
+            }
+            let editRouterProvider: EditRouterProvider = { siteID in
+                await EditRouterRegistry.shared.router(for: siteID)
+            }
+            let assistant: AssistantBuilder = { editBridge, contentGraph, knowledgeIndex, semanticRanker, integrationService in
+                KnowledgeAugmentedAssistant(
+                    base: FoundationModelAssistant(
+                        tier: .onDevice,
+                        editBridge: editBridge,
+                        contentGraph: contentGraph,
+                        knowledgeIndex: knowledgeIndex,
+                        semanticRanker: semanticRanker,
+                        integrationService: integrationService
+                    ),
+                    index: knowledgeIndex
+                )
+            }
+            return Dependencies(
+                annotationFeed: annotationFeed,
+                resolveAnnotation: resolveAnnotation,
+                undoCommand: undoCommand,
+                editRouterProvider: editRouterProvider,
+                assistant: assistant,
+                altTextGenerator: { siteID, sourceDirectory, mcpClient in
+                    AltTextGenerator(
+                        siteID: siteID,
+                        siteDirectory: sourceDirectory,
+                        isEnabled: { AppSettings.shared.autoGenerateAltText },
+                        produce: { imageURL, context in
+                            try await FoundationModelAssistant(tier: .onDevice).generateStructured(
+                                prompt: "Generate concise, descriptive alt text for this image as it would appear on a website. If the image is purely decorative, mark it decorative and use empty alt text.",
+                                imageURL: imageURL,
+                                context: context,
+                                resultType: GeneratedAltText.self
+                            )
+                        },
+                        apply: { edit in
+                            let reply = await MCPApplyEditRouter(mcpClient: mcpClient).apply(edit)
+                            if reply.status == .failed {
+                                await LogCenter.shared.append(
+                                    source: "alt-text:\(siteID)", stream: .stderr,
+                                    text: "applying generated alt text failed: \(reply.message ?? "unknown error")"
+                                )
+                            }
+                        },
+                        log: { message in
+                            await LogCenter.shared.append(
+                                source: "alt-text:\(siteID)", stream: .stderr, text: message)
+                        }
+                    )
+                }
+            )
+        }()
+    }
+
+    static func makeSession(
+        siteID: String,
+        sourceDirectory: URL,
+        configDirectory: URL,
+        mcpClient: @escaping MCPClientProvider,
+        contentGraph: SiteContentGraph,
+        knowledgeIndex: SiteKnowledgeIndex,
+        semanticRanker: SemanticRanker?,
+        integrationService: any IntegrationOperationsService,
+        dependencies: Dependencies = .live
+    ) -> SiteAssistantSession {
+        let editBridge = IntentEditBridge(routerProvider: dependencies.editRouterProvider)
+        let chat = ChatModel(
+            siteID: siteID,
+            siteDirectory: sourceDirectory,
+            configDirectory: configDirectory,
+            assistant: dependencies.assistant(
+                editBridge,
+                contentGraph,
+                knowledgeIndex,
+                semanticRanker,
+                integrationService
+            ),
+            annotationFeed: dependencies.annotationFeed(sourceDirectory),
+            annotationResolver: { [resolveAnnotation = dependencies.resolveAnnotation] id in
+                try await resolveAnnotation(sourceDirectory, id)
+            },
+            undoCommand: dependencies.undoCommand(mcpClient)
+        )
+
+        let altTextGenerator = dependencies.altTextGenerator(siteID, sourceDirectory, mcpClient)
+        let postProcessor: MCPApplyEditRouter.PostProcessor? = { reply, message in
+            await altTextGenerator.postProcess(reply: reply, message: message)
+        }
+
+        return SiteAssistantSession(
+            chat: chat,
+            // The router may retain this observer for the preview lifetime. Capture weakly to avoid
+            // a PreviewModel -> editRouter -> observer -> ChatModel cycle; SiteWindow stores the
+            // returned chat model immediately, so normal window ownership still keeps it alive.
+            editObserver: { [weak chat] reply in
+                Task { @MainActor in
+                    chat?.recordEdit(reply)
+                }
+            },
+            editPostProcessor: postProcessor
+        )
+    }
+}

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -735,13 +735,6 @@ struct SiteWindow: View {
 
     // MARK: - Lifecycle
 
-    /// Per-site edit bridge for the on-device assistant's `ApplyEditTool` (#193). Resolves the live
-    /// router from `EditRouterRegistry` lazily per call, so `setEditObserver`'s re-registration is
-    /// always visible — mirroring `AnglesiteIntents.bootstrap`.
-    private func makeEditBridge() -> IntentEditBridge {
-        IntentEditBridge(routerProvider: { id in await EditRouterRegistry.shared.router(for: id) })
-    }
-
     /// React to registry changes for this window's site (#188, #266). Subscribes to the store's
     /// broadcast only after `site` is resolved. On the first snapshot that no longer contains this
     /// site's id — an explicit `remove(id:)` from the launcher, or a `refresh()` that prunes a stale
@@ -1033,84 +1026,24 @@ struct SiteWindow: View {
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
         applyPendingNavigation(for: resolved.id)
-        // The annotation feed, undo command, and edit observer feed the chat panel. They're all
-        // MCP-based (the edit overlay applies edits via MCP on both targets), so they're wired the
-        // same way regardless of which assistant backs the chat.
         let mcpClient: @Sendable () async -> MCPClient? = { [preview] in
             await preview.mcpClient()
         }
-        // Annotations are read/resolved by the native `AnnotationStore` over
-        // `Source/annotations.json` (#275) — no MCP hop. `undo_edit` stays MCP-backed (Bucket 2).
-        let sourceDirectory = resolved.sourceDirectory
-        let feed = AnnotationFeedFactory.native(directory: sourceDirectory)
-        let undoCommand = UndoCommand(mcpClient: mcpClient)
-        // Resolve directly against the on-disk store — `AnnotationStore.resolve` throws if the id
-        // is unknown, surfacing as a chat error the same way the MCP path did.
-        let annotationResolver: ChatModel.AnnotationResolver = { id in
-            try AnnotationStore.resolve(in: sourceDirectory, id: id)
-        }
-        // Chat is backed by the on-device `FoundationModelAssistant` (#159).
-        // The per-site `editBridge` + app-lifetime `contentGraph` attach `ApplyEditTool` +
-        // `SearchContentTool`, so the on-device path advertises `supportsTools` and runs a local
-        // agentic loop with no network (#193).
-        chat = ChatModel(
+        let assistantSession = SiteAssistantSessionFactory.makeSession(
             siteID: resolved.id,
-            siteDirectory: resolved.sourceDirectory,
+            sourceDirectory: resolved.sourceDirectory,
             configDirectory: resolved.configDirectory,
-            assistant: KnowledgeAugmentedAssistant(
-                base: FoundationModelAssistant(
-                    tier: .onDevice,
-                    editBridge: makeEditBridge(),
-                    contentGraph: contentGraph,
-                    knowledgeIndex: knowledgeIndex,
-                    semanticRanker: semanticRanker,
-                    integrationService: integrationOps
-                ),
-                index: knowledgeIndex
-            ),
-            annotationFeed: feed,
-            annotationResolver: annotationResolver,
-            undoCommand: undoCommand
+            mcpClient: mcpClient,
+            contentGraph: contentGraph,
+            knowledgeIndex: knowledgeIndex,
+            semanticRanker: semanticRanker,
+            integrationService: integrationOps
         )
-        // Auto alt-text (C.7 / #157): after a successful image drop, generate alt text on-device and
-        // apply it to the `<img>`. Target-agnostic — the on-device vision model runs on both builds.
-        // The follow-up edit routes through its own (post-process-free) apply_edit router so it can't
-        // recurse. Best-effort and opt-out via Settings.
-        let altTextGenerator = AltTextGenerator(
-            siteID: resolved.id,
-            siteDirectory: resolved.sourceDirectory,
-            isEnabled: { AppSettings.shared.autoGenerateAltText },
-            produce: { imageURL, context in
-                try await FoundationModelAssistant(tier: .onDevice).generateStructured(
-                    prompt: "Generate concise, descriptive alt text for this image as it would appear on a website. If the image is purely decorative, mark it decorative and use empty alt text.",
-                    imageURL: imageURL,
-                    context: context,
-                    resultType: GeneratedAltText.self
-                )
-            },
-            apply: { edit in
-                // Surface a failed apply (MCP down, plugin error) — otherwise the drop would succeed
-                // with no alt text and nothing in the debug pane explaining why. Generation failures
-                // are handled separately via `log`.
-                let reply = await MCPApplyEditRouter(mcpClient: mcpClient).apply(edit)
-                if reply.status == .failed {
-                    await LogCenter.shared.append(
-                        source: "alt-text:\(resolved.id)", stream: .stderr,
-                        text: "applying generated alt text failed: \(reply.message ?? "unknown error")"
-                    )
-                }
-            },
-            log: { message in
-                Task { await LogCenter.shared.append(source: "alt-text:\(resolved.id)", stream: .stderr, text: message) }
-            }
+        chat = assistantSession.chat
+        preview.setEditObserver(
+            assistantSession.editObserver,
+            postProcess: assistantSession.editPostProcessor
         )
-        preview.setEditObserver({ [weak chat] reply in
-            Task { @MainActor in
-                chat?.recordEdit(reply)
-            }
-        }, postProcess: { reply, message in
-            await altTextGenerator.postProcess(reply: reply, message: message)
-        })
         deploy.onScanComplete = { [health] outcome in
             health.ingestDeployOutcome(outcome)
         }

--- a/Sources/AnglesiteCore/AltTextGenerator.swift
+++ b/Sources/AnglesiteCore/AltTextGenerator.swift
@@ -29,7 +29,7 @@ public struct AltTextGenerator: Sendable {
     private let isEnabled: @Sendable () -> Bool
     private let produce: Producer
     private let apply: Applier
-    private let log: @Sendable (String) -> Void
+    private let log: @Sendable (String) async -> Void
 
     public init(
         siteID: String,
@@ -37,7 +37,7 @@ public struct AltTextGenerator: Sendable {
         isEnabled: @escaping @Sendable () -> Bool,
         produce: @escaping Producer,
         apply: @escaping Applier,
-        log: @escaping @Sendable (String) -> Void = { _ in }
+        log: @escaping @Sendable (String) async -> Void = { _ in }
     ) {
         self.siteID = siteID
         self.siteDirectory = siteDirectory
@@ -66,7 +66,7 @@ public struct AltTextGenerator: Sendable {
         do {
             alt = try await produce(imageFileURL(forSrc: src), context)
         } catch {
-            log("alt-text generation failed for \(src): \(error)")
+            await log("alt-text generation failed for \(src): \(error)")
             return
         }
 


### PR DESCRIPTION
## Summary
- Add SiteAssistantSessionFactory to build per-site chat, annotation, undo, edit observer, and alt-text wiring
- Reduce SiteWindow.loadAndStart() to installing the returned assistant session
- Preserve existing annotation, undo, edit-recording, and alt-text behavior behind injectable dependencies

Fixes #433

## Verification
- xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build

Note: this worktree did not have the sibling plugin checkout available, so I created the ignored Resources/plugin/ directory for Xcode resource-copy verification; the real plugin was not bundled during the local build.