### PR TITLE
Add host Node retirement audit

### DIFF
--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -134,6 +134,8 @@ The long-term architecture replaces the in-process Node subprocess with a contai
   - 🔲 **End-to-end boot verification (Task 10)** — the entitlement-gated boot → preview → `apply_edit` round-trip on an Apple-Silicon Mac is **author-run** (`com.apple.security.virtualization` can't be exercised on CI). Everything below the gate is verified as far as possible without it (conformer compiles against real 0.34; the sidecar boots + serves MCP in plain Docker). A distribution-grade vendor-kernel pipeline (vs. the current env-override + `vendor-container-kernel.sh`) is the remaining provisioning piece.
   - 🔲 **Virtualization entitlement approval (Wall 2)** — `com.apple.security.virtualization` is present in `Resources/Anglesite.entitlements`; file/complete the Apple approval request so the App Store provisioning profile grants it. Precedented (`try-containers/Containers`) but still a release gate.
 - 🔲 **Retire embedded Node** (#70) — once containers land, the vendored Node + JIT re-sign can be removed.
+  `scripts/audit-host-node-retirement.sh` inventories the remaining host-Node surface today and
+  becomes the `--expect-retired` cleanup gate when #66/#69 are proven.
 - 🔲 **iOS target** (#71) — thin SwiftUI/UIKit client using only the remote (Cloudflare) runtime.
 
 ---

--- a/docs/qa/host-node-retirement-audit.md
+++ b/docs/qa/host-node-retirement-audit.md
@@ -1,0 +1,46 @@
+# Host Node Retirement Audit
+
+**Issues:** [#59](https://github.com/Anglesite/Anglesite-app/issues/59), [#70](https://github.com/Anglesite/Anglesite-app/issues/70)  
+**Scope:** Phase 4 pre-retirement checklist for the embedded host Node path.
+
+## Purpose
+
+The app still needs the host subprocess runtime until the local and remote container runtimes are
+proven end to end. This audit keeps that transitional surface visible so #70 can become a mechanical
+cleanup instead of a treasure hunt.
+
+Run:
+
+```sh
+scripts/audit-host-node-retirement.sh
+```
+
+Expected today:
+
+- The command exits 0.
+- It lists the remaining host-side Node dependencies, including vendor scripts, Node entitlements,
+  Xcode build phases, `NodeRuntime`, `LocalSiteRuntime`, `InProcessBackend`, and the MCP stdio spawn
+  path.
+
+## Retirement Gate
+
+After #66 and #69 have live end-to-end coverage and no platform depends on `LocalSiteRuntime`, run:
+
+```sh
+scripts/audit-host-node-retirement.sh --expect-retired
+```
+
+Expected after #70 cleanup:
+
+- The command exits 0.
+- It prints `No tracked host-side Node dependencies remain.`
+
+Fail if `--expect-retired` exits 0 before container runtimes are the only execution paths, or if it
+still reports tracked dependencies after #70 cleanup.
+
+## Evidence To Record On #70
+
+- Commit or PR that removes each tracked dependency.
+- Output of `scripts/audit-host-node-retirement.sh --expect-retired`.
+- Confirmation that the app build no longer runs the Node vendor/re-sign phases.
+- Confirmation that app entitlements no longer carry host-Node-only JIT carve-outs.

--- a/scripts/audit-host-node-retirement.sh
+++ b/scripts/audit-host-node-retirement.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Inventory the host-side embedded Node apparatus that must disappear for #70.
+#
+# Default mode is informational and exits 0 while the transitional host runtime still exists.
+# Use --expect-retired once both container runtimes are proven; that mode fails if any tracked
+# host-Node dependency remains in build config or source.
+
+set -euo pipefail
+
+MODE="inventory"
+if [[ "${1:-}" == "--expect-retired" ]]; then
+    MODE="expect-retired"
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat <<'USAGE'
+Usage: scripts/audit-host-node-retirement.sh [--expect-retired]
+
+Default mode prints the remaining host-side Node dependencies and exits 0.
+--expect-retired exits non-zero when any tracked dependency remains.
+USAGE
+    exit 0
+elif [[ $# -gt 0 ]]; then
+    echo "unknown argument: $1" >&2
+    exit 2
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+cd "$REPO_ROOT"
+
+declare -a FINDINGS=()
+
+check_path() {
+    local label="$1"
+    local path="$2"
+    if [[ -e "$path" ]]; then
+        FINDINGS+=("$label -> $path")
+    fi
+}
+
+check_pattern() {
+    local label="$1"
+    local path="$2"
+    local pattern="$3"
+    if [[ -e "$path" ]] && rg -q "$pattern" "$path"; then
+        FINDINGS+=("$label -> $path")
+    fi
+}
+
+check_path "Node vendor script" "scripts/vendor-node.sh"
+check_path "Node re-sign script" "scripts/resign-node.sh"
+check_path "Primed npm cache vendor script" "scripts/vendor-npm-cache.sh"
+check_path "Bundled Node entitlements" "Resources/node-runtime.entitlements"
+check_pattern "Xcode project vendors node-runtime resources" "project.yml" "Resources/node-runtime"
+check_pattern "Xcode project vendors Node during build" "project.yml" "Vendor Node runtime"
+check_pattern "Xcode project re-signs bundled Node" "project.yml" "Re-sign bundled Node"
+check_pattern "Swift resolves bundled Node" "Sources/AnglesiteCore/NodeRuntime.swift" "node-runtime"
+check_pattern "Swift host subprocess runtime remains" "Sources/AnglesiteCore/LocalSiteRuntime.swift" "host-subprocess|LocalSiteRuntime"
+check_pattern "Swift in-process spawn backend remains" "Sources/AnglesiteCore/InProcessBackend.swift" "Process\\("
+check_pattern "MCP stdio spawn path remains" "Sources/AnglesiteCore/MCPClient.swift" "start\\(executable:"
+
+echo "Host Node retirement audit (#70)"
+echo "Mode: $MODE"
+echo
+
+if [[ ${#FINDINGS[@]} -eq 0 ]]; then
+    echo "No tracked host-side Node dependencies remain."
+    exit 0
+fi
+
+echo "Tracked host-side Node dependencies still present:"
+for finding in "${FINDINGS[@]}"; do
+    echo "  - $finding"
+done
+
+echo
+echo "Count: ${#FINDINGS[@]}"
+
+if [[ "$MODE" == "expect-retired" ]]; then
+    echo "ERROR: host Node retirement is expected, but tracked dependencies remain." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add `scripts/audit-host-node-retirement.sh` to inventory the remaining host-side embedded Node/JIT surface for #70
- add a QA checklist explaining today's inventory mode and the future `--expect-retired` gate
- link the audit from the container epic section of `docs/build-plan.md`

## Validation
- `bash -n scripts/audit-host-node-retirement.sh`
- `scripts/audit-host-node-retirement.sh`
- `scripts/audit-host-node-retirement.sh --expect-retired` exits 1 today with the expected remaining dependencies
- `env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`

Refs #59
Refs #70