### PR TITLE
fix(template): replace scaffold.sh heredoc with printf for .site-config

### DIFF
--- a/Resources/Template/scripts/scaffold.sh
+++ b/Resources/Template/scripts/scaffold.sh
@@ -46,15 +46,20 @@ rsync -a \
     "$TEMPLATE_ROOT/" "$TARGET/"
 
 # Stamp the scaffolded site with the Anglesite version and document config keys.
+#
+# Written with printf (not a heredoc): zsh implements heredocs via a scratch
+# file in the process's Darwin temp dir, which can fail to create in some
+# sandboxed/subprocess-spawned environments (#501). printf redirection writes
+# straight to $TARGET/.site-config with no intermediate temp file.
 VERSION="1.0.0"
-cat > "$TARGET/.site-config" <<SITECONFIG
-ANGLESITE_VERSION=$VERSION
-# SITE_URL=https://example.com        — site domain (used in feeds, sitemap, security.txt)
-# SECURITY_CONTACT=security@example.com — RFC 9116 security.txt contact (email or URI)
-# HSTS_PRELOAD=true                    — opt-in HSTS preload submission (hard to reverse)
-# SCRIPT_ALLOW=example.com             — additional CSP script-src domains (comma-separated)
-# BLOCK_AI=true                        — block AI training crawlers via robots.txt (off by default;
-#                                        trades away AI-search discoverability)
-SITECONFIG
+printf '%s\n' \
+    "ANGLESITE_VERSION=$VERSION" \
+    "# SITE_URL=https://example.com        — site domain (used in feeds, sitemap, security.txt)" \
+    "# SECURITY_CONTACT=security@example.com — RFC 9116 security.txt contact (email or URI)" \
+    "# HSTS_PRELOAD=true                    — opt-in HSTS preload submission (hard to reverse)" \
+    "# SCRIPT_ALLOW=example.com             — additional CSP script-src domains (comma-separated)" \
+    "# BLOCK_AI=true                        — block AI training crawlers via robots.txt (off by default;" \
+    "#                                        trades away AI-search discoverability)" \
+    > "$TARGET/.site-config"
 
 echo "==> Scaffolded Anglesite site in $TARGET"

--- a/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
@@ -159,6 +159,43 @@ final class SiteScaffolderTests: XCTestCase {
         XCTAssertEqual(step, "copyingTemplate")
     }
 
+    /// Resolve the real scaffold.sh from the in-repo template (Resources/Template/), mirroring
+    /// HomepageWriterTests.realIndexAstroURL()'s repo-root-relative lookup.
+    private static func realScaffoldScriptURL() -> URL {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        return repoRoot.appendingPathComponent("Resources/Template/scripts/scaffold.sh")
+    }
+
+    /// Regression coverage for #501: exercises the real scaffold.sh subprocess (not the mocked
+    /// CommandRunner the other tests use) to confirm .site-config is still generated correctly
+    /// now that the heredoc has been replaced with printf. Other tests in this file mock
+    /// scaffold.sh entirely, so they wouldn't catch a reintroduced heredoc-shaped regression here.
+    func testRealScaffoldScriptWritesSiteConfigWithoutHeredoc() throws {
+        let script = Self.realScaffoldScriptURL()
+        guard FileManager.default.fileExists(atPath: script.path) else {
+            throw XCTSkip("scaffold.sh not found at \(script.path)")
+        }
+        let target = tmpDir().appendingPathComponent("scaffold-test")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = [script.path, "--yes", target.path]
+        let stderrPipe = Pipe()
+        process.standardError = stderrPipe
+        try process.run()
+        process.waitUntilExit()
+
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        XCTAssertEqual(process.terminationStatus, 0, "scaffold.sh failed: \(stderr)")
+        XCTAssertFalse(stderr.contains("here document"), "heredoc scratch-file error reintroduced: \(stderr)")
+
+        let cfg = try String(contentsOf: target.appendingPathComponent(".site-config"), encoding: .utf8)
+        XCTAssertTrue(cfg.contains("ANGLESITE_VERSION=1.0.0"))
+        XCTAssertTrue(cfg.contains("# SITE_URL=https://example.com"))
+        XCTAssertTrue(cfg.contains("# BLOCK_AI=true"))
+    }
+
     func testGitInitFailureIsNonFatalAndStillRegisters() async throws {
         let root = tmpDir()
         let registered = OSAllocatedUnfairLock<Bool>(initialState: false)


### PR DESCRIPTION
## Summary

Fixes #501 — new-site creation was failing at the "Building your website..." step with:

```
scaffold.sh:50: can't create temp file for here document: operation not permitted
```

## Root cause

zsh implements heredocs (`<<EOF`) via a scratch file in the process's Darwin temp dir. That scratch-file creation was failing for the app's spawned scaffold subprocess (likely sandbox/subprocess-related — overriding `$TMPDIR` directly does not reproduce it, since this mechanism doesn't just read the env var). This blocked scaffolding any new site.

## Fix

Replaced the heredoc in `scaffold.sh` used to stamp `.site-config` with `printf` redirected straight into the target file. No intermediate temp file is created, so it's immune to whatever was breaking heredoc scratch-file creation. Output is byte-identical to the previous heredoc (verified by diffing generated `.site-config` contents).

## Test plan

- [x] Ran `scaffold.sh --yes <dir>` directly and confirmed `.site-config` output matches the old heredoc byte-for-byte
- [x] `swift test --filter SiteScaffolderTests` — 6/6 pass
- [ ] Manual repro of the original bug (File ▸ New ▸ Site…) — reporter's environment-specific; fix removes the failure mode at its source (no temp file created at all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)