### PR TITLE
fix(container): raise preview-ready timeout from 90s to 300s

### DIFF
--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -150,7 +150,7 @@ public struct ContainerizationControl: LocalContainerControl {
         //    doesn't get connection-refused. Poll the preview URL through the host proxy until it
         //    answers (or time out). Cancellation-friendly: `Task.sleep` throws on cancel.
         do {
-            try await waitUntilServing(previewURL)
+            try await waitUntilServing(previewURL, timeout: Self.previewReadyTimeout)
         } catch {
             await previewProxy.stop()
             await mcpProxy.stop()
@@ -366,6 +366,14 @@ public struct ContainerizationControl: LocalContainerControl {
 
     /// Bound on `container.create()`/`.start()` — see the call site's comment on why this exists.
     private static let vmBootTimeout: Duration = .seconds(30)
+
+    /// Bound on `waitUntilServing`'s poll of the preview URL after `astro dev` is launched. Covers
+    /// `anglesite-hydrate` rsyncing baked `node_modules` into the freshly-cloned workspace plus astro's
+    /// own cold start — the rootfs is recreated per start (#59), so every boot pays this in full, not
+    /// just the first. #550's field data: a *minimal* throwaway site took 186s wall-clock; a real
+    /// template site with more integrations took 220s. 90s (the old default) failed both. 300s keeps
+    /// meaningful margin over the worst observed case without masking a truly hung guest for minutes.
+    private static let previewReadyTimeout: Duration = .seconds(300)
 
     /// Races `operation` against a `timeout`, resolving to whichever finishes first. Unlike a
     /// `withThrowingTaskGroup`-based race, this does NOT wait for `operation` to finish once the


### PR DESCRIPTION
## Summary
- `waitUntilServing`'s default 90s deadline in `ContainerizationControl.start()` covers `astro dev` becoming ready — but that budget also has to absorb `anglesite-hydrate` rsyncing baked `node_modules` into the freshly-cloned workspace, and the rootfs ext4 is intentionally recreated per start (#59), so every boot pays this in full, not just the first.
- Field data from #550: a *minimal* throwaway site's cold boot took 186s wall-clock; a real template site with more integrations took 220s. Both blow the old 90s window.
- Added a dedicated `previewReadyTimeout` constant (300s) alongside the existing `vmBootTimeout` pattern, and pass it explicitly at the one real call site instead of relying on `waitUntilServing`'s default.

Fixes #550

## Test plan
- [x] `swift build --package-path .` — clean build
- [ ] Full `swift test` run: blocked locally by the known #541 FoundationModels SDK/OS symbol mismatch (`dlopen` fails for every xctest bundle on this host) — CI is the test arbiter here per project convention.
- [ ] `ContainerizationControlTests.bootsAndServes` (entitlement-gated, `ANGLESITE_CONTAINER_E2E=1`) not run locally — no assertion depends on the timeout value, only on eventual 200.