### PR TITLE
feat(#59): Cloudflare free-services slices 0+3 — unified Anglesite token & harden pack

### DIFF
--- a/Sources/AnglesiteApp/CloudflareTokenPromptView.swift
+++ b/Sources/AnglesiteApp/CloudflareTokenPromptView.swift
@@ -7,11 +7,11 @@ import AnglesiteCore
 /// Deploy.
 ///
 /// The hard part for newcomers isn't pasting — it's knowing *which* token to make. So step 1 links
-/// to a pre-filled Cloudflare token form that reproduces the built-in "Edit Cloudflare Workers"
-/// template (the exact permissions `wrangler deploy` needs), and the numbered steps name that
-/// template by hand in case the (undocumented) pre-fill ever stops working. The token isn't trusted
-/// on faith: `DeployModel.verifyAndSaveToken` runs `wrangler whoami` before persisting, so a bad
-/// token is caught here instead of failing later inside the deploy.
+/// to a pre-filled Cloudflare token form that creates a custom token named "Anglesite" covering
+/// deploy + harden + the integration wizards (`AnglesiteTokenTemplate`), and the numbered steps
+/// describe that pre-fill by hand in case the (undocumented) pre-fill ever stops working. The token
+/// isn't trusted on faith: `DeployModel.verifyAndSaveToken` runs `wrangler whoami` before
+/// persisting, so a bad token is caught here instead of failing later inside the deploy.
 ///
 /// The view is intentionally narrow — it only onboards the token. Long-term management (replacing,
 /// clearing) happens in Settings → Advanced → Credentials, which shares the same `KeychainStore`
@@ -22,30 +22,6 @@ struct CloudflareTokenPromptView: View {
 
     @State private var token: String = ""
     @FocusState private var fieldFocused: Bool
-
-    /// Cloudflare's dashboard accepts undocumented query params that pre-fill the token-creation
-    /// form. These five permission groups reproduce the built-in "Edit Cloudflare Workers" template
-    /// — everything a Workers + Static Assets `wrangler deploy` needs. Verified against the live
-    /// dashboard on 2026-06-16: all five rows + the name pre-fill. If Cloudflare ever changes the
-    /// param schema, the link still lands on the token page and the on-screen steps name the
-    /// template to pick by hand, so the flow degrades rather than breaks.
-    private static let createTokenURL: URL = {
-        let permissions = """
-        [{"key":"workers_routes","type":"edit"},\
-        {"key":"workers_scripts","type":"edit"},\
-        {"key":"workers_kv_storage","type":"edit"},\
-        {"key":"workers_tail","type":"read"},\
-        {"key":"workers_r2","type":"edit"}]
-        """
-        var components = URLComponents(string: "https://dash.cloudflare.com/profile/api-tokens")!
-        components.queryItems = [
-            URLQueryItem(name: "name", value: "Anglesite Deploy"),
-            URLQueryItem(name: "accountId", value: "*"),
-            URLQueryItem(name: "zoneId", value: "all"),
-            URLQueryItem(name: "permissionGroupKeys", value: permissions)
-        ]
-        return components.url!
-    }()
 
     /// True once a verification is in flight (`.checking`) and during the brief success flash
     /// (`.connected`) — i.e. whenever the field and submit button should be locked so the user
@@ -74,12 +50,12 @@ struct CloudflareTokenPromptView: View {
 
             VStack(alignment: .leading, spacing: 10) {
                 step(1) {
-                    Link(destination: Self.createTokenURL) {
+                    Link(destination: AnglesiteTokenTemplate.createTokenURL) {
                         Label("Open Cloudflare API tokens", systemImage: "arrow.up.forward.app")
                     }
                 }
                 step(2) {
-                    Text("The “Edit Cloudflare Workers” permissions should already be selected (if not, pick that template). Click **Continue to summary**.")
+                    Text("A custom token named “Anglesite” should be pre-filled with all permissions Anglesite uses (if not, choose **Create Custom Token** and continue — deploy still works and Anglesite will ask again when a feature needs more access). Click **Continue to summary**.")
                 }
                 step(3) {
                     Text("Click **Create Token**, then copy it and paste it below.")

--- a/Sources/AnglesiteApp/CloudflareTokenPromptView.swift
+++ b/Sources/AnglesiteApp/CloudflareTokenPromptView.swift
@@ -55,7 +55,7 @@ struct CloudflareTokenPromptView: View {
                     }
                 }
                 step(2) {
-                    Text("A custom token named “Anglesite” should be pre-filled with all permissions Anglesite uses (if not, choose **Create Custom Token** and continue — deploy still works and Anglesite will ask again when a feature needs more access). Click **Continue to summary**.")
+                    Text("A custom token named “Anglesite” should be pre-filled with all permissions Anglesite uses. If it isn’t, add at least the “Edit Cloudflare Workers” template’s permissions so deploying works — Anglesite will ask again when a feature needs more access. Click **Continue to summary**.")
                 }
                 step(3) {
                     Text("Click **Create Token**, then copy it and paste it below.")

--- a/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
+++ b/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
@@ -5,13 +5,20 @@ import Foundation
 /// docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md §4).
 ///
 /// The dashboard pre-fill query params are undocumented; if Cloudflare changes the schema the link
-/// still lands on the token page and the prompt's numbered steps describe the permissions to add by
-/// hand, so the flow degrades rather than breaks (verified pre-fill behavior last on 2026-06-16 for
+/// still lands on the token page and the prompt tells the user to fall back to at least the built-in
+/// Edit Cloudflare Workers permissions, so deploy keeps working and feature wizards re-prompt for the
+/// rest, so the flow degrades rather than breaks (verified pre-fill behavior last on 2026-06-16 for
 /// the original five groups).
 public enum AnglesiteTokenTemplate {
     public static let tokenName = "Anglesite"
 
     /// Dashboard permission-group keys with their access level. Order is display order.
+    ///
+    /// `response_compression` and the `page_shield` access level are best-known and unverified
+    /// against the live dashboard (same degrade-gracefully caveat as the rest): Harden's Zstandard
+    /// write targets the `http_response_compression` ruleset phase, which is governed by the
+    /// Response Compression permission group, not `zone_waf`; and Page Shield needs write access
+    /// because Harden enables the script monitor via a `PUT`, not just reads its state.
     public static let permissionGroups: [(key: String, type: String)] = [
         // Deploy (the original "Edit Cloudflare Workers" set)
         ("workers_routes", "edit"),
@@ -24,7 +31,8 @@ public enum AnglesiteTokenTemplate {
         ("zone_settings", "edit"),
         ("dns", "edit"),
         ("zone_waf", "edit"),
-        ("page_shield", "read"),
+        ("response_compression", "edit"),
+        ("page_shield", "edit"),
         ("analytics", "read"),
         // Integration wizards (slices 1, 2, 5, 7)
         ("challenge_widgets", "edit"),

--- a/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
+++ b/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// The single "Anglesite" Cloudflare API token: one custom template carrying every permission the
+/// app can use across deploy, harden, and the integration wizards (spec:
+/// docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md §4).
+///
+/// The dashboard pre-fill query params are undocumented; if Cloudflare changes the schema the link
+/// still lands on the token page and the prompt's numbered steps describe the permissions to add by
+/// hand, so the flow degrades rather than breaks (verified pre-fill behavior last on 2026-06-16 for
+/// the original five groups).
+public enum AnglesiteTokenTemplate {
+    public static let tokenName = "Anglesite"
+
+    /// Dashboard permission-group keys with their access level. Order is display order.
+    public static let permissionGroups: [(key: String, type: String)] = [
+        // Deploy (the original "Edit Cloudflare Workers" set)
+        ("workers_routes", "edit"),
+        ("workers_scripts", "edit"),
+        ("workers_kv_storage", "edit"),
+        ("workers_tail", "read"),
+        ("workers_r2", "edit"),
+        ("d1", "edit"),
+        // Harden + zone state
+        ("zone_settings", "edit"),
+        ("dns", "edit"),
+        ("zone_waf", "edit"),
+        ("page_shield", "read"),
+        ("analytics", "read"),
+        // Integration wizards (slices 1, 2, 5, 7)
+        ("challenge_widgets", "edit"),
+        ("email_routing_rules", "edit"),
+        ("email_routing_addresses", "edit"),
+        ("zaraz", "edit"),
+        ("registrar", "edit"),
+    ]
+
+    public static var createTokenURL: URL {
+        let permissions = "[" + permissionGroups
+            .map { #"{"key":"\#($0.key)","type":"\#($0.type)"}"# }
+            .joined(separator: ",") + "]"
+        var components = URLComponents(string: "https://dash.cloudflare.com/profile/api-tokens")!
+        components.queryItems = [
+            URLQueryItem(name: "name", value: tokenName),
+            URLQueryItem(name: "accountId", value: "*"),
+            URLQueryItem(name: "zoneId", value: "all"),
+            URLQueryItem(name: "permissionGroupKeys", value: permissions),
+        ]
+        return components.url!
+    }
+}

--- a/Sources/AnglesiteCore/CloudflareCapabilityProber.swift
+++ b/Sources/AnglesiteCore/CloudflareCapabilityProber.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Observes which permission groups a stored Cloudflare token actually has, by issuing one cheap
+/// authenticated GET per group. 401/403 means the group is missing; any other response (including
+/// 404s like "Email Routing not enabled") proves the permission. A thrown transport error counts as
+/// missing — probes are advisory and callers may re-probe.
+///
+/// This exists so wizards can gate on `TokenCapabilities` up front and route the user through token
+/// re-onboarding (`AnglesiteTokenTemplate`) instead of failing halfway through an API orchestration.
+public struct CloudflareCapabilityProber: Sendable {
+    private let baseURL: URL
+    private let transport: CloudflareTransport
+
+    public init(
+        baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!,
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) {
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    public func probe(token: String, zoneID: String?) async -> TokenCapabilities {
+        var caps = TokenCapabilities()
+
+        var probes: [(TokenCapability, String)] = []
+        if let accountID = await firstAccountID(token: token) {
+            probes += [
+                (.workers, "accounts/\(accountID)/workers/scripts"),
+                (.turnstile, "accounts/\(accountID)/challenges/widgets"),
+                (.registrar, "accounts/\(accountID)/registrar/domains"),
+            ]
+        }
+        if let zoneID {
+            probes += [
+                (.zoneSettings, "zones/\(zoneID)/settings/ssl"),
+                (.dns, "zones/\(zoneID)/dns_records?per_page=1"),
+                (.rulesets, "zones/\(zoneID)/rulesets"),
+                (.emailRouting, "zones/\(zoneID)/email/routing"),
+                (.zaraz, "zones/\(zoneID)/settings/zaraz/config"),
+                (.pageShield, "zones/\(zoneID)/page_shield"),
+            ]
+        }
+        for (cap, path) in probes {
+            if await allowed(path, token: token) {
+                caps.insert(cap)
+            }
+        }
+        return caps
+    }
+
+    /// First account id visible to the token, or nil (account-scoped probes are then skipped).
+    private func firstAccountID(token: String) async -> String? {
+        struct Envelope: Decodable { let result: [Account]?; struct Account: Decodable { let id: String } }
+        guard let (data, http) = try? await get("accounts?per_page=1", token: token),
+              (200..<300).contains(http.statusCode),
+              let envelope = try? JSONDecoder().decode(Envelope.self, from: data)
+        else { return nil }
+        return envelope.result?.first?.id
+    }
+
+    private func allowed(_ path: String, token: String) async -> Bool {
+        guard let (_, http) = try? await get(path, token: token) else { return false }
+        return http.statusCode != 401 && http.statusCode != 403
+    }
+
+    private func get(_ path: String, token: String) async throws -> (Data, HTTPURLResponse) {
+        guard let url = URL(string: baseURL.absoluteString + "/" + path) else {
+            throw CloudflareError.malformedResponse
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return try await transport(request)
+    }
+}

--- a/Sources/AnglesiteCore/CloudflareTokenVerifier.swift
+++ b/Sources/AnglesiteCore/CloudflareTokenVerifier.swift
@@ -26,7 +26,7 @@ public enum TokenVerifyError: Error, Equatable, Sendable {
     public var userMessage: String {
         switch self {
         case .invalidToken:
-            return "That token didn’t work. Make sure you picked the “Edit Cloudflare Workers” template and copied the whole token."
+            return "That token didn’t work. Use the “Create token” link (it pre-fills the “Anglesite” token) and copy the whole token."
         case .network:
             return "Couldn’t reach Cloudflare. Check your connection and try again."
         case .unavailable(let reason):

--- a/Sources/AnglesiteCore/CloudflareWriting.swift
+++ b/Sources/AnglesiteCore/CloudflareWriting.swift
@@ -10,6 +10,12 @@ public protocol CloudflareWriting: Sendable {
     func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws
     func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws
     func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws
+    func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws
+    func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws
+    /// Idempotent: creates the `http_response_compression` ruleset with a zstd-first rule, or
+    /// appends the rule to the existing ruleset.
+    func enableZstandardCompression(zoneID: String, apiToken: String) async throws
+    func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws
 }
 
 /// Payload for creating a DNS record via the Cloudflare API.

--- a/Sources/AnglesiteCore/CloudflareZoneState.swift
+++ b/Sources/AnglesiteCore/CloudflareZoneState.swift
@@ -31,6 +31,14 @@ public struct CloudflareZoneState: Sendable, Equatable {
     public var botFightMode: Bool
     /// Custom WAF rules in the `http_request_firewall_custom` phase.
     public var wafCustomRules: [WAFCustomRule]
+    /// Speed Brain (speculation-rules prefetching) zone setting.
+    public var speedBrain: Bool
+    /// Encrypted Client Hello zone setting.
+    public var ech: Bool
+    /// Whether a compression rule enables Zstandard (`http_response_compression` phase).
+    public var zstdCompression: Bool
+    /// Page Shield (client-side security) status + detected script hosts. `nil` when unreadable.
+    public var pageShield: PageShieldState?
 
     /// A single custom WAF rule from the zone's firewall ruleset.
     public struct WAFCustomRule: Sendable, Equatable {
@@ -44,9 +52,22 @@ public struct CloudflareZoneState: Sendable, Equatable {
         }
     }
 
+    /// Page Shield script-monitor snapshot.
+    public struct PageShieldState: Sendable, Equatable {
+        public var enabled: Bool
+        /// Unique, sorted hosts of scripts Page Shield has seen loading on the site.
+        public var scriptHosts: [String]
+        public init(enabled: Bool, scriptHosts: [String]) {
+            self.enabled = enabled
+            self.scriptHosts = scriptHosts
+        }
+    }
+
     public init(dnssecActive: Bool, sslMode: String, alwaysUseHTTPS: Bool, hsts: HSTS?,
                 caaRecords: [String], mxRecords: [String], spfRecords: [String], dmarcRecords: [String],
-                botFightMode: Bool = false, wafCustomRules: [WAFCustomRule] = []) {
+                botFightMode: Bool = false, wafCustomRules: [WAFCustomRule] = [],
+                speedBrain: Bool = false, ech: Bool = false, zstdCompression: Bool = false,
+                pageShield: PageShieldState? = nil) {
         self.dnssecActive = dnssecActive
         self.sslMode = sslMode
         self.alwaysUseHTTPS = alwaysUseHTTPS
@@ -57,5 +78,9 @@ public struct CloudflareZoneState: Sendable, Equatable {
         self.dmarcRecords = dmarcRecords
         self.botFightMode = botFightMode
         self.wafCustomRules = wafCustomRules
+        self.speedBrain = speedBrain
+        self.ech = ech
+        self.zstdCompression = zstdCompression
+        self.pageShield = pageShield
     }
 }

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -49,6 +49,16 @@ private struct CFRulesetRule: Decodable, Sendable {
     let description: String?
     let expression: String
     let action: String
+    let action_parameters: Params?
+    struct Params: Decodable, Sendable {
+        let algorithms: [Algorithm]?
+        struct Algorithm: Decodable, Sendable { let name: String? }
+    }
+}
+private struct CFPageShield: Decodable, Sendable { let enabled: Bool? }
+private struct CFPageShieldScript: Decodable, Sendable {
+    let url: String?
+    let host: String?
 }
 
 /// Read-only Cloudflare v4 client. All methods are GETs.
@@ -109,7 +119,12 @@ public struct HTTPCloudflareClient: CloudflareReading {
             botFight = false
         }
 
-        let wafRules = try await fetchWAFCustomRules(zoneID: zoneID, apiToken: apiToken)
+        let wafRules = (try? await fetchWAFCustomRules(zoneID: zoneID, apiToken: apiToken)) ?? []
+
+        let speedBrain = await settingIsOn("/zones/\(zoneID)/settings/speed_brain", apiToken: apiToken)
+        let ech = await settingIsOn("/zones/\(zoneID)/settings/ech", apiToken: apiToken)
+        let zstd = await zstdEnabled(zoneID: zoneID, apiToken: apiToken)
+        let pageShield = await pageShieldState(zoneID: zoneID, apiToken: apiToken)
 
         let sts = header.value.strict_transport_security
         let hsts: CloudflareZoneState.HSTS? = sts.enabled
@@ -133,7 +148,8 @@ public struct HTTPCloudflareClient: CloudflareReading {
             spfRecords: spf,
             dmarcRecords: dmarc,
             botFightMode: botFight,
-            wafCustomRules: wafRules)
+            wafCustomRules: wafRules,
+            speedBrain: speedBrain, ech: ech, zstdCompression: zstd, pageShield: pageShield)
     }
 
     private func fetchWAFCustomRules(zoneID: String, apiToken: String) async throws -> [CloudflareZoneState.WAFCustomRule] {
@@ -145,6 +161,35 @@ public struct HTTPCloudflareClient: CloudflareReading {
         return (full.rules ?? []).map {
             .init(description: $0.description ?? "", expression: $0.expression, action: $0.action)
         }
+    }
+
+    /// Reads an on/off zone setting, defaulting to `false` when the token can't see it.
+    private func settingIsOn(_ path: String, apiToken: String) async -> Bool {
+        ((try? await get(path, apiToken: apiToken, as: CFStringSetting.self))?.value.lowercased()) == "on"
+    }
+
+    private func zstdEnabled(zoneID: String, apiToken: String) async -> Bool {
+        guard let rulesets = try? await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self),
+              let compression = rulesets.first(where: { $0.phase == "http_response_compression" }),
+              let full = try? await get("/zones/\(zoneID)/rulesets/\(compression.id)", apiToken: apiToken, as: CFRuleset.self)
+        else { return false }
+        return (full.rules ?? []).contains { rule in
+            rule.action == "compress_response"
+                && (rule.action_parameters?.algorithms ?? []).contains { $0.name == "zstd" }
+        }
+    }
+
+    private func pageShieldState(zoneID: String, apiToken: String) async -> CloudflareZoneState.PageShieldState? {
+        guard let shield = try? await get("/zones/\(zoneID)/page_shield", apiToken: apiToken, as: CFPageShield.self) else {
+            return nil
+        }
+        let enabled = shield.enabled ?? false
+        var hosts: [String] = []
+        if enabled,
+           let scripts = try? await get("/zones/\(zoneID)/page_shield/scripts", apiToken: apiToken, as: [CFPageShieldScript].self) {
+            hosts = Set(scripts.compactMap { $0.host ?? $0.url.flatMap { URL(string: $0)?.host } }).sorted()
+        }
+        return .init(enabled: enabled, scriptHosts: hosts)
     }
 
     // MARK: - Write helpers

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -322,6 +322,12 @@ extension HTTPCloudflareClient: CloudflareWriting {
 
         let rulesets = try await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self)
         if let existing = rulesets.first(where: { $0.phase == "http_response_compression" }) {
+            let full = try await get("/zones/\(zoneID)/rulesets/\(existing.id)", apiToken: apiToken, as: CFRuleset.self)
+            let alreadyHasZstd = (full.rules ?? []).contains { rule in
+                rule.action == "compress_response"
+                    && (rule.action_parameters?.algorithms ?? []).contains { $0.name == "zstd" }
+            }
+            if alreadyHasZstd { return }
             try await mutate(method: "POST", "/zones/\(zoneID)/rulesets/\(existing.id)/rules",
                              body: rule, apiToken: apiToken)
         } else {

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -285,4 +285,57 @@ extension HTTPCloudflareClient: CloudflareWriting {
                              apiToken: apiToken)
         }
     }
+
+    public func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try await mutate(method: "PATCH", "/zones/\(zoneID)/settings/speed_brain",
+                         body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
+    }
+
+    public func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try await mutate(method: "PATCH", "/zones/\(zoneID)/settings/ech",
+                         body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
+    }
+
+    public func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try await mutate(method: "PUT", "/zones/\(zoneID)/page_shield",
+                         body: ["enabled": enabled], apiToken: apiToken)
+    }
+
+    public func enableZstandardCompression(zoneID: String, apiToken: String) async throws {
+        struct CompressionRule: Encodable, Sendable {
+            struct Params: Encodable, Sendable {
+                struct Algorithm: Encodable, Sendable { let name: String }
+                let algorithms: [Algorithm]
+            }
+            let description: String
+            let expression: String
+            let action: String
+            let action_parameters: Params
+        }
+        let rule = CompressionRule(
+            description: "Anglesite: prefer Zstandard compression",
+            expression: "true",
+            action: "compress_response",
+            action_parameters: .init(algorithms: [
+                .init(name: "zstd"), .init(name: "brotli"), .init(name: "gzip"),
+            ]))
+
+        let rulesets = try await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self)
+        if let existing = rulesets.first(where: { $0.phase == "http_response_compression" }) {
+            try await mutate(method: "POST", "/zones/\(zoneID)/rulesets/\(existing.id)/rules",
+                             body: rule, apiToken: apiToken)
+        } else {
+            struct NewRuleset: Encodable, Sendable {
+                let name: String
+                let kind: String
+                let phase: String
+                let rules: [CompressionRule]
+            }
+            try await mutate(method: "POST", "/zones/\(zoneID)/rulesets",
+                             body: NewRuleset(name: "Anglesite compression rules",
+                                              kind: "zone", phase: "http_response_compression",
+                                              rules: [rule]),
+                             apiToken: apiToken)
+        }
+    }
 }

--- a/Sources/AnglesiteCore/HardenExecutor.swift
+++ b/Sources/AnglesiteCore/HardenExecutor.swift
@@ -106,6 +106,14 @@ public struct HardenExecutor: Sendable {
                 zoneID: zoneID,
                 rule: WAFRulePayload(description: desc, expression: expr, action: action),
                 apiToken: apiToken)
+        case .enableSpeedBrain:
+            try await writer.setSpeedBrain(zoneID: zoneID, enabled: true, apiToken: apiToken)
+        case .enableZstandardCompression:
+            try await writer.enableZstandardCompression(zoneID: zoneID, apiToken: apiToken)
+        case .enableECH:
+            try await writer.setECH(zoneID: zoneID, enabled: true, apiToken: apiToken)
+        case .enablePageShieldMonitoring:
+            try await writer.setPageShield(zoneID: zoneID, enabled: true, apiToken: apiToken)
         }
     }
 }

--- a/Sources/AnglesiteCore/HardenPlan.swift
+++ b/Sources/AnglesiteCore/HardenPlan.swift
@@ -24,6 +24,10 @@ public enum HardenPlanItem: Sendable, Hashable, CustomStringConvertible {
     case addSPFRejectAll
     case addDMARCReject
     case addWAFRule(description: String, expression: String, action: String)
+    case enableSpeedBrain
+    case enableZstandardCompression
+    case enableECH
+    case enablePageShieldMonitoring
 
     public var description: String {
         switch self {
@@ -48,6 +52,14 @@ public enum HardenPlanItem: Sendable, Hashable, CustomStringConvertible {
             return "+ Add DMARC record: v=DMARC1; p=reject"
         case .addWAFRule(let desc, _, let action):
             return "+ Add WAF rule [\(action)]: \(desc)"
+        case .enableSpeedBrain:
+            return "+ Enable Speed Brain (speculative prefetching)"
+        case .enableZstandardCompression:
+            return "+ Enable Zstandard compression"
+        case .enableECH:
+            return "+ Enable Encrypted Client Hello (ECH)"
+        case .enablePageShieldMonitoring:
+            return "+ Enable client-side script monitoring (Page Shield)"
         }
     }
 }

--- a/Sources/AnglesiteCore/HardenPlanner.swift
+++ b/Sources/AnglesiteCore/HardenPlanner.swift
@@ -73,6 +73,19 @@ public enum HardenPlanner {
             items.append(.enableBotFightMode)
         }
 
+        if !state.speedBrain {
+            items.append(.enableSpeedBrain)
+        }
+        if !state.zstdCompression {
+            items.append(.enableZstandardCompression)
+        }
+        if !state.ech {
+            items.append(.enableECH)
+        }
+        if state.pageShield?.enabled != true {
+            items.append(.enablePageShieldMonitoring)
+        }
+
         // Email hardening only for domains that don't send mail.
         if state.mxRecords.isEmpty {
             items.append(.addNullMX)

--- a/Sources/AnglesiteCore/SecurityAudit.swift
+++ b/Sources/AnglesiteCore/SecurityAudit.swift
@@ -55,6 +55,20 @@ public enum SecurityAudit {
                     "Publish _dmarc TXT: v=DMARC1; p=reject")
             }
         }
+        if !state.ech {
+            add(.info, "Encrypted Client Hello is off",
+                "Without ECH, the site hostname is visible in plaintext during TLS handshakes.",
+                "Enable Encrypted Client Hello (ECH) in the zone's TLS settings.")
+        }
+        if state.pageShield?.enabled != true {
+            add(.info, "Client-side script monitoring is off",
+                "Page Shield is not watching which scripts run on the site, so a compromised third-party script would go unnoticed.",
+                "Enable Page Shield's script monitor (free on all plans).")
+        } else if let shield = state.pageShield, !shield.scriptHosts.isEmpty {
+            add(.info, "Third-party scripts detected",
+                "Page Shield sees scripts loading from: \(shield.scriptHosts.joined(separator: ", ")).",
+                "Review each host; remove any you don't recognize and keep the CSP in sync.")
+        }
         return findings
     }
 }

--- a/Sources/AnglesiteCore/TokenCapabilities.swift
+++ b/Sources/AnglesiteCore/TokenCapabilities.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A permission group the stored Cloudflare token has been *observed* to have, via
 /// `CloudflareCapabilityProber`. Capabilities are read-probe signals: presence means the token can
 /// at least read that product's API; absence (401/403 on the probe) means a wizard needing it must

--- a/Sources/AnglesiteCore/TokenCapabilities.swift
+++ b/Sources/AnglesiteCore/TokenCapabilities.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// A permission group the stored Cloudflare token has been *observed* to have, via
+/// `CloudflareCapabilityProber`. Capabilities are read-probe signals: presence means the token can
+/// at least read that product's API; absence (401/403 on the probe) means a wizard needing it must
+/// route the user through token re-onboarding (`AnglesiteTokenTemplate`) instead of failing mid-flow.
+public enum TokenCapability: String, CaseIterable, Codable, Sendable {
+    /// Workers scripts (deploy).
+    case workers
+    /// Zone settings (SSL mode, HSTS, Speed Brain, ECH, …).
+    case zoneSettings
+    /// DNS record reads/writes.
+    case dns
+    /// Zone rulesets (WAF custom rules, compression rules).
+    case rulesets
+    /// Turnstile widget management.
+    case turnstile
+    /// Email Routing (rules + destination addresses).
+    case emailRouting
+    /// Zaraz configuration.
+    case zaraz
+    /// Page Shield (client-side security) status + script reports.
+    case pageShield
+    /// Registrar domain search/registration.
+    case registrar
+}
+
+/// The set of permission groups a probe observed on the stored token.
+public typealias TokenCapabilities = Set<TokenCapability>

--- a/Tests/AnglesiteCoreTests/AnglesiteTokenTemplateTests.swift
+++ b/Tests/AnglesiteCoreTests/AnglesiteTokenTemplateTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct AnglesiteTokenTemplateTests {
+    @Test("the template keeps every permission the old Workers-deploy template had")
+    func supersetOfDeployTemplate() {
+        let keys = Set(AnglesiteTokenTemplate.permissionGroups.map(\.key))
+        for legacy in ["workers_routes", "workers_scripts", "workers_kv_storage", "workers_tail", "workers_r2"] {
+            #expect(keys.contains(legacy))
+        }
+    }
+
+    @Test("the template covers the new integration surface")
+    func coversNewServices() {
+        let keys = Set(AnglesiteTokenTemplate.permissionGroups.map(\.key))
+        for needed in ["d1", "zone_settings", "dns", "zone_waf", "challenge_widgets",
+                       "email_routing_rules", "email_routing_addresses", "zaraz",
+                       "page_shield", "analytics", "registrar"] {
+            #expect(keys.contains(needed), "missing permission group: \(needed)")
+        }
+    }
+
+    @Test("createTokenURL lands on the dashboard token page with name + permission pre-fill")
+    func urlShape() throws {
+        let components = try #require(URLComponents(url: AnglesiteTokenTemplate.createTokenURL,
+                                                    resolvingAgainstBaseURL: false))
+        #expect(components.host == "dash.cloudflare.com")
+        #expect(components.path == "/profile/api-tokens")
+        let items = components.queryItems ?? []
+        #expect(items.contains { $0.name == "name" && $0.value == "Anglesite" })
+        let permissions = items.first { $0.name == "permissionGroupKeys" }?.value ?? ""
+        #expect(permissions.contains(#""key":"workers_scripts""#))
+        #expect(permissions.contains(#""key":"registrar""#))
+    }
+}

--- a/Tests/AnglesiteCoreTests/AnglesiteTokenTemplateTests.swift
+++ b/Tests/AnglesiteCoreTests/AnglesiteTokenTemplateTests.swift
@@ -14,9 +14,9 @@ struct AnglesiteTokenTemplateTests {
     @Test("the template covers the new integration surface")
     func coversNewServices() {
         let keys = Set(AnglesiteTokenTemplate.permissionGroups.map(\.key))
-        for needed in ["d1", "zone_settings", "dns", "zone_waf", "challenge_widgets",
-                       "email_routing_rules", "email_routing_addresses", "zaraz",
-                       "page_shield", "analytics", "registrar"] {
+        for needed in ["d1", "zone_settings", "dns", "zone_waf", "response_compression",
+                       "challenge_widgets", "email_routing_rules", "email_routing_addresses",
+                       "zaraz", "page_shield", "analytics", "registrar"] {
             #expect(keys.contains(needed), "missing permission group: \(needed)")
         }
     }

--- a/Tests/AnglesiteCoreTests/CloudflareCapabilityProberTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareCapabilityProberTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct CloudflareCapabilityProberTests {
+    private let accountsOK = (200, #"{"success":true,"result":[{"id":"acc1","name":"Acme"}]}"#)
+
+    @Test("2xx and non-auth errors mark a capability present; 403 marks it absent")
+    func classifiesStatuses() async {
+        let prober = CloudflareCapabilityProber(transport: fakeTransport([
+            "/accounts?": accountsOK,
+            "accounts/acc1/workers/scripts": (200, #"{"success":true,"result":[]}"#),
+            "accounts/acc1/challenges/widgets": (403, #"{"success":false}"#),
+            "accounts/acc1/registrar/domains": (200, #"{"success":true,"result":[]}"#),
+            "zones/z1/settings/ssl": (200, #"{"success":true,"result":{"value":"strict"}}"#),
+            "zones/z1/dns_records": (403, #"{"success":false}"#),
+            "zones/z1/rulesets": (200, #"{"success":true,"result":[]}"#),
+            "zones/z1/email/routing": (404, #"{"success":false}"#),
+            "zones/z1/settings/zaraz/config": (403, #"{"success":false}"#),
+            "zones/z1/page_shield": (200, #"{"success":true,"result":{"enabled":false}}"#),
+        ]))
+        let caps = await prober.probe(token: "t", zoneID: "z1")
+        #expect(caps.contains(.workers))
+        #expect(!caps.contains(.turnstile))
+        #expect(caps.contains(.registrar))
+        #expect(caps.contains(.zoneSettings))
+        #expect(!caps.contains(.dns))
+        #expect(caps.contains(.rulesets))
+        #expect(caps.contains(.emailRouting))  // 404 = enabled-state miss, permission present
+        #expect(!caps.contains(.zaraz))
+        #expect(caps.contains(.pageShield))
+    }
+
+    @Test("nil zoneID skips zone probes; unresolvable account skips account probes")
+    func skipsUnscopedProbes() async {
+        let prober = CloudflareCapabilityProber(transport: fakeTransport([
+            "/accounts?": (403, #"{"success":false}"#),
+        ]))
+        let caps = await prober.probe(token: "t", zoneID: nil)
+        #expect(caps.isEmpty)
+    }
+
+    @Test("probe requests carry the bearer token")
+    func sendsBearer() async {
+        let spy = TransportSpy()
+        let inner = fakeTransport(["/accounts?": accountsOK])
+        let prober = CloudflareCapabilityProber(transport: { request in
+            spy.record(request)
+            return try await inner(request)
+        })
+        _ = await prober.probe(token: "sekret", zoneID: nil)
+        #expect(spy.requests.allSatisfy {
+            $0.value(forHTTPHeaderField: "Authorization") == "Bearer sekret"
+        })
+    }
+}

--- a/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
@@ -157,3 +157,45 @@ func zoneStateHSTSDisabled() async throws {
     #expect(!s.botFightMode)
     #expect(s.wafCustomRules.isEmpty)
 }
+
+extension CloudflareClientTests {
+    private static let baseRoutes: [String: (Int, String)] = [
+        "/dnssec": (200, #"{"success":true,"result":{"status":"active"}}"#),
+        "/settings/ssl": (200, #"{"success":true,"result":{"value":"strict"}}"#),
+        "/settings/always_use_https": (200, #"{"success":true,"result":{"value":"on"}}"#),
+        "/settings/security_header": (200, #"{"success":true,"result":{"value":{"strict_transport_security":{"enabled":true,"max_age":31536000,"include_subdomains":true,"preload":false}}}}"#),
+        "/dns_records": (200, #"{"success":true,"result":[]}"#),
+        "/settings/bot_management": (403, #"{"success":false}"#),
+    ]
+
+    @Test("zoneState reads the harden-pack settings when the API grants them")
+    func zoneStateHardenPack() async throws {
+        var routes = Self.baseRoutes
+        routes["/settings/speed_brain"] = (200, #"{"success":true,"result":{"value":"on"}}"#)
+        routes["/settings/ech"] = (200, #"{"success":true,"result":{"value":"off"}}"#)
+        routes["/zones/z/rulesets/comp1"] = (200, #"{"success":true,"result":{"id":"comp1","phase":"http_response_compression","rules":[{"expression":"true","action":"compress_response","action_parameters":{"algorithms":[{"name":"zstd"},{"name":"gzip"}]}}]}}"#)
+        routes["/zones/z/rulesets"] = (200, #"{"success":true,"result":[{"id":"comp1","phase":"http_response_compression"}]}"#)
+        routes["/page_shield/scripts"] = (200, #"{"success":true,"result":[{"url":"https://cdn.evil.example/t.js","host":"cdn.evil.example"}]}"#)
+        routes["/page_shield"] = (200, #"{"success":true,"result":{"enabled":true}}"#)
+
+        let client = HTTPCloudflareClient(transport: fakeTransport(routes))
+        let state = try await client.zoneState(zoneID: "z", apiToken: "t")
+        #expect(state.speedBrain)
+        #expect(!state.ech)
+        #expect(state.zstdCompression)
+        #expect(state.pageShield == .init(enabled: true, scriptHosts: ["cdn.evil.example"]))
+    }
+
+    @Test("zoneState defaults the harden-pack fields when the token can't read them")
+    func zoneStateHardenPackDegrades() async throws {
+        // No speed_brain/ech/page_shield routes at all -> fakeTransport 404s -> envelope failure.
+        var routes = Self.baseRoutes
+        routes["/zones/z/rulesets"] = (403, #"{"success":false}"#)
+        let client = HTTPCloudflareClient(transport: fakeTransport(routes))
+        let state = try await client.zoneState(zoneID: "z", apiToken: "t")
+        #expect(!state.speedBrain)
+        #expect(!state.ech)
+        #expect(!state.zstdCompression)
+        #expect(state.pageShield == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/CloudflareTokenVerifierTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareTokenVerifierTests.swift
@@ -5,9 +5,9 @@ import Foundation
 /// Tests for the user-facing copy of `TokenVerifyError`. The verifier behavior itself lives in
 /// `CloudflareAPITokenVerifierTests` (the native, Node-free conformer).
 struct CloudflareTokenVerifierTests {
-    @Test("Invalid-token error names the Edit Cloudflare Workers template")
+    @Test("Invalid-token error names the Anglesite token")
     func invalidTokenCopyNamesTemplate() {
-        #expect(TokenVerifyError.invalidToken.userMessage.contains("Edit Cloudflare Workers"))
+        #expect(TokenVerifyError.invalidToken.userMessage.contains("Anglesite"))
     }
 
     @Test("Network error tells the user to check their connection")

--- a/Tests/AnglesiteCoreTests/CloudflareWritingTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareWritingTests.swift
@@ -100,3 +100,74 @@ struct CloudflareWritingTests {
         }
     }
 }
+
+extension CloudflareWritingTests {
+    private func spiedClient(_ routes: [String: (Int, String)]) -> (HTTPCloudflareClient, TransportSpy) {
+        let spy = TransportSpy()
+        let inner = fakeTransport(routes)
+        let client = HTTPCloudflareClient(transport: { request in
+            spy.record(request)
+            return try await inner(request)
+        })
+        return (client, spy)
+    }
+
+    @Test("setSpeedBrain PATCHes the speed_brain setting")
+    func speedBrainWrite() async throws {
+        let (client, spy) = spiedClient([
+            "/settings/speed_brain": (200, #"{"success":true,"result":{}}"#),
+        ])
+        try await client.setSpeedBrain(zoneID: "z", enabled: true, apiToken: "t")
+        let request = try #require(spy.requests.last)
+        #expect(request.httpMethod == "PATCH")
+        #expect(request.url!.path.hasSuffix("/zones/z/settings/speed_brain"))
+        #expect(String(data: request.httpBody ?? Data(), encoding: .utf8)!.contains(#""value":"on""#))
+    }
+
+    @Test("setECH PATCHes the ech setting")
+    func echWrite() async throws {
+        let (client, spy) = spiedClient([
+            "/settings/ech": (200, #"{"success":true,"result":{}}"#),
+        ])
+        try await client.setECH(zoneID: "z", enabled: true, apiToken: "t")
+        let request = try #require(spy.requests.last)
+        #expect(request.httpMethod == "PATCH")
+        #expect(request.url!.path.hasSuffix("/zones/z/settings/ech"))
+    }
+
+    @Test("setPageShield PUTs enabled")
+    func pageShieldWrite() async throws {
+        let (client, spy) = spiedClient([
+            "/page_shield": (200, #"{"success":true,"result":{}}"#),
+        ])
+        try await client.setPageShield(zoneID: "z", enabled: true, apiToken: "t")
+        let request = try #require(spy.requests.last)
+        #expect(request.httpMethod == "PUT")
+        #expect(String(data: request.httpBody ?? Data(), encoding: .utf8)!.contains(#""enabled":true"#))
+    }
+
+    @Test("enableZstandardCompression creates the compression ruleset when absent")
+    func zstdCreatesRuleset() async throws {
+        let (client, spy) = spiedClient([
+            "/zones/z/rulesets": (200, #"{"success":true,"result":[]}"#),
+        ])
+        try await client.enableZstandardCompression(zoneID: "z", apiToken: "t")
+        let post = try #require(spy.requests.last)
+        #expect(post.httpMethod == "POST")
+        #expect(post.url!.path.hasSuffix("/zones/z/rulesets"))
+        let body = String(data: post.httpBody ?? Data(), encoding: .utf8)!
+        #expect(body.contains("http_response_compression"))
+        #expect(body.contains(#""name":"zstd""#))
+    }
+
+    @Test("enableZstandardCompression appends a rule when the ruleset exists")
+    func zstdAppendsRule() async throws {
+        let (client, spy) = spiedClient([
+            "/zones/z/rulesets/comp1/rules": (200, #"{"success":true,"result":{}}"#),
+            "/zones/z/rulesets": (200, #"{"success":true,"result":[{"id":"comp1","phase":"http_response_compression"}]}"#),
+        ])
+        try await client.enableZstandardCompression(zoneID: "z", apiToken: "t")
+        let post = try #require(spy.requests.last)
+        #expect(post.url!.path.hasSuffix("/zones/z/rulesets/comp1/rules"))
+    }
+}

--- a/Tests/AnglesiteCoreTests/CloudflareWritingTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareWritingTests.swift
@@ -164,10 +164,29 @@ extension CloudflareWritingTests {
     func zstdAppendsRule() async throws {
         let (client, spy) = spiedClient([
             "/zones/z/rulesets/comp1/rules": (200, #"{"success":true,"result":{}}"#),
+            "/zones/z/rulesets/comp1": (200, #"{"success":true,"result":{"id":"comp1","phase":"http_response_compression","rules":[]}}"#),
             "/zones/z/rulesets": (200, #"{"success":true,"result":[{"id":"comp1","phase":"http_response_compression"}]}"#),
         ])
         try await client.enableZstandardCompression(zoneID: "z", apiToken: "t")
         let post = try #require(spy.requests.last)
         #expect(post.url!.path.hasSuffix("/zones/z/rulesets/comp1/rules"))
+    }
+
+    @Test("enableZstandardCompression is a no-op when the ruleset already has a zstd rule")
+    func zstdAlreadyPresentSkipsPost() async throws {
+        let existingRuleJSON = """
+        {"success":true,"result":{"id":"comp1","phase":"http_response_compression","rules":[
+            {"description":"existing","expression":"true","action":"compress_response",
+             "action_parameters":{"algorithms":[{"name":"zstd"},{"name":"gzip"}]}}
+        ]}}
+        """
+        let (client, spy) = spiedClient([
+            "/zones/z/rulesets/comp1": (200, existingRuleJSON),
+            "/zones/z/rulesets": (200, #"{"success":true,"result":[{"id":"comp1","phase":"http_response_compression"}]}"#),
+        ])
+        try await client.enableZstandardCompression(zoneID: "z", apiToken: "t")
+        #expect(spy.requests.allSatisfy { $0.httpMethod == "GET" })
+        let last = try #require(spy.requests.last)
+        #expect(last.url!.path.hasSuffix("/zones/z/rulesets/comp1"))
     }
 }

--- a/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
@@ -156,4 +156,16 @@ final class MockCloudflareWriter: CloudflareWriting, @unchecked Sendable {
     func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws {
         try record("createWAFCustomRule")
     }
+    func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try record("setSpeedBrain")
+    }
+    func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try record("setECH")
+    }
+    func enableZstandardCompression(zoneID: String, apiToken: String) async throws {
+        try record("enableZstandardCompression")
+    }
+    func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try record("setPageShield")
+    }
 }

--- a/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
@@ -36,10 +36,14 @@ struct HardenExecutorTests {
             .addSPFRejectAll,
             .addDMARCReject,
             .addWAFRule(description: "Block dotfiles", expression: "(x)", action: "block"),
+            .enableSpeedBrain,
+            .enableZstandardCompression,
+            .enableECH,
+            .enablePageShieldMonitoring,
         ])
         let result = await exec.execute(
             plan: plan, zoneID: "z", domain: "example.com", apiToken: "t")
-        #expect(result.appliedCount == 9)
+        #expect(result.appliedCount == 13)
         #expect(result.failedItems.isEmpty)
         #expect(writer.calls.contains("enableDNSSEC"))
         #expect(writer.calls.contains { $0.hasPrefix("addDNSRecord:CAA") })
@@ -50,6 +54,10 @@ struct HardenExecutorTests {
         #expect(writer.calls.contains("addDNSRecord:TXT:v=spf1 -all"))
         #expect(writer.calls.contains("addDNSRecord:TXT:v=DMARC1; p=reject"))
         #expect(writer.calls.contains("createWAFCustomRule"))
+        #expect(writer.calls.contains("setSpeedBrain"))
+        #expect(writer.calls.contains("enableZstandardCompression"))
+        #expect(writer.calls.contains("setECH"))
+        #expect(writer.calls.contains("setPageShield"))
     }
 
     @Test("a per-item failure does not abort remaining items")
@@ -108,7 +116,9 @@ final class MockCloudflareReader: CloudflareReading, @unchecked Sendable {
         dnssecActive: true, sslMode: "strict", alwaysUseHTTPS: true,
         hsts: .init(maxAge: 31_536_000, includeSubdomains: true, preload: false),
         caaRecords: [], mxRecords: [], spfRecords: ["v=spf1 -all"],
-        dmarcRecords: ["v=DMARC1; p=reject"], botFightMode: true)) {
+        dmarcRecords: ["v=DMARC1; p=reject"], botFightMode: true,
+        speedBrain: true, ech: true, zstdCompression: true,
+        pageShield: .init(enabled: true, scriptHosts: []))) {
         self.state = state
     }
 

--- a/Tests/AnglesiteCoreTests/HardenPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenPlannerTests.swift
@@ -16,7 +16,9 @@ struct HardenPlannerTests {
             botFightMode: true,
             wafCustomRules: HardenPlanner.curatedWAFRules.map {
                 .init(description: $0.description, expression: $0.expression, action: $0.action)
-            })
+            },
+            speedBrain: true, ech: true, zstdCompression: true,
+            pageShield: .init(enabled: true, scriptHosts: []))
     }
 
     private func bare() -> CloudflareZoneState {
@@ -137,5 +139,22 @@ struct HardenPlannerTests {
         s.dmarcRecords = ["v=DMARC1; sp=none; p=reject; rua=mailto:x@example.com"]
         let plan = HardenPlanner.plan(from: s, domain: "example.com")
         #expect(!plan.items.contains(.addDMARCReject))
+    }
+
+    @Test("a bare zone plans the harden-pack items")
+    func bareGetsHardenPack() {
+        let plan = HardenPlanner.plan(from: bare(), domain: "example.com")
+        #expect(plan.items.contains(.enableSpeedBrain))
+        #expect(plan.items.contains(.enableZstandardCompression))
+        #expect(plan.items.contains(.enableECH))
+        #expect(plan.items.contains(.enablePageShieldMonitoring))
+    }
+
+    @Test("page shield monitoring is planned when the state is unreadable (nil)")
+    func pageShieldNilPlansEnable() {
+        var state = hardened()
+        state.pageShield = nil
+        let plan = HardenPlanner.plan(from: state, domain: "example.com")
+        #expect(plan.items == [.enablePageShieldMonitoring])
     }
 }

--- a/Tests/AnglesiteCoreTests/SecurityAuditTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityAuditTests.swift
@@ -8,7 +8,9 @@ struct SecurityAuditTests {
             hsts: .init(maxAge: 31_536_000, includeSubdomains: true, preload: false),
             caaRecords: ["0 issue \"letsencrypt.org\""], mxRecords: [],
             spfRecords: ["v=spf1 -all"], dmarcRecords: ["v=DMARC1; p=reject"],
-            botFightMode: true)
+            botFightMode: true,
+            speedBrain: true, ech: true, zstdCompression: true,
+            pageShield: .init(enabled: true, scriptHosts: []))
     }
 
     @Test("a fully hardened non-mail zone yields no findings")
@@ -71,5 +73,31 @@ struct SecurityAuditTests {
     func allSecurityCategory() {
         var s = clean(); s.dnssecActive = false; s.sslMode = "off"
         #expect(SecurityAudit.evaluate(s, expectsMail: false).allSatisfy { $0.category == .security })
+    }
+
+    @Test("ECH off yields an info finding")
+    func echOffInfo() {
+        var state = clean()
+        state.ech = false
+        let findings = SecurityAudit.evaluate(state, expectsMail: true)
+        #expect(findings.contains { $0.title.contains("Encrypted Client Hello") && $0.severity == .info })
+    }
+
+    @Test("Page Shield disabled yields an info finding")
+    func pageShieldOffInfo() {
+        var state = clean()
+        state.pageShield = nil
+        let findings = SecurityAudit.evaluate(state, expectsMail: true)
+        #expect(findings.contains { $0.title.contains("script monitoring") })
+    }
+
+    @Test("detected third-party scripts are surfaced with their hosts")
+    func pageShieldScriptsSurfaced() {
+        var state = clean()
+        state.pageShield = .init(enabled: true, scriptHosts: ["cdn.evil.example"])
+        let findings = SecurityAudit.evaluate(state, expectsMail: true)
+        let finding = findings.first { $0.title.contains("Third-party scripts") }
+        #expect(finding != nil)
+        #expect(finding?.detail.contains("cdn.evil.example") == true)
     }
 }

--- a/Tests/AnglesiteCoreTests/TokenCapabilitiesTests.swift
+++ b/Tests/AnglesiteCoreTests/TokenCapabilitiesTests.swift
@@ -1,0 +1,21 @@
+// Tests/AnglesiteCoreTests/TokenCapabilitiesTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct TokenCapabilitiesTests {
+    @Test("capabilities round-trip through Codable (persistable alongside the token)")
+    func codableRoundTrip() throws {
+        let caps: TokenCapabilities = [.workers, .turnstile, .emailRouting]
+        let data = try JSONEncoder().encode(caps.sorted { $0.rawValue < $1.rawValue })
+        let decoded = TokenCapabilities(try JSONDecoder().decode([TokenCapability].self, from: data))
+        #expect(decoded == caps)
+    }
+
+    @Test("every capability has a stable raw value")
+    func stableRawValues() {
+        #expect(TokenCapability.allCases.count == 9)
+        #expect(TokenCapability.zoneSettings.rawValue == "zoneSettings")
+        #expect(TokenCapability(rawValue: "registrar") == .registrar)
+    }
+}

--- a/docs/superpowers/plans/2026-07-04-cloudflare-slice0-token-slice3-harden-pack.md
+++ b/docs/superpowers/plans/2026-07-04-cloudflare-slice0-token-slice3-harden-pack.md
@@ -1,0 +1,1147 @@
+# Cloudflare Slice 0 (Unified Token) + Slice 3 (Harden Pack) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the unified "Anglesite" Cloudflare token (template + capability probe) and extend the Harden/Audit flow with the newly-free zone features: Speed Brain, Zstandard compression, ECH, and Page Shield script monitoring.
+
+**Architecture:** Two slices from `docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md`. Slice 0 adds pure-Swift types in AnglesiteCore (`TokenCapability`, `CloudflareCapabilityProber`, `AnglesiteTokenTemplate`) and repoints the token-prompt UI at the new template. Slice 3 extends the existing read→plan→execute→audit pipeline (`CloudflareZoneState` → `HardenPlanner` → `HardenExecutor` → `SecurityAudit`) with four new zone capabilities, all via `HTTPCloudflareClient` with injected transport.
+
+**Tech Stack:** Swift 6.4 / Xcode 27, SwiftPM, Swift Testing (`import Testing`, `@Test`, `#expect`). No new dependencies.
+
+## Global Constraints
+
+- Run tests with: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .` (the default CommandLineTools swift is broken/too old).
+- All work happens in this worktree (`.claude/worktrees/peaceful-bun-85c4b5`), branch `claude/peaceful-bun-85c4b5`. `cd` there before any git op.
+- No frameworks beyond Apple's. No `Process()` outside ProcessSupervisor (this plan spawns none).
+- New-endpoint reads in `zoneState` must degrade gracefully (catch → default) so existing narrow tokens keep working — same pattern as the existing `bot_management` read.
+- CI note: don't call macOS-27-only Foundation symbols in AnglesiteCore/tests (links `libswift_DarwinFoundation3.dylib`, absent on CI runners). Everything in this plan uses long-available APIs.
+- Conventional commits, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` footer.
+
+**Cloudflare API endpoints used (verified against docs 2026-07-04):**
+
+| Feature | Read | Write |
+|---|---|---|
+| Speed Brain | `GET /zones/{z}/settings/speed_brain` → `{value:"on"/"off"}` | `PATCH` same path, body `{"value":"on"}` |
+| ECH | `GET /zones/{z}/settings/ech` → `{value:"on"/"off"}` | `PATCH` same path, body `{"value":"on"}` |
+| Zstandard | ruleset phase `http_response_compression`, rule `action:"compress_response"` with `action_parameters.algorithms[].name == "zstd"` | POST rule into that phase's ruleset (create ruleset if absent — same upsert shape as `createWAFCustomRule`) |
+| Page Shield | `GET /zones/{z}/page_shield` → `{enabled}`; `GET /zones/{z}/page_shield/scripts` → `[{url, host, …}]` | `PUT /zones/{z}/page_shield`, body `{"enabled":true}` |
+| Capability probes | cheap GETs per group (see Task 2 table) | — |
+
+---
+
+### Task 1: `TokenCapability` model
+
+**Files:**
+- Create: `Sources/AnglesiteCore/TokenCapabilities.swift`
+- Test: `Tests/AnglesiteCoreTests/TokenCapabilitiesTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `public enum TokenCapability: String, CaseIterable, Codable, Sendable` with cases `workers, zoneSettings, dns, rulesets, turnstile, emailRouting, zaraz, pageShield, registrar`; `public typealias TokenCapabilities = Set<TokenCapability>`. Task 2's prober returns `TokenCapabilities`; future slices (1/2/5/7) gate wizards on `caps.contains(.turnstile)` etc.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// Tests/AnglesiteCoreTests/TokenCapabilitiesTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct TokenCapabilitiesTests {
+    @Test("capabilities round-trip through Codable (persistable alongside the token)")
+    func codableRoundTrip() throws {
+        let caps: TokenCapabilities = [.workers, .turnstile, .emailRouting]
+        let data = try JSONEncoder().encode(caps.sorted { $0.rawValue < $1.rawValue })
+        let decoded = TokenCapabilities(try JSONDecoder().decode([TokenCapability].self, from: data))
+        #expect(decoded == caps)
+    }
+
+    @Test("every capability has a stable raw value")
+    func stableRawValues() {
+        #expect(TokenCapability.allCases.count == 9)
+        #expect(TokenCapability.zoneSettings.rawValue == "zoneSettings")
+        #expect(TokenCapability(rawValue: "registrar") == .registrar)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter TokenCapabilitiesTests`
+Expected: FAIL to compile — `cannot find 'TokenCapability' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+// Sources/AnglesiteCore/TokenCapabilities.swift
+import Foundation
+
+/// A permission group the stored Cloudflare token has been *observed* to have, via
+/// `CloudflareCapabilityProber`. Capabilities are read-probe signals: presence means the token can
+/// at least read that product's API; absence (401/403 on the probe) means a wizard needing it must
+/// route the user through token re-onboarding (`AnglesiteTokenTemplate`) instead of failing mid-flow.
+public enum TokenCapability: String, CaseIterable, Codable, Sendable {
+    /// Workers scripts (deploy).
+    case workers
+    /// Zone settings (SSL mode, HSTS, Speed Brain, ECH, …).
+    case zoneSettings
+    /// DNS record reads/writes.
+    case dns
+    /// Zone rulesets (WAF custom rules, compression rules).
+    case rulesets
+    /// Turnstile widget management.
+    case turnstile
+    /// Email Routing (rules + destination addresses).
+    case emailRouting
+    /// Zaraz configuration.
+    case zaraz
+    /// Page Shield (client-side security) status + script reports.
+    case pageShield
+    /// Registrar domain search/registration.
+    case registrar
+}
+
+/// The set of permission groups a probe observed on the stored token.
+public typealias TokenCapabilities = Set<TokenCapability>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter TokenCapabilitiesTests`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/TokenCapabilities.swift Tests/AnglesiteCoreTests/TokenCapabilitiesTests.swift
+git commit -m "feat(#59): add TokenCapability model for Cloudflare token capability probing
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `CloudflareCapabilityProber`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/CloudflareCapabilityProber.swift`
+- Test: `Tests/AnglesiteCoreTests/CloudflareCapabilityProberTests.swift`
+
+**Interfaces:**
+- Consumes: `TokenCapability`/`TokenCapabilities` (Task 1), `CloudflareTransport` typealias (`Sources/AnglesiteCore/CloudflareReading.swift:22`), `fakeTransport(_:)` helper (`Tests/AnglesiteCoreTests/CloudflareClientTests.swift` — file-scope, visible test-target-wide).
+- Produces: `public struct CloudflareCapabilityProber: Sendable` with `init(baseURL: URL = …, transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport)` and `public func probe(token: String, zoneID: String?) async -> TokenCapabilities`.
+
+Probe endpoints (GET; **401/403 ⇒ capability absent; any other HTTP status ⇒ present** — a 404 like "Email Routing not enabled yet" still proves the permission; a thrown transport error ⇒ absent, callers may re-probe):
+
+| Capability | Probe path |
+|---|---|
+| `.workers` | `accounts/{accountID}/workers/scripts` |
+| `.turnstile` | `accounts/{accountID}/challenges/widgets` |
+| `.registrar` | `accounts/{accountID}/registrar/domains` |
+| `.zoneSettings` | `zones/{zoneID}/settings/ssl` |
+| `.dns` | `zones/{zoneID}/dns_records?per_page=1` |
+| `.rulesets` | `zones/{zoneID}/rulesets` |
+| `.emailRouting` | `zones/{zoneID}/email/routing` |
+| `.zaraz` | `zones/{zoneID}/settings/zaraz/config` |
+| `.pageShield` | `zones/{zoneID}/page_shield` |
+
+Account ID is resolved internally via `GET accounts` (first account, like `CloudflareAPITokenVerifier.accountName`). If it can't be resolved, account-scoped probes are skipped (absent). If `zoneID` is nil, zone-scoped probes are skipped (absent).
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// Tests/AnglesiteCoreTests/CloudflareCapabilityProberTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct CloudflareCapabilityProberTests {
+    private let accountsOK = (200, #"{"success":true,"result":[{"id":"acc1","name":"Acme"}]}"#)
+
+    @Test("2xx and non-auth errors mark a capability present; 403 marks it absent")
+    func classifiesStatuses() async {
+        let prober = CloudflareCapabilityProber(transport: fakeTransport([
+            "/accounts?": accountsOK,
+            "accounts/acc1/workers/scripts": (200, #"{"success":true,"result":[]}"#),
+            "accounts/acc1/challenges/widgets": (403, #"{"success":false}"#),
+            "accounts/acc1/registrar/domains": (200, #"{"success":true,"result":[]}"#),
+            "zones/z1/settings/ssl": (200, #"{"success":true,"result":{"value":"strict"}}"#),
+            "zones/z1/dns_records": (403, #"{"success":false}"#),
+            "zones/z1/rulesets": (200, #"{"success":true,"result":[]}"#),
+            "zones/z1/email/routing": (404, #"{"success":false}"#),
+            "zones/z1/settings/zaraz/config": (403, #"{"success":false}"#),
+            "zones/z1/page_shield": (200, #"{"success":true,"result":{"enabled":false}}"#),
+        ]))
+        let caps = await prober.probe(token: "t", zoneID: "z1")
+        #expect(caps.contains(.workers))
+        #expect(!caps.contains(.turnstile))
+        #expect(caps.contains(.registrar))
+        #expect(caps.contains(.zoneSettings))
+        #expect(!caps.contains(.dns))
+        #expect(caps.contains(.rulesets))
+        #expect(caps.contains(.emailRouting))  // 404 = enabled-state miss, permission present
+        #expect(!caps.contains(.zaraz))
+        #expect(caps.contains(.pageShield))
+    }
+
+    @Test("nil zoneID skips zone probes; unresolvable account skips account probes")
+    func skipsUnscopedProbes() async {
+        let prober = CloudflareCapabilityProber(transport: fakeTransport([
+            "/accounts?": (403, #"{"success":false}"#),
+        ]))
+        let caps = await prober.probe(token: "t", zoneID: nil)
+        #expect(caps.isEmpty)
+    }
+
+    @Test("probe requests carry the bearer token")
+    func sendsBearer() async {
+        let spy = TransportSpy()
+        let inner = fakeTransport(["/accounts?": accountsOK])
+        let prober = CloudflareCapabilityProber(transport: { request in
+            spy.record(request)
+            return try await inner(request)
+        })
+        _ = await prober.probe(token: "sekret", zoneID: nil)
+        #expect(spy.requests.allSatisfy {
+            $0.value(forHTTPHeaderField: "Authorization") == "Bearer sekret"
+        })
+    }
+}
+```
+
+Note: `fakeTransport` routes by URL substring. The `"/accounts?"` needle must not collide with `accounts/acc1/...` paths — so the implementation must request the account list as `accounts?per_page=1` (the `?` disambiguates the route; longest-needle-first matching handles the rest).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter CloudflareCapabilityProberTests`
+Expected: FAIL to compile — `cannot find 'CloudflareCapabilityProber' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+// Sources/AnglesiteCore/CloudflareCapabilityProber.swift
+import Foundation
+
+/// Observes which permission groups a stored Cloudflare token actually has, by issuing one cheap
+/// authenticated GET per group. 401/403 means the group is missing; any other response (including
+/// 404s like "Email Routing not enabled") proves the permission. A thrown transport error counts as
+/// missing — probes are advisory and callers may re-probe.
+///
+/// This exists so wizards can gate on `TokenCapabilities` up front and route the user through token
+/// re-onboarding (`AnglesiteTokenTemplate`) instead of failing halfway through an API orchestration.
+public struct CloudflareCapabilityProber: Sendable {
+    private let baseURL: URL
+    private let transport: CloudflareTransport
+
+    public init(
+        baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!,
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) {
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    public func probe(token: String, zoneID: String?) async -> TokenCapabilities {
+        var caps = TokenCapabilities()
+
+        var probes: [(TokenCapability, String)] = []
+        if let accountID = await firstAccountID(token: token) {
+            probes += [
+                (.workers, "accounts/\(accountID)/workers/scripts"),
+                (.turnstile, "accounts/\(accountID)/challenges/widgets"),
+                (.registrar, "accounts/\(accountID)/registrar/domains"),
+            ]
+        }
+        if let zoneID {
+            probes += [
+                (.zoneSettings, "zones/\(zoneID)/settings/ssl"),
+                (.dns, "zones/\(zoneID)/dns_records?per_page=1"),
+                (.rulesets, "zones/\(zoneID)/rulesets"),
+                (.emailRouting, "zones/\(zoneID)/email/routing"),
+                (.zaraz, "zones/\(zoneID)/settings/zaraz/config"),
+                (.pageShield, "zones/\(zoneID)/page_shield"),
+            ]
+        }
+        for (cap, path) in probes {
+            if await allowed(path, token: token) {
+                caps.insert(cap)
+            }
+        }
+        return caps
+    }
+
+    /// First account id visible to the token, or nil (account-scoped probes are then skipped).
+    private func firstAccountID(token: String) async -> String? {
+        struct Envelope: Decodable { let result: [Account]?; struct Account: Decodable { let id: String } }
+        guard let (data, http) = try? await get("accounts?per_page=1", token: token),
+              (200..<300).contains(http.statusCode),
+              let envelope = try? JSONDecoder().decode(Envelope.self, from: data)
+        else { return nil }
+        return envelope.result?.first?.id
+    }
+
+    private func allowed(_ path: String, token: String) async -> Bool {
+        guard let (_, http) = try? await get(path, token: token) else { return false }
+        return http.statusCode != 401 && http.statusCode != 403
+    }
+
+    private func get(_ path: String, token: String) async throws -> (Data, HTTPURLResponse) {
+        guard let url = URL(string: baseURL.absoluteString + "/" + path) else {
+            throw CloudflareError.malformedResponse
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return try await transport(request)
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter CloudflareCapabilityProberTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CloudflareCapabilityProber.swift Tests/AnglesiteCoreTests/CloudflareCapabilityProberTests.swift
+git commit -m "feat(#59): probe Cloudflare token capabilities per permission group
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `AnglesiteTokenTemplate` + token prompt repoint
+
+**Files:**
+- Create: `Sources/AnglesiteCore/AnglesiteTokenTemplate.swift`
+- Modify: `Sources/AnglesiteApp/CloudflareTokenPromptView.swift:26-48` (delete local `createTokenURL`, use the core type; update step copy), `Sources/AnglesiteCore/CloudflareTokenVerifier.swift:29` (invalidToken copy)
+- Test: `Tests/AnglesiteCoreTests/AnglesiteTokenTemplateTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `public enum AnglesiteTokenTemplate` with `public static let tokenName: String` (= `"Anglesite"`), `public static let permissionGroups: [(key: String, type: String)]`, `public static var createTokenURL: URL`. The view consumes `createTokenURL`; docs/UI copy consume `tokenName`.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// Tests/AnglesiteCoreTests/AnglesiteTokenTemplateTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct AnglesiteTokenTemplateTests {
+    @Test("the template keeps every permission the old Workers-deploy template had")
+    func supersetOfDeployTemplate() {
+        let keys = Set(AnglesiteTokenTemplate.permissionGroups.map(\.key))
+        for legacy in ["workers_routes", "workers_scripts", "workers_kv_storage", "workers_tail", "workers_r2"] {
+            #expect(keys.contains(legacy))
+        }
+    }
+
+    @Test("the template covers the new integration surface")
+    func coversNewServices() {
+        let keys = Set(AnglesiteTokenTemplate.permissionGroups.map(\.key))
+        for needed in ["d1", "zone_settings", "dns", "zone_waf", "challenge_widgets",
+                       "email_routing_rules", "email_routing_addresses", "zaraz",
+                       "page_shield", "analytics", "registrar"] {
+            #expect(keys.contains(needed), "missing permission group: \(needed)")
+        }
+    }
+
+    @Test("createTokenURL lands on the dashboard token page with name + permission pre-fill")
+    func urlShape() throws {
+        let components = try #require(URLComponents(url: AnglesiteTokenTemplate.createTokenURL,
+                                                    resolvingAgainstBaseURL: false))
+        #expect(components.host == "dash.cloudflare.com")
+        #expect(components.path == "/profile/api-tokens")
+        let items = components.queryItems ?? []
+        #expect(items.contains { $0.name == "name" && $0.value == "Anglesite" })
+        let permissions = items.first { $0.name == "permissionGroupKeys" }?.value ?? ""
+        #expect(permissions.contains(#""key":"workers_scripts""#))
+        #expect(permissions.contains(#""key":"registrar""#))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesiteTokenTemplateTests`
+Expected: FAIL to compile — `cannot find 'AnglesiteTokenTemplate' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
+import Foundation
+
+/// The single "Anglesite" Cloudflare API token: one custom template carrying every permission the
+/// app can use across deploy, harden, and the integration wizards (spec:
+/// docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md §4).
+///
+/// The dashboard pre-fill query params are undocumented; if Cloudflare changes the schema the link
+/// still lands on the token page and the prompt's numbered steps describe the permissions to add by
+/// hand, so the flow degrades rather than breaks (verified pre-fill behavior last on 2026-06-16 for
+/// the original five groups).
+public enum AnglesiteTokenTemplate {
+    public static let tokenName = "Anglesite"
+
+    /// Dashboard permission-group keys with their access level. Order is display order.
+    public static let permissionGroups: [(key: String, type: String)] = [
+        // Deploy (the original "Edit Cloudflare Workers" set)
+        ("workers_routes", "edit"),
+        ("workers_scripts", "edit"),
+        ("workers_kv_storage", "edit"),
+        ("workers_tail", "read"),
+        ("workers_r2", "edit"),
+        ("d1", "edit"),
+        // Harden + zone state
+        ("zone_settings", "edit"),
+        ("dns", "edit"),
+        ("zone_waf", "edit"),
+        ("page_shield", "read"),
+        ("analytics", "read"),
+        // Integration wizards (slices 1, 2, 5, 7)
+        ("challenge_widgets", "edit"),
+        ("email_routing_rules", "edit"),
+        ("email_routing_addresses", "edit"),
+        ("zaraz", "edit"),
+        ("registrar", "edit"),
+    ]
+
+    public static var createTokenURL: URL {
+        let permissions = "[" + permissionGroups
+            .map { #"{"key":"\#($0.key)","type":"\#($0.type)"}"# }
+            .joined(separator: ",") + "]"
+        var components = URLComponents(string: "https://dash.cloudflare.com/profile/api-tokens")!
+        components.queryItems = [
+            URLQueryItem(name: "name", value: tokenName),
+            URLQueryItem(name: "accountId", value: "*"),
+            URLQueryItem(name: "zoneId", value: "all"),
+            URLQueryItem(name: "permissionGroupKeys", value: permissions),
+        ]
+        return components.url!
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesiteTokenTemplateTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Repoint the prompt view and error copy**
+
+In `Sources/AnglesiteApp/CloudflareTokenPromptView.swift`:
+- Delete the whole `private static let createTokenURL: URL = { … }()` block (lines 26–48) and replace every use of `Self.createTokenURL` with `AnglesiteTokenTemplate.createTokenURL`.
+- Update the doc comment (lines 9–14): the link now pre-fills a custom token named "Anglesite" covering deploy + harden + integrations, not the built-in "Edit Cloudflare Workers" template.
+- Update the step copy at line 82 from
+  `Text("The “Edit Cloudflare Workers” permissions should already be selected (if not, pick that template). Click **Continue to summary**.")`
+  to
+  `Text("A custom token named “Anglesite” should be pre-filled with all permissions Anglesite uses (if not, choose **Create Custom Token** and continue — deploy still works and Anglesite will ask again when a feature needs more access). Click **Continue to summary**.")`
+
+In `Sources/AnglesiteCore/CloudflareTokenVerifier.swift:29`, change the `.invalidToken` message to:
+
+```swift
+return "That token didn’t work. Use the “Create token” link (it pre-fills the “Anglesite” token) and copy the whole token."
+```
+
+- [ ] **Step 6: Fix any test asserting the old copy, run core tests**
+
+Run: `grep -rn "Edit Cloudflare Workers" Tests/ Sources/` — update any remaining test assertion or UI string to the new copy (the verifier tests assert `userMessage` content).
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .`
+Expected: PASS (full suite).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteCore/AnglesiteTokenTemplate.swift Sources/AnglesiteApp/CloudflareTokenPromptView.swift Sources/AnglesiteCore/CloudflareTokenVerifier.swift Tests/
+git commit -m "feat(#59): unify token onboarding on the Anglesite token template
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Zone-state reads for Speed Brain, ECH, Zstandard, Page Shield
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/CloudflareZoneState.swift`, `Sources/AnglesiteCore/HTTPCloudflareClient.swift`
+- Test: `Tests/AnglesiteCoreTests/CloudflareClientTests.swift` (append tests)
+
+**Interfaces:**
+- Consumes: existing `CFStringSetting`, `CFRuleset`, `get(_:apiToken:as:)` in `HTTPCloudflareClient`.
+- Produces: on `CloudflareZoneState`: `public var speedBrain: Bool`, `public var ech: Bool`, `public var zstdCompression: Bool`, `public var pageShield: PageShieldState?` with `public struct PageShieldState: Sendable, Equatable { public var enabled: Bool; public var scriptHosts: [String] }`. All new init params are defaulted (`false`/`nil`) so every existing call site compiles unchanged. Tasks 6–8 consume these fields.
+
+- [ ] **Step 1: Write the failing test** (append to `CloudflareClientTests.swift`)
+
+```swift
+extension CloudflareClientTests {
+    private static let baseRoutes: [String: (Int, String)] = [
+        "/dnssec": (200, #"{"success":true,"result":{"status":"active"}}"#),
+        "/settings/ssl": (200, #"{"success":true,"result":{"value":"strict"}}"#),
+        "/settings/always_use_https": (200, #"{"success":true,"result":{"value":"on"}}"#),
+        "/settings/security_header": (200, #"{"success":true,"result":{"value":{"strict_transport_security":{"enabled":true,"max_age":31536000,"include_subdomains":true,"preload":false}}}}"#),
+        "/dns_records": (200, #"{"success":true,"result":[]}"#),
+        "/settings/bot_management": (403, #"{"success":false}"#),
+    ]
+
+    @Test("zoneState reads the harden-pack settings when the API grants them")
+    func zoneStateHardenPack() async throws {
+        var routes = Self.baseRoutes
+        routes["/settings/speed_brain"] = (200, #"{"success":true,"result":{"value":"on"}}"#)
+        routes["/settings/ech"] = (200, #"{"success":true,"result":{"value":"off"}}"#)
+        routes["/zones/z/rulesets/comp1"] = (200, #"{"success":true,"result":{"id":"comp1","phase":"http_response_compression","rules":[{"expression":"true","action":"compress_response","action_parameters":{"algorithms":[{"name":"zstd"},{"name":"gzip"}]}}]}}"#)
+        routes["/zones/z/rulesets"] = (200, #"{"success":true,"result":[{"id":"comp1","phase":"http_response_compression"}]}"#)
+        routes["/page_shield/scripts"] = (200, #"{"success":true,"result":[{"url":"https://cdn.evil.example/t.js","host":"cdn.evil.example"}]}"#)
+        routes["/page_shield"] = (200, #"{"success":true,"result":{"enabled":true}}"#)
+
+        let client = HTTPCloudflareClient(transport: fakeTransport(routes))
+        let state = try await client.zoneState(zoneID: "z", apiToken: "t")
+        #expect(state.speedBrain)
+        #expect(!state.ech)
+        #expect(state.zstdCompression)
+        #expect(state.pageShield == .init(enabled: true, scriptHosts: ["cdn.evil.example"]))
+    }
+
+    @Test("zoneState defaults the harden-pack fields when the token can't read them")
+    func zoneStateHardenPackDegrades() async throws {
+        // No speed_brain/ech/page_shield routes at all -> fakeTransport 404s -> envelope failure.
+        var routes = Self.baseRoutes
+        routes["/zones/z/rulesets"] = (403, #"{"success":false}"#)
+        let client = HTTPCloudflareClient(transport: fakeTransport(routes))
+        let state = try await client.zoneState(zoneID: "z", apiToken: "t")
+        #expect(!state.speedBrain)
+        #expect(!state.ech)
+        #expect(!state.zstdCompression)
+        #expect(state.pageShield == nil)
+    }
+}
+```
+
+Note: `fakeTransport` matches longest needle first, so `"/zones/z/rulesets/comp1"` wins over `"/zones/z/rulesets"`, and `"/page_shield/scripts"` wins over `"/page_shield"`. The 404 fallback returns `{"success":false}`, which the client maps to a thrown error — exactly what the degrade path catches. **Heads-up:** the existing WAF fetch shares `"/zones/z/rulesets"`; in `zoneStateHardenPack` it now sees the compression ruleset and no `http_request_firewall_custom` phase, which yields `wafCustomRules == []` — fine.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter CloudflareClientTests`
+Expected: FAIL to compile — `value of type 'CloudflareZoneState' has no member 'speedBrain'`.
+
+- [ ] **Step 3: Extend `CloudflareZoneState`**
+
+Add inside the struct (after `wafCustomRules` and `WAFCustomRule`):
+
+```swift
+    /// Speed Brain (speculation-rules prefetching) zone setting.
+    public var speedBrain: Bool
+    /// Encrypted Client Hello zone setting.
+    public var ech: Bool
+    /// Whether a compression rule enables Zstandard (`http_response_compression` phase).
+    public var zstdCompression: Bool
+    /// Page Shield (client-side security) status + detected script hosts. `nil` when unreadable.
+    public var pageShield: PageShieldState?
+
+    /// Page Shield script-monitor snapshot.
+    public struct PageShieldState: Sendable, Equatable {
+        public var enabled: Bool
+        /// Unique, sorted hosts of scripts Page Shield has seen loading on the site.
+        public var scriptHosts: [String]
+        public init(enabled: Bool, scriptHosts: [String]) {
+            self.enabled = enabled
+            self.scriptHosts = scriptHosts
+        }
+    }
+```
+
+Extend the init signature with defaulted trailing parameters and assignments:
+
+```swift
+    public init(dnssecActive: Bool, sslMode: String, alwaysUseHTTPS: Bool, hsts: HSTS?,
+                caaRecords: [String], mxRecords: [String], spfRecords: [String], dmarcRecords: [String],
+                botFightMode: Bool = false, wafCustomRules: [WAFCustomRule] = [],
+                speedBrain: Bool = false, ech: Bool = false, zstdCompression: Bool = false,
+                pageShield: PageShieldState? = nil) {
+        // …existing assignments…
+        self.speedBrain = speedBrain
+        self.ech = ech
+        self.zstdCompression = zstdCompression
+        self.pageShield = pageShield
+    }
+```
+
+- [ ] **Step 4: Extend `HTTPCloudflareClient.zoneState`**
+
+Add private decode types near the other `CF*` types in `HTTPCloudflareClient.swift`:
+
+```swift
+private struct CFPageShield: Decodable, Sendable { let enabled: Bool? }
+private struct CFPageShieldScript: Decodable, Sendable {
+    let url: String?
+    let host: String?
+}
+```
+
+Extend `CFRulesetRule` with the compression parameters:
+
+```swift
+private struct CFRulesetRule: Decodable, Sendable {
+    let description: String?
+    let expression: String
+    let action: String
+    let action_parameters: Params?
+    struct Params: Decodable, Sendable {
+        let algorithms: [Algorithm]?
+        struct Algorithm: Decodable, Sendable { let name: String? }
+    }
+}
+```
+
+Add helpers to `HTTPCloudflareClient`:
+
+```swift
+    /// Reads an on/off zone setting, defaulting to `false` when the token can't see it.
+    private func settingIsOn(_ path: String, apiToken: String) async -> Bool {
+        ((try? await get(path, apiToken: apiToken, as: CFStringSetting.self))?.value.lowercased()) == "on"
+    }
+
+    private func zstdEnabled(zoneID: String, apiToken: String) async -> Bool {
+        guard let rulesets = try? await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self),
+              let compression = rulesets.first(where: { $0.phase == "http_response_compression" }),
+              let full = try? await get("/zones/\(zoneID)/rulesets/\(compression.id)", apiToken: apiToken, as: CFRuleset.self)
+        else { return false }
+        return (full.rules ?? []).contains { rule in
+            rule.action == "compress_response"
+                && (rule.action_parameters?.algorithms ?? []).contains { $0.name == "zstd" }
+        }
+    }
+
+    private func pageShieldState(zoneID: String, apiToken: String) async -> CloudflareZoneState.PageShieldState? {
+        guard let shield = try? await get("/zones/\(zoneID)/page_shield", apiToken: apiToken, as: CFPageShield.self) else {
+            return nil
+        }
+        let enabled = shield.enabled ?? false
+        var hosts: [String] = []
+        if enabled,
+           let scripts = try? await get("/zones/\(zoneID)/page_shield/scripts", apiToken: apiToken, as: [CFPageShieldScript].self) {
+            hosts = Set(scripts.compactMap { $0.host ?? $0.url.flatMap { URL(string: $0)?.host } }).sorted()
+        }
+        return .init(enabled: enabled, scriptHosts: hosts)
+    }
+```
+
+In `zoneState(zoneID:apiToken:)`, before the final `return`, add:
+
+```swift
+        let speedBrain = await settingIsOn("/zones/\(zoneID)/settings/speed_brain", apiToken: apiToken)
+        let ech = await settingIsOn("/zones/\(zoneID)/settings/ech", apiToken: apiToken)
+        let zstd = await zstdEnabled(zoneID: zoneID, apiToken: apiToken)
+        let pageShield = await pageShieldState(zoneID: zoneID, apiToken: apiToken)
+```
+
+and pass them in the returned initializer: `speedBrain: speedBrain, ech: ech, zstdCompression: zstd, pageShield: pageShield`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter CloudflareClientTests`
+Expected: PASS (existing + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CloudflareZoneState.swift Sources/AnglesiteCore/HTTPCloudflareClient.swift Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+git commit -m "feat(#59): read Speed Brain, ECH, Zstandard, and Page Shield zone state
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Write methods for the harden pack
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/CloudflareWriting.swift`, `Sources/AnglesiteCore/HTTPCloudflareClient.swift` (CloudflareWriting extension), `Tests/AnglesiteCoreTests/HardenExecutorTests.swift:122-159` (`MockCloudflareWriter`)
+- Test: `Tests/AnglesiteCoreTests/CloudflareWritingTests.swift` (append)
+
+**Interfaces:**
+- Consumes: `mutate(method:_:body:apiToken:)`, ruleset-upsert pattern from `createWAFCustomRule` (`HTTPCloudflareClient.swift:222-242`).
+- Produces (protocol additions on `CloudflareWriting`):
+  - `func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws`
+  - `func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws`
+  - `func enableZstandardCompression(zoneID: String, apiToken: String) async throws`
+  - `func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws`
+
+- [ ] **Step 1: Write the failing test** (append to `CloudflareWritingTests.swift`, following that file's existing spy/route pattern — it uses `TransportSpy` + `fakeTransport` from `CloudflareClientTests.swift`)
+
+```swift
+extension CloudflareWritingTests {
+    private func spiedClient(_ routes: [String: (Int, String)]) -> (HTTPCloudflareClient, TransportSpy) {
+        let spy = TransportSpy()
+        let inner = fakeTransport(routes)
+        let client = HTTPCloudflareClient(transport: { request in
+            spy.record(request)
+            return try await inner(request)
+        })
+        return (client, spy)
+    }
+
+    @Test("setSpeedBrain PATCHes the speed_brain setting")
+    func speedBrainWrite() async throws {
+        let (client, spy) = spiedClient([
+            "/settings/speed_brain": (200, #"{"success":true,"result":{}}"#),
+        ])
+        try await client.setSpeedBrain(zoneID: "z", enabled: true, apiToken: "t")
+        let request = try #require(spy.requests.last)
+        #expect(request.httpMethod == "PATCH")
+        #expect(request.url!.path.hasSuffix("/zones/z/settings/speed_brain"))
+        #expect(String(data: request.httpBody ?? Data(), encoding: .utf8)!.contains(#""value":"on""#))
+    }
+
+    @Test("setECH PATCHes the ech setting")
+    func echWrite() async throws {
+        let (client, spy) = spiedClient([
+            "/settings/ech": (200, #"{"success":true,"result":{}}"#),
+        ])
+        try await client.setECH(zoneID: "z", enabled: true, apiToken: "t")
+        let request = try #require(spy.requests.last)
+        #expect(request.httpMethod == "PATCH")
+        #expect(request.url!.path.hasSuffix("/zones/z/settings/ech"))
+    }
+
+    @Test("setPageShield PUTs enabled")
+    func pageShieldWrite() async throws {
+        let (client, spy) = spiedClient([
+            "/page_shield": (200, #"{"success":true,"result":{}}"#),
+        ])
+        try await client.setPageShield(zoneID: "z", enabled: true, apiToken: "t")
+        let request = try #require(spy.requests.last)
+        #expect(request.httpMethod == "PUT")
+        #expect(String(data: request.httpBody ?? Data(), encoding: .utf8)!.contains(#""enabled":true"#))
+    }
+
+    @Test("enableZstandardCompression creates the compression ruleset when absent")
+    func zstdCreatesRuleset() async throws {
+        let (client, spy) = spiedClient([
+            "/zones/z/rulesets": (200, #"{"success":true,"result":[]}"#),
+        ])
+        try await client.enableZstandardCompression(zoneID: "z", apiToken: "t")
+        let post = try #require(spy.requests.last)
+        #expect(post.httpMethod == "POST")
+        #expect(post.url!.path.hasSuffix("/zones/z/rulesets"))
+        let body = String(data: post.httpBody ?? Data(), encoding: .utf8)!
+        #expect(body.contains("http_response_compression"))
+        #expect(body.contains(#""name":"zstd""#))
+    }
+
+    @Test("enableZstandardCompression appends a rule when the ruleset exists")
+    func zstdAppendsRule() async throws {
+        let (client, spy) = spiedClient([
+            "/zones/z/rulesets/comp1/rules": (200, #"{"success":true,"result":{}}"#),
+            "/zones/z/rulesets": (200, #"{"success":true,"result":[{"id":"comp1","phase":"http_response_compression"}]}"#),
+        ])
+        try await client.enableZstandardCompression(zoneID: "z", apiToken: "t")
+        let post = try #require(spy.requests.last)
+        #expect(post.url!.path.hasSuffix("/zones/z/rulesets/comp1/rules"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter CloudflareWritingTests`
+Expected: FAIL to compile — `value of type 'HTTPCloudflareClient' has no member 'setSpeedBrain'`.
+
+- [ ] **Step 3: Add the protocol requirements** (in `CloudflareWriting.swift`, after `createWAFCustomRule`)
+
+```swift
+    func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws
+    func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws
+    /// Idempotent: creates the `http_response_compression` ruleset with a zstd-first rule, or
+    /// appends the rule to the existing ruleset.
+    func enableZstandardCompression(zoneID: String, apiToken: String) async throws
+    func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws
+```
+
+- [ ] **Step 4: Implement in the `CloudflareWriting` extension of `HTTPCloudflareClient`**
+
+```swift
+    public func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try await mutate(method: "PATCH", "/zones/\(zoneID)/settings/speed_brain",
+                         body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
+    }
+
+    public func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try await mutate(method: "PATCH", "/zones/\(zoneID)/settings/ech",
+                         body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
+    }
+
+    public func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try await mutate(method: "PUT", "/zones/\(zoneID)/page_shield",
+                         body: ["enabled": enabled], apiToken: apiToken)
+    }
+
+    public func enableZstandardCompression(zoneID: String, apiToken: String) async throws {
+        struct CompressionRule: Encodable, Sendable {
+            struct Params: Encodable, Sendable {
+                struct Algorithm: Encodable, Sendable { let name: String }
+                let algorithms: [Algorithm]
+            }
+            let description: String
+            let expression: String
+            let action: String
+            let action_parameters: Params
+        }
+        let rule = CompressionRule(
+            description: "Anglesite: prefer Zstandard compression",
+            expression: "true",
+            action: "compress_response",
+            action_parameters: .init(algorithms: [
+                .init(name: "zstd"), .init(name: "brotli"), .init(name: "gzip"),
+            ]))
+
+        let rulesets = try await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self)
+        if let existing = rulesets.first(where: { $0.phase == "http_response_compression" }) {
+            try await mutate(method: "POST", "/zones/\(zoneID)/rulesets/\(existing.id)/rules",
+                             body: rule, apiToken: apiToken)
+        } else {
+            struct NewRuleset: Encodable, Sendable {
+                let name: String
+                let kind: String
+                let phase: String
+                let rules: [CompressionRule]
+            }
+            try await mutate(method: "POST", "/zones/\(zoneID)/rulesets",
+                             body: NewRuleset(name: "Anglesite compression rules",
+                                              kind: "zone", phase: "http_response_compression",
+                                              rules: [rule]),
+                             apiToken: apiToken)
+        }
+    }
+```
+
+- [ ] **Step 5: Extend `MockCloudflareWriter`** (in `HardenExecutorTests.swift`, after `createWAFCustomRule`)
+
+```swift
+    func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try record("setSpeedBrain")
+    }
+    func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try record("setECH")
+    }
+    func enableZstandardCompression(zoneID: String, apiToken: String) async throws {
+        try record("enableZstandardCompression")
+    }
+    func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {
+        try record("setPageShield")
+    }
+```
+
+Also run `grep -rn ": CloudflareWriting" Sources Tests` — if any other conformer exists, add the four methods there the same way.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter "CloudflareWritingTests|HardenExecutorTests"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CloudflareWriting.swift Sources/AnglesiteCore/HTTPCloudflareClient.swift Tests/AnglesiteCoreTests/CloudflareWritingTests.swift Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+git commit -m "feat(#59): add Speed Brain, ECH, Zstandard, Page Shield write methods
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Harden plan items + planner logic
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/HardenPlan.swift`, `Sources/AnglesiteCore/HardenPlanner.swift`, `Tests/AnglesiteCoreTests/HardenPlannerTests.swift` (fixtures + new tests)
+
+**Interfaces:**
+- Consumes: `CloudflareZoneState.speedBrain/ech/zstdCompression/pageShield` (Task 4).
+- Produces: `HardenPlanItem` cases `.enableSpeedBrain`, `.enableZstandardCompression`, `.enableECH`, `.enablePageShieldMonitoring` (Task 7 dispatches on these).
+
+- [ ] **Step 1: Update fixtures and write failing tests**
+
+In `HardenPlannerTests.swift`, extend the `hardened()` fixture's initializer call with:
+
+```swift
+            speedBrain: true, ech: true, zstdCompression: true,
+            pageShield: .init(enabled: true, scriptHosts: [])
+```
+
+(`bare()` needs no change — the new init params default to off.) Then append:
+
+```swift
+    @Test("a bare zone plans the harden-pack items")
+    func bareGetsHardenPack() {
+        let plan = HardenPlanner.plan(from: bare(), domain: "example.com")
+        #expect(plan.items.contains(.enableSpeedBrain))
+        #expect(plan.items.contains(.enableZstandardCompression))
+        #expect(plan.items.contains(.enableECH))
+        #expect(plan.items.contains(.enablePageShieldMonitoring))
+    }
+
+    @Test("page shield monitoring is planned when the state is unreadable (nil)")
+    func pageShieldNilPlansEnable() {
+        var state = hardened()
+        state.pageShield = nil
+        let plan = HardenPlanner.plan(from: state, domain: "example.com")
+        #expect(plan.items == [.enablePageShieldMonitoring])
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter HardenPlannerTests`
+Expected: FAIL to compile — `type 'HardenPlanItem' has no member 'enableSpeedBrain'`.
+
+- [ ] **Step 3: Add the plan items** (in `HardenPlan.swift`, after `.enableBotFightMode` case and in `description`)
+
+```swift
+    case enableSpeedBrain
+    case enableZstandardCompression
+    case enableECH
+    case enablePageShieldMonitoring
+```
+
+```swift
+        case .enableSpeedBrain:
+            return "+ Enable Speed Brain (speculative prefetching)"
+        case .enableZstandardCompression:
+            return "+ Enable Zstandard compression"
+        case .enableECH:
+            return "+ Enable Encrypted Client Hello (ECH)"
+        case .enablePageShieldMonitoring:
+            return "+ Enable client-side script monitoring (Page Shield)"
+```
+
+- [ ] **Step 4: Add the planner logic** (in `HardenPlanner.plan`, after the Bot Fight Mode check and before the email block)
+
+```swift
+        if !state.speedBrain {
+            items.append(.enableSpeedBrain)
+        }
+        if !state.zstdCompression {
+            items.append(.enableZstandardCompression)
+        }
+        if !state.ech {
+            items.append(.enableECH)
+        }
+        if state.pageShield?.enabled != true {
+            items.append(.enablePageShieldMonitoring)
+        }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter HardenPlannerTests`
+Expected: PASS (including the pre-existing `fullyHardenedIsEmpty`, now green because the fixture gained the new fields).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/HardenPlan.swift Sources/AnglesiteCore/HardenPlanner.swift Tests/AnglesiteCoreTests/HardenPlannerTests.swift
+git commit -m "feat(#59): plan Speed Brain, Zstandard, ECH, and Page Shield hardening
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Executor dispatch for the new items
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/HardenExecutor.swift:70-110` (`apply`), `Tests/AnglesiteCoreTests/HardenExecutorTests.swift` (extend `itemsDispatchCorrectly` + `MockCloudflareReader` default state)
+
+**Interfaces:**
+- Consumes: `HardenPlanItem` new cases (Task 6), `CloudflareWriting` new methods (Task 5).
+- Produces: nothing new — completes the plan→write loop.
+
+- [ ] **Step 1: Extend the dispatch test**
+
+In `itemsDispatchCorrectly`, add to the plan array:
+
+```swift
+            .enableSpeedBrain,
+            .enableZstandardCompression,
+            .enableECH,
+            .enablePageShieldMonitoring,
+```
+
+change `#expect(result.appliedCount == 9)` to `#expect(result.appliedCount == 13)`, and add:
+
+```swift
+        #expect(writer.calls.contains("setSpeedBrain"))
+        #expect(writer.calls.contains("enableZstandardCompression"))
+        #expect(writer.calls.contains("setECH"))
+        #expect(writer.calls.contains("setPageShield"))
+```
+
+Also extend `MockCloudflareReader`'s default `init` state so post-harden audits stay clean (append to the `CloudflareZoneState` call):
+
+```swift
+        botFightMode: true,
+        speedBrain: true, ech: true, zstdCompression: true,
+        pageShield: .init(enabled: true, scriptHosts: [])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter HardenExecutorTests`
+Expected: FAIL — `switch must be exhaustive` compile error in `HardenExecutor.apply` (the new cases are unhandled).
+
+- [ ] **Step 3: Add the dispatch cases** (in `HardenExecutor.apply`, after `.enableBotFightMode`)
+
+```swift
+        case .enableSpeedBrain:
+            try await writer.setSpeedBrain(zoneID: zoneID, enabled: true, apiToken: apiToken)
+        case .enableZstandardCompression:
+            try await writer.enableZstandardCompression(zoneID: zoneID, apiToken: apiToken)
+        case .enableECH:
+            try await writer.setECH(zoneID: zoneID, enabled: true, apiToken: apiToken)
+        case .enablePageShieldMonitoring:
+            try await writer.setPageShield(zoneID: zoneID, enabled: true, apiToken: apiToken)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter HardenExecutorTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/HardenExecutor.swift Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+git commit -m "feat(#59): execute harden-pack items via the Cloudflare write API
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: SecurityAudit findings for ECH + Page Shield
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SecurityAudit.swift`, `Tests/AnglesiteCoreTests/SecurityAuditTests.swift`
+
+**Interfaces:**
+- Consumes: `CloudflareZoneState.ech/pageShield` (Task 4).
+- Produces: three new `.info` findings. Speed Brain and Zstandard are deliberately **not** audited — they're performance, not security; they live only in the harden plan.
+
+- [ ] **Step 1: Update fixtures and write failing tests**
+
+First run `grep -n "CloudflareZoneState(" Tests/AnglesiteCoreTests/SecurityAuditTests.swift` and, in every fixture the tests expect to produce **zero** findings, append the new fields:
+
+```swift
+            speedBrain: true, ech: true, zstdCompression: true,
+            pageShield: .init(enabled: true, scriptHosts: [])
+```
+
+Then append tests:
+
+```swift
+    @Test("ECH off yields an info finding")
+    func echOffInfo() {
+        var state = clean()  // use the file's existing fully-clean fixture name
+        state.ech = false
+        let findings = SecurityAudit.evaluate(state, expectsMail: true)
+        #expect(findings.contains { $0.title.contains("Encrypted Client Hello") && $0.severity == .info })
+    }
+
+    @Test("Page Shield disabled yields an info finding")
+    func pageShieldOffInfo() {
+        var state = clean()
+        state.pageShield = nil
+        let findings = SecurityAudit.evaluate(state, expectsMail: true)
+        #expect(findings.contains { $0.title.contains("script monitoring") })
+    }
+
+    @Test("detected third-party scripts are surfaced with their hosts")
+    func pageShieldScriptsSurfaced() {
+        var state = clean()
+        state.pageShield = .init(enabled: true, scriptHosts: ["cdn.evil.example"])
+        let findings = SecurityAudit.evaluate(state, expectsMail: true)
+        let finding = findings.first { $0.title.contains("Third-party scripts") }
+        #expect(finding != nil)
+        #expect(finding?.detail.contains("cdn.evil.example") == true)
+    }
+```
+
+(If the file's clean-state fixture has a different name, keep that name — only the field additions matter.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SecurityAuditTests`
+Expected: FAIL — new tests fail (no such findings yet); pre-existing tests pass.
+
+- [ ] **Step 3: Add the findings** (in `SecurityAudit.evaluate`, before `return findings`)
+
+```swift
+        if !state.ech {
+            add(.info, "Encrypted Client Hello is off",
+                "Without ECH, the site hostname is visible in plaintext during TLS handshakes.",
+                "Enable Encrypted Client Hello (ECH) in the zone's TLS settings.")
+        }
+        if state.pageShield?.enabled != true {
+            add(.info, "Client-side script monitoring is off",
+                "Page Shield is not watching which scripts run on the site, so a compromised third-party script would go unnoticed.",
+                "Enable Page Shield's script monitor (free on all plans).")
+        } else if let shield = state.pageShield, !shield.scriptHosts.isEmpty {
+            add(.info, "Third-party scripts detected",
+                "Page Shield sees scripts loading from: \(shield.scriptHosts.joined(separator: ", ")).",
+                "Review each host; remove any you don't recognize and keep the CSP in sync.")
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SecurityAuditTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SecurityAudit.swift Tests/AnglesiteCoreTests/SecurityAuditTests.swift
+git commit -m "feat(#59): audit ECH and Page Shield script-monitor state
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Full verification + app build + wrap-up
+
+**Files:** none new.
+
+- [ ] **Step 1: Full SwiftPM suite**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .`
+Expected: PASS, zero failures. (If it hangs with no output: `pgrep -fl swift-test` and kill the orphan holding the `.build` lock.)
+
+- [ ] **Step 2: App target builds** (CloudflareTokenPromptView changed)
+
+```bash
+ANGLESITE_PLUGIN_SRC=../../../../../anglesite scripts/copy-plugin.sh   # populate gitignored Resources/plugin (adjust path to the real plugin checkout: …/github.com/Anglesite/anglesite)
+xcodegen generate
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+```
+
+Expected: `BUILD SUCCEEDED`. (If "Too many levels of symbolic links": remove the self-pointing `Resources/plugin` symlink and re-run copy-plugin.sh.)
+
+- [ ] **Step 3: Verify the docs stay honest**
+
+The spec §4 says capabilities are "persisted alongside the token reference". This plan lands probe-on-demand with `Codable` types and **defers persistence to the first consumer slice** (YAGNI — nothing reads a stored value yet). Add one line to the spec's §4 noting persistence lands with Slice 1, and commit:
+
+```bash
+git add docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md
+git commit -m "docs: note capability persistence lands with the first consumer slice
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Finish the branch**
+
+Invoke the superpowers:finishing-a-development-branch skill (merge vs PR decision, per repo convention: PR to `main` via `gh`). Remember: push before citing the PR.

--- a/docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md
+++ b/docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md
@@ -25,7 +25,7 @@ This design adds the free (or at-cost) Cloudflare services that are *not* yet in
 ## 2. Decisions (from brainstorming)
 
 1. **Scope: all three lanes.** Site-owner wizard features, zone hardening/perf extensions, and third-party-provider reduction.
-2. **CF default, keep others.** Where a Cloudflare service overlaps an existing catalog provider (contact → Formspree, tracking → Plausible/Fathom/GA4), Cloudflare becomes the recommended/default provider; existing providers remain selectable. No forced migrations.
+2. **CF default, keep others.** Where a Cloudflare service overlaps an existing catalog provider (contact → Formspree, tracking → Plausible/Fathom/GA4), Cloudflare becomes the recommended/default provider; existing providers remain selectable. No forced migrations. **Exception — email:** iCloud Custom Email Domains ships at launch as a *peer* of Cloudflare Email Routing, neither defaulted (see Slice 2).
 3. **Free bar: at-cost extras included.** Generous free tiers qualify (Zaraz 1M events/mo, image transformations 5k unique/mo). Cloudflare Registrar (at-cost domains) is in scope. Paid-only products (Stream, Images storage) are out.
 4. **One "Anglesite" token.** A single custom token template covering all permissions the app can use, replacing the current "Edit Cloudflare Workers" template. Capability probing gives graceful degradation for existing narrow tokens.
 5. **Sequencing: vertical slices, value-first** (approach 1 of 3 considered; alternatives were harden-pack-first and a new top-level Cloudflare dashboard pane — the latter rejected as it bypasses the catalog and Harden seams).
@@ -79,15 +79,21 @@ The guided token-creation URL (pre-filled permissions) is updated accordingly.
 
 ## 6. Slice 2 — Email Routing + Cloudflare-native contact form
 
-**Deliverable A — new `email` integration descriptor ("Get you@yourdomain.com"):**
+**Deliverable A — new `email` integration descriptor ("Get you@yourdomain.com") with two peer providers:**
 
-1. Enable Email Routing on the zone (adds MX/TXT via API; surfaces conflicts if custom MX exists — abort with explanation rather than clobber).
-2. Create destination address → Cloudflare emails a verification link → wizard polls the API until verified ("check your inbox" step; resumable if the user quits).
-3. Create routing rule(s): named addresses (`hello@`, `contact@`…) and optional catch-all.
+- **iCloud Custom Email Domains** (peer option, shipping at launch): full mailboxes via the user's existing iCloud+ subscription. The wizard pre-creates Apple's required DNS records on the Cloudflare zone (MX to `mx01/mx02.mail.icloud.com`, SPF include, DKIM CNAME with the Apple-provided values), then hands off to icloud.com for the domain-verification step Apple requires, and verifies the records afterward. Apple-first fit for the app's audience (successor to the `anglesite:email` skill's recommendation under #459).
+- **Cloudflare Email Routing** (peer option): forwarding-only, no new mailbox.
+  1. Enable Email Routing on the zone (adds MX/TXT via API).
+  2. Create destination address → Cloudflare emails a verification link → wizard polls the API until verified ("check your inbox" step; resumable if the user quits).
+  3. Create routing rule(s): named addresses (`hello@`, `contact@`…) and optional catch-all.
+
+The two providers are **mutually exclusive MX owners**. The wizard reads current MX state first and treats it as either/or: switching providers is an explicit, confirmed step that replaces the records; pre-existing third-party MX (Google Workspace, Fastmail…) aborts with an explanation rather than clobbering. Neither provider is "default" — the wizard presents both as peers (iCloud = real mailboxes, needs iCloud+; Cloudflare = free forwarding to an inbox you already have).
 
 **Deliverable B — contact wizard gains a "Cloudflare" provider (new default):** a Worker route `/api/contact` with a `send_email` binding whose `destination_address` is locked to the owner's verified address. Sends to verified destination addresses are free on all plans. Submissions are Turnstile-verified (Slice 1). `WorkerComposition` learns the `send_email` binding type in `wrangler.toml` generation. Formspree and mailto remain selectable.
 
-**Interaction with Harden:** Harden already writes SPF/DMARC; enabling Email Routing changes the correct SPF answer (`include:_spf.mx.cloudflare.net`). `HardenPlanner` must become Email-Routing-aware so the two features don't fight over TXT records.
+**Deliverable B is provider-independent:** the contact-form Worker sends to any verified destination address — including an iCloud custom-domain mailbox once verified — so choosing iCloud email does not forgo the Cloudflare-native contact form.
+
+**Interaction with Harden:** Harden already writes SPF/DMARC; the correct SPF answer now depends on the email provider (`include:_spf.mx.cloudflare.net` for Email Routing, `include:icloud.com` for iCloud). `HardenPlanner` must become email-provider-aware so the two features don't fight over TXT records.
 
 ## 7. Slice 3 — Harden pack
 

--- a/docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md
+++ b/docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md
@@ -1,0 +1,169 @@
+# Cloudflare Free Services — First-Class Integration Design
+
+**Date:** 2026-07-04
+**Status:** Approved design, pending implementation plans
+**Prompt:** [Cloudflare's commitment to free](https://blog.cloudflare.com/cloudflares-commitment-to-free/) — which free Cloudflare services should become first-class Anglesite integrations, and in what order.
+
+## 1. Context
+
+Anglesite already integrates deeply with Cloudflare:
+
+| Already integrated | Where |
+|---|---|
+| Workers deploy (static assets + social worker) | `DeployCommand`, `DeployExecutor`, `WorkerComposition`, `SocialWorkerProvisionCommand` |
+| D1 / KV / R2 provisioning (social worker bindings) | `WorkerComposition`, `worker/wrangler.toml.template` |
+| Web Analytics (beacon injection, GA migration) | `CloudflareWebAnalyticsClient`, `WebsiteAnalyticsAsset` |
+| DNS / DNSSEC / SPF / DMARC / CAA | `HTTPCloudflareClient`, `HardenPlanner`, `SecurityAudit` |
+| SSL mode, Always-HTTPS, HSTS, security headers | `SecurityAudit`, `HardenExecutor` |
+| Bot Fight Mode, free-plan WAF custom rules (5) | `HardenPlanner` |
+| API token onboarding + Keychain storage | `TokenOnboarding`, `CloudflareAPITokenVerifier`, `CloudflareTokenPromptView` |
+
+The #462 integrations wizard catalog (`IntegrationDescriptor` / `IntegrationCatalog` / `IntegrationWizardModel` / `IntegrationScaffolder`) provides a declarative seam — providers, fields, conditions, operations (file copy, config write, anchor injection, CSP domains) — that new integrations plug into without new framework code.
+
+This design adds the free (or at-cost) Cloudflare services that are *not* yet integrated, as eight vertical slices on existing seams.
+
+## 2. Decisions (from brainstorming)
+
+1. **Scope: all three lanes.** Site-owner wizard features, zone hardening/perf extensions, and third-party-provider reduction.
+2. **CF default, keep others.** Where a Cloudflare service overlaps an existing catalog provider (contact → Formspree, tracking → Plausible/Fathom/GA4), Cloudflare becomes the recommended/default provider; existing providers remain selectable. No forced migrations.
+3. **Free bar: at-cost extras included.** Generous free tiers qualify (Zaraz 1M events/mo, image transformations 5k unique/mo). Cloudflare Registrar (at-cost domains) is in scope. Paid-only products (Stream, Images storage) are out.
+4. **One "Anglesite" token.** A single custom token template covering all permissions the app can use, replacing the current "Edit Cloudflare Workers" template. Capability probing gives graceful degradation for existing narrow tokens.
+5. **Sequencing: vertical slices, value-first** (approach 1 of 3 considered; alternatives were harden-pack-first and a new top-level Cloudflare dashboard pane — the latter rejected as it bypasses the catalog and Harden seams).
+
+Constraints inherited from the project:
+
+- **#459:** all journeys are deterministic Swift/TypeScript (or Apple Intelligence). No new `claude --print` / markdown-skill paths. No external LLM APIs.
+- **MAS sandbox:** all Cloudflare access is HTTPS API calls (`HTTPCloudflareClient`) or wrangler running inside the site container — no new host requirements.
+- **Logs are sacred:** every API orchestration streams progress/failures to the debug pane.
+- **The app cannot bypass `pre-deploy-check.sh`.**
+
+## 3. Services considered and filtered out
+
+| Service | Verdict | Why |
+|---|---|---|
+| Turnstile | **In (Slice 1)** | Free CAPTCHA; protects catalog forms |
+| Email Routing + free sends | **In (Slice 2)** | Free forwarding; free Worker `send_email` to verified destinations enables CF-native contact form |
+| Speed Brain, Zstandard, ECH, Page Shield monitor | **In (Slice 3)** | Free zone toggles/readbacks; direct Harden fit |
+| Image transformations | **In (Slice 4)** | Now free on all plans (5k unique/mo) |
+| Zaraz | **In (Slice 5)** | Free ≤1M events/mo; removes third-party JS from pages |
+| Workers Logs (3-day) + tail | **In (Slice 6)** | Free; closes observability loop for deployed Workers |
+| Registrar | **In (Slice 7)** | At-cost; API in beta (search/check/register, subset of TLDs) |
+| Stream | Out | Paid product |
+| Images storage/delivery | Out | Paid plan only (transformations free tier used instead) |
+| Access / Tunnel / CASB / DLP / DEX / MNM | Out | Team/network products; no fit for static-site owners |
+| Calls managed TURN | Out | No realtime feature in Anglesite |
+| API Shield schema validation, Leaked Credential Checks | Out | No origin API / no login surface on static sites |
+| Web Analytics, DNSSEC, WAF free rules, Bot Fight Mode | Already integrated | — |
+
+## 4. Slice 0 — Unified "Anglesite" token (prerequisite)
+
+**What:** Revise `TokenOnboarding` / `CloudflareTokenPromptView` to a single custom token template named "Anglesite" containing every permission the app can use:
+
+- Existing: Workers Scripts (Edit/Account), Workers KV (Edit/Account), Workers R2 (Edit/Account), D1 (Edit/Account), Workers Routes (Edit/Zone), Workers Tail (Read/Account)
+- Zone: Zone Settings (Edit), Zone Rulesets (Edit), DNS (Edit) — already exercised by Harden
+- New: Turnstile (Edit/Account), Email Routing (Edit/Zone + Account destination addresses), Zaraz (Edit/Zone), Zone Analytics (Read), Page Shield (Read), Registrar (Edit/Account)
+
+The guided token-creation URL (pre-filled permissions) is updated accordingly.
+
+**Capability probe:** after signature verification, `CloudflareAPITokenVerifier` performs cheap read probes per permission group and produces a `TokenCapabilities` option set, persisted alongside the token reference. Wizards and Harden check capabilities up front; a missing capability renders an inline "Upgrade your Cloudflare token" step that re-runs onboarding with the new template. Existing narrow tokens keep working for everything they already do — no forced re-mint.
+
+**Testing:** verifier probe logic against a stubbed HTTP layer; capability-gating unit tests.
+
+## 5. Slice 1 — Turnstile
+
+**What:** a cross-cutting **"Protect with Turnstile"** bool field (not a new catalog entry) added to the `contact` and `newsletter` descriptors, available to future form integrations.
+
+**Flow:** wizard creates a widget via `POST /accounts/{account_id}/challenges/widgets` (managed mode, domains = site apex + www) → captures `sitekey` (public) and `secret` (never written to disk) → injects the `https://challenges.cloudflare.com/turnstile/v0/api.js` script and `cf-turnstile` div via existing `injectAtAnchor` operations → pushes the secret as a Worker secret so the subscribe/contact Worker calls `siteverify` server-side. CSP domains extend via the catalog's existing `addCSPDomains` operation.
+
+**Notes:** widget create/read requires `Account.Turnstile:Edit`/`Read` (API error 10000 signals missing scope → capability upgrade path). Re-running the wizard must not recreate the widget (that would rotate keys) — look up existing widget by name/domain first; idempotent like `SocialWorkerProvisionCommand`.
+
+## 6. Slice 2 — Email Routing + Cloudflare-native contact form
+
+**Deliverable A — new `email` integration descriptor ("Get you@yourdomain.com"):**
+
+1. Enable Email Routing on the zone (adds MX/TXT via API; surfaces conflicts if custom MX exists — abort with explanation rather than clobber).
+2. Create destination address → Cloudflare emails a verification link → wizard polls the API until verified ("check your inbox" step; resumable if the user quits).
+3. Create routing rule(s): named addresses (`hello@`, `contact@`…) and optional catch-all.
+
+**Deliverable B — contact wizard gains a "Cloudflare" provider (new default):** a Worker route `/api/contact` with a `send_email` binding whose `destination_address` is locked to the owner's verified address. Sends to verified destination addresses are free on all plans. Submissions are Turnstile-verified (Slice 1). `WorkerComposition` learns the `send_email` binding type in `wrangler.toml` generation. Formspree and mailto remain selectable.
+
+**Interaction with Harden:** Harden already writes SPF/DMARC; enabling Email Routing changes the correct SPF answer (`include:_spf.mx.cloudflare.net`). `HardenPlanner` must become Email-Routing-aware so the two features don't fight over TXT records.
+
+## 7. Slice 3 — Harden pack
+
+Extend `HardenPlanner` / `HardenExecutor` / `SecurityAudit` with newly free zone capabilities:
+
+- **Speed Brain** — enable (perf; speculation rules).
+- **Zstandard compression** — enable.
+- **ECH (Encrypted Client Hello)** — enable.
+- **Page Shield script monitor** — read-only: surface detected third-party scripts in the audit report, cross-referenced against the CSP domains the integration catalog knows it added (an unexpected script is a red flag).
+
+Pure extension of the existing plan/execute/audit pattern; smallest slice. Audit/Harden App Intents pick these up automatically.
+
+## 8. Slice 4 — Image transformations
+
+1. Enable transformations for the zone (one API call; capability-gated).
+2. Template opt-in: production builds emit `/cdn-cgi/image/format=auto,width=…/<path>` URLs via an Astro image-service wrapper in `Resources/Template/` (dev builds and non-CF deploys emit plain URLs). Sharp keeps doing build-time resizing; the edge adds per-browser format negotiation (AVIF/WebP).
+3. Quota safety: always include `onerror=redirect` so exceeding the 5,000 unique transformations/month free quota degrades to the original image, never a broken one. (Over-quota returns error 9422; no surprise billing on free.)
+
+Template changes are app-only (no plugin pairing). Run `swift test` — Swift smoke tests couple to template markup.
+
+## 9. Slice 5 — Zaraz provider
+
+The `tracking` wizard gains a **"Cloudflare Zaraz"** provider (recommended when the site is on a CF zone): GA4/Meta/etc. are configured server-side via the Zaraz config API, so no third-party JS ships in the page at all. Zaraz consent mode maps onto the existing `consent` integration's categories (analytics/embeds/ads) instead of a bespoke banner when Zaraz is the tracker.
+
+**Risk:** the Zaraz config API is a single JSON document (read-modify-write). The client must fetch, patch only Anglesite-managed tools (namespaced naming), and write back — never overwrite user-managed tools. This is the most schema-heavy slice; budget accordingly.
+
+## 10. Slice 6 — Worker observability
+
+Surface the deployed Worker's logs in the app's debug pane (today: local subprocesses only):
+
+- **Workers Logs** (free 3-day retention) fetched on demand for the site's worker.
+- Live **tail** (token already has Workers Tail read) while the debug pane is open.
+
+Closes the loop for Slices 1–2: a failing contact-form submission is diagnosable in-app. Read-only; no schema changes.
+
+## 11. Slice 7 — Registrar ("Get a domain")
+
+Domain search → real-time availability/price check → registration, via the **beta** Registrar API, offered in the New Site wizard and as a standalone flow for existing sites on free subdomains.
+
+Guardrails:
+
+- **Explicit purchase confirmation** — the app never registers without a click-through showing the at-cost price. No App Intent for purchase.
+- Beta TLD coverage is partial: unsupported TLDs get a prefilled dashboard-handoff link.
+- Registration may be async — poll the workflow per API docs.
+- Last in sequence: beta API + the only slice that spends money.
+
+## 12. Cross-cutting
+
+- **Idempotency:** every wizard operation is create-if-absent; re-running a wizard converges instead of duplicating (pattern: `SocialWorkerProvisionCommand`).
+- **Errors:** missing token capability → inline upgrade prompt; API failures stream to the debug pane with the raw response logged.
+- **Secrets:** Turnstile secret and any future secrets go Keychain → Worker secret; never to disk, never to git.
+- **Testing:** stub `CloudflareReading`/`CloudflareWriting` fakes in `AnglesiteCoreTests`; descriptor `validate()` tests; live e2e behind env flags (e.g. `ANGLESITE_CF_E2E=1`) like the container suites.
+- **App Intents:** Email forwarding setup and the Harden additions get intents; Registrar purchase does not.
+- **Config ownership:** all per-site integration state stays in the package `Config/` or in `Source/` per existing catalog conventions; nothing new enters git that shouldn't.
+
+## 13. Sequencing summary
+
+| # | Slice | Seam | Size |
+|---|---|---|---|
+| 0 | Unified token + capability probe | TokenOnboarding | S |
+| 1 | Turnstile | Catalog (contact/newsletter) + Worker | M |
+| 2 | Email Routing + CF contact form | New descriptor + WorkerComposition + Harden interplay | L |
+| 3 | Harden pack (Speed Brain, Zstd, ECH, Page Shield) | HardenPlanner/Executor/Audit | S |
+| 4 | Image transformations | Zone setting + Template | M |
+| 5 | Zaraz provider | Catalog (tracking/consent) | L |
+| 6 | Worker observability | Debug pane + Workers Logs API | M |
+| 7 | Registrar | New Site wizard | M (beta-gated) |
+
+Slices 1–7 all depend on Slice 0. Slice 2's contact form depends on Slice 1 (Turnstile). Everything else is independent and can reorder opportunistically.
+
+Each slice gets its own implementation plan (`docs/superpowers/plans/`) when picked up, per the #242/#459 convention.
+
+## 14. API facts verified (2026-07-04)
+
+- Turnstile widget CRUD: `POST /accounts/{id}/challenges/widgets` returns `sitekey` + `secret`; needs `Account.Turnstile:Edit`.
+- Email Routing free on all plans; sends to **verified destination addresses** via Worker `send_email` binding / REST / SMTP are free on all plans and don't count toward quotas. Full Email Sending (arbitrary recipients) is Workers Paid — not required by this design.
+- Image transformations: free plan includes 5,000 unique transformations/month; over-quota → error 9422, cached transformations keep serving, `onerror` can redirect to the original; no charges on free.
+- Registrar API: beta (Apr 2025) — search, availability/pricing, programmatic registration for a subset of TLDs; registration is a pollable workflow.
+- Blog-post freebies folded into Slice 3: Speed Brain, Zstandard, ECH, Page Shield script monitor, Security Analytics; Worker logs 3-day retention into Slice 6.

--- a/docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md
+++ b/docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md
@@ -61,7 +61,7 @@ Constraints inherited from the project:
 
 - Existing: Workers Scripts (Edit/Account), Workers KV (Edit/Account), Workers R2 (Edit/Account), D1 (Edit/Account), Workers Routes (Edit/Zone), Workers Tail (Read/Account)
 - Zone: Zone Settings (Edit), Zone Rulesets (Edit), DNS (Edit) — already exercised by Harden
-- New: Turnstile (Edit/Account), Email Routing (Edit/Zone + Account destination addresses), Zaraz (Edit/Zone), Zone Analytics (Read), Page Shield (Read), Registrar (Edit/Account)
+- New: Turnstile (Edit/Account), Email Routing (Edit/Zone + Account destination addresses), Zaraz (Edit/Zone), Zone Analytics (Read), Page Shield (Edit — Harden enables the script monitor), Response Compression (Edit), Registrar (Edit/Account)
 
 The guided token-creation URL (pre-filled permissions) is updated accordingly.
 
@@ -105,6 +105,8 @@ Extend `HardenPlanner` / `HardenExecutor` / `SecurityAudit` with newly free zone
 - **Page Shield script monitor** — read-only: surface detected third-party scripts in the audit report, cross-referenced against the CSP domains the integration catalog knows it added (an unexpected script is a red flag).
 
 Pure extension of the existing plan/execute/audit pattern; smallest slice. Audit/Harden App Intents pick these up automatically.
+
+**Implementation note:** the audit currently lists detected script hosts without cross-referencing the integration catalog's CSP domains — the comparison described above (flagging scripts the catalog didn't add) is deferred to a follow-up.
 
 ## 8. Slice 4 — Image transformations
 

--- a/docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md
+++ b/docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md
@@ -65,7 +65,7 @@ Constraints inherited from the project:
 
 The guided token-creation URL (pre-filled permissions) is updated accordingly.
 
-**Capability probe:** after signature verification, `CloudflareAPITokenVerifier` performs cheap read probes per permission group and produces a `TokenCapabilities` option set, persisted alongside the token reference. Wizards and Harden check capabilities up front; a missing capability renders an inline "Upgrade your Cloudflare token" step that re-runs onboarding with the new template. Existing narrow tokens keep working for everything they already do — no forced re-mint.
+**Capability probe:** after signature verification, a `CloudflareCapabilityProber` performs cheap read probes per permission group and produces a `TokenCapabilities` set, persisted alongside the token reference. *(Implementation note: Slice 0 shipped the probe with `Codable` types but probe-on-demand only; persistence lands with the first consumer slice — Slice 1.)* Wizards and Harden check capabilities up front; a missing capability renders an inline "Upgrade your Cloudflare token" step that re-runs onboarding with the new template. Existing narrow tokens keep working for everything they already do — no forced re-mint.
 
 **Testing:** verifier probe logic against a stubbed HTTP layer; capability-gating unit tests.
 


### PR DESCRIPTION
## Summary

- Adds the **Cloudflare free-services integration design spec** (8 slices covering Turnstile, Email Routing + iCloud Custom Domains, harden pack, image transformations, Zaraz, Worker observability, Registrar) plus the implementation plan for the first two slices.
- **Slice 0 — unified "Anglesite" token:** one custom token template covering deploy + harden + all planned integrations (`AnglesiteTokenTemplate`), a `CloudflareCapabilityProber` that observes which permission groups a stored token actually has (401/403 ⇒ absent), and token-prompt/copy updates. Existing narrow tokens keep working; wizards can gate on `TokenCapabilities` and route users through re-onboarding.
- **Slice 3 — harden pack:** Speed Brain, Zstandard compression (idempotent compression-rule upsert), ECH, and Page Shield script monitoring wired through the whole read→plan→execute→audit pipeline (`CloudflareZoneState` reads with graceful degradation for narrow tokens, `CloudflareWriting` methods, `HardenPlanItem`s, executor dispatch, and `.info` audit findings incl. detected third-party script hosts).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks). Link it here:

## Test plan

- [x] `swift test --package-path .` — 1149 tests / 173 suites + 18 / 3 suites, all green
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [ ] Manual smoke (if UI-touching): token prompt copy changed (`CloudflareTokenPromptView`); before release, verify the extended dashboard pre-fill keys (esp. `response_compression`, `page_shield` edit) against the live Cloudflare token-creation page — the flow degrades to manual token creation if the undocumented pre-fill schema rejects them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)