### PR TITLE
fix(app): make New Site's git init failure loud, not silently swallowed

### DIFF
--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -366,8 +366,17 @@ struct SitesLauncherView: View {
                 try await ProcessSupervisor.shared.run(executable: exe, arguments: args, currentDirectoryURL: cwd)
             },
             gitInit: { sourceDir in
-                let git = URL(fileURLWithPath: "/usr/bin/git")
-                _ = try await ProcessSupervisor.shared.run(executable: git, arguments: ["init"], currentDirectoryURL: sourceDir)
+                // Route through GitInitRunner so a nonzero exit throws (with stderr) instead of
+                // being discarded — see #548, where this used to `_ = try await ...run(...)` and
+                // silently kept a Source/ with no .git that could never preview.
+                try await GitInitRunner.run(in: sourceDir) { exe, args, cwd in
+                    let result = try await ProcessSupervisor.shared.run(executable: exe, arguments: args, currentDirectoryURL: cwd)
+                    // Logs are sacred: this is a one-shot `run`, not a streamed `launch`, so forward
+                    // its captured output to the debug pane ourselves.
+                    if !result.stdout.isEmpty { await LogCenter.shared.append(source: "git-init", stream: .stdout, text: result.stdout) }
+                    if !result.stderr.isEmpty { await LogCenter.shared.append(source: "git-init", stream: .stderr, text: result.stderr) }
+                    return result
+                }
             },
             register: { package in
                 let site = try await SiteStore.shared.record(package)

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -43,14 +43,7 @@ public struct ContainerizationControl: LocalContainerControl {
         ref: String,
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> LocalContainerSession {
-        // Fail fast with a clear reason instead of a raw `git clone ... exited 128`: hydration
-        // hard-depends on `sourceRepo` being a real git repo, and a `Source/` without `.git` (e.g.
-        // a scaffold whose `git init` step failed, or a pre-#548 site created before that failure
-        // became loud) would otherwise die inside the guest with no indication why (#548).
-        guard FileManager.default.fileExists(atPath: sourceRepo.appendingPathComponent(".git").path) else {
-            throw LocalContainerError.cloneFailed(
-                "this site has no git repository — recreate it, or run `git init` in its Source folder")
-        }
+        try SourceRepoPrecondition.requireGitRepo(at: sourceRepo)
 
         let container = try await makeBareContainer(siteID: siteID, sourceRepo: sourceRepo, onOutput: onOutput)
 

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -43,6 +43,15 @@ public struct ContainerizationControl: LocalContainerControl {
         ref: String,
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> LocalContainerSession {
+        // Fail fast with a clear reason instead of a raw `git clone ... exited 128`: hydration
+        // hard-depends on `sourceRepo` being a real git repo, and a `Source/` without `.git` (e.g.
+        // a scaffold whose `git init` step failed, or a pre-#548 site created before that failure
+        // became loud) would otherwise die inside the guest with no indication why (#548).
+        guard FileManager.default.fileExists(atPath: sourceRepo.appendingPathComponent(".git").path) else {
+            throw LocalContainerError.cloneFailed(
+                "this site has no git repository — recreate it, or run `git init` in its Source folder")
+        }
+
         let container = try await makeBareContainer(siteID: siteID, sourceRepo: sourceRepo, onOutput: onOutput)
 
         // 3. Hydrate from the repo: clone the virtio-fs-shared host repo into /workspace/site, then

--- a/Sources/AnglesiteCore/GitInitRunner.swift
+++ b/Sources/AnglesiteCore/GitInitRunner.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// `git init`'s nonzero exit must not be discarded: it previously was in `SitesLauncherView`'s
+/// production wiring (`_ = try await ProcessSupervisor...run(...)`), which meant a failing `git
+/// init` never even reached `SiteScaffolder`'s `.warning` step — the new site silently kept a
+/// `Source/` with no `.git`, and could never preview (#548).
+public enum GitInitError: LocalizedError, Sendable, Equatable {
+    case failed(exitCode: Int32, stderr: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .failed(let exitCode, let stderr):
+            let detail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return detail.isEmpty ? "git init exited \(exitCode)." : "git init exited \(exitCode): \(detail)"
+        }
+    }
+}
+
+public enum GitInitRunner {
+    /// Runs `git init` in `sourceDirectory` via `run`, throwing `GitInitError` (carrying stderr) on
+    /// a nonzero exit instead of discarding the result.
+    public static func run(
+        in sourceDirectory: URL,
+        using run: @Sendable (_ executable: URL, _ arguments: [String], _ cwd: URL?) async throws -> ProcessSupervisor.RunResult
+    ) async throws {
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        let result = try await run(git, ["init"], sourceDirectory)
+        guard result.exitCode == 0 else {
+            throw GitInitError.failed(exitCode: result.exitCode, stderr: result.stderr)
+        }
+    }
+}

--- a/Sources/AnglesiteCore/LocalContainerControl.swift
+++ b/Sources/AnglesiteCore/LocalContainerControl.swift
@@ -18,6 +18,21 @@ public enum LocalContainerError: Error, Equatable {
     case cloneFailed(String)            // git clone of Source/ into the guest failed
 }
 
+/// Hydration precondition: a `LocalContainerControl.start()` implementation hard-depends on
+/// `sourceRepo` being a real git repo (it clones it into the guest). Kept as a plain, always-CI-
+/// tested `AnglesiteCore` check rather than living inline in `ContainerizationControl` (whose test
+/// target is excluded from CI's `swift test` unless `ANGLESITE_CONTAINER_TESTS=1`) — see #548,
+/// where a `Source/` without `.git` (a failed scaffold git-init, or a pre-existing site) died
+/// inside the guest with a raw `git clone ... exited 128` and no indication why.
+public enum SourceRepoPrecondition {
+    public static func requireGitRepo(at sourceRepo: URL, fileManager: FileManager = .default) throws {
+        guard fileManager.fileExists(atPath: sourceRepo.appendingPathComponent(".git").path) else {
+            throw LocalContainerError.cloneFailed(
+                "this site has no git repository — recreate it, or run `git init` in its Source folder")
+        }
+    }
+}
+
 /// The captured output of a guest `exec` call. No `Containerization`/`Virtualization` types cross
 /// this boundary — only `String` and `Int32`.
 public struct ContainerExecResult: Sendable, Equatable {

--- a/Tests/AnglesiteCoreTests/GitInitRunnerTests.swift
+++ b/Tests/AnglesiteCoreTests/GitInitRunnerTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import AnglesiteCore
+
+/// Regression coverage for #548: production wiring in `SitesLauncherView` used to discard the
+/// `RunResult` of `git init` entirely (`_ = try await ...run(...)`), so a nonzero exit code never
+/// surfaced as an error or even a warning — the scaffolder's "non-fatal" git-init step silently
+/// believed it had succeeded. `GitInitRunner` centralizes the exit-code check so it can't regress.
+final class GitInitRunnerTests: XCTestCase {
+
+    func testThrowsWithStderrOnNonzeroExit() async {
+        let dir = URL(fileURLWithPath: "/tmp/some-site")
+        do {
+            try await GitInitRunner.run(in: dir) { _, _, _ in
+                ProcessSupervisor.RunResult(stdout: "", stderr: "fatal: not a valid path", exitCode: 128)
+            }
+            XCTFail("expected GitInitError to be thrown")
+        } catch let error as GitInitError {
+            guard case .failed(let exitCode, let stderr) = error else { return XCTFail("wrong case") }
+            XCTAssertEqual(exitCode, 128)
+            XCTAssertEqual(stderr, "fatal: not a valid path")
+            XCTAssertEqual(error.errorDescription, "git init exited 128: fatal: not a valid path")
+        } catch {
+            XCTFail("expected GitInitError, got \(error)")
+        }
+    }
+
+    func testSucceedsOnZeroExit() async throws {
+        let dir = URL(fileURLWithPath: "/tmp/some-site")
+        var capturedArgs: [String] = []
+        var capturedCwd: URL?
+        try await GitInitRunner.run(in: dir) { executable, args, cwd in
+            capturedArgs = args
+            capturedCwd = cwd
+            XCTAssertEqual(executable.path, "/usr/bin/git")
+            return ProcessSupervisor.RunResult(stdout: "Initialized empty Git repository", stderr: "", exitCode: 0)
+        }
+        XCTAssertEqual(capturedArgs, ["init"])
+        XCTAssertEqual(capturedCwd, dir)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SourceRepoPreconditionTests.swift
+++ b/Tests/AnglesiteCoreTests/SourceRepoPreconditionTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import AnglesiteCore
+
+/// Regression coverage for #548's review follow-up: the fail-fast `.git` guard added to
+/// `ContainerizationControl.start()` lived in the `AnglesiteContainer` module, whose test target
+/// (`AnglesiteContainerLocalTests`) is excluded from CI's `swift test` entirely unless
+/// `ANGLESITE_CONTAINER_TESTS=1` — which CI never sets. So the guard had no coverage CI actually
+/// runs. Extracting it into `SourceRepoPrecondition` (AnglesiteCore, always built/tested in CI)
+/// gives the check real regression coverage.
+final class SourceRepoPreconditionTests: XCTestCase {
+
+    private func tmpDir() -> URL {
+        let d = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    func testThrowsCloneFailedWhenNoGitDirectory() {
+        let dir = tmpDir()
+        XCTAssertThrowsError(try SourceRepoPrecondition.requireGitRepo(at: dir)) { error in
+            guard case LocalContainerError.cloneFailed(let message) = error else {
+                return XCTFail("expected .cloneFailed, got \(error)")
+            }
+            XCTAssertTrue(message.contains("no git repository"), "unexpected message: \(message)")
+        }
+    }
+
+    func testSucceedsWhenGitDirectoryExists() throws {
+        let dir = tmpDir()
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        try SourceRepoPrecondition.requireGitRepo(at: dir)   // must not throw
+    }
+}


### PR DESCRIPTION
## Summary
- `SiteScaffolder`'s "non-fatal" git-init step (`SitesLauncherView.swift`) used to discard `ProcessSupervisor`'s `RunResult` entirely (`_ = try await ...run(...)`), so a nonzero `git init` exit never surfaced as even a warning — the site's `Source/` silently kept no `.git`, and it could never preview (`git clone ... exited 128` inside the container, with no indication why).
- New `GitInitRunner` (AnglesiteCore) centralizes the exit-code check: a failure now throws `GitInitError` carrying stderr, which `SiteScaffolder` correctly surfaces as its existing `.warning` step — this in turn triggers the New Site wizard's already-existing "Your website was created, but something above needs attention before it can preview" banner.
- `ContainerizationControl.start()` now fails fast with a clear reason ("this site has no git repository — recreate it, or run `git init` in its Source folder") when `Source/` has no `.git`, instead of a raw clone exit code — covers pre-existing sites already in this state, not just newly-scaffolded ones.
- The container clone/checkout output-streaming half of this issue (`runToCompletion` piping stdout/stderr) was already fixed separately in #557 — not touched here.

Fixes #548

## Test plan
- [x] `swift build --package-path .` — clean build
- [x] `xcodegen generate` + `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [x] New `GitInitRunnerTests` (RED verified via compile failure before `GitInitRunner` existed, GREEN via successful build after)
- [ ] Full `swift test` run: blocked locally by the known #541 FoundationModels SDK/OS symbol mismatch (`dlopen` fails for every xctest bundle on this host, unrelated to this change) — CI is the test arbiter here per project convention.