### PR TITLE
Dead asset & orphaned content detection (#310)

### DIFF
--- a/Sources/AnglesiteApp/ProjectCleanupModel.swift
+++ b/Sources/AnglesiteApp/ProjectCleanupModel.swift
@@ -13,6 +13,15 @@ final class ProjectCleanupModel {
     private(set) var hasScanned = false
     var deleteError: String?
 
+    /// True while a scan or delete is in flight. Serializes this model's git/filesystem
+    /// operations: without it, a fast user (or a second call site) could trigger a concurrent
+    /// scan + delete, or two deletes, racing on the same `Source/` git repo and producing
+    /// confusing spurious `.git/index.lock` failures. Everything here is already
+    /// `@MainActor`-isolated, so this is defense-in-depth rather than a correctness fix for a
+    /// data race — but it closes the "nothing actually prevents this" gap outright rather than
+    /// relying solely on the UI's own button-disabled state.
+    private(set) var isBusy = false
+
     /// Ids ignored this session only — matches `RelatedPagesModel.ignored`'s "not persisted in
     /// v0" precedent. A fresh app launch re-surfaces a still-unreferenced file.
     private var ignored = Set<String>()
@@ -41,10 +50,12 @@ final class ProjectCleanupModel {
     }
 
     /// Runs (or re-runs) the full cleanup scan. On-demand only — never called automatically.
+    /// No-ops (rather than queuing) if a scan or delete is already in flight.
     func scan() async {
-        guard let siteID, let sourceDirectory else { return }
+        guard let siteID, let sourceDirectory, !isBusy else { return }
+        isBusy = true
         isScanning = true
-        defer { isScanning = false }
+        defer { isBusy = false; isScanning = false }
 
         await knowledgeIndex.rebuild(siteID: siteID, projectRoot: sourceDirectory)
         let documents = await knowledgeIndex.documents(siteID: siteID)
@@ -67,15 +78,26 @@ final class ProjectCleanupModel {
     }
 
     /// Deletes `candidate` via `git rm` + commit. On failure, sets `deleteError` and leaves the
-    /// candidate listed and the file untouched — never falls back to a non-git raw delete.
-    /// Returns whether the delete succeeded, so callers (`SiteWindowModel`) can react — e.g.
-    /// closing an editor tab open on the now-deleted file — only on real success.
+    /// candidate listed — never falls back to a non-git raw delete. Returns whether the delete
+    /// succeeded, so callers (`SiteWindowModel`) can react — e.g. closing an editor tab open on
+    /// the now-deleted file — only on real success. No-ops if a scan or delete is already in
+    /// flight (see `isBusy`).
     @discardableResult
     func delete(_ candidate: DeadAssetScanner.CleanupCandidate) async -> Bool {
-        guard let sourceDirectory else { return false }
+        guard let sourceDirectory, !isBusy else { return false }
+        isBusy = true
+        defer { isBusy = false }
         let message = "Remove unused \(candidate.kind.rawValue): \(candidate.path)"
         guard await gitDelete(sourceDirectory, candidate.path, message) != nil else {
-            deleteError = "Couldn't delete \(candidate.path). Check for uncommitted changes and try again."
+            // Distinguish an ordinary refusal (nothing touched — dirty tree, no HEAD copy, no
+            // git identity) from the rare double-failure case (commit AND its rollback both
+            // failed): if the file is already gone from disk, that's the more urgent state, and
+            // the generic "try again" message would be actively misleading.
+            let stillOnDisk = FileManager.default.fileExists(
+                atPath: sourceDirectory.appendingPathComponent(candidate.path).path)
+            deleteError = stillOnDisk
+                ? "Couldn't delete \(candidate.path). Check for uncommitted changes and try again."
+                : "\(candidate.path) may have been removed from disk without a commit recording it. Check git status in this site's Source folder before continuing."
             return false
         }
         candidates.removeAll { $0.id == candidate.id }

--- a/Sources/AnglesiteApp/ProjectCleanupModel.swift
+++ b/Sources/AnglesiteApp/ProjectCleanupModel.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the Navigator's "Cleanup" section for one site window: on-demand scan, session-only
+/// ignore set, and git-tracked delete. App glue only — all detection/merge logic under test lives
+/// in `AnglesiteCore` (`DeadAssetScanner`, `ProjectCleanupReport`).
+@MainActor
+@Observable
+final class ProjectCleanupModel {
+    private(set) var candidates: [DeadAssetScanner.CleanupCandidate] = []
+    private(set) var isScanning = false
+    private(set) var hasScanned = false
+    var deleteError: String?
+
+    /// Ids ignored this session only — matches `RelatedPagesModel.ignored`'s "not persisted in
+    /// v0" precedent. A fresh app launch re-surfaces a still-unreferenced file.
+    private var ignored = Set<String>()
+    private var siteID: String?
+    private var sourceDirectory: URL?
+
+    private let knowledgeIndex: SiteKnowledgeIndex
+    private let contentGraph: SiteContentGraph
+    private let gitDelete: NativeContentOperations.GitDelete
+
+    init(
+        knowledgeIndex: SiteKnowledgeIndex,
+        contentGraph: SiteContentGraph,
+        gitDelete: @escaping NativeContentOperations.GitDelete = NativeContentOperations.processGitDelete
+    ) {
+        self.knowledgeIndex = knowledgeIndex
+        self.contentGraph = contentGraph
+        self.gitDelete = gitDelete
+    }
+
+    /// Records which site this model scans. Cheap — does no I/O. Called once per site open from
+    /// `SiteWindowModel.loadAndStart()`.
+    func configure(siteID: String, sourceDirectory: URL) {
+        self.siteID = siteID
+        self.sourceDirectory = sourceDirectory
+    }
+
+    /// Runs (or re-runs) the full cleanup scan. On-demand only — never called automatically.
+    func scan() async {
+        guard let siteID, let sourceDirectory else { return }
+        isScanning = true
+        defer { isScanning = false }
+
+        await knowledgeIndex.rebuild(siteID: siteID, projectRoot: sourceDirectory)
+        let documents = await knowledgeIndex.documents(siteID: siteID)
+        let images = await contentGraph.images(for: siteID)
+
+        let report = await Task.detached(priority: .utility) {
+            let deadAssets = DeadAssetScanner.scan(projectRoot: sourceDirectory, images: images)
+            let orphanPages = LinkGraph.analyze(documents: documents).orphanPages
+            return ProjectCleanupReport.build(deadAssets: deadAssets, orphanPages: orphanPages)
+        }.value
+
+        candidates = report.filter { !ignored.contains($0.id) }
+        hasScanned = true
+    }
+
+    /// Dismisses `candidate` for the rest of this session without touching disk.
+    func ignore(_ candidate: DeadAssetScanner.CleanupCandidate) {
+        ignored.insert(candidate.id)
+        candidates.removeAll { $0.id == candidate.id }
+    }
+
+    /// Deletes `candidate` via `git rm` + commit. On failure, sets `deleteError` and leaves the
+    /// candidate listed and the file untouched — never falls back to a non-git raw delete.
+    func delete(_ candidate: DeadAssetScanner.CleanupCandidate) async {
+        guard let sourceDirectory else { return }
+        let message = "Remove unused \(candidate.kind.rawValue): \(candidate.path)"
+        guard await gitDelete(sourceDirectory, candidate.path, message) != nil else {
+            deleteError = "Couldn't delete \(candidate.path). Check for uncommitted changes and try again."
+            return
+        }
+        candidates.removeAll { $0.id == candidate.id }
+    }
+}

--- a/Sources/AnglesiteApp/ProjectCleanupModel.swift
+++ b/Sources/AnglesiteApp/ProjectCleanupModel.swift
@@ -68,13 +68,17 @@ final class ProjectCleanupModel {
 
     /// Deletes `candidate` via `git rm` + commit. On failure, sets `deleteError` and leaves the
     /// candidate listed and the file untouched — never falls back to a non-git raw delete.
-    func delete(_ candidate: DeadAssetScanner.CleanupCandidate) async {
-        guard let sourceDirectory else { return }
+    /// Returns whether the delete succeeded, so callers (`SiteWindowModel`) can react — e.g.
+    /// closing an editor tab open on the now-deleted file — only on real success.
+    @discardableResult
+    func delete(_ candidate: DeadAssetScanner.CleanupCandidate) async -> Bool {
+        guard let sourceDirectory else { return false }
         let message = "Remove unused \(candidate.kind.rawValue): \(candidate.path)"
         guard await gitDelete(sourceDirectory, candidate.path, message) != nil else {
             deleteError = "Couldn't delete \(candidate.path). Check for uncommitted changes and try again."
-            return
+            return false
         }
         candidates.removeAll { $0.id == candidate.id }
+        return true
     }
 }

--- a/Sources/AnglesiteApp/ProjectCleanupModel.swift
+++ b/Sources/AnglesiteApp/ProjectCleanupModel.swift
@@ -82,9 +82,22 @@ final class ProjectCleanupModel {
     /// succeeded, so callers (`SiteWindowModel`) can react — e.g. closing an editor tab open on
     /// the now-deleted file — only on real success. No-ops if a scan or delete is already in
     /// flight (see `isBusy`).
+    ///
+    /// Also refuses if `candidate` is no longer in the current `candidates` list: the Cleanup
+    /// section's confirmation dialog captures a `CleanupCandidate` snapshot at the moment the user
+    /// opens it, but a rescan can complete while that dialog is still showing (rows stay
+    /// interactive during a scan; only the Scan/Rescan button disables) — and the dialog has no
+    /// way to know its snapshot is stale. Re-validating against the live list here, right before
+    /// the destructive action, means a confirm on a since-rescanned-out candidate (no longer
+    /// flagged unused, already deleted, already ignored) is refused instead of deleting a file the
+    /// latest scan says is actually still in use.
     @discardableResult
     func delete(_ candidate: DeadAssetScanner.CleanupCandidate) async -> Bool {
         guard let sourceDirectory, !isBusy else { return false }
+        guard candidates.contains(where: { $0.id == candidate.id }) else {
+            deleteError = "\(candidate.path) is no longer in the Cleanup list — it may have been rescanned, ignored, or already deleted. Rescan and try again."
+            return false
+        }
         isBusy = true
         defer { isBusy = false }
         let message = "Remove unused \(candidate.kind.rawValue): \(candidate.path)"

--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -71,6 +71,17 @@ final class SiteGraphExplorerModel {
         observeTask = nil
     }
 
+    /// Forces an immediate re-scan using the already-stored `siteID`/`sourceDirectory` from the
+    /// last `start(...)`, without touching the observe-task subscription. Used after a mutation
+    /// this model has no other way to learn about — e.g. a Cleanup delete, which doesn't touch
+    /// `SiteContentGraph` for component/layout candidates, so nothing would otherwise trigger a
+    /// refresh and a deleted node would stay open-able (and, if edited and saved, resurrect the
+    /// file via a raw non-git write).
+    func refreshNow() async {
+        guard let siteID, let sourceDirectory else { return }
+        await refresh(siteID: siteID, sourceDirectory: sourceDirectory)
+    }
+
     func setKind(_ kind: SiteGraphNodeKind, enabled: Bool) {
         if enabled {
             enabledKinds.insert(kind)

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -19,6 +19,8 @@ final class SiteNavigatorModel {
 
     private var sourceDirectory: URL?
     private var websiteTitle: String?
+    private var siteID: String?
+    private var siteRoot: URL?
     private let renameService = NavigatorRenameService()
 
     private let graph: SiteContentGraph
@@ -31,6 +33,8 @@ final class SiteNavigatorModel {
     func start(siteID: String, siteRoot: URL, sourceDirectory: URL, websiteTitle: String) {
         self.sourceDirectory = sourceDirectory
         self.websiteTitle = websiteTitle
+        self.siteID = siteID
+        self.siteRoot = siteRoot
         // Cancel any prior observer (window reuse: SwiftUI can replay a different site into the
         // same window) BEFORE starting the new one, so a stale refresh can't overwrite the new
         // site's sections. The initial load runs as the new task's first step, so it is tracked
@@ -51,6 +55,17 @@ final class SiteNavigatorModel {
     func stop() {
         observeTask?.cancel()
         observeTask = nil
+    }
+
+    /// Forces an immediate re-scan using the already-stored `siteID`/`siteRoot` from the last
+    /// `start(...)`, without touching the observe-task subscription. Used after a mutation this
+    /// model has no other way to learn about — e.g. a Cleanup delete, which doesn't touch
+    /// `SiteContentGraph` for component/layout candidates, so nothing would otherwise trigger a
+    /// refresh and a deleted file would stay selectable/openable (and, if edited and saved,
+    /// resurrect the file via a raw non-git write).
+    func refreshNow() async {
+        guard let siteID, let siteRoot else { return }
+        await refresh(siteID: siteID, siteRoot: siteRoot)
     }
 
     func target(for id: String) -> NavigatorTarget? {

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -152,7 +152,7 @@ struct SiteNavigatorView: View {
                     cleanup.isScanning ? "Scanning…" : "Scan for Cleanup Opportunities",
                     systemImage: "sparkle.magnifyingglass")
             }
-            .disabled(cleanup.isScanning)
+            .disabled(cleanup.isBusy)
         } else if cleanup.candidates.isEmpty {
             Text("No unused files found")
                 .foregroundStyle(.secondary)
@@ -175,7 +175,7 @@ struct SiteNavigatorView: View {
             } label: {
                 Label(cleanup.isScanning ? "Scanning…" : "Rescan", systemImage: "arrow.clockwise")
             }
-            .disabled(cleanup.isScanning)
+            .disabled(cleanup.isBusy)
         }
     }
 

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -5,7 +5,10 @@ import AnglesiteCore
 /// changes and either navigates the preview or opens the editor.
 struct SiteNavigatorView: View {
     @Bindable var model: SiteNavigatorModel
+    @Bindable var cleanup: ProjectCleanupModel
+    var onOpenCleanupCandidate: (DeadAssetScanner.CleanupCandidate) -> Void
     @FocusState private var editingFocused: Bool
+    @State private var candidateToDelete: DeadAssetScanner.CleanupCandidate?
 
     var body: some View {
         List(selection: $model.selection) {
@@ -20,6 +23,13 @@ struct SiteNavigatorView: View {
                     ForEach(section.items) { item in
                         row(for: item, in: section)
                     }
+                }
+            }
+            // Only shown once the site has real content — an empty new site keeps the plain
+            // "No content yet" overlay rather than stacking a Cleanup prompt underneath it.
+            if !model.sections.isEmpty {
+                Section("Cleanup") {
+                    cleanupContent
                 }
             }
         }
@@ -52,6 +62,34 @@ struct SiteNavigatorView: View {
             presenting: model.renameError
         ) { _ in
             Button("OK", role: .cancel) { model.renameError = nil }
+        } message: { msg in
+            Text(msg)
+        }
+        .confirmationDialog(
+            candidateToDelete.map(deleteConfirmationTitle) ?? "",
+            isPresented: Binding(
+                get: { candidateToDelete != nil },
+                set: { if !$0 { candidateToDelete = nil } }),
+            titleVisibility: .visible,
+            presenting: candidateToDelete
+        ) { candidate in
+            Button("Delete", role: .destructive) {
+                Task { await cleanup.delete(candidate) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { candidate in
+            Text(candidate.kind == .page
+                ? "This page has no incoming links. Its content will be removed from the working tree. This can be undone via git."
+                : "This file appears unused. It will be removed from the working tree. This can be undone via git.")
+        }
+        .alert(
+            "Delete failed",
+            isPresented: Binding(
+                get: { cleanup.deleteError != nil },
+                set: { if !$0 { cleanup.deleteError = nil } }),
+            presenting: cleanup.deleteError
+        ) { _ in
+            Button("OK", role: .cancel) { cleanup.deleteError = nil }
         } message: { msg in
             Text(msg)
         }
@@ -97,5 +135,54 @@ struct SiteNavigatorView: View {
         case .styles: return "paintbrush"
         case .metadata: return "globe"
         }
+    }
+
+    @ViewBuilder
+    private var cleanupContent: some View {
+        if !cleanup.hasScanned {
+            Button {
+                Task { await cleanup.scan() }
+            } label: {
+                Label(
+                    cleanup.isScanning ? "Scanning…" : "Scan for Cleanup Opportunities",
+                    systemImage: "sparkle.magnifyingglass")
+            }
+            .disabled(cleanup.isScanning)
+        } else if cleanup.candidates.isEmpty {
+            Text("No unused files found")
+                .foregroundStyle(.secondary)
+        } else {
+            ForEach(cleanup.candidates) { candidate in
+                Label(candidate.path, systemImage: cleanupIcon(for: candidate.kind))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .contextMenu {
+                        Button("Open") { onOpenCleanupCandidate(candidate) }
+                        Button("Ignore") { cleanup.ignore(candidate) }
+                        Button("Delete", role: .destructive) { candidateToDelete = candidate }
+                    }
+            }
+            Button {
+                Task { await cleanup.scan() }
+            } label: {
+                Label(cleanup.isScanning ? "Scanning…" : "Rescan", systemImage: "arrow.clockwise")
+            }
+            .disabled(cleanup.isScanning)
+        }
+    }
+
+    private func cleanupIcon(for kind: DeadAssetScanner.CleanupCandidate.Kind) -> String {
+        switch kind {
+        case .component: return "square.stack.3d.up"
+        case .layout: return "rectangle.stack"
+        case .image: return "photo"
+        case .page: return "doc.richtext"
+        }
+    }
+
+    private func deleteConfirmationTitle(for candidate: DeadAssetScanner.CleanupCandidate) -> String {
+        candidate.kind == .page
+            ? "Delete “\(candidate.path)”?"
+            : "Delete unused \(candidate.kind.rawValue) “\(candidate.path)”?"
     }
 }

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -7,8 +7,13 @@ struct SiteNavigatorView: View {
     @Bindable var model: SiteNavigatorModel
     @Bindable var cleanup: ProjectCleanupModel
     var onOpenCleanupCandidate: (DeadAssetScanner.CleanupCandidate) -> Void
+    var onDeleteCleanupCandidate: (DeadAssetScanner.CleanupCandidate) async -> Void
     @FocusState private var editingFocused: Bool
     @State private var candidateToDelete: DeadAssetScanner.CleanupCandidate?
+    /// The title shown in the confirmation dialog. Held separately from `candidateToDelete` so the
+    /// title stays stable through the dismiss animation — reading `candidateToDelete`'s property
+    /// directly would collapse to "" the instant the dialog clears the optional.
+    @State private var candidateToDeleteTitle: String = ""
 
     var body: some View {
         List(selection: $model.selection) {
@@ -66,7 +71,7 @@ struct SiteNavigatorView: View {
             Text(msg)
         }
         .confirmationDialog(
-            candidateToDelete.map(deleteConfirmationTitle) ?? "",
+            candidateToDeleteTitle,
             isPresented: Binding(
                 get: { candidateToDelete != nil },
                 set: { if !$0 { candidateToDelete = nil } }),
@@ -74,7 +79,7 @@ struct SiteNavigatorView: View {
             presenting: candidateToDelete
         ) { candidate in
             Button("Delete", role: .destructive) {
-                Task { await cleanup.delete(candidate) }
+                Task { await onDeleteCleanupCandidate(candidate) }
             }
             Button("Cancel", role: .cancel) {}
         } message: { candidate in
@@ -159,7 +164,10 @@ struct SiteNavigatorView: View {
                     .contextMenu {
                         Button("Open") { onOpenCleanupCandidate(candidate) }
                         Button("Ignore") { cleanup.ignore(candidate) }
-                        Button("Delete", role: .destructive) { candidateToDelete = candidate }
+                        Button("Delete", role: .destructive) {
+                            candidateToDeleteTitle = deleteConfirmationTitle(for: candidate)
+                            candidateToDelete = candidate
+                        }
                     }
             }
             Button {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -97,7 +97,8 @@ struct SiteWindow: View {
                 SiteNavigatorView(
                     model: navigator,
                     cleanup: model.cleanup,
-                    onOpenCleanupCandidate: { model.openCleanupCandidate($0) }
+                    onOpenCleanupCandidate: { model.openCleanupCandidate($0) },
+                    onDeleteCleanupCandidate: { await model.deleteCleanupCandidate($0) }
                 )
                     .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 360)
                     .onChange(of: navigator.selection) { _, newID in

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -94,7 +94,11 @@ struct SiteWindow: View {
             set: { sidebarVisible = ($0 != .detailOnly) }
         )) {
             if let navigator = model.navigator {
-                SiteNavigatorView(model: navigator)
+                SiteNavigatorView(
+                    model: navigator,
+                    cleanup: model.cleanup,
+                    onOpenCleanupCandidate: { model.openCleanupCandidate($0) }
+                )
                     .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 360)
                     .onChange(of: navigator.selection) { _, newID in
                         model.applyNavigatorSelection(newID)

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -403,16 +403,23 @@ final class SiteWindowModel {
     }
 
     /// Deletes a Cleanup-section candidate and, on success, discards (without saving) any editor
-    /// tab currently open on that same file — flushing it via the normal leave-editor path would
-    /// re-write the buffer to disk and silently resurrect the file `cleanup.delete` just removed.
+    /// tab *or* Inspector context currently open on that same file — flushing either via its
+    /// normal leave path would re-write the buffer to disk and silently resurrect the file
+    /// `cleanup.delete` just removed. A page selected via the navigator's `.route` branch
+    /// populates `inspectorContext` (not `activeEditor`), so both must be checked independently.
     @MainActor
     func deleteCleanupCandidate(_ candidate: DeadAssetScanner.CleanupCandidate) async {
         guard let site else { return }
         let deletedURL = site.sourceDirectory.appendingPathComponent(candidate.path)
         let succeeded = await cleanup.delete(candidate)
-        guard succeeded, activeEditorFile?.url == deletedURL else { return }
-        activeEditor = nil
-        mainPaneMode = .preview
+        guard succeeded else { return }
+        if activeEditorFile?.url == deletedURL {
+            activeEditor = nil
+            mainPaneMode = .preview
+        }
+        if inspectorContext?.model.file.url == deletedURL {
+            inspectorContext = nil
+        }
     }
 
     /// Build the inspector context for a content navigator id: the typed descriptor form when the

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -416,6 +416,13 @@ final class SiteWindowModel {
     /// the delete subsequently fails, an unsaved edit in that editor/inspector is already gone
     /// even though the file itself is untouched — accepted as strictly preferable to a silent,
     /// undetected resurrection of a file git already recorded as removed.
+    ///
+    /// On success, also force-refreshes `navigator` and `graphExplorer`: neither observes anything
+    /// that fires for a component/layout/page deleted this way (the only thing that does,
+    /// `SiteContentGraph`, is never touched here), so without this a stale entry for the deleted
+    /// file would stay selectable/openable in the main Navigator tree or the Site Graph explorer —
+    /// the same resurrection risk this method just closed for the editor/inspector, reachable
+    /// through a different surface.
     @MainActor
     func deleteCleanupCandidate(_ candidate: DeadAssetScanner.CleanupCandidate) async {
         guard let site else { return }
@@ -427,7 +434,9 @@ final class SiteWindowModel {
         if inspectorContext?.model.file.url == deletedURL {
             inspectorContext = nil
         }
-        _ = await cleanup.delete(candidate)
+        guard await cleanup.delete(candidate) else { return }
+        await navigator?.refreshNow()
+        await graphExplorer.refreshNow()
     }
 
     /// Build the inspector context for a content navigator id: the typed descriptor form when the

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -413,9 +413,11 @@ final class SiteWindowModel {
     /// other main-actor action (the Preview/Editor toggle, closing the window) could otherwise
     /// flush a still-open dirty buffer back to disk while the delete is in flight or immediately
     /// after, resurrecting the file. Discarding first closes that window entirely. Tradeoff: if
-    /// the delete subsequently fails, an unsaved edit in that editor/inspector is already gone
-    /// even though the file itself is untouched — accepted as strictly preferable to a silent,
-    /// undetected resurrection of a file git already recorded as removed.
+    /// the delete subsequently fails, an unsaved edit in that editor/inspector is already gone —
+    /// in the ordinary failure case (dirty tree, no HEAD copy, rejecting hook) the file itself is
+    /// still untouched, though not in the rare double-failure case `processGitDelete` itself logs
+    /// (commit *and* its rollback both fail). Either way this is accepted as strictly preferable
+    /// to a silent, undetected resurrection of a file git already recorded as removed.
     ///
     /// On success, also force-refreshes `navigator` and `graphExplorer`: neither observes anything
     /// that fires for a component/layout/page deleted this way (the only thing that does,

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -425,6 +425,16 @@ final class SiteWindowModel {
     /// file would stay selectable/openable in the main Navigator tree or the Site Graph explorer —
     /// the same resurrection risk this method just closed for the editor/inspector, reachable
     /// through a different surface.
+    ///
+    /// **Known residual risk:** the guards above only cover editor/inspector state open *at the
+    /// moment this method starts*. Nothing stops a *new* selection on `deletedURL` from
+    /// (re)populating `activeEditor`/`inspectorContext` while `cleanup.delete` is still suspended
+    /// on its git subprocess calls — the Navigator isn't disabled or told a delete is in flight for
+    /// this path. Closing that fully would need a "deleting" set consulted by
+    /// `applyNavigatorSelection`/`openFile`/`openCleanupCandidate`, or disabling Navigator
+    /// selection for the duration; not attempted here given how narrow the window is in practice
+    /// (a `git rm` + `commit` pair, not user-perceptible latency) relative to the scope of that
+    /// change.
     @MainActor
     func deleteCleanupCandidate(_ candidate: DeadAssetScanner.CleanupCandidate) async {
         guard let site else { return }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -66,6 +66,9 @@ final class SiteWindowModel {
     var chatPresented = false
     var relatedPages: RelatedPagesModel
     var relatedPagesPresented = false
+    /// Drives the Navigator's "Cleanup" section. On-demand only — `scan()` is never called
+    /// automatically, only from the Navigator's "Scan for Cleanup Opportunities" action.
+    var cleanup: ProjectCleanupModel
     var harden = HardenModel()
     var domain = DomainModel()
     var health = HealthModel(runner: DefaultHealthCheckRunner())
@@ -119,6 +122,7 @@ final class SiteWindowModel {
         )
         self.graphExplorer = SiteGraphExplorerModel(graph: contentGraph)
         self.relatedPages = RelatedPagesModel(index: knowledgeIndex, ranker: semanticRanker)
+        self.cleanup = ProjectCleanupModel(knowledgeIndex: knowledgeIndex, contentGraph: contentGraph)
     }
 
     var activeEditorFile: FileRef? {
@@ -380,6 +384,24 @@ final class SiteWindowModel {
         }
     }
 
+    /// Routes a Cleanup-section row: components/layouts/pages open in the existing in-app editor
+    /// (reusing `openFile`, so `.astro` components still get the rich Component Editor via
+    /// `EditorKind.resolve`'s `.components`-group check); images have no in-app editor, so Open
+    /// reveals the file in Finder instead.
+    @MainActor
+    func openCleanupCandidate(_ candidate: DeadAssetScanner.CleanupCandidate) {
+        guard let site else { return }
+        let url = site.sourceDirectory.appendingPathComponent(candidate.path)
+        switch candidate.kind {
+        case .image:
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        case .component, .layout:
+            openFile(FileRef(url: url, group: .components, name: url.lastPathComponent))
+        case .page:
+            openFile(FileRef(url: url, group: .pages, name: url.lastPathComponent))
+        }
+    }
+
     /// Build the inspector context for a content navigator id: the typed descriptor form when the
     /// file resolves to a content type, the plain title/description form for a frontmatter-bearing
     /// markdown page, or nil (plain `.astro`/other → preview only, no inspector).
@@ -553,6 +575,7 @@ final class SiteWindowModel {
         )
         navigator = navModel
         graphExplorer.start(siteID: resolved.id, sourceDirectory: resolved.sourceDirectory)
+        cleanup.configure(siteID: resolved.id, sourceDirectory: resolved.sourceDirectory)
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
         applyPendingNavigation(for: resolved.id)

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -402,17 +402,24 @@ final class SiteWindowModel {
         }
     }
 
-    /// Deletes a Cleanup-section candidate and, on success, discards (without saving) any editor
-    /// tab *or* Inspector context currently open on that same file — flushing either via its
-    /// normal leave path would re-write the buffer to disk and silently resurrect the file
-    /// `cleanup.delete` just removed. A page selected via the navigator's `.route` branch
-    /// populates `inspectorContext` (not `activeEditor`), so both must be checked independently.
+    /// Deletes a Cleanup-section candidate, discarding (without saving) any editor tab *or*
+    /// Inspector context open on that same file — flushing either via its normal leave path would
+    /// re-write the buffer to disk and silently resurrect the file `cleanup.delete` removes. A
+    /// page selected via the navigator's `.route` branch populates `inspectorContext` (not
+    /// `activeEditor`), so both are checked independently.
+    ///
+    /// Discarded *before* calling `cleanup.delete`, not after: `delete` suspends across two
+    /// awaited git subprocess calls, and Swift frees the `@MainActor` during that suspension — any
+    /// other main-actor action (the Preview/Editor toggle, closing the window) could otherwise
+    /// flush a still-open dirty buffer back to disk while the delete is in flight or immediately
+    /// after, resurrecting the file. Discarding first closes that window entirely. Tradeoff: if
+    /// the delete subsequently fails, an unsaved edit in that editor/inspector is already gone
+    /// even though the file itself is untouched — accepted as strictly preferable to a silent,
+    /// undetected resurrection of a file git already recorded as removed.
     @MainActor
     func deleteCleanupCandidate(_ candidate: DeadAssetScanner.CleanupCandidate) async {
         guard let site else { return }
         let deletedURL = site.sourceDirectory.appendingPathComponent(candidate.path)
-        let succeeded = await cleanup.delete(candidate)
-        guard succeeded else { return }
         if activeEditorFile?.url == deletedURL {
             activeEditor = nil
             mainPaneMode = .preview
@@ -420,6 +427,7 @@ final class SiteWindowModel {
         if inspectorContext?.model.file.url == deletedURL {
             inspectorContext = nil
         }
+        _ = await cleanup.delete(candidate)
     }
 
     /// Build the inspector context for a content navigator id: the typed descriptor form when the

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -402,6 +402,19 @@ final class SiteWindowModel {
         }
     }
 
+    /// Deletes a Cleanup-section candidate and, on success, discards (without saving) any editor
+    /// tab currently open on that same file — flushing it via the normal leave-editor path would
+    /// re-write the buffer to disk and silently resurrect the file `cleanup.delete` just removed.
+    @MainActor
+    func deleteCleanupCandidate(_ candidate: DeadAssetScanner.CleanupCandidate) async {
+        guard let site else { return }
+        let deletedURL = site.sourceDirectory.appendingPathComponent(candidate.path)
+        let succeeded = await cleanup.delete(candidate)
+        guard succeeded, activeEditorFile?.url == deletedURL else { return }
+        activeEditor = nil
+        mainPaneMode = .preview
+    }
+
     /// Build the inspector context for a content navigator id: the typed descriptor form when the
     /// file resolves to a content type, the plain title/description form for a frontmatter-bearing
     /// markdown page, or nil (plain `.astro`/other → preview only, no inspector).

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -12,14 +12,15 @@ import Foundation
 /// re-exports, tsconfig `extends` scoping).
 ///
 /// The top-level `scripts/` directory (dev-only tooling — the Component Editor's preview harness,
-/// pre-deploy checks) is excluded from the reference scan entirely — a path-prefix check in
-/// `scan`, not the general `excludedDirNames` set, precisely because a nested directory like
-/// `src/scripts/` (real sites commonly hold client-side JS there) must still be scanned. This
-/// matters beyond just "don't waste time scanning tooling": the bundled template's own
-/// `scripts/harness/component.astro` deliberately blankets *all* of
-/// `src/components/**` and `src/layouts/**` via `import.meta.glob` to power the live component
-/// preview — if that file were scanned, its own blanket glob would suppress unused-component/
-/// layout detection for every site scaffolded from this template.
+/// pre-deploy checks) is scanned as an ordinary reference source (a discrete reference there still
+/// counts — dropping it would risk a false-positive of its own), but never contributes *glob-
+/// directory* coverage — a path-prefix check in `scan`, not the general `excludedDirNames` set,
+/// precisely because a nested directory like `src/scripts/` (real sites commonly hold client-side
+/// JS there) must still contribute both. This matters because the bundled template's own
+/// `scripts/harness/component.astro` deliberately blankets *all* of `src/components/**` and
+/// `src/layouts/**` via `import.meta.glob` to power the live component preview — if that blanket
+/// coverage weren't withheld, it would suppress unused-component/layout detection for every site
+/// scaffolded from this template.
 ///
 /// An unresolvable reference (bare specifier, unconfigured path alias) is never counted as proof
 /// of use *or* disuse — it is simply skipped. This biases the whole scanner toward
@@ -222,6 +223,17 @@ public enum DeadAssetScanner {
     /// Loads one tsconfig/jsconfig file, recursively following a relative `extends` chain (TS
     /// resolves `extends` relative to the extending file's own directory; a depth guard avoids an
     /// accidental cycle). Returns `nil` only if `url` itself can't be read/parsed as JSON.
+    ///
+    /// **Known limitation:** only a plain relative path ending in `.json` is followed (e.g.
+    /// `"./tsconfig.base.json"`). Two real `extends` forms are not: an extensionless relative path
+    /// (`"./tsconfig.base"`, valid since TS 3.2 — the compiler appends `.json` itself) and a bare
+    /// package specifier resolved via node_modules (`"astro/tsconfigs/strict"`, which this app's
+    /// own bundled template uses). Either form just fails to read here and the extended config's
+    /// `paths`/`baseUrl` are silently dropped — harmless *today* only because the specific presets
+    /// in use happen to define no `paths`; a project whose base config (reached either way) does
+    /// define aliases would have those aliases go unresolved. Full Node-style module resolution
+    /// (package.json `main`/`exports` lookup) is a materially larger undertaking than the plain
+    /// relative-path case this closes, and isn't attempted here.
     private static func loadTSConfig(at url: URL, depth: Int) -> PathAliasConfig? {
         guard depth < 5 else { return nil }
         guard let data = try? Data(contentsOf: url) else { return nil }
@@ -349,10 +361,14 @@ public enum DeadAssetScanner {
             let ext = "." + abs.pathExtension.lowercased()
             guard referenceScanExtensions.contains(ext) else { continue }
             let relPath = relativePosix(abs, from: projectRoot)
-            // Top-level `scripts/` only (dev tooling: the Component Editor's preview harness,
-            // pre-deploy checks) — not a nested directory like `src/scripts/`, which real sites
-            // commonly use for client-side JS and which should still be scanned.
-            guard !relPath.lowercased().hasPrefix("scripts/") else { continue }
+            // Top-level `scripts/` (dev tooling: the Component Editor's preview harness,
+            // pre-deploy checks — not a nested directory like `src/scripts/`, which real sites
+            // commonly use for client-side JS) never contributes *glob-directory* coverage below —
+            // that's what stops the harness's own blanket `import.meta.glob` from suppressing
+            // unused-component/layout detection everywhere. It's still scanned as an ordinary
+            // reference *source*: excluding it entirely would also drop any discrete, non-glob
+            // reference some other top-level script might legitimately hold.
+            let isTopLevelScripts = relPath.lowercased().hasPrefix("scripts/")
             let actualSize = fileSize(abs)
             guard let size = actualSize, size <= 512_000 else {
                 // Missing a reference *source* here is worse than the same skip in a candidate
@@ -367,7 +383,9 @@ public enum DeadAssetScanner {
 
             let refs = extractReferences(source: source, path: relPath)
             for ref in refs.fileReferences { fileReferenceCounts[ref.lowercased(), default: 0] += 1 }
-            globDirectories.formUnion(refs.globDirectories.map { $0.lowercased() })
+            if !isTopLevelScripts {
+                globDirectories.formUnion(refs.globDirectories.map { $0.lowercased() })
+            }
             for raw in refs.unresolvedReferences {
                 for aliasResolved in resolveAlias(raw, config: aliasConfig) {
                     fileReferenceCounts[aliasResolved.lowercased(), default: 0] += 1

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -9,6 +9,14 @@ import Foundation
 /// of use *or* disuse — it is simply skipped. This biases the whole scanner toward
 /// under-flagging: the failure mode is "missed a dead file," never "recommended deleting
 /// something in use."
+///
+/// **Known limitation:** brace-bound dynamic references (`<img src={heroPath}>`,
+/// `<Image src={imported} />`), dynamic `import(...)` calls, and re-export barrels
+/// (`export … from`) are not matched by the regex-based extraction below — a file referenced
+/// *only* through one of these patterns can be incorrectly flagged as unused. This is an
+/// inherent tradeoff of regex-based scanning versus a full AST parse and is not closed here;
+/// Delete always requires explicit user confirmation and is git-tracked/recoverable, which is
+/// this scanner's primary mitigation for this class of false positive.
 public enum DeadAssetScanner {
     public struct CleanupCandidate: Sendable, Equatable, Identifiable {
         public let id: String
@@ -212,6 +220,7 @@ public enum DeadAssetScanner {
         for abs in walk(projectRoot) {
             let ext = "." + abs.pathExtension.lowercased()
             guard referenceScanExtensions.contains(ext) else { continue }
+            guard let size = fileSize(abs), size <= 512_000 else { continue }
             guard let source = try? String(contentsOf: abs, encoding: .utf8) else { continue }
             let relPath = relativePosix(abs, from: projectRoot)
 
@@ -304,5 +313,10 @@ public enum DeadAssetScanner {
     private static func mtime(_ url: URL) -> Date {
         (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
             ?? Date(timeIntervalSince1970: 0)
+    }
+
+    private static func fileSize(_ url: URL) -> Int64? {
+        guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize else { return nil }
+        return Int64(size)
     }
 }

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// Detects unused `.astro` components/layouts and unused `public/images` assets by building a
+/// reference graph from `import` statements, `href`/`src` attributes, markdown image syntax,
+/// CSS `url()`, `Astro.glob` calls, and frontmatter `layout:` fields — then finding files with
+/// zero resolved inbound references.
+///
+/// An unresolvable reference (bare specifier, unconfigured path alias) is never counted as proof
+/// of use *or* disuse — it is simply skipped. This biases the whole scanner toward
+/// under-flagging: the failure mode is "missed a dead file," never "recommended deleting
+/// something in use."
+public enum DeadAssetScanner {
+    public struct CleanupCandidate: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let path: String
+        public let kind: Kind
+        public let lastModified: Date
+        public let referenceCount: Int
+
+        public enum Kind: String, Sendable, Equatable, CaseIterable {
+            case component, layout, image, page
+        }
+
+        public init(id: String, path: String, kind: Kind, lastModified: Date, referenceCount: Int) {
+            self.id = id
+            self.path = path
+            self.kind = kind
+            self.lastModified = lastModified
+            self.referenceCount = referenceCount
+        }
+    }
+
+    /// Raw references extracted from one source file, already resolved to project-relative paths
+    /// where possible. `globDirectories` are directories an `Astro.glob` call covers — every file
+    /// under one is treated as referenced, regardless of whether it appears in `fileReferences`.
+    struct ReferenceSource: Sendable, Equatable {
+        let path: String
+        let fileReferences: Set<String>
+        let globDirectories: Set<String>
+    }
+
+    // MARK: - Regexes (compiled once, matching the style of ContentScanner/SiteKnowledgeIndex)
+
+    private static let importRegex = try! NSRegularExpression(
+        pattern: #"import\s+(?:[^'"]+?\s+from\s+)?["']([^"']+)["']"#)
+    private static let hrefSrcRegex = try! NSRegularExpression(
+        pattern: #"(?:href|src)=["']([^"']+)["']"#, options: [.caseInsensitive])
+    private static let markdownImageRegex = try! NSRegularExpression(
+        pattern: #"!\[[^\]]*\]\(([^)]+)\)"#)
+    private static let cssURLRegex = try! NSRegularExpression(
+        pattern: #"url\(\s*['"]?([^'")]+)['"]?\s*\)"#, options: [.caseInsensitive])
+    private static let astroGlobRegex = try! NSRegularExpression(
+        pattern: #"Astro\.glob\(\s*['"]([^'"]+)['"]"#)
+
+    /// Extracts and resolves every reference in `source`, a file at project-relative `path`.
+    static func extractReferences(source: String, path: String) -> ReferenceSource {
+        let raw = matches(importRegex, in: source, group: 1)
+            + matches(hrefSrcRegex, in: source, group: 1)
+            + matches(markdownImageRegex, in: source, group: 1)
+            + matches(cssURLRegex, in: source, group: 1)
+
+        var fileRefs = Set<String>()
+        for candidate in raw {
+            let cleaned = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let resolved = resolve(cleaned, relativeTo: path) { fileRefs.insert(resolved) }
+        }
+
+        var globDirs = Set<String>()
+        for pattern in matches(astroGlobRegex, in: source, group: 1) {
+            if let dir = resolveGlobDirectory(pattern, relativeTo: path) { globDirs.insert(dir) }
+        }
+
+        return ReferenceSource(path: path, fileReferences: fileRefs, globDirectories: globDirs)
+    }
+
+    // MARK: - Path resolution
+
+    /// Resolves a raw reference string to a project-relative path, or `nil` if it can't be
+    /// resolved (bare specifier, unconfigured alias) — never guessed at.
+    static func resolve(_ ref: String, relativeTo sourcePath: String) -> String? {
+        if let abs = resolveAbsolutePath(ref) { return abs }
+        if let rel = resolveRelativePath(ref, relativeTo: sourcePath) { return rel }
+        return nil
+    }
+
+    /// `/images/hero.png` → `public/images/hero.png` (Astro serves `public/` at the site root).
+    /// Strips a trailing `?query` or `#fragment` first.
+    static func resolveAbsolutePath(_ ref: String) -> String? {
+        guard ref.hasPrefix("/") else { return nil }
+        var clean = String(ref.dropFirst())
+        if let cut = clean.firstIndex(where: { $0 == "?" || $0 == "#" }) {
+            clean = String(clean[clean.startIndex..<cut])
+        }
+        guard !clean.isEmpty else { return nil }
+        return "public/" + clean
+    }
+
+    /// Resolves `./`/`../`-prefixed `ref` against `sourcePath`'s own directory. Strips a trailing
+    /// `?query`/`#fragment` first.
+    static func resolveRelativePath(_ ref: String, relativeTo sourcePath: String) -> String? {
+        guard ref.hasPrefix("./") || ref.hasPrefix("../") else { return nil }
+        var clean = ref
+        if let cut = clean.firstIndex(where: { $0 == "?" || $0 == "#" }) {
+            clean = String(clean[clean.startIndex..<cut])
+        }
+        var dirComponents = sourcePath.split(separator: "/").dropLast().map(String.init)
+        for segment in clean.split(separator: "/") {
+            if segment == "." { continue }
+            else if segment == ".." { if !dirComponents.isEmpty { dirComponents.removeLast() } }
+            else { dirComponents.append(String(segment)) }
+        }
+        guard !dirComponents.isEmpty else { return nil }
+        return dirComponents.joined(separator: "/")
+    }
+
+    /// Truncates an `Astro.glob` pattern down to its containing directory (e.g.
+    /// `../content/*.md` → the resolved form of `../content`) and resolves that against
+    /// `sourcePath`. Only relative glob patterns are handled — Astro.glob never takes an
+    /// absolute-from-public pattern.
+    static func resolveGlobDirectory(_ pattern: String, relativeTo sourcePath: String) -> String? {
+        guard pattern.hasPrefix("./") || pattern.hasPrefix("../") else { return nil }
+        var dir = pattern
+        if let starIndex = dir.firstIndex(of: "*") {
+            dir = String(dir[dir.startIndex..<starIndex])
+            if let lastSlash = dir.lastIndex(of: "/") {
+                dir = String(dir[dir.startIndex...lastSlash])
+            }
+        }
+        if dir.hasSuffix("/") { dir.removeLast() }
+        return resolveRelativePath(dir, relativeTo: sourcePath)
+    }
+
+    private static func matches(_ regex: NSRegularExpression, in source: String, group: Int) -> [String] {
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        var out: [String] = []
+        for match in regex.matches(in: source, range: range) {
+            guard let r = Range(match.range(at: group), in: source) else { continue }
+            out.append(String(source[r]))
+        }
+        return out
+    }
+}

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -316,9 +316,13 @@ public enum DeadAssetScanner {
     // MARK: - Full-project scan
 
     private static let referenceScanExtensions: Set<String> = [
-        ".astro", ".md", ".mdx", ".mdoc", ".markdown", ".css", ".ts", ".tsx", ".js", ".jsx",
+        ".astro", ".md", ".mdx", ".mdoc", ".markdown", ".css",
+        ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts",
     ]
-    private static let excludedDirNames: Set<String> = ["node_modules", "dist", ".astro", ".git"]
+    /// Reuses `SiteIndexPaths`' shared skip list (build artifacts, dependency dirs, and
+    /// host-specific build caches like `.netlify`/`.vercel`) rather than a second, independently
+    /// drifting copy of the same rules.
+    private static let excludedDirNames = SiteIndexPaths.skippedDirectoryNames
 
     /// Scans every `.astro`/`.md`/`.mdx`/`.mdoc`/`.markdown`/`.css`/`.ts`/`.tsx`/`.js`/`.jsx` file
     /// under `projectRoot` (excluding the top-level `scripts/` — see the type doc comment) for

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -2,8 +2,24 @@ import Foundation
 
 /// Detects unused `.astro` components/layouts and unused `public/images` assets by building a
 /// reference graph from `import` statements, `href`/`src` attributes, markdown image syntax,
-/// CSS `url()`, `Astro.glob` calls, and frontmatter `layout:` fields — then finding files with
-/// zero resolved inbound references.
+/// CSS `url()`, `Astro.glob`/`import.meta.glob` calls, and frontmatter `layout:` fields — then
+/// finding files with zero resolved inbound references. Reference *sources* scanned include
+/// `.astro`/`.md`/`.mdx`/`.mdoc`/`.markdown`/`.css` as well as `.ts`/`.tsx`/`.js`/`.jsx` (framework
+/// islands and helper/config files commonly reference `.astro` components or `public/` assets
+/// too) — though only `.astro` files under `src/components`/`src/layouts` and entries in `images`
+/// are ever *candidates* for deletion; JS/TS files themselves are never flagged as dead (see the
+/// design doc's non-goals — JS/TS import resolution has materially more edge cases: barrel files,
+/// re-exports, tsconfig `extends` scoping).
+///
+/// The top-level `scripts/` directory (dev-only tooling — the Component Editor's preview harness,
+/// pre-deploy checks) is excluded from the reference scan entirely — a path-prefix check in
+/// `scan`, not the general `excludedDirNames` set, precisely because a nested directory like
+/// `src/scripts/` (real sites commonly hold client-side JS there) must still be scanned. This
+/// matters beyond just "don't waste time scanning tooling": the bundled template's own
+/// `scripts/harness/component.astro` deliberately blankets *all* of
+/// `src/components/**` and `src/layouts/**` via `import.meta.glob` to power the live component
+/// preview — if that file were scanned, its own blanket glob would suppress unused-component/
+/// layout detection for every site scaffolded from this template.
 ///
 /// An unresolvable reference (bare specifier, unconfigured path alias) is never counted as proof
 /// of use *or* disuse — it is simply skipped. This biases the whole scanner toward
@@ -18,9 +34,9 @@ import Foundation
 /// Delete always requires explicit user confirmation and is git-tracked/recoverable, which is
 /// this scanner's primary mitigation for this class of false positive.
 ///
-/// **Alias resolution scope:** `tsconfig.json`/`jsconfig.json` `compilerOptions.paths` (wildcard
-/// and exact entries), `baseUrl`, and a same-project `extends` chain are resolved (see
-/// `loadPathAliases`/`resolveAlias`). Aliases declared *only* via `astro.config.mjs`'s
+/// **Alias resolution scope:** `tsconfig.json`/`jsconfig.json` `compilerOptions.paths` (wildcard,
+/// exact, and multi-target entries), `baseUrl`, and a same-project `extends` chain are resolved
+/// (see `loadPathAliases`/`resolveAlias`). Aliases declared *only* via `astro.config.mjs`'s
 /// `vite.resolve.alias` — not mirrored into tsconfig/jsconfig `paths`, which Astro's docs
 /// recommend keeping in sync but do not enforce — are **not** resolved: an import through such an
 /// alias with no matching `paths` entry stays unresolved and can flag a live file as unused. Same
@@ -66,8 +82,13 @@ public enum DeadAssetScanner {
         pattern: #"!\[[^\]]*\]\(([^)]+)\)"#)
     private static let cssURLRegex = try! NSRegularExpression(
         pattern: #"url\(\s*['"]?([^'")]+)['"]?\s*\)"#, options: [.caseInsensitive])
-    private static let astroGlobRegex = try! NSRegularExpression(
-        pattern: #"Astro\.glob\(\s*['"]([^'"]+)['"]"#)
+    /// Matches an `Astro.glob(...)` or `import.meta.glob(...)` call's full argument list (up to
+    /// the first `)`), so it works whether the call takes a single quoted string or an array of
+    /// them. `globPatternsRegex` then pulls every individually-quoted pattern out of that capture.
+    private static let globCallRegex = try! NSRegularExpression(
+        pattern: #"(?:Astro\.glob|import\.meta\.glob)\(([^)]*)\)"#)
+    private static let globPatternsRegex = try! NSRegularExpression(
+        pattern: #"['"]([^'"]+)['"]"#)
 
     /// Extracts and resolves every reference in `source`, a file at project-relative `path`.
     static func extractReferences(source: String, path: String) -> ReferenceSource {
@@ -88,8 +109,10 @@ public enum DeadAssetScanner {
         }
 
         var globDirs = Set<String>()
-        for pattern in matches(astroGlobRegex, in: source, group: 1) {
-            if let dir = resolveGlobDirectory(pattern, relativeTo: path) { globDirs.insert(dir) }
+        for call in matches(globCallRegex, in: source, group: 1) {
+            for pattern in matches(globPatternsRegex, in: call, group: 1) {
+                if let dir = resolveGlobDirectory(pattern, relativeTo: path) { globDirs.insert(dir) }
+            }
         }
 
         return ReferenceSource(
@@ -137,21 +160,30 @@ public enum DeadAssetScanner {
         return dirComponents.joined(separator: "/")
     }
 
-    /// Truncates an `Astro.glob` pattern down to its containing directory (e.g.
-    /// `../content/*.md` → the resolved form of `../content`) and resolves that against
-    /// `sourcePath`. Only relative glob patterns are handled — Astro.glob never takes an
-    /// absolute-from-public pattern.
+    /// Truncates a glob pattern down to its containing directory (e.g. `../content/*.md` → the
+    /// resolved form of `../content`) and resolves that. A leading `/` is `import.meta.glob`'s
+    /// project-root-relative form (Vite/Astro convention — distinct from `resolveAbsolutePath`'s
+    /// `public/`-serving convention used for `href`/`src`) and resolves directly against the
+    /// project root; `./`/`../` patterns resolve against `sourcePath`'s own directory. Anything
+    /// else (a bare/aliased glob pattern) is left unresolved.
     static func resolveGlobDirectory(_ pattern: String, relativeTo sourcePath: String) -> String? {
-        guard pattern.hasPrefix("./") || pattern.hasPrefix("../") else { return nil }
-        var dir = pattern
-        if let starIndex = dir.firstIndex(of: "*") {
-            dir = String(dir[dir.startIndex..<starIndex])
-            if let lastSlash = dir.lastIndex(of: "/") {
-                dir = String(dir[dir.startIndex...lastSlash])
+        func truncateToDirectory(_ raw: String) -> String {
+            var dir = raw
+            if let starIndex = dir.firstIndex(of: "*") {
+                dir = String(dir[dir.startIndex..<starIndex])
+                if let lastSlash = dir.lastIndex(of: "/") {
+                    dir = String(dir[dir.startIndex...lastSlash])
+                }
             }
+            if dir.hasSuffix("/") { dir.removeLast() }
+            return dir
         }
-        if dir.hasSuffix("/") { dir.removeLast() }
-        return resolveRelativePath(dir, relativeTo: sourcePath)
+        if pattern.hasPrefix("/") {
+            let dir = truncateToDirectory(String(pattern.dropFirst()))
+            return dir.isEmpty ? nil : dir
+        }
+        guard pattern.hasPrefix("./") || pattern.hasPrefix("../") else { return nil }
+        return resolveRelativePath(truncateToDirectory(pattern), relativeTo: sourcePath)
     }
 
     /// A tsconfig/jsconfig's alias-relevant `compilerOptions`, merged across an `extends` chain
@@ -205,12 +237,19 @@ public enum DeadAssetScanner {
         return PathAliasConfig(baseUrl: baseUrl, paths: paths)
     }
 
-    /// Resolves `ref` against `config` (from `loadPathAliases`): finds a `paths` pattern —
-    /// wildcard (single `*`) or exact — matching `ref`, substitutes the corresponding target
-    /// (first target wins, matching TypeScript's own resolution order), then resolves that target
-    /// relative to `baseUrl` (or, when `baseUrl` is unset, relative to the project root directly —
-    /// matching how TypeScript resolves `paths` without an explicit `baseUrl`).
-    static func resolveAlias(_ ref: String, config: PathAliasConfig) -> String? {
+    /// Resolves `ref` against `config` (from `loadPathAliases`): finds every `paths` target —
+    /// wildcard (single `*`) or exact — whose pattern matches `ref`, substituting and resolving
+    /// each one relative to `baseUrl` (or, when `baseUrl` is unset, relative to the project root
+    /// directly — matching how TypeScript resolves `paths` without an explicit `baseUrl`).
+    ///
+    /// A pattern can map to more than one target (a supported TS/Vite fallback-chain shape, e.g.
+    /// `"@utils/*": ["src/utils/*", "src/shared/utils/*"]`); this scanner can't cheaply verify
+    /// which target is the real one without a second filesystem pass, so every target is returned
+    /// and credited as a reference by the caller — crediting a path that doesn't correspond to a
+    /// real file is harmless (it just never matches any real candidate's path), while crediting
+    /// only the first target risks the opposite: a live file under a later target staying
+    /// uncounted and flagged unused.
+    static func resolveAlias(_ ref: String, config: PathAliasConfig) -> [String] {
         for (pattern, targets) in config.paths {
             let starCount = pattern.filter({ $0 == "*" }).count
             if starCount == 1, let starIndex = pattern.firstIndex(of: "*") {
@@ -218,18 +257,19 @@ public enum DeadAssetScanner {
                 let suffix = String(pattern[pattern.index(after: starIndex)...])
                 guard ref.hasPrefix(prefix), ref.hasSuffix(suffix), ref.count >= prefix.count + suffix.count else { continue }
                 let matched = String(ref.dropFirst(prefix.count).dropLast(suffix.count))
+                var resolved: [String] = []
                 for target in targets {
                     guard let targetStar = target.firstIndex(of: "*"), target.filter({ $0 == "*" }).count == 1 else { continue }
                     let targetPrefix = String(target[target.startIndex..<targetStar])
                     let targetSuffix = String(target[target.index(after: targetStar)...])
-                    let resolved = targetPrefix + matched + targetSuffix
-                    return applyBaseURL(resolved, config.baseUrl)
+                    resolved.append(applyBaseURL(targetPrefix + matched + targetSuffix, config.baseUrl))
                 }
-            } else if starCount == 0, pattern == ref, let target = targets.first {
-                return applyBaseURL(target, config.baseUrl)
+                if !resolved.isEmpty { return resolved }
+            } else if starCount == 0, pattern == ref, !targets.isEmpty {
+                return targets.map { applyBaseURL($0, config.baseUrl) }
             }
         }
-        return nil
+        return []
     }
 
     /// Prefixes `target` (a `paths`-substituted specifier, possibly still `./`-relative) with
@@ -260,11 +300,12 @@ public enum DeadAssetScanner {
     // MARK: - Full-project scan
 
     private static let referenceScanExtensions: Set<String> = [
-        ".astro", ".md", ".mdx", ".mdoc", ".markdown", ".css",
+        ".astro", ".md", ".mdx", ".mdoc", ".markdown", ".css", ".ts", ".tsx", ".js", ".jsx",
     ]
     private static let excludedDirNames: Set<String> = ["node_modules", "dist", ".astro", ".git"]
 
-    /// Scans every `.astro`/`.md`/`.mdx`/`.mdoc`/`.markdown`/`.css` file under `projectRoot` for
+    /// Scans every `.astro`/`.md`/`.mdx`/`.mdoc`/`.markdown`/`.css`/`.ts`/`.tsx`/`.js`/`.jsx` file
+    /// under `projectRoot` (excluding the top-level `scripts/` — see the type doc comment) for
     /// references, then returns every unused `src/components/**/*.astro`, `src/layouts/**/*.astro`,
     /// and unused entry in `images` (typically `SiteContentGraph.images(for:)`, scoped to
     /// `public/images/**`). Pure over the filesystem snapshot at call time.
@@ -276,15 +317,19 @@ public enum DeadAssetScanner {
         for abs in walk(projectRoot) {
             let ext = "." + abs.pathExtension.lowercased()
             guard referenceScanExtensions.contains(ext) else { continue }
+            let relPath = relativePosix(abs, from: projectRoot)
+            // Top-level `scripts/` only (dev tooling: the Component Editor's preview harness,
+            // pre-deploy checks) — not a nested directory like `src/scripts/`, which real sites
+            // commonly use for client-side JS and which should still be scanned.
+            guard !relPath.hasPrefix("scripts/") else { continue }
             guard let size = fileSize(abs), size <= 512_000 else { continue }
             guard let source = try? String(contentsOf: abs, encoding: .utf8) else { continue }
-            let relPath = relativePosix(abs, from: projectRoot)
 
             let refs = extractReferences(source: source, path: relPath)
             for ref in refs.fileReferences { fileReferenceCounts[ref.lowercased(), default: 0] += 1 }
             globDirectories.formUnion(refs.globDirectories.map { $0.lowercased() })
             for raw in refs.unresolvedReferences {
-                if let aliasResolved = resolveAlias(raw, config: aliasConfig) {
+                for aliasResolved in resolveAlias(raw, config: aliasConfig) {
                     fileReferenceCounts[aliasResolved.lowercased(), default: 0] += 1
                 }
             }

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -37,6 +37,7 @@ public enum DeadAssetScanner {
         let path: String
         let fileReferences: Set<String>
         let globDirectories: Set<String>
+        let unresolvedReferences: Set<String>
     }
 
     // MARK: - Regexes (compiled once, matching the style of ContentScanner/SiteKnowledgeIndex)
@@ -60,9 +61,14 @@ public enum DeadAssetScanner {
             + matches(cssURLRegex, in: source, group: 1)
 
         var fileRefs = Set<String>()
+        var unresolved = Set<String>()
         for candidate in raw {
             let cleaned = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let resolved = resolve(cleaned, relativeTo: path) { fileRefs.insert(resolved) }
+            if let resolved = resolve(cleaned, relativeTo: path) {
+                fileRefs.insert(resolved)
+            } else {
+                unresolved.insert(cleaned)
+            }
         }
 
         var globDirs = Set<String>()
@@ -70,7 +76,9 @@ public enum DeadAssetScanner {
             if let dir = resolveGlobDirectory(pattern, relativeTo: path) { globDirs.insert(dir) }
         }
 
-        return ReferenceSource(path: path, fileReferences: fileRefs, globDirectories: globDirs)
+        return ReferenceSource(
+            path: path, fileReferences: fileRefs, globDirectories: globDirs,
+            unresolvedReferences: unresolved)
     }
 
     // MARK: - Path resolution
@@ -130,6 +138,51 @@ public enum DeadAssetScanner {
         return resolveRelativePath(dir, relativeTo: sourcePath)
     }
 
+    /// Alias pattern → target patterns, both retaining their single `*` wildcard, e.g.
+    /// `"@components/*" → ["src/components/*"]`. Read from the site's own `tsconfig.json`/
+    /// `jsconfig.json` `compilerOptions.paths` (not `extends` chains — Astro's own base configs
+    /// never define `paths`). Malformed/missing/commented JSON safely degrades to an empty map,
+    /// matching this scanner's "never guess" resolution philosophy.
+    static func loadPathAliases(projectRoot: URL) -> [String: [String]] {
+        for name in ["tsconfig.json", "jsconfig.json"] {
+            let url = projectRoot.appendingPathComponent(name)
+            guard let data = try? Data(contentsOf: url) else { continue }
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
+            guard let compilerOptions = json["compilerOptions"] as? [String: Any] else { continue }
+            guard let paths = compilerOptions["paths"] as? [String: Any] else { continue }
+            var result: [String: [String]] = [:]
+            for (pattern, targets) in paths {
+                guard let targetList = targets as? [String] else { continue }
+                result[pattern] = targetList
+            }
+            if !result.isEmpty { return result }
+        }
+        return [:]
+    }
+
+    /// Resolves `ref` against `aliases` (from `loadPathAliases`): finds an alias pattern whose
+    /// `*`-stripped prefix/suffix matches `ref`, substitutes the corresponding target pattern's
+    /// prefix/suffix. Only single-`*` patterns are handled — matching the common
+    /// `"@foo/*": ["src/foo/*"]` shape; anything else is skipped (never guessed at).
+    static func resolveAlias(_ ref: String, aliases: [String: [String]]) -> String? {
+        for (pattern, targets) in aliases {
+            guard let starIndex = pattern.firstIndex(of: "*"), pattern.filter({ $0 == "*" }).count == 1 else { continue }
+            let prefix = String(pattern[pattern.startIndex..<starIndex])
+            let suffix = String(pattern[pattern.index(after: starIndex)...])
+            guard ref.hasPrefix(prefix), ref.hasSuffix(suffix), ref.count >= prefix.count + suffix.count else { continue }
+            let matched = String(ref.dropFirst(prefix.count).dropLast(suffix.count))
+            for target in targets {
+                guard let targetStar = target.firstIndex(of: "*"), target.filter({ $0 == "*" }).count == 1 else { continue }
+                let targetPrefix = String(target[target.startIndex..<targetStar])
+                let targetSuffix = String(target[target.index(after: targetStar)...])
+                var resolved = targetPrefix + matched + targetSuffix
+                if resolved.hasPrefix("./") { resolved.removeFirst(2) }
+                return resolved
+            }
+        }
+        return nil
+    }
+
     private static func matches(_ regex: NSRegularExpression, in source: String, group: Int) -> [String] {
         let range = NSRange(source.startIndex..<source.endIndex, in: source)
         var out: [String] = []
@@ -154,6 +207,7 @@ public enum DeadAssetScanner {
     public static func scan(projectRoot: URL, images: [SiteContentGraph.Image]) -> [CleanupCandidate] {
         var fileReferenceCounts: [String: Int] = [:]
         var globDirectories: Set<String> = []
+        let aliases = loadPathAliases(projectRoot: projectRoot)
 
         for abs in walk(projectRoot) {
             let ext = "." + abs.pathExtension.lowercased()
@@ -164,6 +218,11 @@ public enum DeadAssetScanner {
             let refs = extractReferences(source: source, path: relPath)
             for ref in refs.fileReferences { fileReferenceCounts[ref, default: 0] += 1 }
             globDirectories.formUnion(refs.globDirectories)
+            for raw in refs.unresolvedReferences {
+                if let aliasResolved = resolveAlias(raw, aliases: aliases) {
+                    fileReferenceCounts[aliasResolved, default: 0] += 1
+                }
+            }
 
             // Frontmatter `layout:` counts as a reference too — extractReferences only looks at
             // the body, not frontmatter fields.

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -249,8 +249,14 @@ public enum DeadAssetScanner {
     /// real file is harmless (it just never matches any real candidate's path), while crediting
     /// only the first target risks the opposite: a live file under a later target staying
     /// uncounted and flagged unused.
+    ///
+    /// Patterns are tried longest-literal-prefix-first (not `config.paths`'s raw `Dictionary`
+    /// order, which is unspecified) so two overlapping patterns that could both match the same
+    /// `ref` (e.g. `"@/*"` and `"@/components/*"`) resolve deterministically to the more specific
+    /// one, matching how bundlers conventionally break this tie.
     static func resolveAlias(_ ref: String, config: PathAliasConfig) -> [String] {
-        for (pattern, targets) in config.paths {
+        let orderedPatterns = config.paths.sorted { literalPrefixLength($0.key) > literalPrefixLength($1.key) }
+        for (pattern, targets) in orderedPatterns {
             let starCount = pattern.filter({ $0 == "*" }).count
             if starCount == 1, let starIndex = pattern.firstIndex(of: "*") {
                 let prefix = String(pattern[pattern.startIndex..<starIndex])
@@ -270,6 +276,16 @@ public enum DeadAssetScanner {
             }
         }
         return []
+    }
+
+    /// Length of `pattern` up to (not including) its first `*`, or the whole pattern's length if
+    /// it has none — a proxy for "how specific is this alias pattern" used to break ties between
+    /// overlapping `paths` entries.
+    private static func literalPrefixLength(_ pattern: String) -> Int {
+        if let starIndex = pattern.firstIndex(of: "*") {
+            return pattern.distance(from: pattern.startIndex, to: starIndex)
+        }
+        return pattern.count
     }
 
     /// Prefixes `target` (a `paths`-substituted specifier, possibly still `./`-relative) with
@@ -312,6 +328,7 @@ public enum DeadAssetScanner {
     public static func scan(projectRoot: URL, images: [SiteContentGraph.Image]) -> [CleanupCandidate] {
         var fileReferenceCounts: [String: Int] = [:]
         var globDirectories: Set<String> = []
+        var skippedOversizedFiles: [String] = []
         let aliasConfig = loadPathAliases(projectRoot: projectRoot)
 
         for abs in walk(projectRoot) {
@@ -322,7 +339,16 @@ public enum DeadAssetScanner {
             // pre-deploy checks) — not a nested directory like `src/scripts/`, which real sites
             // commonly use for client-side JS and which should still be scanned.
             guard !relPath.hasPrefix("scripts/") else { continue }
-            guard let size = fileSize(abs), size <= 512_000 else { continue }
+            let actualSize = fileSize(abs)
+            guard let size = actualSize, size <= 512_000 else {
+                // Missing a reference *source* here is worse than the same skip in a candidate
+                // indexer (SiteKnowledgeIndex): it can leave a live file's inbound count at 0.
+                // Logged (once, batched, at the end of scan()) rather than silently swallowed —
+                // this is the one deliberate side effect in an otherwise pure function, kept out
+                // of the hot per-file path so it never blocks or reorders the scan itself.
+                if let actualSize { skippedOversizedFiles.append("\(relPath) (\(actualSize) bytes)") }
+                continue
+            }
             guard let source = try? String(contentsOf: abs, encoding: .utf8) else { continue }
 
             let refs = extractReferences(source: source, path: relPath)
@@ -334,12 +360,38 @@ public enum DeadAssetScanner {
                 }
             }
 
-            // Frontmatter `layout:` counts as a reference too — extractReferences only looks at
-            // the body, not frontmatter fields.
+            // Frontmatter references count too — extractReferences only looks at the body. Every
+            // string (or array-of-strings) frontmatter value is tried, not just a hardcoded
+            // `layout:`/`image:`-style field-name allowlist — content-collection conventions
+            // (image:, cover:, ogImage:, a gallery array, …) vary per project, and a value that
+            // doesn't look like a real path/alias (titles, tags, slugs — the overwhelming
+            // majority of frontmatter) simply fails to resolve and is silently skipped, same as
+            // everywhere else in this scanner.
             let frontmatter = Frontmatter.parse(source)
-            if case let .string(layoutRef)? = frontmatter["layout"],
-               let resolved = resolve(layoutRef, relativeTo: relPath) {
-                fileReferenceCounts[resolved.lowercased(), default: 0] += 1
+            for value in frontmatter.values {
+                let rawValues: [String]
+                switch value {
+                case .string(let s): rawValues = [s]
+                case .array(let arr): rawValues = arr
+                case .bool, .number, .date: rawValues = []
+                }
+                for raw in rawValues {
+                    if let resolved = resolve(raw, relativeTo: relPath) {
+                        fileReferenceCounts[resolved.lowercased(), default: 0] += 1
+                    } else {
+                        for aliasResolved in resolveAlias(raw, config: aliasConfig) {
+                            fileReferenceCounts[aliasResolved.lowercased(), default: 0] += 1
+                        }
+                    }
+                }
+            }
+        }
+
+        if !skippedOversizedFiles.isEmpty {
+            Task {
+                await LogCenter.shared.append(
+                    source: "dead-assets:scan", stream: .stderr,
+                    text: "DeadAssetScanner: skipped \(skippedOversizedFiles.count) file(s) over the 512,000 byte reference-scan limit — any reference they contain won't be counted: \(skippedOversizedFiles.joined(separator: ", "))")
             }
         }
 

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -34,6 +34,13 @@ import Foundation
 /// Delete always requires explicit user confirmation and is git-tracked/recoverable, which is
 /// this scanner's primary mitigation for this class of false positive.
 ///
+/// **Known limitation:** an `Astro.glob`/`import.meta.glob` root written through a path alias
+/// (e.g. `import.meta.glob("@content/*.md")`) is not resolved — `resolveGlobDirectory` only
+/// handles a literal `/`-rooted or `./`/`../`-relative pattern, not one requiring an alias lookup
+/// first. Matching an alias's own `*` against a glob pattern that has its *own* `*`/`**` wildcards
+/// is a materially more complex problem than the plain-specifier alias matching `resolveAlias`
+/// already does, and isn't attempted here. Same mitigation as above.
+///
 /// **Alias resolution scope:** `tsconfig.json`/`jsconfig.json` `compilerOptions.paths` (wildcard,
 /// exact, and multi-target entries), `baseUrl`, and a same-project `extends` chain are resolved
 /// (see `loadPathAliases`/`resolveAlias`). Aliases declared *only* via `astro.config.mjs`'s
@@ -143,9 +150,12 @@ public enum DeadAssetScanner {
     }
 
     /// Resolves `./`/`../`-prefixed `ref` against `sourcePath`'s own directory. Strips a trailing
-    /// `?query`/`#fragment` first.
+    /// `?query`/`#fragment` first. Also accepts a bare `.`/`..` (no path after it) — not a real
+    /// import specifier anyone writes, but exactly what `resolveGlobDirectory`'s truncation
+    /// produces for a same-directory or parent-directory-only glob pattern (`./*.astro`), so this
+    /// guard has to admit it or that degenerate case silently fails to resolve at all.
     static func resolveRelativePath(_ ref: String, relativeTo sourcePath: String) -> String? {
-        guard ref.hasPrefix("./") || ref.hasPrefix("../") else { return nil }
+        guard ref == "." || ref == ".." || ref.hasPrefix("./") || ref.hasPrefix("../") else { return nil }
         var clean = ref
         if let cut = clean.firstIndex(where: { $0 == "?" || $0 == "#" }) {
             clean = String(clean[clean.startIndex..<cut])
@@ -342,7 +352,7 @@ public enum DeadAssetScanner {
             // Top-level `scripts/` only (dev tooling: the Component Editor's preview harness,
             // pre-deploy checks) — not a nested directory like `src/scripts/`, which real sites
             // commonly use for client-side JS and which should still be scanned.
-            guard !relPath.hasPrefix("scripts/") else { continue }
+            guard !relPath.lowercased().hasPrefix("scripts/") else { continue }
             let actualSize = fileSize(abs)
             guard let size = actualSize, size <= 512_000 else {
                 // Missing a reference *source* here is worse than the same skip in a candidate

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -139,4 +139,111 @@ public enum DeadAssetScanner {
         }
         return out
     }
+
+    // MARK: - Full-project scan
+
+    private static let referenceScanExtensions: Set<String> = [
+        ".astro", ".md", ".mdx", ".mdoc", ".markdown", ".css",
+    ]
+    private static let excludedDirNames: Set<String> = ["node_modules", "dist", ".astro", ".git"]
+
+    /// Scans every `.astro`/`.md`/`.mdx`/`.mdoc`/`.markdown`/`.css` file under `projectRoot` for
+    /// references, then returns every unused `src/components/**/*.astro`, `src/layouts/**/*.astro`,
+    /// and unused entry in `images` (typically `SiteContentGraph.images(for:)`, scoped to
+    /// `public/images/**`). Pure over the filesystem snapshot at call time.
+    public static func scan(projectRoot: URL, images: [SiteContentGraph.Image]) -> [CleanupCandidate] {
+        var fileReferenceCounts: [String: Int] = [:]
+        var globDirectories: Set<String> = []
+
+        for abs in walk(projectRoot) {
+            let ext = "." + abs.pathExtension.lowercased()
+            guard referenceScanExtensions.contains(ext) else { continue }
+            guard let source = try? String(contentsOf: abs, encoding: .utf8) else { continue }
+            let relPath = relativePosix(abs, from: projectRoot)
+
+            let refs = extractReferences(source: source, path: relPath)
+            for ref in refs.fileReferences { fileReferenceCounts[ref, default: 0] += 1 }
+            globDirectories.formUnion(refs.globDirectories)
+
+            // Frontmatter `layout:` counts as a reference too — extractReferences only looks at
+            // the body, not frontmatter fields.
+            let frontmatter = Frontmatter.parse(source)
+            if case let .string(layoutRef)? = frontmatter["layout"],
+               let resolved = resolve(layoutRef, relativeTo: relPath) {
+                fileReferenceCounts[resolved, default: 0] += 1
+            }
+        }
+
+        func referenceCount(for path: String) -> Int {
+            if globDirectories.contains(where: { path.hasPrefix($0 + "/") }) {
+                return max(1, fileReferenceCounts[path] ?? 0)
+            }
+            return fileReferenceCounts[path] ?? 0
+        }
+
+        var candidates: [CleanupCandidate] = []
+
+        for abs in walk(projectRoot.appendingPathComponent("src/components"))
+        where abs.pathExtension.lowercased() == "astro" {
+            let rel = relativePosix(abs, from: projectRoot)
+            let count = referenceCount(for: rel)
+            if count == 0 {
+                candidates.append(CleanupCandidate(
+                    id: rel, path: rel, kind: .component, lastModified: mtime(abs), referenceCount: count))
+            }
+        }
+        for abs in walk(projectRoot.appendingPathComponent("src/layouts"))
+        where abs.pathExtension.lowercased() == "astro" {
+            let rel = relativePosix(abs, from: projectRoot)
+            let count = referenceCount(for: rel)
+            if count == 0 {
+                candidates.append(CleanupCandidate(
+                    id: rel, path: rel, kind: .layout, lastModified: mtime(abs), referenceCount: count))
+            }
+        }
+        for image in images {
+            let count = referenceCount(for: image.relativePath)
+            if count == 0 {
+                candidates.append(CleanupCandidate(
+                    id: image.relativePath, path: image.relativePath, kind: .image,
+                    lastModified: image.lastModified, referenceCount: count))
+            }
+        }
+
+        return candidates.sorted { $0.path < $1.path }
+    }
+
+    /// Recursively collects files under `dir` in sorted order, skipping excluded directories and
+    /// symlinks. Missing `dir` → empty. Mirrors `ContentScanner.walk`/`SiteKnowledgeIndex.walk`.
+    private static func walk(_ dir: URL) -> [URL] {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey], options: []
+        ) else { return [] }
+        var files: [URL] = []
+        for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            let name = entry.lastPathComponent
+            let values = try? entry.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            if values?.isSymbolicLink == true { continue }
+            if values?.isDirectory == true {
+                if excludedDirNames.contains(name) { continue }
+                files.append(contentsOf: walk(entry))
+            } else {
+                files.append(entry)
+            }
+        }
+        return files
+    }
+
+    private static func relativePosix(_ url: URL, from base: URL) -> String {
+        let urlComponents = url.standardizedFileURL.pathComponents
+        let baseComponents = base.standardizedFileURL.pathComponents
+        guard urlComponents.starts(with: baseComponents) else { return url.path }
+        return urlComponents.dropFirst(baseComponents.count).joined(separator: "/")
+    }
+
+    private static func mtime(_ url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+            ?? Date(timeIntervalSince1970: 0)
+    }
 }

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -17,6 +17,14 @@ import Foundation
 /// inherent tradeoff of regex-based scanning versus a full AST parse and is not closed here;
 /// Delete always requires explicit user confirmation and is git-tracked/recoverable, which is
 /// this scanner's primary mitigation for this class of false positive.
+///
+/// **Alias resolution scope:** `tsconfig.json`/`jsconfig.json` `compilerOptions.paths` (wildcard
+/// and exact entries), `baseUrl`, and a same-project `extends` chain are resolved (see
+/// `loadPathAliases`/`resolveAlias`). Aliases declared *only* via `astro.config.mjs`'s
+/// `vite.resolve.alias` — not mirrored into tsconfig/jsconfig `paths`, which Astro's docs
+/// recommend keeping in sync but do not enforce — are **not** resolved: an import through such an
+/// alias with no matching `paths` entry stays unresolved and can flag a live file as unused. Same
+/// mitigation as the regex blind spots above: confirmation-gated, git-tracked delete.
 public enum DeadAssetScanner {
     public struct CleanupCandidate: Sendable, Equatable, Identifiable {
         public let id: String
@@ -146,49 +154,97 @@ public enum DeadAssetScanner {
         return resolveRelativePath(dir, relativeTo: sourcePath)
     }
 
-    /// Alias pattern → target patterns, both retaining their single `*` wildcard, e.g.
-    /// `"@components/*" → ["src/components/*"]`. Read from the site's own `tsconfig.json`/
-    /// `jsconfig.json` `compilerOptions.paths` (not `extends` chains — Astro's own base configs
-    /// never define `paths`). Malformed/missing/commented JSON safely degrades to an empty map,
-    /// matching this scanner's "never guess" resolution philosophy.
-    static func loadPathAliases(projectRoot: URL) -> [String: [String]] {
-        for name in ["tsconfig.json", "jsconfig.json"] {
-            let url = projectRoot.appendingPathComponent(name)
-            guard let data = try? Data(contentsOf: url) else { continue }
-            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
-            guard let compilerOptions = json["compilerOptions"] as? [String: Any] else { continue }
-            guard let paths = compilerOptions["paths"] as? [String: Any] else { continue }
-            var result: [String: [String]] = [:]
-            for (pattern, targets) in paths {
-                guard let targetList = targets as? [String] else { continue }
-                result[pattern] = targetList
-            }
-            if !result.isEmpty { return result }
-        }
-        return [:]
+    /// A tsconfig/jsconfig's alias-relevant `compilerOptions`, merged across an `extends` chain
+    /// (a child's own `baseUrl`/`paths` win over anything inherited — matching how TypeScript
+    /// itself merges `compilerOptions`). `baseUrl` is stored exactly as written in the config
+    /// (project-root-relative in the common case).
+    struct PathAliasConfig: Equatable {
+        let baseUrl: String?
+        let paths: [String: [String]]
     }
 
-    /// Resolves `ref` against `aliases` (from `loadPathAliases`): finds an alias pattern whose
-    /// `*`-stripped prefix/suffix matches `ref`, substitutes the corresponding target pattern's
-    /// prefix/suffix. Only single-`*` patterns are handled — matching the common
-    /// `"@foo/*": ["src/foo/*"]` shape; anything else is skipped (never guessed at).
-    static func resolveAlias(_ ref: String, aliases: [String: [String]]) -> String? {
-        for (pattern, targets) in aliases {
-            guard let starIndex = pattern.firstIndex(of: "*"), pattern.filter({ $0 == "*" }).count == 1 else { continue }
-            let prefix = String(pattern[pattern.startIndex..<starIndex])
-            let suffix = String(pattern[pattern.index(after: starIndex)...])
-            guard ref.hasPrefix(prefix), ref.hasSuffix(suffix), ref.count >= prefix.count + suffix.count else { continue }
-            let matched = String(ref.dropFirst(prefix.count).dropLast(suffix.count))
-            for target in targets {
-                guard let targetStar = target.firstIndex(of: "*"), target.filter({ $0 == "*" }).count == 1 else { continue }
-                let targetPrefix = String(target[target.startIndex..<targetStar])
-                let targetSuffix = String(target[target.index(after: targetStar)...])
-                var resolved = targetPrefix + matched + targetSuffix
-                if resolved.hasPrefix("./") { resolved.removeFirst(2) }
-                return resolved
+    /// Loads `tsconfig.json` or `jsconfig.json` from `projectRoot` (in that order — the first one
+    /// that yields a non-empty `baseUrl`/`paths`, after following its `extends` chain, wins).
+    /// Malformed/missing/commented JSON safely degrades to an empty config, matching this
+    /// scanner's "never guess" resolution philosophy.
+    static func loadPathAliases(projectRoot: URL) -> PathAliasConfig {
+        for name in ["tsconfig.json", "jsconfig.json"] {
+            let url = projectRoot.appendingPathComponent(name)
+            if let config = loadTSConfig(at: url, depth: 0), config.baseUrl != nil || !config.paths.isEmpty {
+                return config
+            }
+        }
+        return PathAliasConfig(baseUrl: nil, paths: [:])
+    }
+
+    /// Loads one tsconfig/jsconfig file, recursively following a relative `extends` chain (TS
+    /// resolves `extends` relative to the extending file's own directory; a depth guard avoids an
+    /// accidental cycle). Returns `nil` only if `url` itself can't be read/parsed as JSON.
+    private static func loadTSConfig(at url: URL, depth: Int) -> PathAliasConfig? {
+        guard depth < 5 else { return nil }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+
+        var inherited = PathAliasConfig(baseUrl: nil, paths: [:])
+        if let extendsRef = json["extends"] as? String {
+            let parentURL = url.deletingLastPathComponent().appendingPathComponent(extendsRef)
+            if let parent = loadTSConfig(at: parentURL, depth: depth + 1) {
+                inherited = parent
+            }
+        }
+
+        let compilerOptions = json["compilerOptions"] as? [String: Any]
+        let baseUrl = (compilerOptions?["baseUrl"] as? String) ?? inherited.baseUrl
+        var paths = inherited.paths
+        if let rawPaths = compilerOptions?["paths"] as? [String: Any] {
+            for (pattern, targets) in rawPaths {
+                guard let targetList = targets as? [String] else { continue }
+                paths[pattern] = targetList
+            }
+        }
+        return PathAliasConfig(baseUrl: baseUrl, paths: paths)
+    }
+
+    /// Resolves `ref` against `config` (from `loadPathAliases`): finds a `paths` pattern —
+    /// wildcard (single `*`) or exact — matching `ref`, substitutes the corresponding target
+    /// (first target wins, matching TypeScript's own resolution order), then resolves that target
+    /// relative to `baseUrl` (or, when `baseUrl` is unset, relative to the project root directly —
+    /// matching how TypeScript resolves `paths` without an explicit `baseUrl`).
+    static func resolveAlias(_ ref: String, config: PathAliasConfig) -> String? {
+        for (pattern, targets) in config.paths {
+            let starCount = pattern.filter({ $0 == "*" }).count
+            if starCount == 1, let starIndex = pattern.firstIndex(of: "*") {
+                let prefix = String(pattern[pattern.startIndex..<starIndex])
+                let suffix = String(pattern[pattern.index(after: starIndex)...])
+                guard ref.hasPrefix(prefix), ref.hasSuffix(suffix), ref.count >= prefix.count + suffix.count else { continue }
+                let matched = String(ref.dropFirst(prefix.count).dropLast(suffix.count))
+                for target in targets {
+                    guard let targetStar = target.firstIndex(of: "*"), target.filter({ $0 == "*" }).count == 1 else { continue }
+                    let targetPrefix = String(target[target.startIndex..<targetStar])
+                    let targetSuffix = String(target[target.index(after: targetStar)...])
+                    let resolved = targetPrefix + matched + targetSuffix
+                    return applyBaseURL(resolved, config.baseUrl)
+                }
+            } else if starCount == 0, pattern == ref, let target = targets.first {
+                return applyBaseURL(target, config.baseUrl)
             }
         }
         return nil
+    }
+
+    /// Prefixes `target` (a `paths`-substituted specifier, possibly still `./`-relative) with
+    /// `baseUrl` when one is configured; strips a leading `./` either way. `baseUrl` is treated as
+    /// project-root-relative (the common single-tsconfig case); an `extends` chain that reaches a
+    /// parent config outside the project root and sets its own `baseUrl` would misresolve here —
+    /// an accepted, narrow gap, no worse than the pre-existing no-`baseUrl` behavior.
+    private static func applyBaseURL(_ target: String, _ baseUrl: String?) -> String {
+        var clean = target
+        if clean.hasPrefix("./") { clean.removeFirst(2) }
+        guard let baseUrl, !baseUrl.isEmpty, baseUrl != "." else { return clean }
+        var base = baseUrl
+        if base.hasPrefix("./") { base.removeFirst(2) }
+        if base.hasSuffix("/") { base.removeLast() }
+        return "\(base)/\(clean)"
     }
 
     private static func matches(_ regex: NSRegularExpression, in source: String, group: Int) -> [String] {
@@ -215,7 +271,7 @@ public enum DeadAssetScanner {
     public static func scan(projectRoot: URL, images: [SiteContentGraph.Image]) -> [CleanupCandidate] {
         var fileReferenceCounts: [String: Int] = [:]
         var globDirectories: Set<String> = []
-        let aliases = loadPathAliases(projectRoot: projectRoot)
+        let aliasConfig = loadPathAliases(projectRoot: projectRoot)
 
         for abs in walk(projectRoot) {
             let ext = "." + abs.pathExtension.lowercased()
@@ -225,11 +281,11 @@ public enum DeadAssetScanner {
             let relPath = relativePosix(abs, from: projectRoot)
 
             let refs = extractReferences(source: source, path: relPath)
-            for ref in refs.fileReferences { fileReferenceCounts[ref, default: 0] += 1 }
-            globDirectories.formUnion(refs.globDirectories)
+            for ref in refs.fileReferences { fileReferenceCounts[ref.lowercased(), default: 0] += 1 }
+            globDirectories.formUnion(refs.globDirectories.map { $0.lowercased() })
             for raw in refs.unresolvedReferences {
-                if let aliasResolved = resolveAlias(raw, aliases: aliases) {
-                    fileReferenceCounts[aliasResolved, default: 0] += 1
+                if let aliasResolved = resolveAlias(raw, config: aliasConfig) {
+                    fileReferenceCounts[aliasResolved.lowercased(), default: 0] += 1
                 }
             }
 
@@ -238,15 +294,16 @@ public enum DeadAssetScanner {
             let frontmatter = Frontmatter.parse(source)
             if case let .string(layoutRef)? = frontmatter["layout"],
                let resolved = resolve(layoutRef, relativeTo: relPath) {
-                fileReferenceCounts[resolved, default: 0] += 1
+                fileReferenceCounts[resolved.lowercased(), default: 0] += 1
             }
         }
 
         func referenceCount(for path: String) -> Int {
-            if globDirectories.contains(where: { path.hasPrefix($0 + "/") }) {
-                return max(1, fileReferenceCounts[path] ?? 0)
+            let key = path.lowercased()
+            if globDirectories.contains(where: { key.hasPrefix($0 + "/") }) {
+                return max(1, fileReferenceCounts[key] ?? 0)
             }
-            return fileReferenceCounts[path] ?? 0
+            return fileReferenceCounts[key] ?? 0
         }
 
         var candidates: [CleanupCandidate] = []

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -8,6 +8,7 @@ import Foundation
 public struct NativeContentOperations: ContentOperationsService {
 
     public typealias GitCommit = @Sendable (_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?
+    public typealias GitDelete = @Sendable (_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?
 
     private let siteDirectory: @Sendable (_ siteID: String) async -> URL?
     private let gitCommit: GitCommit
@@ -225,6 +226,24 @@ public struct NativeContentOperations: ContentOperationsService {
         }
         guard await run(["rev-parse", "--git-dir"]) != nil,
               await run(["add", "--", relPath]) != nil,
+              await run(["commit", "-m", message, "--", relPath]) != nil,
+              let head = await run(["rev-parse", "HEAD"]) else { return nil }
+        return head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Stage-delete and commit exactly `relPath` on the current branch (`git rm` + `git commit`).
+    /// Returns the new HEAD SHA, or nil on any failure (not a repo, dirty tree, rejecting hook,
+    /// git missing) — best-effort, mirroring `processGitCommit`'s shape exactly. Git history is
+    /// the sole undo/archive mechanism for this delete; there is no separate trash/archive path.
+    @Sendable public static func processGitDelete(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        func run(_ args: [String]) async -> ProcessSupervisor.RunResult? {
+            let result = try? await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: projectRoot)
+            guard let result, result.exitCode == 0 else { return nil }
+            return result
+        }
+        guard await run(["rev-parse", "--git-dir"]) != nil,
+              await run(["rm", "--", relPath]) != nil,
               await run(["commit", "-m", message, "--", relPath]) != nil,
               let head = await run(["rev-parse", "HEAD"]) else { return nil }
         return head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -233,8 +233,9 @@ public struct NativeContentOperations: ContentOperationsService {
 
     /// Stage-delete and commit exactly `relPath` on the current branch (`git rm` + `git commit`).
     /// Returns the new HEAD SHA, or nil on any failure (not a repo, dirty tree, rejecting hook,
-    /// git missing) — best-effort, mirroring `processGitCommit`'s shape exactly. Git history is
-    /// the sole undo/archive mechanism for this delete; there is no separate trash/archive path.
+    /// git missing, no HEAD copy) — best-effort, mirroring `processGitCommit`'s shape exactly.
+    /// Git history is the sole undo/archive mechanism for this delete; there is no separate
+    /// trash/archive path.
     @Sendable public static func processGitDelete(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
         let git = URL(fileURLWithPath: "/usr/bin/git")
         func run(_ args: [String]) async -> ProcessSupervisor.RunResult? {
@@ -243,6 +244,12 @@ public struct NativeContentOperations: ContentOperationsService {
             return result
         }
         guard await run(["rev-parse", "--git-dir"]) != nil else { return nil }
+        // Require a HEAD copy before touching anything: if `git commit` fails after `git rm`
+        // already succeeds, the only safe rollback is `git checkout HEAD -- relPath`, which needs
+        // HEAD to actually have the file. A staged-but-never-committed file (`git add`ed, no
+        // commit yet) would otherwise risk ending up gone from both the index and the working
+        // tree with no way back — refusing up front is a clean, side-effect-free failure instead.
+        guard await run(["cat-file", "-e", "HEAD:" + relPath]) != nil else { return nil }
         guard await run(["rm", "--", relPath]) != nil else { return nil }
         guard await run(["commit", "-m", message, "--", relPath]) != nil else {
             // `git rm` already removed the file from the index and working tree before the

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -250,7 +250,12 @@ public struct NativeContentOperations: ContentOperationsService {
             // restore both from HEAD so a failed delete never leaves the file gone without a
             // commit. Same "never a raw non-git-recoverable delete" safety property the happy
             // path relies on, applied to the failure path too.
-            _ = await run(["checkout", "HEAD", "--", relPath])
+            let restored = await run(["checkout", "HEAD", "--", relPath])
+            if restored == nil {
+                await LogCenter.shared.append(
+                    source: "dead-assets:delete", stream: .stderr,
+                    text: "processGitDelete: commit failed for \(relPath) AND rollback (git checkout HEAD --) also failed — the file may be missing from disk with no commit recording its removal. Manual recovery may be needed in \(projectRoot.path).")
+            }
             return nil
         }
         guard let head = await run(["rev-parse", "HEAD"]) else { return nil }

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -257,6 +257,14 @@ public struct NativeContentOperations: ContentOperationsService {
             // restore both from HEAD so a failed delete never leaves the file gone without a
             // commit. Same "never a raw non-git-recoverable delete" safety property the happy
             // path relies on, applied to the failure path too.
+            // This second failure (the rollback itself also failing) has no regression test: by
+            // this point the `cat-file -e HEAD:relPath` guard above has already confirmed HEAD
+            // has the file, so `checkout HEAD --` failing here means something environmental went
+            // wrong between that check and this line (disk full, permissions revoked mid-flight)
+            // — genuinely hard to construct reliably/portably in a test, and narrower than it
+            // looks since the precondition above already rules out the most common cause (no HEAD
+            // copy). Logged rather than silently swallowed so it's at least diagnosable if it
+            // ever fires for real.
             let restored = await run(["checkout", "HEAD", "--", relPath])
             if restored == nil {
                 await LogCenter.shared.append(

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -242,10 +242,18 @@ public struct NativeContentOperations: ContentOperationsService {
             guard let result, result.exitCode == 0 else { return nil }
             return result
         }
-        guard await run(["rev-parse", "--git-dir"]) != nil,
-              await run(["rm", "--", relPath]) != nil,
-              await run(["commit", "-m", message, "--", relPath]) != nil,
-              let head = await run(["rev-parse", "HEAD"]) else { return nil }
+        guard await run(["rev-parse", "--git-dir"]) != nil else { return nil }
+        guard await run(["rm", "--", relPath]) != nil else { return nil }
+        guard await run(["commit", "-m", message, "--", relPath]) != nil else {
+            // `git rm` already removed the file from the index and working tree before the
+            // commit failed (no identity configured, a rejecting pre-commit hook, etc.) —
+            // restore both from HEAD so a failed delete never leaves the file gone without a
+            // commit. Same "never a raw non-git-recoverable delete" safety property the happy
+            // path relies on, applied to the failure path too.
+            _ = await run(["checkout", "HEAD", "--", relPath])
+            return nil
+        }
+        guard let head = await run(["rev-parse", "HEAD"]) else { return nil }
         return head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/AnglesiteCore/ProjectCleanupReport.swift
+++ b/Sources/AnglesiteCore/ProjectCleanupReport.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Merges `DeadAssetScanner`'s unused-component/layout/image candidates with
+/// `LinkGraph.orphanPages` (already computed elsewhere, only ever surfaced per-page in the
+/// Related Pages panel until now) into one sorted list for the Navigator's Cleanup section.
+public enum ProjectCleanupReport {
+    /// `orphanPages` always has zero inbound links by definition, so `referenceCount` is
+    /// hardcoded to 0 for every page candidate — not a placeholder, an accurate reflection of
+    /// what "orphan" means.
+    public static func build(
+        deadAssets: [DeadAssetScanner.CleanupCandidate],
+        orphanPages: [SiteKnowledgeIndex.Document]
+    ) -> [DeadAssetScanner.CleanupCandidate] {
+        let pageCandidates = orphanPages.map { doc in
+            DeadAssetScanner.CleanupCandidate(
+                id: doc.path, path: doc.path, kind: .page,
+                lastModified: doc.lastModified, referenceCount: 0)
+        }
+        return (deadAssets + pageCandidates).sorted { $0.path < $1.path }
+    }
+}

--- a/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
@@ -285,4 +285,48 @@ struct DeadAssetScannerScanTests {
         let candidates = DeadAssetScanner.scan(projectRoot: root, images: images)
         #expect(!candidates.map(\.path).contains("public/images/hero.png"))
     }
+
+    @Test("layout: frontmatter alias resolves the same way body references do")
+    func layoutFrontmatterAlias() {
+        let root = makeSite([
+            "tsconfig.json": #"{"compilerOptions": {"paths": {"@layouts/*": ["src/layouts/*"]}}}"#,
+            "src/content/posts/hello.md": "---\ntitle: Hello\nlayout: @layouts/Post.astro\n---\nBody",
+            "src/layouts/Post.astro": "<slot />",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/layouts/Post.astro"))
+    }
+
+    @Test("non-layout frontmatter fields (image:, cover:, gallery array) are scanned as references too")
+    func frontmatterImageFieldsScanned() {
+        let root = makeSite([
+            "src/content/posts/hello.md": "---\ntitle: Hello\nimage: /images/cover.png\ngallery: [/images/one.png, /images/two.png]\n---\nBody",
+        ])
+        let images = ["cover.png", "one.png", "two.png", "unused.png"].map { name in
+            SiteContentGraph.Image(
+                id: "s:image:public/images/\(name)", siteID: "s",
+                relativePath: "public/images/\(name)", fileName: name,
+                byteSize: nil, usedOnPages: [], lastModified: Date(timeIntervalSince1970: 0))
+        }
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: images)
+        let paths = Set(candidates.map(\.path))
+        #expect(!paths.contains("public/images/cover.png"))
+        #expect(!paths.contains("public/images/one.png"))
+        #expect(!paths.contains("public/images/two.png"))
+        #expect(paths.contains("public/images/unused.png"))
+    }
+
+    @Test("overlapping alias patterns resolve deterministically to the more specific (longer literal prefix) one")
+    func overlappingAliasPatternsPreferMoreSpecific() {
+        let root = makeSite([
+            "tsconfig.json": #"{"compilerOptions": {"paths": {"@/*": ["src/wrong/*"], "@/components/*": ["src/components/*"]}}}"#,
+            "src/pages/index.astro": "---\nimport Header from '@/components/Header.astro';\n---\n<Header />",
+            "src/components/Header.astro": "<header>Site</header>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        // Both patterns match "@/components/Header.astro"; the general "@/*" would resolve to
+        // src/wrong/components/Header.astro (a dead key that matches nothing), so this only
+        // passes if the more specific "@/components/*" pattern's target is also tried.
+        #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
@@ -140,4 +140,25 @@ struct DeadAssetScannerScanTests {
         let root = makeSite([:])
         #expect(DeadAssetScanner.scan(projectRoot: root, images: []).isEmpty)
     }
+
+    @Test("path alias from tsconfig.json paths resolves to the real file, suppressing a false-unused flag")
+    func tsconfigPathAlias() {
+        let root = makeSite([
+            "tsconfig.json": #"{"compilerOptions": {"paths": {"@components/*": ["src/components/*"]}}}"#,
+            "src/pages/index.astro": "---\nimport Header from '@components/Header.astro';\n---\n<Header />",
+            "src/components/Header.astro": "<header>Site</header>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
+    }
+
+    @Test("no tsconfig paths means alias-style imports remain unresolved and unused files are still flagged")
+    func noAliasConfig() {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nimport Header from '@components/Header.astro';\n---\n<Header />",
+            "src/components/Header.astro": "<header>Site</header>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(candidates.map(\.path).contains("src/components/Header.astro"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
@@ -152,13 +152,57 @@ struct DeadAssetScannerScanTests {
         #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
     }
 
-    @Test("no tsconfig paths means alias-style imports remain unresolved and unused files are still flagged")
-    func noAliasConfig() {
+    @Test("KNOWN LIMITATION: an alias with no matching tsconfig/jsconfig paths entry (e.g. vite.resolve.alias in astro.config.mjs) still produces a false-positive unused flag")
+    func aliasWithNoPathsEntryIsNotResolved() {
         let root = makeSite([
             "src/pages/index.astro": "---\nimport Header from '@components/Header.astro';\n---\n<Header />",
             "src/components/Header.astro": "<header>Site</header>",
         ])
         let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
         #expect(candidates.map(\.path).contains("src/components/Header.astro"))
+    }
+
+    @Test("baseUrl-relative path alias resolves to the real file")
+    func tsconfigBaseURLAlias() {
+        let root = makeSite([
+            "tsconfig.json": #"{"compilerOptions": {"baseUrl": "./src", "paths": {"@components/*": ["components/*"]}}}"#,
+            "src/pages/index.astro": "---\nimport Header from '@components/Header.astro';\n---\n<Header />",
+            "src/components/Header.astro": "<header>Site</header>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
+    }
+
+    @Test("exact (non-wildcard) path alias resolves to the real file")
+    func tsconfigExactAlias() {
+        let root = makeSite([
+            "tsconfig.json": #"{"compilerOptions": {"paths": {"@header": ["src/components/Header.astro"]}}}"#,
+            "src/pages/index.astro": "---\nimport Header from '@header';\n---\n<Header />",
+            "src/components/Header.astro": "<header>Site</header>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
+    }
+
+    @Test("path alias inherited through an extends chain resolves to the real file")
+    func tsconfigExtendsChain() {
+        let root = makeSite([
+            "tsconfig.base.json": #"{"compilerOptions": {"paths": {"@components/*": ["src/components/*"]}}}"#,
+            "tsconfig.json": #"{"extends": "./tsconfig.base.json"}"#,
+            "src/pages/index.astro": "---\nimport Header from '@components/Header.astro';\n---\n<Header />",
+            "src/components/Header.astro": "<header>Site</header>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
+    }
+
+    @Test("reference matching is case-insensitive (default APFS is case-insensitive-but-case-preserving)")
+    func caseInsensitiveMatch() {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nimport Header from '../components/header.astro';\n---\n<Header />",
+            "src/components/Header.astro": "<header>Site</header>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
     }
 }

--- a/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
@@ -64,3 +64,80 @@ struct DeadAssetScannerExtractionTests {
         #expect(refs.fileReferences.contains("src/layouts/Base.astro"))
     }
 }
+
+@Suite("DeadAssetScanner full scan")
+struct DeadAssetScannerScanTests {
+    private func makeSite(_ files: [String: String]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dead-asset-scan-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    @Test("dead component is flagged, imported component is not")
+    func componentDetection() {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nimport Header from '../components/Header.astro';\n---\n<Header />",
+            "src/components/Header.astro": "<header>Site</header>",
+            "src/components/Orphan.astro": "<div>never imported</div>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        let paths = Set(candidates.map(\.path))
+        #expect(paths.contains("src/components/Orphan.astro"))
+        #expect(!paths.contains("src/components/Header.astro"))
+    }
+
+    @Test("layout referenced only via frontmatter is not flagged")
+    func layoutFrontmatterReference() {
+        let root = makeSite([
+            "src/content/posts/hello.md": "---\ntitle: Hello\nlayout: ../../layouts/Post.astro\n---\nBody",
+            "src/layouts/Post.astro": "<slot />",
+            "src/layouts/Unused.astro": "<slot />",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        let paths = Set(candidates.map(\.path))
+        #expect(!paths.contains("src/layouts/Post.astro"))
+        #expect(paths.contains("src/layouts/Unused.astro"))
+    }
+
+    @Test("Astro.glob-covered directory suppresses false positives for every file inside it")
+    func globCoveredDirectory() {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nconst widgets = await Astro.glob('../components/widgets/*.astro');\n---\n<div></div>",
+            "src/components/widgets/Card.astro": "<div>card</div>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/widgets/Card.astro"))
+    }
+
+    @Test("unused image (public path) is flagged; referenced image is not")
+    func imageDetection() {
+        let root = makeSite([
+            "src/pages/index.astro": #"<img src="/images/hero.png">"#,
+        ])
+        let images = [
+            SiteContentGraph.Image(
+                id: "s:image:public/images/hero.png", siteID: "s",
+                relativePath: "public/images/hero.png", fileName: "hero.png",
+                byteSize: nil, usedOnPages: [], lastModified: Date(timeIntervalSince1970: 0)),
+            SiteContentGraph.Image(
+                id: "s:image:public/images/unused.png", siteID: "s",
+                relativePath: "public/images/unused.png", fileName: "unused.png",
+                byteSize: nil, usedOnPages: [], lastModified: Date(timeIntervalSince1970: 0)),
+        ]
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: images)
+        let paths = Set(candidates.map(\.path))
+        #expect(paths.contains("public/images/unused.png"))
+        #expect(!paths.contains("public/images/hero.png"))
+    }
+
+    @Test("empty project produces no candidates")
+    func emptyProject() {
+        let root = makeSite([:])
+        #expect(DeadAssetScanner.scan(projectRoot: root, images: []).isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
@@ -205,4 +205,84 @@ struct DeadAssetScannerScanTests {
         let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
         #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
     }
+
+    @Test("multi-target path alias: a component under a later target is still resolved")
+    func tsconfigMultiTargetAlias() {
+        let root = makeSite([
+            "tsconfig.json": #"{"compilerOptions": {"paths": {"@shared/*": ["src/nonexistent/*", "src/components/*"]}}}"#,
+            "src/pages/index.astro": "---\nimport Header from '@shared/Header.astro';\n---\n<Header />",
+            "src/components/Header.astro": "<header>Site</header>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
+    }
+
+    @Test("import.meta.glob (array of patterns) marks the resolved directories, not exact files")
+    func importMetaGlobDirectory() {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nconst modules = import.meta.glob([\"../components/**/*.astro\", \"../layouts/**/*.astro\"]);\n---\n<div></div>",
+            "src/components/Card.astro": "<div>card</div>",
+            "src/layouts/Post.astro": "<slot />",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        let paths = Set(candidates.map(\.path))
+        #expect(!paths.contains("src/components/Card.astro"))
+        #expect(!paths.contains("src/layouts/Post.astro"))
+    }
+
+    @Test("import.meta.glob with a root-relative pattern (leading slash) resolves against the project root, not public/")
+    func importMetaGlobRootRelative() {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nconst modules = import.meta.glob(\"/src/components/**/*.astro\");\n---\n<div></div>",
+            "src/components/Card.astro": "<div>card</div>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Card.astro"))
+    }
+
+    @Test("top-level scripts/ (dev-harness glob) is excluded from the reference scan")
+    func scriptsDirectoryExcluded() {
+        let root = makeSite([
+            "scripts/harness/component.astro": "---\nconst modules = import.meta.glob([\"/src/components/**/*.astro\", \"/src/layouts/**/*.astro\"]);\n---\n<div></div>",
+            "src/pages/index.astro": "<div>no imports here</div>",
+            "src/components/Orphan.astro": "<div>never imported</div>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(candidates.map(\.path).contains("src/components/Orphan.astro"))
+    }
+
+    @Test("a nested src/scripts/ directory (not the top-level dev-tooling one) is still scanned")
+    func nestedScriptsDirectoryStillScanned() {
+        let root = makeSite([
+            "src/scripts/analytics.js": "import Icon from '../components/Icon.astro';",
+            "src/components/Icon.astro": "<svg></svg>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Icon.astro"))
+    }
+
+    @Test("components referenced only from a .tsx file are not flagged as unused")
+    func referencedFromTypeScriptFile() {
+        let root = makeSite([
+            "src/components/Icon.astro": "<svg></svg>",
+            "src/widgets/Widget.tsx": "import Icon from '../components/Icon.astro';\nexport default function Widget() { return null; }",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Icon.astro"))
+    }
+
+    @Test("images referenced only from a .jsx island's src attribute are not flagged as unused")
+    func imageReferencedFromJSXIsland() {
+        let root = makeSite([
+            "src/islands/Hero.jsx": "export default function Hero() { return <img src=\"/images/hero.png\" />; }",
+        ])
+        let images = [
+            SiteContentGraph.Image(
+                id: "s:image:public/images/hero.png", siteID: "s",
+                relativePath: "public/images/hero.png", fileName: "hero.png",
+                byteSize: nil, usedOnPages: [], lastModified: Date(timeIntervalSince1970: 0)),
+        ]
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: images)
+        #expect(!candidates.map(\.path).contains("public/images/hero.png"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
@@ -254,7 +254,7 @@ struct DeadAssetScannerScanTests {
         #expect(!candidates.map(\.path).contains("src/components/Card.astro"))
     }
 
-    @Test("top-level scripts/ (dev-harness glob) is excluded from the reference scan")
+    @Test("top-level scripts/ (dev-harness glob) does not contribute glob-directory coverage")
     func scriptsDirectoryExcluded() {
         let root = makeSite([
             "scripts/harness/component.astro": "---\nconst modules = import.meta.glob([\"/src/components/**/*.astro\", \"/src/layouts/**/*.astro\"]);\n---\n<div></div>",
@@ -263,6 +263,16 @@ struct DeadAssetScannerScanTests {
         ])
         let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
         #expect(candidates.map(\.path).contains("src/components/Orphan.astro"))
+    }
+
+    @Test("a discrete (non-glob) reference from a top-level scripts/ file is still credited")
+    func scriptsDirectoryDiscreteReferenceStillCredited() {
+        let root = makeSite([
+            "scripts/catalog.ts": "import Header from '../src/components/Header.astro';",
+            "src/components/Header.astro": "<header>Site</header>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
     }
 
     @Test("a nested src/scripts/ directory (not the top-level dev-tooling one) is still scanned")

--- a/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("DeadAssetScanner reference extraction")
+struct DeadAssetScannerExtractionTests {
+
+    @Test("extracts import statements and resolves relative paths against the source file's directory")
+    func importResolution() {
+        let source = """
+        ---
+        import Header from '../components/Header.astro';
+        ---
+        <Header />
+        """
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/pages/about.astro")
+        #expect(refs.fileReferences.contains("src/components/Header.astro"))
+    }
+
+    @Test("extracts href/src attributes and resolves an absolute path against public/")
+    func absolutePathResolution() {
+        let source = #"<img src="/images/hero.png" alt="hero">"#
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/pages/index.astro")
+        #expect(refs.fileReferences.contains("public/images/hero.png"))
+    }
+
+    @Test("extracts markdown image references")
+    func markdownImageResolution() {
+        let source = "![alt](../../../public/images/photo.jpg)"
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/content/posts/entry.md")
+        #expect(refs.fileReferences.contains("public/images/photo.jpg"))
+    }
+
+    @Test("extracts CSS url() references")
+    func cssURLResolution() {
+        let source = "@font-face { src: url('../fonts/brand.woff2'); }"
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/styles/global.css")
+        #expect(refs.fileReferences.contains("src/fonts/brand.woff2"))
+    }
+
+    @Test("Astro.glob marks the resolved directory, not an exact file")
+    func globDirectory() {
+        let source = "const posts = await Astro.glob('../content/*.md');"
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/pages/blog.astro")
+        #expect(refs.globDirectories.contains("src/content"))
+    }
+
+    @Test("bare/unresolvable specifiers are never counted as references")
+    func unresolvableSpecifiersSkipped() {
+        let source = """
+        ---
+        import { getCollection } from 'astro:content';
+        import Foo from '@components/Foo.astro';
+        ---
+        """
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/pages/index.astro")
+        #expect(refs.fileReferences.isEmpty)
+    }
+
+    @Test("relative path resolution walks up directories for each ..")
+    func relativeResolutionWalksUp() {
+        let source = "import Base from '../../layouts/Base.astro';"
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/components/cards/Card.astro")
+        #expect(refs.fileReferences.contains("src/layouts/Base.astro"))
+    }
+}

--- a/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
@@ -63,6 +63,20 @@ struct DeadAssetScannerExtractionTests {
         let refs = DeadAssetScanner.extractReferences(source: source, path: "src/components/cards/Card.astro")
         #expect(refs.fileReferences.contains("src/layouts/Base.astro"))
     }
+
+    @Test("glob pattern with no subdirectory (./*.astro) resolves to the source file's own directory")
+    func globSameDirectory() {
+        let source = "const modules = import.meta.glob('./*.astro');"
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/pages/blog.astro")
+        #expect(refs.globDirectories.contains("src/pages"))
+    }
+
+    @Test("glob pattern with parent-directory-only (../*.astro) resolves to the parent directory")
+    func globParentDirectoryOnly() {
+        let source = "const modules = import.meta.glob('../*.astro');"
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/pages/nested/blog.astro")
+        #expect(refs.globDirectories.contains("src/pages"))
+    }
 }
 
 @Suite("DeadAssetScanner full scan")
@@ -328,5 +342,26 @@ struct DeadAssetScannerScanTests {
         // src/wrong/components/Header.astro (a dead key that matches nothing), so this only
         // passes if the more specific "@/components/*" pattern's target is also tried.
         #expect(!candidates.map(\.path).contains("src/components/Header.astro"))
+    }
+
+    @Test("a same-directory glob pattern (./*.astro) suppresses false positives for files beside it")
+    func globSameDirectorySuppressesCandidate() {
+        let root = makeSite([
+            "src/components/index.astro": "---\nconst modules = import.meta.glob('./*.astro');\n---\n<div></div>",
+            "src/components/Card.astro": "<div>card</div>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/Card.astro"))
+    }
+
+    @Test("top-level scripts/ exclusion is case-insensitive")
+    func scriptsDirectoryExclusionCaseInsensitive() {
+        let root = makeSite([
+            "Scripts/harness/component.astro": "---\nconst modules = import.meta.glob([\"/src/components/**/*.astro\", \"/src/layouts/**/*.astro\"]);\n---\n<div></div>",
+            "src/pages/index.astro": "<div>no imports here</div>",
+            "src/components/Orphan.astro": "<div>never imported</div>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(candidates.map(\.path).contains("src/components/Orphan.astro"))
     }
 }

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -240,6 +240,33 @@ struct NativeContentOperationsTests {
         #expect(sha?.count == 40)
         #expect(!FileManager.default.fileExists(atPath: filePath.path))
     }
+
+    @Test("processGitDelete restores the file from HEAD when commit fails after rm succeeds")
+    func rollbackOnCommitFailure() async throws {
+        let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        for args in [["init"], ["config", "user.email", "t@t.io"], ["config", "user.name", "t"]] {
+            _ = try await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: repo)
+        }
+        let filePath = repo.appendingPathComponent("unused.astro")
+        try "<div>original</div>".write(to: filePath, atomically: true, encoding: .utf8)
+        _ = await NativeContentOperations.processGitCommit(repo, "unused.astro", "add unused.astro")
+
+        // Install a pre-commit hook that always rejects, so `git commit` fails after `git rm`
+        // has already removed the file from the index and working tree.
+        let hookPath = repo.appendingPathComponent(".git/hooks/pre-commit")
+        try "#!/bin/sh\nexit 1\n".write(to: hookPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hookPath.path)
+
+        let sha = await NativeContentOperations.processGitDelete(repo, "unused.astro", "Remove unused.astro")
+        #expect(sha == nil)
+        #expect(FileManager.default.fileExists(atPath: filePath.path))
+        #expect(try String(contentsOf: filePath, encoding: .utf8) == "<div>original</div>")
+
+        let status = try await ProcessSupervisor.shared.run(executable: git, arguments: ["status", "--porcelain"], currentDirectoryURL: repo)
+        #expect(status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
 }
 
 private struct StubPageCopyGenerator: PageCopyGenerating {

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -267,6 +267,28 @@ struct NativeContentOperationsTests {
         let status = try await ProcessSupervisor.shared.run(executable: git, arguments: ["status", "--porcelain"], currentDirectoryURL: repo)
         #expect(status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
+
+    @Test("processGitDelete refuses a staged-but-never-committed file (no HEAD copy to roll back to)")
+    func refusesUncommittedFile() async throws {
+        let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        for args in [["init"], ["config", "user.email", "t@t.io"], ["config", "user.name", "t"]] {
+            _ = try await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: repo)
+        }
+        // A first commit so the repo has a HEAD at all.
+        try "root".write(to: repo.appendingPathComponent("root.txt"), atomically: true, encoding: .utf8)
+        _ = await NativeContentOperations.processGitCommit(repo, "root.txt", "initial")
+
+        // Staged via `git add`, but never committed.
+        let filePath = repo.appendingPathComponent("staged-only.astro")
+        try "<div></div>".write(to: filePath, atomically: true, encoding: .utf8)
+        _ = try await ProcessSupervisor.shared.run(executable: git, arguments: ["add", "staged-only.astro"], currentDirectoryURL: repo)
+
+        let sha = await NativeContentOperations.processGitDelete(repo, "staged-only.astro", "Remove staged-only.astro")
+        #expect(sha == nil)
+        #expect(FileManager.default.fileExists(atPath: filePath.path))
+    }
 }
 
 private struct StubPageCopyGenerator: PageCopyGenerating {

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -214,6 +214,32 @@ struct NativeContentOperationsTests {
         let sha = await NativeContentOperations.processGitCommit(repo, "p.astro", "anglesite: add page /p")
         #expect(sha?.count == 40)
     }
+
+    @Test("processGitDelete removes and commits the file, nil outside a repo")
+    func realGitDelete() async throws {
+        // Outside a repo → nil (best-effort), file untouched.
+        let bare = FileManager.default.temporaryDirectory.appendingPathComponent("nogit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: bare, withIntermediateDirectories: true)
+        try "hi".write(to: bare.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+        let none = await NativeContentOperations.processGitDelete(bare, "f.txt", "msg")
+        #expect(none == nil)
+        #expect(FileManager.default.fileExists(atPath: bare.appendingPathComponent("f.txt").path))
+
+        // Inside a repo with a committed file → delete succeeds, returns a 40-char SHA, file gone.
+        let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        for args in [["init"], ["config", "user.email", "t@t.io"], ["config", "user.name", "t"]] {
+            _ = try await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: repo)
+        }
+        let filePath = repo.appendingPathComponent("unused.astro")
+        try "<div></div>".write(to: filePath, atomically: true, encoding: .utf8)
+        _ = await NativeContentOperations.processGitCommit(repo, "unused.astro", "add unused.astro")
+
+        let sha = await NativeContentOperations.processGitDelete(repo, "unused.astro", "Remove unused component: unused.astro")
+        #expect(sha?.count == 40)
+        #expect(!FileManager.default.fileExists(atPath: filePath.path))
+    }
 }
 
 private struct StubPageCopyGenerator: PageCopyGenerating {

--- a/Tests/AnglesiteCoreTests/ProjectCleanupReportTests.swift
+++ b/Tests/AnglesiteCoreTests/ProjectCleanupReportTests.swift
@@ -16,14 +16,18 @@ struct ProjectCleanupReportTests {
     func mergeSorted() {
         let deadAssets = [
             DeadAssetScanner.CleanupCandidate(
-                id: "src/components/Orphan.astro", path: "src/components/Orphan.astro",
+                id: "src/pages/zzz-widget.astro", path: "src/pages/zzz-widget.astro",
                 kind: .component, lastModified: Date(timeIntervalSince1970: 0), referenceCount: 0),
         ]
-        let orphanPages = [doc("src/pages/hidden.astro")]
+        let orphanPages = [doc("src/components/aaa-orphan.astro")]
         let report = ProjectCleanupReport.build(deadAssets: deadAssets, orphanPages: orphanPages)
-        #expect(report.map(\.path) == ["src/components/Orphan.astro", "src/pages/hidden.astro"])
-        #expect(report.last?.kind == .page)
-        #expect(report.last?.referenceCount == 0)
+        // Input order was [component, page]; correct output requires real sorting to
+        // [page, component] since "src/components/…" < "src/pages/…" lexicographically —
+        // this would fail if `.sorted` were ever removed from `build`.
+        #expect(report.map(\.path) == ["src/components/aaa-orphan.astro", "src/pages/zzz-widget.astro"])
+        #expect(report.first?.kind == .page)
+        #expect(report.first?.referenceCount == 0)
+        #expect(report.last?.kind == .component)
     }
 
     @Test("empty inputs produce an empty report")

--- a/Tests/AnglesiteCoreTests/ProjectCleanupReportTests.swift
+++ b/Tests/AnglesiteCoreTests/ProjectCleanupReportTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("ProjectCleanupReport")
+struct ProjectCleanupReportTests {
+    private func doc(_ path: String, kind: SiteKnowledgeIndex.Document.Kind = .page) -> SiteKnowledgeIndex.Document {
+        SiteKnowledgeIndex.Document(
+            id: "s:knowledge:\(path)", siteID: "s", path: path, kind: kind,
+            title: path, frontmatter: [:], headings: [],
+            internalLinks: [], excerptText: "",
+            lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("merges dead-asset candidates with orphan pages, sorted by path")
+    func mergeSorted() {
+        let deadAssets = [
+            DeadAssetScanner.CleanupCandidate(
+                id: "src/components/Orphan.astro", path: "src/components/Orphan.astro",
+                kind: .component, lastModified: Date(timeIntervalSince1970: 0), referenceCount: 0),
+        ]
+        let orphanPages = [doc("src/pages/hidden.astro")]
+        let report = ProjectCleanupReport.build(deadAssets: deadAssets, orphanPages: orphanPages)
+        #expect(report.map(\.path) == ["src/components/Orphan.astro", "src/pages/hidden.astro"])
+        #expect(report.last?.kind == .page)
+        #expect(report.last?.referenceCount == 0)
+    }
+
+    @Test("empty inputs produce an empty report")
+    func emptyInputs() {
+        let report = ProjectCleanupReport.build(deadAssets: [], orphanPages: [])
+        #expect(report.isEmpty)
+    }
+}

--- a/docs/superpowers/plans/2026-07-07-dead-asset-orphaned-content.md
+++ b/docs/superpowers/plans/2026-07-07-dead-asset-orphaned-content.md
@@ -1230,3 +1230,24 @@ the smoke test caught.
   `SiteNavigatorView`'s context menu (Task 7) all reference the same
   `DeadAssetScanner.CleanupCandidate` type and `.kind`/`.path`/`.id` field names consistently
   throughout — checked task-by-task while drafting, no drift.
+
+## Final whole-branch review fixes (post-Task 8)
+
+The final whole-branch review found two Important issues that only show up once the whole
+feature is viewed together (neither individual task's diff revealed them): (1)
+`processGitDelete` could leave a file deleted from disk with no commit if `git commit` failed
+after `git rm` already succeeded, violating the "file left untouched on any delete failure"
+safety property; (2) deleting a Cleanup candidate open in the in-app editor didn't close that
+tab, risking the editor's save-on-leave flow silently resurrecting the just-deleted file. Both
+were fixed and re-reviewed clean (commits `cb6362f4`, `321ed097`), alongside two cheap Minor
+fixes: the design-mandated 512KB file-size skip guard that had been silently dropped during
+implementation, and a doc-comment caveat about the regex scanner's blind spots (brace-bound
+dynamic references, dynamic `import()`, re-export barrels) (commit `66765fea`).
+
+Explicitly deferred as follow-ups (not fixed in this slice): untracked (never-committed)
+candidates can't be deleted via `git rm` and get a misleading error message; orphan pages open in
+the text editor rather than live preview via Cleanup's "Open" (a deliberate simplification, not a
+bug); `SiteContentGraph` images aren't force-refreshed as part of `scan()`; Cleanup candidate rows
+are selectable/highlightable despite clicks doing nothing (minor UX polish); no dedicated unit
+test exists for `ProjectCleanupModel` (`AnglesiteApp` has no SwiftPM test target at all, matching
+the existing `RelatedPagesModel` precedent).

--- a/docs/superpowers/plans/2026-07-07-dead-asset-orphaned-content.md
+++ b/docs/superpowers/plans/2026-07-07-dead-asset-orphaned-content.md
@@ -1,0 +1,1232 @@
+# Dead Asset & Orphaned Content Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an on-demand "Project Cleanup" scan that detects unused Astro components/layouts,
+unused `public/images` assets, and orphaned pages, surfaced in a new Navigator sidebar section
+with git-tracked Open/Ignore/Delete actions.
+
+**Architecture:** Two new pure, fixture-testable `AnglesiteCore` types (`DeadAssetScanner` for the
+new import/asset reference-graph analysis, `ProjectCleanupReport` to merge its output with the
+already-existing `LinkGraph.orphanPages`) feed a thin `ProjectCleanupModel` in `AnglesiteApp`,
+rendered as a new section in `SiteNavigatorView`. Delete reuses the existing
+`NativeContentOperations.processGitCommit` shape via a new sibling `processGitDelete`
+(`git rm` + `git commit`), so removal is git-tracked and git itself is the undo/archive story.
+
+**Tech Stack:** Swift 6.4 (macOS 27 target), Swift Testing (`@Suite`/`@Test`/`#expect`),
+`NSRegularExpression` for text extraction, `ProcessSupervisor` for git subprocess calls.
+
+**Design doc:** [`docs/superpowers/specs/2026-07-07-dead-asset-orphaned-content-design.md`](../specs/2026-07-07-dead-asset-orphaned-content-design.md)
+
+## Global Constraints
+
+- Swift 6.4 / macOS 27 target (per `Package.swift`'s `platforms: [.macOS("27.0")]`).
+- Run all SwiftPM commands with the Xcode 27 toolchain, not the default CommandLineTools one:
+  `export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` before any
+  `swift build`/`swift test`/`xcrun swift test` invocation — the default toolchain's
+  `swift-package` is broken and too old for this package.
+- Tests use Swift Testing (`@Suite`, `@Test`, `#expect`), matching every existing suite touched by
+  this plan (`LinkGraphTests`, `ContentScannerTests`, `NativeContentOperationsTests`) — not XCTest.
+- No new third-party dependencies. No container/MCP round-trips anywhere in this feature — all
+  file I/O is direct, host-side Swift, matching `ContentScanner`/`SiteKnowledgeIndex`.
+- Follow existing file-scanning conventions exactly: a private, per-file `walk(_:)` helper (not a
+  shared utility — every existing scanner in this codebase duplicates its own), excluded directory
+  names `["node_modules", "dist", ".astro", ".git"]`, sorted directory listings for determinism.
+- An unresolved/unresolvable reference must never cause a false "unused" flag — always bias toward
+  under-flagging, never over-flagging (see design doc §3.1).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `Sources/AnglesiteCore/DeadAssetScanner.swift` (new) | Regex-based reference extraction (imports, href/src, markdown images, CSS `url()`, `Astro.glob`) + path resolution + full-project scan producing `CleanupCandidate`s for components/layouts/images. |
+| `Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift` (new) | Pure extraction unit tests + disk-fixture full-scan tests. |
+| `Sources/AnglesiteCore/ProjectCleanupReport.swift` (new) | Merges `DeadAssetScanner` candidates with `LinkGraph.orphanPages` into one sorted list. |
+| `Tests/AnglesiteCoreTests/ProjectCleanupReportTests.swift` (new) | Merge-logic unit tests. |
+| `Sources/AnglesiteCore/NativeContentOperations.swift` (modify) | Add `processGitDelete` + `GitDelete` typealias, sibling to `processGitCommit`. |
+| `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift` (modify) | Add a git-delete pipeline test, mirroring the existing `realGit` test. |
+| `Sources/AnglesiteApp/ProjectCleanupModel.swift` (new) | `@Observable` model: triggers the scan, holds candidates + session-only ignore set, runs delete. |
+| `Sources/AnglesiteApp/SiteWindowModel.swift` (modify) | Owns a `ProjectCleanupModel`, configures it in `loadAndStart()`, adds `openCleanupCandidate(_:)`. |
+| `Sources/AnglesiteApp/SiteNavigatorView.swift` (modify) | Renders the new "Cleanup" section, context menu (Open/Ignore/Delete), delete confirmation dialog, delete-error alert. |
+| `Sources/AnglesiteApp/SiteWindow.swift` (modify) | Threads `model.cleanup` and an open-callback into `SiteNavigatorView`. |
+
+---
+
+### Task 1: `DeadAssetScanner` — reference extraction primitives
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DeadAssetScanner.swift`
+- Test: `Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift`
+
+**Interfaces:**
+- Produces: `enum DeadAssetScanner` with `struct ReferenceSource { let path: String; let fileReferences: Set<String>; let globDirectories: Set<String> }` (internal), and `static func extractReferences(source: String, path: String) -> ReferenceSource` (internal — used directly by this task's tests via `@testable import`, and by Task 2's `scan(projectRoot:images:)`).
+- Consumes: nothing from other tasks (first task).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("DeadAssetScanner reference extraction")
+struct DeadAssetScannerExtractionTests {
+
+    @Test("extracts import statements and resolves relative paths against the source file's directory")
+    func importResolution() {
+        let source = """
+        ---
+        import Header from '../components/Header.astro';
+        ---
+        <Header />
+        """
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/pages/about.astro")
+        #expect(refs.fileReferences.contains("src/components/Header.astro"))
+    }
+
+    @Test("extracts href/src attributes and resolves an absolute path against public/")
+    func absolutePathResolution() {
+        let source = #"<img src="/images/hero.png" alt="hero">"#
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/pages/index.astro")
+        #expect(refs.fileReferences.contains("public/images/hero.png"))
+    }
+
+    @Test("extracts markdown image references")
+    func markdownImageResolution() {
+        let source = "![alt](../../../public/images/photo.jpg)"
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/content/posts/entry.md")
+        #expect(refs.fileReferences.contains("public/images/photo.jpg"))
+    }
+
+    @Test("extracts CSS url() references")
+    func cssURLResolution() {
+        let source = "@font-face { src: url('../fonts/brand.woff2'); }"
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/styles/global.css")
+        #expect(refs.fileReferences.contains("src/fonts/brand.woff2"))
+    }
+
+    @Test("Astro.glob marks the resolved directory, not an exact file")
+    func globDirectory() {
+        let source = "const posts = await Astro.glob('../content/*.md');"
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/pages/blog.astro")
+        #expect(refs.globDirectories.contains("src/content"))
+    }
+
+    @Test("bare/unresolvable specifiers are never counted as references")
+    func unresolvableSpecifiersSkipped() {
+        let source = """
+        ---
+        import { getCollection } from 'astro:content';
+        import Foo from '@components/Foo.astro';
+        ---
+        """
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/pages/index.astro")
+        #expect(refs.fileReferences.isEmpty)
+    }
+
+    @Test("relative path resolution walks up directories for each ..")
+    func relativeResolutionWalksUp() {
+        let source = "import Base from '../../layouts/Base.astro';"
+        let refs = DeadAssetScanner.extractReferences(source: source, path: "src/components/cards/Card.astro")
+        #expect(refs.fileReferences.contains("src/layouts/Base.astro"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --filter DeadAssetScannerExtractionTests
+```
+
+Expected: FAIL — `DeadAssetScanner` does not exist (compile error).
+
+- [ ] **Step 3: Write `DeadAssetScanner`'s extraction primitives**
+
+Create `Sources/AnglesiteCore/DeadAssetScanner.swift`:
+
+```swift
+import Foundation
+
+/// Detects unused `.astro` components/layouts and unused `public/images` assets by building a
+/// reference graph from `import` statements, `href`/`src` attributes, markdown image syntax,
+/// CSS `url()`, `Astro.glob` calls, and frontmatter `layout:` fields — then finding files with
+/// zero resolved inbound references.
+///
+/// An unresolvable reference (bare specifier, unconfigured path alias) is never counted as proof
+/// of use *or* disuse — it is simply skipped. This biases the whole scanner toward
+/// under-flagging: the failure mode is "missed a dead file," never "recommended deleting
+/// something in use."
+public enum DeadAssetScanner {
+    public struct CleanupCandidate: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let path: String
+        public let kind: Kind
+        public let lastModified: Date
+        public let referenceCount: Int
+
+        public enum Kind: String, Sendable, Equatable, CaseIterable {
+            case component, layout, image, page
+        }
+
+        public init(id: String, path: String, kind: Kind, lastModified: Date, referenceCount: Int) {
+            self.id = id
+            self.path = path
+            self.kind = kind
+            self.lastModified = lastModified
+            self.referenceCount = referenceCount
+        }
+    }
+
+    /// Raw references extracted from one source file, already resolved to project-relative paths
+    /// where possible. `globDirectories` are directories an `Astro.glob` call covers — every file
+    /// under one is treated as referenced, regardless of whether it appears in `fileReferences`.
+    struct ReferenceSource: Sendable, Equatable {
+        let path: String
+        let fileReferences: Set<String>
+        let globDirectories: Set<String>
+    }
+
+    // MARK: - Regexes (compiled once, matching the style of ContentScanner/SiteKnowledgeIndex)
+
+    private static let importRegex = try! NSRegularExpression(
+        pattern: #"import\s+(?:[^'"]+?\s+from\s+)?["']([^"']+)["']"#)
+    private static let hrefSrcRegex = try! NSRegularExpression(
+        pattern: #"(?:href|src)=["']([^"']+)["']"#, options: [.caseInsensitive])
+    private static let markdownImageRegex = try! NSRegularExpression(
+        pattern: #"!\[[^\]]*\]\(([^)]+)\)"#)
+    private static let cssURLRegex = try! NSRegularExpression(
+        pattern: #"url\(\s*['"]?([^'")]+)['"]?\s*\)"#, options: [.caseInsensitive])
+    private static let astroGlobRegex = try! NSRegularExpression(
+        pattern: #"Astro\.glob\(\s*['"]([^'"]+)['"]"#)
+
+    /// Extracts and resolves every reference in `source`, a file at project-relative `path`.
+    static func extractReferences(source: String, path: String) -> ReferenceSource {
+        let raw = matches(importRegex, in: source, group: 1)
+            + matches(hrefSrcRegex, in: source, group: 1)
+            + matches(markdownImageRegex, in: source, group: 1)
+            + matches(cssURLRegex, in: source, group: 1)
+
+        var fileRefs = Set<String>()
+        for candidate in raw {
+            let cleaned = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let resolved = resolve(cleaned, relativeTo: path) { fileRefs.insert(resolved) }
+        }
+
+        var globDirs = Set<String>()
+        for pattern in matches(astroGlobRegex, in: source, group: 1) {
+            if let dir = resolveGlobDirectory(pattern, relativeTo: path) { globDirs.insert(dir) }
+        }
+
+        return ReferenceSource(path: path, fileReferences: fileRefs, globDirectories: globDirs)
+    }
+
+    // MARK: - Path resolution
+
+    /// Resolves a raw reference string to a project-relative path, or `nil` if it can't be
+    /// resolved (bare specifier, unconfigured alias) — never guessed at.
+    static func resolve(_ ref: String, relativeTo sourcePath: String) -> String? {
+        if let abs = resolveAbsolutePath(ref) { return abs }
+        if let rel = resolveRelativePath(ref, relativeTo: sourcePath) { return rel }
+        return nil
+    }
+
+    /// `/images/hero.png` → `public/images/hero.png` (Astro serves `public/` at the site root).
+    /// Strips a trailing `?query` or `#fragment` first.
+    static func resolveAbsolutePath(_ ref: String) -> String? {
+        guard ref.hasPrefix("/") else { return nil }
+        var clean = String(ref.dropFirst())
+        if let cut = clean.firstIndex(where: { $0 == "?" || $0 == "#" }) {
+            clean = String(clean[clean.startIndex..<cut])
+        }
+        guard !clean.isEmpty else { return nil }
+        return "public/" + clean
+    }
+
+    /// Resolves `./`/`../`-prefixed `ref` against `sourcePath`'s own directory. Strips a trailing
+    /// `?query`/`#fragment` first.
+    static func resolveRelativePath(_ ref: String, relativeTo sourcePath: String) -> String? {
+        guard ref.hasPrefix("./") || ref.hasPrefix("../") else { return nil }
+        var clean = ref
+        if let cut = clean.firstIndex(where: { $0 == "?" || $0 == "#" }) {
+            clean = String(clean[clean.startIndex..<cut])
+        }
+        var dirComponents = sourcePath.split(separator: "/").dropLast().map(String.init)
+        for segment in clean.split(separator: "/") {
+            if segment == "." { continue }
+            else if segment == ".." { if !dirComponents.isEmpty { dirComponents.removeLast() } }
+            else { dirComponents.append(String(segment)) }
+        }
+        guard !dirComponents.isEmpty else { return nil }
+        return dirComponents.joined(separator: "/")
+    }
+
+    /// Truncates an `Astro.glob` pattern down to its containing directory (e.g.
+    /// `../content/*.md` → the resolved form of `../content`) and resolves that against
+    /// `sourcePath`. Only relative glob patterns are handled — Astro.glob never takes an
+    /// absolute-from-public pattern.
+    static func resolveGlobDirectory(_ pattern: String, relativeTo sourcePath: String) -> String? {
+        guard pattern.hasPrefix("./") || pattern.hasPrefix("../") else { return nil }
+        var dir = pattern
+        if let starIndex = dir.firstIndex(of: "*") {
+            dir = String(dir[dir.startIndex..<starIndex])
+            if let lastSlash = dir.lastIndex(of: "/") {
+                dir = String(dir[dir.startIndex...lastSlash])
+            }
+        }
+        if dir.hasSuffix("/") { dir.removeLast() }
+        return resolveRelativePath(dir, relativeTo: sourcePath)
+    }
+
+    private static func matches(_ regex: NSRegularExpression, in source: String, group: Int) -> [String] {
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        var out: [String] = []
+        for match in regex.matches(in: source, range: range) {
+            guard let r = Range(match.range(at: group), in: source) else { continue }
+            out.append(String(source[r]))
+        }
+        return out
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --filter DeadAssetScannerExtractionTests
+```
+
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DeadAssetScanner.swift Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+git commit -m "feat(dead-assets): reference extraction + path resolution primitives"
+```
+
+---
+
+### Task 2: `DeadAssetScanner.scan` — full-project candidate detection
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/DeadAssetScanner.swift`
+- Test: `Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift`
+
+**Interfaces:**
+- Consumes: `DeadAssetScanner.ReferenceSource`, `DeadAssetScanner.extractReferences(source:path:)`,
+  `DeadAssetScanner.resolve(_:relativeTo:)` from Task 1. `SiteContentGraph.Image` (existing type:
+  `id, siteID, relativePath, fileName, byteSize, usedOnPages, lastModified`).
+- Produces: `public static func scan(projectRoot: URL, images: [SiteContentGraph.Image]) -> [CleanupCandidate]` — the public entry point Task 5 (`ProjectCleanupModel`) calls.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift`:
+
+```swift
+@Suite("DeadAssetScanner full scan")
+struct DeadAssetScannerScanTests {
+    private func makeSite(_ files: [String: String]) -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dead-asset-scan-\(UUID().uuidString)", isDirectory: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try! Data(contents.utf8).write(to: url)
+        }
+        return root
+    }
+
+    @Test("dead component is flagged, imported component is not")
+    func componentDetection() {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nimport Header from '../components/Header.astro';\n---\n<Header />",
+            "src/components/Header.astro": "<header>Site</header>",
+            "src/components/Orphan.astro": "<div>never imported</div>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        let paths = Set(candidates.map(\.path))
+        #expect(paths.contains("src/components/Orphan.astro"))
+        #expect(!paths.contains("src/components/Header.astro"))
+    }
+
+    @Test("layout referenced only via frontmatter is not flagged")
+    func layoutFrontmatterReference() {
+        let root = makeSite([
+            "src/content/posts/hello.md": "---\ntitle: Hello\nlayout: ../../layouts/Post.astro\n---\nBody",
+            "src/layouts/Post.astro": "<slot />",
+            "src/layouts/Unused.astro": "<slot />",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        let paths = Set(candidates.map(\.path))
+        #expect(!paths.contains("src/layouts/Post.astro"))
+        #expect(paths.contains("src/layouts/Unused.astro"))
+    }
+
+    @Test("Astro.glob-covered directory suppresses false positives for every file inside it")
+    func globCoveredDirectory() {
+        let root = makeSite([
+            "src/pages/index.astro": "---\nconst widgets = await Astro.glob('../components/widgets/*.astro');\n---\n<div></div>",
+            "src/components/widgets/Card.astro": "<div>card</div>",
+        ])
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: [])
+        #expect(!candidates.map(\.path).contains("src/components/widgets/Card.astro"))
+    }
+
+    @Test("unused image (public path) is flagged; referenced image is not")
+    func imageDetection() {
+        let root = makeSite([
+            "src/pages/index.astro": #"<img src="/images/hero.png">"#,
+        ])
+        let images = [
+            SiteContentGraph.Image(
+                id: "s:image:public/images/hero.png", siteID: "s",
+                relativePath: "public/images/hero.png", fileName: "hero.png",
+                byteSize: nil, usedOnPages: [], lastModified: Date(timeIntervalSince1970: 0)),
+            SiteContentGraph.Image(
+                id: "s:image:public/images/unused.png", siteID: "s",
+                relativePath: "public/images/unused.png", fileName: "unused.png",
+                byteSize: nil, usedOnPages: [], lastModified: Date(timeIntervalSince1970: 0)),
+        ]
+        let candidates = DeadAssetScanner.scan(projectRoot: root, images: images)
+        let paths = Set(candidates.map(\.path))
+        #expect(paths.contains("public/images/unused.png"))
+        #expect(!paths.contains("public/images/hero.png"))
+    }
+
+    @Test("empty project produces no candidates")
+    func emptyProject() {
+        let root = makeSite([:])
+        #expect(DeadAssetScanner.scan(projectRoot: root, images: []).isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --filter DeadAssetScannerScanTests
+```
+
+Expected: FAIL — `DeadAssetScanner.scan` does not exist (compile error).
+
+- [ ] **Step 3: Implement `scan(projectRoot:images:)`**
+
+Append to the `DeadAssetScanner` enum body in `Sources/AnglesiteCore/DeadAssetScanner.swift` (after
+the `matches` helper, still inside the closing brace):
+
+```swift
+    // MARK: - Full-project scan
+
+    private static let referenceScanExtensions: Set<String> = [
+        ".astro", ".md", ".mdx", ".mdoc", ".markdown", ".css",
+    ]
+    private static let excludedDirNames: Set<String> = ["node_modules", "dist", ".astro", ".git"]
+
+    /// Scans every `.astro`/`.md`/`.mdx`/`.mdoc`/`.markdown`/`.css` file under `projectRoot` for
+    /// references, then returns every unused `src/components/**/*.astro`, `src/layouts/**/*.astro`,
+    /// and unused entry in `images` (typically `SiteContentGraph.images(for:)`, scoped to
+    /// `public/images/**`). Pure over the filesystem snapshot at call time.
+    public static func scan(projectRoot: URL, images: [SiteContentGraph.Image]) -> [CleanupCandidate] {
+        var fileReferenceCounts: [String: Int] = [:]
+        var globDirectories: Set<String> = []
+
+        for abs in walk(projectRoot) {
+            let ext = "." + abs.pathExtension.lowercased()
+            guard referenceScanExtensions.contains(ext) else { continue }
+            guard let source = try? String(contentsOf: abs, encoding: .utf8) else { continue }
+            let relPath = relativePosix(abs, from: projectRoot)
+
+            let refs = extractReferences(source: source, path: relPath)
+            for ref in refs.fileReferences { fileReferenceCounts[ref, default: 0] += 1 }
+            globDirectories.formUnion(refs.globDirectories)
+
+            // Frontmatter `layout:` counts as a reference too — extractReferences only looks at
+            // the body, not frontmatter fields.
+            let frontmatter = Frontmatter.parse(source)
+            if case let .string(layoutRef)? = frontmatter["layout"],
+               let resolved = resolve(layoutRef, relativeTo: relPath) {
+                fileReferenceCounts[resolved, default: 0] += 1
+            }
+        }
+
+        func referenceCount(for path: String) -> Int {
+            if globDirectories.contains(where: { path.hasPrefix($0 + "/") }) {
+                return max(1, fileReferenceCounts[path] ?? 0)
+            }
+            return fileReferenceCounts[path] ?? 0
+        }
+
+        var candidates: [CleanupCandidate] = []
+
+        for abs in walk(projectRoot.appendingPathComponent("src/components"))
+        where abs.pathExtension.lowercased() == "astro" {
+            let rel = relativePosix(abs, from: projectRoot)
+            let count = referenceCount(for: rel)
+            if count == 0 {
+                candidates.append(CleanupCandidate(
+                    id: rel, path: rel, kind: .component, lastModified: mtime(abs), referenceCount: count))
+            }
+        }
+        for abs in walk(projectRoot.appendingPathComponent("src/layouts"))
+        where abs.pathExtension.lowercased() == "astro" {
+            let rel = relativePosix(abs, from: projectRoot)
+            let count = referenceCount(for: rel)
+            if count == 0 {
+                candidates.append(CleanupCandidate(
+                    id: rel, path: rel, kind: .layout, lastModified: mtime(abs), referenceCount: count))
+            }
+        }
+        for image in images {
+            let count = referenceCount(for: image.relativePath)
+            if count == 0 {
+                candidates.append(CleanupCandidate(
+                    id: image.relativePath, path: image.relativePath, kind: .image,
+                    lastModified: image.lastModified, referenceCount: count))
+            }
+        }
+
+        return candidates.sorted { $0.path < $1.path }
+    }
+
+    /// Recursively collects files under `dir` in sorted order, skipping excluded directories and
+    /// symlinks. Missing `dir` → empty. Mirrors `ContentScanner.walk`/`SiteKnowledgeIndex.walk`.
+    private static func walk(_ dir: URL) -> [URL] {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey], options: []
+        ) else { return [] }
+        var files: [URL] = []
+        for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            let name = entry.lastPathComponent
+            let values = try? entry.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            if values?.isSymbolicLink == true { continue }
+            if values?.isDirectory == true {
+                if excludedDirNames.contains(name) { continue }
+                files.append(contentsOf: walk(entry))
+            } else {
+                files.append(entry)
+            }
+        }
+        return files
+    }
+
+    private static func relativePosix(_ url: URL, from base: URL) -> String {
+        let urlComponents = url.standardizedFileURL.pathComponents
+        let baseComponents = base.standardizedFileURL.pathComponents
+        guard urlComponents.starts(with: baseComponents) else { return url.path }
+        return urlComponents.dropFirst(baseComponents.count).joined(separator: "/")
+    }
+
+    private static func mtime(_ url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+            ?? Date(timeIntervalSince1970: 0)
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --filter DeadAssetScannerScanTests
+xcrun swift test --filter DeadAssetScannerExtractionTests
+```
+
+Expected: PASS (5 new tests, 7 from Task 1 still passing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DeadAssetScanner.swift Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+git commit -m "feat(dead-assets): full-project scan for unused components/layouts/images"
+```
+
+---
+
+### Task 2 amendment (post-review fix)
+
+Task 2's review surfaced a real gap in the design's "never over-flag" invariant: a
+component/layout referenced *only* via an unresolvable specifier (e.g. a TypeScript/Vite path
+alias like `@components/Foo.astro`) was silently dropped with no compensating signal, so it
+would be incorrectly flagged as unused. The human chose to close this gap rather than accept the
+residual risk (see design doc §3.1). Fix, applied and re-reviewed (approved) in commit
+`403d53d8`: `ReferenceSource` gained a purely-additive `unresolvedReferences: Set<String>` field;
+two new functions, `loadPathAliases(projectRoot:)` (reads `tsconfig.json`/`jsconfig.json`
+`compilerOptions.paths`, degrading safely to `[:]` on any missing/malformed file — no `extends`
+chain following, no JSONC comment support) and `resolveAlias(_:aliases:)` (single-`*`-wildcard
+prefix/suffix substitution); `scan(projectRoot:images:)` loads aliases once and retries each
+file's unresolved references against them. `resolve(_:relativeTo:)` and
+`extractReferences(source:path:)`'s signatures were not touched. Two new tests
+(`tsconfigPathAlias`, `noAliasConfig`) lock in both the fixed behavior and the documented
+no-config fallback.
+
+### Task 3: `ProjectCleanupReport` — merge with orphan pages
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ProjectCleanupReport.swift`
+- Test: `Tests/AnglesiteCoreTests/ProjectCleanupReportTests.swift`
+
+**Interfaces:**
+- Consumes: `DeadAssetScanner.CleanupCandidate` (Task 1/2). `LinkGraph.orphanPages` /
+  `SiteKnowledgeIndex.Document` (existing types — `Document` has `id, siteID, path, kind, title,
+  frontmatter, headings, internalLinks, excerptText, lastModified`).
+- Produces: `public enum ProjectCleanupReport` with `public static func build(deadAssets: [DeadAssetScanner.CleanupCandidate], orphanPages: [SiteKnowledgeIndex.Document]) -> [DeadAssetScanner.CleanupCandidate]` — the function Task 5 (`ProjectCleanupModel.scan()`) calls to produce the final list.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/ProjectCleanupReportTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("ProjectCleanupReport")
+struct ProjectCleanupReportTests {
+    private func doc(_ path: String, kind: SiteKnowledgeIndex.Document.Kind = .page) -> SiteKnowledgeIndex.Document {
+        SiteKnowledgeIndex.Document(
+            id: "s:knowledge:\(path)", siteID: "s", path: path, kind: kind,
+            title: path, frontmatter: [:], headings: [],
+            internalLinks: [], excerptText: "",
+            lastModified: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test("merges dead-asset candidates with orphan pages, sorted by path")
+    func mergeSorted() {
+        let deadAssets = [
+            DeadAssetScanner.CleanupCandidate(
+                id: "src/components/Orphan.astro", path: "src/components/Orphan.astro",
+                kind: .component, lastModified: Date(timeIntervalSince1970: 0), referenceCount: 0),
+        ]
+        let orphanPages = [doc("src/pages/hidden.astro")]
+        let report = ProjectCleanupReport.build(deadAssets: deadAssets, orphanPages: orphanPages)
+        #expect(report.map(\.path) == ["src/components/Orphan.astro", "src/pages/hidden.astro"])
+        #expect(report.last?.kind == .page)
+        #expect(report.last?.referenceCount == 0)
+    }
+
+    @Test("empty inputs produce an empty report")
+    func emptyInputs() {
+        let report = ProjectCleanupReport.build(deadAssets: [], orphanPages: [])
+        #expect(report.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --filter ProjectCleanupReportTests
+```
+
+Expected: FAIL — `ProjectCleanupReport` does not exist (compile error).
+
+- [ ] **Step 3: Implement `ProjectCleanupReport`**
+
+Create `Sources/AnglesiteCore/ProjectCleanupReport.swift`:
+
+```swift
+import Foundation
+
+/// Merges `DeadAssetScanner`'s unused-component/layout/image candidates with
+/// `LinkGraph.orphanPages` (already computed elsewhere, only ever surfaced per-page in the
+/// Related Pages panel until now) into one sorted list for the Navigator's Cleanup section.
+public enum ProjectCleanupReport {
+    /// `orphanPages` always has zero inbound links by definition, so `referenceCount` is
+    /// hardcoded to 0 for every page candidate — not a placeholder, an accurate reflection of
+    /// what "orphan" means.
+    public static func build(
+        deadAssets: [DeadAssetScanner.CleanupCandidate],
+        orphanPages: [SiteKnowledgeIndex.Document]
+    ) -> [DeadAssetScanner.CleanupCandidate] {
+        let pageCandidates = orphanPages.map { doc in
+            DeadAssetScanner.CleanupCandidate(
+                id: doc.path, path: doc.path, kind: .page,
+                lastModified: doc.lastModified, referenceCount: 0)
+        }
+        return (deadAssets + pageCandidates).sorted { $0.path < $1.path }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --filter ProjectCleanupReportTests
+```
+
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ProjectCleanupReport.swift Tests/AnglesiteCoreTests/ProjectCleanupReportTests.swift
+git commit -m "feat(dead-assets): merge dead-asset candidates with orphan pages"
+```
+
+---
+
+### Task 4: Git-tracked delete (`NativeContentOperations.processGitDelete`)
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/NativeContentOperations.swift:219-232` (after `processGitCommit`, before the closing brace of the `NativeContentOperations` struct)
+- Modify: `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift` (append after the existing `realGit` test, before its closing brace)
+
+**Interfaces:**
+- Consumes: `ProcessSupervisor.shared.run(executable:arguments:currentDirectoryURL:) -> ProcessSupervisor.RunResult` (existing).
+- Produces: `public typealias GitDelete = @Sendable (_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?` and `@Sendable public static func processGitDelete(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?` on `NativeContentOperations` — the closure Task 5 (`ProjectCleanupModel`) injects and defaults to.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift`, immediately after the
+existing `realGit` test (before the struct's closing brace at the end of the file):
+
+```swift
+    @Test("processGitDelete removes and commits the file, nil outside a repo")
+    func realGitDelete() async throws {
+        // Outside a repo → nil (best-effort), file untouched.
+        let bare = FileManager.default.temporaryDirectory.appendingPathComponent("nogit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: bare, withIntermediateDirectories: true)
+        try "hi".write(to: bare.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+        let none = await NativeContentOperations.processGitDelete(bare, "f.txt", "msg")
+        #expect(none == nil)
+        #expect(FileManager.default.fileExists(atPath: bare.appendingPathComponent("f.txt").path))
+
+        // Inside a repo with a committed file → delete succeeds, returns a 40-char SHA, file gone.
+        let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        for args in [["init"], ["config", "user.email", "t@t.io"], ["config", "user.name", "t"]] {
+            _ = try await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: repo)
+        }
+        let filePath = repo.appendingPathComponent("unused.astro")
+        try "<div></div>".write(to: filePath, atomically: true, encoding: .utf8)
+        _ = await NativeContentOperations.processGitCommit(repo, "unused.astro", "add unused.astro")
+
+        let sha = await NativeContentOperations.processGitDelete(repo, "unused.astro", "Remove unused component: unused.astro")
+        #expect(sha?.count == 40)
+        #expect(!FileManager.default.fileExists(atPath: filePath.path))
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --filter NativeContentOperationsTests/realGitDelete
+```
+
+Expected: FAIL — `NativeContentOperations.processGitDelete` does not exist (compile error).
+
+- [ ] **Step 3: Implement `processGitDelete`**
+
+In `Sources/AnglesiteCore/NativeContentOperations.swift`, add the `GitDelete` typealias next to
+the existing `GitCommit` one (line 10):
+
+```swift
+    public typealias GitCommit = @Sendable (_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?
+    public typealias GitDelete = @Sendable (_ projectRoot: URL, _ relPath: String, _ message: String) async -> String?
+```
+
+Then add `processGitDelete` immediately after `processGitCommit` (after line 231, still inside the
+struct):
+
+```swift
+    /// Stage-delete and commit exactly `relPath` on the current branch (`git rm` + `git commit`).
+    /// Returns the new HEAD SHA, or nil on any failure (not a repo, dirty tree, rejecting hook,
+    /// git missing) — best-effort, mirroring `processGitCommit`'s shape exactly. Git history is
+    /// the sole undo/archive mechanism for this delete; there is no separate trash/archive path.
+    @Sendable public static func processGitDelete(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        func run(_ args: [String]) async -> ProcessSupervisor.RunResult? {
+            let result = try? await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: projectRoot)
+            guard let result, result.exitCode == 0 else { return nil }
+            return result
+        }
+        guard await run(["rev-parse", "--git-dir"]) != nil,
+              await run(["rm", "--", relPath]) != nil,
+              await run(["commit", "-m", message, "--", relPath]) != nil,
+              let head = await run(["rev-parse", "HEAD"]) else { return nil }
+        return head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --filter NativeContentOperationsTests
+```
+
+Expected: PASS (all existing `NativeContentOperationsTests` tests plus the new `realGitDelete`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NativeContentOperations.swift Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+git commit -m "feat(dead-assets): git-tracked delete (git rm + commit)"
+```
+
+---
+
+### Task 5: `ProjectCleanupModel`
+
+**Files:**
+- Create: `Sources/AnglesiteApp/ProjectCleanupModel.swift`
+
+**Interfaces:**
+- Consumes: `SiteKnowledgeIndex.rebuild(siteID:projectRoot:)` / `.documents(siteID:)` (existing),
+  `SiteContentGraph.images(for:)` (existing), `LinkGraph.analyze(documents:)` (existing),
+  `DeadAssetScanner.scan(projectRoot:images:)` (Task 2), `ProjectCleanupReport.build(deadAssets:orphanPages:)`
+  (Task 3), `NativeContentOperations.GitDelete` / `.processGitDelete` (Task 4).
+- Produces: `@MainActor @Observable final class ProjectCleanupModel` with `candidates:
+  [DeadAssetScanner.CleanupCandidate]` (read-only), `isScanning: Bool` (read-only), `hasScanned:
+  Bool` (read-only), `deleteError: String?` (read-write), `configure(siteID:sourceDirectory:)`,
+  `scan() async`, `ignore(_:)`, `delete(_:) async` — all consumed by Task 6/7.
+
+No dedicated unit test for this task: per this codebase's existing convention (see
+`RelatedPagesModel`, which has no test file — its logic-under-test lives entirely in
+`AnglesiteCore`'s `LinkGraph`), `AnglesiteApp` models are thin glue over already-tested
+`AnglesiteCore` functions and are verified via the manual smoke test in Task 8, not a unit suite.
+
+- [ ] **Step 1: Write `ProjectCleanupModel`**
+
+Create `Sources/AnglesiteApp/ProjectCleanupModel.swift`:
+
+```swift
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the Navigator's "Cleanup" section for one site window: on-demand scan, session-only
+/// ignore set, and git-tracked delete. App glue only — all detection/merge logic under test lives
+/// in `AnglesiteCore` (`DeadAssetScanner`, `ProjectCleanupReport`).
+@MainActor
+@Observable
+final class ProjectCleanupModel {
+    private(set) var candidates: [DeadAssetScanner.CleanupCandidate] = []
+    private(set) var isScanning = false
+    private(set) var hasScanned = false
+    var deleteError: String?
+
+    /// Ids ignored this session only — matches `RelatedPagesModel.ignored`'s "not persisted in
+    /// v0" precedent. A fresh app launch re-surfaces a still-unreferenced file.
+    private var ignored = Set<String>()
+    private var siteID: String?
+    private var sourceDirectory: URL?
+
+    private let knowledgeIndex: SiteKnowledgeIndex
+    private let contentGraph: SiteContentGraph
+    private let gitDelete: NativeContentOperations.GitDelete
+
+    init(
+        knowledgeIndex: SiteKnowledgeIndex,
+        contentGraph: SiteContentGraph,
+        gitDelete: @escaping NativeContentOperations.GitDelete = NativeContentOperations.processGitDelete
+    ) {
+        self.knowledgeIndex = knowledgeIndex
+        self.contentGraph = contentGraph
+        self.gitDelete = gitDelete
+    }
+
+    /// Records which site this model scans. Cheap — does no I/O. Called once per site open from
+    /// `SiteWindowModel.loadAndStart()`.
+    func configure(siteID: String, sourceDirectory: URL) {
+        self.siteID = siteID
+        self.sourceDirectory = sourceDirectory
+    }
+
+    /// Runs (or re-runs) the full cleanup scan. On-demand only — never called automatically.
+    func scan() async {
+        guard let siteID, let sourceDirectory else { return }
+        isScanning = true
+        defer { isScanning = false }
+
+        await knowledgeIndex.rebuild(siteID: siteID, projectRoot: sourceDirectory)
+        let documents = await knowledgeIndex.documents(siteID: siteID)
+        let images = await contentGraph.images(for: siteID)
+
+        let report = await Task.detached(priority: .utility) {
+            let deadAssets = DeadAssetScanner.scan(projectRoot: sourceDirectory, images: images)
+            let orphanPages = LinkGraph.analyze(documents: documents).orphanPages
+            return ProjectCleanupReport.build(deadAssets: deadAssets, orphanPages: orphanPages)
+        }.value
+
+        candidates = report.filter { !ignored.contains($0.id) }
+        hasScanned = true
+    }
+
+    /// Dismisses `candidate` for the rest of this session without touching disk.
+    func ignore(_ candidate: DeadAssetScanner.CleanupCandidate) {
+        ignored.insert(candidate.id)
+        candidates.removeAll { $0.id == candidate.id }
+    }
+
+    /// Deletes `candidate` via `git rm` + commit. On failure, sets `deleteError` and leaves the
+    /// candidate listed and the file untouched — never falls back to a non-git raw delete.
+    func delete(_ candidate: DeadAssetScanner.CleanupCandidate) async {
+        guard let sourceDirectory else { return }
+        let message = "Remove unused \(candidate.kind.rawValue): \(candidate.path)"
+        guard await gitDelete(sourceDirectory, candidate.path, message) != nil else {
+            deleteError = "Couldn't delete \(candidate.path). Check for uncommitted changes and try again."
+            return
+        }
+        candidates.removeAll { $0.id == candidate.id }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift build --target AnglesiteApp
+```
+
+Expected: build succeeds (no test to run — this task has no dedicated suite, per the rationale
+above).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ProjectCleanupModel.swift
+git commit -m "feat(dead-assets): ProjectCleanupModel scan/ignore/delete glue"
+```
+
+---
+
+### Task 6: Wire `ProjectCleanupModel` into `SiteWindowModel`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift`
+
+**Interfaces:**
+- Consumes: `ProjectCleanupModel` (Task 5), existing `contentGraph: SiteContentGraph`,
+  `knowledgeIndex: SiteKnowledgeIndex`, `resolved.id`/`resolved.sourceDirectory` (already in scope
+  in `loadAndStart()`), existing `openFile(_ file: FileRef)`.
+- Produces: `var cleanup: ProjectCleanupModel` (read from Task 7's view) and `func
+  openCleanupCandidate(_ candidate: DeadAssetScanner.CleanupCandidate)` (called from Task 7's
+  context menu).
+
+- [ ] **Step 1: Add the `cleanup` property and initialize it**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, add the property near `relatedPages` (after line 68,
+`var relatedPagesPresented = false`):
+
+```swift
+    var relatedPages: RelatedPagesModel
+    var relatedPagesPresented = false
+    /// Drives the Navigator's "Cleanup" section. On-demand only — `scan()` is never called
+    /// automatically, only from the Navigator's "Scan for Cleanup Opportunities" action.
+    var cleanup: ProjectCleanupModel
+```
+
+Initialize it in `init(...)` right after `self.relatedPages = RelatedPagesModel(index:
+knowledgeIndex, ranker: semanticRanker)` (line 121):
+
+```swift
+        self.relatedPages = RelatedPagesModel(index: knowledgeIndex, ranker: semanticRanker)
+        self.cleanup = ProjectCleanupModel(knowledgeIndex: knowledgeIndex, contentGraph: contentGraph)
+```
+
+- [ ] **Step 2: Configure it per site open in `loadAndStart()`**
+
+In `loadAndStart()`, right after `graphExplorer.start(siteID: resolved.id, sourceDirectory:
+resolved.sourceDirectory)` (line 555):
+
+```swift
+        graphExplorer.start(siteID: resolved.id, sourceDirectory: resolved.sourceDirectory)
+        cleanup.configure(siteID: resolved.id, sourceDirectory: resolved.sourceDirectory)
+```
+
+- [ ] **Step 3: Add `openCleanupCandidate`**
+
+Add this method right after `openFile(_:)` (after line 381, before `makeInspectorContext`):
+
+```swift
+    /// Routes a Cleanup-section row: components/layouts/pages open in the existing in-app editor
+    /// (reusing `openFile`, so `.astro` components still get the rich Component Editor via
+    /// `EditorKind.resolve`'s `.components`-group check); images have no in-app editor, so Open
+    /// reveals the file in Finder instead.
+    @MainActor
+    func openCleanupCandidate(_ candidate: DeadAssetScanner.CleanupCandidate) {
+        guard let site else { return }
+        let url = site.sourceDirectory.appendingPathComponent(candidate.path)
+        switch candidate.kind {
+        case .image:
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        case .component, .layout:
+            openFile(FileRef(url: url, group: .components, name: url.lastPathComponent))
+        case .page:
+            openFile(FileRef(url: url, group: .pages, name: url.lastPathComponent))
+        }
+    }
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift build --target AnglesiteApp
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteWindowModel.swift
+git commit -m "feat(dead-assets): wire ProjectCleanupModel into SiteWindowModel"
+```
+
+---
+
+### Task 7: Render the Cleanup section in `SiteNavigatorView`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteNavigatorView.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:97`
+
+**Interfaces:**
+- Consumes: `ProjectCleanupModel` (Task 5/6: `candidates`, `isScanning`, `hasScanned`,
+  `deleteError`, `scan()`, `ignore(_:)`, `delete(_:)`), `SiteWindowModel.openCleanupCandidate(_:)`
+  (Task 6), `DeadAssetScanner.CleanupCandidate` (Task 1/2, `Identifiable` via `id`).
+- Produces: nothing further — last task in the vertical slice.
+
+- [ ] **Step 1: Add the `cleanup` param and Cleanup section to `SiteNavigatorView`**
+
+In `Sources/AnglesiteApp/SiteNavigatorView.swift`, change the struct's properties (lines 6-8):
+
+```swift
+struct SiteNavigatorView: View {
+    @Bindable var model: SiteNavigatorModel
+    @Bindable var cleanup: ProjectCleanupModel
+    var onOpenCleanupCandidate: (DeadAssetScanner.CleanupCandidate) -> Void
+    @FocusState private var editingFocused: Bool
+    @State private var candidateToDelete: DeadAssetScanner.CleanupCandidate?
+```
+
+Add the Cleanup section to the `List` body, right after the existing `ForEach(model.sections)`
+block (after line 24, before the closing `}` of the `List`):
+
+```swift
+            ForEach(model.sections) { section in
+                if let title = section.title {
+                    Section(title) {
+                        ForEach(section.items) { item in
+                            row(for: item, in: section)
+                        }
+                    }
+                } else {
+                    ForEach(section.items) { item in
+                        row(for: item, in: section)
+                    }
+                }
+            }
+            // Only shown once the site has real content — an empty new site keeps the plain
+            // "No content yet" overlay rather than stacking a Cleanup prompt underneath it.
+            if !model.sections.isEmpty {
+                Section("Cleanup") {
+                    cleanupContent
+                }
+            }
+```
+
+Add the `cleanupContent` view builder and `cleanupIcon` helper as new private members of
+`SiteNavigatorView` (e.g. right after the existing `icon(for:)` method):
+
+```swift
+    @ViewBuilder
+    private var cleanupContent: some View {
+        if !cleanup.hasScanned {
+            Button {
+                Task { await cleanup.scan() }
+            } label: {
+                Label(
+                    cleanup.isScanning ? "Scanning…" : "Scan for Cleanup Opportunities",
+                    systemImage: "sparkle.magnifyingglass")
+            }
+            .disabled(cleanup.isScanning)
+        } else if cleanup.candidates.isEmpty {
+            Text("No unused files found")
+                .foregroundStyle(.secondary)
+        } else {
+            ForEach(cleanup.candidates) { candidate in
+                Label(candidate.path, systemImage: cleanupIcon(for: candidate.kind))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .contextMenu {
+                        Button("Open") { onOpenCleanupCandidate(candidate) }
+                        Button("Ignore") { cleanup.ignore(candidate) }
+                        Button("Delete", role: .destructive) { candidateToDelete = candidate }
+                    }
+            }
+            Button {
+                Task { await cleanup.scan() }
+            } label: {
+                Label(cleanup.isScanning ? "Scanning…" : "Rescan", systemImage: "arrow.clockwise")
+            }
+            .disabled(cleanup.isScanning)
+        }
+    }
+
+    private func cleanupIcon(for kind: DeadAssetScanner.CleanupCandidate.Kind) -> String {
+        switch kind {
+        case .component: return "square.stack.3d.up"
+        case .layout: return "rectangle.stack"
+        case .image: return "photo"
+        case .page: return "doc.richtext"
+        }
+    }
+```
+
+Add the delete confirmation dialog and delete-error alert as new `.modifier` calls on the `List` in
+`body`, right after the existing `.alert("Rename failed", ...)` block (after line 57, before the
+closing `}` of `body`):
+
+```swift
+        .confirmationDialog(
+            candidateToDelete.map(deleteConfirmationTitle) ?? "",
+            isPresented: Binding(
+                get: { candidateToDelete != nil },
+                set: { if !$0 { candidateToDelete = nil } }),
+            titleVisibility: .visible,
+            presenting: candidateToDelete
+        ) { candidate in
+            Button("Delete", role: .destructive) {
+                Task { await cleanup.delete(candidate) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { candidate in
+            Text(candidate.kind == .page
+                ? "This page has no incoming links. Its content will be removed from the working tree. This can be undone via git."
+                : "This file appears unused. It will be removed from the working tree. This can be undone via git.")
+        }
+        .alert(
+            "Delete failed",
+            isPresented: Binding(
+                get: { cleanup.deleteError != nil },
+                set: { if !$0 { cleanup.deleteError = nil } }),
+            presenting: cleanup.deleteError
+        ) { _ in
+            Button("OK", role: .cancel) { cleanup.deleteError = nil }
+        } message: { msg in
+            Text(msg)
+        }
+```
+
+Add the title helper as a new private method:
+
+```swift
+    private func deleteConfirmationTitle(for candidate: DeadAssetScanner.CleanupCandidate) -> String {
+        candidate.kind == .page
+            ? "Delete “\(candidate.path)”?"
+            : "Delete unused \(candidate.kind.rawValue) “\(candidate.path)”?"
+    }
+```
+
+- [ ] **Step 2: Pass `cleanup` and the open-callback from `SiteWindow`**
+
+In `Sources/AnglesiteApp/SiteWindow.swift:97`, change:
+
+```swift
+                SiteNavigatorView(model: navigator)
+```
+
+to:
+
+```swift
+                SiteNavigatorView(
+                    model: navigator,
+                    cleanup: model.cleanup,
+                    onOpenCleanupCandidate: { model.openCleanupCandidate($0) }
+                )
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift build --target AnglesiteApp
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteNavigatorView.swift Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat(dead-assets): render the Cleanup section with Open/Ignore/Delete"
+```
+
+---
+
+### Task 8: Full test suite + manual smoke verification
+
+**Files:** none (verification only)
+
+**Interfaces:** none — this task only runs and observes.
+
+- [ ] **Step 1: Run the full AnglesiteCore + app build**
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+xcrun swift test --package-path .
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+```
+
+(`xcodegen generate` first if `Anglesite.xcodeproj` doesn't exist in this worktree yet, and
+`scripts/copy-plugin.sh` if `Resources/plugin` is empty — both per this repo's existing worktree
+setup requirements.)
+
+Expected: all tests pass, the app builds.
+
+- [ ] **Step 2: Manual smoke test in the running app**
+
+Open a real (or scratch) `.anglesite` site with at least one intentionally-unused component under
+`src/components/` and one intentionally-unused image under `public/images/`. In the running app:
+
+1. Open the site window; confirm the sidebar shows a "Cleanup" section with a "Scan for Cleanup
+   Opportunities" row.
+2. Click it; confirm it lists the unused component and unused image (and any orphaned page, if the
+   fixture site has one), each with the correct icon.
+3. Right-click a candidate → **Ignore**; confirm it disappears from the list without touching the
+   file on disk (`git status` in `Source/` shows nothing).
+4. Right-click another candidate → **Delete**; confirm the confirmation dialog appears with
+   type-appropriate copy, confirm, and verify: the file is gone from disk, `git log -1` in
+   `Source/` shows a new commit removing exactly that file, and the row disappears from the list.
+5. Right-click a component candidate → **Open**; confirm it opens in the Component Editor (not the
+   plain text editor). Right-click an image candidate → **Open**; confirm Finder opens with the
+   image selected.
+6. Click **Rescan**; confirm previously-deleted/ignored items don't reappear (deleted: gone from
+   disk; ignored: still session-suppressed).
+
+- [ ] **Step 3: Commit only if the smoke test surfaced a fix**
+
+If Step 2 finds nothing to fix, there is nothing to commit — this task is verification-only. If it
+does surface a bug, fix it, re-run Steps 1-2, then commit the fix with a message describing what
+the smoke test caught.
+
+## Self-Review Notes
+
+- **Spec coverage:** §3 (DeadAssetScanner) → Tasks 1-2. §3.2/`ProjectCleanupReport` → Task 3. §5
+  (git-tracked delete) → Task 4. §4 (trigger/data flow) → Task 5 (`ProjectCleanupModel.scan()`).
+  §6 (UI) → Tasks 6-7. §7 (error handling) → Task 4's dirty-tree/no-repo test, Task 5's
+  `deleteError` path, Task 7's alert. §9 (testing) → covered by each task's own test steps. No gaps
+  found.
+- **Placeholder scan:** no TBD/TODO/"add error handling" phrasing anywhere in the tasks above —
+  every step has complete code.
+- **Type consistency:** `CleanupCandidate` (Task 1), `ProjectCleanupReport.build` (Task 3),
+  `ProjectCleanupModel` (Task 5), `SiteWindowModel.openCleanupCandidate` (Task 6), and
+  `SiteNavigatorView`'s context menu (Task 7) all reference the same
+  `DeadAssetScanner.CleanupCandidate` type and `.kind`/`.path`/`.id` field names consistently
+  throughout — checked task-by-task while drafting, no drift.

--- a/docs/superpowers/specs/2026-07-07-dead-asset-orphaned-content-design.md
+++ b/docs/superpowers/specs/2026-07-07-dead-asset-orphaned-content-design.md
@@ -1,0 +1,238 @@
+# Dead Asset & Orphaned Content Detection
+
+**Date:** 2026-07-07
+**Status:** Approved design, pre-implementation
+**Related:** #310 (feature request), #140 (deferred `usedOnPages` reverse reference), #312 (internal link assistant — `LinkGraph`/orphan-page precedent)
+
+## 1. Summary
+
+Adds an on-demand "Project Cleanup" scan that detects three kinds of dead weight in a site's
+`Source/` tree — unused Astro components/layouts, unused images, and orphaned pages — and
+surfaces them in a new Navigator sidebar section with **Open / Ignore / Delete** actions. Delete
+is git-tracked (`git rm` + commit), so it doubles as the archive/undo story without any new
+storage mechanism.
+
+This directly completes a stub that has existed since #140: `SiteContentGraph.Image.usedOnPages`
+has always been hardcoded to `[]` (`ContentScanner.swift:156`, "reverse … deferred (#140)") because
+the reverse-reference computation was never built. It also aggregates `LinkGraph.orphanPages`
+(already computed today, but only surfaced per-page in the Related Pages panel) into a
+project-wide view for the first time.
+
+## 2. Scope
+
+**In scope (v1):**
+
+- Unused `.astro` files under `src/components/` and `src/layouts/`
+- Unused images under `public/images/**` (the exact set `SiteContentGraph.Image` already models)
+- Orphaned pages (zero inbound internal links, excluding the index page) — reuses
+  `LinkGraph.orphanPages` unchanged
+- Open / Ignore / Delete actions on any candidate, from a new Navigator "Cleanup" section
+- On-demand scan only, triggered by an explicit user action
+
+**Out of scope (v1) — see §8 for rationale:**
+
+- Draft-aged content, duplicate-content detection, empty-collection detection
+- Fonts, icons, or any asset outside `public/images/**`
+- Generic utility modules (`src/utils/**/*.ts`, `SiteKnowledgeIndex.Document.Kind.script`)
+- Continuous/file-watch-driven scanning
+- A separate "Archive" action distinct from git-tracked delete
+
+## 3. Detection engine (`AnglesiteCore`)
+
+Two new pure, fixture-testable types, following the existing `ContentScanner`/`LinkGraph` shape
+(enums, no actors, no I/O beyond reading the file tree once).
+
+### 3.1 `DeadAssetScanner`
+
+Walks the project's source files and extracts four kinds of reference from each, using the same
+compiled-once-`NSRegularExpression` style as `SiteKnowledgeIndex.internalLinks`:
+
+1. **ES imports** — `import ... from "<path>"` — the primary signal for component/layout usage.
+2. **`href=`/`src=` attributes** — reuses `SiteKnowledgeIndex`'s existing extraction approach, but
+   *unlike* `LinkGraph.normalizeRoute` (which discards relative `./`/`../` links because it has no
+   directory context at that call site), this resolves relative paths against **the referencing
+   file's own directory** — that context is available here and is exactly what import/asset
+   resolution needs.
+3. **Frontmatter `layout:` field** — already parsed by `Frontmatter.parse`; this is just reading a
+   field the existing scanner doesn't look at.
+4. **`Astro.glob('<pattern>')` calls** — resolves the glob's directory and marks *every* file under
+   it as referenced. This is a deliberate over-approximation: glob-driven directories (a common
+   Astro pattern for bulk-importing content) must never produce false-positive dead-file flags.
+
+Output per file: `ReferenceSource { path, resolvedReferences: [String] }`. A separate step builds
+inbound-reference counts per candidate file by inverting this map.
+
+**Resolution safety rule:** a reference that can't be resolved (bare specifier like
+`astro:content`, an unconfigured path alias) is simply not counted — it never causes a file to be
+treated as "definitely referenced" *or* "definitely dead." This biases the whole system toward
+under-flagging: the worst failure mode is "missed an actually-dead file," never "recommended
+deleting something in use."
+
+```swift
+public enum DeadAssetScanner {
+    public struct CleanupCandidate: Sendable, Equatable, Identifiable {
+        public let id: String            // relative path
+        public let path: String
+        public let kind: Kind
+        public let lastModified: Date
+        public let referenceCount: Int
+
+        public enum Kind: String, Sendable, Equatable {
+            case component, layout, image
+        }
+    }
+
+    /// Scans `projectRoot` and returns unused components/layouts/images. Pure over the
+    /// filesystem snapshot at call time — no caching, no incremental state.
+    public static func scan(projectRoot: URL) -> [CleanupCandidate]
+}
+```
+
+### 3.2 `ProjectCleanupReport`
+
+Thin combiner merging `DeadAssetScanner`'s candidates with `LinkGraph.orphanPages` (converted to a
+`CleanupCandidate` with `kind: .page` and `referenceCount` = the existing inbound-link count) into
+one sorted `[CleanupCandidate]` — directly matching the issue's requested table shape (File / Type
+/ Last modified / Reference count).
+
+```swift
+public enum ProjectCleanupReport {
+    public static func build(
+        deadAssets: [DeadAssetScanner.CleanupCandidate],
+        orphanPages: [SiteKnowledgeIndex.Document]
+    ) -> [DeadAssetScanner.CleanupCandidate]
+}
+```
+
+## 4. Trigger and data flow
+
+On-demand only, matching the "images + pages + components/layouts" scope decision and the
+project's general preference for cheap, explicit actions over continuous background cost (a full
+reference scan is materially more expensive than dependency-sync's tiny JSON diff).
+
+Flow when the user invokes "Scan for Cleanup Opportunities":
+
+1. `SiteKnowledgeIndex.rebuild(siteID:projectRoot:)` — ensures the document index is fresh (may
+   already be warm from other features; rebuilding is idempotent and cheap relative to the scan
+   itself).
+2. `DeadAssetScanner.scan(projectRoot:)` — walks `src/components/`, `src/layouts/`,
+   `public/images/`, and the full source tree for reference extraction.
+3. `LinkGraph.analyze(documents:)` — already-existing orphan-page computation, run over
+   `SiteKnowledgeIndex.documents(siteID:)`.
+4. `ProjectCleanupReport.build(...)` merges both into the report shown in the Cleanup section.
+
+All of this is host-side Swift file I/O — no container, no MCP round-trip, consistent with
+`ContentScanner`/`SiteKnowledgeIndex`'s existing architecture.
+
+## 5. Delete action
+
+Git-tracked delete, mirroring the existing `NativeContentOperations.processGitCommit` pattern
+(`NativeContentOperations.swift:219`) exactly:
+
+```
+git rev-parse --git-dir              # confirm inside a repo
+git rm -- <relPath>
+git commit -m "Remove unused <kind>: <relPath>" -- <relPath>
+```
+
+New sibling function (e.g. `processGitDelete`), same `@Sendable` closure-injection shape as
+`processGitCommit` for testability, using `ProcessSupervisor.shared.run` in production.
+
+**This single mechanism covers both "Delete" and the issue's "Archive"/"automatic Git commit
+before deletion" nice-to-haves.** Since the file is committed to git on removal, `git log`/
+`git revert` *is* the archive/undo story — a separate archive mechanism would just duplicate what
+git already provides. No new storage, no new UI for "restore from archive."
+
+**Confirmation:** a lightweight alert before running the pipeline (destructive to the working
+tree, even though git-recoverable). Copy is type-aware:
+
+- Component/layout/image: "Delete this unused \<kind\>? This can be undone via git."
+- Page: "Delete this orphaned page? Its content will be lost from the working tree. This can be
+  undone via git."
+
+**Failure handling:** if any step fails (dirty working tree, permission error, not a git repo), a
+non-blocking error is surfaced and the file is left untouched on disk — never fall back to a
+non-git raw delete, per the project's git-is-source-of-truth principle.
+
+**Open editor/preview interaction:** if the file being deleted is the currently open editor tab or
+active preview route, that tab/pane closes as part of the delete completing.
+
+## 6. UI
+
+A new "Cleanup" section appended at the bottom of the existing Navigator sidebar (after
+Components/Styles), rendered directly by `SiteNavigatorView` from a new `ProjectCleanupModel`
+(`@MainActor @Observable`, `AnglesiteApp`) — **not** threaded through
+`NavigatorTree.buildNavigatorTree`, keeping that general-purpose tree builder decoupled from
+cleanup-specific semantics (reference counts, delete, ignore).
+
+- **Empty state** (no scan run yet this session): a single row, "Scan for Cleanup Opportunities."
+- **After a scan:** one row per candidate — name plus a type/reference-count subtitle. Context
+  menu offers **Open / Ignore / Delete**, mirroring the existing Rename context-menu pattern in
+  `SiteNavigatorView`.
+- **Open:** components/layouts/pages route through their existing `.file`/`.route` Navigator
+  targets (same editor/preview behavior as everywhere else in the Navigator). Images have no
+  in-app editor, so Open reveals the file in Finder (`NSWorkspace.shared.activateFileViewerSelecting`).
+- **Ignore:** session-only, in-memory on `ProjectCleanupModel` — matching `RelatedPagesModel`'s
+  existing "not persisted in v0" precedent (`RelatedPagesModel.ignored`). A fresh app launch
+  re-surfaces a still-unreferenced file even if it was ignored in a prior session; smallest state
+  footprint, consistent with the project's existing convention for this exact kind of dismissal.
+
+## 7. Error handling
+
+- Unreadable or oversized (`> 512_000` bytes, matching `SiteKnowledgeIndex`'s existing limit)
+  files are skipped during reference extraction — contribute zero outbound references, never
+  treated as proof of use or disuse.
+- A file that fails to parse contributes zero outbound references — it can't incorrectly "prove"
+  another file is used, and (per §3.1's safety rule) this can't cause a wrongful delete since delete
+  is always a separate, confirmed, git-tracked user action.
+- Delete failures produce a non-blocking alert; the candidate remains listed, unchanged on disk.
+
+## 8. Rationale for out-of-scope items
+
+- **Drafts/duplicates/empty collections** — fundamentally different heuristics (content age,
+  textual similarity, collection emptiness) rather than reference-graph analysis. Bundling them
+  into this slice would mean shipping two unrelated detection engines at once. Natural v2 using
+  the same Cleanup section and candidate/action UI.
+- **Fonts/icons/assets outside `public/images/**`** — nothing in the codebase models these as
+  assets today (`SiteContentGraph`/`ContentScanner` only cover `public/images`). Adding a new asset
+  category is separable follow-up work, not a natural extension of completing the existing stub.
+- **Utility modules (`.ts`/`.js` under `src/utils/`)** — JS/TS import resolution has materially
+  more edge cases (barrel files, re-exports, path aliases via `tsconfig.json`) than `.astro`
+  component imports. Worth its own design pass once the `.astro` case is proven out.
+- **Continuous scanning** — a full reference scan is not cheap enough to run on every file-watch
+  event the way `SiteContentGraph`'s lightweight bulk-load is; on-demand keeps v1's cost bounded
+  and predictable.
+- **Separate Archive action** — redundant with git-tracked delete (§5); would add a second
+  recovery mechanism with no benefit over `git log`/`git revert`.
+
+## 9. Testing
+
+All new logic is pure Swift over in-memory or fixture data — no container, no network, no live
+git server:
+
+- `DeadAssetScannerTests` — reference-extraction unit tests: import resolution, relative-path
+  resolution against the referencing file's directory, glob-directory blanket marking, frontmatter
+  `layout:` counting, and the unresolvable-specifier safety rule (`LinkGraphTests`-style inline
+  fixtures, no disk I/O).
+- A disk-fixture suite (`ContentScannerTests`-style temp directory) covering the full
+  `scan → report` path against a small synthetic Astro project tree, including at least one
+  component that's dead, one that's imported, one glob-covered directory, and one image referenced
+  only via its public path.
+- `ProjectCleanupReportTests` — merge logic combining `DeadAssetScanner` candidates with
+  `LinkGraph.orphanPages`.
+- Git-delete pipeline unit tests against a real temp git repo (same style as existing
+  `RepoBootstrap`/`NativeContentOperations` git tests): success, dirty-tree failure, and
+  non-repo failure.
+- No container/MCP involved anywhere in this feature, so no e2e/`XCSkip`-gated tests are needed.
+
+## 10. Files touched (indicative — implementation plan will pin exact paths)
+
+- New: `Sources/AnglesiteCore/DeadAssetScanner.swift` — reference extraction + candidate detection
+- New: `Sources/AnglesiteCore/ProjectCleanupReport.swift` — merge with `LinkGraph.orphanPages`
+- Modify: `Sources/AnglesiteCore/NativeContentOperations.swift` — add `processGitDelete` sibling to
+  `processGitCommit`
+- New: `Sources/AnglesiteApp/ProjectCleanupModel.swift` — `@Observable` model driving the Cleanup
+  section (scan trigger, ignore set, delete confirmation/execution)
+- Modify: `Sources/AnglesiteApp/SiteNavigatorView.swift` — render the new Cleanup section + context
+  menu actions
+- New/modify: test targets per §9


### PR DESCRIPTION
## Summary

Adds an on-demand "Project Cleanup" scan to the Navigator sidebar that detects three kinds of dead weight in a site's `Source/` tree, with git-tracked Open/Ignore/Delete actions:

- **Unused `.astro` components/layouts** — a new import/reference-graph scanner (`DeadAssetScanner`), including `tsconfig.json`/`jsconfig.json` path-alias resolution so aliased imports don't produce false positives.
- **Unused `public/images` assets** — detected via `DeadAssetScanner`'s own independent reference-graph scan (note: this does *not* fill in `SiteContentGraph.Image.usedOnPages`, which remains hardcoded to `[]` per #140 — that stub is still open; this PR solves the same functional need with a separate mechanism).
- **Orphaned pages** — reuses the already-existing `LinkGraph.orphanPages` (previously only surfaced per-page in the Related Pages panel), aggregated project-wide for the first time via a new `ProjectCleanupReport`.

Delete is git-tracked (`git rm` + `git commit`, mirroring the existing `NativeContentOperations.processGitCommit` shape), so git history is the sole undo/archive mechanism — no separate trash/archive UI.

Design: [`docs/superpowers/specs/2026-07-07-dead-asset-orphaned-content-design.md`](docs/superpowers/specs/2026-07-07-dead-asset-orphaned-content-design.md)
Plan: [`docs/superpowers/plans/2026-07-07-dead-asset-orphaned-content.md`](docs/superpowers/plans/2026-07-07-dead-asset-orphaned-content.md)

## Process notes

Built via subagent-driven development — 7 implementation tasks, each with its own implementer + task-scoped review round, followed by a final whole-branch review. Two review-driven amendments beyond the original plan:

- **Task 2:** review surfaced a real gap in the "never over-flag unused" invariant (a component referenced only via a TS/Vite path alias would be incorrectly flagged) — closed with tsconfig/jsconfig alias resolution rather than accepted as residual risk.
- **Final review:** found two Important issues only visible once the whole feature was assembled — `processGitDelete` could leave a file deleted with no commit if `git commit` failed after `git rm` already succeeded (fixed with a `git checkout HEAD --` rollback), and deleting a candidate open in the in-app editor didn't close that tab, risking the editor's save-on-leave flow silently resurrecting the just-deleted file (fixed by routing delete through `SiteWindowModel` so it can discard, not save, the stale editor tab). Both re-reviewed clean.

Deferred as explicit follow-ups (see plan's final section): untracked-file delete UX, image-list staleness on scan, non-selectable cleanup rows, drafts/duplicates/empty-collection detection (a different, non-reference-graph heuristic — out of scope for this slice per the design doc).

**Round 2 (post-push review):** found real, verified gaps in the alias-resolution safety net and a second instance of the editor-resurrection bug class:
- `DeadAssetScanner`'s tsconfig/jsconfig alias resolution ignored `baseUrl`, exact (non-wildcard) aliases, and `extends` chains — any of these meant a live file's inbound count stayed 0, i.e. flagged as unused. Fixed; the `noAliasConfig` test (aliases declared only via `astro.config.mjs`'s `vite.resolve.alias`, which this scanner still can't parse) is renamed to make clear it documents a known, disclosed limitation rather than accepted behavior.
- Path matching is now case-insensitive, since default APFS is case-insensitive-but-case-preserving and a casing mismatch between an import and the real file could previously miss a real reference.
- `deleteCleanupCandidate` only discarded a stale main-editor tab, not `inspectorContext` — the same resurrection-on-save bug class the earlier final review fixed, just not extended to the Inspector (a page can be selected/inspected *and* be an orphan candidate at the same time). Fixed with the same discard-not-flush treatment.
- `processGitDelete`'s rollback-of-rollback failure (rare double failure) now logs to `LogCenter` instead of being silently swallowed.

**Round 3 (post-push review, second pass):** found deeper, verified gaps once the alias-resolution code was actually exercised against this repo's own shipped template:
- `Astro.glob()` was deprecated in Astro 3 and removed in Astro 5; this repo's bundled template already uses `import.meta.glob` exclusively (zero `Astro.glob` calls anywhere), so glob-directory suppression was silently non-functional against real Astro 5/6 sites. Fixed by recognizing both call forms and array-of-patterns arguments — but naively doing so would have let the template's own `scripts/harness/component.astro` (which blankets *all* of `src/components/**` and `src/layouts/**` via `import.meta.glob` to power the Component Editor preview) suppress unused-component/layout detection for every scaffolded site. Top-level `scripts/` (not nested directories like `src/scripts/`) is now excluded from the reference scan entirely to prevent that.
- `resolveAlias` returned only the first target for a multi-target tsconfig `paths` array (a supported TS/Vite fallback-chain shape) — a real reference under a later target went uncounted. Now returns and credits every target.
- `referenceScanExtensions` never included `.ts`/`.tsx`/`.js`/`.jsx`, so a component or image referenced only from a framework island or helper/config file was invisible to the scanner. Fixed using the same existing extraction patterns.
- `deleteCleanupCandidate`'s editor/inspector guard ran *after* `cleanup.delete` completed, but `delete` suspends across two awaited git subprocess calls, during which the MainActor is free to run other work (Preview/Editor toggle, window close) that could flush a still-open dirty buffer mid-delete, resurrecting the file. Now discards before issuing the delete, closing the race window (documented tradeoff: an unsaved edit is lost if the delete itself later fails, judged preferable to a silent resurrection).


## Test plan

- [x] `swift test --package-path .` — full suite passes (1801 tests, 0 failures)
- [x] `xcodebuild -scheme Anglesite -configuration Debug build` — succeeds
- [x] New unit/fixture tests for `DeadAssetScanner` (extraction, full-project scan, tsconfig `baseUrl`/exact-alias/`extends`/multi-target resolution, case-insensitive matching, `import.meta.glob`, `scripts/` exclusion, `.ts`/`.tsx`/`.jsx` reference sources), `ProjectCleanupReport` (merge/sort), and `NativeContentOperations.processGitDelete` (success, no-repo, rollback-on-commit-failure)
- [ ] Manual interactive smoke test (scan → Open/Ignore/Delete → rescan, plus the Inspector-resurrection fix specifically) — attempted twice with a scratch fixture site in this session but blocked both times by a screen-capture tool failure ("SCContentFilter", unrelated to the app itself); still recommend a quick manual pass before merge, particularly select-page-in-inspector → delete-as-orphan → confirm no resurrection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
