### PR TITLE
feat(core): add newsletter integration (Buttondown/Mailchimp subscribe form)

### DIFF
--- a/Resources/Template/integrations/components/NewsletterForm.astro
+++ b/Resources/Template/integrations/components/NewsletterForm.astro
@@ -1,0 +1,12 @@
+---
+interface Props {
+  workerUrl?: string;
+  buttonText?: string;
+}
+const { workerUrl = "", buttonText = "Subscribe" } = Astro.props;
+---
+<form action={workerUrl} method="POST" class="newsletter-form">
+  <label for="newsletter-email">Email address</label>
+  <input id="newsletter-email" type="email" name="email" required autocomplete="email" placeholder="you@example.com" />
+  <button type="submit">{buttonText}</button>
+</form>

--- a/Resources/Template/integrations/docs/newsletter-setup.md
+++ b/Resources/Template/integrations/docs/newsletter-setup.md
@@ -1,0 +1,43 @@
+# Newsletter subscribe Worker setup
+
+The newsletter integration's subscribe form posts to a small Cloudflare Worker
+that forwards each submission to your newsletter platform. Running it as a
+separate Worker keeps your platform API key off the client — it never appears
+in the site's HTML or JavaScript.
+
+This site includes the Worker's source at `worker/subscribe-worker.js` and its
+config at `worker/subscribe-wrangler.toml`. Deploying it is a one-time, manual
+step from a terminal (it isn't deployed automatically when you deploy the
+site itself):
+
+1. **Get an API key.**
+   - **Buttondown**: sign up at buttondown.email, then Settings → API → copy the key.
+   - **Mailchimp**: sign up at mailchimp.com, create an audience, then Account → Extras → API keys → create a key. Also note the Audience ID (Audience → Settings → Audience name and defaults).
+
+2. **From a terminal, in this site's directory, store the secrets:**
+
+   ```sh
+   npx wrangler secret put NEWSLETTER_API_KEY --config worker/subscribe-wrangler.toml
+   npx wrangler secret put NEWSLETTER_PLATFORM --config worker/subscribe-wrangler.toml
+   npx wrangler secret put SITE_DOMAIN --config worker/subscribe-wrangler.toml
+   ```
+
+   Paste the API key, `buttondown` or `mailchimp`, and your site's domain
+   (e.g. `example.com`) when prompted. If you're using Mailchimp, also run:
+
+   ```sh
+   npx wrangler secret put MAILCHIMP_LIST_ID --config worker/subscribe-wrangler.toml
+   ```
+
+3. **Deploy the Worker:**
+
+   ```sh
+   npx wrangler deploy --config worker/subscribe-wrangler.toml
+   ```
+
+   Wrangler prints the deployed Worker's URL (something like
+   `https://newsletter-subscribe.<your-account>.workers.dev`).
+
+4. **Paste that URL into the newsletter wizard's "Subscribe Worker URL" field.**
+   The wizard writes it to `.site-config` and allows it through the site's
+   Content-Security-Policy automatically.

--- a/Resources/Template/integrations/pages/subscribe.astro
+++ b/Resources/Template/integrations/pages/subscribe.astro
@@ -1,0 +1,18 @@
+---
+import BaseLayout from "../../src/layouts/BaseLayout.astro";
+import NewsletterForm from "../components/NewsletterForm.astro";
+import { readConfig } from "../../scripts/config";
+---
+
+<BaseLayout
+  title="Subscribe"
+  description="Subscribe to get updates delivered straight to your inbox. No spam — unsubscribe anytime."
+>
+  <h1>Subscribe</h1>
+  <p>Get updates delivered to your inbox.</p>
+  <NewsletterForm
+    workerUrl={readConfig("NEWSLETTER_WORKER_URL")}
+    buttonText={readConfig("NEWSLETTER_BUTTON_TEXT")}
+  />
+  <p>No spam. Unsubscribe anytime.</p>
+</BaseLayout>

--- a/Resources/Template/integrations/pages/subscribe/thanks.astro
+++ b/Resources/Template/integrations/pages/subscribe/thanks.astro
@@ -1,0 +1,12 @@
+---
+import BaseLayout from "../../../src/layouts/BaseLayout.astro";
+---
+
+<BaseLayout
+  title="Subscribed"
+  description="You've been subscribed. Check your inbox for a confirmation email to finish signing up."
+>
+  <h1>You're subscribed!</h1>
+  <p>Check your inbox for a confirmation email. Once confirmed, you'll receive updates from us.</p>
+  <p><a href="/">Back to home</a></p>
+</BaseLayout>

--- a/Resources/Template/integrations/worker/subscribe-worker.js
+++ b/Resources/Template/integrations/worker/subscribe-worker.js
@@ -1,0 +1,158 @@
+/**
+ * Cloudflare Worker — Newsletter subscribe proxy.
+ *
+ * Proxies email subscribe form submissions to the newsletter API so the API key
+ * is never exposed client-side. Deployed separately from the site itself — see
+ * ../../../docs/newsletter-setup.md (staged to docs/newsletter-setup.md).
+ *
+ * Secrets (set via `wrangler secret put`):
+ *   NEWSLETTER_API_KEY  — Buttondown or Mailchimp API key
+ *   NEWSLETTER_PLATFORM — "buttondown" or "mailchimp"
+ *   MAILCHIMP_LIST_ID   — Mailchimp audience/list ID (Mailchimp only)
+ *   SITE_DOMAIN         — For CORS origin validation
+ */
+
+const RATE_LIMIT_SECONDS = 30;
+const recentSubmissions = new Map();
+
+function isRateLimited(ip) {
+  const now = Date.now();
+  const last = recentSubmissions.get(ip);
+  if (last && now - last < RATE_LIMIT_SECONDS * 1000) {
+    return true;
+  }
+  recentSubmissions.set(ip, now);
+  for (const [key, time] of recentSubmissions) {
+    if (now - time > RATE_LIMIT_SECONDS * 2000) {
+      recentSubmissions.delete(key);
+    }
+  }
+  return false;
+}
+
+function isAllowedOrigin(origin, siteDomain) {
+  if (!origin || !siteDomain) return false;
+  const allowed = `https://${siteDomain}`;
+  return origin === allowed || origin === `https://www.${siteDomain}`;
+}
+
+function corsHeaders(origin, siteDomain) {
+  if (!isAllowedOrigin(origin, siteDomain)) return {};
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+}
+
+async function subscribeButtondown(email, apiKey) {
+  const response = await fetch("https://api.buttondown.email/v1/subscribers", {
+    method: "POST",
+    headers: {
+      Authorization: `Token ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email, type: "regular" }),
+  });
+
+  if (response.status === 201) return { ok: true };
+  if (response.status === 409) return { ok: false, errors: ["Already subscribed."] };
+  return { ok: false, errors: ["Subscribe failed. Please try again later."] };
+}
+
+async function subscribeMailchimp(email, apiKey, listId) {
+  // Mailchimp API key format: key-dc (e.g., abc123-us21)
+  const dc = apiKey.split("-").pop();
+  const response = await fetch(`https://${dc}.api.mailchimp.com/3.0/lists/${listId}/members`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email_address: email, status: "pending" }), // double opt-in
+  });
+
+  if (response.ok) return { ok: true };
+  if (response.status === 400) {
+    try {
+      const body = await response.json();
+      if (body.title === "Member Exists") return { ok: false, errors: ["Already subscribed."] };
+    } catch {
+      // Ignore JSON parse errors from Mailchimp.
+    }
+  }
+  return { ok: false, errors: ["Subscribe failed. Please try again later."] };
+}
+
+export default {
+  async fetch(request, env) {
+    const origin = request.headers.get("Origin");
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: corsHeaders(origin, env.SITE_DOMAIN) });
+    }
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405, headers: corsHeaders(origin, env.SITE_DOMAIN) });
+    }
+
+    const ip = request.headers.get("CF-Connecting-IP") || "unknown";
+    if (isRateLimited(ip)) {
+      return new Response("Too many requests. Please wait a moment.", {
+        status: 429,
+        headers: corsHeaders(origin, env.SITE_DOMAIN),
+      });
+    }
+
+    const contentType = request.headers.get("Content-Type") || "";
+    let email;
+    try {
+      if (contentType.includes("application/x-www-form-urlencoded")) {
+        const formData = await request.formData();
+        email = formData.get("email");
+      } else if (contentType.includes("application/json")) {
+        const body = await request.json();
+        email = body.email;
+      } else {
+        return new Response("Unsupported content type", { status: 415, headers: corsHeaders(origin, env.SITE_DOMAIN) });
+      }
+    } catch {
+      return new Response(JSON.stringify({ errors: ["Invalid request body."] }), {
+        status: 400,
+        headers: { ...corsHeaders(origin, env.SITE_DOMAIN), "Content-Type": "application/json" },
+      });
+    }
+
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return new Response(JSON.stringify({ errors: ["A valid email address is required."] }), {
+        status: 400,
+        headers: { ...corsHeaders(origin, env.SITE_DOMAIN), "Content-Type": "application/json" },
+      });
+    }
+
+    const platform = (env.NEWSLETTER_PLATFORM || "buttondown").toLowerCase();
+    let result;
+    if (platform === "buttondown") {
+      result = await subscribeButtondown(email, env.NEWSLETTER_API_KEY);
+    } else if (platform === "mailchimp") {
+      result = await subscribeMailchimp(email, env.NEWSLETTER_API_KEY, env.MAILCHIMP_LIST_ID);
+    } else {
+      result = { ok: false, errors: ["Newsletter service not configured."] };
+    }
+
+    if (result.ok) {
+      // For a plain HTML form submission, redirect the browser to the thanks page.
+      if (contentType.includes("application/x-www-form-urlencoded") && origin) {
+        return Response.redirect(`${origin}/subscribe/thanks`, 303);
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { ...corsHeaders(origin, env.SITE_DOMAIN), "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ errors: result.errors }), {
+      status: 400,
+      headers: { ...corsHeaders(origin, env.SITE_DOMAIN), "Content-Type": "application/json" },
+    });
+  },
+};

--- a/Resources/Template/integrations/worker/subscribe-wrangler.toml
+++ b/Resources/Template/integrations/worker/subscribe-wrangler.toml
@@ -1,0 +1,16 @@
+# Newsletter subscribe Worker — see docs/newsletter-setup.md for deployment steps.
+# Receives subscribe form submissions and forwards them to your newsletter platform.
+#
+# Secrets are set via: npx wrangler secret put <NAME> --config worker/subscribe-wrangler.toml
+#   NEWSLETTER_API_KEY  — Buttondown or Mailchimp API key
+#   NEWSLETTER_PLATFORM — "buttondown" or "mailchimp"
+#   MAILCHIMP_LIST_ID   — Mailchimp audience/list ID (Mailchimp only)
+#   SITE_DOMAIN         — your site's domain, for CORS origin validation
+
+name = "newsletter-subscribe"
+main = "subscribe-worker.js"
+compatibility_date = "2024-01-01"
+
+[observability]
+enabled = true
+head_sampling_rate = 1.0

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -213,7 +213,7 @@ public enum IntegrationCatalog {
         ],
         fields: [
             Field(key: "workerUrl", label: "Subscribe Worker URL", kind: .url,
-                  help: "The Cloudflare Worker URL that proxies subscribe requests to your newsletter platform — see docs/newsletter-sending.md."),
+                  help: "The Cloudflare Worker URL that proxies subscribe requests to your newsletter platform — see docs/newsletter-setup.md, included in this site, for how to deploy it."),
             Field(key: "buttonText", label: "Button text", kind: .text, isOptional: true, defaultValue: "Subscribe"),
         ],
         operations: [
@@ -223,6 +223,12 @@ public enum IntegrationCatalog {
                       to: "src/pages/subscribe.astro", when: .always),
             .copyFile(from: TemplateRef("integrations/pages/subscribe/thanks.astro"),
                       to: "src/pages/subscribe/thanks.astro", when: .always),
+            .copyFile(from: TemplateRef("integrations/worker/subscribe-worker.js"),
+                      to: "worker/subscribe-worker.js", when: .always),
+            .copyFile(from: TemplateRef("integrations/worker/subscribe-wrangler.toml"),
+                      to: "worker/subscribe-wrangler.toml", when: .always),
+            .copyFile(from: TemplateRef("integrations/docs/newsletter-setup.md"),
+                      to: "docs/newsletter-setup.md", when: .always),
             .writeConfig([
                 ConfigEntry(key: "NEWSLETTER_PLATFORM", value: "{{provider}}"),
                 ConfigEntry(key: "NEWSLETTER_WORKER_URL", value: "{{workerUrl}}"),

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -32,10 +32,13 @@ public extension IntegrationDescriptor {
             switch op {
             case .copyFile(_, _, let w), .writeConfig(_, let w), .injectAtAnchor(_, _, _, let w, _):
                 check(w, "operation \(i)")
-            case .addCSPDomains(let fromProvider, _, let w):
+            case .addCSPDomains(let fromProvider, _, let fromFieldHost, let w):
                 check(w, "operation \(i)")
                 if fromProvider && providers.isEmpty {
                     problems.append("operation \(i): addCSPDomains(fromProvider:) but integration has no providers")
+                }
+                if let key = fromFieldHost, !fieldKeys.contains(key) {
+                    problems.append("operation \(i): addCSPDomains(fromFieldHost:) references unknown field \"\(key)\"")
                 }
             }
         }
@@ -44,7 +47,7 @@ public extension IntegrationDescriptor {
 }
 
 public enum IntegrationCatalog {
-    public static let all: [IntegrationDescriptor] = [booking, contact, donations, giscus]
+    public static let all: [IntegrationDescriptor] = [booking, contact, donations, giscus, newsletter]
 
     public static func descriptor(for id: IntegrationID) -> IntegrationDescriptor {
         guard let d = all.first(where: { $0.id == id }) else {
@@ -101,7 +104,7 @@ public enum IntegrationCatalog {
                 ConfigEntry(key: "BOOKING_EVENT_SLUG", value: "{{eventSlug}}"),
                 ConfigEntry(key: "BOOKING_BUTTON_TEXT", value: "{{buttonText}}"),
             ], when: .always),
-            .addCSPDomains(fromProvider: true, extra: [], when: .always),
+            .addCSPDomains(fromProvider: true, extra: [], fromFieldHost: nil, when: .always),
         ])
 
     // MARK: contact
@@ -133,7 +136,7 @@ public enum IntegrationCatalog {
                 ConfigEntry(key: "CONTACT_EMAIL", value: "{{email}}"),
                 ConfigEntry(key: "CONTACT_BUTTON_TEXT", value: "{{buttonText}}"),
             ], when: .always),
-            .addCSPDomains(fromProvider: true, extra: [], when: .always),
+            .addCSPDomains(fromProvider: true, extra: [], fromFieldHost: nil, when: .always),
         ])
 
     // MARK: donations
@@ -161,7 +164,7 @@ public enum IntegrationCatalog {
                 ConfigEntry(key: "DONATIONS_LINK", value: "{{link}}"),
                 ConfigEntry(key: "DONATIONS_BUTTON_TEXT", value: "{{buttonText}}"),
             ], when: .always),
-            .addCSPDomains(fromProvider: true, extra: [], when: .always),
+            .addCSPDomains(fromProvider: true, extra: [], fromFieldHost: nil, when: .always),
         ])
 
     // MARK: giscus
@@ -196,6 +199,37 @@ public enum IntegrationCatalog {
                 ConfigEntry(key: "GISCUS_CATEGORY_ID", value: "{{categoryId}}"),
                 ConfigEntry(key: "GISCUS_MAPPING", value: "{{mapping}}"),
             ], when: .always),
-            .addCSPDomains(fromProvider: false, extra: ["giscus.app"], when: .always),
+            .addCSPDomains(fromProvider: false, extra: ["giscus.app"], fromFieldHost: nil, when: .always),
+        ])
+
+    // MARK: newsletter
+    static let newsletter = IntegrationDescriptor(
+        id: .newsletter,
+        displayName: "Newsletter",
+        summary: "Let visitors subscribe to email updates (Buttondown or Mailchimp), via a Worker that keeps your API key off the client.",
+        providers: [
+            Provider(id: "buttondown", displayName: "Buttondown", cspDomains: []),
+            Provider(id: "mailchimp", displayName: "Mailchimp", cspDomains: []),
+        ],
+        fields: [
+            Field(key: "workerUrl", label: "Subscribe Worker URL", kind: .url,
+                  help: "The Cloudflare Worker URL that proxies subscribe requests to your newsletter platform — see docs/newsletter-sending.md."),
+            Field(key: "buttonText", label: "Button text", kind: .text, isOptional: true, defaultValue: "Subscribe"),
+        ],
+        operations: [
+            .copyFile(from: TemplateRef("integrations/components/NewsletterForm.astro"),
+                      to: "src/components/NewsletterForm.astro", when: .always),
+            .copyFile(from: TemplateRef("integrations/pages/subscribe.astro"),
+                      to: "src/pages/subscribe.astro", when: .always),
+            .copyFile(from: TemplateRef("integrations/pages/subscribe/thanks.astro"),
+                      to: "src/pages/subscribe/thanks.astro", when: .always),
+            .writeConfig([
+                ConfigEntry(key: "NEWSLETTER_PLATFORM", value: "{{provider}}"),
+                ConfigEntry(key: "NEWSLETTER_WORKER_URL", value: "{{workerUrl}}"),
+                ConfigEntry(key: "NEWSLETTER_BUTTON_TEXT", value: "{{buttonText}}"),
+            ], when: .always),
+            // The Worker's own domain isn't a fixed per-provider CSP domain (it's a per-site
+            // deployment) — extract it from the workerUrl field instead of a static list.
+            .addCSPDomains(fromProvider: false, extra: [], fromFieldHost: "workerUrl", when: .always),
         ])
 }

--- a/Sources/AnglesiteCore/IntegrationDescriptor.swift
+++ b/Sources/AnglesiteCore/IntegrationDescriptor.swift
@@ -1,4 +1,4 @@
-public enum IntegrationID: String, Sendable, CaseIterable { case booking, contact, donations, giscus }
+public enum IntegrationID: String, Sendable, CaseIterable { case booking, contact, donations, giscus, newsletter }
 
 public struct Template: Sendable, Equatable, ExpressibleByStringLiteral {
     public let raw: String
@@ -67,7 +67,10 @@ public struct TemplateRef: Sendable, Equatable { public let path: String
 public enum Operation: Sendable, Equatable {
     case copyFile(from: TemplateRef, to: Template, when: Condition)
     case writeConfig([ConfigEntry], when: Condition)
-    case addCSPDomains(fromProvider: Bool, extra: [String], when: Condition)
+    /// `fromFieldHost` names a `.url`-kind field whose value's host (e.g. a per-site
+    /// Cloudflare Worker subdomain) is extracted at plan time and added alongside
+    /// `extra`/provider domains — for endpoints that aren't a fixed per-provider domain.
+    case addCSPDomains(fromProvider: Bool, extra: [String], fromFieldHost: String?, when: Condition)
     case injectAtAnchor(file: Template, anchor: String, snippet: Template, when: Condition, style: MarkerInjector.CommentStyle)
 }
 

--- a/Sources/AnglesiteCore/IntegrationPlanner.swift
+++ b/Sources/AnglesiteCore/IntegrationPlanner.swift
@@ -38,8 +38,11 @@ public enum IntegrationPlanner {
             switch field.kind {
             case .email where !value.contains("@"):
                 return .failure(.invalidValue(key: field.key, reason: "not an email address"))
-            case .url where URL(string: value)?.scheme == nil:
-                return .failure(.invalidValue(key: field.key, reason: "not a URL"))
+            // Require a host (not just a parseable scheme) so a value like "https:" or
+            // "mailto:foo@bar.com" fails here with a clear message, instead of silently
+            // producing no CSP entry later for a descriptor that uses addCSPDomains(fromFieldHost:).
+            case .url where URL(string: value)?.host == nil:
+                return .failure(.invalidValue(key: field.key, reason: "not an absolute URL (needs a host, e.g. https://example.com)"))
             case .choice(let choices) where !choices.contains(where: { $0.value == value }):
                 return .failure(.invalidValue(key: field.key, reason: "not one of the allowed choices"))
             default: break

--- a/Sources/AnglesiteCore/IntegrationPlanner.swift
+++ b/Sources/AnglesiteCore/IntegrationPlanner.swift
@@ -75,12 +75,15 @@ public enum IntegrationPlanner {
             case .writeConfig(let entries, let when):
                 guard isVisible(when, answers: effective, providerID: providerID) else { continue }
                 steps.append(.upsertConfig(entries.map { ConfigKV(key: $0.key, value: $0.value.resolve(tokens)) }))
-            case .addCSPDomains(let fromProvider, let extra, let when):
+            case .addCSPDomains(let fromProvider, let extra, let fromFieldHost, let when):
                 guard isVisible(when, answers: effective, providerID: providerID) else { continue }
                 var domains = extra
                 if fromProvider, let p = providerID,
                    let provider = descriptor.providers.first(where: { $0.id == p }) {
                     domains = provider.cspDomains + extra
+                }
+                if let key = fromFieldHost, let value = effective[key], let host = URL(string: value)?.host {
+                    domains.append(host)
                 }
                 if !domains.isEmpty { steps.append(.addCSP(domains)) }
             case .injectAtAnchor(let file, let anchor, let snippet, let when, let style):

--- a/Sources/AnglesiteCore/SetupIntegrationTool.swift
+++ b/Sources/AnglesiteCore/SetupIntegrationTool.swift
@@ -61,11 +61,11 @@ import FoundationModels
 public struct SetupIntegrationTool: Tool, Sendable {
     public static let toolName = "setupIntegration"
     public let name = SetupIntegrationTool.toolName
-    public let description = "Set up a website integration (booking, donations, or giscus comments). Returns a plan to confirm before applying."
+    public let description = "Set up a website integration (booking, contact form, donations, giscus comments, or newsletter). Returns a plan to confirm before applying."
 
     @Generable
     public struct Arguments {
-        @Guide(description: "Integration to add: 'booking', 'donations', or 'giscus'.")
+        @Guide(description: "Integration to add: 'booking', 'contact', 'donations', 'giscus', or 'newsletter'.")
         public var integrationType: String
         @Guide(description: "Provider id when the integration needs one (e.g. 'cal', 'calendly', 'stripe').")
         public var provider: String?
@@ -83,7 +83,7 @@ public struct SetupIntegrationTool: Tool, Sendable {
 
     public func call(arguments: Arguments) async throws -> String {
         guard let id = SetupIntegrationArguments.id(for: arguments.integrationType) else {
-            return "I can set up booking, donations, or giscus comments. Which one?"
+            return "I can set up booking, a contact form, donations, giscus comments, or a newsletter. Which one?"
         }
         var answers = SetupIntegrationArguments.parseConfig(arguments.config)
         if let p = arguments.provider { answers["provider"] = p }

--- a/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite struct IntegrationCatalogTests {
     @Test func hasAllIntegrations() {
-        #expect(Set(IntegrationCatalog.all.map(\.id)) == Set([.booking, .contact, .donations, .giscus]))
+        #expect(Set(IntegrationCatalog.all.map(\.id)) == Set([.booking, .contact, .donations, .giscus, .newsletter]))
     }
 
     @Test(arguments: IntegrationCatalog.all)
@@ -45,6 +45,14 @@ import Testing
             fields: [Field(key: "f", label: "F", kind: .text,
                            visibleWhen: .fieldIn(key: "nope", values: ["x"]))],
             operations: [])
+        #expect(bad.validate().contains { $0.contains("nope") })
+    }
+
+    @Test func validateCatchesDanglingCSPFieldHostReference() {
+        let bad = IntegrationDescriptor(
+            id: .newsletter, displayName: "N", summary: "s",
+            providers: [], fields: [],
+            operations: [.addCSPDomains(fromProvider: false, extra: [], fromFieldHost: "nope", when: .always)])
         #expect(bad.validate().contains { $0.contains("nope") })
     }
 
@@ -89,7 +97,7 @@ import Testing
         let formspree = contact.providers.first { $0.id == "formspree" }
         #expect(formspree?.cspDomains == ["formspree.io"])
         let hasAddCSP = contact.operations.contains {
-            if case .addCSPDomains(let fromProvider, _, _) = $0 { return fromProvider }
+            if case .addCSPDomains(let fromProvider, _, _, _) = $0 { return fromProvider }
             return false
         }
         #expect(hasAddCSP)
@@ -103,6 +111,27 @@ import Testing
     @Test func giscusWritesAllIds() {
         let keys = writtenConfigKeys(for: IntegrationCatalog.descriptor(for: .giscus))
         #expect(keys.isSuperset(of: ["GISCUS_REPO", "GISCUS_CATEGORY", "GISCUS_REPO_ID", "GISCUS_CATEGORY_ID", "GISCUS_MAPPING"]))
+    }
+
+    @Test func newsletterHasPlatformChoice() {
+        let newsletter = IntegrationCatalog.descriptor(for: .newsletter)
+        #expect(Set(newsletter.providers.map(\.id)) == Set(["buttondown", "mailchimp"]))
+    }
+
+    @Test func newsletterWritesPlatformWorkerUrlAndButtonText() {
+        let keys = writtenConfigKeys(for: IntegrationCatalog.descriptor(for: .newsletter))
+        #expect(keys.isSuperset(of: ["NEWSLETTER_PLATFORM", "NEWSLETTER_WORKER_URL", "NEWSLETTER_BUTTON_TEXT"]))
+    }
+
+    /// The subscribe Worker's domain is a per-site deployment, not a fixed per-provider
+    /// domain — the CSP op must derive it from the workerUrl field, not a static/provider list.
+    @Test func newsletterDeclaresCSPDomainFromWorkerUrlField() {
+        let newsletter = IntegrationCatalog.descriptor(for: .newsletter)
+        let hasFieldHostCSP = newsletter.operations.contains {
+            if case .addCSPDomains(_, _, let fromFieldHost, _) = $0 { return fromFieldHost == "workerUrl" }
+            return false
+        }
+        #expect(hasFieldHostCSP)
     }
 
     @Test func injectedSnippetKeysAreWrittenByDescriptor() throws {

--- a/Tests/AnglesiteCoreTests/IntegrationOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationOperationsTests.swift
@@ -144,4 +144,51 @@ import Foundation
         let r = await ops.plan(integrationID: .contact, answers: [:], siteID: "s1")
         #expect(r == .failure(.providerRequired))
     }
+
+    func makeNewsletterTemplate() -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("tmpl-newsletter-\(UUID().uuidString)")
+        for p in ["integrations/components/NewsletterForm.astro", "integrations/pages/subscribe.astro",
+                  "integrations/pages/subscribe/thanks.astro"] {
+            let url = root.appendingPathComponent(p)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! "N".write(to: url, atomically: true, encoding: .utf8)
+        }
+        return root
+    }
+
+    @Test func planThenApplySucceedsForNewsletter() async {
+        let src = makeBookingSource()
+        let tmpl = makeNewsletterTemplate()
+        let ops = IntegrationOperations(sourceDirectory: { _ in src }, templateDirectory: { tmpl })
+        let answers: Answers = ["provider": "buttondown", "workerUrl": "https://newsletter-subscribe.jane.workers.dev"]
+        guard case .success(let plan) = await ops.plan(integrationID: .newsletter, answers: answers, siteID: "s1") else {
+            Issue.record("plan failed"); return
+        }
+        let terminal = await ops.apply(plan, siteID: "s1")
+        #expect(terminal == .done(integrationID: "newsletter"))
+        #expect(FileManager.default.fileExists(atPath: src.appendingPathComponent("src/pages/subscribe.astro").path))
+        #expect(FileManager.default.fileExists(atPath: src.appendingPathComponent("src/pages/subscribe/thanks.astro").path))
+        #expect(FileManager.default.fileExists(atPath: src.appendingPathComponent("src/components/NewsletterForm.astro").path))
+    }
+
+    /// The Worker's host is per-site, so it must land in `.site-config`'s SCRIPT_ALLOW via the
+    /// workerUrl field, not a static provider domain (see #462 batch-2 CSP field-derivation).
+    @Test func newsletterAddsWorkerHostToCSPConfig() async {
+        let src = makeBookingSource()
+        let tmpl = makeNewsletterTemplate()
+        let ops = IntegrationOperations(sourceDirectory: { _ in src }, templateDirectory: { tmpl })
+        let answers: Answers = ["provider": "mailchimp", "workerUrl": "https://newsletter-subscribe.jane.workers.dev/subscribe"]
+        guard case .success(let plan) = await ops.plan(integrationID: .newsletter, answers: answers, siteID: "s1") else {
+            Issue.record("plan failed"); return
+        }
+        _ = await ops.apply(plan, siteID: "s1")
+        let config = try! String(contentsOf: src.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(config.contains("newsletter-subscribe.jane.workers.dev"))
+    }
+
+    @Test func newsletterMissingWorkerUrlFails() async {
+        let ops = IntegrationOperations(sourceDirectory: { _ in self.makeBookingSource() }, templateDirectory: { self.makeNewsletterTemplate() })
+        let r = await ops.plan(integrationID: .newsletter, answers: ["provider": "buttondown"], siteID: "s1")
+        #expect(r == .failure(.missingRequiredField(key: "workerUrl")))
+    }
 }

--- a/Tests/AnglesiteCoreTests/IntegrationOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationOperationsTests.swift
@@ -148,7 +148,8 @@ import Foundation
     func makeNewsletterTemplate() -> URL {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("tmpl-newsletter-\(UUID().uuidString)")
         for p in ["integrations/components/NewsletterForm.astro", "integrations/pages/subscribe.astro",
-                  "integrations/pages/subscribe/thanks.astro"] {
+                  "integrations/pages/subscribe/thanks.astro", "integrations/worker/subscribe-worker.js",
+                  "integrations/worker/subscribe-wrangler.toml", "integrations/docs/newsletter-setup.md"] {
             let url = root.appendingPathComponent(p)
             try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
             try! "N".write(to: url, atomically: true, encoding: .utf8)

--- a/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -35,6 +35,26 @@ import Foundation
         if case .failure(.invalidValue(let key, _)) = r { #expect(key == "link") } else { Issue.record("expected invalidValue") }
     }
 
+    /// A scheme-only value like "https:" or a "mailto:" address parses with a non-nil scheme but
+    /// no host — without this check it would pass field validation, then addCSPDomains(fromFieldHost:)
+    /// would silently add no CSP domain, leaving the subscribe form blocked by CSP at runtime with
+    /// no error surfaced at plan time. See #471 review.
+    @Test(arguments: ["https:", "mailto:foo@bar.com", "not a url"])
+    func urlFieldRequiresHostNotJustScheme(_ badValue: String) {
+        let tmpl = FileManager.default.temporaryDirectory.appendingPathComponent("tmpl-newsletter-\(UUID().uuidString)")
+        for p in ["integrations/components/NewsletterForm.astro", "integrations/pages/subscribe.astro",
+                  "integrations/pages/subscribe/thanks.astro"] {
+            let url = tmpl.appendingPathComponent(p)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! "N".write(to: url, atomically: true, encoding: .utf8)
+        }
+        let r = IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .newsletter),
+                                        answers: ["provider": "buttondown", "workerUrl": badValue],
+                                        sourceDirectory: makeSource(), templateDirectory: tmpl)
+        if case .failure(.invalidValue(let key, _)) = r { #expect(key == "workerUrl") }
+        else { Issue.record("expected invalidValue for workerUrl=\(badValue), got \(r)") }
+    }
+
     @Test func bookingInlineProducesBookPageNotAnchorInjection() throws {
         let r = try IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .booking),
             answers: ["provider": "cal", "username": "jane", "style": "inline"],

--- a/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
@@ -37,14 +37,18 @@ import Foundation
         // staged (copied on-demand):
         for p in ["integrations/components/BookingWidget.astro", "integrations/components/DonationButton.astro",
                   "integrations/components/Comments.astro", "integrations/components/ContactForm.astro",
-                  "integrations/pages/book.astro", "integrations/pages/donate.astro", "integrations/pages/contact.astro"] {
+                  "integrations/components/NewsletterForm.astro",
+                  "integrations/pages/book.astro", "integrations/pages/donate.astro", "integrations/pages/contact.astro",
+                  "integrations/pages/subscribe.astro", "integrations/pages/subscribe/thanks.astro"] {
             #expect(FileManager.default.fileExists(atPath: root.appendingPathComponent(p).path), "missing staged \(p)")
         }
         // NOT base-scaffolded: every staged asset must be absent from src/ (covers all five —
         // both components previously omitted, DonationButton and Comments, are now checked).
         for p in ["src/components/BookingWidget.astro", "src/components/DonationButton.astro",
                   "src/components/Comments.astro", "src/components/ContactForm.astro",
-                  "src/pages/book.astro", "src/pages/donate.astro", "src/pages/contact.astro"] {
+                  "src/components/NewsletterForm.astro",
+                  "src/pages/book.astro", "src/pages/donate.astro", "src/pages/contact.astro",
+                  "src/pages/subscribe.astro", "src/pages/subscribe/thanks.astro"] {
             #expect(!FileManager.default.fileExists(atPath: root.appendingPathComponent(p).path), "should be staged, not in src: \(p)")
         }
     }
@@ -68,7 +72,8 @@ import Foundation
 
     @Test func onDemandPagesUseReadConfigNotImportMetaEnv() throws {
         let root = templateRoot()
-        for p in ["integrations/pages/book.astro", "integrations/pages/donate.astro", "integrations/pages/contact.astro"] {
+        for p in ["integrations/pages/book.astro", "integrations/pages/donate.astro", "integrations/pages/contact.astro",
+                  "integrations/pages/subscribe.astro"] {
             let s = try String(contentsOf: root.appendingPathComponent(p), encoding: .utf8)
             #expect(s.contains("readConfig("), "\(p) should use readConfig")
             #expect(!s.contains("import.meta.env"), "\(p) must not use import.meta.env")
@@ -150,5 +155,14 @@ import Foundation
         let contactUnknown = contactReferenced.subtracting(contactWritten)
         #expect(contactUnknown.isEmpty,
             "contact.astro references config keys not written by contact descriptor: \(contactUnknown.sorted())")
+
+        // Newsletter: integrations/pages/subscribe.astro
+        let subscribeURL = root.appendingPathComponent("integrations/pages/subscribe.astro")
+        let subscribeSource = try String(contentsOf: subscribeURL, encoding: .utf8)
+        let subscribeReferenced = readConfigKeysReferenced(in: subscribeSource)
+        let subscribeWritten = writtenConfigKeys(for: IntegrationCatalog.descriptor(for: .newsletter))
+        let subscribeUnknown = subscribeReferenced.subtracting(subscribeWritten)
+        #expect(subscribeUnknown.isEmpty,
+            "subscribe.astro references config keys not written by newsletter descriptor: \(subscribeUnknown.sorted())")
     }
 }

--- a/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
@@ -39,7 +39,9 @@ import Foundation
                   "integrations/components/Comments.astro", "integrations/components/ContactForm.astro",
                   "integrations/components/NewsletterForm.astro",
                   "integrations/pages/book.astro", "integrations/pages/donate.astro", "integrations/pages/contact.astro",
-                  "integrations/pages/subscribe.astro", "integrations/pages/subscribe/thanks.astro"] {
+                  "integrations/pages/subscribe.astro", "integrations/pages/subscribe/thanks.astro",
+                  "integrations/worker/subscribe-worker.js", "integrations/worker/subscribe-wrangler.toml",
+                  "integrations/docs/newsletter-setup.md"] {
             #expect(FileManager.default.fileExists(atPath: root.appendingPathComponent(p).path), "missing staged \(p)")
         }
         // NOT base-scaffolded: every staged asset must be absent from src/ (covers all five —
@@ -48,7 +50,8 @@ import Foundation
                   "src/components/Comments.astro", "src/components/ContactForm.astro",
                   "src/components/NewsletterForm.astro",
                   "src/pages/book.astro", "src/pages/donate.astro", "src/pages/contact.astro",
-                  "src/pages/subscribe.astro", "src/pages/subscribe/thanks.astro"] {
+                  "src/pages/subscribe.astro", "src/pages/subscribe/thanks.astro",
+                  "worker/subscribe-worker.js", "worker/subscribe-wrangler.toml", "docs/newsletter-setup.md"] {
             #expect(!FileManager.default.fileExists(atPath: root.appendingPathComponent(p).path), "should be staged, not in src: \(p)")
         }
     }


### PR DESCRIPTION
## Summary
- Adds a fifth integration, `newsletter`, to the Bucket-3 wizard catalog: platform choice (Buttondown/Mailchimp), a subscribe form + thanks page, and `.site-config` writes — following the same descriptor-driven pattern as `booking`/`contact`/`donations`/`giscus`.
- Extends `Operation.addCSPDomains` with a `fromFieldHost` option so the CSP `form-action` allowance can be derived from a user-entered URL field (the per-site Cloudflare Worker that proxies the subscribe request), rather than only a static per-provider domain list.
- Refreshes `SetupIntegrationTool`'s description/guide text, which had drifted out of sync with the catalog since `contact` was added.

## Context
Part of [#462](https://github.com/Anglesite/Anglesite-app/issues/462) (Slice 3 of the Claude Code removal roadmap, [#459](https://github.com/Anglesite/Anglesite-app/issues/459)) — 5 of ~21 integrations now covered (`booking`, `contact`, `donations`, `giscus`, `newsletter`). Remaining integrations land as follow-up batches.

Scoped to match the existing pattern: the wizard assumes the subscribe Worker is already deployed (the user pastes its URL), mirroring how `booking`/`donations` assume an already-set-up external account. Worker provisioning (secrets, `wrangler deploy`) and auto-syndication from the plugin's `newsletter` skill are out of scope for this deterministic wizard layer.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test --filter "IntegrationCatalogTests|IntegrationOperationsTests|IntegrationTemplateAssetsTests|IntegrationWizardModelTests"` — 44/44 pass
- [x] Full `swift test --filter "AnglesiteCoreTests"` — clean (one `FSEventsFileWatcher` flake on the first run, reproduced as passing on rerun; unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)