### PR TITLE
fix: land #614's on-device explain feature on main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let weakLinkFoundationModels: [LinkerSetting] = [
     .unsafeFlags(["-Xlinker", "-weak_framework", "-Xlinker", "FoundationModels"])
 ]
 
-// AnglesiteCore is the only target that `import`s FoundationModels. Swift embeds a *hard*
+// AnglesiteCore and AnglesiteAppCore (ChatView.swift) `import` FoundationModels. Swift embeds a *hard*
 // `-framework FoundationModels` autolink hint in its compiled object code, which wins over the
 // app target's explicit `-weak_framework FoundationModels` (project.yml) when the final app
 // binary is linked — so the app still hard-links FoundationModels despite that flag. Disabling

--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -2,21 +2,47 @@ import Foundation
 import Observation
 import AnglesiteCore
 
+/// Lifecycle of the AI explanation for the selected node (#614). `unavailable` is deliberately
+/// distinct from `failed`: the on-device model being off (Apple Intelligence disabled, model not
+/// downloaded) is an expected state with a user-facing remedy, not an error — and per the LLM
+/// policy it must surface as such rather than silently falling back to any cloud call.
+enum SiteGraphExplainState: Equatable {
+    case idle
+    /// Streaming in progress; the associated text grows as chunks arrive (empty until the first).
+    case generating(String)
+    case complete(String)
+    case unavailable(String)
+    case failed(String)
+}
+
 @MainActor
 @Observable
 final class SiteGraphExplorerModel {
     private(set) var snapshot = SiteGraphExplorerSnapshot(nodes: [], edges: [])
-    var selectedNodeID: String?
+    var selectedNodeID: String? {
+        didSet {
+            // A new selection invalidates the previous node's explanation — reset instead of
+            // showing stale prose (or a stale error) under the new node's inspector.
+            if oldValue != selectedNodeID { resetExplain() }
+        }
+    }
     var searchText = ""
     var enabledKinds = Set(SiteGraphNodeKind.allCases)
+    private(set) var explainState: SiteGraphExplainState = .idle
 
     private let graph: SiteContentGraph
+    private let explainer: (any SiteGraphNodeExplaining)?
     private var observeTask: Task<Void, Never>?
+    private var explainTask: Task<Void, Never>?
     private var siteID: String?
     private var sourceDirectory: URL?
 
-    init(graph: SiteContentGraph) {
+    init(
+        graph: SiteContentGraph,
+        explainer: (any SiteGraphNodeExplaining)? = SiteGraphExplainerFactory.makeDefault()
+    ) {
         self.graph = graph
+        self.explainer = explainer
     }
 
     var filteredNodes: [SiteGraphNode] {
@@ -138,6 +164,64 @@ final class SiteGraphExplorerModel {
     func node(id: String) -> SiteGraphNode? {
         snapshot.nodes.first { $0.id == id }
     }
+
+    // MARK: AI explanation (#614)
+
+    /// Whether the Explain action can run: a backend exists on this toolchain *and* a node is
+    /// selected. Runtime unavailability (Apple Intelligence off) is not gated here — the action
+    /// stays offered and resolves to ``SiteGraphExplainState/unavailable(_:)``, which tells the
+    /// user how to fix it.
+    var canExplain: Bool {
+        explainer != nil && selectedNode != nil
+    }
+
+    /// Streams an on-device AI explanation of the selected node into ``explainState``, grounded
+    /// in the node's edges and its ``ImpactAnalysis.Report`` (never a free-form guess about the
+    /// site). Neighbors are read from the *full* snapshot, matching `selectedImpact` — facts must
+    /// not shrink because a kind is toggled off in the toolbar.
+    func explainSelectedNode() {
+        guard let explainer, let node = selectedNode, let impact = selectedImpact,
+              let siteID, let sourceDirectory else { return }
+        explainTask?.cancel()
+        let prompt = SiteGraphExplainPrompt.prompt(
+            node: node,
+            impact: impact,
+            dependsOn: snapshot.edges.filter { $0.sourceID == node.id }.compactMap { self.node(id: $0.targetID) },
+            referencedBy: snapshot.edges.filter { $0.targetID == node.id }.compactMap { self.node(id: $0.sourceID) }
+        )
+        explainState = .generating("")
+        explainTask = Task { [explainer] in
+            do {
+                var text = ""
+                let stream = try await explainer.explain(prompt: prompt, siteID: siteID, siteDirectory: sourceDirectory)
+                for try await chunk in stream {
+                    if Task.isCancelled { return }
+                    text += chunk
+                    explainState = .generating(text)
+                }
+                guard !Task.isCancelled else { return }
+                explainState = .complete(text)
+            } catch AssistantError.unavailable(let message) {
+                guard !Task.isCancelled else { return }
+                explainState = .unavailable(message)
+            } catch {
+                guard !Task.isCancelled else { return }
+                explainState = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    /// Cancels delivery of an in-flight explanation and clears the state. Only consumption stops —
+    /// an underlying FoundationModels stream is never cancelled mid-iteration (that traps the
+    /// process); its detached drain finishes harmlessly, matching `FoundationModelAssistant`.
+    private func resetExplain() {
+        explainTask?.cancel()
+        explainTask = nil
+        explainState = .idle
+    }
+
+    /// Test-only: the in-flight explain task, so tests can await completion deterministically.
+    var explainTaskForTesting: Task<Void, Never>? { explainTask }
 
     private func refresh(siteID: String, sourceDirectory: URL) async {
         let pages = await graph.pages(for: siteID)

--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -137,6 +137,9 @@ final class SiteGraphExplorerModel {
     func stop() {
         observeTask?.cancel()
         observeTask = nil
+        // Wind down an in-flight explanation too, or its task (strongly capturing self for
+        // explainState writes) keeps draining the model stream for a window that's gone.
+        resetExplain()
     }
 
     /// Forces an immediate re-scan using the already-stored `siteID`/`sourceDirectory` from the
@@ -183,11 +186,20 @@ final class SiteGraphExplorerModel {
         guard let explainer, let node = selectedNode, let impact = selectedImpact,
               let siteID, let sourceDirectory else { return }
         explainTask?.cancel()
+        // Single edge pass + ID-keyed lookup, not a linear node scan per matched edge — a hub
+        // node on a large site would otherwise do O(edges × nodes) work on the main actor.
+        let nodesByID = Dictionary(snapshot.nodes.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        var dependsOn: [SiteGraphNode] = []
+        var referencedBy: [SiteGraphNode] = []
+        for edge in snapshot.edges {
+            if edge.sourceID == node.id, let target = nodesByID[edge.targetID] { dependsOn.append(target) }
+            if edge.targetID == node.id, let source = nodesByID[edge.sourceID] { referencedBy.append(source) }
+        }
         let prompt = SiteGraphExplainPrompt.prompt(
             node: node,
             impact: impact,
-            dependsOn: snapshot.edges.filter { $0.sourceID == node.id }.compactMap { self.node(id: $0.targetID) },
-            referencedBy: snapshot.edges.filter { $0.targetID == node.id }.compactMap { self.node(id: $0.sourceID) }
+            dependsOn: dependsOn,
+            referencedBy: referencedBy
         )
         explainState = .generating("")
         explainTask = Task { [explainer] in
@@ -241,6 +253,10 @@ final class SiteGraphExplorerModel {
         }.value
         if Task.isCancelled { return }
         snapshot = next
+        // The explanation was grounded in the snapshot just replaced; even when the selected node
+        // survives (so the didSet won't fire), keeping it risks stale prose contradicting the
+        // freshly-recomputed Impact section right above it.
+        resetExplain()
         if let selectedNodeID, !next.nodes.contains(where: { $0.id == selectedNodeID }) {
             self.selectedNodeID = nil
         }

--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import OSLog
 import AnglesiteCore
 
 /// Lifecycle of the AI explanation for the selected node (#614). `unavailable` is deliberately
@@ -32,6 +33,7 @@ final class SiteGraphExplorerModel {
 
     private let graph: SiteContentGraph
     private let explainer: (any SiteGraphNodeExplaining)?
+    private let logger = Logger(subsystem: "dev.anglesite.app", category: "SiteGraphExplorer")
     private var observeTask: Task<Void, Never>?
     private var explainTask: Task<Void, Never>?
     private var siteID: String?
@@ -170,12 +172,14 @@ final class SiteGraphExplorerModel {
 
     // MARK: AI explanation (#614)
 
-    /// Whether the Explain action can run: a backend exists on this toolchain *and* a node is
-    /// selected. Runtime unavailability (Apple Intelligence off) is not gated here — the action
-    /// stays offered and resolves to ``SiteGraphExplainState/unavailable(_:)``, which tells the
-    /// user how to fix it.
+    /// Whether the Explain action can run — mirrors every precondition `explainSelectedNode()`
+    /// itself guards on, so the two can't drift apart if `start()`'s sequencing ever changes.
+    /// Runtime unavailability (Apple Intelligence off) is not gated here — the action stays
+    /// offered and resolves to ``SiteGraphExplainState/unavailable(_:)``, which tells the user how
+    /// to fix it.
     var canExplain: Bool {
-        explainer != nil && selectedNode != nil
+        explainer != nil && selectedNode != nil && selectedImpact != nil
+            && siteID != nil && sourceDirectory != nil
     }
 
     /// Streams an on-device AI explanation of the selected node into ``explainState``, grounded
@@ -202,23 +206,31 @@ final class SiteGraphExplorerModel {
             referencedBy: referencedBy
         )
         explainState = .generating("")
-        explainTask = Task { [explainer] in
+        // Weak self: a live FoundationModels stream is deliberately never cancelled mid-iteration
+        // (see resetExplain()), so this task can outlive the model (e.g. the window closes while
+        // streaming) — it must not keep the whole model alive for that duration, matching the
+        // observeTask pattern in start() above.
+        explainTask = Task { [weak self, explainer] in
             do {
                 var text = ""
                 let stream = try await explainer.explain(prompt: prompt, siteID: siteID, siteDirectory: sourceDirectory)
                 for try await chunk in stream {
                     if Task.isCancelled { return }
                     text += chunk
-                    explainState = .generating(text)
+                    guard let self else { return }
+                    self.explainState = .generating(text)
                 }
-                guard !Task.isCancelled else { return }
-                explainState = .complete(text)
+                guard !Task.isCancelled, let self else { return }
+                self.explainState = .complete(text)
             } catch AssistantError.unavailable(let message) {
-                guard !Task.isCancelled else { return }
-                explainState = .unavailable(message)
+                guard !Task.isCancelled, let self else { return }
+                self.explainState = .unavailable(message)
             } catch {
-                guard !Task.isCancelled else { return }
-                explainState = .failed(error.localizedDescription)
+                guard !Task.isCancelled, let self else { return }
+                // The site owner, not a developer, reads this — a raw NSError/Foundation
+                // description isn't actionable for them. Keep it in the debug log only.
+                self.logger.error("Site graph explanation failed: \(error.localizedDescription, privacy: .public)")
+                self.explainState = .failed("Something went wrong generating this explanation. Please try again.")
             }
         }
     }

--- a/Sources/AnglesiteApp/SiteGraphExplorerView.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerView.swift
@@ -245,6 +245,11 @@ private struct SiteGraphCanvas: View {
 /// as kind-tinted dots and edges as hairlines at the same relative positions as the main canvas;
 /// clicking selects the nearest node there. No viewport rectangle yet — the main canvas has no
 /// pan/zoom to reflect (see #613's "if/when" note).
+///
+/// Like any corner mini-map, it occludes the canvas region beneath it (where `SiteGraphLayout`
+/// clamps overflow rows). Accepted tradeoff: a click there lands on the mini-map, whose scaled
+/// coordinates put the tap next to the *same* node's dot, so click-to-jump still selects the
+/// intended node; the bounded hit radius makes genuinely empty space a no-op.
 private struct SiteGraphMiniMap: View {
     let nodes: [SiteGraphNode]
     let edges: [SiteGraphEdge]
@@ -284,7 +289,9 @@ private struct SiteGraphMiniMap: View {
                 .stroke(Color(NSColor.separatorColor), lineWidth: 1)
         }
         .onTapGesture { location in
-            if let id = SiteGraphMiniMapGeometry.nearestNodeID(to: location, positions: miniPositions) {
+            // Bounded hit radius: a click on empty mini-map space is a no-op, not a jump to
+            // whatever node happens to be least far away.
+            if let id = SiteGraphMiniMapGeometry.nearestNodeID(to: location, positions: miniPositions, maxDistance: 16) {
                 onSelect(id)
             }
         }
@@ -428,24 +435,19 @@ private struct SiteGraphExplainSection: View {
                 }
             case .complete(let text):
                 explanationText(text)
-                Button("Regenerate", systemImage: "arrow.clockwise") {
-                    model.explainSelectedNode()
-                }
-                .buttonStyle(.borderless)
-                .controlSize(.small)
+                retryButton("Regenerate")
             case .unavailable(let message):
                 Label(message, systemImage: "info.circle")
                     .font(.callout)
                     .foregroundStyle(.secondary)
+                // The message names a remedy (enable Apple Intelligence); once the user has
+                // applied it they must be able to retry without changing the selection.
+                retryButton("Try Again")
             case .failed(let message):
                 Label(message, systemImage: "exclamationmark.triangle")
                     .font(.callout)
                     .foregroundStyle(.secondary)
-                Button("Try Again", systemImage: "arrow.clockwise") {
-                    model.explainSelectedNode()
-                }
-                .buttonStyle(.borderless)
-                .controlSize(.small)
+                retryButton("Try Again")
             }
         }
         .accessibilityElement(children: .contain)
@@ -457,6 +459,14 @@ private struct SiteGraphExplainSection: View {
             .font(.callout)
             .textSelection(.enabled)
             .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func retryButton(_ title: LocalizedStringKey) -> some View {
+        Button(title, systemImage: "arrow.clockwise") {
+            model.explainSelectedNode()
+        }
+        .buttonStyle(.borderless)
+        .controlSize(.small)
     }
 }
 

--- a/Sources/AnglesiteApp/SiteGraphExplorerView.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerView.swift
@@ -365,6 +365,10 @@ private struct SiteGraphInspector: View {
                             Divider()
                             SiteGraphImpactSection(impact: impact, model: model)
                         }
+                        if model.canExplain {
+                            Divider()
+                            SiteGraphExplainSection(model: model)
+                        }
                         Divider()
                         SiteGraphEdgeList(
                             title: "Depends On",
@@ -387,6 +391,72 @@ private struct SiteGraphInspector: View {
             }
         }
         .background(Color(NSColor.controlBackgroundColor))
+    }
+}
+
+/// AI explanation of the selected node (#614): a plain-language synthesis of the structured
+/// Impact Analysis above it, generated on-device by Apple Intelligence (never a network call —
+/// see the LLM policy under #459). Runtime unavailability renders as guidance, not an error.
+private struct SiteGraphExplainSection: View {
+    @Bindable var model: SiteGraphExplorerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Explain", systemImage: "sparkles")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            switch model.explainState {
+            case .idle:
+                Button("Explain This Node", systemImage: "sparkles") {
+                    model.explainSelectedNode()
+                }
+                .buttonStyle(.bordered)
+                Text("Uses on-device Apple Intelligence. Nothing leaves your Mac.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .generating(let text):
+                if text.isEmpty {
+                    HStack(spacing: 6) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Thinking…")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    explanationText(text)
+                }
+            case .complete(let text):
+                explanationText(text)
+                Button("Regenerate", systemImage: "arrow.clockwise") {
+                    model.explainSelectedNode()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+            case .unavailable(let message):
+                Label(message, systemImage: "info.circle")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            case .failed(let message):
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Button("Try Again", systemImage: "arrow.clockwise") {
+                    model.explainSelectedNode()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("AI explanation")
+    }
+
+    private func explanationText(_ text: String) -> some View {
+        Text(text)
+            .font(.callout)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Sources/AnglesiteApp/SiteGraphMiniMap.swift
+++ b/Sources/AnglesiteApp/SiteGraphMiniMap.swift
@@ -22,13 +22,24 @@ enum SiteGraphMiniMapGeometry {
     }
 
     /// The node whose position is closest to `point`, for click-to-jump selection. Exact-distance
-    /// ties break lexicographically by ID so repeated clicks are deterministic.
-    static func nearestNodeID(to point: CGPoint, positions: [String: CGPoint]) -> String? {
-        positions.min { lhs, rhs in
+    /// ties break lexicographically by ID so repeated clicks are deterministic. `maxDistance`
+    /// bounds the hit radius so a click on empty mini-map space is a no-op rather than jumping
+    /// the selection (and resetting inspector state) to some arbitrary far-away node.
+    static func nearestNodeID(
+        to point: CGPoint,
+        positions: [String: CGPoint],
+        maxDistance: CGFloat? = nil
+    ) -> String? {
+        let nearest = positions.min { lhs, rhs in
             let lhsDistance = hypot(lhs.value.x - point.x, lhs.value.y - point.y)
             let rhsDistance = hypot(rhs.value.x - point.x, rhs.value.y - point.y)
             if lhsDistance != rhsDistance { return lhsDistance < rhsDistance }
             return lhs.key < rhs.key
-        }?.key
+        }
+        guard let nearest else { return nil }
+        if let maxDistance, hypot(nearest.value.x - point.x, nearest.value.y - point.y) > maxDistance {
+            return nil
+        }
+        return nearest.key
     }
 }

--- a/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
+++ b/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
@@ -43,15 +43,19 @@ public enum SiteGraphExplainPrompt {
         dependsOn: [SiteGraphNode],
         referencedBy: [SiteGraphNode]
     ) -> String {
+        // A neighbor reachable through several edge kinds (e.g. both `imports` and `usesLayout`)
+        // arrives once per edge — list it once, or the capped fact list fills with duplicates.
+        let uniqueDependsOn = deduplicated(dependsOn)
+        let uniqueReferencedBy = deduplicated(referencedBy)
         var facts: [String] = []
         facts.append("- This file: \(node.title) (a \(kindLabel(node.kind)) on the site)")
         if let route = node.route { facts.append("- Its page address: \(route)") }
         if let filePath = node.filePath { facts.append("- Its source file: \(filePath)") }
-        if !dependsOn.isEmpty {
-            facts.append("- Depends on: \(nameList(dependsOn, withKinds: true))")
+        if !uniqueDependsOn.isEmpty {
+            facts.append("- Depends on: \(nameList(uniqueDependsOn, withKinds: true))")
         }
-        if !referencedBy.isEmpty {
-            facts.append("- Referenced by: \(nameList(referencedBy, withKinds: true))")
+        if !uniqueReferencedBy.isEmpty {
+            facts.append("- Referenced by: \(nameList(uniqueReferencedBy, withKinds: true))")
         }
         facts.append(contentsOf: impactFacts(impact))
 
@@ -92,6 +96,11 @@ public enum SiteGraphExplainPrompt {
         guard !nodes.isEmpty else { return }
         let noun = nodes.count == 1 ? singular : (plural ?? singular + "s")
         facts.append("- \(verb) \(nodes.count) \(noun): \(nameList(nodes, withKinds: false))")
+    }
+
+    private static func deduplicated(_ nodes: [SiteGraphNode]) -> [SiteGraphNode] {
+        var seen = Set<String>()
+        return nodes.filter { seen.insert($0.id).inserted }
     }
 
     private static func nameList(_ nodes: [SiteGraphNode], withKinds: Bool) -> String {

--- a/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
+++ b/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// AI explanation of a Site Graph node (#614): turns the deterministic facts the explorer already
+/// computes — the node's identity, its direct neighbors, and its `ImpactAnalysis.Report` — into a
+/// short plain-language summary of the node's role on the site.
+///
+/// Per the LLM policy (#459), this is on-device-only: the default backend is Apple's
+/// FoundationModels via ``FoundationModelAssistant``, there is no network fallback, and hosts
+/// without a usable model surface ``AssistantError/unavailable(_:)`` instead of degrading to a
+/// cloud call.
+public protocol SiteGraphNodeExplaining: Sendable {
+    /// Streams the explanation text for a prompt built by ``SiteGraphExplainPrompt``. Throws
+    /// ``AssistantError/unavailable(_:)`` before the stream opens when the on-device model can't
+    /// run on this host.
+    func explain(prompt: String, siteID: String, siteDirectory: URL) async throws -> AsyncThrowingStream<String, Error>
+}
+
+/// Chooses the node explainer for the current toolchain. Non-gated so `SiteGraphExplorerModel`
+/// can default its dependency without importing FoundationModels; `nil` on toolchains without
+/// FoundationModels means "no backend exists" (hide the feature), distinct from the runtime
+/// ``AssistantError/unavailable(_:)`` ("backend exists, Apple Intelligence is off").
+public enum SiteGraphExplainerFactory {
+    public static func makeDefault() -> (any SiteGraphNodeExplaining)? {
+        #if compiler(>=6.4)
+        return FoundationModelSiteGraphExplainer()
+        #else
+        return nil
+        #endif
+    }
+}
+
+/// Deterministic grounding-prompt builder for ``SiteGraphNodeExplaining``. The model is given
+/// only facts the explorer already computed — never asked to guess about the site — so the
+/// explanation can't outrun the graph's own accuracy.
+public enum SiteGraphExplainPrompt {
+    /// Cap per impact group so a site-wide component (used by hundreds of pages) can't flood the
+    /// on-device model's small context window; the remainder is summarized as "and N more".
+    public static let maxListedNames = 12
+
+    public static func prompt(
+        node: SiteGraphNode,
+        impact: ImpactAnalysis.Report,
+        dependsOn: [SiteGraphNode],
+        referencedBy: [SiteGraphNode]
+    ) -> String {
+        var facts: [String] = []
+        facts.append("- This file: \(node.title) (a \(kindLabel(node.kind)) on the site)")
+        if let route = node.route { facts.append("- Its page address: \(route)") }
+        if let filePath = node.filePath { facts.append("- Its source file: \(filePath)") }
+        if !dependsOn.isEmpty {
+            facts.append("- Depends on: \(nameList(dependsOn, withKinds: true))")
+        }
+        if !referencedBy.isEmpty {
+            facts.append("- Referenced by: \(nameList(referencedBy, withKinds: true))")
+        }
+        facts.append(contentsOf: impactFacts(impact))
+
+        return """
+        You are explaining one file in a static website's dependency graph to the site's owner, \
+        who is not a developer. Using only the facts below, write a short plain-language \
+        explanation (2 to 4 sentences) of this file's role on the site and what editing it would \
+        affect. Do not invent details that are not in the facts, and do not repeat the facts as a \
+        list — synthesize them.
+
+        Facts:
+        \(facts.joined(separator: "\n"))
+        """
+    }
+
+    private static func impactFacts(_ impact: ImpactAnalysis.Report) -> [String] {
+        var facts: [String] = []
+        appendGroup(&facts, impact.affectedPages, "Editing it would affect", "page")
+        appendGroup(&facts, impact.affectedEntries, "Editing it would affect", "content entry", plural: "content entries")
+        appendGroup(&facts, impact.affectedCollections, "It belongs to", "collection")
+        appendGroup(&facts, impact.dependentLayouts, "It is used by", "layout")
+        appendGroup(&facts, impact.dependentComponents, "It is used by", "component")
+        appendGroup(&facts, impact.dependentStyles, "It is used by", "stylesheet")
+        appendGroup(&facts, impact.referencedAssets, "It references", "asset")
+        if facts.isEmpty {
+            facts.append("- Nothing else on the site depends on this file.")
+        }
+        return facts
+    }
+
+    private static func appendGroup(
+        _ facts: inout [String],
+        _ nodes: [SiteGraphNode],
+        _ verb: String,
+        _ singular: String,
+        plural: String? = nil
+    ) {
+        guard !nodes.isEmpty else { return }
+        let noun = nodes.count == 1 ? singular : (plural ?? singular + "s")
+        facts.append("- \(verb) \(nodes.count) \(noun): \(nameList(nodes, withKinds: false))")
+    }
+
+    private static func nameList(_ nodes: [SiteGraphNode], withKinds: Bool) -> String {
+        let listed = nodes.prefix(maxListedNames).map {
+            withKinds ? "\($0.title) (\(kindLabel($0.kind)))" : $0.title
+        }
+        let overflow = nodes.count - maxListedNames
+        return listed.joined(separator: ", ") + (overflow > 0 ? ", and \(overflow) more" : "")
+    }
+
+    private static func kindLabel(_ kind: SiteGraphNodeKind) -> String {
+        switch kind {
+        case .page: return "page"
+        case .layout: return "layout"
+        case .component: return "component"
+        case .collection: return "collection"
+        case .contentEntry: return "content entry"
+        case .asset: return "asset"
+        case .style: return "stylesheet"
+        }
+    }
+}
+
+// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).
+// See FoundationModelAssistant.swift for the pattern.
+#if compiler(>=6.4)
+/// On-device explainer: streams ``FoundationModelAssistant``'s one-shot `generate` output. A host
+/// without Apple Intelligence throws ``AssistantError/unavailable(_:)`` from `generate` before
+/// the stream opens — surfaced by the UI as its "unavailable" state, never a cloud fallback.
+public struct FoundationModelSiteGraphExplainer: SiteGraphNodeExplaining {
+    public init() {}
+
+    public func explain(prompt: String, siteID: String, siteDirectory: URL) async throws -> AsyncThrowingStream<String, Error> {
+        try await FoundationModelAssistant(tier: .onDevice).generate(
+            prompt: prompt,
+            context: AssistantContext(siteID: siteID, siteDirectory: siteDirectory)
+        )
+    }
+}
+#endif

--- a/Tests/AnglesiteAppTests/SiteGraphExplorerModelExplainTests.swift
+++ b/Tests/AnglesiteAppTests/SiteGraphExplorerModelExplainTests.swift
@@ -1,0 +1,123 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// Streams fixed chunks, or the received prompt itself when `echoPrompt` is set (so tests can
+/// assert the model grounded the request in the selected node without a stateful spy).
+private struct FakeExplainer: SiteGraphNodeExplaining {
+    var chunks: [String] = []
+    var echoPrompt = false
+
+    func explain(prompt: String, siteID: String, siteDirectory: URL) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            if echoPrompt {
+                continuation.yield(prompt)
+            } else {
+                for chunk in chunks { continuation.yield(chunk) }
+            }
+            continuation.finish()
+        }
+    }
+}
+
+private struct ThrowingExplainer: SiteGraphNodeExplaining {
+    let error: any Error
+
+    func explain(prompt: String, siteID: String, siteDirectory: URL) async throws -> AsyncThrowingStream<String, Error> {
+        throw error
+    }
+}
+
+@Suite("SiteGraphExplorerModel explain (#614)")
+@MainActor
+struct SiteGraphExplorerModelExplainTests {
+    /// A started model with one page node loaded and selected.
+    private func makeModel(explainer: (any SiteGraphNodeExplaining)?) async throws -> (SiteGraphExplorerModel, URL) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date())],
+            posts: [], images: []
+        )
+        let model = SiteGraphExplorerModel(graph: graph, explainer: explainer)
+        model.start(siteID: "site-1", sourceDirectory: root)
+        while model.snapshot.nodes.isEmpty { await Task.yield() }
+        model.selectedNodeID = model.snapshot.nodes.first?.id
+        return (model, root)
+    }
+
+    @Test("canExplain requires both a backend and a selection")
+    func canExplainGating() async throws {
+        let (noBackend, root1) = try await makeModel(explainer: nil)
+        defer { try? FileManager.default.removeItem(at: root1) }
+        #expect(noBackend.canExplain == false)
+
+        let (model, root2) = try await makeModel(explainer: FakeExplainer())
+        defer { try? FileManager.default.removeItem(at: root2) }
+        #expect(model.canExplain == true)
+        model.selectedNodeID = nil
+        #expect(model.canExplain == false)
+    }
+
+    @Test("a successful stream accumulates chunks and ends in .complete")
+    func successAccumulates() async throws {
+        let (model, root) = try await makeModel(explainer: FakeExplainer(chunks: ["This page ", "is the About page."]))
+        defer { try? FileManager.default.removeItem(at: root) }
+        model.explainSelectedNode()
+        await model.explainTaskForTesting?.value
+        #expect(model.explainState == .complete("This page is the About page."))
+    }
+
+    @Test("the request is grounded in the selected node's facts")
+    func promptIsGrounded() async throws {
+        let (model, root) = try await makeModel(explainer: FakeExplainer(echoPrompt: true))
+        defer { try? FileManager.default.removeItem(at: root) }
+        model.explainSelectedNode()
+        await model.explainTaskForTesting?.value
+        guard case .complete(let echoed) = model.explainState else {
+            Issue.record("expected .complete, got \(model.explainState)")
+            return
+        }
+        #expect(echoed.contains("About"))
+        #expect(echoed.contains("Do not invent"))
+    }
+
+    @Test("AssistantError.unavailable becomes the .unavailable state, not .failed")
+    func unavailableState() async throws {
+        let (model, root) = try await makeModel(
+            explainer: ThrowingExplainer(error: AssistantError.unavailable("Enable Apple Intelligence.")))
+        defer { try? FileManager.default.removeItem(at: root) }
+        model.explainSelectedNode()
+        await model.explainTaskForTesting?.value
+        #expect(model.explainState == .unavailable("Enable Apple Intelligence."))
+    }
+
+    @Test("any other error becomes .failed")
+    func failedState() async throws {
+        struct BoomError: Error {}
+        let (model, root) = try await makeModel(explainer: ThrowingExplainer(error: BoomError()))
+        defer { try? FileManager.default.removeItem(at: root) }
+        model.explainSelectedNode()
+        await model.explainTaskForTesting?.value
+        guard case .failed = model.explainState else {
+            Issue.record("expected .failed, got \(model.explainState)")
+            return
+        }
+    }
+
+    @Test("changing the selection resets the explanation to .idle")
+    func selectionChangeResets() async throws {
+        let (model, root) = try await makeModel(explainer: FakeExplainer(chunks: ["done"]))
+        defer { try? FileManager.default.removeItem(at: root) }
+        model.explainSelectedNode()
+        await model.explainTaskForTesting?.value
+        #expect(model.explainState == .complete("done"))
+        model.selectedNodeID = nil
+        #expect(model.explainState == .idle)
+    }
+}

--- a/Tests/AnglesiteAppTests/SiteGraphExplorerModelExplainTests.swift
+++ b/Tests/AnglesiteAppTests/SiteGraphExplorerModelExplainTests.swift
@@ -110,6 +110,28 @@ struct SiteGraphExplorerModelExplainTests {
         }
     }
 
+    @Test("a graph refresh resets the explanation — its grounding snapshot is gone")
+    func refreshResets() async throws {
+        let (model, root) = try await makeModel(explainer: FakeExplainer(chunks: ["done"]))
+        defer { try? FileManager.default.removeItem(at: root) }
+        model.explainSelectedNode()
+        await model.explainTaskForTesting?.value
+        #expect(model.explainState == .complete("done"))
+        await model.refreshNow()
+        #expect(model.explainState == .idle)
+    }
+
+    @Test("stop() winds down an explanation along with the rest of the model")
+    func stopResets() async throws {
+        let (model, root) = try await makeModel(explainer: FakeExplainer(chunks: ["done"]))
+        defer { try? FileManager.default.removeItem(at: root) }
+        model.explainSelectedNode()
+        await model.explainTaskForTesting?.value
+        #expect(model.explainState == .complete("done"))
+        model.stop()
+        #expect(model.explainState == .idle)
+    }
+
     @Test("changing the selection resets the explanation to .idle")
     func selectionChangeResets() async throws {
         let (model, root) = try await makeModel(explainer: FakeExplainer(chunks: ["done"]))

--- a/Tests/AnglesiteAppTests/SiteGraphMiniMapGeometryTests.swift
+++ b/Tests/AnglesiteAppTests/SiteGraphMiniMapGeometryTests.swift
@@ -47,6 +47,13 @@ struct SiteGraphMiniMapGeometryTests {
         #expect(SiteGraphMiniMapGeometry.nearestNodeID(to: CGPoint(x: 10, y: 10), positions: positions) == "near")
     }
 
+    @Test("nearestNodeID misses when the closest node is beyond maxDistance")
+    func nearestNodeRespectsMaxDistance() {
+        let positions = ["only": CGPoint(x: 100, y: 100)]
+        #expect(SiteGraphMiniMapGeometry.nearestNodeID(to: .zero, positions: positions, maxDistance: 20) == nil)
+        #expect(SiteGraphMiniMapGeometry.nearestNodeID(to: CGPoint(x: 90, y: 100), positions: positions, maxDistance: 20) == "only")
+    }
+
     @Test("nearestNodeID breaks exact-distance ties deterministically by node ID")
     func nearestNodeTieBreak() {
         let positions: [String: CGPoint] = [

--- a/Tests/AnglesiteCoreTests/SiteGraphExplainPromptTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphExplainPromptTests.swift
@@ -90,6 +90,19 @@ struct SiteGraphExplainPromptTests {
         #expect(prompt.contains("Nothing else on the site depends on this file"))
     }
 
+    @Test("a neighbor reachable through multiple edge kinds is listed once, not per edge")
+    func dedupesNeighbors() {
+        let target = node("p1", kind: .page, title: "Home")
+        let layout = node("l1", kind: .layout, title: "BaseLayout")
+        let prompt = SiteGraphExplainPrompt.prompt(
+            node: target,
+            impact: impact(forComponentImportedBy: 1),
+            dependsOn: [layout, layout],  // e.g. both imports and usesLayout edges to the same node
+            referencedBy: []
+        )
+        #expect(prompt.ranges(of: "BaseLayout").count == 1)
+    }
+
     @Test("prompt instructs the model to ground on the given facts only")
     func groundingInstruction() {
         let target = node("c1", kind: .component, title: "Header")

--- a/Tests/AnglesiteCoreTests/SiteGraphExplainPromptTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphExplainPromptTests.swift
@@ -1,0 +1,100 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("SiteGraphExplainPrompt")
+struct SiteGraphExplainPromptTests {
+    private func node(
+        _ id: String,
+        kind: SiteGraphNodeKind = .component,
+        title: String? = nil,
+        route: String? = nil,
+        filePath: String? = nil
+    ) -> SiteGraphNode {
+        SiteGraphNode(id: id, kind: kind, title: title ?? id, detail: nil, filePath: filePath, route: route)
+    }
+
+    /// A component imported by `pageCount` pages, so `ImpactAnalysis.analyze` produces a real
+    /// report (Report has no public memberwise init — by design, it's derived, not assembled).
+    private func impact(forComponentImportedBy pageCount: Int) -> ImpactAnalysis.Report {
+        let component = node("c1", kind: .component, title: "Header")
+        let pages = (1...pageCount).map { node("p\($0)", kind: .page, title: "Page \($0)", route: "/page-\($0)") }
+        let snapshot = SiteGraphExplorerSnapshot(
+            nodes: [component] + pages,
+            edges: pages.map { SiteGraphEdge(sourceID: $0.id, targetID: "c1", kind: .imports) }
+        )
+        return ImpactAnalysis.analyze(snapshot: snapshot, targetID: "c1")!
+    }
+
+    @Test("prompt states the node's identity: title, kind, route, and file path")
+    func nodeIdentity() {
+        let target = node("c1", kind: .component, title: "Header", route: "/header", filePath: "src/components/Header.astro")
+        let prompt = SiteGraphExplainPrompt.prompt(node: target, impact: impact(forComponentImportedBy: 1), dependsOn: [], referencedBy: [])
+        #expect(prompt.contains("Header"))
+        #expect(prompt.lowercased().contains("component"))
+        #expect(prompt.contains("/header"))
+        #expect(prompt.contains("src/components/Header.astro"))
+    }
+
+    @Test("prompt lists depends-on and referenced-by neighbors with their kinds")
+    func neighborLists() {
+        let target = node("c1", kind: .component, title: "Header")
+        let prompt = SiteGraphExplainPrompt.prompt(
+            node: target,
+            impact: impact(forComponentImportedBy: 1),
+            dependsOn: [node("a1", kind: .asset, title: "logo.svg")],
+            referencedBy: [node("l1", kind: .layout, title: "BaseLayout")]
+        )
+        #expect(prompt.contains("logo.svg"))
+        #expect(prompt.contains("BaseLayout"))
+        #expect(prompt.lowercased().contains("asset"))
+        #expect(prompt.lowercased().contains("layout"))
+    }
+
+    @Test("prompt omits neighbor lines entirely when there are no neighbors")
+    func omitsEmptyNeighborLines() {
+        let target = node("c1", kind: .component, title: "Header")
+        let prompt = SiteGraphExplainPrompt.prompt(node: target, impact: impact(forComponentImportedBy: 1), dependsOn: [], referencedBy: [])
+        #expect(!prompt.contains("Depends on:"))
+        #expect(!prompt.contains("Referenced by:"))
+    }
+
+    @Test("prompt includes the affected-page count and page titles from the impact report")
+    func impactPages() {
+        let target = node("c1", kind: .component, title: "Header")
+        let prompt = SiteGraphExplainPrompt.prompt(node: target, impact: impact(forComponentImportedBy: 3), dependsOn: [], referencedBy: [])
+        #expect(prompt.contains("3 page"))
+        #expect(prompt.contains("Page 1"))
+        #expect(prompt.contains("Page 3"))
+    }
+
+    @Test("long impact lists are capped and summarized as 'and N more'")
+    func capsLongLists() {
+        let target = node("c1", kind: .component, title: "Header")
+        let count = SiteGraphExplainPrompt.maxListedNames + 5
+        let prompt = SiteGraphExplainPrompt.prompt(node: target, impact: impact(forComponentImportedBy: count), dependsOn: [], referencedBy: [])
+        #expect(prompt.contains("and 5 more"))
+        // "Page 9" would appear within the first maxListedNames (sorted titles: Page 1, Page 10, …);
+        // the highest-sorting title must have been cut.
+        let lastSortedTitle = (1...count).map { "Page \($0)" }.sorted { $0.localizedStandardCompare($1) == .orderedAscending }.last!
+        #expect(!prompt.contains(lastSortedTitle))
+    }
+
+    @Test("prompt says nothing depends on the node when the impact report is empty")
+    func statesNoDependents() {
+        // An isolated asset: nothing references it, it references nothing.
+        let asset = node("a1", kind: .asset, title: "orphan.png")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [asset], edges: [])
+        let report = ImpactAnalysis.analyze(snapshot: snapshot, targetID: "a1")!
+        let prompt = SiteGraphExplainPrompt.prompt(node: asset, impact: report, dependsOn: [], referencedBy: [])
+        #expect(prompt.contains("Nothing else on the site depends on this file"))
+    }
+
+    @Test("prompt instructs the model to ground on the given facts only")
+    func groundingInstruction() {
+        let target = node("c1", kind: .component, title: "Header")
+        let prompt = SiteGraphExplainPrompt.prompt(node: target, impact: impact(forComponentImportedBy: 1), dependsOn: [], referencedBy: [])
+        #expect(prompt.contains("Do not invent"))
+        #expect(prompt.lowercased().contains("only the facts"))
+    }
+}


### PR DESCRIPTION
## Summary

#625 (\"feat: on-device AI explanations of Site Graph nodes (#614)\") was merged into its own base branch, `feat/613-site-graph-minimap` — not `main`. That base branch had *already* been squash-merged into `main` earlier as #622, so #625's commits never actually landed on `main`; they sat on a branch nothing points at anymore.

This PR cherry-picks the three explain-feature commits from #625 onto current `main`:

* `feat: on-device AI explanations of Site Graph nodes (#614)`
* `fix: address self-review findings on Site Graph mini-map + explain`
* `fix: address PR #625 review feedback on explain task`

No content changes — this is a retarget, not a revision. All three cherry-picks applied cleanly with no conflicts.

## Testing

`swift test --filter "SiteGraphExplain|SiteGraphMiniMapGeometry|SiteGraphExplorerModel"` — 23 tests, all green.

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)