### PR TITLE
fix(#93): deploy-summary race guard, digest perf, and audit UI polish

### DIFF
--- a/Sources/AnglesiteApp/AuditSheetView.swift
+++ b/Sources/AnglesiteApp/AuditSheetView.swift
@@ -139,13 +139,12 @@ struct AuditSheetView: View {
         } else {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 14) {
-                    Section {
-                        Text(report.summary)
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                            .textSelection(.enabled)
-                            .accessibilityLabel("Audit summary: \(report.summary)")
-                    }
+                    // Plain Text, not Section — Section has no effect inside a LazyVStack.
+                    Text(report.summary)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .accessibilityLabel("Audit summary: \(report.summary)")
                     ForEach(groupedFindings(report), id: \.0) { (category, items) in
                         categorySection(category: category, findings: items)
                     }

--- a/Sources/AnglesiteApp/DeployDrawerView.swift
+++ b/Sources/AnglesiteApp/DeployDrawerView.swift
@@ -21,6 +21,9 @@ struct DeployDrawerView: View {
             header
             Divider()
             failureSummarySection
+            if hasFailureSummaryContent {
+                Divider()
+            }
             logScroller
             Divider()
             footer
@@ -99,6 +102,15 @@ struct DeployDrawerView: View {
         }
     }
 
+    /// True when `failureSummarySection` renders content (spinner or a summary) — drives the
+    /// separator below it so the summary and the raw log don't run together visually.
+    private var hasFailureSummaryContent: Bool {
+        if case .failed = model.phase {
+            return model.summarizing || model.failureSummary != nil
+        }
+        return false
+    }
+
     @ViewBuilder
     private var failureSummarySection: some View {
         if case .failed = model.phase {
@@ -107,8 +119,14 @@ struct DeployDrawerView: View {
                     ProgressView().controlSize(.small)
                     Text("Summarizing…").font(.callout).foregroundStyle(.secondary)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
             } else if let s = model.failureSummary {
                 VStack(alignment: .leading, spacing: 6) {
+                    Label("AI summary — verify against the log below", systemImage: "sparkles")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
                     Text(s.summary).font(.callout)
                     if !s.likelyCause.isEmpty {
                         Text("Likely cause: \(s.likelyCause)").font(.callout).foregroundStyle(.secondary)
@@ -117,6 +135,9 @@ struct DeployDrawerView: View {
                         Text("Suggested fix: \(s.suggestedFix)").font(.callout).foregroundStyle(.secondary)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
                 .textSelection(.enabled)
                 .accessibilityElement(children: .combine)
             }

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -125,6 +125,10 @@ final class DeployModel {
             tokenPromptPresented = true
             return
         }
+        // Flip `phase` synchronously, before scheduling the Task, so a second `deploy()` call
+        // on the same actor hop (e.g. a rapid re-invocation before this Task starts running)
+        // sees `isRunning == true` and bails via the guard above instead of racing runDeploy.
+        phase = .running(siteID: siteID, since: Date())
         inFlight = Task { @MainActor [weak self] in
             await self?.runDeploy(siteID: siteID, siteDirectory: siteDirectory, containerControl: containerControl)
         }
@@ -207,6 +211,10 @@ final class DeployModel {
         failureSummary = nil
         summarizing = false
         summarizationGeneration &+= 1   // invalidate any still-in-flight summary from a prior deploy
+        // Captured immediately after the bump — the authoritative "my generation" value for
+        // this call's summarization branch. Must NOT be re-read later via the live field, which
+        // may have moved on if a second `runDeploy` call started concurrently (see guard below).
+        let myGeneration = summarizationGeneration
         drawerPresented = true
         blockedPresented = false
 
@@ -264,7 +272,6 @@ final class DeployModel {
             phase = .succeeded(url: url, duration: duration)
         case .failed(let reason, let exit):
             phase = .failed(reason: reason, exitCode: exit)
-            let generation = summarizationGeneration
             let capturedLog = logText   // snapshot before the suspension; a later deploy clears logLines
             summarizing = true
             let summary = await DeployFailureSummaryRequest.run(
@@ -275,7 +282,7 @@ final class DeployModel {
             )
             // Drop the result if another deploy started while we were summarizing — it has already
             // reset failureSummary/summarizing and we must not clobber its state.
-            guard summarizationGeneration == generation else { return }
+            guard summarizationGeneration == myGeneration else { return }
             failureSummary = summary
             summarizing = false
         case .blocked(let failures, let warnings):

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -63,6 +63,11 @@ final class DeployModel {
     private let keychain: KeychainStore
     private let onboarding: TokenOnboarding
     private let summarizer: any DeployFailureSummarizing
+    /// Bumped at the start of every `runDeploy`. The async failure-summarization captures the
+    /// value at dispatch and only writes its result back if it still matches — so a summary from
+    /// a superseded deploy can't stomp the current deploy's state, even though
+    /// `generateStructured` doesn't honour cooperative cancellation.
+    private var summarizationGeneration: UInt = 0
     private var inFlight: Task<Void, Never>?
     /// Site to retry once the user pastes a token. `nil` outside the prompt flow.
     /// Carries the container control (if any) so the parked-then-retried deploy
@@ -201,6 +206,7 @@ final class DeployModel {
         currentMilestone = nil
         failureSummary = nil
         summarizing = false
+        summarizationGeneration &+= 1   // invalidate any still-in-flight summary from a prior deploy
         drawerPresented = true
         blockedPresented = false
 
@@ -258,13 +264,19 @@ final class DeployModel {
             phase = .succeeded(url: url, duration: duration)
         case .failed(let reason, let exit):
             phase = .failed(reason: reason, exitCode: exit)
+            let generation = summarizationGeneration
+            let capturedLog = logText   // snapshot before the suspension; a later deploy clears logLines
             summarizing = true
-            failureSummary = await DeployFailureSummaryRequest.run(
-                logText: logText,
+            let summary = await DeployFailureSummaryRequest.run(
+                logText: capturedLog,
                 siteID: siteID,
                 siteDirectory: siteDirectory,
                 using: summarizer
             )
+            // Drop the result if another deploy started while we were summarizing — it has already
+            // reset failureSummary/summarizing and we must not clobber its state.
+            guard summarizationGeneration == generation else { return }
+            failureSummary = summary
             summarizing = false
         case .blocked(let failures, let warnings):
             phase = .blocked(failures: failures, warnings: warnings)

--- a/Sources/AnglesiteCore/AuditReport.swift
+++ b/Sources/AnglesiteCore/AuditReport.swift
@@ -105,16 +105,27 @@ public extension AuditReport {
         return sentence
     }
 
+    // Explicit switch (not `rawValue`) so a new `Finding.Category` case is a compile error
+    // here rather than a silently-wrong display string at runtime.
     private static func displayName(_ category: Finding.Category) -> String {
-        category == .seo ? "SEO" : category.rawValue
+        switch category {
+        case .seo: return "SEO"
+        case .security: return "security"
+        case .accessibility: return "accessibility"
+        case .performance: return "performance"
+        }
     }
 
     private static func skippedClause(_ names: [String]) -> String {
         let joined: String
-        if names.count == 1 {
+        switch names.count {
+        case 1:
             joined = names[0]
-        } else {
-            joined = names.dropLast().joined(separator: ", ") + " and " + (names.last ?? "")
+        case 2:
+            joined = names[0] + " and " + names[1]
+        default:
+            // Serial (Oxford) comma before the final "and": "a, b, and c".
+            joined = names.dropLast().joined(separator: ", ") + ", and " + (names.last ?? "")
         }
         let verb = names.count == 1 ? "check couldn't" : "checks couldn't"
         return "The \(joined) \(verb) run."

--- a/Sources/AnglesiteCore/DeployLogDigest.swift
+++ b/Sources/AnglesiteCore/DeployLogDigest.swift
@@ -13,8 +13,9 @@ public enum DeployLogDigest {
         let lines = logText.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
         let kept = lines.filter { !isBuildNoise($0) }
         var digest = kept.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-        if digest.count > maxCharacters {
-            digest = String(digest.suffix(maxCharacters))
+        // Single-pass tail trim: index arithmetic avoids the double O(n) walk of `count` + `suffix`.
+        if let start = digest.index(digest.endIndex, offsetBy: -maxCharacters, limitedBy: digest.startIndex) {
+            digest = String(digest[start...])
         }
         return digest
     }
@@ -24,7 +25,9 @@ public enum DeployLogDigest {
     private static func isBuildNoise(_ line: String) -> Bool {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         if trimmed.contains("npm run build") { return true }
-        if trimmed.hasPrefix("> ") { return true }                 // npm script echo, e.g. "> astro build"
+        // npm script echo, e.g. "> astro build" — require an identifier after "> " so we don't
+        // drop wrangler/JSON lines like "> https://…" or "> {".
+        if trimmed.range(of: #"^> \w"#, options: .regularExpression) != nil { return true }
         if trimmed.hasPrefix("✓ ") { return true }                 // Vite "✓ N modules transformed"
         if trimmed.lowercased().hasPrefix("vite v") { return true } // Vite banner
         if trimmed.lowercased().hasPrefix("transforming") { return true }

--- a/Sources/AnglesiteCore/DeployLogDigest.swift
+++ b/Sources/AnglesiteCore/DeployLogDigest.swift
@@ -25,9 +25,14 @@ public enum DeployLogDigest {
     private static func isBuildNoise(_ line: String) -> Bool {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         if trimmed.contains("npm run build") { return true }
-        // npm script echo, e.g. "> astro build" — require an identifier after "> " so we don't
-        // drop wrangler/JSON lines like "> https://…" or "> {".
-        if trimmed.range(of: #"^> \w"#, options: .regularExpression) != nil { return true }
+        // npm script echo, e.g. "> astro build" — requires a letter (not digit) right after "> "
+        // *and* no "://" anywhere in the line, so wrangler/JSON lines like "> https://…",
+        // "> 1.2.3 deployed", or "> {" all survive (the first two would otherwise still match
+        // `\w`, which includes digits, since "h" and "1" are both word characters).
+        if trimmed.range(of: #"^> [A-Za-z]"#, options: .regularExpression) != nil,
+           !trimmed.contains("://") {
+            return true
+        }
         if trimmed.hasPrefix("✓ ") { return true }                 // Vite "✓ N modules transformed"
         if trimmed.lowercased().hasPrefix("vite v") { return true } // Vite banner
         if trimmed.lowercased().hasPrefix("transforming") { return true }

--- a/Sources/AnglesiteCore/FoundationModelDeploySummarizer.swift
+++ b/Sources/AnglesiteCore/FoundationModelDeploySummarizer.swift
@@ -14,12 +14,15 @@ public enum DeploySummarizerFactory {
 
 #if compiler(>=6.4)
 import FoundationModels
+import os
 
 /// On-device summarizer: runs the digested failure log through the macOS 27 model via guided
 /// generation, then maps the result to the non-gated `DeployFailureSummary`. Any failure —
 /// including `AssistantError.unavailable` when Apple Intelligence is off — collapses to `nil`
 /// so the caller falls back to showing the raw log.
 public struct FoundationModelDeploySummarizer: DeployFailureSummarizing {
+    private let logger = Logger(subsystem: "dev.anglesite.app", category: "DeployFailureSummarizer")
+
     public init() {}
 
     public func summarize(failureLog: String, siteID: String, siteDirectory: URL) async -> DeployFailureSummary? {
@@ -37,6 +40,8 @@ public struct FoundationModelDeploySummarizer: DeployFailureSummarizing {
                 suggestedFix: generated.suggestedFix
             )
         } catch {
+            // Don't swallow silently — surface the failure (the caller still degrades to the raw log).
+            logger.warning("Deploy-failure summarization failed: \(error, privacy: .public)")
             return nil
         }
     }

--- a/Tests/AnglesiteCoreTests/AuditReportSummaryTests.swift
+++ b/Tests/AnglesiteCoreTests/AuditReportSummaryTests.swift
@@ -42,4 +42,17 @@ private func finding(_ category: AuditReport.Finding.Category) -> AuditReport.Fi
         )
         #expect(report.summary == "No issues found in the checks that ran. The performance and SEO checks couldn't run.")
     }
+
+    @Test func threeSkippedRunnersUseOxfordComma() {
+        let report = AuditReport(
+            findings: [finding(.security)],
+            runnersExecuted: [.security],
+            runnersSkipped: [
+                .init(category: .accessibility, reason: "a"),
+                .init(category: .performance, reason: "b"),
+                .init(category: .seo, reason: "c"),
+            ]
+        )
+        #expect(report.summary == "1 security issue. The accessibility, performance, and SEO checks couldn't run.")
+    }
 }

--- a/Tests/AnglesiteCoreTests/DeployFailureSummaryRequestTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployFailureSummaryRequestTests.swift
@@ -28,13 +28,19 @@ private actor SpySummarizer: DeployFailureSummarizing {
     @Test func nonEmptyLogPassesDigestThrough() async {
         let expected = DeployFailureSummary(summary: "boom", likelyCause: "c", suggestedFix: "f")
         let spy = SpySummarizer(stub: expected)
+        // A log with build noise so the digest genuinely differs from the raw input — this proves
+        // the *digest* reaches the summarizer, not the raw log.
+        let rawLog = """
+        > astro build
+        ✓ 42 modules transformed
+        ✘ [ERROR] Could not resolve "./x"
+        """
         let result = await DeployFailureSummaryRequest.run(
-            logText: "✘ [ERROR] Could not resolve \"./x\"", siteID: "s", siteDirectory: dir, using: spy
+            logText: rawLog, siteID: "s", siteDirectory: dir, using: spy
         )
         #expect(result == expected)
-        // Assert the summarizer received the *digest*, not the raw log — so a future
-        // DeployLogDigest change that dropped the error line would fail here.
-        let rawLog = "✘ [ERROR] Could not resolve \"./x\""
-        #expect(await spy.receivedLog == DeployLogDigest.extract(from: rawLog))
+        let digest = DeployLogDigest.extract(from: rawLog)
+        #expect(digest != rawLog)                       // the noise was actually stripped
+        #expect(await spy.receivedLog == digest)        // and the digest is what was passed through
     }
 }

--- a/Tests/AnglesiteCoreTests/DeployLogDigestTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployLogDigestTests.swift
@@ -29,4 +29,19 @@ import Testing
         #expect(digest.count == DeployLogDigest.maxCharacters)
         #expect(digest == String(long.suffix(DeployLogDigest.maxCharacters)))
     }
+
+    @Test func keepsWranglerURLAndVersionLines() {
+        let raw = """
+        > astro build
+        > https://my-worker.username.workers.dev
+        > 1.2.3 deployed
+        > {"success":true}
+        ✘ [ERROR] deploy failed
+        """
+        let digest = DeployLogDigest.extract(from: raw)
+        #expect(!digest.contains("astro build"))
+        #expect(digest.contains("https://my-worker.username.workers.dev"))
+        #expect(digest.contains("1.2.3 deployed"))
+        #expect(digest.contains("{\"success\":true}"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/FoundationModelDeploySummarizerTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelDeploySummarizerTests.swift
@@ -23,10 +23,10 @@ import Testing
 #endif
 
 @Suite struct DeploySummarizerFactoryTests {
-    // The factory's product differs per toolchain (real conformer under Xcode 27, Noop on CI),
-    // but BOTH short-circuit a whitespace-only log to nil before touching any model — a real
-    // behavioral assertion that holds everywhere and never invokes Apple Intelligence.
-    @Test func makeDefaultProductShortCircuitsEmptyLog() async {
+    // A whitespace-only log returns nil on both toolchains, for different reasons: under Xcode 27
+    // the real conformer short-circuits before any model call; on CI the Noop returns nil for any
+    // input. Either way the assertion holds everywhere and never invokes Apple Intelligence.
+    @Test func makeDefaultProductReturnsNilForEmptyLog() async {
         let result = await DeploySummarizerFactory.makeDefault().summarize(
             failureLog: "   ", siteID: "s", siteDirectory: URL(fileURLWithPath: "/tmp/s")
         )


### PR DESCRIPTION
## Summary
- `DeployModel` guards against a stale on-device failure summary from a superseded deploy overwriting the current deploy's state, via a generation counter bumped at the start of every `runDeploy`
- `DeployLogDigest` does a single-pass tail-trim (avoids the double O(n) `count`+`suffix` walk) and tightens the npm-script-echo noise filter so it doesn't eat wrangler/JSON lines starting with `>`
- `AuditReport.displayName` switches from a `rawValue` fallback to an explicit switch (new categories become a compile error instead of a silently-wrong display string) and adds a proper Oxford comma for 3+ skipped checks
- `DeployDrawerView` adds a divider and an "AI summary — verify against the log" disclaimer label; `AuditSheetView` drops a `Section` that had no effect inside a `LazyVStack`
- Summarizer failures now log via `os.Logger` instead of being silently swallowed

Recovered from a stale worktree (`93-deploy-audit-summaries`) with in-progress review-response fixes on top of the already-merged #93 work.

## Test plan
- [ ] `swift test --package-path .` — new/updated tests in `AuditReportSummaryTests`, `DeployFailureSummaryRequestTests`, `FoundationModelDeploySummarizerTests`
- [ ] Manual: trigger a failed deploy, confirm the failure summary panel renders with the divider + disclaimer
- [ ] Manual: trigger two deploys in quick succession, confirm the second deploy's summary isn't clobbered by a late-arriving summary from the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)