### PR TITLE
reland(app): View menu panes/panels + File menu Rename/Reveal (#512, #513)

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -205,6 +205,9 @@ struct AnglesiteApp: App {
             SiteMenuCommands()
             // View ▸ pane switching ⌘1–3 + panel toggles (Chat ⌘K, Related Pages, Inspector ⌥⌘I) —
             // declared before WebInspectorCommands so they sit above the developer tools (#512).
+            // NOTE the anchor asymmetry (verified in the running app): `after:` groups render in
+            // DECLARATION order (this one above Web Inspector/Debug Pane), while `before:` groups
+            // render in REVERSE declaration order (see FileItemCommands/SaveCommands above).
             ViewMenuCommands()
             // "Show Web Inspector" in the View menu — its own Commands type for the same focus reason.
             WebInspectorCommands()

--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -165,6 +165,11 @@ struct AnglesiteApp: App {
             }
 
             NewContentCommands()
+            // Both groups anchor `before: .importExport`; later declarations insert ABOVE earlier
+            // ones, so FileItemCommands is declared first to land BELOW Save/Revert in the menu
+            // (Close · Save · Revert · Rename… · Reveal — TextEdit's File-menu order).
+            // File ▸ Rename… / Reveal in Finder for the focused window (#513).
+            FileItemCommands()
             // File ▸ Save ⌘S / Revert to Saved for the focused window's editors (#509).
             SaveCommands()
             // Standard View-menu items: Show/Hide Sidebar ⌃⌘S and Customize Toolbar… (#510).
@@ -198,6 +203,9 @@ struct AnglesiteApp: App {
             ExportSiteCommands()
             // Site menu: the site window's primary operations (#511).
             SiteMenuCommands()
+            // View ▸ pane switching ⌘1–3 + panel toggles (Chat ⌘K, Related Pages, Inspector ⌥⌘I) —
+            // declared before WebInspectorCommands so they sit above the developer tools (#512).
+            ViewMenuCommands()
             // "Show Web Inspector" in the View menu — its own Commands type for the same focus reason.
             WebInspectorCommands()
             // Debug pane lives off the View menu — `⌥⌘D` keeps it discoverable without crowding

--- a/Sources/AnglesiteApp/FileItemCommands.swift
+++ b/Sources/AnglesiteApp/FileItemCommands.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// File ▸ Rename… / Reveal in Finder for the focused site window (#513). Rename targets the
+/// navigator's selected item (the same inline-edit flow as its context menu); Reveal targets the
+/// most specific focused surface — the open editor's file, else the inspected page's file, else
+/// the site's `Source/` directory. Declared after `SaveCommands`, so these land between
+/// Save/Revert and Export Site Source… in the File menu.
+struct FileItemCommands: Commands {
+    @FocusedValue(\.siteWindowModel) private var model
+
+    var body: some Commands {
+        CommandGroup(before: .importExport) {
+            Button("Rename…") { model?.renameNavigatorItem() }
+                .disabled(model?.canRenameNavigatorItem != true)
+
+            Button("Reveal in Finder") { model?.revealInFinder() }
+                .disabled(model?.canRevealInFinder != true)
+        }
+    }
+}

--- a/Sources/AnglesiteApp/FileItemCommands.swift
+++ b/Sources/AnglesiteApp/FileItemCommands.swift
@@ -3,8 +3,9 @@ import SwiftUI
 /// File ▸ Rename… / Reveal in Finder for the focused site window (#513). Rename targets the
 /// navigator's selected item (the same inline-edit flow as its context menu); Reveal targets the
 /// most specific focused surface — the open editor's file, else the inspected page's file, else
-/// the site's `Source/` directory. Declared after `SaveCommands`, so these land between
-/// Save/Revert and Export Site Source… in the File menu.
+/// the site's `Source/` directory. Declared BEFORE `SaveCommands` in AnglesiteApp.swift: groups
+/// sharing a `before:` anchor insert above earlier declarations, so declaring this one first is
+/// what lands Rename/Reveal below Save/Revert (between them and Export Site Source…).
 struct FileItemCommands: Commands {
     @FocusedValue(\.siteWindowModel) private var model
 

--- a/Sources/AnglesiteApp/SiteMenuCommands.swift
+++ b/Sources/AnglesiteApp/SiteMenuCommands.swift
@@ -58,14 +58,9 @@ struct SiteMenuCommands: Commands {
 
             Divider()
 
+            // The graph pane itself is View ▸ Graph ⌘3 (#512) — pane modes are View-menu domain.
             Button("Open in Browser") { model?.openPreviewInBrowser() }
                 .disabled(model?.canOpenPreviewInBrowser != true)
-
-            Button("Show Site Graph") {
-                guard let model else { return }
-                Task { await model.showGraph() }
-            }
-            .disabled(model?.canShowGraph != true)
         }
     }
 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -89,6 +89,13 @@ struct SiteWindow: View {
         // Publishes the whole window model so menu commands (File ▸ Save/Revert today, the Site
         // menu in #511) can reach the focused window's editing surfaces and site operations.
         .focusedSceneValue(\.siteWindowModel, model)
+        // Inspector visibility is scene state (@SceneStorage), so the View menu's Show/Hide
+        // Inspector reaches it through its own focused value rather than the window model (#512).
+        .focusedSceneValue(\.inspectorPanel, InspectorPanelActions(
+            isShown: inspectorShown && model.inspectorContext != nil,
+            isAvailable: model.inspectorContext != nil,
+            toggle: { inspectorShown.toggle() }
+        ))
         .onDisappear { model.close() }
     }
 
@@ -248,7 +255,8 @@ struct SiteWindow: View {
                         : "bubble.left.and.bubble.right")
                 }
                 .help(model.chatPresented ? "Hide chat panel" : "Show chat panel")
-                .keyboardShortcut("k", modifiers: [.command])
+                // ⌘K moved to View ▸ Show/Hide Chat (#512) — a second registration here would
+                // recreate the duplicate-shortcut ambiguity #509 removed for ⌘S.
             }
 
             ToolbarItem(placement: .primaryAction) {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -179,8 +179,35 @@ struct SiteWindow: View {
         }
         .navigationTitle(site.name)
         .navigationSubtitle(model.preview.readyURL?.absoluteString ?? "")
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
+        // Leading title, free center — the document-style layout (Pages/Freeform) that makes room
+        // for the .principal pane switcher.
+        .toolbarRole(.editor)
+        // Customizable toolbar (#519): every item has a STABLE id — saved customizations key off
+        // these strings, so renaming one silently discards users' layouts (the id set is frozen
+        // by SiteToolbarItemIDTests in AnglesiteCoreTests). Items must also be
+        // unconditional (no `if let` wrappers): identity-swapping or appearing/vanishing items
+        // fight the customization palette, so state-dependent items render disabled instead.
+        // Curated default ≈8 items; episodic setup/maintenance actions ship hidden and live in
+        // the palette (View ▸ Customize Toolbar…, added in #510).
+        .toolbar(id: "site") {
+            // Fixed center, not movable/removable: the pane switcher is navigation, not a command
+            // (Finder/Freeform convention). Replaces the old Picker row above the main pane.
+            ToolbarItem(id: SiteToolbarItemID.panes.rawValue, placement: .principal) {
+                Picker("View", selection: Binding(
+                    get: { model.paneSelection },
+                    set: { model.setPaneSelection($0) }
+                )) {
+                    Text("Preview").tag(0)
+                    if model.activeEditorFile != nil { Text("Editor").tag(1) }
+                    Text("Graph").tag(2)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .help("Switch between Preview, Editor, and Graph")
+            }
+            .customizationBehavior(.disabled)
+
+            ToolbarItem(id: SiteToolbarItemID.graph.rawValue, placement: .primaryAction) {
                 Button {
                     Task { await model.showGraph() }
                 } label: {
@@ -189,17 +216,7 @@ struct SiteWindow: View {
                 .help("Explore pages, layouts, components, collections, and assets")
             }
 
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    inspectorShown.toggle()
-                } label: {
-                    Label("Inspector", systemImage: "sidebar.right")
-                }
-                .disabled(model.inspectorContext == nil)
-                .help("Show or hide the page inspector")
-            }
-
-            ToolbarItem(placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.backup.rawValue, placement: .primaryAction) {
                 Button {
                     model.backupSite()
                 } label: {
@@ -210,26 +227,8 @@ struct SiteWindow: View {
                       ? "Commit and push working-tree changes to your current branch"
                       : "Site is missing required files")
             }
-            .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
 
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    model.harden.openSheet()
-                } label: {
-                    if model.harden.isRunning {
-                        Label("Hardening…", systemImage: "shield.lefthalf.filled")
-                    } else {
-                        Label("Harden", systemImage: "shield.lefthalf.filled")
-                    }
-                }
-                .disabled(!model.canRunHarden)
-                .help(site.isValid
-                      ? "Preview and apply Cloudflare security hardening for this site"
-                      : "Site is missing required files")
-            }
-            .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
-
-            ToolbarItem(placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.audit.rawValue, placement: .primaryAction) {
                 Button {
                     model.auditSite()
                 } label: {
@@ -244,22 +243,70 @@ struct SiteWindow: View {
                       ? "Run the structured accessibility audit against this site"
                       : "Site is missing required files")
             }
-            .visibilityPriority(.low)
 
-            ToolbarItem(placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.openInBrowser.rawValue, placement: .primaryAction) {
                 Button {
-                    model.chatPresented.toggle()
+                    model.openPreviewInBrowser()
                 } label: {
-                    Label("Chat", systemImage: model.chatPresented
-                        ? "bubble.left.and.bubble.right.fill"
-                        : "bubble.left.and.bubble.right")
+                    Label("Open in browser", systemImage: "arrow.up.forward.app")
                 }
-                .help(model.chatPresented ? "Hide chat panel" : "Show chat panel")
-                // ⌘K moved to View ▸ Show/Hide Chat (#512) — a second registration here would
-                // recreate the duplicate-shortcut ambiguity #509 removed for ⌘S.
+                .disabled(!model.canOpenPreviewInBrowser)
+                .help("Open the live preview in your default browser")
             }
 
-            ToolbarItem(placement: .primaryAction) {
+            // — Palette-only items (View ▸ Customize Toolbar…) —
+
+            ToolbarItem(id: SiteToolbarItemID.harden.rawValue, placement: .primaryAction) {
+                Button {
+                    model.harden.openSheet()
+                } label: {
+                    if model.harden.isRunning {
+                        Label("Hardening…", systemImage: "shield.lefthalf.filled")
+                    } else {
+                        Label("Harden", systemImage: "shield.lefthalf.filled")
+                    }
+                }
+                .disabled(!model.canRunHarden)
+                .help(site.isValid
+                      ? "Preview and apply Cloudflare security hardening for this site"
+                      : "Site is missing required files")
+            }
+            .defaultCustomization(.hidden)
+
+            ToolbarItem(id: SiteToolbarItemID.domain.rawValue, placement: .primaryAction) {
+                Button {
+                    model.domain.openSheet()
+                } label: {
+                    Label("Domain", systemImage: "globe")
+                }
+                .disabled(!model.canOpenDomain)
+                .help("View and manage this domain's DNS records")
+            }
+            .defaultCustomization(.hidden)
+
+            ToolbarItem(id: SiteToolbarItemID.integration.rawValue, placement: .primaryAction) {
+                Button {
+                    model.openIntegrationWizard()
+                } label: {
+                    Label("Add Integration…", systemImage: "puzzlepiece.extension")
+                }
+                .disabled(!model.canOpenIntegrationWizard)
+                .help("Set up a third-party integration for this site")
+            }
+            .defaultCustomization(.hidden)
+
+            ToolbarItem(id: SiteToolbarItemID.siriReadiness.rawValue, placement: .primaryAction) {
+                Button {
+                    model.openSiriReadiness()
+                } label: {
+                    Label("Siri AI Readiness", systemImage: "sparkles")
+                }
+                .disabled(!model.canOpenSiriReadiness)
+                .help("Check whether Siri workflows are ready for this site")
+            }
+            .defaultCustomization(.hidden)
+
+            ToolbarItem(id: SiteToolbarItemID.relatedPages.rawValue, placement: .primaryAction) {
                 Button {
                     model.relatedPagesPresented.toggle()
                 } label: {
@@ -268,33 +315,12 @@ struct SiteWindow: View {
                 }
                 .help(model.relatedPagesPresented ? "Hide related pages" : "Show related pages")
             }
-
-            if let url = model.preview.readyURL {
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        NSWorkspace.shared.open(url)
-                    } label: {
-                        Label("Open in browser", systemImage: "arrow.up.forward.app")
-                    }
-                    .help("Open the live preview in your default browser")
-                }
-            }
-
-            ToolbarItem(placement: .primaryAction) {
-                HealthBadgeView(
-                    model: model.health,
-                    onRecheck: { model.health.recheck(siteID: site.id, siteDirectory: site.sourceDirectory) },
-                    onAskAssistant: {
-                        guard let chat = model.chat else { return }
-                        model.chatPresented = true
-                        chat.send(SiteWindowModel.healthAssistantPrompt)
-                    }
-                )
-            }
-            .visibilityPriority(.high)
+            .defaultCustomization(.hidden)
 
             #if !ANGLESITE_MAS
-            ToolbarItem(placement: .primaryAction) {
+            // One stable item whose label/action reflects publish state — two swapping items
+            // would break saved customizations.
+            ToolbarItem(id: SiteToolbarItemID.github.rawValue, placement: .primaryAction) {
                 if let remote = model.publish.existingRemote {
                     Button {
                         NSWorkspace.shared.open(remote.url)
@@ -312,56 +338,63 @@ struct SiteWindow: View {
                     .help(site.isValid ? "Create a private GitHub repo and push this site" : "Site is missing required files")
                 }
             }
-            .visibilityPriority(.low)
+            .defaultCustomization(.hidden)
             #endif
 
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    model.deploySite()
-                } label: {
-                    Label("Deploy", systemImage: "paperplane.fill")
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(!model.canRunDeploy)
-                .help(site.isValid && model.preview.canDeploy
-                      ? "Build, scan, and run wrangler deploy on this site"
-                      : site.isValid
-                        ? "Open the preview first to start the runtime before deploying"
-                        : "Site is missing required files")
-            }
-            .visibilityPriority(.high)
+            // — Default trailing cluster —
 
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    model.openSiriReadiness()
-                } label: {
-                    Label("Siri AI Readiness", systemImage: "sparkles")
+            // Health badge and Deploy are one item: the badge is the readiness signal for the
+            // button it gates, so customization can never separate them.
+            ToolbarItem(id: SiteToolbarItemID.deploy.rawValue, placement: .primaryAction) {
+                HStack(spacing: 8) {
+                    HealthBadgeView(
+                        model: model.health,
+                        onRecheck: { model.recheckHealth() },
+                        onAskAssistant: {
+                            guard let chat = model.chat else { return }
+                            model.chatPresented = true
+                            chat.send(SiteWindowModel.healthAssistantPrompt)
+                        }
+                    )
+                    Button {
+                        model.deploySite()
+                    } label: {
+                        Label("Deploy", systemImage: "paperplane.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!model.canRunDeploy)
+                    .help(site.isValid && model.preview.canDeploy
+                          ? "Build, scan, and run wrangler deploy on this site"
+                          : site.isValid
+                            ? "Open the preview first to start the runtime before deploying"
+                            : "Site is missing required files")
                 }
-                .help("Check whether Siri workflows are ready for this site")
-                .disabled(!model.canOpenSiriReadiness)
+            }
+            .customizationBehavior(.reorderable)
+
+            ToolbarItem(id: SiteToolbarItemID.chat.rawValue, placement: .primaryAction) {
+                Button {
+                    model.chatPresented.toggle()
+                } label: {
+                    Label("Chat", systemImage: model.chatPresented
+                        ? "bubble.left.and.bubble.right.fill"
+                        : "bubble.left.and.bubble.right")
+                }
+                .help(model.chatPresented ? "Hide chat panel" : "Show chat panel")
+                // ⌘K moved to View ▸ Show/Hide Chat (#512) — a second registration here would
+                // recreate the duplicate-shortcut ambiguity #509 removed for ⌘S.
             }
 
-            ToolbarItem(placement: .primaryAction) {
+            // Far trailing, adjacent to the inspector panel it controls (Pages/Freeform convention).
+            ToolbarItem(id: SiteToolbarItemID.inspector.rawValue, placement: .primaryAction) {
                 Button {
-                    model.openIntegrationWizard()
+                    inspectorShown.toggle()
                 } label: {
-                    Label("Add Integration…", systemImage: "puzzlepiece.extension")
+                    Label("Inspector", systemImage: "sidebar.right")
                 }
-                .disabled(!model.canOpenIntegrationWizard)
-                .help("Set up a third-party integration for this site")
+                .disabled(model.inspectorContext == nil)
+                .help("Show or hide the page inspector")
             }
-            .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
-
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    model.domain.openSheet()
-                } label: {
-                    Label("Domain", systemImage: "globe")
-                }
-                .help("View and manage this domain's DNS records")
-                .disabled(!model.canOpenDomain)
-            }
-            .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
         }
         .sheet(isPresented: $bindableModel.deploy.blockedPresented) {
             if case .blocked(let failures, let warnings) = model.deploy.phase {
@@ -481,22 +514,9 @@ struct SiteWindow: View {
 
     @ViewBuilder
     private func mainPane(for site: SiteStore.Site) -> some View {
-        VStack(spacing: 0) {
-            Picker("", selection: Binding(
-                get: { model.paneSelection },
-                set: { model.setPaneSelection($0) }
-            )) {
-                Text("Preview").tag(0)
-                if model.activeEditorFile != nil { Text("Editor").tag(1) }
-                Text("Graph").tag(2)
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .frame(width: model.activeEditorFile == nil ? 220 : 270)
-            .padding(6)
-            Divider()
-            mainPaneContent(for: site)
-        }
+        // The Preview/Editor/Graph switcher lives in the toolbar (`id: "panes"`, .principal) and
+        // the View menu (⌘1–3) — no in-content picker row (#519).
+        mainPaneContent(for: site)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -271,6 +271,37 @@ final class SiteWindowModel {
         NSWorkspace.shared.open(url)
     }
 
+    // MARK: - File-menu targets (#513)
+
+    var canRevealInFinder: Bool {
+        activeEditorFile != nil || inspectorContext != nil || site != nil
+    }
+
+    /// File ▸ Reveal in Finder: the most specific focused surface wins — the open editor's file,
+    /// else the inspected page's source file, else the site's `Source/` directory (the package
+    /// itself is opaque in Finder, so revealing its contents is the useful target).
+    func revealInFinder() {
+        if let file = activeEditorFile {
+            NSWorkspace.shared.activateFileViewerSelecting([file.url])
+        } else if let model = inspectorContext?.model {
+            NSWorkspace.shared.activateFileViewerSelecting([model.file.url])
+        } else if let site {
+            NSWorkspace.shared.activateFileViewerSelecting([site.sourceDirectory])
+        }
+    }
+
+    var canRenameNavigatorItem: Bool {
+        guard let navigator, let selection = navigator.selection else { return false }
+        return navigator.canRename(selection)
+    }
+
+    /// File ▸ Rename…: begins the navigator's inline-edit flow for the selected item (same path as
+    /// its context menu). Site display-name rename stays in the launcher's context menu.
+    func renameNavigatorItem() {
+        guard let navigator, let selection = navigator.selection, navigator.canRename(selection) else { return }
+        navigator.beginEditing(selection)
+    }
+
     /// True when the main-pane editor or the inspector holds unsaved edits — drives File ▸ Save /
     /// Revert to Saved enablement (#509). The `.plist` editor has two independent dirty flags:
     /// plist entries (`isDirty`) and analytics settings (`isAnalyticsDirty`) — both count, matching

--- a/Sources/AnglesiteApp/ViewMenuCommands.swift
+++ b/Sources/AnglesiteApp/ViewMenuCommands.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// The page inspector's visibility lives in `SiteWindow` scene state (`@SceneStorage`), not on the
+/// window model, so the View menu reaches it through this focused value rather than
+/// `\.siteWindowModel` (#512).
+struct InspectorPanelActions {
+    let isShown: Bool
+    let isAvailable: Bool
+    let toggle: @MainActor () -> Void
+}
+
+private struct FocusedInspectorPanelKey: FocusedValueKey { typealias Value = InspectorPanelActions }
+
+extension FocusedValues {
+    var inspectorPanel: InspectorPanelActions? {
+        get { self[FocusedInspectorPanelKey.self] }
+        set { self[FocusedInspectorPanelKey.self] = newValue }
+    }
+}
+
+/// View-menu commands for the focused site window: main-pane switching (⌘1–3) and the side-panel
+/// toggles (#512). Declared before `WebInspectorCommands` so these sit above the developer tools
+/// in the View menu.
+struct ViewMenuCommands: Commands {
+    @FocusedValue(\.siteWindowModel) private var model
+    @FocusedValue(\.inspectorPanel) private var inspectorPanel
+
+    var body: some Commands {
+        CommandGroup(after: .toolbar) {
+            // Toggles (not Buttons) so the active pane gets a menu checkmark; setting an already-on
+            // pane to false is a no-op, giving radio behavior.
+            Toggle("Preview", isOn: paneBinding(0))
+                .keyboardShortcut("1")
+                .disabled(model == nil)
+
+            Toggle("Editor", isOn: paneBinding(1))
+                .keyboardShortcut("2")
+                .disabled(model?.activeEditorFile == nil)
+
+            Toggle("Graph", isOn: paneBinding(2))
+                .keyboardShortcut("3")
+                .disabled(model?.canShowGraph != true)
+
+            Divider()
+
+            // ⌘K lives here, not on the toolbar chat button — a shortcut on a toolbar item is
+            // invisible in the menu bar (the discoverability gap #512 exists to close).
+            Button(model?.chatPresented == true ? "Hide Chat" : "Show Chat") {
+                model?.chatPresented.toggle()
+            }
+            .keyboardShortcut("k")
+            .disabled(model == nil)
+
+            Button(model?.relatedPagesPresented == true ? "Hide Related Pages" : "Show Related Pages") {
+                model?.relatedPagesPresented.toggle()
+            }
+            .disabled(model == nil)
+
+            // ⌥⌘I per the HIG-standard inspector shortcut — reserved for this in #510, when the
+            // Web Inspector moved to ⌥⇧⌘I.
+            Button(inspectorPanel?.isShown == true ? "Hide Inspector" : "Show Inspector") {
+                inspectorPanel?.toggle()
+            }
+            .keyboardShortcut("i", modifiers: [.command, .option])
+            .disabled(inspectorPanel?.isAvailable != true)
+
+            Divider()
+        }
+    }
+
+    private func paneBinding(_ index: Int) -> Binding<Bool> {
+        Binding(
+            get: { model?.paneSelection == index },
+            set: { isOn in if isOn { model?.setPaneSelection(index) } }
+        )
+    }
+}

--- a/Sources/AnglesiteCore/SiteToolbarItemID.swift
+++ b/Sources/AnglesiteCore/SiteToolbarItemID.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Stable identifiers for the site window's customizable toolbar items (#519).
+///
+/// These raw values are API: macOS persists each user's toolbar customization keyed by them, so
+/// renaming one silently discards every user's saved layout. `SiteToolbarItemIDTests` freezes the
+/// full set — change a raw value only with a deliberate migration story.
+///
+/// Lives in AnglesiteCore (not the app target) solely so CI's SwiftPM test suites can enforce the
+/// freeze; hosted app-target tests don't run on CI (see CLAUDE.md "Build").
+public enum SiteToolbarItemID: String, CaseIterable, Sendable {
+    case panes
+    case graph
+    case backup
+    case audit
+    case openInBrowser
+    case harden
+    case domain
+    case integration
+    case siriReadiness
+    case relatedPages
+    /// Non-MAS builds only; the id stays reserved on MAS so layouts roam across build flavors.
+    case github
+    case deploy
+    case chat
+    case inspector
+}

--- a/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import AnglesiteCore
+
+struct SiteToolbarItemIDTests {
+    /// The site-window toolbar item ids are API: macOS persists user toolbar customizations keyed
+    /// by these strings, so a rename silently discards every user's saved layout (#519). This test
+    /// freezes the exact set — if it fails, you are breaking saved customizations; only proceed
+    /// with a deliberate migration story, then update the expectation.
+    @Test func toolbarItemIDsAreFrozen() {
+        #expect(SiteToolbarItemID.allCases.map(\.rawValue) == [
+            "panes",
+            "graph",
+            "backup",
+            "audit",
+            "openInBrowser",
+            "harden",
+            "domain",
+            "integration",
+            "siriReadiness",
+            "relatedPages",
+            "github",
+            "deploy",
+            "chat",
+            "inspector",
+        ])
+    }
+}


### PR DESCRIPTION
Reland of #536, which merged into `claude/511-site-menu` twenty seconds *after* that branch's own PR (#533) had already squash-merged to main — so its content (ViewMenuCommands, FileItemCommands, the ⌘K move off the toolbar button, Show Site Graph → View ▸ Graph ⌘3) never reached main. This is a clean cherry-pick of that squash commit (`1d272041`) onto main; build verified green. See #536 for the full description and live verification.

Closes #512, closes #513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)