### PR TITLE
feat(app): wire app-applied edits into the window UndoManager so ⌘Z works (#527)

### DIFF
--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -112,10 +112,22 @@ final class ChatModel {
     /// (#527). `recordEdit` registers each applied edit; ⌘Z delegates back to ``undoEdit`` —
     /// the same inverse-application + conflict-detection path as the per-row Undo button.
     /// `SiteWindowModel` attaches the window's undo manager (from `@Environment(\.undoManager)`).
+    ///
+    /// The row is resolved by **commit SHA**, not the message UUID the record was created
+    /// under: `loadHistory()` re-creates every row with a fresh UUID whenever the chat panel
+    /// remounts, so a UUID captured at apply time can go stale while the edit (and its commit)
+    /// remains perfectly undoable.
     @ObservationIgnored
     private(set) lazy var editUndoCoordinator = EditUndoCoordinator { [weak self] record in
-        Task { await self?.undoEdit(messageID: record.editID) }
+        guard let self,
+              let row = self.messages.first(where: { $0.editMetadata?.commit == record.commit })
+        else { return .stale }
+        return await self.undoEdit(messageID: row.id)
     }
+    /// Commits with an `undo_edit` round trip in flight. Checked synchronously at the top of
+    /// ``undoEdit`` so the per-row Undo button and ⌘Z can't double-submit the same revert —
+    /// both entry points run on the main actor, and the guard closes before the first `await`.
+    private var undoCommitsInFlight: Set<String> = []
     private var streamTask: Task<Void, Never>?
     /// IDs of annotations already surfaced in chat, so repeated calls to `loadAnnotations()`
     /// don't double-post the same sticky note when the user revisits a site mid-session.
@@ -240,7 +252,7 @@ final class ChatModel {
             editMetadata: metadata
         )
         transcript.append(message)
-        editUndoCoordinator.registerApplied(.init(editID: message.id, file: file, commit: commit))
+        editUndoCoordinator.registerApplied(.init(file: file, commit: commit))
         let entry = ChatHistoryStore.Entry(
             timestamp: message.timestamp,
             role: .edit,
@@ -257,32 +269,52 @@ final class ChatModel {
     /// Call `undo_edit` for the message identified by `messageID`. On success, flip the
     /// row's `undone` flag and persist a sidecar. On working-tree drift, set `conflictPrompt`
     /// so the view shows a sheet. On failure, append an `.error` system message.
-    func undoEdit(messageID: UUID, force: Bool = false) async {
+    ///
+    /// The returned outcome drives ``editUndoCoordinator``'s re-arm decision when the call
+    /// came from ⌘Z (the row-button path discards it): `.undone` spends the record,
+    /// `.retryable` keeps the edit reachable via ⌘Z (failure, conflict sheet pending, MCP
+    /// down, or another revert already in flight for this commit), `.stale` drops it (the
+    /// record no longer maps to an undoable row).
+    @discardableResult
+    func undoEdit(messageID: UUID, force: Bool = false) async -> EditUndoCoordinator.UndoOutcome {
         guard let target = messages.first(where: { $0.id == messageID }),
               target.role == .edit,
               let metadata = target.editMetadata,
               !metadata.undone
-        else { return }
+        else { return .stale }
         guard let undoCommand else {
             lastError = "Undo unavailable: MCP not running."
-            return
+            return .retryable
         }
+        // Double-submit guard: the row button and ⌘Z are independent entry points into this
+        // function, and `metadata.undone` only flips after the `await` below — so without
+        // this, a click + reflexive ⌘Z would send two concurrent reverts for the same commit.
+        // Checked and inserted synchronously (no suspension) on the main actor.
+        guard !undoCommitsInFlight.contains(metadata.commit) else { return .retryable }
+        undoCommitsInFlight.insert(metadata.commit)
+        defer { undoCommitsInFlight.remove(metadata.commit) }
         let result = await undoCommand.undo(commit: metadata.commit, force: force)
         switch result {
         case .success(let newCommit):
             transcript.update(id: messageID) { $0.editMetadata?.undone = true }
-            // Drop any still-pending ⌘Z record for this edit (the per-row Undo button path).
-            // No-op when the undo *came from* ⌘Z — the coordinator consumed its record first.
-            editUndoCoordinator.invalidate(editID: messageID)
+            // Drop any still-pending ⌘Z record for this edit (the per-row Undo button path,
+            // or a record re-armed after an earlier failed/conflicted ⌘Z). No-op when the
+            // undo *came from* ⌘Z — the coordinator consumed its record first.
+            editUndoCoordinator.invalidate(commit: metadata.commit)
             Task { [history] in
                 try? await history.appendUndone(messageID: messageID, newCommit: newCommit)
             }
+            return .undone
         case .workingTreeModified(let files):
             conflictPrompt = ConflictPrompt(messageID: messageID, commit: metadata.commit, files: files)
+            // Not undone yet: the sheet is pending. Re-arming keeps ⌘Z truthful if the user
+            // cancels; if they confirm, the forced retry's success invalidates by commit.
+            return .retryable
         case .failed(let reason, let detail):
             let errorContent = "Couldn't undo: \(detail) (\(reason))"
             transcript.append(Message(role: .error, content: errorContent))
             lastError = errorContent
+            return .retryable
         }
     }
 
@@ -311,6 +343,10 @@ final class ChatModel {
         cancel()
         streamTask = nil
         transcript.reset()
+        // The rows backing the window's ⌘Z records are gone (and the truncated history can't
+        // resurrect them) — drop the records too, or ⌘Z would silently consume entries whose
+        // reverts can no longer be located.
+        editUndoCoordinator.invalidateAll()
         await assistant.resetSession()
         do { try await history.clear() } catch { lastError = "couldn't clear history: \(error)" }
     }

--- a/Sources/AnglesiteApp/ChatModel.swift
+++ b/Sources/AnglesiteApp/ChatModel.swift
@@ -108,6 +108,14 @@ final class ChatModel {
     /// Optional. Wired to the per-site `MCPClient` in production; nil in tests where the
     /// chat has no MCP backing yet.
     private let undoCommand: UndoCommand?
+    /// Bridges applied edits into the window's `UndoManager` so Edit ▸ Undo (⌘Z) reverses them
+    /// (#527). `recordEdit` registers each applied edit; ⌘Z delegates back to ``undoEdit`` —
+    /// the same inverse-application + conflict-detection path as the per-row Undo button.
+    /// `SiteWindowModel` attaches the window's undo manager (from `@Environment(\.undoManager)`).
+    @ObservationIgnored
+    private(set) lazy var editUndoCoordinator = EditUndoCoordinator { [weak self] record in
+        Task { await self?.undoEdit(messageID: record.editID) }
+    }
     private var streamTask: Task<Void, Never>?
     /// IDs of annotations already surfaced in chat, so repeated calls to `loadAnnotations()`
     /// don't double-post the same sticky note when the user revisits a site mid-session.
@@ -232,6 +240,7 @@ final class ChatModel {
             editMetadata: metadata
         )
         transcript.append(message)
+        editUndoCoordinator.registerApplied(.init(editID: message.id, file: file, commit: commit))
         let entry = ChatHistoryStore.Entry(
             timestamp: message.timestamp,
             role: .edit,
@@ -262,6 +271,9 @@ final class ChatModel {
         switch result {
         case .success(let newCommit):
             transcript.update(id: messageID) { $0.editMetadata?.undone = true }
+            // Drop any still-pending ⌘Z record for this edit (the per-row Undo button path).
+            // No-op when the undo *came from* ⌘Z — the coordinator consumed its record first.
+            editUndoCoordinator.invalidate(editID: messageID)
             Task { [history] in
                 try? await history.appendUndone(messageID: messageID, newCommit: newCommit)
             }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -27,6 +27,9 @@ struct SiteWindow: View {
     @Environment(\.dismissWindow) private var dismissWindow
     /// Reduce Motion → fade the chat panel and deploy drawer in/out instead of sliding them.
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// The window's undo manager, published into the model so app-applied edits register with
+    /// Edit ▸ Undo (⌘Z) — see `ChatModel.editUndoCoordinator` (#527).
+    @Environment(\.undoManager) private var undoManager
 
     init(
         siteID: String?,
@@ -71,6 +74,11 @@ struct SiteWindow: View {
             if let id = model.site?.id { model.applyPendingNavigation(for: id) }
         }
         .onChange(of: model.site?.id) { _, _ in model.handleSiteChanged() }
+        // `initial: true` covers the common case where the environment value is already set on
+        // first render; the change handler covers SwiftUI delivering/replacing it later.
+        .onChange(of: undoManager, initial: true) { _, newValue in
+            model.windowUndoManager = newValue
+        }
         .onChange(of: model.preview.state) { _, newState in
             model.startup.ingest(state: newState)
         }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -69,6 +69,15 @@ final class SiteWindowModel {
     /// same lifecycle as `chat`. Its own `sheetPresented` drives the `.sheet(isPresented:)` in
     /// `SiteWindow`, following `AuditModel`'s pattern rather than the item-based sheets.
     var styleGuide: ProjectConventionsModel?
+    /// The window's `UndoManager`, published down from `SiteWindow`'s
+    /// `@Environment(\.undoManager)` so applied edits register for Edit ▸ Undo (#527). Weak +
+    /// `@ObservationIgnored`: the window owns it and it isn't render state. Forwarded on set
+    /// (environment arrives/changes) and again in `loadAndStart` (chat is created after the
+    /// first set on cold open).
+    @ObservationIgnored
+    weak var windowUndoManager: UndoManager? {
+        didSet { chat?.editUndoCoordinator.undoManager = windowUndoManager }
+    }
     var relatedPages: RelatedPagesModel
     var relatedPagesPresented = false
     /// Drives the Navigator's "Cleanup" section. On-demand only — `scan()` is never called
@@ -824,6 +833,9 @@ final class SiteWindowModel {
             integrationService: integrationOps
         )
         chat = assistantSession.chat
+        // The environment undo manager usually lands before the chat exists (cold open) —
+        // attach it now so edits applied with the chat panel closed still register for ⌘Z.
+        assistantSession.chat.editUndoCoordinator.undoManager = windowUndoManager
         preview.setEditObserver(
             assistantSession.editObserver,
             postProcess: assistantSession.editPostProcessor

--- a/Sources/AnglesiteCore/EditUndoCoordinator.swift
+++ b/Sources/AnglesiteCore/EditUndoCoordinator.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Bridges app-applied edits into a window's `UndoManager` so Edit ▸ Undo (⌘Z) reverses them (#527).
+///
+/// This sits at the shared edit-pipeline level, not inside any one assistant: every applied
+/// edit with a commit — overlay drops, chat/assistant tool edits, alt-text follow-ups — flows
+/// through `MCPApplyEditRouter.onEdit` into the app's edit recorder, which registers a
+/// ``Record`` here at apply time. The reverse-apply itself is the plugin's git-revert
+/// (`undo_edit`, wrapped by ``UndoCommand``), so the record only needs the commit SHA and the
+/// row identity — the injected `perform` closure delegates to the existing inverse-application
+/// + conflict-detection path (`ChatModel.undoEdit`).
+///
+/// The app-target glue stays thin: set ``undoManager`` from SwiftUI's
+/// `@Environment(\.undoManager)` and supply `perform`; everything else lives here where it's
+/// unit-testable against a plain Foundation `UndoManager`.
+///
+/// Policy notes:
+/// - **No redo.** The plugin exposes revert (`undo_edit`) but no re-apply primitive, so
+///   ``perform`` runs without registering an inverse — after ⌘Z, Edit ▸ Redo stays disabled.
+/// - **LIFO matches git.** `UndoManager` pops newest-first, which is exactly the head-first
+///   order the edits branch wants reverts in.
+/// - **Out-of-band undos invalidate their record.** When an edit is undone by another path
+///   (the chat row's Undo button), call ``invalidate(editID:)`` so ⌘Z doesn't replay a stale
+///   action. Each record registers against its own private token target, so removal is
+///   per-record (`removeAllActions(withTarget:)` on that token), not stack-wide.
+@MainActor
+public final class EditUndoCoordinator {
+    /// One applied edit, as registered on the undo stack.
+    public struct Record: Sendable, Equatable {
+        /// Identity of the edit row in the transcript (`ChatMessage.id`) — what the perform
+        /// closure uses to locate the row and flip its `undone` flag.
+        public let editID: UUID
+        /// Source file the edit landed on (site-relative path). Drives the menu action name.
+        public let file: String
+        /// SHA of the commit on `refs/heads/anglesite/edits` that captures this edit.
+        public let commit: String
+
+        public init(editID: UUID, file: String, commit: String) {
+            self.editID = editID
+            self.file = file
+            self.commit = commit
+        }
+    }
+
+    /// Kicks off the reverse-apply for one record. Called on the main actor when the user
+    /// invokes Edit ▸ Undo; implementations typically spawn a `Task` for the async MCP call.
+    public typealias Performer = @MainActor (Record) -> Void
+
+    /// Per-record registration target. `UndoManager` does not retain targets, so each token is
+    /// kept alive by the registered handler capturing it — its lifetime is exactly the
+    /// lifetime of its undo-stack entry — and indexed in ``tokens`` for selective removal.
+    private final class Token {
+        let record: Record
+        init(_ record: Record) { self.record = record }
+    }
+
+    /// The focused window's undo manager. Weak: the window owns it; this coordinator only
+    /// registers into it. `nil` (no window attached yet) makes ``registerApplied(_:)`` a no-op.
+    public weak var undoManager: UndoManager?
+
+    private let perform: Performer
+    /// Live registrations by edit ID, so ``invalidate(editID:)`` can remove exactly one
+    /// record's action. Entries are dropped when their undo fires or they're invalidated.
+    private var tokens: [UUID: Token] = [:]
+
+    public init(perform: @escaping Performer) {
+        self.perform = perform
+    }
+
+    /// Registers an applied edit on the undo stack. Call at apply time, right after the edit
+    /// row is recorded. No-op when no ``undoManager`` is attached.
+    public func registerApplied(_ record: Record) {
+        guard let undoManager else { return }
+        let token = Token(record)
+        tokens[record.editID] = token
+        // `token` is captured strongly by the handler on purpose: UndoManager holds its target
+        // unsafely-unretained, so the capture pins the token (and nothing else — self is weak)
+        // for exactly as long as the stack entry exists.
+        undoManager.registerUndo(withTarget: token) { [weak self, token] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.tokens[token.record.editID] = nil
+                self.perform(token.record)
+            }
+        }
+        undoManager.setActionName(Self.actionName(for: record))
+    }
+
+    /// Removes a still-pending record from the undo stack — call after an edit was undone via
+    /// another path (e.g. the chat row's Undo button) so ⌘Z skips it. No-op for unknown or
+    /// already-fired records.
+    public func invalidate(editID: UUID) {
+        guard let token = tokens.removeValue(forKey: editID) else { return }
+        undoManager?.removeAllActions(withTarget: token)
+    }
+
+    /// Menu action name for a record: "Edit <filename>" → the menu shows "Undo Edit <filename>".
+    public static func actionName(for record: Record) -> String {
+        let filename = record.file.split(separator: "/").last.map(String.init) ?? record.file
+        return "Edit \(filename)"
+    }
+}

--- a/Sources/AnglesiteCore/EditUndoCoordinator.swift
+++ b/Sources/AnglesiteCore/EditUndoCoordinator.swift
@@ -6,9 +6,10 @@ import Foundation
 /// edit with a commit — overlay drops, chat/assistant tool edits, alt-text follow-ups — flows
 /// through `MCPApplyEditRouter.onEdit` into the app's edit recorder, which registers a
 /// ``Record`` here at apply time. The reverse-apply itself is the plugin's git-revert
-/// (`undo_edit`, wrapped by ``UndoCommand``), so the record only needs the commit SHA and the
-/// row identity — the injected `perform` closure delegates to the existing inverse-application
-/// + conflict-detection path (`ChatModel.undoEdit`).
+/// (`undo_edit`, wrapped by ``UndoCommand``), so the record only needs the commit SHA (the
+/// stable identity of the edit — chat rows are re-created with fresh UUIDs on every history
+/// reload) plus the file path for the menu action name. The injected ``Performer`` delegates
+/// to the existing inverse-application + conflict-detection path (`ChatModel.undoEdit`).
 ///
 /// The app-target glue stays thin: set ``undoManager`` from SwiftUI's
 /// `@Environment(\.undoManager)` and supply `perform`; everything else lives here where it's
@@ -16,35 +17,51 @@ import Foundation
 ///
 /// Policy notes:
 /// - **No redo.** The plugin exposes revert (`undo_edit`) but no re-apply primitive, so
-///   ``perform`` runs without registering an inverse — after ⌘Z, Edit ▸ Redo stays disabled.
+///   nothing lands on the redo stack — after a successful ⌘Z, Edit ▸ Redo stays disabled.
+/// - **Failure re-arms.** `UndoManager` pops the action synchronously the instant ⌘Z fires,
+///   before the async revert resolves. If the revert then fails or hits the working-tree
+///   conflict sheet (``UndoOutcome/retryable``), the record is re-registered so the edit stays
+///   reachable via ⌘Z — symmetric with the chat row's Undo button, which also keeps its entry
+///   on failure. (If newer edits were applied during the round trip, the re-armed record sits
+///   above them; a tolerable ordering skew for a failure path.)
 /// - **LIFO matches git.** `UndoManager` pops newest-first, which is exactly the head-first
 ///   order the edits branch wants reverts in.
 /// - **Out-of-band undos invalidate their record.** When an edit is undone by another path
-///   (the chat row's Undo button), call ``invalidate(editID:)`` so ⌘Z doesn't replay a stale
-///   action. Each record registers against its own private token target, so removal is
-///   per-record (`removeAllActions(withTarget:)` on that token), not stack-wide.
+///   (the chat row's Undo button), call ``invalidate(commit:)`` so ⌘Z doesn't replay a stale
+///   action; when the transcript is cleared wholesale (reset conversation), call
+///   ``invalidateAll()``. Each record registers against its own private token target, so
+///   removal is per-record (`removeAllActions(withTarget:)` on that token), not stack-wide.
 @MainActor
 public final class EditUndoCoordinator {
     /// One applied edit, as registered on the undo stack.
     public struct Record: Sendable, Equatable {
-        /// Identity of the edit row in the transcript (`ChatMessage.id`) — what the perform
-        /// closure uses to locate the row and flip its `undone` flag.
-        public let editID: UUID
         /// Source file the edit landed on (site-relative path). Drives the menu action name.
         public let file: String
-        /// SHA of the commit on `refs/heads/anglesite/edits` that captures this edit.
+        /// SHA of the commit on `refs/heads/anglesite/edits` that captures this edit — the
+        /// record's identity. Stable across transcript reloads, unlike chat-row UUIDs.
         public let commit: String
 
-        public init(editID: UUID, file: String, commit: String) {
-            self.editID = editID
+        public init(file: String, commit: String) {
             self.file = file
             self.commit = commit
         }
     }
 
-    /// Kicks off the reverse-apply for one record. Called on the main actor when the user
-    /// invokes Edit ▸ Undo; implementations typically spawn a `Task` for the async MCP call.
-    public typealias Performer = @MainActor (Record) -> Void
+    /// What actually happened when a popped record's reverse-apply resolved.
+    public enum UndoOutcome: Sendable, Equatable {
+        /// The edit was reverted. The record is spent.
+        case undone
+        /// The revert didn't happen but could later (MCP error, conflict sheet cancelled,
+        /// MCP not running). The coordinator re-registers the record so ⌘Z can retry.
+        case retryable
+        /// The record no longer maps to an undoable edit (row gone or already undone via
+        /// another path). Dropped without re-registering.
+        case stale
+    }
+
+    /// Runs the reverse-apply for one record and reports what happened. Called on the main
+    /// actor from a `Task` the coordinator spawns when the user invokes Edit ▸ Undo.
+    public typealias Performer = @MainActor (Record) async -> UndoOutcome
 
     /// Per-record registration target. `UndoManager` does not retain targets, so each token is
     /// kept alive by the registered handler capturing it — its lifetime is exactly the
@@ -59,9 +76,13 @@ public final class EditUndoCoordinator {
     public weak var undoManager: UndoManager?
 
     private let perform: Performer
-    /// Live registrations by edit ID, so ``invalidate(editID:)`` can remove exactly one
-    /// record's action. Entries are dropped when their undo fires or they're invalidated.
-    private var tokens: [UUID: Token] = [:]
+    /// Live registrations by commit SHA, so ``invalidate(commit:)`` can remove exactly one
+    /// record's action. Entries are dropped when their undo fires or they're invalidated;
+    /// a `.retryable` outcome re-inserts.
+    private var tokens: [String: Token] = [:]
+    /// The in-flight reverse-apply spawned by the most recent ⌘Z. Exposed for tests, which
+    /// `await` it to observe the re-register-on-retryable behavior deterministically.
+    private(set) var pendingPerform: Task<Void, Never>?
 
     public init(perform: @escaping Performer) {
         self.perform = perform
@@ -72,13 +93,16 @@ public final class EditUndoCoordinator {
     public func registerApplied(_ record: Record) {
         guard let undoManager else { return }
         let token = Token(record)
-        tokens[record.editID] = token
+        tokens[record.commit] = token
         // Explicit group per record: without one, registrations coalesce into whatever group is
         // open and a single ⌘Z would revert several edits at once. Under `groupsByEvent` (the
-        // app default) this just nests inside the run loop's event group — still one edit per
-        // gesture, since each apply lands in its own main-run-loop turn. It is load-bearing for
-        // run-loop-free consumers (unit tests set `groupsByEvent = false`), where no implicit
-        // event group ever opens or closes around registrations.
+        // app default) this nests inside the run loop's event group, so edits applied in
+        // *separate* main-run-loop turns — every real apply, since each arrives as its own MCP
+        // reply hop — stay independent ⌘Z steps, while edits somehow registered in the same
+        // turn batch into one ⌘Z (well-defined: reverts both, LIFO order within the group;
+        // exercised by `sameRunLoopBurstBatchesUnderGroupsByEvent`). The explicit group is
+        // load-bearing for run-loop-free consumers (unit tests set `groupsByEvent = false`),
+        // where no implicit event group ever opens or closes around registrations.
         undoManager.beginUndoGrouping()
         // `token` is captured strongly by the handler on purpose: UndoManager holds its target
         // unsafely-unretained, so the capture pins the token (and nothing else — self is weak)
@@ -86,8 +110,17 @@ public final class EditUndoCoordinator {
         undoManager.registerUndo(withTarget: token) { [weak self, token] _ in
             MainActor.assumeIsolated {
                 guard let self else { return }
-                self.tokens[token.record.editID] = nil
-                self.perform(token.record)
+                // The stack entry is popped synchronously right now, whatever the async revert
+                // later resolves to — mirror that in `tokens`, then re-arm on `.retryable`.
+                self.tokens[token.record.commit] = nil
+                self.pendingPerform = Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    if await self.perform(token.record) == .retryable {
+                        // Runs after `undo()` returned (`isUndoing` is false again), so this
+                        // lands back on the undo stack — not the redo stack.
+                        self.registerApplied(token.record)
+                    }
+                }
             }
         }
         // Named while the group is still open — the name attaches to the open group; after
@@ -99,9 +132,18 @@ public final class EditUndoCoordinator {
     /// Removes a still-pending record from the undo stack — call after an edit was undone via
     /// another path (e.g. the chat row's Undo button) so ⌘Z skips it. No-op for unknown or
     /// already-fired records.
-    public func invalidate(editID: UUID) {
-        guard let token = tokens.removeValue(forKey: editID) else { return }
+    public func invalidate(commit: String) {
+        guard let token = tokens.removeValue(forKey: commit) else { return }
         undoManager?.removeAllActions(withTarget: token)
+    }
+
+    /// Drops every pending record — call when the transcript backing the records is cleared
+    /// wholesale (reset conversation), so ⌘Z can't fire actions whose rows no longer exist.
+    public func invalidateAll() {
+        for token in tokens.values {
+            undoManager?.removeAllActions(withTarget: token)
+        }
+        tokens.removeAll()
     }
 
     /// Menu action name for a record: "Edit <filename>" → the menu shows "Undo Edit <filename>".

--- a/Sources/AnglesiteCore/EditUndoCoordinator.swift
+++ b/Sources/AnglesiteCore/EditUndoCoordinator.swift
@@ -73,6 +73,13 @@ public final class EditUndoCoordinator {
         guard let undoManager else { return }
         let token = Token(record)
         tokens[record.editID] = token
+        // Explicit group per record: without one, registrations coalesce into whatever group is
+        // open and a single ⌘Z would revert several edits at once. Under `groupsByEvent` (the
+        // app default) this just nests inside the run loop's event group — still one edit per
+        // gesture, since each apply lands in its own main-run-loop turn. It is load-bearing for
+        // run-loop-free consumers (unit tests set `groupsByEvent = false`), where no implicit
+        // event group ever opens or closes around registrations.
+        undoManager.beginUndoGrouping()
         // `token` is captured strongly by the handler on purpose: UndoManager holds its target
         // unsafely-unretained, so the capture pins the token (and nothing else — self is weak)
         // for exactly as long as the stack entry exists.
@@ -83,7 +90,10 @@ public final class EditUndoCoordinator {
                 self.perform(token.record)
             }
         }
+        // Named while the group is still open — the name attaches to the open group; after
+        // `endUndoGrouping` there may be no group left to attach to.
         undoManager.setActionName(Self.actionName(for: record))
+        undoManager.endUndoGrouping()
     }
 
     /// Removes a still-pending record from the undo stack — call after an edit was undone via

--- a/Tests/AnglesiteCoreTests/EditUndoCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/EditUndoCoordinatorTests.swift
@@ -6,12 +6,15 @@ import Testing
 /// applied edit into a window `UndoManager` record so Edit ▸ Undo (⌘Z) reverses it.
 ///
 /// Every test drives a real Foundation `UndoManager` (no window needed): registration,
-/// LIFO pops, selective invalidation, and the no-redo policy are all observable through
-/// `canUndo`/`canRedo`/`undoActionName` plus the injected perform closure.
+/// LIFO pops, selective + bulk invalidation, outcome-driven re-arming, and the no-redo
+/// policy are all observable through `canUndo`/`canRedo`/`undoActionName` plus the injected
+/// perform closure. ⌘Z pops the stack entry synchronously but resolves the revert in a
+/// `Task`; tests await `pendingPerform` to observe the settled state.
 @MainActor
 struct EditUndoCoordinatorTests {
     private final class PerformSpy {
         var performed: [EditUndoCoordinator.Record] = []
+        var outcome: EditUndoCoordinator.UndoOutcome = .undone
     }
 
     /// A run-loop-free `UndoManager`. With the default `groupsByEvent`, the implicit event
@@ -19,7 +22,9 @@ struct EditUndoCoordinatorTests {
     /// so a single `undo()` would pop every registration at once and
     /// `removeAllActions(withTarget:)` couldn't clear the still-open group. Disabling it makes
     /// the coordinator's explicit per-record group the top-level group — the same shape
-    /// production gets from one registration per main-run-loop turn.
+    /// production gets from one registration per main-run-loop turn. The production
+    /// configuration (`groupsByEvent = true`) is exercised separately in
+    /// ``sameRunLoopBurstBatchesUnderGroupsByEvent()``.
     private func makeUndoManager() -> UndoManager {
         let undoManager = UndoManager()
         undoManager.groupsByEvent = false
@@ -30,20 +35,20 @@ struct EditUndoCoordinatorTests {
         let spy = PerformSpy()
         let coordinator = EditUndoCoordinator { record in
             spy.performed.append(record)
+            return spy.outcome
         }
         coordinator.undoManager = undoManager
         return (coordinator, spy)
     }
 
     private func record(
-        editID: UUID = UUID(),
         file: String = "src/pages/index.astro",
         commit: String = "abcd1234"
     ) -> EditUndoCoordinator.Record {
-        EditUndoCoordinator.Record(editID: editID, file: file, commit: commit)
+        EditUndoCoordinator.Record(file: file, commit: commit)
     }
 
-    @Test func registeredEditIsUndoableAndUndoPerformsIt() {
+    @Test func registeredEditIsUndoableAndUndoPerformsIt() async {
         let undoManager = makeUndoManager()
         let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
         let record = record()
@@ -53,6 +58,7 @@ struct EditUndoCoordinatorTests {
         #expect(undoManager.canUndo)
 
         undoManager.undo()
+        await coordinator.pendingPerform?.value
 
         #expect(spy.performed == [record])
         #expect(!undoManager.canUndo)
@@ -67,19 +73,20 @@ struct EditUndoCoordinatorTests {
         #expect(undoManager.undoActionName == "Edit about.astro")
     }
 
-    @Test func undoDoesNotRegisterARedo() {
+    @Test func undoDoesNotRegisterARedo() async {
         let undoManager = makeUndoManager()
         let (coordinator, _) = makeCoordinator(undoManager: undoManager)
 
         coordinator.registerApplied(record())
         undoManager.undo()
+        await coordinator.pendingPerform?.value
 
         // Reverse-apply is a git revert via the plugin's `undo_edit`; there is no re-apply
         // primitive, so the coordinator must not put anything on the redo stack.
         #expect(!undoManager.canRedo)
     }
 
-    @Test func multipleEditsUndoInLIFOOrder() {
+    @Test func multipleEditsUndoInLIFOOrder() async {
         let undoManager = makeUndoManager()
         let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
         let first = record(file: "src/pages/index.astro", commit: "c1")
@@ -89,8 +96,10 @@ struct EditUndoCoordinatorTests {
         coordinator.registerApplied(second)
 
         undoManager.undo()
+        await coordinator.pendingPerform?.value
         #expect(spy.performed == [second])
         undoManager.undo()
+        await coordinator.pendingPerform?.value
         #expect(spy.performed == [second, first])
     }
 
@@ -102,19 +111,76 @@ struct EditUndoCoordinatorTests {
         #expect(spy.performed.isEmpty)
     }
 
+    @Test func retryableOutcomeReArmsTheRecord() async {
+        let undoManager = makeUndoManager()
+        let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
+        let record = record(file: "src/pages/index.astro", commit: "c1")
+        spy.outcome = .retryable
+
+        coordinator.registerApplied(record)
+        undoManager.undo()
+        await coordinator.pendingPerform?.value
+
+        // The stack entry was popped synchronously, but the revert failed/conflicted —
+        // the coordinator re-registers so ⌘Z can retry, and nothing lands on redo.
+        #expect(spy.performed == [record])
+        #expect(undoManager.canUndo)
+        #expect(!undoManager.canRedo)
+        #expect(undoManager.undoActionName == "Edit index.astro")
+
+        // The retry succeeds this time and the record is spent.
+        spy.outcome = .undone
+        undoManager.undo()
+        await coordinator.pendingPerform?.value
+        #expect(spy.performed == [record, record])
+        #expect(!undoManager.canUndo)
+    }
+
+    @Test func staleOutcomeDoesNotReArm() async {
+        let undoManager = makeUndoManager()
+        let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
+        spy.outcome = .stale
+
+        coordinator.registerApplied(record())
+        undoManager.undo()
+        await coordinator.pendingPerform?.value
+
+        // The record no longer maps to an undoable edit (row gone / already undone) —
+        // consumed without re-arming.
+        #expect(spy.performed.count == 1)
+        #expect(!undoManager.canUndo)
+    }
+
+    @Test func reArmedRecordCanBeInvalidatedOutOfBand() async {
+        let undoManager = makeUndoManager()
+        let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
+        let record = record(commit: "c1")
+        spy.outcome = .retryable
+
+        coordinator.registerApplied(record)
+        undoManager.undo()
+        await coordinator.pendingPerform?.value
+        #expect(undoManager.canUndo)  // re-armed
+
+        // The conflict sheet's "Undo anyway" (or the row button) eventually reverts it via
+        // another path — the success path invalidates the re-armed entry by commit.
+        coordinator.invalidate(commit: "c1")
+        #expect(!undoManager.canUndo)
+    }
+
     @Test func invalidateRemovesTheRecordFromTheUndoStack() {
         let undoManager = makeUndoManager()
         let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
         let record = record()
 
         coordinator.registerApplied(record)
-        coordinator.invalidate(editID: record.editID)
+        coordinator.invalidate(commit: record.commit)
 
         #expect(!undoManager.canUndo)
         #expect(spy.performed.isEmpty)
     }
 
-    @Test func invalidateOnlyRemovesTheMatchingRecord() {
+    @Test func invalidateOnlyRemovesTheMatchingRecord() async {
         let undoManager = makeUndoManager()
         let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
         let kept = record(file: "src/pages/index.astro", commit: "c1")
@@ -122,15 +188,16 @@ struct EditUndoCoordinatorTests {
 
         coordinator.registerApplied(kept)
         coordinator.registerApplied(dropped)
-        coordinator.invalidate(editID: dropped.editID)
+        coordinator.invalidate(commit: dropped.commit)
 
         #expect(undoManager.canUndo)
         undoManager.undo()
+        await coordinator.pendingPerform?.value
         #expect(spy.performed == [kept])
         #expect(!undoManager.canUndo)
     }
 
-    @Test func invalidateAfterUndoFiredIsANoOp() {
+    @Test func invalidateAfterUndoFiredIsANoOp() async {
         let undoManager = makeUndoManager()
         let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
         let first = record(commit: "c1")
@@ -139,24 +206,67 @@ struct EditUndoCoordinatorTests {
         coordinator.registerApplied(first)
         coordinator.registerApplied(second)
         undoManager.undo()  // consumes `second`
+        await coordinator.pendingPerform?.value
 
-        // ⌘Z already popped `second`; the model's post-undo invalidate for it must not
-        // disturb the remaining `first` entry.
-        coordinator.invalidate(editID: second.editID)
+        // ⌘Z already popped `second` (and its `.undone` outcome spent it); the model's
+        // post-undo invalidate for it must not disturb the remaining `first` entry.
+        coordinator.invalidate(commit: second.commit)
 
         #expect(undoManager.canUndo)
         undoManager.undo()
+        await coordinator.pendingPerform?.value
         #expect(spy.performed == [second, first])
     }
 
-    @Test func invalidateForUnknownEditIsANoOp() {
+    @Test func invalidateForUnknownCommitIsANoOp() {
         let undoManager = makeUndoManager()
         let (coordinator, _) = makeCoordinator(undoManager: undoManager)
 
-        coordinator.registerApplied(record())
-        coordinator.invalidate(editID: UUID())
+        coordinator.registerApplied(record(commit: "c1"))
+        coordinator.invalidate(commit: "not-registered")
 
         #expect(undoManager.canUndo)
+    }
+
+    @Test func invalidateAllDropsEveryPendingRecord() {
+        let undoManager = makeUndoManager()
+        let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
+
+        coordinator.registerApplied(record(commit: "c1"))
+        coordinator.registerApplied(record(file: "src/pages/about.astro", commit: "c2"))
+        coordinator.invalidateAll()
+
+        #expect(!undoManager.canUndo)
+        #expect(spy.performed.isEmpty)
+    }
+
+    /// The production configuration: `groupsByEvent = true` with no run loop cycling between
+    /// registrations — the worst case where two edits land in the same main-run-loop turn.
+    /// The coordinator's explicit groups nest inside the still-open event group, so one ⌘Z
+    /// batches both reverts (well-defined, stack fully consumed, nothing on redo) rather than
+    /// corrupting the stack. In the app, every real apply arrives in its own run-loop turn
+    /// (each is a separate MCP-reply hop), which restores the one-edit-per-⌘Z behavior — that
+    /// cross-turn split needs a cycling run loop, so it isn't unit-testable here; it was
+    /// verified against a live `RunLoop` (see PR #544).
+    @Test func sameRunLoopBurstBatchesUnderGroupsByEvent() async {
+        let undoManager = UndoManager()  // groupsByEvent stays true, as in the app
+        let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
+        let first = record(commit: "c1")
+        let second = record(file: "src/pages/about.astro", commit: "c2")
+
+        coordinator.registerApplied(first)
+        coordinator.registerApplied(second)
+
+        undoManager.undo()
+        // The one undo fires both handlers synchronously; each resolves in its own Task.
+        for _ in 0..<1000 where spy.performed.count < 2 { await Task.yield() }
+
+        // Both records revert (handler order within the group is LIFO, but the two Tasks'
+        // completion order is not contractual — assert membership, not order).
+        #expect(Set(spy.performed.map(\.commit)) == ["c1", "c2"])
+        #expect(spy.performed.count == 2)
+        #expect(!undoManager.canUndo)
+        #expect(!undoManager.canRedo)
     }
 
     @Test func actionNameForFileWithoutDirectoryUsesTheWholeName() {

--- a/Tests/AnglesiteCoreTests/EditUndoCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/EditUndoCoordinatorTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+/// Unit tests for ``EditUndoCoordinator`` — the AnglesiteCore piece of #527 that turns each
+/// applied edit into a window `UndoManager` record so Edit ▸ Undo (⌘Z) reverses it.
+///
+/// Every test drives a real Foundation `UndoManager` (no window needed): registration,
+/// LIFO pops, selective invalidation, and the no-redo policy are all observable through
+/// `canUndo`/`canRedo`/`undoActionName` plus the injected perform closure.
+@MainActor
+struct EditUndoCoordinatorTests {
+    private final class PerformSpy {
+        var performed: [EditUndoCoordinator.Record] = []
+    }
+
+    private func makeCoordinator(undoManager: UndoManager?) -> (EditUndoCoordinator, PerformSpy) {
+        let spy = PerformSpy()
+        let coordinator = EditUndoCoordinator { record in
+            spy.performed.append(record)
+        }
+        coordinator.undoManager = undoManager
+        return (coordinator, spy)
+    }
+
+    private func record(
+        editID: UUID = UUID(),
+        file: String = "src/pages/index.astro",
+        commit: String = "abcd1234"
+    ) -> EditUndoCoordinator.Record {
+        EditUndoCoordinator.Record(editID: editID, file: file, commit: commit)
+    }
+
+    @Test func registeredEditIsUndoableAndUndoPerformsIt() {
+        let undoManager = UndoManager()
+        let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
+        let record = record()
+
+        #expect(!undoManager.canUndo)
+        coordinator.registerApplied(record)
+        #expect(undoManager.canUndo)
+
+        undoManager.undo()
+
+        #expect(spy.performed == [record])
+        #expect(!undoManager.canUndo)
+    }
+
+    @Test func actionNameCarriesTheEditedFilename() {
+        let undoManager = UndoManager()
+        let (coordinator, _) = makeCoordinator(undoManager: undoManager)
+
+        coordinator.registerApplied(record(file: "src/pages/about.astro"))
+
+        #expect(undoManager.undoActionName == "Edit about.astro")
+    }
+
+    @Test func undoDoesNotRegisterARedo() {
+        let undoManager = UndoManager()
+        let (coordinator, _) = makeCoordinator(undoManager: undoManager)
+
+        coordinator.registerApplied(record())
+        undoManager.undo()
+
+        // Reverse-apply is a git revert via the plugin's `undo_edit`; there is no re-apply
+        // primitive, so the coordinator must not put anything on the redo stack.
+        #expect(!undoManager.canRedo)
+    }
+
+    @Test func multipleEditsUndoInLIFOOrder() {
+        let undoManager = UndoManager()
+        let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
+        let first = record(file: "src/pages/index.astro", commit: "c1")
+        let second = record(file: "src/pages/about.astro", commit: "c2")
+
+        coordinator.registerApplied(first)
+        coordinator.registerApplied(second)
+
+        undoManager.undo()
+        #expect(spy.performed == [second])
+        undoManager.undo()
+        #expect(spy.performed == [second, first])
+    }
+
+    @Test func registeringWithoutAnUndoManagerIsANoOp() {
+        let (coordinator, spy) = makeCoordinator(undoManager: nil)
+
+        coordinator.registerApplied(record())
+
+        #expect(spy.performed.isEmpty)
+    }
+
+    @Test func invalidateRemovesTheRecordFromTheUndoStack() {
+        let undoManager = UndoManager()
+        let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
+        let record = record()
+
+        coordinator.registerApplied(record)
+        coordinator.invalidate(editID: record.editID)
+
+        #expect(!undoManager.canUndo)
+        #expect(spy.performed.isEmpty)
+    }
+
+    @Test func invalidateOnlyRemovesTheMatchingRecord() {
+        let undoManager = UndoManager()
+        let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
+        let kept = record(file: "src/pages/index.astro", commit: "c1")
+        let dropped = record(file: "src/pages/about.astro", commit: "c2")
+
+        coordinator.registerApplied(kept)
+        coordinator.registerApplied(dropped)
+        coordinator.invalidate(editID: dropped.editID)
+
+        #expect(undoManager.canUndo)
+        undoManager.undo()
+        #expect(spy.performed == [kept])
+        #expect(!undoManager.canUndo)
+    }
+
+    @Test func invalidateAfterUndoFiredIsANoOp() {
+        let undoManager = UndoManager()
+        let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
+        let first = record(commit: "c1")
+        let second = record(commit: "c2")
+
+        coordinator.registerApplied(first)
+        coordinator.registerApplied(second)
+        undoManager.undo()  // consumes `second`
+
+        // ⌘Z already popped `second`; the model's post-undo invalidate for it must not
+        // disturb the remaining `first` entry.
+        coordinator.invalidate(editID: second.editID)
+
+        #expect(undoManager.canUndo)
+        undoManager.undo()
+        #expect(spy.performed == [second, first])
+    }
+
+    @Test func invalidateForUnknownEditIsANoOp() {
+        let undoManager = UndoManager()
+        let (coordinator, _) = makeCoordinator(undoManager: undoManager)
+
+        coordinator.registerApplied(record())
+        coordinator.invalidate(editID: UUID())
+
+        #expect(undoManager.canUndo)
+    }
+
+    @Test func actionNameForFileWithoutDirectoryUsesTheWholeName() {
+        #expect(EditUndoCoordinator.actionName(for: record(file: "astro.config.mjs")) == "Edit astro.config.mjs")
+    }
+}

--- a/Tests/AnglesiteCoreTests/EditUndoCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/EditUndoCoordinatorTests.swift
@@ -14,6 +14,18 @@ struct EditUndoCoordinatorTests {
         var performed: [EditUndoCoordinator.Record] = []
     }
 
+    /// A run-loop-free `UndoManager`. With the default `groupsByEvent`, the implicit event
+    /// group opens at the first registration and never closes (tests don't spin the run loop),
+    /// so a single `undo()` would pop every registration at once and
+    /// `removeAllActions(withTarget:)` couldn't clear the still-open group. Disabling it makes
+    /// the coordinator's explicit per-record group the top-level group — the same shape
+    /// production gets from one registration per main-run-loop turn.
+    private func makeUndoManager() -> UndoManager {
+        let undoManager = UndoManager()
+        undoManager.groupsByEvent = false
+        return undoManager
+    }
+
     private func makeCoordinator(undoManager: UndoManager?) -> (EditUndoCoordinator, PerformSpy) {
         let spy = PerformSpy()
         let coordinator = EditUndoCoordinator { record in
@@ -32,7 +44,7 @@ struct EditUndoCoordinatorTests {
     }
 
     @Test func registeredEditIsUndoableAndUndoPerformsIt() {
-        let undoManager = UndoManager()
+        let undoManager = makeUndoManager()
         let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
         let record = record()
 
@@ -47,7 +59,7 @@ struct EditUndoCoordinatorTests {
     }
 
     @Test func actionNameCarriesTheEditedFilename() {
-        let undoManager = UndoManager()
+        let undoManager = makeUndoManager()
         let (coordinator, _) = makeCoordinator(undoManager: undoManager)
 
         coordinator.registerApplied(record(file: "src/pages/about.astro"))
@@ -56,7 +68,7 @@ struct EditUndoCoordinatorTests {
     }
 
     @Test func undoDoesNotRegisterARedo() {
-        let undoManager = UndoManager()
+        let undoManager = makeUndoManager()
         let (coordinator, _) = makeCoordinator(undoManager: undoManager)
 
         coordinator.registerApplied(record())
@@ -68,7 +80,7 @@ struct EditUndoCoordinatorTests {
     }
 
     @Test func multipleEditsUndoInLIFOOrder() {
-        let undoManager = UndoManager()
+        let undoManager = makeUndoManager()
         let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
         let first = record(file: "src/pages/index.astro", commit: "c1")
         let second = record(file: "src/pages/about.astro", commit: "c2")
@@ -91,7 +103,7 @@ struct EditUndoCoordinatorTests {
     }
 
     @Test func invalidateRemovesTheRecordFromTheUndoStack() {
-        let undoManager = UndoManager()
+        let undoManager = makeUndoManager()
         let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
         let record = record()
 
@@ -103,7 +115,7 @@ struct EditUndoCoordinatorTests {
     }
 
     @Test func invalidateOnlyRemovesTheMatchingRecord() {
-        let undoManager = UndoManager()
+        let undoManager = makeUndoManager()
         let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
         let kept = record(file: "src/pages/index.astro", commit: "c1")
         let dropped = record(file: "src/pages/about.astro", commit: "c2")
@@ -119,7 +131,7 @@ struct EditUndoCoordinatorTests {
     }
 
     @Test func invalidateAfterUndoFiredIsANoOp() {
-        let undoManager = UndoManager()
+        let undoManager = makeUndoManager()
         let (coordinator, spy) = makeCoordinator(undoManager: undoManager)
         let first = record(commit: "c1")
         let second = record(commit: "c2")
@@ -138,7 +150,7 @@ struct EditUndoCoordinatorTests {
     }
 
     @Test func invalidateForUnknownEditIsANoOp() {
-        let undoManager = UndoManager()
+        let undoManager = makeUndoManager()
         let (coordinator, _) = makeCoordinator(undoManager: undoManager)
 
         coordinator.registerApplied(record())


### PR DESCRIPTION
Fixes #527

## What

Edit ▸ Undo (⌘Z) now reverses app-applied edits. Previously only text fields participated in undo; edits the app applies to site source (overlay drops, assistant tool edits) were only reversible via the chat row's per-row Undo button.

## How

**`EditUndoCoordinator` (AnglesiteCore, new)** — the unit-testable undo-record piece:
- Registers one undo record (`editID` + `file` + `commit`) with the window's `UndoManager` at apply time; the injected perform closure runs the reverse-apply.
- LIFO pops match the head-first order git reverts want on `refs/heads/anglesite/edits`.
- Menu action name is "Edit \<filename\>" → "Undo Edit index.astro".
- **No redo**: the plugin exposes revert (`undo_edit`) but no re-apply primitive, so nothing is registered during undo and Redo stays disabled.
- **Per-record invalidation**: each record registers against a private token target (kept alive by the handler capture — `UndoManager` doesn't retain targets), so an edit undone via the chat row button removes exactly its own stale ⌘Z entry via `removeAllActions(withTarget:)`.

**App-target glue (thin, per the issue's design direction):**
- `ChatModel.recordEdit` — the sink every applied-with-commit edit reaches through `MCPApplyEditRouter.onEdit`, i.e. the shared pipeline level (not assistant-specific, per epic #459) — registers the record.
- ⌘Z delegates to the existing `ChatModel.undoEdit(messageID:)`, so the `undo_edit` MCP reverse-apply, the `undone` row flip, history sidecar, and the working-tree-drift conflict sheet are all reused unchanged. Row-button undos call `invalidate` so ⌘Z skips them.
- `SiteWindow` publishes `@Environment(\.undoManager)` → `SiteWindowModel.windowUndoManager` → the chat's coordinator (forwarded on set and after chat creation), so edits register even while the chat panel is closed.

Out of scope (as the issue states): renames, plist edits, typed-entry rows, and anything spanning git operations.

## Testing

- `Tests/AnglesiteCoreTests/EditUndoCoordinatorTests.swift` (Swift Testing, written first): register→undo performs the record, action naming, LIFO ordering, no-redo, nil-undo-manager no-op, selective invalidation, invalidate-after-fire/unknown-ID no-ops.
- `swift build --package-path . --build-tests` ✅ and `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` ✅ **BUILD SUCCEEDED**.
- ⚠️ Local test *runtime* is blocked by the known FoundationModels SDK/OS mismatch (every test bundle fails at dlopen with `Symbol not found: … Attachment … imageURL:orientation:` before any test runs — pre-existing, unrelated to this change); CI is the arbiter for the test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)