### PR TITLE
[CI-only] stack check for #572 + #574 — do not merge

### DIFF
--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -229,7 +229,10 @@ public struct ContainerizationControl: LocalContainerControl {
         let initfs: Containerization.Mount
         do {
             onOutput("[boot] importing OCI layouts into image store", .stdout)
-            let store = try ImageStore(path: storeURL)
+            // Process-shared, NOT constructed per boot: ImageStore's internal AsyncLock is
+            // per-instance, and the orphaned-blob cleanup below is only safe against another
+            // window's concurrent import if both go through the same lock (#573).
+            let store = try SharedImageStore.store(at: storeURL)
 
             // App image -> ext4 rootfs mount.
             let stagedImageLayout = try BundledImage.stagedLayoutURL(source: imageLayoutURL, name: "app-image")
@@ -248,6 +251,26 @@ public struct ContainerizationControl: LocalContainerControl {
                 artifactName: "vminit-initfs", storeRoot: storeURL))
             onOutput("[boot] unpacking vminit initfs to ext4", .stdout)
             initfs = try await initImage.initBlock(at: initfsURL, for: .linuxArm)
+
+            // Reclaim blobs orphaned by a #549 re-import — after one, the previous image's whole
+            // blob set (hundreds of MB) sits unreferenced in the content store forever (#573).
+            // Runs every boot (not just after a re-import) so it also self-heals orphans left by
+            // app updates that predate this cleanup, and a failed pass just retries next boot.
+            // Safe while other windows boot concurrently: the shared store above means this
+            // serializes on the same AsyncLock as their imports, so it can never delete blobs an
+            // in-flight load has ingested but not yet referenced — and it never touches running
+            // containers, which read from unpacked ext4 files, not the blob store. Best-effort:
+            // a cleanup failure must not fail the boot.
+            do {
+                let (deleted, freed) = try await store.cleanUpOrphanedBlobs()
+                if !deleted.isEmpty {
+                    let freedText = ByteCountFormatter.string(
+                        fromByteCount: Int64(clamping: freed), countStyle: .file)
+                    onOutput("[boot] reclaimed \(deleted.count) orphaned image blob(s), \(freedText)", .stdout)
+                }
+            } catch {
+                onOutput("[boot] orphaned-blob cleanup failed (will retry next boot): \(error)", .stderr)
+            }
         } catch {
             // Unpacking may have created partial ext4 files before failing; don't leak them.
             try? FileManager.default.removeItem(at: rootfsURL)

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -221,9 +221,10 @@ public struct ContainerizationControl: LocalContainerControl {
         try? FileManager.default.removeItem(at: initfsURL)
 
         // 1. Import the bundled OCI layouts into the on-disk ImageStore and unpack to bootable mounts.
-        //    `load(from:)` is idempotent against an existing store (re-import returns the same image),
-        //    but it also needs to write into the layout directory itself (not just the store), so both
-        //    layouts are staged to a writable copy first — the bundled originals are read-only.
+        //    `loadOrGet` re-imports whenever the bundled layout changed since the last import (#549),
+        //    so app updates that ship a new image actually take effect. `load(from:)` also needs to
+        //    write into the layout directory itself (not just the store), so both layouts are staged
+        //    to a writable copy first — the bundled originals are read-only.
         let rootfs: Containerization.Mount
         let initfs: Containerization.Mount
         do {
@@ -232,7 +233,9 @@ public struct ContainerizationControl: LocalContainerControl {
 
             // App image -> ext4 rootfs mount.
             let stagedImageLayout = try BundledImage.stagedLayoutURL(source: imageLayoutURL, name: "app-image")
-            let appImage = try await loadOrGet(store, layout: stagedImageLayout, reference: BundledImage.imageReference)
+            let appImage = try await loadOrGet(
+                store, layout: stagedImageLayout, reference: BundledImage.imageReference,
+                artifactName: "app-image", storeRoot: storeURL)
             onOutput("[boot] unpacking app image to ext4 rootfs", .stdout)
             rootfs = try await EXT4Unpacker(blockSizeInBytes: 8 * 1024 * 1024 * 1024)
                 .unpack(appImage, for: .current, at: rootfsURL)
@@ -240,7 +243,9 @@ public struct ContainerizationControl: LocalContainerControl {
             // vminit initfs OCI layout -> ext4 init mount (the guest-agent root filesystem).
             let stagedInitfsLayout = try BundledImage.stagedLayoutURL(source: initfsLayoutURL, name: "vminit-initfs")
             let initImageRef = "vminit:latest"
-            let initImage = InitImage(image: try await loadOrGet(store, layout: stagedInitfsLayout, reference: initImageRef))
+            let initImage = InitImage(image: try await loadOrGet(
+                store, layout: stagedInitfsLayout, reference: initImageRef,
+                artifactName: "vminit-initfs", storeRoot: storeURL))
             onOutput("[boot] unpacking vminit initfs to ext4", .stdout)
             initfs = try await initImage.initBlock(at: initfsURL, for: .linuxArm)
         } catch {
@@ -499,13 +504,29 @@ public struct ContainerizationControl: LocalContainerControl {
 
     // MARK: - Helpers
 
-    /// Import an OCI layout into the store, tolerating a prior import (idempotent): if `load` fails
-    /// because the reference already resolves, fall back to `get`.
-    private func loadOrGet(_ store: ImageStore, layout: URL, reference: String) async throws -> Containerization.Image {
-        if let existing = try? await store.get(reference: reference) {
+    /// Resolve `reference` from the store, importing (or re-importing) the OCI layout as needed.
+    ///
+    /// The `get(reference:)` fast path is taken only while `OCILayoutImportMarker` confirms the
+    /// store's import came from this exact layout. Without that check the first-ever import is
+    /// served forever: an app update that ships a new bundled image never reaches the store, and
+    /// the guest keeps booting the old rootfs (#549). On mismatch `load(from:)` re-imports —
+    /// `ImageStore`'s reference state is an overwrite-on-create map, so loading repoints the tag
+    /// to the new image. `artifactName` must match the staging name so marker and staged copy
+    /// describe the same artifact.
+    private func loadOrGet(
+        _ store: ImageStore,
+        layout: URL,
+        reference: String,
+        artifactName: String,
+        storeRoot: URL
+    ) async throws -> Containerization.Image {
+        if OCILayoutImportMarker.isCurrent(layout: layout, name: artifactName, storeRoot: storeRoot),
+            let existing = try? await store.get(reference: reference) {
             return existing
         }
         let loaded = try await store.load(from: layout)
+        // Best-effort: a failed marker write only costs a redundant re-import next boot.
+        try? OCILayoutImportMarker.recordImported(layout: layout, name: artifactName, storeRoot: storeRoot)
         if let match = try? await store.get(reference: reference) {
             return match
         }

--- a/Sources/AnglesiteContainer/SharedImageStore.swift
+++ b/Sources/AnglesiteContainer/SharedImageStore.swift
@@ -1,0 +1,23 @@
+import Foundation
+import AnglesiteCore
+import Containerization
+
+/// Process-wide `ImageStore` per store directory (#573).
+///
+/// `ImageStore` serializes its multi-step operations — `load(from:)`'s move-blobs-then-write-
+/// reference window, `cleanUpOrphanedBlobs()`'s list-then-delete sweep — with an `AsyncLock`
+/// stored on the *instance*. That serialization only protects callers who share the instance:
+/// constructing a fresh `ImageStore(path:)` per boot (the pre-#573 behavior) gave each site
+/// window its own lock over the same on-disk store, so one window's cleanup could delete blobs
+/// another window's in-flight import had ingested but not yet referenced. Every store access goes
+/// through here so all windows resolve the same instance — upstream models the same requirement
+/// with its own process-wide `ImageStore.default`. The sharing semantics (one instance per key,
+/// even under concurrent callers) are CI-covered via `SharedInstanceCache` in AnglesiteCore.
+enum SharedImageStore {
+    private static let cache = SharedInstanceCache<ImageStore>()
+
+    /// Returns the process-wide `ImageStore` for the store directory at `url`.
+    static func store(at url: URL) throws -> ImageStore {
+        try cache.instance(forKey: url.standardizedFileURL.path) { try ImageStore(path: url) }
+    }
+}

--- a/Sources/AnglesiteCore/OCILayoutImportMarker.swift
+++ b/Sources/AnglesiteCore/OCILayoutImportMarker.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Records which bundled OCI layout was last imported into the on-disk `ImageStore`, so the boot
+/// path can tell "already imported this exact image" from "the app update shipped a new one" (#549).
+///
+/// The store's own `load(from:)` *does* repoint a tag on re-import, but importing on every boot is
+/// wasteful — so `ContainerizationControl.loadOrGet` short-circuits to `get(reference:)` when the
+/// store already has the reference. Without this marker that short-circuit is unconditional: the
+/// first-ever imported image is served forever and image updates shipped by app updates never take
+/// effect. Like `OCILayoutStaging`, the identity check is byte-equality of the layout's
+/// `index.json` (it carries the manifest digests, so any image change changes it) — and the logic
+/// lives here (pure Foundation, no Containerization dependency) so it stays covered by CI's
+/// `swift test`, which never compiles the AnglesiteContainer module.
+public enum OCILayoutImportMarker {
+    /// True when the layout at `layout` is byte-identical (by `index.json`) to what
+    /// `recordImported` last recorded for `name` — i.e. the store already holds this exact image
+    /// and the import can be skipped. False on first boot, after an app update that ships a
+    /// changed layout, or when either `index.json` is unreadable (fail toward re-importing).
+    public static func isCurrent(layout: URL, name: String, storeRoot: URL) -> Bool {
+        guard
+            let recorded = try? Data(contentsOf: markerURL(name: name, storeRoot: storeRoot)),
+            let current = try? Data(contentsOf: layout.appendingPathComponent("index.json"))
+        else { return false }
+        return recorded == current
+    }
+
+    /// Records that the layout at `layout` was just imported into the store for `name`.
+    /// Call only after a successful `ImageStore.load(from:)` — recording first would let a failed
+    /// import masquerade as current. The write is atomic, so a concurrent `isCurrent` reader sees
+    /// either the old marker or the new one, never a torn file.
+    public static func recordImported(layout: URL, name: String, storeRoot: URL) throws {
+        let marker = markerURL(name: name, storeRoot: storeRoot)
+        try FileManager.default.createDirectory(
+            at: marker.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(contentsOf: layout.appendingPathComponent("index.json"))
+            .write(to: marker, options: .atomic)
+    }
+
+    private static func markerURL(name: String, storeRoot: URL) -> URL {
+        storeRoot.appendingPathComponent("imported-markers/\(name).index.json")
+    }
+}

--- a/Sources/AnglesiteCore/SharedInstanceCache.swift
+++ b/Sources/AnglesiteCore/SharedInstanceCache.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// A process-wide "one instance per key" cache: the first caller for a key constructs the value,
+/// every later (or concurrent) caller for that key gets that same instance back.
+///
+/// This exists for types whose internal synchronization is per-instance, so correctness depends on
+/// everyone using the *same* instance for the same underlying resource. The concrete case (#573):
+/// apple/containerization's `ImageStore` guards multi-step operations with an `AsyncLock` stored on
+/// the instance — two `ImageStore(path:)` constructions over the same store directory hold two
+/// unrelated locks, letting `cleanUpOrphanedBlobs()` through one instance delete blobs that a
+/// `load(from:)` through another has ingested but not yet referenced. Keying instances by store
+/// path restores "one lock per store directory". The consumer (`SharedImageStore` in
+/// AnglesiteContainer) can't be CI-tested — CI never compiles that module — so the sharing
+/// semantics live here, in pure Foundation, under `swift test`.
+///
+/// Entries live for the process lifetime; there is no eviction (the expected population is one or
+/// two store paths). The lock is held while `make` runs, which is what guarantees the factory runs
+/// at most once per key even under concurrent callers — keep factories cheap and non-reentrant.
+/// A `make` that throws caches nothing, so the next call for that key retries.
+public final class SharedInstanceCache<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var instances: [String: Value] = [:]
+
+    public init() {}
+
+    /// Returns the cached instance for `key`, constructing and caching it via `make` if absent.
+    public func instance(forKey key: String, make: () throws -> Value) rethrows -> Value {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = instances[key] {
+            return existing
+        }
+        let made = try make()
+        instances[key] = made
+        return made
+    }
+}

--- a/Tests/AnglesiteCoreTests/OCILayoutImportMarkerTests.swift
+++ b/Tests/AnglesiteCoreTests/OCILayoutImportMarkerTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Unit tests for the imported-layout marker backing `ContainerizationControl.loadOrGet` (which
+/// lives in the CI-excluded AnglesiteContainer module and delegates the staleness decision here so
+/// it stays CI-covered). The marker records which bundled layout was last imported into the on-disk
+/// `ImageStore`, so an app update that ships a new image triggers a re-import instead of the store
+/// serving the first-ever imported image forever (#549).
+struct OCILayoutImportMarkerTests {
+    private func makeTempRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("oci-import-marker-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    /// Creates a minimal fake OCI layout (just the `index.json` the marker compares) at `dir`.
+    private func makeLayout(at dir: URL, indexContent: String) throws -> URL {
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try indexContent.write(to: dir.appendingPathComponent("index.json"), atomically: true, encoding: .utf8)
+        return dir
+    }
+
+    @Test("a layout is stale before any import has been recorded (first boot)")
+    func staleBeforeFirstRecord() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = try makeLayout(at: root.appendingPathComponent("layout"), indexContent: "index-v1")
+
+        #expect(OCILayoutImportMarker.isCurrent(layout: layout, name: "app-image", storeRoot: root) == false)
+    }
+
+    @Test("recording an import makes that layout current")
+    func recordMakesCurrent() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = try makeLayout(at: root.appendingPathComponent("layout"), indexContent: "index-v1")
+
+        try OCILayoutImportMarker.recordImported(layout: layout, name: "app-image", storeRoot: root)
+
+        #expect(OCILayoutImportMarker.isCurrent(layout: layout, name: "app-image", storeRoot: root))
+    }
+
+    @Test("a changed layout is stale again (app update ships a new bundled image)")
+    func changedLayoutIsStale() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = try makeLayout(at: root.appendingPathComponent("layout"), indexContent: "index-v1")
+        try OCILayoutImportMarker.recordImported(layout: layout, name: "app-image", storeRoot: root)
+
+        // Simulate the app update: same staged path, new index.json (new manifest digest).
+        try "index-v2".write(to: layout.appendingPathComponent("index.json"), atomically: true, encoding: .utf8)
+
+        #expect(OCILayoutImportMarker.isCurrent(layout: layout, name: "app-image", storeRoot: root) == false)
+    }
+
+    @Test("re-recording after a re-import makes the new layout current")
+    func rerecordAfterReimport() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = try makeLayout(at: root.appendingPathComponent("layout"), indexContent: "index-v1")
+        try OCILayoutImportMarker.recordImported(layout: layout, name: "app-image", storeRoot: root)
+        try "index-v2".write(to: layout.appendingPathComponent("index.json"), atomically: true, encoding: .utf8)
+
+        try OCILayoutImportMarker.recordImported(layout: layout, name: "app-image", storeRoot: root)
+
+        #expect(OCILayoutImportMarker.isCurrent(layout: layout, name: "app-image", storeRoot: root))
+    }
+
+    @Test("markers are namespaced per artifact (app image vs vminit initfs)")
+    func markersAreNamespacedPerArtifact() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let appLayout = try makeLayout(at: root.appendingPathComponent("app"), indexContent: "app-index")
+        let initfsLayout = try makeLayout(at: root.appendingPathComponent("initfs"), indexContent: "initfs-index")
+
+        try OCILayoutImportMarker.recordImported(layout: appLayout, name: "app-image", storeRoot: root)
+
+        #expect(OCILayoutImportMarker.isCurrent(layout: appLayout, name: "app-image", storeRoot: root))
+        #expect(OCILayoutImportMarker.isCurrent(layout: initfsLayout, name: "vminit-initfs", storeRoot: root) == false)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SharedInstanceCacheTests.swift
+++ b/Tests/AnglesiteCoreTests/SharedInstanceCacheTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Unit tests for the process-wide keyed instance cache backing `SharedImageStore` in
+/// AnglesiteContainer (CI never compiles that module, so the sharing semantics are proven here).
+/// The cache exists because `ImageStore`'s `AsyncLock` is per-instance: two instances over the
+/// same store directory hold two locks, so a `cleanUpOrphanedBlobs()` through one can delete
+/// blobs a `load(from:)` through the other has ingested but not yet referenced (#573). Sharing
+/// one instance per key restores "one lock per store directory".
+struct SharedInstanceCacheTests {
+    private final class Token: Sendable {}
+
+    @Test("the same key returns the identical instance, constructing it only once")
+    func sameKeyReturnsSameInstance() throws {
+        let cache = SharedInstanceCache<Token>()
+        var factoryCalls = 0
+
+        let first = cache.instance(forKey: "store-a") { factoryCalls += 1; return Token() }
+        let second = cache.instance(forKey: "store-a") { factoryCalls += 1; return Token() }
+
+        #expect(first === second)
+        #expect(factoryCalls == 1)
+    }
+
+    @Test("distinct keys get distinct instances")
+    func distinctKeysGetDistinctInstances() throws {
+        let cache = SharedInstanceCache<Token>()
+
+        let a = cache.instance(forKey: "store-a") { Token() }
+        let b = cache.instance(forKey: "store-b") { Token() }
+
+        #expect(a !== b)
+    }
+
+    @Test("a throwing factory propagates its error and caches nothing, so a later call can succeed")
+    func factoryErrorIsNotCached() throws {
+        struct MakeFailed: Error {}
+        let cache = SharedInstanceCache<Token>()
+
+        #expect(throws: MakeFailed.self) {
+            try cache.instance(forKey: "store-a") { throw MakeFailed() }
+        }
+
+        // The failure must not poison the key: the next attempt constructs and caches normally.
+        let recovered = cache.instance(forKey: "store-a") { Token() }
+        let again = cache.instance(forKey: "store-a") { Token() }
+        #expect(recovered === again)
+    }
+
+    @Test("concurrent callers for one key all receive the identical instance (factory runs once)")
+    func concurrentCallersShareOneInstance() async throws {
+        let cache = SharedInstanceCache<Token>()
+        let factoryCalls = Atomic(0)
+
+        let instances = await withTaskGroup(of: Token.self, returning: [Token].self) { group in
+            for _ in 0..<64 {
+                group.addTask {
+                    cache.instance(forKey: "store-a") {
+                        factoryCalls.increment()
+                        return Token()
+                    }
+                }
+            }
+            var results: [Token] = []
+            for await token in group { results.append(token) }
+            return results
+        }
+
+        #expect(factoryCalls.value == 1)
+        let canonical = try #require(instances.first)
+        #expect(instances.allSatisfy { $0 === canonical })
+    }
+}
+
+/// Minimal lock-guarded counter for asserting factory-call counts from concurrent tasks.
+private final class Atomic: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count: Int
+    init(_ value: Int) { count = value }
+    func increment() { lock.lock(); count += 1; lock.unlock() }
+    var value: Int { lock.lock(); defer { lock.unlock() }; return count }
+}


### PR DESCRIPTION
Draft opened only to run CI on the #572+#574 stack: ci.yml triggers solely on PRs targeting `main`, so the stacked PR #574 (base `fix/549-reimport-changed-bundled-image`) gets no checks, and local `swift test` is currently dead at dlopen (#541), leaving CI as the only test arbiter.

Do not merge — merge #572 then #574. Close this once #574's own checks run (after #572 merges and #574 retargets to `main`, kick CI with an empty commit since a base-retarget alone doesn't trigger `pull_request: synchronize`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)