### PR TITLE
fix(container): write /etc/hosts in the guest at boot; stream clone/checkout output

### DIFF
--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -49,13 +49,21 @@ public struct ContainerizationControl: LocalContainerControl {
         //    check out ref. Cloning from the read-only share (not in place) keeps /workspace writable
         //    and preserves full git history — native, no network. Two steps because `git clone
         //    --branch` rejects "HEAD"/bare SHAs; `git checkout` accepts both.
+        // The image ships no /etc/hosts: docker/containerd write one at container create, but
+        // Apple Containerization boots the rootfs as-is — without it even `localhost` becomes a
+        // real DNS query (vite does dns.lookup("localhost") at astro config load → EAI_AGAIN,
+        // astro exits, and the preview never becomes ready). Write the standard entries first.
+        // Wrapped separately from the clone below so a hosts failure reads as a boot problem,
+        // not a misleading `cloneFailed`.
         do {
-            // The image ships no /etc/hosts: docker/containerd write one at container create, but
-            // Apple Containerization boots the rootfs as-is — without it even `localhost` becomes a
-            // real DNS query (vite does dns.lookup("localhost") at astro config load → EAI_AGAIN,
-            // astro exits, and the preview never becomes ready). Write the standard entries first.
             try await runToCompletion(container, id: "hosts", onOutput: onOutput,
                 ["sh", "-c", "printf '127.0.0.1\\tlocalhost\\n::1\\tlocalhost\\n' > /etc/hosts"])
+        } catch {
+            await stopBareContainer(container, siteID: siteID)
+            throw LocalContainerError.bootFailed("guest /etc/hosts setup failed: \(error)")
+        }
+
+        do {
             try await runToCompletion(container, id: "clone", onOutput: onOutput,
                 ["git", "clone", Self.repoSharePath, "/workspace/site"])
             try await runToCompletion(container, id: "checkout", onOutput: onOutput,
@@ -626,6 +634,10 @@ public struct ContainerizationControl: LocalContainerControl {
         }
         try await proc.start()
         let status = try await proc.wait()
+        // `wait()` returns only after the IO streams have drained — flush any trailing partial
+        // (unterminated) line on each stream, same as `exec()` below.
+        stdoutSink?.flush()
+        stderrSink?.flush()
         try? await proc.delete()
         guard status.exitCode == 0 else {
             throw LocalContainerError.cloneFailed("`\(argv.joined(separator: " "))` exited \(status.exitCode)")

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -50,9 +50,15 @@ public struct ContainerizationControl: LocalContainerControl {
         //    and preserves full git history — native, no network. Two steps because `git clone
         //    --branch` rejects "HEAD"/bare SHAs; `git checkout` accepts both.
         do {
-            try await runToCompletion(container, id: "clone",
+            // The image ships no /etc/hosts: docker/containerd write one at container create, but
+            // Apple Containerization boots the rootfs as-is — without it even `localhost` becomes a
+            // real DNS query (vite does dns.lookup("localhost") at astro config load → EAI_AGAIN,
+            // astro exits, and the preview never becomes ready). Write the standard entries first.
+            try await runToCompletion(container, id: "hosts", onOutput: onOutput,
+                ["sh", "-c", "printf '127.0.0.1\\tlocalhost\\n::1\\tlocalhost\\n' > /etc/hosts"])
+            try await runToCompletion(container, id: "clone", onOutput: onOutput,
                 ["git", "clone", Self.repoSharePath, "/workspace/site"])
-            try await runToCompletion(container, id: "checkout",
+            try await runToCompletion(container, id: "checkout", onOutput: onOutput,
                 ["git", "-C", "/workspace/site", "checkout", ref])
         } catch {
             await stopBareContainer(container, siteID: siteID)
@@ -593,10 +599,30 @@ public struct ContainerizationControl: LocalContainerControl {
         return nil
     }
 
-    /// Run a guest process to completion, throwing if it exits non-zero.
-    private func runToCompletion(_ container: LinuxContainer, id: String, _ argv: [String]) async throws {
+    /// Run a guest process to completion, throwing if it exits non-zero. When `onOutput` is
+    /// provided, the process's stdout/stderr stream to it line-by-line tagged `[id]` — without
+    /// this, a failing step (e.g. `git clone`) dies with only an exit code and no diagnostic.
+    private func runToCompletion(
+        _ container: LinuxContainer, id: String,
+        onOutput: (@Sendable (String, LogCenter.Stream) -> Void)? = nil,
+        _ argv: [String]
+    ) async throws {
+        let stdoutSink: LineStreamingWriter?
+        let stderrSink: LineStreamingWriter?
+        if let onOutput {
+            let tag: @Sendable (String, LogCenter.Stream) -> Void = { line, stream in
+                onOutput("[\(id)] \(line)", stream)
+            }
+            stdoutSink = LineStreamingWriter(stream: .stdout, onLine: tag)
+            stderrSink = LineStreamingWriter(stream: .stderr, onLine: tag)
+        } else {
+            stdoutSink = nil
+            stderrSink = nil
+        }
         let proc = try await container.exec(id) { config in
             config.arguments = argv
+            if let stdoutSink { config.stdout = stdoutSink }
+            if let stderrSink { config.stderr = stderrSink }
         }
         try await proc.start()
         let status = try await proc.wait()


### PR DESCRIPTION
## Problem

Two container-runtime defects found during the #491 GUI smoke (session that filed #548/#549/#550):

1. **The guest image has no `/etc/hosts`** — verified by walking the vendored OCI layer tarballs (only `etc/nsswitch.conf` + `etc/resolv.conf` exist). Docker/containerd write `/etc/hosts` at container create; Apple Containerization boots the rootfs as-is. Result: `localhost` resolution goes to real DNS over the NAT, vite's `dns.lookup("localhost")` during astro config load fails `EAI_AGAIN`, astro exits before binding 4321, and every preview boot dies at the ready-timeout with an opaque error. A Dockerfile `RUN … > /etc/hosts` cannot fix this — `/etc/hosts` is runtime-mounted during `docker build` and never lands in a layer, so the boot step is the right place.

2. **`runToCompletion` (clone/checkout) discarded guest output** — a failing `git clone` surfaced only as `exited 128` with git's actual diagnostic thrown away ("logs are sacred" gap; this is what made #548 hard to diagnose).

## Fix

- Write standard `127.0.0.1`/`::1 localhost` entries into the guest's `/etc/hosts` as the first boot step, before hydrate.
- Give `runToCompletion` optional line-streaming stdout/stderr writers (same `LineStreamingWriter` pattern as `runDetached`) and pass `onOutput` at the clone/checkout call sites, tagged `[clone]`/`[checkout]`/`[hosts]`.

## Verification

- `xcodebuild -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- `swift build --build-tests` — Build complete (local `swift test` runtime is blocked machine-wide by #541; CI is the arbiter)
- End-to-end: with this change a freshly scaffolded template site boots to a **served preview** in the GUI, and `scripts/run-container-probe.sh boot` passes — before it, astro died at config load on every boot of the freshly vendored image

Related: #548, #549, #550, #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)