### PR TITLE
fix(app): disable FoundationModels autolink so weak-link actually takes effect (#541)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,16 @@ let weakLinkFoundationModels: [LinkerSetting] = [
     .unsafeFlags(["-Xlinker", "-weak_framework", "-Xlinker", "FoundationModels"])
 ]
 
+// AnglesiteCore is the only target that `import`s FoundationModels. Swift embeds a *hard*
+// `-framework FoundationModels` autolink hint in its compiled object code, which wins over the
+// app target's explicit `-weak_framework FoundationModels` (project.yml) when the final app
+// binary is linked — so the app still hard-links FoundationModels despite that flag. Disabling
+// the autolink hint at the source makes the app target's weak-link flag the only (and effective)
+// link request. See #541.
+let disableFoundationModelsAutolink: [SwiftSetting] = [
+    .unsafeFlags(["-Xfrontend", "-disable-autolink-framework", "-Xfrontend", "FoundationModels"])
+]
+
 // AnglesiteContainer imports apple/containerization — a Swift 6.2, macOS-15+ package that pulls in
 // the native NIO/gRPC/protobuf graph and only links on Apple-Silicon machines with the
 // virtualization entitlement. `swift build` / `swift test` compile ALL of a package's products, so
@@ -50,7 +60,7 @@ var packageTargets: [Target] = [
         name: "AnglesiteCore",
         dependencies: ["AnglesiteSiteModel"],
         path: "Sources/AnglesiteCore",
-        swiftSettings: strictConcurrency
+        swiftSettings: strictConcurrency + disableFoundationModelsAutolink
     ),
     .target(
         name: "AnglesiteBridge",


### PR DESCRIPTION
## Summary
- PR #580 weak-linked `FoundationModels` on the `Anglesite` app target's `OTHER_LDFLAGS`, but the app still hard dyld-aborted at launch on `Attachment(imageURL:orientation:)` — a symbol the beta Xcode SDK added ahead of what the installed macOS beta seed exports.
- Root cause: `AnglesiteCore` (the only target with `import FoundationModels`) embeds a hard, non-weak `-framework FoundationModels` autolink hint in its compiled object code, which wins over the app target's explicit `-weak_framework` flag at final link.
- Fix: disable the autolink hint at the source (`-Xfrontend -disable-autolink-framework -Xfrontend FoundationModels` on `AnglesiteCore`'s `swiftSettings`), leaving the app target's `-weak_framework FoundationModels` as the sole, effective link request.

## Test plan
- [x] `xcodegen generate` + `xcodebuild -scheme Anglesite -configuration Debug build` succeeds
- [x] `otool -l Anglesite.debug.dylib` confirms `FoundationModels.framework` load command changed from `LC_LOAD_DYLIB` to `LC_LOAD_WEAK_DYLIB`
- [x] Launched the built `.app` directly (`open -W -n`) — process stays alive (verified via `pgrep` over ~16s), no crash report generated, no abort/SIGABRT/"Symbol not found" in `log show` — previously it died at dyld before `main`
- [x] `swift build --build-tests` compiles cleanly (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)