### PR TITLE
chore(#71): gate bridge Writing Tools for iOS readiness

### DIFF
--- a/Sources/AnglesiteBridge/WebViewBridge.swift
+++ b/Sources/AnglesiteBridge/WebViewBridge.swift
@@ -109,15 +109,14 @@ public enum WebViewBridge {
     /// before the web view is created), not a `WKWebView` instance property — `WKWebView` only
     /// exposes the read-only `isWritingToolsActive`. `.complete` selects the full inline experience;
     /// the WebKit default is `.limited` (a panel-only fallback), so this opt-in is required to get
-    /// the inline popover. Gated on macOS 15.0+ since `writingToolsBehavior` (and Writing Tools
-    /// itself) ships there; the app's deployment target is higher, but the guard keeps
-    /// `AnglesiteBridge` (which declares a lower SPM floor and builds on CI's older runners) honest.
-    /// On a Mac without Apple Intelligence this is a safe no-op: WebKit simply never offers the
-    /// affordance.
+    /// the inline popover. The setting is macOS-only for Anglesite's current WebKit usage, so the
+    /// shared bridge gates it at compile time and leaves the future iOS `UIViewRepresentable`
+    /// preview on WebKit's platform default. On a Mac without Apple Intelligence this is a safe
+    /// no-op: WebKit simply never offers the affordance.
     @MainActor
     public static func enableWritingTools(on configuration: WKWebViewConfiguration) {
-        if #available(macOS 15.0, *) {
-            configuration.writingToolsBehavior = .complete
-        }
+        #if os(macOS)
+        configuration.writingToolsBehavior = .complete
+        #endif
     }
 }

--- a/docs/qa/ios-thin-client-readiness.md
+++ b/docs/qa/ios-thin-client-readiness.md
@@ -19,10 +19,9 @@ scripts/audit-ios-thin-client-readiness.sh
 Expected today:
 
 - The command exits 0.
-- It lists the remote-runtime pieces already present.
+- It lists the remote-runtime and bridge pieces already present.
 - It lists the remaining blockers, including package/project platform declarations, the missing iOS
-  shell, AppKit-shaped bridge wrappers, FSEvents/security-scoped/Core host runtime surfaces, and
-  AppKit-bound intents code.
+  shell, FSEvents/security-scoped/Core host runtime surfaces, and AppKit-bound intents code.
 
 ## Readiness Gate
 

--- a/scripts/audit-ios-thin-client-readiness.sh
+++ b/scripts/audit-ios-thin-client-readiness.sh
@@ -76,10 +76,10 @@ else
     blocker "No iOS bundle metadata" "project.yml/Resources do not define an iOS Info.plist"
 fi
 
-if pattern_exists "Sources/AnglesiteBridge/WebViewBridge.swift" "#available\\(macOS"; then
-    blocker "Bridge has macOS-only availability" "Sources/AnglesiteBridge/WebViewBridge.swift"
+if pattern_exists "Sources/AnglesiteBridge/WebViewBridge.swift" "writingToolsBehavior" && ! pattern_exists "Sources/AnglesiteBridge/WebViewBridge.swift" "#if os\\(macOS\\)"; then
+    blocker "Bridge Writing Tools behavior is not platform-gated" "Sources/AnglesiteBridge/WebViewBridge.swift"
 else
-    ready "Bridge availability is not hard-coded to macOS"
+    ready "Bridge Writing Tools behavior is macOS-gated"
 fi
 
 if pattern_exists "Sources/AnglesiteBridge/WebViewBridge.swift" "NSViewRepresentable"; then

--- a/scripts/audit-ios-thin-client-readiness.sh
+++ b/scripts/audit-ios-thin-client-readiness.sh
@@ -52,6 +52,44 @@ pattern_exists() {
     [[ -e "$path" ]] && rg -q "$pattern" "$path"
 }
 
+writing_tools_assignment_is_mac_gated() {
+    local path="$1"
+    [[ -e "$path" ]] || return 1
+    awk '
+        /public static func enableWritingTools/ {
+            inFunction = 1
+            braceDepth = 0
+            sawAssignment = 0
+            gatedAssignment = 0
+            ungatedAssignment = 0
+        }
+        inFunction {
+            for (i = 1; i <= length($0); i++) {
+                char = substr($0, i, 1)
+                if (char == "{") { braceDepth++ }
+                if (char == "}") { braceDepth-- }
+            }
+            if ($0 ~ /^[[:space:]]*#if[[:space:]]+os\(macOS\)/) { macGuard = 1 }
+            if ($0 ~ /writingToolsBehavior[[:space:]]*=/) {
+                sawAssignment = 1
+                if (macGuard == 1) {
+                    gatedAssignment = 1
+                } else {
+                    ungatedAssignment = 1
+                }
+            }
+            if ($0 ~ /^[[:space:]]*#endif/) { macGuard = 0 }
+            if (braceDepth == 0) {
+                inFunction = 0
+                macGuard = 0
+            }
+        }
+        END {
+            exit (sawAssignment == 1 && gatedAssignment == 1 && ungatedAssignment == 0) ? 0 : 1
+        }
+    ' "$path"
+}
+
 if pattern_exists "Package.swift" "\\.iOS\\("; then
     ready "Swift package declares an iOS platform"
 else
@@ -76,10 +114,10 @@ else
     blocker "No iOS bundle metadata" "project.yml/Resources do not define an iOS Info.plist"
 fi
 
-if pattern_exists "Sources/AnglesiteBridge/WebViewBridge.swift" "writingToolsBehavior" && ! pattern_exists "Sources/AnglesiteBridge/WebViewBridge.swift" "#if os\\(macOS\\)"; then
-    blocker "Bridge Writing Tools behavior is not platform-gated" "Sources/AnglesiteBridge/WebViewBridge.swift"
-else
+if writing_tools_assignment_is_mac_gated "Sources/AnglesiteBridge/WebViewBridge.swift"; then
     ready "Bridge Writing Tools behavior is macOS-gated"
+else
+    blocker "Bridge Writing Tools behavior is not platform-gated" "Sources/AnglesiteBridge/WebViewBridge.swift"
 fi
 
 if pattern_exists "Sources/AnglesiteBridge/WebViewBridge.swift" "NSViewRepresentable"; then


### PR DESCRIPTION
## Summary
- gate the bridge Writing Tools opt-in behind `#if os(macOS)` so the shared WebKit configuration path stays usable for the future iOS bridge
- update the #71 readiness audit to recognize the bridge Writing Tools blocker as resolved
- refresh the QA readiness note to describe the bridge as already in place

## Verification
- `bash -n scripts/audit-ios-thin-client-readiness.sh`
- `env ANGLESITE_SKIP_CONTAINER=1 swift test --package-path . --filter WebViewBridgeTests`
- `scripts/audit-ios-thin-client-readiness.sh` now reports 10 blockers, down from 11