### PR TITLE
test: pass explicit 30s initializeTimeout in MCPClientTests subprocess tests

### DIFF
--- a/Tests/AnglesiteCoreTests/MCPClientTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientTests.swift
@@ -80,6 +80,10 @@ struct MCPClientTests {
         sys.stdout.flush()
     """
 
+    /// Generous initialize-handshake timeout for the python fake server: interpreter startup can
+    /// exceed `MCPClient.start`'s 10s default on a contended CI runner (same class of flake as #177).
+    private static let initializeTimeout: TimeInterval = 30
+
     private static let pythonURL: URL = {
         for path in ["/usr/bin/python3", "/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/opt/anaconda3/bin/python3"] {
             if FileManager.default.isExecutableFile(atPath: path) {
@@ -101,7 +105,8 @@ struct MCPClientTests {
         try await client.start(
             executable: Self.pythonURL,
             arguments: ["-u", "-c", Self.fakeServerScript],
-            source: "mcp-handshake"
+            source: "mcp-handshake",
+            initializeTimeout: Self.initializeTimeout
         )
         let running = await client.isRunning
         #expect(running)
@@ -115,7 +120,8 @@ struct MCPClientTests {
         try await client.start(
             executable: Self.pythonURL,
             arguments: ["-u", "-c", Self.fakeServerScript],
-            source: "mcp-list"
+            source: "mcp-list",
+            initializeTimeout: Self.initializeTimeout
         )
         defer { Task { await client.stop() } }
 
@@ -131,7 +137,8 @@ struct MCPClientTests {
         try await client.start(
             executable: Self.pythonURL,
             arguments: ["-u", "-c", Self.fakeServerScript],
-            source: "mcp-call"
+            source: "mcp-call",
+            initializeTimeout: Self.initializeTimeout
         )
         defer { Task { await client.stop() } }
 
@@ -150,7 +157,8 @@ struct MCPClientTests {
         try await client.start(
             executable: Self.pythonURL,
             arguments: ["-u", "-c", Self.fakeServerScript],
-            source: "mcp-error"
+            source: "mcp-error",
+            initializeTimeout: Self.initializeTimeout
         )
         defer { Task { await client.stop() } }
 
@@ -174,7 +182,8 @@ struct MCPClientTests {
             executable: Self.pythonURL,
             arguments: ["-u", "-c", Self.crashOnceServerScript],
             source: "mcp-reconnect",
-            restartPolicy: .onCrash(maxAttempts: 3, baseBackoff: 0.05)
+            restartPolicy: .onCrash(maxAttempts: 3, baseBackoff: 0.05),
+            initializeTimeout: Self.initializeTimeout
         )
         defer { Task { await client.stop() } }
 
@@ -186,7 +195,7 @@ struct MCPClientTests {
         // Poll instead of a fixed sleep: respawn + handshake comfortably fits in a few hundred ms
         // locally but can take seconds on a loaded CI runner. .notInitialized / .reconnecting are
         // the documented transient errors during a supervised respawn; anything else is real.
-        let tools = try await Self.listToolsAwaitingReconnect(client, timeout: 10)
+        let tools = try await Self.listToolsAwaitingReconnect(client, timeout: Self.initializeTimeout)
         #expect(tools.first?.name == "echo")
 
         let echoed = try await client.callTool(name: "echo", arguments: .object(["text": .string("after-reconnect")]))


### PR DESCRIPTION
## Summary

- Fixes the CI flake where `MCPClientTests` "Start runs initialize handshake" failed with `Caught error: timeout` after 12.9s (build-test job, run 29051592970 on #604): python3 interpreter startup on a contended runner can exceed `MCPClient.start`'s default 10s `initializeTimeout`.
- All five `MCPClientTests` tests that spawn the python fake server now pass an explicit 30s `initializeTimeout` via a shared constant, consistent with how #177 stabilized subprocess-contention flakes (the e2e suites already pass 15s explicitly).
- The reconnect test's post-crash polling deadline (`listToolsAwaitingReconnect`) reuses the same constant, since it races the same respawn + handshake under load.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks). Link it here:

> Cross-cutting work (extending MCP messages, changing the plugin's hook contract, adjusting the site template the app scaffolds, etc.) lands as paired PRs. The plugin PR ships first in a tagged release; the app PR consumes it and bumps `Resources/plugin/`'s source-of-truth pointer. See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [ ] `swift test --package-path .` (via CI — this session's Linux container has no Swift toolchain; the change is test-only and touches macOS-hosted subprocess tests)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (n/a — no app-target source changed)
- [ ] Manual smoke (if UI-touching): n/a, test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117DoFbT3DLnQ5avdmSHc6N

---
_Generated by [Claude Code](https://claude.ai/code/session_0117DoFbT3DLnQ5avdmSHc6N)_