### PR TITLE
fix(app): extend redirect safety net to blog posts (#584)

### DIFF
--- a/Sources/AnglesiteApp/AddRedirectSheet.swift
+++ b/Sources/AnglesiteApp/AddRedirectSheet.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 import AnglesiteCore
 
-/// "Add Redirect?" prompt shown after a page delete succeeds (#530) — `SiteWindowModel.confirmDelete()`
-/// sets `pendingRedirectOfferRoute` to the deleted page's route (never for posts, which carry no
-/// route), and `SiteWindow` presents this sheet pre-filled with that route as the source. Saving
+/// "Add Redirect?" prompt shown after a page or post delete succeeds (#530, #584) —
+/// `SiteWindowModel.confirmDelete()` sets `pendingRedirectOfferRoute` to the deleted item's route
+/// (a page's `route`, or a post's `postRoute(for:)`), and `SiteWindow` presents this sheet
+/// pre-filled with that route as the source. Saving
 /// appends to `Source/redirects.json` via the injected `onSave` closure
 /// (`SiteNavigatorModel.saveRedirect(source:destination:code:)`); dismissing without saving is a
 /// no-op, matching the delete's "you can always add one later in Site Settings → Redirects" framing.

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -202,10 +202,10 @@ final class SiteNavigatorModel {
 
     /// Appends a redirect for `source` → `destination` to `Source/redirects.json` (#530). Used by
     /// the "Add Redirect?" prompt `SiteWindow` shows after `SiteWindowModel.confirmDelete()`
-    /// successfully deletes a page — that method captures the deleted page's route before the
-    /// delete call and, on success, offers this via a sheet hosted in `SiteWindow` (not here:
-    /// delete itself is owned by `SiteWindowModel`/`NativeContentOperations` since #516, not this
-    /// model). Returns whether the save succeeded; on failure sets `redirectSaveError`.
+    /// successfully deletes a page or post (#584) — that method captures the deleted item's route
+    /// before the delete call and, on success, offers this via a sheet hosted in `SiteWindow` (not
+    /// here: delete itself is owned by `SiteWindowModel`/`NativeContentOperations` since #516, not
+    /// this model). Returns whether the save succeeded; on failure sets `redirectSaveError`.
     @discardableResult
     func saveRedirect(source: String, destination: String, code: RedirectsStore.RedirectEntry.Code) async -> Bool {
         guard let sourceDirectory else { return false }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -111,9 +111,9 @@ final class SiteWindowModel {
     /// (page/post) delete/duplicate rather than Cleanup's dead-asset delete.
     var contentActionError: String?
     /// Non-nil ⟺ the "Add Redirect?" prompt is showing (#530), holding the route that was just
-    /// deleted. Set by `confirmDelete()` only when the deleted item was a page (posts carry no
-    /// `route`) and the delete actually succeeded — never break an inbound URL a user didn't
-    /// choose to abandon.
+    /// deleted (a page's `route`, or a post's `postRoute(for:)`) — set by `confirmDelete()` only
+    /// when the delete actually succeeded. Never break an inbound URL a user didn't choose to
+    /// abandon (#584).
     var pendingRedirectOfferRoute: String?
     /// File ▸ Revert to Saved is destructive, so it routes through a confirmation alert hosted by
     /// `SiteWindow` (#509).
@@ -299,7 +299,11 @@ final class SiteWindowModel {
         guard let site, canRunDeploy else { return }
         Task { @MainActor in
             let containerControl = await preview.activeContainerControl()
-            let currentRoutes = await contentGraph.pages(for: site.id).map(\.route)
+            // Posts are routed too (#584) — a vanished post's URL must trip the same
+            // orphaned-route scan as a vanished page's, not vanish silently from the snapshot.
+            let pageRoutes = await contentGraph.pages(for: site.id).map(\.route)
+            let postRoutes = await contentGraph.posts(for: site.id).map(postRoute(for:))
+            let currentRoutes = pageRoutes + postRoutes
             deploy.deploy(
                 siteID: site.id, siteDirectory: site.sourceDirectory,
                 configDirectory: site.configDirectory, currentRoutes: currentRoutes,
@@ -782,14 +786,16 @@ final class SiteWindowModel {
 
         let relPath: String
         // Captured before the delete call, not derived after: `.deleted(filePath:)` doesn't carry
-        // a route, and posts have none to carry regardless (#530) — only a page's route is ever a
-        // redirect-offer candidate.
-        var deletedPageRoute: String?
+        // a route. Both pages and posts are redirect-offer candidates (#584) — a post's route is
+        // derived via `postRoute(for:)`, the same helper the navigator uses to give posts a
+        // `.route` target in the first place.
+        var deletedRoute: String?
         if let page = await contentGraph.page(id: item.id) {
             relPath = page.filePath
-            deletedPageRoute = page.route
+            deletedRoute = page.route
         } else if let post = await contentGraph.post(id: item.id) {
             relPath = post.filePath
+            deletedRoute = postRoute(for: post)
         } else {
             return
         }
@@ -810,8 +816,8 @@ final class SiteWindowModel {
         switch result {
         case .deleted:
             if navigator?.selection == item.id { navigator?.selection = nil }
-            if let deletedPageRoute {
-                pendingRedirectOfferRoute = deletedPageRoute
+            if let deletedRoute {
+                pendingRedirectOfferRoute = deletedRoute
             }
         case .failed(let reason):
             contentActionError = reason

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -3,9 +3,12 @@ import Foundation
 import AnglesiteCore
 @testable import AnglesiteAppCore
 
-/// Never actually starts a runtime — `makeRuntime` isn't invoked by any test in this file, since
-/// none of them call `preview.startDevServer()`. If a future test needs a working fake runtime,
-/// extend this rather than adding a second fake type.
+/// `SiteWindowModel.init()` constructs `PreviewModel` (and thus calls `makeRuntime`) eagerly, so
+/// this can't `fatalError` on `makeRuntime` itself — only on an actual start. Returns
+/// `UnavailableSiteRuntime`, the same production type used when no container runtime is
+/// provisioned: its `start(siteID:siteDirectory:)` settles to `.failed` rather than spawning
+/// anything, so a test that accidentally called `preview.startDevServer()` would see a failed
+/// preview state instead of a working runtime — no new fake type needed.
 struct NeverStartedSiteRuntimeFactory: SiteRuntimeFactory {
     func makeRuntime(
         contentGraph: SiteContentGraph?,
@@ -13,7 +16,7 @@ struct NeverStartedSiteRuntimeFactory: SiteRuntimeFactory {
         semanticRanker: SemanticRanker?,
         conventionsEngine: ProjectConventionsEngine?
     ) -> any SiteRuntime {
-        fatalError("NeverStartedSiteRuntimeFactory.makeRuntime should not be called in this test suite")
+        UnavailableSiteRuntime(reason: "NeverStartedSiteRuntimeFactory: this test suite never starts a runtime")
     }
 }
 
@@ -25,9 +28,9 @@ struct NeverStartedSiteRuntimeFactory: SiteRuntimeFactory {
 @Suite("SiteWindowModel")
 @MainActor
 struct SiteWindowModelTests {
-    private func makeModel() -> SiteWindowModel {
+    private func makeModel(contentGraph: SiteContentGraph = SiteContentGraph()) -> SiteWindowModel {
         SiteWindowModel(
-            contentGraph: SiteContentGraph(),
+            contentGraph: contentGraph,
             knowledgeIndex: SiteKnowledgeIndex(),
             semanticRanker: nil,
             conventionsEngine: ProjectConventionsEngine(),
@@ -128,6 +131,44 @@ extension SiteWindowModelTests {
         let model = makeModel()
         await model.duplicate(id: "site-1:page:/about")
         // No crash, no error surfaced — there's nothing to duplicate without an open site.
+        #expect(model.contentActionError == nil)
+    }
+
+    /// `confirmDelete`'s post branch now resolves `deletedRoute` via `postRoute(for:)` (#584)
+    /// instead of leaving it `nil` — this exercises that the lookup + route derivation for a real,
+    /// graph-registered post runs cleanly (finds the post, computes its route, proceeds to the
+    /// delete call) rather than crashing or mis-typing. It stops short of proving the route reaches
+    /// `pendingRedirectOfferRoute`, because that only happens on a real `.deleted` result, and
+    /// `ContentCreationWorkflow.native`'s `siteDirectory` resolver is hardwired to `SiteStore.shared`
+    /// (`SiteWindowModel.swift`'s `contentCreation` init) — a real process-wide singleton that
+    /// persists to the developer's actual `recents.json`. There's no test seam to redirect it to a
+    /// throwaway location, and registering a fake site into the real one would risk corrupting real
+    /// user data. That's a pre-existing gap shared with the page case (#530 never had this coverage
+    /// either), not one #584 introduces; `postRoute(for:)` itself is covered in `NavigatorTreeTests`,
+    /// and the full end-to-end behavior is left to manual GUI verification (#586).
+    @Test("confirmDelete resolves a registered post's route without crashing, even though delete itself can't succeed here")
+    func confirmDeletePostRouteResolvesCleanly() async {
+        let graph = SiteContentGraph()
+        let model = makeModel(contentGraph: graph)
+        model.site = SiteStore.Site(
+            id: "site-a", name: "Test", packageURL: URL(fileURLWithPath: "/tmp/nonexistent.anglesite"),
+            isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil
+        )
+        let post = SiteContentGraph.Post(
+            id: "site-a:post:hello-world", siteID: "site-a", collection: "blog", slug: "hello-world",
+            title: "Hello World", draft: false, publishDate: nil, tags: [],
+            filePath: "src/content/blog/hello-world.md", lastModified: Date()
+        )
+        await graph.upsertPost(post)
+        model.deleteConfirmation = NavigatorItem(id: post.id, title: "Hello World", target: .route(postRoute(for: post)))
+
+        await model.confirmDelete()
+
+        #expect(model.deleteConfirmation == nil)
+        // `SiteStore.shared` doesn't know "site-a" — `deleteContent` resolves `.siteNotFound`, so no
+        // redirect offer (correctly: nothing was actually deleted) and no error surfaced (`.siteNotFound`
+        // is a silent no-op in confirmDelete, matching `duplicateNoSiteIsNoOp`'s established expectation).
+        #expect(model.pendingRedirectOfferRoute == nil)
         #expect(model.contentActionError == nil)
     }
 }


### PR DESCRIPTION
## Summary
- Deleting a post now offers an "Add Redirect?" prompt via `SiteWindowModel.confirmDelete()`, just like deleting a page already did — previously only pages captured a route, so posts silently skipped the offer.
- The pre-deploy orphaned-route scan (`RouteCoverageScanner`, fed from `SiteWindowModel.deploySite()`) now includes post routes alongside page routes, so a vanished post's URL is no longer invisible to the warning.
- Both reuse the existing `postRoute(for:)` helper (`/{collection}/{slug}/`) already used elsewhere to give posts a `.route` navigator target — no new route-derivation logic needed.
- Fixed a pre-existing bug found along the way: every test in `SiteWindowModelTests` was crashing via `fatalError` in a test fixture (`NeverStartedSiteRuntimeFactory.makeRuntime`), because `SiteWindowModel.init()` actually calls `makeRuntime` eagerly during construction rather than lazily on start. Swapped it for `UnavailableSiteRuntime` (an existing production type) so construction succeeds and the file's existing tests (plus the new one) can actually run.

## Context
Follow-up from #530 / PR #583, flagged by that PR's review as a known, deliberate scope gap — see #584 for the full writeup. Blog posts are the content type most associated with long-lived, sacred permalinks, and were the one type the redirect-management feature couldn't protect.

## Test plan
- [x] `swift build --package-path .` — clean build
- [x] `swift test --package-path . --filter "SiteWindowModelTests|SiteContentGraphTests|RouteCoverageScannerTests|NavigatorTreeTests|SiteNavigatorModel"` — all pass
- [x] Full `swift test --package-path .` run — all suites pass except a pre-existing, unrelated `ProjectCleanupModelTests` failure (confirmed via diff against branch tip to be untouched by this change; flagged separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)