### PR TITLE
feat(app): Site menu — deploy, backup, audit, and site ops in the menu bar

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -196,6 +196,8 @@ struct AnglesiteApp: App {
             }
             // Export is its own Commands type so @FocusedValue tracks scene focus (see ExportSiteCommands).
             ExportSiteCommands()
+            // Site menu: the site window's primary operations (#511).
+            SiteMenuCommands()
             // "Show Web Inspector" in the View menu — its own Commands type for the same focus reason.
             WebInspectorCommands()
             // Debug pane lives off the View menu — `⌥⌘D` keeps it discoverable without crowding

--- a/Sources/AnglesiteApp/FileEditorModel.swift
+++ b/Sources/AnglesiteApp/FileEditorModel.swift
@@ -52,10 +52,17 @@ final class FileEditorModel {
         }
     }
 
+    /// True while `save()`'s off-main write is in flight. Read by
+    /// `SiteWindowModel.editCommandInFlight` so File ▸ Save / Revert to Saved disable instead of
+    /// racing the write with a concurrent `load()` (PR #532 review).
+    private(set) var isSaving = false
+
     /// Explicit ⌘S / Save. Writes off the main actor. Returns true when the buffer is clean afterward.
     @discardableResult
     func save() async -> Bool {
-        guard isDirty else { return true }
+        guard isDirty, !isSaving else { return true }
+        isSaving = true
+        defer { isSaving = false }
         let url = file.url
         let contents = text
         do {

--- a/Sources/AnglesiteApp/InspectorContext.swift
+++ b/Sources/AnglesiteApp/InspectorContext.swift
@@ -8,6 +8,9 @@ import AnglesiteCore
 protocol InspectorEditorModel: AnyObject {
     var file: FileRef { get }
     var isDirty: Bool { get }
+    /// True while a save's off-main write is in flight — File ▸ Save / Revert disable during it
+    /// rather than racing the write with a concurrent `load()` (PR #532 review).
+    var isSaving: Bool { get }
     var loadError: String? { get }
     var isLoading: Bool { get }
     var conflictDiskContents: String? { get set }

--- a/Sources/AnglesiteApp/PageMetadataModel.swift
+++ b/Sources/AnglesiteApp/PageMetadataModel.swift
@@ -18,8 +18,9 @@ final class PageMetadataModel: InspectorEditorModel {
     private var savedMetadata = PageMetadata(title: "", description: "")
     private var fileSession = EditableFileSession()
     private var contents: String { fileSession.savedContents }
-    /// Guards against a concurrent second `save()` capturing a stale `contents` base.
-    private var isSaving = false
+    /// Guards against a concurrent second `save()` capturing a stale `contents` base. `private(set)`
+    /// so `SiteWindowModel.editCommandInFlight` can read it (PR #532 review).
+    private(set) var isSaving = false
     private(set) var loadError: String?
     private(set) var isLoading = false
     var conflictDiskContents: String? {

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -100,10 +100,16 @@ final class PlistEditorModel {
         }
     }
 
+    /// True while `save()`'s off-main write is in flight — same contract as
+    /// `FileEditorModel.isSaving` (analytics writes have their own `isSavingAnalytics`).
+    private(set) var isSaving = false
+
     @discardableResult
     func save() async -> Bool {
-        guard isDirty else { return true }
+        guard isDirty, !isSaving else { return true }
         guard validationMessage == nil else { return false }
+        isSaving = true
+        defer { isSaving = false }
         let url = file.url
         let entries = entriesForSaving()
         do {

--- a/Sources/AnglesiteApp/SaveCommands.swift
+++ b/Sources/AnglesiteApp/SaveCommands.swift
@@ -27,17 +27,19 @@ struct SaveCommands: Commands {
         // `before:` puts Save/Revert between Close and Export Site Source…, matching the
         // File-menu order of Apple's document apps.
         CommandGroup(before: .importExport) {
+            // Both items also disable while a save/revert is already in flight — a revert racing a
+            // slow in-flight save would desync the buffer from disk (PR #532 review).
             Button("Save") {
                 guard let model = siteWindowModel else { return }
                 Task { await model.saveAllEdits() }
             }
             .keyboardShortcut("s")
-            .disabled(siteWindowModel?.hasUnsavedEdits != true)
+            .disabled(siteWindowModel?.hasUnsavedEdits != true || siteWindowModel?.editCommandInFlight == true)
 
             Button("Revert to Saved") {
                 siteWindowModel?.requestRevertToSaved()
             }
-            .disabled(siteWindowModel?.hasUnsavedEdits != true)
+            .disabled(siteWindowModel?.hasUnsavedEdits != true || siteWindowModel?.editCommandInFlight == true)
         }
     }
 }

--- a/Sources/AnglesiteApp/SiteMenuCommands.swift
+++ b/Sources/AnglesiteApp/SiteMenuCommands.swift
@@ -17,7 +17,7 @@ struct SiteMenuCommands: Commands {
                 .disabled(model?.canRunDeploy != true)
 
             Button("Recheck Deploy Readiness") { model?.recheckHealth() }
-                .disabled(model?.site == nil)
+                .disabled(model?.canRecheckHealth != true)
 
             Button("Backup") { model?.backupSite() }
                 .disabled(model?.canRunBackup != true)
@@ -34,13 +34,13 @@ struct SiteMenuCommands: Commands {
             Divider()
 
             Button("Domain…") { model?.domain.openSheet() }
-                .disabled(model == nil || model?.domain.isRunning == true)
+                .disabled(model?.canOpenDomain != true)
 
             Button("Add Integration…") { model?.openIntegrationWizard() }
-                .disabled(model?.site == nil)
+                .disabled(model?.canOpenIntegrationWizard != true)
 
             Button("Siri AI Readiness…") { model?.openSiriReadiness() }
-                .disabled(model?.canOpenSiriReadiness != true || model?.site == nil)
+                .disabled(model?.canOpenSiriReadiness != true)
 
             #if !ANGLESITE_MAS
             // Same identity swap as the toolbar: menus rebuild on every open, so a state-dependent
@@ -52,20 +52,20 @@ struct SiteMenuCommands: Commands {
                     guard let model, let site = model.site else { return }
                     model.publish.publish(source: site.sourceDirectory, repoName: site.name)
                 }
-                .disabled(model?.site?.isValid != true || model?.publish.isRunning == true)
+                .disabled(model?.canPublishToGitHub != true)
             }
             #endif
 
             Divider()
 
             Button("Open in Browser") { model?.openPreviewInBrowser() }
-                .disabled(model?.preview.readyURL == nil)
+                .disabled(model?.canOpenPreviewInBrowser != true)
 
             Button("Show Site Graph") {
                 guard let model else { return }
                 Task { await model.showGraph() }
             }
-            .disabled(model?.site == nil)
+            .disabled(model?.canShowGraph != true)
         }
     }
 }

--- a/Sources/AnglesiteApp/SiteMenuCommands.swift
+++ b/Sources/AnglesiteApp/SiteMenuCommands.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import AppKit
+
+/// The Site menu: the focused site window's primary operations, mirroring the toolbar so every
+/// action has a menu home and a keyboard path (#511). Reads the `\.siteWindowModel` focused scene
+/// value (SaveCommands.swift); every item disables when no site window is focused. Enablement
+/// mirrors the toolbar via the shared `canRun…` properties on `SiteWindowModel`.
+struct SiteMenuCommands: Commands {
+    @FocusedValue(\.siteWindowModel) private var model
+
+    var body: some Commands {
+        // SwiftUI inserts a CommandMenu between the View and Window menus — the standard spot
+        // for an app-domain menu.
+        CommandMenu("Site") {
+            Button("Deploy") { model?.deploySite() }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
+                .disabled(model?.canRunDeploy != true)
+
+            Button("Recheck Deploy Readiness") { model?.recheckHealth() }
+                .disabled(model?.site == nil)
+
+            Button("Backup") { model?.backupSite() }
+                .disabled(model?.canRunBackup != true)
+
+            Divider()
+
+            Button("Audit") { model?.auditSite() }
+                .disabled(model?.canRunAudit != true)
+
+            // Ellipsis items open a sheet for further input, per the HIG.
+            Button("Harden…") { model?.harden.openSheet() }
+                .disabled(model?.canRunHarden != true)
+
+            Divider()
+
+            Button("Domain…") { model?.domain.openSheet() }
+                .disabled(model == nil || model?.domain.isRunning == true)
+
+            Button("Add Integration…") { model?.openIntegrationWizard() }
+                .disabled(model?.site == nil)
+
+            Button("Siri AI Readiness…") { model?.openSiriReadiness() }
+                .disabled(model?.canOpenSiriReadiness != true || model?.site == nil)
+
+            #if !ANGLESITE_MAS
+            // Same identity swap as the toolbar: menus rebuild on every open, so a state-dependent
+            // item is fine here (unlike the customizable toolbar, see #519).
+            if let remote = model?.publish.existingRemote {
+                Button("View on GitHub") { NSWorkspace.shared.open(remote.url) }
+            } else {
+                Button("Publish to GitHub…") {
+                    guard let model, let site = model.site else { return }
+                    model.publish.publish(source: site.sourceDirectory, repoName: site.name)
+                }
+                .disabled(model?.site?.isValid != true || model?.publish.isRunning == true)
+            }
+            #endif
+
+            Divider()
+
+            Button("Open in Browser") { model?.openPreviewInBrowser() }
+                .disabled(model?.preview.readyURL == nil)
+
+            Button("Show Site Graph") {
+                guard let model else { return }
+                Task { await model.showGraph() }
+            }
+            .disabled(model?.site == nil)
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -300,7 +300,7 @@ struct SiteWindow: View {
                     } label: {
                         Label("Publish to GitHub", systemImage: "square.and.arrow.up.on.square")
                     }
-                    .disabled(model.publish.isRunning || !site.isValid)
+                    .disabled(!model.canPublishToGitHub)
                     .help(site.isValid ? "Create a private GitHub repo and push this site" : "Site is missing required files")
                 }
             }
@@ -339,6 +339,7 @@ struct SiteWindow: View {
                 } label: {
                     Label("Add Integration…", systemImage: "puzzlepiece.extension")
                 }
+                .disabled(!model.canOpenIntegrationWizard)
                 .help("Set up a third-party integration for this site")
             }
             .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
@@ -350,7 +351,7 @@ struct SiteWindow: View {
                     Label("Domain", systemImage: "globe")
                 }
                 .help("View and manage this domain's DNS records")
-                .disabled(model.domain.isRunning)
+                .disabled(!model.canOpenDomain)
             }
             .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
         }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -194,11 +194,11 @@ struct SiteWindow: View {
 
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    model.backup.backup(siteID: site.id, siteDirectory: site.sourceDirectory)
+                    model.backupSite()
                 } label: {
                     Label("Backup", systemImage: "externaldrive.fill.badge.icloud")
                 }
-                .disabled(model.backup.isRunning || model.audit.isRunning || model.deploy.isRunning || !site.isValid)
+                .disabled(!model.canRunBackup)
                 .help(site.isValid
                       ? "Commit and push working-tree changes to your current branch"
                       : "Site is missing required files")
@@ -215,7 +215,7 @@ struct SiteWindow: View {
                         Label("Harden", systemImage: "shield.lefthalf.filled")
                     }
                 }
-                .disabled(model.harden.isRunning || !site.isValid)
+                .disabled(!model.canRunHarden)
                 .help(site.isValid
                       ? "Preview and apply Cloudflare security hardening for this site"
                       : "Site is missing required files")
@@ -224,7 +224,7 @@ struct SiteWindow: View {
 
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    model.audit.audit(siteID: site.id, siteDirectory: site.sourceDirectory)
+                    model.auditSite()
                 } label: {
                     if model.audit.isRunning {
                         Label("Auditing…", systemImage: "magnifyingglass")
@@ -232,7 +232,7 @@ struct SiteWindow: View {
                         Label("Audit", systemImage: "checkmark.shield.fill")
                     }
                 }
-                .disabled(model.audit.isRunning || model.backup.isRunning || model.deploy.isRunning || !site.isValid)
+                .disabled(!model.canRunAudit)
                 .help(site.isValid
                       ? "Run the structured accessibility audit against this site"
                       : "Site is missing required files")
@@ -309,15 +309,12 @@ struct SiteWindow: View {
 
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    Task { @MainActor in
-                        let cc = await model.preview.activeContainerControl()
-                        model.deploy.deploy(siteID: site.id, siteDirectory: site.sourceDirectory, containerControl: cc)
-                    }
+                    model.deploySite()
                 } label: {
                     Label("Deploy", systemImage: "paperplane.fill")
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(model.deploy.isRunning || model.backup.isRunning || model.audit.isRunning || !site.isValid || !model.preview.canDeploy)
+                .disabled(!model.canRunDeploy)
                 .help(site.isValid && model.preview.canDeploy
                       ? "Build, scan, and run wrangler deploy on this site"
                       : site.isValid

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -160,7 +160,7 @@ final class SiteWindowModel {
     }
 
     var canOpenSiriReadiness: Bool {
-        contentIndexerStore.indexer != nil
+        contentIndexerStore.indexer != nil && site != nil
     }
 
     func openIntegrationWizard() {
@@ -232,6 +232,14 @@ final class SiteWindowModel {
     var canRunBackup: Bool { site?.isValid == true && !siteOperationRunning }
     var canRunAudit: Bool { site?.isValid == true && !siteOperationRunning }
     var canRunHarden: Bool { site?.isValid == true && !harden.isRunning }
+    var canRecheckHealth: Bool { site != nil }
+    var canOpenDomain: Bool { site != nil && !domain.isRunning }
+    var canOpenIntegrationWizard: Bool { site != nil }
+    var canOpenPreviewInBrowser: Bool { preview.readyURL != nil }
+    var canShowGraph: Bool { site != nil }
+    #if !ANGLESITE_MAS
+    var canPublishToGitHub: Bool { site?.isValid == true && !publish.isRunning }
+    #endif
 
     /// Build, scan, and `wrangler deploy` — resolves the active container control first, like the
     /// toolbar button always has.
@@ -264,23 +272,48 @@ final class SiteWindowModel {
     }
 
     /// True when the main-pane editor or the inspector holds unsaved edits — drives File ▸ Save /
-    /// Revert to Saved enablement (#509).
+    /// Revert to Saved enablement (#509). The `.plist` editor has two independent dirty flags:
+    /// plist entries (`isDirty`) and analytics settings (`isAnalyticsDirty`) — both count, matching
+    /// `PlistEditorModel.flushBeforeLeaving()` (PR #532 review).
     var hasUnsavedEdits: Bool {
         let editorDirty = switch activeEditor {
         case .text(let model): model.isDirty
-        case .plist(let model): model.isDirty
+        case .plist(let model): model.isDirty || model.isAnalyticsDirty
         case nil: false
         }
         return editorDirty || (inspectorContext?.model.isDirty ?? false)
     }
 
+    /// True while any save/revert IO is in flight on either editing surface. File ▸ Save / Revert
+    /// disable during it: none of the editor models guard `load()` against a concurrent in-flight
+    /// `save()`, so a revert racing a slow save could desync the buffer from disk (PR #532 review).
+    var editCommandInFlight: Bool {
+        if menuEditCommandRunning { return true }
+        switch activeEditor {
+        case .text(let model): if model.isSaving { return true }
+        case .plist(let model): if model.isSaving || model.isSavingAnalytics { return true }
+        case nil: break
+        }
+        return inspectorContext?.model.isSaving ?? false
+    }
+
+    /// Serializes File ▸ Save / Revert themselves (the per-model `isSaving` flags only cover each
+    /// model's own write).
+    private var menuEditCommandRunning = false
+
     /// File ▸ Save. Writes every dirty editing surface: a page's content (main-pane editor) and its
     /// metadata (inspector) are one document to the user, so Save covers both. Each model's `save()`
-    /// no-ops when clean.
+    /// no-ops when clean; the plist editor's analytics settings save separately (`saveAnalytics()`).
     func saveAllEdits() async {
+        guard !menuEditCommandRunning else { return }
+        menuEditCommandRunning = true
+        defer { menuEditCommandRunning = false }
         switch activeEditor {
-        case .text(let model): await model.save()
-        case .plist(let model): await model.save()
+        case .text(let model):
+            await model.save()
+        case .plist(let model):
+            await model.save()
+            if model.isAnalyticsDirty { await model.saveAnalytics() }
         case nil: break
         }
         if let model = inspectorContext?.model { await model.save() }
@@ -289,16 +322,21 @@ final class SiteWindowModel {
     /// File ▸ Revert to Saved: present the confirmation alert (no-op when nothing is dirty, so a
     /// stale-enabled menu item can't surface a pointless prompt).
     func requestRevertToSaved() {
-        guard hasUnsavedEdits else { return }
+        guard hasUnsavedEdits, !editCommandInFlight else { return }
         revertConfirmationPresented = true
     }
 
     /// Discard unsaved edits by re-reading each dirty surface from disk. Uses `load()` — not
     /// `reloadFromDisk()`, which is conflict-flow-specific and no-ops without a pending conflict.
+    /// `load()` also re-reads the plist editor's analytics settings, so the `isAnalyticsDirty`
+    /// surface reverts too.
     func confirmRevertToSaved() async {
+        guard !menuEditCommandRunning else { return }
+        menuEditCommandRunning = true
+        defer { menuEditCommandRunning = false }
         switch activeEditor {
         case .text(let model) where model.isDirty: await model.load()
-        case .plist(let model) where model.isDirty: await model.load()
+        case .plist(let model) where model.isDirty || model.isAnalyticsDirty: await model.load()
         default: break
         }
         if let model = inspectorContext?.model, model.isDirty { await model.load() }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -220,6 +220,49 @@ final class SiteWindowModel {
     /// model raises its conflict alert) when the file changed externally — so the caller aborts the
     /// switch instead of clobbering the other tool's edit. Safe to call when not editing. Async
     /// because the save/check IO runs off the main actor.
+    // MARK: - Site operations (shared by the toolbar and the Site menu, #511)
+
+    /// Deploy, Backup, and Audit are mutually exclusive: each is unavailable while any of the
+    /// three runs (matches the long-standing toolbar behavior).
+    private var siteOperationRunning: Bool {
+        deploy.isRunning || backup.isRunning || audit.isRunning
+    }
+
+    var canRunDeploy: Bool { site?.isValid == true && !siteOperationRunning && preview.canDeploy }
+    var canRunBackup: Bool { site?.isValid == true && !siteOperationRunning }
+    var canRunAudit: Bool { site?.isValid == true && !siteOperationRunning }
+    var canRunHarden: Bool { site?.isValid == true && !harden.isRunning }
+
+    /// Build, scan, and `wrangler deploy` — resolves the active container control first, like the
+    /// toolbar button always has.
+    func deploySite() {
+        guard let site, canRunDeploy else { return }
+        Task { @MainActor in
+            let containerControl = await preview.activeContainerControl()
+            deploy.deploy(siteID: site.id, siteDirectory: site.sourceDirectory, containerControl: containerControl)
+        }
+    }
+
+    func backupSite() {
+        guard let site, canRunBackup else { return }
+        backup.backup(siteID: site.id, siteDirectory: site.sourceDirectory)
+    }
+
+    func auditSite() {
+        guard let site, canRunAudit else { return }
+        audit.audit(siteID: site.id, siteDirectory: site.sourceDirectory)
+    }
+
+    func recheckHealth() {
+        guard let site else { return }
+        health.recheck(siteID: site.id, siteDirectory: site.sourceDirectory)
+    }
+
+    func openPreviewInBrowser() {
+        guard let url = preview.readyURL else { return }
+        NSWorkspace.shared.open(url)
+    }
+
     /// True when the main-pane editor or the inspector holds unsaved edits — drives File ▸ Save /
     /// Revert to Saved enablement (#509).
     var hasUnsavedEdits: Bool {

--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -23,8 +23,9 @@ final class TypedEntryEditorModel: InspectorEditorModel {
     private var contents: String { fileSession.savedContents } // last-loaded/saved file text (verbatim base)
     private var numberDrafts: [String: String] = [:]
     /// Guards against a concurrent second `save()` capturing a stale `contents` base while an
-    /// earlier save is still in flight (e.g. ⌘S mash, or a teardown flush racing a save).
-    private var isSaving = false
+    /// earlier save is still in flight (e.g. ⌘S mash, or a teardown flush racing a save). `private(set)`
+    /// so `SiteWindowModel.editCommandInFlight` can read it (PR #532 review).
+    private(set) var isSaving = false
     private(set) var loadError: String?
     private(set) var isLoading = false
     var conflictDiskContents: String? {


### PR DESCRIPTION
Second slice of the menu-bar epic #518, stacked on #532. Closes #511.

## What

A **Site** menu (between View and Window) giving every site-window toolbar action a menu home and keyboard path:

Deploy **⇧⌘D** · Recheck Deploy Readiness · Backup · — · Audit · Harden… · — · Domain… · Add Integration… · Siri AI Readiness… · Publish to GitHub…/View on GitHub (non-MAS builds) · — · Open in Browser · Show Site Graph

It reads the `\.siteWindowModel` focused scene value introduced in #532; every item disables when no site window is focused.

## Shared enablement

`canRunDeploy/Backup/Audit/Harden` and `deploySite()/backupSite()/auditSite()/recheckHealth()/openPreviewInBrowser()` now live on `SiteWindowModel`, and the **toolbar buttons call the same entry points** — menu and toolbar enablement can't diverge (the mutual-exclusion rule between Deploy/Backup/Audit is stated once).

## Verification

Drove the built app (`-derivedDataPath` build): Site menu present in the right spot; enablement mirrors window state exactly — Deploy greyed (no preview runtime → `canDeploy` false), Open in Browser greyed (no ready URL), the rest enabled; GitHub items correctly compiled out of the MAS target; Show Site Graph via the menu switches the main pane to the graph. Build green; all edits are app-target only (SwiftPM suites unaffected since their last full green run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
