### PR TITLE
fix: startup progress bar's log filter uses stale astro:<id> tag

### DIFF
--- a/Sources/AnglesiteApp/StartupProgressModel.swift
+++ b/Sources/AnglesiteApp/StartupProgressModel.swift
@@ -3,7 +3,7 @@ import AnglesiteCore
 
 /// Drives the determinate startup progress bar for one site window. Owns a pure
 /// `StartupProgressEstimator` and feeds it three things: runtime-state changes (pushed in by
-/// `SiteWindow` via `ingest(state:)`), the site's `astro:<id>` stdout lines (subscribed from
+/// `SiteWindow` via `ingest(state:)`), the site's `container:<id>` stdout lines (subscribed from
 /// `LogCenter`), and ~20 fps `tick`s that ease the fill forward. On success it persists the
 /// measured timing so the next startup paces itself. The estimator stays host-independent and
 /// CI-tested; this class is the SwiftUI/actor wiring around it.
@@ -74,7 +74,11 @@ final class StartupProgressModel {
 
     private func subscribeToLogs(siteID: String) {
         logTask?.cancel()
-        let source = "astro:\(siteID)"
+        // `LocalContainerSiteRuntime` is the only `SiteRuntime` that currently streams to
+        // `LogCenter`, tagged `container:<id>` (see `LocalContainerSiteRuntime.swift`).
+        // `RemoteSandboxSiteRuntime` doesn't stream logs yet; when it does, it should use the
+        // same tag scheme so this subscription picks it up too.
+        let source = "container:\(siteID)"
         logTask = Task { @MainActor [weak self] in
             guard let center = self?.logCenter else { return }
             let subscription = await center.subscribe()

--- a/Sources/AnglesiteCore/XPC/SpawnTypes.swift
+++ b/Sources/AnglesiteCore/XPC/SpawnTypes.swift
@@ -18,7 +18,7 @@ public struct SpawnSpec: Sendable, Codable, Equatable {
     public let workingDirectory: URL?
     /// When `true`, the spawned process gets a writable stdin pipe (MCP JSON-RPC framing needs this).
     public let stdinPipe: Bool
-    /// Tag used by `LogCenter` when streaming stdout/stderr — e.g. `"astro:dev:<siteID>"`.
+    /// Tag used by `LogCenter` when streaming stdout/stderr — e.g. `"container:<siteID>"`.
     public let logSource: String
 
     public init(

--- a/Tests/AnglesiteCoreTests/StartupProgressEstimatorTests.swift
+++ b/Tests/AnglesiteCoreTests/StartupProgressEstimatorTests.swift
@@ -49,6 +49,19 @@ struct StartupProgressEstimatorTests {
         #expect(est.fraction >= 0.55)
     }
 
+    @Test("A container-prefixed astro line still parses through to connecting")
+    func containerPrefixedLineParses() {
+        // Real lines from `LocalContainerSiteRuntime` are prefixed by the guest process label,
+        // e.g. "[astro] ┃ Local    http://127.0.0.1:4321/" — the URL regex must still find the
+        // URL despite the leading "[astro] " tag.
+        var est = make()
+        est.ingest(runtimeState: .starting(siteID: "s"), at: 0)
+        est.ingest(logText: "[astro] Building for production...", at: 0.2)
+        est.ingest(logText: "[astro] ┃ Local    http://127.0.0.1:4321/", at: 0.5)
+        #expect(est.phase == .connecting)
+        #expect(est.fraction >= 0.55)
+    }
+
     @Test("A URL line as the very first log jumps straight to connecting")
     func urlFirstLineSkipsBuilding() {
         var est = make()


### PR DESCRIPTION
## Summary
- `StartupProgressModel.subscribeToLogs` filtered `LogCenter` lines on a hardcoded `astro:<siteID>` source tag, a leftover from the retired host-side Node subprocess runtime (#70).
- Neither current `SiteRuntime` implementation emits that tag: `LocalContainerSiteRuntime` tags its lines `container:<siteID>`, and `RemoteSandboxSiteRuntime` doesn't stream to `LogCenter` at all yet.
- Net effect: the log-driven phase refinement in `StartupProgressEstimator.ingest(logText:)` was dead code — the startup progress bar only ever advanced via the timer-based `tick()` easing, never via a real astro-ready signal.
- Fixed the tag to `container:<siteID>` and left a comment noting `RemoteSandboxSiteRuntime` should adopt the same tag scheme once it streams logs.
- Confirmed (and added a test for) the estimator's URL-parsing already tolerates the container's real `[astro] ...`-prefixed log line format, so no change was needed there.

## Test plan
- [x] `swift test --filter StartupProgressEstimatorTests` — all 15 tests pass, including the new container-prefix test.