### PR TITLE
fix(intents): add missing member case to ContentTypeAppEnum

### DIFF
--- a/Sources/AnglesiteIntents/ContentTypeAppEnum.swift
+++ b/Sources/AnglesiteIntents/ContentTypeAppEnum.swift
@@ -9,6 +9,7 @@ import AnglesiteCore
 public enum ContentTypeAppEnum: String, AppEnum, Sendable, CaseIterable {
     case note, article, photo, album, bookmark, reply, like
     case announcement, event, review
+    case member
 
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Content Type" }
 
@@ -16,6 +17,7 @@ public enum ContentTypeAppEnum: String, AppEnum, Sendable, CaseIterable {
         .note: "Note", .article: "Article", .photo: "Photo", .album: "Album",
         .bookmark: "Bookmark", .reply: "Reply", .like: "Like",
         .announcement: "Announcement", .event: "Event", .review: "Review",
+        .member: "Member",
     ]
 
     /// The Astro content collection backing this type (e.g. `.event` → "events"), via the registry.


### PR DESCRIPTION
## Summary
- `ContentTypeAppEnum.allCases.map(\.rawValue)` must exactly match `ContentTypeRegistry.default.collectionBackedTypeIDs`, in order — enforced by a drift-guard test in `ContentTypeAppEnumTests`.
- The `member` content type was added to the registry under #462 ("Identity and directory", `member` collection) but `ContentTypeAppEnum` was never updated, leaving it out of sync and breaking the drift-guard test.
- Adds `case member` (with a `"Member"` display representation) to `ContentTypeAppEnum`, matching the registry's registration order: `note, article, photo, album, bookmark, reply, like, announcement, event, review, member`.

## Why
Reported as a deterministic failure of `enum cases match the registry's collection-backed type ids exactly, in order (drift guard)` in `Tests/AnglesiteIntentsTests/ContentTypeAppEnumTests.swift`, likely a follow-on gap from commit b79ea123 which fixed the equivalent drift in `ContentTypeRegistryTests` but missed this enum.

## Test plan
- [x] `swift test --package-path . --filter AnglesiteIntentsTests` — all 238 tests pass, including the drift-guard test (run twice for confirmation; needed `-j 2` due to unrelated network-filesystem build flakiness on this worktree's mount).

🤖 Generated with [Claude Code](https://claude.com/claude-code)