### PR TITLE
refactor(port): SecretStore seam — portable protocol, Keychain behind it

### DIFF
--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -322,14 +322,14 @@ public actor DeployCommand {
     }
 
     /// Default `TokenSource` for production: env var first (so a developer's shell still wins),
-    /// then the user's Keychain. A Keychain error is surfaced to the caller — we'd rather show
-    /// the user "couldn't read token" than silently fall through to `nil` and prompt for a
-    /// re-paste of a token that's actually stored fine.
+    /// then the platform secret store (the user's Keychain on macOS). A store error is surfaced
+    /// to the caller — we'd rather show the user "couldn't read token" than silently fall
+    /// through to `nil` and prompt for a re-paste of a token that's actually stored fine.
     public static let keychainTokenSource: TokenSource = {
         if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
             return env
         }
-        return try KeychainStore().readCloudflareToken()
+        return try PlatformSecretStore.make().readCloudflareToken()
     }
 
     /// Default `PreflightChecker`: host-side preflight was retired with embedded Node. Container

--- a/Sources/AnglesiteCore/DomainOperationsService.swift
+++ b/Sources/AnglesiteCore/DomainOperationsService.swift
@@ -36,12 +36,13 @@ public struct DomainOperations: DomainOperationsService {
         self.tokenProvider = tokenProvider
     }
 
-    /// Env var first (matches `HardenModel.apiToken()`), then the Keychain-stored token.
+    /// Env var first (matches `HardenModel.apiToken()`), then the platform secret store
+    /// (the user's Keychain on macOS).
     public static let defaultTokenProvider: @Sendable () -> String? = {
         if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
             return env
         }
-        return try? KeychainStore().readCloudflareToken()
+        return try? PlatformSecretStore.make().readCloudflareToken()
     }
 
     private func resolveZone(domain: String, token: String) async -> Result<String, DomainOperationError> {

--- a/Sources/AnglesiteCore/Platform/KeychainStore.swift
+++ b/Sources/AnglesiteCore/Platform/KeychainStore.swift
@@ -1,3 +1,6 @@
+// Darwin implementation of the SecretStore seam. The whole file compiles out on
+// platforms without the Security framework.
+#if canImport(Security)
 import Foundation
 import Security
 
@@ -18,7 +21,7 @@ import Security
 ///   inaccessible while the Mac is locked.
 /// - The token must never be logged. `DeployCommand` passes it via `environment` (which is opaque
 ///   to the supervisor's stdout/stderr pump), so it does not end up in `LogCenter`.
-public struct KeychainStore: Sendable {
+public struct KeychainStore: SecretStore {
     public enum Error: Swift.Error, Equatable {
         /// `SecItemCopyMatching` / `SecItemAdd` / `SecItemUpdate` / `SecItemDelete` returned a
         /// non-success `OSStatus`. The raw value is carried so test assertions can pin it down.
@@ -31,10 +34,9 @@ public struct KeychainStore: Sendable {
     /// Default service identifier. Matches the app's bundle id.
     public static let defaultService = "io.dwk.anglesite"
 
-    /// Account key under the default service for the Cloudflare API token used by
-    /// `wrangler deploy`. Centralized here so the Settings UI and `DeployCommand` refer to the
-    /// same slot.
-    public static let cloudflareTokenAccount = "cloudflare-api-token"
+    /// Account key for the Cloudflare API token. Forwarded from the portable
+    /// `SecretAccounts` namespace (the shared slot definition since the SecretStore seam).
+    public static let cloudflareTokenAccount = SecretAccounts.cloudflareToken
 
     public let service: String
 
@@ -106,22 +108,8 @@ public struct KeychainStore: Sendable {
         }
     }
 
-    // MARK: Cloudflare convenience
-
-    /// Read the Cloudflare API token under the default account.
-    public func readCloudflareToken() throws -> String? {
-        try read(account: Self.cloudflareTokenAccount)
-    }
-
-    /// Store the Cloudflare API token under the default account. Empty string clears.
-    public func writeCloudflareToken(_ token: String) throws {
-        try write(token, account: Self.cloudflareTokenAccount)
-    }
-
-    /// Clear the Cloudflare API token slot.
-    public func clearCloudflareToken() throws {
-        try delete(account: Self.cloudflareTokenAccount)
-    }
+    // Cloudflare token convenience (readCloudflareToken()/writeCloudflareToken(_:)/
+    // clearCloudflareToken()) comes from the SecretStore protocol extension.
 
     // MARK: Internals
 
@@ -134,3 +122,4 @@ public struct KeychainStore: Sendable {
         ]
     }
 }
+#endif

--- a/Sources/AnglesiteCore/Platform/SecretStore.swift
+++ b/Sources/AnglesiteCore/Platform/SecretStore.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Portable seam for storing small user secrets (API tokens) — seam 1 of the cross-platform
+/// port design (docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md §5).
+///
+/// Implementations: `KeychainStore` (Darwin, SecItem generic passwords); a libsecret/Secret
+/// Service store arrives with the Linux MVP; Windows gets Credential Manager. Platforms
+/// without a native implementation yet use `UnavailableSecretStore`, which reads as "nothing
+/// stored" and refuses writes — features degrade capability-flagged, never by silently
+/// dropping a secret.
+///
+/// Semantics all implementations must uphold (mirrored from `KeychainStore`, the reference
+/// implementation, and pinned by its test suite):
+/// - `read` returns `nil` (not an error) when no entry exists.
+/// - `write("")` deletes the entry, so an empty write round-trips as `read → nil`.
+/// - `delete` of a missing entry is a no-op, not an error.
+/// - Values are secrets: implementations and callers must never log them.
+public protocol SecretStore: Sendable {
+    /// Returns the stored secret for `account`, or `nil` if no entry exists.
+    func read(account: String) throws -> String?
+    /// Writes `value` for `account`, replacing any existing entry. An empty `value` deletes.
+    func write(_ value: String, account: String) throws
+    /// Removes the stored entry for `account`. No-op if no entry exists.
+    func delete(account: String) throws
+}
+
+/// Well-known account keys, shared across platform stores so the Settings UI, deploy path,
+/// and onboarding all address the same slot regardless of backend.
+public enum SecretAccounts {
+    /// The Cloudflare API token used by `wrangler deploy`.
+    public static let cloudflareToken = "cloudflare-api-token"
+}
+
+public extension SecretStore {
+    /// Read the Cloudflare API token under the shared account key.
+    func readCloudflareToken() throws -> String? {
+        try read(account: SecretAccounts.cloudflareToken)
+    }
+
+    /// Store the Cloudflare API token under the shared account key. Empty string clears.
+    func writeCloudflareToken(_ token: String) throws {
+        try write(token, account: SecretAccounts.cloudflareToken)
+    }
+
+    /// Clear the Cloudflare API token slot.
+    func clearCloudflareToken() throws {
+        try delete(account: SecretAccounts.cloudflareToken)
+    }
+}
+
+/// Placeholder store for platforms without a native secret-store implementation yet
+/// (Linux until the libsecret store lands). Reads report "nothing stored" so token
+/// resolution falls through to environment variables; writes fail loudly rather than
+/// pretending a secret was persisted.
+public struct UnavailableSecretStore: SecretStore {
+    public struct WriteUnsupported: Error {}
+
+    public init() {}
+
+    public func read(account: String) throws -> String? { nil }
+    public func write(_ value: String, account: String) throws { throw WriteUnsupported() }
+    public func delete(account: String) throws {}
+}
+
+/// Composition-root factory for the platform's default secret store. Call sites in the
+/// portable core depend on `any SecretStore` and use this only as their production default;
+/// tests and the app shell inject concrete stores directly.
+public enum PlatformSecretStore {
+    public static func make() -> any SecretStore {
+        #if canImport(Security)
+        KeychainStore()
+        #else
+        UnavailableSecretStore()
+        #endif
+    }
+}

--- a/Sources/AnglesiteCore/Platform/SecretStore.swift
+++ b/Sources/AnglesiteCore/Platform/SecretStore.swift
@@ -58,7 +58,14 @@ public struct UnavailableSecretStore: SecretStore {
     public init() {}
 
     public func read(account: String) throws -> String? { nil }
-    public func write(_ value: String, account: String) throws { throw WriteUnsupported() }
+
+    public func write(_ value: String, account: String) throws {
+        // Uphold the protocol contract: an empty write means delete, and deleting from a
+        // store that holds nothing is a successful no-op. Only persisting is unsupported.
+        if value.isEmpty { return }
+        throw WriteUnsupported()
+    }
+
     public func delete(account: String) throws {}
 }
 

--- a/Tests/AnglesiteCoreTests/KeychainStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/KeychainStoreTests.swift
@@ -1,3 +1,5 @@
+// Exercises the Darwin SecretStore implementation; compiles out with it off-Darwin.
+#if canImport(Security)
 import XCTest
 @testable import AnglesiteCore
 
@@ -98,3 +100,4 @@ final class KeychainStoreTests: XCTestCase {
         XCTAssertNil(try store.readCloudflareToken())
     }
 }
+#endif

--- a/Tests/AnglesiteCoreTests/SecretStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SecretStoreTests.swift
@@ -46,6 +46,9 @@ struct SecretStoreTests {
         let store = UnavailableSecretStore()
         #expect(try store.read(account: "anything") == nil)
         try store.delete(account: "anything")  // must not throw
+        // Empty write means delete (protocol contract), so it must succeed as a no-op
+        // even though persisting is unsupported.
+        try store.write("", account: "anything")
         #expect(throws: UnavailableSecretStore.WriteUnsupported.self) {
             try store.write("secret", account: "anything")
         }

--- a/Tests/AnglesiteCoreTests/SecretStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SecretStoreTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+/// Portable contract tests for the SecretStore seam — run on every platform (unlike
+/// `KeychainStoreTests`, which exercises the Darwin implementation against the real
+/// keychain). The in-memory store below doubles as a reference for the semantics every
+/// platform implementation must uphold.
+struct SecretStoreTests {
+    /// Minimal conforming store used to pin the protocol-extension convenience methods.
+    private final class InMemorySecretStore: SecretStore, @unchecked Sendable {
+        private var entries: [String: String] = [:]
+        private let lock = NSLock()
+
+        func read(account: String) throws -> String? {
+            lock.withLock { entries[account] }
+        }
+
+        func write(_ value: String, account: String) throws {
+            lock.withLock {
+                if value.isEmpty {
+                    entries[account] = nil
+                } else {
+                    entries[account] = value
+                }
+            }
+        }
+
+        func delete(account: String) throws {
+            lock.withLock { entries[account] = nil }
+        }
+    }
+
+    @Test("Cloudflare convenience methods address the shared SecretAccounts slot")
+    func cloudflareConvenienceUsesSharedAccount() throws {
+        let store = InMemorySecretStore()
+        try store.writeCloudflareToken("tok-123")
+        #expect(try store.read(account: SecretAccounts.cloudflareToken) == "tok-123")
+        #expect(try store.readCloudflareToken() == "tok-123")
+        try store.clearCloudflareToken()
+        #expect(try store.readCloudflareToken() == nil)
+    }
+
+    @Test("UnavailableSecretStore reads nothing, deletes as no-op, and refuses writes")
+    func unavailableStoreBehavior() throws {
+        let store = UnavailableSecretStore()
+        #expect(try store.read(account: "anything") == nil)
+        try store.delete(account: "anything")  // must not throw
+        #expect(throws: UnavailableSecretStore.WriteUnsupported.self) {
+            try store.write("secret", account: "anything")
+        }
+    }
+
+    @Test("PlatformSecretStore.make returns the platform default")
+    func platformDefaultResolves() {
+        let store = PlatformSecretStore.make()
+        #if canImport(Security)
+        #expect(store is KeychainStore)
+        #else
+        #expect(store is UnavailableSecretStore)
+        #endif
+    }
+}


### PR DESCRIPTION
Stacked on #606. Seam 1 of the [cross-platform port design](docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md) §5, establishing the `Sources/AnglesiteCore/Platform/` pattern the remaining seams follow: portable protocol + per-platform implementations, `#if` guards confined to `Platform/`.

## Changes

- **Platform/SecretStore.swift** (new): the `SecretStore` protocol with the contract `KeychainStore` already implements (nil on missing read, empty write deletes, idempotent delete), shared `SecretAccounts` slot names, Cloudflare-token convenience as a protocol extension, an `UnavailableSecretStore` placeholder (reads "nothing stored", refuses writes — capability-flagged degradation, never silently dropping a secret), and the `PlatformSecretStore.make()` composition-root factory.
- **KeychainStore** moves to `Platform/` (`git mv`, history preserved), compiles only where Security exists, and conforms to `SecretStore`. Public API unchanged for the five app-target call sites; the Cloudflare convenience trio now comes from the protocol extension with identical behavior.
- **Call sites**: `DeployCommand.keychainTokenSource` and `DomainOperations.defaultTokenProvider` — the only portable-core references — resolve tokens via `PlatformSecretStore.make()`. Env-var precedence unchanged.
- **Tests**: new portable `SecretStoreTests` (Swift Testing) pin the protocol contract, slot wiring, placeholder behavior, and platform-default resolution; `KeychainStoreTests` gains the same `canImport(Security)` gate as the implementation it exercises.

## Verification

Linux scratch build (remaining seam files excluded): unique errors drop **35 → 33** with the secret-store family fully clean. A real Linux store (libsecret/Secret Service) slots in at the Linux MVP without touching call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)