### PR TITLE
feat(app): View menu panes/panels + File menu Rename/Reveal

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -165,6 +165,11 @@ struct AnglesiteApp: App {
             }
 
             NewContentCommands()
+            // Both groups anchor `before: .importExport`; later declarations insert ABOVE earlier
+            // ones, so FileItemCommands is declared first to land BELOW Save/Revert in the menu
+            // (Close · Save · Revert · Rename… · Reveal — TextEdit's File-menu order).
+            // File ▸ Rename… / Reveal in Finder for the focused window (#513).
+            FileItemCommands()
             // File ▸ Save ⌘S / Revert to Saved for the focused window's editors (#509).
             SaveCommands()
             // Standard View-menu items: Show/Hide Sidebar ⌃⌘S and Customize Toolbar… (#510).
@@ -198,6 +203,9 @@ struct AnglesiteApp: App {
             ExportSiteCommands()
             // Site menu: the site window's primary operations (#511).
             SiteMenuCommands()
+            // View ▸ pane switching ⌘1–3 + panel toggles (Chat ⌘K, Related Pages, Inspector ⌥⌘I) —
+            // declared before WebInspectorCommands so they sit above the developer tools (#512).
+            ViewMenuCommands()
             // "Show Web Inspector" in the View menu — its own Commands type for the same focus reason.
             WebInspectorCommands()
             // Debug pane lives off the View menu — `⌥⌘D` keeps it discoverable without crowding

--- a/Sources/AnglesiteApp/FileItemCommands.swift
+++ b/Sources/AnglesiteApp/FileItemCommands.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// File ▸ Rename… / Reveal in Finder for the focused site window (#513). Rename targets the
+/// navigator's selected item (the same inline-edit flow as its context menu); Reveal targets the
+/// most specific focused surface — the open editor's file, else the inspected page's file, else
+/// the site's `Source/` directory. Declared after `SaveCommands`, so these land between
+/// Save/Revert and Export Site Source… in the File menu.
+struct FileItemCommands: Commands {
+    @FocusedValue(\.siteWindowModel) private var model
+
+    var body: some Commands {
+        CommandGroup(before: .importExport) {
+            Button("Rename…") { model?.renameNavigatorItem() }
+                .disabled(model?.canRenameNavigatorItem != true)
+
+            Button("Reveal in Finder") { model?.revealInFinder() }
+                .disabled(model?.canRevealInFinder != true)
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteMenuCommands.swift
+++ b/Sources/AnglesiteApp/SiteMenuCommands.swift
@@ -58,14 +58,9 @@ struct SiteMenuCommands: Commands {
 
             Divider()
 
+            // The graph pane itself is View ▸ Graph ⌘3 (#512) — pane modes are View-menu domain.
             Button("Open in Browser") { model?.openPreviewInBrowser() }
                 .disabled(model?.canOpenPreviewInBrowser != true)
-
-            Button("Show Site Graph") {
-                guard let model else { return }
-                Task { await model.showGraph() }
-            }
-            .disabled(model?.canShowGraph != true)
         }
     }
 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -89,6 +89,13 @@ struct SiteWindow: View {
         // Publishes the whole window model so menu commands (File ▸ Save/Revert today, the Site
         // menu in #511) can reach the focused window's editing surfaces and site operations.
         .focusedSceneValue(\.siteWindowModel, model)
+        // Inspector visibility is scene state (@SceneStorage), so the View menu's Show/Hide
+        // Inspector reaches it through its own focused value rather than the window model (#512).
+        .focusedSceneValue(\.inspectorPanel, InspectorPanelActions(
+            isShown: inspectorShown && model.inspectorContext != nil,
+            isAvailable: model.inspectorContext != nil,
+            toggle: { inspectorShown.toggle() }
+        ))
         .onDisappear { model.close() }
     }
 
@@ -248,7 +255,8 @@ struct SiteWindow: View {
                         : "bubble.left.and.bubble.right")
                 }
                 .help(model.chatPresented ? "Hide chat panel" : "Show chat panel")
-                .keyboardShortcut("k", modifiers: [.command])
+                // ⌘K moved to View ▸ Show/Hide Chat (#512) — a second registration here would
+                // recreate the duplicate-shortcut ambiguity #509 removed for ⌘S.
             }
 
             ToolbarItem(placement: .primaryAction) {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -271,6 +271,37 @@ final class SiteWindowModel {
         NSWorkspace.shared.open(url)
     }
 
+    // MARK: - File-menu targets (#513)
+
+    var canRevealInFinder: Bool {
+        activeEditorFile != nil || inspectorContext != nil || site != nil
+    }
+
+    /// File ▸ Reveal in Finder: the most specific focused surface wins — the open editor's file,
+    /// else the inspected page's source file, else the site's `Source/` directory (the package
+    /// itself is opaque in Finder, so revealing its contents is the useful target).
+    func revealInFinder() {
+        if let file = activeEditorFile {
+            NSWorkspace.shared.activateFileViewerSelecting([file.url])
+        } else if let model = inspectorContext?.model {
+            NSWorkspace.shared.activateFileViewerSelecting([model.file.url])
+        } else if let site {
+            NSWorkspace.shared.activateFileViewerSelecting([site.sourceDirectory])
+        }
+    }
+
+    var canRenameNavigatorItem: Bool {
+        guard let navigator, let selection = navigator.selection else { return false }
+        return navigator.canRename(selection)
+    }
+
+    /// File ▸ Rename…: begins the navigator's inline-edit flow for the selected item (same path as
+    /// its context menu). Site display-name rename stays in the launcher's context menu.
+    func renameNavigatorItem() {
+        guard let navigator, let selection = navigator.selection, navigator.canRename(selection) else { return }
+        navigator.beginEditing(selection)
+    }
+
     /// True when the main-pane editor or the inspector holds unsaved edits — drives File ▸ Save /
     /// Revert to Saved enablement (#509). The `.plist` editor has two independent dirty flags:
     /// plist entries (`isDirty`) and analytics settings (`isAnalyticsDirty`) — both count, matching

--- a/Sources/AnglesiteApp/ViewMenuCommands.swift
+++ b/Sources/AnglesiteApp/ViewMenuCommands.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// The page inspector's visibility lives in `SiteWindow` scene state (`@SceneStorage`), not on the
+/// window model, so the View menu reaches it through this focused value rather than
+/// `\.siteWindowModel` (#512).
+struct InspectorPanelActions {
+    let isShown: Bool
+    let isAvailable: Bool
+    let toggle: @MainActor () -> Void
+}
+
+private struct FocusedInspectorPanelKey: FocusedValueKey { typealias Value = InspectorPanelActions }
+
+extension FocusedValues {
+    var inspectorPanel: InspectorPanelActions? {
+        get { self[FocusedInspectorPanelKey.self] }
+        set { self[FocusedInspectorPanelKey.self] = newValue }
+    }
+}
+
+/// View-menu commands for the focused site window: main-pane switching (⌘1–3) and the side-panel
+/// toggles (#512). Declared before `WebInspectorCommands` so these sit above the developer tools
+/// in the View menu.
+struct ViewMenuCommands: Commands {
+    @FocusedValue(\.siteWindowModel) private var model
+    @FocusedValue(\.inspectorPanel) private var inspectorPanel
+
+    var body: some Commands {
+        CommandGroup(after: .toolbar) {
+            // Toggles (not Buttons) so the active pane gets a menu checkmark; setting an already-on
+            // pane to false is a no-op, giving radio behavior.
+            Toggle("Preview", isOn: paneBinding(0))
+                .keyboardShortcut("1")
+                .disabled(model == nil)
+
+            Toggle("Editor", isOn: paneBinding(1))
+                .keyboardShortcut("2")
+                .disabled(model?.activeEditorFile == nil)
+
+            Toggle("Graph", isOn: paneBinding(2))
+                .keyboardShortcut("3")
+                .disabled(model?.canShowGraph != true)
+
+            Divider()
+
+            // ⌘K lives here, not on the toolbar chat button — a shortcut on a toolbar item is
+            // invisible in the menu bar (the discoverability gap #512 exists to close).
+            Button(model?.chatPresented == true ? "Hide Chat" : "Show Chat") {
+                model?.chatPresented.toggle()
+            }
+            .keyboardShortcut("k")
+            .disabled(model == nil)
+
+            Button(model?.relatedPagesPresented == true ? "Hide Related Pages" : "Show Related Pages") {
+                model?.relatedPagesPresented.toggle()
+            }
+            .disabled(model == nil)
+
+            // ⌥⌘I per the HIG-standard inspector shortcut — reserved for this in #510, when the
+            // Web Inspector moved to ⌥⇧⌘I.
+            Button(inspectorPanel?.isShown == true ? "Hide Inspector" : "Show Inspector") {
+                inspectorPanel?.toggle()
+            }
+            .keyboardShortcut("i", modifiers: [.command, .option])
+            .disabled(inspectorPanel?.isAvailable != true)
+
+            Divider()
+        }
+    }
+
+    private func paneBinding(_ index: Int) -> Binding<Bool> {
+        Binding(
+            get: { model?.paneSelection == index },
+            set: { isOn in if isOn { model?.setPaneSelection(index) } }
+        )
+    }
+}


### PR DESCRIPTION
Third slice of the menu-bar epic #518, stacked on #533. Closes #512, closes #513.

## View menu (#512)

- **Preview / Editor / Graph** pane switching on **⌘1/⌘2/⌘3** — checkmarked `Toggle`s (radio behavior; Editor disables when no file is open). Show Site Graph moves out of the Site menu: the graph pane's home is View ▸ Graph ⌘3.
- **Show/Hide Chat ⌘K** — the shortcut moves off the toolbar button (a shortcut on a toolbar item appears in no menu, and keeping both would recreate the duplicate-registration ambiguity #509 removed for ⌘S).
- **Show/Hide Related Pages**, **Show/Hide Inspector ⌥⌘I** — the HIG-standard inspector shortcut reserved back in #510. Inspector visibility is `@SceneStorage` scene state, so it's reached via a new `InspectorPanelActions` focused value rather than `\.siteWindowModel`.
- Declared above `WebInspectorCommands`, so panes → panels → developer tools reads top-down.

## File menu (#513)

- **Rename…** — the navigator selection's inline-edit flow (same gating as its context menu; disabled for non-renamable items). Site display-name rename stays in the launcher context menu.
- **Reveal in Finder** — most specific focused surface wins: open editor's file, else the inspected page's source file, else the site's `Source/` directory (the `.anglesite` package is opaque in Finder, so revealing contents is the useful target).
- Menu order matches TextEdit: Close · Save · Revert to Saved · Rename… · Reveal in Finder · Export. (Placement quirk documented in code: same-anchor `CommandGroup`s insert above earlier declarations, so declaration order is reversed.)

## Verification

Drove the built app: View menu shows Preview ✓/Editor greyed/Graph with ⌘1–3; ⌘K toggles the chat panel from the keyboard; Show Inspector correctly greyed with nothing inspected; File menu order and enablement verified (Reveal enabled via site fallback with no editor; Rename greyed for a non-renamable styles item; Save/Revert greyed when clean). Build green; app-target-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
