### PR TITLE
feat(#71): add iOS remote preview shell target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ var packageTargets: [Target] = [
     ),
     .target(
         name: "AnglesiteIOS",
-        dependencies: ["AnglesiteBridge"],
+        dependencies: [],
         path: "Sources/AnglesiteIOS",
         swiftSettings: strictConcurrency
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,12 @@ var packageTargets: [Target] = [
         swiftSettings: strictConcurrency
     ),
     .target(
+        name: "AnglesiteIOS",
+        dependencies: ["AnglesiteBridge"],
+        path: "Sources/AnglesiteIOS",
+        swiftSettings: strictConcurrency
+    ),
+    .target(
         name: "AnglesiteIntents",
         dependencies: ["AnglesiteCore"],
         path: "Sources/AnglesiteIntents",
@@ -137,6 +143,7 @@ var packageProducts: [Product] = [
     .library(name: "AnglesiteSiteModel", targets: ["AnglesiteSiteModel"]),
     .library(name: "AnglesiteCore", targets: ["AnglesiteCore"]),
     .library(name: "AnglesiteBridge", targets: ["AnglesiteBridge"]),
+    .library(name: "AnglesiteIOS", targets: ["AnglesiteIOS"]),
     .library(name: "AnglesiteIntents", targets: ["AnglesiteIntents"])
 ]
 

--- a/Sources/AnglesiteIOS/RemotePreviewWebView.swift
+++ b/Sources/AnglesiteIOS/RemotePreviewWebView.swift
@@ -1,35 +1,42 @@
 #if os(iOS)
 import SwiftUI
 import WebKit
-import AnglesiteBridge
 
 /// iOS `WKWebView` preview shell for the remote-only runtime path (#71).
 ///
 /// The caller owns the remote session and supplies the preview URL plus an optional
-/// `AnglesiteScriptHandler`. This wrapper deliberately does not know about local files,
-/// subprocesses, or container selection.
+/// script handler. This wrapper deliberately does not know about local files, subprocesses,
+/// local containers, or the macOS `AnglesiteCore` runtime graph.
 @MainActor
 public struct RemotePreviewWebView: UIViewRepresentable {
     public typealias UIViewType = WKWebView
 
+    public static let defaultScriptMessageNamespace = "anglesite"
+
     private let url: URL
     private let scriptHandler: WKScriptMessageHandler?
+    private let scriptMessageNamespace: String
     private let configureWebView: (WKWebView) -> Void
 
     public init(
         url: URL,
         scriptHandler: WKScriptMessageHandler? = nil,
+        scriptMessageNamespace: String = Self.defaultScriptMessageNamespace,
         configureWebView: @escaping (WKWebView) -> Void = { _ in }
     ) {
         self.url = url
         self.scriptHandler = scriptHandler
+        self.scriptMessageNamespace = scriptMessageNamespace
         self.configureWebView = configureWebView
     }
 
     public func makeUIView(context: Context) -> WKWebView {
-        let configuration = WebViewBridge.localDevConfiguration(handler: scriptHandler)
+        let configuration = WKWebViewConfiguration()
+        if let scriptHandler {
+            configuration.userContentController.add(scriptHandler, name: scriptMessageNamespace)
+        }
         let webView = WKWebView(frame: .zero, configuration: configuration)
-        WebViewBridge.applyPreviewDefaults(to: webView)
+        webView.isInspectable = true
         configureWebView(webView)
         webView.load(URLRequest(url: url))
         context.coordinator.loadedURL = url

--- a/Sources/AnglesiteIOS/RemotePreviewWebView.swift
+++ b/Sources/AnglesiteIOS/RemotePreviewWebView.swift
@@ -1,0 +1,49 @@
+#if os(iOS)
+import SwiftUI
+import WebKit
+import AnglesiteBridge
+
+/// iOS `WKWebView` preview shell for the remote-only runtime path (#71).
+///
+/// The caller owns the remote session and supplies the preview URL plus an optional
+/// `AnglesiteScriptHandler`. This wrapper deliberately does not know about local files,
+/// subprocesses, or container selection.
+@MainActor
+public struct RemotePreviewWebView: UIViewRepresentable {
+    public typealias UIViewType = WKWebView
+
+    private let url: URL
+    private let scriptHandler: WKScriptMessageHandler?
+    private let configureWebView: (WKWebView) -> Void
+
+    public init(
+        url: URL,
+        scriptHandler: WKScriptMessageHandler? = nil,
+        configureWebView: @escaping (WKWebView) -> Void = { _ in }
+    ) {
+        self.url = url
+        self.scriptHandler = scriptHandler
+        self.configureWebView = configureWebView
+    }
+
+    public func makeUIView(context: Context) -> WKWebView {
+        let configuration = WebViewBridge.localDevConfiguration(handler: scriptHandler)
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        WebViewBridge.applyPreviewDefaults(to: webView)
+        configureWebView(webView)
+        webView.load(URLRequest(url: url))
+        context.coordinator.loadedURL = url
+        return webView
+    }
+
+    public func updateUIView(_ webView: WKWebView, context: Context) {
+        guard context.coordinator.loadedURL != url else { return }
+        context.coordinator.loadedURL = url
+        webView.load(URLRequest(url: url))
+    }
+
+    public func makeCoordinator() -> RemotePreviewWebViewCoordinator {
+        RemotePreviewWebViewCoordinator()
+    }
+}
+#endif

--- a/Sources/AnglesiteIOS/RemotePreviewWebViewCoordinator.swift
+++ b/Sources/AnglesiteIOS/RemotePreviewWebViewCoordinator.swift
@@ -1,0 +1,10 @@
+#if os(iOS)
+import Foundation
+
+@MainActor
+public final class RemotePreviewWebViewCoordinator {
+    var loadedURL: URL?
+
+    public init() {}
+}
+#endif

--- a/docs/qa/ios-thin-client-readiness.md
+++ b/docs/qa/ios-thin-client-readiness.md
@@ -20,8 +20,8 @@ Expected today:
 
 - The command exits 0.
 - It lists the remote-runtime and bridge pieces already present.
-- It lists the remaining blockers, including package/project platform declarations, the missing iOS
-  shell, FSEvents/security-scoped/Core host runtime surfaces, and AppKit-bound intents code.
+- It lists the remaining blockers, including package/project platform declarations, iOS app bundle
+  metadata, FSEvents/security-scoped/Core host runtime surfaces, and AppKit-bound intents code.
 
 ## Readiness Gate
 

--- a/docs/qa/ios-thin-client-readiness.md
+++ b/docs/qa/ios-thin-client-readiness.md
@@ -23,6 +23,9 @@ Expected today:
 - It lists the remaining blockers, including package/project platform declarations, iOS app bundle
   metadata, FSEvents/security-scoped/Core host runtime surfaces, and AppKit-bound intents code.
 
+The `AnglesiteIOS` shell target must not depend on `AnglesiteBridge` until the bridge can be split
+away from `AnglesiteCore`; otherwise SwiftPM pulls macOS-only host runtime files into iOS builds.
+
 ## Readiness Gate
 
 When adding the iOS target, run:

--- a/scripts/audit-ios-thin-client-readiness.sh
+++ b/scripts/audit-ios-thin-client-readiness.sh
@@ -102,10 +102,10 @@ else
     blocker "No iOS app target" "project.yml has only macOS targets"
 fi
 
-if path_exists "Sources/AnglesiteIOS"; then
-    ready "iOS shell source directory exists"
+if path_exists "Sources/AnglesiteIOS" && pattern_exists "Package.swift" "name: \"AnglesiteIOS\""; then
+    ready "iOS shell source target exists"
 else
-    blocker "No iOS shell sources" "Sources/AnglesiteIOS is absent"
+    blocker "No iOS shell sources" "Sources/AnglesiteIOS and Package.swift lack an AnglesiteIOS target"
 fi
 
 if path_exists "Resources/Info-iOS.plist" || pattern_exists "project.yml" "INFOPLIST_FILE:.*iOS"; then

--- a/scripts/audit-ios-thin-client-readiness.sh
+++ b/scripts/audit-ios-thin-client-readiness.sh
@@ -90,6 +90,23 @@ writing_tools_assignment_is_mac_gated() {
     ' "$path"
 }
 
+ios_shell_target_is_safe() {
+    path_exists "Sources/AnglesiteIOS" || return 1
+    awk '
+        /name: "AnglesiteIOS"/ { inTarget = 1; foundTarget = 1 }
+        inTarget && /dependencies:/ {
+            if ($0 ~ /AnglesiteBridge|AnglesiteCore/) { unsafeDependency = 1 }
+        }
+        inTarget && /path: "Sources\/AnglesiteIOS"/ { sawPath = 1 }
+        inTarget && /^[[:space:]]*\),[[:space:]]*$/ {
+            inTarget = 0
+        }
+        END {
+            exit (foundTarget == 1 && sawPath == 1 && unsafeDependency != 1) ? 0 : 1
+        }
+    ' Package.swift
+}
+
 if pattern_exists "Package.swift" "\\.iOS\\("; then
     ready "Swift package declares an iOS platform"
 else
@@ -102,10 +119,10 @@ else
     blocker "No iOS app target" "project.yml has only macOS targets"
 fi
 
-if path_exists "Sources/AnglesiteIOS" && pattern_exists "Package.swift" "name: \"AnglesiteIOS\""; then
+if ios_shell_target_is_safe; then
     ready "iOS shell source target exists"
 else
-    blocker "No iOS shell sources" "Sources/AnglesiteIOS and Package.swift lack an AnglesiteIOS target"
+    blocker "No iOS shell sources" "Sources/AnglesiteIOS and Package.swift lack an iOS-safe AnglesiteIOS target"
 fi
 
 if path_exists "Resources/Info-iOS.plist" || pattern_exists "project.yml" "INFOPLIST_FILE:.*iOS"; then


### PR DESCRIPTION
## Summary
- add an `AnglesiteIOS` SwiftPM target/product as the first iOS shell boundary
- add an iOS-only `RemotePreviewWebView` using `UIViewRepresentable` and bare `WKWebView` configuration so it does not pull in `AnglesiteBridge -> AnglesiteCore` yet
- update the #71 readiness audit so the shell-source blocker is resolved and the count drops from 10 to 9
- document that `AnglesiteIOS` must stay off `AnglesiteBridge` until the bridge can be split away from macOS-only `AnglesiteCore`

## Verification
- `bash -n scripts/audit-ios-thin-client-readiness.sh`
- `env ANGLESITE_SKIP_CONTAINER=1 swift build --package-path . --product AnglesiteIOS`
- `env ANGLESITE_SKIP_CONTAINER=1 swift build --package-path . --product AnglesiteIOS --triple arm64-apple-ios17.0`
- `scripts/audit-ios-thin-client-readiness.sh --expect-ready` expected non-zero today, reports 9 blockers