### PR TITLE
feat(app): "Show Logs" button on loading/updating screens (#560)

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -620,7 +620,10 @@ struct SiteWindow: View {
                     title: model.preview.isUpdatingDependencies
                         ? "Updating dependencies — this may take a minute…"
                         : "Starting dev server for \(site.name)…",
-                    model: model.startup
+                    model: model.startup,
+                    // Deliberately ungated (unlike the ⌥⌘D menu item): the point of #560 is
+                    // letting non-developers look under the hood while they wait.
+                    onShowLogs: { openWindow(id: "debug") }
                 )
             }
         case .failed(_, let message):

--- a/Sources/AnglesiteApp/StartupProgressView.swift
+++ b/Sources/AnglesiteApp/StartupProgressView.swift
@@ -6,6 +6,9 @@ import SwiftUI
 struct StartupProgressView: View {
     let title: String
     let model: StartupProgressModel
+    /// When set, a "Show Logs" button appears beneath the status message so the curious can
+    /// watch the raw subprocess output while they wait (#560).
+    var onShowLogs: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 12) {
@@ -21,6 +24,12 @@ struct StartupProgressView: View {
                 .foregroundStyle(.secondary)
                 .frame(height: 18)
                 .animation(.easeInOut(duration: 0.2), value: model.message)
+            if let onShowLogs {
+                Button("Show Logs", action: onShowLogs)
+                    .buttonStyle(.link)
+                    .font(.callout)
+                    .accessibilityHint("Opens the live log of the running dev server and dependency install.")
+            }
         }
         .frame(maxWidth: 360)
         .animation(.easeInOut(duration: 0.2), value: model.fraction)

--- a/Sources/AnglesiteApp/StartupProgressView.swift
+++ b/Sources/AnglesiteApp/StartupProgressView.swift
@@ -28,7 +28,7 @@ struct StartupProgressView: View {
                 Button("Show Logs", action: onShowLogs)
                     .buttonStyle(.link)
                     .font(.callout)
-                    .accessibilityHint("Opens the live log of the running dev server and dependency install.")
+                    .accessibilityHint("Opens the live log of the running dev server and dependency installation.")
             }
         }
         .frame(maxWidth: 360)

--- a/docs/superpowers/specs/2026-07-08-show-logs-button-design.md
+++ b/docs/superpowers/specs/2026-07-08-show-logs-button-design.md
@@ -1,0 +1,56 @@
+# "Show Logs" button on loading/updating screens (#560)
+
+**Issue:** [#560](https://github.com/Anglesite/Anglesite-app/issues/560) — while the Astro dev
+server boots or npm dependencies update, the site window shows a progress bar. Techies and people
+learning want to look under the hood: add a "Show Logs" affordance that opens the running log in a
+Console.app-style view.
+
+## Context
+
+- Both loading screens are the **same view**: `SiteWindow.previewPane(for:)`'s `.starting` case
+  renders `StartupProgressView`, with the title keyed off `PreviewModel.isUpdatingDependencies`
+  (`Sources/AnglesiteApp/SiteWindow.swift`).
+- The Console.app-style viewer **already exists**: `DebugPaneView` (source/stream filters, search,
+  pause, copy, save) in the top-level `Window("Anglesite Debug", id: "debug")`
+  (`Sources/AnglesiteApp/AnglesiteApp.swift`), live-tailing `LogCenter.shared`, which every
+  subprocess already streams into ("logs are sacred").
+- The debug pane's *menu item* (⌥⌘D) is gated by `DebugPaneVisibility` (Debug build / Settings
+  toggle / Option at launch), but the window scene is always registered.
+
+## Design
+
+Pure wiring — no new log infrastructure:
+
+1. `StartupProgressView` gains `let onShowLogs: (() -> Void)?` (defaulting to `nil`) and renders a
+   small borderless "Show Logs" button beneath the status message when the closure is present.
+2. `SiteWindow`'s `.starting` case passes `onShowLogs: { openWindow(id: "debug") }` —
+   `@Environment(\.openWindow)` is already in scope. SwiftUI dedupes `openWindow(id:)`, so a
+   second press focuses the existing window.
+3. The button opens the log window **unconditionally**, independent of the `DebugPaneVisibility`
+   menu gate: the issue's whole point is surfacing logs to non-developers, and the gate only
+   governs the menu item's discoverability, not the pane's existence.
+
+One placement covers both screens the issue names (dev-server start and dependency update) because
+they share the `.starting` case.
+
+## Alternatives rejected
+
+- **In-window log drawer** (split view under the progress bar): duplicates `DebugPaneView` or
+  requires extracting/refactoring it; far more scope for the same information.
+- **Launch Console.app**: app subprocess logs live in `LogCenter`'s in-memory ring buffer, not the
+  unified system log, so Console.app would show nothing useful.
+- **Pre-filtering the pane to `container:<siteID>`**: would require converting the plain
+  `Window(id: "debug")` into a value-presented `WindowGroup` and touching the existing ⌥⌘D path.
+  The pane already has a Source picker; YAGNI for now.
+
+## Testing
+
+The change is SwiftUI view wiring with no new logic (no model changes, no branching beyond
+`if let`). There is no existing view-test harness for `StartupProgressView`/`DebugPaneView`;
+verification is `xcodebuild` (app links), `swift test` (no regressions), and a GUI check of the
+loading screen.
+
+## Follow-up (out of scope)
+
+The `.failed` preview state (which shows *Retry*) would also benefit from a "Show Logs" button —
+failures are when logs matter most. Tracked separately rather than widening this change.


### PR DESCRIPTION
Closes #560

## What

While the Astro dev server boots or npm dependencies update, the site window's progress screen now shows a link-style **Show Logs** button beneath the status message. It opens the existing Console.app-style **Anglesite Debug** window (`DebugPaneView` tailing `LogCenter`), so techies and the curious can watch the raw subprocess output while they wait.

## How

- `StartupProgressView` gains an optional `onShowLogs: (() -> Void)?` closure; when set, a `.link`-style button renders beneath the status message (with an accessibility hint).
- `SiteWindow`'s `.starting` case passes `{ openWindow(id: "debug") }`. One placement covers **both** screens the issue names — dev-server start and dependency update share the `.starting` case, differing only in title.
- No new log infrastructure: `DebugPaneView` already offers source/stream filters, search, pause, copy, and save, and every subprocess already streams into `LogCenter` ("logs are sacred").

## Design decisions (made autonomously — flag if you'd like different)

- **Ungated on purpose:** the ⌥⌘D *menu item* is gated by `DebugPaneVisibility` (Debug build / Settings toggle / Option at launch), but the button opens the window unconditionally — the issue's point is surfacing logs to non-developers. The gate governs menu discoverability, not the pane's existence.
- **Existing debug window, not a new in-window drawer or Console.app:** a drawer duplicates `DebugPaneView` for much more scope, and Console.app can't see `LogCenter`'s in-memory ring buffer.
- **No pane pre-filtering** to `container:<siteID>`: would require converting the plain `Window(id: "debug")` to a value-presented `WindowGroup`; the pane's Source picker already covers it. YAGNI.

Spec: `docs/superpowers/specs/2026-07-08-show-logs-button-design.md`

## Follow-up (out of scope)

The `.failed` preview state (which shows *Retry*) would also benefit from a "Show Logs" button — failures are when logs matter most. Happy to do that as a tiny follow-up if wanted.

## Verification

- `xcodebuild -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED** (after `xcodegen generate`; the worktree's generated project predated recently merged files).
- `swift test` is dead locally on this machine — every test bundle fails at `dlopen` with the FoundationModels SDK/OS symbol mismatch (#541), on clean main as well. Per that issue, **CI is the test arbiter** until the macOS seed catches up; the same launch crash blocks local GUI verification.
- The change is view wiring only (no model/logic changes), and `AnglesiteApp` sources aren't in the SwiftPM test targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)