### PR TITLE
refactor(port): misc purity seam — CryptoKit, UTType, FM gates, FoundationNetworking

### DIFF
--- a/Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift
+++ b/Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Verifies a Cloudflare API token by calling the Cloudflare REST API directly — no Node, no
 /// wrangler. `GET /user/tokens/verify` confirms the token is valid and active; a best-effort

--- a/Sources/AnglesiteCore/CloudflareCapabilityProber.swift
+++ b/Sources/AnglesiteCore/CloudflareCapabilityProber.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Observes which permission groups a stored Cloudflare token actually has, by issuing one cheap
 /// authenticated GET per group. 401/403 means the group is missing; any other response (including

--- a/Sources/AnglesiteCore/CloudflareReading.swift
+++ b/Sources/AnglesiteCore/CloudflareReading.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Errors surfaced by the Cloudflare read client.
 public enum CloudflareError: Error, Equatable, Sendable {

--- a/Sources/AnglesiteCore/CloudflareWebAnalyticsClient.swift
+++ b/Sources/AnglesiteCore/CloudflareWebAnalyticsClient.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public struct CloudflareWebAnalyticsSite: Sendable, Equatable {
     public let host: String

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Pagination metadata returned alongside list results.
 private struct CFResultInfo: Decodable, Sendable {

--- a/Sources/AnglesiteCore/HTTPSandboxControlClient.swift
+++ b/Sources/AnglesiteCore/HTTPSandboxControlClient.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// `SandboxControlClient` that calls the user's deployed Control Worker over HTTPS. No Cloudflare
 /// SDK — plain JSON. Used by the iOS app once onboarding has stored the Worker URL + API token.

--- a/Sources/AnglesiteCore/HTTPTransport.swift
+++ b/Sources/AnglesiteCore/HTTPTransport.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// `MCPTransport` over MCP Streamable HTTP. Each `send` POSTs one JSON-RPC message to the `/mcp`
 /// endpoint; the response (single `application/json` object, or one-or-more messages over a

--- a/Sources/AnglesiteCore/MCPClient.swift
+++ b/Sources/AnglesiteCore/MCPClient.swift
@@ -1,4 +1,9 @@
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Minimal JSON value used at the MCP boundary so request/response shapes stay `Sendable` and
 /// `Equatable` without forcing every caller to define a `Codable` model.

--- a/Sources/AnglesiteCore/SessionToken.swift
+++ b/Sources/AnglesiteCore/SessionToken.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CryptoKit
 
 /// A per-session bearer secret minted by the app and validated in-container (auth-proxy + MCP
 /// sidecar). Opaque; symmetric compare. The value is a secret — never log it (see `KeychainStore`).
@@ -10,7 +9,11 @@ public struct SessionToken: Sendable, Equatable, CustomStringConvertible {
 
     /// 32 cryptographically-random bytes, hex-encoded (64 chars).
     public static func mint() -> SessionToken {
-        let bytes = SymmetricKey(size: .bits256).withUnsafeBytes { Array($0) }
+        // SystemRandomNumberGenerator is cryptographically secure on every supported platform
+        // (arc4random_buf on Darwin, getrandom(2) on Linux), so minting needs no CryptoKit /
+        // swift-crypto dependency — this file is part of the portable core.
+        var rng = SystemRandomNumberGenerator()
+        let bytes = (0..<32).map { _ in UInt8.random(in: .min ... .max, using: &rng) }
         return SessionToken(value: bytes.map { String(format: "%02x", $0) }.joined())
     }
 

--- a/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
+++ b/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
@@ -1,5 +1,7 @@
 import Foundation
-#if compiler(>=6.4)
+// canImport joins the compiler gate: >=6.4 alone was a proxy for "the Xcode 27 SDK is
+// present", which a Swift 6.4 Linux toolchain will satisfy without having FoundationModels.
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -80,7 +82,7 @@ public struct FoundationModelsProbe: ReadinessProbe {
 /// Case names below must match the `FoundationModels` SDK; `@unknown default` absorbs drift.
 public enum LiveFoundationModelsAvailability {
     public static func current() -> FoundationModelsAvailability {
-        #if compiler(>=6.4)
+        #if compiler(>=6.4) && canImport(FoundationModels)
         switch SystemLanguageModel.default.availability {
         case .available:
             return .available

--- a/Sources/AnglesiteCore/UTType+Anglesite.swift
+++ b/Sources/AnglesiteCore/UTType+Anglesite.swift
@@ -1,3 +1,9 @@
+// Compiled out off-Darwin (cross-platform port design §5): there is no package-UTI concept
+// on Linux/Windows — `.anglesite` is a plain directory there, and identity comes from the
+// Info.plist UUID (AnglesiteSiteModel), which is fully portable. No AnglesiteCore code
+// references this extension; its consumers (NSOpenPanel, Finder integration) live in the
+// Darwin-only app shell.
+#if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers
 
 public extension UTType {
@@ -11,3 +17,4 @@ public extension UTType {
     /// call sites should use `.anglesiteSite`.
     static let anglesiteSite = UTType(exportedAs: "io.dwk.anglesite.site")
 }
+#endif


### PR DESCRIPTION
Stacked on #605. Purity seam 5 ("misc") of the [cross-platform port design](docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md) §5, plus the FoundationNetworking sweep.

## Changes

- **SessionToken.mint()**: `SymmetricKey` was only a source of 32 random bytes; `SystemRandomNumberGenerator` is cryptographically secure on all supported platforms (arc4random_buf / getrandom), so the portable core needs no CryptoKit or swift-crypto dependency at all.
- **UTType+Anglesite**: compiled out off-Darwin — no package-UTI concept exists there, site identity is the Info.plist UUID, and all consumers live in the Darwin app shell.
- **SiriReadinessSystemProbes**: FoundationModels gates were `#if compiler(>=6.4)` — a proxy for "Xcode 27 SDK present" that a Swift 6.4 Linux toolchain would wrongly satisfy. `canImport(FoundationModels)` joins the condition.
- **FoundationNetworking imports** in the 8 files using URLSession types (Cloudflare clients, `HTTPTransport`, `MCPClient`) — a no-op on macOS, required on Linux.

## Ground-truth note vs the design doc

The planned swift-log and swift-crypto swaps (§5 row 5) turned out to be **unnecessary**: every `os`/`OSLog` import in AnglesiteCore lives in files already owned by the assistant/embedding seams, and the sole CryptoKit use is replaced here. The portable core has no logging or crypto dependency to swap.

## Verification

Scratch Linux build with the remaining seam files excluded: unique portable-core compile errors drop **73 → 35**. Default `swift build && swift test` stays green on Linux and macOS behavior is unchanged (all edits are `canImport`-conditional or dependency-free swaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)