### PR TITLE
feat(app): File ▸ Save/Revert menu commands + standard View commands

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -165,6 +165,12 @@ struct AnglesiteApp: App {
             }
 
             NewContentCommands()
+            // File ▸ Save ⌘S / Revert to Saved for the focused window's editors (#509).
+            SaveCommands()
+            // Standard View-menu items: Show/Hide Sidebar ⌃⌘S and Customize Toolbar… (#510).
+            // Customize Toolbar… stays inert until the toolbar adopts .toolbar(id:) — see #519.
+            SidebarCommands()
+            ToolbarCommands()
             CommandGroup(after: .newItem) {
                 Menu("Open Recent") {
                     ForEach(recent.sites) { site in

--- a/Sources/AnglesiteApp/InspectorContext.swift
+++ b/Sources/AnglesiteApp/InspectorContext.swift
@@ -2,8 +2,8 @@
 import Foundation
 import AnglesiteCore
 
-/// Shared surface the inspector chrome (load/save/conflict/⌘S) drives, so one chrome wraps both the
-/// typed descriptor form and the plain page metadata form.
+/// Shared surface the inspector chrome (load/save/conflict) and File ▸ Save (SaveCommands) drive,
+/// so one chrome wraps both the typed descriptor form and the plain page metadata form.
 @MainActor
 protocol InspectorEditorModel: AnyObject {
     var file: FileRef { get }

--- a/Sources/AnglesiteApp/MainPaneEditorView.swift
+++ b/Sources/AnglesiteApp/MainPaneEditorView.swift
@@ -55,9 +55,8 @@ struct MainPaneEditorView: View {
         .onChange(of: controlActiveState) { _, new in
             if new == .key { Task { await model.checkExternalChange() } }
         }
-        .background(
-            Button("") { Task { await model.save() } }.keyboardShortcut("s", modifiers: [.command]).hidden()
-        )
+        // ⌘S is File ▸ Save (SaveCommands), which saves via SiteWindowModel.saveAllEdits() — no
+        // per-view hidden shortcut button (it double-registered ⌘S alongside the inspector's, #509).
         .alert("\(model.file.name) changed on disk", isPresented: conflictBinding) {
             // Each button is solely responsible for resolving the conflict; the binding's setter has
             // NO side effect, so a system-initiated dismissal can't silently pick "Keep" (or race the

--- a/Sources/AnglesiteApp/PageInspectorView.swift
+++ b/Sources/AnglesiteApp/PageInspectorView.swift
@@ -4,7 +4,8 @@ import AnglesiteCore
 
 /// Right-hand inspector content for the selected page. Renders the typed descriptor form or the
 /// plain title/description form, wrapped in shared chrome (header + dirty/Save, off-main load,
-/// external-change conflict alert, ⌘S). Phase 1 has a single "Page" section; a tab picker for
+/// external-change conflict alert; ⌘S arrives via File ▸ Save, see SaveCommands). Phase 1 has a
+/// single "Page" section; a tab picker for
 /// selection-level editing comes in Phase 3.
 struct PageInspectorView: View {
     let context: InspectorContext
@@ -65,8 +66,8 @@ private struct InspectorChrome<M: InspectorEditorModel & Observable, Form: View>
         .onChange(of: controlActiveState) { _, new in
             if new == .key { Task { await model.checkExternalChange() } }
         }
-        .background(Button("") { Task { await model.save() } }
-            .keyboardShortcut("s", modifiers: [.command]).hidden())
+        // ⌘S is File ▸ Save (SaveCommands), which saves via SiteWindowModel.saveAllEdits() — no
+        // per-view hidden shortcut button (it double-registered ⌘S alongside the editor's, #509).
         .alert("\(model.file.name) changed on disk", isPresented: conflictBinding) {
             Button("Keep My Changes", role: .cancel) { model.keepMyChanges() }
             Button("Reload from Disk") { Task { await model.reloadFromDisk() } }

--- a/Sources/AnglesiteApp/SaveCommands.swift
+++ b/Sources/AnglesiteApp/SaveCommands.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+private struct FocusedSiteWindowModelKey: FocusedValueKey { typealias Value = SiteWindowModel }
+
+extension FocusedValues {
+    /// The focused site window's `SiteWindowModel`, published by `SiteWindow`. Lets menu commands
+    /// reach the window's editing surfaces (and, later, its site operations — #511) without
+    /// owning them.
+    var siteWindowModel: SiteWindowModel? {
+        get { self[FocusedSiteWindowModelKey.self] }
+        set { self[FocusedSiteWindowModelKey.self] = newValue }
+    }
+}
+
+/// File ▸ Save / Revert to Saved for the focused site window's editing surfaces (main-pane editor
+/// and inspector). Replaces the hidden per-view ⌘S buttons, which double-registered the shortcut
+/// whenever the editor and inspector were both on screen (#509).
+struct SaveCommands: Commands {
+    // SwiftUI exposes `.focusedSceneValue(...)` as the publishing modifier; command readers still
+    // use `@FocusedValue`. There is no `@FocusedSceneValue` property wrapper in the macOS 27 SDK.
+    @FocusedValue(\.siteWindowModel) private var siteWindowModel
+
+    var body: some Commands {
+        // Anchored to .importExport, not .saveItem: in a non-DocumentGroup app the .saveItem
+        // placement is dead — both `replacing:` and `after:` render nothing (verified empirically
+        // on the macOS 27 SDK). .importExport demonstrably works (ExportSiteCommands), and
+        // `before:` puts Save/Revert between Close and Export Site Source…, matching the
+        // File-menu order of Apple's document apps.
+        CommandGroup(before: .importExport) {
+            Button("Save") {
+                guard let model = siteWindowModel else { return }
+                Task { await model.saveAllEdits() }
+            }
+            .keyboardShortcut("s")
+            .disabled(siteWindowModel?.hasUnsavedEdits != true)
+
+            Button("Revert to Saved") {
+                siteWindowModel?.requestRevertToSaved()
+            }
+            .disabled(siteWindowModel?.hasUnsavedEdits != true)
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -72,7 +72,11 @@ struct SiteWindow: View {
         .onChange(of: model.preview.state) { _, newState in
             model.startup.ingest(state: newState)
         }
-        .focusedValue(\.siteID, model.site?.id ?? siteID)
+        // `focusedSceneValue`, not `focusedValue`: keyboard focus often sits in an AppKit responder
+        // (the WKWebView preview) where nothing in SwiftUI's focus system is focused, so a plain
+        // focusedValue resolves to nil and File ▸ Export Site Source… stays disabled even with the
+        // site window frontmost (same trap documented for `\.preview` below).
+        .focusedSceneValue(\.siteID, model.site?.id ?? siteID)
         .focusedSceneValue(\.newContentActions, model.site == nil ? nil : NewContentActions(
             newPage: { model.newPagePresented = true },
             newCollection: { model.newCollectionPresented = true }
@@ -82,6 +86,9 @@ struct SiteWindow: View {
         // responder), so nothing in SwiftUI's focus system is focused and a plain `focusedValue`
         // would resolve to nil — leaving "Show Web Inspector" perpetually disabled.
         .focusedSceneValue(\.preview, model.preview)
+        // Publishes the whole window model so menu commands (File ▸ Save/Revert today, the Site
+        // menu in #511) can reach the focused window's editing surfaces and site operations.
+        .focusedSceneValue(\.siteWindowModel, model)
         .onDisappear { model.close() }
     }
 
@@ -444,6 +451,12 @@ struct SiteWindow: View {
                         }
                     }
             }
+        }
+        .alert("Revert to the last saved version?", isPresented: $bindableModel.revertConfirmationPresented) {
+            Button("Revert", role: .destructive) { Task { await model.confirmRevertToSaved() } }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Unsaved changes in the editor and inspector will be discarded.")
         }
         .sheet(isPresented: $bindableModel.newPagePresented) {
             NewPageSheet(site: site) { title, route, template in

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -84,6 +84,9 @@ final class SiteWindowModel {
     var dependencyUpdateModel: DependencyUpdateModel?
     var newPagePresented = false
     var newCollectionPresented = false
+    /// File ▸ Revert to Saved is destructive, so it routes through a confirmation alert hosted by
+    /// `SiteWindow` (#509).
+    var revertConfirmationPresented = false
     var navigator: SiteNavigatorModel?
     var graphExplorer: SiteGraphExplorerModel
     var mainPaneMode: MainPaneMode = .preview
@@ -217,6 +220,47 @@ final class SiteWindowModel {
     /// model raises its conflict alert) when the file changed externally — so the caller aborts the
     /// switch instead of clobbering the other tool's edit. Safe to call when not editing. Async
     /// because the save/check IO runs off the main actor.
+    /// True when the main-pane editor or the inspector holds unsaved edits — drives File ▸ Save /
+    /// Revert to Saved enablement (#509).
+    var hasUnsavedEdits: Bool {
+        let editorDirty = switch activeEditor {
+        case .text(let model): model.isDirty
+        case .plist(let model): model.isDirty
+        case nil: false
+        }
+        return editorDirty || (inspectorContext?.model.isDirty ?? false)
+    }
+
+    /// File ▸ Save. Writes every dirty editing surface: a page's content (main-pane editor) and its
+    /// metadata (inspector) are one document to the user, so Save covers both. Each model's `save()`
+    /// no-ops when clean.
+    func saveAllEdits() async {
+        switch activeEditor {
+        case .text(let model): await model.save()
+        case .plist(let model): await model.save()
+        case nil: break
+        }
+        if let model = inspectorContext?.model { await model.save() }
+    }
+
+    /// File ▸ Revert to Saved: present the confirmation alert (no-op when nothing is dirty, so a
+    /// stale-enabled menu item can't surface a pointless prompt).
+    func requestRevertToSaved() {
+        guard hasUnsavedEdits else { return }
+        revertConfirmationPresented = true
+    }
+
+    /// Discard unsaved edits by re-reading each dirty surface from disk. Uses `load()` — not
+    /// `reloadFromDisk()`, which is conflict-flow-specific and no-ops without a pending conflict.
+    func confirmRevertToSaved() async {
+        switch activeEditor {
+        case .text(let model) where model.isDirty: await model.load()
+        case .plist(let model) where model.isDirty: await model.load()
+        default: break
+        }
+        if let model = inspectorContext?.model, model.isDirty { await model.load() }
+    }
+
     func leaveCurrentEditor() async -> Bool {
         guard case .editor = mainPaneMode else { return true }
         switch activeEditor {

--- a/Sources/AnglesiteApp/WebInspectorCommands.swift
+++ b/Sources/AnglesiteApp/WebInspectorCommands.swift
@@ -25,7 +25,9 @@ struct WebInspectorCommands: Commands {
             Button("Show Web Inspector") {
                 focusedPreview?.showWebInspector()
             }
-            .keyboardShortcut("i", modifiers: [.command, .option])
+            // ⌥⇧⌘I, not ⌥⌘I: the HIG-standard inspector shortcut ⌥⌘I is reserved for the page
+            // Inspector toggle (#512); the web developer tool takes the shifted variant (#510).
+            .keyboardShortcut("i", modifiers: [.command, .option, .shift])
             .disabled(focusedPreview == nil)
         }
     }


### PR DESCRIPTION
First slice of the menu-bar epic #518. Closes #509, closes #510.

## What

- **File ▸ Save ⌘S / Revert to Saved** (`SaveCommands`, new): drives `SiteWindowModel.saveAllEdits()` / `confirmRevertToSaved()` across both editing surfaces (main-pane editor `.text`/`.plist` + inspector), published via a new `\.siteWindowModel` focused scene value — the same pipe #511's Site menu will use. Deletes the two hidden per-view ⌘S buttons (`MainPaneEditorView`, `InspectorChrome`) that double-registered the shortcut when editor and inspector were both visible. Revert is destructive → confirmation alert in `SiteWindow`. The plist editor gains a working ⌘S it never had.
- **`SidebarCommands()` + `ToolbarCommands()`**: Show/Hide Sidebar ⌃⌘S and Customize Toolbar… (inert until #519 adopts `.toolbar(id:)`, as planned).
- **⌥⌘I decision (#510)**: Show Web Inspector moves to **⌥⇧⌘I**, reserving HIG-standard ⌥⌘I for the page Inspector toggle (#512).
- **Drive-by fix**: `siteID` now published with `focusedSceneValue` — the plain `focusedValue` resolved nil whenever keyboard focus sat in an AppKit responder, leaving **File ▸ Export Site Source… permanently disabled** (verified live before/after).

## Implementation notes

- `CommandGroup(replacing:/after: .saveItem)` renders **nothing** in a non-DocumentGroup app (verified empirically on the macOS 27 SDK); Save/Revert anchor `before: .importExport`, landing between Close and Export — TextEdit's File-menu order.
- Revert uses `load()`, not `reloadFromDisk()` — the latter is conflict-flow-specific (`reloadFromConflict` no-ops without a pending conflict).

## Verification

Drove the built app end-to-end via UI automation: menu items present and correctly disabled when clean; dirtying `global.css` enables Save/Revert (Observation-driven enablement works); Revert shows the confirmation alert and discards the buffer; ⌘S fires through the menu and saves (dirty dot clears); test site left byte-identical (`git status` clean). `xcodebuild` green; full `swift test` suite passed pre-change and no SwiftPM-target files changed after that run (all edits are app-target; a re-run hit .build cache-lock contention with parallel agent sessions in sibling worktrees).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
