### PR TITLE
feat(app): preview navigation menu commands — Reload, Back/Forward, zoom (#514)

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -209,6 +209,10 @@ struct AnglesiteApp: App {
             // DECLARATION order (this one above Web Inspector/Debug Pane), while `before:` groups
             // render in REVERSE declaration order (see FileItemCommands/SaveCommands above).
             ViewMenuCommands()
+            // Preview navigation — Reload ⌘R, Back/Forward, zoom (#514) — between the pane/panel
+            // toggles above and the developer tools below (`after:` groups render in declaration
+            // order, see the note above).
+            PreviewNavigationCommands()
             // "Show Web Inspector" in the View menu — its own Commands type for the same focus reason.
             WebInspectorCommands()
             // Debug pane lives off the View menu — `⌥⌘D` keeps it discoverable without crowding

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -29,12 +29,18 @@ final class PreviewModel {
 
     private let runtime: any SiteRuntime
 
-    /// The live preview `WKWebView`, registered by `PreviewView` when it's created. Weak: SwiftUI's
-    /// `NSViewRepresentable` owns the web view's lifetime; the model only borrows it for the
-    /// View-menu commands — Show Web Inspector (`showWebInspector()`) and the preview navigation
-    /// commands (#514: reload, back/forward, zoom). Setting it (re)installs the KVO mirrors for
-    /// `canGoBack`/`canGoForward` and re-applies the persisted `zoomLevel`, so a web view recreated
-    /// across a dev-server restart keeps the user's zoom.
+    /// The live preview `WKWebView`, registered by `PreviewView` when it's created and detached
+    /// via `detachWebView(_:)` when SwiftUI dismantles it. Weak: SwiftUI's `NSViewRepresentable`
+    /// owns the web view's lifetime; the model only borrows it for the View-menu commands — Show
+    /// Web Inspector (`showWebInspector()`) and the preview navigation commands (#514: reload,
+    /// back/forward, zoom). Setting it (re)installs the KVO mirrors for `canGoBack`/`canGoForward`
+    /// and re-applies the persisted `zoomLevel`, so a web view recreated across a dev-server
+    /// restart keeps the user's zoom.
+    ///
+    /// The explicit detach path matters: ARC zeroing a weak var does NOT fire `didSet`, so
+    /// relying on zeroing alone would leave the KVO mirrors frozen at their last values whenever
+    /// the web view is torn down without a replacement (dev-server restart/failure switches
+    /// `previewPane` off the `.ready` branch) — Back/Forward would stay enabled with no web view.
     weak var webView: WKWebView? {
         didSet {
             guard oldValue !== webView else { return }
@@ -44,8 +50,8 @@ final class PreviewModel {
     }
 
     /// Mirrors of `WKWebView.canGoBack`/`.canGoForward`, observable so the View-menu Back/Forward
-    /// items enable/disable live. KVO-fed by `observeNavigationState()`; false whenever no web view
-    /// exists.
+    /// items enable/disable live. KVO-fed by `observeNavigationState()`; reset to false when the
+    /// web view detaches (`detachWebView(_:)`) or is replaced.
     private(set) var canGoBack = false
     private(set) var canGoForward = false
 
@@ -54,7 +60,12 @@ final class PreviewModel {
     /// `PreviewZoom.levels`.
     private(set) var zoomLevel: Double = PreviewZoom.actualSize
 
-    /// KVO tokens for the `canGoBack`/`canGoForward` mirrors; replaced whenever `webView` changes.
+    /// KVO tokens for the `canGoBack`/`canGoForward` mirrors; replaced whenever `webView` changes
+    /// and cleared on `detachWebView(_:)`. Note the modern closure-based `observe(...)` token does
+    /// NOT retain the observed object — it holds it weakly and auto-invalidates when the observed
+    /// object deallocates (verified empirically on the Swift 6.4 toolchain), so a stale token here
+    /// cannot keep a torn-down web view alive; clearing on detach is about resetting the mirrors,
+    /// not about breaking a retain.
     private var webViewObservations: [NSKeyValueObservation] = []
 
     /// The `EditRouter` that the WKWebView's `AnglesiteScriptHandler` forwards overlay edits to.
@@ -187,6 +198,23 @@ final class PreviewModel {
     /// True once the preview web view exists — the enablement gate for the View-menu preview
     /// navigation commands. The web view is created when the dev server first becomes ready.
     var hasWebView: Bool { webView != nil }
+
+    /// Explicit teardown signal from `PreviewView.dismantleNSView` — the counterpart to the
+    /// `onWebView` registration. Required because ARC zeroing the weak `webView` does not fire
+    /// its `didSet`, so without this call the `canGoBack`/`canGoForward` mirrors (and the KVO
+    /// tokens) would outlive the web view they mirror.
+    ///
+    /// Identity-checked: SwiftUI may create a replacement view (`makeNSView` → `onWebView`)
+    /// before dismantling the old one, in which case `webView` already points at the new
+    /// instance and the stale dismantle must not clobber it. The `nil` case is accepted too —
+    /// ARC may have zeroed the reference before the dismantle callback runs, leaving stale
+    /// mirrors that still need the reset (the `didSet` skips its work when old and new are both
+    /// nil, so `observeNavigationState()` is called directly).
+    func detachWebView(_ dismantled: WKWebView) {
+        guard webView === dismantled || webView == nil else { return }
+        webView = nil
+        observeNavigationState()
+    }
 
     /// Reload the current preview page (View ▸ Reload Preview, ⌘R). No-ops when the web view
     /// doesn't exist yet, so it's always safe to call.

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -30,9 +30,32 @@ final class PreviewModel {
     private let runtime: any SiteRuntime
 
     /// The live preview `WKWebView`, registered by `PreviewView` when it's created. Weak: SwiftUI's
-    /// `NSViewRepresentable` owns the web view's lifetime; the model only borrows it to open the Web
-    /// Inspector from the "Show Web Inspector" View-menu command (`showWebInspector()`).
-    weak var webView: WKWebView?
+    /// `NSViewRepresentable` owns the web view's lifetime; the model only borrows it for the
+    /// View-menu commands — Show Web Inspector (`showWebInspector()`) and the preview navigation
+    /// commands (#514: reload, back/forward, zoom). Setting it (re)installs the KVO mirrors for
+    /// `canGoBack`/`canGoForward` and re-applies the persisted `zoomLevel`, so a web view recreated
+    /// across a dev-server restart keeps the user's zoom.
+    weak var webView: WKWebView? {
+        didSet {
+            guard oldValue !== webView else { return }
+            observeNavigationState()
+            webView?.pageZoom = CGFloat(zoomLevel)
+        }
+    }
+
+    /// Mirrors of `WKWebView.canGoBack`/`.canGoForward`, observable so the View-menu Back/Forward
+    /// items enable/disable live. KVO-fed by `observeNavigationState()`; false whenever no web view
+    /// exists.
+    private(set) var canGoBack = false
+    private(set) var canGoForward = false
+
+    /// The preview's page-zoom level (View ▸ Zoom In/Out/Actual Size, #514). Owned by the model —
+    /// not read back from the web view — so it survives web-view recreation. Always one of
+    /// `PreviewZoom.levels`.
+    private(set) var zoomLevel: Double = PreviewZoom.actualSize
+
+    /// KVO tokens for the `canGoBack`/`canGoForward` mirrors; replaced whenever `webView` changes.
+    private var webViewObservations: [NSKeyValueObservation] = []
 
     /// The `EditRouter` that the WKWebView's `AnglesiteScriptHandler` forwards overlay edits to.
     /// Wired to the runtime's `MCPClient` via a weak getter so the router doesn't outlive the
@@ -157,6 +180,73 @@ final class PreviewModel {
     func showWebInspector() {
         guard let webView else { return }
         PreviewWebInspector.show(webView)
+    }
+
+    // MARK: Preview navigation (#514)
+
+    /// True once the preview web view exists — the enablement gate for the View-menu preview
+    /// navigation commands. The web view is created when the dev server first becomes ready.
+    var hasWebView: Bool { webView != nil }
+
+    /// Reload the current preview page (View ▸ Reload Preview, ⌘R). No-ops when the web view
+    /// doesn't exist yet, so it's always safe to call.
+    func reloadPreview() {
+        webView?.reload()
+    }
+
+    /// Navigate the preview's history (View ▸ Back ⌘[ / Forward ⌘]). WKWebView no-ops these when
+    /// there's nowhere to go, and the menu items are additionally disabled via
+    /// `canGoBack`/`canGoForward`.
+    func goBack() {
+        webView?.goBack()
+    }
+
+    func goForward() {
+        webView?.goForward()
+    }
+
+    /// Zoom commands (View ▸ Zoom In ⌘+ / Zoom Out ⌘− / Actual Size ⌘0). The step policy lives in
+    /// `PreviewZoom` (AnglesiteCore, CI-tested); this glue just applies the chosen detent to
+    /// `WKWebView.pageZoom`.
+    var canZoomIn: Bool { PreviewZoom.canZoomIn(from: zoomLevel) }
+    var canZoomOut: Bool { PreviewZoom.canZoomOut(from: zoomLevel) }
+
+    func zoomIn() {
+        setZoomLevel(PreviewZoom.zoomIn(from: zoomLevel))
+    }
+
+    func zoomOut() {
+        setZoomLevel(PreviewZoom.zoomOut(from: zoomLevel))
+    }
+
+    func zoomActualSize() {
+        setZoomLevel(PreviewZoom.actualSize)
+    }
+
+    private func setZoomLevel(_ level: Double) {
+        zoomLevel = level
+        webView?.pageZoom = CGFloat(level)
+    }
+
+    /// (Re)install the KVO mirrors of the web view's history state. `canGoBack`/`canGoForward`
+    /// are KVO-compliant on WKWebView and fire on the main thread (`assumeIsolated` asserts that);
+    /// mirroring them into observable properties lets the SwiftUI Commands enable/disable without
+    /// polling the web view.
+    private func observeNavigationState() {
+        webViewObservations = []
+        canGoBack = false
+        canGoForward = false
+        guard let webView else { return }
+        webViewObservations = [
+            webView.observe(\.canGoBack, options: [.initial, .new]) { [weak self] _, change in
+                let value = change.newValue ?? false
+                MainActor.assumeIsolated { self?.canGoBack = value }
+            },
+            webView.observe(\.canGoForward, options: [.initial, .new]) { [weak self] _, change in
+                let value = change.newValue ?? false
+                MainActor.assumeIsolated { self?.canGoForward = value }
+            },
+        ]
     }
 
     /// Exposes the runtime's `MCPClient` via the same weak-getter pattern `editRouter` uses,

--- a/Sources/AnglesiteApp/PreviewNavigationCommands.swift
+++ b/Sources/AnglesiteApp/PreviewNavigationCommands.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Browser-style View-menu commands for the live preview (#514): Reload Preview ⌘R, Back ⌘[ /
+/// Forward ⌘], and page zoom (Actual Size ⌘0, Zoom In ⌘+, Zoom Out ⌘−).
+///
+/// Reads the focused site window's `PreviewModel` through the same `\.preview` focused value as
+/// `WebInspectorCommands`. Everything is disabled until that window's preview web view exists
+/// (the dev server has become ready at least once); Back/Forward additionally track the web view's
+/// history via the model's KVO-fed `canGoBack`/`canGoForward` mirrors, and the zoom items pin at
+/// the `PreviewZoom` detent-ladder bounds. All actions no-op safely if the weak web view has
+/// already been torn down.
+struct PreviewNavigationCommands: Commands {
+    @FocusedValue(\.preview) private var focusedPreview
+
+    var body: some Commands {
+        CommandGroup(after: .toolbar) {
+            Button("Reload Preview") {
+                focusedPreview?.reloadPreview()
+            }
+            .keyboardShortcut("r")
+            .disabled(focusedPreview?.hasWebView != true)
+
+            Button("Back") {
+                focusedPreview?.goBack()
+            }
+            .keyboardShortcut("[")
+            .disabled(focusedPreview?.canGoBack != true)
+
+            Button("Forward") {
+                focusedPreview?.goForward()
+            }
+            .keyboardShortcut("]")
+            .disabled(focusedPreview?.canGoForward != true)
+
+            Divider()
+
+            Button("Actual Size") {
+                focusedPreview?.zoomActualSize()
+            }
+            .keyboardShortcut("0")
+            .disabled(focusedPreview?.hasWebView != true || focusedPreview?.zoomLevel == PreviewZoom.actualSize)
+
+            Button("Zoom In") {
+                focusedPreview?.zoomIn()
+            }
+            // KeyEquivalent "+" — macOS menu matching also accepts the unshifted ⌘= chord for it,
+            // matching Safari/Xcode behavior.
+            .keyboardShortcut("+")
+            .disabled(focusedPreview?.hasWebView != true || focusedPreview?.canZoomIn != true)
+
+            Button("Zoom Out") {
+                focusedPreview?.zoomOut()
+            }
+            .keyboardShortcut("-")
+            .disabled(focusedPreview?.hasWebView != true || focusedPreview?.canZoomOut != true)
+
+            Divider()
+        }
+    }
+}

--- a/Sources/AnglesiteApp/PreviewView.swift
+++ b/Sources/AnglesiteApp/PreviewView.swift
@@ -25,9 +25,17 @@ struct PreviewView: NSViewRepresentable {
     let annotationProvider: PreviewAnnotationProvider?
 
     /// Called with the `WKWebView` once it's created, so the owning `PreviewModel` can hold a weak
-    /// reference and open the Web Inspector from the View menu. Defaults to a no-op for callers
-    /// (e.g. tests) that don't need it.
+    /// reference and drive the View-menu preview commands (Web Inspector, reload/history/zoom).
+    /// Defaults to a no-op for callers (e.g. tests) that don't need it.
     var onWebView: (WKWebView) -> Void = { _ in }
+
+    /// Called with the `WKWebView` when SwiftUI tears this view down (`dismantleNSView`) — e.g. a
+    /// dev-server restart or failure switches `previewPane` away from the `.ready` branch. The
+    /// owning `PreviewModel` needs this explicit signal: its `webView` reference is weak, and ARC
+    /// zeroing a weak var does NOT fire `didSet`, so without it the model's KVO-fed
+    /// `canGoBack`/`canGoForward` mirrors would freeze at their last values (#546 review).
+    /// Defaults to a no-op for callers that don't track the web view.
+    var onWebViewDismantled: (WKWebView) -> Void = { _ in }
 
     func makeNSView(context: Context) -> WKWebView {
         let onVisibleElements: AnglesiteScriptHandler.VisibleElementsHandler? = annotationProvider.map { provider in
@@ -52,19 +60,28 @@ struct PreviewView: NSViewRepresentable {
         }
         webView.load(URLRequest(url: url))
         context.coordinator.loadedURL = url
+        // Stashed on the coordinator because `dismantleNSView` is static — it has no access to
+        // this instance's closures at teardown time.
+        context.coordinator.onDismantle = onWebViewDismantled
         onWebView(webView)
         return webView
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
+        context.coordinator.onDismantle = onWebViewDismantled
         guard context.coordinator.loadedURL != url else { return }
         context.coordinator.loadedURL = url
         webView.load(URLRequest(url: url))
+    }
+
+    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        coordinator.onDismantle?(webView)
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     final class Coordinator {
         var loadedURL: URL?
+        var onDismantle: ((WKWebView) -> Void)?
     }
 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -565,7 +565,11 @@ struct SiteWindow: View {
                 url: model.preview.displayURL ?? url,
                 router: model.preview.editRouter,
                 annotationProvider: model.annotationProvider,
-                onWebView: { [preview = model.preview] webView in preview.webView = webView }
+                onWebView: { [preview = model.preview] webView in preview.webView = webView },
+                // Explicit detach: ARC zeroing the model's weak `webView` doesn't fire `didSet`,
+                // so without this the Back/Forward menu enablement would freeze when the dev
+                // server restarts or fails (see PreviewModel.detachWebView).
+                onWebViewDismantled: { [preview = model.preview] webView in preview.detachWebView(webView) }
             )
         case .starting:
             centeredStatus {

--- a/Sources/AnglesiteCore/PreviewZoom.swift
+++ b/Sources/AnglesiteCore/PreviewZoom.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Zoom-step policy for the live-preview web view (View ▸ Zoom In / Zoom Out / Actual Size, #514).
+///
+/// Pure and `AnglesiteCore`-scoped so it's unit-testable on CI — the app-target glue
+/// (`PreviewModel`) applies the returned level to `WKWebView.pageZoom`. The detent ladder matches
+/// Safari's page-zoom steps so the preview zooms the way users expect a browser to.
+public enum PreviewZoom {
+    /// The zoom detents, ascending. `actualSize` (1.0) is always a member.
+    public static let levels: [Double] = [0.5, 0.75, 0.85, 1.0, 1.15, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0]
+
+    /// The 100% detent — View ▸ Actual Size (⌘0).
+    public static let actualSize: Double = 1.0
+
+    public static var minimum: Double { levels[0] }
+    public static var maximum: Double { levels[levels.count - 1] }
+
+    /// Comparison slop so a level reproduced through floating-point arithmetic still counts as
+    /// "at" its detent instead of half a step away from it.
+    private static let tolerance: Double = 0.001
+
+    /// The next detent above `level`, clamped to `maximum`. An off-detent `level` snaps up to
+    /// the nearest detent strictly above it.
+    public static func zoomIn(from level: Double) -> Double {
+        levels.first { $0 > level + tolerance } ?? maximum
+    }
+
+    /// The next detent below `level`, clamped to `minimum`. An off-detent `level` snaps down to
+    /// the nearest detent strictly below it.
+    public static func zoomOut(from level: Double) -> Double {
+        levels.last { $0 < level - tolerance } ?? minimum
+    }
+
+    public static func canZoomIn(from level: Double) -> Bool {
+        level + tolerance < maximum
+    }
+
+    public static func canZoomOut(from level: Double) -> Bool {
+        level - tolerance > minimum
+    }
+}

--- a/Tests/AnglesiteCoreTests/PreviewZoomTests.swift
+++ b/Tests/AnglesiteCoreTests/PreviewZoomTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct PreviewZoomTests {
+    @Test("zooming in from actual size steps to the next detent")
+    func zoomInFromActualSize() {
+        #expect(PreviewZoom.zoomIn(from: 1.0) == 1.15)
+    }
+
+    @Test("zooming out from actual size steps to the previous detent")
+    func zoomOutFromActualSize() {
+        #expect(PreviewZoom.zoomOut(from: 1.0) == 0.85)
+    }
+
+    @Test("zoom in walks the detent ladder to the maximum")
+    func zoomInLadder() {
+        var level = PreviewZoom.actualSize
+        var visited: [Double] = []
+        while PreviewZoom.canZoomIn(from: level) {
+            level = PreviewZoom.zoomIn(from: level)
+            visited.append(level)
+        }
+        #expect(visited == [1.15, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0])
+    }
+
+    @Test("zoom out walks the detent ladder to the minimum")
+    func zoomOutLadder() {
+        var level = PreviewZoom.actualSize
+        var visited: [Double] = []
+        while PreviewZoom.canZoomOut(from: level) {
+            level = PreviewZoom.zoomOut(from: level)
+            visited.append(level)
+        }
+        #expect(visited == [0.85, 0.75, 0.5])
+    }
+
+    @Test("zoom in at the maximum stays clamped")
+    func zoomInClampedAtMaximum() {
+        #expect(PreviewZoom.zoomIn(from: PreviewZoom.maximum) == PreviewZoom.maximum)
+        #expect(!PreviewZoom.canZoomIn(from: PreviewZoom.maximum))
+    }
+
+    @Test("zoom out at the minimum stays clamped")
+    func zoomOutClampedAtMinimum() {
+        #expect(PreviewZoom.zoomOut(from: PreviewZoom.minimum) == PreviewZoom.minimum)
+        #expect(!PreviewZoom.canZoomOut(from: PreviewZoom.minimum))
+    }
+
+    @Test("an off-detent level snaps to the surrounding detents")
+    func offDetentSnaps() {
+        #expect(PreviewZoom.zoomIn(from: 1.1) == 1.15)
+        #expect(PreviewZoom.zoomOut(from: 1.1) == 1.0)
+    }
+
+    @Test("a level beyond the ladder clamps back into range")
+    func outOfRangeClamps() {
+        #expect(PreviewZoom.zoomIn(from: 10.0) == PreviewZoom.maximum)
+        #expect(PreviewZoom.zoomOut(from: 0.1) == PreviewZoom.minimum)
+    }
+
+    @Test("float noise near a detent does not double-step")
+    func floatNoiseTolerated() {
+        // 1.15 arrived at via repeated arithmetic can carry ulp noise; the next step up
+        // must still be 1.25 (not 1.15 again) and the next step down 1.0.
+        let noisy = 1.15 + 1e-9
+        #expect(PreviewZoom.zoomIn(from: noisy) == 1.25)
+        #expect(PreviewZoom.zoomOut(from: noisy) == 1.0)
+    }
+
+    @Test("actual size is a detent and the ladder bounds are sane")
+    func ladderShape() {
+        #expect(PreviewZoom.levels.contains(PreviewZoom.actualSize))
+        #expect(PreviewZoom.levels == PreviewZoom.levels.sorted())
+        #expect(PreviewZoom.minimum == 0.5)
+        #expect(PreviewZoom.maximum == 3.0)
+        #expect(PreviewZoom.canZoomIn(from: PreviewZoom.actualSize))
+        #expect(PreviewZoom.canZoomOut(from: PreviewZoom.actualSize))
+    }
+}


### PR DESCRIPTION
Adds browser-style View-menu commands for the live preview (#514, part of the menu-bar completeness tracking #518).

## What

- **Reload Preview** ⌘R — reloads the preview WKWebView; disabled until the web view exists.
- **Back** ⌘[ / **Forward** ⌘] — WKWebView history navigation, enabled live via KVO mirrors of `canGoBack`/`canGoForward` on `PreviewModel`.
- **Actual Size** ⌘0 / **Zoom In** ⌘+ / **Zoom Out** ⌘− — page zoom on a detent ladder matching Safari's page-zoom steps (0.5×–3×), applied to `WKWebView.pageZoom`.

## How

- `PreviewZoom` (new, `AnglesiteCore`) — pure detent-ladder step policy (`zoomIn(from:)`/`zoomOut(from:)`/`canZoomIn`/`canZoomOut`, float-noise tolerant), unit-tested with Swift Testing so the logic runs on CI; the app-target glue stays thin per the hosted-tests-don't-run-on-CI rule.
- `PreviewModel` — the `webView` registration hook now (re)installs KVO observers for the `canGoBack`/`canGoForward` mirrors and re-applies the model-owned `zoomLevel`, so zoom survives web-view recreation across dev-server restarts. New thin actions: `reloadPreview()`, `goBack()`, `goForward()`, `zoomIn()`, `zoomOut()`, `zoomActualSize()`; all no-op safely when the weak web view is gone.
- `PreviewNavigationCommands` (new) — reads the same `\.preview` focused value as `WebInspectorCommands`, declared between `ViewMenuCommands` and `WebInspectorCommands` so the items sit between the pane/panel toggles and the developer tools in the View menu.

No shortcut collisions: ⌘R, ⌘[, ⌘], ⌘0, ⌘+, ⌘− are all unclaimed in the current command set.

## Verification

- `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**, no new warnings.
- `swift build --package-path . --build-tests` — **Build complete** (new `PreviewZoomTests` compile).
- ⚠️ Local `swift test` runtime is currently blocked machine-wide by a FoundationModels SDK/OS mismatch (every test bundle fails at dlopen with `Symbol not found: …Attachment…imageURL:orientation:`) — unrelated to this change; CI is the arbiter for the test run.

Fixes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)