### PR TITLE
Project Impact Analysis: show the blast radius of editing a file (#309)

### DIFF
--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -20,14 +20,27 @@ final class SiteGraphExplorerModel {
     }
 
     var filteredNodes: [SiteGraphNode] {
+        snapshot.nodes.filter { enabledKinds.contains($0.kind) && matchesSearch($0) }
+    }
+
+    private func matchesSearch(_ node: SiteGraphNode) -> Bool {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return snapshot.nodes.filter { node in
-            guard enabledKinds.contains(node.kind) else { return false }
-            guard !query.isEmpty else { return true }
-            return node.title.lowercased().contains(query)
-                || node.detail?.lowercased().contains(query) == true
-                || node.filePath?.lowercased().contains(query) == true
-        }
+        guard !query.isEmpty else { return true }
+        return node.title.lowercased().contains(query)
+            || node.detail?.lowercased().contains(query) == true
+            || node.filePath?.lowercased().contains(query) == true
+    }
+
+    /// Selects a node navigated to from the Impact section. Impact is computed over the *full*
+    /// snapshot, so the target may currently be hidden by the toolbar kind filter or the search
+    /// query — a plain `selectedNodeID = …` would then leave the explorer visibly inconsistent:
+    /// no canvas highlight, and `selectedIncoming`/`selectedOutgoing` silently empty because
+    /// `filteredEdges` drops edges touching hidden nodes. Re-enable the node's kind and clear a
+    /// search that hides it, so the rest of the explorer can actually show the new selection.
+    func revealNode(_ node: SiteGraphNode) {
+        enabledKinds.insert(node.kind)
+        if !matchesSearch(node) { searchText = "" }
+        selectedNodeID = node.id
     }
 
     var filteredEdges: [SiteGraphEdge] {

--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -40,6 +40,14 @@ final class SiteGraphExplorerModel {
         return snapshot.nodes.first { $0.id == selectedNodeID }
     }
 
+    /// Impact analysis for the selected node (#309): what on the site changes if this file is
+    /// edited. Computed over the *full* snapshot, not the filtered view — impact is factual and
+    /// must not shrink because a node kind is toggled off in the toolbar.
+    var selectedImpact: ImpactAnalysis.Report? {
+        guard let selectedNodeID else { return nil }
+        return ImpactAnalysis.analyze(snapshot: snapshot, targetID: selectedNodeID)
+    }
+
     var selectedIncoming: [SiteGraphEdge] {
         guard let selectedNodeID else { return [] }
         return filteredEdges.filter { $0.targetID == selectedNodeID }

--- a/Sources/AnglesiteApp/SiteGraphExplorerView.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerView.swift
@@ -203,6 +203,10 @@ private struct SiteGraphInspector: View {
                             }
                             .buttonStyle(.borderedProminent)
                         }
+                        if let impact = model.selectedImpact {
+                            Divider()
+                            SiteGraphImpactSection(impact: impact, model: model)
+                        }
                         Divider()
                         SiteGraphEdgeList(
                             title: "Depends On",
@@ -225,6 +229,108 @@ private struct SiteGraphInspector: View {
             }
         }
         .background(Color(NSColor.controlBackgroundColor))
+    }
+}
+
+/// Project Impact Analysis (#309): shows what editing the selected node would affect — pages
+/// (transitively, through any depth of layouts/components), plus dependent layouts, components,
+/// styles, containing collections, and directly referenced assets. Every row navigates to that
+/// node so the blast radius can be explored in place.
+private struct SiteGraphImpactSection: View {
+    let impact: ImpactAnalysis.Report
+    @Bindable var model: SiteGraphExplorerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Impact", systemImage: "dot.radiowaves.left.and.right")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            if impact.hasDependents {
+                Text(summary)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("Nothing else on this site depends on it — editing it affects only this file.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            SiteGraphImpactNodeList(
+                title: "Affects \(count(impact.affectedPages.count, "Page"))",
+                nodes: impact.affectedPages, model: model)
+            SiteGraphImpactNodeList(
+                title: "Affects \(count(impact.affectedEntries.count, "Entry", plural: "Entries"))",
+                nodes: impact.affectedEntries, model: model)
+            SiteGraphImpactNodeList(
+                title: "Included in \(count(impact.affectedCollections.count, "Collection"))",
+                nodes: impact.affectedCollections, model: model)
+            SiteGraphImpactNodeList(
+                title: "Used by \(count(impact.dependentLayouts.count, "Layout"))",
+                nodes: impact.dependentLayouts, model: model)
+            SiteGraphImpactNodeList(
+                title: "Used by \(count(impact.dependentComponents.count, "Component"))",
+                nodes: impact.dependentComponents, model: model)
+            SiteGraphImpactNodeList(
+                title: "Used by \(count(impact.dependentStyles.count, "Style"))",
+                nodes: impact.dependentStyles, model: model)
+            SiteGraphImpactNodeList(
+                title: "References \(count(impact.referencedAssets.count, "Asset"))",
+                nodes: impact.referencedAssets, model: model)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Impact analysis")
+    }
+
+    /// "This change would affect 18 pages." — the issue's headline number, pages + entries.
+    private var summary: String {
+        let routes = impact.affectedPages.count + impact.affectedEntries.count
+        if routes > 0 {
+            return "Editing this would affect \(count(routes, "page"))."
+        }
+        return "Editing this would affect other site files, but no rendered pages."
+    }
+
+    private func count(_ n: Int, _ singular: String, plural: String? = nil) -> String {
+        "\(n) \(n == 1 ? singular : (plural ?? singular + "s"))"
+    }
+}
+
+/// A titled, clickable node list for one impact group. Hidden entirely when the group is empty —
+/// unlike `SiteGraphEdgeList`, an empty impact group is noise, not information.
+private struct SiteGraphImpactNodeList: View {
+    let title: String
+    let nodes: [SiteGraphNode]
+    @Bindable var model: SiteGraphExplorerModel
+
+    var body: some View {
+        if !nodes.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                ForEach(nodes) { node in
+                    Button {
+                        model.selectedNodeID = node.id
+                    } label: {
+                        HStack {
+                            Label(node.title, systemImage: node.kind.systemImage)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            if let route = node.route {
+                                Text(route)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .help(node.detail ?? node.title)
+                }
+            }
+        }
     }
 }
 

--- a/Sources/AnglesiteApp/SiteGraphExplorerView.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerView.swift
@@ -245,15 +245,9 @@ private struct SiteGraphImpactSection: View {
             Label("Impact", systemImage: "dot.radiowaves.left.and.right")
                 .font(.subheadline)
                 .fontWeight(.semibold)
-            if impact.hasDependents {
-                Text(summary)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            } else {
-                Text("Nothing else on this site depends on it — editing it affects only this file.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
+            Text(summary)
+                .font(.callout)
+                .foregroundStyle(.secondary)
             SiteGraphImpactNodeList(
                 title: "Affects \(count(impact.affectedPages.count, "Page"))",
                 nodes: impact.affectedPages, model: model)
@@ -281,12 +275,21 @@ private struct SiteGraphImpactSection: View {
     }
 
     /// "This change would affect 18 pages." — the issue's headline number, pages + entries.
+    /// The zero-dependents copy acknowledges a non-empty collection membership shown right
+    /// below it (membership isn't a dependency, but "nothing else depends on it" directly above
+    /// an "Included in 1 Collection" list reads as self-contradictory).
     private var summary: String {
         let routes = impact.affectedPages.count + impact.affectedEntries.count
         if routes > 0 {
             return "Editing this would affect \(count(routes, "page"))."
         }
-        return "Editing this would affect other site files, but no rendered pages."
+        if impact.hasDependents {
+            return "Editing this would affect other site files, but no rendered pages."
+        }
+        if !impact.affectedCollections.isEmpty {
+            return "Nothing else on this site depends on it — editing it affects only this entry within its collection."
+        }
+        return "Nothing else on this site depends on it — editing it affects only this file."
     }
 
     private func count(_ n: Int, _ singular: String, plural: String? = nil) -> String {
@@ -310,7 +313,11 @@ private struct SiteGraphImpactNodeList: View {
                     .foregroundStyle(.secondary)
                 ForEach(nodes) { node in
                     Button {
-                        model.selectedNodeID = node.id
+                        // Not a plain `selectedNodeID = …`: the impact list is computed over the
+                        // full snapshot, so the node may be hidden by the toolbar kind filter or
+                        // search — revealNode un-hides it so the canvas and edge lists can show
+                        // the new selection (PR #545 review).
+                        model.revealNode(node)
                     } label: {
                         HStack {
                             Label(node.title, systemImage: node.kind.systemImage)

--- a/Sources/AnglesiteCore/ImpactAnalysis.swift
+++ b/Sources/AnglesiteCore/ImpactAnalysis.swift
@@ -57,7 +57,9 @@ public enum ImpactAnalysis {
             dependents[edge.targetID, default: []].append(edge.sourceID)
         }
 
-        // Breadth-first reverse reachability from the target.
+        // Iterative reverse reachability from the target. `popLast()` makes `frontier` a stack,
+        // so this walks depth-first — traversal order is irrelevant to the output (the visited
+        // set counts each dependent exactly once, and groups are title-sorted before returning).
         var visited: Set<String> = [targetID]
         var frontier = [targetID]
         var affected: [SiteGraphNode] = []

--- a/Sources/AnglesiteCore/ImpactAnalysis.swift
+++ b/Sources/AnglesiteCore/ImpactAnalysis.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// Deterministic project impact analysis (#309) over a `SiteGraphExplorerSnapshot`.
+///
+/// Given a target node (component, layout, style, asset, page, or content entry), computes the
+/// **transitive reverse closure** of the graph's dependency edges — `imports`, `usesLayout`, and
+/// `referencesAsset`, each meaning "source depends on target" — to answer "what on this site
+/// changes if I edit this file?" before the edit happens. `contains` edges (collection → entry)
+/// are membership, not dependency: they never propagate impact, and are only used to map affected
+/// entries back to the collections that include them.
+///
+/// Pure over an in-memory snapshot — no I/O, no model calls — so it is exactly as fresh (and
+/// exactly as approximate) as `SiteGraphExplorer.build`'s regex-based extraction. Unresolved
+/// references never appear in the snapshot at all, so this analysis inherits the graph's
+/// under-reporting bias: it may miss an affected page, but never invents one.
+public enum ImpactAnalysis {
+    /// Everything affected by editing one target node, grouped by kind and sorted by title for
+    /// stable presentation. All dependent groups are *transitive* (a page that reaches the target
+    /// through two layers of components is still affected); `referencedAssets` is the one
+    /// forward-looking group — the assets the target itself directly references.
+    public struct Report: Sendable, Equatable {
+        public let targetID: String
+        /// Pages whose rendered output could change.
+        public let affectedPages: [SiteGraphNode]
+        /// Content-collection entries whose rendered output could change.
+        public let affectedEntries: [SiteGraphNode]
+        /// Collections containing at least one affected entry (or the target itself, when the
+        /// target is an entry).
+        public let affectedCollections: [SiteGraphNode]
+        /// Layouts that (transitively) depend on the target.
+        public let dependentLayouts: [SiteGraphNode]
+        /// Components that (transitively) depend on the target.
+        public let dependentComponents: [SiteGraphNode]
+        /// Stylesheets that (transitively) depend on the target.
+        public let dependentStyles: [SiteGraphNode]
+        /// Assets the target itself directly references.
+        public let referencedAssets: [SiteGraphNode]
+
+        /// True when anything on the site depends on the target — the "this edit has blast
+        /// radius" signal.
+        public var hasDependents: Bool {
+            !affectedPages.isEmpty || !affectedEntries.isEmpty || !dependentLayouts.isEmpty
+                || !dependentComponents.isEmpty || !dependentStyles.isEmpty
+        }
+    }
+
+    /// Analyzes the impact of editing `targetID`. Returns `nil` when the snapshot has no such
+    /// node. Cycle-safe: a visited set guarantees termination and counts each dependent once.
+    public static func analyze(snapshot: SiteGraphExplorerSnapshot, targetID: String) -> Report? {
+        var nodesByID: [String: SiteGraphNode] = [:]
+        for node in snapshot.nodes { nodesByID[node.id] = node }
+        guard nodesByID[targetID] != nil else { return nil }
+
+        // Reverse adjacency over dependency edges only: dependents[X] = nodes that depend on X.
+        var dependents: [String: [String]] = [:]
+        for edge in snapshot.edges where edge.kind != .contains {
+            dependents[edge.targetID, default: []].append(edge.sourceID)
+        }
+
+        // Breadth-first reverse reachability from the target.
+        var visited: Set<String> = [targetID]
+        var frontier = [targetID]
+        var affected: [SiteGraphNode] = []
+        while let current = frontier.popLast() {
+            for dependentID in dependents[current] ?? [] where !visited.contains(dependentID) {
+                visited.insert(dependentID)
+                frontier.append(dependentID)
+                if let node = nodesByID[dependentID] { affected.append(node) }
+            }
+        }
+
+        var pages: [SiteGraphNode] = []
+        var entries: [SiteGraphNode] = []
+        var layouts: [SiteGraphNode] = []
+        var components: [SiteGraphNode] = []
+        var styles: [SiteGraphNode] = []
+        for node in affected {
+            switch node.kind {
+            case .page: pages.append(node)
+            case .contentEntry: entries.append(node)
+            case .layout: layouts.append(node)
+            case .component: components.append(node)
+            case .style: styles.append(node)
+            case .collection, .asset: break  // Neither can depend on anything (no outgoing deps).
+            }
+        }
+
+        // Collections that include an affected entry — or the target itself when it is an entry,
+        // so editing an entry still reports where it lives.
+        var entryIDs = Set(entries.map(\.id))
+        if nodesByID[targetID]?.kind == .contentEntry { entryIDs.insert(targetID) }
+        var collectionIDs: Set<String> = []
+        for edge in snapshot.edges
+        where edge.kind == .contains && entryIDs.contains(edge.targetID) {
+            collectionIDs.insert(edge.sourceID)
+        }
+        let collections = collectionIDs.compactMap { nodesByID[$0] }
+
+        // Forward direct references from the target to assets ("References 12 images").
+        var assetIDs: Set<String> = []
+        for edge in snapshot.edges
+        where edge.sourceID == targetID && nodesByID[edge.targetID]?.kind == .asset {
+            assetIDs.insert(edge.targetID)
+        }
+        let assets = assetIDs.compactMap { nodesByID[$0] }
+
+        return Report(
+            targetID: targetID,
+            affectedPages: sorted(pages),
+            affectedEntries: sorted(entries),
+            affectedCollections: sorted(collections),
+            dependentLayouts: sorted(layouts),
+            dependentComponents: sorted(components),
+            dependentStyles: sorted(styles),
+            referencedAssets: sorted(assets)
+        )
+    }
+
+    /// Title-sorted (id tiebreak) for stable, deterministic presentation.
+    private static func sorted(_ nodes: [SiteGraphNode]) -> [SiteGraphNode] {
+        nodes.sorted {
+            let byTitle = $0.title.localizedStandardCompare($1.title)
+            if byTitle != .orderedSame { return byTitle == .orderedAscending }
+            return $0.id < $1.id
+        }
+    }
+}

--- a/Sources/AnglesiteCore/SiteGraphExplorer.swift
+++ b/Sources/AnglesiteCore/SiteGraphExplorer.swift
@@ -203,6 +203,27 @@ public enum SiteGraphExplorer {
                 let edge = SiteGraphEdge(sourceID: node.id, targetID: targetID, kind: .referencesAsset)
                 edgesByID[edge.id] = edge
             }
+            // Markdown pages/entries reference their layout through the frontmatter `layout:`
+            // field, not an import statement — without this, editing a layout under-reports its
+            // impact on markdown content (#309). Markdown-ish files only: an `.astro` frontmatter
+            // block is JS, not YAML, and must not go through the YAML parser.
+            if isMarkdownPath(filePath) {
+                let frontmatter = Frontmatter.parse(text)
+                if case .string(let layoutRef)? = frontmatter["layout"],
+                   let targetID = resolveImport(
+                       layoutRef,
+                       from: filePath,
+                       projectRoot: projectRoot,
+                       nodeIDByRelativePath: nodeIDByRelativePath,
+                       nodeIDByPublicPath: nodeIDByPublicPath,
+                       fileManager: fileManager
+                   ) {
+                    let kind: SiteGraphEdgeKind =
+                        nodesByID[targetID]?.kind == .layout ? .usesLayout : .imports
+                    let edge = SiteGraphEdge(sourceID: node.id, targetID: targetID, kind: kind)
+                    edgesByID[edge.id] = edge
+                }
+            }
         }
 
         let incomingCounts = Dictionary(grouping: edgesByID.values, by: \.targetID)
@@ -229,6 +250,12 @@ public enum SiteGraphExplorer {
 
     private static func kindRank(_ kind: SiteGraphNodeKind) -> Int {
         SiteGraphNodeKind.allCases.firstIndex(of: kind) ?? Int.max
+    }
+
+    private static let markdownExtensions: Set<String> = [".md", ".mdx", ".mdoc", ".markdown"]
+
+    private static func isMarkdownPath(_ relativePath: String) -> Bool {
+        markdownExtensions.contains(fileExtension(relativePath))
     }
 
     private static func kind(for relativePath: String) -> SiteGraphNodeKind? {

--- a/Tests/AnglesiteCoreTests/ImpactAnalysisTests.swift
+++ b/Tests/AnglesiteCoreTests/ImpactAnalysisTests.swift
@@ -1,0 +1,220 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ImpactAnalysis")
+struct ImpactAnalysisTests {
+    private let siteID = "impact-site"
+
+    // MARK: - Snapshot builders
+
+    private func node(
+        _ id: String,
+        _ kind: SiteGraphNodeKind,
+        title: String? = nil,
+        filePath: String? = nil,
+        route: String? = nil
+    ) -> SiteGraphNode {
+        SiteGraphNode(
+            id: "\(siteID):\(id)",
+            kind: kind,
+            title: title ?? id,
+            detail: nil,
+            filePath: filePath,
+            route: route
+        )
+    }
+
+    private func edge(_ source: String, _ target: String, _ kind: SiteGraphEdgeKind) -> SiteGraphEdge {
+        SiteGraphEdge(sourceID: "\(siteID):\(source)", targetID: "\(siteID):\(target)", kind: kind)
+    }
+
+    private func id(_ short: String) -> String { "\(siteID):\(short)" }
+
+    /// page:index → layout:Base → component:Nav → asset:logo, plus page:about importing Nav
+    /// directly. The shape most tests share.
+    private var chainSnapshot: SiteGraphExplorerSnapshot {
+        SiteGraphExplorerSnapshot(
+            nodes: [
+                node("page:index", .page, title: "Home", route: "/"),
+                node("page:about", .page, title: "About", route: "/about"),
+                node("layout:Base", .layout, title: "Base.astro", filePath: "src/layouts/Base.astro"),
+                node("component:Nav", .component, title: "Nav.astro", filePath: "src/components/Nav.astro"),
+                node("asset:logo", .asset, title: "logo.png", filePath: "public/images/logo.png"),
+            ],
+            edges: [
+                edge("page:index", "layout:Base", .usesLayout),
+                edge("layout:Base", "component:Nav", .imports),
+                edge("page:about", "component:Nav", .imports),
+                edge("component:Nav", "asset:logo", .referencesAsset),
+            ]
+        )
+    }
+
+    // MARK: - Basics
+
+    @Test("unknown target returns nil")
+    func unknownTarget() {
+        #expect(ImpactAnalysis.analyze(snapshot: chainSnapshot, targetID: "nope") == nil)
+    }
+
+    @Test("component impact includes transitively affected pages and direct dependent layouts")
+    func transitiveComponentImpact() throws {
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: chainSnapshot, targetID: id("component:Nav")))
+
+        // index reaches Nav through Base; about imports Nav directly.
+        #expect(report.affectedPages.map(\.title) == ["About", "Home"])
+        #expect(report.dependentLayouts.map(\.title) == ["Base.astro"])
+        #expect(report.dependentComponents.isEmpty)
+        #expect(report.hasDependents)
+    }
+
+    @Test("component impact reports the assets the component itself references")
+    func forwardAssetReferences() throws {
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: chainSnapshot, targetID: id("component:Nav")))
+        #expect(report.referencedAssets.map(\.title) == ["logo.png"])
+    }
+
+    @Test("layout impact lists every page that uses it")
+    func layoutImpact() throws {
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: chainSnapshot, targetID: id("layout:Base")))
+        #expect(report.affectedPages.map(\.title) == ["Home"])
+        #expect(report.dependentLayouts.isEmpty)
+        // Forward references pass through imports to components but only assets are reported.
+        #expect(report.referencedAssets.isEmpty)
+    }
+
+    @Test("asset impact walks back through components to pages")
+    func assetImpact() throws {
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: chainSnapshot, targetID: id("asset:logo")))
+        #expect(report.affectedPages.map(\.title) == ["About", "Home"])
+        #expect(report.dependentComponents.map(\.title) == ["Nav.astro"])
+        #expect(report.dependentLayouts.map(\.title) == ["Base.astro"])
+    }
+
+    @Test("a leaf page has no dependents")
+    func leafPage() throws {
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: chainSnapshot, targetID: id("page:about")))
+        #expect(!report.hasDependents)
+        #expect(report.affectedPages.isEmpty)
+        #expect(report.affectedCollections.isEmpty)
+    }
+
+    // MARK: - Content collections
+
+    @Test("affected content entries surface their collections")
+    func entriesAndCollections() throws {
+        let snapshot = SiteGraphExplorerSnapshot(
+            nodes: [
+                node("component:Callout", .component, title: "Callout.astro"),
+                node("entry:hello", .contentEntry, title: "Hello"),
+                node("entry:world", .contentEntry, title: "World"),
+                node("collection:posts", .collection, title: "posts"),
+                node("collection:docs", .collection, title: "docs"),
+            ],
+            edges: [
+                edge("entry:hello", "component:Callout", .imports),
+                edge("collection:posts", "entry:hello", .contains),
+                edge("collection:docs", "entry:world", .contains),
+            ]
+        )
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: snapshot, targetID: id("component:Callout")))
+
+        #expect(report.affectedEntries.map(\.title) == ["Hello"])
+        // Only posts contains an affected entry; docs does not.
+        #expect(report.affectedCollections.map(\.title) == ["posts"])
+    }
+
+    @Test("contains edges are not dependency edges — a collection does not affect its entries")
+    func containsIsNotDependency() throws {
+        let snapshot = SiteGraphExplorerSnapshot(
+            nodes: [
+                node("entry:hello", .contentEntry, title: "Hello"),
+                node("collection:posts", .collection, title: "posts"),
+            ],
+            edges: [
+                edge("collection:posts", "entry:hello", .contains)
+            ]
+        )
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: snapshot, targetID: id("entry:hello")))
+        // The collection "contains" the entry, but nothing *depends* on the entry.
+        #expect(!report.hasDependents)
+        // Editing the entry still reports the collection it belongs to.
+        #expect(report.affectedCollections.map(\.title) == ["posts"])
+    }
+
+    // MARK: - Robustness
+
+    @Test("import cycles terminate and count each dependent once")
+    func cycleSafety() throws {
+        let snapshot = SiteGraphExplorerSnapshot(
+            nodes: [
+                node("page:index", .page, title: "Home", route: "/"),
+                node("component:A", .component, title: "A.astro"),
+                node("component:B", .component, title: "B.astro"),
+            ],
+            edges: [
+                edge("component:A", "component:B", .imports),
+                edge("component:B", "component:A", .imports),
+                edge("page:index", "component:A", .imports),
+            ]
+        )
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: snapshot, targetID: id("component:B")))
+        #expect(report.affectedPages.map(\.title) == ["Home"])
+        #expect(report.dependentComponents.map(\.title) == ["A.astro"])
+    }
+
+    @Test("dependent styles are reported when an asset is used from CSS")
+    func stylesAsDependents() throws {
+        let snapshot = SiteGraphExplorerSnapshot(
+            nodes: [
+                node("page:index", .page, title: "Home", route: "/"),
+                node("style:global", .style, title: "global.css", filePath: "src/styles/global.css"),
+                node("asset:bg", .asset, title: "bg.png", filePath: "public/images/bg.png"),
+            ],
+            edges: [
+                edge("page:index", "style:global", .imports),
+                edge("style:global", "asset:bg", .referencesAsset),
+            ]
+        )
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: snapshot, targetID: id("asset:bg")))
+        #expect(report.affectedPages.map(\.title) == ["Home"])
+        #expect(report.dependentStyles.map(\.title) == ["global.css"])
+    }
+
+    @Test("results are sorted by title for stable presentation")
+    func deterministicOrdering() throws {
+        let snapshot = SiteGraphExplorerSnapshot(
+            nodes: [
+                node("component:X", .component, title: "X.astro"),
+                node("page:z", .page, title: "Zebra", route: "/zebra"),
+                node("page:a", .page, title: "Alpha", route: "/alpha"),
+                node("page:m", .page, title: "Mango", route: "/mango"),
+            ],
+            edges: [
+                edge("page:z", "component:X", .imports),
+                edge("page:a", "component:X", .imports),
+                edge("page:m", "component:X", .imports),
+            ]
+        )
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: snapshot, targetID: id("component:X")))
+        #expect(report.affectedPages.map(\.title) == ["Alpha", "Mango", "Zebra"])
+    }
+
+    @Test("the target itself is never listed as its own dependent")
+    func targetExcluded() throws {
+        let report = try #require(
+            ImpactAnalysis.analyze(snapshot: chainSnapshot, targetID: id("page:index")))
+        #expect(!report.affectedPages.contains { $0.id == id("page:index") })
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
@@ -166,6 +166,29 @@ struct SiteGraphExplorerTests {
         })
     }
 
+    @Test("markdown frontmatter layout fields create usesLayout edges")
+    func frontmatterLayoutEdges() throws {
+        let root = makeSite([
+            "src/pages/about.md": "---\ntitle: About\nlayout: ../layouts/Base.astro\n---\nBody",
+            "src/layouts/Base.astro": "<slot />",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let page = try #require(graph.nodes.first { $0.kind == .page })
+        let layout = try #require(graph.nodes.first { $0.kind == .layout })
+
+        #expect(graph.edges.contains {
+            $0.sourceID == page.id && $0.targetID == layout.id && $0.kind == .usesLayout
+        })
+    }
+
     @Test("src styles files become style nodes")
     func styleNodes() {
         let root = makeSite([

--- a/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
@@ -189,6 +189,50 @@ struct SiteGraphExplorerTests {
         })
     }
 
+    @Test("markdown without frontmatter creates no layout edge")
+    func markdownWithoutFrontmatter() throws {
+        let root = makeSite([
+            "src/pages/plain.md": "Just a body, no frontmatter block.",
+            "src/layouts/Base.astro": "<slot />",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let page = try #require(graph.nodes.first { $0.kind == .page })
+
+        #expect(!graph.edges.contains { $0.sourceID == page.id })
+    }
+
+    @Test("unresolvable frontmatter layout references are skipped, not guessed")
+    func unresolvableFrontmatterLayout() throws {
+        let root = makeSite([
+            // A bare specifier and a relative path to a file that doesn't exist — neither may
+            // produce an edge (`resolveImport` returns nil for both, never a best-effort guess).
+            "src/pages/bare.md": "---\ntitle: Bare\nlayout: some-package-layout\n---\nBody",
+            "src/pages/missing.md": "---\ntitle: Missing\nlayout: ../layouts/Nope.astro\n---\nBody",
+            "src/layouts/Base.astro": "<slot />",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
+        let graph = SiteGraphExplorer.build(
+            projectRoot: root,
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images
+        )
+        let layout = try #require(graph.nodes.first { $0.kind == .layout })
+
+        #expect(!graph.edges.contains { $0.targetID == layout.id })
+        #expect(graph.edges.isEmpty)
+    }
+
     @Test("src styles files become style nodes")
     func styleNodes() {
         let root = makeSite([

--- a/docs/superpowers/specs/2026-07-08-project-impact-analysis-design.md
+++ b/docs/superpowers/specs/2026-07-08-project-impact-analysis-design.md
@@ -1,0 +1,73 @@
+# Project Impact Analysis (#309) — design
+
+## Problem
+
+Changing a shared Astro component or layout can affect dozens of pages, and users discover the
+blast radius only after previewing or deploying. The app already maintains a project dependency
+graph (`SiteGraphExplorer`); #309 asks it to *predict* the impact of an edit before it happens:
+"Used by 27 pages", "Imported by 4 layouts", "References 12 images", "Included in 3 content
+collections".
+
+## Approach — v1, fully deterministic
+
+Reuse the existing graph rather than building a second scanner (contrast: PR #535's
+`DeadAssetScanner` needed its own scan because dead-asset detection has a different safety
+posture — "never over-flag unused" — and needed alias-resolution machinery the explorer graph
+doesn't have; impact analysis only needs *reachability* over the graph that already ships).
+
+### Core: `ImpactAnalysis` (AnglesiteCore)
+
+Pure function over a `SiteGraphExplorerSnapshot`:
+
+- `analyze(snapshot:targetID:) -> Report?` — BFS over the **reverse** of the dependency edges
+  (`imports`, `usesLayout`, `referencesAsset`; each means "source depends on target"), collecting
+  the transitive set of nodes that would change if the target is edited. Cycle-safe via a visited
+  set; `nil` for an unknown target.
+- `contains` edges (collection → entry) are membership, not dependency: they never propagate
+  impact, and only map affected entries back to `affectedCollections`.
+- Grouped, title-sorted output: `affectedPages`, `affectedEntries`, `affectedCollections`,
+  `dependentLayouts`, `dependentComponents`, `dependentStyles`, plus the one forward-looking
+  group `referencedAssets` (the target's own direct asset references).
+- Inherits the graph's under-reporting bias: an unresolvable reference never becomes an edge, so
+  the analysis may miss an affected page but never invents one.
+
+### Graph fix: frontmatter `layout:` edges
+
+`SiteGraphExplorer.build` only extracted import statements and asset references, so a markdown
+page using `layout: ../layouts/Base.astro` had **no** edge to its layout — editing a layout would
+under-report exactly the headline case the issue opens with. Markdown-ish files (`.md`, `.mdx`,
+`.mdoc`, `.markdown`) now also get a `usesLayout` edge from their frontmatter `layout` field
+(via the existing `Frontmatter.parse` + `resolveImport`). `.astro` files are excluded — their
+frontmatter is JS, not YAML.
+
+### UI: "Impact" section in the Site Graph inspector
+
+The Site Graph pane is already the app's "select a component" surface, refreshed live from
+`SiteContentGraph`'s change stream. Selecting any node now shows an Impact section between the
+node header and the existing Depends On / Referenced By edge lists:
+
+- A one-line summary — "Editing this would affect N pages." — the issue's headline number
+  (pages + entries), or an explicit "nothing else depends on it" when the blast radius is zero.
+- One clickable list per non-empty group (affected pages with their routes, entries,
+  collections, layouts, components, styles, referenced assets); clicking navigates the selection
+  so the blast radius can be walked in place.
+
+Computed as a `SiteGraphExplorerModel.selectedImpact` property over the **full** snapshot (not
+the kind-filtered view — impact is factual and must not shrink because a node kind is toggled
+off in the toolbar), matching the model's existing recompute-on-read style.
+
+## Non-goals (follow-ups, not this slice)
+
+- AI-edit integration ("this AI edit will affect 18 pages" before apply) — belongs to the
+  #459-era edit pipeline, not the Claude-plugin path.
+- Preview of affected routes, deployment-scope estimation, dependency diffing (new/removed
+  edges) — the issue's nice-to-haves.
+- Impact badges outside the graph pane (editor toolbar, navigator rows).
+
+## Testing
+
+`ImpactAnalysisTests` (Swift Testing, pure snapshots — no filesystem): transitive closure through
+layouts, direct + indirect dependents, forward asset references, collection membership,
+contains-is-not-dependency, cycle termination, style dependents, deterministic ordering,
+self-exclusion, unknown target. `SiteGraphExplorerTests` gains a frontmatter-layout edge case
+over a real temp-dir site.


### PR DESCRIPTION
## Summary

Fixes #309.

Adds a deterministic **Project Impact Analysis** to the Site Graph pane: selecting any node (component, layout, style, asset, page, entry) now shows an **Impact** section answering "what changes if I edit this?" *before* the edit happens —

- a headline summary ("Editing this would affect N pages."), counting pages + content entries reachable through any depth of layouts/components,
- clickable per-group lists: affected pages (with routes), entries, containing collections, dependent layouts/components/styles, and directly referenced assets — each row navigates the graph selection so the blast radius can be walked in place.

This maps 1:1 onto the issue's examples ("Used by 27 pages", "Imported by 4 layouts", "References 12 images", "Included in 3 content collections"; "Editing a layout could show: Homepage, Blog, …").

### How

- **`AnglesiteCore/ImpactAnalysis`** — pure, cycle-safe reverse-reachability (BFS) over the *existing* `SiteGraphExplorerSnapshot` dependency edges (`imports`/`usesLayout`/`referencesAsset`). `contains` edges are membership, not dependency — they never propagate impact and only map affected entries back to their collections. No new scanner (contrast PR #535's `DeadAssetScanner`, which needed its own scan for a different safety posture); no I/O; inherits the graph's under-reporting bias — may miss an affected page, never invents one.
- **Graph gap fix** — `SiteGraphExplorer.build` had no edge for markdown frontmatter `layout:` fields, so editing a layout under-reported exactly the issue's headline case. Markdown-ish files (`.md`/`.mdx`/`.mdoc`/`.markdown`) now emit a `usesLayout` edge via the existing `Frontmatter.parse` + `resolveImport`; `.astro` files are excluded (their frontmatter is JS, not YAML).
- **UI** — `SiteGraphExplorerModel.selectedImpact` computes over the **full** snapshot (not the kind-filtered view — impact is factual and must not shrink when a node kind is toggled off in the toolbar), matching the model's existing recompute-on-read style; `SiteGraphImpactSection` renders between the node header and the existing Depends On / Referenced By lists.

Design: [`docs/superpowers/specs/2026-07-08-project-impact-analysis-design.md`](docs/superpowers/specs/2026-07-08-project-impact-analysis-design.md) — includes explicit non-goals (AI-edit pre-apply report belongs to the #459 pipeline; route preview / deploy-scope estimation / dependency diffing are the issue's nice-to-haves, deferred).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change needs a paired PR in `Anglesite/anglesite`.

## Test plan

- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**
- [x] `swift build --package-path . --build-tests` — **Build complete** (all test targets compile)
- [ ] `swift test --package-path .` — **local test runtime blocked by a FoundationModels SDK/OS mismatch; CI is the arbiter.** Every test bundle on this machine (including untouched ones) fails at dlopen with `Symbol not found: FoundationModels Attachment.init(imageURL:orientation:)` — the installed Xcode 27 beta SDK is newer than the installed macOS 27 seed. Unrelated to this change.
- New unit tests: `ImpactAnalysisTests` (pure snapshot fixtures — transitive closure through layouts, asset back-walk, forward asset references, collection membership, contains-is-not-dependency, cycle termination, style dependents, deterministic ordering, self-exclusion, unknown target) and a frontmatter-`layout:` edge case in `SiteGraphExplorerTests` over a real temp-dir site.
- [ ] Manual smoke (UI-touching): open a site → View ▸ Graph → select a shared component → confirm the Impact section lists the expected pages and clicking a row navigates. Not run in this session (no interactive GUI available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)