### PR TITLE
Feature Request: Visual Site Graph Explorer #308

### DIFF
--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -50,6 +50,27 @@ final class SiteGraphExplorerModel {
         return filteredEdges.filter { $0.sourceID == selectedNodeID }
     }
 
+    var groupedFilteredNodes: [(kind: SiteGraphNodeKind, nodes: [SiteGraphNode])] {
+        let grouped = Dictionary(grouping: filteredNodes, by: \.kind)
+        return SiteGraphNodeKind.allCases.compactMap { kind in
+            let visibleNodes = (grouped[kind] ?? []).filter { node in
+                kind != .asset || node.referencedByCount > 0
+            }
+            guard !visibleNodes.isEmpty else { return nil }
+            return (kind, visibleNodes.sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending })
+        }
+    }
+
+    var unusedAssets: [SiteGraphNode] {
+        filteredNodes
+            .filter { $0.kind == .asset && $0.referencedByCount == 0 }
+            .sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+    }
+
+    var visibleSummary: String {
+        "\(filteredNodes.count) nodes, \(filteredEdges.count) links"
+    }
+
     func start(siteID: String, sourceDirectory: URL) {
         self.siteID = siteID
         self.sourceDirectory = sourceDirectory

--- a/Sources/AnglesiteApp/SiteGraphExplorerView.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerView.swift
@@ -7,6 +7,9 @@ struct SiteGraphExplorerView: View {
 
     var body: some View {
         HSplitView {
+            SiteGraphTree(model: model)
+                .frame(minWidth: 220, idealWidth: 260, maxWidth: 340)
+
             VStack(spacing: 0) {
                 SiteGraphToolbar(model: model)
                 Divider()
@@ -37,6 +40,9 @@ private struct SiteGraphToolbar: View {
             HStack(spacing: 8) {
                 Label("Site Graph", systemImage: "point.3.connected.trianglepath.dotted")
                     .font(.headline)
+                Text(model.visibleSummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 Spacer()
                 TextField("Search graph", text: $model.searchText)
                     .textFieldStyle(.roundedBorder)
@@ -60,6 +66,82 @@ private struct SiteGraphToolbar: View {
             .scrollIndicators(.hidden)
         }
         .padding(12)
+    }
+}
+
+private struct SiteGraphTree: View {
+    @Bindable var model: SiteGraphExplorerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Label("Explorer", systemImage: "list.bullet.indent")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            Divider()
+            List(selection: $model.selectedNodeID) {
+                ForEach(model.groupedFilteredNodes, id: \.kind) { group in
+                    Section {
+                        ForEach(group.nodes) { node in
+                            SiteGraphTreeRow(node: node)
+                                .tag(Optional(node.id))
+                        }
+                    } header: {
+                        Label(group.kind.title, systemImage: group.kind.systemImage)
+                    }
+                }
+                if !model.unusedAssets.isEmpty {
+                    Section {
+                        ForEach(model.unusedAssets) { node in
+                            SiteGraphTreeRow(node: node, badge: "unused")
+                                .tag(Optional(node.id))
+                        }
+                    } header: {
+                        Label("Unused Assets", systemImage: "exclamationmark.triangle")
+                    }
+                }
+            }
+            .listStyle(.sidebar)
+        }
+        .background(Color(NSColor.controlBackgroundColor))
+    }
+}
+
+private struct SiteGraphTreeRow: View {
+    let node: SiteGraphNode
+    var badge: String?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: node.kind.systemImage)
+                .foregroundStyle(node.kind.tint)
+                .frame(width: 16)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(node.title)
+                    .lineLimit(1)
+                if let detail = node.detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 4)
+            if let badge {
+                Text(badge)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            } else if node.referencedByCount > 0 {
+                Text("\(node.referencedByCount)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .help("\(node.referencedByCount) incoming references")
+            }
+        }
+        .help(node.filePath ?? node.detail ?? node.title)
     }
 }
 

--- a/Sources/AnglesiteCore/SiteGraphExplorer.swift
+++ b/Sources/AnglesiteCore/SiteGraphExplorer.swift
@@ -293,8 +293,6 @@ public enum SiteGraphExplorer {
             regex.matches(in: text, range: range).compactMap { match in
                 guard let found = Range(match.range(at: 1), in: text) else { return nil }
                 let value = String(text[found])
-                if value.hasPrefix("/") { return value }
-                if value.hasPrefix("public/") { return "/" + String(value.dropFirst("public".count + 1)) }
                 return value
             }
         }
@@ -313,6 +311,10 @@ public enum SiteGraphExplorer {
             return nodeIDByPublicPath["/" + String(value.dropFirst("public".count + 1))]
         }
         if value.hasPrefix("./") || value.hasPrefix("../") {
+            let base = (relativePath as NSString).deletingLastPathComponent
+            return nodeIDByRelativePath[normalizeRelativePath((base as NSString).appendingPathComponent(value))]
+        }
+        if !value.contains("://") && !value.hasPrefix("#") {
             let base = (relativePath as NSString).deletingLastPathComponent
             return nodeIDByRelativePath[normalizeRelativePath((base as NSString).appendingPathComponent(value))]
         }

--- a/Sources/AnglesiteCore/SiteGraphExplorer.swift
+++ b/Sources/AnglesiteCore/SiteGraphExplorer.swift
@@ -84,11 +84,11 @@ public enum SiteGraphExplorer {
         pattern: #"import\(\s*['"]([^'"]+)['"]\s*\)"#
     )
     private static let srcHrefRegex = try! NSRegularExpression(
-        pattern: #"\b(?:src|href)\s*=\s*["']([^"']+\.(?:jpg|jpeg|png|webp|gif|svg|avif))["']"#,
+        pattern: #"\b(?:src|href)\s*=\s*["']([^"']+\.(?:jpg|jpeg|png|webp|gif|svg|avif))(?:[?#][^"']*)?["']"#,
         options: [.caseInsensitive]
     )
     private static let urlAssetRegex = try! NSRegularExpression(
-        pattern: #"url\(\s*['"]?([^'")]+\.(?:jpg|jpeg|png|webp|gif|svg|avif))['"]?\s*\)"#,
+        pattern: #"url\(\s*['"]?([^'")]+\.(?:jpg|jpeg|png|webp|gif|svg|avif))(?:[?#][^'")]*)?['"]?\s*\)"#,
         options: [.caseInsensitive]
     )
 
@@ -304,15 +304,14 @@ public enum SiteGraphExplorer {
         nodeIDByRelativePath: [String: String],
         nodeIDByPublicPath: [String: String]
     ) -> String? {
+        if value.hasPrefix("//") {
+            return nil
+        }
         if value.hasPrefix("/") {
             return nodeIDByPublicPath[value]
         }
         if value.hasPrefix("public/") {
             return nodeIDByPublicPath["/" + String(value.dropFirst("public".count + 1))]
-        }
-        if value.hasPrefix("./") || value.hasPrefix("../") {
-            let base = (relativePath as NSString).deletingLastPathComponent
-            return nodeIDByRelativePath[normalizeRelativePath((base as NSString).appendingPathComponent(value))]
         }
         if !value.contains("://") && !value.hasPrefix("#") {
             let base = (relativePath as NSString).deletingLastPathComponent

--- a/Sources/AnglesiteCore/SiteGraphExplorer.swift
+++ b/Sources/AnglesiteCore/SiteGraphExplorer.swift
@@ -77,6 +77,9 @@ public enum SiteGraphExplorer {
     private static let sourceExtensions: Set<String> = [
         ".astro", ".md", ".mdx", ".markdown", ".js", ".jsx", ".ts", ".tsx", ".css"
     ]
+    private static let assetExtensions: Set<String> = [
+        ".jpg", ".jpeg", ".png", ".webp", ".gif", ".svg", ".avif"
+    ]
     private static let dynamicImportRegex = try! NSRegularExpression(
         pattern: #"import\(\s*['"]([^'"]+)['"]\s*\)"#
     )
@@ -165,9 +168,17 @@ public enum SiteGraphExplorer {
 
         for file in walk(projectRoot, fileManager: fileManager) {
             let relativePath = relativePosix(file, from: projectRoot)
-            guard sourceExtensions.contains(fileExtension(file)) else { continue }
             guard nodesByID[nodeIDByRelativePath[relativePath] ?? ""] == nil else { continue }
-            guard let kind = kind(for: relativePath) else { continue }
+            let ext = fileExtension(file)
+            let nodeKind: SiteGraphNodeKind?
+            if sourceExtensions.contains(ext) {
+                nodeKind = kind(for: relativePath)
+            } else if assetExtensions.contains(ext) {
+                nodeKind = .asset
+            } else {
+                nodeKind = nil
+            }
+            guard let kind = nodeKind else { continue }
             addNode(SiteGraphNode(
                 id: "\(siteID):file:\(relativePath)",
                 kind: kind,
@@ -194,12 +205,24 @@ public enum SiteGraphExplorer {
                     fileManager: fileManager
                 ) else { continue }
                 let targetKind = nodesByID[targetID]?.kind
-                let edgeKind: SiteGraphEdgeKind = targetKind == .layout ? .usesLayout : .imports
+                let edgeKind: SiteGraphEdgeKind
+                if targetKind == .layout {
+                    edgeKind = .usesLayout
+                } else if targetKind == .asset {
+                    edgeKind = .referencesAsset
+                } else {
+                    edgeKind = .imports
+                }
                 let edge = SiteGraphEdge(sourceID: node.id, targetID: targetID, kind: edgeKind)
                 edgesByID[edge.id] = edge
             }
             for assetPath in assetReferences(in: text) {
-                guard let targetID = nodeIDByPublicPath[assetPath] else { continue }
+                guard let targetID = resolveAssetReference(
+                    assetPath,
+                    from: filePath,
+                    nodeIDByRelativePath: nodeIDByRelativePath,
+                    nodeIDByPublicPath: nodeIDByPublicPath
+                ) else { continue }
                 let edge = SiteGraphEdge(sourceID: node.id, targetID: targetID, kind: .referencesAsset)
                 edgesByID[edge.id] = edge
             }
@@ -272,9 +295,28 @@ public enum SiteGraphExplorer {
                 let value = String(text[found])
                 if value.hasPrefix("/") { return value }
                 if value.hasPrefix("public/") { return "/" + String(value.dropFirst("public".count + 1)) }
-                return nil
+                return value
             }
         }
+    }
+
+    private static func resolveAssetReference(
+        _ value: String,
+        from relativePath: String,
+        nodeIDByRelativePath: [String: String],
+        nodeIDByPublicPath: [String: String]
+    ) -> String? {
+        if value.hasPrefix("/") {
+            return nodeIDByPublicPath[value]
+        }
+        if value.hasPrefix("public/") {
+            return nodeIDByPublicPath["/" + String(value.dropFirst("public".count + 1))]
+        }
+        if value.hasPrefix("./") || value.hasPrefix("../") {
+            let base = (relativePath as NSString).deletingLastPathComponent
+            return nodeIDByRelativePath[normalizeRelativePath((base as NSString).appendingPathComponent(value))]
+        }
+        return nil
     }
 
     private static func resolveImport(

--- a/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
@@ -120,6 +120,53 @@ struct SiteGraphExplorerTests {
         #expect(unused.referencedByCount == 0)
     }
 
+    @Test("source image imports create asset reference edges")
+    func sourceImageImportEdges() throws {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nimport hero from '../assets/hero.png';\n---\n<img src={hero.src} />",
+            "src/assets/hero.png": "PNG",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let page = try #require(graph.nodes.first { $0.kind == .page })
+        let hero = try #require(graph.nodes.first { $0.kind == .asset && $0.filePath == "src/assets/hero.png" })
+
+        #expect(graph.edges.contains {
+            $0.sourceID == page.id && $0.targetID == hero.id && $0.kind == .referencesAsset
+        })
+        #expect(hero.referencedByCount == 1)
+    }
+
+    @Test("relative src asset references resolve from source files")
+    func relativeAssetReferences() throws {
+        let root = makeSite([
+            "src/components/Hero.astro": "<img src=\"../assets/hero.webp\" />",
+            "src/assets/hero.webp": "WEBP",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let component = try #require(graph.nodes.first { $0.kind == .component })
+        let hero = try #require(graph.nodes.first { $0.kind == .asset && $0.filePath == "src/assets/hero.webp" })
+
+        #expect(graph.edges.contains {
+            $0.sourceID == component.id && $0.targetID == hero.id && $0.kind == .referencesAsset
+        })
+    }
+
     @Test("@ alias imports resolve to src-relative nodes")
     func aliasImports() throws {
         let root = makeSite([

--- a/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
@@ -167,6 +167,29 @@ struct SiteGraphExplorerTests {
         })
     }
 
+    @Test("bare relative src asset references resolve from source files")
+    func bareRelativeAssetReferences() throws {
+        let root = makeSite([
+            "src/components/Hero.astro": "<img src=\"hero.png\" />",
+            "src/components/hero.png": "PNG",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let component = try #require(graph.nodes.first { $0.kind == .component })
+        let hero = try #require(graph.nodes.first { $0.kind == .asset && $0.filePath == "src/components/hero.png" })
+
+        #expect(graph.edges.contains {
+            $0.sourceID == component.id && $0.targetID == hero.id && $0.kind == .referencesAsset
+        })
+    }
+
     @Test("@ alias imports resolve to src-relative nodes")
     func aliasImports() throws {
         let root = makeSite([

--- a/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
@@ -190,6 +190,48 @@ struct SiteGraphExplorerTests {
         })
     }
 
+    @Test("src references with a trailing query string or fragment still resolve")
+    func queryStringAssetReferences() throws {
+        let root = makeSite([
+            "src/pages/index.astro": "<img src=\"/images/hero.png?width=400\" />",
+            "public/images/hero.png": "PNG",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let page = try #require(graph.nodes.first { $0.kind == .page })
+        let hero = try #require(graph.nodes.first { $0.filePath == "public/images/hero.png" })
+
+        #expect(graph.edges.contains {
+            $0.sourceID == page.id && $0.targetID == hero.id && $0.kind == .referencesAsset
+        })
+        #expect(hero.referencedByCount == 1)
+    }
+
+    @Test("protocol-relative asset URLs are not treated as public-root paths")
+    func protocolRelativeAssetReferences() throws {
+        let root = makeSite([
+            "src/pages/index.astro": "<img src=\"//cdn.example.com/hero.png\" />",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+
+        #expect(!graph.edges.contains { $0.kind == .referencesAsset })
+    }
+
     @Test("@ alias imports resolve to src-relative nodes")
     func aliasImports() throws {
         let root = makeSite([


### PR DESCRIPTION
## Summary
- add an explorer tree beside the visual site graph, grouped by node kind with unused assets called out separately
- surface visible graph node/link counts and incoming-reference badges in the graph UI
- include source-side image assets in the graph and resolve imported or relative asset references as asset edges

## Verification
- swift build --package-path . --target AnglesiteCore
- git diff --check

## Notes
- swift test builds but cannot load test bundles on this host because the runtime FoundationModels.framework is missing a symbol compiled from the Xcode 27 SDK.
- xcodebuild was attempted but stalled at Resolve Package Graph in this environment.