### PR TITLE
fix(app): make Site Graph Explorer badges filter-aware

### DIFF
--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -71,11 +71,21 @@ final class SiteGraphExplorerModel {
         return filteredEdges.filter { $0.sourceID == selectedNodeID }
     }
 
+    /// Incoming-edge counts recomputed from `filteredEdges`, not the global
+    /// `SiteGraphNode.referencedByCount` baked in at `SiteGraphExplorer.build()` time. Badges and
+    /// the "Unused Assets" grouping must reflect the *visible* graph (matching `visibleSummary`'s
+    /// framing) — otherwise an asset referenced only by a currently kind-filtered-out node still
+    /// shows a stale "used" badge (#552).
+    var visibleReferenceCounts: [String: Int] {
+        Dictionary(grouping: filteredEdges, by: \.targetID).mapValues(\.count)
+    }
+
     var groupedFilteredNodes: [(kind: SiteGraphNodeKind, nodes: [SiteGraphNode])] {
+        let referenceCounts = visibleReferenceCounts
         let grouped = Dictionary(grouping: filteredNodes, by: \.kind)
         return SiteGraphNodeKind.allCases.compactMap { kind in
             let visibleNodes = (grouped[kind] ?? []).filter { node in
-                kind != .asset || node.referencedByCount > 0
+                kind != .asset || (referenceCounts[node.id, default: 0]) > 0
             }
             guard !visibleNodes.isEmpty else { return nil }
             return (kind, visibleNodes.sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending })
@@ -83,8 +93,9 @@ final class SiteGraphExplorerModel {
     }
 
     var unusedAssets: [SiteGraphNode] {
-        filteredNodes
-            .filter { $0.kind == .asset && $0.referencedByCount == 0 }
+        let referenceCounts = visibleReferenceCounts
+        return filteredNodes
+            .filter { $0.kind == .asset && referenceCounts[$0.id, default: 0] == 0 }
             .sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
     }
 

--- a/Sources/AnglesiteApp/SiteGraphExplorerView.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerView.swift
@@ -16,6 +16,7 @@ struct SiteGraphExplorerView: View {
                 SiteGraphCanvas(
                     nodes: model.filteredNodes,
                     edges: model.filteredEdges,
+                    referenceCounts: model.visibleReferenceCounts,
                     selectedNodeID: model.selectedNodeID,
                     onSelect: { model.selectedNodeID = $0 }
                 )
@@ -86,8 +87,11 @@ private struct SiteGraphTree: View {
                 ForEach(model.groupedFilteredNodes, id: \.kind) { group in
                     Section {
                         ForEach(group.nodes) { node in
-                            SiteGraphTreeRow(node: node)
-                                .tag(Optional(node.id))
+                            SiteGraphTreeRow(
+                                node: node,
+                                referenceCount: model.visibleReferenceCounts[node.id, default: 0]
+                            )
+                            .tag(Optional(node.id))
                         }
                     } header: {
                         Label(group.kind.title, systemImage: group.kind.systemImage)
@@ -96,7 +100,7 @@ private struct SiteGraphTree: View {
                 if !model.unusedAssets.isEmpty {
                     Section {
                         ForEach(model.unusedAssets) { node in
-                            SiteGraphTreeRow(node: node, badge: "unused")
+                            SiteGraphTreeRow(node: node, referenceCount: 0, badge: "unused")
                                 .tag(Optional(node.id))
                         }
                     } header: {
@@ -112,6 +116,7 @@ private struct SiteGraphTree: View {
 
 private struct SiteGraphTreeRow: View {
     let node: SiteGraphNode
+    var referenceCount: Int
     var badge: String?
 
     var body: some View {
@@ -134,11 +139,11 @@ private struct SiteGraphTreeRow: View {
                 Text(badge)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-            } else if node.referencedByCount > 0 {
-                Text("\(node.referencedByCount)")
+            } else if referenceCount > 0 {
+                Text("\(referenceCount)")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-                    .help("\(node.referencedByCount) incoming references")
+                    .help("\(referenceCount) incoming references")
             }
         }
         .help(node.filePath ?? node.detail ?? node.title)
@@ -148,6 +153,7 @@ private struct SiteGraphTreeRow: View {
 private struct SiteGraphCanvas: View {
     let nodes: [SiteGraphNode]
     let edges: [SiteGraphEdge]
+    let referenceCounts: [String: Int]
     let selectedNodeID: String?
     let onSelect: (String) -> Void
 
@@ -177,6 +183,7 @@ private struct SiteGraphCanvas: View {
                     if let point = positions[node.id] {
                         SiteGraphNodeButton(
                             node: node,
+                            referenceCount: referenceCounts[node.id, default: 0],
                             selected: node.id == selectedNodeID,
                             related: isRelated(node.id, selectedNodeID: selectedNodeID)
                         ) {
@@ -221,6 +228,7 @@ private struct SiteGraphCanvas: View {
 
 private struct SiteGraphNodeButton: View {
     let node: SiteGraphNode
+    let referenceCount: Int
     let selected: Bool
     let related: Bool
     let action: () -> Void
@@ -235,8 +243,8 @@ private struct SiteGraphNodeButton: View {
                     .lineLimit(2)
                     .multilineTextAlignment(.center)
                     .frame(width: 112)
-                if node.referencedByCount > 0 {
-                    Text("\(node.referencedByCount) refs")
+                if referenceCount > 0 {
+                    Text("\(referenceCount) refs")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/AnglesiteApp/SiteGraphExplorerView.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerView.swift
@@ -74,6 +74,7 @@ private struct SiteGraphTree: View {
     @Bindable var model: SiteGraphExplorerModel
 
     var body: some View {
+        let referenceCounts = model.visibleReferenceCounts
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Label("Explorer", systemImage: "list.bullet.indent")
@@ -89,7 +90,7 @@ private struct SiteGraphTree: View {
                         ForEach(group.nodes) { node in
                             SiteGraphTreeRow(
                                 node: node,
-                                referenceCount: model.visibleReferenceCounts[node.id, default: 0]
+                                referenceCount: referenceCounts[node.id, default: 0]
                             )
                             .tag(Optional(node.id))
                         }


### PR DESCRIPTION
## Summary
- `groupedFilteredNodes`/`unusedAssets` in `SiteGraphExplorerModel` now derive incoming-reference counts from `filteredEdges` instead of the global `SiteGraphNode.referencedByCount` baked in at `SiteGraphExplorer.build()` time, so a kind-filtered-out reference no longer leaves a stale "used" badge.
- Threaded the same filter-aware counts through `SiteGraphTreeRow` (Explorer tree badges) and `SiteGraphNodeButton` (canvas "N refs" badges), which previously read `node.referencedByCount` directly, bypassing the model entirely.
- `SiteGraphInspector`'s "Referenced By" list was already filter-aware via `selectedIncoming`/`filteredEdges` — no change needed there.

Fixes #552.

## Verification
- `xcodegen generate` + `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- `swift test --package-path .` — no `AnglesiteApp` SwiftPM test target exists yet (tracked separately in #554/#555); `AnglesiteIntentsTests` fails to load due to the known FoundationModels SDK/OS symbol mismatch on this host (#541), unrelated to this change.
- **Live GUI verification attempted but blocked**: both the freshly-built app and the machine's previously-registered `Anglesite.app` crash at launch (`EXC_CRASH`/`SIGABRT`, `DYLD Symbol missing` in `FoundationModels.framework`) — the same pre-existing OS/SDK seed mismatch as #541. This is a host-level blocker unrelated to this diff; couldn't exercise the toggle-filter flow interactively on this machine as a result. Traced the logic by hand instead against `~/Sites/a-website.anglesite/Source/public/hero.png`, which is referenced only from `src/pages/index.astro` (a `.page`-kind node) — toggling off the "Pages" kind filter should remove that edge from `filteredEdges` and move the asset into "Unused Assets".

## Test plan
- [ ] On a host where the app launches, open a site with an asset referenced only by a page (e.g. `~/Sites/a-website.anglesite`, `hero.png`), toggle off the "Pages" kind filter in the Graph Explorer toolbar, and confirm the asset moves to "Unused Assets" (and its tree/canvas badge count drops) instead of showing a stale reference count.