### PR TITLE
Fix #436: centralize content creation workflow

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -49,6 +49,7 @@ struct SiteWindow: View {
     private let contentIndexerStore: ContentIndexerStore
 
     private let integrationOps = IntegrationOperations.live()
+    private let contentCreation: ContentCreationWorkflow
     private let contentTypeRegistry = ContentTypeRegistry()
 
     init(
@@ -64,6 +65,11 @@ struct SiteWindow: View {
         self.knowledgeIndex = knowledgeIndex
         self.semanticRanker = semanticRanker
         self.contentIndexerStore = contentIndexerStore
+        self.contentCreation = ContentCreationWorkflow.native(
+            contentGraph: contentGraph,
+            knowledgeIndex: knowledgeIndex,
+            siteDirectory: { id in await SiteStore.shared.find(id: id)?.sourceDirectory }
+        )
         _preview = State(initialValue: PreviewModel(
             contentGraph: contentGraph,
             knowledgeIndex: knowledgeIndex,
@@ -913,17 +919,12 @@ struct SiteWindow: View {
         template: ContentScaffold.PageTemplate
     ) async -> ContentCreateResult {
         guard let site else { return .siteNotFound }
-        let ops = NativeContentOperations(siteDirectory: { id in
-            await SiteStore.shared.find(id: id)?.sourceDirectory
-        })
-        let result = await ops.createPage(
+        return await contentCreation.createPage(
             siteID: site.id,
-            name: title,
+            title: title,
             route: route,
             template: template
         )
-        await refreshContentGraphIfCreated(result, site: site)
-        return result
     }
 
     private func createCollectionEntry(
@@ -932,37 +933,11 @@ struct SiteWindow: View {
         descriptor: ContentTypeDescriptor
     ) async -> ContentCreateResult {
         guard let site else { return .siteNotFound }
-        let ops = NativeContentOperations(siteDirectory: { id in
-            await SiteStore.shared.find(id: id)?.sourceDirectory
-        })
-        let result = await ops.createTyped(
+        return await contentCreation.createTyped(
             siteID: site.id,
             typeID: descriptor.id,
             title: title,
             slug: slug
-        )
-        await refreshContentGraphIfCreated(result, site: site)
-        return result
-    }
-
-    private func refreshContentGraphIfCreated(
-        _ result: ContentCreateResult,
-        site: SiteStore.Site
-    ) async {
-        guard case let .created(filePath, _) = result else { return }
-        let listing = await Task.detached(priority: .userInitiated) {
-            ContentScanner.scan(projectRoot: site.sourceDirectory, siteID: site.id)
-        }.value
-        await contentGraph.load(
-            siteID: site.id,
-            pages: listing.pages,
-            posts: listing.posts,
-            images: listing.images
-        )
-        await knowledgeIndex.upsertFile(
-            siteID: site.id,
-            projectRoot: site.sourceDirectory,
-            relativePath: filePath
         )
     }
 

--- a/Sources/AnglesiteCore/ContentCreationWorkflow.swift
+++ b/Sources/AnglesiteCore/ContentCreationWorkflow.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+/// App-facing content creation workflow.
+///
+/// Owns the full post-create lifecycle: delegate the write to the selected
+/// `ContentOperationsService`, then rescan and publish the site's content graph after a successful
+/// create. `SiteContentGraph.load` emits the graph change that drives the semantic indexer, so UI
+/// and App Intent callers get the same refresh behavior.
+public struct ContentCreationWorkflow: ContentOperationsService {
+    public typealias SiteDirectoryResolver = @Sendable (_ siteID: String) async -> URL?
+    public typealias PageTemplateCreator = @Sendable (
+        _ siteID: String,
+        _ title: String,
+        _ route: String?,
+        _ template: ContentScaffold.PageTemplate,
+        _ onProgress: ProgressHandler?
+    ) async -> ContentCreateResult
+    public typealias TypedSlugCreator = @Sendable (
+        _ siteID: String,
+        _ typeID: String,
+        _ title: String,
+        _ slug: String?,
+        _ onProgress: ProgressHandler?
+    ) async -> ContentCreateResult
+
+    private let operations: any ContentOperationsService
+    private let contentGraph: SiteContentGraph?
+    private let knowledgeIndex: SiteKnowledgeIndex?
+    private let siteDirectory: SiteDirectoryResolver
+    private let pageTemplateCreator: PageTemplateCreator?
+    private let typedSlugCreator: TypedSlugCreator?
+
+    public init(
+        operations: any ContentOperationsService,
+        contentGraph: SiteContentGraph?,
+        knowledgeIndex: SiteKnowledgeIndex? = nil,
+        siteDirectory: @escaping SiteDirectoryResolver,
+        pageTemplateCreator: PageTemplateCreator? = nil,
+        typedSlugCreator: TypedSlugCreator? = nil
+    ) {
+        self.operations = operations
+        self.contentGraph = contentGraph
+        self.knowledgeIndex = knowledgeIndex
+        self.siteDirectory = siteDirectory
+        self.pageTemplateCreator = pageTemplateCreator
+        self.typedSlugCreator = typedSlugCreator
+    }
+
+    public static func native(
+        contentGraph: SiteContentGraph?,
+        knowledgeIndex: SiteKnowledgeIndex? = nil,
+        siteDirectory: @escaping SiteDirectoryResolver
+    ) -> ContentCreationWorkflow {
+        let native = NativeContentOperations(siteDirectory: siteDirectory)
+        return ContentCreationWorkflow(
+            operations: native,
+            contentGraph: contentGraph,
+            knowledgeIndex: knowledgeIndex,
+            siteDirectory: siteDirectory,
+            pageTemplateCreator: { siteID, title, route, template, onProgress in
+                await native.createPage(
+                    siteID: siteID,
+                    name: title,
+                    route: route,
+                    template: template,
+                    onProgress: onProgress
+                )
+            },
+            typedSlugCreator: { siteID, typeID, title, slug, onProgress in
+                await native.createTyped(
+                    siteID: siteID,
+                    typeID: typeID,
+                    title: title,
+                    slug: slug,
+                    onProgress: onProgress
+                )
+            }
+        )
+    }
+
+    public func createPage(
+        siteID: String,
+        name: String,
+        route: String?,
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+        let result = await operations.createPage(
+            siteID: siteID,
+            name: name,
+            route: route,
+            onProgress: onProgress
+        )
+        await refreshContentGraphIfCreated(result, siteID: siteID)
+        return result
+    }
+
+    public func createPage(
+        siteID: String,
+        title: String,
+        route: String?,
+        template: ContentScaffold.PageTemplate,
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+        let result: ContentCreateResult
+        if let pageTemplateCreator {
+            result = await pageTemplateCreator(siteID, title, route, template, onProgress)
+        } else {
+            result = await operations.createPage(
+                siteID: siteID,
+                name: title,
+                route: route,
+                onProgress: onProgress
+            )
+        }
+        await refreshContentGraphIfCreated(result, siteID: siteID)
+        return result
+    }
+
+    public func createPost(
+        siteID: String,
+        title: String,
+        collection: String?,
+        slug: String?,
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+        let result = await operations.createPost(
+            siteID: siteID,
+            title: title,
+            collection: collection,
+            slug: slug,
+            onProgress: onProgress
+        )
+        await refreshContentGraphIfCreated(result, siteID: siteID)
+        return result
+    }
+
+    public func createTyped(
+        siteID: String,
+        typeID: String,
+        title: String,
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+        let result = await operations.createTyped(
+            siteID: siteID,
+            typeID: typeID,
+            title: title,
+            onProgress: onProgress
+        )
+        await refreshContentGraphIfCreated(result, siteID: siteID)
+        return result
+    }
+
+    public func createTyped(
+        siteID: String,
+        typeID: String,
+        title: String,
+        slug: String?,
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+        let result: ContentCreateResult
+        if let typedSlugCreator {
+            result = await typedSlugCreator(siteID, typeID, title, slug, onProgress)
+        } else {
+            result = await operations.createTyped(
+                siteID: siteID,
+                typeID: typeID,
+                title: title,
+                onProgress: onProgress
+            )
+        }
+        await refreshContentGraphIfCreated(result, siteID: siteID)
+        return result
+    }
+
+    private func refreshContentGraphIfCreated(_ result: ContentCreateResult, siteID: String) async {
+        guard case let .created(filePath, _) = result, let root = await siteDirectory(siteID) else {
+            return
+        }
+        if let contentGraph {
+            let listing = await Task.detached(priority: .utility) {
+                ContentScanner.scan(projectRoot: root, siteID: siteID)
+            }.value
+            await contentGraph.load(
+                siteID: siteID,
+                pages: listing.pages,
+                posts: listing.posts,
+                images: listing.images
+            )
+        }
+        await knowledgeIndex?.upsertFile(siteID: siteID, projectRoot: root, relativePath: filePath)
+    }
+}

--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -49,7 +49,13 @@ public enum AnglesiteIntents {
         // Slice 2). Replaces the MCP-routed ContentOperations; the Node create_page/create_post
         // tools are retired in the roadmap's cleanup slice.
         AppDependencyManager.shared.add { () -> any ContentOperationsService in
-            NativeContentOperations(siteDirectory: { id in await SiteStore.shared.find(id: id)?.sourceDirectory })
+            let siteDirectory: ContentCreationWorkflow.SiteDirectoryResolver = { id in
+                await SiteStore.shared.find(id: id)?.sourceDirectory
+            }
+            return ContentCreationWorkflow.native(
+                contentGraph: contentGraph,
+                siteDirectory: siteDirectory
+            )
         }
         AppDependencyManager.shared.add { () -> any IntegrationOperationsService in
             IntegrationOperations.live()

--- a/Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("ContentCreationWorkflow")
+struct ContentCreationWorkflowTests {
+    private static let siteID = "site-1"
+
+    private func makeSite(_ files: [String: String] = [:]) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("content-workflow-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for (relativePath, contents) in files {
+            let url = root.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    @Test("successful page create reloads content graph and emits for indexer")
+    func createPageRefreshesGraph() async throws {
+        let root = try makeSite()
+        let graph = SiteContentGraph()
+        let emissions = Emissions()
+        await graph.setChangeHandler { siteID in await emissions.record(siteID) }
+        let operations = FakeCreateOperations { _, _, _ in
+            let relativePath = "src/pages/about.astro"
+            let url = root.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try ContentScaffold.renderPage(
+                title: "About",
+                layoutImport: "../layouts/BaseLayout.astro"
+            ).write(to: url, atomically: true, encoding: .utf8)
+            return .created(filePath: relativePath, identifier: "/about")
+        } createPost: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        } createTyped: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        }
+        let workflow = ContentCreationWorkflow(
+            operations: operations,
+            contentGraph: graph,
+            siteDirectory: { _ in root }
+        )
+
+        let result = await workflow.createPage(siteID: Self.siteID, name: "About", route: nil)
+
+        #expect(result == .created(filePath: "src/pages/about.astro", identifier: "/about"))
+        #expect(await graph.pages(for: Self.siteID).map(\.route) == ["/about"])
+        #expect(await graph.pages(for: Self.siteID).first?.title == "About")
+        #expect(await emissions.values == [Self.siteID])
+    }
+
+    @Test("failed create leaves graph unchanged and does not emit")
+    func failedCreateDoesNotRefreshGraph() async throws {
+        let root = try makeSite([
+            "src/pages/original.md": "---\ntitle: Original\n---\nBody",
+        ])
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: Self.siteID,
+            pages: ContentScanner.scan(projectRoot: root, siteID: Self.siteID).pages,
+            posts: [],
+            images: []
+        )
+        let emissions = Emissions()
+        await graph.setChangeHandler { siteID in await emissions.record(siteID) }
+        let operations = FakeCreateOperations { _, _, _ in
+            try "new".write(
+                to: root.appendingPathComponent("src/pages/new.md"),
+                atomically: true,
+                encoding: .utf8
+            )
+            return .failed(reason: "nope")
+        } createPost: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        } createTyped: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        }
+        let workflow = ContentCreationWorkflow(
+            operations: operations,
+            contentGraph: graph,
+            siteDirectory: { _ in root }
+        )
+
+        let result = await workflow.createPage(siteID: Self.siteID, name: "New", route: nil)
+
+        #expect(result == .failed(reason: "nope"))
+        #expect(await graph.pages(for: Self.siteID).map(\.route) == ["/original"])
+        #expect(await emissions.values.isEmpty)
+    }
+
+    @Test("successful post create reloads posts through the same workflow")
+    func createPostRefreshesGraph() async throws {
+        let root = try makeSite()
+        let graph = SiteContentGraph()
+        let operations = FakeCreateOperations { _, _, _ in
+            .failed(reason: "unexpected")
+        } createPost: { _, _, _, _ in
+            let relativePath = "src/content/posts/hello-world.md"
+            let url = root.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try """
+            ---
+            title: Hello World
+            draft: true
+            tags: [intro]
+            ---
+            Body
+            """.write(to: url, atomically: true, encoding: .utf8)
+            return .created(filePath: relativePath, identifier: "hello-world")
+        } createTyped: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        }
+        let workflow = ContentCreationWorkflow(
+            operations: operations,
+            contentGraph: graph,
+            siteDirectory: { _ in root }
+        )
+
+        let result = await workflow.createPost(
+            siteID: Self.siteID,
+            title: "Hello World",
+            collection: nil,
+            slug: nil
+        )
+
+        #expect(result == .created(filePath: "src/content/posts/hello-world.md", identifier: "hello-world"))
+        let posts = await graph.posts(for: Self.siteID)
+        #expect(posts.map(\.slug) == ["hello-world"])
+        #expect(posts.first?.title == "Hello World")
+        #expect(posts.first?.draft == true)
+        #expect(posts.first?.tags == ["intro"])
+    }
+
+    @Test("successful typed create refreshes graph and knowledge index")
+    func createTypedRefreshesGraphAndKnowledgeIndex() async throws {
+        let root = try makeSite()
+        let graph = SiteContentGraph()
+        let knowledgeIndex = SiteKnowledgeIndex()
+        let operations = FakeCreateOperations { _, _, _ in
+            .failed(reason: "unexpected")
+        } createPost: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        } createTyped: { _, _, title, slug in
+            let finalSlug = slug ?? "note"
+            let relativePath = "src/content/notes/\(finalSlug).md"
+            let url = root.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try """
+            ---
+            title: \(title)
+            ---
+            Body
+            """.write(to: url, atomically: true, encoding: .utf8)
+            return .created(filePath: relativePath, identifier: finalSlug)
+        }
+        let workflow = ContentCreationWorkflow(
+            operations: operations,
+            contentGraph: graph,
+            knowledgeIndex: knowledgeIndex,
+            siteDirectory: { _ in root },
+            typedSlugCreator: { siteID, typeID, title, slug, _ in
+                await operations.createTyped(siteID: siteID, typeID: typeID, title: title, slug: slug)
+            }
+        )
+
+        let result = await workflow.createTyped(
+            siteID: Self.siteID,
+            typeID: "note",
+            title: "Hello Typed",
+            slug: "hello-typed"
+        )
+
+        #expect(result == .created(filePath: "src/content/notes/hello-typed.md", identifier: "hello-typed"))
+        #expect(await graph.posts(for: Self.siteID).map(\.slug) == ["hello-typed"])
+        let document = await knowledgeIndex.document(siteID: Self.siteID, relativePath: "src/content/notes/hello-typed.md")
+        #expect(document?.title == "Hello Typed")
+    }
+}
+
+private struct FakeCreateOperations: ContentOperationsService {
+    typealias PageCreate = @Sendable (String, String, String?) async throws -> ContentCreateResult
+    typealias PostCreate = @Sendable (String, String, String?, String?) async throws -> ContentCreateResult
+    typealias TypedCreate = @Sendable (String, String, String, String?) async throws -> ContentCreateResult
+
+    let createPageHandler: PageCreate
+    let createPostHandler: PostCreate
+    let createTypedHandler: TypedCreate
+
+    init(
+        createPage: @escaping PageCreate,
+        createPost: @escaping PostCreate,
+        createTyped: @escaping TypedCreate
+    ) {
+        self.createPageHandler = createPage
+        self.createPostHandler = createPost
+        self.createTypedHandler = createTyped
+    }
+
+    func createPage(
+        siteID: String,
+        name: String,
+        route: String?,
+        onProgress: ProgressHandler?
+    ) async -> ContentCreateResult {
+        do {
+            return try await createPageHandler(siteID, name, route)
+        } catch {
+            return .failed(reason: String(describing: error))
+        }
+    }
+
+    func createPost(
+        siteID: String,
+        title: String,
+        collection: String?,
+        slug: String?,
+        onProgress: ProgressHandler?
+    ) async -> ContentCreateResult {
+        do {
+            return try await createPostHandler(siteID, title, collection, slug)
+        } catch {
+            return .failed(reason: String(describing: error))
+        }
+    }
+
+    func createTyped(
+        siteID: String,
+        typeID: String,
+        title: String,
+        onProgress: ProgressHandler?
+    ) async -> ContentCreateResult {
+        await createTyped(siteID: siteID, typeID: typeID, title: title, slug: nil)
+    }
+
+    func createTyped(
+        siteID: String,
+        typeID: String,
+        title: String,
+        slug: String?
+    ) async -> ContentCreateResult {
+        do {
+            return try await createTypedHandler(siteID, typeID, title, slug)
+        } catch {
+            return .failed(reason: String(describing: error))
+        }
+    }
+}
+
+private actor Emissions {
+    private var recorded: [String] = []
+
+    var values: [String] { recorded }
+
+    func record(_ value: String) {
+        recorded.append(value)
+    }
+}


### PR DESCRIPTION
## Summary
- Add ContentCreationWorkflow as the single app-facing create path around ContentOperationsService
- Move graph reload and knowledge-index upsert after successful creates into the workflow
- Route SiteWindow and App Intents dependency registration through the workflow

## Tests
- swift test --filter ContentCreationWorkflowTests
- swift test --filter 'ContentCreationWorkflowTests|NativeContentOperationsTests|ContentOperationsTests|ContentOperationsProgressTests|ContentIntentsTests'

Fixes #436