### PR TITLE
fix(container): re-import the bundled OCI layout when an app update changes it (#549)

### DIFF
--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -221,9 +221,10 @@ public struct ContainerizationControl: LocalContainerControl {
         try? FileManager.default.removeItem(at: initfsURL)
 
         // 1. Import the bundled OCI layouts into the on-disk ImageStore and unpack to bootable mounts.
-        //    `load(from:)` is idempotent against an existing store (re-import returns the same image),
-        //    but it also needs to write into the layout directory itself (not just the store), so both
-        //    layouts are staged to a writable copy first — the bundled originals are read-only.
+        //    `loadOrGet` re-imports whenever the bundled layout changed since the last import (#549),
+        //    so app updates that ship a new image actually take effect. `load(from:)` also needs to
+        //    write into the layout directory itself (not just the store), so both layouts are staged
+        //    to a writable copy first — the bundled originals are read-only.
         let rootfs: Containerization.Mount
         let initfs: Containerization.Mount
         do {
@@ -232,7 +233,9 @@ public struct ContainerizationControl: LocalContainerControl {
 
             // App image -> ext4 rootfs mount.
             let stagedImageLayout = try BundledImage.stagedLayoutURL(source: imageLayoutURL, name: "app-image")
-            let appImage = try await loadOrGet(store, layout: stagedImageLayout, reference: BundledImage.imageReference)
+            let appImage = try await loadOrGet(
+                store, layout: stagedImageLayout, reference: BundledImage.imageReference,
+                artifactName: "app-image", storeRoot: storeURL)
             onOutput("[boot] unpacking app image to ext4 rootfs", .stdout)
             rootfs = try await EXT4Unpacker(blockSizeInBytes: 8 * 1024 * 1024 * 1024)
                 .unpack(appImage, for: .current, at: rootfsURL)
@@ -240,7 +243,9 @@ public struct ContainerizationControl: LocalContainerControl {
             // vminit initfs OCI layout -> ext4 init mount (the guest-agent root filesystem).
             let stagedInitfsLayout = try BundledImage.stagedLayoutURL(source: initfsLayoutURL, name: "vminit-initfs")
             let initImageRef = "vminit:latest"
-            let initImage = InitImage(image: try await loadOrGet(store, layout: stagedInitfsLayout, reference: initImageRef))
+            let initImage = InitImage(image: try await loadOrGet(
+                store, layout: stagedInitfsLayout, reference: initImageRef,
+                artifactName: "vminit-initfs", storeRoot: storeURL))
             onOutput("[boot] unpacking vminit initfs to ext4", .stdout)
             initfs = try await initImage.initBlock(at: initfsURL, for: .linuxArm)
         } catch {
@@ -499,13 +504,29 @@ public struct ContainerizationControl: LocalContainerControl {
 
     // MARK: - Helpers
 
-    /// Import an OCI layout into the store, tolerating a prior import (idempotent): if `load` fails
-    /// because the reference already resolves, fall back to `get`.
-    private func loadOrGet(_ store: ImageStore, layout: URL, reference: String) async throws -> Containerization.Image {
-        if let existing = try? await store.get(reference: reference) {
+    /// Resolve `reference` from the store, importing (or re-importing) the OCI layout as needed.
+    ///
+    /// The `get(reference:)` fast path is taken only while `OCILayoutImportMarker` confirms the
+    /// store's import came from this exact layout. Without that check the first-ever import is
+    /// served forever: an app update that ships a new bundled image never reaches the store, and
+    /// the guest keeps booting the old rootfs (#549). On mismatch `load(from:)` re-imports —
+    /// `ImageStore`'s reference state is an overwrite-on-create map, so loading repoints the tag
+    /// to the new image. `artifactName` must match the staging name so marker and staged copy
+    /// describe the same artifact.
+    private func loadOrGet(
+        _ store: ImageStore,
+        layout: URL,
+        reference: String,
+        artifactName: String,
+        storeRoot: URL
+    ) async throws -> Containerization.Image {
+        if OCILayoutImportMarker.isCurrent(layout: layout, name: artifactName, storeRoot: storeRoot),
+            let existing = try? await store.get(reference: reference) {
             return existing
         }
         let loaded = try await store.load(from: layout)
+        // Best-effort: a failed marker write only costs a redundant re-import next boot.
+        try? OCILayoutImportMarker.recordImported(layout: layout, name: artifactName, storeRoot: storeRoot)
         if let match = try? await store.get(reference: reference) {
             return match
         }

--- a/Sources/AnglesiteCore/OCILayoutIdentity.swift
+++ b/Sources/AnglesiteCore/OCILayoutIdentity.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Byte-identity checks for OCI layouts, shared by `OCILayoutStaging` (staged copy vs bundled
+/// source) and `OCILayoutImportMarker` (recorded import vs current layout) so the two can't drift.
+///
+/// In an OCI layout `index.json` carries the manifest digests, so any change to the image changes
+/// it — byte-comparing it is an image-identity check without hashing the blobs. Unreadable inputs
+/// compare as non-matching, so every consumer fails toward re-staging/re-importing (cheap and
+/// correct) rather than trusting stale state.
+public enum OCILayoutIdentity {
+    /// The identity-bearing file of an OCI layout.
+    public static func indexURL(of layout: URL) -> URL {
+        layout.appendingPathComponent("index.json")
+    }
+
+    /// True when both files exist and byte-match; false otherwise.
+    public static func contentsMatch(_ a: URL, _ b: URL) -> Bool {
+        guard
+            let aData = try? Data(contentsOf: a),
+            let bData = try? Data(contentsOf: b)
+        else { return false }
+        return aData == bData
+    }
+}

--- a/Sources/AnglesiteCore/OCILayoutImportMarker.swift
+++ b/Sources/AnglesiteCore/OCILayoutImportMarker.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Records which bundled OCI layout was last imported into the on-disk `ImageStore`, so the boot
+/// path can tell "already imported this exact image" from "the app update shipped a new one" (#549).
+///
+/// The store's own `load(from:)` *does* repoint a tag on re-import, but importing on every boot is
+/// wasteful — so `ContainerizationControl.loadOrGet` short-circuits to `get(reference:)` when the
+/// store already has the reference. Without this marker that short-circuit is unconditional: the
+/// first-ever imported image is served forever and image updates shipped by app updates never take
+/// effect. Like `OCILayoutStaging`, the identity check is byte-equality of the layout's
+/// `index.json` (it carries the manifest digests, so any image change changes it) — and the logic
+/// lives here (pure Foundation, no Containerization dependency) so it stays covered by CI's
+/// `swift test`, which never compiles the AnglesiteContainer module.
+public enum OCILayoutImportMarker {
+    /// True when the layout at `layout` is byte-identical (by `index.json`) to what
+    /// `recordImported` last recorded for `name` — i.e. the store already holds this exact image
+    /// and the import can be skipped. False on first boot, after an app update that ships a
+    /// changed layout, or when either `index.json` is unreadable (fail toward re-importing).
+    public static func isCurrent(layout: URL, name: String, storeRoot: URL) -> Bool {
+        guard
+            let recorded = try? Data(contentsOf: markerURL(name: name, storeRoot: storeRoot)),
+            let current = try? Data(contentsOf: layout.appendingPathComponent("index.json"))
+        else { return false }
+        return recorded == current
+    }
+
+    /// Records that the layout at `layout` was just imported into the store for `name`.
+    /// Call only after a successful `ImageStore.load(from:)` — recording first would let a failed
+    /// import masquerade as current. The write is atomic, so a concurrent `isCurrent` reader sees
+    /// either the old marker or the new one, never a torn file.
+    public static func recordImported(layout: URL, name: String, storeRoot: URL) throws {
+        let marker = markerURL(name: name, storeRoot: storeRoot)
+        try FileManager.default.createDirectory(
+            at: marker.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(contentsOf: layout.appendingPathComponent("index.json"))
+            .write(to: marker, options: .atomic)
+    }
+
+    private static func markerURL(name: String, storeRoot: URL) -> URL {
+        storeRoot.appendingPathComponent("imported-markers/\(name).index.json")
+    }
+}

--- a/Sources/AnglesiteCore/OCILayoutImportMarker.swift
+++ b/Sources/AnglesiteCore/OCILayoutImportMarker.swift
@@ -17,11 +17,9 @@ public enum OCILayoutImportMarker {
     /// and the import can be skipped. False on first boot, after an app update that ships a
     /// changed layout, or when either `index.json` is unreadable (fail toward re-importing).
     public static func isCurrent(layout: URL, name: String, storeRoot: URL) -> Bool {
-        guard
-            let recorded = try? Data(contentsOf: markerURL(name: name, storeRoot: storeRoot)),
-            let current = try? Data(contentsOf: layout.appendingPathComponent("index.json"))
-        else { return false }
-        return recorded == current
+        OCILayoutIdentity.contentsMatch(
+            markerURL(name: name, storeRoot: storeRoot),
+            OCILayoutIdentity.indexURL(of: layout))
     }
 
     /// Records that the layout at `layout` was just imported into the store for `name`.
@@ -32,7 +30,7 @@ public enum OCILayoutImportMarker {
         let marker = markerURL(name: name, storeRoot: storeRoot)
         try FileManager.default.createDirectory(
             at: marker.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try Data(contentsOf: layout.appendingPathComponent("index.json"))
+        try Data(contentsOf: OCILayoutIdentity.indexURL(of: layout))
             .write(to: marker, options: .atomic)
     }
 

--- a/Sources/AnglesiteCore/OCILayoutStaging.swift
+++ b/Sources/AnglesiteCore/OCILayoutStaging.swift
@@ -31,11 +31,12 @@ public enum OCILayoutStaging {
     /// double-install is at worst a same-content replace.)
     public static func stagedLayoutURL(source: URL, name: String, storeRoot: URL) throws -> URL {
         let staged = storeRoot.appendingPathComponent("layout-staging/\(name)", isDirectory: true)
-        let sourceIndexData = try Data(contentsOf: source.appendingPathComponent("index.json"))
+        let sourceIndex = OCILayoutIdentity.indexURL(of: source)
+        // A missing/unreadable source index is a hard error (there is nothing valid to stage) —
+        // unlike the staleness checks below, which fail soft toward re-staging.
+        _ = try Data(contentsOf: sourceIndex)
         func stagedIsCurrent() -> Bool {
-            guard let stagedIndexData = try? Data(contentsOf: staged.appendingPathComponent("index.json"))
-            else { return false }
-            return stagedIndexData == sourceIndexData
+            OCILayoutIdentity.contentsMatch(OCILayoutIdentity.indexURL(of: staged), sourceIndex)
         }
         if stagedIsCurrent() {
             return staged

--- a/Tests/AnglesiteCoreTests/OCILayoutImportMarkerTests.swift
+++ b/Tests/AnglesiteCoreTests/OCILayoutImportMarkerTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Unit tests for the imported-layout marker backing `ContainerizationControl.loadOrGet` (which
+/// lives in the CI-excluded AnglesiteContainer module and delegates the staleness decision here so
+/// it stays CI-covered). The marker records which bundled layout was last imported into the on-disk
+/// `ImageStore`, so an app update that ships a new image triggers a re-import instead of the store
+/// serving the first-ever imported image forever (#549).
+struct OCILayoutImportMarkerTests {
+    private func makeTempRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("oci-import-marker-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    /// Creates a minimal fake OCI layout (just the `index.json` the marker compares) at `dir`.
+    private func makeLayout(at dir: URL, indexContent: String) throws -> URL {
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try indexContent.write(to: dir.appendingPathComponent("index.json"), atomically: true, encoding: .utf8)
+        return dir
+    }
+
+    @Test("a layout is stale before any import has been recorded (first boot)")
+    func staleBeforeFirstRecord() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = try makeLayout(at: root.appendingPathComponent("layout"), indexContent: "index-v1")
+
+        #expect(OCILayoutImportMarker.isCurrent(layout: layout, name: "app-image", storeRoot: root) == false)
+    }
+
+    @Test("recording an import makes that layout current")
+    func recordMakesCurrent() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = try makeLayout(at: root.appendingPathComponent("layout"), indexContent: "index-v1")
+
+        try OCILayoutImportMarker.recordImported(layout: layout, name: "app-image", storeRoot: root)
+
+        #expect(OCILayoutImportMarker.isCurrent(layout: layout, name: "app-image", storeRoot: root))
+    }
+
+    @Test("a changed layout is stale again (app update ships a new bundled image)")
+    func changedLayoutIsStale() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = try makeLayout(at: root.appendingPathComponent("layout"), indexContent: "index-v1")
+        try OCILayoutImportMarker.recordImported(layout: layout, name: "app-image", storeRoot: root)
+
+        // Simulate the app update: same staged path, new index.json (new manifest digest).
+        try "index-v2".write(to: layout.appendingPathComponent("index.json"), atomically: true, encoding: .utf8)
+
+        #expect(OCILayoutImportMarker.isCurrent(layout: layout, name: "app-image", storeRoot: root) == false)
+    }
+
+    @Test("re-recording after a re-import makes the new layout current")
+    func rerecordAfterReimport() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = try makeLayout(at: root.appendingPathComponent("layout"), indexContent: "index-v1")
+        try OCILayoutImportMarker.recordImported(layout: layout, name: "app-image", storeRoot: root)
+        try "index-v2".write(to: layout.appendingPathComponent("index.json"), atomically: true, encoding: .utf8)
+
+        try OCILayoutImportMarker.recordImported(layout: layout, name: "app-image", storeRoot: root)
+
+        #expect(OCILayoutImportMarker.isCurrent(layout: layout, name: "app-image", storeRoot: root))
+    }
+
+    @Test("markers are namespaced per artifact (app image vs vminit initfs)")
+    func markersAreNamespacedPerArtifact() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let appLayout = try makeLayout(at: root.appendingPathComponent("app"), indexContent: "app-index")
+        let initfsLayout = try makeLayout(at: root.appendingPathComponent("initfs"), indexContent: "initfs-index")
+
+        try OCILayoutImportMarker.recordImported(layout: appLayout, name: "app-image", storeRoot: root)
+
+        #expect(OCILayoutImportMarker.isCurrent(layout: appLayout, name: "app-image", storeRoot: root))
+        #expect(OCILayoutImportMarker.isCurrent(layout: initfsLayout, name: "vminit-initfs", storeRoot: root) == false)
+    }
+}


### PR DESCRIPTION
## Problem (#549)

`ContainerizationControl.loadOrGet` returned `store.get(reference:)` whenever the tag already resolved — `load(from:)` never ran again. So the first-ever import under `docker.io/library/anglesite-dev:latest` was served forever: app updates that ship a new bundled image never reached the on-disk `ImageStore`, and the guest kept booting the old rootfs (observed as `failed to find target executable /usr/bin/socat` against an image that demonstrably contains it).

Notably, Apple's `ImageStore` is not the problem: its reference state is an overwrite-on-create map, so `load(from:)` *does* repoint a tag. The unconditional `get` fast path in our wrapper was the bug.

## Fix

- **`OCILayoutImportMarker`** (new, AnglesiteCore): records which layout was last imported into the store, per artifact name, and answers "is the store's import current for this layout?" The identity check is byte-equality of the layout's `index.json` — the same digest-free image-identity trick `OCILayoutStaging` already uses. Pure Foundation, so CI's `swift test` covers it (CI never compiles AnglesiteContainer).
- **`loadOrGet`** now takes the `get(reference:)` fast path only while the marker confirms the store's import came from this exact layout. Otherwise it `load(from:)`s (first boot *and* changed-image re-import) and records the marker after success. A failed marker write is non-fatal — it only costs a redundant re-import next boot.

This matches the issue's suggested fix, except no explicit reference deletion is needed (overwrite-on-create makes it redundant, and skipping it avoids a window where the reference is absent for a concurrently booting window).

## Not in this PR

Re-import leaves the previous image's blobs orphaned in the content store (~one stale image set per app update). `ImageStore.cleanUpOrphanedBlobs()` exists, but its lock is per-instance and two site windows hold separate `ImageStore` instances, so running it here could race a concurrent import. Follow-up material.

## Testing

- `OCILayoutImportMarkerTests` (5 cases: first-boot stale, record→current, changed layout→stale, re-record→current, per-artifact namespacing). Watched red (missing type), then green.
- Local caveat: `swift test` can't currently *run* any bundle on this machine (#541 FoundationModels dlopen mismatch — CI is the arbiter). Semantics additionally verified locally by compiling the production `OCILayoutImportMarker.swift` standalone against the same five assertions: all pass.
- `swift build` (whole package incl. AnglesiteContainer) and `xcodebuild -scheme Anglesite` both succeed.
- Not yet: a live two-image boot smoke on entitled hardware (`scripts/run-container-probe.sh`) — happy to run if wanted.

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)