### PR TITLE
docs(core): verify #541 launch fix on current seeds; keep workaround, track removal in #623

### DIFF
--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -31,10 +31,13 @@ import CoreSpotlight
 /// Compiled into AnglesiteCore on both build targets; it needs no subprocess, so it is the
 /// on-device path usable from the sandboxed MAS build.
 public actor FoundationModelAssistant: ConversationalAssistant {
-    // TODO(#541): this hardcoded mangled-symbol check is a workaround for a beta Xcode/macOS SDK-OS
-    // skew. Re-verify the symbol name against the shipping GA SDK and delete this guard (and the
-    // weak-link linker settings in Package.swift/project.yml) once Xcode 27 and macOS 27 are both
-    // out of beta and the toolchain/OS pair is guaranteed to match.
+    // TODO(#623): this hardcoded mangled-symbol check is a workaround for a beta Xcode/macOS SDK-OS
+    // skew (#541). Verified still live 2026-07-09 (#618, Xcode 27A5209h / macOS 26A5378j): the OS
+    // now exports this same initializer under a *different* mangling (the extension signature's
+    // Copyable requirement marker was dropped, `Rszrl` → `Rszl`), while the SDK still emits — and
+    // this binary therefore still references — the old one. The hardcoded name must track what the
+    // SDK emits, not what the OS exports; #623 has the re-sync recipe and the exit condition for
+    // deleting this guard plus the weak-link settings in Package.swift/project.yml.
     /// Whether `Attachment(imageURL:orientation:)` actually resolves on this host. FoundationModels
     /// is weak-linked (#541), so a mangled name the installed OS doesn't export binds to a NULL
     /// pointer rather than failing to load — `dlsym` against the already-loaded image is the way to


### PR DESCRIPTION
## Summary

Completes the verification asked for in #618 and refreshes the `TODO(#541)` in `FoundationModelAssistant.swift` to reflect what was found. The workaround **stays** (per #618's acceptance clause for that outcome); its removal now has a concrete exit condition tracked in #623.

## What was verified (macOS 27.0 seed 26A5378j + Xcode 27 beta 27A5209h, 2026-07-09)

- **Launch is clean in both configurations.** Debug and Release builds of the `Anglesite` scheme launch and stay alive with no dyld abort. `otool -l` confirms `LC_LOAD_WEAK_DYLIB` for FoundationModels in both binaries, and `nm -m` shows the `Attachment(imageURL:orientation:)` reference as `weak external` — the #580 weak-link + #591 autolink-disable pair works end-to-end.
- **#586's "crash still reproduces" is explained**: its merge-base had only #580; the Swift autolink hint re-hard-linked the framework until #591. With both fixes in, launch is stable — this unblocks the manual verifications queued behind #541 (#586, #491).
- **The skew itself is NOT resolved, so the dlsym guard cannot be deleted.** The installed OS now exports the same initializer under a *different* mangling than the SDK emits (`…ContentVRszlE…` vs `…ContentVRszrlE…` — a Copyable requirement marker dropped from the extension's generic signature). The symbol this binary references genuinely does not exist on this OS: without the weak link, dyld aborts at launch; without the guard, the vision path calls through a NULL weak import. The guard checks exactly the mangling the SDK emits, so it is still accurate and load-bearing.

## Changes

- Refresh the workaround TODO in `FoundationModelAssistant.swift`: point it at #623 (which carries the symbol-diff evidence, the re-sync recipe, and the delete-when condition) and record the verified state.

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)
