### PR TITLE
feat: mini-map overview for the Site Graph Explorer canvas (#613)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -173,7 +173,10 @@ packageTargets.append(
         dependencies: ["AnglesiteCore", "AnglesiteBridge", "AnglesiteIntents"],
         path: "Sources/AnglesiteApp",
         exclude: ["AnglesiteApp.swift", "LiveSiteRuntimeFactory.swift"],
-        swiftSettings: strictConcurrency + [.define("ANGLESITE_MAS")]
+        // #541: ChatView.swift imports FoundationModels, so without this its object code embeds a
+        // hard `-framework FoundationModels` autolink hint that overrides the test bundle's
+        // weak-link flag below (same mechanism as AnglesiteCore's setting).
+        swiftSettings: strictConcurrency + [.define("ANGLESITE_MAS")] + disableFoundationModelsAutolink
     )
 )
 packageTargets.append(
@@ -181,7 +184,8 @@ packageTargets.append(
         name: "AnglesiteAppTests",
         dependencies: ["AnglesiteAppCore", "AnglesiteTestSupport"],
         path: "Tests/AnglesiteAppTests",
-        swiftSettings: strictConcurrency
+        swiftSettings: strictConcurrency,
+        linkerSettings: weakLinkFoundationModels
     )
 )
 packageTargets.append(

--- a/Sources/AnglesiteApp/SiteGraphExplorerView.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerView.swift
@@ -200,6 +200,19 @@ private struct SiteGraphCanvas: View {
                     ContentUnavailableView("No matching graph nodes", systemImage: "point.3.connected.trianglepath.dotted")
                 }
             }
+            .overlay(alignment: .bottomTrailing) {
+                if SiteGraphMiniMapGeometry.shouldShow(nodeCount: nodes.count) {
+                    SiteGraphMiniMap(
+                        nodes: nodes,
+                        edges: edges,
+                        positions: positions,
+                        canvasSize: proxy.size,
+                        selectedNodeID: selectedNodeID,
+                        onSelect: onSelect
+                    )
+                    .padding(12)
+                }
+            }
         }
     }
 
@@ -224,6 +237,60 @@ private struct SiteGraphCanvas: View {
         case .referencesAsset: return .green.opacity(0.5)
         case .contains: return .orange.opacity(0.45)
         }
+    }
+}
+
+/// Scaled-down overview of the whole visible graph (#613), overlaid bottom-trailing on the main
+/// canvas once the node count crosses `SiteGraphMiniMapGeometry.nodeCountThreshold`. Nodes render
+/// as kind-tinted dots and edges as hairlines at the same relative positions as the main canvas;
+/// clicking selects the nearest node there. No viewport rectangle yet — the main canvas has no
+/// pan/zoom to reflect (see #613's "if/when" note).
+private struct SiteGraphMiniMap: View {
+    let nodes: [SiteGraphNode]
+    let edges: [SiteGraphEdge]
+    let positions: [String: CGPoint]
+    let canvasSize: CGSize
+    let selectedNodeID: String?
+    let onSelect: (String) -> Void
+
+    private static let size = CGSize(width: 180, height: 120)
+
+    var body: some View {
+        let miniPositions = positions.mapValues {
+            SiteGraphMiniMapGeometry.scaledPoint($0, from: canvasSize, to: Self.size)
+        }
+        Canvas { context, _ in
+            for edge in edges {
+                guard let start = miniPositions[edge.sourceID], let end = miniPositions[edge.targetID] else { continue }
+                var path = Path()
+                path.move(to: start)
+                path.addLine(to: end)
+                context.stroke(path, with: .color(.secondary.opacity(0.25)), lineWidth: 0.5)
+            }
+            for node in nodes {
+                guard let point = miniPositions[node.id] else { continue }
+                let selected = node.id == selectedNodeID
+                let radius: CGFloat = selected ? 3.5 : 2
+                context.fill(
+                    Path(ellipseIn: CGRect(x: point.x - radius, y: point.y - radius, width: radius * 2, height: radius * 2)),
+                    with: .color(selected ? Color.accentColor : node.kind.tint.opacity(0.9))
+                )
+            }
+        }
+        .frame(width: Self.size.width, height: Self.size.height)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(NSColor.separatorColor), lineWidth: 1)
+        }
+        .onTapGesture { location in
+            if let id = SiteGraphMiniMapGeometry.nearestNodeID(to: location, positions: miniPositions) {
+                onSelect(id)
+            }
+        }
+        .accessibilityLabel("Site graph overview")
+        .accessibilityHint("Click to select the nearest node")
+        .help("Overview of the whole graph — click to jump to a node")
     }
 }
 

--- a/Sources/AnglesiteApp/SiteGraphMiniMap.swift
+++ b/Sources/AnglesiteApp/SiteGraphMiniMap.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Pure geometry for the Site Graph mini-map (#613): threshold gating, canvas→mini-map point
+/// scaling, and click-to-jump hit-testing. Kept UI-free so `AnglesiteAppTests` can cover it.
+enum SiteGraphMiniMapGeometry {
+    /// Below this many visible nodes the main canvas is legible on its own and a mini-map is
+    /// redundant clutter, so it only appears *above* the threshold.
+    static let nodeCountThreshold = 30
+
+    static func shouldShow(nodeCount: Int) -> Bool {
+        nodeCount > nodeCountThreshold
+    }
+
+    /// Maps a point in the main canvas' coordinate space proportionally into the mini-map's.
+    /// A degenerate (zero-sized) source collapses to `.zero` rather than dividing by zero.
+    static func scaledPoint(_ point: CGPoint, from source: CGSize, to target: CGSize) -> CGPoint {
+        guard source.width > 0, source.height > 0 else { return .zero }
+        return CGPoint(
+            x: point.x / source.width * target.width,
+            y: point.y / source.height * target.height
+        )
+    }
+
+    /// The node whose position is closest to `point`, for click-to-jump selection. Exact-distance
+    /// ties break lexicographically by ID so repeated clicks are deterministic.
+    static func nearestNodeID(to point: CGPoint, positions: [String: CGPoint]) -> String? {
+        positions.min { lhs, rhs in
+            let lhsDistance = hypot(lhs.value.x - point.x, lhs.value.y - point.y)
+            let rhsDistance = hypot(rhs.value.x - point.x, rhs.value.y - point.y)
+            if lhsDistance != rhsDistance { return lhsDistance < rhsDistance }
+            return lhs.key < rhs.key
+        }?.key
+    }
+}

--- a/Tests/AnglesiteAppTests/SiteGraphMiniMapGeometryTests.swift
+++ b/Tests/AnglesiteAppTests/SiteGraphMiniMapGeometryTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+
+@Suite("SiteGraphMiniMapGeometry")
+struct SiteGraphMiniMapGeometryTests {
+    @Test("mini-map is hidden at or below the node-count threshold and shown above it")
+    func thresholdBoundary() {
+        let threshold = SiteGraphMiniMapGeometry.nodeCountThreshold
+        #expect(SiteGraphMiniMapGeometry.shouldShow(nodeCount: 0) == false)
+        #expect(SiteGraphMiniMapGeometry.shouldShow(nodeCount: threshold) == false)
+        #expect(SiteGraphMiniMapGeometry.shouldShow(nodeCount: threshold + 1) == true)
+    }
+
+    @Test("scaledPoint maps a canvas point proportionally into the mini-map rect")
+    func scaledPointProportional() {
+        let scaled = SiteGraphMiniMapGeometry.scaledPoint(
+            CGPoint(x: 200, y: 100),
+            from: CGSize(width: 800, height: 400),
+            to: CGSize(width: 160, height: 100)
+        )
+        #expect(scaled == CGPoint(x: 40, y: 25))
+    }
+
+    @Test("scaledPoint degrades to .zero instead of dividing by a zero source dimension")
+    func scaledPointZeroSource() {
+        let scaled = SiteGraphMiniMapGeometry.scaledPoint(
+            CGPoint(x: 200, y: 100),
+            from: .zero,
+            to: CGSize(width: 160, height: 100)
+        )
+        #expect(scaled == .zero)
+    }
+
+    @Test("nearestNodeID returns nil when there are no positions")
+    func nearestNodeEmpty() {
+        #expect(SiteGraphMiniMapGeometry.nearestNodeID(to: CGPoint(x: 10, y: 10), positions: [:]) == nil)
+    }
+
+    @Test("nearestNodeID picks the closest node to the tap point")
+    func nearestNodePicksClosest() {
+        let positions: [String: CGPoint] = [
+            "far": CGPoint(x: 100, y: 100),
+            "near": CGPoint(x: 12, y: 9),
+            "middle": CGPoint(x: 50, y: 50),
+        ]
+        #expect(SiteGraphMiniMapGeometry.nearestNodeID(to: CGPoint(x: 10, y: 10), positions: positions) == "near")
+    }
+
+    @Test("nearestNodeID breaks exact-distance ties deterministically by node ID")
+    func nearestNodeTieBreak() {
+        let positions: [String: CGPoint] = [
+            "b": CGPoint(x: 20, y: 10),
+            "a": CGPoint(x: 0, y: 10),
+        ]
+        // Both are exactly 10 points from the tap; the lexicographically smaller ID wins.
+        #expect(SiteGraphMiniMapGeometry.nearestNodeID(to: CGPoint(x: 10, y: 10), positions: positions) == "a")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a **mini-map overlay** to `SiteGraphCanvas` (bottom-trailing) once the visible graph exceeds 30 nodes: kind-tinted node dots and hairline edges rendered at the same relative positions as the main canvas, selected node highlighted in accent color.
- **Click-to-jump**: clicking the mini-map selects the nearest node (deterministic tie-break by node ID). No viewport rectangle yet — the main canvas has no pan/zoom to reflect, per the issue's "if/when" note.
- Pure geometry (threshold gating, canvas→mini-map scaling, hit-testing) lives in a UI-free `SiteGraphMiniMapGeometry` enum covered by new `AnglesiteAppTests`.

## Test-infra fix (needed to run the tests at all)

`AnglesiteAppTests` was the only test target missing `linkerSettings: weakLinkFoundationModels`, and `AnglesiteAppCore` (via `ChatView.swift`'s `import FoundationModels`) embeds the hard autolink hint that overrides the weak-link flag — so the whole test bundle failed to `dlopen` on a beta seed with the #541 symbol skew. Applied the same weak-link + autolink-disable pair every other target already uses. (Relevant evidence for #618 — noted there.)

## Testing

- `swift test` full run: 5 test binaries, all green (incl. new `SiteGraphMiniMapGeometry` suite, 6 tests).

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)