### PR TITLE
chore: require plugin >= 1.3.0 (get_component_model)

### DIFF
--- a/scripts/copy-plugin.sh
+++ b/scripts/copy-plugin.sh
@@ -40,7 +40,7 @@ fi
 # best-effort (handled above — PluginRuntime reports it at runtime), but bundling
 # a plugin that IS present yet too old would ship an app whose edit pipeline
 # fails in confusing ways at runtime — fail the build loudly instead.
-MIN_PLUGIN_VERSION="1.2.0"
+MIN_PLUGIN_VERSION="1.3.0"
 # plutil parses the JSON and extracts the top-level key specifically — a first-match
 # grep could be fooled by a nested "version" (engines/mcpServers/…) appearing earlier
 # in the manifest. This script only runs on macOS (Xcode build phase), so plutil is

--- a/scripts/copy-plugin.sh
+++ b/scripts/copy-plugin.sh
@@ -35,8 +35,8 @@ if [[ ! -f "$SRC/.claude-plugin/plugin.json" ]]; then
     exit 0
 fi
 
-# Minimum-version guard: the app requires plugin features introduced in 1.2.0
-# (apply_edit dry_run/edit-style, typed create_content). A MISSING plugin stays
+# Minimum-version guard: the app requires plugin features introduced in 1.3.0
+# (get_component_model, used by the Component Editor). A MISSING plugin stays
 # best-effort (handled above — PluginRuntime reports it at runtime), but bundling
 # a plugin that IS present yet too old would ship an app whose edit pipeline
 # fails in confusing ways at runtime — fail the build loudly instead.


### PR DESCRIPTION
Follow-up to #487 / Anglesite/anglesite#410: the Component Editor depends on the `get_component_model` MCP tool, released in plugin **v1.3.0**. This bumps the `copy-plugin.sh` floor so a build against an older plugin fails loudly at build time instead of shipping an editor that errors at runtime.

Verified: `copy-plugin.sh` passes against the v1.3.0 plugin checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)