### PR TITLE
feat(port): SiteFileWatching seam — inotify Linux watcher, FSEventsFileWatcher behind Platform/

### DIFF
--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -37,7 +37,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         conventionsEngine: ProjectConventionsEngine? = nil,
         logCenter: LogCenter = .shared,
         connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { c, u in try await c.connect(httpEndpoint: u) },
-        makeFileWatcher: @escaping @Sendable () -> any SiteFileWatching = { FSEventsFileWatcher() }
+        makeFileWatcher: @escaping @Sendable () -> any SiteFileWatching = { PlatformFileWatcher.make() }
     ) {
         self.ref = ref
         self.control = control

--- a/Sources/AnglesiteCore/Platform/FSEventsFileWatcher.swift
+++ b/Sources/AnglesiteCore/Platform/FSEventsFileWatcher.swift
@@ -1,0 +1,115 @@
+// Darwin implementation of the SiteFileWatching seam. The whole file compiles out on
+// platforms without the CoreServices framework.
+#if canImport(CoreServices)
+import Foundation
+import CoreServices
+
+/// Production `SiteFileWatching` backed by the CoreServices FSEvents API. Coalescing latency
+/// (0.3s) doubles as the debounce, so no separate timer is needed. State (`stream`, `onBatch`)
+/// is guarded by `lock` because the FSEvents callback fires on `queue` while `start`/`stop` are
+/// called from the owning actor.
+public final class FSEventsFileWatcher: SiteFileWatching, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "io.dwk.anglesite.fswatcher")
+    private let lock = NSLock()
+    private var stream: FSEventStreamRef?
+    private var onBatch: (@Sendable (FileChangeBatch) -> Void)?
+
+    public init() {}
+
+    public enum WatchError: Error { case streamCreationFailed }
+
+    public func start(root: URL, onBatch: @escaping @Sendable (FileChangeBatch) -> Void) throws {
+        // Tolerate being called while a previous stream is still live: tear it down first so we
+        // never orphan an FSEventStreamRef (which would leak and silently cut off its callback).
+        stop()
+
+        lock.lock()
+        self.onBatch = onBatch
+        lock.unlock()
+
+        // FSEvents holds its own strong reference to `self` for the stream's lifetime via the
+        // retain/release callbacks below: `info` is passed +0 and the retain callback takes the
+        // +1. That keeps `self` alive while callbacks are in flight on `queue`, closing the
+        // use-after-free window that `passUnretained` + nil callbacks would leave (a queued
+        // callback dereferencing a deallocated watcher). The reference is balanced by
+        // `FSEventStreamRelease` in `stop()`, so `stop()` MUST be called to release the watcher —
+        // every owner does on teardown.
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: { rawSelf in
+                guard let rawSelf else { return nil }
+                return UnsafeRawPointer(Unmanaged<FSEventsFileWatcher>.fromOpaque(rawSelf).retain().toOpaque())
+            },
+            release: { rawSelf in
+                guard let rawSelf else { return }
+                Unmanaged<FSEventsFileWatcher>.fromOpaque(rawSelf).release()
+            },
+            copyDescription: nil
+        )
+        let flags = UInt32(
+            kFSEventStreamCreateFlagFileEvents
+            | kFSEventStreamCreateFlagNoDefer
+            | kFSEventStreamCreateFlagUseCFTypes
+        )
+        let callback: FSEventStreamCallback = { _, info, count, eventPaths, eventFlags, _ in
+            guard let info else { return }
+            let watcher = Unmanaged<FSEventsFileWatcher>.fromOpaque(info).takeUnretainedValue()
+            // UseCFTypes => eventPaths is a CFArray of CFString.
+            let paths = (unsafeBitCast(eventPaths, to: NSArray.self) as? [String]) ?? []
+            var urls: [URL] = []
+            var needsRescan = false
+            let rescanMask = FSEventStreamEventFlags(
+                kFSEventStreamEventFlagMustScanSubDirs
+                | kFSEventStreamEventFlagUserDropped
+                | kFSEventStreamEventFlagKernelDropped
+                | kFSEventStreamEventFlagRootChanged
+                | kFSEventStreamEventFlagMount
+                | kFSEventStreamEventFlagUnmount
+            )
+            for i in 0..<count {
+                if eventFlags[i] & rescanMask != 0 { needsRescan = true }
+                if i < paths.count { urls.append(URL(fileURLWithPath: paths[i])) }
+            }
+            watcher.lock.lock()
+            let handler = watcher.onBatch
+            watcher.lock.unlock()
+            handler?(FileChangeBatch(paths: urls, needsFullRescan: needsRescan))
+        }
+
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault, callback, &context,
+            [root.path] as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.3, flags
+        ) else {
+            lock.lock(); self.onBatch = nil; lock.unlock()
+            throw WatchError.streamCreationFailed
+        }
+        FSEventStreamSetDispatchQueue(stream, queue)
+        FSEventStreamStart(stream)
+        lock.lock(); self.stream = stream; lock.unlock()
+    }
+
+    /// Idempotent. Safe to call when nothing is running. Not callable from the FSEvents callback
+    /// itself (the callback dispatches a `Task` rather than re-entering), so the `queue.sync` hop
+    /// below cannot deadlock.
+    public func stop() {
+        lock.lock()
+        let s = stream
+        stream = nil
+        onBatch = nil
+        lock.unlock()
+        guard let s else { return }
+        // Stop + invalidate on the stream's own dispatch queue, per FSEvents' threading contract.
+        // Because `queue` is serial, this also drains any in-flight callback before we invalidate,
+        // so no callback runs afterward. `FSEventStreamRelease` (which fires the release callback
+        // that drops FSEvents' strong ref to `self`) runs off-queue to avoid re-entrancy.
+        queue.sync {
+            FSEventStreamStop(s)
+            FSEventStreamInvalidate(s)
+        }
+        FSEventStreamRelease(s)
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/Platform/InotifyFileWatcher.swift
+++ b/Sources/AnglesiteCore/Platform/InotifyFileWatcher.swift
@@ -115,15 +115,20 @@ public final class InotifyFileWatcher: SiteFileWatching, @unchecked Sendable {
         lock.lock(); watchedDirectories[wd] = directory; lock.unlock()
 
         guard let entries = try? FileManager.default.contentsOfDirectory(
-            at: directory, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]
+            at: directory, includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey], options: [.skipsHiddenFiles]
         ) else { return }
 
         for entry in entries {
             guard !SiteIndexPaths.skippedDirectoryNames.contains(entry.lastPathComponent) else { continue }
-            let values = try? entry.resourceValues(forKeys: [.isDirectoryKey])
-            if values?.isDirectory == true {
-                try addWatches(under: entry, fd: fd)
-            }
+            let values = try? entry.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            // A symlinked subdirectory is skipped rather than recursed into: `isDirectoryKey`
+            // resolves through the link, so an unfiltered walk could cycle back up the tree (a
+            // symlink pointing at an ancestor) or fan out into an unrelated, unbounded directory
+            // — either way well past `fs.inotify.max_user_watches`. FSEvents doesn't have this
+            // failure mode (it watches the real filesystem tree, not a manually-walked listing),
+            // so this is inotify-specific.
+            guard values?.isSymbolicLink != true, values?.isDirectory == true else { continue }
+            try addWatches(under: entry, fd: fd)
         }
     }
 
@@ -186,8 +191,20 @@ public final class InotifyFileWatcher: SiteFileWatching, @unchecked Sendable {
         guard let directory, currentFD >= 0 else { return }
 
         if event.mask & UInt32(IN_DELETE_SELF | IN_MOVE_SELF) != 0 {
-            // The watched directory itself vanished or moved; its subtree's state is now
-            // unknowable from here.
+            // The watched directory itself vanished or moved — possibly outside `root`
+            // entirely. Per inotify(7), only IN_DELETE_SELF is reliably followed by an
+            // automatic IN_IGNORED; a plain rename (IN_MOVE_SELF) leaves the kernel watch
+            // armed on the same inode wherever it now lives, with no further event on this fd
+            // if that's outside our tree. Clean up immediately rather than waiting for an
+            // IN_IGNORED that may never come: drop the map entry so a moved-away directory's
+            // future changes can't resolve against this stale URL, and release the kernel-side
+            // watch so it doesn't sit there consuming `fs.inotify.max_user_watches` forever.
+            // If this was actually an in-place rename, the kernel's `fsnotify_move()` emits
+            // this IN_MOVE_SELF *before* the paired IN_MOVED_TO on the parent directory's own
+            // watch, so the parent's handler (which re-walks and re-arms via `addWatches`)
+            // always runs after this cleanup, never racing it.
+            lock.lock(); watchedDirectories.removeValue(forKey: event.wd); lock.unlock()
+            inotify_rm_watch(currentFD, event.wd)
             pendingRescan = true
             scheduleFlush()
             return

--- a/Sources/AnglesiteCore/Platform/InotifyFileWatcher.swift
+++ b/Sources/AnglesiteCore/Platform/InotifyFileWatcher.swift
@@ -1,0 +1,242 @@
+// Linux implementation of the SiteFileWatching seam. The whole file compiles out on platforms
+// without Glibc.
+#if canImport(Glibc)
+import Foundation
+import Glibc
+
+/// Production `SiteFileWatching` backed by Linux's inotify API.
+///
+/// inotify watches are per-directory and non-recursive, so `start()` walks the tree and arms a
+/// watch on every subdirectory (skipping `SiteIndexPaths.skippedDirectoryNames` — watching
+/// `node_modules` wholesale would multiply the watch count for no reindexing benefit), then arms
+/// a new watch whenever a subdirectory is created.
+///
+/// Structural changes — a directory appearing, disappearing, or being renamed, plus a
+/// watch-queue overflow — are conservatively reported as `needsFullRescan` rather than tracked
+/// file-by-file: a directory that appears may already contain files written into it before its
+/// watch could be armed (inotify has no atomic watch-and-list), so per-file tracking of its
+/// contents can't be trusted. This mirrors the FSEvents watcher's `MustScanSubDirs` /
+/// `UserDropped` / `RootChanged` handling. Events are coalesced over the same 0.3s window
+/// FSEvents uses, via a debounce timer on `queue`.
+///
+/// Threading: `fd`, `readSource`, `onBatch`, and `watchedDirectories` are guarded by `lock`
+/// because they're written both from the calling thread (`start`/`stop`) and from `queue` (a
+/// newly-created subdirectory arms its own watch from inside the event handler). The debounce
+/// state (`pendingPaths`, `pendingRescan`, `flushTimer`) is confined to `queue` — it's only ever
+/// touched by the read source's event handler and its own timer, both scheduled on `queue`.
+public final class InotifyFileWatcher: SiteFileWatching, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "io.dwk.anglesite.inotifywatcher")
+    private let lock = NSLock()
+    private var fd: Int32 = -1
+    private var readSource: DispatchSourceRead?
+    private var onBatch: (@Sendable (FileChangeBatch) -> Void)?
+    private var watchedDirectories: [Int32: URL] = [:]
+
+    private var pendingPaths: Set<URL> = []
+    private var pendingRescan = false
+    private var flushTimer: DispatchSourceTimer?
+
+    private static let watchMask: UInt32 = UInt32(
+        IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO | IN_CLOSE_WRITE
+        | IN_DELETE_SELF | IN_MOVE_SELF
+    )
+
+    public init() {}
+
+    public enum WatchError: Error {
+        case initFailed
+        case addWatchFailed(String)
+    }
+
+    public func start(root: URL, onBatch: @escaping @Sendable (FileChangeBatch) -> Void) throws {
+        // Tolerate being called while a previous watch is still live, matching
+        // FSEventsFileWatcher's contract.
+        stop()
+
+        let newFD = inotify_init1(Int32(IN_NONBLOCK) | Int32(IN_CLOEXEC))
+        guard newFD >= 0 else { throw WatchError.initFailed }
+
+        lock.lock()
+        fd = newFD
+        self.onBatch = onBatch
+        lock.unlock()
+
+        do {
+            try addWatches(under: root, fd: newFD)
+        } catch {
+            lock.lock()
+            fd = -1
+            self.onBatch = nil
+            watchedDirectories.removeAll()
+            lock.unlock()
+            close(newFD)
+            throw error
+        }
+
+        let source = DispatchSource.makeReadSource(fileDescriptor: newFD, queue: queue)
+        source.setEventHandler { [weak self] in self?.drainEvents() }
+        source.setCancelHandler { close(newFD) }
+        source.resume()
+        lock.lock(); readSource = source; lock.unlock()
+    }
+
+    /// Idempotent. Safe to call when nothing is running.
+    public func stop() {
+        lock.lock()
+        let source = readSource
+        readSource = nil
+        onBatch = nil
+        watchedDirectories.removeAll()
+        fd = -1
+        lock.unlock()
+        guard let source else { return }
+        // Drain debounce state on `queue` before cancelling, so a flush already in flight
+        // can't fire into a stopped watcher. `source.cancel()` is async; the read source's
+        // cancel handler closes the fd once any in-flight read completes.
+        queue.sync {
+            flushTimer?.cancel()
+            flushTimer = nil
+            pendingPaths.removeAll()
+            pendingRescan = false
+        }
+        source.cancel()
+    }
+
+    // MARK: Watch tree setup
+
+    private func addWatches(under directory: URL, fd: Int32) throws {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            return
+        }
+
+        let wd = directory.path.withCString { inotify_add_watch(fd, $0, Self.watchMask) }
+        guard wd >= 0 else { throw WatchError.addWatchFailed(directory.path) }
+        lock.lock(); watchedDirectories[wd] = directory; lock.unlock()
+
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]
+        ) else { return }
+
+        for entry in entries {
+            guard !SiteIndexPaths.skippedDirectoryNames.contains(entry.lastPathComponent) else { continue }
+            let values = try? entry.resourceValues(forKeys: [.isDirectoryKey])
+            if values?.isDirectory == true {
+                try addWatches(under: entry, fd: fd)
+            }
+        }
+    }
+
+    // MARK: Event draining (runs on `queue`)
+
+    private func drainEvents() {
+        lock.lock()
+        let currentFD = fd
+        lock.unlock()
+        guard currentFD >= 0 else { return }
+
+        // inotify events are variable-length (a fixed header plus an optional trailing name);
+        // 64 headers' worth of slack room keeps a burst of same-directory events from requiring
+        // multiple `read`s in the common case without over-allocating.
+        let bufferSize = 64 * (MemoryLayout<inotify_event>.size + 256)
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        while true {
+            let bytesRead = buffer.withUnsafeMutableBytes { ptr -> Int in
+                read(currentFD, ptr.baseAddress, bufferSize)
+            }
+            // EAGAIN (no more data on the non-blocking fd) and any other read failure both just
+            // mean "nothing left to drain right now."
+            guard bytesRead > 0 else { break }
+
+            var offset = 0
+            while offset + MemoryLayout<inotify_event>.size <= bytesRead {
+                let (event, name, recordSize) = buffer.withUnsafeBytes { raw -> (inotify_event, String?, Int) in
+                    let eventPtr = raw.baseAddress!.advanced(by: offset).assumingMemoryBound(to: inotify_event.self)
+                    let event = eventPtr.pointee
+                    var name: String?
+                    if event.len > 0 {
+                        let nameStart = raw.baseAddress!.advanced(by: offset + MemoryLayout<inotify_event>.size)
+                        name = String(cString: nameStart.assumingMemoryBound(to: CChar.self))
+                    }
+                    return (event, name, MemoryLayout<inotify_event>.size + Int(event.len))
+                }
+                handle(event: event, name: name)
+                offset += recordSize
+            }
+        }
+    }
+
+    private func handle(event: inotify_event, name: String?) {
+        if event.mask & UInt32(IN_Q_OVERFLOW) != 0 {
+            // The kernel dropped events wholesale; we have no idea what changed.
+            pendingRescan = true
+            scheduleFlush()
+            return
+        }
+        if event.mask & UInt32(IN_IGNORED) != 0 {
+            // Watch removed (explicitly, or because its directory was deleted/moved away).
+            lock.lock(); watchedDirectories.removeValue(forKey: event.wd); lock.unlock()
+            return
+        }
+
+        lock.lock()
+        let directory = watchedDirectories[event.wd]
+        let currentFD = fd
+        lock.unlock()
+        guard let directory, currentFD >= 0 else { return }
+
+        if event.mask & UInt32(IN_DELETE_SELF | IN_MOVE_SELF) != 0 {
+            // The watched directory itself vanished or moved; its subtree's state is now
+            // unknowable from here.
+            pendingRescan = true
+            scheduleFlush()
+            return
+        }
+
+        guard let name, !name.isEmpty else { return }
+        let childURL = directory.appendingPathComponent(name)
+
+        if event.mask & UInt32(IN_ISDIR) != 0 {
+            guard !SiteIndexPaths.skippedDirectoryNames.contains(name) else {
+                // We never watch this subtree (node_modules, .git, …), so its appearing,
+                // vanishing, or being renamed has no reindexing impact — nothing to arm and
+                // nothing to rescan for.
+                return
+            }
+            if event.mask & UInt32(IN_CREATE | IN_MOVED_TO) != 0 {
+                // Arm a watch on the new subtree so its own future changes are tracked. Its
+                // current contents (if any raced ahead of us) are covered by the rescan below.
+                try? addWatches(under: childURL, fd: currentFD)
+            }
+            pendingRescan = true
+            scheduleFlush()
+            return
+        }
+
+        pendingPaths.insert(childURL)
+        scheduleFlush()
+    }
+
+    // MARK: Debounce (queue-confined)
+
+    private func scheduleFlush() {
+        guard flushTimer == nil else { return }
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 0.3)
+        timer.setEventHandler { [weak self] in self?.flush() }
+        timer.resume()
+        flushTimer = timer
+    }
+
+    private func flush() {
+        flushTimer?.cancel()
+        flushTimer = nil
+        guard !pendingPaths.isEmpty || pendingRescan else { return }
+        let batch = FileChangeBatch(paths: Array(pendingPaths), needsFullRescan: pendingRescan)
+        pendingPaths.removeAll()
+        pendingRescan = false
+        lock.lock(); let handler = onBatch; lock.unlock()
+        handler?(batch)
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/Platform/SiteFileWatching.swift
+++ b/Sources/AnglesiteCore/Platform/SiteFileWatching.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Portable seam for watching a site's source tree for changes — seam 2 of the cross-platform
+/// port design (docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md §5).
+///
+/// Implementations: `FSEventsFileWatcher` (Darwin, CoreServices FSEvents); `InotifyFileWatcher`
+/// (Linux, inotify via Glibc). Windows gets a `ReadDirectoryChangesW` watcher. Platforms without
+/// a native implementation yet use `UnavailableFileWatcher`, whose `start` throws immediately —
+/// callers already treat a watcher failure as "run without live reindexing" (see
+/// `LocalContainerSiteRuntime`), so this degrades capability-flagged rather than silently
+/// pretending to watch.
+public protocol SiteFileWatching: Sendable {
+    /// Begin watching `root`, delivering batches to `onBatch` until `stop()`. Throws if the
+    /// underlying watch cannot be established.
+    func start(root: URL, onBatch: @escaping @Sendable (FileChangeBatch) -> Void) throws
+    func stop()
+}
+
+/// A debounced batch of filesystem changes under a watched root.
+public struct FileChangeBatch: Sendable, Equatable {
+    /// Absolute URLs the watcher reported as changed in this batch.
+    public let paths: [URL]
+    /// The watcher dropped per-file granularity (coalesced bulk event, root moved, or
+    /// mount/unmount). Consumers should fall back to a full rebuild rather than per-file updates.
+    public let needsFullRescan: Bool
+
+    public init(paths: [URL], needsFullRescan: Bool) {
+        self.paths = paths
+        self.needsFullRescan = needsFullRescan
+    }
+}
+
+/// Placeholder watcher for platforms without a native implementation yet. `start` always throws,
+/// so callers see the same "watch unavailable" path they already handle for a real watcher that
+/// fails to establish (e.g. a root that vanished under it).
+public struct UnavailableFileWatcher: SiteFileWatching {
+    public struct Unavailable: Error {}
+
+    public init() {}
+
+    public func start(root: URL, onBatch: @escaping @Sendable (FileChangeBatch) -> Void) throws {
+        throw Unavailable()
+    }
+
+    public func stop() {}
+}
+
+/// Composition-root factory for the platform's default file watcher. Call sites in the portable
+/// core depend on `any SiteFileWatching` and use this only as their production default; tests
+/// inject fakes (e.g. `ControllableWatcher`) directly.
+public enum PlatformFileWatcher {
+    public static func make() -> any SiteFileWatching {
+        #if canImport(CoreServices)
+        FSEventsFileWatcher()
+        #elseif canImport(Glibc)
+        InotifyFileWatcher()
+        #else
+        UnavailableFileWatcher()
+        #endif
+    }
+}

--- a/Sources/AnglesiteCore/SiteFileWatcher.swift
+++ b/Sources/AnglesiteCore/SiteFileWatcher.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CoreServices
 
 /// Shared rules for which project paths the knowledge index cares about. Lifted out of
 /// `SiteKnowledgeIndex` so the file watcher and the index agree on what to skip.
@@ -25,32 +24,11 @@ public enum SiteIndexPaths {
     }
 }
 
-/// A debounced batch of filesystem changes under a watched root.
-public struct FileChangeBatch: Sendable, Equatable {
-    /// Absolute URLs the watcher reported as changed in this batch.
-    public let paths: [URL]
-    /// The watcher dropped per-file granularity (coalesced bulk event, root moved, or
-    /// mount/unmount). Consumers should fall back to a full rebuild rather than per-file updates.
-    public let needsFullRescan: Bool
-
-    public init(paths: [URL], needsFullRescan: Bool) {
-        self.paths = paths
-        self.needsFullRescan = needsFullRescan
-    }
-}
-
-/// Watches a directory tree and delivers debounced change batches. The seam tests inject against.
-public protocol SiteFileWatching: Sendable {
-    /// Begin watching `root`, delivering batches to `onBatch` until `stop()`. Throws if the
-    /// underlying watch cannot be established.
-    func start(root: URL, onBatch: @escaping @Sendable (FileChangeBatch) -> Void) throws
-    func stop()
-}
-
 /// Translates a `FileChangeBatch` into `SiteKnowledgeIndex` mutations, and (when supplied) mirrors
 /// each mutation into the `SemanticRanker` so the lexical and semantic halves stay consistent after
 /// incremental edits (#383). Kept free-standing (not on the runtime actor) so it is unit-testable
-/// without spinning a runtime.
+/// without spinning a runtime. Portable — reindexing has no platform-specific code; only the
+/// watcher that feeds it (`Platform/SiteFileWatching.swift`) does.
 public enum KnowledgeReindex {
     public static func apply(
         _ batch: FileChangeBatch,
@@ -70,7 +48,7 @@ public enum KnowledgeReindex {
             }
             return
         }
-        // FSEvents can list the same path multiple times in one coalesced batch (e.g. write →
+        // A watcher can list the same path multiple times in one coalesced batch (e.g. write →
         // rename → write). Each index key only needs to be reconciled once against its current
         // on-disk state, so collapse duplicates before touching the index actor.
         var seen = Set<String>()
@@ -95,114 +73,5 @@ public enum KnowledgeReindex {
                 await ranker?.remove(siteID: siteID, docID: SiteKnowledgeIndex.documentID(siteID: siteID, relativePath: relativePath))
             }
         }
-    }
-}
-
-/// Production `SiteFileWatching` backed by the CoreServices FSEvents API. Coalescing latency
-/// (0.3s) doubles as the debounce, so no separate timer is needed. State (`stream`, `onBatch`)
-/// is guarded by `lock` because the FSEvents callback fires on `queue` while `start`/`stop` are
-/// called from the owning actor.
-public final class FSEventsFileWatcher: SiteFileWatching, @unchecked Sendable {
-    private let queue = DispatchQueue(label: "io.dwk.anglesite.fswatcher")
-    private let lock = NSLock()
-    private var stream: FSEventStreamRef?
-    private var onBatch: (@Sendable (FileChangeBatch) -> Void)?
-
-    public init() {}
-
-    public enum WatchError: Error { case streamCreationFailed }
-
-    public func start(root: URL, onBatch: @escaping @Sendable (FileChangeBatch) -> Void) throws {
-        // Tolerate being called while a previous stream is still live: tear it down first so we
-        // never orphan an FSEventStreamRef (which would leak and silently cut off its callback).
-        stop()
-
-        lock.lock()
-        self.onBatch = onBatch
-        lock.unlock()
-
-        // FSEvents holds its own strong reference to `self` for the stream's lifetime via the
-        // retain/release callbacks below: `info` is passed +0 and the retain callback takes the
-        // +1. That keeps `self` alive while callbacks are in flight on `queue`, closing the
-        // use-after-free window that `passUnretained` + nil callbacks would leave (a queued
-        // callback dereferencing a deallocated watcher). The reference is balanced by
-        // `FSEventStreamRelease` in `stop()`, so `stop()` MUST be called to release the watcher —
-        // every owner does on teardown.
-        var context = FSEventStreamContext(
-            version: 0,
-            info: Unmanaged.passUnretained(self).toOpaque(),
-            retain: { rawSelf in
-                guard let rawSelf else { return nil }
-                return UnsafeRawPointer(Unmanaged<FSEventsFileWatcher>.fromOpaque(rawSelf).retain().toOpaque())
-            },
-            release: { rawSelf in
-                guard let rawSelf else { return }
-                Unmanaged<FSEventsFileWatcher>.fromOpaque(rawSelf).release()
-            },
-            copyDescription: nil
-        )
-        let flags = UInt32(
-            kFSEventStreamCreateFlagFileEvents
-            | kFSEventStreamCreateFlagNoDefer
-            | kFSEventStreamCreateFlagUseCFTypes
-        )
-        let callback: FSEventStreamCallback = { _, info, count, eventPaths, eventFlags, _ in
-            guard let info else { return }
-            let watcher = Unmanaged<FSEventsFileWatcher>.fromOpaque(info).takeUnretainedValue()
-            // UseCFTypes => eventPaths is a CFArray of CFString.
-            let paths = (unsafeBitCast(eventPaths, to: NSArray.self) as? [String]) ?? []
-            var urls: [URL] = []
-            var needsRescan = false
-            let rescanMask = FSEventStreamEventFlags(
-                kFSEventStreamEventFlagMustScanSubDirs
-                | kFSEventStreamEventFlagUserDropped
-                | kFSEventStreamEventFlagKernelDropped
-                | kFSEventStreamEventFlagRootChanged
-                | kFSEventStreamEventFlagMount
-                | kFSEventStreamEventFlagUnmount
-            )
-            for i in 0..<count {
-                if eventFlags[i] & rescanMask != 0 { needsRescan = true }
-                if i < paths.count { urls.append(URL(fileURLWithPath: paths[i])) }
-            }
-            watcher.lock.lock()
-            let handler = watcher.onBatch
-            watcher.lock.unlock()
-            handler?(FileChangeBatch(paths: urls, needsFullRescan: needsRescan))
-        }
-
-        guard let stream = FSEventStreamCreate(
-            kCFAllocatorDefault, callback, &context,
-            [root.path] as CFArray,
-            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
-            0.3, flags
-        ) else {
-            lock.lock(); self.onBatch = nil; lock.unlock()
-            throw WatchError.streamCreationFailed
-        }
-        FSEventStreamSetDispatchQueue(stream, queue)
-        FSEventStreamStart(stream)
-        lock.lock(); self.stream = stream; lock.unlock()
-    }
-
-    /// Idempotent. Safe to call when nothing is running. Not callable from the FSEvents callback
-    /// itself (the callback dispatches a `Task` rather than re-entering), so the `queue.sync` hop
-    /// below cannot deadlock.
-    public func stop() {
-        lock.lock()
-        let s = stream
-        stream = nil
-        onBatch = nil
-        lock.unlock()
-        guard let s else { return }
-        // Stop + invalidate on the stream's own dispatch queue, per FSEvents' threading contract.
-        // Because `queue` is serial, this also drains any in-flight callback before we invalidate,
-        // so no callback runs afterward. `FSEventStreamRelease` (which fires the release callback
-        // that drops FSEvents' strong ref to `self`) runs off-queue to avoid re-entrancy.
-        queue.sync {
-            FSEventStreamStop(s)
-            FSEventStreamInvalidate(s)
-        }
-        FSEventStreamRelease(s)
     }
 }

--- a/Tests/AnglesiteCoreTests/InotifyFileWatcherTests.swift
+++ b/Tests/AnglesiteCoreTests/InotifyFileWatcherTests.swift
@@ -95,5 +95,53 @@ struct InotifyFileWatcherTests {
         try? await Task.sleep(nanoseconds: 2_000_000_000)
         #expect(box.all().isEmpty)
     }
+
+    @Test("moving a watched subdirectory outside root releases its watch instead of leaking it", .timeLimit(.minutes(1)))
+    func releasesWatchOnMoveOutOfTree() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("inotify-\(UUID().uuidString)", isDirectory: true)
+        let sub = root.appendingPathComponent("posts", isDirectory: true)
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: sub.appendingPathComponent("f.txt"))
+
+        let box = BatchBox()
+        let watcher = InotifyFileWatcher()
+        try watcher.start(root: root) { box.add($0) }
+        defer { watcher.stop() }
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("inotify-outside-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.moveItem(at: sub, to: outside)
+        defer { try? FileManager.default.removeItem(at: outside) }
+
+        _ = await poll(timeout: 10) { box.all().contains { $0.needsFullRescan } }
+        let countAfterMove = box.all().count
+
+        // Editing the file at its new, out-of-tree location must not surface here: if the old
+        // watch on `posts` leaked (IN_MOVE_SELF doesn't auto-remove the kernel watch, unlike
+        // deletion), this edit would show up as a batch reporting a path under the stale,
+        // no-longer-existent `root/posts` — see the review that caught this.
+        try Data("y".utf8).write(to: outside.appendingPathComponent("f.txt"))
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        #expect(box.all().count == countAfterMove)
+    }
+
+    @Test("a symlinked subdirectory is not recursed into", .timeLimit(.minutes(1)))
+    func skipsSymlinkedSubdirectories() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("inotify-\(UUID().uuidString)", isDirectory: true)
+        let child = root.appendingPathComponent("child", isDirectory: true)
+        try FileManager.default.createDirectory(at: child, withIntermediateDirectories: true)
+        // A symlink back to `root` would send an unfiltered recursive walk into an infinite
+        // cycle; `start()` returning promptly (within the test's time limit) is the assertion.
+        try FileManager.default.createSymbolicLink(
+            at: child.appendingPathComponent("loop"), withDestinationURL: root
+        )
+
+        let watcher = InotifyFileWatcher()
+        try watcher.start(root: root) { _ in }
+        watcher.stop()
+    }
 }
 #endif

--- a/Tests/AnglesiteCoreTests/InotifyFileWatcherTests.swift
+++ b/Tests/AnglesiteCoreTests/InotifyFileWatcherTests.swift
@@ -1,0 +1,99 @@
+// Exercises the Linux SiteFileWatching implementation; compiles out off-Linux.
+#if canImport(Glibc)
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("InotifyFileWatcher")
+struct InotifyFileWatcherTests {
+    /// Poll `condition` until true or `timeout` elapses — inotify delivery, like FSEvents, is
+    /// asynchronous. Returns whether the condition was met.
+    private func poll(timeout: TimeInterval, _ condition: @Sendable () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        }
+        return condition()
+    }
+
+    private final class BatchBox: @unchecked Sendable {
+        let lock = NSLock()
+        private var batches: [FileChangeBatch] = []
+        func add(_ batch: FileChangeBatch) { lock.lock(); batches.append(batch); lock.unlock() }
+        func all() -> [FileChangeBatch] { lock.lock(); defer { lock.unlock() }; return batches }
+    }
+
+    @Test("watcher reports a file write under the watched root", .timeLimit(.minutes(1)))
+    func reportsFileWrite() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("inotify-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let box = BatchBox()
+        let watcher = InotifyFileWatcher()
+        try watcher.start(root: root) { box.add($0) }
+        defer { watcher.stop() }
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        try Data("hi".utf8).write(to: root.appendingPathComponent("hello.astro"))
+
+        let saw = await poll(timeout: 10) {
+            box.all().contains { $0.paths.contains { $0.lastPathComponent == "hello.astro" } && !$0.needsFullRescan }
+        }
+        #expect(saw)
+    }
+
+    @Test("a new subdirectory is watched for its own subsequent changes", .timeLimit(.minutes(1)))
+    func tracksNewSubdirectory() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("inotify-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let box = BatchBox()
+        let watcher = InotifyFileWatcher()
+        try watcher.start(root: root) { box.add($0) }
+        defer { watcher.stop() }
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        let sub = root.appendingPathComponent("posts", isDirectory: true)
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+
+        // The directory's own creation is reported as a conservative rescan (its initial
+        // contents can't be trusted to have been captured file-by-file).
+        let sawRescan = await poll(timeout: 10) { box.all().contains { $0.needsFullRescan } }
+        #expect(sawRescan)
+
+        // But a change written into it *after* that settles is tracked precisely, proving the
+        // watcher armed a watch on the new subdirectory rather than only on the original root.
+        try Data("hi".utf8).write(to: sub.appendingPathComponent("first-post.md"))
+        let sawTargeted = await poll(timeout: 10) {
+            box.all().contains { $0.paths.contains { $0.lastPathComponent == "first-post.md" } && !$0.needsFullRescan }
+        }
+        #expect(sawTargeted)
+    }
+
+    @Test("changes inside a skipped directory name never surface", .timeLimit(.minutes(1)))
+    func ignoresSkippedDirectories() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("inotify-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let box = BatchBox()
+        let watcher = InotifyFileWatcher()
+        try watcher.start(root: root) { box.add($0) }
+        defer { watcher.stop() }
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        let nodeModules = root.appendingPathComponent("node_modules", isDirectory: true)
+        try FileManager.default.createDirectory(at: nodeModules, withIntermediateDirectories: true)
+        try Data("noise".utf8).write(to: nodeModules.appendingPathComponent("pkg.js"))
+
+        // Give it as long as the other tests wait for a positive signal, then assert nothing
+        // arrived — a skipped directory should never be watched, so it should never produce
+        // a batch (rescan or otherwise).
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        #expect(box.all().isEmpty)
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/SiteFileWatcherTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteFileWatcherTests.swift
@@ -1,3 +1,5 @@
+// Exercises the Darwin SiteFileWatching implementation; compiles out with it off-Darwin.
+#if canImport(CoreServices)
 import Foundation
 import Testing
 @testable import AnglesiteCore
@@ -43,3 +45,4 @@ struct SiteFileWatcherTests {
         #expect(saw)
     }
 }
+#endif


### PR DESCRIPTION
Seam 2 of the [cross-platform port design](docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md) §5, part of [#566](https://github.com/Anglesite/Anglesite-app/issues/566). Follows the `Platform/` pattern #607 established for `SecretStore`.

## Changes

- **Platform/SiteFileWatching.swift** (new): the `SiteFileWatching` protocol, `FileChangeBatch`, an `UnavailableFileWatcher` placeholder, and the `PlatformFileWatcher.make()` composition-root factory.
- **Platform/FSEventsFileWatcher.swift**: `FSEventsFileWatcher` moved here (`git mv` from `SiteFileWatcher.swift`) and gated behind `#if canImport(CoreServices)` — previously an unconditional `import CoreServices` at the top of the file.
- **Platform/InotifyFileWatcher.swift** (new): Linux implementation via Glibc's inotify. Watches are per-directory and non-recursive, so it walks the tree at `start()` and arms a watch per subdirectory (skipping `SiteIndexPaths.skippedDirectoryNames` — `node_modules` etc.), then arms new watches as subdirectories appear. Structural changes (a directory appearing, disappearing, being renamed, or a watch-queue overflow) are conservatively reported as `needsFullRescan` rather than tracked file-by-file, mirroring FSEvents' `MustScanSubDirs`/`UserDropped`/`RootChanged` handling — a new directory may already contain files written into it before its watch could be armed, so per-file tracking of its initial contents can't be trusted. Events coalesce over the same 0.3s window FSEvents uses.
- **SiteFileWatcher.swift**: trimmed to just `SiteIndexPaths` + `KnowledgeReindex`, the portable reindexing logic that has no platform-specific code (only the watcher feeding it does).
- **LocalContainerSiteRuntime**'s default file watcher now resolves via `PlatformFileWatcher.make()` instead of hardcoding `FSEventsFileWatcher()`.
- **Tests**: `SiteFileWatcherTests` gains the same `canImport(CoreServices)` gate as the implementation it exercises; new `InotifyFileWatcherTests` (`canImport(Glibc)`-gated) covers a targeted file write, a new subdirectory's contents being tracked after its watch arms, and skipped directories never producing a batch.

## Verification

On this Linux/aarch64 dev environment (Swift 6.3.3):
- `swift build`/`swift test` for `AnglesiteSiteModel` (what Linux CI actually runs today) stays green.
- `ANGLESITE_PORT_WIP=1 swift build --target AnglesiteCore` reaches the same pre-existing `FoundationModelAssistant.swift` `OSLog` wall as before this change (seam 3, out of scope) — confirms no new, earlier compile error was introduced by this seam.
- `InotifyFileWatcher` was additionally verified directly: an isolated scratch build exercised create/modify/delete/subdirectory-tracking/rename-self-healing/skip-list/double-stop/restart. The new Testing-suite file was extracted into a throwaway SwiftPM package and run for real via `swift test` (3/3 passing) before being committed here.

Not done in this PR (left for the Linux MVP, same as the `SecretStore` seam left the libsecret implementation for later): nothing — this seam is complete on both Darwin and Linux. Windows (`ReadDirectoryChangesW`) is P3/P4 territory per the design doc's phasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)