### PR TITLE
fix: address navigator content-command bugs found in #586 smoke testing

### DIFF
--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -86,8 +86,8 @@ struct SiteNavigatorView: View {
             Button("Cancel", role: .cancel) {}
         } message: { candidate in
             Text(candidate.kind == .page
-                ? "This page has no incoming links. Its content will be removed from the working tree. This can be undone via git."
-                : "This file appears unused. It will be removed from the working tree. This can be undone via git.")
+                ? "This page has no incoming links and will be permanently removed."
+                : "This file appears unused and will be permanently removed.")
         }
         .alert(
             "Delete failed",
@@ -144,6 +144,7 @@ struct SiteNavigatorView: View {
         switch group {
         case .pages: return "doc.richtext"
         case .posts: return "text.document"
+        case .collections: return "rectangle.stack"
         case .components: return "square.stack.3d.up"
         case .styles: return "paintbrush"
         case .metadata: return "globe"

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -26,6 +26,10 @@ struct SiteWindow: View {
     /// `model.deleteConfirmation` so the title stays stable through the dismiss animation —
     /// mirrors `SiteNavigatorView`'s `candidateToDeleteTitle` for the same reason.
     @State private var contentDeleteTitle: String = ""
+    /// The title shown in the post-delete Undo alert. Held separately from
+    /// `model.pendingDeleteUndo` for the same dismiss-animation-stability reason as
+    /// `contentDeleteTitle` above.
+    @State private var deleteUndoTitle: String = ""
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -584,7 +588,21 @@ struct SiteWindow: View {
             Button("Delete", role: .destructive) { Task { await model.confirmDelete() } }
             Button("Cancel", role: .cancel) { model.deleteConfirmation = nil }
         } message: {
-            Text("This content will be removed from the working tree. This can be undone via git.")
+            Text("This will remove the file from your site. You can undo it right after deleting.")
+        }
+        .onChange(of: bindableModel.pendingDeleteUndo) { _, offer in
+            if let offer { deleteUndoTitle = "Deleted \u{201C}\(offer.title)\u{201D}" }
+        }
+        .alert(
+            deleteUndoTitle,
+            isPresented: Binding(
+                get: { bindableModel.pendingDeleteUndo != nil },
+                set: { if !$0 { model.dismissDeleteUndo() } })
+        ) {
+            Button("Undo") { Task { await model.undoDelete() } }
+            Button("OK") { model.dismissDeleteUndo() }
+        } message: {
+            Text("Choose Undo now to bring it back, or OK to keep it deleted.")
         }
         .alert(
             "Couldn't complete that action",

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -132,6 +132,14 @@ final class SiteWindowModel {
     /// instruction: the delete dialog no longer mentions git at all, so this is the only way a user
     /// gets the file back.
     var pendingDeleteUndo: DeleteUndoOffer?
+    /// Editor/inspector state open on the file `pendingDeleteUndo` covers, snapshotted by
+    /// `confirmDelete()` at the same moment as the `.failed`-path snapshot below it. Consumed by
+    /// `undoDelete()` (restored, mirroring the `.failed` path) or discarded by
+    /// `dismissDeleteUndo()` (the file stays deleted, so there's nothing to reopen). Not stored on
+    /// `DeleteUndoOffer` itself: `ActiveEditor`/`InspectorContext` aren't `Equatable`, which
+    /// `DeleteUndoOffer` needs for the alert's `onChange(of:)` title capture.
+    private var pendingDeleteUndoEditor: (mode: MainPaneMode, editor: ActiveEditor)?
+    private var pendingDeleteUndoInspector: InspectorContext?
     /// File ▸ Revert to Saved is destructive, so it routes through a confirmation alert hosted by
     /// `SiteWindow` (#509).
     var revertConfirmationPresented = false
@@ -866,6 +874,8 @@ final class SiteWindowModel {
                 pendingDeleteUndo = DeleteUndoOffer(
                     id: relPath, title: item.title, relativePath: relPath,
                     contents: savedContents, redirectRoute: deletedRoute)
+                pendingDeleteUndoEditor = savedEditor
+                pendingDeleteUndoInspector = savedInspector
             } else if let deletedRoute {
                 pendingRedirectOfferRoute = deletedRoute
             }
@@ -886,10 +896,21 @@ final class SiteWindowModel {
     /// Restores the file captured by `pendingDeleteUndo` — the app-level "recover the last version"
     /// affordance (#586) the delete dialog's copy now points to instead of git. Re-writes the exact
     /// captured contents and re-commits, mirroring every other content mutation in this model.
+    /// Also reopens the editor/inspector `confirmDelete()` snapshotted, same as its own `.failed`
+    /// path restores them — an undo that brings the file back but leaves the user staring at
+    /// Preview would be only half a restore (PR #608 review).
     @MainActor
     func undoDelete() async {
-        guard let offer = pendingDeleteUndo, let site else { return }
+        guard let offer = pendingDeleteUndo else { return }
         pendingDeleteUndo = nil
+        let savedEditor = pendingDeleteUndoEditor
+        let savedInspector = pendingDeleteUndoInspector
+        pendingDeleteUndoEditor = nil
+        pendingDeleteUndoInspector = nil
+        // Cleared above regardless of `site`, mirroring `confirmDelete()`'s
+        // clear-before-guard ordering — an offer for a site that's since closed shouldn't linger.
+        guard let site else { return }
+
         let result = await contentCreation.restoreContent(
             siteID: site.id, relativePath: offer.relativePath, contents: offer.contents)
         switch result {
@@ -900,15 +921,31 @@ final class SiteWindowModel {
         case .siteNotFound:
             break
         }
+
+        // Reopen iff the file is actually back on disk — true both when `restoreContent` fully
+        // succeeds and when only its best-effort recommit fails (the write itself still landed);
+        // not true if the write itself failed, in which case there's nothing to reopen.
+        let restoredURL = site.sourceDirectory.appendingPathComponent(offer.relativePath)
+        guard FileManager.default.fileExists(atPath: restoredURL.path) else { return }
+        if let savedEditor {
+            activeEditor = savedEditor.editor
+            mainPaneMode = savedEditor.mode
+        }
+        if let savedInspector {
+            inspectorContext = savedInspector
+        }
     }
 
     /// Dismisses the Undo offer without restoring — the deferred half of `confirmDelete()`'s
     /// mutual-exclusion with the redirect offer: only now (Undo declined) does a deleted page/post
-    /// get its "Add Redirect?" prompt.
+    /// get its "Add Redirect?" prompt. The snapshotted editor/inspector state is discarded, not
+    /// restored: the file stays deleted, so there's nothing valid to reopen it onto.
     @MainActor
     func dismissDeleteUndo() {
         guard let offer = pendingDeleteUndo else { return }
         pendingDeleteUndo = nil
+        pendingDeleteUndoEditor = nil
+        pendingDeleteUndoInspector = nil
         if let route = offer.redirectRoute {
             pendingRedirectOfferRoute = route
         }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -24,6 +24,17 @@ enum ActiveEditor {
     }
 }
 
+/// A just-deleted page/post's contents, held so `SiteWindowModel.undoDelete()` can restore it
+/// (#586). `redirectRoute` carries the "Add Redirect?" offer through — deferred until the user
+/// declines to undo, see `dismissDeleteUndo()`.
+struct DeleteUndoOffer: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let relativePath: String
+    let contents: String
+    let redirectRoute: String?
+}
+
 /// Per-site coordinator for `SiteWindow`. Owns runtime startup, child model wiring,
 /// selection transitions, editor persistence, and teardown; `SiteWindow` owns only
 /// SwiftUI layout and scene storage.
@@ -115,6 +126,12 @@ final class SiteWindowModel {
     /// when the delete actually succeeded. Never break an inbound URL a user didn't choose to
     /// abandon (#584).
     var pendingRedirectOfferRoute: String?
+    /// Non-nil ⟺ the post-delete "Undo" affordance is showing (#586) — set by `confirmDelete()`
+    /// only when the delete actually succeeded and the deleted file's contents were captured before
+    /// the delete call. Deliberately app-level recovery (re-write + re-commit), not a "use git"
+    /// instruction: the delete dialog no longer mentions git at all, so this is the only way a user
+    /// gets the file back.
+    var pendingDeleteUndo: DeleteUndoOffer?
     /// File ▸ Revert to Saved is destructive, so it routes through a confirmation alert hosted by
     /// `SiteWindow` (#509).
     var revertConfirmationPresented = false
@@ -724,43 +741,61 @@ final class SiteWindowModel {
         }
     }
 
+    /// `contentCreation`'s successful create already rescans `SiteContentGraph` and publishes a
+    /// change event, but the Navigator consumes that event on its own long-running observer `Task`
+    /// (`SiteNavigatorModel.start()`) — decoupled from this call, so nothing guarantees it has
+    /// drained and rebuilt `sections` before the New-content sheet reads `.created` and dismisses
+    /// itself. Force-refreshing here closes that race, same as `createComponent` already did (#586).
     func createPage(
         title: String,
         route: String?,
         template: ContentScaffold.PageTemplate
     ) async -> ContentCreateResult {
         guard let site else { return .siteNotFound }
-        return await contentCreation.createPage(
+        let result = await contentCreation.createPage(
             siteID: site.id,
             title: title,
             route: route,
             template: template
         )
+        if case .created = result {
+            await navigator?.refreshNow()
+        }
+        return result
     }
 
+    /// See `createPage`'s force-refresh note (#586) — same race, same fix.
     func createCollectionEntry(
         title: String,
         slug: String?,
         descriptor: ContentTypeDescriptor
     ) async -> ContentCreateResult {
         guard let site else { return .siteNotFound }
-        return await contentCreation.createTyped(
+        let result = await contentCreation.createTyped(
             siteID: site.id,
             typeID: descriptor.id,
             title: title,
             slug: slug
         )
+        if case .created = result {
+            await navigator?.refreshNow()
+        }
+        return result
     }
 
+    /// See `createPage`'s force-refresh note (#586) — same race, same fix.
     func createPost(title: String) async -> ContentCreateResult {
         guard let site else { return .siteNotFound }
-        return await contentCreation.createPost(siteID: site.id, title: title, collection: nil, slug: nil)
+        let result = await contentCreation.createPost(siteID: site.id, title: title, collection: nil, slug: nil)
+        if case .created = result {
+            await navigator?.refreshNow()
+        }
+        return result
     }
 
-    /// Components aren't tracked in `SiteContentGraph`, so — unlike `createPage`/`createPost`/
-    /// `createCollectionEntry`, whose graph rescan already triggers the Navigator's own
-    /// change-stream refresh — this force-refreshes the Navigator directly on success. Same
-    /// reasoning as `deleteCleanupCandidate`'s force-refresh for non-graph-tracked files.
+    /// Components aren't tracked in `SiteContentGraph` at all, so there's no change-stream event to
+    /// race with — this force-refresh is the *only* way the Navigator learns about a new component.
+    /// Same reasoning as `deleteCleanupCandidate`'s force-refresh for non-graph-tracked files.
     func createComponent(name: String) async -> ContentCreateResult {
         guard let site else { return .siteNotFound }
         let result = await contentCreation.createComponent(siteID: site.id, name: name)
@@ -801,6 +836,10 @@ final class SiteWindowModel {
         }
 
         let deletedURL = site.sourceDirectory.appendingPathComponent(relPath)
+        // Read before the delete call, not after: the file is gone from disk once the delete
+        // succeeds. Best-effort — a read failure (unreadable encoding, permissions) just means no
+        // Undo offer, not a blocked delete.
+        let savedContents = try? String(contentsOf: deletedURL, encoding: .utf8)
         var savedEditor: (mode: MainPaneMode, editor: ActiveEditor)?
         if activeEditorFile?.url == deletedURL, let editor = activeEditor {
             savedEditor = (mainPaneMode, editor)
@@ -816,7 +855,18 @@ final class SiteWindowModel {
         switch result {
         case .deleted:
             if navigator?.selection == item.id { navigator?.selection = nil }
-            if let deletedRoute {
+            // `deleteContent` only rescans `SiteContentGraph`; the Navigator's own consumption of
+            // that change is a decoupled async observer task, so nothing guarantees it has rebuilt
+            // `sections` yet — force it, same race/fix as the create paths (#586).
+            await navigator?.refreshNow()
+            // The Undo offer and the "Add Redirect?" offer are mutually exclusive at any one
+            // moment (both are presented as modal UI): Undo takes priority, and choosing not to
+            // undo (`dismissDeleteUndo()`) is what surfaces the redirect offer instead.
+            if let savedContents {
+                pendingDeleteUndo = DeleteUndoOffer(
+                    id: relPath, title: item.title, relativePath: relPath,
+                    contents: savedContents, redirectRoute: deletedRoute)
+            } else if let deletedRoute {
                 pendingRedirectOfferRoute = deletedRoute
             }
         case .failed(let reason):
@@ -830,6 +880,37 @@ final class SiteWindowModel {
             }
         case .siteNotFound:
             break
+        }
+    }
+
+    /// Restores the file captured by `pendingDeleteUndo` — the app-level "recover the last version"
+    /// affordance (#586) the delete dialog's copy now points to instead of git. Re-writes the exact
+    /// captured contents and re-commits, mirroring every other content mutation in this model.
+    @MainActor
+    func undoDelete() async {
+        guard let offer = pendingDeleteUndo, let site else { return }
+        pendingDeleteUndo = nil
+        let result = await contentCreation.restoreContent(
+            siteID: site.id, relativePath: offer.relativePath, contents: offer.contents)
+        switch result {
+        case .created:
+            await navigator?.refreshNow()
+        case .failed(let reason):
+            contentActionError = reason
+        case .siteNotFound:
+            break
+        }
+    }
+
+    /// Dismisses the Undo offer without restoring — the deferred half of `confirmDelete()`'s
+    /// mutual-exclusion with the redirect offer: only now (Undo declined) does a deleted page/post
+    /// get its "Add Redirect?" prompt.
+    @MainActor
+    func dismissDeleteUndo() {
+        guard let offer = pendingDeleteUndo else { return }
+        pendingDeleteUndo = nil
+        if let route = offer.redirectRoute {
+            pendingRedirectOfferRoute = route
         }
     }
 

--- a/Sources/AnglesiteCore/ContentCreationWorkflow.swift
+++ b/Sources/AnglesiteCore/ContentCreationWorkflow.swift
@@ -23,6 +23,7 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         _ onProgress: ProgressHandler?
     ) async -> ContentCreateResult
     public typealias ContentDeleter = @Sendable (_ siteID: String, _ relativePath: String) async -> ContentDeleteResult
+    public typealias ContentRestorer = @Sendable (_ siteID: String, _ relativePath: String, _ contents: String) async -> ContentCreateResult
     public typealias PageDuplicator = @Sendable (_ siteID: String, _ relativePath: String, _ title: String) async -> ContentCreateResult
     public typealias PostDuplicator = @Sendable (_ siteID: String, _ relativePath: String, _ collection: String, _ title: String) async -> ContentCreateResult
     public typealias ComponentCreator = @Sendable (_ siteID: String, _ name: String) async -> ContentCreateResult
@@ -34,6 +35,7 @@ public struct ContentCreationWorkflow: ContentOperationsService {
     private let pageTemplateCreator: PageTemplateCreator?
     private let typedSlugCreator: TypedSlugCreator?
     private let contentDeleter: ContentDeleter?
+    private let contentRestorer: ContentRestorer?
     private let pageDuplicator: PageDuplicator?
     private let postDuplicator: PostDuplicator?
     private let componentCreator: ComponentCreator?
@@ -46,6 +48,7 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         pageTemplateCreator: PageTemplateCreator? = nil,
         typedSlugCreator: TypedSlugCreator? = nil,
         contentDeleter: ContentDeleter? = nil,
+        contentRestorer: ContentRestorer? = nil,
         pageDuplicator: PageDuplicator? = nil,
         postDuplicator: PostDuplicator? = nil,
         componentCreator: ComponentCreator? = nil
@@ -57,6 +60,7 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         self.pageTemplateCreator = pageTemplateCreator
         self.typedSlugCreator = typedSlugCreator
         self.contentDeleter = contentDeleter
+        self.contentRestorer = contentRestorer
         self.pageDuplicator = pageDuplicator
         self.postDuplicator = postDuplicator
         self.componentCreator = componentCreator
@@ -97,6 +101,9 @@ public struct ContentCreationWorkflow: ContentOperationsService {
             },
             contentDeleter: { siteID, relativePath in
                 await native.deleteContent(siteID: siteID, relativePath: relativePath)
+            },
+            contentRestorer: { siteID, relativePath, contents in
+                await native.restoreContent(siteID: siteID, relativePath: relativePath, contents: contents)
             },
             pageDuplicator: { siteID, relativePath, title in
                 await native.duplicatePage(siteID: siteID, relativePath: relativePath, title: title)
@@ -236,6 +243,15 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         if case .deleted = result {
             await refreshContentGraph(siteID: siteID)
         }
+        return result
+    }
+
+    /// Undo half of `deleteContent` (#586) — re-writes previously-captured contents and rescans the
+    /// graph on success, same as every other successful create.
+    public func restoreContent(siteID: String, relativePath: String, contents: String) async -> ContentCreateResult {
+        guard let contentRestorer else { return .failed(reason: "Restore is not configured for this workflow") }
+        let result = await contentRestorer(siteID, relativePath, contents)
+        await refreshContentGraphIfCreated(result, siteID: siteID)
         return result
     }
 

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -213,8 +213,9 @@ public struct NativeContentOperations: ContentOperationsService {
     }
 
     /// Delete a page/post/component file: `git rm` + commit via the injected `gitDelete` closure
-    /// (default `processGitDelete`). No Trash involved — git history is the sole undo mechanism,
-    /// matching `ProjectCleanupModel.delete`'s existing precedent for dead-asset deletion.
+    /// (default `processGitDelete`). Git is the underlying mechanism, but not a user-facing
+    /// concept: the in-app "Undo" affordance (`restoreContent`, driven by the caller holding the
+    /// pre-delete contents) is what recovers a deleted file, not an instruction to use git.
     public func deleteContent(siteID: String, relativePath: String) async -> ContentDeleteResult {
         guard let root = await siteDirectory(siteID) else { return .siteNotFound }
         let abs = root.appendingPathComponent(relativePath)
@@ -222,9 +223,21 @@ public struct NativeContentOperations: ContentOperationsService {
             return .failed(reason: "No file exists at \(relativePath)")
         }
         guard await gitDelete(root, relativePath, "anglesite: delete \(relativePath)") != nil else {
-            return .failed(reason: "Couldn't delete \(relativePath). Check for uncommitted changes and try again.")
+            return .failed(reason: "Couldn't delete \(relativePath). Try again in a moment.")
         }
         return .deleted(filePath: relativePath)
+    }
+
+    /// Re-writes `contents` back to `relativePath` and commits — the "Undo" half of `deleteContent`
+    /// (#586). The caller is responsible for having captured `contents` before the delete; this
+    /// method doesn't itself know what was deleted.
+    public func restoreContent(siteID: String, relativePath: String, contents: String) async -> ContentCreateResult {
+        guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+        let abs = root.appendingPathComponent(relativePath)
+        do { try write(contents, to: abs) }
+        catch { return .failed(reason: "\(error)") }
+        _ = await gitCommit(root, relativePath, "anglesite: restore \(relativePath)")
+        return .created(filePath: relativePath, identifier: relativePath)
     }
 
     /// Duplicate an existing page: read its contents, retitle to `"<title> Copy"` (bumping to

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -231,12 +231,23 @@ public struct NativeContentOperations: ContentOperationsService {
     /// Re-writes `contents` back to `relativePath` and commits — the "Undo" half of `deleteContent`
     /// (#586). The caller is responsible for having captured `contents` before the delete; this
     /// method doesn't itself know what was deleted.
+    ///
+    /// Unlike the best-effort `_ = await gitCommit(...)` elsewhere in this file (a freshly-created
+    /// file simply has no prior git history to protect), a failed recommit here is reported as
+    /// `.failed` rather than silently swallowed: `processGitDelete`'s `cat-file -e HEAD:relPath`
+    /// guard requires a committed HEAD copy, so an uncommitted restore would leave the file
+    /// existing on disk (and reported to the user as "undone") while any *later* delete of it keeps
+    /// failing opaquely — the file is back but the app's own recovery mechanism can no longer touch
+    /// it. Surfacing the failure here at least tells the user restoration is incomplete (PR #608
+    /// review).
     public func restoreContent(siteID: String, relativePath: String, contents: String) async -> ContentCreateResult {
         guard let root = await siteDirectory(siteID) else { return .siteNotFound }
         let abs = root.appendingPathComponent(relativePath)
         do { try write(contents, to: abs) }
         catch { return .failed(reason: "\(error)") }
-        _ = await gitCommit(root, relativePath, "anglesite: restore \(relativePath)")
+        guard await gitCommit(root, relativePath, "anglesite: restore \(relativePath)") != nil else {
+            return .failed(reason: "Restored \(relativePath), but couldn't save it to your site's history. Try again in a moment.")
+        }
         return .created(filePath: relativePath, identifier: relativePath)
     }
 

--- a/Sources/AnglesiteCore/NavigatorTree.swift
+++ b/Sources/AnglesiteCore/NavigatorTree.swift
@@ -33,25 +33,44 @@ public func postRoute(for post: SiteContentGraph.Post) -> String {
     return "/\(collection)/\(slug)/"
 }
 
-/// Display titles for the five groups, in canonical sidebar order.
+/// Display titles for the six groups, in canonical sidebar order.
 private let groupTitles: [(FileGroup, String?)] = [
-    (.metadata, nil), (.pages, "Pages"), (.posts, "Posts"),
+    (.metadata, nil), (.pages, "Pages"), (.posts, "Posts"), (.collections, "Collections"),
     (.components, "Components"), (.styles, "Styles"),
 ]
 
+/// `SiteContentGraph.Post` covers every `src/content/<collection>/` entry, not just blog posts —
+/// a "New Collection…" entry (e.g. a note or bookmark) is a `Post` too, just with a different
+/// `collection`. This is the one collection name that's actually a blog post.
+private let blogCollectionName = "posts"
+
 /// Merges content-graph pages/posts with the filesystem scan into ordered, non-empty sections.
+/// Splits `posts` by `collection`: blog posts (`collection == "posts"`) go to the Posts section;
+/// everything else (notes, articles, bookmarks, …) goes to a separate Collections section so a
+/// freshly-created collection entry doesn't read as "a post got created instead" (#586).
 public func buildNavigatorTree(
     pages: [SiteContentGraph.Page],
     posts: [SiteContentGraph.Post],
     fileGroups: [FileGroup: [FileRef]],
-    websiteTitle: String? = nil
+    websiteTitle: String? = nil,
+    contentTypes: ContentTypeRegistry = .default
 ) -> [NavigatorSection] {
     let pageItems = pages
         .sorted { $0.route < $1.route }
         .map { NavigatorItem(id: $0.id, title: $0.title ?? $0.route, target: .route($0.route)) }
     let postItems = posts
+        .filter { $0.collection == blogCollectionName }
         .sorted { $0.title < $1.title }
         .map { NavigatorItem(id: $0.id, title: $0.title, target: .route(postRoute(for: $0))) }
+    let collectionItems = posts
+        .filter { $0.collection != blogCollectionName }
+        .sorted { $0.collection == $1.collection ? $0.title < $1.title : $0.collection < $1.collection }
+        .map { post in
+            NavigatorItem(
+                id: post.id,
+                title: "\(collectionLabel(post.collection, contentTypes: contentTypes)): \(post.title)",
+                target: .route(postRoute(for: post)))
+        }
 
     var sections: [NavigatorSection] = []
     for (group, title) in groupTitles {
@@ -59,6 +78,7 @@ public func buildNavigatorTree(
         switch group {
         case .pages: items = pageItems
         case .posts: items = postItems
+        case .collections: items = collectionItems
         case .metadata:
             items = siteMetadataItems(from: fileGroups[group] ?? [], websiteTitle: websiteTitle)
         default:
@@ -69,6 +89,16 @@ public func buildNavigatorTree(
         if !items.isEmpty { sections.append(NavigatorSection(id: group, title: title, items: items)) }
     }
     return sections
+}
+
+/// A collection-entry's registered content type display name (e.g. `Note`), falling back to the
+/// capitalized collection folder name for a collection with no matching descriptor.
+private func collectionLabel(_ collection: String, contentTypes: ContentTypeRegistry) -> String {
+    if let descriptor = contentTypes.descriptor(forCollection: collection) {
+        return descriptor.displayName
+    }
+    guard let first = collection.first else { return collection }
+    return first.uppercased() + collection.dropFirst()
 }
 
 private func siteMetadataItems(from refs: [FileRef], websiteTitle: String?) -> [NavigatorItem] {

--- a/Sources/AnglesiteCore/SiteFileTree.swift
+++ b/Sources/AnglesiteCore/SiteFileTree.swift
@@ -8,7 +8,7 @@ import AnglesiteSiteModel
 /// Roots are resolved adaptively: an `.anglesite` package (#242) exposes `Source/` and `Config/`;
 /// a plain directory (the current pre-package layout) is treated as the project root directly.
 public enum FileGroup: String, Sendable, CaseIterable {
-    case pages, posts, components, styles, metadata
+    case pages, posts, collections, components, styles, metadata
 }
 
 public struct FileRef: Sendable, Equatable, Identifiable {

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -172,4 +172,43 @@ extension SiteWindowModelTests {
         #expect(model.pendingRedirectOfferRoute == nil)
         #expect(model.contentActionError == nil)
     }
+
+    @Test("dismissDeleteUndo declines the restore and surfaces the deferred redirect offer")
+    func dismissDeleteUndoSurfacesRedirectOffer() {
+        let model = makeModel()
+        model.pendingDeleteUndo = DeleteUndoOffer(
+            id: "src/pages/about.astro", title: "About", relativePath: "src/pages/about.astro",
+            contents: "stub", redirectRoute: "/about/")
+
+        model.dismissDeleteUndo()
+
+        #expect(model.pendingDeleteUndo == nil)
+        #expect(model.pendingRedirectOfferRoute == "/about/")
+    }
+
+    @Test("dismissDeleteUndo with no redirect route just clears the offer")
+    func dismissDeleteUndoWithoutRedirectRoute() {
+        let model = makeModel()
+        model.pendingDeleteUndo = DeleteUndoOffer(
+            id: "src/components/Widget.astro", title: "Widget", relativePath: "src/components/Widget.astro",
+            contents: "stub", redirectRoute: nil)
+
+        model.dismissDeleteUndo()
+
+        #expect(model.pendingDeleteUndo == nil)
+        #expect(model.pendingRedirectOfferRoute == nil)
+    }
+
+    @Test("undoDelete no-ops safely when there is no open site, clearing the offer rather than leaving it stale")
+    func undoDeleteNoSiteClearsOffer() async {
+        let model = makeModel()
+        model.pendingDeleteUndo = DeleteUndoOffer(
+            id: "src/pages/about.astro", title: "About", relativePath: "src/pages/about.astro",
+            contents: "stub", redirectRoute: nil)
+
+        await model.undoDelete()
+
+        #expect(model.pendingDeleteUndo == nil)
+        #expect(model.contentActionError == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
@@ -327,6 +327,78 @@ struct ContentCreationWorkflowTests {
 
         guard case .failed = result else { Issue.record("expected .failed, got \(result)"); return }
     }
+
+    @Test("successful restoreContent reloads content graph so the restored page reappears")
+    func restoreContentRefreshesGraph() async throws {
+        let root = try makeSite()
+        let graph = SiteContentGraph()
+        let operations = FakeCreateOperations { _, _, _ in
+            .failed(reason: "unexpected")
+        } createPost: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        } createTyped: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        }
+        let workflow = ContentCreationWorkflow(
+            operations: operations,
+            contentGraph: graph,
+            siteDirectory: { _ in root },
+            contentRestorer: { _, relPath, contents in
+                let url = root.appendingPathComponent(relPath)
+                try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try? contents.write(to: url, atomically: true, encoding: .utf8)
+                return .created(filePath: relPath, identifier: "/about")
+            }
+        )
+
+        let result = await workflow.restoreContent(
+            siteID: Self.siteID, relativePath: "src/pages/about.astro",
+            contents: ContentScaffold.renderPage(title: "About", layoutImport: "../layouts/BaseLayout.astro"))
+
+        #expect(result == .created(filePath: "src/pages/about.astro", identifier: "/about"))
+        #expect(await graph.pages(for: Self.siteID).map(\.route) == ["/about"])
+    }
+
+    @Test("failed restoreContent leaves content graph unchanged")
+    func failedRestoreContentDoesNotRefreshGraph() async throws {
+        let root = try makeSite()
+        let graph = SiteContentGraph()
+        let operations = FakeCreateOperations { _, _, _ in
+            .failed(reason: "unexpected")
+        } createPost: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        } createTyped: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        }
+        let workflow = ContentCreationWorkflow(
+            operations: operations,
+            contentGraph: graph,
+            siteDirectory: { _ in root },
+            contentRestorer: { _, _, _ in .failed(reason: "couldn't save it to your site's history") }
+        )
+
+        let result = await workflow.restoreContent(siteID: Self.siteID, relativePath: "src/pages/about.astro", contents: "x")
+
+        guard case .failed = result else { Issue.record("expected .failed, got \(result)"); return }
+        #expect(await graph.pages(for: Self.siteID).isEmpty)
+    }
+
+    @Test("restoreContent reports failed when the workflow has no contentRestorer configured")
+    func restoreContentUnconfigured() async throws {
+        let root = try makeSite()
+        let operations = FakeCreateOperations { _, _, _ in
+            .failed(reason: "unexpected")
+        } createPost: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        } createTyped: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        }
+        let workflow = ContentCreationWorkflow(operations: operations, contentGraph: nil, siteDirectory: { _ in root })
+
+        let result = await workflow.restoreContent(siteID: Self.siteID, relativePath: "src/pages/about.astro", contents: "x")
+
+        guard case .failed = result else { Issue.record("expected .failed, got \(result)"); return }
+    }
 }
 
 private struct FakeCreateOperations: ContentOperationsService {

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -368,6 +368,60 @@ struct NativeContentOperationsDeleteTests {
 
         #expect(result == .siteNotFound)
     }
+
+    @Test("restoreContent writes the given contents back and commits via the injected closure")
+    func restoresContent() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let relPath = "src/pages/about.astro"
+
+        var committedArgs: (URL, String, String)?
+        let ops = NativeContentOperations(
+            siteDirectory: { _ in root },
+            gitCommit: { projectRoot, path, message in
+                committedArgs = (projectRoot, path, message)
+                return "deadbeef"
+            }
+        )
+
+        let result = await ops.restoreContent(siteID: "site-1", relativePath: relPath, contents: "restored body")
+
+        #expect(result == .created(filePath: relPath, identifier: relPath))
+        let written = try String(contentsOf: root.appendingPathComponent(relPath), encoding: .utf8)
+        #expect(written == "restored body")
+        #expect(committedArgs?.1 == relPath)
+    }
+
+    @Test("restoreContent reports .failed when the recommit fails, even though the write itself landed")
+    func restoreContentFailsWhenCommitFails() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let relPath = "src/pages/about.astro"
+        let ops = NativeContentOperations(
+            siteDirectory: { _ in root },
+            gitCommit: { _, _, _ in nil }
+        )
+
+        let result = await ops.restoreContent(siteID: "site-1", relativePath: relPath, contents: "restored body")
+
+        guard case .failed = result else { Issue.record("expected .failed, got \(result)"); return }
+        // The write itself is not rolled back on a commit failure — the caller (SiteWindowModel)
+        // relies on this to decide whether to reopen the editor/inspector on the restored file.
+        let written = try String(contentsOf: root.appendingPathComponent(relPath), encoding: .utf8)
+        #expect(written == "restored body")
+    }
+
+    @Test("restoreContent reports siteNotFound when siteDirectory resolves nil")
+    func restoreContentSiteNotFound() async {
+        let ops = NativeContentOperations(
+            siteDirectory: { _ in nil },
+            gitCommit: { _, _, _ in "deadbeef" }
+        )
+
+        let result = await ops.restoreContent(siteID: "missing-site", relativePath: "src/pages/about.astro", contents: "x")
+
+        #expect(result == .siteNotFound)
+    }
 }
 
 @Suite("NativeContentOperations.duplicatePage/duplicatePost")

--- a/Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
+++ b/Tests/AnglesiteCoreTests/NavigatorTreeTests.swift
@@ -48,6 +48,27 @@ struct NavigatorTreeTests {
         #expect(item.target == .file(ref))
     }
 
+    @Test("blog posts and collection entries land in separate sections (#586)")
+    func collectionEntriesSeparateFromPosts() throws {
+        let sections = buildNavigatorTree(
+            pages: [],
+            posts: [post("posts", "hello-world", "Hello World"), post("notes", "aside", "An aside")],
+            fileGroups: [:]
+        )
+        let posts = try #require(sections.first { $0.id == .posts })
+        #expect(posts.items.map(\.title) == ["Hello World"])
+
+        let collections = try #require(sections.first { $0.id == .collections })
+        #expect(collections.items.map(\.title) == ["Note: An aside"])
+    }
+
+    @Test("collection section omitted when every post is a blog post")
+    func noCollectionSectionWhenOnlyBlogPosts() {
+        let sections = buildNavigatorTree(
+            pages: [], posts: [post("posts", "hello-world", "Hello World")], fileGroups: [:])
+        #expect(sections.map(\.id) == [.posts])
+    }
+
     @Test("package Info.plist appears as the headerless first website item")
     func packageMetadataAppearsAsWebsiteItem() throws {
         let info = FileRef(url: URL(fileURLWithPath: "/tmp/Site.anglesite/Info.plist"), group: .metadata, name: "Info.plist")


### PR DESCRIPTION
## Summary
Three bugs surfaced by manual GUI verification of PR #585's Delete/Duplicate/New Post/New Component commands (reported as comments on #586):

- **New page not found on creation** — the New Page/Post/Collection Entry sheets could dismiss before the Navigator's async change-stream observer finished rebuilding its sections, so a freshly created item could appear missing. Force-refreshes the Navigator on success now, matching `createComponent`'s existing pattern.
- **Delete workflow exposed git; sidebar not updated** — the delete confirmation dialog and failure message referenced git ("working tree", "undone via git") instead of an in-app recovery affordance. Added a real Undo action (captures the deleted file's contents before delete, restores + recommits on request) and reworded both dialogs. Also force-refreshes the Navigator after a successful delete, which had the same stale-sidebar race as create.
- **New Collection created what looked like a post** — collection entries (notes, articles, bookmarks, …) were written correctly on disk but rendered indistinguishable from blog posts, since the Navigator lumped every `SiteContentGraph.Post` (any collection) into one "Posts" section. Non-blog collection entries now get their own "Collections" section, labeled with the entry's registered content type (e.g. "Note: An aside").

## Test plan
- [x] `swift build --package-path .` — clean build
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — app links
- [x] `xcrun xctest` against `AnglesiteCoreTests.xctest` directly (the `AnglesiteAppTests` bundle can't dlopen locally due to the known #541 FoundationModels symbol mismatch — CI is the arbiter there) — `NavigatorTreeTests`, `EditorKindTests`, `ContentCreationWorkflowTests`, `NativeContentOperationsTests` all pass, including 2 new tests for the Collections-section split
- [ ] Manual GUI re-verification of the three fixed flows on a machine where the app launches (same #541 gap that blocked #586's original Task 11)

Closes the three reported issues on #586.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>