### PR TITLE
feat(app): "Show Logs" button on the failed-preview state (#563)

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -635,6 +635,12 @@ struct SiteWindow: View {
                     Button("Retry") {
                         model.retryPreview()
                     }
+                    // Same deliberately-ungated affordance as the .starting screen (#560/#562):
+                    // the message above is a one-liner, but the *why* is in the subprocess log.
+                    Button("Show Logs") { openWindow(id: "debug") }
+                        .buttonStyle(.link)
+                        .font(.callout)
+                        .accessibilityHint("Opens the log of the failed dev server launch.")
                 }
             }
         case .idle:


### PR DESCRIPTION
Closes #563. Follow-up to #560 / PR #562, whose design doc explicitly tracked this as the next slice.

## What

The `.failed` case in `SiteWindow.previewPane(for:)` — the "Can't preview *site*" state — now offers a **Show Logs** button beneath **Retry**, opening the existing `Window(id: "debug")` log viewer (`DebugPaneView` live-tailing `LogCenter.shared`).

## Why

Failures are when logs matter most. The failure message shown in the window is a one-liner, but the full dev-server / npm output explaining *why* is already streaming into `LogCenter` ("logs are sacred") — this just surfaces it.

## Design notes

- **Styling matches PR #562**: `.buttonStyle(.link)` + `.font(.callout)` + an accessibility hint, so the loading and failed screens share one visual language. Retry stays the visually primary (bordered) action.
- **Deliberately ungated** by `DebugPaneVisibility`, same as #562: the gate only governs the ⌥⌘D menu item's discoverability; the window scene is always registered, and the point is letting non-developers look under the hood.
- Pure view wiring — no model changes, no new log infrastructure. `@Environment(\.openWindow)` was already in scope, and SwiftUI dedupes `openWindow(id:)` so a second press focuses the existing window.
- Based on `main`, not stacked on #562's branch — the two changes touch adjacent but non-overlapping hunks of `previewPane(for:)` and neither depends on the other's code.

## Verification

- `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` → **BUILD SUCCEEDED** (fresh worktree, `xcodegen generate`).
- Local `swift test` is blocked by #541 (FoundationModels dlopen symbol mismatch on this seed) — CI is the test arbiter for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)