### PR TITLE
fix(tests): deflake VsockTCPProxyTests — 20s read deadline like its sibling

### DIFF
--- a/Tests/AnglesiteCoreTests/VsockTCPProxyTests.swift
+++ b/Tests/AnglesiteCoreTests/VsockTCPProxyTests.swift
@@ -58,7 +58,12 @@ struct VsockTCPProxyTests {
     /// Polling against a generous deadline never fails on scheduling jitter, yet still bounds a
     /// genuinely-stuck splice instead of hanging CI forever. Requires SO_RCVTIMEO on `fh` so each
     /// `read` returns promptly to let the loop spin.
-    private func readExactly(_ count: Int, from fh: FileHandle, timeout: Duration = .seconds(10)) async -> Data {
+    ///
+    /// 20s default: a 10s budget still flaked on a loaded CI runner (`clientToGuest` timed out at
+    /// 10.7s with 0 bytes ever received, on an unmodified commit — see PR #558's CI run). Match
+    /// `fullPayloadDrainsBeforeTeardown`'s already-proven 20s budget rather than inventing a new
+    /// number.
+    private func readExactly(_ count: Int, from fh: FileHandle, timeout: Duration = .seconds(20)) async -> Data {
         let deadline = ContinuousClock.now + timeout
         var acc = Data()
         while acc.count < count && ContinuousClock.now < deadline {


### PR DESCRIPTION
## Summary
- `main`'s CI (commit d7174f31, PR #558) failed `VsockTCPProxyTests.clientToGuest` — `readExactly` timed out at 10.7s having received 0 bytes, on a commit that didn't touch this file.
- The suite's own top-of-file comment already documents this exact "0 bytes ever received" signature from a prior flake investigation (which added `.serialized`); it recurred anyway once the runner was loaded enough.
- Same shape as #556: a poll/read deadline that was fine in isolation flakes under a busier CI runner. `fullPayloadDrainsBeforeTeardown` already uses a 20s budget for the same helper under heavy load — bump `readExactly`'s default from 10s to 20s to match instead of inventing a new number. `clientToGuest`, `guestToClient`, `survivesRepeatedAbruptDisconnects`, and `closedConnectionRemovedFromConnections` all pick up the more generous default.

## Test plan
- [x] `swift build` compiles the change cleanly (`AnglesiteCoreTests-product Build complete!`).
- [ ] Local `swift test --filter VsockTCPProxyTests` is currently blocked by the unrelated #541 FoundationModels SDK/OS symbol mismatch, which prevents *any* xctest bundle here from `dlopen`ing on this machine — confirmed by also failing to launch the already-built `AnglesiteCoreTests.xctest` directly. Verification relies on CI.
- [ ] Watch the next CI run of `VsockTCPProxyTests` for green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)