### PR TITLE
feat(port): Linux CI leg, Darwin-gated manifest, and dev-env setup script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,30 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: scripts/check-help-links.sh
 
+  linux-build-test:
+    name: Linux (portable SwiftPM targets)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Cross-platform port, phase 1 "purity" (2026-07-08 design §9/§10): the compiler is the
+    # purity lint. Off-Darwin, Package.swift exposes only the targets that compile there
+    # (AnglesiteSiteModel today); each seam PR that purifies more of AnglesiteCore expands
+    # that set until `swift build && swift test` covers the whole portable core. The official
+    # Swift image pins the toolchain (and ships the right libxml2), so this lane is immune to
+    # runner-image drift.
+    container:
+      image: swift:6.3.3-noble
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Show toolchain versions
+        run: swift --version
+
+      - name: Build (debug)
+        run: swift build -c debug
+
+      - name: Test
+        run: swift test -c debug --parallel
+
   build-test:
     runs-on: macos-15
     timeout-minutes: 15

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,14 @@ let disableFoundationModelsAutolink: [SwiftSetting] = [
 // inject env, gets the product to link — and dropped only when ANGLESITE_SKIP_CONTAINER=1, which
 // CI sets at the workflow level. The virtualization entitlement, not this flag, gates the runtime
 // at launch (see the #69 design §3 / §2.6).
+#if canImport(Darwin)
 let includeContainer = ProcessInfo.processInfo.environment["ANGLESITE_SKIP_CONTAINER"] != "1"
+#else
+// Apple Containerization is the macOS substrate; off-Darwin platforms get their own
+// SiteRuntime implementations (cross-platform port design §7), so the container target —
+// and its apple/containerization dependency — never enter the manifest there.
+let includeContainer = false
+#endif
 
 // AnglesiteIntentsTests is conditionally included only on Swift 6.4+ (Xcode 27).
 // The test binary loads `AnglesiteIntents` whose AppIntent metadata references
@@ -156,7 +163,10 @@ if includeContainer {
     )
 }
 
-#if compiler(>=6.4)
+// canImport(Darwin) joins the compiler gate: these targets depend on AnglesiteBridge /
+// AnglesiteIntents (WKWebView / AppIntents), so a future Swift 6.4 Linux toolchain must
+// not pull them in.
+#if compiler(>=6.4) && canImport(Darwin)
 packageTargets.append(
     .target(
         name: "AnglesiteAppCore",
@@ -224,6 +234,27 @@ if includeContainer {
         .package(url: "https://github.com/apple/containerization.git", .upToNextMinor(from: "0.35.0"))
     )
 }
+
+// Cross-platform port, phase 1 "purity" (docs/superpowers/specs/2026-07-08-cross-platform-
+// swift-port-design.md §10): off-Darwin, expose only the targets that actually compile
+// there, so `swift build && swift test` stays green on the Linux CI leg and the compiler is
+// the purity lint as seam PRs expand the portable set. Today that's AnglesiteSiteModel
+// (pure Foundation). AnglesiteCore still has Apple-only imports (FoundationModels, OSLog,
+// Security, …); ANGLESITE_PORT_WIP=1 opts it back in so in-flight seam work can
+// compile-check it locally before the final purity PR flips it on unconditionally.
+// Filtering by name here (rather than duplicating target definitions in per-platform
+// lists) keeps the single source of truth above.
+#if !canImport(Darwin)
+var portableTargets: Set<String> = ["AnglesiteSiteModel", "AnglesiteSiteModelTests"]
+if ProcessInfo.processInfo.environment["ANGLESITE_PORT_WIP"] == "1" {
+    portableTargets.insert("AnglesiteCore")
+}
+packageTargets.removeAll { !portableTargets.contains($0.name) }
+// Every library product above is named after its single target, so the same name set
+// filters products. (The container probe executable breaks that convention, but it is
+// Darwin-only and already excluded via includeContainer.)
+packageProducts.removeAll { !portableTargets.contains($0.name) }
+#endif
 
 let package = Package(
     name: "Anglesite",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ See [`docs/build-plan.md`](docs/build-plan.md) for the full phased status.
 
 ## Requirements
 
+These are the requirements for building the macOS app — the primary development flow. For working on the portable core from a Linux machine, see [Developing on Linux](#developing-on-linux).
+
+On either platform, `scripts/setup-dev-env.sh` checks the prerequisites below, fixes what it safely can (generating the Xcode project, enabling git hooks, the Linux libxml2 shim), and prints instructions for the rest.
+
 - macOS 27+
 - Xcode 27+ (Swift 6.4; required for the SwiftUI 27 `@State` macro semantics audited in [`docs/specs/2026-06-10-xcode27-state-macro-audit-notes.md`](docs/specs/2026-06-10-xcode27-state-macro-audit-notes.md))
 - [XcodeGen](https://github.com/yonaskolb/XcodeGen) (`brew install xcodegen`) — the `.xcodeproj` is generated from [`project.yml`](project.yml)
@@ -39,6 +43,10 @@ See [`docs/build-plan.md`](docs/build-plan.md) for the full phased status.
 # Clone alongside the plugin repo
 git clone https://github.com/Anglesite/Anglesite-app.git
 cd Anglesite-app
+
+# One-shot environment check/bootstrap (generates the Xcode project, enables the
+# git hooks below, and reports anything missing) — or follow the steps manually:
+scripts/setup-dev-env.sh
 
 # Generate the Xcode project
 xcodegen generate
@@ -69,6 +77,30 @@ There is one app target, ad-hoc-signed in Debug so it builds without an Apple ac
 > **Don't `xed .`** — this repo contains both a `Package.swift` and an `Anglesite.xcodeproj`. `xed .` opens the package, whose scheme picker only shows `Anglesite-Package` (libraries only, no runnable target). Open the `.xcodeproj` explicitly; the scheme picker should then show `Anglesite`, `AnglesiteCore`, `AnglesiteBridge`, `AnglesiteSiteModel`, `AnglesiteIntents`, and `AnglesiteContainer`, and ⌘R should run the app.
 
 The Debug configuration uses ad-hoc signing so contributors can build and run locally without any Apple Developer enrollment. App Store Release builds require a paid Apple Developer account and a provisioning profile with the app's restricted entitlements; see [`docs/release.md`](docs/release.md).
+
+## Developing on Linux
+
+The app shell is macOS-only today, but Anglesite is going multi-platform — Linux first — per the [cross-platform port design](docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md). On Linux, `Package.swift` exposes only the **portable SwiftPM targets** (currently `AnglesiteSiteModel`; the set grows as the "purity phase" lands seam by seam), and CI runs `swift build && swift test` on Ubuntu to enforce that boundary.
+
+```sh
+git clone https://github.com/Anglesite/Anglesite-app.git
+cd Anglesite-app
+
+# Checks for a Swift 6.3+ toolchain (installable via swiftly: https://www.swift.org/install/linux/),
+# creates the libxml2 soname shim if your distro needs it (see below), enables git hooks,
+# and runs a smoke build of the portable targets.
+scripts/setup-dev-env.sh
+
+swift build   # portable targets only
+swift test
+```
+
+Notes:
+
+- **Toolchain:** Swift 6.3+ (via [swiftly](https://www.swift.org/install/linux/)). No Xcode, XcodeGen, or Node needed on Linux.
+- **libxml2 on newer distros:** distros shipping libxml2 ≥ 2.15 (e.g. Ubuntu 26.04) provide `libxml2.so.16`, but the swift.org toolchain links `libxml2.so.2`. The setup script creates a user-level symlink shim and prints the `LD_LIBRARY_PATH` export to activate it; loader warnings about "no version information" are expected and harmless. (CI is unaffected — the `swift:*` container images ship a matching libxml2.)
+- **Working on the port itself:** `ANGLESITE_PORT_WIP=1 swift build --target AnglesiteCore` opts the not-yet-portable core into the manifest so in-flight seam work can be compile-checked locally. Apple-only targets (`AnglesiteBridge`, `AnglesiteIntents`, `AnglesiteContainer`, …) never build off-Darwin.
+- **Containers:** `podman` is not needed for the purity phase; it becomes relevant with the Linux MVP's `PodmanSiteRuntime`.
 
 ## Relationship to the plugin repo
 

--- a/Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift
+++ b/Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Verifies a Cloudflare API token by calling the Cloudflare REST API directly — no Node, no
 /// wrangler. `GET /user/tokens/verify` confirms the token is valid and active; a best-effort

--- a/Sources/AnglesiteCore/CloudflareCapabilityProber.swift
+++ b/Sources/AnglesiteCore/CloudflareCapabilityProber.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Observes which permission groups a stored Cloudflare token actually has, by issuing one cheap
 /// authenticated GET per group. 401/403 means the group is missing; any other response (including

--- a/Sources/AnglesiteCore/CloudflareReading.swift
+++ b/Sources/AnglesiteCore/CloudflareReading.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Errors surfaced by the Cloudflare read client.
 public enum CloudflareError: Error, Equatable, Sendable {

--- a/Sources/AnglesiteCore/CloudflareWebAnalyticsClient.swift
+++ b/Sources/AnglesiteCore/CloudflareWebAnalyticsClient.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public struct CloudflareWebAnalyticsSite: Sendable, Equatable {
     public let host: String

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -322,14 +322,14 @@ public actor DeployCommand {
     }
 
     /// Default `TokenSource` for production: env var first (so a developer's shell still wins),
-    /// then the user's Keychain. A Keychain error is surfaced to the caller — we'd rather show
-    /// the user "couldn't read token" than silently fall through to `nil` and prompt for a
-    /// re-paste of a token that's actually stored fine.
+    /// then the platform secret store (the user's Keychain on macOS). A store error is surfaced
+    /// to the caller — we'd rather show the user "couldn't read token" than silently fall
+    /// through to `nil` and prompt for a re-paste of a token that's actually stored fine.
     public static let keychainTokenSource: TokenSource = {
         if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
             return env
         }
-        return try KeychainStore().readCloudflareToken()
+        return try PlatformSecretStore.make().readCloudflareToken()
     }
 
     /// Default `PreflightChecker`: host-side preflight was retired with embedded Node. Container

--- a/Sources/AnglesiteCore/DomainOperationsService.swift
+++ b/Sources/AnglesiteCore/DomainOperationsService.swift
@@ -36,12 +36,13 @@ public struct DomainOperations: DomainOperationsService {
         self.tokenProvider = tokenProvider
     }
 
-    /// Env var first (matches `HardenModel.apiToken()`), then the Keychain-stored token.
+    /// Env var first (matches `HardenModel.apiToken()`), then the platform secret store
+    /// (the user's Keychain on macOS).
     public static let defaultTokenProvider: @Sendable () -> String? = {
         if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
             return env
         }
-        return try? KeychainStore().readCloudflareToken()
+        return try? PlatformSecretStore.make().readCloudflareToken()
     }
 
     private func resolveZone(domain: String, token: String) async -> Result<String, DomainOperationError> {

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Pagination metadata returned alongside list results.
 private struct CFResultInfo: Decodable, Sendable {

--- a/Sources/AnglesiteCore/HTTPSandboxControlClient.swift
+++ b/Sources/AnglesiteCore/HTTPSandboxControlClient.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// `SandboxControlClient` that calls the user's deployed Control Worker over HTTPS. No Cloudflare
 /// SDK — plain JSON. Used by the iOS app once onboarding has stored the Worker URL + API token.

--- a/Sources/AnglesiteCore/HTTPTransport.swift
+++ b/Sources/AnglesiteCore/HTTPTransport.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// `MCPTransport` over MCP Streamable HTTP. Each `send` POSTs one JSON-RPC message to the `/mcp`
 /// endpoint; the response (single `application/json` object, or one-or-more messages over a

--- a/Sources/AnglesiteCore/MCPClient.swift
+++ b/Sources/AnglesiteCore/MCPClient.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Minimal JSON value used at the MCP boundary so request/response shapes stay `Sendable` and
 /// `Equatable` without forcing every caller to define a `Codable` model.

--- a/Sources/AnglesiteCore/Platform/KeychainStore.swift
+++ b/Sources/AnglesiteCore/Platform/KeychainStore.swift
@@ -1,3 +1,6 @@
+// Darwin implementation of the SecretStore seam. The whole file compiles out on
+// platforms without the Security framework.
+#if canImport(Security)
 import Foundation
 import Security
 
@@ -18,7 +21,7 @@ import Security
 ///   inaccessible while the Mac is locked.
 /// - The token must never be logged. `DeployCommand` passes it via `environment` (which is opaque
 ///   to the supervisor's stdout/stderr pump), so it does not end up in `LogCenter`.
-public struct KeychainStore: Sendable {
+public struct KeychainStore: SecretStore {
     public enum Error: Swift.Error, Equatable {
         /// `SecItemCopyMatching` / `SecItemAdd` / `SecItemUpdate` / `SecItemDelete` returned a
         /// non-success `OSStatus`. The raw value is carried so test assertions can pin it down.
@@ -31,10 +34,9 @@ public struct KeychainStore: Sendable {
     /// Default service identifier. Matches the app's bundle id.
     public static let defaultService = "io.dwk.anglesite"
 
-    /// Account key under the default service for the Cloudflare API token used by
-    /// `wrangler deploy`. Centralized here so the Settings UI and `DeployCommand` refer to the
-    /// same slot.
-    public static let cloudflareTokenAccount = "cloudflare-api-token"
+    /// Account key for the Cloudflare API token. Forwarded from the portable
+    /// `SecretAccounts` namespace (the shared slot definition since the SecretStore seam).
+    public static let cloudflareTokenAccount = SecretAccounts.cloudflareToken
 
     public let service: String
 
@@ -106,22 +108,8 @@ public struct KeychainStore: Sendable {
         }
     }
 
-    // MARK: Cloudflare convenience
-
-    /// Read the Cloudflare API token under the default account.
-    public func readCloudflareToken() throws -> String? {
-        try read(account: Self.cloudflareTokenAccount)
-    }
-
-    /// Store the Cloudflare API token under the default account. Empty string clears.
-    public func writeCloudflareToken(_ token: String) throws {
-        try write(token, account: Self.cloudflareTokenAccount)
-    }
-
-    /// Clear the Cloudflare API token slot.
-    public func clearCloudflareToken() throws {
-        try delete(account: Self.cloudflareTokenAccount)
-    }
+    // Cloudflare token convenience (readCloudflareToken()/writeCloudflareToken(_:)/
+    // clearCloudflareToken()) comes from the SecretStore protocol extension.
 
     // MARK: Internals
 
@@ -134,3 +122,4 @@ public struct KeychainStore: Sendable {
         ]
     }
 }
+#endif

--- a/Sources/AnglesiteCore/Platform/SecretStore.swift
+++ b/Sources/AnglesiteCore/Platform/SecretStore.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Portable seam for storing small user secrets (API tokens) — seam 1 of the cross-platform
+/// port design (docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md §5).
+///
+/// Implementations: `KeychainStore` (Darwin, SecItem generic passwords); a libsecret/Secret
+/// Service store arrives with the Linux MVP; Windows gets Credential Manager. Platforms
+/// without a native implementation yet use `UnavailableSecretStore`, which reads as "nothing
+/// stored" and refuses writes — features degrade capability-flagged, never by silently
+/// dropping a secret.
+///
+/// Semantics all implementations must uphold (mirrored from `KeychainStore`, the reference
+/// implementation, and pinned by its test suite):
+/// - `read` returns `nil` (not an error) when no entry exists.
+/// - `write("")` deletes the entry, so an empty write round-trips as `read → nil`.
+/// - `delete` of a missing entry is a no-op, not an error.
+/// - Values are secrets: implementations and callers must never log them.
+public protocol SecretStore: Sendable {
+    /// Returns the stored secret for `account`, or `nil` if no entry exists.
+    func read(account: String) throws -> String?
+    /// Writes `value` for `account`, replacing any existing entry. An empty `value` deletes.
+    func write(_ value: String, account: String) throws
+    /// Removes the stored entry for `account`. No-op if no entry exists.
+    func delete(account: String) throws
+}
+
+/// Well-known account keys, shared across platform stores so the Settings UI, deploy path,
+/// and onboarding all address the same slot regardless of backend.
+public enum SecretAccounts {
+    /// The Cloudflare API token used by `wrangler deploy`.
+    public static let cloudflareToken = "cloudflare-api-token"
+}
+
+public extension SecretStore {
+    /// Read the Cloudflare API token under the shared account key.
+    func readCloudflareToken() throws -> String? {
+        try read(account: SecretAccounts.cloudflareToken)
+    }
+
+    /// Store the Cloudflare API token under the shared account key. Empty string clears.
+    func writeCloudflareToken(_ token: String) throws {
+        try write(token, account: SecretAccounts.cloudflareToken)
+    }
+
+    /// Clear the Cloudflare API token slot.
+    func clearCloudflareToken() throws {
+        try delete(account: SecretAccounts.cloudflareToken)
+    }
+}
+
+/// Placeholder store for platforms without a native secret-store implementation yet
+/// (Linux until the libsecret store lands). Reads report "nothing stored" so token
+/// resolution falls through to environment variables; writes fail loudly rather than
+/// pretending a secret was persisted.
+public struct UnavailableSecretStore: SecretStore {
+    public struct WriteUnsupported: Error {}
+
+    public init() {}
+
+    public func read(account: String) throws -> String? { nil }
+    public func write(_ value: String, account: String) throws { throw WriteUnsupported() }
+    public func delete(account: String) throws {}
+}
+
+/// Composition-root factory for the platform's default secret store. Call sites in the
+/// portable core depend on `any SecretStore` and use this only as their production default;
+/// tests and the app shell inject concrete stores directly.
+public enum PlatformSecretStore {
+    public static func make() -> any SecretStore {
+        #if canImport(Security)
+        KeychainStore()
+        #else
+        UnavailableSecretStore()
+        #endif
+    }
+}

--- a/Sources/AnglesiteCore/Platform/SecretStore.swift
+++ b/Sources/AnglesiteCore/Platform/SecretStore.swift
@@ -58,7 +58,14 @@ public struct UnavailableSecretStore: SecretStore {
     public init() {}
 
     public func read(account: String) throws -> String? { nil }
-    public func write(_ value: String, account: String) throws { throw WriteUnsupported() }
+
+    public func write(_ value: String, account: String) throws {
+        // Uphold the protocol contract: an empty write means delete, and deleting from a
+        // store that holds nothing is a successful no-op. Only persisting is unsupported.
+        if value.isEmpty { return }
+        throw WriteUnsupported()
+    }
+
     public func delete(account: String) throws {}
 }
 

--- a/Sources/AnglesiteCore/SessionToken.swift
+++ b/Sources/AnglesiteCore/SessionToken.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CryptoKit
 
 /// A per-session bearer secret minted by the app and validated in-container (auth-proxy + MCP
 /// sidecar). Opaque; symmetric compare. The value is a secret — never log it (see `KeychainStore`).
@@ -10,7 +9,11 @@ public struct SessionToken: Sendable, Equatable, CustomStringConvertible {
 
     /// 32 cryptographically-random bytes, hex-encoded (64 chars).
     public static func mint() -> SessionToken {
-        let bytes = SymmetricKey(size: .bits256).withUnsafeBytes { Array($0) }
+        // SystemRandomNumberGenerator is cryptographically secure on every supported platform
+        // (arc4random_buf on Darwin, getrandom(2) on Linux), so minting needs no CryptoKit /
+        // swift-crypto dependency — this file is part of the portable core.
+        var rng = SystemRandomNumberGenerator()
+        let bytes = (0..<32).map { _ in UInt8.random(in: .min ... .max, using: &rng) }
         return SessionToken(value: bytes.map { String(format: "%02x", $0) }.joined())
     }
 

--- a/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
+++ b/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
@@ -1,5 +1,7 @@
 import Foundation
-#if compiler(>=6.4)
+// canImport joins the compiler gate: >=6.4 alone was a proxy for "the Xcode 27 SDK is
+// present", which a Swift 6.4 Linux toolchain will satisfy without having FoundationModels.
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -80,7 +82,7 @@ public struct FoundationModelsProbe: ReadinessProbe {
 /// Case names below must match the `FoundationModels` SDK; `@unknown default` absorbs drift.
 public enum LiveFoundationModelsAvailability {
     public static func current() -> FoundationModelsAvailability {
-        #if compiler(>=6.4)
+        #if compiler(>=6.4) && canImport(FoundationModels)
         switch SystemLanguageModel.default.availability {
         case .available:
             return .available

--- a/Sources/AnglesiteCore/UTType+Anglesite.swift
+++ b/Sources/AnglesiteCore/UTType+Anglesite.swift
@@ -1,3 +1,9 @@
+// Compiled out off-Darwin (cross-platform port design §5): there is no package-UTI concept
+// on Linux/Windows — `.anglesite` is a plain directory there, and identity comes from the
+// Info.plist UUID (AnglesiteSiteModel), which is fully portable. No AnglesiteCore code
+// references this extension; its consumers (NSOpenPanel, Finder integration) live in the
+// Darwin-only app shell.
+#if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers
 
 public extension UTType {
@@ -11,3 +17,4 @@ public extension UTType {
     /// call sites should use `.anglesiteSite`.
     static let anglesiteSite = UTType(exportedAs: "io.dwk.anglesite.site")
 }
+#endif

--- a/Tests/AnglesiteCoreTests/KeychainStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/KeychainStoreTests.swift
@@ -1,3 +1,5 @@
+// Exercises the Darwin SecretStore implementation; compiles out with it off-Darwin.
+#if canImport(Security)
 import XCTest
 @testable import AnglesiteCore
 
@@ -98,3 +100,4 @@ final class KeychainStoreTests: XCTestCase {
         XCTAssertNil(try store.readCloudflareToken())
     }
 }
+#endif

--- a/Tests/AnglesiteCoreTests/SecretStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SecretStoreTests.swift
@@ -46,6 +46,9 @@ struct SecretStoreTests {
         let store = UnavailableSecretStore()
         #expect(try store.read(account: "anything") == nil)
         try store.delete(account: "anything")  // must not throw
+        // Empty write means delete (protocol contract), so it must succeed as a no-op
+        // even though persisting is unsupported.
+        try store.write("", account: "anything")
         #expect(throws: UnavailableSecretStore.WriteUnsupported.self) {
             try store.write("secret", account: "anything")
         }

--- a/Tests/AnglesiteCoreTests/SecretStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SecretStoreTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+/// Portable contract tests for the SecretStore seam — run on every platform (unlike
+/// `KeychainStoreTests`, which exercises the Darwin implementation against the real
+/// keychain). The in-memory store below doubles as a reference for the semantics every
+/// platform implementation must uphold.
+struct SecretStoreTests {
+    /// Minimal conforming store used to pin the protocol-extension convenience methods.
+    private final class InMemorySecretStore: SecretStore, @unchecked Sendable {
+        private var entries: [String: String] = [:]
+        private let lock = NSLock()
+
+        func read(account: String) throws -> String? {
+            lock.withLock { entries[account] }
+        }
+
+        func write(_ value: String, account: String) throws {
+            lock.withLock {
+                if value.isEmpty {
+                    entries[account] = nil
+                } else {
+                    entries[account] = value
+                }
+            }
+        }
+
+        func delete(account: String) throws {
+            lock.withLock { entries[account] = nil }
+        }
+    }
+
+    @Test("Cloudflare convenience methods address the shared SecretAccounts slot")
+    func cloudflareConvenienceUsesSharedAccount() throws {
+        let store = InMemorySecretStore()
+        try store.writeCloudflareToken("tok-123")
+        #expect(try store.read(account: SecretAccounts.cloudflareToken) == "tok-123")
+        #expect(try store.readCloudflareToken() == "tok-123")
+        try store.clearCloudflareToken()
+        #expect(try store.readCloudflareToken() == nil)
+    }
+
+    @Test("UnavailableSecretStore reads nothing, deletes as no-op, and refuses writes")
+    func unavailableStoreBehavior() throws {
+        let store = UnavailableSecretStore()
+        #expect(try store.read(account: "anything") == nil)
+        try store.delete(account: "anything")  // must not throw
+        #expect(throws: UnavailableSecretStore.WriteUnsupported.self) {
+            try store.write("secret", account: "anything")
+        }
+    }
+
+    @Test("PlatformSecretStore.make returns the platform default")
+    func platformDefaultResolves() {
+        let store = PlatformSecretStore.make()
+        #if canImport(Security)
+        #expect(store is KeychainStore)
+        #else
+        #expect(store is UnavailableSecretStore)
+        #endif
+    }
+}

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Bootstrap / verify a development environment for this repo, on macOS or Linux.
+#
+# macOS — full app development: Xcode 27+, XcodeGen (Anglesite.xcodeproj is gitignored
+# and generated from project.yml), the auto-regen git hooks, and optionally Node for
+# the JS edit overlay.
+#
+# Linux — cross-platform port work (2026-07-08 design, Linux first): a Swift 6.3+
+# toolchain for the portable SwiftPM targets. No Xcode, XcodeGen, or Node required.
+# Known wrinkle: distros shipping libxml2 ≥ 2.15 (e.g. Ubuntu 26.04) provide
+# libxml2.so.16, but the swift.org toolchain's libFoundationXML links libxml2.so.2 —
+# this script creates a user-level soname shim (no sudo needed) and prints the
+# LD_LIBRARY_PATH export that activates it.
+#
+# Check-and-fix: fixes what it safely can (soname shim, xcodegen generate, git hooks)
+# and prints actionable instructions for the rest.
+# Exit 0 = ready for this platform's development flow. Exit 1 = blocking gap remains.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+FAILURES=0
+ok()   { printf '  \342\234\223 %s\n' "$1"; }
+todo() { printf '  \342\234\227 %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+note() { printf '    %s\n' "$1"; }
+
+# Both platforms: the git hooks keep generated state in sync after pulls/switches
+# (on macOS they regenerate the .xcodeproj). Harmless to enable everywhere.
+setup_git_hooks() {
+    if [[ "$(git -C "$REPO_ROOT" config core.hooksPath || true)" == "scripts/git-hooks" ]]; then
+        ok "git hooks (core.hooksPath = scripts/git-hooks)"
+    else
+        git -C "$REPO_ROOT" config core.hooksPath scripts/git-hooks
+        ok "git hooks enabled (core.hooksPath = scripts/git-hooks)"
+    fi
+}
+
+setup_macos() {
+    echo "Platform: macOS (full app development)"
+
+    if xcodebuild -version >/dev/null 2>&1; then
+        XCODE_MAJOR=$(xcodebuild -version | sed -n 's/^Xcode \([0-9]*\).*/\1/p')
+        if [[ "${XCODE_MAJOR:-0}" -ge 27 ]]; then
+            ok "Xcode ${XCODE_MAJOR} (need 27+)"
+        else
+            todo "Xcode 27+ required (found ${XCODE_MAJOR:-unknown}) — needed for Swift 6.4 / SwiftUI 27 @State semantics"
+        fi
+    else
+        todo "Xcode not found — install Xcode 27+ from the App Store or developer.apple.com"
+    fi
+
+    if command -v xcodegen >/dev/null 2>&1; then
+        if [[ -d "$REPO_ROOT/Anglesite.xcodeproj" ]]; then
+            ok "Anglesite.xcodeproj present (regenerate anytime with: xcodegen generate)"
+        else
+            (cd "$REPO_ROOT" && xcodegen generate >/dev/null)
+            ok "Anglesite.xcodeproj generated from project.yml"
+        fi
+    else
+        todo "XcodeGen not found — brew install xcodegen (the .xcodeproj is gitignored and generated from project.yml)"
+    fi
+
+    setup_git_hooks
+
+    # Node is only needed to rebuild the JS edit overlay (scripts/build-overlay.sh);
+    # the app itself embeds no host Node (#70). Warn-only.
+    if command -v node >/dev/null 2>&1; then
+        ok "Node $(node --version) (used by scripts/build-overlay.sh for the edit overlay)"
+    else
+        note "Node not found — only needed if you work on JS/edit-overlay (see scripts/node-version.txt)"
+    fi
+
+    if [[ -d "$REPO_ROOT/../anglesite" ]]; then
+        ok "sibling plugin checkout found (../anglesite) — MCP e2e tests can run (ANGLESITE_PLUGIN_PATH)"
+    else
+        note "sibling plugin repo not found at ../anglesite — MCP e2e tests will skip cleanly (optional)"
+    fi
+
+    echo
+    echo "Build:  open Anglesite.xcodeproj   (not \`xed .\`) — or:"
+    echo "        xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build"
+    echo "Tests:  swift test"
+}
+
+setup_linux() {
+    echo "Platform: Linux (portable core — cross-platform port, Linux-first)"
+
+    if command -v swift >/dev/null 2>&1; then
+        SWIFT_VERSION=$(swift --version 2>/dev/null | sed -n 's/^Swift version \([0-9.]*\).*/\1/p' | head -1)
+        SWIFT_MINOR=$(printf '%s' "${SWIFT_VERSION:-0}" | awk -F. '{ printf "%d%02d", $1, $2 }')
+        if [[ "${SWIFT_MINOR:-0}" -ge 603 ]]; then
+            ok "Swift ${SWIFT_VERSION} (need 6.3+)"
+        else
+            todo "Swift 6.3+ required (found ${SWIFT_VERSION:-unknown}) — swiftly install latest"
+        fi
+    else
+        todo "Swift toolchain not found — install swiftly, then a toolchain:"
+        note "curl -O https://download.swift.org/swiftly/linux/swiftly-\$(uname -m).tar.gz && tar zxf swiftly-*.tar.gz && ./swiftly init"
+        note "swiftly install latest"
+    fi
+
+    # libxml2 soname shim: the swift.org toolchain's libFoundationXML.so links
+    # libxml2.so.2; distros with libxml2 >= 2.15 (Ubuntu 26.04+) ship libxml2.so.16
+    # and no compat package. A user-level symlink satisfies the loader — the API
+    # subset FoundationXML uses survived the soname bump. Loader warnings about
+    # "no version information" are expected and harmless.
+    SHIM_DIR="$HOME/.local/lib/anglesite-shims"
+    if ldconfig -p 2>/dev/null | grep -qF 'libxml2.so.2 '; then
+        ok "libxml2.so.2 present (no shim needed)"
+    else
+        LIBXML2_NEW=$(ldconfig -p 2>/dev/null | awk '/libxml2\.so\.[0-9]+ /{ print $NF; exit }')
+        if [[ -n "$LIBXML2_NEW" ]]; then
+            mkdir -p "$SHIM_DIR"
+            ln -sf "$LIBXML2_NEW" "$SHIM_DIR/libxml2.so.2"
+            ok "libxml2 soname shim created: $SHIM_DIR/libxml2.so.2 -> $LIBXML2_NEW"
+            note "activate it for every swift invocation:"
+            note "export LD_LIBRARY_PATH=\"$SHIM_DIR\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\""
+            note "(add that line to your shell profile)"
+        else
+            todo "libxml2 not found — install your distro's libxml2 runtime package"
+        fi
+    fi
+
+    setup_git_hooks
+
+    if command -v podman >/dev/null 2>&1; then
+        ok "podman $(podman --version | awk '{ print $NF }') (needed for the Linux MVP site runtime)"
+    else
+        note "podman not found — not needed for the purity phase; required later for PodmanSiteRuntime (Linux MVP)"
+    fi
+
+    echo
+    if [[ "$FAILURES" -eq 0 ]] && command -v swift >/dev/null 2>&1; then
+        echo "Smoke build (portable targets)…"
+        if (cd "$REPO_ROOT" && LD_LIBRARY_PATH="$SHIM_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" swift build --target AnglesiteSiteModel 2>&1 | tail -1); then
+            ok "swift build --target AnglesiteSiteModel"
+        else
+            todo "smoke build failed — see output above"
+        fi
+    fi
+
+    echo
+    echo "Build:  swift build          (portable targets only — Package.swift filters off-Darwin)"
+    echo "Tests:  swift test"
+    echo "Seams:  ANGLESITE_PORT_WIP=1 swift build --target AnglesiteCore   (in-flight purity work)"
+}
+
+case "$(uname -s)" in
+    Darwin) setup_macos ;;
+    Linux)  setup_linux ;;
+    *)
+        echo "error: unsupported platform '$(uname -s)' — this repo supports macOS and Linux development" >&2
+        exit 1
+        ;;
+esac
+
+echo
+if [[ "$FAILURES" -gt 0 ]]; then
+    echo "Environment NOT ready: $FAILURES blocking item(s) above."
+    exit 1
+fi
+echo "Environment ready."

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -111,7 +111,9 @@ setup_linux() {
     if ldconfig -p 2>/dev/null | grep -qF 'libxml2.so.2 '; then
         ok "libxml2.so.2 present (no shim needed)"
     else
-        LIBXML2_NEW=$(ldconfig -p 2>/dev/null | awk '/libxml2\.so\.[0-9]+ /{ print $NF; exit }')
+        # `|| true`: under set -e/pipefail a failed pipeline inside $() aborts the whole
+        # script (e.g. ldconfig not on a non-root PATH); fall through to the todo below instead.
+        LIBXML2_NEW=$(ldconfig -p 2>/dev/null | awk '/libxml2\.so\.[0-9]+ /{ print $NF; exit }' || true)
         if [[ -n "$LIBXML2_NEW" ]]; then
             mkdir -p "$SHIM_DIR"
             ln -sf "$LIBXML2_NEW" "$SHIM_DIR/libxml2.so.2"


### PR DESCRIPTION
First slice of the cross-platform port's **phase 1 "purity"** ([design §10](docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md)) — lands the enforcement mechanism before any porting work.

## Changes

- **Package.swift**: off-Darwin, expose only the targets that actually compile there (`AnglesiteSiteModel` + tests today), so `swift build && swift test` is green on Linux and the compiler is the purity lint as seam PRs expand the set. `ANGLESITE_PORT_WIP=1` opts `AnglesiteCore` back in for in-flight seam work. `AnglesiteContainer` and the `compiler(>=6.4)` app targets are Darwin-gated. **macOS manifest evaluation is unchanged.**
- **CI**: new `linux-build-test` lane on `ubuntu-latest` in the official `swift:6.3.3-noble` container running `swift build && swift test`.
- **scripts/setup-dev-env.sh**: check-and-fix bootstrap for both platforms — macOS (Xcode 27+, XcodeGen, git hooks, optional Node/plugin checkout) and Linux (Swift 6.3+ via swiftly, user-level `libxml2.so.2` soname shim for distros shipping libxml2 ≥ 2.15 like Ubuntu 26.04, smoke build).
- **README**: setup script in the macOS flow + a "Developing on Linux" section.

## Verification

On Ubuntu 26.04 / aarch64 (Swift 6.3.3): `swift build && swift test` pass (19 tests, 3 suites); `ANGLESITE_PORT_WIP=1` exposes `AnglesiteCore` (fails at the known OSLog seam, as expected pre-purity); setup script runs end-to-end. macOS lanes in this CI run verify the Darwin manifest path.

Stack: this PR → `claude/port-misc-seam` → `claude/port-secretstore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)