### PR TITLE
feat(app): customizable site-window toolbar — curated defaults + palette extras

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -183,7 +183,8 @@ struct SiteWindow: View {
         // for the .principal pane switcher.
         .toolbarRole(.editor)
         // Customizable toolbar (#519): every item has a STABLE id — saved customizations key off
-        // these strings, so renaming one silently discards users' layouts. Items must also be
+        // these strings, so renaming one silently discards users' layouts (the id set is frozen
+        // by SiteToolbarItemIDTests in AnglesiteCoreTests). Items must also be
         // unconditional (no `if let` wrappers): identity-swapping or appearing/vanishing items
         // fight the customization palette, so state-dependent items render disabled instead.
         // Curated default ≈8 items; episodic setup/maintenance actions ship hidden and live in
@@ -191,7 +192,7 @@ struct SiteWindow: View {
         .toolbar(id: "site") {
             // Fixed center, not movable/removable: the pane switcher is navigation, not a command
             // (Finder/Freeform convention). Replaces the old Picker row above the main pane.
-            ToolbarItem(id: "panes", placement: .principal) {
+            ToolbarItem(id: SiteToolbarItemID.panes.rawValue, placement: .principal) {
                 Picker("View", selection: Binding(
                     get: { model.paneSelection },
                     set: { model.setPaneSelection($0) }
@@ -202,10 +203,11 @@ struct SiteWindow: View {
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
+                .help("Switch between Preview, Editor, and Graph")
             }
             .customizationBehavior(.disabled)
 
-            ToolbarItem(id: "graph", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.graph.rawValue, placement: .primaryAction) {
                 Button {
                     Task { await model.showGraph() }
                 } label: {
@@ -214,7 +216,7 @@ struct SiteWindow: View {
                 .help("Explore pages, layouts, components, collections, and assets")
             }
 
-            ToolbarItem(id: "backup", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.backup.rawValue, placement: .primaryAction) {
                 Button {
                     model.backupSite()
                 } label: {
@@ -226,7 +228,7 @@ struct SiteWindow: View {
                       : "Site is missing required files")
             }
 
-            ToolbarItem(id: "audit", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.audit.rawValue, placement: .primaryAction) {
                 Button {
                     model.auditSite()
                 } label: {
@@ -242,7 +244,7 @@ struct SiteWindow: View {
                       : "Site is missing required files")
             }
 
-            ToolbarItem(id: "openInBrowser", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.openInBrowser.rawValue, placement: .primaryAction) {
                 Button {
                     model.openPreviewInBrowser()
                 } label: {
@@ -254,7 +256,7 @@ struct SiteWindow: View {
 
             // — Palette-only items (View ▸ Customize Toolbar…) —
 
-            ToolbarItem(id: "harden", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.harden.rawValue, placement: .primaryAction) {
                 Button {
                     model.harden.openSheet()
                 } label: {
@@ -271,7 +273,7 @@ struct SiteWindow: View {
             }
             .defaultCustomization(.hidden)
 
-            ToolbarItem(id: "domain", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.domain.rawValue, placement: .primaryAction) {
                 Button {
                     model.domain.openSheet()
                 } label: {
@@ -282,7 +284,7 @@ struct SiteWindow: View {
             }
             .defaultCustomization(.hidden)
 
-            ToolbarItem(id: "integration", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.integration.rawValue, placement: .primaryAction) {
                 Button {
                     model.openIntegrationWizard()
                 } label: {
@@ -293,7 +295,7 @@ struct SiteWindow: View {
             }
             .defaultCustomization(.hidden)
 
-            ToolbarItem(id: "siriReadiness", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.siriReadiness.rawValue, placement: .primaryAction) {
                 Button {
                     model.openSiriReadiness()
                 } label: {
@@ -304,7 +306,7 @@ struct SiteWindow: View {
             }
             .defaultCustomization(.hidden)
 
-            ToolbarItem(id: "relatedPages", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.relatedPages.rawValue, placement: .primaryAction) {
                 Button {
                     model.relatedPagesPresented.toggle()
                 } label: {
@@ -318,7 +320,7 @@ struct SiteWindow: View {
             #if !ANGLESITE_MAS
             // One stable item whose label/action reflects publish state — two swapping items
             // would break saved customizations.
-            ToolbarItem(id: "github", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.github.rawValue, placement: .primaryAction) {
                 if let remote = model.publish.existingRemote {
                     Button {
                         NSWorkspace.shared.open(remote.url)
@@ -343,7 +345,7 @@ struct SiteWindow: View {
 
             // Health badge and Deploy are one item: the badge is the readiness signal for the
             // button it gates, so customization can never separate them.
-            ToolbarItem(id: "deploy", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.deploy.rawValue, placement: .primaryAction) {
                 HStack(spacing: 8) {
                     HealthBadgeView(
                         model: model.health,
@@ -370,7 +372,7 @@ struct SiteWindow: View {
             }
             .customizationBehavior(.reorderable)
 
-            ToolbarItem(id: "chat", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.chat.rawValue, placement: .primaryAction) {
                 Button {
                     model.chatPresented.toggle()
                 } label: {
@@ -384,7 +386,7 @@ struct SiteWindow: View {
             }
 
             // Far trailing, adjacent to the inspector panel it controls (Pages/Freeform convention).
-            ToolbarItem(id: "inspector", placement: .primaryAction) {
+            ToolbarItem(id: SiteToolbarItemID.inspector.rawValue, placement: .primaryAction) {
                 Button {
                     inspectorShown.toggle()
                 } label: {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -179,8 +179,33 @@ struct SiteWindow: View {
         }
         .navigationTitle(site.name)
         .navigationSubtitle(model.preview.readyURL?.absoluteString ?? "")
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
+        // Leading title, free center — the document-style layout (Pages/Freeform) that makes room
+        // for the .principal pane switcher.
+        .toolbarRole(.editor)
+        // Customizable toolbar (#519): every item has a STABLE id — saved customizations key off
+        // these strings, so renaming one silently discards users' layouts. Items must also be
+        // unconditional (no `if let` wrappers): identity-swapping or appearing/vanishing items
+        // fight the customization palette, so state-dependent items render disabled instead.
+        // Curated default ≈8 items; episodic setup/maintenance actions ship hidden and live in
+        // the palette (View ▸ Customize Toolbar…, added in #510).
+        .toolbar(id: "site") {
+            // Fixed center, not movable/removable: the pane switcher is navigation, not a command
+            // (Finder/Freeform convention). Replaces the old Picker row above the main pane.
+            ToolbarItem(id: "panes", placement: .principal) {
+                Picker("View", selection: Binding(
+                    get: { model.paneSelection },
+                    set: { model.setPaneSelection($0) }
+                )) {
+                    Text("Preview").tag(0)
+                    if model.activeEditorFile != nil { Text("Editor").tag(1) }
+                    Text("Graph").tag(2)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+            }
+            .customizationBehavior(.disabled)
+
+            ToolbarItem(id: "graph", placement: .primaryAction) {
                 Button {
                     Task { await model.showGraph() }
                 } label: {
@@ -189,17 +214,7 @@ struct SiteWindow: View {
                 .help("Explore pages, layouts, components, collections, and assets")
             }
 
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    inspectorShown.toggle()
-                } label: {
-                    Label("Inspector", systemImage: "sidebar.right")
-                }
-                .disabled(model.inspectorContext == nil)
-                .help("Show or hide the page inspector")
-            }
-
-            ToolbarItem(placement: .primaryAction) {
+            ToolbarItem(id: "backup", placement: .primaryAction) {
                 Button {
                     model.backupSite()
                 } label: {
@@ -210,26 +225,8 @@ struct SiteWindow: View {
                       ? "Commit and push working-tree changes to your current branch"
                       : "Site is missing required files")
             }
-            .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
 
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    model.harden.openSheet()
-                } label: {
-                    if model.harden.isRunning {
-                        Label("Hardening…", systemImage: "shield.lefthalf.filled")
-                    } else {
-                        Label("Harden", systemImage: "shield.lefthalf.filled")
-                    }
-                }
-                .disabled(!model.canRunHarden)
-                .help(site.isValid
-                      ? "Preview and apply Cloudflare security hardening for this site"
-                      : "Site is missing required files")
-            }
-            .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
-
-            ToolbarItem(placement: .primaryAction) {
+            ToolbarItem(id: "audit", placement: .primaryAction) {
                 Button {
                     model.auditSite()
                 } label: {
@@ -244,22 +241,70 @@ struct SiteWindow: View {
                       ? "Run the structured accessibility audit against this site"
                       : "Site is missing required files")
             }
-            .visibilityPriority(.low)
 
-            ToolbarItem(placement: .primaryAction) {
+            ToolbarItem(id: "openInBrowser", placement: .primaryAction) {
                 Button {
-                    model.chatPresented.toggle()
+                    model.openPreviewInBrowser()
                 } label: {
-                    Label("Chat", systemImage: model.chatPresented
-                        ? "bubble.left.and.bubble.right.fill"
-                        : "bubble.left.and.bubble.right")
+                    Label("Open in browser", systemImage: "arrow.up.forward.app")
                 }
-                .help(model.chatPresented ? "Hide chat panel" : "Show chat panel")
-                // ⌘K moved to View ▸ Show/Hide Chat (#512) — a second registration here would
-                // recreate the duplicate-shortcut ambiguity #509 removed for ⌘S.
+                .disabled(!model.canOpenPreviewInBrowser)
+                .help("Open the live preview in your default browser")
             }
 
-            ToolbarItem(placement: .primaryAction) {
+            // — Palette-only items (View ▸ Customize Toolbar…) —
+
+            ToolbarItem(id: "harden", placement: .primaryAction) {
+                Button {
+                    model.harden.openSheet()
+                } label: {
+                    if model.harden.isRunning {
+                        Label("Hardening…", systemImage: "shield.lefthalf.filled")
+                    } else {
+                        Label("Harden", systemImage: "shield.lefthalf.filled")
+                    }
+                }
+                .disabled(!model.canRunHarden)
+                .help(site.isValid
+                      ? "Preview and apply Cloudflare security hardening for this site"
+                      : "Site is missing required files")
+            }
+            .defaultCustomization(.hidden)
+
+            ToolbarItem(id: "domain", placement: .primaryAction) {
+                Button {
+                    model.domain.openSheet()
+                } label: {
+                    Label("Domain", systemImage: "globe")
+                }
+                .disabled(!model.canOpenDomain)
+                .help("View and manage this domain's DNS records")
+            }
+            .defaultCustomization(.hidden)
+
+            ToolbarItem(id: "integration", placement: .primaryAction) {
+                Button {
+                    model.openIntegrationWizard()
+                } label: {
+                    Label("Add Integration…", systemImage: "puzzlepiece.extension")
+                }
+                .disabled(!model.canOpenIntegrationWizard)
+                .help("Set up a third-party integration for this site")
+            }
+            .defaultCustomization(.hidden)
+
+            ToolbarItem(id: "siriReadiness", placement: .primaryAction) {
+                Button {
+                    model.openSiriReadiness()
+                } label: {
+                    Label("Siri AI Readiness", systemImage: "sparkles")
+                }
+                .disabled(!model.canOpenSiriReadiness)
+                .help("Check whether Siri workflows are ready for this site")
+            }
+            .defaultCustomization(.hidden)
+
+            ToolbarItem(id: "relatedPages", placement: .primaryAction) {
                 Button {
                     model.relatedPagesPresented.toggle()
                 } label: {
@@ -268,33 +313,12 @@ struct SiteWindow: View {
                 }
                 .help(model.relatedPagesPresented ? "Hide related pages" : "Show related pages")
             }
-
-            if let url = model.preview.readyURL {
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        NSWorkspace.shared.open(url)
-                    } label: {
-                        Label("Open in browser", systemImage: "arrow.up.forward.app")
-                    }
-                    .help("Open the live preview in your default browser")
-                }
-            }
-
-            ToolbarItem(placement: .primaryAction) {
-                HealthBadgeView(
-                    model: model.health,
-                    onRecheck: { model.health.recheck(siteID: site.id, siteDirectory: site.sourceDirectory) },
-                    onAskAssistant: {
-                        guard let chat = model.chat else { return }
-                        model.chatPresented = true
-                        chat.send(SiteWindowModel.healthAssistantPrompt)
-                    }
-                )
-            }
-            .visibilityPriority(.high)
+            .defaultCustomization(.hidden)
 
             #if !ANGLESITE_MAS
-            ToolbarItem(placement: .primaryAction) {
+            // One stable item whose label/action reflects publish state — two swapping items
+            // would break saved customizations.
+            ToolbarItem(id: "github", placement: .primaryAction) {
                 if let remote = model.publish.existingRemote {
                     Button {
                         NSWorkspace.shared.open(remote.url)
@@ -312,56 +336,63 @@ struct SiteWindow: View {
                     .help(site.isValid ? "Create a private GitHub repo and push this site" : "Site is missing required files")
                 }
             }
-            .visibilityPriority(.low)
+            .defaultCustomization(.hidden)
             #endif
 
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    model.deploySite()
-                } label: {
-                    Label("Deploy", systemImage: "paperplane.fill")
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(!model.canRunDeploy)
-                .help(site.isValid && model.preview.canDeploy
-                      ? "Build, scan, and run wrangler deploy on this site"
-                      : site.isValid
-                        ? "Open the preview first to start the runtime before deploying"
-                        : "Site is missing required files")
-            }
-            .visibilityPriority(.high)
+            // — Default trailing cluster —
 
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    model.openSiriReadiness()
-                } label: {
-                    Label("Siri AI Readiness", systemImage: "sparkles")
+            // Health badge and Deploy are one item: the badge is the readiness signal for the
+            // button it gates, so customization can never separate them.
+            ToolbarItem(id: "deploy", placement: .primaryAction) {
+                HStack(spacing: 8) {
+                    HealthBadgeView(
+                        model: model.health,
+                        onRecheck: { model.recheckHealth() },
+                        onAskAssistant: {
+                            guard let chat = model.chat else { return }
+                            model.chatPresented = true
+                            chat.send(SiteWindowModel.healthAssistantPrompt)
+                        }
+                    )
+                    Button {
+                        model.deploySite()
+                    } label: {
+                        Label("Deploy", systemImage: "paperplane.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!model.canRunDeploy)
+                    .help(site.isValid && model.preview.canDeploy
+                          ? "Build, scan, and run wrangler deploy on this site"
+                          : site.isValid
+                            ? "Open the preview first to start the runtime before deploying"
+                            : "Site is missing required files")
                 }
-                .help("Check whether Siri workflows are ready for this site")
-                .disabled(!model.canOpenSiriReadiness)
+            }
+            .customizationBehavior(.reorderable)
+
+            ToolbarItem(id: "chat", placement: .primaryAction) {
+                Button {
+                    model.chatPresented.toggle()
+                } label: {
+                    Label("Chat", systemImage: model.chatPresented
+                        ? "bubble.left.and.bubble.right.fill"
+                        : "bubble.left.and.bubble.right")
+                }
+                .help(model.chatPresented ? "Hide chat panel" : "Show chat panel")
+                // ⌘K moved to View ▸ Show/Hide Chat (#512) — a second registration here would
+                // recreate the duplicate-shortcut ambiguity #509 removed for ⌘S.
             }
 
-            ToolbarItem(placement: .primaryAction) {
+            // Far trailing, adjacent to the inspector panel it controls (Pages/Freeform convention).
+            ToolbarItem(id: "inspector", placement: .primaryAction) {
                 Button {
-                    model.openIntegrationWizard()
+                    inspectorShown.toggle()
                 } label: {
-                    Label("Add Integration…", systemImage: "puzzlepiece.extension")
+                    Label("Inspector", systemImage: "sidebar.right")
                 }
-                .disabled(!model.canOpenIntegrationWizard)
-                .help("Set up a third-party integration for this site")
+                .disabled(model.inspectorContext == nil)
+                .help("Show or hide the page inspector")
             }
-            .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
-
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    model.domain.openSheet()
-                } label: {
-                    Label("Domain", systemImage: "globe")
-                }
-                .help("View and manage this domain's DNS records")
-                .disabled(!model.canOpenDomain)
-            }
-            .visibilityPriority(ToolbarItemVisibilityPriority(lowerThan: .low))
         }
         .sheet(isPresented: $bindableModel.deploy.blockedPresented) {
             if case .blocked(let failures, let warnings) = model.deploy.phase {
@@ -481,22 +512,9 @@ struct SiteWindow: View {
 
     @ViewBuilder
     private func mainPane(for site: SiteStore.Site) -> some View {
-        VStack(spacing: 0) {
-            Picker("", selection: Binding(
-                get: { model.paneSelection },
-                set: { model.setPaneSelection($0) }
-            )) {
-                Text("Preview").tag(0)
-                if model.activeEditorFile != nil { Text("Editor").tag(1) }
-                Text("Graph").tag(2)
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .frame(width: model.activeEditorFile == nil ? 220 : 270)
-            .padding(6)
-            Divider()
-            mainPaneContent(for: site)
-        }
+        // The Preview/Editor/Graph switcher lives in the toolbar (`id: "panes"`, .principal) and
+        // the View menu (⌘1–3) — no in-content picker row (#519).
+        mainPaneContent(for: site)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteCore/SiteToolbarItemID.swift
+++ b/Sources/AnglesiteCore/SiteToolbarItemID.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Stable identifiers for the site window's customizable toolbar items (#519).
+///
+/// These raw values are API: macOS persists each user's toolbar customization keyed by them, so
+/// renaming one silently discards every user's saved layout. `SiteToolbarItemIDTests` freezes the
+/// full set — change a raw value only with a deliberate migration story.
+///
+/// Lives in AnglesiteCore (not the app target) solely so CI's SwiftPM test suites can enforce the
+/// freeze; hosted app-target tests don't run on CI (see CLAUDE.md "Build").
+public enum SiteToolbarItemID: String, CaseIterable, Sendable {
+    case panes
+    case graph
+    case backup
+    case audit
+    case openInBrowser
+    case harden
+    case domain
+    case integration
+    case siriReadiness
+    case relatedPages
+    /// Non-MAS builds only; the id stays reserved on MAS so layouts roam across build flavors.
+    case github
+    case deploy
+    case chat
+    case inspector
+}

--- a/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import AnglesiteCore
+
+struct SiteToolbarItemIDTests {
+    /// The site-window toolbar item ids are API: macOS persists user toolbar customizations keyed
+    /// by these strings, so a rename silently discards every user's saved layout (#519). This test
+    /// freezes the exact set — if it fails, you are breaking saved customizations; only proceed
+    /// with a deliberate migration story, then update the expectation.
+    @Test func toolbarItemIDsAreFrozen() {
+        #expect(SiteToolbarItemID.allCases.map(\.rawValue) == [
+            "panes",
+            "graph",
+            "backup",
+            "audit",
+            "openInBrowser",
+            "harden",
+            "domain",
+            "integration",
+            "siriReadiness",
+            "relatedPages",
+            "github",
+            "deploy",
+            "chat",
+            "inspector",
+        ])
+    }
+}


### PR DESCRIPTION
Fourth slice of #518, stacked on #537 (the #536 reland). Closes #519.

## What

The site window toolbar becomes a native customizable toolbar (`.toolbar(id: "site")`):

- **Curated default set (~8)**: Preview/Editor/Graph switcher at `.principal` (customization disabled — it's navigation, not a command), Site Graph, Backup, Audit, Open in Browser, health badge + **Deploy** (one welded item so the readiness signal can never separate from the button it gates; reorderable but not removable), Chat, Inspector far trailing.
- **Palette extras** (`defaultCustomization(.hidden)`, reachable via View ▸ Customize Toolbar… / right-click): Harden, Domain, Add Integration…, Siri AI Readiness, Related Pages, and GitHub (non-MAS, one stable item whose label/action reflects publish state).
- **No conditional items**: Open in Browser is always present, disabled without a ready URL — appearing/vanishing items fight the customization palette.
- **`.toolbarRole(.editor)`**: leading title, freeing the center; the in-content picker row above the main pane is deleted (the switcher lives in the toolbar and the View menu ⌘1–3).
- `visibilityPriority` overflow hints dropped — user customization supersedes them.

Item ids (`panes`, `graph`, `backup`, `audit`, `openInBrowser`, `harden`, `domain`, `integration`, `siriReadiness`, `relatedPages`, `github`, `deploy`, `chat`, `inspector`) are **API**: saved customizations key off them; renames silently discard user layouts.

## Verification

Drove the built app: default toolbar renders the curated set with leading title and centered switcher; the in-content picker row is gone and the toolbar Graph segment switches the pane; **View ▸ Customize Toolbar… is now enabled** (it was permanently greyed before this change) and opens the native sheet with the five palette extras, the default-set strip, and Icon Only/Icon+Text modes; GitHub item correctly absent from the MAS build. Drag-to-add couldn't be exercised via synthetic automation drags (AppKit sheet limitation) — the sheet, palette, and defaults machinery this PR owns all verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
