### PR TITLE
fix(#242): package-model follow-through — sourceDirectory/packageURL, onOpenURL

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -101,8 +101,8 @@ struct AnglesiteApp: App {
             openWindow(value: site.id)
         } catch {
             let alert = NSAlert()
-            alert.messageText = "Couldn't open that folder"
-            // `SiteActions.ImportError.localizedDescription` names the folder and the reason;
+            alert.messageText = "Couldn't open that site"
+            // `SiteActions.ImportError.localizedDescription` names the package and the reason;
             // other errors fall back to their OS-provided message rather than a raw enum dump.
             alert.informativeText = error.localizedDescription
             alert.alertStyle = .warning
@@ -116,6 +116,22 @@ struct AnglesiteApp: App {
         // own .task — see SitesLauncherView.onFirstAppear().
         Window("Sites", id: "sites") {
             SitesWindowRoot(openWindow: openWindow)
+                .onOpenURL { url in
+                    guard AnglesitePackage.isPackage(at: url) else { return }
+                    Task { @MainActor in
+                        do {
+                            let site = try await SiteStore.shared.record(AnglesitePackage(url: url))
+                            #if ANGLESITE_MAS
+                            if let bm = try? SecurityScopedBookmark.create(for: url) {
+                                try? await SiteStore.shared.setBookmark(bm, for: site.id)
+                            }
+                            #endif
+                            openWindow(value: site.id)
+                        } catch {
+                            await LogCenter.shared.append(source: "open-url", stream: .stderr, text: "open \(url.lastPathComponent) failed: \(error)")
+                        }
+                    }
+                }
         }
         .windowResizability(.contentSize)
         .commands {

--- a/Sources/AnglesiteApp/RecentSitesModel.swift
+++ b/Sources/AnglesiteApp/RecentSitesModel.swift
@@ -24,16 +24,16 @@ final class RecentSitesModel {
         guard !started else { return }
         started = true
         Task {
-            // Populate from disk + scan first so the menu is correct before any mutation.
+            // Load from disk so the menu is correct before any mutation.
+            // The registry no longer scans ~/Sites — it is the authoritative list.
+            // `changeStream()` re-emits the current snapshot on subscribe, so we don't
+            // need a separate sites read after `load()`.
             do {
                 try await SiteStore.shared.load()
-                let scanned = try await SiteStore.shared.refresh()
-                sites = RecentSites.select(from: scanned)
             } catch {
                 await LogCenter.shared.append(source: "recent-sites", stream: .stderr, text: "initial load failed: \(error)")
             }
-            // Then track every mutation. `changeStream()` also re-emits the current snapshot
-            // on subscribe, which simply reaffirms what we just set.
+            // Track every mutation (and the initial snapshot emitted on subscribe).
             for await snapshot in SiteStore.shared.changeStream() {
                 sites = RecentSites.select(from: snapshot)
             }

--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -1,39 +1,43 @@
 import AppKit
+import UniformTypeIdentifiers
 import AnglesiteCore
 
 /// File-menu / launcher actions that are window-independent. Today this is just the
-/// "open an existing folder as a site" flow, extracted from `SitesLauncherView.openFolder()`
+/// “open an existing package as a site” flow, extracted from `SitesLauncherView.openFolder()`
 /// so the File ▸ Open Site… command and the launcher footer share one implementation —
 /// in particular the MAS security-scoped-bookmark minting, which must live in exactly one place.
 @MainActor
 enum SiteActions {
-    /// Surfaced when registering a chosen folder fails. Carries the folder name so callers
+    /// Surfaced when registering a chosen package fails. Carries the package name so callers
     /// get a readable, location-specific message via `localizedDescription` — the regression
-    /// that motivated this was a generic "couldn't add the chosen folder" that dropped the name.
+    /// that motivated this was a generic “couldn't add the chosen folder” that dropped the name.
     struct ImportError: LocalizedError {
         let folderName: String
         let underlying: Error
         var errorDescription: String? {
-            "Couldn't add “\(folderName)”: \(underlying.localizedDescription)"
+            "Couldn't add \"\(folderName)\": \(underlying.localizedDescription)"
         }
     }
 
-    /// Run the folder picker, register the chosen project with `SiteStore`, and (on MAS)
-    /// mint + persist a security-scoped bookmark so the grant survives relaunch.
+    /// Run the package picker, register the chosen `.anglesite` package with `SiteStore`, and
+    /// (on MAS) mint + persist a security-scoped bookmark so the grant survives relaunch.
     ///
     /// - Returns: the newly registered site, or `nil` if the user cancelled the panel.
-    /// - Throws: `ImportError` (naming the chosen folder) if registration or bookmarking fails.
+    /// - Throws: `ImportError` (naming the chosen package) if registration or bookmarking fails.
     static func pickAndRegisterSite() async throws -> SiteStore.Site? {
         let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.anglesiteSite]
+        panel.treatsFilePackagesAsDirectories = false
         panel.allowsMultipleSelection = false
         panel.prompt = "Open"
-        panel.message = "Choose an Anglesite project directory."
+        panel.message = "Choose an Anglesite site package."
         guard panel.runModal() == .OK, let url = panel.url else { return nil }
 
         do {
-            let site = try await SiteStore.shared.add(url)
+            let package = AnglesitePackage(url: url)
+            let site = try await SiteStore.shared.record(package)
             #if ANGLESITE_MAS
             // The panel grant is the only chance to mint a scoped bookmark — persist it now so
             // the grant survives relaunch. SiteWindow resolves it and holds access.

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -160,7 +160,7 @@ struct SiteWindow: View {
             // Backup — lowest priority, first to collapse into the native overflow chevron.
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    backup.backup(siteID: site.id, siteDirectory: site.path)
+                    backup.backup(siteID: site.id, siteDirectory: site.sourceDirectory)
                 } label: {
                     Label("Backup", systemImage: "externaldrive.fill.badge.icloud")
                 }
@@ -174,7 +174,7 @@ struct SiteWindow: View {
             // Audit — low priority, collapses before Chat.
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    audit.audit(siteID: site.id, siteDirectory: site.path)
+                    audit.audit(siteID: site.id, siteDirectory: site.sourceDirectory)
                 } label: {
                     if audit.isRunning {
                         Label("Auditing…", systemImage: "magnifyingglass")
@@ -220,7 +220,7 @@ struct SiteWindow: View {
             ToolbarItem(placement: .primaryAction) {
                 HealthBadgeView(
                     model: health,
-                    onRecheck: { health.recheck(siteID: site.id, siteDirectory: site.path) },
+                    onRecheck: { health.recheck(siteID: site.id, siteDirectory: site.sourceDirectory) },
                     onAskClaude: {
                         #if !ANGLESITE_MAS
                         chatPresented = true
@@ -235,7 +235,7 @@ struct SiteWindow: View {
             // Declared LAST so it renders at the trailing edge (macOS primary-action position).
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    deploy.deploy(siteID: site.id, siteDirectory: site.path)
+                    deploy.deploy(siteID: site.id, siteDirectory: site.sourceDirectory)
                 } label: {
                     Label("Deploy", systemImage: "paperplane.fill")
                 }
@@ -280,7 +280,7 @@ struct SiteWindow: View {
             AuditSheetView(
                 model: audit,
                 siteName: site.name,
-                onRunAgain: { audit.audit(siteID: site.id, siteDirectory: site.path) }
+                onRunAgain: { audit.audit(siteID: site.id, siteDirectory: site.sourceDirectory) }
             )
         }
         .sheet(item: $siriReadinessModel) { model in
@@ -324,7 +324,7 @@ struct SiteWindow: View {
                         .font(.callout).foregroundStyle(.secondary)
                         .multilineTextAlignment(.center).frame(maxWidth: 420)
                     Button("Retry") {
-                        preview.open(siteID: site.id, siteDirectory: site.path)
+                        preview.open(siteID: site.id, siteDirectory: site.sourceDirectory)
                     }
                 }
             }
@@ -394,7 +394,6 @@ struct SiteWindow: View {
         let store = SiteStore.shared
         do {
             try await store.load()
-            _ = try await store.refresh()
         } catch {
             // Non-fatal: we'll fall back to whatever's already in the persisted list.
         }
@@ -405,6 +404,7 @@ struct SiteWindow: View {
         }
         site = resolved
         AppSettings.shared.lastOpenedSiteID = resolved.id
+        try? await store.touch(id: resolved.id)
 
         #if ANGLESITE_MAS
         await acquireGrant(for: resolved, in: store)
@@ -425,7 +425,7 @@ struct SiteWindow: View {
             PreviewAnnotationProviderRegistry.shared.register(provider, for: resolved.id)
         }
 
-        preview.open(siteID: resolved.id, siteDirectory: resolved.path)
+        preview.open(siteID: resolved.id, siteDirectory: resolved.sourceDirectory)
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
         applyPendingNavigation(for: resolved.id)
@@ -460,7 +460,7 @@ struct SiteWindow: View {
         // agentic loop with no network (#193).
         chat = ChatModel(
             siteID: resolved.id,
-            siteDirectory: resolved.path,
+            siteDirectory: resolved.sourceDirectory,
             assistant: FoundationModelAssistant(
                 tier: .onDevice,
                 editBridge: makeEditBridge(),
@@ -497,9 +497,9 @@ struct SiteWindow: View {
                 contentGraph: contentGraph
             )
         case .claude:
-            assistant = ClaudeAssistant(siteID: resolved.id, siteDirectory: resolved.path)
+            assistant = ClaudeAssistant(siteID: resolved.id, siteDirectory: resolved.sourceDirectory)
         }
-        chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.path, assistant: assistant, annotationFeed: feed, annotationResolver: annotationResolver, undoCommand: undoCommand)
+        chat = ChatModel(siteID: resolved.id, siteDirectory: resolved.sourceDirectory, assistant: assistant, annotationFeed: feed, annotationResolver: annotationResolver, undoCommand: undoCommand)
         #endif
         // Auto alt-text (C.7 / #157): after a successful image drop, generate alt text on-device and
         // apply it to the `<img>`. Target-agnostic — the on-device vision model runs on both builds.
@@ -507,7 +507,7 @@ struct SiteWindow: View {
         // recurse. Best-effort and opt-out via Settings.
         let altTextGenerator = AltTextGenerator(
             siteID: resolved.id,
-            siteDirectory: resolved.path,
+            siteDirectory: resolved.sourceDirectory,
             isEnabled: { AppSettings.shared.autoGenerateAltText },
             produce: { imageURL, context in
                 try await FoundationModelAssistant(tier: .onDevice).generateStructured(
@@ -553,7 +553,7 @@ struct SiteWindow: View {
         guard let bookmark = await store.bookmarkData(for: site.id) else {
             await LogCenter.shared.append(
                 source: "grant:\(site.id)", stream: .stderr,
-                text: "No security-scoped bookmark for \(site.name); preview will fail until the folder is re-added via Open Folder…"
+                text: "No security-scoped bookmark for \(site.name); preview will fail until the package is re-added via Open Site…"
             )
             return
         }

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -105,12 +105,12 @@ struct SitesLauncherView: View {
         HStack {
             Text("Sites").font(.title2.bold())
             Spacer()
-            Button("Rescan sites", systemImage: "arrow.clockwise") {
+            Button("Reload sites", systemImage: "arrow.clockwise") {
                 Task { await refreshSites() }
             }
             .labelStyle(.iconOnly)
             .buttonStyle(.borderless)
-            .help("Rescan ~/Sites")
+            .help("Reload site list")
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
@@ -129,7 +129,7 @@ struct SitesLauncherView: View {
                         .accessibilityHidden(true)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(site.name).font(.body.monospaced())
-                        Text(site.path.path)
+                        Text(site.packageURL.path)
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
@@ -159,7 +159,7 @@ struct SitesLauncherView: View {
         }
         .listStyle(.inset)
         .confirmationDialog(
-            "Remove “\(siteToRemoveName)” from Anglesite?",
+            "Remove \"\(siteToRemoveName)\" from Anglesite?",
             isPresented: Binding(
                 get: { siteToRemove != nil },
                 set: { if !$0 { siteToRemove = nil } }
@@ -170,9 +170,9 @@ struct SitesLauncherView: View {
             Button("Remove from Anglesite", role: .destructive) { removeSite(site) }
             Button("Cancel", role: .cancel) {}
         } message: { site in
-            // Removal only forgets the site here — the folder on disk is untouched, matching
+            // Removal only forgets the site here — the package on disk is untouched, matching
             // `SiteStore.remove(id:)`. Owners can still open it in Finder, VS Code, or the CLI.
-            Text("This removes it from Anglesite's list only. The files in \(site.path.path) are left on disk.")
+            Text("This removes it from Anglesite's list only. The files in \(site.packageURL.path) are left on disk.")
         }
     }
 
@@ -182,7 +182,7 @@ struct SitesLauncherView: View {
                 .font(.largeTitle).foregroundStyle(.tertiary)
             Text("No Anglesite sites found")
                 .font(.headline)
-            Text("Create one with `/anglesite:start` in `~/Sites/<name>/`, or use **Add Site → Import existing site…** to add an existing project.")
+            Text("Create one with **Add Site → Create new site…**, or use **Add Site → Import existing site…** to add an existing `.anglesite` package.")
                 .font(.callout).foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 360)
@@ -236,9 +236,8 @@ struct SitesLauncherView: View {
 
     /// Forget `site` from the registry without touching its files. On MAS this also drops the
     /// site's persisted security-scoped bookmark, since that lives inline in the `Site` entry.
-    /// We prune the local list directly rather than re-running `refreshSites()`: a DevID rescan
-    /// of `~/Sites` would immediately rediscover a still-present in-root folder, undoing the
-    /// removal visually. Persistence is handled by `remove(id:)`.
+    /// We prune the local list directly rather than re-running `refreshSites()`: the registry no
+    /// longer scans `~/Sites`, so removal is permanent until the package is re-opened.
     ///
     /// An already-open `SiteWindow` for this site auto-closes: it observes `SiteStore.changeStream()`
     /// and dismisses itself when its id leaves the registry, which tears down its dev-server/MCP
@@ -261,7 +260,7 @@ struct SitesLauncherView: View {
                 await refreshSites()
                 open(site: site)
             } catch {
-                // `SiteActions.ImportError.localizedDescription` names the folder and the reason.
+                // `SiteActions.ImportError.localizedDescription` names the package and the reason.
                 loadError = error.localizedDescription
             }
         }
@@ -290,8 +289,10 @@ struct SitesLauncherView: View {
         #endif
         try? FileManager.default.createDirectory(at: sitesRoot, withIntermediateDirectories: true)
 
-        let known = (try? await SiteStore.shared.refresh()) ?? []
-        let takenSlugs = Set(known.map { SiteSlug.derive(from: $0.name) })
+        // Load persisted registry to derive taken slugs; no scan needed (registry = source of truth).
+        try? await SiteStore.shared.load()
+        let knownSites = await SiteStore.shared.sites
+        let takenSlugs = Set(knownSites.map { SiteSlug.derive(from: $0.name) })
 
         let model = NewSiteWizardModel(catalog: catalog, slugTaken: { takenSlugs.contains($0) })
 
@@ -302,11 +303,16 @@ struct SitesLauncherView: View {
             run: { exe, args, cwd in
                 try await ProcessSupervisor.shared.run(executable: exe, arguments: args, currentDirectoryURL: cwd)
             },
-            register: { url in
-                let site = try await SiteStore.shared.add(url)
+            gitInit: { sourceDir in
+                let git = URL(fileURLWithPath: "/usr/bin/git")
+                _ = try await ProcessSupervisor.shared.run(executable: git, arguments: ["init"], currentDirectoryURL: sourceDir)
+            },
+            register: { package in
+                let site = try await SiteStore.shared.record(package)
                 #if ANGLESITE_MAS
-                let bookmark = try SecurityScopedBookmark.create(for: url)
-                try await SiteStore.shared.setBookmark(bookmark, for: site.id)
+                if let bm = try? SecurityScopedBookmark.create(for: package.url) {
+                    try? await SiteStore.shared.setBookmark(bm, for: site.id)
+                }
                 #endif
                 return site
             }
@@ -370,7 +376,7 @@ struct SitesLauncherView: View {
     private func refreshSites() async {
         do {
             try await SiteStore.shared.load()
-            sites = try await SiteStore.shared.refresh()
+            sites = await SiteStore.shared.sites
             loadError = nil
         } catch {
             loadError = "\(error)"


### PR DESCRIPTION
## Summary
- `SiteWindow` and its child models (backup/audit/deploy/preview/chat/alt-text) now read `site.sourceDirectory` instead of the retired `site.path`
- `SitesLauncherView` opens packages via `NSOpenPanel` filtered on the `anglesiteSite` UTI instead of a plain directory picker
- The `Window("Sites", ...)` scene now handles `onOpenURL` for Finder double-click on a `.anglesite` package
- `RecentSitesModel` and the launcher no longer re-scan `~/Sites` — `SiteStore`'s registry is now the sole source of truth, so removing a site from the list is permanent until the package is re-opened

Recovered from a stale worktree (`agent-ae3de02c4404d5134`) that predated a rebase onto main; two string literals had been corrupted with curly quotes as Swift string delimiters (syntax errors) — fixed as part of landing this.

## Test plan
- [ ] `swift test --package-path .` (AnglesiteCore/AnglesiteSiteModel/AnglesiteBridge suites)
- [ ] Manual: Finder double-click on a `.anglesite` package opens it via `onOpenURL`
- [ ] Manual: File ▸ Open Site… filters to `.anglesite` packages only
- [ ] Manual: removing a site from the launcher stays removed after relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)