### PR TITLE
docs: app icon & identity brainstorm (anglesite crystal direction)

### DIFF
--- a/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
+++ b/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
@@ -91,9 +91,11 @@ than a literal rock bed.
 Study 3's beam-through-prism carries the mark; study 2's specular chevrons graft
 on as a large-size flourish (they melt into sparkle below ~48 px, which is the
 intended behavior); and the galena field is a brighter steel blue
-(`#5B7192 → #364764 → #202C40`) so the complementary blue/gold pairing does the
-dock-pop work. Refined same day: the beam runs **edge to edge** across the frame
-and the caustic pool is gone — the gem's own glow grounds it. Composite study:
+(`#6E86AB → #45587A → #2A3A55`) so the complementary blue/gold pairing does the
+dock-pop work. Refined same day: the beam runs **edge to edge** across the frame,
+the caustic pool is gone — the gem's own glow grounds it — and the center
+vertical ridge is softened (body-face gradients pulled closer, highlight quieted)
+so the two front faces read as one glassy volume. Composite study:
 [`assets/icon-studies/study-4-winner.svg`](assets/icon-studies/study-4-winner.svg).
 
 ## Palette (working values)

--- a/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
+++ b/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
@@ -87,6 +87,14 @@ plus a light beam), keep **2** as the stretch goal if the renders support it, an
 fold 4's galena *material* into whichever wins as the background treatment rather
 than a literal rock bed.
 
+**Winner (decided 2026-07-09): Slash of Light + Bracket Facet's chevrons.**
+Study 3's beam-through-prism carries the mark; study 2's specular chevrons graft
+on as a large-size flourish (they melt into sparkle below ~48 px, which is the
+intended behavior); and the galena field is tinted further toward blue
+(`#4A5C74 → #2B3850 → #172030`) so the complementary blue/gold pairing does the
+dock-pop work. Composite study:
+[`assets/icon-studies/study-4-winner.svg`](assets/icon-studies/study-4-winner.svg).
+
 ## Palette (working values)
 
 | Role | Hex | Notes |
@@ -141,7 +149,8 @@ what makes the 16 px read work — the silhouette carries everything.
 2. ~~Decide whether the beam in concept 3 stays champagne or deliberately echoes
    the old icon's blue for one release of continuity.~~ **Resolved 2026-07-09:
    the beam stays champagne** — mineral-true throughout, no blue continuity nod.
-3. Pick the winner, then commission/produce the final layered render and export
-   the `.icon` document + appiconset.
+3. ~~Pick the winner~~ **Picked 2026-07-09** (study 4, see above) — remaining:
+   produce the final layered render from it and export the `.icon` document +
+   appiconset.
 4. Follow-up pass for accent-color adoption in `AnglesiteApp` (tint, edit-overlay
    active state, empty-state art).

--- a/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
+++ b/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
@@ -1,0 +1,140 @@
+# App icon & identity brainstorm — the anglesite crystal
+
+*2026-07-09. Concept exploration for replacing the current `</>`-in-a-squircle app
+icon and extending the result into an in-app accent identity. Direction set in an
+interview with @dwk; concepts below are candidates, not a final pick.*
+
+## Why change it
+
+The current icon (dark `</>` glyph, blue slash, light squircle) is appropriate but
+generic — dozens of dev tools use bracket glyphs. Meanwhile the app's name is doing
+much more work than the icon lets on: **anglesite** is a real mineral (lead sulfate,
+PbSO₄) — colorless-to-pale-champagne orthorhombic crystals with a near-adamantine
+luster, first described at Parys Mountain on **Anglesey, Wales**, and classically
+found on steel-blue **galena**. The name puns across angle brackets, websites,
+geologic *sites*, and a lesser-known gem. The icon should own that.
+
+## Direction (locked in interview)
+
+| Axis | Decision |
+|---|---|
+| Lead motif | **The crystal/gem** — the mineral leads; brackets become secondary |
+| Brackets | **Hidden in the facets** — silhouette/facet lines subtly form `<` `>`; an easter egg, never a typeset glyph |
+| Composition | **Single hero crystal** — one bold prism, centered; iconic silhouette, legible at 16 px |
+| Treatment | **Glassy/refractive** — lean into the translucent-glass macOS icon language; real refraction and depth |
+| Color | **Mineral-true** — champagne/pale-gold crystal on dark steel-blue galena |
+| Personality | **Friendly & magical** — the app does heavy lifting invisibly; the gem glows. Not pro-tool severe, not game-y sparkle |
+| Reference vibe | **Indie Mac craft** — Panic/Nova, Things, CleanShot lineage: lovingly rendered, personality over corporate flatness. Study Sketch's diamond only to differentiate from it |
+| Scope | **Icon + in-app accents** — also rethink accent color and small glyphs (toolbar, empty states) to match |
+
+## Icon concepts
+
+All concepts share the locked direction; they differ in *how the brackets hide* and
+*where the light comes from*.
+
+### 1. The Prism (baseline)
+
+An upright orthorhombic prism with a chisel/wedge termination — anglesite's actual
+habit — centered on a dark galena field. The crystal's tapering left and right
+edges *are* the brackets: the negative space between crystal and squircle corners
+reads as `<` and `>` without drawing them. One caustic pool of light where the
+crystal meets the ground plane, as if lit from within.
+
+- **Why it wins:** strongest silhouette of the set; the bracket easter egg is pure
+  negative space, so it never fights the gem.
+- **Risk:** an upright hexagon-ish silhouette is adjacent to Sketch's diamond;
+  differentiation rides on the glassy 3D treatment and the dark ground.
+
+### 2. Bracket Facet
+
+The crystal sits rotated a few degrees so its front corner faces the viewer. The
+facet junctions on the two visible faces catch specular light as a chevron pair —
+a lit `<` on the left face, `>` on the right. The brackets are literally *how the
+light breaks on the stone*.
+
+- **Why it wins:** the most magical version of the easter egg — you only see the
+  brackets when the light does. Rewards the second look.
+- **Risk:** specular chevrons need real rendering care to read as facets, not as
+  decals pasted on glass; hardest to keep honest at 32 px.
+
+### 3. Slash of Light
+
+Concept 1's prism, but a single diagonal refraction beam passes through the body —
+the old icon's blue `/` reborn as light bending through the crystal. Continuity
+easter egg for anyone who knew the previous mark; "angle of incidence" pun for
+free (refraction *is* light changing angle).
+
+- **Why it wins:** carries lineage from the current icon; the beam gives the
+  composition motion and a natural place for the champagne-gold to go hot.
+- **Risk:** a strong diagonal can dominate the silhouette at small sizes and
+  read as a "no entry" slash if the contrast is mishandled.
+
+### 4. On Galena
+
+The bottom quarter of the squircle is a bed of dark, subtly *cubic* galena
+(galena crystallizes in cubes — a nice geometric floor that stays quiet), with the
+hero crystal rising out of it. Tells the "site where you unearth something
+precious" story — your website, brought to light — while staying a single-hero
+composition.
+
+- **Why it wins:** most narratively complete; mineral-true down to the matrix; the
+  cubic bed gives the icon a horizon line, which macOS icons rarely have.
+- **Risk:** the busiest of the four; the galena bed must simplify to a plain dark
+  band below ~64 px or it turns to noise.
+
+**Recommended path:** develop **1 and 3 together** (they share geometry — 3 is 1
+plus a light beam), keep **2** as the stretch goal if the renders support it, and
+fold 4's galena *material* into whichever wins as the background treatment rather
+than a literal rock bed.
+
+## Palette (working values)
+
+| Role | Hex | Notes |
+|---|---|---|
+| Galena deep | `#1B222C` | Icon background field; near-black steel blue |
+| Galena steel | `#2E3A47` | Facet shadows, matrix highlights |
+| Champagne core | `#E8D5A3` | Crystal body mid-tone |
+| Gold hot | `#C9A24B` | Refraction concentrations, caustics |
+| Ice highlight | `#F8F2E0` | Specular hits, top facet |
+
+The pairing is inherently high-contrast (bright wedge on dark field), which is
+what makes the 16 px read work — the silhouette carries everything.
+
+## Production notes (macOS 27)
+
+- Author as a **layered Icon Composer document**, not flat PNGs: galena background
+  layer, crystal body layer with glass material, specular/caustic layer on top.
+  The system's dynamic glass lighting then works *with* the refraction story
+  instead of fighting a baked render. Keep the current `AppIcon.appiconset` PNGs
+  as the fallback export from the same source.
+- Provide explicit **dark and tinted variants**: dark mode inverts nothing here
+  (the field is already dark), but the tinted/clear variants should reduce to the
+  crystal silhouette alone.
+- Test gates: 16 px dock/Finder read (silhouette-only), 32 px (facet lines must
+  survive or be dropped per-size), 512 px marketing (full refraction).
+
+## In-app accents (identity beyond the icon)
+
+- **Chrome stays cool, magic goes gold.** UI chrome and selection tint shift from
+  system blue toward galena-steel; **champagne-gold is reserved for the "magical"
+  moments** — Apple Intelligence actions, deploy success, the edit overlay's
+  active state. Gold as a scarce accent reads precious; gold everywhere reads
+  like a warning state, so budget it.
+- **Small glyphs:** toolbar icons remain SF Symbols (Mac-assed Mac app), but empty
+  states and onboarding get one drawn asset each from the icon's crystal geometry
+  — the same prism, simplified to a two-tone line illustration.
+- **Sparkle alignment:** where the system uses its Intelligence sparkle language,
+  ours glows through the crystal rather than adding a second sparkle vocabulary.
+- **Website/template branding and the wordmark are out of scope** for this pass
+  (icon + in-app accents only, per interview).
+
+## Open questions / next steps
+
+1. Produce rough facet-geometry studies (SVG or Icon Composer) for concepts 1–3
+   and evaluate the bracket easter egg at 32 px.
+2. Decide whether the beam in concept 3 stays champagne or deliberately echoes the
+   old icon's blue for one release of continuity.
+3. Pick the winner, then commission/produce the final layered render and export
+   the `.icon` document + appiconset.
+4. Follow-up pass for accent-color adoption in `AnglesiteApp` (tint, edit-overlay
+   active state, empty-state art).

--- a/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
+++ b/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
@@ -90,9 +90,10 @@ than a literal rock bed.
 **Winner (decided 2026-07-09): Slash of Light + Bracket Facet's chevrons.**
 Study 3's beam-through-prism carries the mark; study 2's specular chevrons graft
 on as a large-size flourish (they melt into sparkle below ~48 px, which is the
-intended behavior); and the galena field is tinted further toward blue
-(`#4A5C74 → #2B3850 → #172030`) so the complementary blue/gold pairing does the
-dock-pop work. Composite study:
+intended behavior); and the galena field is a brighter steel blue
+(`#5B7192 → #364764 → #202C40`) so the complementary blue/gold pairing does the
+dock-pop work. Refined same day: the beam runs **edge to edge** across the frame
+and the caustic pool is gone — the gem's own glow grounds it. Composite study:
 [`assets/icon-studies/study-4-winner.svg`](assets/icon-studies/study-4-winner.svg).
 
 ## Palette (working values)

--- a/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
+++ b/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
@@ -95,7 +95,12 @@ intended behavior); and the galena field is a brighter steel blue
 dock-pop work. Refined same day: the beam runs **edge to edge** across the frame,
 the caustic pool is gone — the gem's own glow grounds it — and the center
 vertical ridge is softened (body-face gradients pulled closer, highlight quieted)
-so the two front faces read as one glassy volume. Composite study:
+so the two front faces read as one glassy volume. A **Liquid Glass pass**
+followed: rounded silhouette, melted facet junctions, translucent body with a
+wet specular and an internal blue environment reflection, a light kiss on the
+top edges instead of a drawn rim, and the chevrons **etched into** the stone
+(shadow wall up-left, lit wall down-right) rather than glowing on it.
+Composite study:
 [`assets/icon-studies/study-4-winner.svg`](assets/icon-studies/study-4-winner.svg).
 
 ## Palette (working values)

--- a/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
+++ b/docs/specs/2026-07-09-app-icon-identity-brainstorm.md
@@ -130,10 +130,17 @@ what makes the 16 px read work — the silhouette carries everything.
 
 ## Open questions / next steps
 
-1. Produce rough facet-geometry studies (SVG or Icon Composer) for concepts 1–3
-   and evaluate the bracket easter egg at 32 px.
-2. Decide whether the beam in concept 3 stays champagne or deliberately echoes the
-   old icon's blue for one release of continuity.
+1. ~~Produce rough facet-geometry studies (SVG or Icon Composer) for concepts 1–3
+   and evaluate the bracket easter egg at 32 px.~~ **Done 2026-07-09** — see
+   [`assets/icon-studies/`](assets/icon-studies/) (`study-1-prism.svg`,
+   `study-2-bracket-facet.svg`, `study-3-slash-of-light.svg`). These are
+   geometry/light studies, not final art. When production starts, verify the
+   "Production notes" above against Apple's current Icon Composer documentation —
+   they were written from memory of the macOS 26/27 icon pipeline and are
+   speculative until checked.
+2. ~~Decide whether the beam in concept 3 stays champagne or deliberately echoes
+   the old icon's blue for one release of continuity.~~ **Resolved 2026-07-09:
+   the beam stays champagne** — mineral-true throughout, no blue continuity nod.
 3. Pick the winner, then commission/produce the final layered render and export
    the `.icon` document + appiconset.
 4. Follow-up pass for accent-color adoption in `AnglesiteApp` (tint, edit-overlay

--- a/docs/specs/assets/icon-studies/study-1-prism.svg
+++ b/docs/specs/assets/icon-studies/study-1-prism.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Study 1 — "The Prism". Facet-geometry study, not final art.
+       Single anglesite prism, chisel terminations, viewed corner-on.
+       Brackets live in the negative space beside the 45° tapers. -->
+  <defs>
+    <radialGradient id="s1-bg" cx="0.38" cy="0.26" r="1.05">
+      <stop offset="0" stop-color="#3A4756"/>
+      <stop offset="0.55" stop-color="#232B36"/>
+      <stop offset="1" stop-color="#141A22"/>
+    </radialGradient>
+    <linearGradient id="s1-gloss" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.10"/>
+      <stop offset="0.45" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="s1-innerGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#EFD9A0" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#EFD9A0" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="s1-topL" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0" stop-color="#FBF5E3"/>
+      <stop offset="1" stop-color="#EFD9A0"/>
+    </linearGradient>
+    <linearGradient id="s1-topR" x1="0" y1="0" x2="0.4" y2="1">
+      <stop offset="0" stop-color="#EDD8A2"/>
+      <stop offset="1" stop-color="#D3B370"/>
+    </linearGradient>
+    <linearGradient id="s1-bodyL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#E9D49E"/>
+      <stop offset="1" stop-color="#C7A356"/>
+    </linearGradient>
+    <linearGradient id="s1-bodyR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#D5B876"/>
+      <stop offset="1" stop-color="#A9853B"/>
+    </linearGradient>
+    <linearGradient id="s1-botL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#C2A052"/>
+      <stop offset="1" stop-color="#8F6E2C"/>
+    </linearGradient>
+    <linearGradient id="s1-botR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#B08F3E"/>
+      <stop offset="1" stop-color="#7A5C22"/>
+    </linearGradient>
+    <linearGradient id="s1-ridge" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FDF8E9" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#FDF8E9" stop-opacity="0.15"/>
+    </linearGradient>
+    <filter id="s1-soft" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="14"/>
+    </filter>
+    <filter id="s1-soft2" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="5"/>
+    </filter>
+  </defs>
+
+  <!-- galena field -->
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s1-bg)"/>
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="none" stroke="#FFFFFF" stroke-opacity="0.06" stroke-width="2"/>
+
+  <!-- lit-from-within glow -->
+  <ellipse cx="256" cy="262" rx="170" ry="190" fill="url(#s1-innerGlow)" filter="url(#s1-soft)"/>
+
+  <!-- caustic pool -->
+  <ellipse cx="256" cy="400" rx="88" ry="20" fill="#EFD9A0" opacity="0.35" filter="url(#s1-soft2)"/>
+
+  <!-- crystal: hexagonal prism, chisel top + bottom, front edge at x=256 -->
+  <g>
+    <polygon points="256,118 176,198 256,214" fill="url(#s1-topL)"/>
+    <polygon points="256,118 336,198 256,214" fill="url(#s1-topR)"/>
+    <polygon points="176,198 256,214 256,298 176,314" fill="url(#s1-bodyL)"/>
+    <polygon points="336,198 256,214 256,298 336,314" fill="url(#s1-bodyR)"/>
+    <polygon points="176,314 256,298 256,394" fill="url(#s1-botL)"/>
+    <polygon points="336,314 256,298 256,394" fill="url(#s1-botR)"/>
+    <!-- specular ridge + apex glints -->
+    <line x1="256" y1="214" x2="256" y2="298" stroke="url(#s1-ridge)" stroke-width="3" stroke-linecap="round"/>
+    <line x1="256" y1="118" x2="176" y2="198" stroke="#FDF8E9" stroke-opacity="0.55" stroke-width="2" stroke-linecap="round"/>
+    <line x1="176" y1="314" x2="256" y2="394" stroke="#F3E7C2" stroke-opacity="0.45" stroke-width="2" stroke-linecap="round"/>
+    <line x1="256" y1="394" x2="336" y2="314" stroke="#F3E7C2" stroke-opacity="0.3" stroke-width="2" stroke-linecap="round"/>
+    <!-- silhouette pull-away -->
+    <polygon points="256,118 336,198 336,314 256,394 176,314 176,198"
+             fill="none" stroke="#FBF3DC" stroke-opacity="0.22" stroke-width="1.5"/>
+  </g>
+
+  <!-- glass gloss over the whole tile -->
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s1-gloss)"/>
+</svg>

--- a/docs/specs/assets/icon-studies/study-2-bracket-facet.svg
+++ b/docs/specs/assets/icon-studies/study-2-bracket-facet.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Study 2 — "Bracket Facet". Facet-geometry study, not final art.
+       Same prism, rotated a few degrees; specular light breaks along the
+       facet junctions as a lit chevron pair — the brackets are how the
+       light hits the stone. Face contrast is pulled back so the chevrons
+       carry the highlight. -->
+  <defs>
+    <radialGradient id="s2-bg" cx="0.38" cy="0.26" r="1.05">
+      <stop offset="0" stop-color="#3A4756"/>
+      <stop offset="0.55" stop-color="#232B36"/>
+      <stop offset="1" stop-color="#141A22"/>
+    </radialGradient>
+    <linearGradient id="s2-gloss" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.10"/>
+      <stop offset="0.45" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="s2-innerGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#EFD9A0" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#EFD9A0" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="s2-topL" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0" stop-color="#F3E2B4"/>
+      <stop offset="1" stop-color="#E0C384"/>
+    </linearGradient>
+    <linearGradient id="s2-topR" x1="0" y1="0" x2="0.4" y2="1">
+      <stop offset="0" stop-color="#E4CB90"/>
+      <stop offset="1" stop-color="#CFAF66"/>
+    </linearGradient>
+    <linearGradient id="s2-bodyL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#DDC488"/>
+      <stop offset="1" stop-color="#BC9A4E"/>
+    </linearGradient>
+    <linearGradient id="s2-bodyR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#CFB170"/>
+      <stop offset="1" stop-color="#A6823A"/>
+    </linearGradient>
+    <linearGradient id="s2-botL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#BC9A4E"/>
+      <stop offset="1" stop-color="#8A6A2B"/>
+    </linearGradient>
+    <linearGradient id="s2-botR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#AA8A3C"/>
+      <stop offset="1" stop-color="#775A21"/>
+    </linearGradient>
+    <linearGradient id="s2-chev" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FFF9E8"/>
+      <stop offset="1" stop-color="#E3C273"/>
+    </linearGradient>
+    <filter id="s2-soft" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="14"/>
+    </filter>
+    <filter id="s2-soft2" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="5"/>
+    </filter>
+    <filter id="s2-glint" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="1.4"/>
+    </filter>
+  </defs>
+
+  <!-- galena field -->
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s2-bg)"/>
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="none" stroke="#FFFFFF" stroke-opacity="0.06" stroke-width="2"/>
+
+  <ellipse cx="256" cy="262" rx="170" ry="190" fill="url(#s2-innerGlow)" filter="url(#s2-soft)"/>
+  <ellipse cx="250" cy="402" rx="88" ry="20" fill="#EFD9A0" opacity="0.3" filter="url(#s2-soft2)"/>
+
+  <!-- crystal, rotated a few degrees so the light finds the junctions -->
+  <g transform="rotate(-6 256 256)">
+    <polygon points="256,118 176,198 256,214" fill="url(#s2-topL)"/>
+    <polygon points="256,118 336,198 256,214" fill="url(#s2-topR)"/>
+    <polygon points="176,198 256,214 256,298 176,314" fill="url(#s2-bodyL)"/>
+    <polygon points="336,198 256,214 256,298 336,314" fill="url(#s2-bodyR)"/>
+    <polygon points="176,314 256,298 256,394" fill="url(#s2-botL)"/>
+    <polygon points="336,314 256,298 256,394" fill="url(#s2-botR)"/>
+
+    <!-- the easter egg: specular chevrons on the facet junctions -->
+    <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="238,212 200,256 238,300" stroke="url(#s2-chev)" stroke-width="8" opacity="0.85" filter="url(#s2-glint)"/>
+      <polyline points="238,212 200,256 238,300" stroke="#FFFDF4" stroke-width="2.5" opacity="0.9"/>
+      <polyline points="274,212 312,256 274,300" stroke="url(#s2-chev)" stroke-width="8" opacity="0.7" filter="url(#s2-glint)"/>
+      <polyline points="274,212 312,256 274,300" stroke="#FFFDF4" stroke-width="2.5" opacity="0.75"/>
+    </g>
+
+    <line x1="256" y1="118" x2="176" y2="198" stroke="#FDF8E9" stroke-opacity="0.45" stroke-width="2" stroke-linecap="round"/>
+    <line x1="176" y1="314" x2="256" y2="394" stroke="#F3E7C2" stroke-opacity="0.35" stroke-width="2" stroke-linecap="round"/>
+    <polygon points="256,118 336,198 336,314 256,394 176,314 176,198"
+             fill="none" stroke="#FBF3DC" stroke-opacity="0.2" stroke-width="1.5"/>
+  </g>
+
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s2-gloss)"/>
+</svg>

--- a/docs/specs/assets/icon-studies/study-3-slash-of-light.svg
+++ b/docs/specs/assets/icon-studies/study-3-slash-of-light.svg
@@ -1,0 +1,113 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Study 3 — "Slash of Light". Facet-geometry study, not final art.
+       Study 1's prism plus a champagne refraction beam: the old icon's
+       "/" reborn as light. The beam kinks ~8° where it enters the stone
+       (angle of incidence) and goes hot inside the body, exiting to a
+       caustic at lower left. Beam stays champagne per 2026-07-09 decision. -->
+  <defs>
+    <radialGradient id="s3-bg" cx="0.38" cy="0.26" r="1.05">
+      <stop offset="0" stop-color="#3A4756"/>
+      <stop offset="0.55" stop-color="#232B36"/>
+      <stop offset="1" stop-color="#141A22"/>
+    </radialGradient>
+    <linearGradient id="s3-gloss" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.10"/>
+      <stop offset="0.45" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="s3-innerGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#EFD9A0" stop-opacity="0.45"/>
+      <stop offset="1" stop-color="#EFD9A0" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="s3-topL" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0" stop-color="#FBF5E3"/>
+      <stop offset="1" stop-color="#EFD9A0"/>
+    </linearGradient>
+    <linearGradient id="s3-topR" x1="0" y1="0" x2="0.4" y2="1">
+      <stop offset="0" stop-color="#EDD8A2"/>
+      <stop offset="1" stop-color="#D3B370"/>
+    </linearGradient>
+    <linearGradient id="s3-bodyL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#E9D49E"/>
+      <stop offset="1" stop-color="#C7A356"/>
+    </linearGradient>
+    <linearGradient id="s3-bodyR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#D5B876"/>
+      <stop offset="1" stop-color="#A9853B"/>
+    </linearGradient>
+    <linearGradient id="s3-botL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#C2A052"/>
+      <stop offset="1" stop-color="#8F6E2C"/>
+    </linearGradient>
+    <linearGradient id="s3-botR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#B08F3E"/>
+      <stop offset="1" stop-color="#7A5C22"/>
+    </linearGradient>
+    <linearGradient id="s3-beamOut" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F8F2E0" stop-opacity="0.16"/>
+      <stop offset="1" stop-color="#F8F2E0" stop-opacity="0.02"/>
+    </linearGradient>
+    <linearGradient id="s3-beamIn" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FFF3D0" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F0CE7E" stop-opacity="0.5"/>
+    </linearGradient>
+    <clipPath id="s3-tile">
+      <rect x="50" y="50" width="412" height="412" rx="92"/>
+    </clipPath>
+    <clipPath id="s3-crystal">
+      <polygon points="256,118 336,198 336,314 256,394 176,314 176,198"/>
+    </clipPath>
+    <filter id="s3-soft" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="14"/>
+    </filter>
+    <filter id="s3-soft2" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="5"/>
+    </filter>
+    <filter id="s3-beamBlur" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="7"/>
+    </filter>
+  </defs>
+
+  <!-- galena field -->
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s3-bg)"/>
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="none" stroke="#FFFFFF" stroke-opacity="0.06" stroke-width="2"/>
+
+  <ellipse cx="256" cy="262" rx="170" ry="190" fill="url(#s3-innerGlow)" filter="url(#s3-soft)"/>
+
+  <!-- incoming beam, faint, across the tile -->
+  <g clip-path="url(#s3-tile)">
+    <polygon points="429.2,67.7 101.2,459.7 82.8,444.3 410.8,52.3"
+             fill="url(#s3-beamOut)" filter="url(#s3-beamBlur)"/>
+  </g>
+
+  <!-- crystal -->
+  <g>
+    <polygon points="256,118 176,198 256,214" fill="url(#s3-topL)"/>
+    <polygon points="256,118 336,198 256,214" fill="url(#s3-topR)"/>
+    <polygon points="176,198 256,214 256,298 176,314" fill="url(#s3-bodyL)"/>
+    <polygon points="336,198 256,214 256,298 336,314" fill="url(#s3-bodyR)"/>
+    <polygon points="176,314 256,298 256,394" fill="url(#s3-botL)"/>
+    <polygon points="336,314 256,298 256,394" fill="url(#s3-botR)"/>
+  </g>
+
+  <!-- the beam inside the body: kinked ~8°, hot champagne -->
+  <g clip-path="url(#s3-crystal)">
+    <g transform="rotate(8 256 256)">
+      <polygon points="433.8,71.6 105.8,463.6 78.2,440.4 406.2,48.4"
+               fill="url(#s3-beamIn)" filter="url(#s3-beamBlur)"/>
+      <line x1="420" y1="60" x2="92" y2="452" stroke="#FFFBEA" stroke-width="6"
+            stroke-linecap="round" opacity="0.9" filter="url(#s3-beamBlur)"/>
+    </g>
+  </g>
+
+  <!-- edges over the beam so the stone keeps its geometry -->
+  <line x1="256" y1="214" x2="256" y2="298" stroke="#FDF8E9" stroke-opacity="0.7" stroke-width="3" stroke-linecap="round"/>
+  <line x1="256" y1="118" x2="176" y2="198" stroke="#FDF8E9" stroke-opacity="0.55" stroke-width="2" stroke-linecap="round"/>
+  <line x1="176" y1="314" x2="256" y2="394" stroke="#F3E7C2" stroke-opacity="0.45" stroke-width="2" stroke-linecap="round"/>
+  <polygon points="256,118 336,198 336,314 256,394 176,314 176,198"
+           fill="none" stroke="#FBF3DC" stroke-opacity="0.25" stroke-width="1.5"/>
+
+  <!-- single caustic pool, stretched toward the beam exit at lower left -->
+  <ellipse cx="228" cy="401" rx="110" ry="20" fill="#EFD9A0" opacity="0.4" filter="url(#s3-soft2)"/>
+
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s3-gloss)"/>
+</svg>

--- a/docs/specs/assets/icon-studies/study-4-winner.svg
+++ b/docs/specs/assets/icon-studies/study-4-winner.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Study 4 — the winner (2026-07-09): Study 3's Slash of Light plus
+       Study 2's specular chevrons, on a field tinted further toward blue
+       to complement the champagne gem. Facet-geometry study, not final art.
+       The chevrons are a large-size flourish: they melt into sparkle below
+       ~48px while the beam and silhouette carry the small-size read. -->
+  <defs>
+    <radialGradient id="s4-bg" cx="0.38" cy="0.26" r="1.05">
+      <stop offset="0" stop-color="#4A5C74"/>
+      <stop offset="0.55" stop-color="#2B3850"/>
+      <stop offset="1" stop-color="#172030"/>
+    </radialGradient>
+    <linearGradient id="s4-gloss" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.10"/>
+      <stop offset="0.45" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="s4-innerGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#EFD9A0" stop-opacity="0.45"/>
+      <stop offset="1" stop-color="#EFD9A0" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="s4-topL" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0" stop-color="#FBF5E3"/>
+      <stop offset="1" stop-color="#EFD9A0"/>
+    </linearGradient>
+    <linearGradient id="s4-topR" x1="0" y1="0" x2="0.4" y2="1">
+      <stop offset="0" stop-color="#EDD8A2"/>
+      <stop offset="1" stop-color="#D3B370"/>
+    </linearGradient>
+    <linearGradient id="s4-bodyL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#E9D49E"/>
+      <stop offset="1" stop-color="#C7A356"/>
+    </linearGradient>
+    <linearGradient id="s4-bodyR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#D5B876"/>
+      <stop offset="1" stop-color="#A9853B"/>
+    </linearGradient>
+    <linearGradient id="s4-botL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#C2A052"/>
+      <stop offset="1" stop-color="#8F6E2C"/>
+    </linearGradient>
+    <linearGradient id="s4-botR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#B08F3E"/>
+      <stop offset="1" stop-color="#7A5C22"/>
+    </linearGradient>
+    <linearGradient id="s4-beamOut" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F8F2E0" stop-opacity="0.16"/>
+      <stop offset="1" stop-color="#F8F2E0" stop-opacity="0.02"/>
+    </linearGradient>
+    <linearGradient id="s4-beamIn" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FFF3D0" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="#F0CE7E" stop-opacity="0.45"/>
+    </linearGradient>
+    <clipPath id="s4-tile">
+      <rect x="50" y="50" width="412" height="412" rx="92"/>
+    </clipPath>
+    <clipPath id="s4-crystal">
+      <polygon points="256,118 336,198 336,314 256,394 176,314 176,198"/>
+    </clipPath>
+    <filter id="s4-soft" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="14"/>
+    </filter>
+    <filter id="s4-soft2" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="5"/>
+    </filter>
+    <filter id="s4-beamBlur" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="7"/>
+    </filter>
+    <linearGradient id="s4-chev" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FFF9E8"/>
+      <stop offset="1" stop-color="#E3C273"/>
+    </linearGradient>
+    <filter id="s4-glint" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="1.4"/>
+    </filter>
+  </defs>
+
+  <!-- galena field -->
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s4-bg)"/>
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="none" stroke="#FFFFFF" stroke-opacity="0.06" stroke-width="2"/>
+
+  <ellipse cx="256" cy="262" rx="170" ry="190" fill="url(#s4-innerGlow)" filter="url(#s4-soft)"/>
+
+  <!-- incoming beam, faint, across the tile -->
+  <g clip-path="url(#s4-tile)">
+    <polygon points="429.2,67.7 101.2,459.7 82.8,444.3 410.8,52.3"
+             fill="url(#s4-beamOut)" filter="url(#s4-beamBlur)"/>
+  </g>
+
+  <!-- crystal -->
+  <g>
+    <polygon points="256,118 176,198 256,214" fill="url(#s4-topL)"/>
+    <polygon points="256,118 336,198 256,214" fill="url(#s4-topR)"/>
+    <polygon points="176,198 256,214 256,298 176,314" fill="url(#s4-bodyL)"/>
+    <polygon points="336,198 256,214 256,298 336,314" fill="url(#s4-bodyR)"/>
+    <polygon points="176,314 256,298 256,394" fill="url(#s4-botL)"/>
+    <polygon points="336,314 256,298 256,394" fill="url(#s4-botR)"/>
+  </g>
+
+  <!-- the beam inside the body: kinked ~8°, hot champagne -->
+  <g clip-path="url(#s4-crystal)">
+    <g transform="rotate(8 256 256)">
+      <polygon points="433.8,71.6 105.8,463.6 78.2,440.4 406.2,48.4"
+               fill="url(#s4-beamIn)" filter="url(#s4-beamBlur)"/>
+      <line x1="420" y1="60" x2="92" y2="452" stroke="#FFFBEA" stroke-width="5"
+            stroke-linecap="round" opacity="0.55" filter="url(#s4-beamBlur)"/>
+    </g>
+  </g>
+
+  <!-- specular chevrons on the facet junctions (from Study 2) -->
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="238,212 200,256 238,300" stroke="url(#s4-chev)" stroke-width="8" opacity="0.8" filter="url(#s4-glint)"/>
+    <polyline points="238,212 200,256 238,300" stroke="#FFFDF4" stroke-width="2.5" opacity="0.85"/>
+    <polyline points="274,212 312,256 274,300" stroke="url(#s4-chev)" stroke-width="8" opacity="0.8" filter="url(#s4-glint)"/>
+    <polyline points="274,212 312,256 274,300" stroke="#FFFDF4" stroke-width="2.5" opacity="0.85"/>
+  </g>
+
+  <!-- edges over the beam so the stone keeps its geometry -->
+  <line x1="256" y1="214" x2="256" y2="298" stroke="#FDF8E9" stroke-opacity="0.7" stroke-width="3" stroke-linecap="round"/>
+  <line x1="256" y1="118" x2="176" y2="198" stroke="#FDF8E9" stroke-opacity="0.55" stroke-width="2" stroke-linecap="round"/>
+  <line x1="176" y1="314" x2="256" y2="394" stroke="#F3E7C2" stroke-opacity="0.45" stroke-width="2" stroke-linecap="round"/>
+  <polygon points="256,118 336,198 336,314 256,394 176,314 176,198"
+           fill="none" stroke="#FBF3DC" stroke-opacity="0.25" stroke-width="1.5"/>
+
+  <!-- single caustic pool, stretched toward the beam exit at lower left -->
+  <ellipse cx="228" cy="401" rx="110" ry="20" fill="#EFD9A0" opacity="0.4" filter="url(#s4-soft2)"/>
+
+  <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s4-gloss)"/>
+</svg>

--- a/docs/specs/assets/icon-studies/study-4-winner.svg
+++ b/docs/specs/assets/icon-studies/study-4-winner.svg
@@ -8,9 +8,9 @@
        silhouette carry the small-size read. -->
   <defs>
     <radialGradient id="s4-bg" cx="0.38" cy="0.26" r="1.05">
-      <stop offset="0" stop-color="#5B7192"/>
-      <stop offset="0.55" stop-color="#364764"/>
-      <stop offset="1" stop-color="#202C40"/>
+      <stop offset="0" stop-color="#6E86AB"/>
+      <stop offset="0.55" stop-color="#45587A"/>
+      <stop offset="1" stop-color="#2A3A55"/>
     </radialGradient>
     <linearGradient id="s4-gloss" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.10"/>
@@ -29,20 +29,20 @@
       <stop offset="1" stop-color="#D3B370"/>
     </linearGradient>
     <linearGradient id="s4-bodyL" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#E9D49E"/>
-      <stop offset="1" stop-color="#C7A356"/>
+      <stop offset="0" stop-color="#E3CC94"/>
+      <stop offset="1" stop-color="#C2A054"/>
     </linearGradient>
     <linearGradient id="s4-bodyR" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#D5B876"/>
-      <stop offset="1" stop-color="#A9853B"/>
+      <stop offset="0" stop-color="#DCC284"/>
+      <stop offset="1" stop-color="#B49148"/>
     </linearGradient>
     <linearGradient id="s4-botL" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#C2A052"/>
-      <stop offset="1" stop-color="#8F6E2C"/>
+      <stop offset="0" stop-color="#BB9A4E"/>
+      <stop offset="1" stop-color="#8C6C2C"/>
     </linearGradient>
     <linearGradient id="s4-botR" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#B08F3E"/>
-      <stop offset="1" stop-color="#7A5C22"/>
+      <stop offset="0" stop-color="#B0913F"/>
+      <stop offset="1" stop-color="#82632A"/>
     </linearGradient>
     <linearGradient id="s4-beamOut" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F8F2E0" stop-opacity="0.22"/>
@@ -117,7 +117,7 @@
   </g>
 
   <!-- edges over the beam so the stone keeps its geometry -->
-  <line x1="256" y1="214" x2="256" y2="298" stroke="#FDF8E9" stroke-opacity="0.7" stroke-width="3" stroke-linecap="round"/>
+  <line x1="256" y1="214" x2="256" y2="298" stroke="#FDF8E9" stroke-opacity="0.35" stroke-width="2" stroke-linecap="round"/>
   <line x1="256" y1="118" x2="176" y2="198" stroke="#FDF8E9" stroke-opacity="0.55" stroke-width="2" stroke-linecap="round"/>
   <line x1="176" y1="314" x2="256" y2="394" stroke="#F3E7C2" stroke-opacity="0.45" stroke-width="2" stroke-linecap="round"/>
   <polygon points="256,118 336,198 336,314 256,394 176,314 176,198"

--- a/docs/specs/assets/icon-studies/study-4-winner.svg
+++ b/docs/specs/assets/icon-studies/study-4-winner.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <!-- Study 4 — the winner (2026-07-09): Study 3's Slash of Light plus
-       Study 2's specular chevrons, on a brighter blue field that
-       complements the champagne gem. The beam runs edge to edge across
-       the frame; no caustic pool — the gem's own glow grounds it.
-       Facet-geometry study, not final art. The chevrons are a large-size
-       flourish: they melt into sparkle below ~48px while the beam and
-       silhouette carry the small-size read. -->
+       Study 2's chevrons, on a bright steel-blue field. Liquid Glass pass:
+       rounded silhouette, melted facet junctions, translucent body with a
+       wet specular and an internal environment reflection, soft rim light
+       instead of drawn edges. Chevrons are etched into the stone (shadow
+       wall up-left, lit wall down-right), not glowing on top of it.
+       Facet-geometry study, not final art. -->
   <defs>
     <radialGradient id="s4-bg" cx="0.38" cy="0.26" r="1.05">
       <stop offset="0" stop-color="#6E86AB"/>
@@ -20,6 +20,12 @@
       <stop offset="0" stop-color="#EFD9A0" stop-opacity="0.45"/>
       <stop offset="1" stop-color="#EFD9A0" stop-opacity="0"/>
     </radialGradient>
+    <!-- rounded glass under-layer: one blended body gradient -->
+    <linearGradient id="s4-glassBase" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#EED9A4"/>
+      <stop offset="0.6" stop-color="#CFAD5F"/>
+      <stop offset="1" stop-color="#A9873C"/>
+    </linearGradient>
     <linearGradient id="s4-topL" x1="0" y1="0" x2="0.6" y2="1">
       <stop offset="0" stop-color="#FBF5E3"/>
       <stop offset="1" stop-color="#EFD9A0"/>
@@ -67,19 +73,19 @@
     <filter id="s4-beamBlur" x="-60%" y="-60%" width="220%" height="220%">
       <feGaussianBlur stdDeviation="7"/>
     </filter>
-    <linearGradient id="s4-chev" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#FFF9E8"/>
-      <stop offset="1" stop-color="#E3C273"/>
-    </linearGradient>
-    <filter id="s4-glint" x="-60%" y="-60%" width="220%" height="220%">
-      <feGaussianBlur stdDeviation="1.4"/>
+    <filter id="s4-melt" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="1.6"/>
+    </filter>
+    <filter id="s4-rim" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="1"/>
     </filter>
   </defs>
 
-  <!-- galena field -->
+  <!-- bright steel-blue field -->
   <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s4-bg)"/>
   <rect x="50" y="50" width="412" height="412" rx="92" fill="none" stroke="#FFFFFF" stroke-opacity="0.06" stroke-width="2"/>
 
+  <!-- the gem's glow -->
   <ellipse cx="256" cy="262" rx="170" ry="190" fill="url(#s4-innerGlow)" filter="url(#s4-soft)"/>
 
   <!-- incoming beam, edge to edge across the frame -->
@@ -88,41 +94,69 @@
              fill="url(#s4-beamOut)" filter="url(#s4-beamBlur)"/>
   </g>
 
-  <!-- crystal -->
+  <!-- crystal: liquid glass -->
   <g>
-    <polygon points="256,118 176,198 256,214" fill="url(#s4-topL)"/>
-    <polygon points="256,118 336,198 256,214" fill="url(#s4-topR)"/>
-    <polygon points="176,198 256,214 256,298 176,314" fill="url(#s4-bodyL)"/>
-    <polygon points="336,198 256,214 256,298 336,314" fill="url(#s4-bodyR)"/>
-    <polygon points="176,314 256,298 256,394" fill="url(#s4-botL)"/>
-    <polygon points="336,314 256,298 256,394" fill="url(#s4-botR)"/>
+    <!-- rounded under-layer carries the silhouette; wide round-joined
+         stroke rounds every corner of the stone -->
+    <polygon points="256,118 336,198 336,314 256,394 176,314 176,198"
+             fill="url(#s4-glassBase)" stroke="url(#s4-glassBase)"
+             stroke-width="14" stroke-linejoin="round" opacity="0.92"/>
+    <!-- facets, melted together and slightly translucent -->
+    <g filter="url(#s4-melt)" opacity="0.9">
+      <polygon points="256,118 176,198 256,214" fill="url(#s4-topL)"/>
+      <polygon points="256,118 336,198 256,214" fill="url(#s4-topR)"/>
+      <polygon points="176,198 256,214 256,298 176,314" fill="url(#s4-bodyL)"/>
+      <polygon points="336,198 256,214 256,298 336,314" fill="url(#s4-bodyR)"/>
+      <polygon points="176,314 256,298 256,394" fill="url(#s4-botL)"/>
+      <polygon points="336,314 256,298 256,394" fill="url(#s4-botR)"/>
+    </g>
+    <!-- internal environment reflection: the blue field seen through
+         the lower-right of the stone -->
+    <g clip-path="url(#s4-crystal)">
+      <polygon points="336,220 336,314 256,394 300,394 336,350"
+               fill="#9FB6D9" opacity="0.2" filter="url(#s4-soft2)"/>
+    </g>
+    <!-- wet specular: soft blob riding the upper-left shoulder -->
+    <g clip-path="url(#s4-crystal)">
+      <ellipse cx="216" cy="182" rx="44" ry="24" transform="rotate(-38 216 182)"
+               fill="#FFFFFF" opacity="0.4" filter="url(#s4-soft2)"/>
+      <ellipse cx="196" cy="230" rx="10" ry="22" transform="rotate(-12 196 230)"
+               fill="#FFFFFF" opacity="0.22" filter="url(#s4-soft2)"/>
+    </g>
   </g>
 
   <!-- the beam inside the body: kinked ~8°, hot champagne -->
   <g clip-path="url(#s4-crystal)">
     <g transform="rotate(8 256 256)">
-      <polygon points="433.8,71.6 105.8,463.6 78.2,440.4 406.2,48.4"
+      <polygon points="486.1,4.4 48.9,526.8 25.9,507.6 463.1,-14.8"
                fill="url(#s4-beamIn)" filter="url(#s4-beamBlur)"/>
-      <line x1="420" y1="60" x2="92" y2="452" stroke="#FFFBEA" stroke-width="5"
-            stroke-linecap="round" opacity="0.55" filter="url(#s4-beamBlur)"/>
+      <line x1="420" y1="60" x2="92" y2="452" stroke="#FFFBEA" stroke-width="6"
+            stroke-linecap="round" opacity="0.7" filter="url(#s4-beamBlur)"/>
     </g>
   </g>
 
-  <!-- specular chevrons on the facet junctions (from Study 2) -->
+  <!-- chevrons etched into the stone: shadow wall up-left, lit wall
+       down-right, groove base between -->
   <g fill="none" stroke-linecap="round" stroke-linejoin="round">
-    <polyline points="238,212 200,256 238,300" stroke="url(#s4-chev)" stroke-width="8" opacity="0.8" filter="url(#s4-glint)"/>
-    <polyline points="238,212 200,256 238,300" stroke="#FFFDF4" stroke-width="2.5" opacity="0.85"/>
-    <polyline points="274,212 312,256 274,300" stroke="url(#s4-chev)" stroke-width="8" opacity="0.8" filter="url(#s4-glint)"/>
-    <polyline points="274,212 312,256 274,300" stroke="#FFFDF4" stroke-width="2.5" opacity="0.85"/>
+    <g>
+      <polyline points="238,212 200,256 238,300" stroke="#9A7930" stroke-width="6" opacity="0.5"/>
+      <polyline points="238,212 200,256 238,300" stroke="#6E521C" stroke-width="4" opacity="0.7" transform="translate(-1.6,-1.6)"/>
+      <polyline points="238,212 200,256 238,300" stroke="#FFF6DC" stroke-width="3" opacity="0.85" transform="translate(1.6,1.6)"/>
+    </g>
+    <g>
+      <polyline points="274,212 312,256 274,300" stroke="#9A7930" stroke-width="6" opacity="0.5"/>
+      <polyline points="274,212 312,256 274,300" stroke="#6E521C" stroke-width="4" opacity="0.7" transform="translate(-1.6,-1.6)"/>
+      <polyline points="274,212 312,256 274,300" stroke="#FFF6DC" stroke-width="3" opacity="0.85" transform="translate(1.6,1.6)"/>
+    </g>
   </g>
 
-  <!-- edges over the beam so the stone keeps its geometry -->
-  <line x1="256" y1="214" x2="256" y2="298" stroke="#FDF8E9" stroke-opacity="0.35" stroke-width="2" stroke-linecap="round"/>
-  <line x1="256" y1="118" x2="176" y2="198" stroke="#FDF8E9" stroke-opacity="0.55" stroke-width="2" stroke-linecap="round"/>
-  <line x1="176" y1="314" x2="256" y2="394" stroke="#F3E7C2" stroke-opacity="0.45" stroke-width="2" stroke-linecap="round"/>
-  <polygon points="256,118 336,198 336,314 256,394 176,314 176,198"
-           fill="none" stroke="#FBF3DC" stroke-opacity="0.25" stroke-width="1.5"/>
+  <!-- light kiss on the upper edges only — no full rim, it reads as a
+       medallion border -->
+  <polyline points="176,198 256,118 336,198"
+            fill="none" stroke="#FFFFFF" stroke-opacity="0.3" stroke-width="3"
+            stroke-linecap="round" stroke-linejoin="round"
+            transform="translate(0,-6)" filter="url(#s4-rim)"/>
 
-
+  <!-- glass gloss over the whole tile -->
   <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s4-gloss)"/>
 </svg>

--- a/docs/specs/assets/icon-studies/study-4-winner.svg
+++ b/docs/specs/assets/icon-studies/study-4-winner.svg
@@ -1,14 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <!-- Study 4 — the winner (2026-07-09): Study 3's Slash of Light plus
-       Study 2's specular chevrons, on a field tinted further toward blue
-       to complement the champagne gem. Facet-geometry study, not final art.
-       The chevrons are a large-size flourish: they melt into sparkle below
-       ~48px while the beam and silhouette carry the small-size read. -->
+       Study 2's specular chevrons, on a brighter blue field that
+       complements the champagne gem. The beam runs edge to edge across
+       the frame; no caustic pool — the gem's own glow grounds it.
+       Facet-geometry study, not final art. The chevrons are a large-size
+       flourish: they melt into sparkle below ~48px while the beam and
+       silhouette carry the small-size read. -->
   <defs>
     <radialGradient id="s4-bg" cx="0.38" cy="0.26" r="1.05">
-      <stop offset="0" stop-color="#4A5C74"/>
-      <stop offset="0.55" stop-color="#2B3850"/>
-      <stop offset="1" stop-color="#172030"/>
+      <stop offset="0" stop-color="#5B7192"/>
+      <stop offset="0.55" stop-color="#364764"/>
+      <stop offset="1" stop-color="#202C40"/>
     </radialGradient>
     <linearGradient id="s4-gloss" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.10"/>
@@ -43,8 +45,8 @@
       <stop offset="1" stop-color="#7A5C22"/>
     </linearGradient>
     <linearGradient id="s4-beamOut" x1="1" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#F8F2E0" stop-opacity="0.16"/>
-      <stop offset="1" stop-color="#F8F2E0" stop-opacity="0.02"/>
+      <stop offset="0" stop-color="#F8F2E0" stop-opacity="0.22"/>
+      <stop offset="1" stop-color="#F8F2E0" stop-opacity="0.08"/>
     </linearGradient>
     <linearGradient id="s4-beamIn" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#FFF3D0" stop-opacity="0.8"/>
@@ -80,9 +82,9 @@
 
   <ellipse cx="256" cy="262" rx="170" ry="190" fill="url(#s4-innerGlow)" filter="url(#s4-soft)"/>
 
-  <!-- incoming beam, faint, across the tile -->
+  <!-- incoming beam, edge to edge across the frame -->
   <g clip-path="url(#s4-tile)">
-    <polygon points="429.2,67.7 101.2,459.7 82.8,444.3 410.8,52.3"
+    <polygon points="486.1,4.4 48.9,526.8 25.9,507.6 463.1,-14.8"
              fill="url(#s4-beamOut)" filter="url(#s4-beamBlur)"/>
   </g>
 
@@ -121,8 +123,6 @@
   <polygon points="256,118 336,198 336,314 256,394 176,314 176,198"
            fill="none" stroke="#FBF3DC" stroke-opacity="0.25" stroke-width="1.5"/>
 
-  <!-- single caustic pool, stretched toward the beam exit at lower left -->
-  <ellipse cx="228" cy="401" rx="110" ry="20" fill="#EFD9A0" opacity="0.4" filter="url(#s4-soft2)"/>
 
   <rect x="50" y="50" width="412" height="412" rx="92" fill="url(#s4-gloss)"/>
 </svg>


### PR DESCRIPTION
## Summary

- Adds `docs/specs/2026-07-09-app-icon-identity-brainstorm.md`, capturing the interview-locked direction for replacing the `</>` app icon: a glassy, refractive anglesite crystal in champagne-gold on steel-blue galena, angle brackets hidden in the facet geometry, friendly/magical tone, indie-Mac-craft rendering.
- Documents four icon concepts (The Prism, Bracket Facet, Slash of Light, On Galena) with a recommended development path, a working palette, macOS 27 layered Icon Composer production notes, and in-app accent guidance (gold reserved for "magical" moments).
- Docs only — no code or asset changes yet; next step is facet-geometry studies for the top concepts.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks). Link it here:

> Cross-cutting work (extending MCP messages, changing the plugin's hook contract, adjusting the site template the app scaffolds, etc.) lands as paired PRs. The plugin PR ships first in a tagged release; the app PR consumes it and bumps `Resources/plugin/`'s source-of-truth pointer. See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [ ] `swift test --package-path .` — n/a, docs only
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — n/a, docs only
- [x] Manual smoke (if UI-touching): n/a — Markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EMcexyPjoD4rXVUPmSuao

---
_Generated by [Claude Code](https://claude.ai/code/session_017EMcexyPjoD4rXVUPmSuao)_