### PR TITLE
feat(app): macOS conventions quick wins — proxy icon, Dock menu, ShareLink, launcher drops, Settings tabs

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -98,7 +98,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func openRecentSiteFromDock(_ sender: NSMenuItem) {
         guard let url = sender.representedObject as? URL else { return }
-        NSWorkspace.shared.open(url)
+        // "Logs are sacred": a declined open (e.g. the package moved since the last registry
+        // revalidation) has no other UI feedback loop from a Dock menu — record it.
+        if !NSWorkspace.shared.open(url) {
+            Task {
+                await LogCenter.shared.append(
+                    source: "dock-menu", stream: .stderr,
+                    text: "open \(url.lastPathComponent) failed: NSWorkspace declined the open"
+                )
+            }
+        }
     }
 
     @objc private func newSiteFromDock() {

--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -75,6 +75,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     }
 
+    /// Dynamic Dock menu (#522): recent sites + New Site, mirroring File ▸ Open Recent. Recent
+    /// sites open via `NSWorkspace.open` on the package URL — the same LaunchServices → `onOpenURL`
+    /// path as a Finder double-click, so it works (and mints MAS bookmarks) regardless of which
+    /// windows exist. AppKit calls this on the main thread, matching `RecentSitesModel`'s actor.
+    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        for site in RecentSitesModel.shared.sites {
+            let item = NSMenuItem(title: site.name, action: #selector(openRecentSiteFromDock(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = site.packageURL
+            item.isEnabled = site.isValid
+            menu.addItem(item)
+        }
+        if !menu.items.isEmpty { menu.addItem(.separator()) }
+        let newSite = NSMenuItem(title: "New Site", action: #selector(newSiteFromDock), keyEquivalent: "")
+        newSite.target = self
+        menu.addItem(newSite)
+        return menu
+    }
+
+    @objc private func openRecentSiteFromDock(_ sender: NSMenuItem) {
+        guard let url = sender.representedObject as? URL else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    @objc private func newSiteFromDock() {
+        NSApp.activate()
+        // Surface the launcher (it hosts the wizard sheet), then request the wizard — the same
+        // two-step used by File ▸ New ▸ Site (FocusedSite.swift).
+        WindowRouter.shared.openSitesWindow?()
+        WindowRouter.shared.requestNewSite()
+    }
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         Task {
             await ProcessSupervisor.shared.shutdownAll(timeout: 5)
@@ -144,13 +178,9 @@ struct AnglesiteApp: App {
                     guard url.pathExtension == AnglesitePackage.packageExtension else { return }
                     Task { @MainActor in
                         do {
-                            let site = try await SiteStore.shared.record(AnglesitePackage(url: url))
-                            #if ANGLESITE_MAS
-                            // Mint from the canonicalized recorded path; let a failure surface to the
-                            // catch (logged) rather than silently leaving the site grantless.
-                            let bm = try SecurityScopedBookmark.create(for: site.packageURL)
-                            try await SiteStore.shared.setBookmark(bm, for: site.id)
-                            #endif
+                            // Shared with launcher drag-drop and the Dock menu (#524/#522);
+                            // includes the MAS bookmark mint.
+                            let site = try await SiteActions.registerPackage(at: url)
                             openWindow(value: site.id)
                         } catch {
                             await LogCenter.shared.append(source: "open-url", stream: .stderr, text: "open \(url.lastPathComponent) failed: \(error.localizedDescription)")

--- a/Sources/AnglesiteApp/DeployDrawerView.swift
+++ b/Sources/AnglesiteApp/DeployDrawerView.swift
@@ -46,6 +46,12 @@ struct DeployDrawerView: View {
             }
             Spacer()
             if case .succeeded(let url, _) = model.phase {
+                // Standard share affordance for the deployed URL (#523) — Copy URL stays for the
+                // clipboard-first workflow.
+                ShareLink(item: url)
+                    .labelStyle(.iconOnly)
+                    .help("Share the deployed site's URL")
+                    .accessibilityLabel("Share deployed URL")
                 Button("Copy URL") {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(url.absoluteString, forType: .string)

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -5,19 +5,20 @@ import AnglesiteCore
 struct SettingsView: View {
     var body: some View {
         TabView {
-            AdvancedSettingsView()
-                .tabItem { Label("Advanced", systemImage: "gearshape.2") }
+            // General leads (#529): everyday toggles shouldn't hide behind an "Advanced" label.
+            GeneralSettingsView()
+                .tabItem { Label("General", systemImage: "gearshape") }
             SiriReadinessSettingsView()
                 .tabItem { Label("Siri AI", systemImage: "sparkles") }
+            AdvancedSettingsView()
+                .tabItem { Label("Advanced", systemImage: "gearshape.2") }
         }
         .frame(width: 540, height: 360)
     }
 }
 
-private struct AdvancedSettingsView: View {
-    @AppStorage(AppSettings.Key.pluginPathOverride) private var pluginPathOverride: String = ""
-    @AppStorage(AppSettings.Key.sitesRootOverride) private var sitesRootOverride: String = ""
-    @AppStorage(AppSettings.Key.debugPaneEnabled) private var debugPaneEnabled: Bool = false
+/// Everyday preferences: editing assists and accessibility (#529).
+private struct GeneralSettingsView: View {
     @AppStorage(AppSettings.Key.autoGenerateAltText) private var autoGenerateAltText: Bool = true
     @AppStorage(AppSettings.Key.autoGeneratePageCopy) private var autoGeneratePageCopy: Bool = true
     @AppStorage(AppSettings.Key.announcesLiveUpdates) private var announcesLiveUpdates: Bool = true
@@ -41,7 +42,20 @@ private struct AdvancedSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+}
 
+/// Development overrides, credentials, and diagnostics — the sharp tools (#529).
+private struct AdvancedSettingsView: View {
+    @AppStorage(AppSettings.Key.pluginPathOverride) private var pluginPathOverride: String = ""
+    @AppStorage(AppSettings.Key.sitesRootOverride) private var sitesRootOverride: String = ""
+    @AppStorage(AppSettings.Key.debugPaneEnabled) private var debugPaneEnabled: Bool = false
+
+    var body: some View {
+        Form {
             Section("Anglesite plugin") {
                 FolderPickerRow(
                     label: "Plugin path override",

--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -20,13 +20,24 @@ enum SiteActions {
     }
 
     /// Register an existing `.anglesite` package and (on MAS) mint its security-scoped bookmark —
-    /// the shared tail of Finder-open (`onOpenURL`), launcher drag-drop (#524), and the Dock menu.
-    /// `record` reads and validates the marker, throwing a legible error for non-packages.
+    /// the ONLY mint call site, shared by every open path: Finder-open (`onOpenURL`), launcher
+    /// drag-drop (#524), the Dock menu, File ▸ Open Site… (`pickAndRegisterSite`), and Import
+    /// (`importPackage`). `record` reads and validates the marker, throwing a legible error for
+    /// non-packages.
     static func registerPackage(at url: URL) async throws -> SiteStore.Site {
-        let site = try await SiteStore.shared.record(AnglesitePackage(url: url))
+        try await registerPackage(AnglesitePackage(url: url))
+    }
+
+    /// Variant for callers that already hold a constructed package (Import creates one via
+    /// `PackageTransfer` before registering).
+    static func registerPackage(_ package: AnglesitePackage) async throws -> SiteStore.Site {
+        let site = try await SiteStore.shared.record(package)
         #if ANGLESITE_MAS
-        // Mint from the canonicalized recorded path; let a failure propagate rather than
-        // silently leaving the site grantless.
+        // The current access grant (open panel, drag, or LaunchServices open) is the only chance
+        // to mint a scoped bookmark — persist it now so the grant survives relaunch. Mint from
+        // `site.packageURL` (the canonicalized path the store recorded) so the bookmark's path
+        // matches what subprocesses are spawned against. Propagate failures (never `try?`): a
+        // grantless site silently fails to preview at open.
         let bookmark = try SecurityScopedBookmark.create(for: site.packageURL)
         try await SiteStore.shared.setBookmark(bookmark, for: site.id)
         #endif
@@ -64,14 +75,7 @@ enum SiteActions {
             throw ImportError(folderName: sourceDir.lastPathComponent, underlying: error)
         }
         do {
-            let site = try await SiteStore.shared.record(pkg)
-            #if ANGLESITE_MAS
-            // Propagate (don't swallow with try?) — a grantless imported site silently fails to
-            // preview at open. Matches pickAndRegisterSite; mint from the canonicalized packageURL.
-            let bm = try SecurityScopedBookmark.create(for: site.packageURL)
-            try await SiteStore.shared.setBookmark(bm, for: site.id)
-            #endif
-            return site
+            return try await registerPackage(pkg)
         } catch {
             // record/bookmark failed after importDirectory wrote the package — remove the orphan
             // (we created it this call) so it isn't left invisible-and-unopenable on disk.
@@ -121,16 +125,7 @@ enum SiteActions {
         guard panel.runModal() == .OK, let url = panel.url else { return nil }
 
         do {
-            let package = AnglesitePackage(url: url)
-            let site = try await SiteStore.shared.record(package)
-            #if ANGLESITE_MAS
-            // The panel grant is the only chance to mint a scoped bookmark — persist it now so
-            // the grant survives relaunch. Mint from `site.packageURL` (the canonicalized path the
-            // store recorded), so the bookmark's path matches what subprocesses are spawned against.
-            let bookmark = try SecurityScopedBookmark.create(for: site.packageURL)
-            try await SiteStore.shared.setBookmark(bookmark, for: site.id)
-            #endif
-            return site
+            return try await registerPackage(at: url)
         } catch {
             throw ImportError(folderName: url.lastPathComponent, underlying: error)
         }

--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -19,6 +19,20 @@ enum SiteActions {
         }
     }
 
+    /// Register an existing `.anglesite` package and (on MAS) mint its security-scoped bookmark —
+    /// the shared tail of Finder-open (`onOpenURL`), launcher drag-drop (#524), and the Dock menu.
+    /// `record` reads and validates the marker, throwing a legible error for non-packages.
+    static func registerPackage(at url: URL) async throws -> SiteStore.Site {
+        let site = try await SiteStore.shared.record(AnglesitePackage(url: url))
+        #if ANGLESITE_MAS
+        // Mint from the canonicalized recorded path; let a failure propagate rather than
+        // silently leaving the site grantless.
+        let bookmark = try SecurityScopedBookmark.create(for: site.packageURL)
+        try await SiteStore.shared.setBookmark(bookmark, for: site.id)
+        #endif
+        return site
+    }
+
     /// Pick a plain Anglesite directory, choose where to save the new package, copy it in, and
     /// register the package. Returns the new site, or nil if either panel was cancelled.
     static func importPackage() async throws -> SiteStore.Site? {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -179,6 +179,9 @@ struct SiteWindow: View {
         }
         .navigationTitle(site.name)
         .navigationSubtitle(model.preview.readyURL?.absoluteString ?? "")
+        // Titlebar proxy icon (#521): ⌘-click shows the package's path, and the icon drags as the
+        // `.anglesite` package itself. The window's security-scoped grant already covers the URL.
+        .navigationDocument(site.packageURL)
         // Leading title, free center — the document-style layout (Pages/Freeform) that makes room
         // for the .principal pane switcher.
         .toolbarRole(.editor)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -96,6 +96,13 @@ struct SiteWindow: View {
             isAvailable: model.inspectorContext != nil,
             toggle: { inspectorShown.toggle() }
         ))
+        .onAppear {
+            // Also stash the launcher-opener here (see SitesWindowRoot): window restoration can
+            // relaunch the app with only site windows, so relying on the launcher's onAppear
+            // alone would leave Dock ▸ New Site a silent no-op on such launches (#522 review).
+            let openWindow = openWindow
+            WindowRouter.shared.openSitesWindow = { openWindow(id: "sites") }
+        }
         .onDisappear { model.close() }
     }
 

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -165,6 +165,26 @@ struct SitesLauncherView: View {
             }
         }
         .listStyle(.inset)
+        // Accept `.anglesite` packages dragged from Finder (#524) — same register path as
+        // Finder double-click (`onOpenURL`), including the MAS bookmark mint (a user drag
+        // conveys sandbox access to the dragged item).
+        .dropDestination(for: URL.self) { urls, _ in
+            let packages = urls.filter { $0.pathExtension == AnglesitePackage.packageExtension }
+            guard !packages.isEmpty else { return false }
+            Task { @MainActor in
+                for url in packages {
+                    do {
+                        let site = try await SiteActions.registerPackage(at: url)
+                        openWindow(value: site.id)
+                    } catch {
+                        NSAlert(error: SiteActions.ImportError(
+                            folderName: url.lastPathComponent, underlying: error
+                        )).runModal()
+                    }
+                }
+            }
+            return true
+        }
         .confirmationDialog(
             "Remove “\(siteToRemoveName)” from Anglesite?",
             isPresented: Binding(

--- a/Sources/AnglesiteApp/SitesWindowRoot.swift
+++ b/Sources/AnglesiteApp/SitesWindowRoot.swift
@@ -15,5 +15,11 @@ struct SitesWindowRoot: View {
                 openWindow(value: id)   // WindowGroup(for: String.self) focuses or opens the site
                 router.requested = nil
             }
+            .onAppear {
+                // Stash a launcher-opener for AppKit callers (Dock menu, #522). OpenWindowAction
+                // is scene-independent, so this stays valid after the launcher closes.
+                let openWindow = openWindow
+                router.openSitesWindow = { openWindow(id: "sites") }
+            }
     }
 }

--- a/Sources/AnglesiteIntents/WindowRouter.swift
+++ b/Sources/AnglesiteIntents/WindowRouter.swift
@@ -47,4 +47,11 @@ public final class WindowRouter {
 
     /// Called by the launcher once it has consumed the request.
     public func clearNewSiteRequest() { newSiteRequested = false }
+
+    /// Opens (or focuses) the "Sites" launcher window. AppKit callers — the Dock menu (#522) —
+    /// can't reach SwiftUI's `openWindow`, so the launcher root stashes a captured
+    /// `OpenWindowAction` here on appear. `OpenWindowAction` is scene-independent, so the closure
+    /// stays valid after the capturing view disappears. Nil only before the launcher's first
+    /// appearance — and the launcher is the app's default first scene.
+    @ObservationIgnored public var openSitesWindow: (@MainActor () -> Void)?
 }


### PR DESCRIPTION
The five macOS-conventions quick wins from the #518 epic, each small and independent. Closes #521, closes #522, closes #523, closes #524, closes #529.

## What

- **#521 Titlebar proxy icon** — `.navigationDocument(site.packageURL)` on the site window: ⌘-clickable path menu, icon drags as the `.anglesite` package.
- **#522 Dock menu** — `applicationDockMenu`: one item per recent site (from `RecentSitesModel`, invalid sites disabled) + **New Site**. Recent sites open via `NSWorkspace.open` on the package URL — the same LaunchServices → `onOpenURL` path as a Finder double-click, so it works regardless of open windows and mints MAS bookmarks. New Site opens the launcher through a `WindowRouter`-stashed `OpenWindowAction` (scene-independent; captured by `SitesWindowRoot` on first appearance) then `requestNewSite()` — the same two-step File ▸ New ▸ Site uses.
- **#523 ShareLink** — share button for the deployed URL in the deploy drawer, beside Copy URL.
- **#524 Launcher drops** — `.dropDestination(for: URL.self)` on the launcher list accepts `.anglesite` packages. The register+bookmark tail of `onOpenURL` is extracted into `SiteActions.registerPackage(at:)` and shared by all three open paths (Finder open, drop, Dock menu), so the MAS bookmark mint lives in exactly one place.
- **#529 Settings** — General tab (Editing, Accessibility) now leads; Advanced keeps the plugin/sites-root overrides, credentials, and diagnostics; Siri AI unchanged.

## Verification

Drove the built app: proxy icon renders in the site-window titlebar; Settings shows General → Siri AI → Advanced with the sections split as described. Build green; full SwiftPM suite passes (257 tests). Not machine-verifiable here: the Dock context menu (the Dock is outside my automation sandbox) and a real Finder drag onto the launcher (synthetic drags don't register) — both are small, standard AppKit/SwiftUI surfaces but worth a 30-second manual smoke: right-click the Dock icon; drag a `.anglesite` from Finder onto the Sites window. ShareLink renders only in a post-deploy drawer, so it's also manual-verify territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
