### PR TITLE
feat(template): add custom 404 page

### DIFF
--- a/Resources/Template/src/pages/404.astro
+++ b/Resources/Template/src/pages/404.astro
@@ -1,0 +1,30 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Page Not Found" description="The page you're looking for doesn't exist.">
+  <main class="not-found-page">
+    <h1>Page not found</h1>
+    <p>The page you're looking for doesn't exist or may have moved.</p>
+    <p><a href="/">Go back home</a></p>
+  </main>
+
+  <style>
+    .not-found-page {
+      text-align: center;
+      padding: calc(var(--spacing-unit, 1rem) * 8) var(--spacing-unit, 1rem);
+    }
+    .not-found-page h1 {
+      margin-block-end: var(--spacing-unit, 1rem);
+    }
+    .not-found-page p {
+      color: var(--color-text-muted, #666);
+      max-width: 32rem;
+      margin-inline: auto;
+      margin-block-end: calc(var(--spacing-unit, 1rem) * 1.5);
+    }
+    .not-found-page a {
+      color: var(--color-primary, #2563eb);
+    }
+  </style>
+</BaseLayout>

--- a/Resources/Template/src/pages/404.astro
+++ b/Resources/Template/src/pages/404.astro
@@ -12,16 +12,16 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <style>
     .not-found-page {
       text-align: center;
-      padding: calc(var(--spacing-unit, 1rem) * 8) var(--spacing-unit, 1rem);
+      padding: calc(var(--spacing-unit, 0.25rem) * 8) var(--spacing-unit, 0.25rem);
     }
     .not-found-page h1 {
-      margin-block-end: var(--spacing-unit, 1rem);
+      margin-block-end: var(--spacing-unit, 0.25rem);
     }
     .not-found-page p {
-      color: var(--color-text-muted, #666);
+      color: var(--color-text-muted, #64748b);
       max-width: 32rem;
       margin-inline: auto;
-      margin-block-end: calc(var(--spacing-unit, 1rem) * 1.5);
+      margin-block-end: calc(var(--spacing-unit, 0.25rem) * 1.5);
     }
     .not-found-page a {
       color: var(--color-primary, #2563eb);


### PR DESCRIPTION
## Summary
- Adds `Resources/Template/src/pages/404.astro`, a themed not-found page using `BaseLayout`.
- Astro auto-detects `src/pages/404.astro` as the 404 route for both `astro dev` and `astro build`, so new/existing sites now show this page instead of Astro's built-in default.

## Test plan
- [x] `npx astro build` in `Resources/Template` — confirms `/404.html` is generated and contains the custom copy.
- [x] `git status` clean aside from the new file (no `dist`/`node_modules` committed).
- [ ] `swift test --filter AnglesiteCoreTests.IntegrationTemplateAssetsTests` — blocked locally by the known FM SDK/OS symbol mismatch (unrelated pre-existing environment issue); relying on CI.

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)