### PR TITLE
feat(app): Site menu Start/Stop/Restart Dev Server commands (#515)

### DIFF
--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -79,6 +79,9 @@ final class PreviewModel {
         Task { @MainActor [weak self] in
             for await newState in await runtime.observe() {
                 self?.state = newState
+                // Any transition acknowledges the last dispatched dev-server command — every
+                // accepted start/stop produces at least one (see `devServerCommandInFlight`).
+                self?.devServerCommandInFlight = false
                 switch newState {
                 case .ready, .failed:
                     self?.isUpdatingDependencies = false
@@ -122,6 +125,10 @@ final class PreviewModel {
         openSiteID = siteID
         openSiteDirectory = siteDirectory
         devServerStoppedByUser = false
+        // `open` dispatches a boot just like the menu commands do, and `siteOpenForDevServer`
+        // just became true while `state` may still read `.idle` — without this, Site ▸ Start
+        // would be enabled during the dispatch gap and could race the opening boot.
+        let token = markDevServerCommandInFlight()
         let router = self.editRouter
         Task {
             // Register before starting the runtime so a Siri edit fired during dev-server boot
@@ -129,6 +136,7 @@ final class PreviewModel {
             // returning the bridge's no-router fallback message.
             await EditRouterRegistry.shared.register(router, for: siteID)
             await runtime.start(siteID: siteID, siteDirectory: siteDirectory)
+            clearDevServerCommandInFlight(token: token)
         }
     }
 
@@ -147,6 +155,35 @@ final class PreviewModel {
 
     // MARK: - Dev-server controls (Site menu, #515)
 
+    /// True from dispatching a Start/Stop/Restart command (or `open`'s initial boot) until the
+    /// runtime acknowledges it. `canStart…`/`canStop…`/`canRestart…` read `state`, which only
+    /// updates asynchronously via the `observe()` stream — without this flag, a rapid
+    /// double-click (or a second command fired before the first's transition lands) would pass
+    /// the stale-state guard and dispatch two racing runtime calls (PR #542 review).
+    ///
+    /// Cleared by whichever acknowledgement arrives first:
+    /// - any observed state transition (the wedged-boot case: `start` emits `.starting` long
+    ///   before it returns, so Restart re-enables while the boot is still in flight), or
+    /// - the dispatched runtime call returning (the no-transition case: e.g.
+    ///   `UnavailableSiteRuntime` re-settling into an identical `.failed`, which `setState`
+    ///   dedups — without this, the flag would stick and permanently disable Start/Retry).
+    ///   Token-guarded so a superseded call's late return can't clear a newer command's flag.
+    private(set) var devServerCommandInFlight = false
+
+    /// Monotonic token identifying the latest dispatched dev-server command — see
+    /// `devServerCommandInFlight`'s completion-clear path.
+    @ObservationIgnored private var devServerCommandToken = 0
+
+    private func markDevServerCommandInFlight() -> Int {
+        devServerCommandToken += 1
+        devServerCommandInFlight = true
+        return devServerCommandToken
+    }
+
+    private func clearDevServerCommandInFlight(token: Int) {
+        if token == devServerCommandToken { devServerCommandInFlight = false }
+    }
+
     /// Whether a site is open enough to (re)start its dev server: both fields are captured by
     /// `open(siteID:siteDirectory:)`, so this is true from first open until `close()`.
     private var siteOpenForDevServer: Bool {
@@ -155,17 +192,42 @@ final class PreviewModel {
 
     /// Enablement mirrors `DevServerControls` (AnglesiteCore) — the CI-tested rules — so the
     /// menu, the stopped pane's Start button, and any future toolbar affordance stay consistent.
-    var canStartDevServer: Bool { DevServerControls.canStart(state: state, siteOpen: siteOpenForDevServer) }
-    var canStopDevServer: Bool { DevServerControls.canStop(state: state, siteOpen: siteOpenForDevServer) }
-    var canRestartDevServer: Bool { DevServerControls.canRestart(state: state, siteOpen: siteOpenForDevServer) }
+    var canStartDevServer: Bool {
+        DevServerControls.canStart(state: state, siteOpen: siteOpenForDevServer, commandInFlight: devServerCommandInFlight)
+    }
+    var canStopDevServer: Bool {
+        DevServerControls.canStop(state: state, siteOpen: siteOpenForDevServer, commandInFlight: devServerCommandInFlight)
+    }
+    var canRestartDevServer: Bool {
+        DevServerControls.canRestart(state: state, siteOpen: siteOpenForDevServer, commandInFlight: devServerCommandInFlight)
+    }
 
     /// Site ▸ Start Dev Server: relaunch the runtime for the already-open site (after an explicit
     /// Stop, or as a recovery from `.failed` — same effect as the preview pane's Retry button).
-    /// The edit router stays registered across a stop, so no re-registration is needed here.
     func startDevServer() {
-        guard canStartDevServer, let siteID = openSiteID, let siteDirectory = openSiteDirectory else { return }
+        guard canStartDevServer else { return }
+        relaunchDevServer()
+    }
+
+    /// Site ▸ Restart Dev Server: for a wedged Astro process that hasn't died. Same body as
+    /// Start — `SiteRuntime.start` tears down any previous run first (protocol contract), so a
+    /// restart is a plain re-start on every runtime; only the enablement differs (see
+    /// `DevServerControls`). Both funnel into `relaunchDevServer()` so the two can't drift.
+    func restartDevServer() {
+        guard canRestartDevServer else { return }
+        relaunchDevServer()
+    }
+
+    /// Shared Start/Restart dispatch. The edit router stays registered across a stop, so no
+    /// re-registration is needed here (unlike `open(siteID:siteDirectory:)`).
+    private func relaunchDevServer() {
+        guard let siteID = openSiteID, let siteDirectory = openSiteDirectory else { return }
         devServerStoppedByUser = false
-        Task { await runtime.start(siteID: siteID, siteDirectory: siteDirectory) }
+        let token = markDevServerCommandInFlight()
+        Task {
+            await runtime.start(siteID: siteID, siteDirectory: siteDirectory)
+            clearDevServerCommandInFlight(token: token)
+        }
     }
 
     /// Site ▸ Stop Dev Server: tear down the runtime but keep the site open in the window
@@ -180,16 +242,11 @@ final class PreviewModel {
         // flag stuck true — the next Start/Restart would then show "Updating dependencies…" for
         // what's actually a plain restart.
         isUpdatingDependencies = false
-        Task { await runtime.stop() }
-    }
-
-    /// Site ▸ Restart Dev Server: for a wedged Astro process that hasn't died. `SiteRuntime.start`
-    /// tears down any previous run first (protocol contract), so restart is a plain re-start —
-    /// works identically for the local-container and remote runtimes.
-    func restartDevServer() {
-        guard canRestartDevServer, let siteID = openSiteID, let siteDirectory = openSiteDirectory else { return }
-        devServerStoppedByUser = false
-        Task { await runtime.start(siteID: siteID, siteDirectory: siteDirectory) }
+        let token = markDevServerCommandInFlight()
+        Task {
+            await runtime.stop()
+            clearDevServerCommandInFlight(token: token)
+        }
     }
 
     /// The ready preview URL, if the session is currently `.ready`.

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -15,6 +15,16 @@ final class PreviewModel {
     /// the runtime is still `.starting`.
     private(set) var openSiteID: String?
 
+    /// The `Source/` directory of the last-opened site, kept so the Site ▸ Start/Restart Dev
+    /// Server commands (#515) can re-launch the runtime without re-resolving the site. Cleared
+    /// in `close()` alongside `openSiteID`.
+    private(set) var openSiteDirectory: URL?
+
+    /// True after Site ▸ Stop Dev Server: distinguishes an owner-stopped `.idle` (show the
+    /// stopped pane with a Start button) from the transient pre-boot `.idle` (show the spinner).
+    /// Cleared by every start path (`open`/`startDevServer`/`restartDevServer`).
+    private(set) var devServerStoppedByUser = false
+
     /// Set by SiteWindowModel right before calling `open()` following an accepted
     /// dependency update (Task 9) — that boot will hit the slow `npm install` path
     /// instead of the instant hardlink path (the lockfile was just deleted), so the
@@ -110,6 +120,8 @@ final class PreviewModel {
 
     func open(siteID: String, siteDirectory: URL) {
         openSiteID = siteID
+        openSiteDirectory = siteDirectory
+        devServerStoppedByUser = false
         let router = self.editRouter
         Task {
             // Register before starting the runtime so a Siri edit fired during dev-server boot
@@ -123,12 +135,56 @@ final class PreviewModel {
     func close() {
         let previousSiteID = openSiteID
         openSiteID = nil
+        openSiteDirectory = nil
+        devServerStoppedByUser = false
         Task {
             if let previousSiteID {
                 await EditRouterRegistry.shared.unregister(siteID: previousSiteID)
             }
             await runtime.stop()
         }
+    }
+
+    // MARK: - Dev-server controls (Site menu, #515)
+
+    /// Whether a site is open enough to (re)start its dev server: both fields are captured by
+    /// `open(siteID:siteDirectory:)`, so this is true from first open until `close()`.
+    private var siteOpenForDevServer: Bool {
+        openSiteID != nil && openSiteDirectory != nil
+    }
+
+    /// Enablement mirrors `DevServerControls` (AnglesiteCore) — the CI-tested rules — so the
+    /// menu, the stopped pane's Start button, and any future toolbar affordance stay consistent.
+    var canStartDevServer: Bool { DevServerControls.canStart(state: state, siteOpen: siteOpenForDevServer) }
+    var canStopDevServer: Bool { DevServerControls.canStop(state: state, siteOpen: siteOpenForDevServer) }
+    var canRestartDevServer: Bool { DevServerControls.canRestart(state: state, siteOpen: siteOpenForDevServer) }
+
+    /// Site ▸ Start Dev Server: relaunch the runtime for the already-open site (after an explicit
+    /// Stop, or as a recovery from `.failed` — same effect as the preview pane's Retry button).
+    /// The edit router stays registered across a stop, so no re-registration is needed here.
+    func startDevServer() {
+        guard canStartDevServer, let siteID = openSiteID, let siteDirectory = openSiteDirectory else { return }
+        devServerStoppedByUser = false
+        Task { await runtime.start(siteID: siteID, siteDirectory: siteDirectory) }
+    }
+
+    /// Site ▸ Stop Dev Server: tear down the runtime but keep the site open in the window
+    /// (unlike `close()`, which also unregisters the edit router and forgets the site). Frees
+    /// the container/dev-server resources for a backgrounded site window; the runtime settles
+    /// to `.idle` and the preview pane shows the stopped state with a Start button.
+    func stopDevServer() {
+        guard canStopDevServer else { return }
+        devServerStoppedByUser = true
+        Task { await runtime.stop() }
+    }
+
+    /// Site ▸ Restart Dev Server: for a wedged Astro process that hasn't died. `SiteRuntime.start`
+    /// tears down any previous run first (protocol contract), so restart is a plain re-start —
+    /// works identically for the local-container and remote runtimes.
+    func restartDevServer() {
+        guard canRestartDevServer, let siteID = openSiteID, let siteDirectory = openSiteDirectory else { return }
+        devServerStoppedByUser = false
+        Task { await runtime.start(siteID: siteID, siteDirectory: siteDirectory) }
     }
 
     /// The ready preview URL, if the session is currently `.ready`.

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -175,6 +175,11 @@ final class PreviewModel {
     func stopDevServer() {
         guard canStopDevServer else { return }
         devServerStoppedByUser = true
+        // Clear here (not just on `.ready`/`.failed`): stopping mid-boot never reaches either of
+        // those, so without this a Stop issued during a dependency-update boot would leave the
+        // flag stuck true — the next Start/Restart would then show "Updating dependencies…" for
+        // what's actually a plain restart.
+        isUpdatingDependencies = false
         Task { await runtime.stop() }
     }
 

--- a/Sources/AnglesiteApp/SiteMenuCommands.swift
+++ b/Sources/AnglesiteApp/SiteMenuCommands.swift
@@ -58,6 +58,22 @@ struct SiteMenuCommands: Commands {
 
             Divider()
 
+            // Dev-server lifecycle (#515). Start covers the stopped and failed states (the same
+            // recovery as the preview pane's Retry button); Restart is for a wedged Astro process
+            // that hasn't died. Enablement rules are `DevServerControls` in AnglesiteCore.
+            Button("Start Dev Server") { model?.startDevServer() }
+                .disabled(model?.canStartDevServer != true)
+
+            Button("Stop Dev Server") { model?.stopDevServer() }
+                .disabled(model?.canStopDevServer != true)
+
+            // ⌥⌘R: plain ⌘R stays reserved for preview reload (#514).
+            Button("Restart Dev Server") { model?.restartDevServer() }
+                .keyboardShortcut("r", modifiers: [.command, .option])
+                .disabled(model?.canRestartDevServer != true)
+
+            Divider()
+
             // The graph pane itself is View ▸ Graph ⌘3 (#512) — pane modes are View-menu domain.
             Button("Open in Browser") { model?.openPreviewInBrowser() }
                 .disabled(model?.canOpenPreviewInBrowser != true)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -626,7 +626,25 @@ struct SiteWindow: View {
                 }
             }
         case .idle:
-            centeredStatus { ProgressView() }
+            if model.preview.devServerStoppedByUser {
+                // Site ▸ Stop Dev Server (#515) parks the runtime at `.idle` on purpose — show a
+                // real stopped state with a restart affordance, not the pre-boot spinner.
+                centeredStatus {
+                    VStack(spacing: 12) {
+                        Image(systemName: "stop.circle")
+                            .font(.largeTitle).foregroundStyle(.secondary)
+                        Text("Dev server stopped").font(.headline)
+                        Text("The preview is paused for \(site.name). Start the dev server to resume.")
+                            .font(.callout).foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center).frame(maxWidth: 420)
+                        Button("Start Dev Server") {
+                            model.startDevServer()
+                        }
+                    }
+                }
+            } else {
+                centeredStatus { ProgressView() }
+            }
         }
     }
 

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -185,9 +185,10 @@ final class SiteWindowModel {
         Task { await styleGuide.presentSheet() }
     }
 
+    /// The `.failed`-state pane's Retry button — same recovery as Site ▸ Start Dev Server (#515),
+    /// kept as one code path rather than two that could drift.
     func retryPreview() {
-        guard let site else { return }
-        preview.open(siteID: site.id, siteDirectory: site.sourceDirectory)
+        preview.startDevServer()
     }
 
     func handleSiteChanged() {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -289,6 +289,19 @@ final class SiteWindowModel {
         NSWorkspace.shared.open(url)
     }
 
+    // MARK: - Dev-server commands (Site menu, #515)
+
+    /// Thin pass-throughs so `SiteMenuCommands` reads one focused model, like every other Site
+    /// item. Enablement rules live in `DevServerControls` (AnglesiteCore, CI-tested); the state
+    /// plumbing lives in `PreviewModel`.
+    var canStartDevServer: Bool { preview.canStartDevServer }
+    var canStopDevServer: Bool { preview.canStopDevServer }
+    var canRestartDevServer: Bool { preview.canRestartDevServer }
+
+    func startDevServer() { preview.startDevServer() }
+    func stopDevServer() { preview.stopDevServer() }
+    func restartDevServer() { preview.restartDevServer() }
+
     // MARK: - File-menu targets (#513)
 
     var canRevealInFinder: Bool {

--- a/Sources/AnglesiteCore/DevServerControls.swift
+++ b/Sources/AnglesiteCore/DevServerControls.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Pure enablement rules for the Site ▸ Start/Stop/Restart Dev Server menu commands (#515):
+/// given the runtime's current `SiteRuntimeState` and whether the window has a site open, which
+/// of the three commands apply. Substrate-agnostic — the same rules hold for the local-container
+/// and remote runtimes because they're stated purely in `SiteRuntimeState` terms.
+///
+/// Lives in `AnglesiteCore` (not the app target) so the rules run under `swift test` on CI; the
+/// app-side `PreviewModel`/`SiteWindowModel`/`SiteMenuCommands` glue stays thin.
+public enum DevServerControls {
+    /// Start applies when nothing is running: the server was explicitly stopped (`.idle`) or it
+    /// crashed / never came up (`.failed` — same recovery as the preview pane's Retry button).
+    public static func canStart(state: SiteRuntimeState, siteOpen: Bool) -> Bool {
+        guard siteOpen else { return false }
+        switch state {
+        case .idle, .failed: return true
+        case .starting, .ready: return false
+        }
+    }
+
+    /// Stop applies while the server is booting or serving — freeing resources for a
+    /// backgrounded site window.
+    public static func canStop(state: SiteRuntimeState, siteOpen: Bool) -> Bool {
+        guard siteOpen else { return false }
+        switch state {
+        case .starting, .ready: return true
+        case .idle, .failed: return false
+        }
+    }
+
+    /// Restart applies whenever there's something to tear down or recover: a wedged boot
+    /// (`.starting` that never settles), a serving-but-unresponsive Astro process (`.ready`),
+    /// or a failure. From `.idle` plain Start is the right verb, so Restart stays disabled.
+    public static func canRestart(state: SiteRuntimeState, siteOpen: Bool) -> Bool {
+        guard siteOpen else { return false }
+        switch state {
+        case .starting, .ready, .failed: return true
+        case .idle: return false
+        }
+    }
+}

--- a/Sources/AnglesiteCore/DevServerControls.swift
+++ b/Sources/AnglesiteCore/DevServerControls.swift
@@ -1,17 +1,26 @@
 import Foundation
 
 /// Pure enablement rules for the Site ▸ Start/Stop/Restart Dev Server menu commands (#515):
-/// given the runtime's current `SiteRuntimeState` and whether the window has a site open, which
-/// of the three commands apply. Substrate-agnostic — the same rules hold for the local-container
+/// given the runtime's current `SiteRuntimeState`, whether the window has a site open, and
+/// whether a previously issued command is still awaiting the runtime's acknowledgement, which of
+/// the three commands apply. Substrate-agnostic — the same rules hold for the local-container
 /// and remote runtimes because they're stated purely in `SiteRuntimeState` terms.
+///
+/// `commandInFlight` closes the state-staleness window (PR #542 review): the caller's mirrored
+/// `state` only updates asynchronously via the runtime's `observe()` stream, so between
+/// dispatching a command and observing its first state transition, `state` alone would still
+/// enable the just-fired command — letting a double-click dispatch two racing runtime calls.
+/// Every accepted command produces a transition (`start` always emits `.starting`, re-entering
+/// it via a transient `.idle`; `stop` emits `.idle` unless superseded by a newer command whose
+/// own emission arrives instead), so the flag always clears.
 ///
 /// Lives in `AnglesiteCore` (not the app target) so the rules run under `swift test` on CI; the
 /// app-side `PreviewModel`/`SiteWindowModel`/`SiteMenuCommands` glue stays thin.
 public enum DevServerControls {
     /// Start applies when nothing is running: the server was explicitly stopped (`.idle`) or it
     /// crashed / never came up (`.failed` — same recovery as the preview pane's Retry button).
-    public static func canStart(state: SiteRuntimeState, siteOpen: Bool) -> Bool {
-        guard siteOpen else { return false }
+    public static func canStart(state: SiteRuntimeState, siteOpen: Bool, commandInFlight: Bool = false) -> Bool {
+        guard siteOpen, !commandInFlight else { return false }
         switch state {
         case .idle, .failed: return true
         case .starting, .ready: return false
@@ -19,9 +28,11 @@ public enum DevServerControls {
     }
 
     /// Stop applies while the server is booting or serving — freeing resources for a
-    /// backgrounded site window.
-    public static func canStop(state: SiteRuntimeState, siteOpen: Bool) -> Bool {
-        guard siteOpen else { return false }
+    /// backgrounded site window. Stopping mid-boot is safe: a boot that discovers it was
+    /// superseded tears down its own container/session (see the runtimes' stale-generation
+    /// paths in `start()`).
+    public static func canStop(state: SiteRuntimeState, siteOpen: Bool, commandInFlight: Bool = false) -> Bool {
+        guard siteOpen, !commandInFlight else { return false }
         switch state {
         case .starting, .ready: return true
         case .idle, .failed: return false
@@ -31,8 +42,10 @@ public enum DevServerControls {
     /// Restart applies whenever there's something to tear down or recover: a wedged boot
     /// (`.starting` that never settles), a serving-but-unresponsive Astro process (`.ready`),
     /// or a failure. From `.idle` plain Start is the right verb, so Restart stays disabled.
-    public static func canRestart(state: SiteRuntimeState, siteOpen: Bool) -> Bool {
-        guard siteOpen else { return false }
+    /// Re-enabled as soon as the new boot's `.starting` is observed (`commandInFlight` clears),
+    /// so a boot that wedges again can still be restarted again.
+    public static func canRestart(state: SiteRuntimeState, siteOpen: Bool, commandInFlight: Bool = false) -> Bool {
+        guard siteOpen, !commandInFlight else { return false }
         switch state {
         case .starting, .ready, .failed: return true
         case .idle: return false

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -184,42 +184,49 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     /// are idempotent; in-flight bytes are not drained by design.
     public func stop() async {
         generation += 1
+        let gen = generation
         await teardown()
+        // Actors are reentrant, so a start()/stop() issued while teardown() was suspended has
+        // superseded this stop and owns the state now — emitting `.idle` here would clobber its
+        // `.starting`/`.ready` (the rapid Stop → Restart race, PR #542 review): the UI would show
+        // the boot spinner forever while the dev server is actually running.
+        guard gen == generation else { return }
         setState(.idle)
     }
 
     // MARK: Internals
 
     private func teardown() async {
-        await mcpClient.stop()
+        // Snapshot-and-clear all bookkeeping before the first suspension: actors are reentrant,
+        // so a superseding start()'s/stop()'s teardown can interleave while this one is suspended,
+        // and a successful boot from a superseding start() can complete and install fresh
+        // bookkeeping before this teardown resumes. Clearing first means each resource is stopped
+        // by exactly one teardown, and a straggling teardown can't stop the newer boot's
+        // container, kill its file watcher, or finish its live boot-log stream (PR #542 review).
         stopFileWatcher()
-        if let siteID = loadedKnowledgeSiteID {
+        let knowledgeSiteID = loadedKnowledgeSiteID
+        loadedKnowledgeSiteID = nil
+        let containerSiteID = activeSiteID
+        activeSiteID = nil
+        let bootLogContinuation = self.bootLogContinuation
+        let bootLogDrainTask = self.bootLogDrainTask
+        self.bootLogContinuation = nil
+        self.bootLogDrainTask = nil
+
+        await mcpClient.stop()
+        if let siteID = knowledgeSiteID {
             await knowledgeIndex?.unload(siteID: siteID)
             await semanticRanker?.unload(siteID: siteID)
             await conventionsEngine?.unload(siteID: siteID)
-            loadedKnowledgeSiteID = nil
         }
-        if let id = activeSiteID {
+        if let id = containerSiteID {
             try? await control.stop(siteID: id)
-            activeSiteID = nil
         }
         // Stop the container first (above) so no more guest output can arrive, then finish the
-        // stream — see finishBootLogStream().
-        await finishBootLogStream()
-    }
-
-    /// Finishes the boot-log continuation and awaits its drain task so any already-buffered lines
-    /// land in `LogCenter` before returning — mirrors `ContainerDeployExecutor`'s finish-then-await-
-    /// drain discipline. Idempotent (safe to call when nothing is running). Called from both
-    /// `teardown()` and `start()`'s catch block, so a failed start cleans up its own stream
-    /// immediately rather than leaking it to whatever the next `start()`/`stop()` happens to be.
-    private func finishBootLogStream() async {
-        if let continuation = bootLogContinuation {
-            continuation.finish()
-            bootLogContinuation = nil
-        }
+        // stream and await the drain so already-buffered lines land in LogCenter — mirrors
+        // `ContainerDeployExecutor`'s finish-then-await-drain discipline.
+        bootLogContinuation?.finish()
         await bootLogDrainTask?.value
-        bootLogDrainTask = nil
     }
 
     private func startFileWatcher(siteID: String, projectRoot: URL, generation gen: Int) {

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -92,6 +92,15 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         await teardown()
         generation += 1
         let gen = generation
+        // `setState` dedups against the current value, so re-entering `.starting(siteID:)` for the
+        // same site (Restart while already `.starting` — the "wedged boot" case this command exists
+        // for) would otherwise be silently dropped: observers never see a change, so the progress
+        // bar stays frozen on the superseded attempt. Force a transient `.idle` first only in that
+        // specific case — `.ready`/`.failed`/`.idle` already differ from the new `.starting` value
+        // and don't need it.
+        if case .starting(let existingSiteID) = current, existingSiteID == siteID {
+            setState(.idle)
+        }
         setState(.starting(siteID: siteID))
 
         // Wire the container's boot/guest-process output (repo clone, npm install + astro dev, the
@@ -102,24 +111,41 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         bootLogContinuation = continuation
         let logCenter = self.logCenter
         let source = "container:\(siteID)"
-        bootLogDrainTask = Task.detached(priority: .utility) {
+        let drainTask = Task.detached(priority: .utility) {
             for await (line, stream) in lines {
                 await logCenter.append(source: source, stream: stream, text: line)
             }
+        }
+        bootLogDrainTask = drainTask
+
+        // Tears down this attempt's own container and finishes its own (locally-captured, not
+        // instance-var) boot log stream. Instance vars aren't used here because by the time an
+        // abandoned attempt resumes past a `gen == generation` check, a superseding start()/stop()
+        // may already have overwritten `bootLogContinuation`/`bootLogDrainTask` with its own —
+        // finishing those would tear down the wrong stream. Actors are reentrant at `await` points,
+        // so a superseding call's `teardown()` can run to completion while this attempt is still
+        // suspended inside `control.start()`/`connect(...)`, before `activeSiteID` is assigned —
+        // `teardown()` alone can't find this attempt's container in that window. Every exit path
+        // that discovers it has been superseded must clean up after itself.
+        func abandonSupersededAttempt() async {
+            try? await control.stop(siteID: siteID)
+            continuation.finish()
+            await drainTask.value
         }
 
         do {
             let session = try await control.start(
                 siteID: siteID, sourceRepo: siteDirectory, ref: ref,
                 onOutput: { line, stream in continuation.yield((line, stream)) })
-            guard gen == generation else { return }
+            guard gen == generation else { await abandonSupersededAttempt(); return }
             try await connect(mcpClient, session.mcpURL)
-            guard gen == generation else { return }
+            guard gen == generation else { await abandonSupersededAttempt(); return }
             await knowledgeIndex?.rebuild(siteID: siteID, projectRoot: siteDirectory)
             await conventionsEngine?.rebuild(siteID: siteID, projectRoot: siteDirectory)
             guard gen == generation else {
                 await knowledgeIndex?.unload(siteID: siteID)
                 await conventionsEngine?.unload(siteID: siteID)
+                await abandonSupersededAttempt()
                 return
             }
             if let documents = await knowledgeIndex?.documents(siteID: siteID) {
@@ -129,6 +155,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
                 await knowledgeIndex?.unload(siteID: siteID)
                 await semanticRanker?.unload(siteID: siteID)
                 await conventionsEngine?.unload(siteID: siteID)
+                await abandonSupersededAttempt()
                 return
             }
             loadedKnowledgeSiteID = siteID
@@ -136,12 +163,18 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             activeSiteID = siteID
             setState(.ready(siteID: siteID, url: session.previewURL))
         } catch {
-            // Finish the boot log stream immediately rather than leaving it for the next start()/
-            // stop() call to clean up via teardown() — every other exit path in this method is
-            // scrupulous about this, and control.start() has already stopped the container on its
-            // own failure paths, so no further guest output can arrive here.
-            await finishBootLogStream()
+            // Finish this attempt's own (locally-captured) boot log stream immediately rather than
+            // leaving it for the next start()/stop() call to clean up via teardown() — control.start()
+            // has already stopped the container on its own failure paths, so no further guest output
+            // can arrive here. Using the local capture, not the instance vars, matters if this attempt
+            // was itself superseded while `control.start()` was in flight: a newer attempt may already
+            // have overwritten `bootLogContinuation`/`bootLogDrainTask` with its own, and finishing
+            // those would tear down the wrong stream.
+            continuation.finish()
+            await drainTask.value
             guard gen == generation else { return }
+            bootLogContinuation = nil
+            bootLogDrainTask = nil
             setState(.failed(siteID: siteID, message: Self.friendlyMessage(for: error)))
         }
     }

--- a/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
+++ b/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
@@ -82,17 +82,29 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
 
     public func stop() async {
         generation += 1
+        let gen = generation
         await teardown()
+        // Actors are reentrant, so a start()/stop() issued while teardown() was suspended has
+        // superseded this stop and owns the state now — emitting `.idle` here would clobber its
+        // `.starting`/`.ready` (the rapid Stop → Restart race, PR #542 review): the UI would show
+        // the boot spinner forever while the dev server is actually running.
+        guard gen == generation else { return }
         setState(.idle)
     }
 
     // MARK: Internals
 
     private func teardown() async {
+        // Clear `activeSiteID` before the suspensions, not after: a superseding start() can
+        // complete a new boot (and re-assign `activeSiteID`) while this teardown is suspended in
+        // `control.stop`, and nilling on resume would clobber the newer boot's bookkeeping —
+        // orphaning its session. Clearing first also means overlapping teardowns stop the
+        // session exactly once (PR #542 review).
+        let sessionSiteID = activeSiteID
+        activeSiteID = nil
         await mcpClient.stop()
-        if let id = activeSiteID {
+        if let id = sessionSiteID {
             try? await control.stop(siteID: id)
-            activeSiteID = nil
         }
     }
 

--- a/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
+++ b/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
@@ -51,14 +51,27 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
         await teardown()
         generation += 1
         let gen = generation
+        // `setState` dedups against the current value, so re-entering `.starting(siteID:)` for the
+        // same site (Restart while already `.starting` — the "wedged boot" case this command exists
+        // for) would otherwise be silently dropped: observers never see a change, so the progress
+        // bar stays frozen on the superseded attempt. Force a transient `.idle` first only in that
+        // specific case — `.ready`/`.failed`/`.idle` already differ from the new `.starting` value
+        // and don't need it.
+        if case .starting(let existingSiteID) = current, existingSiteID == siteID {
+            setState(.idle)
+        }
         setState(.starting(siteID: siteID))
         do {
             let token = mintToken()
             let session = try await control.start(
                 siteID: siteID, gitRemote: gitRemote, gitRef: gitRef, token: token)
-            guard gen == generation else { return }
+            // A superseding start()/stop() may have run its teardown() while this attempt was
+            // suspended above — before `activeSiteID` was assigned, so that teardown() had nothing
+            // of ours to stop. If we've been superseded, this attempt alone knows about the session
+            // it just created, so it alone is responsible for tearing it down.
+            guard gen == generation else { try? await control.stop(siteID: siteID); return }
             try await connect(mcpClient, session.mcpURL, token)
-            guard gen == generation else { return }
+            guard gen == generation else { try? await control.stop(siteID: siteID); return }
             activeSiteID = siteID
             setState(.ready(siteID: siteID, url: session.previewURL))
         } catch {

--- a/Tests/AnglesiteCoreTests/DevServerControlsTests.swift
+++ b/Tests/AnglesiteCoreTests/DevServerControlsTests.swift
@@ -64,4 +64,23 @@ struct DevServerControlsTests {
             #expect(!DevServerControls.canRestart(state: state, siteOpen: false))
         }
     }
+
+    // MARK: - Command in flight
+
+    @Test("Everything is disabled while a dispatched command awaits the runtime's acknowledgement")
+    func allDisabledWhileCommandInFlight() {
+        // The mirrored `state` is stale by definition during this window (that's why the flag
+        // exists — PR #542 review), so the rules must reject every state, not just the ones a
+        // fresh read would reject.
+        for state: SiteRuntimeState in [
+            .idle,
+            .starting(siteID: "s"),
+            .ready(siteID: "s", url: url),
+            .failed(siteID: "s", message: "boom"),
+        ] {
+            #expect(!DevServerControls.canStart(state: state, siteOpen: true, commandInFlight: true))
+            #expect(!DevServerControls.canStop(state: state, siteOpen: true, commandInFlight: true))
+            #expect(!DevServerControls.canRestart(state: state, siteOpen: true, commandInFlight: true))
+        }
+    }
 }

--- a/Tests/AnglesiteCoreTests/DevServerControlsTests.swift
+++ b/Tests/AnglesiteCoreTests/DevServerControlsTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+/// Enablement rules for the Site ▸ Start/Stop/Restart Dev Server commands (#515).
+@Suite("DevServerControls")
+struct DevServerControlsTests {
+    private let url = URL(string: "http://127.0.0.1:4321")!
+
+    // MARK: - Start
+
+    @Test("Start is enabled from idle and failed when a site is open")
+    func startEnabledWhenNotRunning() {
+        #expect(DevServerControls.canStart(state: .idle, siteOpen: true))
+        #expect(DevServerControls.canStart(state: .failed(siteID: "s", message: "boom"), siteOpen: true))
+    }
+
+    @Test("Start is disabled while the server is booting or serving")
+    func startDisabledWhileRunning() {
+        #expect(!DevServerControls.canStart(state: .starting(siteID: "s"), siteOpen: true))
+        #expect(!DevServerControls.canStart(state: .ready(siteID: "s", url: url), siteOpen: true))
+    }
+
+    // MARK: - Stop
+
+    @Test("Stop is enabled while the server is booting or serving")
+    func stopEnabledWhileRunning() {
+        #expect(DevServerControls.canStop(state: .starting(siteID: "s"), siteOpen: true))
+        #expect(DevServerControls.canStop(state: .ready(siteID: "s", url: url), siteOpen: true))
+    }
+
+    @Test("Stop is disabled when there is nothing running")
+    func stopDisabledWhenNotRunning() {
+        #expect(!DevServerControls.canStop(state: .idle, siteOpen: true))
+        #expect(!DevServerControls.canStop(state: .failed(siteID: "s", message: "boom"), siteOpen: true))
+    }
+
+    // MARK: - Restart
+
+    @Test("Restart is enabled while booting (wedged start), serving, or failed")
+    func restartEnabledWithSomethingToRecover() {
+        #expect(DevServerControls.canRestart(state: .starting(siteID: "s"), siteOpen: true))
+        #expect(DevServerControls.canRestart(state: .ready(siteID: "s", url: url), siteOpen: true))
+        #expect(DevServerControls.canRestart(state: .failed(siteID: "s", message: "boom"), siteOpen: true))
+    }
+
+    @Test("Restart is disabled from idle — plain Start is the right verb there")
+    func restartDisabledFromIdle() {
+        #expect(!DevServerControls.canRestart(state: .idle, siteOpen: true))
+    }
+
+    // MARK: - No site open
+
+    @Test("Everything is disabled when no site is open in the window")
+    func allDisabledWithoutSite() {
+        for state: SiteRuntimeState in [
+            .idle,
+            .starting(siteID: "s"),
+            .ready(siteID: "s", url: url),
+            .failed(siteID: "s", message: "boom"),
+        ] {
+            #expect(!DevServerControls.canStart(state: state, siteOpen: false))
+            #expect(!DevServerControls.canStop(state: state, siteOpen: false))
+            #expect(!DevServerControls.canRestart(state: state, siteOpen: false))
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
+++ b/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
@@ -61,6 +61,56 @@ actor FakeLocalContainerControl: LocalContainerControl {
 /// Note: the park/release rendezvous relies on Swift's cooperative executor not running the
 /// spawned `start()` Task before `waitUntilParked()` installs its continuation. This matches the
 /// pattern in `GatedFakeSandboxControlClient` and is sufficient for Swift Testing's executor.
+/// The mirror image of `GatedFakeLocalContainerControl`: `start` succeeds immediately, while the
+/// FIRST `stop` suspends until `releaseStop()` — for deterministically interleaving a superseding
+/// `start()` while a `stop()`'s teardown is parked inside `control.stop(...)` (the rapid
+/// Stop → Restart race from the PR #542 review). Subsequent `stop` calls pass straight through so
+/// the superseding path can't deadlock on the gate.
+actor StopGatedFakeLocalContainerControl: LocalContainerControl {
+    private let result: Result<LocalContainerSession, LocalContainerError>
+    private(set) var stopped: [String] = []
+    private var parkedContinuation: CheckedContinuation<Void, Never>?
+    private var gateContinuation: CheckedContinuation<Void, Never>?
+    private var gateArmed = true
+
+    init(result: Result<LocalContainerSession, LocalContainerError>) { self.result = result }
+
+    func waitUntilStopParked() async {
+        await withCheckedContinuation { cont in parkedContinuation = cont }
+    }
+    func releaseStop() { gateContinuation?.resume(); gateContinuation = nil }
+
+    func start(
+        siteID: String,
+        sourceRepo: URL,
+        ref: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> LocalContainerSession {
+        try result.get()
+    }
+
+    func stop(siteID: String) async throws {
+        stopped.append(siteID)
+        guard gateArmed else { return }
+        gateArmed = false
+        await withCheckedContinuation { cont in
+            parkedContinuation?.resume()
+            parkedContinuation = nil
+            gateContinuation = cont
+        }
+    }
+
+    func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> ContainerExecResult {
+        ContainerExecResult(exitCode: 0, stdout: "", stderr: "")
+    }
+}
+
 actor GatedFakeLocalContainerControl: LocalContainerControl {
     private let result: Result<LocalContainerSession, LocalContainerError>
     private(set) var stopped: [String] = []

--- a/Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift
+++ b/Tests/AnglesiteCoreTests/FakeSandboxControlClient.swift
@@ -29,6 +29,45 @@ actor FakeSandboxControlClient: SandboxControlClient {
     func stop(siteID: String) async throws { stopped.append(siteID) }
 }
 
+/// The mirror image of `GatedFakeSandboxControlClient`: `start` succeeds immediately, while the
+/// FIRST `stop` suspends until `releaseStop()` — for deterministically interleaving a superseding
+/// `start()` while a `stop()`'s teardown is parked inside `control.stop(...)` (the rapid
+/// Stop → Restart race from the PR #542 review). Subsequent `stop` calls pass straight through so
+/// the superseding path can't deadlock on the gate.
+actor StopGatedFakeSandboxControlClient: SandboxControlClient {
+    private let result: Result<SandboxSession, SandboxControlError>
+    private(set) var stopped: [String] = []
+    private var parkedContinuation: CheckedContinuation<Void, Never>?
+    private var gateContinuation: CheckedContinuation<Void, Never>?
+    private var gateArmed = true
+
+    init(result: Result<SandboxSession, SandboxControlError>) { self.result = result }
+
+    func waitUntilStopParked() async {
+        await withCheckedContinuation { cont in parkedContinuation = cont }
+    }
+    func releaseStop() { gateContinuation?.resume(); gateContinuation = nil }
+
+    func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
+        try result.get()
+    }
+
+    func status(siteID: String) async throws -> SandboxStatus {
+        SandboxStatus(siteID: siteID, previewReady: true, mcpReady: true)
+    }
+
+    func stop(siteID: String) async throws {
+        stopped.append(siteID)
+        guard gateArmed else { return }
+        gateArmed = false
+        await withCheckedContinuation { cont in
+            parkedContinuation?.resume()
+            parkedContinuation = nil
+            gateContinuation = cont
+        }
+    }
+}
+
 /// A `SandboxControlClient` whose `start` suspends until `release()` is called.
 /// Use this to deterministically interleave a concurrent `stop()` or second `start()`
 /// while the first `start()` is parked inside `control.start(...)`.

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -146,6 +146,40 @@ struct LocalContainerSiteRuntimeTests {
         await gated.release()
         await startTask.value
         #expect(await rt.state == .idle)
+        // The superseded boot must tear down the container it created, not orphan it: at the
+        // time the stop() ran, `activeSiteID` was still unset, so its teardown had nothing to
+        // stop — the abandoned start() alone knows about the just-booted container (PR #542
+        // review; user-reachable via Site ▸ Stop Dev Server during a boot).
+        #expect(await gated.stopped == ["s1"])
+    }
+
+    /// The rapid Stop → Restart race (PR #542 review): `stop()`'s final `.idle` used to be
+    /// emitted unconditionally, so a stop suspended in `control.stop(...)` could resume AFTER a
+    /// superseding `start()` had already settled to `.ready` and overwrite it — stranding the UI
+    /// on the boot spinner while the dev server is actually running.
+    @Test("a stop superseded by a concurrent restart does not clobber the new boot's .ready")
+    func stopSupersededByRestartKeepsReady() async {
+        let control = StopGatedFakeLocalContainerControl(result: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(
+            ref: "HEAD", control: control, mcpClient: mcp, connect: { _, _ in })
+        let dir = URL(fileURLWithPath: "/unused")
+        await rt.start(siteID: "s1", siteDirectory: dir)
+
+        // Park a stop() inside control.stop(...), then restart while it's suspended.
+        let stopTask = Task { await rt.stop() }
+        await control.waitUntilStopParked()
+        await rt.start(siteID: "s1", siteDirectory: dir)
+        #expect(await rt.state == .ready(siteID: "s1", url: Self.ok.previewURL))
+
+        // Let the superseded stop resume: it must NOT overwrite the newer boot's state.
+        await control.releaseStop()
+        await stopTask.value
+        #expect(await rt.state == .ready(siteID: "s1", url: Self.ok.previewURL))
+        // And the old container was stopped exactly once — the restart's teardown found the
+        // bookkeeping already claimed by the in-flight stop (cleared before its suspension),
+        // so it didn't double-stop, and the straggler didn't stop the NEW container either.
+        #expect(await control.stopped == ["s1"])
     }
 
     // MARK: - Observer tests (ported from RemoteSandboxSiteRuntimeTests)

--- a/Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
@@ -107,6 +107,45 @@ struct RemoteSandboxSiteRuntimeTests {
 
         // The stale-generation guard must have fired; state is .idle, not .ready.
         #expect(await rt.state == .idle)
+        // And the superseded boot must tear down the session it created, not orphan it: at the
+        // time the stop() ran, `activeSiteID` was still unset, so its teardown had nothing to
+        // stop — the abandoned start() alone knows about the just-created session (PR #542
+        // review; user-reachable via Site ▸ Stop Dev Server during a boot).
+        #expect(await gated.stopped == ["s1"])
+    }
+
+    /// The rapid Stop → Restart race (PR #542 review): `stop()`'s final `.idle` used to be
+    /// emitted unconditionally, so a stop suspended in `control.stop(...)` could resume AFTER a
+    /// superseding `start()` had already settled to `.ready` and overwrite it — stranding the UI
+    /// on the boot spinner while the dev server is actually running.
+    @Test("a stop superseded by a concurrent restart does not clobber the new boot's .ready")
+    func stopSupersededByRestartKeepsReady() async {
+        let control = StopGatedFakeSandboxControlClient(result: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = RemoteSandboxSiteRuntime(
+            gitRemote: URL(string: "https://example.com/repo.git")!,
+            gitRef: "main",
+            control: control,
+            mcpClient: mcp,
+            mintToken: { SessionToken(value: "fixedtoken") },
+            connect: { _, _, _ in })
+        let dir = URL(fileURLWithPath: "/unused")
+        await rt.start(siteID: "s1", siteDirectory: dir)
+
+        // Park a stop() inside control.stop(...), then restart while it's suspended.
+        let stopTask = Task { await rt.stop() }
+        await control.waitUntilStopParked()
+        await rt.start(siteID: "s1", siteDirectory: dir)
+        #expect(await rt.state == .ready(siteID: "s1", url: Self.ok.previewURL))
+
+        // Let the superseded stop resume: it must NOT overwrite the newer boot's state.
+        await control.releaseStop()
+        await stopTask.value
+        #expect(await rt.state == .ready(siteID: "s1", url: Self.ok.previewURL))
+        // The old session was stopped exactly once — the restart's teardown found the
+        // bookkeeping already claimed by the in-flight stop (cleared before its suspension),
+        // so it didn't double-stop, and the straggler didn't stop the NEW session either.
+        #expect(await control.stopped == ["s1"])
     }
 
     // MARK: - setState dedup guard


### PR DESCRIPTION
Adds user-facing dev-server lifecycle control to the Site menu (#515, part of the menu-bar completeness tracking in #518).

## What

- **Site ▸ Start Dev Server** — relaunch after an explicit stop, or recover from a failed boot (same effect as the preview pane's Retry).
- **Site ▸ Stop Dev Server** — tear down the runtime but keep the site window open, freeing container/dev-server resources for backgrounded windows.
- **Site ▸ Restart Dev Server (⌥⌘R)** — for a wedged Astro process that hasn't died. Plain ⌘R stays reserved for preview reload (#514).

## How

The issue anticipated SiteRuntime work, but the protocol already supports everything needed: `start(siteID:siteDirectory:)` tears down any previous run first (so restart is a plain re-start, identical for the local-container and remote runtimes), and `stop()` exists. The runtimes' generation discipline already makes a mid-boot stop/restart safe. So the change is model + menu plumbing:

- `DevServerControls` (AnglesiteCore, new): pure enablement rules for the three commands, stated purely in `SiteRuntimeState` terms — CI-testable, with a new Swift Testing suite.
- `PreviewModel`: remembers `openSiteDirectory` so start/restart can re-launch without re-resolving the site; exposes `startDevServer()` / `stopDevServer()` / `restartDevServer()` and the matching `can…` gates. Stop keeps `openSiteID` and the edit router registered (unlike `close()`), so a Siri edit against a stopped server gets the documented "MCP not running" reply.
- `SiteWindow`: an owner-stopped `.idle` renders a "Dev server stopped" pane with a Start button instead of the pre-boot spinner (`devServerStoppedByUser` distinguishes the two).
- `SiteWindowModel` + `SiteMenuCommands`: thin focused-scene-value pass-throughs following the established `canRun…` pattern (#511).

Logs stay sacred: the runtime's LogCenter streaming is untouched, and a restart re-arms the startup progress bar through the existing `onChange(of: preview.state)` ingestion.

## Verification

- `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**
- `swift build --package-path . --build-tests` — **Build complete** (all test targets compile)
- `swift test` — **unverifiable locally**: every test bundle (including on unmodified main) fails at dlopen with `Symbol not found: FoundationModels Attachment.init(imageURL:orientation:)` — the installed Xcode 27 beta SDK is newer than the installed macOS 27 seed. Local test runtime blocked by the FoundationModels SDK/OS mismatch; CI is the arbiter for the new `DevServerControlsTests` suite.

Fixes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)