### PR TITLE
fix(container): reclaim blobs orphaned by bundled-image re-imports (#573)

### DIFF
--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -229,7 +229,10 @@ public struct ContainerizationControl: LocalContainerControl {
         let initfs: Containerization.Mount
         do {
             onOutput("[boot] importing OCI layouts into image store", .stdout)
-            let store = try ImageStore(path: storeURL)
+            // Process-shared, NOT constructed per boot: ImageStore's internal AsyncLock is
+            // per-instance, and the orphaned-blob cleanup below is only safe against another
+            // window's concurrent import if both go through the same lock (#573).
+            let store = try SharedImageStore.store(at: storeURL)
 
             // App image -> ext4 rootfs mount.
             let stagedImageLayout = try BundledImage.stagedLayoutURL(source: imageLayoutURL, name: "app-image")
@@ -248,6 +251,26 @@ public struct ContainerizationControl: LocalContainerControl {
                 artifactName: "vminit-initfs", storeRoot: storeURL))
             onOutput("[boot] unpacking vminit initfs to ext4", .stdout)
             initfs = try await initImage.initBlock(at: initfsURL, for: .linuxArm)
+
+            // Reclaim blobs orphaned by a #549 re-import — after one, the previous image's whole
+            // blob set (hundreds of MB) sits unreferenced in the content store forever (#573).
+            // Runs every boot (not just after a re-import) so it also self-heals orphans left by
+            // app updates that predate this cleanup, and a failed pass just retries next boot.
+            // Safe while other windows boot concurrently: the shared store above means this
+            // serializes on the same AsyncLock as their imports, so it can never delete blobs an
+            // in-flight load has ingested but not yet referenced — and it never touches running
+            // containers, which read from unpacked ext4 files, not the blob store. Best-effort:
+            // a cleanup failure must not fail the boot.
+            do {
+                let (deleted, freed) = try await store.cleanUpOrphanedBlobs()
+                if !deleted.isEmpty {
+                    let freedText = ByteCountFormatter.string(
+                        fromByteCount: Int64(clamping: freed), countStyle: .file)
+                    onOutput("[boot] reclaimed \(deleted.count) orphaned image blob(s), \(freedText)", .stdout)
+                }
+            } catch {
+                onOutput("[boot] orphaned-blob cleanup failed (will retry next boot): \(error)", .stderr)
+            }
         } catch {
             // Unpacking may have created partial ext4 files before failing; don't leak them.
             try? FileManager.default.removeItem(at: rootfsURL)

--- a/Sources/AnglesiteContainer/SharedImageStore.swift
+++ b/Sources/AnglesiteContainer/SharedImageStore.swift
@@ -13,6 +13,23 @@ import Containerization
 /// through here so all windows resolve the same instance — upstream models the same requirement
 /// with its own process-wide `ImageStore.default`. The sharing semantics (one instance per key,
 /// even under concurrent callers) are CI-covered via `SharedInstanceCache` in AnglesiteCore.
+///
+/// Confirmed against the vendored source (apple/containerization @ `44bec8b9`, package
+/// version 0.35.0, pinned in `Package.resolved`):
+/// - `ImageStore.load(from:)` (`ImageStore+OCILayout.swift:92-100`) moves ingested blobs into the
+///   content store (`completeIngestSession`) and writes each image's reference (`_create`) inside
+///   one `self.lock.withLock { ... }` call — both steps are the same critical section, not two.
+/// - `ImageStore.cleanUpOrphanedBlobs()` (`ImageStore.swift:138-142`) takes the identical
+///   `self.lock.withLock`.
+/// - `AsyncLock.withLock` (`AsyncLock.swift:37-60`) is a true mutex: a `busy` flag plus a FIFO
+///   continuation queue, set before `body` runs and cleared only in `body`'s `defer` — so a second
+///   `withLock` call on the same instance genuinely suspends until the first's `body` (the whole
+///   ingest-complete-then-create step, or the whole cleanup sweep) has returned. No reentrancy, no
+///   partial release.
+///
+/// Together this means: on one shared instance, `cleanUpOrphanedBlobs()` can never observe a state
+/// where blobs are ingested but not yet referenced — that window only exists *inside* the other
+/// `withLock` call, which cleanup cannot enter until it exits.
 enum SharedImageStore {
     private static let cache = SharedInstanceCache<ImageStore>()
 

--- a/Sources/AnglesiteContainer/SharedImageStore.swift
+++ b/Sources/AnglesiteContainer/SharedImageStore.swift
@@ -1,0 +1,23 @@
+import Foundation
+import AnglesiteCore
+import Containerization
+
+/// Process-wide `ImageStore` per store directory (#573).
+///
+/// `ImageStore` serializes its multi-step operations — `load(from:)`'s move-blobs-then-write-
+/// reference window, `cleanUpOrphanedBlobs()`'s list-then-delete sweep — with an `AsyncLock`
+/// stored on the *instance*. That serialization only protects callers who share the instance:
+/// constructing a fresh `ImageStore(path:)` per boot (the pre-#573 behavior) gave each site
+/// window its own lock over the same on-disk store, so one window's cleanup could delete blobs
+/// another window's in-flight import had ingested but not yet referenced. Every store access goes
+/// through here so all windows resolve the same instance — upstream models the same requirement
+/// with its own process-wide `ImageStore.default`. The sharing semantics (one instance per key,
+/// even under concurrent callers) are CI-covered via `SharedInstanceCache` in AnglesiteCore.
+enum SharedImageStore {
+    private static let cache = SharedInstanceCache<ImageStore>()
+
+    /// Returns the process-wide `ImageStore` for the store directory at `url`.
+    static func store(at url: URL) throws -> ImageStore {
+        try cache.instance(forKey: url.standardizedFileURL.path) { try ImageStore(path: url) }
+    }
+}

--- a/Sources/AnglesiteCore/SharedInstanceCache.swift
+++ b/Sources/AnglesiteCore/SharedInstanceCache.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// A process-wide "one instance per key" cache: the first caller for a key constructs the value,
+/// every later (or concurrent) caller for that key gets that same instance back.
+///
+/// This exists for types whose internal synchronization is per-instance, so correctness depends on
+/// everyone using the *same* instance for the same underlying resource. The concrete case (#573):
+/// apple/containerization's `ImageStore` guards multi-step operations with an `AsyncLock` stored on
+/// the instance — two `ImageStore(path:)` constructions over the same store directory hold two
+/// unrelated locks, letting `cleanUpOrphanedBlobs()` through one instance delete blobs that a
+/// `load(from:)` through another has ingested but not yet referenced. Keying instances by store
+/// path restores "one lock per store directory". The consumer (`SharedImageStore` in
+/// AnglesiteContainer) can't be CI-tested — CI never compiles that module — so the sharing
+/// semantics live here, in pure Foundation, under `swift test`.
+///
+/// Entries live for the process lifetime; there is no eviction (the expected population is one or
+/// two store paths). The lock is held while `make` runs, which is what guarantees the factory runs
+/// at most once per key even under concurrent callers — keep factories cheap and non-reentrant.
+/// A `make` that throws caches nothing, so the next call for that key retries.
+public final class SharedInstanceCache<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var instances: [String: Value] = [:]
+
+    public init() {}
+
+    /// Returns the cached instance for `key`, constructing and caching it via `make` if absent.
+    public func instance(forKey key: String, make: () throws -> Value) rethrows -> Value {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = instances[key] {
+            return existing
+        }
+        let made = try make()
+        instances[key] = made
+        return made
+    }
+}

--- a/Sources/AnglesiteCore/SharedInstanceCache.swift
+++ b/Sources/AnglesiteCore/SharedInstanceCache.swift
@@ -24,6 +24,12 @@ public final class SharedInstanceCache<Value: Sendable>: @unchecked Sendable {
     public init() {}
 
     /// Returns the cached instance for `key`, constructing and caching it via `make` if absent.
+    ///
+    /// `make` runs synchronously while `lock` is held — if a caller's `make` does blocking I/O
+    /// (the `ImageStore(path:)` constructor above does) from an `async` context, that briefly ties
+    /// up a cooperative-pool thread. Acceptable here: `make` runs at most once per key, and the
+    /// expected key population is one or two store paths. Reconsider this locking strategy if this
+    /// cache ever backs a hot path or a `make` that isn't cheap and one-shot.
     public func instance(forKey key: String, make: () throws -> Value) rethrows -> Value {
         lock.lock()
         defer { lock.unlock() }

--- a/Tests/AnglesiteCoreTests/SharedInstanceCacheTests.swift
+++ b/Tests/AnglesiteCoreTests/SharedInstanceCacheTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Unit tests for the process-wide keyed instance cache backing `SharedImageStore` in
+/// AnglesiteContainer (CI never compiles that module, so the sharing semantics are proven here).
+/// The cache exists because `ImageStore`'s `AsyncLock` is per-instance: two instances over the
+/// same store directory hold two locks, so a `cleanUpOrphanedBlobs()` through one can delete
+/// blobs a `load(from:)` through the other has ingested but not yet referenced (#573). Sharing
+/// one instance per key restores "one lock per store directory".
+struct SharedInstanceCacheTests {
+    private final class Token: Sendable {}
+
+    @Test("the same key returns the identical instance, constructing it only once")
+    func sameKeyReturnsSameInstance() throws {
+        let cache = SharedInstanceCache<Token>()
+        var factoryCalls = 0
+
+        let first = cache.instance(forKey: "store-a") { factoryCalls += 1; return Token() }
+        let second = cache.instance(forKey: "store-a") { factoryCalls += 1; return Token() }
+
+        #expect(first === second)
+        #expect(factoryCalls == 1)
+    }
+
+    @Test("distinct keys get distinct instances")
+    func distinctKeysGetDistinctInstances() throws {
+        let cache = SharedInstanceCache<Token>()
+
+        let a = cache.instance(forKey: "store-a") { Token() }
+        let b = cache.instance(forKey: "store-b") { Token() }
+
+        #expect(a !== b)
+    }
+
+    @Test("a throwing factory propagates its error and caches nothing, so a later call can succeed")
+    func factoryErrorIsNotCached() throws {
+        struct MakeFailed: Error {}
+        let cache = SharedInstanceCache<Token>()
+
+        #expect(throws: MakeFailed.self) {
+            try cache.instance(forKey: "store-a") { throw MakeFailed() }
+        }
+
+        // The failure must not poison the key: the next attempt constructs and caches normally.
+        let recovered = cache.instance(forKey: "store-a") { Token() }
+        let again = cache.instance(forKey: "store-a") { Token() }
+        #expect(recovered === again)
+    }
+
+    @Test("concurrent callers for one key all receive the identical instance (factory runs once)")
+    func concurrentCallersShareOneInstance() async throws {
+        let cache = SharedInstanceCache<Token>()
+        let factoryCalls = Atomic(0)
+
+        let instances = await withTaskGroup(of: Token.self, returning: [Token].self) { group in
+            for _ in 0..<64 {
+                group.addTask {
+                    cache.instance(forKey: "store-a") {
+                        factoryCalls.increment()
+                        return Token()
+                    }
+                }
+            }
+            var results: [Token] = []
+            for await token in group { results.append(token) }
+            return results
+        }
+
+        #expect(factoryCalls.value == 1)
+        let canonical = try #require(instances.first)
+        #expect(instances.allSatisfy { $0 === canonical })
+    }
+}
+
+/// Minimal lock-guarded counter for asserting factory-call counts from concurrent tasks.
+private final class Atomic: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count: Int
+    init(_ value: Int) { count = value }
+    func increment() { lock.lock(); count += 1; lock.unlock() }
+    var value: Int { lock.lock(); defer { lock.unlock() }; return count }
+}


### PR DESCRIPTION
Fixes #573. Stacked on #572 (`fix/549-reimport-changed-bundled-image`) — merge that first; this PR's base is that branch so its diff shows only the reclamation work.

## Problem

#572 re-imports the bundled OCI layout when an app update changes it. `ImageStore.load(from:)` repoints the tag, but the previous image's blobs stay in `content/blobs/sha256` unreferenced — roughly one stale image set (hundreds of MB) per app update, never reclaimed.

## Why not just call `cleanUpOrphanedBlobs()`

Upstream has it, but its `AsyncLock` is **per-`ImageStore`-instance**, and each site window's boot constructed its own `ImageStore` over the same store directory. `load(from:)` moves ingested blobs into the content store and writes the reference inside `lock.withLock` — so a cleanup through a *different* instance (different lock) can run exactly between those steps and delete blobs another window just ingested but hasn't referenced yet. (`LocalContentStore.delete(keeping:)` only scans `blobs/sha256`, so ingest temp dirs are safe; the complete→create window is the one hazard.)

## Fix

1. **`SharedInstanceCache` (AnglesiteCore, CI-covered)** — a process-wide "one instance per key" cache: factory runs at most once per key even under concurrent callers; a throwing factory caches nothing. TDD'd; 4 Swift Testing tests.
2. **`SharedImageStore` (AnglesiteContainer)** — one `ImageStore` per store path process-wide, backed by the cache. Mirrors upstream's own `ImageStore.default` singleton pattern. `ContainerizationControl.makeBareContainer` now resolves the store through it instead of constructing one per boot.
3. **Cleanup on every boot** — after both images resolve, `cleanUpOrphanedBlobs()` runs best-effort (a failure logs and never fails the boot), logging reclaimed blob count/bytes to the boot output. Running every boot (not only after a re-import) self-heals orphans left by app updates that predate this fix.

## Safety — verified against the exact upstream source, not inferred

Confirmed against the vendored `apple/containerization` source at revision `44bec8b9` (package version `0.35.0`, pinned in `Package.resolved`):

- `ImageStore.load(from:)` (`ImageStore+OCILayout.swift:92-100`) moves ingested blobs into the content store (`completeIngestSession`) **and** writes each image's reference (`_create`) inside one `self.lock.withLock { ... }` call — a single critical section, not two.
- `ImageStore.cleanUpOrphanedBlobs()` (`ImageStore.swift:138-142`) takes the identical `self.lock.withLock`.
- `AsyncLock.withLock` (`AsyncLock.swift:37-60`) is a true mutex — a `busy` flag plus a FIFO continuation queue, set before `body` runs and cleared only in `body`'s `defer` after it returns. No reentrancy, no partial release.

Together: on one shared `ImageStore` instance (this PR's `SharedImageStore`), `cleanUpOrphanedBlobs()` can never observe blobs that are ingested but not yet referenced — that window exists only *inside* the other `withLock` call, which cleanup cannot enter until it exits. Sharing the instance is therefore sufficient on its own. Running containers are also untouched by cleanup — they read unpacked ext4 files, not the blob store.

**Alternative considered:** cleanup only at a quiescent app-launch point — rejected; it doesn't fix the lock-identity hazard (windows restored at launch can boot concurrently), while the shared instance makes cleanup safe whenever it runs.

## Testing

- `SharedInstanceCacheTests` (AnglesiteCoreTests, Swift Testing): same key → identical instance + factory once; distinct keys distinct; throwing factory not cached; 64 concurrent callers share one instance. RED→GREEN verified in an isolated package locally (local `swift test` is dead at dlopen per #541 — CI is the arbiter for the in-repo copy).
- `swift build --build-tests` and `xcodebuild -scheme Anglesite -configuration Debug build` both pass locally.
- Container path is compile-verified only (CI never compiles `AnglesiteContainer`); the concurrency safety claim above is verified against upstream's own lock implementation rather than by an observational smoke test — see the review discussion for why that's sufficient here.
- CI green via #575 (draft, stacked content): build-test, ThreadSanitizer relay suites, AppIntents schema, JS edit-overlay, Xcode project sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
