### PR TITLE
fix(#69): re-stage the bundled OCI layout when the shipped image changes

### DIFF
--- a/Sources/AnglesiteContainer/BundledImage.swift
+++ b/Sources/AnglesiteContainer/BundledImage.swift
@@ -1,3 +1,4 @@
+import AnglesiteCore
 import Foundation
 
 /// Sentinel for `Bundle(for:)`-based resource-bundle discovery (no NSObject subclass needed elsewhere).
@@ -175,37 +176,13 @@ public enum BundledImage {
     /// bundled `layoutURL()`/`initfsLayoutURL()` straight in fails with EPERM on a real, read-only
     /// `.app`. `name` identifies the artifact (e.g. "app-image", "vminit-initfs") and namespaces its
     /// staged copy under `storeURL()` so repeated launches reuse it instead of re-copying every time.
+    /// A staged copy whose `index.json` no longer matches the source's (an app update shipped a new
+    /// bundled image) is replaced, so installs never keep booting a stale image.
     ///
-    /// `name` is shared across all sites (not site-scoped, unlike the ext4 rootfs/initfs), so two
-    /// site windows cold-booting `LocalContainerSiteRuntime` around the same time can call this
-    /// concurrently for the same artifact. Each caller copies into its own uniquely-named temp
-    /// directory and only atomically moves it into place if `staged` still doesn't exist by the
-    /// time the copy finishes — so a slower caller can never delete or observe a partial copy from
-    /// a faster one; it just discards its own redundant copy and reuses the winner's result.
+    /// Implemented by `OCILayoutStaging` in AnglesiteCore (pure Foundation) so the staging/staleness
+    /// behavior stays unit-tested on CI, which never compiles this module.
     public static func stagedLayoutURL(source: URL, name: String) throws -> URL {
-        let staged = try storeURL().appendingPathComponent("layout-staging/\(name)", isDirectory: true)
-        let stagedIndex = staged.appendingPathComponent("index.json").path
-        if FileManager.default.fileExists(atPath: stagedIndex) {
-            return staged
-        }
-        let parent = staged.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
-
-        let tempDir = parent.appendingPathComponent(".staging-\(name)-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.copyItem(at: source, to: tempDir)
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-
-        if FileManager.default.fileExists(atPath: stagedIndex) {
-            return staged  // another caller finished staging while we were copying
-        }
-        do {
-            try FileManager.default.moveItem(at: tempDir, to: staged)
-        } catch {
-            // Lost the race to a concurrent stager. If they succeeded, use their result;
-            // otherwise this is a real failure (e.g. disk full) and should propagate.
-            guard FileManager.default.fileExists(atPath: stagedIndex) else { throw error }
-        }
-        return staged
+        try OCILayoutStaging.stagedLayoutURL(source: source, name: name, storeRoot: storeURL())
     }
 }
 

--- a/Sources/AnglesiteCore/OCILayoutStaging.swift
+++ b/Sources/AnglesiteCore/OCILayoutStaging.swift
@@ -52,8 +52,13 @@ public enum OCILayoutStaging {
         }
         if FileManager.default.fileExists(atPath: staged.path) {
             // Stale copy from a previously-bundled image: swap the fresh copy in atomically so a
-            // concurrent reader never observes a partially-replaced layout.
-            _ = try FileManager.default.replaceItemAt(staged, withItemAt: tempDir)
+            // concurrent reader never observes a partially-replaced layout. `replaceItemAt` is
+            // documented as possibly not replacing in place — honor the URL it reports the new
+            // item at rather than assuming it landed at `staged`.
+            if let replaced = try FileManager.default.replaceItemAt(staged, withItemAt: tempDir) {
+                return replaced
+            }
+            return staged
         } else {
             do {
                 try FileManager.default.moveItem(at: tempDir, to: staged)

--- a/Sources/AnglesiteCore/OCILayoutStaging.swift
+++ b/Sources/AnglesiteCore/OCILayoutStaging.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Stages a (possibly read-only, bundle-hosted) OCI layout into a writable directory.
+///
+/// This is the engine behind `BundledImage.stagedLayoutURL` in AnglesiteContainer.
+/// `ImageStore.load(from:)` writes ingest-tracking files (e.g. `ingest/`) directly inside the
+/// layout directory it reads from — not just into the destination store — so passing a bundled
+/// layout straight in fails with EPERM on a real, read-only `.app`. The logic lives here (pure
+/// Foundation, no Containerization dependency) so it stays covered by CI's `swift test`, which
+/// never compiles the AnglesiteContainer module.
+public enum OCILayoutStaging {
+    /// Returns a writable staged copy of the OCI layout at `source`, staging it if needed.
+    ///
+    /// `name` identifies the artifact (e.g. "app-image", "vminit-initfs") and namespaces its
+    /// staged copy under `storeRoot` so repeated launches reuse it instead of re-copying every
+    /// time.
+    ///
+    /// A staged copy is reused only while its `index.json` byte-matches the source's. In an OCI
+    /// layout `index.json` carries the manifest digest, so any change to the bundled image changes
+    /// it — comparing it is an image-identity check without hashing the blobs. A mismatch means an
+    /// app update shipped a new bundled image; the stale copy is then replaced atomically (via the
+    /// safe-save `replaceItemAt`), so existing installs pick up the new image instead of booting
+    /// the first-ever staged copy forever.
+    ///
+    /// `name` is shared across all sites (not site-scoped, unlike the ext4 rootfs/initfs), so two
+    /// site windows cold-booting `LocalContainerSiteRuntime` around the same time can call this
+    /// concurrently for the same artifact. Each caller copies into its own uniquely-named temp
+    /// directory and re-checks before installing it — so a slower caller can never delete or
+    /// observe a partial copy from a faster one; it just discards its own redundant copy and
+    /// reuses the winner's result. (Concurrent callers always read the same bundled source, so a
+    /// double-install is at worst a same-content replace.)
+    public static func stagedLayoutURL(source: URL, name: String, storeRoot: URL) throws -> URL {
+        let staged = storeRoot.appendingPathComponent("layout-staging/\(name)", isDirectory: true)
+        let sourceIndexData = try Data(contentsOf: source.appendingPathComponent("index.json"))
+        func stagedIsCurrent() -> Bool {
+            guard let stagedIndexData = try? Data(contentsOf: staged.appendingPathComponent("index.json"))
+            else { return false }
+            return stagedIndexData == sourceIndexData
+        }
+        if stagedIsCurrent() {
+            return staged
+        }
+        let parent = staged.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        let tempDir = parent.appendingPathComponent(".staging-\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.copyItem(at: source, to: tempDir)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        if stagedIsCurrent() {
+            return staged  // another caller finished staging while we were copying
+        }
+        if FileManager.default.fileExists(atPath: staged.path) {
+            // Stale copy from a previously-bundled image: swap the fresh copy in atomically so a
+            // concurrent reader never observes a partially-replaced layout.
+            _ = try FileManager.default.replaceItemAt(staged, withItemAt: tempDir)
+        } else {
+            do {
+                try FileManager.default.moveItem(at: tempDir, to: staged)
+            } catch {
+                // Lost the race to a concurrent stager. If they succeeded, use their result;
+                // otherwise this is a real failure (e.g. disk full) and should propagate.
+                guard stagedIsCurrent() else { throw error }
+            }
+        }
+        return staged
+    }
+}

--- a/Tests/AnglesiteCoreTests/OCILayoutStagingTests.swift
+++ b/Tests/AnglesiteCoreTests/OCILayoutStagingTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Unit tests for the writable-staging logic backing `BundledImage.stagedLayoutURL` (which lives in
+/// the CI-excluded AnglesiteContainer module and delegates here so this behavior stays CI-covered).
+struct OCILayoutStagingTests {
+    /// Creates a minimal fake OCI layout (`index.json` + `oci-layout` + one blob) at `dir`.
+    private func makeLayout(at dir: URL, indexContent: String, blobName: String) throws -> URL {
+        let fm = FileManager.default
+        let blobs = dir.appendingPathComponent("blobs/sha256", isDirectory: true)
+        try fm.createDirectory(at: blobs, withIntermediateDirectories: true)
+        try indexContent.write(to: dir.appendingPathComponent("index.json"), atomically: true, encoding: .utf8)
+        try #"{"imageLayoutVersion":"1.0.0"}"#
+            .write(to: dir.appendingPathComponent("oci-layout"), atomically: true, encoding: .utf8)
+        try "blob-bytes".write(to: blobs.appendingPathComponent(blobName), atomically: true, encoding: .utf8)
+        return dir
+    }
+
+    private func makeTempRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("oci-staging-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    @Test("stages a fresh copy of the source layout")
+    func stagesFreshCopy() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = try makeLayout(
+            at: root.appendingPathComponent("source"), indexContent: "index-v1", blobName: "blob-v1")
+
+        let staged = try OCILayoutStaging.stagedLayoutURL(
+            source: source, name: "app-image", storeRoot: root.appendingPathComponent("store"))
+
+        #expect(try String(contentsOf: staged.appendingPathComponent("index.json"), encoding: .utf8) == "index-v1")
+        #expect(FileManager.default.fileExists(atPath: staged.appendingPathComponent("blobs/sha256/blob-v1").path))
+    }
+
+    @Test("reuses the staged copy while the source layout is unchanged")
+    func reusesStagedCopyWhenSourceUnchanged() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = try makeLayout(
+            at: root.appendingPathComponent("source"), indexContent: "index-v1", blobName: "blob-v1")
+        let store = root.appendingPathComponent("store")
+
+        let first = try OCILayoutStaging.stagedLayoutURL(source: source, name: "app-image", storeRoot: store)
+        // ImageStore.load(from:) writes ingest-tracking state into the staged dir; simulate it so we
+        // can prove the second call reuses the existing copy rather than re-staging over it.
+        let ingestMarker = first.appendingPathComponent("ingest/marker")
+        try FileManager.default.createDirectory(
+            at: ingestMarker.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "in-progress".write(to: ingestMarker, atomically: true, encoding: .utf8)
+
+        let second = try OCILayoutStaging.stagedLayoutURL(source: source, name: "app-image", storeRoot: store)
+
+        #expect(second == first)
+        #expect(FileManager.default.fileExists(atPath: ingestMarker.path))
+    }
+
+    @Test("re-stages when the bundled source layout changes (new app version ships a new image)")
+    func restagesWhenSourceLayoutChanges() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = try makeLayout(
+            at: root.appendingPathComponent("source"), indexContent: "index-v1", blobName: "blob-v1")
+        let store = root.appendingPathComponent("store")
+
+        let first = try OCILayoutStaging.stagedLayoutURL(source: source, name: "app-image", storeRoot: store)
+        #expect(try String(contentsOf: first.appendingPathComponent("index.json"), encoding: .utf8) == "index-v1")
+
+        // Simulate an app update shipping a new bundled image: different index.json (new manifest
+        // digest) and a different blob set at the same source path.
+        let blobs = source.appendingPathComponent("blobs/sha256")
+        try FileManager.default.removeItem(at: blobs.appendingPathComponent("blob-v1"))
+        try "blob-bytes".write(to: blobs.appendingPathComponent("blob-v2"), atomically: true, encoding: .utf8)
+        try "index-v2".write(to: source.appendingPathComponent("index.json"), atomically: true, encoding: .utf8)
+
+        let second = try OCILayoutStaging.stagedLayoutURL(source: source, name: "app-image", storeRoot: store)
+
+        #expect(second == first, "the staged path is stable across re-staging")
+        #expect(try String(contentsOf: second.appendingPathComponent("index.json"), encoding: .utf8) == "index-v2")
+        #expect(FileManager.default.fileExists(atPath: second.appendingPathComponent("blobs/sha256/blob-v2").path))
+        #expect(
+            !FileManager.default.fileExists(atPath: second.appendingPathComponent("blobs/sha256/blob-v1").path),
+            "stale blobs from the previous bundled image must not survive re-staging")
+    }
+}


### PR DESCRIPTION
## Problem

`BundledImage.stagedLayoutURL(source:name:)` copies the bundled OCI layout into `~/Library/Application Support/Anglesite/container-store/layout-staging/` once and reuses it based on the mere **existence** of `index.json`. When an app update ships a new bundled image, existing installs keep booting the first-ever staged (stale) image forever. Discovered during #69 work (it caused a Task-4 gate false-failure on `claude/mystifying-noether-aad6be`).

## Fix

- Reuse the staged copy only while its `index.json` **byte-matches** the source's. In an OCI layout `index.json` carries the manifest digest, so this is an image-identity comparison without hashing blobs.
- Replace a stale staged copy atomically with `FileManager.replaceItemAt` (safe-save), so a concurrent reader never observes a missing or partially-replaced layout. All concurrent-stager race guards became content-based checks for the same reason — an "exists" check would let a stale rival copy win.
- `ImageStore`'s ingest-tracking files inside a stale staged dir are intentionally discarded on re-stage; they describe blobs of the previous image.

## Testability

The staging logic is pure Foundation but lived in `AnglesiteContainer`, which is compile-gated out of CI (`ANGLESITE_SKIP_CONTAINER=1`), so it had zero CI-runnable test coverage. Following the `TokenOnboarding` pattern from CLAUDE.md, the logic moves to `AnglesiteCore` as `OCILayoutStaging.stagedLayoutURL(source:name:storeRoot:)`; `BundledImage.stagedLayoutURL` keeps its public signature and delegates. New `OCILayoutStagingTests` in `AnglesiteCoreTests` cover:

- fresh staging copies the layout
- unchanged source reuses the staged copy (ingest-marker sentinel survives, proving no re-copy)
- **changed source re-stages** — new `index.json`/blobs picked up, stale blobs gone (written first, watched fail against the old logic)

## Coordination

Independent of `claude/mystifying-noether-aad6be` (stacked on #475): that branch touches `ContainerizationControl.swift` call sites but not `BundledImage.stagedLayoutURL`'s signature or `BundledImage.swift` itself, so no conflict.

## Verification

- `swift test --filter OCILayoutStagingTests` — 3/3 pass (staleness test observed failing before the fix)
- Full `swift test` — 1125 tests in 170 suites + bridge run, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)