### PR TITLE
fix(#406): paginate DNS records, fan out zone reads, distinguish SSL Full from Strict

### DIFF
--- a/Sources/AnglesiteApp/HardenModel.swift
+++ b/Sources/AnglesiteApp/HardenModel.swift
@@ -115,7 +115,7 @@ final class HardenModel {
                 return
             }
 
-            let state = try await reader.zoneState(zoneID: zoneID, apiToken: token)
+            let state = try await reader.zoneState(zoneID: zoneID, domain: domain, apiToken: token)
             let plan = HardenPlanner.plan(from: state, domain: domain)
             phase = .preview(plan: plan, domain: domain, zoneID: zoneID)
         } catch let error as CloudflareError {

--- a/Sources/AnglesiteCore/CloudflareReading.swift
+++ b/Sources/AnglesiteCore/CloudflareReading.swift
@@ -6,7 +6,6 @@ public enum CloudflareError: Error, Equatable, Sendable {
     case http(status: Int)
     case api(message: String)
     case malformedResponse
-    case zoneNotFound(domain: String)
 }
 
 /// Read-only Cloudflare API seam. The concrete `HTTPCloudflareClient` talks to the
@@ -14,8 +13,10 @@ public enum CloudflareError: Error, Equatable, Sendable {
 public protocol CloudflareReading: Sendable {
     /// Resolve a zone's id from its apex domain, or nil if the token can't see it.
     func resolveZoneID(domain: String, apiToken: String) async throws -> String?
-    /// Fetch the security-relevant state for a zone.
-    func zoneState(zoneID: String, apiToken: String) async throws -> CloudflareZoneState
+    /// Fetch the security-relevant state for a zone. `domain` is the zone's apex hostname
+    /// (already known to callers via `resolveZoneID`) — used to scope CAA/MX/SPF/DMARC
+    /// grading to the apex, so a record on an unrelated subdomain can't count toward it.
+    func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState
 }
 
 /// Injectable HTTP boundary — identical shape to `CloudflareAPITokenVerifier.Transport`.

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -1,11 +1,18 @@
 import Foundation
 
+/// Pagination metadata returned alongside list results.
+private struct CFResultInfo: Decodable, Sendable {
+    let page: Int
+    let total_pages: Int
+}
+
 /// Standard Cloudflare v4 response envelope.
 private struct CFEnvelope<T: Decodable & Sendable>: Decodable, Sendable {
     let success: Bool
     let result: T?
     struct APIError: Decodable, Sendable { let message: String }
     let errors: [APIError]?
+    let result_info: CFResultInfo?
 }
 
 /// Placeholder for write responses where we only check `success`.
@@ -76,13 +83,13 @@ public struct HTTPCloudflareClient: CloudflareReading {
         return (data, http)
     }
 
-    /// GET `path`, decode `CFEnvelope<T>`, return `result` or throw a mapped error.
-    private func get<T: Decodable & Sendable>(_ path: String, apiToken: String, as: T.Type) async throws -> T {
+    /// GET `path`, decode `CFEnvelope<T>`, return the whole envelope or throw a mapped error.
+    private func getEnvelope<T: Decodable & Sendable>(_ path: String, apiToken: String, as: T.Type) async throws -> CFEnvelope<T> {
         guard let url = URL(string: Self.base + path) else { throw CloudflareError.malformedResponse }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
         let (data, http) = try await transport(request)
         if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
         guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
@@ -92,10 +99,34 @@ public struct HTTPCloudflareClient: CloudflareReading {
         } catch {
             throw CloudflareError.malformedResponse
         }
-        guard env.success, let result = env.result else {
+        guard env.success else {
             throw CloudflareError.api(message: env.errors?.first?.message ?? "request failed")
         }
+        return env
+    }
+
+    /// GET `path` and return the decoded `result`, or throw `.api` when it is absent.
+    private func get<T: Decodable & Sendable>(_ path: String, apiToken: String, as type: T.Type) async throws -> T {
+        let env = try await getEnvelope(path, apiToken: apiToken, as: type)
+        guard let result = env.result else {
+            throw CloudflareError.api(message: env.errors?.first?.message ?? "missing result")
+        }
         return result
+    }
+
+    /// Fetch every DNS record across pages (Cloudflare caps `per_page` at 100, so a
+    /// single page silently truncates zones with more records).
+    private func allDNSRecords(zoneID: String, apiToken: String) async throws -> [CFDNSRecord] {
+        var all: [CFDNSRecord] = []
+        var page = 1
+        while true {
+            let env = try await getEnvelope("/zones/\(zoneID)/dns_records?per_page=100&page=\(page)",
+                                            apiToken: apiToken, as: [CFDNSRecord].self)
+            all.append(contentsOf: env.result ?? [])
+            guard let info = env.result_info, info.page < info.total_pages else { break }
+            page += 1
+        }
+        return all
     }
 
     public func resolveZoneID(domain: String, apiToken: String) async throws -> String? {
@@ -104,12 +135,20 @@ public struct HTTPCloudflareClient: CloudflareReading {
         return zones.first(where: { $0.name.lowercased() == domain.lowercased() })?.id
     }
 
-    public func zoneState(zoneID: String, apiToken: String) async throws -> CloudflareZoneState {
-        let dnssec = try await get("/zones/\(zoneID)/dnssec", apiToken: apiToken, as: CFDNSSEC.self)
-        let ssl = try await get("/zones/\(zoneID)/settings/ssl", apiToken: apiToken, as: CFStringSetting.self)
-        let https = try await get("/zones/\(zoneID)/settings/always_use_https", apiToken: apiToken, as: CFStringSetting.self)
-        let header = try await get("/zones/\(zoneID)/settings/security_header", apiToken: apiToken, as: CFSecurityHeader.self)
-        let records = try await get("/zones/\(zoneID)/dns_records?per_page=100", apiToken: apiToken, as: [CFDNSRecord].self)
+    public func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState {
+        // Independent reads — fan out concurrently rather than paying 5× round-trip latency.
+        async let dnssecCall = get("/zones/\(zoneID)/dnssec", apiToken: apiToken, as: CFDNSSEC.self)
+        async let sslCall = get("/zones/\(zoneID)/settings/ssl", apiToken: apiToken, as: CFStringSetting.self)
+        async let httpsCall = get("/zones/\(zoneID)/settings/always_use_https", apiToken: apiToken, as: CFStringSetting.self)
+        async let headerCall = get("/zones/\(zoneID)/settings/security_header", apiToken: apiToken, as: CFSecurityHeader.self)
+        async let recordsCall = allDNSRecords(zoneID: zoneID, apiToken: apiToken)
+
+        let dnssec = try await dnssecCall
+        let ssl = try await sslCall
+        let https = try await httpsCall
+        let header = try await headerCall
+        let records = try await recordsCall
+        let apex = domain.lowercased()
 
         let botFight: Bool
         do {
@@ -131,12 +170,18 @@ public struct HTTPCloudflareClient: CloudflareReading {
             ? .init(maxAge: sts.max_age ?? 0, includeSubdomains: sts.include_subdomains ?? false, preload: sts.preload ?? false)
             : nil
 
+        // Scoped to the zone apex — a record published on an unrelated subdomain must not
+        // count toward the apex domain's CAA/MX/SPF/DMARC posture (that direction of error
+        // produces a false "all clear" in a security audit).
         func contents(ofType t: String) -> [String] {
-            records.filter { $0.type.uppercased() == t }.map(\.content)
+            records.filter { $0.type.uppercased() == t && $0.name.lowercased() == apex }.map(\.content)
         }
-        let txt = records.filter { $0.type.uppercased() == "TXT" }
+        let txt = records.filter { $0.type.uppercased() == "TXT" && $0.name.lowercased() == apex }
         let spf = txt.filter { $0.content.lowercased().hasPrefix("v=spf1") }.map(\.content)
-        let dmarc = txt.filter { $0.name.lowercased().hasPrefix("_dmarc.") && $0.content.lowercased().hasPrefix("v=dmarc1") }.map(\.content)
+        let dmarcName = "_dmarc.\(apex)"
+        let dmarc = records
+            .filter { $0.type.uppercased() == "TXT" && $0.name.lowercased() == dmarcName && $0.content.lowercased().hasPrefix("v=dmarc1") }
+            .map(\.content)
 
         return CloudflareZoneState(
             dnssecActive: dnssec.status.lowercased() == "active",

--- a/Sources/AnglesiteCore/HardenExecutor.swift
+++ b/Sources/AnglesiteCore/HardenExecutor.swift
@@ -54,7 +54,7 @@ public struct HardenExecutor: Sendable {
         let findings: [AuditReport.Finding]
         var auditErr: String?
         do {
-            let freshState = try await reader.zoneState(zoneID: zoneID, apiToken: apiToken)
+            let freshState = try await reader.zoneState(zoneID: zoneID, domain: domain, apiToken: apiToken)
             let expectsMail = !freshState.mxRecords.isEmpty
                 && !freshState.mxRecords.allSatisfy({ $0.trimmingCharacters(in: .whitespaces) == "." || $0.hasPrefix("0 .") })
             findings = SecurityAudit.evaluate(freshState, expectsMail: expectsMail)

--- a/Sources/AnglesiteCore/SecurityAudit.swift
+++ b/Sources/AnglesiteCore/SecurityAudit.swift
@@ -14,7 +14,14 @@ public enum SecurityAudit {
                 "DNSSEC is disabled, leaving DNS responses unauthenticated.",
                 "Enable DNSSEC for the zone and publish the DS record at your registrar.")
         }
-        if !["full", "strict"].contains(state.sslMode.lowercased()) {
+        switch state.sslMode.lowercased() {
+        case "strict":
+            break // Full (strict): origin cert validated — the secure target.
+        case "full":
+            add(.warning, "SSL/TLS mode is Full but not Strict",
+                "Full mode encrypts the Cloudflare↔origin hop but does not validate the origin certificate, leaving it open to an active MITM on that hop.",
+                "Set the zone's SSL/TLS mode to Full (strict).")
+        default:
             add(.critical, "Weak SSL/TLS mode (\(state.sslMode))",
                 "SSL mode \"\(state.sslMode)\" allows unencrypted or unauthenticated origin connections.",
                 "Set the zone's SSL/TLS mode to Full (strict).")

--- a/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
@@ -124,7 +124,7 @@ func zoneStateAssembles() async throws {
         "/rulesets": (200, env("[{\"id\":\"rs1\",\"phase\":\"http_request_firewall_custom\"}]")),
     ]
     let client = HTTPCloudflareClient(transport: fakeTransport(routes))
-    let s = try await client.zoneState(zoneID: "z", apiToken: "t")
+    let s = try await client.zoneState(zoneID: "z", domain: "example.com", apiToken: "t")
     #expect(s.dnssecActive)
     #expect(s.sslMode == "strict")
     #expect(s.alwaysUseHTTPS)
@@ -150,7 +150,7 @@ func zoneStateHSTSDisabled() async throws {
         "/rulesets": (200, env("[]")),
     ]
     let client = HTTPCloudflareClient(transport: fakeTransport(routes))
-    let s = try await client.zoneState(zoneID: "z", apiToken: "t")
+    let s = try await client.zoneState(zoneID: "z", domain: "example.com", apiToken: "t")
     #expect(!s.dnssecActive)
     #expect(s.hsts == nil)
     #expect(s.caaRecords.isEmpty)
@@ -179,7 +179,7 @@ extension CloudflareClientTests {
         routes["/page_shield"] = (200, #"{"success":true,"result":{"enabled":true}}"#)
 
         let client = HTTPCloudflareClient(transport: fakeTransport(routes))
-        let state = try await client.zoneState(zoneID: "z", apiToken: "t")
+        let state = try await client.zoneState(zoneID: "z", domain: "example.com", apiToken: "t")
         #expect(state.speedBrain)
         #expect(!state.ech)
         #expect(state.zstdCompression)
@@ -192,10 +192,48 @@ extension CloudflareClientTests {
         var routes = Self.baseRoutes
         routes["/zones/z/rulesets"] = (403, #"{"success":false}"#)
         let client = HTTPCloudflareClient(transport: fakeTransport(routes))
-        let state = try await client.zoneState(zoneID: "z", apiToken: "t")
+        let state = try await client.zoneState(zoneID: "z", domain: "example.com", apiToken: "t")
         #expect(!state.speedBrain)
         #expect(!state.ech)
         #expect(!state.zstdCompression)
         #expect(state.pageShield == nil)
+    }
+}
+
+@Test("zoneState follows DNS-record pagination across pages")
+func zoneStatePaginates() async throws {
+    let plain = { (r: String) in "{\"success\":true,\"errors\":[],\"messages\":[],\"result\":\(r)}" }
+    func paged(_ result: String, page: Int, totalPages: Int) -> String {
+        "{\"success\":true,\"errors\":[],\"result\":\(result),\"result_info\":{\"page\":\(page),\"total_pages\":\(totalPages)}}"
+    }
+    let routes: [String: (Int, String)] = [
+        "/dnssec": (200, plain("{\"status\":\"active\"}")),
+        "/settings/ssl": (200, plain("{\"value\":\"strict\"}")),
+        "/settings/always_use_https": (200, plain("{\"value\":\"on\"}")),
+        "/settings/security_header": (200, plain("{\"value\":{\"strict_transport_security\":{\"enabled\":false}}}")),
+        // "&page=" (not bare "page=") so this can't collide with "per_page=100" in the request URL.
+        "&page=1": (200, paged("[{\"type\":\"CAA\",\"name\":\"example.com\",\"content\":\"0 issue \\\"letsencrypt.org\\\"\"}]", page: 1, totalPages: 2)),
+        "&page=2": (200, paged("[{\"type\":\"TXT\",\"name\":\"example.com\",\"content\":\"v=spf1 -all\"}]", page: 2, totalPages: 2)),
+    ]
+    let client = HTTPCloudflareClient(transport: fakeTransport(routes))
+    let s = try await client.zoneState(zoneID: "z", domain: "example.com", apiToken: "t")
+    #expect(s.caaRecords == ["0 issue \"letsencrypt.org\""]) // page 1
+    #expect(s.spfRecords == ["v=spf1 -all"])                 // page 2 — proves pagination
+}
+
+@Test("success:false with an error message surfaces as .api")
+func apiErrorMaps() async {
+    let body = "{\"success\":false,\"errors\":[{\"message\":\"nope\"}],\"result\":null}"
+    let client = HTTPCloudflareClient(transport: fakeTransport(["/zones?": (200, body)]))
+    await #expect(throws: CloudflareError.api(message: "nope")) {
+        _ = try await client.resolveZoneID(domain: "example.com", apiToken: "t")
+    }
+}
+
+@Test("a 500 surfaces as .http(status:)")
+func httpErrorMaps() async {
+    let client = HTTPCloudflareClient(transport: fakeTransport(["/zones?": (500, "{}")]))
+    await #expect(throws: CloudflareError.http(status: 500)) {
+        _ = try await client.resolveZoneID(domain: "example.com", apiToken: "t")
     }
 }

--- a/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
@@ -123,7 +123,7 @@ final class MockCloudflareReader: CloudflareReading, @unchecked Sendable {
     }
 
     func resolveZoneID(domain: String, apiToken: String) async throws -> String? { "z" }
-    func zoneState(zoneID: String, apiToken: String) async throws -> CloudflareZoneState {
+    func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState {
         if shouldFail { throw CloudflareError.malformedResponse }
         return state
     }

--- a/Tests/AnglesiteCoreTests/SecurityAuditTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityAuditTests.swift
@@ -32,12 +32,27 @@ struct SecurityAuditTests {
         #expect(f.contains { $0.severity == .critical && $0.title.contains("SSL") })
     }
 
+    @Test("SSL mode Full (not Strict) is a warning, not clean and not critical")
+    func sslFullWarns() {
+        var s = clean(); s.sslMode = "full"
+        let f = SecurityAudit.evaluate(s, expectsMail: false)
+        #expect(f.contains { $0.severity == .warning && $0.title.contains("SSL") })
+        #expect(!f.contains { $0.severity == .critical })
+    }
+
     @Test("missing HSTS and Always-Use-HTTPS each warn")
     func httpsWarnings() {
         var s = clean(); s.hsts = nil; s.alwaysUseHTTPS = false
         let f = SecurityAudit.evaluate(s, expectsMail: false)
         #expect(f.contains { $0.title.contains("HSTS") })
         #expect(f.contains { $0.title.contains("HTTPS") })
+    }
+
+    @Test("a short HSTS max-age warns even when HSTS is enabled")
+    func hstsShortMaxAge() {
+        var s = clean(); s.hsts = .init(maxAge: 3600, includeSubdomains: true, preload: false)
+        let f = SecurityAudit.evaluate(s, expectsMail: false)
+        #expect(f.contains { $0.severity == .warning && $0.title.contains("HSTS") && $0.title.contains("short") })
     }
 
     @Test("missing CAA is an info finding")
@@ -60,6 +75,7 @@ struct SecurityAuditTests {
         var s = clean(); s.spfRecords = []; s.dmarcRecords = []
         let f = SecurityAudit.evaluate(s, expectsMail: true)
         #expect(!f.contains { $0.title.contains("SPF") })
+        #expect(!f.contains { $0.title.contains("DMARC") })
     }
 
     @Test("Bot Fight Mode off is an info finding")


### PR DESCRIPTION
## Summary
- `HTTPCloudflareClient.zoneState` previously fetched only the first 100 DNS records per zone (Cloudflare's `per_page` cap), silently truncating larger zones; `allDNSRecords` now follows `result_info` pagination across pages
- The five independent zone-state reads (DNSSEC, SSL, HTTPS, security header, DNS records) now fan out concurrently via `async let` instead of five serial round-trips
- `SecurityAudit` no longer treats SSL mode `full` the same as `strict` — `full` encrypts the Cloudflare↔origin hop but doesn't validate the origin cert, so it now warns instead of passing clean or failing critical

Recovered from a stale worktree (`feat-406-cloudflare-audit`) with in-progress hardening on top of the already-merged #406 work.

## Test plan
- [ ] `swift test --package-path .` — new tests for pagination (`zoneStatePaginates`), `.api`/`.http` error mapping, SSL Full-vs-Strict, and DMARC exemption when mail isn't expected
- [ ] Manual: run a security audit against a zone with >100 DNS records, confirm all records are captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)