### PR TITLE
chore(#71): add iOS thin client readiness audit

### DIFF
--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -137,6 +137,8 @@ The long-term architecture replaces the in-process Node subprocess with a contai
   `scripts/audit-host-node-retirement.sh` inventories the remaining host-Node surface today and
   becomes the `--expect-retired` cleanup gate when #66/#69 are proven.
 - 🔲 **iOS target** (#71) — thin SwiftUI/UIKit client using only the remote (Cloudflare) runtime.
+  `scripts/audit-ios-thin-client-readiness.sh` inventories the current platform blockers and
+  becomes the `--expect-ready` gate before wiring the iOS app target.
 
 ---
 

--- a/docs/qa/ios-thin-client-readiness.md
+++ b/docs/qa/ios-thin-client-readiness.md
@@ -1,0 +1,52 @@
+# iOS Thin Client Readiness Audit
+
+**Issues:** [#59](https://github.com/Anglesite/Anglesite-app/issues/59), [#71](https://github.com/Anglesite/Anglesite-app/issues/71)  
+**Scope:** Phase 5 preflight for the remote-only iOS/iPadOS app target.
+
+## Purpose
+
+#71 is a new iOS thin client, not a conditional build of the existing macOS shell. The iOS app should
+host SwiftUI plus `WKWebView` via `UIViewRepresentable`, drive `RemoteSandboxSiteRuntime`, and avoid
+host subprocesses, local container runtime code, security-scoped package access, and AppKit-only
+targets.
+
+Run:
+
+```sh
+scripts/audit-ios-thin-client-readiness.sh
+```
+
+Expected today:
+
+- The command exits 0.
+- It lists the remote-runtime pieces already present.
+- It lists the remaining blockers, including package/project platform declarations, the missing iOS
+  shell, AppKit-shaped bridge wrappers, FSEvents/security-scoped/Core host runtime surfaces, and
+  AppKit-bound intents code.
+
+## Readiness Gate
+
+When adding the iOS target, run:
+
+```sh
+scripts/audit-ios-thin-client-readiness.sh --expect-ready
+```
+
+Expected once #71 is ready to compile:
+
+- The command exits 0.
+- It prints `No tracked iOS thin-client blockers remain.`
+- The new iOS target links only the shared pieces it can actually use: `AnglesiteBridge` boundary
+  code, the HTTP MCP client, `SandboxControlClient`, and `RemoteSandboxSiteRuntime`.
+
+Fail if `--expect-ready` exits 0 while the target still links host runtime, local container,
+FSEvents, AppKit-only, or security-scoped package code.
+
+## Evidence To Record On #71
+
+- Output of `scripts/audit-ios-thin-client-readiness.sh --expect-ready`.
+- The new iOS scheme build command and result.
+- Confirmation that preview uses `WKWebView` through `UIViewRepresentable`.
+- Confirmation that runtime selection is remote-only and never reaches `LocalSiteRuntime`,
+  `ProcessSupervisor`, `NodeRuntime`, or `LocalContainerSiteRuntime`.
+- Confirmation that the Cloudflare Worker URL/API token path uses iOS Keychain storage.

--- a/scripts/audit-ios-thin-client-readiness.sh
+++ b/scripts/audit-ios-thin-client-readiness.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Inventory the platform seams that must be resolved before #71 can add the iOS thin client.
+#
+# Default mode is informational and exits 0 while the app/package are still macOS-only.
+# Use --expect-ready when the iOS target is being wired; that mode fails if any tracked
+# blocker remains.
+
+set -euo pipefail
+
+MODE="inventory"
+if [[ "${1:-}" == "--expect-ready" ]]; then
+    MODE="expect-ready"
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat <<'USAGE'
+Usage: scripts/audit-ios-thin-client-readiness.sh [--expect-ready]
+
+Default mode prints the remaining iOS thin-client blockers and exits 0.
+--expect-ready exits non-zero when any tracked blocker remains.
+USAGE
+    exit 0
+elif [[ $# -gt 0 ]]; then
+    echo "unknown argument: $1" >&2
+    exit 2
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+cd "$REPO_ROOT"
+
+declare -a BLOCKERS=()
+declare -a READY=()
+
+blocker() {
+    local label="$1"
+    local detail="$2"
+    BLOCKERS+=("$label -> $detail")
+}
+
+ready() {
+    local label="$1"
+    READY+=("$label")
+}
+
+path_exists() {
+    [[ -e "$1" ]]
+}
+
+pattern_exists() {
+    local path="$1"
+    local pattern="$2"
+    [[ -e "$path" ]] && rg -q "$pattern" "$path"
+}
+
+if pattern_exists "Package.swift" "\\.iOS\\("; then
+    ready "Swift package declares an iOS platform"
+else
+    blocker "Swift package is macOS-only" "Package.swift lacks an .iOS platform"
+fi
+
+if pattern_exists "project.yml" "platform: iOS"; then
+    ready "XcodeGen project declares an iOS application target"
+else
+    blocker "No iOS app target" "project.yml has only macOS targets"
+fi
+
+if path_exists "Sources/AnglesiteIOS"; then
+    ready "iOS shell source directory exists"
+else
+    blocker "No iOS shell sources" "Sources/AnglesiteIOS is absent"
+fi
+
+if path_exists "Resources/Info-iOS.plist" || pattern_exists "project.yml" "INFOPLIST_FILE:.*iOS"; then
+    ready "iOS Info.plist or generated plist config exists"
+else
+    blocker "No iOS bundle metadata" "project.yml/Resources do not define an iOS Info.plist"
+fi
+
+if pattern_exists "Sources/AnglesiteBridge/WebViewBridge.swift" "#available\\(macOS"; then
+    blocker "Bridge has macOS-only availability" "Sources/AnglesiteBridge/WebViewBridge.swift"
+else
+    ready "Bridge availability is not hard-coded to macOS"
+fi
+
+if pattern_exists "Sources/AnglesiteBridge/WebViewBridge.swift" "NSViewRepresentable"; then
+    blocker "Bridge preview wrapper is AppKit-shaped" "Sources/AnglesiteBridge/WebViewBridge.swift"
+else
+    ready "Bridge preview wrapper is split away from AppKit"
+fi
+
+if pattern_exists "Sources/AnglesiteCore/SiteFileWatcher.swift" "CoreServices|FSEvent"; then
+    blocker "AnglesiteCore includes FSEvents file watching" "Sources/AnglesiteCore/SiteFileWatcher.swift"
+else
+    ready "File watching is platform-gated or split out of iOS Core"
+fi
+
+if pattern_exists "Sources/AnglesiteCore/SecurityScopedBookmark.swift" "securityScope|startAccessingSecurityScopedResource|bookmarkData"; then
+    blocker "AnglesiteCore includes macOS package access bookmarks" "Sources/AnglesiteCore/SecurityScopedBookmark.swift"
+else
+    ready "Security-scoped bookmark code is platform-gated or split out of iOS Core"
+fi
+
+if pattern_exists "Sources/AnglesiteCore/InProcessBackend.swift" "Process\\("; then
+    blocker "Host subprocess backend remains in shared Core" "Sources/AnglesiteCore/InProcessBackend.swift"
+else
+    ready "Shared Core has no direct host Process backend"
+fi
+
+if pattern_exists "Sources/AnglesiteCore/LocalSiteRuntime.swift" "LocalSiteRuntime|ProcessSupervisor|NodeRuntime"; then
+    blocker "Local host runtime remains in shared Core" "Sources/AnglesiteCore/LocalSiteRuntime.swift"
+else
+    ready "Shared Core has no local host runtime dependency"
+fi
+
+if pattern_exists "Sources/AnglesiteCore/LocalContainerSiteRuntime.swift" "LocalContainerSiteRuntime|FSEventsFileWatcher"; then
+    blocker "Local container runtime is still visible from shared Core" "Sources/AnglesiteCore/LocalContainerSiteRuntime.swift"
+else
+    ready "Local container runtime is split away from iOS Core"
+fi
+
+if pattern_exists "Sources/AnglesiteIntents/PreviewAnnotationProvider.swift" "import AppKit"; then
+    blocker "AnglesiteIntents imports AppKit" "Sources/AnglesiteIntents/PreviewAnnotationProvider.swift"
+else
+    ready "Intents target is not AppKit-bound or is excluded from iOS"
+fi
+
+if pattern_exists "Sources/AnglesiteCore/HTTPSandboxControlClient.swift" "Used by the iOS app"; then
+    ready "Remote sandbox control client exists"
+else
+    blocker "Remote sandbox control client missing" "Sources/AnglesiteCore/HTTPSandboxControlClient.swift"
+fi
+
+if pattern_exists "Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift" "actor RemoteSandboxSiteRuntime"; then
+    ready "RemoteSandboxSiteRuntime exists"
+else
+    blocker "RemoteSandboxSiteRuntime missing" "Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift"
+fi
+
+echo "iOS thin-client readiness audit (#71)"
+echo "Mode: $MODE"
+echo
+
+if [[ ${#READY[@]} -gt 0 ]]; then
+    echo "Already in place:"
+    for item in "${READY[@]}"; do
+        echo "  - $item"
+    done
+    echo
+fi
+
+if [[ ${#BLOCKERS[@]} -eq 0 ]]; then
+    echo "No tracked iOS thin-client blockers remain."
+    exit 0
+fi
+
+echo "Tracked blockers still present:"
+for item in "${BLOCKERS[@]}"; do
+    echo "  - $item"
+done
+
+echo
+echo "Count: ${#BLOCKERS[@]}"
+
+if [[ "$MODE" == "expect-ready" ]]; then
+    echo "ERROR: iOS thin-client readiness is expected, but tracked blockers remain." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add a repeatable #71 readiness audit for the iOS thin-client target
- document the QA/readiness gate under docs/qa
- link the audit from the containerization epic checklist

## Verification
- bash -n scripts/audit-ios-thin-client-readiness.sh
- scripts/audit-ios-thin-client-readiness.sh
- scripts/audit-ios-thin-client-readiness.sh --expect-ready (expected non-zero today; reports 11 blockers)