### PR TITLE
build: guard against unvendored container resources at build time

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -35,6 +35,11 @@ targets:
         buildPhase: resources
         optional: true
     preBuildScripts:
+      # Guard first so a Release build with unvendored container resources fails
+      # before the (slow) plugin copy/npm install phases run. Debug only warns.
+      - name: Check container resources
+        script: "${PROJECT_DIR}/scripts/check-container-resources.sh"
+        basedOnDependencyAnalysis: false
       - name: Bundle Anglesite plugin
         script: "${PROJECT_DIR}/scripts/copy-plugin.sh"
         basedOnDependencyAnalysis: false

--- a/scripts/check-container-resources.sh
+++ b/scripts/check-container-resources.sh
@@ -34,15 +34,33 @@ RESOURCES="$REPO_ROOT/Resources"
 
 # Per-artifact runtime overrides (BundledImage honors these at runtime, so a dev
 # running against external artifacts shouldn't be nagged about unvendored dirs).
+# Mirror BundledImage.swift exactly: a set override still gets its own
+# file-existence check, not a free pass — a stale/mistyped override must fail
+# here too, or this guard can't be trusted (it would print "provisioned — OK"
+# and pass a Release build that still hits NotProvisioned at runtime).
 missing=()
 
-if [[ -z "${ANGLESITE_CONTAINER_IMAGE:-}" && ! -f "$RESOURCES/container-image/index.json" ]]; then
+if [[ -n "${ANGLESITE_CONTAINER_IMAGE:-}" ]]; then
+    if [[ ! -f "$ANGLESITE_CONTAINER_IMAGE/index.json" ]]; then
+        missing+=("ANGLESITE_CONTAINER_IMAGE=$ANGLESITE_CONTAINER_IMAGE has no index.json — fix or unset the override")
+    fi
+elif [[ ! -f "$RESOURCES/container-image/index.json" ]]; then
     missing+=("Resources/container-image is unvendored (no index.json) — run scripts/vendor-container-image.sh")
 fi
-if [[ -z "${ANGLESITE_CONTAINER_KERNEL:-}" && ! -f "$RESOURCES/container-kernel/vmlinux" ]]; then
+
+if [[ -n "${ANGLESITE_CONTAINER_KERNEL:-}" ]]; then
+    if [[ ! -f "$ANGLESITE_CONTAINER_KERNEL" ]]; then
+        missing+=("ANGLESITE_CONTAINER_KERNEL=$ANGLESITE_CONTAINER_KERNEL does not exist — fix or unset the override")
+    fi
+elif [[ ! -f "$RESOURCES/container-kernel/vmlinux" ]]; then
     missing+=("Resources/container-kernel is unvendored (no vmlinux) — run scripts/vendor-container-kernel.sh")
 fi
-if [[ -z "${ANGLESITE_CONTAINER_INITFS:-}" && ! -f "$RESOURCES/container-initfs/index.json" ]]; then
+
+if [[ -n "${ANGLESITE_CONTAINER_INITFS:-}" ]]; then
+    if [[ ! -f "$ANGLESITE_CONTAINER_INITFS/index.json" ]]; then
+        missing+=("ANGLESITE_CONTAINER_INITFS=$ANGLESITE_CONTAINER_INITFS has no index.json — fix or unset the override")
+    fi
+elif [[ ! -f "$RESOURCES/container-initfs/index.json" ]]; then
     missing+=("Resources/container-initfs is unvendored (no index.json) — run scripts/vendor-container-kernel.sh")
 fi
 

--- a/scripts/check-container-resources.sh
+++ b/scripts/check-container-resources.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Build-time guard for the vendored container boot artifacts.
+#
+# `Resources/container-{image,kernel,initfs}/` are gitignored and populated by
+# scripts/vendor-container-image.sh (image) and scripts/vendor-container-kernel.sh
+# (kernel + initfs). They ship into the app via SwiftPM `.copy()` resources on
+# AnglesiteContainer, so an unvendored tree (fresh clone, new worktree, git clean)
+# still BUILDS fine — the app only fails at runtime, when preview reports
+# "imageLayoutNotProvisioned; kernelNotProvisioned; initfsNotProvisioned"
+# (BundledImage.swift). This script surfaces that gap at build time instead.
+#
+# The checks mirror BundledImage.swift's provisioning markers exactly — the dirs
+# always exist (each keeps a committed .gitkeep so the `.copy()` rule never
+# breaks), so presence of the real artifact files is what "provisioned" means:
+#   container-image/index.json    (OCI layout — vendor-container-image.sh)
+#   container-kernel/vmlinux      (kernel binary — vendor-container-kernel.sh)
+#   container-initfs/index.json   (vminit OCI layout — vendor-container-kernel.sh)
+#
+# Policy: Debug builds WARN (Xcode issue-navigator warnings, build continues) —
+# a fresh worktree must stay buildable for work that never boots a container.
+# Release builds FAIL — an archive without boot artifacts ships an app whose
+# local-container preview can never work, and nothing downstream would catch it.
+# Set ANGLESITE_ALLOW_UNPROVISIONED_CONTAINER=1 to downgrade a Release failure
+# to a warning (e.g. exercising the Release configuration without vendoring).
+#
+# Lines prefixed `warning:` / `error:` are parsed by Xcode into real build issues.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+RESOURCES="$REPO_ROOT/Resources"
+
+# Per-artifact runtime overrides (BundledImage honors these at runtime, so a dev
+# running against external artifacts shouldn't be nagged about unvendored dirs).
+missing=()
+
+if [[ -z "${ANGLESITE_CONTAINER_IMAGE:-}" && ! -f "$RESOURCES/container-image/index.json" ]]; then
+    missing+=("Resources/container-image is unvendored (no index.json) — run scripts/vendor-container-image.sh")
+fi
+if [[ -z "${ANGLESITE_CONTAINER_KERNEL:-}" && ! -f "$RESOURCES/container-kernel/vmlinux" ]]; then
+    missing+=("Resources/container-kernel is unvendored (no vmlinux) — run scripts/vendor-container-kernel.sh")
+fi
+if [[ -z "${ANGLESITE_CONTAINER_INITFS:-}" && ! -f "$RESOURCES/container-initfs/index.json" ]]; then
+    missing+=("Resources/container-initfs is unvendored (no index.json) — run scripts/vendor-container-kernel.sh")
+fi
+
+if [[ ${#missing[@]} -eq 0 ]]; then
+    echo "==> Container boot artifacts provisioned — OK"
+    exit 0
+fi
+
+# Release archives must not ship without boot artifacts; everything else warns.
+severity="warning"
+if [[ "${CONFIGURATION:-Debug}" == "Release" && "${ANGLESITE_ALLOW_UNPROVISIONED_CONTAINER:-0}" != "1" ]]; then
+    severity="error"
+fi
+
+for m in "${missing[@]}"; do
+    echo "$severity: $m" >&2
+done
+echo "$severity: local-container preview will fail at runtime with 'NotProvisioned' until the vendor scripts above are run (see BundledImage.swift)." >&2
+
+if [[ "$severity" == "error" ]]; then
+    echo "       To build Release anyway (NOT for distribution), set ANGLESITE_ALLOW_UNPROVISIONED_CONTAINER=1." >&2
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem

`Resources/container-image/`, `Resources/container-kernel/`, and `Resources/container-initfs/` are gitignored and populated by `scripts/vendor-container-image.sh` / `scripts/vendor-container-kernel.sh`. When they're unvendored (fresh clone, new worktree, `git clean`) the app still **builds successfully** — the gap only surfaces at runtime, when preview fails with:

> Local container runtime is required… imageLayoutNotProvisioned; kernelNotProvisioned; initfsNotProvisioned

(`Sources/AnglesiteContainer/BundledImage.swift`)

## Change

New `scripts/check-container-resources.sh`, wired as the **first** `preBuildScripts` entry on the app target in `project.yml` (fail-fast, before the slower plugin-copy/npm phases).

- **Mirrors `BundledImage.swift`'s exact provisioning markers** — `container-image/index.json`, `container-kernel/vmlinux`, `container-initfs/index.json` — not a loose "dir non-empty" test (the dirs always hold a committed `.gitkeep`), so the build guard and runtime `isProvisioned` can never disagree.
- **Honors the same `ANGLESITE_CONTAINER_{IMAGE,KERNEL,INITFS}` env overrides** as the runtime, so devs pointing at external artifacts aren't nagged.
- Each message names the missing artifact and the vendor script that produces it.

### Policy: Debug warns, Release fails

- **Debug → warning** (Xcode issue-navigator entries, build continues): fresh worktrees must stay buildable for work that never boots a container, and vendoring needs the Apple `container` CLI. Matches `copy-plugin.sh`'s best-effort precedent for a *missing* input.
- **Release → error** (build fails): an archive without boot artifacts ships an app whose local-container preview can never work, and `scripts/release.sh` (which archives Release) has no downstream check that would catch it. Matches `copy-plugin.sh`'s fail-loudly precedent for a *broken* input.
- Escape hatch: `ANGLESITE_ALLOW_UNPROVISIONED_CONTAINER=1` downgrades the Release failure to a warning for deliberately unprovisioned Release-config builds.

## Verification

All run in a worktree whose three resource dirs genuinely contain only `.gitkeep`:

- Script directly: Debug/unset → 4 warnings + exit 0; `CONFIGURATION=Release` → 4 errors + exit 1; Release + escape hatch → exit 0; env overrides set → OK; marker files present → OK.
- `xcodebuild … -configuration Debug build` → **BUILD SUCCEEDED** with the four `warning:` lines parsed into the build log.
- `xcodebuild … -configuration Release CODE_SIGNING_ALLOWED=NO build` → **BUILD FAILED** on the guard's `error:` lines before any compilation. (Signing disabled only for this verification — this machine has no Apple Distribution identity; the plain Release run fails earlier at signing validation, before phases execute.)
- CI impact: none — the only `xcodebuild` lane builds the `AnglesiteIntents` scheme, which doesn't run the app target's pre-build scripts, and `check-xcodeproj-sync.sh` only asserts source membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)