### PR TITLE
Add remote sandbox status contract

### DIFF
--- a/Sources/AnglesiteCore/HTTPSandboxControlClient.swift
+++ b/Sources/AnglesiteCore/HTTPSandboxControlClient.swift
@@ -15,6 +15,8 @@ public struct HTTPSandboxControlClient: SandboxControlClient {
 
     private struct StartBody: Encodable { let siteID, gitRemote, gitRef, token: String }
     private struct StartResponse: Decodable { let previewURL: URL; let mcpURL: URL }
+    private struct StatusBody: Encodable { let siteID: String }
+    private struct StatusResponse: Decodable { let siteID: String; let previewReady: Bool; let mcpReady: Bool }
     private struct StopBody: Encodable { let siteID: String }
 
     public func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
@@ -30,6 +32,16 @@ public struct HTTPSandboxControlClient: SandboxControlClient {
 
     public func stop(siteID: String) async throws {
         _ = try await post("stop", body: StopBody(siteID: siteID))
+    }
+
+    public func status(siteID: String) async throws -> SandboxStatus {
+        let data = try await post("status", body: StatusBody(siteID: siteID))
+        do {
+            let r = try JSONDecoder().decode(StatusResponse.self, from: data)
+            return SandboxStatus(siteID: r.siteID, previewReady: r.previewReady, mcpReady: r.mcpReady)
+        } catch {
+            throw SandboxControlError.startFailed("bad response: \(error)")
+        }
     }
 
     private func post(_ path: String, body: some Encodable) async throws -> Data {

--- a/Sources/AnglesiteCore/SandboxControlClient.swift
+++ b/Sources/AnglesiteCore/SandboxControlClient.swift
@@ -11,6 +11,20 @@ public struct SandboxSession: Sendable, Equatable {
     }
 }
 
+public struct SandboxStatus: Sendable, Equatable {
+    public let siteID: String
+    public let previewReady: Bool
+    public let mcpReady: Bool
+
+    public init(siteID: String, previewReady: Bool, mcpReady: Bool) {
+        self.siteID = siteID
+        self.previewReady = previewReady
+        self.mcpReady = mcpReady
+    }
+
+    public var isReady: Bool { previewReady && mcpReady }
+}
+
 public enum SandboxControlError: Error, Equatable {
     case notProvisioned          // no Control Worker / token on file → route to onboarding
     case unauthorized            // token rejected by the Worker
@@ -24,6 +38,8 @@ public protocol SandboxControlClient: Sendable {
     /// Boot (or resume) the sandbox for `siteID`, clone `gitRemote` at `gitRef`, start the in-guest
     /// processes with `token` in their environment, and return the two tunnel URLs.
     func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession
+    /// Probe whether the in-guest preview proxy and MCP endpoint are reachable.
+    func status(siteID: String) async throws -> SandboxStatus
     /// Stop the session (drop tunnels, let the sandbox sleep).
     func stop(siteID: String) async throws
 }

--- a/Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift
+++ b/Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift
@@ -3,16 +3,27 @@ import Foundation
 
 actor FakeSandboxControlClient: SandboxControlClient {
     var startResult: Result<SandboxSession, SandboxControlError>
+    var statusResult: Result<SandboxStatus, SandboxControlError>
     private(set) var stopped: [String] = []
     private(set) var startedToken: SessionToken?
 
-    init(startResult: Result<SandboxSession, SandboxControlError>) {
+    init(
+        startResult: Result<SandboxSession, SandboxControlError>,
+        statusResult: Result<SandboxStatus, SandboxControlError> = .success(
+            SandboxStatus(siteID: "site-1", previewReady: true, mcpReady: true)
+        )
+    ) {
         self.startResult = startResult
+        self.statusResult = statusResult
     }
 
     func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
         startedToken = token
         return try startResult.get()
+    }
+
+    func status(siteID: String) async throws -> SandboxStatus {
+        try statusResult.get()
     }
 
     func stop(siteID: String) async throws { stopped.append(siteID) }
@@ -56,6 +67,10 @@ actor GatedFakeSandboxControlClient: SandboxControlClient {
             gateContinuation = cont
         }
         return try result.get()
+    }
+
+    func status(siteID: String) async throws -> SandboxStatus {
+        SandboxStatus(siteID: siteID, previewReady: true, mcpReady: true)
     }
 
     func stop(siteID: String) async throws { stopped.append(siteID) }

--- a/Tests/AnglesiteCoreTests/HTTPSandboxControlClientTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPSandboxControlClientTests.swift
@@ -38,6 +38,22 @@ struct HTTPSandboxControlClientTests {
                 siteID: "s", gitRemote: URL(string: "https://x/r.git")!, gitRef: "main", token: SessionToken(value: "t"))
         }
     }
+
+    @Test("status posts and parses readiness")
+    func statusParses() async throws {
+        SandboxStubURLProtocol.handler = { req in
+            #expect(req.url?.path == "/status")
+            #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer api-tok")
+            let body = #"{"siteID":"s1","previewReady":true,"mcpReady":false}"#
+            return (200, Data(body.utf8))
+        }
+        let client = HTTPSandboxControlClient(
+            workerBaseURL: URL(string: "https://worker.example.workers.dev")!,
+            apiToken: "api-tok", urlSession: session())
+        let status = try await client.status(siteID: "s1")
+        #expect(status == SandboxStatus(siteID: "s1", previewReady: true, mcpReady: false))
+        #expect(status.isReady == false)
+    }
 }
 
 /// Minimal URLProtocol stub for offline HTTP-client tests (sandbox control client variant).

--- a/Tests/AnglesiteCoreTests/SandboxControlClientTests.swift
+++ b/Tests/AnglesiteCoreTests/SandboxControlClientTests.swift
@@ -37,4 +37,16 @@ struct SandboxControlClientTests {
         try await fake.stop(siteID: "site-1")
         #expect(await fake.stopped == ["site-1"])
     }
+
+    @Test("fake returns configured status")
+    func fakeStatus() async throws {
+        let expected = SandboxStatus(siteID: "site-1", previewReady: true, mcpReady: false)
+        let fake = FakeSandboxControlClient(
+            startResult: .success(SandboxSession(
+                previewURL: URL(string: "https://p")!, mcpURL: URL(string: "https://m/mcp")!)),
+            statusResult: .success(expected))
+        let got = try await fake.status(siteID: "site-1")
+        #expect(got == expected)
+        #expect(got.isReady == false)
+    }
 }

--- a/Workers/ControlWorker/src/types.ts
+++ b/Workers/ControlWorker/src/types.ts
@@ -9,7 +9,17 @@ export interface StopBody {
   siteID: string;
 }
 
+export interface StatusBody {
+  siteID: string;
+}
+
 export interface StartResponse {
   previewURL: string;
   mcpURL: string;
+}
+
+export interface StatusResponse {
+  siteID: string;
+  previewReady: boolean;
+  mcpReady: boolean;
 }

--- a/Workers/ControlWorker/src/validation.ts
+++ b/Workers/ControlWorker/src/validation.ts
@@ -1,4 +1,4 @@
-import type { StartBody, StopBody } from "./types.js";
+import type { StartBody, StatusBody, StopBody } from "./types.js";
 
 const REPO_RE = /^https:\/\/github\.com\/[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+(?:\.git)?$/;
 const REF_RE = /^[A-Za-z0-9._\-/]+$/;
@@ -40,6 +40,14 @@ export function validateStartBody(
 }
 
 export function validateStopBody(body: unknown): StopBody | ValidationError {
+  return validateSiteBody(body);
+}
+
+export function validateStatusBody(body: unknown): StatusBody | ValidationError {
+  return validateSiteBody(body);
+}
+
+function validateSiteBody(body: unknown): StopBody | ValidationError {
   if (typeof body !== "object" || body === null)
     return { field: "body", message: "must be a JSON object" };
   const b = body as Record<string, unknown>;

--- a/Workers/ControlWorker/src/worker.ts
+++ b/Workers/ControlWorker/src/worker.ts
@@ -3,10 +3,11 @@ import { Sandbox, type Env } from "./sandbox-env.js";
 import { authorized } from "./auth.js";
 import {
   validateStartBody,
+  validateStatusBody,
   validateStopBody,
   isValidationError,
 } from "./validation.js";
-import type { StartResponse } from "./types.js";
+import type { StartResponse, StatusResponse } from "./types.js";
 
 export { Sandbox };
 
@@ -15,6 +16,13 @@ const json = (data: unknown, status = 200) =>
     status,
     headers: { "content-type": "application/json" },
   });
+
+function withMCPPath(rawURL: string): string {
+  const url = new URL(rawURL);
+  const base = url.pathname.replace(/\/$/, "");
+  url.pathname = `${base}/mcp`;
+  return url.toString();
+}
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -109,7 +117,29 @@ export default {
 
         const response: StartResponse = {
           previewURL: previewTunnel.url,
-          mcpURL: mcpTunnel.url,
+          mcpURL: withMCPPath(mcpTunnel.url),
+        };
+        return json(response, 200);
+      }
+
+      if (url.pathname === "/status" && request.method === "POST") {
+        const rawBody = await request.json();
+        const parsed = validateStatusBody(rawBody);
+        if (isValidationError(parsed))
+          return json(
+            { error: parsed.message, field: parsed.field },
+            400,
+          );
+
+        const sandbox = getSandbox(env.Sandbox, parsed.siteID);
+        const [previewProbe, mcpProbe] = await Promise.all([
+          sandbox.exec(`curl -s -o /dev/null 'http://localhost:${PROXY_PORT}/'`),
+          sandbox.exec(`curl -s -o /dev/null 'http://localhost:${MCP_PORT}/mcp'`),
+        ]);
+        const response: StatusResponse = {
+          siteID: parsed.siteID,
+          previewReady: previewProbe.success,
+          mcpReady: mcpProbe.success,
         };
         return json(response, 200);
       }
@@ -125,8 +155,8 @@ export default {
 
         const sandbox = getSandbox(env.Sandbox, parsed.siteID);
         await Promise.allSettled([
-          sandbox.tunnels.drop(Number(PROXY_PORT)),
-          sandbox.tunnels.drop(Number(MCP_PORT)),
+          sandbox.tunnels.destroy(Number(PROXY_PORT)),
+          sandbox.tunnels.destroy(Number(MCP_PORT)),
         ]);
         return json({ stopped: true }, 200);
       }

--- a/Workers/ControlWorker/test/validation.test.ts
+++ b/Workers/ControlWorker/test/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   validateStartBody,
+  validateStatusBody,
   validateStopBody,
   isValidationError,
 } from "../src/validation.js";
@@ -97,6 +98,19 @@ describe("validateStopBody", () => {
 
   it("rejects empty siteID", () => {
     const result = validateStopBody({ siteID: "" });
+    expect(isValidationError(result)).toBe(true);
+  });
+});
+
+describe("validateStatusBody", () => {
+  it("accepts a valid body", () => {
+    const result = validateStatusBody({ siteID: "site-1" });
+    expect(isValidationError(result)).toBe(false);
+    expect(result).toEqual({ siteID: "site-1" });
+  });
+
+  it("rejects invalid siteID", () => {
+    const result = validateStatusBody({ siteID: "bad chars!!" });
     expect(isValidationError(result)).toBe(true);
   });
 });

--- a/Workers/ControlWorker/test/worker.test.ts
+++ b/Workers/ControlWorker/test/worker.test.ts
@@ -4,13 +4,13 @@ import type { Env } from "../src/sandbox-env.js";
 const mockExec = vi.fn();
 const mockStartProcess = vi.fn();
 const mockTunnelsGet = vi.fn();
-const mockTunnelsDrop = vi.fn();
+const mockTunnelsDestroy = vi.fn();
 
 vi.mock("@cloudflare/sandbox", () => ({
   getSandbox: () => ({
     exec: mockExec,
     startProcess: mockStartProcess,
-    tunnels: { get: mockTunnelsGet, drop: mockTunnelsDrop },
+    tunnels: { get: mockTunnelsGet, destroy: mockTunnelsDestroy },
   }),
   Sandbox: class {},
 }));
@@ -169,7 +169,7 @@ describe("POST /start", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.previewURL).toBe("https://preview.trycloudflare.com");
-    expect(body.mcpURL).toBe("https://mcp.trycloudflare.com");
+    expect(body.mcpURL).toBe("https://mcp.trycloudflare.com/mcp");
   });
 
   it("passes quoted shell args to sandbox.exec", async () => {
@@ -206,6 +206,32 @@ describe("POST /start", () => {
   });
 });
 
+describe("POST /status", () => {
+  it("returns 400 for invalid body", async () => {
+    const req = authedRequest("/status", { siteID: "bad chars!!" });
+    const res = await worker.fetch(req, makeEnv());
+    expect(res.status).toBe(400);
+  });
+
+  it("probes preview and MCP readiness", async () => {
+    mockExec
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false });
+    const req = authedRequest("/status", { siteID: "my-site-123" });
+    const res = await worker.fetch(req, makeEnv());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      siteID: "my-site-123",
+      previewReady: true,
+      mcpReady: false,
+    });
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    expect(mockExec.mock.calls[0][0]).toContain("localhost:8080");
+    expect(mockExec.mock.calls[1][0]).toContain("localhost:4399/mcp");
+  });
+});
+
 describe("POST /stop", () => {
   it("returns 400 for invalid body", async () => {
     const req = authedRequest("/stop", { siteID: "bad chars!!" });
@@ -214,13 +240,13 @@ describe("POST /stop", () => {
   });
 
   it("drops tunnels and returns stopped on success", async () => {
-    mockTunnelsDrop.mockResolvedValue(undefined);
+    mockTunnelsDestroy.mockResolvedValue(undefined);
     const req = authedRequest("/stop", { siteID: "my-site-123" });
     const res = await worker.fetch(req, makeEnv());
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.stopped).toBe(true);
-    expect(mockTunnelsDrop).toHaveBeenCalledTimes(2);
+    expect(mockTunnelsDestroy).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `SandboxStatus` and `SandboxControlClient.status(siteID:)` to the Swift remote runtime seam
- implement `/status` in `HTTPSandboxControlClient` and the Cloudflare Control Worker
- have the Worker return MCP tunnel URLs with the `/mcp` endpoint path
- align Worker stop teardown with the actual `sandbox.tunnels.destroy(...)` SDK method

## Validation
- `env ANGLESITE_SKIP_CONTAINER=1 swift test --package-path . --filter SandboxControlClientTests --filter HTTPSandboxControlClientTests --filter RemoteSandboxSiteRuntimeTests`
- `cd Workers/ControlWorker && npm ci && npm test`
- `cd Workers/ControlWorker && npx tsc -b && npm run build:guest && npm test`
- `env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`

Refs #59
Refs #66