### PR TITLE
Factor editable-file conflict lifecycle

### DIFF
--- a/Sources/AnglesiteApp/FileEditorModel.swift
+++ b/Sources/AnglesiteApp/FileEditorModel.swift
@@ -15,13 +15,17 @@ import AnglesiteCore
 final class FileEditorModel {
     let file: FileRef
     var text: String = ""
-    private(set) var savedText: String = ""
-    private(set) var lastModified: Date?
+    private var fileSession = EditableFileSession()
+    var savedText: String { fileSession.savedContents }
+    var lastModified: Date? { fileSession.lastModified }
     private(set) var loadError: String?
     private(set) var isLoading = false
     /// Non-nil ⟺ the on-disk file changed under a dirty buffer and the user must choose
     /// Keep/Reload. Drives the conflict alert in `MainPaneEditorView`.
-    var conflictDiskContents: String?
+    var conflictDiskContents: String? {
+        get { fileSession.conflictDiskContents }
+        set { fileSession.conflictDiskContents = newValue }
+    }
 
     /// True only when there are unsaved edits AND the file loaded cleanly and isn't mid-load. The
     /// `loadError == nil` term means an errored file is never "dirty", so callers (e.g. the Save
@@ -38,12 +42,7 @@ final class FileEditorModel {
         defer { isLoading = false }
         let url = file.url
         do {
-            let loaded = try await Task.detached(priority: .userInitiated) {
-                try FileDocumentIO.load(url)
-            }.value
-            text = loaded.contents
-            savedText = loaded.contents
-            lastModified = loaded.modificationDate
+            text = try await fileSession.load(from: url)
             loadError = nil
             warnIfNoModificationDate(after: "load")
         } catch {
@@ -58,11 +57,7 @@ final class FileEditorModel {
         let url = file.url
         let contents = text
         do {
-            let mtime = try await Task.detached(priority: .userInitiated) {
-                try FileDocumentIO.save(contents, to: url)
-            }.value
-            lastModified = mtime
-            savedText = contents
+            try await fileSession.save(contents, to: url)
             warnIfNoModificationDate(after: "save")
             return true
         } catch {
@@ -76,13 +71,7 @@ final class FileEditorModel {
     /// rather than clobbering the other tool's edit. Returns true when it is safe to leave.
     func flushBeforeLeaving() async -> Bool {
         guard isDirty else { return true }
-        let url = file.url
-        let known = lastModified
-        let change = try? await Task.detached(priority: .userInitiated) {
-            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: true)
-        }.value
-        if case .conflict(let disk)? = change {
-            conflictDiskContents = disk
+        guard await fileSession.canFlushBeforeLeaving(file: file.url, bufferIsDirty: true) else {
             return false
         }
         return await save()
@@ -91,39 +80,24 @@ final class FileEditorModel {
     /// Re-check the file when the window regains focus — chat/overlay/CLI may have written it.
     func checkExternalChange() async {
         guard loadError == nil else { return }
-        let url = file.url
-        let known = lastModified
         let dirty = isDirty
-        let change = try? await Task.detached(priority: .userInitiated) {
-            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
-        }.value
+        let change = await fileSession.externalChange(at: file.url, bufferIsDirty: dirty)
         guard let change else { return }
         switch change {
         case .none:
             break
         case .reloadable(let disk):
-            text = disk; savedText = disk
-            lastModified = await freshModificationDate()
+            text = disk
         case .conflict(let disk):
             conflictDiskContents = disk
         }
     }
 
-    func keepMyChanges() { conflictDiskContents = nil }
+    func keepMyChanges() { fileSession.keepMyChanges() }
 
     func reloadFromDisk() async {
-        guard let disk = conflictDiskContents else { return }
+        guard let disk = await fileSession.reloadFromConflict(file: file.url) else { return }
         text = disk
-        savedText = disk
-        lastModified = await freshModificationDate()
-        conflictDiskContents = nil
-    }
-
-    private func freshModificationDate() async -> Date? {
-        let url = file.url
-        return try? await Task.detached(priority: .userInitiated) {
-            try FileDocumentIO.load(url).modificationDate
-        }.value
     }
 
     /// Surface (in the debug pane) when a file has no modification date after a successful load/save:
@@ -135,7 +109,7 @@ final class FileEditorModel {
         Task {
             await LogCenter.shared.append(
                 source: "editor", stream: .stderr,
-                text: "No modification date for \(path) after \(op); external-change detection is disabled for this file."
+                text: EditableFileSession.missingModificationDateWarning(after: op, path: path)
             )
         }
     }

--- a/Sources/AnglesiteApp/PageMetadataModel.swift
+++ b/Sources/AnglesiteApp/PageMetadataModel.swift
@@ -16,13 +16,16 @@ final class PageMetadataModel: InspectorEditorModel {
 
     var metadata = PageMetadata(title: "", description: "")
     private var savedMetadata = PageMetadata(title: "", description: "")
-    private var contents = ""
-    private var lastModified: Date?
+    private var fileSession = EditableFileSession()
+    private var contents: String { fileSession.savedContents }
     /// Guards against a concurrent second `save()` capturing a stale `contents` base.
     private var isSaving = false
     private(set) var loadError: String?
     private(set) var isLoading = false
-    var conflictDiskContents: String?
+    var conflictDiskContents: String? {
+        get { fileSession.conflictDiskContents }
+        set { fileSession.conflictDiskContents = newValue }
+    }
 
     var isDirty: Bool { metadata != savedMetadata && loadError == nil && !isLoading }
 
@@ -39,10 +42,9 @@ final class PageMetadataModel: InspectorEditorModel {
         defer { isLoading = false }
         let url = file.url
         do {
-            let loaded = try await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url) }.value
-            adopt(loaded.contents)
-            lastModified = loaded.modificationDate
+            adopt(try await fileSession.load(from: url))
             loadError = nil
+            warnIfNoModificationDate(after: "load")
         } catch {
             loadError = error.localizedDescription
         }
@@ -56,12 +58,9 @@ final class PageMetadataModel: InspectorEditorModel {
         let newContents = PageMetadataEditor.write(metadata, into: contents)
         let url = file.url
         do {
-            let mtime = try await Task.detached(priority: .userInitiated) {
-                try FileDocumentIO.save(newContents, to: url)
-            }.value
-            lastModified = mtime
-            contents = newContents
+            try await fileSession.save(newContents, to: url)
             savedMetadata = metadata
+            warnIfNoModificationDate(after: "save")
             await commit()
             return true
         } catch {
@@ -72,26 +71,17 @@ final class PageMetadataModel: InspectorEditorModel {
 
     func flushBeforeLeaving() async -> Bool {
         guard isDirty else { return true }
-        let url = file.url
-        let known = lastModified
-        let change = try? await Task.detached(priority: .userInitiated) {
-            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: true)
-        }.value
-        if case .conflict(let disk)? = change { conflictDiskContents = disk; return false }
+        guard await fileSession.canFlushBeforeLeaving(file: file.url, bufferIsDirty: true) else { return false }
         return await save()
     }
 
     func checkExternalChange() async {
         guard loadError == nil else { return }
-        let url = file.url
-        let known = lastModified
         let dirty = isDirty
-        let change = try? await Task.detached(priority: .userInitiated) {
-            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
-        }.value
+        let change = await fileSession.externalChange(at: file.url, bufferIsDirty: dirty)
         switch change {
         case .some(.reloadable(let disk)):
-            adopt(disk); lastModified = await freshModificationDate()
+            adopt(disk)
         case .some(.conflict(let disk)):
             conflictDiskContents = disk
         case .some(.none), nil:
@@ -99,13 +89,11 @@ final class PageMetadataModel: InspectorEditorModel {
         }
     }
 
-    func keepMyChanges() { conflictDiskContents = nil }
+    func keepMyChanges() { fileSession.keepMyChanges() }
 
     func reloadFromDisk() async {
-        guard let disk = conflictDiskContents else { return }
+        guard let disk = await fileSession.reloadFromConflict(file: file.url) else { return }
         adopt(disk)
-        lastModified = await freshModificationDate()
-        conflictDiskContents = nil
     }
 
     // `[weak self]` — see the note in TypedEntryEditorModel: view-lifetime bindings on a model that
@@ -120,10 +108,20 @@ final class PageMetadataModel: InspectorEditorModel {
     }
 
     private func adopt(_ text: String) {
-        contents = text
         let read = PageMetadataEditor.read(text)
         metadata = read
         savedMetadata = read
+    }
+
+    private func warnIfNoModificationDate(after op: String) {
+        guard fileSession.lastModified == nil else { return }
+        let path = file.url.path(percentEncoded: false)
+        Task {
+            await LogCenter.shared.append(
+                source: "editor", stream: .stderr,
+                text: EditableFileSession.missingModificationDateWarning(after: op, path: path)
+            )
+        }
     }
 
     private func commit() async {
@@ -139,8 +137,4 @@ final class PageMetadataModel: InspectorEditorModel {
         return url.lastPathComponent
     }
 
-    private func freshModificationDate() async -> Date? {
-        let url = file.url
-        return try? await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url).modificationDate }.value
-    }
 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -654,9 +654,7 @@ struct SiteWindow: View {
     private func persistEditorBufferBestEffort() {
         switch activeEditor {
         case .text(let model) where model.isDirty:
-            let url = model.file.url
-            let contents = model.text
-            Task.detached(priority: .userInitiated) { try? FileDocumentIO.save(contents, to: url) }
+            EditableFileSession.saveBestEffort(model.text, to: model.file.url)
         case .plist(let model):
             if model.isDirty, model.validationMessage == nil {
                 let url = model.file.url

--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -19,15 +19,18 @@ final class TypedEntryEditorModel: InspectorEditorModel {
 
     var values: TypedContentEditor.Values = .init()
     private var savedValues: TypedContentEditor.Values = .init()
-    private var contents: String = ""               // last-loaded/saved file text (verbatim base)
-    private var lastModified: Date?
+    private var fileSession = EditableFileSession()
+    private var contents: String { fileSession.savedContents } // last-loaded/saved file text (verbatim base)
     private var numberDrafts: [String: String] = [:]
     /// Guards against a concurrent second `save()` capturing a stale `contents` base while an
     /// earlier save is still in flight (e.g. ⌘S mash, or a teardown flush racing a save).
     private var isSaving = false
     private(set) var loadError: String?
     private(set) var isLoading = false
-    var conflictDiskContents: String?
+    var conflictDiskContents: String? {
+        get { fileSession.conflictDiskContents }
+        set { fileSession.conflictDiskContents = newValue }
+    }
 
     var isDirty: Bool { values != savedValues && loadError == nil && !isLoading }
 
@@ -46,9 +49,7 @@ final class TypedEntryEditorModel: InspectorEditorModel {
         defer { isLoading = false }
         let url = file.url
         do {
-            let loaded = try await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url) }.value
-            adopt(loaded.contents)
-            lastModified = loaded.modificationDate
+            adopt(try await fileSession.load(from: url))
             loadError = nil
             warnIfNoModificationDate(after: "load")
         } catch {
@@ -67,11 +68,7 @@ final class TypedEntryEditorModel: InspectorEditorModel {
         let newContents = TypedContentEditor.write(edited, into: base, descriptor: descriptor)
         let url = file.url
         do {
-            let mtime = try await Task.detached(priority: .userInitiated) {
-                try FileDocumentIO.save(newContents, to: url)
-            }.value
-            lastModified = mtime
-            contents = newContents
+            try await fileSession.save(newContents, to: url)
             savedValues = edited
             warnIfNoModificationDate(after: "save")
             await commit()
@@ -84,41 +81,30 @@ final class TypedEntryEditorModel: InspectorEditorModel {
 
     func flushBeforeLeaving() async -> Bool {
         guard isDirty else { return true }
-        let url = file.url
-        let known = lastModified
-        let change = try? await Task.detached(priority: .userInitiated) {
-            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: true)
-        }.value
-        if case .conflict(let disk)? = change { conflictDiskContents = disk; return false }
+        guard await fileSession.canFlushBeforeLeaving(file: file.url, bufferIsDirty: true) else { return false }
         return await save()
     }
 
     func checkExternalChange() async {
         guard loadError == nil else { return }
-        let url = file.url
-        let known = lastModified
         let dirty = isDirty
-        let change = try? await Task.detached(priority: .userInitiated) {
-            try FileDocumentIO.externalChange(at: url, lastKnownModificationDate: known, bufferIsDirty: dirty)
-        }.value
+        let change = await fileSession.externalChange(at: file.url, bufferIsDirty: dirty)
         guard let change else { return }
         switch change {
         case .none:
             break
         case .reloadable(let disk):
-            adopt(disk); lastModified = await freshModificationDate()
+            adopt(disk)
         case .conflict(let disk):
             conflictDiskContents = disk
         }
     }
 
-    func keepMyChanges() { conflictDiskContents = nil }
+    func keepMyChanges() { fileSession.keepMyChanges() }
 
     func reloadFromDisk() async {
-        guard let disk = conflictDiskContents else { return }
+        guard let disk = await fileSession.reloadFromConflict(file: file.url) else { return }
         adopt(disk)
-        lastModified = await freshModificationDate()
-        conflictDiskContents = nil
     }
 
     // MARK: Bindings used by the view
@@ -168,7 +154,6 @@ final class TypedEntryEditorModel: InspectorEditorModel {
     // MARK: Private
 
     private func adopt(_ text: String) {
-        contents = text
         let read = TypedContentEditor.read(text, descriptor: descriptor)
         values = read
         savedValues = read
@@ -186,12 +171,12 @@ final class TypedEntryEditorModel: InspectorEditorModel {
     /// `FileDocumentIO.externalChange` keys on mtime, so a `nil` here silently disables external-change
     /// detection for this file. "Logs are sacred" — make it visible rather than failing quietly.
     private func warnIfNoModificationDate(after op: String) {
-        guard lastModified == nil else { return }
+        guard fileSession.lastModified == nil else { return }
         let path = file.url.path(percentEncoded: false)
         Task {
             await LogCenter.shared.append(
                 source: "editor", stream: .stderr,
-                text: "No modification date for \(path) after \(op); external-change detection is disabled for this file."
+                text: EditableFileSession.missingModificationDateWarning(after: op, path: path)
             )
         }
     }
@@ -209,8 +194,4 @@ final class TypedEntryEditorModel: InspectorEditorModel {
         return url.lastPathComponent
     }
 
-    private func freshModificationDate() async -> Date? {
-        let url = file.url
-        return try? await Task.detached(priority: .userInitiated) { try FileDocumentIO.load(url).modificationDate }.value
-    }
 }

--- a/Sources/AnglesiteCore/EditableFileSession.swift
+++ b/Sources/AnglesiteCore/EditableFileSession.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Shared lifecycle state for text-backed app editors.
+///
+/// The app models own domain-specific parsing, validation, bindings, and commit messages. This
+/// session owns the raw file mechanics they share: off-main load/save, saved contents, modification
+/// date tracking, external-change decisions, conflict retention, and keep/reload resolution.
+public struct EditableFileSession: Sendable, Equatable {
+    public private(set) var savedContents: String
+    public private(set) var lastModified: Date?
+    public var conflictDiskContents: String?
+
+    public init(savedContents: String = "", lastModified: Date? = nil, conflictDiskContents: String? = nil) {
+        self.savedContents = savedContents
+        self.lastModified = lastModified
+        self.conflictDiskContents = conflictDiskContents
+    }
+
+    @discardableResult
+    public mutating func load(from url: URL) async throws -> String {
+        let loaded = try await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.load(url)
+        }.value
+        savedContents = loaded.contents
+        lastModified = loaded.modificationDate
+        conflictDiskContents = nil
+        return loaded.contents
+    }
+
+    public mutating func save(_ contents: String, to url: URL) async throws {
+        let mtime = try await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.save(contents, to: url)
+        }.value
+        savedContents = contents
+        lastModified = mtime
+        conflictDiskContents = nil
+    }
+
+    public mutating func externalChange(at url: URL, bufferIsDirty: Bool) async -> FileDocumentIO.ExternalChange? {
+        let known = lastModified
+        let change = try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.externalChange(
+                at: url,
+                lastKnownModificationDate: known,
+                bufferIsDirty: bufferIsDirty
+            )
+        }.value
+        guard let change else { return nil }
+
+        switch change {
+        case .none:
+            break
+        case .reloadable(let disk):
+            savedContents = disk
+            lastModified = await freshModificationDate(for: url)
+            conflictDiskContents = nil
+        case .conflict(let disk):
+            conflictDiskContents = disk
+        }
+        return change
+    }
+
+    public mutating func canFlushBeforeLeaving(file url: URL, bufferIsDirty: Bool) async -> Bool {
+        guard bufferIsDirty else { return true }
+        let change = await externalChange(at: url, bufferIsDirty: true)
+        if case .conflict = change {
+            return false
+        }
+        return true
+    }
+
+    public mutating func keepMyChanges() {
+        conflictDiskContents = nil
+    }
+
+    public mutating func reloadFromConflict(file url: URL) async -> String? {
+        guard let disk = conflictDiskContents else { return nil }
+        savedContents = disk
+        lastModified = await freshModificationDate(for: url)
+        conflictDiskContents = nil
+        return disk
+    }
+
+    public static func missingModificationDateWarning(after operation: String, path: String) -> String {
+        "No modification date for \(path) after \(operation); external-change detection is disabled for this file."
+    }
+
+    public static func saveBestEffort(_ contents: String, to url: URL) {
+        Task.detached(priority: .userInitiated) {
+            try? FileDocumentIO.save(contents, to: url)
+        }
+    }
+
+    private func freshModificationDate(for url: URL) async -> Date? {
+        try? await Task.detached(priority: .userInitiated) {
+            try FileDocumentIO.load(url).modificationDate
+        }.value
+    }
+}

--- a/Tests/AnglesiteCoreTests/EditableFileSessionTests.swift
+++ b/Tests/AnglesiteCoreTests/EditableFileSessionTests.swift
@@ -1,0 +1,154 @@
+import Testing
+import Foundation
+import Observation
+@testable import AnglesiteCore
+
+private final class ObservationInvalidationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var invalidated = false
+
+    var value: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return invalidated
+    }
+
+    func markInvalidated() {
+        lock.lock()
+        invalidated = true
+        lock.unlock()
+    }
+}
+
+@MainActor
+@Observable
+private final class SessionBackedObservationProbe {
+    var text = "saved"
+    private var session = EditableFileSession(savedContents: "saved")
+
+    var savedText: String { session.savedContents }
+    var conflictDiskContents: String? {
+        get { session.conflictDiskContents }
+        set { session.conflictDiskContents = newValue }
+    }
+    var isDirty: Bool { text != savedText }
+
+    func adoptSavedText(_ text: String) {
+        session = EditableFileSession(savedContents: text)
+    }
+}
+
+struct EditableFileSessionTests {
+    private func tempFile(_ contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("editable-session-\(UUID().uuidString).txt")
+        try Data(contents.utf8).write(to: url)
+        return url
+    }
+
+    private func writeExternally(_ contents: String, to url: URL, after date: Date?) throws {
+        let newer = (date ?? Date()).addingTimeInterval(2)
+        try Data(contents.utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: newer], ofItemAtPath: url.path)
+    }
+
+    @Test("clean save updates saved contents and clears conflicts")
+    func cleanSaveUpdatesSavedState() async throws {
+        let url = try tempFile("old")
+        defer { try? FileManager.default.removeItem(at: url) }
+        var session = EditableFileSession()
+
+        let loaded = try await session.load(from: url)
+        #expect(loaded == "old")
+        session.conflictDiskContents = "other"
+
+        try await session.save("new", to: url)
+
+        #expect(try String(contentsOf: url, encoding: .utf8) == "new")
+        #expect(session.savedContents == "new")
+        #expect(session.lastModified != nil)
+        #expect(session.conflictDiskContents == nil)
+    }
+
+    @Test("clean external write is reloadable and updates saved contents")
+    func reloadableExternalChangeUpdatesSavedState() async throws {
+        let url = try tempFile("a")
+        defer { try? FileManager.default.removeItem(at: url) }
+        var session = EditableFileSession()
+        _ = try await session.load(from: url)
+
+        try writeExternally("b", to: url, after: session.lastModified)
+        let change = await session.externalChange(at: url, bufferIsDirty: false)
+
+        #expect(change == .reloadable("b"))
+        #expect(session.savedContents == "b")
+        #expect(session.conflictDiskContents == nil)
+    }
+
+    @Test("dirty external write records a conflict without replacing saved contents")
+    func dirtyExternalChangeRecordsConflict() async throws {
+        let url = try tempFile("a")
+        defer { try? FileManager.default.removeItem(at: url) }
+        var session = EditableFileSession()
+        _ = try await session.load(from: url)
+
+        try writeExternally("b", to: url, after: session.lastModified)
+        let change = await session.externalChange(at: url, bufferIsDirty: true)
+
+        #expect(change == .conflict("b"))
+        #expect(session.savedContents == "a")
+        #expect(session.conflictDiskContents == "b")
+    }
+
+    @Test("keep and reload resolve dirty conflicts explicitly")
+    func keepAndReloadResolveConflicts() async throws {
+        let url = try tempFile("a")
+        defer { try? FileManager.default.removeItem(at: url) }
+        var session = EditableFileSession()
+        _ = try await session.load(from: url)
+
+        try writeExternally("b", to: url, after: session.lastModified)
+        #expect(await session.canFlushBeforeLeaving(file: url, bufferIsDirty: true) == false)
+        #expect(session.conflictDiskContents == "b")
+
+        session.keepMyChanges()
+        #expect(session.conflictDiskContents == nil)
+        #expect(session.savedContents == "a")
+
+        _ = await session.externalChange(at: url, bufferIsDirty: true)
+        let reloaded = await session.reloadFromConflict(file: url)
+
+        #expect(reloaded == "b")
+        #expect(session.savedContents == "b")
+        #expect(session.conflictDiskContents == nil)
+    }
+
+    @MainActor
+    @Test("session-backed computed properties invalidate Observation tracking")
+    func sessionBackedComputedPropertiesInvalidateObservationTracking() {
+        let model = SessionBackedObservationProbe()
+        let conflictInvalidated = ObservationInvalidationFlag()
+        withObservationTracking {
+            _ = model.conflictDiskContents
+        } onChange: {
+            conflictInvalidated.markInvalidated()
+        }
+
+        model.conflictDiskContents = "disk"
+
+        #expect(conflictInvalidated.value)
+        #expect(model.conflictDiskContents == "disk")
+
+        let dirtyInvalidated = ObservationInvalidationFlag()
+        withObservationTracking {
+            _ = model.isDirty
+        } onChange: {
+            dirtyInvalidated.markInvalidated()
+        }
+
+        model.adoptSavedText("new saved")
+
+        #expect(dirtyInvalidated.value)
+        #expect(model.isDirty)
+    }
+}


### PR DESCRIPTION
## Summary
- add EditableFileSession to share raw text load/save, mtime tracking, external-change detection, conflict state, keep/reload, and best-effort teardown saves
- route text, page metadata, and typed entry editor models through the shared session while preserving their parsing and commit behavior
- add focused tests for clean save, reloadable external changes, dirty conflicts, and keep/reload resolution

Fixes #435

## Tests
- swift test --package-path . --filter EditableFileSessionTests
- xcodegen generate
- xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug -destination generic/platform=macOS -derivedDataPath .DerivedData build (reached app resource/link stages; failed because Resources/plugin could not be populated in this worktree, with no sibling plugin checkout available)