### PR TITLE
test: replace real subprocess with in-process fake transport in MCPClientTests

### DIFF
--- a/Tests/AnglesiteCoreTests/MCPClientTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientTests.swift
@@ -2,48 +2,95 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
-/// `.serialized` so this suite's many subprocess spawns (a fresh fake MCP server per test) don't
-/// run concurrently with each other under `swift test --parallel`. With ~6 subprocess suites each
-/// spawning serially, peak concurrent Node/Python spawns stays low enough that the `initialize`
-/// handshake doesn't time out on a CPU-saturated CI runner (the flake). See CI-flakiness fix.
+/// `.serialized` so the one test that still spawns a real subprocess (`reconnectsAfterServerCrash`,
+/// exercising `ProcessSupervisor`'s crash-detection and restart) doesn't contend for CPU with other
+/// subprocess-spawning suites under `swift test --parallel`. See #609 / #610.
 @Suite(.serialized)
 struct MCPClientTests {
-    /// Python fake MCP server speaking JSON-RPC 2.0 over stdio. `-u` keeps it unbuffered.
-    private static let fakeServerScript = """
-    import sys, json
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            msg = json.loads(line)
-        except Exception:
-            continue
-        method = msg.get("method", "")
-        rid = msg.get("id")
-        if rid is None:
-            # notification — no response
-            continue
-        if method == "initialize":
-            resp = {"jsonrpc":"2.0","id":rid,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"fake","version":"0.0.0"}}}
-        elif method == "tools/list":
-            resp = {"jsonrpc":"2.0","id":rid,"result":{"tools":[{"name":"echo","description":"Echoes back","inputSchema":{"type":"object","properties":{"text":{"type":"string"}}}}]}}
-        elif method == "tools/call":
-            params = msg.get("params", {})
-            name = params.get("name")
-            args = params.get("arguments", {}) or {}
-            if name == "echo":
-                resp = {"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":args.get("text","")}],"isError":False}}
-            else:
-                resp = {"jsonrpc":"2.0","id":rid,"error":{"code":-32601,"message":"unknown tool"}}
-        else:
-            resp = {"jsonrpc":"2.0","id":rid,"error":{"code":-32601,"message":"method not found"}}
-        sys.stdout.write(json.dumps(resp) + chr(10))
-        sys.stdout.flush()
-    """
+    /// In-process fake `MCPTransport` implementing the same `initialize` / `tools/list` /
+    /// `tools/call` behavior the old python fake server used, but with no subprocess, no pipes, and
+    /// no wall-clock dependency — responses are yielded synchronously from `send(_:)`. This is the
+    /// event-driven fix #609 asked for: the CI flake was CPU contention delaying a real python3
+    /// interpreter's startup past a fixed timeout, and the fix is to not depend on process
+    /// scheduling at all for tests that aren't actually exercising subprocess behavior.
+    private actor FakeMCPServerTransport: MCPTransport {
+        private var continuation: AsyncStream<JSONValue>.Continuation?
+        private let stream: AsyncStream<JSONValue>
+
+        init() {
+            var cont: AsyncStream<JSONValue>.Continuation!
+            stream = AsyncStream { cont = $0 }
+            continuation = cont
+        }
+
+        func open() async throws {}
+        nonisolated func inbound() -> AsyncStream<JSONValue> { stream }
+        func close() async { continuation?.finish() }
+
+        func send(_ message: JSONValue) async throws {
+            guard case .object(let obj) = message, case .string(let method)? = obj["method"] else { return }
+            guard case .int(let id)? = obj["id"] else { return }  // notifications get no response
+            switch method {
+            case "initialize":
+                continuation?.yield(.object([
+                    "jsonrpc": .string("2.0"),
+                    "id": .int(id),
+                    "result": .object([
+                        "protocolVersion": .string("2024-11-05"),
+                        "capabilities": .object(["tools": .object([:])]),
+                        "serverInfo": .object(["name": .string("fake"), "version": .string("0.0.0")]),
+                    ]),
+                ]))
+            case "tools/list":
+                continuation?.yield(.object([
+                    "jsonrpc": .string("2.0"),
+                    "id": .int(id),
+                    "result": .object(["tools": .array([
+                        .object([
+                            "name": .string("echo"),
+                            "description": .string("Echoes back"),
+                            "inputSchema": .object([
+                                "type": .string("object"),
+                                "properties": .object(["text": .object(["type": .string("string")])]),
+                            ]),
+                        ]),
+                    ])]),
+                ]))
+            case "tools/call":
+                guard case .object(let params)? = obj["params"], case .string(let name)? = params["name"], name == "echo" else {
+                    continuation?.yield(errorResponse(id: id, code: -32601, message: "unknown tool"))
+                    return
+                }
+                let text: String = {
+                    if case .object(let args)? = params["arguments"], case .string(let t)? = args["text"] { return t }
+                    return ""
+                }()
+                continuation?.yield(.object([
+                    "jsonrpc": .string("2.0"),
+                    "id": .int(id),
+                    "result": .object([
+                        "content": .array([.object(["type": .string("text"), "text": .string(text)])]),
+                        "isError": .bool(false),
+                    ]),
+                ]))
+            default:
+                continuation?.yield(errorResponse(id: id, code: -32601, message: "method not found"))
+            }
+        }
+
+        private func errorResponse(id: Int, code: Int, message: String) -> JSONValue {
+            .object([
+                "jsonrpc": .string("2.0"),
+                "id": .int(id),
+                "error": .object(["code": .int(code), "message": .string(message)]),
+            ])
+        }
+    }
 
     /// Fake server that handles one `crash` tool call (responds, then `exit(1)`) so the supervisor
-    /// restarts it. The fresh instance behaves like `fakeServerScript`. Lets us exercise reconnect.
+    /// restarts it. The fresh instance behaves like the standard fake server. Lets us exercise
+    /// reconnect — genuinely needs a real subprocess since it tests `ProcessSupervisor`'s
+    /// crash-detection and restart, not just JSON-RPC request/response shape.
     private static let crashOnceServerScript = """
     import sys, json
     for line in sys.stdin:
@@ -80,9 +127,10 @@ struct MCPClientTests {
         sys.stdout.flush()
     """
 
-    /// Generous initialize-handshake timeout for the python fake server: interpreter startup can
-    /// exceed `MCPClient.start`'s 10s default on a contended CI runner (same class of flake as #177).
-    private static let initializeTimeout: TimeInterval = 30
+    /// Timeout for the one test that still spawns a real python3 subprocess — matches the
+    /// already-proven precedent from `AppliesEditEndToEndTests`/`ComponentModelEndToEndTests`
+    /// (heavier real-Node-server handshake) rather than introducing a new number.
+    private static let realSubprocessInitializeTimeout: TimeInterval = 15
 
     private static let pythonURL: URL = {
         for path in ["/usr/bin/python3", "/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/opt/anaconda3/bin/python3"] {
@@ -93,21 +141,15 @@ struct MCPClientTests {
         return URL(fileURLWithPath: "/usr/bin/python3")
     }()
 
-    private func makeClient() -> (MCPClient, LogCenter, ProcessSupervisor) {
-        let center = LogCenter()
-        let supervisor = ProcessSupervisor()
-        let client = MCPClient(supervisor: supervisor, logCenter: center)
-        return (client, center, supervisor)
+    private func makeFakeClient() async throws -> (MCPClient, FakeMCPServerTransport) {
+        let transport = FakeMCPServerTransport()
+        let client = MCPClient(supervisor: .shared)
+        try await client.startWithTransport(transport, initializeTimeout: 5, clientName: "test", clientVersion: "0")
+        return (client, transport)
     }
 
     @Test("Start runs initialize handshake") func startRunsInitializeHandshake() async throws {
-        let (client, _, _) = makeClient()
-        try await client.start(
-            executable: Self.pythonURL,
-            arguments: ["-u", "-c", Self.fakeServerScript],
-            source: "mcp-handshake",
-            initializeTimeout: Self.initializeTimeout
-        )
+        let (client, _) = try await makeFakeClient()
         let running = await client.isRunning
         #expect(running)
         await client.stop()
@@ -116,13 +158,7 @@ struct MCPClientTests {
     }
 
     @Test("List tools returns server tool definitions") func listToolsReturnsServerToolDefinitions() async throws {
-        let (client, _, _) = makeClient()
-        try await client.start(
-            executable: Self.pythonURL,
-            arguments: ["-u", "-c", Self.fakeServerScript],
-            source: "mcp-list",
-            initializeTimeout: Self.initializeTimeout
-        )
+        let (client, _) = try await makeFakeClient()
         defer { Task { await client.stop() } }
 
         let tools = try await client.listTools()
@@ -133,13 +169,7 @@ struct MCPClientTests {
     }
 
     @Test("Call tool returns text content") func callToolReturnsTextContent() async throws {
-        let (client, _, _) = makeClient()
-        try await client.start(
-            executable: Self.pythonURL,
-            arguments: ["-u", "-c", Self.fakeServerScript],
-            source: "mcp-call",
-            initializeTimeout: Self.initializeTimeout
-        )
+        let (client, _) = try await makeFakeClient()
         defer { Task { await client.stop() } }
 
         let result = try await client.callTool(
@@ -153,13 +183,7 @@ struct MCPClientTests {
     }
 
     @Test("Call tool unknown returns RPC error") func callToolUnknownReturnsRPCError() async throws {
-        let (client, _, _) = makeClient()
-        try await client.start(
-            executable: Self.pythonURL,
-            arguments: ["-u", "-c", Self.fakeServerScript],
-            source: "mcp-error",
-            initializeTimeout: Self.initializeTimeout
-        )
+        let (client, _) = try await makeFakeClient()
         defer { Task { await client.stop() } }
 
         await #expect(throws: MCPClient.MCPError.rpcError(code: -32601, message: "unknown tool")) {
@@ -168,7 +192,7 @@ struct MCPClientTests {
     }
 
     @Test("Call tool before start throws not initialized") func callToolBeforeStartThrowsNotInitialized() async throws {
-        let (client, _, _) = makeClient()
+        let client = MCPClient(supervisor: .shared)
         await #expect(throws: MCPClient.MCPError.notInitialized) {
             _ = try await client.callTool(name: "echo")
         }
@@ -177,13 +201,13 @@ struct MCPClientTests {
     // MARK: reconnect on crash
 
     @Test("Reconnects after server crash") func reconnectsAfterServerCrash() async throws {
-        let (client, _, _) = makeClient()
+        let client = MCPClient(supervisor: ProcessSupervisor())
         try await client.start(
             executable: Self.pythonURL,
             arguments: ["-u", "-c", Self.crashOnceServerScript],
             source: "mcp-reconnect",
             restartPolicy: .onCrash(maxAttempts: 3, baseBackoff: 0.05),
-            initializeTimeout: Self.initializeTimeout
+            initializeTimeout: Self.realSubprocessInitializeTimeout
         )
         defer { Task { await client.stop() } }
 
@@ -195,7 +219,7 @@ struct MCPClientTests {
         // Poll instead of a fixed sleep: respawn + handshake comfortably fits in a few hundred ms
         // locally but can take seconds on a loaded CI runner. .notInitialized / .reconnecting are
         // the documented transient errors during a supervised respawn; anything else is real.
-        let tools = try await Self.listToolsAwaitingReconnect(client, timeout: Self.initializeTimeout)
+        let tools = try await Self.listToolsAwaitingReconnect(client, timeout: Self.realSubprocessInitializeTimeout)
         #expect(tools.first?.name == "echo")
 
         let echoed = try await client.callTool(name: "echo", arguments: .object(["text": .string("after-reconnect")]))


### PR DESCRIPTION
## Summary

- Follow-up to #610 (merged), per [davidwkeith's review](https://github.com/Anglesite/Anglesite-app/pull/610#pullrequestreview-4667552014) and issue #609's preferred long-term fix: an event-driven readiness wait over widening a fixed timeout, and specifically the review's own suggestion to "mock the subprocess spawn/IPC layer instead of shelling out to a real Python interpreter, removing the process-scheduling variable entirely."
- The four `MCPClientTests` tests that only exercise JSON-RPC request/response shape (`startRunsInitializeHandshake`, `listToolsReturnsServerToolDefinitions`, `callToolReturnsTextContent`, `callToolUnknownReturnsRPCError`) now run against an in-process `FakeMCPServerTransport` instead of spawning a real python3 subprocess — the same `MCPTransport`-mocking pattern `MCPClientCancellationTests` already established with `HangingTransport`. Responses are yielded synchronously from `send(_:)`, so these tests have zero process-spawn latency and no wall-clock dependency at all, which fully eliminates their share of the CI flake rather than tuning a timeout value to fit CI contention that varies across runners.
- `reconnectsAfterServerCrash` keeps the real python3 subprocess, since it specifically tests `ProcessSupervisor`'s crash-detection and restart behavior — something a fake transport can't exercise. It now uses 15s (matching the already-proven `AppliesEditEndToEndTests`/`ComponentModelEndToEndTests` precedent) instead of #610's new 30s value, per the review's suggestion not to add a third timeout value to the codebase.
- Net effect: only one test in the suite still spawns a subprocess at all, sharply reducing both the surface area for the flake and CPU contention with other subprocess-spawning suites under `.serialized`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks). Link it here:

> Cross-cutting work (extending MCP messages, changing the plugin's hook contract, adjusting the site template the app scaffolds, etc.) lands as paired PRs. The plugin PR ships first in a tagged release; the app PR consumes it and bumps `Resources/plugin/`'s source-of-truth pointer. See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [ ] `swift test --package-path . --filter MCPClientTests` (via CI — this session's Linux container has no Swift toolchain)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (n/a — no app-target source changed)
- [ ] Manual smoke (if UI-touching): n/a, test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117DoFbT3DLnQ5avdmSHc6N

---
_Generated by [Claude Code](https://claude.ai/code/session_0117DoFbT3DLnQ5avdmSHc6N)_