### PR TITLE
Add local container runtime diagnostics

### DIFF
--- a/Sources/AnglesiteApp/SiteRuntimeFactory.swift
+++ b/Sources/AnglesiteApp/SiteRuntimeFactory.swift
@@ -10,6 +10,12 @@ protocol SiteRuntimeFactory: Sendable {
 }
 
 struct LiveSiteRuntimeFactory: SiteRuntimeFactory {
+    private let logCenter: LogCenter
+
+    init(logCenter: LogCenter = .shared) {
+        self.logCenter = logCenter
+    }
+
     /// Pick the runtime by capability (no feature flag): a local Apple-Containerization VM when the
     /// build is entitled + the kernel/initfs are provisioned; otherwise the existing host-subprocess
     /// runtime.
@@ -21,8 +27,12 @@ struct LiveSiteRuntimeFactory: SiteRuntimeFactory {
         knowledgeIndex: SiteKnowledgeIndex?,
         semanticRanker: SemanticRanker?
     ) -> any SiteRuntime {
-        if LocalContainerSupport.isAvailable(hasVirtualizationEntitlement: VirtualizationEntitlement.isPresent)
-            && BundledImage.isProvisioned {
+        let support = LocalContainerSupport.availability(
+            hasVirtualizationEntitlement: VirtualizationEntitlement.isPresent
+        )
+        let provisioning = BundledImage.provisioningReport
+        if support.isAvailable && provisioning.isProvisioned {
+            logRuntimeSelection("selected LocalContainerSiteRuntime")
             return LocalContainerSiteRuntime(
                 ref: "HEAD",
                 control: ContainerizationControl(),
@@ -31,6 +41,25 @@ struct LiveSiteRuntimeFactory: SiteRuntimeFactory {
                 semanticRanker: semanticRanker
             )
         }
+        logRuntimeSelection(Self.fallbackReason(support: support, provisioning: provisioning))
         return LocalSiteRuntime(contentGraph: contentGraph, knowledgeIndex: knowledgeIndex, semanticRanker: semanticRanker)
+    }
+
+    private static func fallbackReason(
+        support: LocalContainerSupport.Availability,
+        provisioning: BundledImageProvisioningReport
+    ) -> String {
+        var reasons: [String] = []
+        if case .unavailable(let supportReasons) = support {
+            reasons.append(contentsOf: supportReasons.map(\.description))
+        }
+        reasons.append(contentsOf: provisioning.missingDescriptions)
+        return "selected LocalSiteRuntime; local container unavailable: \(reasons.joined(separator: "; "))"
+    }
+
+    private func logRuntimeSelection(_ text: String) {
+        Task {
+            await logCenter.append(source: "runtime", stream: .stdout, text: text)
+        }
     }
 }

--- a/Sources/AnglesiteContainer/BundledImage.swift
+++ b/Sources/AnglesiteContainer/BundledImage.swift
@@ -48,7 +48,11 @@ public enum BundledImage {
     /// crash. Resolved inside `start()` (not in `init`) so constructing the type can never trap.
     public static func layoutURL() throws -> URL {
         if let override = ProcessInfo.processInfo.environment["ANGLESITE_CONTAINER_IMAGE"] {
-            return URL(fileURLWithPath: override)
+            let url = URL(fileURLWithPath: override)
+            if FileManager.default.fileExists(atPath: url.appendingPathComponent("index.json").path) {
+                return url
+            }
+            throw BundledImageError.imageLayoutNotProvisioned
         }
         // The `.copy` rule always bundles the `container-image/` dir (with its `.gitkeep`) even when
         // the image isn't vendored, so resolving the dir is not enough — verify the OCI layout's
@@ -78,7 +82,11 @@ public enum BundledImage {
     /// Override with `ANGLESITE_CONTAINER_KERNEL` to point at a freshly-built kernel for local dev.
     public static func kernelURL() throws -> URL {
         if let override = ProcessInfo.processInfo.environment["ANGLESITE_CONTAINER_KERNEL"] {
-            return URL(fileURLWithPath: override)
+            let url = URL(fileURLWithPath: override)
+            if FileManager.default.fileExists(atPath: url.path) {
+                return url
+            }
+            throw BundledImageError.kernelNotProvisioned
         }
         if let dirURL = resourceBundle?.url(forResource: "container-kernel", withExtension: nil) {
             let kernelURL = dirURL.appendingPathComponent("vmlinux")
@@ -98,7 +106,11 @@ public enum BundledImage {
     /// Override with `ANGLESITE_CONTAINER_INITFS` to point at a different layout for local dev.
     public static func initfsLayoutURL() throws -> URL {
         if let override = ProcessInfo.processInfo.environment["ANGLESITE_CONTAINER_INITFS"] {
-            return URL(fileURLWithPath: override)
+            let url = URL(fileURLWithPath: override)
+            if FileManager.default.fileExists(atPath: url.appendingPathComponent("index.json").path) {
+                return url
+            }
+            throw BundledImageError.initfsNotProvisioned
         }
         if let dirURL = resourceBundle?.url(forResource: "container-initfs", withExtension: nil) {
             let indexURL = dirURL.appendingPathComponent("index.json")
@@ -115,13 +127,22 @@ public enum BundledImage {
     /// runtime until provisioning is complete, so `ContainerizationControl` is never selected in a
     /// state where `start()` would fail with `.imageUnavailable`.
     public static var isProvisioned: Bool {
+        provisioningReport.isProvisioned
+    }
+
+    public static var provisioningReport: BundledImageProvisioningReport {
+        BundledImageProvisioningReport(
+            image: artifactStatus { try layoutURL() },
+            kernel: artifactStatus { try kernelURL() },
+            initfs: artifactStatus { try initfsLayoutURL() }
+        )
+    }
+
+    private static func artifactStatus(_ resolve: () throws -> URL) -> BundledImageArtifactStatus {
         do {
-            _ = try layoutURL()
-            _ = try kernelURL()
-            _ = try initfsLayoutURL()
-            return true
+            return .provisioned(path: try resolve().path)
         } catch {
-            return false
+            return .missing(reason: "\(error)")
         }
     }
 
@@ -148,4 +169,36 @@ public enum BundledImageError: Error, Equatable {
     case kernelNotProvisioned
     /// The vminit initfs is not vendored and no `ANGLESITE_CONTAINER_INITFS` override was set.
     case initfsNotProvisioned
+}
+
+public struct BundledImageProvisioningReport: Sendable, Equatable {
+    public let image: BundledImageArtifactStatus
+    public let kernel: BundledImageArtifactStatus
+    public let initfs: BundledImageArtifactStatus
+
+    public var isProvisioned: Bool {
+        image.isProvisioned && kernel.isProvisioned && initfs.isProvisioned
+    }
+
+    public var missingDescriptions: [String] {
+        [
+            image.missingDescription(label: "container image"),
+            kernel.missingDescription(label: "Linux kernel"),
+            initfs.missingDescription(label: "vminit initfs")
+        ].compactMap { $0 }
+    }
+}
+
+public enum BundledImageArtifactStatus: Sendable, Equatable {
+    case provisioned(path: String)
+    case missing(reason: String)
+
+    public var isProvisioned: Bool {
+        if case .provisioned = self { true } else { false }
+    }
+
+    fileprivate func missingDescription(label: String) -> String? {
+        guard case .missing(let reason) = self else { return nil }
+        return "\(label): \(reason)"
+    }
 }

--- a/Sources/AnglesiteCore/LocalContainerSupport.swift
+++ b/Sources/AnglesiteCore/LocalContainerSupport.swift
@@ -3,12 +3,54 @@
 /// #60 spike), so no feature flag is needed: a build without it simply reports `false` and the app
 /// falls back to `LocalSiteRuntime` / `RemoteSandboxSiteRuntime`.
 public enum LocalContainerSupport {
+    public enum Availability: Sendable, Equatable {
+        case available
+        case unavailable([UnavailabilityReason])
+
+        public var isAvailable: Bool {
+            if case .available = self { true } else { false }
+        }
+    }
+
+    public enum UnavailabilityReason: String, Sendable, Equatable, CaseIterable {
+        case notAppleSilicon
+        case unsupportedOS
+        case missingVirtualizationEntitlement
+
+        public var description: String {
+            switch self {
+            case .notAppleSilicon:
+                "Apple Silicon is required"
+            case .unsupportedOS:
+                "macOS 26 or newer is required"
+            case .missingVirtualizationEntitlement:
+                "signed build is missing com.apple.security.virtualization"
+            }
+        }
+    }
+
     public static func isAvailable(
         isAppleSilicon: Bool = hostIsAppleSilicon,
         osIsSupported: Bool = hostOSIsSupported,
         hasVirtualizationEntitlement: Bool = hostHasVirtualizationEntitlement
     ) -> Bool {
-        isAppleSilicon && osIsSupported && hasVirtualizationEntitlement
+        availability(
+            isAppleSilicon: isAppleSilicon,
+            osIsSupported: osIsSupported,
+            hasVirtualizationEntitlement: hasVirtualizationEntitlement
+        ).isAvailable
+    }
+
+    public static func availability(
+        isAppleSilicon: Bool = hostIsAppleSilicon,
+        osIsSupported: Bool = hostOSIsSupported,
+        hasVirtualizationEntitlement: Bool = hostHasVirtualizationEntitlement
+    ) -> Availability {
+        var reasons: [UnavailabilityReason] = []
+        if !isAppleSilicon { reasons.append(.notAppleSilicon) }
+        if !osIsSupported { reasons.append(.unsupportedOS) }
+        if !hasVirtualizationEntitlement { reasons.append(.missingVirtualizationEntitlement) }
+        return reasons.isEmpty ? .available : .unavailable(reasons)
     }
 
     /// True on arm64. Intel Macs report false.

--- a/Tests/AnglesiteCoreTests/LocalContainerSupportTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSupportTests.swift
@@ -5,20 +5,33 @@ struct LocalContainerSupportTests {
     @Test("available only when all three conditions hold")
     func allThree() {
         #expect(LocalContainerSupport.isAvailable(isAppleSilicon: true, osIsSupported: true, hasVirtualizationEntitlement: true) == true)
+        #expect(LocalContainerSupport.availability(isAppleSilicon: true, osIsSupported: true, hasVirtualizationEntitlement: true) == .available)
     }
 
     @Test("unavailable if not Apple Silicon")
     func notAppleSilicon() {
         #expect(LocalContainerSupport.isAvailable(isAppleSilicon: false, osIsSupported: true, hasVirtualizationEntitlement: true) == false)
+        #expect(LocalContainerSupport.availability(isAppleSilicon: false, osIsSupported: true, hasVirtualizationEntitlement: true) == .unavailable([.notAppleSilicon]))
     }
 
     @Test("unavailable if OS too old")
     func oldOS() {
         #expect(LocalContainerSupport.isAvailable(isAppleSilicon: true, osIsSupported: false, hasVirtualizationEntitlement: true) == false)
+        #expect(LocalContainerSupport.availability(isAppleSilicon: true, osIsSupported: false, hasVirtualizationEntitlement: true) == .unavailable([.unsupportedOS]))
     }
 
     @Test("unavailable without the virtualization entitlement")
     func noEntitlement() {
         #expect(LocalContainerSupport.isAvailable(isAppleSilicon: true, osIsSupported: true, hasVirtualizationEntitlement: false) == false)
+        #expect(LocalContainerSupport.availability(isAppleSilicon: true, osIsSupported: true, hasVirtualizationEntitlement: false) == .unavailable([.missingVirtualizationEntitlement]))
+    }
+
+    @Test("diagnostic returns every missing gate in stable order")
+    func multipleReasons() {
+        #expect(LocalContainerSupport.availability(
+            isAppleSilicon: false,
+            osIsSupported: false,
+            hasVirtualizationEntitlement: false
+        ) == .unavailable([.notAppleSilicon, .unsupportedOS, .missingVirtualizationEntitlement]))
     }
 }

--- a/docs/qa/local-container-runtime-smoke-test.md
+++ b/docs/qa/local-container-runtime-smoke-test.md
@@ -147,8 +147,12 @@ Fail if the app is signed but the entitlement probe returns false.
 Expected:
 
 - The preview runtime is `LocalContainerSiteRuntime`.
+- The debug pane includes `runtime/stdout selected LocalContainerSiteRuntime`.
 - There is no fallback to `LocalSiteRuntime` once artifacts and entitlement are available.
 - If artifacts or entitlement are deliberately removed, the app falls back to `LocalSiteRuntime` without crashing.
+- Fallback logs include `runtime/stdout selected LocalSiteRuntime; local container unavailable: ...`
+  with the failed host gate and/or missing artifact named (`container image`, `Linux kernel`, or
+  `vminit initfs`).
 
 Fail if the container runtime is selected when artifacts are missing, or if fallback breaks preview startup.
 


### PR DESCRIPTION
## Summary
- add structured local-container availability reasons for host capability gates
- validate container artifact env overrides and expose a provisioning report naming missing image/kernel/initfs artifacts
- log runtime selection/fallback decisions to the debug pane under `runtime`
- update the local-container smoke runbook with the new diagnostic expectations

## Validation
- `env ANGLESITE_SKIP_CONTAINER=1 swift test --package-path . --filter LocalContainerSupportTests`
- `env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`

Refs #59
Refs #69