### PR TITLE
feat(app): String Catalog localization scaffolding

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -90,7 +90,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             menu.addItem(item)
         }
         if !menu.items.isEmpty { menu.addItem(.separator()) }
-        let newSite = NSMenuItem(title: "New Site", action: #selector(newSiteFromDock), keyEquivalent: "")
+        let newSite = NSMenuItem(title: String(localized: "New Site"), action: #selector(newSiteFromDock), keyEquivalent: "")
         newSite.target = self
         menu.addItem(newSite)
         return menu

--- a/Sources/AnglesiteApp/FocusedSite.swift
+++ b/Sources/AnglesiteApp/FocusedSite.swift
@@ -65,7 +65,7 @@ struct NewContentCommands: Commands {
             openWindow(value: site.id)
         } catch {
             let alert = NSAlert()
-            alert.messageText = "Couldn't open that site"
+            alert.messageText = String(localized: "Couldn't open that site")
             alert.informativeText = error.localizedDescription
             alert.alertStyle = .warning
             alert.runModal()

--- a/Sources/AnglesiteApp/InfoPlist.xcstrings
+++ b/Sources/AnglesiteApp/InfoPlist.xcstrings
@@ -1,0 +1,7 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+
+  },
+  "version" : "1.0"
+}

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -342,6 +342,9 @@
     "Choose Image" : {
 
     },
+    "Choose Logo" : {
+
+    },
     "Choose where to save the local .anglesite file." : {
 
     },
@@ -999,6 +1002,9 @@
 
     },
     "Save Website…" : {
+
+    },
+    "Save Your Website" : {
 
     },
     "Save your website" : {

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1,0 +1,1345 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "" : {
+
+    },
+    "@media %@" : {
+
+    },
+    "/" : {
+
+    },
+    "%@ %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@"
+          }
+        }
+      }
+    },
+    "%@ %@ → %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@ → %3$@"
+          }
+        }
+      }
+    },
+    "%@ → %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ → %2$@"
+          }
+        }
+      }
+    },
+    "%@ changed on disk" : {
+
+    },
+    "%@ has been changed since this edit. Undoing will overwrite those changes." : {
+
+    },
+    "%@ tool" : {
+
+    },
+    "%@, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$@"
+          }
+        }
+      }
+    },
+    "%@: %@;" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: %2$@;"
+          }
+        }
+      }
+    },
+    "%@. %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@. %2$@"
+          }
+        }
+      }
+    },
+    "%lld" : {
+
+    },
+    "%lld change%@ applied successfully." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld change%2$@ applied successfully."
+          }
+        }
+      }
+    },
+    "%lld refs" : {
+
+    },
+    "%lld selected" : {
+
+    },
+    "%lld%%" : {
+
+    },
+    "A custom token named “Anglesite” should be pre-filled with all permissions Anglesite uses. If it isn’t, add at least the “Edit Cloudflare Workers” template’s permissions so deploying works — Anglesite will ask again when a feature needs more access. Click **Continue to summary**." : {
+
+    },
+    "A full, growing catalog" : {
+
+    },
+    "A service or one-off" : {
+
+    },
+    "About Anglesite" : {
+
+    },
+    "About custom analytics" : {
+
+    },
+    "Abstract shapes in my brand colors, no text" : {
+
+    },
+    "Accent color" : {
+
+    },
+    "Accessibility" : {
+
+    },
+    "Add" : {
+
+    },
+    "Add a ${type} record to ${domain}" : {
+
+    },
+    "Add a link back to **%@**" : {
+
+    },
+    "Add a Store" : {
+
+    },
+    "Add a store to ${site}" : {
+
+    },
+    "Add Bluesky verification" : {
+
+    },
+    "Add booking to ${site}" : {
+
+    },
+    "Add comments to ${site}" : {
+
+    },
+    "Add donations to ${site}" : {
+
+    },
+    "Add Google verification" : {
+
+    },
+    "Add Integration" : {
+
+    },
+    "Add Integration…" : {
+
+    },
+    "Add one above to get started." : {
+
+    },
+    "Add page ${name} to ${site}" : {
+
+    },
+    "Add post ${title2} to ${site}" : {
+
+    },
+    "Add record" : {
+
+    },
+    "Add Site" : {
+
+    },
+    "Advanced" : {
+
+    },
+    "AI summary — verify against the log below" : {
+
+    },
+    "All" : {
+
+    },
+    "All types" : {
+
+    },
+    "Anglesite Debug" : {
+
+    },
+    "Anglesite plugin" : {
+
+    },
+    "Announce live updates to VoiceOver" : {
+
+    },
+    "Another tool edited the website details while you had unsaved changes." : {
+
+    },
+    "Another tool edited this file while you had unsaved changes." : {
+
+    },
+    "Answer a couple of questions and we'll pick the right commerce integration." : {
+
+    },
+    "API token" : {
+
+    },
+    "Apply %lld change%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apply %1$lld change%2$@"
+          }
+        }
+      }
+    },
+    "Applying hardening changes…" : {
+
+    },
+    "Ask Assistant" : {
+
+    },
+    "Ask the assistant…" : {
+
+    },
+    "Audit" : {
+
+    },
+    "Audit summary: %@" : {
+
+    },
+    "Audited: %@." : {
+
+    },
+    "Auditing…" : {
+
+    },
+    "Auto-generate alt text for dropped images" : {
+
+    },
+    "Auto-scroll" : {
+
+    },
+    "Auto-suggest descriptions for new pages and posts" : {
+
+    },
+    "Back" : {
+
+    },
+    "Back up ${site}" : {
+
+    },
+    "Backup" : {
+
+    },
+    "Blocking (%lld)" : {
+
+    },
+    "Body" : {
+
+    },
+    "Build failed" : {
+
+    },
+    "Build, scan, and run wrangler deploy on this site" : {
+
+    },
+    "Building your website…" : {
+
+    },
+    "Buy a domain" : {
+
+    },
+    "By default, Anglesite saves new and imported site packages under `~/Sites/`. Override this for development or testing." : {
+
+    },
+    "Can't open %@" : {
+
+    },
+    "Can't Open Component" : {
+
+    },
+    "Can't open website details" : {
+
+    },
+    "Can't preview %@" : {
+
+    },
+    "Cancel" : {
+
+    },
+    "Cancel response" : {
+
+    },
+    "Change" : {
+
+    },
+    "Change ${element} \\u{2014} ${instruction}" : {
+
+    },
+    "Change Image" : {
+
+    },
+    "Change Logo…" : {
+
+    },
+    "Chat" : {
+
+    },
+    "Check ${site}" : {
+
+    },
+    "Check whether Siri workflows are ready for this site" : {
+
+    },
+    "Checking token…" : {
+
+    },
+    "Checking…" : {
+
+    },
+    "Choose" : {
+
+    },
+    "Choose %@" : {
+
+    },
+    "Choose a provider" : {
+
+    },
+    "Choose an Anglesite site package." : {
+
+    },
+    "Choose an existing Anglesite site folder to import." : {
+
+    },
+    "Choose Image" : {
+
+    },
+    "Choose where to save the local .anglesite file." : {
+
+    },
+    "Choose your own colors and add a logo." : {
+
+    },
+    "Choose your Sites folder so Anglesite can create the new site there." : {
+
+    },
+    "Choose…" : {
+
+    },
+    "Clear" : {
+
+    },
+    "Clear %@" : {
+
+    },
+    "Clear filter" : {
+
+    },
+    "Click **Create Token**, then copy it and paste it below." : {
+
+    },
+    "Click Recheck to run the pre-deploy scan against this site." : {
+
+    },
+    "Close" : {
+
+    },
+    "Cloudflare" : {
+
+    },
+    "Cloudflare API token" : {
+
+    },
+    "Collection" : {
+
+    },
+    "Collection Entry" : {
+
+    },
+    "Collection…" : {
+
+    },
+    "Commit and push working-tree changes to your current branch" : {
+
+    },
+    "Computed" : {
+
+    },
+    "Connect & deploy" : {
+
+    },
+    "Connect to Cloudflare" : {
+
+    },
+    "Connected to %@" : {
+
+    },
+    "Content" : {
+
+    },
+    "Content type filter" : {
+
+    },
+    "Continue" : {
+
+    },
+    "Copies %@ to the clipboard" : {
+
+    },
+    "Copy" : {
+
+    },
+    "Copy log" : {
+
+    },
+    "Copy markdown link to clipboard" : {
+
+    },
+    "Copy SHA" : {
+
+    },
+    "Copy URL" : {
+
+    },
+    "Couldn't add “%@”: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Couldn't add “%1$@”: %2$@"
+          }
+        }
+      }
+    },
+    "Couldn't finish setup" : {
+
+    },
+    "Couldn't load sites" : {
+
+    },
+    "Couldn't open that site" : {
+
+    },
+    "Couldn't run the check" : {
+
+    },
+    "Create" : {
+
+    },
+    "Create a website" : {
+
+    },
+    "Create new site…" : {
+
+    },
+    "Create one with **Add Site → Create new site…**, or use **Add Site → Import existing site…** to add an existing `.anglesite` package." : {
+
+    },
+    "Creating…" : {
+
+    },
+    "Credentials" : {
+
+    },
+    "Custom" : {
+
+    },
+    "Custom Analytics" : {
+
+    },
+    "Custom. Choose your own colors and add a logo." : {
+
+    },
+    "Delete" : {
+
+    },
+    "Delete a DNS record from ${domain}" : {
+
+    },
+    "Dependency Updates Available" : {
+
+    },
+    "Deploy" : {
+
+    },
+    "Deploy ${site}" : {
+
+    },
+    "Deploy blocked" : {
+
+    },
+    "Deploy readiness" : {
+
+    },
+    "Deploying" : {
+
+    },
+    "Deploying needs a one-time API token. It takes about a minute." : {
+
+    },
+    "Description" : {
+
+    },
+    "Destination" : {
+
+    },
+    "Dev Server Starting…" : {
+
+    },
+    "Diagnostics" : {
+
+    },
+    "Digital downloads" : {
+
+    },
+    "Dismiss" : {
+
+    },
+    "Dismiss suggestion" : {
+
+    },
+    "Domain" : {
+
+    },
+    "Domain…" : {
+
+    },
+    "Donations or fundraising" : {
+
+    },
+    "Done" : {
+
+    },
+    "Editing" : {
+
+    },
+    "Editor" : {
+
+    },
+    "Enter the domain to harden" : {
+
+    },
+    "Enter the domain to manage" : {
+
+    },
+    "Enter the domain you already own." : {
+
+    },
+    "Error" : {
+
+    },
+    "example.com" : {
+
+    },
+    "Explicitly not included" : {
+
+    },
+    "Explore pages, layouts, components, collections, and assets" : {
+
+    },
+    "Export Site Source…" : {
+
+    },
+    "Export this site's source files to a folder." : {
+
+    },
+    "Failed" : {
+
+    },
+    "File" : {
+
+    },
+    "File modified outside Anglesite" : {
+
+    },
+    "Filter retrieval by content type" : {
+
+    },
+    "Filtering: %@" : {
+
+    },
+    "Find ${contentType} in ${site}" : {
+
+    },
+    "Finished" : {
+
+    },
+    "First words" : {
+
+    },
+    "General" : {
+
+    },
+    "Generate hero image…" : {
+
+    },
+    "GitHub" : {
+
+    },
+    "Got it" : {
+
+    },
+    "Grant Access" : {
+
+    },
+    "Graph" : {
+
+    },
+    "Harden" : {
+
+    },
+    "Harden…" : {
+
+    },
+    "Hardening…" : {
+
+    },
+    "Hero image (optional)" : {
+
+    },
+    "Hero image ready" : {
+
+    },
+    "Hide" : {
+
+    },
+    "Hide Chat" : {
+
+    },
+    "Hide chat panel" : {
+
+    },
+    "Hide Inspector" : {
+
+    },
+    "Hide related pages" : {
+
+    },
+    "Hide Related Pages" : {
+
+    },
+    "Homepage headline" : {
+
+    },
+    "How many products?" : {
+
+    },
+    "Icons" : {
+
+    },
+    "Import existing site…" : {
+
+    },
+    "Import Site…" : {
+
+    },
+    "Include Git history (.git)" : {
+
+    },
+    "Input" : {
+
+    },
+    "Inspector" : {
+
+    },
+    "Installed" : {
+
+    },
+    "Just a few" : {
+
+    },
+    "Keep My Changes" : {
+
+    },
+    "Kind" : {
+
+    },
+    "Last checked %@" : {
+
+    },
+    "Lemon Squeezy" : {
+
+    },
+    "Likely cause: %@" : {
+
+    },
+    "List DNS records for ${domain}" : {
+
+    },
+    "Load records" : {
+
+    },
+    "Loading site…" : {
+
+    },
+    "Lower numbers are preferred mail servers, e.g. 10." : {
+
+    },
+    "Missing Reciprocal Links" : {
+
+    },
+    "Missing required files" : {
+
+    },
+    "Mode" : {
+
+    },
+    "My Website" : {
+
+    },
+    "Name" : {
+
+    },
+    "New" : {
+
+    },
+    "New Collection" : {
+
+    },
+    "New Page" : {
+
+    },
+    "New Site" : {
+
+    },
+    "No Anglesite sites found" : {
+
+    },
+    "No changes needed." : {
+
+    },
+    "No Collection Types" : {
+
+    },
+    "No content yet" : {
+
+    },
+    "No DNS records found." : {
+
+    },
+    "No issues found in the most recent scan." : {
+
+    },
+    "No issues found." : {
+
+    },
+    "No matching graph nodes" : {
+
+    },
+    "No Recent Sites" : {
+
+    },
+    "No scoped styles" : {
+
+    },
+    "No Suggestions" : {
+
+    },
+    "No website details" : {
+
+    },
+    "None" : {
+
+    },
+    "Not Set" : {
+
+    },
+    "Off" : {
+
+    },
+    "OK" : {
+
+    },
+    "On" : {
+
+    },
+    "Open" : {
+
+    },
+    "Open %@ in its own window" : {
+
+    },
+    "Open ${target}" : {
+
+    },
+    "Open Cloudflare API tokens" : {
+
+    },
+    "Open Cloudflare Domains" : {
+
+    },
+    "Open Dashboard" : {
+
+    },
+    "Open File" : {
+
+    },
+    "Open in browser" : {
+
+    },
+    "Open in Browser" : {
+
+    },
+    "Open Recent" : {
+
+    },
+    "Open Site…" : {
+
+    },
+    "Open the chat panel for a deeper AI audit of this site" : {
+
+    },
+    "Open the live preview in your default browser" : {
+
+    },
+    "Open the preview first to start the runtime before deploying" : {
+
+    },
+    "Open Website Anyway" : {
+
+    },
+    "Opens %@" : {
+
+    },
+    "Opens %@ in the default editor" : {
+
+    },
+    "optional" : {
+
+    },
+    "Page" : {
+
+    },
+    "Page…" : {
+
+    },
+    "Paste the HTML code from another analytics provider here, such as Google Analytics, Plausible, Fathom, or a conversion tag." : {
+
+    },
+    "paste token" : {
+
+    },
+    "Pause" : {
+
+    },
+    "Physical goods" : {
+
+    },
+    "Pick a color scheme" : {
+
+    },
+    "Point at a checkout of the plugin (e.g. `../anglesite`) to iterate without rebuilding the app." : {
+
+    },
+    "Polar" : {
+
+    },
+    "Preview" : {
+
+    },
+    "Preview ${site}" : {
+
+    },
+    "Preview and apply Cloudflare security hardening for this site" : {
+
+    },
+    "Primary color" : {
+
+    },
+    "Priority" : {
+
+    },
+    "Provider" : {
+
+    },
+    "Re-check" : {
+
+    },
+    "Recheck" : {
+
+    },
+    "Recheck Deploy Readiness" : {
+
+    },
+    "Refresh" : {
+
+    },
+    "Regenerate…" : {
+
+    },
+    "Related Pages" : {
+
+    },
+    "Reload DNS records for this domain" : {
+
+    },
+    "Reload from Disk" : {
+
+    },
+    "Reload site list" : {
+
+    },
+    "Reload sites" : {
+
+    },
+    "Remaining audit findings" : {
+
+    },
+    "Remove" : {
+
+    },
+    "Remove “%@” from Anglesite?" : {
+
+    },
+    "Remove from Anglesite" : {
+
+    },
+    "Remove from Anglesite…" : {
+
+    },
+    "Rename" : {
+
+    },
+    "Rename failed" : {
+
+    },
+    "Rename Site" : {
+
+    },
+    "Rename…" : {
+
+    },
+    "Reset conversation" : {
+
+    },
+    "Resolve" : {
+
+    },
+    "Resolve this annotation" : {
+
+    },
+    "Resolving zone and reading current state…" : {
+
+    },
+    "Result" : {
+
+    },
+    "Retrieved context from %lld file%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Retrieved context from %1$lld file%2$@"
+          }
+        }
+      }
+    },
+    "Retry" : {
+
+    },
+    "Reveal in Finder" : {
+
+    },
+    "Revert" : {
+
+    },
+    "Revert to Saved" : {
+
+    },
+    "Revert to the last saved version?" : {
+
+    },
+    "Route" : {
+
+    },
+    "Run again" : {
+
+    },
+    "Run the structured accessibility audit against this site" : {
+
+    },
+    "Running" : {
+
+    },
+    "running…" : {
+
+    },
+    "Save" : {
+
+    },
+    "Save the imported site package." : {
+
+    },
+    "Save Website…" : {
+
+    },
+    "Save your website" : {
+
+    },
+    "Save…" : {
+
+    },
+    "Scan" : {
+
+    },
+    "Scan couldn't run" : {
+
+    },
+    "Search" : {
+
+    },
+    "Search ${site} for ${query}" : {
+
+    },
+    "Search graph" : {
+
+    },
+    "Select a node" : {
+
+    },
+    "Select an element in the canvas" : {
+
+    },
+    "Selected" : {
+
+    },
+    "Selection" : {
+
+    },
+    "Send" : {
+
+    },
+    "Send (⏎)" : {
+
+    },
+    "Set this up later" : {
+
+    },
+    "Set Up" : {
+
+    },
+    "Set up a third-party integration for this site" : {
+
+    },
+    "Sets a display name just for Anglesite. Leave blank to use the site's built-in name." : {
+
+    },
+    "Setting up…" : {
+
+    },
+    "Settings" : {
+
+    },
+    "Share deployed URL" : {
+
+    },
+    "Share the deployed site's URL" : {
+
+    },
+    "Short description (optional)" : {
+
+    },
+    "Show Chat" : {
+
+    },
+    "Show chat panel" : {
+
+    },
+    "Show Debug Pane" : {
+
+    },
+    "Show Debug Pane menu item" : {
+
+    },
+    "Show Inspector" : {
+
+    },
+    "Show or hide %@" : {
+
+    },
+    "Show or hide the page inspector" : {
+
+    },
+    "Show related pages" : {
+
+    },
+    "Show Related Pages" : {
+
+    },
+    "Show Web Inspector" : {
+
+    },
+    "Shows the most recent pre-deploy scan results" : {
+
+    },
+    "Siri AI" : {
+
+    },
+    "Siri AI Readiness" : {
+
+    },
+    "Siri AI readiness for “%@”." : {
+
+    },
+    "Siri AI Readiness…" : {
+
+    },
+    "Site" : {
+
+    },
+    "Site Graph" : {
+
+    },
+    "Site is missing required files" : {
+
+    },
+    "Site is missing required files: %@" : {
+
+    },
+    "Site name" : {
+
+    },
+    "Sites" : {
+
+    },
+    "Sites root" : {
+
+    },
+    "Skip" : {
+
+    },
+    "Skipped" : {
+
+    },
+    "Slug" : {
+
+    },
+    "Software or SaaS" : {
+
+    },
+    "Source" : {
+
+    },
+    "Sources" : {
+
+    },
+    "Speaks streaming chat responses (start, and the reply when it finishes) and deploy progress (start, errors, and the final result) as VoiceOver announcements. Turn off if you prefer to read these surfaces by navigating to them yourself." : {
+
+    },
+    "Standard error" : {
+
+    },
+    "Standard output" : {
+
+    },
+    "Status of ${site}" : {
+
+    },
+    "Stored in the macOS Keychain under `io.dwk.anglesite`. The token is passed to `wrangler deploy` as `CLOUDFLARE_API_TOKEN` and never written to logs. An exported `CLOUDFLARE_API_TOKEN` in the shell that launched Anglesite takes precedence over this entry." : {
+
+    },
+    "Stream" : {
+
+    },
+    "Styles" : {
+
+    },
+    "Suggested fix: %@" : {
+
+    },
+    "Suggested Links" : {
+
+    },
+    "Summarizing…" : {
+
+    },
+    "Switch between Preview, Editor, and Graph" : {
+
+    },
+    "Tag" : {
+
+    },
+    "Template" : {
+
+    },
+    "The App Store build doesn't bundle `gh`. Anglesite uses whatever `git` credentials are already configured on your Mac (Keychain or SSH key) when pushing." : {
+
+    },
+    "The build produced no output." : {
+
+    },
+    "The domain must be managed in Cloudflare. Your API token needs Zone DNS Edit, Zone Settings Edit, and WAF Edit permissions." : {
+
+    },
+    "The domain must be managed in Cloudflare. Your API token needs Zone DNS Read and Edit permissions." : {
+
+    },
+    "The pre-deploy scan found issues that need fixing before this site can ship." : {
+
+    },
+    "There are no editable website details." : {
+
+    },
+    "This can't be undone." : {
+
+    },
+    "This page already links to all related content." : {
+
+    },
+    "This page has no inbound links from other pages." : {
+
+    },
+    "This removes it from Anglesite's list only. The files in %@ are left on disk." : {
+
+    },
+    "This site does not have any collection-backed content types." : {
+
+    },
+    "This zone already has all recommended hardening settings." : {
+
+    },
+    "Title" : {
+
+    },
+    "Token usage and cost" : {
+
+    },
+    "Token verified" : {
+
+    },
+    "Transfer an existing domain" : {
+
+    },
+    "Try again" : {
+
+    },
+    "TTL" : {
+
+    },
+    "Type" : {
+
+    },
+    "Unavailable — newer edits have been made since" : {
+
+    },
+    "Undo" : {
+
+    },
+    "Undo anyway" : {
+
+    },
+    "Undo this edit" : {
+
+    },
+    "Undone" : {
+
+    },
+    "Unsaved changes" : {
+
+    },
+    "Unsaved changes in the editor and inspector will be discarded." : {
+
+    },
+    "Update" : {
+
+    },
+    "Upload Logo…" : {
+
+    },
+    "URL" : {
+
+    },
+    "Use a temporary Cloudflare Pages domain later, such as %@." : {
+
+    },
+    "Uses Apple Intelligence on your device. No content leaves your Mac without your say-so." : {
+
+    },
+    "Uses your existing `git` credentials" : {
+
+    },
+    "Valid" : {
+
+    },
+    "View" : {
+
+    },
+    "View and manage this domain's DNS records" : {
+
+    },
+    "Waiting for output…" : {
+
+    },
+    "Warnings" : {
+
+    },
+    "Warnings (%lld)" : {
+
+    },
+    "Website details changed on disk" : {
+
+    },
+    "Website name" : {
+
+    },
+    "Welcome to …" : {
+
+    },
+    "What are you selling?" : {
+
+    },
+    "What kind of website are you creating?" : {
+
+    },
+    "What this website is about, in a sentence" : {
+
+    },
+    "When you create a page or post, Anglesite uses Apple's on-device model to suggest a short SEO description. Runs locally; requires Apple Intelligence to be enabled. Falls back to a title-derived description when off or unavailable." : {
+
+    },
+    "When you drop an image onto the preview, Anglesite uses Apple's on-device vision model to write descriptive alt text and applies it automatically. Runs locally; requires Apple Intelligence to be enabled. Purely decorative images get empty alt text and role=\"presentation\"." : {
+
+    },
+    "Whether this Mac can run Siri-driven Anglesite workflows. Per-site readiness is in each site window (Site ▸ Siri AI Readiness)." : {
+
+    },
+    "Which platform?" : {
+
+    },
+    "Your website was created with warnings. You can open it anyway and fix it from the website window." : {
+
+    },
+    "Your website was created, but something above needs attention before it can preview. You can open it anyway and fix it from the website window." : {
+
+    }
+  },
+  "version" : "1.0"
+}

--- a/Sources/AnglesiteApp/NewSiteWizard.swift
+++ b/Sources/AnglesiteApp/NewSiteWizard.swift
@@ -334,7 +334,7 @@ struct NewSiteWizard: View {
 
     @MainActor private func saveWebsite() {
         let panel = NSSavePanel()
-        panel.title = "Save Your Website"
+        panel.title = String(localized: "Save Your Website")
         panel.prompt = String(localized: "Save")
         panel.allowedContentTypes = [.anglesiteSite]
         panel.canCreateDirectories = true
@@ -356,7 +356,7 @@ struct NewSiteWizard: View {
 
     @MainActor private func chooseLogo() {
         let panel = NSOpenPanel()
-        panel.title = "Choose Logo"
+        panel.title = String(localized: "Choose Logo")
         panel.prompt = String(localized: "Choose")
         panel.allowedContentTypes = [.image]
         panel.allowsMultipleSelection = false

--- a/Sources/AnglesiteApp/NewSiteWizard.swift
+++ b/Sources/AnglesiteApp/NewSiteWizard.swift
@@ -335,7 +335,7 @@ struct NewSiteWizard: View {
     @MainActor private func saveWebsite() {
         let panel = NSSavePanel()
         panel.title = "Save Your Website"
-        panel.prompt = "Save"
+        panel.prompt = String(localized: "Save")
         panel.allowedContentTypes = [.anglesiteSite]
         panel.canCreateDirectories = true
         panel.directoryURL = model.draft.saveDirectory ?? model.defaultSaveDirectory
@@ -357,7 +357,7 @@ struct NewSiteWizard: View {
     @MainActor private func chooseLogo() {
         let panel = NSOpenPanel()
         panel.title = "Choose Logo"
-        panel.prompt = "Choose"
+        panel.prompt = String(localized: "Choose")
         panel.allowedContentTypes = [.image]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -258,7 +258,7 @@ struct PlistEditorView: View {
         panel.canChooseFiles = true
         panel.allowsMultipleSelection = false
         panel.allowedContentTypes = WebsiteIconInstaller.allowedContentTypes
-        panel.prompt = model.hasWebsiteIcons ? "Change" : "Choose"
+        panel.prompt = model.hasWebsiteIcons ? String(localized: "Change") : String(localized: "Choose")
         guard panel.runModal() == .OK, let url = panel.url else { return }
         Task { await model.installWebsiteIcons(from: url) }
     }

--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -15,7 +15,7 @@ enum SiteActions {
         let folderName: String
         let underlying: Error
         var errorDescription: String? {
-            "Couldn't add “\(folderName)”: \(underlying.localizedDescription)"
+            String(localized: "Couldn't add “\(folderName)”: \(underlying.localizedDescription)")
         }
     }
 
@@ -51,13 +51,13 @@ enum SiteActions {
         picker.canChooseDirectories = true
         picker.canChooseFiles = false
         picker.allowsMultipleSelection = false
-        picker.prompt = "Choose"
-        picker.message = "Choose an existing Anglesite site folder to import."
+        picker.prompt = String(localized: "Choose")
+        picker.message = String(localized: "Choose an existing Anglesite site folder to import.")
         guard picker.runModal() == .OK, let sourceDir = picker.url else { return nil }
 
         let name = sourceDir.deletingPathExtension().lastPathComponent
         let save = NSSavePanel()
-        save.message = "Save the imported site package."
+        save.message = String(localized: "Save the imported site package.")
         save.nameFieldStringValue = "\(name).anglesite"
         save.directoryURL = AppSettings.shared.sitesRoot
         guard save.runModal() == .OK, let dest = save.url else { return nil }
@@ -87,9 +87,9 @@ enum SiteActions {
     /// Export the given site's source tree to a chosen folder, with an opt-in for `.git` history.
     static func exportSource(of site: SiteStore.Site) {
         let save = NSSavePanel()
-        save.message = "Export this site's source files to a folder."
+        save.message = String(localized: "Export this site's source files to a folder.")
         save.nameFieldStringValue = site.name
-        let gitToggle = NSButton(checkboxWithTitle: "Include Git history (.git)", target: nil, action: nil)
+        let gitToggle = NSButton(checkboxWithTitle: String(localized: "Include Git history (.git)"), target: nil, action: nil)
         gitToggle.state = .off
         let accessory = NSView(frame: NSRect(x: 0, y: 0, width: 280, height: 28))
         gitToggle.frame = NSRect(x: 12, y: 4, width: 256, height: 20)
@@ -120,8 +120,8 @@ enum SiteActions {
         panel.allowedContentTypes = [.anglesiteSite]
         panel.treatsFilePackagesAsDirectories = false
         panel.allowsMultipleSelection = false
-        panel.prompt = "Open"
-        panel.message = "Choose an Anglesite site package."
+        panel.prompt = String(localized: "Open")
+        panel.message = String(localized: "Choose an Anglesite site package.")
         guard panel.runModal() == .OK, let url = panel.url else { return nil }
 
         do {

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -400,8 +400,8 @@ struct SitesLauncherView: View {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.directoryURL = sitesRoot
-        panel.prompt = "Grant Access"
-        panel.message = "Choose your Sites folder so Anglesite can create the new site there."
+        panel.prompt = String(localized: "Grant Access")
+        panel.message = String(localized: "Choose your Sites folder so Anglesite can create the new site there.")
         guard panel.runModal() == .OK, let url = panel.url else { return nil }
         if let data = try? SecurityScopedBookmark.create(for: url) {
             AppSettings.shared.sitesRootBookmark = data

--- a/project.yml
+++ b/project.yml
@@ -53,6 +53,10 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Resources/Anglesite.entitlements
         ENABLE_HARDENED_RUNTIME: YES
         MACOSX_DEPLOYMENT_TARGET: "27.0"
+        # String Catalog scaffolding (#528): the compiler extracts SwiftUI/String(localized:)
+        # literals into Sources/AnglesiteApp/Localizable.xcstrings during Xcode builds.
+        SWIFT_EMIT_LOC_STRINGS: YES
+        LOCALIZATION_PREFERS_STRING_CATALOGS: YES
         SWIFT_VERSION: "5.10"
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "0.1.0"


### PR DESCRIPTION
Localization scaffolding so strings flow through a catalog from now on — the change that gets more expensive every week it waits. Stacked on #540 (so the sweep covers its new Dock-menu strings). Closes #528.

## What

- **`Localizable.xcstrings` + `InfoPlist.xcstrings`** in the app target, with `SWIFT_EMIT_LOC_STRINGS` and `LOCALIZATION_PREFERS_STRING_CATALOGS` in `project.yml`. Xcode populates/syncs the catalog automatically on IDE builds (⌘B); `xcodebuild` alone doesn't write back — that sync is an IDE behavior.
- **AppKit-path sweep**: strings the compiler can't extract as SwiftUI literals are now `String(localized:)` — `NSAlert` text, every `NSOpenPanel`/`NSSavePanel` prompt+message, the Dock menu's New Site item, the export dialog's git-history checkbox, and the interpolated `LocalizedError` descriptions in `SiteActions`.
- **Out of scope, deliberately**: the Help Book and `Resources/Template/` are end-user content with their own localization story; the SwiftPM library targets (AnglesiteCore etc.) have user-facing error strings that would need per-module catalogs + `defaultLocalization` — noted as a follow-up if/when a second language is actually planned. English-only ships unchanged.

## Verification

`xcodebuild -exportLocalizations` against this branch produces an `en.xcloc` with **428 trans-units**: spot-checked that SwiftUI literals (Deploy, Grant Access, the panes tooltip), every new `String(localized:)` wrap, and the interpolated ImportError (correctly converted to `%1$@`/`%2$@` positional specifiers) are all present. Build green.

One expected side effect to be aware of: the committed catalogs are empty until the first Xcode IDE build, which will populate `Localizable.xcstrings` and show as a large mechanical diff in whatever branch that happens on — that's the catalog syncing, not noise to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
