### PR TITLE
fix(#69): container-image/kernel/initfs resources never reached the app bundle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -100,10 +100,16 @@ if includeContainer {
                 .product(name: "ContainerizationExtras", package: "containerization")
             ],
             path: "Sources/AnglesiteContainer",
+            // `swift-tools-version: 5.10` silently drops `.copy()` resources whose path
+            // escapes the target directory (no warning, no error — the resource bundle
+            // just never gets the content). `Resources/container-{image,kernel,initfs}/`
+            // are symlinked in-target here so the copy stays within
+            // Sources/AnglesiteContainer while the vendored artifacts still live at the
+            // top-level Resources/ alongside the rest of the app's bundled resources.
             resources: [
-                .copy("../../Resources/container-image"),
-                .copy("../../Resources/container-kernel"),
-                .copy("../../Resources/container-initfs")
+                .copy("Resources/container-image"),
+                .copy("Resources/container-kernel"),
+                .copy("Resources/container-initfs")
             ],
             swiftSettings: strictConcurrency
         )

--- a/Sources/AnglesiteContainer/Resources/container-image
+++ b/Sources/AnglesiteContainer/Resources/container-image
@@ -1,0 +1,1 @@
+../../../Resources/container-image

--- a/Sources/AnglesiteContainer/Resources/container-initfs
+++ b/Sources/AnglesiteContainer/Resources/container-initfs
@@ -1,0 +1,1 @@
+../../../Resources/container-initfs

--- a/Sources/AnglesiteContainer/Resources/container-kernel
+++ b/Sources/AnglesiteContainer/Resources/container-kernel
@@ -1,0 +1,1 @@
+../../../Resources/container-kernel


### PR DESCRIPTION
## Summary

Found while running the [#69 local-container runtime manual smoke test](docs/qa/local-container-runtime-smoke-test.md): `AnglesiteContainer`'s vendored artifacts never actually reached the built app, on any machine, ever.

`Package.swift` declared:

```swift
resources: [
    .copy("../../Resources/container-image"),
    .copy("../../Resources/container-kernel"),
    .copy("../../Resources/container-initfs")
]
```

These paths escape `Sources/AnglesiteContainer`'s own directory. Under this package's `// swift-tools-version: 5.10`, SwiftPM silently drops any `.copy()` resource whose path escapes the target directory — no warning, no error, the build just succeeds without the content. I isolated this in a throwaway package: the identical `.copy("../../Resources/...")` line produces a populated resource bundle under `swift-tools-version:6.0` and produces nothing under `5.10`.

Practical effect: `BundledImage.isProvisioned` could never be `true` in a real build, so `LiveSiteRuntimeFactory` always fell back to `LocalSiteRuntime` regardless of how carefully the image/kernel/initfs were vendored. Every prior #69 QA comment only validated that the build *compiled* — none checked that the resource bundle actually carried the artifacts, so this shipped unnoticed through Phases 1–2.

## Fix

Symlink `Resources/container-{image,kernel,initfs}/` into `Sources/AnglesiteContainer/Resources/` and reference the in-target symlinks from `Package.swift`, keeping the `.copy()` within the target directory while the vendored artifacts still live at the top-level `Resources/` alongside the rest of the app's bundled resources (Template, node-runtime, plugin, etc). Minimal change, `swift-tools-version` untouched.

## Validation

- Vendored real artifacts (`scripts/vendor-container-image.sh`, `scripts/vendor-container-kernel.sh`) and confirmed `Anglesite_AnglesiteContainer.bundle` now contains `container-image/index.json`, `container-kernel/vmlinux`, and `container-initfs/index.json` after a clean `swift build --product AnglesiteContainer`.
- `env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug clean build` — confirmed the real-signed `Anglesite.app` carries all three artifacts under `Contents/Resources/Anglesite_AnglesiteContainer.bundle/` and still carries the `com.apple.security.virtualization` entitlement.
- `swift test --package-path . --filter LocalContainerSupportTests` — 5/5 pass.

## What's still open

Smoke matrix cases 3–9 (runtime selection, VM boot, preview/MCP through the vsock proxy, `apply_edit`, teardown, fallback) need a human at the keyboard — this session's computer-use bridge timed out repeatedly (`request_access` never got an interactive response), so I could not drive the actual GUI boot smoke. The artifacts are vendored in this worktree and the app is built with the fix; someone can pick up at "Test Case 3: Confirm Runtime Selection" in the runbook directly.

Refs #59
Refs #69