### PR TITLE
docs(#81): update App Store container smoke

### DIFF
--- a/Resources/Anglesite.entitlements
+++ b/Resources/Anglesite.entitlements
@@ -6,9 +6,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<!-- The directly-spawned Node/astro dev server binds localhost; children inherit
-	     the app's sandbox profile, so the listen entitlement must live here
-	     (docs/specs/2026-05-28-node-sandbox-subspike-notes.md, Finding 3). -->
+	<!-- The container runtime exposes preview/MCP through app-owned loopback proxies. -->
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>

--- a/docs/qa/app-store-container-smoke-test.md
+++ b/docs/qa/app-store-container-smoke-test.md
@@ -1,0 +1,88 @@
+# App Store Container Runtime Smoke Test
+
+**Issue:** [#81](https://github.com/Anglesite/Anglesite-app/issues/81)  
+**Scope:** real-signed, write-heavy smoke for the single sandboxed `Anglesite` App Store target.  
+**Target runtime:** `LocalContainerSiteRuntime` through Apple Containerization.
+
+## Purpose
+
+Validate the release-signing shape that CI cannot exercise:
+
+- the App Store-sandboxed app carries the granted `com.apple.security.virtualization` entitlement;
+- the app selects `LocalContainerSiteRuntime`, not any retired host Node preview path;
+- preview, MCP/edit, image writes, build/preflight, deploy prompting, and teardown all work through the package security-scoped grant;
+- sandbox denials and container failures are visible in logs.
+
+This is an interactive author-run smoke. A no-signing or ad-hoc build is not sufficient.
+
+## Preconditions
+
+- Apple Silicon Mac on the supported macOS/Xcode versions.
+- Apple Development or distribution signing identity for the app team.
+- Provisioning profile that grants `com.apple.security.virtualization`.
+- Container artifacts provisioned in the app bundle, or equivalent release artifact path:
+  - `Resources/container-image/index.json`
+  - `Resources/container-kernel/vmlinux`
+  - `Resources/container-initfs/index.json`
+- Cloudflare token available if the deploy step should reach a real `wrangler deploy`.
+
+Run the local runtime probes first:
+
+```sh
+SIGN_IDENTITY="Apple Development: <name> (<TEAMID>)" scripts/run-container-probe.sh echo
+SIGN_IDENTITY="Apple Development: <name> (<TEAMID>)" scripts/run-container-probe.sh boot
+```
+
+Both must pass, or the App Store smoke is expected to fail at runtime startup.
+
+## Build Fixture And App
+
+Use the helper script to create the site fixture and a real-signed app:
+
+```sh
+DEVELOPMENT_TEAM=<TEAMID> scripts/create-smoke-fixture.sh
+```
+
+The script prints the built app path and the interactive steps. Copy the built app to `~/Applications/` before launching; signed sandboxed apps should not be launched from temporary build directories.
+
+## Smoke Matrix
+
+| Case | Result | Evidence |
+|---|---|---|
+| Real-signed app launches from `~/Applications` |  |  |
+| App signature has expected Team ID |  |  |
+| Provisioning profile grants `com.apple.security.virtualization` |  |  |
+| Imported fixture package opens with a security-scoped grant |  |  |
+| Runtime selection logs `LocalContainerSiteRuntime` |  |  |
+| No host Node preview fallback starts |  |  |
+| Preview loads through loopback proxy |  |  |
+| MCP/edit path applies a text edit through the in-container sidecar |  |  |
+| Image drop writes optimized assets under `Source/public/images/` |  |  |
+| Build/preflight/deploy path reaches the expected Cloudflare token or wrangler result |  |  |
+| Foundation Models chat is present |  |  |
+| GitHub `gh` settings/auth UI is absent in App Store build |  |  |
+| Window close tears down VM/proxies |  |  |
+| No relevant sandbox denials appear during the run |  |  |
+
+Use `PASS`, `FAIL`, or `N/A`, and record exact failure logs for every non-pass.
+
+## Log Capture
+
+In a separate terminal, capture sandbox denials while running the smoke:
+
+```sh
+log stream --predicate 'eventMessage CONTAINS "deny"' --style compact
+```
+
+Also save the app debug pane logs for these sources when present:
+
+- `runtime`
+- `container:<siteID>`
+- `deploy:<siteID>:build`
+- `deploy:<siteID>:preflight`
+- `deploy:<siteID>:wrangler`
+
+## Acceptance
+
+#81 can close when the matrix passes on a real-signed App Store-target build, or when every failure has a follow-up issue with captured logs and a clear owner.
+

--- a/docs/release.md
+++ b/docs/release.md
@@ -52,9 +52,9 @@ The script:
 
 1. runs `xcodegen generate`;
 2. archives the `Anglesite` scheme;
-3. verifies the bundled Node re-sign survived the archive;
-4. exports an App Store `.pkg`;
-5. validates and uploads with `xcrun altool`.
+3. verifies the archived app signature and Team ID;
+4. exports, and unless `--validate-only` uploads, an App Store `.pkg` via
+   `xcodebuild -exportArchive`.
 
 Use `--validate-only` to archive/export/validate without uploading. Transporter
 is still a valid manual fallback: drop the exported `.pkg` onto Transporter.app.

--- a/scripts/create-smoke-fixture.sh
+++ b/scripts/create-smoke-fixture.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 #
 # Creates a smoke-test Anglesite site at ~/Sites/anglesite-smoke/, populated
-# from the in-repo template (Resources/Template/) with `node_modules` installed.
+# from the in-repo template (Resources/Template/).
 #
 # Use this fixture to manually verify the sandboxed App Store app end-to-end.
 # A real-signed build is produced so the run exercises the App Sandbox, hardened
 # runtime signing, and local Apple Containerization capability gates.
 #
-# Idempotent: re-running mirrors any template changes and runs `npm install`
-# incrementally.
+# Idempotent: re-running mirrors any template changes. A local `npm install`
+# still runs to keep the fixture usable outside the app, but the App Store smoke
+# must validate the container-backed runtime path, not host Node.
 
 set -euo pipefail
 
@@ -126,8 +127,9 @@ cat <<EOF
 ✓ Smoke fixture ready: $FIXTURE_DIR
 ✓ Real-signed App Store app built: $APP
 
-  This is the load-bearing Phase 10.1 validation — it must run INTERACTIVELY
-  under the real signature (the sandbox/JIT entitlements aren't enforced ad-hoc).
+  This is the load-bearing Phase 10.1 / #81 validation — it must run
+  INTERACTIVELY under the real signature (the App Sandbox and virtualization
+  entitlement path are not representative under unsigned/no-signing builds).
 
   Launch the built app from a normal location (signed sandboxed apps refuse to
   run from /private/tmp):
@@ -142,19 +144,21 @@ cat <<EOF
        The save-panel Powerbox grant is the per-site security-scoped grant on the
        package (do NOT pre-inject a bookmark — a foreign process's scoped bookmark
        won't resolve in the app; cf. spike 6.5). It persists for next launch.
-    2. Preview should be served by the selected container runtime, not by a host
-       subprocess. The debug log must not mention LocalSiteRuntime.
-    3. Deploy button → build/preflight/deploy must run inside the container runtime
-       against the granted package's Source/, then the pre-deploy scan runs, or the
-       app must clearly report that container validation is unavailable. (A real
-       'wrangler deploy' needs a Cloudflare token; reaching the wrangler spawn is
-       the in-sandbox signal.)
+    2. Preview should be served by LocalContainerSiteRuntime, not by a host
+       subprocess. The debug log should include the runtime selection and must
+       not show any host Node preview fallback.
+    3. Deploy button → build/preflight/deploy must run against the granted
+       package's Source/ using the active container runtime where applicable,
+       then the pre-deploy scan runs. A real 'wrangler deploy' needs a Cloudflare
+       token; if no token is configured, capture the prompt/error instead of
+       treating it as a sandbox failure.
     4. Drag an image onto an <img> in the preview → bytes write to public/images/
        through the container-backed edit path. Record any sandbox denial.
     5. Close the window → runtime children reaped. Quit → no orphan runtime process.
-    6. Chat button must be ABSENT (compiled out of App Store); Settings → no GitHub
-       Connect row, and updates are handled by the App Store.
+    6. Foundation Models chat should be present. Settings → no GitHub Connect
+       row, and updates are handled by the App Store.
 
-  Capture PASS/FAIL per step (esp. #2 runtime selection and #3 container deploy path)
-  in a notes file; this is the validation evidence required before #70 merges.
+  Capture PASS/FAIL per step (especially #2 runtime selection, #3 deploy path,
+  #4 image-drop writes, and any sandbox denials) in a notes file; this is the
+  validation evidence required for #81 / Phase 10.1 closeout.
 EOF


### PR DESCRIPTION
## Summary
- add a #81 App Store container runtime smoke-test runbook
- update the smoke fixture script from host-Node/JIT-era language to local-container validation
- clean stale release/entitlement wording now that host Node is retired
- rewrite #81 itself to track the real-signed App Store container smoke and remove the stale node-runtime label

## Validation
- `bash -n scripts/create-smoke-fixture.sh`
- `bash -n scripts/run-container-probe.sh`
- `bash -n scripts/release.sh`
- `git diff --check`

## Notes
- This does not run the interactive signed smoke; it creates the current checklist and fixes stale guidance so the human-run pass has a precise target.

