### PR TITLE
fix(test): seed SiteContentGraph in ProjectCleanupModel scan test

### DIFF
--- a/Tests/AnglesiteAppTests/ProjectCleanupModelTests.swift
+++ b/Tests/AnglesiteAppTests/ProjectCleanupModelTests.swift
@@ -51,9 +51,33 @@ struct ProjectCleanupModelTests {
         defer { try? FileManager.default.removeItem(at: root) }
         try Data().write(to: root.appendingPathComponent("public/images/orphan.png"))
 
+        let contentGraph = SiteContentGraph()
+        // `scan()` sources image candidates from `contentGraph.images(for:)`, not from its own
+        // filesystem walk (`DeadAssetScanner.scan` only evaluates entries in the `images` array
+        // it's given) — the graph is normally populated by `ContentScanner.scan` +
+        // `contentGraph.load(...)` when a site opens. A bare `SiteContentGraph()` stays empty
+        // forever, so the on-disk `orphan.png` must be registered here or it can never appear in
+        // `candidates` regardless of what `DeadAssetScanner` finds.
+        await contentGraph.load(
+            siteID: "site-a",
+            pages: [],
+            posts: [],
+            images: [
+                SiteContentGraph.Image(
+                    id: "site-a:image:public/images/orphan.png",
+                    siteID: "site-a",
+                    relativePath: "public/images/orphan.png",
+                    fileName: "orphan.png",
+                    byteSize: 0,
+                    usedOnPages: [],
+                    lastModified: Date(timeIntervalSince1970: 0)
+                )
+            ]
+        )
+
         let model = ProjectCleanupModel(
             knowledgeIndex: SiteKnowledgeIndex(),
-            contentGraph: SiteContentGraph(),
+            contentGraph: contentGraph,
             // Blocks until the test opens the gate, giving the test a controllable window in
             // which delete() is provably mid-flight (isBusy == true) — the seam the prior version
             // of this test lacked.


### PR DESCRIPTION
## Summary

- `Tests/AnglesiteAppTests/ProjectCleanupModelTests.swift`'s `scan() is refused while delete() is in flight, and isBusy survives the refused attempt` test was failing 100% of the time (verified 3x), asserting `model.candidates` contains a `public/images/orphan.png` entry that never showed up.
- Root cause: `ProjectCleanupModel.scan()` sources image candidates from `contentGraph.images(for: siteID)`, not from its own filesystem walk — `DeadAssetScanner.scan(projectRoot:images:)` only evaluates entries in the `images` array it's handed. `SiteContentGraph` is a pure in-memory cache with no I/O of its own; in production it's populated by `ContentScanner.scan` + `contentGraph.load(...)` when a site opens. This has been true since the dead-asset-detection feature originally shipped (PR #535/#310) — not a recent regression.
- The test wrote `orphan.png` to disk but constructed a bare `SiteContentGraph()` and never registered the file with it, so `contentGraph.images(for:)` returned `[]` and `candidates` could never contain the file regardless of what `DeadAssetScanner` found on disk. It was a fixture gap, not a production bug.
- Fix: seed the test's `SiteContentGraph` with an `Image` entry for `orphan.png` via `contentGraph.load(siteID:pages:posts:images:)` before configuring/scanning, matching the real population path.

## Test plan

- [x] `swift test --package-path . --filter "ProjectCleanupModelTests"` — both tests pass, run 3x in a row for determinism.
- [x] Confirmed (via `git stash`) that the unrelated `SiteWindowModelTests.swift:16` fatal error (`NeverStartedSiteRuntimeFactory.makeRuntime should not be called in this test suite`) when running the full `AnglesiteAppTests` target is pre-existing on this branch and unaffected by this change — flagged separately, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)