### PR TITLE
fix(build): quote PROJECT_DIR in project.yml run-script phases

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -36,13 +36,13 @@ targets:
         optional: true
     preBuildScripts:
       - name: Bundle Anglesite plugin
-        script: "${PROJECT_DIR}/scripts/copy-plugin.sh"
+        script: "\"${PROJECT_DIR}/scripts/copy-plugin.sh\""
         basedOnDependencyAnalysis: false
       - name: Build edit overlay
-        script: "${PROJECT_DIR}/scripts/build-overlay.sh"
+        script: "\"${PROJECT_DIR}/scripts/build-overlay.sh\""
         basedOnDependencyAnalysis: false
       - name: Build Help index
-        script: "${PROJECT_DIR}/scripts/build-help-index.sh"
+        script: "\"${PROJECT_DIR}/scripts/build-help-index.sh\""
         basedOnDependencyAnalysis: false
     settings:
       base:


### PR DESCRIPTION
## Summary
- `project.yml`'s three pre-build run-script phases (`copy-plugin.sh`, `build-overlay.sh`, `build-help-index.sh`) interpolated `${PROJECT_DIR}` unquoted, so a checkout under a path containing a space (e.g. a mounted shared folder) breaks the build: the shell word-splits the path and tries to execute the segment before the space as a command.
- Quoted all three script paths so `xcodegen generate` emits a properly-quoted `shellScript` in the generated project.

## Test plan
- [x] `xcodegen generate` and confirmed the generated `Anglesite.xcodeproj/project.pbxproj` carries the quoted `shellScript` values for all three phases.
- [x] Reproduced the original failure on a path with a space, applied the fix, and confirmed the build proceeds past those script phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)