### PR TITLE
feat(runtime): LAN-reachable site runtime — guest side (#601)

### DIFF
--- a/Sources/AnglesiteApp/LiveSiteRuntimeFactory.swift
+++ b/Sources/AnglesiteApp/LiveSiteRuntimeFactory.swift
@@ -3,9 +3,11 @@ import AnglesiteCore
 
 struct LiveSiteRuntimeFactory: SiteRuntimeFactory {
     private let logCenter: LogCenter
+    private let settings: AppSettings
 
-    init(logCenter: LogCenter = .shared) {
+    init(logCenter: LogCenter = .shared, settings: AppSettings = .shared) {
         self.logCenter = logCenter
+        self.settings = settings
     }
 
     /// Pick the runtime by capability (no feature flag): a local Apple-Containerization VM when the
@@ -34,6 +36,26 @@ struct LiveSiteRuntimeFactory: SiteRuntimeFactory {
                 knowledgeIndex: knowledgeIndex,
                 semanticRanker: semanticRanker,
                 conventionsEngine: conventionsEngine
+            )
+        }
+        // LAN runtime (#589/#601): dev/test-only fallback for hosts that can't boot the local
+        // container (e.g. a UTM guest VM, where kern.hv_support == 0). Only reachable when the
+        // Settings → Advanced override is set — absent that, behavior is unchanged below.
+        if let lan = settings.lanRuntimeConfiguration {
+            logRuntimeSelection(
+                "selected RemoteSandboxSiteRuntime via LAN host \(lan.host) "
+                + "(preview :\(lan.previewPort), mcp :\(lan.mcpPort)); "
+                + Self.fallbackReason(support: support, provisioning: provisioning))
+            return RemoteSandboxSiteRuntime(
+                gitRemote: LANControlClient.unusedGitRemote,
+                gitRef: "HEAD",
+                control: LANControlClient(configuration: lan),
+                mcpClient: MCPClient(supervisor: .shared),
+                connect: { client, url, _ in
+                    // Trusted-LAN path: the host process doesn't know the guest-minted token,
+                    // so connect without a bearer (design note 2026-07-09, non-goals).
+                    try await client.connect(httpEndpoint: url)
+                }
             )
         }
         logRuntimeSelection(Self.fallbackReason(support: support, provisioning: provisioning))

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -61,6 +61,20 @@ private struct AdvancedSettingsView: View {
     @AppStorage(AppSettings.Key.pluginPathOverride) private var pluginPathOverride: String = ""
     @AppStorage(AppSettings.Key.sitesRootOverride) private var sitesRootOverride: String = ""
     @AppStorage(AppSettings.Key.debugPaneEnabled) private var debugPaneEnabled: Bool = false
+    @AppStorage(AppSettings.Key.lanRuntimeHost) private var lanRuntimeHost: String = ""
+    @AppStorage(AppSettings.Key.lanRuntimePreviewPort) private var lanRuntimePreviewPort: String = ""
+    @AppStorage(AppSettings.Key.lanRuntimeMCPPort) private var lanRuntimeMCPPort: String = ""
+
+    /// Same visibility rule as the Debug pane (`DebugPaneVisibility`): always present in Debug
+    /// builds; in Release only after the diagnostics opt-in. The LAN runtime is dev/test
+    /// infrastructure (#589/#601), not a user-facing feature.
+    private var showsLANRuntimeSection: Bool {
+        #if DEBUG
+        return true
+        #else
+        return debugPaneEnabled
+        #endif
+    }
 
     var body: some View {
         Form {
@@ -108,6 +122,34 @@ private struct AdvancedSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 #endif
+            }
+
+            if showsLANRuntimeSection {
+                Section("LAN site runtime") {
+                    LabeledContent("Runtime host") {
+                        TextField("", text: $lanRuntimeHost, prompt: Text("mac-studio.local"))
+                            .textFieldStyle(.roundedBorder)
+                            .frame(minWidth: 240)
+                            .accessibilityLabel("LAN runtime host")
+                    }
+                    LabeledContent("Preview port") {
+                        TextField("", text: $lanRuntimePreviewPort,
+                                  prompt: Text("\(LANRuntimeConfiguration.defaultPreviewPort)"))
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 100)
+                            .accessibilityLabel("LAN runtime preview port")
+                    }
+                    LabeledContent("MCP port") {
+                        TextField("", text: $lanRuntimeMCPPort,
+                                  prompt: Text("\(LANRuntimeConfiguration.defaultMCPPort)"))
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 100)
+                            .accessibilityLabel("LAN runtime MCP port")
+                    }
+                    Text("Dev/test only: when this Mac can't boot the local container runtime (e.g. inside a VM without nested virtualization), Anglesite connects preview and editing to a dev server already running on the named host over the trusted local network. Leave the host blank to disable. Takes effect the next time a site window opens.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Section("Diagnostics") {

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -15,6 +15,9 @@ public final class AppSettings: @unchecked Sendable {
         public static let pluginPathOverride   = "anglesite.pluginPathOverride"
         public static let templatePathOverride = "anglesite.templatePathOverride"
         public static let sitesRootOverride    = "anglesite.sitesRootOverride"
+        public static let lanRuntimeHost        = "anglesite.lanRuntimeHost"
+        public static let lanRuntimePreviewPort = "anglesite.lanRuntimePreviewPort"
+        public static let lanRuntimeMCPPort     = "anglesite.lanRuntimeMCPPort"
         public static let debugPaneEnabled   = "anglesite.debugPaneEnabled"
         public static let lastOpenedSiteID   = "anglesite.lastOpenedSiteID"
         public static let sitesRootBookmark  = "anglesite.sitesRootBookmark"
@@ -83,6 +86,27 @@ public final class AppSettings: @unchecked Sendable {
                 defaults.removeObject(forKey: Key.sitesRootOverride)
             }
         }
+    }
+
+    /// Optional dev/test override pointing preview + MCP at a LAN-hosted runtime (#589/#601):
+    /// `nil` (the default) unless a host is configured, so runtime selection is untouched for
+    /// real users. Ports fall back to the container-guest convention when blank or invalid.
+    /// See `LANRuntimeConfiguration` and `docs/specs/2026-07-09-lan-site-runtime-design.md`.
+    public var lanRuntimeConfiguration: LANRuntimeConfiguration? {
+        guard let host = defaults.string(forKey: Key.lanRuntimeHost)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty else { return nil }
+        return LANRuntimeConfiguration(
+            host: host,
+            previewPort: port(forKey: Key.lanRuntimePreviewPort, default: LANRuntimeConfiguration.defaultPreviewPort),
+            mcpPort: port(forKey: Key.lanRuntimeMCPPort, default: LANRuntimeConfiguration.defaultMCPPort))
+    }
+
+    /// Ports are stored as strings (the Settings UI uses plain text fields whose empty state
+    /// means "default"); `UserDefaults.string(forKey:)` also coerces a number if one was stored.
+    private func port(forKey key: String, default defaultPort: Int) -> Int {
+        guard let raw = defaults.string(forKey: key)?.trimmingCharacters(in: .whitespaces),
+              let port = Int(raw), (1...65535).contains(port) else { return defaultPort }
+        return port
     }
 
     /// Effective root for site discovery. Returns the override when set, otherwise `~/Sites/`.

--- a/Sources/AnglesiteCore/LANControlClient.swift
+++ b/Sources/AnglesiteCore/LANControlClient.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Where a LAN-hosted site runtime lives: a trusted machine on the local network (e.g. the
+/// owner's Mac Studio) already running the site's dev server and MCP server, reachable over
+/// plain TCP. Dev/test infrastructure for the UTM-VM rig (#589/#601) — not a production
+/// runtime option. See `docs/specs/2026-07-09-lan-site-runtime-design.md`.
+public struct LANRuntimeConfiguration: Sendable, Equatable {
+    /// Default ports match the container guest convention (`ContainerizationControl`):
+    /// `astro dev` on 4321, the Node MCP sidecar on 4399.
+    public static let defaultPreviewPort = 4321
+    public static let defaultMCPPort = 4399
+
+    /// Hostname or IP of the LAN runtime host, e.g. `mac-studio.local` or `192.168.64.1`.
+    public let host: String
+    public let previewPort: Int
+    public let mcpPort: Int
+
+    public init(
+        host: String,
+        previewPort: Int = Self.defaultPreviewPort,
+        mcpPort: Int = Self.defaultMCPPort
+    ) {
+        self.host = host
+        self.previewPort = previewPort
+        self.mcpPort = mcpPort
+    }
+
+    /// `nil` when `host` can't form a valid URL (empty, embedded whitespace, …).
+    public var previewURL: URL? { url(port: previewPort, path: "/") }
+    public var mcpURL: URL? { url(port: mcpPort, path: "/mcp") }
+
+    private func url(port: Int, path: String) -> URL? {
+        guard !host.isEmpty, host.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else { return nil }
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = host
+        components.port = port
+        components.path = path
+        return components.url
+    }
+}
+
+/// `SandboxControlClient` over nothing: the host-side server process is assumed already running
+/// and serving this site, so `start` performs no RPC — it just constructs the LAN URL pair
+/// `RemoteSandboxSiteRuntime` expects. `gitRemote`/`gitRef`/`token` are accepted but unused: the
+/// host serves its own working copy, and the trusted-LAN path skips bearer auth (the factory's
+/// `connect` closure omits the token; see the design note's non-goals).
+public struct LANControlClient: SandboxControlClient {
+    /// `RemoteSandboxSiteRuntime.init` requires a `gitRemote`, but this control client never
+    /// clones — the host process owns its working copy. Callers wiring a LAN runtime pass this
+    /// explicit stand-in so no real-looking repo URL shows up in logs or state.
+    public static let unusedGitRemote = URL(string: "lan-runtime://unused")!
+
+    public let configuration: LANRuntimeConfiguration
+
+    public init(configuration: LANRuntimeConfiguration) {
+        self.configuration = configuration
+    }
+
+    public func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
+        guard let previewURL = configuration.previewURL, let mcpURL = configuration.mcpURL else {
+            throw SandboxControlError.startFailed("invalid LAN runtime host “\(configuration.host)”")
+        }
+        return SandboxSession(previewURL: previewURL, mcpURL: mcpURL)
+    }
+
+    /// The host process is a standing server with no status RPC; report ready and let the MCP
+    /// connect or the preview load surface unreachability with a real error.
+    public func status(siteID: String) async throws -> SandboxStatus {
+        SandboxStatus(siteID: siteID, previewReady: true, mcpReady: true)
+    }
+
+    /// No-op: stopping the guest-side session must not stop the shared host process, which other
+    /// guests (or the host's own Anglesite) may be using.
+    public func stop(siteID: String) async throws {}
+}

--- a/Tests/AnglesiteCoreTests/LANControlClientTests.swift
+++ b/Tests/AnglesiteCoreTests/LANControlClientTests.swift
@@ -1,0 +1,115 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct LANControlClientTests {
+    private static let unusedRemote = LANControlClient.unusedGitRemote
+    private static let anyToken = SessionToken(value: "unused")
+
+    @Test("start returns the LAN preview/MCP URL pair without any RPC")
+    func startBuildsURLPair() async throws {
+        let client = LANControlClient(
+            configuration: LANRuntimeConfiguration(host: "mac-studio.local", previewPort: 8080, mcpPort: 9090))
+        let session = try await client.start(
+            siteID: "s1", gitRemote: Self.unusedRemote, gitRef: "HEAD", token: Self.anyToken)
+        #expect(session.previewURL == URL(string: "http://mac-studio.local:8080/"))
+        #expect(session.mcpURL == URL(string: "http://mac-studio.local:9090/mcp"))
+    }
+
+    @Test("default ports match the container guest convention")
+    func defaultPorts() async throws {
+        let client = LANControlClient(configuration: LANRuntimeConfiguration(host: "192.168.64.1"))
+        let session = try await client.start(
+            siteID: "s1", gitRemote: Self.unusedRemote, gitRef: "HEAD", token: Self.anyToken)
+        #expect(session.previewURL == URL(string: "http://192.168.64.1:4321/"))
+        #expect(session.mcpURL == URL(string: "http://192.168.64.1:4399/mcp"))
+    }
+
+    @Test("an unusable host throws startFailed instead of crashing on URL construction",
+          arguments: ["", "not a host"])
+    func invalidHostThrows(host: String) async {
+        let client = LANControlClient(configuration: LANRuntimeConfiguration(host: host))
+        await #expect(throws: SandboxControlError.startFailed("invalid LAN runtime host “\(host)”")) {
+            _ = try await client.start(
+                siteID: "s1", gitRemote: Self.unusedRemote, gitRef: "HEAD", token: Self.anyToken)
+        }
+    }
+
+    @Test("status reports ready — the standing host process has no status RPC")
+    func statusAlwaysReady() async throws {
+        let client = LANControlClient(configuration: LANRuntimeConfiguration(host: "mac-studio.local"))
+        let status = try await client.status(siteID: "s1")
+        #expect(status == SandboxStatus(siteID: "s1", previewReady: true, mcpReady: true))
+    }
+
+    @Test("RemoteSandboxSiteRuntime over a LANControlClient settles to .ready with the LAN preview URL")
+    func runtimeIntegration() async {
+        let client = LANControlClient(configuration: LANRuntimeConfiguration(host: "mac-studio.local"))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let runtime = RemoteSandboxSiteRuntime(
+            gitRemote: LANControlClient.unusedGitRemote,
+            gitRef: "HEAD",
+            control: client,
+            mcpClient: mcp,
+            connect: { _, _, _ in })  // trusted-LAN path: factory connects without a bearer
+        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        #expect(await runtime.state == .ready(siteID: "s1", url: URL(string: "http://mac-studio.local:4321/")!))
+    }
+}
+
+/// `AppSettings.lanRuntimeConfiguration` parsing — the seam `LiveSiteRuntimeFactory` gates its
+/// LAN branch on (kept in AnglesiteCore so it's testable off the app target, per CLAUDE.md).
+final class LANRuntimeSettingsTests {
+    private let suiteName: String
+    private let defaults: UserDefaults
+
+    init() {
+        let suite = "test-anglesite-\(UUID().uuidString)"
+        suiteName = suite
+        defaults = UserDefaults(suiteName: suite)!
+    }
+
+    deinit {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    @Test("nil until a host is configured — runtime selection stays untouched by default")
+    func nilByDefault() {
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.lanRuntimeConfiguration == nil)
+    }
+
+    @Test("blank or whitespace host still disables the LAN runtime", arguments: ["", "   ", "\n"])
+    func blankHostIsNil(host: String) {
+        defaults.set(host, forKey: AppSettings.Key.lanRuntimeHost)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.lanRuntimeConfiguration == nil)
+    }
+
+    @Test("host alone gets the default ports")
+    func hostWithDefaultPorts() {
+        defaults.set("mac-studio.local", forKey: AppSettings.Key.lanRuntimeHost)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.lanRuntimeConfiguration == LANRuntimeConfiguration(host: "mac-studio.local"))
+    }
+
+    @Test("host is trimmed; custom ports are parsed")
+    func customPorts() {
+        defaults.set("  192.168.64.1 ", forKey: AppSettings.Key.lanRuntimeHost)
+        defaults.set("8080", forKey: AppSettings.Key.lanRuntimePreviewPort)
+        defaults.set("9090", forKey: AppSettings.Key.lanRuntimeMCPPort)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.lanRuntimeConfiguration
+            == LANRuntimeConfiguration(host: "192.168.64.1", previewPort: 8080, mcpPort: 9090))
+    }
+
+    @Test("unparseable or out-of-range ports fall back to the defaults",
+          arguments: ["", "abc", "0", "-1", "70000"])
+    func badPortsFallBack(port: String) {
+        defaults.set("mac-studio.local", forKey: AppSettings.Key.lanRuntimeHost)
+        defaults.set(port, forKey: AppSettings.Key.lanRuntimePreviewPort)
+        defaults.set(port, forKey: AppSettings.Key.lanRuntimeMCPPort)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.lanRuntimeConfiguration == LANRuntimeConfiguration(host: "mac-studio.local"))
+    }
+}


### PR DESCRIPTION
## What

The guest half of #601 (part of #589 Phase 1), implementing [`docs/specs/2026-07-09-lan-site-runtime-design.md`](../blob/main/docs/specs/2026-07-09-lan-site-runtime-design.md): a host without local-container support (e.g. a UTM guest VM, where `kern.hv_support == 0`) can now point preview + MCP at a dev server already running on a trusted LAN host, instead of hard-failing into `UnavailableSiteRuntime`.

- **`LANControlClient` + `LANRuntimeConfiguration`** (`Sources/AnglesiteCore/LANControlClient.swift`): a `SandboxControlClient` over nothing — `start` performs no RPC and just constructs the `http://<host>:<port>` preview/MCP pair for `RemoteSandboxSiteRuntime`; `status` reports ready (the standing host process has no status RPC — unreachability surfaces as a real error from the MCP connect / preview load); `stop` is a no-op so a guest never kills the shared host process. Ports default to the container-guest convention (4321 preview / 4399 MCP, matching `ContainerizationControl`).
- **`AppSettings.lanRuntimeConfiguration`**: `nil` unless a host is configured — the parsing/validation seam lives in AnglesiteCore so it's testable off the app target (per the CLAUDE.md thin-app-target rule). Blank/invalid ports fall back to defaults.
- **`LiveSiteRuntimeFactory`**: third branch — when the local container is unavailable **and** a LAN host is configured, return `RemoteSandboxSiteRuntime(control: LANControlClient(...))`, connecting MCP **without a bearer token** via the runtime's injectable `connect` closure (the host process doesn't know the guest-minted token; trusted-LAN per the design note's non-goals). No changes to `RemoteSandboxSiteRuntime` itself.
- **Settings → Advanced → "LAN site runtime"** (host, preview port, MCP port): visible always in Debug builds, behind the existing diagnostics opt-in in Release — same visibility rule as the Debug pane.

## Why

Confirmed in a macOS UTM guest: nested virtualization is unavailable, so the factory's only two outcomes were `LocalContainerSiteRuntime` or a hard failure — a guest VM could not preview or edit a site at all. This is dev/test infrastructure for the #589 UTM-VM rig, not a shipping runtime change: **absent the Settings override, runtime selection is byte-for-byte unchanged.**

## Notes for review

- The design note's sketch used an optional `token` and a plain-string host; the real `SandboxControlClient` signature takes a non-optional `SessionToken` and a `URL` `gitRemote`, so `LANControlClient` accepts and ignores them, and exposes an explicit `LANControlClient.unusedGitRemote` stand-in (`lan-runtime://unused`) so no real-looking repo URL appears in logs or state.
- Invalid hosts (empty, embedded whitespace) throw `SandboxControlError.startFailed` at `start` rather than crashing URL construction; the runtime surfaces that as a friendly `.failed` state.
- **Remaining #601 work (not in this PR):** the host-side LAN-bound dev-server/MCP process on the Mac Studio — it needs the #587-overlap check and its own small design pass first.

## Tests

- New `LANControlClientTests` + `LANRuntimeSettingsTests` (10 Swift Testing tests): URL-pair construction, default ports, invalid-host errors, settings parsing/fallbacks, and an end-to-end `RemoteSandboxSiteRuntime`-over-`LANControlClient` `.ready` transition.
- `swift test --filter "AppSettings|RemoteSandbox|SandboxControl|LAN"` — 47 tests, 6 suites, all passing.
- `xcodebuild -scheme Anglesite -configuration Debug build` — succeeds (covers the factory + Settings UI changes SwiftPM doesn't compile).

Closes nothing yet — part of #601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)