### PR TITLE
fix(tests): deflake conventions reindex test (unbreaks main CI)

### DIFF
--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeReindexTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeReindexTests.swift
@@ -90,9 +90,11 @@ struct LocalContainerSiteRuntimeReindexTests {
         let added = root.appendingPathComponent("src/pages/about.astro")
         try! Data("# About\n".utf8).write(to: added)
         watcher.deliver(FileChangeBatch(paths: [added], needsFullRescan: false))
-        _ = await poll(1.0) {
+        // 5s budget like the knowledge-index test above: the batch applies on an unstructured
+        // Task, and a 1s poll flaked on loaded CI runners once the suite grew (first seen when
+        // #535's suites landed alongside this test).
+        #expect(await poll(5) {
             await conventions.conventions(siteID: "s1")?.writing.headingCapitalization.sampleSize == 2
-        }
-        #expect(await conventions.conventions(siteID: "s1")?.writing.headingCapitalization.sampleSize == 2)
+        })
     }
 }


### PR DESCRIPTION
Main CI has been red since #535 merged: `LocalContainerSiteRuntimeReindexTests`' conventions test (added in #539) polls only **1s** for the watcher batch to apply — the apply runs on an unstructured `Task`, and once #535's ~100 new tests changed the parallel scheduling load, 1s stopped being enough on CI runners. Not a semantic conflict: #535 only added files, and #539's own merge-ref run (without #535's suites) was green.

Fix: give it the same **5s** poll budget its knowledge-index sibling in the same file already uses, and assert the poll result directly instead of poll-then-re-read.

This also unblocks PR #540, whose merge-ref run fails on this same test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)