### PR TITLE
fix(test): fix deterministic failure in ProjectCleanupModel's isBusy-during-delete test

### DIFF
--- a/Tests/AnglesiteAppTests/ProjectCleanupModelTests.swift
+++ b/Tests/AnglesiteAppTests/ProjectCleanupModelTests.swift
@@ -51,9 +51,32 @@ struct ProjectCleanupModelTests {
         defer { try? FileManager.default.removeItem(at: root) }
         try Data().write(to: root.appendingPathComponent("public/images/orphan.png"))
 
+        // `DeadAssetScanner.scan(projectRoot:images:)` only ever proposes an `.image` candidate
+        // from the `images` list it's handed — it does not scan `public/images` on disk itself.
+        // `SiteContentGraph` is a pure in-memory cache with no filesystem awareness of its own
+        // (populated externally via `load`/`upsertImage`), so the orphan file on disk is invisible
+        // to `scan()` unless it's also registered here.
+        let contentGraph = SiteContentGraph()
+        await contentGraph.load(
+            siteID: "site-a",
+            pages: [],
+            posts: [],
+            images: [
+                SiteContentGraph.Image(
+                    id: "site-a:image:public/images/orphan.png",
+                    siteID: "site-a",
+                    relativePath: "public/images/orphan.png",
+                    fileName: "orphan.png",
+                    byteSize: 0,
+                    usedOnPages: [],
+                    lastModified: Date(timeIntervalSince1970: 0)
+                )
+            ]
+        )
+
         let model = ProjectCleanupModel(
             knowledgeIndex: SiteKnowledgeIndex(),
-            contentGraph: SiteContentGraph(),
+            contentGraph: contentGraph,
             // Blocks until the test opens the gate, giving the test a controllable window in
             // which delete() is provably mid-flight (isBusy == true) — the seam the prior version
             // of this test lacked.


### PR DESCRIPTION
## Summary
- `ProjectCleanupModelTests.scanRefusedWhileDeleteInFlight` was failing deterministically at `#require(model.candidates.first { $0.path == "public/images/orphan.png" })` — reproduced twice via `swift test --package-path . --filter ProjectCleanupModelTests`.
- Root cause: `DeadAssetScanner.scan(projectRoot:images:)` only proposes `.image` candidates from the `images` list it's handed (`contentGraph.images(for: siteID)`) — it never scans `public/images` on disk itself. `SiteContentGraph` is a pure in-memory cache with no filesystem awareness (populated externally via `load`/`upsertImage`). The test wrote `orphan.png` to disk but never registered it with the (empty) `SiteContentGraph()` passed into the model, so `model.candidates` was always empty regardless of the `isBusy` guard the test was actually meant to exercise.
- Fix: register `public/images/orphan.png` with `contentGraph.load(siteID:pages:posts:images:)` before `configure()`/`scan()`, so `DeadAssetScanner` has something real to report as unreferenced.

This is pre-existing breakage introduced by the PR #581/#555 cluster (commits 213a9a3b, 6d53edb6, 40d532cc, 526325fc), unrelated to any other work on this branch.

## Test plan
- [x] `swift test --package-path . --filter ProjectCleanupModelTests` — both tests pass reliably (verified across a clean rebuild, twice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)