### PR TITLE
fix(app): stop SiteWindowModelTests crashing the whole test process

### DIFF
--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -3,9 +3,13 @@ import Foundation
 import AnglesiteCore
 @testable import AnglesiteAppCore
 
-/// Never actually starts a runtime — `makeRuntime` isn't invoked by any test in this file, since
-/// none of them call `preview.startDevServer()`. If a future test needs a working fake runtime,
-/// extend this rather than adding a second fake type.
+/// `PreviewModel`'s convenience init constructs its runtime eagerly via `makeRuntime` (not lazily
+/// on `startDevServer()`), so this factory must hand back a real, safe-to-construct `SiteRuntime`
+/// rather than fatal-erroring. `UnavailableSiteRuntime` is the same inert runtime
+/// `LiveSiteRuntimeFactory` falls back to in production when no container runtime is available:
+/// its `start()` just settles to `.failed` rather than spawning anything, so it stays inert for
+/// every test in this file — none of them call `preview.startDevServer()`. If a future test needs
+/// a working fake runtime, extend this rather than adding a second fake type.
 struct NeverStartedSiteRuntimeFactory: SiteRuntimeFactory {
     func makeRuntime(
         contentGraph: SiteContentGraph?,
@@ -13,7 +17,7 @@ struct NeverStartedSiteRuntimeFactory: SiteRuntimeFactory {
         semanticRanker: SemanticRanker?,
         conventionsEngine: ProjectConventionsEngine?
     ) -> any SiteRuntime {
-        fatalError("NeverStartedSiteRuntimeFactory.makeRuntime should not be called in this test suite")
+        UnavailableSiteRuntime(reason: "NeverStartedSiteRuntimeFactory should not be started in this test suite")
     }
 }
 


### PR DESCRIPTION
## Summary
- `NeverStartedSiteRuntimeFactory.makeRuntime` (added in #581) unconditionally called `fatalError(...)`, on the (incorrect) assumption that `makeRuntime` is only invoked lazily from `preview.startDevServer()`.
- In fact, `PreviewModel`'s convenience init calls `runtimeFactory.makeRuntime(...)` synchronously and unconditionally during construction — so `SiteWindowModel.init()` → `PreviewModel(...)` crashed the entire `swift test` process on every single test in `SiteWindowModelTests.swift`, including the trivial `constructs()` smoke test.
- Swapped the `fatalError` for `UnavailableSiteRuntime` — an existing, production-safe inert `SiteRuntime` that `LiveSiteRuntimeFactory` already returns when no container runtime is available. Its `start()` just settles to `.failed` without spawning any process, so it's safe to construct and still satisfies "never actually started," since none of these tests call `startDevServer()`.

## Test plan
- [x] `swift test --package-path . --filter "SiteWindowModelTests"` — all 7 tests pass (previously: process crash, signal 5)
- [x] Full `swift test --package-path .` run — `SiteWindowModelTests` suite passes; two unrelated pre-existing failures were found elsewhere (`ProjectCleanupModelTests` and `ContentTypeAppEnumTests`) and flagged separately, out of scope for this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)