### PR TITLE
feat(app): File ▸ Print ⌘P for the previewed page (#525)

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -244,6 +244,9 @@ struct AnglesiteApp: App {
             }
             // Export is its own Commands type so @FocusedValue tracks scene focus (see ExportSiteCommands).
             ExportSiteCommands()
+            // File ▸ Print… ⌘P for the previewed page — declared after ExportSiteCommands so it
+            // renders below Export Site Source… (`after:` groups render in declaration order, #525).
+            PrintCommands()
             // Site menu: the site window's primary operations (#511).
             SiteMenuCommands()
             // View ▸ pane switching ⌘1–3 + panel toggles (Chat ⌘K, Related Pages, Inspector ⌥⌘I) —

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import WebKit
+import AnglesiteBridge
 import AnglesiteCore
 
 /// SwiftUI-facing wrapper over a `SiteRuntime` actor: mirrors the runtime's `SiteRuntimeState` into
@@ -277,6 +278,27 @@ final class PreviewModel {
                 MainActor.assumeIsolated { self?.canGoForward = value }
             },
         ]
+    }
+
+    /// Whether File ▸ Print… has something to print: the preview web view exists and the runtime
+    /// is ready with a page to show. The rule itself lives in `PreviewPrinting` (AnglesiteBridge)
+    /// so it's covered by `swift test` — this is just the glue reading this model's fields (#525).
+    var canPrintPreview: Bool {
+        PreviewPrinting.isAvailable(webView: webView, displayURL: displayURL)
+    }
+
+    /// Print the previewed page (File ▸ Print ⌘P, #525). Runs the operation as a sheet on the
+    /// preview's window when it has one, else app-modal. No-ops when the preview isn't printable
+    /// yet (weak `webView` nil or runtime not ready), so this is always safe to call.
+    @MainActor
+    func printPreview() {
+        guard canPrintPreview, let webView else { return }
+        let operation = PreviewPrinting.makeOperation(for: webView)
+        if let window = webView.window {
+            operation.runModal(for: window, delegate: nil, didRun: nil, contextInfo: nil)
+        } else {
+            operation.run()
+        }
     }
 
     /// Exposes the runtime's `MCPClient` via the same weak-getter pattern `editRouter` uses,

--- a/Sources/AnglesiteApp/PrintCommands.swift
+++ b/Sources/AnglesiteApp/PrintCommands.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// File ▸ Print… ⌘P — prints the focused site window's previewed page (#525). The heavy lifting
+/// (`NSPrintInfo` for web content, the WKWebView print operation) lives in
+/// `AnglesiteBridge.PreviewPrinting`; this command is only the menu plumbing.
+struct PrintCommands: Commands {
+    // SwiftUI exposes `.focusedSceneValue(...)` as the publishing modifier; command readers still
+    // use `@FocusedValue`. There is no `@FocusedSceneValue` property wrapper in the macOS 27 SDK.
+    @FocusedValue(\.preview) private var focusedPreview
+
+    var body: some Commands {
+        // Anchored to .importExport, not .printItem: in a non-DocumentGroup app the standard
+        // document placements are dead — `.saveItem` renders nothing for both `replacing:` and
+        // `after:` (verified empirically for SaveCommands, #509), and `.printItem` is the same
+        // machinery. `after: .importExport` groups render in DECLARATION order (see the anchor
+        // note in AnglesiteApp.swift), so declaring this after ExportSiteCommands lands
+        // Print… below Export Site Source… — the bottom of the File menu, where the HIG puts it.
+        CommandGroup(after: .importExport) {
+            Divider()
+            Button("Print…") {
+                focusedPreview?.printPreview()
+            }
+            .keyboardShortcut("p")
+            // Disabled until the focused window's preview has a page to print — the rule is
+            // `PreviewPrinting.isAvailable`, tested in AnglesiteBridgeTests.
+            .disabled(focusedPreview?.canPrintPreview != true)
+        }
+    }
+}

--- a/Sources/AnglesiteBridge/PreviewPrinting.swift
+++ b/Sources/AnglesiteBridge/PreviewPrinting.swift
@@ -1,5 +1,6 @@
 import AppKit
 import WebKit
+import AnglesiteCore
 
 /// Bridge entry point for printing the previewed page (File ▸ Print ⌘P, #525).
 ///
@@ -12,6 +13,16 @@ public enum PreviewPrinting {
     /// pane has been created) and the preview must have a page to show (`displayURL` is derived
     /// only once the site runtime is `.ready`). Mirrors `PreviewModel`'s two nullable fields so
     /// the menu item's `.disabled` logic is this one testable function.
+    ///
+    /// Deliberately does NOT gate on `webView.isLoading` / navigation completion (PR #543
+    /// review): printing during an in-flight navigation prints whatever is currently rendered —
+    /// the same print-what-you-see behavior as Safari, whose Print stays enabled mid-load, and
+    /// the right answer when the still-visible previous page is what the user means to print.
+    /// It's also the only tractable rule from here: `isLoading` is KVO-based and invisible to
+    /// the Observation tracking that drives the menu item's `.disabled` state, so reading it
+    /// could leave Print stuck disabled after a load finishes. If blank first-paint prints turn
+    /// out to matter in practice, the fix is an observable did-finish-navigation signal fed from
+    /// `PreviewView`'s navigation delegate into `PreviewModel`, not a raw `isLoading` read.
     @MainActor
     public static func isAvailable(webView: WKWebView?, displayURL: URL?) -> Bool {
         webView != nil && displayURL != nil
@@ -23,7 +34,10 @@ public enum PreviewPrinting {
     @MainActor
     public static func webContentPrintInfo() -> NSPrintInfo {
         // `NSPrintInfo()` copies the shared print info, so the user's default paper/orientation
-        // and printer selection are preserved.
+        // and printer selection are preserved. Note `paperSize` is orientation-adjusted — a
+        // landscape print info reports (h, w), e.g. US Letter landscape → (792, 612). Verified
+        // empirically on the macOS 27 SDK (PR #543 review) and pinned by
+        // `PreviewPrintingTests.configureLandscapeFrame`.
         let info = NSPrintInfo()
         info.horizontalPagination = .fit
         info.verticalPagination = .automatic
@@ -46,8 +60,15 @@ public enum PreviewPrinting {
     /// Applies the app's presentation defaults to a print operation: show the standard print
     /// panel (the user picks printer/PDF/preview there), show a progress panel while WebKit
     /// paginates, and size the printing view to the paper — WKWebView's internal printing view
-    /// starts zero-sized, and with a zero frame the operation paginates nothing and every page
-    /// prints blank (long-standing WebKit quirk).
+    /// starts zero-sized (observed on the macOS 27 SDK), and with a zero frame the operation
+    /// paginates nothing and every page prints blank (long-standing WebKit quirk).
+    ///
+    /// The frame is set once, at creation: its job is only to cure the zero-sized *initial*
+    /// view. Pagination itself happens after the print panel is dismissed (AppKit calls the
+    /// view's `knowsPageRange`/`rectForPage` then), where WebKit's printing view lays out
+    /// against the operation's *current* `printInfo` — so paper/orientation changes made in the
+    /// panel are WebKit's to honor, not this frame's. `paperSize` is orientation-adjusted (see
+    /// `webContentPrintInfo()`), so a landscape default gets a landscape-shaped frame here.
     ///
     /// Split from `makeOperation(for:)` so this half is testable against a plain
     /// `NSPrintOperation`: the operation WebKit returns behaves differently on older OS
@@ -57,6 +78,19 @@ public enum PreviewPrinting {
     public static func configure(_ operation: NSPrintOperation) {
         operation.showsPrintPanel = true
         operation.showsProgressPanel = true
-        operation.view?.frame = NSRect(origin: .zero, size: operation.printInfo.paperSize)
+        guard let view = operation.view else {
+            // The zero-frame workaround can't apply — if this ever happens outside the known
+            // headless-CI case, printing will likely produce blank pages with no other signal,
+            // so leave a trace in the debug pane (logs are sacred).
+            Task {
+                await LogCenter.shared.append(
+                    source: "print",
+                    stream: .stderr,
+                    text: "Print operation has no printing view; paper-size frame workaround not applied — output may be blank (#525)"
+                )
+            }
+            return
+        }
+        view.frame = NSRect(origin: .zero, size: operation.printInfo.paperSize)
     }
 }

--- a/Sources/AnglesiteBridge/PreviewPrinting.swift
+++ b/Sources/AnglesiteBridge/PreviewPrinting.swift
@@ -1,0 +1,50 @@
+import AppKit
+import WebKit
+
+/// Bridge entry point for printing the previewed page (File ▸ Print ⌘P, #525).
+///
+/// Wraps `WKWebView.printOperation(with:)` with an `NSPrintInfo` tuned for web content and the
+/// AppKit-side plumbing the web view needs to produce non-blank output. Lives in `AnglesiteBridge`
+/// (not the app target) so the availability rule and print-info configuration are covered by
+/// `swift test` — hosted app tests don't run on CI.
+public enum PreviewPrinting {
+    /// Whether File ▸ Print should be enabled: the preview's `WKWebView` must exist (the preview
+    /// pane has been created) and the preview must have a page to show (`displayURL` is derived
+    /// only once the site runtime is `.ready`). Mirrors `PreviewModel`'s two nullable fields so
+    /// the menu item's `.disabled` logic is this one testable function.
+    @MainActor
+    public static func isAvailable(webView: WKWebView?, displayURL: URL?) -> Bool {
+        webView != nil && displayURL != nil
+    }
+
+    /// An `NSPrintInfo` configured for web content: pages scale to fit the paper width (long pages
+    /// paginate vertically), and the URL/date headers and footers WebKit can draw are off by
+    /// default — the print panel still lets the user turn them back on.
+    @MainActor
+    public static func webContentPrintInfo() -> NSPrintInfo {
+        // `NSPrintInfo()` copies the shared print info, so the user's default paper/orientation
+        // and printer selection are preserved.
+        let info = NSPrintInfo()
+        info.horizontalPagination = .fit
+        info.verticalPagination = .automatic
+        // `dictionary()` returns the live attributes dictionary; mutations apply to `info`.
+        info.dictionary()[NSPrintInfo.AttributeKey.headerAndFooter] = NSNumber(value: false)
+        return info
+    }
+
+    /// Builds the print operation for the previewed page. Shows the standard print panel (the
+    /// user picks printer/PDF/preview there) and a progress panel while WebKit paginates.
+    ///
+    /// The caller runs it — `runModal(for:...)` as a window sheet, or `run()` without one.
+    @MainActor
+    public static func makeOperation(for webView: WKWebView) -> NSPrintOperation {
+        let info = webContentPrintInfo()
+        let operation = webView.printOperation(with: info)
+        operation.showsPrintPanel = true
+        operation.showsProgressPanel = true
+        // WKWebView's internal printing view starts zero-sized; without a nonzero frame the
+        // operation paginates nothing and every page prints blank (long-standing WebKit quirk).
+        operation.view?.frame = NSRect(origin: .zero, size: info.paperSize)
+        return operation
+    }
+}

--- a/Sources/AnglesiteBridge/PreviewPrinting.swift
+++ b/Sources/AnglesiteBridge/PreviewPrinting.swift
@@ -32,19 +32,31 @@ public enum PreviewPrinting {
         return info
     }
 
-    /// Builds the print operation for the previewed page. Shows the standard print panel (the
-    /// user picks printer/PDF/preview there) and a progress panel while WebKit paginates.
+    /// Builds the print operation for the previewed page: `WKWebView.printOperation(with:)`
+    /// against `webContentPrintInfo()`, then `configure(_:)`.
     ///
     /// The caller runs it — `runModal(for:...)` as a window sheet, or `run()` without one.
     @MainActor
     public static func makeOperation(for webView: WKWebView) -> NSPrintOperation {
-        let info = webContentPrintInfo()
-        let operation = webView.printOperation(with: info)
+        let operation = webView.printOperation(with: webContentPrintInfo())
+        configure(operation)
+        return operation
+    }
+
+    /// Applies the app's presentation defaults to a print operation: show the standard print
+    /// panel (the user picks printer/PDF/preview there), show a progress panel while WebKit
+    /// paginates, and size the printing view to the paper — WKWebView's internal printing view
+    /// starts zero-sized, and with a zero frame the operation paginates nothing and every page
+    /// prints blank (long-standing WebKit quirk).
+    ///
+    /// Split from `makeOperation(for:)` so this half is testable against a plain
+    /// `NSPrintOperation`: the operation WebKit returns behaves differently on older OS
+    /// releases/headless CI (setters don't stick, `view` is nil), so tests exercise this
+    /// function directly rather than asserting through WebKit's object.
+    @MainActor
+    public static func configure(_ operation: NSPrintOperation) {
         operation.showsPrintPanel = true
         operation.showsProgressPanel = true
-        // WKWebView's internal printing view starts zero-sized; without a nonzero frame the
-        // operation paginates nothing and every page prints blank (long-standing WebKit quirk).
-        operation.view?.frame = NSRect(origin: .zero, size: info.paperSize)
-        return operation
+        operation.view?.frame = NSRect(origin: .zero, size: operation.printInfo.paperSize)
     }
 }

--- a/Tests/AnglesiteBridgeTests/PreviewPrintingTests.swift
+++ b/Tests/AnglesiteBridgeTests/PreviewPrintingTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import AppKit
+import WebKit
+@testable import AnglesiteBridge
+
+/// Covers `PreviewPrinting` — the bridge entry point behind File ▸ Print ⌘P (#525).
+/// `@MainActor` because WebKit/AppKit print types must be created on the main thread.
+@MainActor
+struct PreviewPrintingTests {
+    // MARK: Availability (the menu item's `.disabled` logic)
+
+    @Test("Print is unavailable with no web view") func unavailableWithoutWebView() {
+        #expect(!PreviewPrinting.isAvailable(webView: nil, displayURL: URL(string: "http://localhost:4321/")))
+    }
+
+    @Test("Print is unavailable before the preview has a page to show") func unavailableWithoutDisplayURL() {
+        let webView = WKWebView(frame: .zero)
+        #expect(!PreviewPrinting.isAvailable(webView: webView, displayURL: nil))
+    }
+
+    @Test("Print is unavailable when neither exists") func unavailableWithNeither() {
+        #expect(!PreviewPrinting.isAvailable(webView: nil, displayURL: nil))
+    }
+
+    @Test("Print is available once the web view exists and a page is loaded") func availableWithBoth() {
+        let webView = WKWebView(frame: .zero)
+        #expect(PreviewPrinting.isAvailable(webView: webView, displayURL: URL(string: "http://localhost:4321/")))
+    }
+
+    // MARK: NSPrintInfo configuration for web content
+
+    @Test("Print info fits web content to the page width") func printInfoPagination() {
+        let info = PreviewPrinting.webContentPrintInfo()
+        #expect(info.horizontalPagination == .fit)
+        #expect(info.verticalPagination == .automatic)
+    }
+
+    @Test("Print info disables URL/date headers and footers by default") func printInfoHeadersOff() {
+        let info = PreviewPrinting.webContentPrintInfo()
+        let headerAndFooter = info.dictionary()[NSPrintInfo.AttributeKey.headerAndFooter] as? Bool
+        #expect(headerAndFooter == false)
+    }
+
+    // MARK: Operation construction
+
+    @Test("Make operation shows the print panel and carries the web-content print info")
+    func makeOperationConfiguration() {
+        let webView = WKWebView(frame: .zero)
+        let operation = PreviewPrinting.makeOperation(for: webView)
+        #expect(operation.showsPrintPanel)
+        #expect(operation.showsProgressPanel)
+        #expect(operation.printInfo.horizontalPagination == .fit)
+    }
+
+    @Test("Make operation sizes the printing view to the paper — a zero frame prints blank pages")
+    func makeOperationViewFrame() {
+        let webView = WKWebView(frame: .zero)
+        let operation = PreviewPrinting.makeOperation(for: webView)
+        let paper = operation.printInfo.paperSize
+        #expect(operation.view?.frame.size == paper)
+    }
+}

--- a/Tests/AnglesiteBridgeTests/PreviewPrintingTests.swift
+++ b/Tests/AnglesiteBridgeTests/PreviewPrintingTests.swift
@@ -63,6 +63,24 @@ struct PreviewPrintingTests {
         #expect(operation.view?.frame.size == operation.printInfo.paperSize)
     }
 
+    @Test("Configure under a landscape print info yields a landscape-shaped frame")
+    func configureLandscapeFrame() {
+        // Pins the load-bearing AppKit behavior the frame workaround relies on (PR #543 review):
+        // `NSPrintInfo.paperSize` is orientation-adjusted (US Letter landscape → (792, 612)),
+        // so a landscape info must produce a wider-than-tall printing view, not portrait dims.
+        let info = PreviewPrinting.webContentPrintInfo()
+        info.orientation = .landscape
+        let operation = NSPrintOperation(view: NSView(), printInfo: info)
+        PreviewPrinting.configure(operation)
+        let paper = operation.printInfo.paperSize
+        #expect(operation.view?.frame.size == paper)
+        // Headless CI runners with no printers can report a degenerate (0, 0) paper; the
+        // orientation assertion is only meaningful when the environment has a real paper size.
+        if paper != .zero {
+            #expect(paper.width > paper.height)
+        }
+    }
+
     @Test("Make operation builds a runnable operation for a web view") func makeOperationSmoke() {
         // Construction only: the returned object's observable state is WebKit-version-dependent
         // (see the note above), so this is a does-not-crash smoke test.

--- a/Tests/AnglesiteBridgeTests/PreviewPrintingTests.swift
+++ b/Tests/AnglesiteBridgeTests/PreviewPrintingTests.swift
@@ -41,22 +41,32 @@ struct PreviewPrintingTests {
         #expect(headerAndFooter == false)
     }
 
-    // MARK: Operation construction
+    // MARK: Operation configuration
+    //
+    // `configure(_:)` is exercised against a plain `NSPrintOperation` — the operation
+    // `WKWebView.printOperation(with:)` returns behaves differently on older OS releases /
+    // headless CI (setters don't stick, `view` is nil), so asserting through it is flaky.
 
-    @Test("Make operation shows the print panel and carries the web-content print info")
-    func makeOperationConfiguration() {
-        let webView = WKWebView(frame: .zero)
-        let operation = PreviewPrinting.makeOperation(for: webView)
+    @Test("Configure shows the print and progress panels") func configurePanels() {
+        let operation = NSPrintOperation(view: NSView(), printInfo: PreviewPrinting.webContentPrintInfo())
+        operation.showsPrintPanel = false
+        operation.showsProgressPanel = false
+        PreviewPrinting.configure(operation)
         #expect(operation.showsPrintPanel)
         #expect(operation.showsProgressPanel)
-        #expect(operation.printInfo.horizontalPagination == .fit)
     }
 
-    @Test("Make operation sizes the printing view to the paper — a zero frame prints blank pages")
-    func makeOperationViewFrame() {
+    @Test("Configure sizes the printing view to the paper — a zero frame prints blank pages")
+    func configureViewFrame() {
+        let operation = NSPrintOperation(view: NSView(), printInfo: PreviewPrinting.webContentPrintInfo())
+        PreviewPrinting.configure(operation)
+        #expect(operation.view?.frame.size == operation.printInfo.paperSize)
+    }
+
+    @Test("Make operation builds a runnable operation for a web view") func makeOperationSmoke() {
+        // Construction only: the returned object's observable state is WebKit-version-dependent
+        // (see the note above), so this is a does-not-crash smoke test.
         let webView = WKWebView(frame: .zero)
-        let operation = PreviewPrinting.makeOperation(for: webView)
-        let paper = operation.printInfo.paperSize
-        #expect(operation.view?.frame.size == paper)
+        _ = PreviewPrinting.makeOperation(for: webView)
     }
 }


### PR DESCRIPTION
Fixes #525. Part of #518.

## What

Adds **File ▸ Print… ⌘P** printing the focused site window's previewed page via `WKWebView.printOperation(with:)`.

## How

- **`AnglesiteBridge.PreviewPrinting`** (new) — the testable core, kept out of the app target so `swift test` covers it on CI:
  - `isAvailable(webView:displayURL:)` — the menu item's `.disabled` rule: the preview's web view must exist and the runtime must be `.ready` with a page to show.
  - `webContentPrintInfo()` — `NSPrintInfo` tuned for web content: fit-to-width horizontal pagination, automatic vertical pagination, URL/date headers+footers off by default (re-enableable in the print panel).
  - `makeOperation(for:)` — builds the operation with print + progress panels, and sizes the printing view to the paper (WKWebView's zero-sized printing view otherwise prints blank pages).
- **`PreviewModel.canPrintPreview` / `printPreview()`** — thin glue reading the model's weak `webView` + `displayURL`; runs the operation as a sheet on the preview's window (app-modal fallback).
- **`PrintCommands`** — menu plumbing off the existing `\.preview` focused scene value (same pattern as `WebInspectorCommands`). Anchored `after: .importExport`, not `.printItem`: the standard document placements are dead in a non-DocumentGroup app (empirically verified for `.saveItem` in #532's SaveCommands). Declared after `ExportSiteCommands` so Print… renders below Export Site Source… at the bottom of the File menu, behind a divider. Disabled until the preview has a page.

## Tests

New `AnglesiteBridgeTests/PreviewPrintingTests` (Swift Testing): availability truth table, print-info pagination + header/footer config, operation panel flags, and the paper-sized view frame.

## Verification

- `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**
- `swift build --package-path . --build-tests` — **Build complete** (all test targets compile)
- `swift test` — **local test runtime blocked by FoundationModels SDK/OS mismatch; CI is the arbiter.** Every test bundle linking AnglesiteCore fails at dlopen with `Symbol not found: FoundationModels.Attachment(imageURL:orientation:)` on this machine (Xcode 27 beta SDK newer than the installed macOS 27 seed) — pre-existing, unrelated to this change. The suites that could load (`AnglesiteSiteModelTests`) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)