### PR TITLE
fix(test): AnglesiteAppTests fails deterministically in ProjectCleanupModelTests

### DIFF
--- a/Tests/AnglesiteAppTests/ProjectCleanupModelTests.swift
+++ b/Tests/AnglesiteAppTests/ProjectCleanupModelTests.swift
@@ -51,9 +51,25 @@ struct ProjectCleanupModelTests {
         defer { try? FileManager.default.removeItem(at: root) }
         try Data().write(to: root.appendingPathComponent("public/images/orphan.png"))
 
+        let contentGraph = SiteContentGraph()
+        // `DeadAssetScanner.scan(projectRoot:images:)` only considers images passed in via
+        // `images` (in production, `SiteContentGraph.images(for:)`, populated by
+        // `ContentScanner.scanImages` during a real site load) — it does not itself walk
+        // `public/images` on disk. Writing the file alone isn't enough to make it a candidate;
+        // the graph must know about it too.
+        await contentGraph.upsertImage(SiteContentGraph.Image(
+            id: "site-a:image:public/images/orphan.png",
+            siteID: "site-a",
+            relativePath: "public/images/orphan.png",
+            fileName: "orphan.png",
+            byteSize: 0,
+            usedOnPages: [],
+            lastModified: Date(timeIntervalSince1970: 0)
+        ))
+
         let model = ProjectCleanupModel(
             knowledgeIndex: SiteKnowledgeIndex(),
-            contentGraph: SiteContentGraph(),
+            contentGraph: contentGraph,
             // Blocks until the test opens the gate, giving the test a controllable window in
             // which delete() is provably mid-flight (isBusy == true) — the seam the prior version
             // of this test lacked.


### PR DESCRIPTION
## Summary

- `swift test --package-path . --filter "AnglesiteAppTests"` was failing 100% of the time (not flaky) on `scanRefusedWhileDeleteInFlight` in `ProjectCleanupModelTests.swift`.
- Root cause: the test wrote `orphan.png` to a temp `public/images/` directory but never registered it in `SiteContentGraph`. `DeadAssetScanner.scan(projectRoot:images:)` only flags images passed in via `images` (in production, `SiteContentGraph.images(for:)`, populated by `ContentScanner.scanImages` during a real site load) — it never walks `public/images` on disk itself. So `scan()` always returned zero candidates and the test's `#require` unwrap failed.
- Fix: upsert a matching `SiteContentGraph.Image` for `orphan.png` before calling `scan()`, mirroring what a real site load does.
- Note: the previously-reported `NeverStartedSiteRuntimeFactory.makeRuntime` fatal-error crash in this same target was already fixed by an earlier commit (`729dcd78`) before this session started; this PR addresses a second, independent failure that was blocking a clean run of the full target.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite`.

## Test plan

- [x] `swift test --package-path . --filter "AnglesiteAppTests"` — ran 4 times, 18/18 tests passing, 6/6 suites passing, no crash, no flake.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke — not applicable (test-only change, no UI surface).