### PR TITLE
feat: Component Editor slice 2 — Styles panel write ops

### DIFF
--- a/JS/edit-overlay/src/component-canvas.ts
+++ b/JS/edit-overlay/src/component-canvas.ts
@@ -7,6 +7,7 @@
 
 const HARNESS_PREFIX = "/_anglesite/component/";
 const RING_CLASS = "anglesite-canvas-ring";
+const SCRUB_STYLE_ID = "anglesite-scrub";
 
 // Curated list shown in the inspector's Computed section.
 const REPORTED_PROPERTIES = [
@@ -51,7 +52,23 @@ export function installComponentCanvas(): void {
       if (el) drawRing(el);
     },
     clear: clearRing,
+    scrub,
+    clearScrub,
   };
+}
+
+function scrub(selector: string, property: string, value: string): void {
+  let style = document.getElementById(SCRUB_STYLE_ID) as HTMLStyleElement | null;
+  if (!style) {
+    style = document.createElement("style");
+    style.id = SCRUB_STYLE_ID;
+    document.head.appendChild(style);
+  }
+  style.textContent = `${selector} { ${property}: ${value}; }`;
+}
+
+function clearScrub(): void {
+  document.getElementById(SCRUB_STYLE_ID)?.remove();
 }
 
 /// Astro's dev server stamps `data-astro-source-loc` at the END of an

--- a/JS/edit-overlay/src/component-canvas.ts
+++ b/JS/edit-overlay/src/component-canvas.ts
@@ -57,7 +57,26 @@ export function installComponentCanvas(): void {
   };
 }
 
+/**
+ * `selector`/`property`/`value` are interpolated into the scrub `<style>` tag's raw text — a
+ * `{` or `}` in any of them would break out of the intended `selector { property: value; }`
+ * block and inject arbitrary rules (or attribute selectors) into this harness page's live DOM
+ * while a drag/scrub is in progress. This is a live-preview-only override (the eventual real
+ * `apply_edit` op is what actually validates and commits the value), so fail safe by skipping
+ * the scrub entirely rather than trusting unescaped input.
+ */
+function containsUnsafeCssBreak(value: string): boolean {
+  return value.includes("{") || value.includes("}");
+}
+
 function scrub(selector: string, property: string, value: string): void {
+  if (
+    containsUnsafeCssBreak(selector) ||
+    containsUnsafeCssBreak(property) ||
+    containsUnsafeCssBreak(value)
+  ) {
+    return;
+  }
   let style = document.getElementById(SCRUB_STYLE_ID) as HTMLStyleElement | null;
   if (!style) {
     style = document.createElement("style");

--- a/JS/edit-overlay/test/component-canvas.test.ts
+++ b/JS/edit-overlay/test/component-canvas.test.ts
@@ -86,4 +86,27 @@ describe("component canvas", () => {
     ring = document.querySelector(".anglesite-canvas-ring") as HTMLElement;
     expect(ring).not.toBeNull();
   });
+
+  it("scrub creates a single #anglesite-scrub style tag and updates its content on repeated calls", () => {
+    setPath("/_anglesite/component/Card");
+    document.body.innerHTML = `<article class="card">hi</article>`;
+    installComponentCanvas();
+
+    (window as any).anglesiteCanvas.scrub(".card", "color", "red");
+    expect(document.querySelectorAll("#anglesite-scrub")).toHaveLength(1);
+    expect(document.getElementById("anglesite-scrub")?.textContent).toContain(".card { color: red; }");
+
+    (window as any).anglesiteCanvas.scrub(".card", "color", "blue");
+    expect(document.querySelectorAll("#anglesite-scrub")).toHaveLength(1);
+    expect(document.getElementById("anglesite-scrub")?.textContent).toContain(".card { color: blue; }");
+
+    (window as any).anglesiteCanvas.clearScrub();
+    expect(document.getElementById("anglesite-scrub")).toBeNull();
+  });
+
+  it("clearScrub is safe to call when no scrub tag exists", () => {
+    setPath("/_anglesite/component/Card");
+    installComponentCanvas();
+    expect(() => (window as any).anglesiteCanvas.clearScrub()).not.toThrow();
+  });
 });

--- a/JS/edit-overlay/test/component-canvas.test.ts
+++ b/JS/edit-overlay/test/component-canvas.test.ts
@@ -104,6 +104,19 @@ describe("component canvas", () => {
     expect(document.getElementById("anglesite-scrub")).toBeNull();
   });
 
+  it("scrub rejects a value containing a brace instead of injecting extra rules", () => {
+    setPath("/_anglesite/component/Card");
+    document.body.innerHTML = `<article class="card">hi</article><body-marker></body-marker>`;
+    installComponentCanvas();
+
+    (window as any).anglesiteCanvas.scrub(".card", "color", "red; } body-marker { display:none");
+    expect(document.getElementById("anglesite-scrub")).toBeNull();
+
+    (window as any).anglesiteCanvas.scrub(".card", "color", "red");
+    (window as any).anglesiteCanvas.scrub("} .card", "color", "red");
+    expect(document.getElementById("anglesite-scrub")?.textContent).toContain(".card { color: red; }");
+  });
+
   it("clearScrub is safe to call when no scrub tag exists", () => {
     setPath("/_anglesite/component/Card");
     installComponentCanvas();

--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -138,7 +138,9 @@ final class ComponentEditorModel {
     // MARK: - Style writes
 
     /// Set (or add) a CSS declaration's value within a `<style>` rule identified by `ruleSpan`.
-    func setStyleProperty(ruleSpan: [Int?], property: String, value: String) async {
+    /// Returns whether the write actually applied — see `applyComponentStyleEdit`.
+    @discardableResult
+    func setStyleProperty(ruleSpan: [Int?], property: String, value: String) async -> Bool {
         await applyComponentStyleEdit(
             ComponentStyleEditBuilder.setStyleProperty(
                 id: UUID().uuidString,
@@ -152,7 +154,9 @@ final class ComponentEditorModel {
     }
 
     /// Remove a CSS declaration from a rule identified by `ruleSpan`.
-    func removeStyleProperty(ruleSpan: [Int?], property: String) async {
+    /// Returns whether the write actually applied — see `applyComponentStyleEdit`.
+    @discardableResult
+    func removeStyleProperty(ruleSpan: [Int?], property: String) async -> Bool {
         await applyComponentStyleEdit(
             ComponentStyleEditBuilder.removeStyleProperty(
                 id: UUID().uuidString,
@@ -165,7 +169,9 @@ final class ComponentEditorModel {
     }
 
     /// Rewrite a rule's selector.
-    func setRuleSelector(ruleSpan: [Int?], newSelector: String) async {
+    /// Returns whether the write actually applied — see `applyComponentStyleEdit`.
+    @discardableResult
+    func setRuleSelector(ruleSpan: [Int?], newSelector: String) async -> Bool {
         await applyComponentStyleEdit(
             ComponentStyleEditBuilder.setRuleSelector(
                 id: UUID().uuidString,
@@ -178,7 +184,9 @@ final class ComponentEditorModel {
     }
 
     /// Add a new CSS rule to the component's `<style>` block.
-    func addStyleRule(selector: String, media: String?, declarations: [(property: String, value: String)]) async {
+    /// Returns whether the write actually applied — see `applyComponentStyleEdit`.
+    @discardableResult
+    func addStyleRule(selector: String, media: String?, declarations: [(property: String, value: String)]) async -> Bool {
         await applyComponentStyleEdit(
             ComponentStyleEditBuilder.addStyleRule(
                 id: UUID().uuidString,
@@ -191,17 +199,33 @@ final class ComponentEditorModel {
         )
     }
 
+    /// The span of a style rule at `index` in the current `model`, or `nil` if the model isn't
+    /// loaded or `index` is out of range. Used to re-derive a rule's span after a prior write in
+    /// the same gesture may have shifted byte offsets within the file (see `ComponentEditorView
+    /// .commitDeclaration`'s rename path, which removes then re-adds a declaration on the same
+    /// rule — the remove shifts the rule's own end offset, so the follow-up add must target the
+    /// freshly reloaded span, not the one captured before either write).
+    func ruleSpan(atIndex index: Int) -> ComponentModel.Span? {
+        guard let styles = model?.styles, styles.indices.contains(index) else { return nil }
+        return styles[index].span
+    }
+
     /// Routes a built `EditMessage` to `context.editRouter` and reconciles the result:
     /// - `.applied` with a piggybacked `reply.model` adopts it directly (no second fetch).
     /// - `.applied` without one falls back to `load()`.
-    /// - `.failed` whose message indicates the base version went stale triggers a `load()`
-    ///   refetch and flips `conflict` so the UI can surface a "changed outside Anglesite —
-    ///   Reload" banner.
+    /// - `.failed` with reason `"stale"` (the plugin's machine-readable refusal code — see
+    ///   `EditReply.reason`) triggers a `load()` refetch and flips `conflict` so the UI can
+    ///   surface a "changed outside Anglesite — Reload" banner.
     /// - Any other `.failed` (or `.ambiguous`/`.preview`, which these ops never return) is a
     ///   routine, recoverable write failure — surfaced via `writeError`, NOT `loadError`/
     ///   `loadErrorReason` (see `writeError`'s doc comment for why).
-    private func applyComponentStyleEdit(_ message: EditMessage) async {
-        guard let editRouter = context.editRouter else { return }
+    ///
+    /// Returns whether the op actually applied — callers that must sequence a follow-up op
+    /// against a rule this call may have mutated (e.g. a property rename's remove-then-add)
+    /// use this to avoid compounding a failure and to know a fresh `model` is available.
+    @discardableResult
+    private func applyComponentStyleEdit(_ message: EditMessage) async -> Bool {
+        guard let editRouter = context.editRouter else { return false }
         let reply = await editRouter.apply(message)
         switch reply.status {
         case .applied:
@@ -212,11 +236,14 @@ final class ComponentEditorModel {
             } else {
                 await load()
             }
-        case .failed where (reply.message ?? "").contains("stale"):
+            return true
+        case .failed where reply.reason == "stale":
             conflict = true
             await load()
+            return false
         default:
             writeError = reply.message ?? "The edit couldn't be applied."
+            return false
         }
     }
 }

--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -40,6 +40,11 @@ final class ComponentEditorModel {
     var selectedNodeID: String?
     var computedStyles: [String: String] = [:]
     var knobValues: [String: String] = [:]
+    /// Set when a write op is refused as stale (the source changed outside Anglesite since
+    /// `model` was fetched) — drives the "changed outside Anglesite — Reload" banner (design
+    /// doc §5). `load()` is triggered automatically to refetch; the flag stays set until the
+    /// caller acknowledges it (e.g. the panel dismisses it once the refreshed model renders).
+    private(set) var conflict = false
 
     init(file: FileRef, context: ComponentEditorContext) {
         self.file = file
@@ -120,5 +125,89 @@ final class ComponentEditorModel {
             return
         }
         selectedNodeID = ComponentOutline.node(atLine: line, column: column, in: model.template)?.id
+    }
+
+    // MARK: - Style writes
+
+    /// Set (or add) a CSS declaration's value within a `<style>` rule identified by `ruleSpan`.
+    func setStyleProperty(ruleSpan: [Int?], property: String, value: String) async {
+        await applyComponentStyleEdit(
+            ComponentStyleEditBuilder.setStyleProperty(
+                id: UUID().uuidString,
+                path: relativePath,
+                baseVersion: model?.version ?? "",
+                ruleSpan: ruleSpan,
+                property: property,
+                value: value
+            )
+        )
+    }
+
+    /// Remove a CSS declaration from a rule identified by `ruleSpan`.
+    func removeStyleProperty(ruleSpan: [Int?], property: String) async {
+        await applyComponentStyleEdit(
+            ComponentStyleEditBuilder.removeStyleProperty(
+                id: UUID().uuidString,
+                path: relativePath,
+                baseVersion: model?.version ?? "",
+                ruleSpan: ruleSpan,
+                property: property
+            )
+        )
+    }
+
+    /// Rewrite a rule's selector.
+    func setRuleSelector(ruleSpan: [Int?], newSelector: String) async {
+        await applyComponentStyleEdit(
+            ComponentStyleEditBuilder.setRuleSelector(
+                id: UUID().uuidString,
+                path: relativePath,
+                baseVersion: model?.version ?? "",
+                ruleSpan: ruleSpan,
+                newSelector: newSelector
+            )
+        )
+    }
+
+    /// Add a new CSS rule to the component's `<style>` block.
+    func addStyleRule(selector: String, media: String?, declarations: [(property: String, value: String)]) async {
+        await applyComponentStyleEdit(
+            ComponentStyleEditBuilder.addStyleRule(
+                id: UUID().uuidString,
+                path: relativePath,
+                baseVersion: model?.version ?? "",
+                selector: selector,
+                media: media,
+                declarations: declarations
+            )
+        )
+    }
+
+    /// Routes a built `EditMessage` to `context.editRouter` and reconciles the result:
+    /// - `.applied` with a piggybacked `reply.model` adopts it directly (no second fetch).
+    /// - `.applied` without one falls back to `load()`.
+    /// - `.failed` whose message indicates the base version went stale triggers a `load()`
+    ///   refetch and flips `conflict` so the UI can surface a "changed outside Anglesite —
+    ///   Reload" banner.
+    /// - Any other `.failed` (or `.ambiguous`/`.preview`, which these ops never return) is
+    ///   surfaced via `loadErrorReason`.
+    private func applyComponentStyleEdit(_ message: EditMessage) async {
+        guard let editRouter = context.editRouter else { return }
+        let reply = await editRouter.apply(message)
+        switch reply.status {
+        case .applied:
+            conflict = false
+            if let freshModel = reply.model {
+                model = freshModel
+            } else {
+                await load()
+            }
+        case .failed where (reply.message ?? "").contains("stale"):
+            conflict = true
+            await load()
+        default:
+            loadError = reply.message
+            loadErrorReason = .other
+        }
     }
 }

--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -44,7 +44,15 @@ final class ComponentEditorModel {
     /// `model` was fetched) — drives the "changed outside Anglesite — Reload" banner (design
     /// doc §5). `load()` is triggered automatically to refetch; the flag stays set until the
     /// caller acknowledges it (e.g. the panel dismisses it once the refreshed model renders).
-    private(set) var conflict = false
+    var conflict = false
+    /// Set when a style write op fails for a reason other than staleness (invalid CSS value, a
+    /// `no-match` on a drifted `ruleSpan`, a transient MCP/transport error). This is intentionally
+    /// distinct from `loadError`/`loadErrorReason`: those drive `ComponentEditorView`'s full-pane
+    /// `ContentUnavailableView` takeover, which would destroy the three-pane editor (outline/canvas/
+    /// inspector) over a routine, retryable write failure and leave the user with no way to retry.
+    /// `writeError` instead drives a small dismissible banner scoped to the Styles panel; `model`
+    /// and `loadError` are left untouched so the editor pane stays live.
+    var writeError: String?
 
     init(file: FileRef, context: ComponentEditorContext) {
         self.file = file
@@ -189,14 +197,16 @@ final class ComponentEditorModel {
     /// - `.failed` whose message indicates the base version went stale triggers a `load()`
     ///   refetch and flips `conflict` so the UI can surface a "changed outside Anglesite —
     ///   Reload" banner.
-    /// - Any other `.failed` (or `.ambiguous`/`.preview`, which these ops never return) is
-    ///   surfaced via `loadErrorReason`.
+    /// - Any other `.failed` (or `.ambiguous`/`.preview`, which these ops never return) is a
+    ///   routine, recoverable write failure — surfaced via `writeError`, NOT `loadError`/
+    ///   `loadErrorReason` (see `writeError`'s doc comment for why).
     private func applyComponentStyleEdit(_ message: EditMessage) async {
         guard let editRouter = context.editRouter else { return }
         let reply = await editRouter.apply(message)
         switch reply.status {
         case .applied:
             conflict = false
+            writeError = nil
             if let freshModel = reply.model {
                 model = freshModel
             } else {
@@ -206,8 +216,7 @@ final class ComponentEditorModel {
             conflict = true
             await load()
         default:
-            loadError = reply.message
-            loadErrorReason = .other
+            writeError = reply.message ?? "The edit couldn't be applied."
         }
     }
 }

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -298,6 +298,15 @@ struct ComponentEditorView: View {
         "\(span.start ?? -1)-\(span.end ?? -1)"
     }
 
+    /// Escapes a Swift string into a double-quoted JS string literal for
+    /// interpolation into `evaluateJavaScript` call sites.
+    private func jsStringLiteral(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+
     private func spanArray(_ span: ComponentModel.Span) -> [Int?] {
         [span.start, span.end]
     }
@@ -339,7 +348,11 @@ struct ComponentEditorView: View {
                 ColorPicker("", selection: Binding(
                     get: { color },
                     set: { newColor in
-                        valueDrafts[key] = CSSColor.format(newColor)
+                        let formatted = CSSColor.format(newColor)
+                        valueDrafts[key] = formatted
+                        webView?.evaluateJavaScript(
+                            "window.anglesiteCanvas?.scrub?.(\(jsStringLiteral(rule.selector)), \(jsStringLiteral(decl.property)), \(jsStringLiteral(formatted)))"
+                        )
                         debounceColorCommit(key, model, rule: rule, decl: decl)
                     }
                 ))
@@ -362,6 +375,7 @@ struct ComponentEditorView: View {
             try? await Task.sleep(for: .milliseconds(350))
             guard !Task.isCancelled else { return }
             commitDeclaration(model, rule: rule, decl: decl)
+            _ = try? await webView?.evaluateJavaScript("window.anglesiteCanvas?.clearScrub?.()")
             colorCommitTasks[key] = nil
         }
     }

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -302,13 +302,27 @@ struct ComponentEditorView: View {
         decl: ComponentModel.Declaration
     ) -> some View {
         let key = spanKey(decl.span)
-        TextField("value", text: Binding(
+        let valueBinding = Binding(
             get: { valueDrafts[key] ?? decl.value },
             set: { valueDrafts[key] = $0 }
-        ))
-        .font(.system(.caption, design: .monospaced))
-        .textFieldStyle(.plain)
-        .onSubmit { commitDeclaration(model, rule: rule, decl: decl) }
+        )
+        HStack(spacing: 4) {
+            TextField("value", text: valueBinding)
+                .font(.system(.caption, design: .monospaced))
+                .textFieldStyle(.plain)
+                .onSubmit { commitDeclaration(model, rule: rule, decl: decl) }
+            if CSSColor.colorProperties.contains(decl.property),
+               let color = CSSColor.parse(valueBinding.wrappedValue) {
+                ColorPicker("", selection: Binding(
+                    get: { color },
+                    set: { newColor in
+                        valueDrafts[key] = CSSColor.format(newColor)
+                        commitDeclaration(model, rule: rule, decl: decl)
+                    }
+                ))
+                .labelsHidden()
+            }
+        }
     }
 
     private func commitSelector(_ model: ComponentEditorModel, rule: ComponentModel.StyleRule) {

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -208,11 +208,11 @@ struct ComponentEditorView: View {
                                             .font(.system(.caption, design: .monospaced))
                                             .textFieldStyle(.plain)
                                             .frame(width: 110)
-                                            .onSubmit { commitDeclaration(model, rule: rule, decl: decl) }
+                                            .onSubmit { commitDeclaration(model, ruleIndex: ruleIndex, rule: rule, decl: decl) }
                                         Text(":")
-                                        declarationValueField(model, rule: rule, decl: decl)
+                                        declarationValueField(model, ruleIndex: ruleIndex, rule: rule, decl: decl)
                                         Button(role: .destructive) {
-                                            Task { await model.removeStyleProperty(ruleSpan: spanArray(rule.span), property: decl.property) }
+                                            removeDeclaration(model, rule: rule, decl: decl)
                                         } label: {
                                             Image(systemName: "minus.circle")
                                         }
@@ -378,6 +378,7 @@ struct ComponentEditorView: View {
     @ViewBuilder
     private func declarationValueField(
         _ model: ComponentEditorModel,
+        ruleIndex: Int,
         rule: ComponentModel.StyleRule,
         decl: ComponentModel.Declaration
     ) -> some View {
@@ -390,7 +391,7 @@ struct ComponentEditorView: View {
             TextField("value", text: valueBinding)
                 .font(.system(.caption, design: .monospaced))
                 .textFieldStyle(.plain)
-                .onSubmit { commitDeclaration(model, rule: rule, decl: decl) }
+                .onSubmit { commitDeclaration(model, ruleIndex: ruleIndex, rule: rule, decl: decl) }
             if CSSColor.colorProperties.contains(decl.property),
                let color = CSSColor.parse(valueBinding.wrappedValue) {
                 ColorPicker("", selection: Binding(
@@ -401,7 +402,7 @@ struct ComponentEditorView: View {
                         webView?.evaluateJavaScript(
                             "window.anglesiteCanvas?.scrub?.(\(jsStringLiteral(rule.selector)), \(jsStringLiteral(decl.property)), \(jsStringLiteral(formatted)))"
                         )
-                        debounceColorCommit(key, model, rule: rule, decl: decl)
+                        debounceColorCommit(key, model, ruleIndex: ruleIndex, rule: rule, decl: decl)
                     }
                 ))
                 .labelsHidden()
@@ -415,6 +416,7 @@ struct ComponentEditorView: View {
     private func debounceColorCommit(
         _ key: String,
         _ model: ComponentEditorModel,
+        ruleIndex: Int,
         rule: ComponentModel.StyleRule,
         decl: ComponentModel.Declaration
     ) {
@@ -422,7 +424,7 @@ struct ComponentEditorView: View {
         colorCommitTasks[key] = Task {
             try? await Task.sleep(for: .milliseconds(350))
             guard !Task.isCancelled else { return }
-            commitDeclaration(model, rule: rule, decl: decl)
+            commitDeclaration(model, ruleIndex: ruleIndex, rule: rule, decl: decl)
             _ = try? await webView?.evaluateJavaScript("window.anglesiteCanvas?.clearScrub?.()")
             colorCommitTasks[key] = nil
         }
@@ -435,11 +437,39 @@ struct ComponentEditorView: View {
         Task { await model.setRuleSelector(ruleSpan: spanArray(rule.span), newSelector: newSelector) }
     }
 
+    /// Cancels any pending debounced `ColorPicker` commit and discards the in-progress drafts
+    /// for `decl` before removing it. Without this, a declaration removed mid-drag (before the
+    /// `debounceColorCommit` delay elapses) would have its pending commit fire afterward and
+    /// resurrect the just-deleted declaration via `setStyleProperty`.
+    private func removeDeclaration(
+        _ model: ComponentEditorModel,
+        rule: ComponentModel.StyleRule,
+        decl: ComponentModel.Declaration
+    ) {
+        let key = spanKey(decl.span)
+        colorCommitTasks[key]?.cancel()
+        colorCommitTasks[key] = nil
+        valueDrafts[key] = nil
+        propertyDrafts[key] = nil
+        Task { await model.removeStyleProperty(ruleSpan: spanArray(rule.span), property: decl.property) }
+    }
+
     /// Commits both the property-name and value drafts for a declaration.
     /// Called from either field's `onSubmit` so an edit to just the property
     /// name (value unchanged) still lands, not only edits to the value field.
+    ///
+    /// A property rename is a remove-then-add sequence against the *same* rule: removing the
+    /// old declaration shifts byte offsets within the file (including, in general, the rule's
+    /// own end offset), so the second write must target the rule's freshly reloaded span, not
+    /// the one captured before either op ran — reusing the stale span would make the add
+    /// mismatch or fail outright on essentially every rename. `ruleIndex` (the rule's stable
+    /// ordinal position — these two ops never add/remove/reorder rules) is used to re-derive
+    /// the fresh span from `model.model` after the remove completes. If the remove itself
+    /// failed, the rename is abandoned rather than adding the new name anyway, which would
+    /// otherwise leave both the old and new declarations present.
     private func commitDeclaration(
         _ model: ComponentEditorModel,
+        ruleIndex: Int,
         rule: ComponentModel.StyleRule,
         decl: ComponentModel.Declaration
     ) {
@@ -451,8 +481,10 @@ struct ComponentEditorView: View {
         let oldProperty = decl.property
         if property != oldProperty {
             Task {
-                await model.removeStyleProperty(ruleSpan: ruleSpan, property: oldProperty)
-                await model.setStyleProperty(ruleSpan: ruleSpan, property: property, value: value)
+                let removed = await model.removeStyleProperty(ruleSpan: ruleSpan, property: oldProperty)
+                guard removed else { return }
+                let freshSpan = model.ruleSpan(atIndex: ruleIndex).map(spanArray) ?? ruleSpan
+                await model.setStyleProperty(ruleSpan: freshSpan, property: property, value: value)
             }
         } else {
             Task { await model.setStyleProperty(ruleSpan: ruleSpan, property: property, value: value) }

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -22,6 +22,13 @@ struct ComponentEditorView: View {
     @State private var propertyDrafts: [String: String] = [:]
     /// In-progress edits to a declaration's value, keyed by `spanKey(decl.span)`.
     @State private var valueDrafts: [String: String] = [:]
+    /// Pending debounced commit from a `ColorPicker` drag, keyed by `spanKey(decl.span)`.
+    /// macOS `ColorPicker` updates its binding continuously while the system color panel is
+    /// being dragged, so committing on every change would fire a burst of redundant
+    /// `setStyleProperty` round-trips (and risk spurious `.failed`/stale-`baseVersion` conflicts).
+    /// Each new picker value cancels the previous pending commit and restarts the delay, so only
+    /// the settled value after the drag pauses actually commits.
+    @State private var colorCommitTasks: [String: Task<Void, Never>] = [:]
 
     enum Mode: String, CaseIterable { case design = "Design", source = "Source" }
 
@@ -317,11 +324,29 @@ struct ComponentEditorView: View {
                     get: { color },
                     set: { newColor in
                         valueDrafts[key] = CSSColor.format(newColor)
-                        commitDeclaration(model, rule: rule, decl: decl)
+                        debounceColorCommit(key, model, rule: rule, decl: decl)
                     }
                 ))
                 .labelsHidden()
             }
+        }
+    }
+
+    /// Debounces `ColorPicker` writes: cancels any pending commit for this declaration and
+    /// schedules a new one after a short pause, so only the settled value after a drag gesture
+    /// actually calls `commitDeclaration` (see `colorCommitTasks` doc comment).
+    private func debounceColorCommit(
+        _ key: String,
+        _ model: ComponentEditorModel,
+        rule: ComponentModel.StyleRule,
+        decl: ComponentModel.Declaration
+    ) {
+        colorCommitTasks[key]?.cancel()
+        colorCommitTasks[key] = Task {
+            try? await Task.sleep(for: .milliseconds(350))
+            guard !Task.isCancelled else { return }
+            commitDeclaration(model, rule: rule, decl: decl)
+            colorCommitTasks[key] = nil
         }
     }
 

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -184,6 +184,12 @@ struct ComponentEditorView: View {
                         }
                     }
                 }
+                if model.conflict {
+                    conflictBanner(model)
+                }
+                if let writeError = model.writeError {
+                    writeErrorBanner(model, message: writeError)
+                }
                 GroupBox("Styles") {
                     if let styles = model.model?.styles, !styles.isEmpty {
                         ForEach(Array(styles.enumerated()), id: \.offset) { ruleIndex, rule in
@@ -257,6 +263,48 @@ struct ComponentEditorView: View {
             }
             .padding(10)
         }
+    }
+
+    /// "This component changed outside Anglesite" banner — the edit that triggered a stale-write
+    /// refusal was never applied; `ComponentEditorModel.applyComponentStyleEdit` already reloaded
+    /// the latest version, so this just informs the user why their change didn't stick.
+    private func conflictBanner(_ model: ComponentEditorModel) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "arrow.triangle.2.circlepath").foregroundStyle(.orange)
+            Text("This component changed outside Anglesite — your edit wasn't applied, reloaded the latest version.")
+                .font(.caption)
+            Spacer()
+            Button {
+                model.conflict = false
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+        }
+        .padding(8)
+        .background(.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    /// Transient, non-fatal banner for a style write op that failed for a reason other than
+    /// staleness (invalid value, drifted `ruleSpan`, transient MCP error). Scoped to the Styles
+    /// panel so a routine write failure never takes over the whole editor pane (see
+    /// `ComponentEditorModel.writeError`'s doc comment).
+    private func writeErrorBanner(_ model: ComponentEditorModel, message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle").foregroundStyle(.red)
+            Text(message).font(.caption)
+            Spacer()
+            Button {
+                model.writeError = nil
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+        }
+        .padding(8)
+        .background(.red.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
     }
 
     private func highlightInCanvas(nodeID: String?) {

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -29,6 +29,8 @@ struct ComponentEditorView: View {
     /// Each new picker value cancels the previous pending commit and restarts the delay, so only
     /// the settled value after the drag pauses actually commits.
     @State private var colorCommitTasks: [String: Task<Void, Never>] = [:]
+    /// Selector text for the inline "Add rule" form at the bottom of the Styles panel.
+    @State private var newRuleSelector: String = ""
 
     enum Mode: String, CaseIterable { case design = "Design", source = "Source" }
 
@@ -226,6 +228,20 @@ struct ComponentEditorView: View {
                         }
                     } else {
                         Text("No scoped styles").foregroundStyle(.secondary)
+                    }
+                    Divider()
+                    HStack {
+                        TextField("New selector, e.g. .card-footer", text: $newRuleSelector)
+                            .font(.system(.caption, design: .monospaced))
+                        Button("Add rule") {
+                            let selector = newRuleSelector.trimmingCharacters(in: .whitespaces)
+                            guard !selector.isEmpty else { return }
+                            Task {
+                                await model.addStyleRule(selector: selector, media: nil, declarations: [])
+                                newRuleSelector = ""
+                            }
+                        }
+                        .disabled(newRuleSelector.trimmingCharacters(in: .whitespaces).isEmpty)
                     }
                 }
                 GroupBox("Computed") {

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -205,7 +205,8 @@ struct ComponentEditorView: View {
                                     }
                                 }
                                 Button("Add declaration") {
-                                    Task { await model.setStyleProperty(ruleSpan: spanArray(rule.span), property: "new-property", value: "") }
+                                    let newProperty = "new-property-\(UUID().uuidString.prefix(8))"
+                                    Task { await model.setStyleProperty(ruleSpan: spanArray(rule.span), property: newProperty, value: "") }
                                 }
                                 .font(.caption2)
                                 .buttonStyle(.plain)
@@ -329,7 +330,16 @@ struct ComponentEditorView: View {
         let property = propertyDrafts[key] ?? decl.property
         let value = valueDrafts[key] ?? decl.value
         guard property != decl.property || value != decl.value else { return }
-        Task { await model.setStyleProperty(ruleSpan: spanArray(rule.span), property: property, value: value) }
+        let ruleSpan = spanArray(rule.span)
+        let oldProperty = decl.property
+        if property != oldProperty {
+            Task {
+                await model.removeStyleProperty(ruleSpan: ruleSpan, property: oldProperty)
+                await model.setStyleProperty(ruleSpan: ruleSpan, property: property, value: value)
+            }
+        } else {
+            Task { await model.setStyleProperty(ruleSpan: ruleSpan, property: property, value: value) }
+        }
     }
 }
 

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -14,6 +14,15 @@ struct ComponentEditorView: View {
     @State private var mode: Mode = .design
     @State private var webView: WKWebView?
 
+    /// In-progress edits to a rule's selector, keyed by `spanKey(rule.span)`,
+    /// pending commit (on focus loss) to `ComponentEditorModel.setRuleSelector`.
+    @State private var selectorDrafts: [String: String] = [:]
+    /// In-progress edits to a declaration's property name, keyed by
+    /// `spanKey(decl.span)`, pending commit to `setStyleProperty`.
+    @State private var propertyDrafts: [String: String] = [:]
+    /// In-progress edits to a declaration's value, keyed by `spanKey(decl.span)`.
+    @State private var valueDrafts: [String: String] = [:]
+
     enum Mode: String, CaseIterable { case design = "Design", source = "Source" }
 
     init(file: FileRef, context: ComponentEditorContext, fileEditor: FileEditorModel) {
@@ -168,18 +177,44 @@ struct ComponentEditorView: View {
                 }
                 GroupBox("Styles") {
                     if let styles = model.model?.styles, !styles.isEmpty {
-                        ForEach(Array(styles.enumerated()), id: \.offset) { _, rule in
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(rule.media.map { "@media \($0)" } ?? "")
-                                    .font(.caption2).foregroundStyle(.secondary)
-                                Text(rule.selector).font(.system(.caption, design: .monospaced)).bold()
-                                ForEach(rule.declarations, id: \.property) { decl in
-                                    Text("\(decl.property): \(decl.value);")
-                                        .font(.system(.caption, design: .monospaced))
+                        ForEach(Array(styles.enumerated()), id: \.offset) { ruleIndex, rule in
+                            VStack(alignment: .leading, spacing: 4) {
+                                if let media = rule.media {
+                                    Text("@media \(media)").font(.caption2).foregroundStyle(.secondary)
                                 }
+                                TextField("selector", text: selectorBinding(for: rule))
+                                    .font(.system(.caption, design: .monospaced))
+                                    .textFieldStyle(.plain)
+                                    .bold()
+                                    .onSubmit { commitSelector(model, rule: rule) }
+                                ForEach(rule.declarations, id: \.property) { decl in
+                                    HStack(spacing: 4) {
+                                        TextField("property", text: propertyBinding(for: decl))
+                                            .font(.system(.caption, design: .monospaced))
+                                            .textFieldStyle(.plain)
+                                            .frame(width: 110)
+                                            .onSubmit { commitDeclaration(model, rule: rule, decl: decl) }
+                                        Text(":")
+                                        declarationValueField(model, rule: rule, decl: decl)
+                                        Button(role: .destructive) {
+                                            Task { await model.removeStyleProperty(ruleSpan: spanArray(rule.span), property: decl.property) }
+                                        } label: {
+                                            Image(systemName: "minus.circle")
+                                        }
+                                        .buttonStyle(.plain)
+                                    }
+                                }
+                                Button("Add declaration") {
+                                    Task { await model.setStyleProperty(ruleSpan: spanArray(rule.span), property: "new-property", value: "") }
+                                }
+                                .font(.caption2)
+                                .buttonStyle(.plain)
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.vertical, 2)
+                            .padding(.vertical, 4)
+                            if ruleIndex < styles.count - 1 {
+                                Divider()
+                            }
                         }
                     } else {
                         Text("No scoped styles").foregroundStyle(.secondary)
@@ -229,6 +264,72 @@ struct ComponentEditorView: View {
         case .expression: "{…}"
         default: node.tag ?? node.kind.rawValue
         }
+    }
+
+    // MARK: - Styles panel editing
+
+    /// `ComponentModel.Span` isn't `CustomStringConvertible`, so build a
+    /// stable dictionary key from its optional start/end offsets directly.
+    private func spanKey(_ span: ComponentModel.Span) -> String {
+        "\(span.start ?? -1)-\(span.end ?? -1)"
+    }
+
+    private func spanArray(_ span: ComponentModel.Span) -> [Int?] {
+        [span.start, span.end]
+    }
+
+    private func selectorBinding(for rule: ComponentModel.StyleRule) -> Binding<String> {
+        let key = spanKey(rule.span)
+        return Binding(
+            get: { selectorDrafts[key] ?? rule.selector },
+            set: { selectorDrafts[key] = $0 }
+        )
+    }
+
+    private func propertyBinding(for decl: ComponentModel.Declaration) -> Binding<String> {
+        let key = spanKey(decl.span)
+        return Binding(
+            get: { propertyDrafts[key] ?? decl.property },
+            set: { propertyDrafts[key] = $0 }
+        )
+    }
+
+    @ViewBuilder
+    private func declarationValueField(
+        _ model: ComponentEditorModel,
+        rule: ComponentModel.StyleRule,
+        decl: ComponentModel.Declaration
+    ) -> some View {
+        let key = spanKey(decl.span)
+        TextField("value", text: Binding(
+            get: { valueDrafts[key] ?? decl.value },
+            set: { valueDrafts[key] = $0 }
+        ))
+        .font(.system(.caption, design: .monospaced))
+        .textFieldStyle(.plain)
+        .onSubmit { commitDeclaration(model, rule: rule, decl: decl) }
+    }
+
+    private func commitSelector(_ model: ComponentEditorModel, rule: ComponentModel.StyleRule) {
+        let key = spanKey(rule.span)
+        let newSelector = selectorDrafts[key] ?? rule.selector
+        guard newSelector != rule.selector else { return }
+        Task { await model.setRuleSelector(ruleSpan: spanArray(rule.span), newSelector: newSelector) }
+    }
+
+    /// Commits both the property-name and value drafts for a declaration.
+    /// Called from either field's `onSubmit` so an edit to just the property
+    /// name (value unchanged) still lands, not only edits to the value field.
+    private func commitDeclaration(
+        _ model: ComponentEditorModel,
+        rule: ComponentModel.StyleRule,
+        decl: ComponentModel.Declaration
+    ) {
+        let key = spanKey(decl.span)
+        let property = propertyDrafts[key] ?? decl.property
+        let value = valueDrafts[key] ?? decl.value
+        guard property != decl.property || value != decl.value else { return }
+        Task { await model.setStyleProperty(ruleSpan: spanArray(rule.span), property: property, value: value) }
     }
 }
 

--- a/Sources/AnglesiteCore/CSSColor.swift
+++ b/Sources/AnglesiteCore/CSSColor.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Best-effort CSS <color> <-> SwiftUI Color bridge for the Styles panel's ColorPicker.
+/// Only handles #rgb/#rrggbb/#rrggbbaa hex forms — named colors and rgb()/hsl() fall back
+/// to the free-text field, which always remains available.
+public enum CSSColor {
+    public static func parse(_ value: String) -> Color? {
+        var hex = value.trimmingCharacters(in: .whitespaces)
+        guard hex.hasPrefix("#") else { return nil }
+        hex.removeFirst()
+        guard hex.count == 3 || hex.count == 6 || hex.count == 8 else { return nil }
+        if hex.count == 3 {
+            hex = hex.map { "\($0)\($0)" }.joined()
+        }
+        guard let value = UInt64(hex, radix: 16) else { return nil }
+        let hasAlpha = hex.count == 8
+        let r = Double((value >> (hasAlpha ? 24 : 16)) & 0xFF) / 255
+        let g = Double((value >> (hasAlpha ? 16 : 8)) & 0xFF) / 255
+        let b = Double((value >> (hasAlpha ? 8 : 0)) & 0xFF) / 255
+        let a = hasAlpha ? Double(value & 0xFF) / 255 : 1
+        return Color(red: r, green: g, blue: b, opacity: a)
+    }
+
+    public static func format(_ color: Color) -> String {
+        guard let components = color.cgColor?.components, components.count >= 3 else { return "#000000" }
+        let r = Int((components[0] * 255).rounded())
+        let g = Int((components[1] * 255).rounded())
+        let b = Int((components[2] * 255).rounded())
+        return String(format: "#%02x%02x%02x", r, g, b)
+    }
+
+    public static let colorProperties: Set<String> = [
+        "color", "background-color", "border-color", "outline-color", "fill", "stroke",
+        "border-top-color", "border-right-color", "border-bottom-color", "border-left-color",
+    ]
+}

--- a/Sources/AnglesiteCore/CSSColor.swift
+++ b/Sources/AnglesiteCore/CSSColor.swift
@@ -22,11 +22,19 @@ public enum CSSColor {
     }
 
     public static func format(_ color: Color) -> String {
-        guard let components = color.cgColor?.components, components.count >= 3 else { return "#000000" }
+        guard let cgColor = color.cgColor, let components = cgColor.components, components.count >= 3 else {
+            return "#000000"
+        }
         let r = Int((components[0] * 255).rounded())
         let g = Int((components[1] * 255).rounded())
         let b = Int((components[2] * 255).rounded())
-        return String(format: "#%02x%02x%02x", r, g, b)
+        // `components` is [r, g, b, alpha] for RGB-family color spaces; `cgColor.alpha` is the
+        // authoritative alpha regardless of component layout, so use it rather than indexing
+        // components[3] (which would be wrong for e.g. a grayscale-backed CGColor).
+        let alpha = cgColor.alpha
+        guard alpha < 1 else { return String(format: "#%02x%02x%02x", r, g, b) }
+        let a = Int((alpha * 255).rounded())
+        return String(format: "#%02x%02x%02x%02x", r, g, b, a)
     }
 
     public static let colorProperties: Set<String> = [

--- a/Sources/AnglesiteCore/ComponentStyleEditBuilder.swift
+++ b/Sources/AnglesiteCore/ComponentStyleEditBuilder.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Builds the wire-format `EditMessage` payloads for the four Component Editor CSS write ops
+/// (`set-style-property`, `remove-style-property`, `add-style-rule`, `set-rule-selector`).
+/// Pure and testable — no MCP/router dependency. `ComponentEditorModel` (AnglesiteApp) calls
+/// this to construct the message, then hands it to `context.editRouter`.
+public enum ComponentStyleEditBuilder {
+    /// `ruleSpan` is the target rule's byte span (`[start, end]`, either may be `nil`) — the wire
+    /// format encodes each element as a JSON number or `null`.
+    private static func ruleSpanValue(_ ruleSpan: [Int?]) -> JSONValue {
+        .array(ruleSpan.map { $0.map(JSONValue.int) ?? .null })
+    }
+
+    public static func setStyleProperty(
+        id: String,
+        path: String,
+        baseVersion: String,
+        ruleSpan: [Int?],
+        property: String,
+        value: String
+    ) -> EditMessage {
+        EditMessage(
+            id: id,
+            path: path,
+            selector: nil,
+            op: EditMessage.Op.setStyleProperty,
+            component: .object([
+                "path": .string(path),
+                "baseVersion": .string(baseVersion),
+                "ruleSpan": ruleSpanValue(ruleSpan),
+                "property": .string(property),
+                "value": .string(value),
+            ]),
+            value: nil
+        )
+    }
+
+    public static func removeStyleProperty(
+        id: String,
+        path: String,
+        baseVersion: String,
+        ruleSpan: [Int?],
+        property: String
+    ) -> EditMessage {
+        EditMessage(
+            id: id,
+            path: path,
+            selector: nil,
+            op: EditMessage.Op.removeStyleProperty,
+            component: .object([
+                "path": .string(path),
+                "baseVersion": .string(baseVersion),
+                "ruleSpan": ruleSpanValue(ruleSpan),
+                "property": .string(property),
+            ]),
+            value: nil
+        )
+    }
+
+    public static func setRuleSelector(
+        id: String,
+        path: String,
+        baseVersion: String,
+        ruleSpan: [Int?],
+        newSelector: String
+    ) -> EditMessage {
+        EditMessage(
+            id: id,
+            path: path,
+            selector: nil,
+            op: EditMessage.Op.setRuleSelector,
+            component: .object([
+                "path": .string(path),
+                "baseVersion": .string(baseVersion),
+                "ruleSpan": ruleSpanValue(ruleSpan),
+                "selector": .string(newSelector),
+            ]),
+            value: nil
+        )
+    }
+
+    public static func addStyleRule(
+        id: String,
+        path: String,
+        baseVersion: String,
+        selector: String,
+        media: String?,
+        declarations: [(property: String, value: String)]
+    ) -> EditMessage {
+        var payload: [String: JSONValue] = [
+            "path": .string(path),
+            "baseVersion": .string(baseVersion),
+            "selector": .string(selector),
+            "declarations": .array(declarations.map {
+                .object(["property": .string($0.property), "value": .string($0.value)])
+            }),
+        ]
+        if let media { payload["media"] = .string(media) }
+        return EditMessage(id: id, path: path, selector: nil, op: EditMessage.Op.addStyleRule, component: .object(payload), value: nil)
+    }
+}

--- a/Sources/AnglesiteCore/EditMessage.swift
+++ b/Sources/AnglesiteCore/EditMessage.swift
@@ -31,6 +31,18 @@ public struct EditMessage: Sendable, Equatable {
         /// interpretation. Used by Foundation Models' chat `ApplyEditTool` (#251). Siri AI's
         /// `EditContentIntent` (B.5 / #149) now emits concrete ops instead.
         public static let applyInstruction = "apply-instruction"
+        /// `"set-style-property"` — Component Editor: set a CSS declaration's value (or add it if
+        /// absent) within a `<style>` rule. Carries a `component` payload, not `selector`.
+        public static let setStyleProperty = "set-style-property"
+        /// `"remove-style-property"` — Component Editor: remove a CSS declaration from a rule.
+        /// Carries a `component` payload, not `selector`.
+        public static let removeStyleProperty = "remove-style-property"
+        /// `"add-style-rule"` — Component Editor: add a new CSS rule to a `<style>` block. Carries
+        /// a `component` payload, not `selector`.
+        public static let addStyleRule = "add-style-rule"
+        /// `"set-rule-selector"` — Component Editor: rewrite a CSS rule's selector. Carries a
+        /// `component` payload, not `selector`.
+        public static let setRuleSelector = "set-rule-selector"
     }
 
     /// Overlay-generated correlation ID so the JS side can match replies to the original message.
@@ -39,10 +51,15 @@ public struct EditMessage: Sendable, Equatable {
     /// Page path (e.g. `/about/`).
     public let path: String
     /// Structured element metadata (`ElementInfo`) — the plugin's `server/selector.mjs` resolves
-    /// this to a CSS selector server-side. The bridge is a relay; #18 records the decision.
-    public let selector: JSONValue
+    /// this to a CSS selector server-side. The bridge is a relay; #18 records the decision. `nil`
+    /// for Component Editor ops, which address a component/rule via `component` instead.
+    public let selector: JSONValue?
     /// Edit operation — `"replace-text"`, `"replace-attr"`, etc. Phase 5 finalizes the taxonomy.
     public let op: String
+    /// Component Editor payload — `{ path, baseVersion, ruleSpan, ... }`, op-specific. Carried by
+    /// the CSS write ops (`set-style-property`, `remove-style-property`, `add-style-rule`,
+    /// `set-rule-selector`) instead of `selector`.
+    public let component: JSONValue?
     /// Operation payload — varies by `op`. Optional because some ops (e.g. `"delete"`) won't carry one.
     public let value: JSONValue?
     /// When `true`, the plugin performs a dry run and returns an `anglesite:edit-preview` body
@@ -50,12 +67,22 @@ public struct EditMessage: Sendable, Equatable {
     /// before committing. Defaults `false` so all existing call sites are unaffected.
     public let dryRun: Bool
 
-    public init(id: String, type: MessageType, path: String, selector: JSONValue, op: String, value: JSONValue?, dryRun: Bool = false) {
+    public init(
+        id: String,
+        type: MessageType = .applyEdit,
+        path: String,
+        selector: JSONValue? = nil,
+        op: String,
+        component: JSONValue? = nil,
+        value: JSONValue?,
+        dryRun: Bool = false
+    ) {
         self.id = id
         self.type = type
         self.path = path
         self.selector = selector
         self.op = op
+        self.component = component
         self.value = value
         self.dryRun = dryRun
     }
@@ -69,9 +96,10 @@ public struct EditMessage: Sendable, Equatable {
             "id": .string(id),
             "type": .string(type.rawValue),
             "path": .string(path),
-            "selector": selector,
             "op": .string(op),
         ]
+        if let selector { obj["selector"] = selector }
+        if let component { obj["component"] = component }
         if let value { obj["value"] = value }
         if dryRun { obj["dry_run"] = .bool(true) }
         return .object(obj)
@@ -116,13 +144,30 @@ public struct EditMessage: Sendable, Equatable {
         case .failure(let e): return .failure(e)
         }
 
-        // `selector` is structured (`ElementInfo` shape) — require an object so it's
-        // routable to the plugin's `selector.mjs.buildSelector(info)` unchanged. See #18.
-        guard let rawSelector = dict["selector"] else { return .failure(.missingField("selector")) }
-        guard let jv = JSONValue.from(rawSelector), case .object = jv else {
-            return .failure(.wrongType(field: "selector", expected: "object"))
+        // `selector` is structured (`ElementInfo` shape) — require an object when present so it's
+        // routable to the plugin's `selector.mjs.buildSelector(info)` unchanged. See #18. Absent
+        // for Component Editor ops, which address a component/rule via `component` instead.
+        let selector: JSONValue?
+        if let rawSelector = dict["selector"] {
+            guard let jv = JSONValue.from(rawSelector), case .object = jv else {
+                return .failure(.wrongType(field: "selector", expected: "object"))
+            }
+            selector = jv
+        } else {
+            selector = nil
         }
-        let selector = jv
+
+        // `component` is structured (`{ path, baseVersion, ruleSpan, ... }`) — require an object
+        // when present, mirroring `selector`.
+        let component: JSONValue?
+        if let rawComponent = dict["component"] {
+            guard let jv = JSONValue.from(rawComponent), case .object = jv else {
+                return .failure(.wrongType(field: "component", expected: "object"))
+            }
+            component = jv
+        } else {
+            component = nil
+        }
 
         guard let type = MessageType(rawValue: typeRaw) else {
             return .failure(.unknownType(typeRaw))
@@ -139,6 +184,6 @@ public struct EditMessage: Sendable, Equatable {
             value = nil
         }
 
-        return .success(EditMessage(id: id, type: type, path: path, selector: selector, op: op, value: value))
+        return .success(EditMessage(id: id, type: type, path: path, selector: selector, op: op, component: component, value: value))
     }
 }

--- a/Sources/AnglesiteCore/EditRouter.swift
+++ b/Sources/AnglesiteCore/EditRouter.swift
@@ -23,6 +23,10 @@ public struct EditReply: Sendable, Equatable, Encodable {
     public let after: String?
     /// The op the preview/apply was for (e.g. "edit-style"). `nil` outside preview.
     public let op: String?
+    /// Piggybacked component model — present when the plugin's structured `.applied` reply
+    /// included a `model` key (Component Editor CSS write ops), sparing the app a second
+    /// `get_component_model` round-trip after the edit. `nil` otherwise.
+    public let model: ComponentModel?
 
     public struct ImageResult: Sendable, Equatable, Encodable {
         public let src: String
@@ -47,7 +51,8 @@ public struct EditReply: Sendable, Equatable, Encodable {
         result: ImageResult? = nil,
         before: String? = nil,
         after: String? = nil,
-        op: String? = nil
+        op: String? = nil,
+        model: ComponentModel? = nil
     ) {
         self.id = id
         self.status = status
@@ -58,6 +63,7 @@ public struct EditReply: Sendable, Equatable, Encodable {
         self.before = before
         self.after = after
         self.op = op
+        self.model = model
     }
 }
 
@@ -87,10 +93,11 @@ public struct LoggingEditRouter: EditRouter {
     }
 
     public func apply(_ message: EditMessage) async -> EditReply {
+        let target = message.selector.map { "\($0)" } ?? message.component.map { "\($0)" } ?? "?"
         await logCenter.append(
             source: "bridge",
             stream: .stdout,
-            text: "(stub) would apply \(message.op) on \(message.selector) at \(message.path) [id=\(message.id)]"
+            text: "(stub) would apply \(message.op) on \(target) at \(message.path) [id=\(message.id)]"
         )
         return EditReply(
             id: message.id,

--- a/Sources/AnglesiteCore/EditRouter.swift
+++ b/Sources/AnglesiteCore/EditRouter.swift
@@ -27,6 +27,12 @@ public struct EditReply: Sendable, Equatable, Encodable {
     /// included a `model` key (Component Editor CSS write ops), sparing the app a second
     /// `get_component_model` round-trip after the edit. `nil` otherwise.
     public let model: ComponentModel?
+    /// Machine-readable refusal code from the plugin's `anglesite:edit-failed` body (e.g.
+    /// `"stale"`, `"no-match"`, `"invalid-input"`) — present whenever the router could parse a
+    /// structured failure. Callers that need to distinguish failure kinds (e.g. staleness vs. a
+    /// routine refusal) should switch on this instead of substring-matching `message`, which is
+    /// free-form prose the plugin is free to reword.
+    public let reason: String?
 
     public struct ImageResult: Sendable, Equatable, Encodable {
         public let src: String
@@ -52,7 +58,8 @@ public struct EditReply: Sendable, Equatable, Encodable {
         before: String? = nil,
         after: String? = nil,
         op: String? = nil,
-        model: ComponentModel? = nil
+        model: ComponentModel? = nil,
+        reason: String? = nil
     ) {
         self.id = id
         self.status = status
@@ -64,6 +71,7 @@ public struct EditReply: Sendable, Equatable, Encodable {
         self.after = after
         self.op = op
         self.model = model
+        self.reason = reason
     }
 }
 

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -78,7 +78,8 @@ public struct MCPApplyEditRouter: EditRouter {
                     file: parsed?.file,
                     commit: parsed?.commit,
                     result: parsed?.result,
-                    model: parsed?.model
+                    model: parsed?.model,
+                    reason: parsed?.reason
                 )
             }
             let reply = EditReply(
@@ -124,9 +125,9 @@ public struct MCPApplyEditRouter: EditRouter {
         return PreviewParsed(file: json["file"] as? String, op: json["op"] as? String, before: before, after: after)
     }
 
-    /// Parses the plugin's edit-applied JSON body out of the MCP tool's content text. Returns
-    /// `nil` for non-JSON content (the router falls back to the message-string behavior in
-    /// that case).
+    /// Parses the plugin's edit-applied/edit-failed JSON body out of the MCP tool's content
+    /// text. Returns `nil` for non-JSON content (the router falls back to the message-string
+    /// behavior in that case).
     static func parseStructured(_ text: String) -> Parsed? {
         guard !text.isEmpty,
               let data = text.data(using: .utf8),
@@ -145,8 +146,11 @@ public struct MCPApplyEditRouter: EditRouter {
            let modelData = try? JSONSerialization.data(withJSONObject: modelDict) {
             model = try? JSONDecoder().decode(ComponentModel.self, from: modelData)
         }
-        if file == nil && commit == nil && image == nil && model == nil { return nil }
-        return Parsed(file: file, commit: commit, result: image, model: model)
+        // Present on `anglesite:edit-failed` bodies (e.g. "stale", "no-match", "invalid-input") —
+        // the machine-readable counterpart to the free-form `detail` prose folded into `message`.
+        let reason = json["reason"] as? String
+        if file == nil && commit == nil && image == nil && model == nil && reason == nil { return nil }
+        return Parsed(file: file, commit: commit, result: image, model: model, reason: reason)
     }
 
     struct Parsed: Equatable {
@@ -154,5 +158,6 @@ public struct MCPApplyEditRouter: EditRouter {
         let commit: String?
         let result: EditReply.ImageResult?
         let model: ComponentModel?
+        let reason: String?
     }
 }

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -77,7 +77,8 @@ public struct MCPApplyEditRouter: EditRouter {
                     message: trimmed,
                     file: parsed?.file,
                     commit: parsed?.commit,
-                    result: parsed?.result
+                    result: parsed?.result,
+                    model: parsed?.model
                 )
             }
             let reply = EditReply(
@@ -86,7 +87,8 @@ public struct MCPApplyEditRouter: EditRouter {
                 message: trimmed,
                 file: parsed?.file,
                 commit: parsed?.commit,
-                result: parsed?.result
+                result: parsed?.result,
+                model: parsed?.model
             )
             if reply.commit != nil { onEdit?(reply) }
             // Fire-and-forget so the overlay gets its reply immediately; alt-text generation and the
@@ -138,13 +140,19 @@ public struct MCPApplyEditRouter: EditRouter {
             let srcset = resultDict["srcset"] as? String
             image = EditReply.ImageResult(src: src, srcset: srcset)
         }
-        if file == nil && commit == nil && image == nil { return nil }
-        return Parsed(file: file, commit: commit, result: image)
+        var model: ComponentModel?
+        if let modelDict = json["model"],
+           let modelData = try? JSONSerialization.data(withJSONObject: modelDict) {
+            model = try? JSONDecoder().decode(ComponentModel.self, from: modelData)
+        }
+        if file == nil && commit == nil && image == nil && model == nil { return nil }
+        return Parsed(file: file, commit: commit, result: image, model: model)
     }
 
     struct Parsed: Equatable {
         let file: String?
         let commit: String?
         let result: EditReply.ImageResult?
+        let model: ComponentModel?
     }
 }

--- a/Tests/AnglesiteCoreTests/CSSColorTests.swift
+++ b/Tests/AnglesiteCoreTests/CSSColorTests.swift
@@ -19,6 +19,11 @@ struct CSSColorTests {
         #expect(CSSColor.format(color) == "#3366ff")
     }
 
+    @Test("format preserves alpha as 8-digit hex") func roundTripWithAlpha() {
+        let color = CSSColor.parse("#3366ff80")!
+        #expect(CSSColor.format(color) == "#3366ff80")
+    }
+
     @Test("color property set includes the common properties") func propertySet() {
         #expect(CSSColor.colorProperties.contains("background-color"))
         #expect(!CSSColor.colorProperties.contains("padding"))

--- a/Tests/AnglesiteCoreTests/CSSColorTests.swift
+++ b/Tests/AnglesiteCoreTests/CSSColorTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import AnglesiteCore
+
+struct CSSColorTests {
+    @Test("parses 6-digit hex") func sixDigit() {
+        #expect(CSSColor.parse("#ff0000") != nil)
+    }
+
+    @Test("parses 3-digit hex") func threeDigit() {
+        #expect(CSSColor.parse("#f00") != nil)
+    }
+
+    @Test("returns nil for named colors") func namedColorFallsBack() {
+        #expect(CSSColor.parse("red") == nil)
+    }
+
+    @Test("format round-trips a parsed hex color") func roundTrip() {
+        let color = CSSColor.parse("#3366ff")!
+        #expect(CSSColor.format(color) == "#3366ff")
+    }
+
+    @Test("color property set includes the common properties") func propertySet() {
+        #expect(CSSColor.colorProperties.contains("background-color"))
+        #expect(!CSSColor.colorProperties.contains("padding"))
+    }
+}

--- a/Tests/AnglesiteCoreTests/ComponentStyleEditBuilderTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentStyleEditBuilderTests.swift
@@ -1,0 +1,100 @@
+import Testing
+@testable import AnglesiteCore
+
+struct ComponentStyleEditBuilderTests {
+    @Test("setStyleProperty builds a component payload with no selector")
+    func setStyleProperty() {
+        let message = ComponentStyleEditBuilder.setStyleProperty(
+            id: "1",
+            path: "src/components/Card.astro",
+            baseVersion: "sha256:abc123456789",
+            ruleSpan: [10, 40],
+            property: "color",
+            value: "red"
+        )
+        #expect(message.op == EditMessage.Op.setStyleProperty)
+        #expect(message.selector == nil)
+        #expect(message.path == "src/components/Card.astro")
+        guard case .object(let component)? = message.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["path"] == .string("src/components/Card.astro"))
+        #expect(component["baseVersion"] == .string("sha256:abc123456789"))
+        #expect(component["ruleSpan"] == .array([.int(10), .int(40)]))
+        #expect(component["property"] == .string("color"))
+        #expect(component["value"] == .string("red"))
+    }
+
+    @Test("removeStyleProperty builds a component payload without value")
+    func removeStyleProperty() {
+        let message = ComponentStyleEditBuilder.removeStyleProperty(
+            id: "2",
+            path: "src/components/Card.astro",
+            baseVersion: "sha256:abc123456789",
+            ruleSpan: [10, nil],
+            property: "color"
+        )
+        #expect(message.op == EditMessage.Op.removeStyleProperty)
+        guard case .object(let component)? = message.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["ruleSpan"] == .array([.int(10), .null]))
+        #expect(component["property"] == .string("color"))
+        #expect(component["value"] == nil)
+    }
+
+    @Test("setRuleSelector builds a component payload with the new selector")
+    func setRuleSelector() {
+        let message = ComponentStyleEditBuilder.setRuleSelector(
+            id: "3",
+            path: "src/components/Card.astro",
+            baseVersion: "sha256:abc123456789",
+            ruleSpan: [10, 40],
+            newSelector: ".card--highlighted"
+        )
+        #expect(message.op == EditMessage.Op.setRuleSelector)
+        guard case .object(let component)? = message.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["selector"] == .string(".card--highlighted"))
+    }
+
+    @Test("addStyleRule includes declarations and omits media when nil")
+    func addStyleRuleNoMedia() {
+        let message = ComponentStyleEditBuilder.addStyleRule(
+            id: "4",
+            path: "src/components/Card.astro",
+            baseVersion: "sha256:abc123456789",
+            selector: "h2",
+            media: nil,
+            declarations: [("font-weight", "bold")]
+        )
+        #expect(message.op == EditMessage.Op.addStyleRule)
+        guard case .object(let component)? = message.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["media"] == nil)
+        #expect(component["declarations"] == .array([.object(["property": .string("font-weight"), "value": .string("bold")])]))
+    }
+
+    @Test("addStyleRule includes media when present")
+    func addStyleRuleWithMedia() {
+        let message = ComponentStyleEditBuilder.addStyleRule(
+            id: "5",
+            path: "src/components/Card.astro",
+            baseVersion: "sha256:abc123456789",
+            selector: "h2",
+            media: "(min-width: 768px)",
+            declarations: [("font-weight", "bold")]
+        )
+        guard case .object(let component)? = message.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["media"] == .string("(min-width: 768px)"))
+    }
+}

--- a/Tests/AnglesiteCoreTests/EditMessageTests.swift
+++ b/Tests/AnglesiteCoreTests/EditMessageTests.swift
@@ -73,7 +73,9 @@ struct EditMessageTests {
     }
 
     @Test("Rejects missing required field") func rejectsMissingRequiredField() {
-        for missing in ["id", "type", "path", "selector", "op"] {
+        // "selector" is intentionally excluded: it's optional now (Component Editor ops carry
+        // `component` instead) — see `legacyMessageStillDecodes` / `componentMessageEncoding`.
+        for missing in ["id", "type", "path", "op"] {
             var body = validBody()
             body.removeValue(forKey: missing)
             #expect(
@@ -105,5 +107,50 @@ struct EditMessageTests {
         #expect(
             EditMessage.decode(from: validBody(overrides: ["type": "anglesite:something-else"])) == .failure(.unknownType("anglesite:something-else"))
         )
+    }
+
+    @Test("New component-style op constants exist")
+    func componentStyleOpConstants() {
+        #expect(EditMessage.Op.setStyleProperty == "set-style-property")
+        #expect(EditMessage.Op.removeStyleProperty == "remove-style-property")
+        #expect(EditMessage.Op.addStyleRule == "add-style-rule")
+        #expect(EditMessage.Op.setRuleSelector == "set-rule-selector")
+    }
+
+    @Test("A component-style message encodes component and omits selector")
+    func componentMessageEncoding() {
+        let message = EditMessage(
+            id: "1",
+            path: "src/components/Card.astro",
+            selector: nil,
+            op: EditMessage.Op.setStyleProperty,
+            component: .object([
+                "path": .string("src/components/Card.astro"),
+                "baseVersion": .string("sha256:abc123456789"),
+                "ruleSpan": .array([.int(10), .int(40)]),
+                "property": .string("color"),
+                "value": .string("red"),
+            ]),
+            value: nil
+        )
+        let wire = message.jsonValue
+        guard case .object(let dict) = wire else { Issue.record("expected object"); return }
+        #expect(dict["selector"] == nil)
+        #expect(dict["component"] != nil)
+    }
+
+    @Test("A legacy replace-attr message still decodes with selector and no component")
+    func legacyMessageStillDecodes() {
+        let body: [String: Any] = [
+            "id": "1", "type": "anglesite:apply-edit", "path": "/about/",
+            "selector": ["tag": "h1", "classes": [], "nthChild": 1],
+            "op": "replace-attr", "value": ["name": "class", "value": "big"],
+        ]
+        switch EditMessage.decode(from: body) {
+        case .success(let message):
+            #expect(message.component == nil)
+        case .failure(let error):
+            Issue.record("expected decode success, got \(error)")
+        }
     }
 }

--- a/Tests/AnglesiteCoreTests/EditReplyAndRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/EditReplyAndRouterTests.swift
@@ -89,4 +89,15 @@ struct EditReplyAndRouterTests {
         let reply = await resolved.apply(msg)
         #expect(reply.status == .failed, "the fallback should be a LoggingEditRouter, which always replies failed")
     }
+
+    // MARK: parseStructured piggybacked model
+
+    @Test("parseStructured decodes a piggybacked model")
+    func parseStructuredDecodesModel() {
+        let json = """
+        {"type":"anglesite:edit-applied","id":"1","file":"src/components/Card.astro","range":{"start":0,"end":1},"model":\(ComponentModelTests.fixture)}
+        """
+        let parsed = MCPApplyEditRouter.parseStructured(json)
+        #expect(parsed?.model?.path == "src/components/Card.astro")
+    }
 }

--- a/Tests/AnglesiteCoreTests/EditReplyAndRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/EditReplyAndRouterTests.swift
@@ -100,4 +100,41 @@ struct EditReplyAndRouterTests {
         let parsed = MCPApplyEditRouter.parseStructured(json)
         #expect(parsed?.model?.path == "src/components/Card.astro")
     }
+
+    // MARK: parseStructured failure reason
+
+    @Test("parseStructured decodes a machine-readable failure reason")
+    func parseStructuredDecodesFailureReason() {
+        let json = """
+        {"type":"anglesite:edit-failed","id":"1","reason":"stale","detail":"src/Card.astro changed since the model was fetched"}
+        """
+        let parsed = MCPApplyEditRouter.parseStructured(json)
+        #expect(parsed?.reason == "stale")
+    }
+
+    @Test("parseStructured returns nil for JSON with no recognized fields")
+    func parseStructuredReturnsNilForUnrecognizedJSON() {
+        let json = #"{"type":"something-else","id":"1"}"#
+        #expect(MCPApplyEditRouter.parseStructured(json) == nil)
+    }
+
+    private struct FailureReasonRouter: EditRouter {
+        let reason: String
+        func apply(_ message: EditMessage) async -> EditReply {
+            EditReply(id: message.id, status: .failed, message: "detail text", reason: reason)
+        }
+    }
+
+    @Test("A .failed reply threads its reason through for callers to switch on, not just message prose")
+    func failedReplyExposesReason() async {
+        let router = FailureReasonRouter(reason: "stale")
+        let msg = EditMessage(
+            id: "e-1", type: .applyEdit, path: "/",
+            selector: .object(["tag": .string("H1"), "classes": .array([]), "nthChild": .int(1)]),
+            op: "replace-text", value: .string("Hi")
+        )
+        let reply = await router.apply(msg)
+        #expect(reply.reason == "stale")
+        #expect(reply.status == .failed)
+    }
 }

--- a/scripts/copy-plugin.sh
+++ b/scripts/copy-plugin.sh
@@ -35,12 +35,13 @@ if [[ ! -f "$SRC/.claude-plugin/plugin.json" ]]; then
     exit 0
 fi
 
-# Minimum-version guard: the app requires plugin features introduced in 1.3.0
-# (get_component_model, used by the Component Editor). A MISSING plugin stays
-# best-effort (handled above — PluginRuntime reports it at runtime), but bundling
-# a plugin that IS present yet too old would ship an app whose edit pipeline
-# fails in confusing ways at runtime — fail the build loudly instead.
-MIN_PLUGIN_VERSION="1.3.0"
+# Minimum-version guard: the app requires plugin features introduced in 1.4.0
+# (set-style-property/remove-style-property/add-style-rule/set-rule-selector,
+# used by the Component Editor's Styles panel write path). A MISSING plugin
+# stays best-effort (handled above — PluginRuntime reports it at runtime), but
+# bundling a plugin that IS present yet too old would ship an app whose edit
+# pipeline fails in confusing ways at runtime — fail the build loudly instead.
+MIN_PLUGIN_VERSION="1.4.0"
 # plutil parses the JSON and extracts the top-level key specifically — a first-match
 # grep could be fooled by a nested "version" (engines/mcpServers/…) appearing earlier
 # in the manifest. This script only runs on macOS (Xcode build phase), so plutil is


### PR DESCRIPTION
## Summary
- Wires the harness canvas to a real `MCPApplyEditRouter` (previously a hardcoded `LoggingEditRouter` stub)
- Editable Styles panel: declaration rows (add/edit/remove), editable rule selectors, add-rule affordance, ColorPicker for color-valued CSS properties with alpha-preserving round-trip and debounced commits, and scrub injection for live drag feedback in the canvas
- Consumes Anglesite/anglesite's new `set-style-property`/`remove-style-property`/`add-style-rule`/`set-rule-selector` ops (content-hash `baseVersion` staleness checking, span-identified rules — never selector-string matching)
- Non-destructive failure handling: write failures now surface as a dismissible inline banner instead of taking down the whole editor pane, and stale-conflict refusals now show a "changed outside Anglesite" banner instead of silently discarding the user's edit
- Bumps `MIN_PLUGIN_VERSION` to 1.4.0 to require the plugin-side write ops (Anglesite/anglesite#413, merged)

Closes #492. Part of #496.

## Process notes
Implemented as 7 tasks (10–16) picking up from PR #507 (which shipped tasks 1–9: plugin ops + initial plumbing). Each task went through an independent implementer + task-scoped review (spec compliance + code quality), with fix rounds where issues surfaced — including a property-rename bug that silently orphaned CSS declarations (Task 12), an alpha-channel round-trip bug and unthrottled ColorPicker writes (Task 13). A final whole-branch review then caught a cross-task integration gap invisible to any single task's narrow review: write-op failures were routed into the view's fatal error channel, destroying the entire editor pane on any recoverable failure, and a `conflict` flag was set but never read anywhere in the UI. Both are fixed in the final commit.

## Test plan
- [x] `swift test --package-path .` — full suite green, aside from two confirmed pre-existing/unrelated environment issues (an `AnglesiteAppTests` dlopen failure from an OS/SDK FoundationModels symbol mismatch, and `AppVersionTests.readsTheShortVersionStringFromABundle`, git-blame-confirmed to predate this branch)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED, with the plugin re-copied at version 1.4.0
- [x] Overlay: `npm test`, `npm run typecheck`, `npm run lint` in `JS/edit-overlay` — clean
- [ ] Manual GUI smoke (open a component, edit a declaration, add a rule, drag a ColorPicker, trigger a stale conflict) — not run, no interactive session available to agents; flagged for the user, same as the still-owed slice-1 smoke (#491)