### PR TITLE
fix(#456, #457): bound and window FoundationModels session context

### DIFF
--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -222,11 +222,15 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         activeDrains += 1
         // Unstructured `Task` in an actor inherits the actor's isolation (Swift 6), so these
         // `activeDrains` mutations are actor-safe — keep it `Task`, not `Task.detached`.
+        // Route/content ride along on the prompt itself, not the session's fixed instructions
+        // (#457) — so each turn reflects the page the user is *currently* viewing, not whatever it
+        // was when the cached session was first created.
+        let turnPrompt = Self.turnPrompt(for: prompt, context: context)
         Task {
             defer { activeDrains -= 1 }
             do {
                 var previous = ""
-                for try await snapshot in session.streamResponse(to: prompt) {
+                for try await snapshot in session.streamResponse(to: turnPrompt) {
                     // `streamResponse` yields cumulative snapshots; emit only the newly-appended tail.
                     let full = snapshot.content
                     if full.hasPrefix(previous) {
@@ -333,7 +337,14 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         @unknown default:
             throw AssistantError.unavailable("The on-device model is unavailable on this device.")
         }
-        let instructions = Self.instructions(for: context)
+        // Conversational sessions (`includeSpotlight: true`, i.e. built via `conversationSession`)
+        // keep minimal, stable instructions — page route/content is folded into each turn's prompt
+        // by `turnPrompt(for:context:)` instead, so a cached session doesn't bake in whatever page
+        // the user was viewing when the conversation started and never update it (#457). One-shot
+        // `generate`/`generateStructured` build a fresh session per call, so there's no staleness
+        // risk there — they keep the fuller instructions (`FoundationModelEditInterpreter` and
+        // `AltTextGenerator` both rely on `currentPageRoute` reaching the model this way).
+        let instructions = Self.instructions(for: context, includePageContext: !includeSpotlight)
         let tools = conversationTools(for: context, includeSpotlight: includeSpotlight)
         // `tools` is empty only on the one-shot paths (`includeSpotlight: false`) with no
         // editBridge/contentGraph; the converse path always appends Spotlight, so its session is
@@ -400,11 +411,48 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         session = LanguageModelSession(tools: tools, transcript: Transcript(entries: retained))
     }
 
-    /// Folds the situational ``AssistantContext`` into session instructions.
-    private static func instructions(for context: AssistantContext) -> String {
+    /// Character cap on how much of ``AssistantContext/currentPageContent`` is folded into a
+    /// prompt (#457). No on-device tokenizer is available to measure the real 4,096-token budget,
+    /// so this is a conservative character-based proxy — chosen so a caller passing e.g. raw page
+    /// HTML can't single-handedly crowd out the user's own prompt and the rest of the
+    /// conversation. Applies to both ``instructions(for:includePageContext:)`` (one-shot paths) and
+    /// ``turnPrompt(for:context:)`` (the conversational path).
+    static let maxPageContentCharacters = 2_000
+
+    /// Truncates `content` to ``maxPageContentCharacters``, operating on whatever text the caller
+    /// passed — extracted text is expected, not raw HTML (no HTML-extraction utility exists yet in
+    /// `AnglesiteCore`; that's separate, larger work, out of scope here).
+    static func truncatedPageContent(_ content: String) -> String {
+        guard content.count > maxPageContentCharacters else { return content }
+        return String(content.prefix(maxPageContentCharacters)) + "…"
+    }
+
+    /// Folds the situational ``AssistantContext`` into session instructions. `includePageContext`
+    /// is false for the conversational session, whose instructions must stay stable across turns —
+    /// see the call site in ``makeSession(context:includeSpotlight:)``.
+    static func instructions(for context: AssistantContext, includePageContext: Bool) -> String {
         var lines = ["You are an assistant helping edit and improve a website."]
+        if includePageContext {
+            if let route = context.currentPageRoute { lines.append("The user is viewing the page at \(route).") }
+            if let content = context.currentPageContent {
+                lines.append("Current page content:\n\(truncatedPageContent(content))")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Composes a conversational turn's actual prompt: the current page's route/content (truncated,
+    /// #457) prepended to the user's message. Used only by ``converse(prompt:context:)`` — the
+    /// session's instructions stay minimal and stable (see ``instructions(for:includePageContext:)``),
+    /// so per-turn context reaches the model without rebuilding the session or leaving it stale when
+    /// the user navigates mid-conversation.
+    static func turnPrompt(for prompt: String, context: AssistantContext) -> String {
+        var lines: [String] = []
         if let route = context.currentPageRoute { lines.append("The user is viewing the page at \(route).") }
-        if let content = context.currentPageContent { lines.append("Current page content:\n\(content)") }
+        if let content = context.currentPageContent {
+            lines.append("Current page content:\n\(truncatedPageContent(content))")
+        }
+        lines.append(prompt)
         return lines.joined(separator: "\n")
     }
 }

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -80,7 +80,11 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         self.knowledgeIndex = knowledgeIndex
         self.semanticRanker = semanticRanker
         self.integrationService = integrationService
-        self.maxRetainedTurns = maxRetainedTurns
+        // `trimSessionIfNeeded`'s cutoff indexing (`promptIndices.count - maxRetainedTurns`) assumes
+        // at least 1: `<= 0` would index at or past the end of `promptIndices` and crash. Clamp
+        // rather than crash so a caller passing e.g. `0` ("keep no history") degrades to the
+        // smallest valid window instead of trapping.
+        self.maxRetainedTurns = max(1, maxRetainedTurns)
         if tier == .privateCloudCompute {
             // v1 has no separate PCC session; fall back to on-device with a logged warning so the
             // requested tier degrades gracefully rather than erroring (see spec / #155).
@@ -262,6 +266,10 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         activeRelay = nil
         session = nil
     }
+
+    /// Test-only: the clamped ``maxRetainedTurns`` actually stored, so tests can assert `init`
+    /// clamps non-positive values rather than crashing later in ``trimSessionIfNeeded``.
+    nonisolated var maxRetainedTurnsForTesting: Int { maxRetainedTurns }
 
     /// Test-only: number of `.prompt` entries in the cached session's transcript, or `nil` if no
     /// session is cached. Exercises ``trimSessionIfNeeded(current:context:)`` (#456) without a

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -50,6 +50,14 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     /// retains conversation history across turns. Created lazily on the first turn and cleared by
     /// ``resetSession()``. The one-shot ``generate(prompt:context:)`` path deliberately bypasses it.
     private var session: LanguageModelSession?
+    /// How many user turns (`Transcript.Entry.prompt` entries) the cached ``session`` retains
+    /// before it's rebuilt from a trimmed window (#456). Apple's session accumulates the full
+    /// prompt/response/tool-call transcript internally with no built-in compaction, and
+    /// `maxContextTokens` (4,096 on-device) is only an advertised capability — nothing enforces it
+    /// against the growing session, so a long-running chat can silently exceed the window. A
+    /// heuristic turn count rather than an exact token budget: FoundationModels exposes no token
+    /// accounting on `Transcript`, so this trades precision for something that's at least bounded.
+    private let maxRetainedTurns: Int
 
     /// The multi-turn ``converse(prompt:context:)`` session attaches Apple's `SpotlightSearchTool`
     /// (budget-fit `.focused(.items)`/`.compact` config) for local RAG over indexed site content,
@@ -63,7 +71,8 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         contentGraph: SiteContentGraph? = nil,
         knowledgeIndex: SiteKnowledgeIndex? = nil,
         semanticRanker: SemanticRanker? = nil,
-        integrationService: (any IntegrationOperationsService)? = nil
+        integrationService: (any IntegrationOperationsService)? = nil,
+        maxRetainedTurns: Int = 12
     ) {
         self.tier = tier
         self.editBridge = editBridge
@@ -71,6 +80,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         self.knowledgeIndex = knowledgeIndex
         self.semanticRanker = semanticRanker
         self.integrationService = integrationService
+        self.maxRetainedTurns = maxRetainedTurns
         if tier == .privateCloudCompute {
             // v1 has no separate PCC session; fall back to on-device with a logged warning so the
             // requested tier degrades gracefully rather than erroring (see spec / #155).
@@ -227,6 +237,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
             } catch {
                 relay.complete(.failed(message: error.localizedDescription))
             }
+            trimSessionIfNeeded(current: session, context: context)
         }
 
         // Consumer dropped the stream: stop delivering, but keep draining (we never cancel the model).
@@ -250,6 +261,15 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         activeRelay?.cancel()
         activeRelay = nil
         session = nil
+    }
+
+    /// Test-only: number of `.prompt` entries in the cached session's transcript, or `nil` if no
+    /// session is cached. Exercises ``trimSessionIfNeeded(current:context:)`` (#456) without a
+    /// public surface.
+    var promptCountForTesting: Int? {
+        session?.transcript.reduce(into: 0) { count, entry in
+            if case .prompt = entry { count += 1 }
+        }
     }
 
     /// Display label for `SpotlightSearchTool` in the `.started` event. `SpotlightSearchTool`
@@ -306,6 +326,19 @@ public actor FoundationModelAssistant: ConversationalAssistant {
             throw AssistantError.unavailable("The on-device model is unavailable on this device.")
         }
         let instructions = Self.instructions(for: context)
+        let tools = conversationTools(for: context, includeSpotlight: includeSpotlight)
+        // `tools` is empty only on the one-shot paths (`includeSpotlight: false`) with no
+        // editBridge/contentGraph; the converse path always appends Spotlight, so its session is
+        // never tool-less. The empty branch preserves the prior tool-less one-shot behavior.
+        return tools.isEmpty
+            ? LanguageModelSession(instructions: instructions)
+            : LanguageModelSession(tools: tools, instructions: instructions)
+    }
+
+    /// Builds the tool set for `context`. Shared by ``makeSession(context:includeSpotlight:)`` and
+    /// ``trimSessionIfNeeded(current:context:)`` so a rebuilt (trimmed) conversational session gets
+    /// the same tools a freshly-created one would.
+    private func conversationTools(for context: AssistantContext, includeSpotlight: Bool) -> [any Tool] {
         var tools: [any Tool] = []
         if includeSpotlight {
             // Default GuidanceLevel.complete injects a ~13k-token query manual that exceeds the
@@ -331,12 +364,32 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         if let integrationService {
             tools.append(SetupIntegrationTool(service: integrationService, siteID: context.siteID))
         }
-        // `tools` is empty only on the one-shot paths (`includeSpotlight: false`) with no
-        // editBridge/contentGraph; the converse path always appends Spotlight, so its session is
-        // never tool-less. The empty branch preserves the prior tool-less one-shot behavior.
-        return tools.isEmpty
-            ? LanguageModelSession(instructions: instructions)
-            : LanguageModelSession(tools: tools, instructions: instructions)
+        return tools
+    }
+
+    /// Rebuilds the cached ``session`` from a trimmed suffix of its transcript once it holds more
+    /// than ``maxRetainedTurns`` turns — the only lever available since FoundationModels exposes no
+    /// compaction API (#456). Runs after each turn drains so the *next* turn (not the one that just
+    /// finished) benefits from the smaller transcript. `current === session` guards against
+    /// clobbering a session a newer turn already replaced while this drain was still in flight (see
+    /// `activeDrains` in ``converse(prompt:context:)``).
+    private func trimSessionIfNeeded(current: LanguageModelSession, context: AssistantContext) {
+        guard session === current else { return }
+        let transcript = current.transcript
+        let promptIndices = transcript.indices.filter {
+            if case .prompt = transcript[$0] { return true }
+            return false
+        }
+        guard promptIndices.count > maxRetainedTurns else { return }
+        let cutoff = promptIndices[promptIndices.count - maxRetainedTurns]
+        var retained = Array(transcript[cutoff...])
+        // Keep the leading instructions entry so the trimmed session still carries the route/page
+        // context it was created with.
+        if let first = transcript.first, case .instructions = first {
+            retained.insert(first, at: 0)
+        }
+        let tools = conversationTools(for: context, includeSpotlight: true)
+        session = LanguageModelSession(tools: tools, transcript: Transcript(entries: retained))
     }
 
     /// Folds the situational ``AssistantContext`` into session instructions.

--- a/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
@@ -290,6 +290,37 @@ struct FoundationModelAssistantTests {
         #expect(reply.localizedCaseInsensitiveContains("Falkor"))
     }
 
+    @Test("converse trims the cached session's transcript once it exceeds the retained-turn budget (#456)")
+    func converseTrimsTranscriptBeyondBudget() async throws {
+        guard modelAvailable() else { return }
+        let assistant = FoundationModelAssistant(maxRetainedTurns: 2)
+        let context = makeContext()
+
+        for turn in 1...4 {
+            let prompt = turn == 3
+                ? "Remember this code word: Falkor. Reply with just 'ok'."
+                : "Reply with just 'ok'."
+            for await _ in try await assistant.converse(prompt: prompt, context: context) {}
+        }
+
+        // Four turns landed but the retained-turn budget is 2 — the cached session must have been
+        // rebuilt from a trimmed window rather than growing unbounded.
+        let promptCount = await assistant.promptCountForTesting
+        #expect(promptCount != nil)
+        if let promptCount { #expect(promptCount <= 2) }
+
+        // The trimmed window keeps the *most recent* turns, so the code word planted on turn 3
+        // (within the last 2 turns as of turn 4's completion) must still be recoverable.
+        var reply = ""
+        for await event in try await assistant.converse(
+            prompt: "What is the code word I gave you? Reply with only the word.",
+            context: context
+        ) {
+            if case .textDelta(let text) = event { reply += text }
+        }
+        #expect(reply.localizedCaseInsensitiveContains("Falkor"))
+    }
+
     @Test("cancel mid-stream yields .cancelled and ends the turn")
     func cancelMidStreamYieldsCancelled() async throws {
         guard modelAvailable() else { return }

--- a/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
@@ -56,6 +56,16 @@ struct FoundationModelAssistantTests {
         #expect(FoundationModelAssistant().capabilities.providerName == "On-Device")
     }
 
+    @Test("maxRetainedTurns is clamped to at least 1, not left non-positive (#456)")
+    func maxRetainedTurnsIsClamped() {
+        // trimSessionIfNeeded's cutoff indexing (`promptIndices.count - maxRetainedTurns`) assumes
+        // at least 1; `<= 0` would index at/past the end of `promptIndices` and crash once a turn
+        // lands. `init` clamps rather than crashing.
+        #expect(FoundationModelAssistant(maxRetainedTurns: 0).maxRetainedTurnsForTesting == 1)
+        #expect(FoundationModelAssistant(maxRetainedTurns: -5).maxRetainedTurnsForTesting == 1)
+        #expect(FoundationModelAssistant(maxRetainedTurns: 3).maxRetainedTurnsForTesting == 3)
+    }
+
     @Test("PCC-tier assistant constructs and remains usable (falls back to on-device)")
     func pccConstructsAndIsUsable() {
         // `capabilities` is a nonisolated var, so it reads synchronously off the actor.

--- a/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
@@ -300,6 +300,94 @@ struct FoundationModelAssistantTests {
         #expect(reply.localizedCaseInsensitiveContains("Falkor"))
     }
 
+    // MARK: Page context budget / placement (#457, pure — no model required)
+
+    @Test("conversational-session instructions never contain page route or content")
+    func conversationalInstructionsOmitPageContext() {
+        let context = AssistantContext(
+            siteID: "site-1",
+            siteDirectory: URL(fileURLWithPath: "/tmp/site"),
+            currentPageRoute: "/about",
+            currentPageContent: "Some page body text."
+        )
+        let instructions = FoundationModelAssistant.instructions(for: context, includePageContext: false)
+        #expect(!instructions.contains("/about"))
+        #expect(!instructions.contains("Some page body text."))
+    }
+
+    @Test("one-shot instructions still carry page route/content (EditInterpreter/AltTextGenerator rely on this)")
+    func oneShotInstructionsIncludePageContext() {
+        let context = AssistantContext(
+            siteID: "site-1",
+            siteDirectory: URL(fileURLWithPath: "/tmp/site"),
+            currentPageRoute: "/about",
+            currentPageContent: "Some page body text."
+        )
+        let instructions = FoundationModelAssistant.instructions(for: context, includePageContext: true)
+        #expect(instructions.contains("/about"))
+        #expect(instructions.contains("Some page body text."))
+    }
+
+    @Test("page content over the character budget is truncated")
+    func pageContentIsTruncated() {
+        let longContent = String(repeating: "x", count: FoundationModelAssistant.maxPageContentCharacters + 500)
+        let truncated = FoundationModelAssistant.truncatedPageContent(longContent)
+        #expect(truncated.count <= FoundationModelAssistant.maxPageContentCharacters + 1)  // +1 for the "…" marker
+        #expect(truncated.hasSuffix("…"))
+    }
+
+    @Test("page content under the character budget passes through unchanged")
+    func shortPageContentIsUnchanged() {
+        let short = "just a short page"
+        #expect(FoundationModelAssistant.truncatedPageContent(short) == short)
+    }
+
+    @Test("turnPrompt composes route + truncated content + the user's prompt, in order")
+    func turnPromptComposesContext() {
+        let context = AssistantContext(
+            siteID: "site-1",
+            siteDirectory: URL(fileURLWithPath: "/tmp/site"),
+            currentPageRoute: "/about",
+            currentPageContent: "Some page body text."
+        )
+        let composed = FoundationModelAssistant.turnPrompt(for: "What does this page say?", context: context)
+        #expect(composed.contains("/about"))
+        #expect(composed.contains("Some page body text."))
+        #expect(composed.hasSuffix("What does this page say?"))
+    }
+
+    @Test("turnPrompt with no page context is just the prompt")
+    func turnPromptWithoutContextIsBare() {
+        let context = makeContext()  // no currentPageRoute/currentPageContent
+        #expect(FoundationModelAssistant.turnPrompt(for: "hello", context: context) == "hello")
+    }
+
+    @Test("converse reflects a navigated page's context on the very next turn, without a session reset (#457)")
+    func converseReflectsUpdatedContextPerTurn() async throws {
+        guard modelAvailable() else { return }
+        let assistant = FoundationModelAssistant()
+
+        // Turn 1: no page context.
+        for await _ in try await assistant.converse(prompt: "Reply with just 'ok'.", context: makeContext()) {}
+
+        // Turn 2: the user "navigated" — a fresh AssistantContext carries new page content, with no
+        // resetSession() call in between. The cached session's *instructions* were fixed at turn 1
+        // (before this page existed), so this only works if the content rides on the turn's prompt.
+        let navigatedContext = AssistantContext(
+            siteID: "site-1",
+            siteDirectory: URL(fileURLWithPath: "/tmp/site"),
+            currentPageContent: "The secret ingredient is saffron."
+        )
+        var reply = ""
+        for await event in try await assistant.converse(
+            prompt: "What is the secret ingredient mentioned in the current page content? Reply with only the word.",
+            context: navigatedContext
+        ) {
+            if case .textDelta(let text) = event { reply += text }
+        }
+        #expect(reply.localizedCaseInsensitiveContains("saffron"))
+    }
+
     @Test("converse trims the cached session's transcript once it exceeds the retained-turn budget (#456)")
     func converseTrimsTranscriptBeyondBudget() async throws {
         guard modelAvailable() else { return }


### PR DESCRIPTION
## Summary

Two related fixes to `FoundationModelAssistant`'s conversational session, both against the on-device model's 4,096-token context window (`FoundationModelAssistant.swift:92`):

### #456 — unbounded transcript growth
- `conversationSession(for:)` caches a `LanguageModelSession` across `converse()` turns. Apple's session accumulates the full prompt/response/tool-call transcript internally with **no built-in compaction**, and the advertised `maxContextTokens` was never enforced against it.
- FoundationModels exposes no compaction API (confirmed via symbol-graph extraction of the framework), so this implements **windowing, not summarization**: after each turn drains, `trimSessionIfNeeded` rebuilds the cached session from a trimmed suffix of its `Transcript` once it holds more than `maxRetainedTurns` (default 12, clamped to ≥1 per review feedback) turns.
- Tool-building was factored out of `makeSession` into `conversationTools(for:includeSpotlight:)` so both fresh-session creation and the trimmed rebuild attach the same tools.

### #457 — unbounded/stale page context
- `currentPageContent` flowed into the session's fixed `instructions:` with no size cap, and for the cached `converse()` session those instructions are fixed at construction — so a page loaded when the conversation started stays baked in even after the user navigates elsewhere.
- Route/content now ride on each `converse()` turn's composed prompt (`turnPrompt`) instead of the session's fixed instructions, which stay minimal and stable. Content is capped at `maxPageContentCharacters` (2,000) wherever it's folded in.
- One-shot `generate`/`generateStructured` build a fresh session per call, so there's no staleness risk there — they keep the fuller instructions (`FoundationModelEditInterpreter` and `AltTextGenerator` both rely on `currentPageRoute` reaching the model this way), just now truncated too.

`ChatHistoryStore.load()` was confirmed UI-only (populates `transcript.messages` for display, never touches the model) — no changes needed there. `KnowledgeAugmentedAssistant`'s RAG injection is out of scope for both fixes (contained to `FoundationModelAssistant`).

Fixes #456. Fixes #457.

## Test plan

- [x] Live-model test for #456: 4 turns with `maxRetainedTurns: 2`, asserts the transcript's prompt count stays ≤ 2, confirms a fact planted within the retained window is still recallable.
- [x] Live-model test for #457 (`converseReflectsUpdatedContextPerTurn`): turn 2 recalls content from a freshly-navigated `AssistantContext` with no `resetSession()` call, proving context isn't stuck at turn-1 instructions.
- [x] 6 pure-string tests for #457 (instructions omit/include page context correctly per path, truncation behavior, `turnPrompt` composition) — no live model needed.
- [x] Regression test for the review-flagged `maxRetainedTurns <= 0` crash.
- [x] `swift test --filter FoundationModelAssistantTests` — 27/27 pass on a machine with Apple Intelligence available, so live-model tests actually exercise the fixes.
- [x] Full `swift test --package-path .` — 0 failures across all `AnglesiteCoreTests` (1112 tests) and all other targets. One unrelated `FSEventsFileWatcher` test failure was confirmed pre-existing (reproduces identically with these changes fully `git stash`ed) — an FSEvents timing/environment flake, not a regression from this diff.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — the app target itself builds and links, not just the library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)