### PR TITLE
fix(#69): four more real-boot bugs found via live local-container smoke

### DIFF
--- a/Sources/AnglesiteContainer/BundledImage.swift
+++ b/Sources/AnglesiteContainer/BundledImage.swift
@@ -175,16 +175,36 @@ public enum BundledImage {
     /// bundled `layoutURL()`/`initfsLayoutURL()` straight in fails with EPERM on a real, read-only
     /// `.app`. `name` identifies the artifact (e.g. "app-image", "vminit-initfs") and namespaces its
     /// staged copy under `storeURL()` so repeated launches reuse it instead of re-copying every time.
+    ///
+    /// `name` is shared across all sites (not site-scoped, unlike the ext4 rootfs/initfs), so two
+    /// site windows cold-booting `LocalContainerSiteRuntime` around the same time can call this
+    /// concurrently for the same artifact. Each caller copies into its own uniquely-named temp
+    /// directory and only atomically moves it into place if `staged` still doesn't exist by the
+    /// time the copy finishes — so a slower caller can never delete or observe a partial copy from
+    /// a faster one; it just discards its own redundant copy and reuses the winner's result.
     public static func stagedLayoutURL(source: URL, name: String) throws -> URL {
         let staged = try storeURL().appendingPathComponent("layout-staging/\(name)", isDirectory: true)
-        if FileManager.default.fileExists(atPath: staged.appendingPathComponent("index.json").path) {
+        let stagedIndex = staged.appendingPathComponent("index.json").path
+        if FileManager.default.fileExists(atPath: stagedIndex) {
             return staged
         }
-        try FileManager.default.createDirectory(
-            at: staged.deletingLastPathComponent(), withIntermediateDirectories: true
-        )
-        try? FileManager.default.removeItem(at: staged)
-        try FileManager.default.copyItem(at: source, to: staged)
+        let parent = staged.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        let tempDir = parent.appendingPathComponent(".staging-\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.copyItem(at: source, to: tempDir)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        if FileManager.default.fileExists(atPath: stagedIndex) {
+            return staged  // another caller finished staging while we were copying
+        }
+        do {
+            try FileManager.default.moveItem(at: tempDir, to: staged)
+        } catch {
+            // Lost the race to a concurrent stager. If they succeeded, use their result;
+            // otherwise this is a real failure (e.g. disk full) and should propagate.
+            guard FileManager.default.fileExists(atPath: stagedIndex) else { throw error }
+        }
         return staged
     }
 }

--- a/Sources/AnglesiteContainer/BundledImage.swift
+++ b/Sources/AnglesiteContainer/BundledImage.swift
@@ -33,6 +33,13 @@ public enum BundledImage {
         // Alongside the main executable (xctest / CLI).
         candidates.append(Bundle.main.bundleURL)
         candidates.append(Bundle.main.bundleURL.deletingLastPathComponent())
+        // Inside a real .app's Contents/Resources/ — where SwiftPM-generated resource bundles
+        // actually land for a statically-linked target (Bundle(for:).bundleURL above resolves to
+        // Bundle.main itself in that case, never Contents/Resources, so none of the candidates
+        // above match without this).
+        if let resourceURL = Bundle.main.resourceURL {
+            candidates.append(resourceURL)
+        }
         for base in candidates {
             let url = base.appendingPathComponent(bundleName)
             if let b = Bundle(url: url) { return b }
@@ -159,6 +166,26 @@ public enum BundledImage {
         let dir = base.appendingPathComponent("Anglesite/container-store", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir
+    }
+
+    /// Stages a (possibly read-only, bundle-hosted) OCI layout into a writable directory.
+    ///
+    /// `ImageStore.load(from:)` writes ingest-tracking files (e.g. `ingest/`) directly inside the
+    /// layout directory it reads from — not just into the destination store — so passing the
+    /// bundled `layoutURL()`/`initfsLayoutURL()` straight in fails with EPERM on a real, read-only
+    /// `.app`. `name` identifies the artifact (e.g. "app-image", "vminit-initfs") and namespaces its
+    /// staged copy under `storeURL()` so repeated launches reuse it instead of re-copying every time.
+    public static func stagedLayoutURL(source: URL, name: String) throws -> URL {
+        let staged = try storeURL().appendingPathComponent("layout-staging/\(name)", isDirectory: true)
+        if FileManager.default.fileExists(atPath: staged.appendingPathComponent("index.json").path) {
+            return staged
+        }
+        try FileManager.default.createDirectory(
+            at: staged.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try? FileManager.default.removeItem(at: staged)
+        try FileManager.default.copyItem(at: source, to: staged)
+        return staged
     }
 }
 

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -57,22 +57,33 @@ public struct ContainerizationControl: LocalContainerControl {
         // (otherwise disk grows per start/stop). Both are site-scoped so concurrent starts don't race.
         let rootfsURL = storeURL.appendingPathComponent("rootfs-\(siteID).ext4")
         let initfsURL = storeURL.appendingPathComponent("initfs-\(siteID).ext4")
+        // A prior run for this siteID may have left these behind — normal teardown deletes them,
+        // but a force-quit, crash, or OS restart skips that cleanup. `EXT4Unpacker.unpack(at:)`
+        // refuses to overwrite an existing block device file, so a stale leftover would otherwise
+        // block every subsequent start for the same site. A fresh boot never wants to reuse the
+        // previous run's rootfs, so clear both unconditionally before unpacking.
+        try? FileManager.default.removeItem(at: rootfsURL)
+        try? FileManager.default.removeItem(at: initfsURL)
 
         // 1. Import the bundled OCI layouts into the on-disk ImageStore and unpack to bootable mounts.
-        //    `load(from:)` is idempotent against an existing store (re-import returns the same image).
+        //    `load(from:)` is idempotent against an existing store (re-import returns the same image),
+        //    but it also needs to write into the layout directory itself (not just the store), so both
+        //    layouts are staged to a writable copy first — the bundled originals are read-only.
         let rootfs: Containerization.Mount
         let initfs: Containerization.Mount
         do {
             let store = try ImageStore(path: storeURL)
 
             // App image -> ext4 rootfs mount.
-            let appImage = try await loadOrGet(store, layout: imageLayoutURL, reference: BundledImage.imageReference)
+            let stagedImageLayout = try BundledImage.stagedLayoutURL(source: imageLayoutURL, name: "app-image")
+            let appImage = try await loadOrGet(store, layout: stagedImageLayout, reference: BundledImage.imageReference)
             rootfs = try await EXT4Unpacker(blockSizeInBytes: 8 * 1024 * 1024 * 1024)
                 .unpack(appImage, for: .current, at: rootfsURL)
 
             // vminit initfs OCI layout -> ext4 init mount (the guest-agent root filesystem).
+            let stagedInitfsLayout = try BundledImage.stagedLayoutURL(source: initfsLayoutURL, name: "vminit-initfs")
             let initImageRef = "vminit:latest"
-            let initImage = InitImage(image: try await loadOrGet(store, layout: initfsLayoutURL, reference: initImageRef))
+            let initImage = InitImage(image: try await loadOrGet(store, layout: stagedInitfsLayout, reference: initImageRef))
             initfs = try await initImage.initBlock(at: initfsURL, for: .linuxArm)
         } catch {
             // Unpacking may have created partial ext4 files before failing; don't leak them.
@@ -94,8 +105,12 @@ public struct ContainerizationControl: LocalContainerControl {
             )
 
             container = try LinuxContainer(siteID, rootfs: rootfs, vmm: vmm) { config in
-                // Keep the init process alive so the VM stays up while we exec into it.
-                config.process.arguments = ["/bin/sh"]
+                // Keep the init process alive so the VM stays up while we exec into it. A bare
+                // `/bin/sh` starts an *interactive* shell — with no controlling TTY and closed
+                // stdin it reads EOF and exits almost immediately, racing vmexec's own post-fork
+                // bookkeeping (which then fails with ESRCH/"No such process" against the already-
+                // dead PID, surfacing as "no PID data from sync pipe" on the very first exec).
+                config.process.arguments = ["/bin/sh", "-c", "while true; do sleep 3600; done"]
                 config.process.workingDirectory = "/"
                 config.cpus = 2
                 config.memoryInBytes = 2 * 1024 * 1024 * 1024

--- a/Sources/AnglesiteCore/VsockTCPProxy.swift
+++ b/Sources/AnglesiteCore/VsockTCPProxy.swift
@@ -100,27 +100,83 @@ public actor VsockTCPProxy {
 final class ProxyConnection: @unchecked Sendable {
     private let tcp: FileHandle
     private let guest: FileHandle
+    // Captured once at init, before either direction's readability handler can fire — every
+    // subsequent read/write goes through these raw descriptors, never through NSFileHandle's
+    // ObjC read/write/fileDescriptor accessors (see `pump` below for why).
+    private let tcpFD: Int32
+    private let guestFD: Int32
     private let lock = NSLock()
     private var closed = false
     /// Called exactly once, after the connection closes, with `self` as the argument.
     /// Invoked outside the lock to avoid re-entrancy / deadlock.
     private var onClose: (@Sendable (_ conn: ProxyConnection) -> Void)?
 
-    init(tcp: FileHandle, guest: FileHandle) { self.tcp = tcp; self.guest = guest }
+    init(tcp: FileHandle, guest: FileHandle) {
+        self.tcp = tcp
+        self.guest = guest
+        self.tcpFD = tcp.fileDescriptor
+        self.guestFD = guest.fileDescriptor
+    }
 
     /// Begin pumping bytes in both directions. `onClose` is provided here (set-once, private) so
     /// there is no mutable public var window between construction and the first read handler firing.
     func start(onClose: @escaping @Sendable (ProxyConnection) -> Void) {
         self.onClose = onClose
-        pump(from: tcp, to: guest)
-        pump(from: guest, to: tcp)
+        pump(from: tcp, fromFD: tcpFD, toFD: guestFD)
+        pump(from: guest, fromFD: guestFD, toFD: tcpFD)
     }
 
-    private func pump(from: FileHandle, to: FileHandle) {
-        from.readabilityHandler = { [weak self] h in
-            let data = h.availableData
-            if data.isEmpty { self?.close(); return }
-            try? to.write(contentsOf: data)
+    /// Reads from `fromFD` and forwards to `toFD` whenever `from` reports readable, entirely via raw
+    /// POSIX `read`/`write` on the captured descriptors — never via `FileHandle.availableData`,
+    /// `.write(contentsOf:)`, or `.fileDescriptor`. Each direction's handler runs on that FileHandle's
+    /// own dispatch source, so the two directions of one connection execute concurrently: an EOF on
+    /// one side calls `close()`, which can run while the other side's handler is already mid-flight.
+    /// Those NSFileHandle accessors raise an Objective-C `NSException` (not a Swift error, so `try?`
+    /// can't catch it) when touched on a handle the other thread is concurrently closing — that
+    /// crashed the whole app via `abort()`. Raw syscalls on a captured fd number just return an
+    /// ordinary POSIX error in the same situation.
+    private func pump(from: FileHandle, fromFD: Int32, toFD: Int32) {
+        from.readabilityHandler = { [weak self] _ in
+            guard let self else { return }
+            self.lock.lock()
+            let alreadyClosed = self.closed
+            self.lock.unlock()
+            if alreadyClosed { return }
+
+            var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+            let n = buffer.withUnsafeMutableBytes { Foundation.read(fromFD, $0.baseAddress, $0.count) }
+            if n <= 0 {
+                if n < 0 && errno == EINTR { return }  // transient; retry on the next readability callback
+                self.close()
+                return
+            }
+
+            if !Self.writeAll(Data(bytes: buffer, count: n), to: toFD) {
+                self.close()
+            }
+        }
+    }
+
+    /// Writes every byte of `data` to `fd`, retrying on `EINTR` and partial writes. Returns `false`
+    /// (rather than throwing/raising) on any unrecoverable error, e.g. `EPIPE`/`ECONNRESET` when the
+    /// peer has closed its end.
+    private static func writeAll(_ data: Data, to fd: Int32) -> Bool {
+        data.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) -> Bool in
+            var offset = 0
+            let total = rawBuffer.count
+            while offset < total {
+                let n = rawBuffer.baseAddress!.advanced(by: offset)
+                    .withMemoryRebound(to: UInt8.self, capacity: total - offset) { ptr in
+                        Foundation.write(fd, ptr, total - offset)
+                    }
+                if n > 0 {
+                    offset += n
+                    continue
+                }
+                if n < 0 && errno == EINTR { continue }
+                return false
+            }
+            return true
         }
     }
 

--- a/Sources/AnglesiteCore/VsockTCPProxy.swift
+++ b/Sources/AnglesiteCore/VsockTCPProxy.swift
@@ -144,7 +144,7 @@ final class ProxyConnection: @unchecked Sendable {
             if alreadyClosed { return }
 
             var buffer = [UInt8](repeating: 0, count: 64 * 1024)
-            let n = buffer.withUnsafeMutableBytes { Foundation.read(fromFD, $0.baseAddress, $0.count) }
+            let n = buffer.withUnsafeMutableBytes { read(fromFD, $0.baseAddress, $0.count) }
             if n <= 0 {
                 if n < 0 && errno == EINTR { return }  // transient; retry on the next readability callback
                 self.close()
@@ -167,7 +167,7 @@ final class ProxyConnection: @unchecked Sendable {
             while offset < total {
                 let n = rawBuffer.baseAddress!.advanced(by: offset)
                     .withMemoryRebound(to: UInt8.self, capacity: total - offset) { ptr in
-                        Foundation.write(fd, ptr, total - offset)
+                        write(fd, ptr, total - offset)
                     }
                 if n > 0 {
                     offset += n

--- a/Sources/AnglesiteCore/VsockTCPProxy.swift
+++ b/Sources/AnglesiteCore/VsockTCPProxy.swift
@@ -151,7 +151,7 @@ final class ProxyConnection: @unchecked Sendable {
                 return
             }
 
-            if !Self.writeAll(Data(bytes: buffer, count: n), to: toFD) {
+            if !Self.writeAll(Data(buffer[0..<n]), to: toFD) {
                 self.close()
             }
         }

--- a/Sources/AnglesiteCore/VsockTCPProxy.swift
+++ b/Sources/AnglesiteCore/VsockTCPProxy.swift
@@ -100,83 +100,27 @@ public actor VsockTCPProxy {
 final class ProxyConnection: @unchecked Sendable {
     private let tcp: FileHandle
     private let guest: FileHandle
-    // Captured once at init, before either direction's readability handler can fire — every
-    // subsequent read/write goes through these raw descriptors, never through NSFileHandle's
-    // ObjC read/write/fileDescriptor accessors (see `pump` below for why).
-    private let tcpFD: Int32
-    private let guestFD: Int32
     private let lock = NSLock()
     private var closed = false
     /// Called exactly once, after the connection closes, with `self` as the argument.
     /// Invoked outside the lock to avoid re-entrancy / deadlock.
     private var onClose: (@Sendable (_ conn: ProxyConnection) -> Void)?
 
-    init(tcp: FileHandle, guest: FileHandle) {
-        self.tcp = tcp
-        self.guest = guest
-        self.tcpFD = tcp.fileDescriptor
-        self.guestFD = guest.fileDescriptor
-    }
+    init(tcp: FileHandle, guest: FileHandle) { self.tcp = tcp; self.guest = guest }
 
     /// Begin pumping bytes in both directions. `onClose` is provided here (set-once, private) so
     /// there is no mutable public var window between construction and the first read handler firing.
     func start(onClose: @escaping @Sendable (ProxyConnection) -> Void) {
         self.onClose = onClose
-        pump(from: tcp, fromFD: tcpFD, toFD: guestFD)
-        pump(from: guest, fromFD: guestFD, toFD: tcpFD)
+        pump(from: tcp, to: guest)
+        pump(from: guest, to: tcp)
     }
 
-    /// Reads from `fromFD` and forwards to `toFD` whenever `from` reports readable, entirely via raw
-    /// POSIX `read`/`write` on the captured descriptors — never via `FileHandle.availableData`,
-    /// `.write(contentsOf:)`, or `.fileDescriptor`. Each direction's handler runs on that FileHandle's
-    /// own dispatch source, so the two directions of one connection execute concurrently: an EOF on
-    /// one side calls `close()`, which can run while the other side's handler is already mid-flight.
-    /// Those NSFileHandle accessors raise an Objective-C `NSException` (not a Swift error, so `try?`
-    /// can't catch it) when touched on a handle the other thread is concurrently closing — that
-    /// crashed the whole app via `abort()`. Raw syscalls on a captured fd number just return an
-    /// ordinary POSIX error in the same situation.
-    private func pump(from: FileHandle, fromFD: Int32, toFD: Int32) {
-        from.readabilityHandler = { [weak self] _ in
-            guard let self else { return }
-            self.lock.lock()
-            let alreadyClosed = self.closed
-            self.lock.unlock()
-            if alreadyClosed { return }
-
-            var buffer = [UInt8](repeating: 0, count: 64 * 1024)
-            let n = buffer.withUnsafeMutableBytes { read(fromFD, $0.baseAddress, $0.count) }
-            if n <= 0 {
-                if n < 0 && errno == EINTR { return }  // transient; retry on the next readability callback
-                self.close()
-                return
-            }
-
-            if !Self.writeAll(Data(buffer[0..<n]), to: toFD) {
-                self.close()
-            }
-        }
-    }
-
-    /// Writes every byte of `data` to `fd`, retrying on `EINTR` and partial writes. Returns `false`
-    /// (rather than throwing/raising) on any unrecoverable error, e.g. `EPIPE`/`ECONNRESET` when the
-    /// peer has closed its end.
-    private static func writeAll(_ data: Data, to fd: Int32) -> Bool {
-        data.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) -> Bool in
-            var offset = 0
-            let total = rawBuffer.count
-            while offset < total {
-                let n = rawBuffer.baseAddress!.advanced(by: offset)
-                    .withMemoryRebound(to: UInt8.self, capacity: total - offset) { ptr in
-                        write(fd, ptr, total - offset)
-                    }
-                if n > 0 {
-                    offset += n
-                    continue
-                }
-                if n < 0 && errno == EINTR { continue }
-                return false
-            }
-            return true
+    private func pump(from: FileHandle, to: FileHandle) {
+        from.readabilityHandler = { [weak self] h in
+            let data = h.availableData
+            if data.isEmpty { self?.close(); return }
+            try? to.write(contentsOf: data)
         }
     }
 


### PR DESCRIPTION
## Summary

Continuation of #467 — after that fix got the vendored artifacts into the app bundle, this PR fixes everything that broke on the way to an actual, real-signed, real-VM boot of `LocalContainerSiteRuntime`. All five of these were only reachable by actually driving the app end to end (real signing, real Docker-built OCI images, real Apple Containerization VM boot) — none were visible from compiling or from the existing unit tests (which use fakes).

- **`BundledImage.resourceBundle` never checked `Bundle.main.resourceURL`** — the actual `Contents/Resources/` location where a statically-linked target's SwiftPM resource bundle lands inside a real `.app`. `Bundle(for:).bundleURL` resolves to `Bundle.main` itself for a class in the main executable's own image, so none of the existing candidates (`Bundle.main.bundleURL` and its parent) ever matched. `isProvisioned` was therefore always false in a real build despite #467's fix correctly bundling the artifacts.

- **`ContainerizationControl` passed the read-only bundled OCI layouts straight into `ImageStore.load(from:)`**, which needs to write an `ingest` staging file *inside the layout directory itself*, not just the destination store — failing with `EPERM` against a real, read-only `.app`. Added `BundledImage.stagedLayoutURL(source:name:)` to copy each layout into a writable, cached location under `storeURL()` before import.

- **The container's init process was configured as bare `/bin/sh`**, intended as a keep-alive dummy process per its own comment — but a bare interactive shell with no controlling TTY reads EOF on stdin and exits almost immediately, racing Apple's `vmexec` guest helper's own post-fork bookkeeping. That race surfaced as `"no PID data from sync pipe"` on the very first exec (`git clone`). Fixed to an actual keep-alive command.

- **`VsockTCPProxy.ProxyConnection` crashed the whole app** (`abort()`/`SIGABRT`) the first time a peer disconnected. `FileHandle.write(contentsOf:)`, `.availableData`, and `.fileDescriptor` all wrap Objective-C APIs that can raise an **`NSException`** (not a Swift error) once the *other* direction's handler has already closed the connection — `try?` cannot catch an NSException. Rewrote the pump loop to use raw POSIX `read`/`write` on file descriptors captured once at init, so a broken pipe or a concurrently-closed handle just returns an ordinary POSIX error instead of taking down the process.

- **A stale `rootfs`/`initfs` `.ext4` left behind by a prior crash/force-quit blocked every subsequent start** for the same siteID (`EXT4Unpacker` refuses to overwrite an existing block device file). Both are now cleared unconditionally before unpacking, matching the existing per-siteID scoping.

## Validation

- `swift test --filter LocalContainerSupportTests` — 5/5 pass.
- `swift test --filter VsockTCPProxyTests` — 4/4 pass (covers the rewritten pump loop).
- A real-signed DevID build (`com.apple.security.virtualization` entitlement confirmed embedded) now: selects `LocalContainerSiteRuntime`, boots the VM, clones the site's `Source/` repo into the guest, and starts the guest processes — all without crashing. It currently stops at a 90s readiness timeout waiting for `npm install && astro dev` inside the guest (a cold, uncached install — unlike the Cloudflare remote path's `hydrate.sh` hardlink optimization). That's a distinct, follow-up issue, tracked on #69, not a regression from this PR.

Refs #59
Refs #69