### PR TITLE
feat: free-form cross-node site Q&A in Chat (#314)

### DIFF
--- a/Sources/AnglesiteApp/ChatView.swift
+++ b/Sources/AnglesiteApp/ChatView.swift
@@ -15,6 +15,10 @@ import FoundationModels
 /// v0.5; #25 follow-ups can introduce a richer renderer if needed).
 struct ChatView: View {
     @Bindable var model: ChatModel
+    /// Resolves a citation's path to a Site Graph Explorer node and reveals it there; returns
+    /// `false` when the path isn't a graph node, so the click falls back to opening the file
+    /// (#314). `nil` in previews/tests that don't wire a graph explorer.
+    var revealCitation: ((String) -> Bool)?
 
     /// Binds the prompt input. Lives in the view (not the model) because it's pure transient
     /// UI state; the model only sees the final string when the user hits Send.
@@ -94,7 +98,7 @@ struct ChatView: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 12) {
                     ForEach(model.messages) { message in
-                        MessageRow(message: message, model: model)
+                        MessageRow(message: message, model: model, revealCitation: revealCitation)
                             .id(message.id)
                     }
                     if let error = model.lastError, !model.messages.contains(where: { $0.role == .error && $0.content == error }) {
@@ -247,6 +251,7 @@ private nonisolated(unsafe) let sharedRelativeTimeFormatter: RelativeDateTimeFor
 private struct MessageRow: View {
     let message: ChatModel.Message
     let model: ChatModel
+    var revealCitation: ((String) -> Bool)?
 
     var body: some View {
         if message.role == .edit {
@@ -255,7 +260,7 @@ private struct MessageRow: View {
             AnnotationRowView(message: message, model: model)
         } else if message.role == .citation {
             if let meta = message.citationMetadata {
-                CitationRowView(citations: meta.citations, siteDirectory: model.siteDirectoryURL)
+                CitationRowView(citations: meta.citations, siteDirectory: model.siteDirectoryURL, revealCitation: revealCitation)
             }
         } else {
             HStack {

--- a/Sources/AnglesiteApp/CitationRowView.swift
+++ b/Sources/AnglesiteApp/CitationRowView.swift
@@ -7,6 +7,10 @@ import AnglesiteCore
 struct CitationRowView: View {
     let citations: [RetrievedCitation]
     let siteDirectory: URL
+    /// Resolves a citation's path to a Site Graph Explorer node and reveals it there; returns
+    /// `false` when the path isn't a graph node, so the click falls back to opening the file
+    /// (#314). `nil` in previews/tests that don't wire a graph explorer.
+    var revealCitation: ((String) -> Bool)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -16,6 +20,7 @@ struct CitationRowView: View {
             FlowLayout(spacing: 6) {
                 ForEach(citations) { citation in
                     CitationChip(citation: citation) {
+                        if revealCitation?(citation.path) == true { return }
                         let url = siteDirectory.appendingPathComponent(citation.path)
                         NSWorkspace.shared.open(url)
                     }

--- a/Sources/AnglesiteApp/CitationRowView.swift
+++ b/Sources/AnglesiteApp/CitationRowView.swift
@@ -20,9 +20,10 @@ struct CitationRowView: View {
             FlowLayout(spacing: 6) {
                 ForEach(citations) { citation in
                     CitationChip(citation: citation) {
-                        if revealCitation?(citation.path) == true { return }
-                        let url = siteDirectory.appendingPathComponent(citation.path)
-                        NSWorkspace.shared.open(url)
+                        Self.handleTap(
+                            citation: citation, siteDirectory: siteDirectory, revealCitation: revealCitation,
+                            openFile: { NSWorkspace.shared.open($0) }
+                        )
                     }
                 }
             }
@@ -31,6 +32,21 @@ struct CitationRowView: View {
         .padding(.vertical, 8)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Retrieved context from \(citations.count) file\(citations.count == 1 ? "" : "s")")
+    }
+
+    /// A citation click tries `revealCitation` first (the Site Graph Explorer reveal, #314) and
+    /// falls back to `openFile` only when that returns `false` or is `nil` — never both, never
+    /// neither. Pulled out of the button's action closure so it's unit-testable without a SwiftUI
+    /// rendering harness: `body` wires the real `NSWorkspace.shared.open` side effect, tests
+    /// inject a spy.
+    nonisolated static func handleTap(
+        citation: RetrievedCitation,
+        siteDirectory: URL,
+        revealCitation: ((String) -> Bool)?,
+        openFile: (URL) -> Void
+    ) {
+        if revealCitation?(citation.path) == true { return }
+        openFile(siteDirectory.appendingPathComponent(citation.path))
     }
 }
 

--- a/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
+++ b/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
@@ -52,19 +52,17 @@ enum SiteAssistantSessionFactory {
                 await EditRouterRegistry.shared.router(for: siteID)
             }
             let assistant: AssistantBuilder = { editBridge, contentGraph, knowledgeIndex, semanticRanker, integrationService, graphSnapshotProvider in
-                SiteGraphAugmentedAssistant(
-                    base: KnowledgeAugmentedAssistant(
-                        base: FoundationModelAssistant(
-                            tier: .onDevice,
-                            editBridge: editBridge,
-                            contentGraph: contentGraph,
-                            knowledgeIndex: knowledgeIndex,
-                            semanticRanker: semanticRanker,
-                            integrationService: integrationService
-                        ),
-                        index: knowledgeIndex
+                CombinedAugmentedAssistant(
+                    base: FoundationModelAssistant(
+                        tier: .onDevice,
+                        editBridge: editBridge,
+                        contentGraph: contentGraph,
+                        knowledgeIndex: knowledgeIndex,
+                        semanticRanker: semanticRanker,
+                        integrationService: integrationService
                     ),
-                    snapshotProvider: graphSnapshotProvider
+                    index: knowledgeIndex,
+                    graphSnapshotProvider: graphSnapshotProvider
                 )
             }
             return Dependencies(

--- a/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
+++ b/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
@@ -15,12 +15,14 @@ struct SiteAssistantSession {
 enum SiteAssistantSessionFactory {
     typealias MCPClientProvider = @Sendable () async -> MCPClient?
     typealias EditRouterProvider = @Sendable (_ siteID: String) async -> (any EditRouter)?
+    typealias GraphSnapshotProvider = @Sendable () async -> SiteGraphExplorerSnapshot
     typealias AssistantBuilder = @Sendable (
         _ editBridge: IntentEditBridge,
         _ contentGraph: SiteContentGraph,
         _ knowledgeIndex: SiteKnowledgeIndex,
         _ semanticRanker: SemanticRanker?,
-        _ integrationService: any IntegrationOperationsService
+        _ integrationService: any IntegrationOperationsService,
+        _ graphSnapshotProvider: @escaping GraphSnapshotProvider
     ) -> any ConversationalAssistant
 
     struct Dependencies {
@@ -49,17 +51,20 @@ enum SiteAssistantSessionFactory {
             let editRouterProvider: EditRouterProvider = { siteID in
                 await EditRouterRegistry.shared.router(for: siteID)
             }
-            let assistant: AssistantBuilder = { editBridge, contentGraph, knowledgeIndex, semanticRanker, integrationService in
-                KnowledgeAugmentedAssistant(
-                    base: FoundationModelAssistant(
-                        tier: .onDevice,
-                        editBridge: editBridge,
-                        contentGraph: contentGraph,
-                        knowledgeIndex: knowledgeIndex,
-                        semanticRanker: semanticRanker,
-                        integrationService: integrationService
+            let assistant: AssistantBuilder = { editBridge, contentGraph, knowledgeIndex, semanticRanker, integrationService, graphSnapshotProvider in
+                SiteGraphAugmentedAssistant(
+                    base: KnowledgeAugmentedAssistant(
+                        base: FoundationModelAssistant(
+                            tier: .onDevice,
+                            editBridge: editBridge,
+                            contentGraph: contentGraph,
+                            knowledgeIndex: knowledgeIndex,
+                            semanticRanker: semanticRanker,
+                            integrationService: integrationService
+                        ),
+                        index: knowledgeIndex
                     ),
-                    index: knowledgeIndex
+                    snapshotProvider: graphSnapshotProvider
                 )
             }
             return Dependencies(
@@ -115,7 +120,8 @@ enum SiteAssistantSessionFactory {
         semanticRanker: SemanticRanker?,
         conventionsEngine: ProjectConventionsEngine?,
         integrationService: any IntegrationOperationsService,
-        dependencies: Dependencies = .live
+        dependencies: Dependencies = .live,
+        graphSnapshotProvider: @escaping GraphSnapshotProvider
     ) -> SiteAssistantSession {
         let editBridge = IntentEditBridge(routerProvider: dependencies.editRouterProvider)
         let chat = ChatModel(
@@ -127,7 +133,8 @@ enum SiteAssistantSessionFactory {
                 contentGraph,
                 knowledgeIndex,
                 semanticRanker,
-                integrationService
+                integrationService,
+                graphSnapshotProvider
             ),
             annotationFeed: dependencies.annotationFeed(sourceDirectory),
             annotationResolver: { [resolveAnnotation = dependencies.resolveAnnotation] id in

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -184,7 +184,7 @@ struct SiteWindow: View {
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                         if model.chatPresented, let chat = model.chat {
                             Divider()
-                            ChatView(model: chat)
+                            ChatView(model: chat, revealCitation: { path in model.revealCitationInGraph(path) })
                                 .frame(width: 420)
                                 .transition(reduceMotion
                                     ? .opacity

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -210,10 +210,16 @@ final class SiteWindowModel {
         }
     }
 
-    func showGraph() async {
-        guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+    /// Returns whether the pane actually switched to Graph — `false` when `leaveCurrentEditor()`/
+    /// `leaveCurrentInspector()` aborted (e.g. an external-change conflict dialog is now showing),
+    /// so callers that queue follow-up work (like `revealCitationInGraph`) can skip it rather than
+    /// mutating `graphExplorer` state the user never navigated to see.
+    @discardableResult
+    func showGraph() async -> Bool {
+        guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return false }
         inspectorContext = nil
         mainPaneMode = .graph
+        return true
     }
 
     /// Resolves a chat citation's file path to a Site Graph Explorer node and reveals it there
@@ -230,8 +236,8 @@ final class SiteWindowModel {
             return false
         }
         Task { [weak self] in
-            await self?.showGraph()
-            self?.graphExplorer.revealNode(node)
+            guard let self, await self.showGraph() else { return }
+            self.graphExplorer.revealNode(node)
         }
         return true
     }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1110,7 +1110,11 @@ final class SiteWindowModel {
             knowledgeIndex: knowledgeIndex,
             semanticRanker: semanticRanker,
             conventionsEngine: conventionsEngine,
-            integrationService: integrationOps
+            integrationService: integrationOps,
+            graphSnapshotProvider: { [weak self] in
+                guard let self else { return SiteGraphExplorerSnapshot(nodes: [], edges: []) }
+                return await MainActor.run { self.graphExplorer.snapshot }
+            }
         )
         chat = assistantSession.chat
         // The environment undo manager usually lands before the chat exists (cold open) —

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -216,6 +216,26 @@ final class SiteWindowModel {
         mainPaneMode = .graph
     }
 
+    /// Resolves a chat citation's file path to a Site Graph Explorer node and reveals it there
+    /// (#314): switches the main pane to Graph and selects the node. Returns `false` — and does
+    /// nothing — when the path doesn't match any node in the current snapshot, so the caller
+    /// (`ChatView`'s citation click handler) can fall back to opening the file directly.
+    ///
+    /// The pane switch and selection happen asynchronously (matching `setPaneSelection`'s
+    /// existing fire-and-forget `Task { await showGraph() }` pattern) — the `Bool` this returns
+    /// reflects only whether a matching node was found, not whether the navigation has finished.
+    @discardableResult
+    func revealCitationInGraph(_ path: String) -> Bool {
+        guard let node = graphExplorer.snapshot.nodes.first(where: { $0.filePath == path }) else {
+            return false
+        }
+        Task { [weak self] in
+            await self?.showGraph()
+            self?.graphExplorer.revealNode(node)
+        }
+        return true
+    }
+
     func openSiriReadiness() {
         guard siriReadinessModel == nil, let indexer = contentIndexerStore.indexer, let site else { return }
         siriReadinessModel = SiriReadinessModel(

--- a/Sources/AnglesiteCore/CombinedAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/CombinedAugmentedAssistant.swift
@@ -73,9 +73,14 @@ public actor CombinedAugmentedAssistant: ConversationalAssistant {
     }
 
     private func enrichedContext(_ prompt: String, context: AssistantContext) async -> (prompt: String, citations: [RetrievedCitation]) {
-        let snapshot = await graphSnapshotProvider()
+        // The graph snapshot read and the content-index search are independent — only
+        // `graphBlock`'s synchronous computation actually depends on the snapshot — so run both
+        // `await`s concurrently instead of paying their latencies back-to-back on every turn.
+        async let snapshotTask = graphSnapshotProvider()
+        async let contentTask = KnowledgeAugmentedAssistant.contentBlock(prompt: prompt, context: context, index: index)
+        let snapshot = await snapshotTask
         let graph = SiteGraphAugmentedAssistant.graphBlock(prompt: prompt, snapshot: snapshot)
-        let content = await KnowledgeAugmentedAssistant.contentBlock(prompt: prompt, context: context, index: index)
+        let content = await contentTask
 
         var blocks: [String] = []
         var citations: [RetrievedCitation] = []

--- a/Sources/AnglesiteCore/CombinedAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/CombinedAugmentedAssistant.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+/// Combines graph-structure grounding (``SiteGraphAugmentedAssistant``) and content-search
+/// grounding (``KnowledgeAugmentedAssistant``) into a single enrichment pass, both run against
+/// the same, untouched user prompt (#314).
+///
+/// Nesting the two decorators (each rewriting `prompt` and forwarding to the next) was the
+/// original approach and was rejected: the inner decorator's retrieval search then runs against
+/// the OUTER decorator's already-enriched prompt — a blob of instructions and fact lines, not
+/// the user's actual question — degrading exactly the citations this feature is meant to
+/// produce. Running both retrievals here, against the same original `prompt`, avoids that.
+public actor CombinedAugmentedAssistant: ConversationalAssistant {
+    private let base: any ConversationalAssistant
+    private let index: SiteKnowledgeIndex
+    private let graphSnapshotProvider: @Sendable () async -> SiteGraphExplorerSnapshot
+
+    public init(
+        base: any ConversationalAssistant,
+        index: SiteKnowledgeIndex,
+        graphSnapshotProvider: @escaping @Sendable () async -> SiteGraphExplorerSnapshot
+    ) {
+        self.base = base
+        self.index = index
+        self.graphSnapshotProvider = graphSnapshotProvider
+    }
+
+    public nonisolated var capabilities: AssistantCapabilities {
+        base.capabilities
+    }
+
+    public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        let (enriched, citations) = await enrichedContext(prompt, context: context)
+        let baseStream = try await base.converse(prompt: enriched, context: context)
+        guard !citations.isEmpty else { return baseStream }
+        return AsyncStream { continuation in
+            let task = Task {
+                continuation.yield(.citations(citations))
+                for await event in baseStream {
+                    continuation.yield(event)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    public func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        let (enriched, _) = await enrichedContext(prompt, context: context)
+        return try await base.generate(prompt: enriched, context: context)
+    }
+
+    #if compiler(>=6.4)
+    public func generateStructured<T: Generable & Sendable>(
+        prompt: String,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        let (enriched, _) = await enrichedContext(prompt, context: context)
+        return try await base.generateStructured(prompt: enriched, context: context, resultType: resultType)
+    }
+    #endif
+
+    public func cancel() async {
+        await base.cancel()
+    }
+
+    public func resetSession() async {
+        await base.resetSession()
+    }
+
+    private func enrichedContext(_ prompt: String, context: AssistantContext) async -> (prompt: String, citations: [RetrievedCitation]) {
+        let snapshot = await graphSnapshotProvider()
+        let graph = SiteGraphAugmentedAssistant.graphBlock(prompt: prompt, snapshot: snapshot)
+        let content = await KnowledgeAugmentedAssistant.contentBlock(prompt: prompt, context: context, index: index)
+
+        var blocks: [String] = []
+        var citations: [RetrievedCitation] = []
+        if let graph {
+            blocks.append(graph.block)
+            citations.append(contentsOf: graph.citations)
+        }
+        if let content {
+            blocks.append(content.block)
+            // A file that's both a matched graph node and a content-search hit is cited once —
+            // the graph citation (added first, above) already covers it and carries the more
+            // specific `SiteGraphNodeKind`-derived kind mapping.
+            let citedPaths = Set(citations.map(\.path))
+            citations.append(contentsOf: content.citations.filter { !citedPaths.contains($0.path) })
+        }
+        guard !blocks.isEmpty else { return (prompt, []) }
+
+        let enriched = """
+        \(blocks.joined(separator: "\n\n"))
+
+        User request:
+        \(prompt)
+        """
+        return (enriched, citations)
+    }
+}

--- a/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
@@ -63,20 +63,34 @@ public actor KnowledgeAugmentedAssistant: ConversationalAssistant {
     }
 
     private func enrichedContext(_ prompt: String, context: AssistantContext) async -> (prompt: String, citations: [RetrievedCitation]) {
+        guard let (block, citations) = await Self.contentBlock(prompt: prompt, context: context, index: index) else {
+            return (prompt, [])
+        }
+        let enriched = """
+        \(block)
+
+        User request:
+        \(prompt)
+        """
+        return (enriched, citations)
+    }
+
+    /// Builds the content-search block and citations for `prompt`, or `nil` when nothing
+    /// matches. Exposed (not `private`) so ``CombinedAugmentedAssistant`` can run this retrieval
+    /// directly against the original user question instead of a prompt another decorator already
+    /// rewrote (#314).
+    static func contentBlock(
+        prompt: String,
+        context: AssistantContext,
+        index: SiteKnowledgeIndex
+    ) async -> (block: String, citations: [RetrievedCitation])? {
         let results = await index.search(
             siteID: context.siteID,
             query: prompt,
             options: context.searchOptions
         )
-        guard !results.isEmpty else { return (prompt, []) }
-        let formatted = Self.formatContext(results)
-        let enriched = """
-        \(formatted)
-
-        User request:
-        \(prompt)
-        """
-        return (enriched, results.map(RetrievedCitation.init))
+        guard !results.isEmpty else { return nil }
+        return (formatContext(results), results.map(RetrievedCitation.init))
     }
 
     private static func formatContext(_ results: [SiteKnowledgeIndex.SearchResult]) -> String {

--- a/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+/// Free-form, cross-node grounding for the Chat panel (#314). Mirrors
+/// ``KnowledgeAugmentedAssistant``'s content-search enrichment, but grounds on the Site Graph
+/// Explorer's dependency graph and ``ImpactAnalysis`` instead of file text — the facts needed to
+/// answer structural questions ("how is navigation generated", "why does this image appear
+/// here") that a text search over file contents can't answer.
+///
+/// Reuses #614's per-node fact list (``SiteGraphExplainPrompt/facts(node:impact:dependsOn:referencedBy:)``)
+/// for up to ``SiteGraphAugmentedAssistant/maxSeedNodes`` nodes matched against the question's
+/// words. Contributes nothing when no node matches, so unrelated chat turns are unaffected.
+public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
+    /// Largest number of matched nodes to ground a single question in — keeps the prompt within
+    /// the small on-device context window, matching the philosophy of
+    /// `SiteGraphExplainPrompt.maxListedNames`.
+    static let maxSeedNodes = 3
+
+    private let base: any ConversationalAssistant
+    private let snapshotProvider: @Sendable () async -> SiteGraphExplorerSnapshot
+
+    public init(
+        base: any ConversationalAssistant,
+        snapshotProvider: @escaping @Sendable () async -> SiteGraphExplorerSnapshot
+    ) {
+        self.base = base
+        self.snapshotProvider = snapshotProvider
+    }
+
+    public nonisolated var capabilities: AssistantCapabilities {
+        base.capabilities
+    }
+
+    public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        let (enriched, citations) = await enrichedContext(prompt)
+        let baseStream = try await base.converse(prompt: enriched, context: context)
+        guard !citations.isEmpty else { return baseStream }
+        // Prepended ahead of whatever `base` itself yields — if `base` is a
+        // `KnowledgeAugmentedAssistant`, its own `.citations` event (content-search sources)
+        // still arrives afterward as a second, separate "Sources" row. That's an accepted UX
+        // trade-off: two decorators, each contributing citations independently, is simpler and
+        // more honest than guessing how to merge two different kinds of retrieval.
+        return AsyncStream { continuation in
+            let task = Task {
+                continuation.yield(.citations(citations))
+                for await event in baseStream {
+                    continuation.yield(event)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    public func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        let (enriched, _) = await enrichedContext(prompt)
+        return try await base.generate(prompt: enriched, context: context)
+    }
+
+    #if compiler(>=6.4)
+    public func generateStructured<T: Generable & Sendable>(
+        prompt: String,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        let (enriched, _) = await enrichedContext(prompt)
+        return try await base.generateStructured(prompt: enriched, context: context, resultType: resultType)
+    }
+    #endif
+
+    public func cancel() async {
+        await base.cancel()
+    }
+
+    public func resetSession() async {
+        await base.resetSession()
+    }
+
+    private func enrichedContext(_ prompt: String) async -> (prompt: String, citations: [RetrievedCitation]) {
+        let snapshot = await snapshotProvider()
+        let seeds = Self.seedNodes(for: prompt, in: snapshot)
+        guard !seeds.isEmpty else { return (prompt, []) }
+
+        var blocks: [String] = []
+        var citations: [RetrievedCitation] = []
+        for node in seeds {
+            guard let impact = ImpactAnalysis.analyze(snapshot: snapshot, targetID: node.id) else { continue }
+            let (dependsOn, referencedBy) = Self.neighbors(of: node, in: snapshot)
+            let facts = SiteGraphExplainPrompt.facts(node: node, impact: impact, dependsOn: dependsOn, referencedBy: referencedBy)
+            blocks.append("Facts about \(node.title):\n" + facts.joined(separator: "\n"))
+            if let citation = Self.citation(for: node) { citations.append(citation) }
+        }
+        guard !blocks.isEmpty else { return (prompt, []) }
+
+        let enriched = """
+        You are answering a question about how this Astro website is built, using only the \
+        facts below about specific files in its dependency graph. Do not invent details that \
+        are not in the facts, and cite file paths when you use a fact.
+
+        \(blocks.joined(separator: "\n\n"))
+
+        User request:
+        \(prompt)
+        """
+        return (enriched, citations)
+    }
+
+    /// Scores every node's title/route/filePath against the question's words (case-insensitive
+    /// substring match, matching `SiteKnowledgeIndex`'s keyword-search style rather than
+    /// embeddings), and returns the top ``maxSeedNodes`` by match count. Ties break by title
+    /// (matching `ImpactAnalysis`'s stable sort), then id.
+    static func seedNodes(for question: String, in snapshot: SiteGraphExplorerSnapshot) -> [SiteGraphNode] {
+        let terms = queryTerms(question)
+        guard !terms.isEmpty else { return [] }
+        let scored: [(node: SiteGraphNode, score: Int)] = snapshot.nodes.compactMap { node in
+            let score = matchScore(node: node, terms: terms)
+            return score > 0 ? (node, score) : nil
+        }
+        return scored
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                let byTitle = lhs.node.title.localizedStandardCompare(rhs.node.title)
+                if byTitle != .orderedSame { return byTitle == .orderedAscending }
+                return lhs.node.id < rhs.node.id
+            }
+            .prefix(maxSeedNodes)
+            .map(\.node)
+    }
+
+    /// Direct neighbors of `node` (one hop each direction), matching what #614's
+    /// `SiteGraphExplorerModel.explainSelectedNode()` computes for the single-node case.
+    static func neighbors(
+        of node: SiteGraphNode,
+        in snapshot: SiteGraphExplorerSnapshot
+    ) -> (dependsOn: [SiteGraphNode], referencedBy: [SiteGraphNode]) {
+        let nodesByID = Dictionary(snapshot.nodes.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        var dependsOn: [SiteGraphNode] = []
+        var referencedBy: [SiteGraphNode] = []
+        for edge in snapshot.edges {
+            if edge.sourceID == node.id, let target = nodesByID[edge.targetID] { dependsOn.append(target) }
+            if edge.targetID == node.id, let source = nodesByID[edge.sourceID] { referencedBy.append(source) }
+        }
+        return (dependsOn, referencedBy)
+    }
+
+    /// `nil` when the node has no file path (e.g. a `.collection` node, which represents a
+    /// grouping rather than a single file) — it still grounds the answer via its facts block,
+    /// but there is nothing sensible to cite or open.
+    static func citation(for node: SiteGraphNode) -> RetrievedCitation? {
+        guard let path = node.filePath else { return nil }
+        return RetrievedCitation(
+            id: node.id,
+            path: path,
+            kind: documentKind(for: node.kind),
+            title: node.title,
+            lineRange: nil,
+            score: 1
+        )
+    }
+
+    static func documentKind(for kind: SiteGraphNodeKind) -> SiteKnowledgeIndex.Document.Kind {
+        switch kind {
+        case .page: return .page
+        case .layout: return .layout
+        case .component: return .component
+        case .collection, .contentEntry: return .content
+        case .asset: return .other
+        case .style: return .style
+        }
+    }
+
+    private static func matchScore(node: SiteGraphNode, terms: [String]) -> Int {
+        let haystack = [node.title, node.route, node.filePath]
+            .compactMap { $0 }
+            .joined(separator: " ")
+            .lowercased()
+        return terms.reduce(0) { count, term in haystack.contains(term) ? count + 1 : count }
+    }
+
+    /// Words of 3+ characters — short words ("is", "the", "of") match nearly every node and add
+    /// noise rather than signal.
+    private static func queryTerms(_ question: String) -> [String] {
+        question
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { $0.count > 2 }
+    }
+}

--- a/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
@@ -38,11 +38,13 @@ public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
         let (enriched, citations) = await enrichedContext(prompt)
         let baseStream = try await base.converse(prompt: enriched, context: context)
         guard !citations.isEmpty else { return baseStream }
-        // Prepended ahead of whatever `base` itself yields — if `base` is a
-        // `KnowledgeAugmentedAssistant`, its own `.citations` event (content-search sources)
-        // still arrives afterward as a second, separate "Sources" row. That's an accepted UX
-        // trade-off: two decorators, each contributing citations independently, is simpler and
-        // more honest than guessing how to merge two different kinds of retrieval.
+        // Prepended ahead of whatever `base` itself yields. Note: the production chat path no
+        // longer composes this decorator around `KnowledgeAugmentedAssistant` — it uses
+        // `CombinedAugmentedAssistant`, which runs both retrievals against the same original
+        // prompt and merges into a single `.citations` event (#314). This instance-level
+        // `converse` stays correct for standalone use (as its own tests exercise it), but if you
+        // do nest another decorator as `base` here, its citations still arrive as a second,
+        // separate event — that combination is untested and not the shipped composition.
         return AsyncStream { continuation in
             let task = Task {
                 continuation.yield(.citations(citations))

--- a/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
@@ -108,12 +108,18 @@ public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
 
         var blocks: [String] = []
         var citations: [RetrievedCitation] = []
+        // Two distinct seed nodes could in principle share a `filePath` (e.g. a future graph
+        // builder change producing a duplicate node) — dedup here rather than assume the snapshot
+        // never does, so one `.citations` event never lists the same file twice.
+        var citedPaths: Set<String> = []
         for node in seeds {
             guard let impact = ImpactAnalysis.analyze(snapshot: snapshot, targetID: node.id) else { continue }
             let (dependsOn, referencedBy) = neighbors(of: node, in: snapshot)
             let facts = SiteGraphExplainPrompt.facts(node: node, impact: impact, dependsOn: dependsOn, referencedBy: referencedBy)
             blocks.append("Facts about \(node.title):\n" + facts.joined(separator: "\n"))
-            if let citation = citation(for: node) { citations.append(citation) }
+            if let citation = citation(for: node), citedPaths.insert(citation.path).inserted {
+                citations.append(citation)
+            }
         }
         guard !blocks.isEmpty else { return nil }
 

--- a/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
@@ -81,31 +81,46 @@ public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
 
     private func enrichedContext(_ prompt: String) async -> (prompt: String, citations: [RetrievedCitation]) {
         let snapshot = await snapshotProvider()
-        let seeds = Self.seedNodes(for: prompt, in: snapshot)
-        guard !seeds.isEmpty else { return (prompt, []) }
-
-        var blocks: [String] = []
-        var citations: [RetrievedCitation] = []
-        for node in seeds {
-            guard let impact = ImpactAnalysis.analyze(snapshot: snapshot, targetID: node.id) else { continue }
-            let (dependsOn, referencedBy) = Self.neighbors(of: node, in: snapshot)
-            let facts = SiteGraphExplainPrompt.facts(node: node, impact: impact, dependsOn: dependsOn, referencedBy: referencedBy)
-            blocks.append("Facts about \(node.title):\n" + facts.joined(separator: "\n"))
-            if let citation = Self.citation(for: node) { citations.append(citation) }
+        guard let (block, citations) = Self.graphBlock(prompt: prompt, snapshot: snapshot) else {
+            return (prompt, [])
         }
-        guard !blocks.isEmpty else { return (prompt, []) }
-
         let enriched = """
-        You are answering a question about how this Astro website is built, using only the \
-        facts below about specific files in its dependency graph. Do not invent details that \
-        are not in the facts, and cite file paths when you use a fact.
-
-        \(blocks.joined(separator: "\n\n"))
+        \(block)
 
         User request:
         \(prompt)
         """
         return (enriched, citations)
+    }
+
+    /// Builds the graph-facts block and citations for `prompt` against `snapshot`, or `nil` when
+    /// no node matches. Exposed (not `private`) so ``CombinedAugmentedAssistant`` can run this
+    /// retrieval directly against the original user question instead of a prompt another
+    /// decorator already rewrote (#314).
+    static func graphBlock(
+        prompt: String,
+        snapshot: SiteGraphExplorerSnapshot
+    ) -> (block: String, citations: [RetrievedCitation])? {
+        let seeds = seedNodes(for: prompt, in: snapshot)
+        guard !seeds.isEmpty else { return nil }
+
+        var blocks: [String] = []
+        var citations: [RetrievedCitation] = []
+        for node in seeds {
+            guard let impact = ImpactAnalysis.analyze(snapshot: snapshot, targetID: node.id) else { continue }
+            let (dependsOn, referencedBy) = neighbors(of: node, in: snapshot)
+            let facts = SiteGraphExplainPrompt.facts(node: node, impact: impact, dependsOn: dependsOn, referencedBy: referencedBy)
+            blocks.append("Facts about \(node.title):\n" + facts.joined(separator: "\n"))
+            if let citation = citation(for: node) { citations.append(citation) }
+        }
+        guard !blocks.isEmpty else { return nil }
+
+        let instructions = """
+        You are answering a question about how this Astro website is built, using only the \
+        facts below about specific files in its dependency graph. Do not invent details that \
+        are not in the facts, and cite file paths when you use a fact.
+        """
+        return (instructions + "\n\n" + blocks.joined(separator: "\n\n"), citations)
     }
 
     /// Scores every node's title/route/filePath against the question's words (case-insensitive

--- a/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
+++ b/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
@@ -37,12 +37,12 @@ public enum SiteGraphExplainPrompt {
     /// on-device model's small context window; the remainder is summarized as "and N more".
     public static let maxListedNames = 12
 
-    public static func prompt(
+    static func facts(
         node: SiteGraphNode,
         impact: ImpactAnalysis.Report,
         dependsOn: [SiteGraphNode],
         referencedBy: [SiteGraphNode]
-    ) -> String {
+    ) -> [String] {
         // A neighbor reachable through several edge kinds (e.g. both `imports` and `usesLayout`)
         // arrives once per edge — list it once, or the capped fact list fills with duplicates.
         let uniqueDependsOn = deduplicated(dependsOn)
@@ -58,7 +58,16 @@ public enum SiteGraphExplainPrompt {
             facts.append("- Referenced by: \(nameList(uniqueReferencedBy, withKinds: true))")
         }
         facts.append(contentsOf: impactFacts(impact))
+        return facts
+    }
 
+    public static func prompt(
+        node: SiteGraphNode,
+        impact: ImpactAnalysis.Report,
+        dependsOn: [SiteGraphNode],
+        referencedBy: [SiteGraphNode]
+    ) -> String {
+        let factLines = facts(node: node, impact: impact, dependsOn: dependsOn, referencedBy: referencedBy)
         return """
         You are explaining one file in a static website's dependency graph to the site's owner, \
         who is not a developer. Using only the facts below, write a short plain-language \
@@ -67,7 +76,7 @@ public enum SiteGraphExplainPrompt {
         list — synthesize them.
 
         Facts:
-        \(facts.joined(separator: "\n"))
+        \(factLines.joined(separator: "\n"))
         """
     }
 

--- a/Tests/AnglesiteAppTests/CitationRowViewTests.swift
+++ b/Tests/AnglesiteAppTests/CitationRowViewTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// Covers `CitationRowView.handleTap`, the citation-chip click logic pulled out of the button's
+/// action closure specifically so it's testable without a SwiftUI rendering harness. A regression
+/// here (e.g. an inverted boolean, always falling through to `openFile`) would previously go
+/// unnoticed — only `SiteWindowModel.revealCitationInGraph` itself was unit-tested, not the view
+/// wiring that calls it (#314 review finding).
+@Suite("CitationRowView.handleTap")
+struct CitationRowViewTests {
+    private func citation(path: String) -> RetrievedCitation {
+        RetrievedCitation(id: path, path: path, kind: .component, title: nil, lineRange: nil, score: 1)
+    }
+
+    @Test("a successful reveal does not fall back to opening the file")
+    func revealSuccessSkipsOpenFile() {
+        var openedURLs: [URL] = []
+        CitationRowView.handleTap(
+            citation: citation(path: "src/components/Header.astro"),
+            siteDirectory: URL(fileURLWithPath: "/site"),
+            revealCitation: { _ in true },
+            openFile: { openedURLs.append($0) }
+        )
+        #expect(openedURLs.isEmpty)
+    }
+
+    @Test("a declined reveal (false) falls back to opening the file at the resolved path")
+    func revealFailureFallsBackToOpenFile() {
+        var openedURLs: [URL] = []
+        CitationRowView.handleTap(
+            citation: citation(path: "src/components/Header.astro"),
+            siteDirectory: URL(fileURLWithPath: "/site"),
+            revealCitation: { _ in false },
+            openFile: { openedURLs.append($0) }
+        )
+        #expect(openedURLs == [URL(fileURLWithPath: "/site/src/components/Header.astro")])
+    }
+
+    @Test("no revealCitation closure (nil) falls back to opening the file")
+    func nilRevealCitationFallsBackToOpenFile() {
+        var openedURLs: [URL] = []
+        CitationRowView.handleTap(
+            citation: citation(path: "src/pages/about.astro"),
+            siteDirectory: URL(fileURLWithPath: "/site"),
+            revealCitation: nil,
+            openFile: { openedURLs.append($0) }
+        )
+        #expect(openedURLs == [URL(fileURLWithPath: "/site/src/pages/about.astro")])
+    }
+
+    @Test("revealCitation is called with the citation's own path, not a different one")
+    func revealCitationReceivesTheCitationsPath() {
+        var receivedPaths: [String] = []
+        CitationRowView.handleTap(
+            citation: citation(path: "src/components/Footer.astro"),
+            siteDirectory: URL(fileURLWithPath: "/site"),
+            revealCitation: { path in
+                receivedPaths.append(path)
+                return true
+            },
+            openFile: { _ in }
+        )
+        #expect(receivedPaths == ["src/components/Footer.astro"])
+    }
+}

--- a/Tests/AnglesiteAppTests/SiteAssistantSessionFactoryTests.swift
+++ b/Tests/AnglesiteAppTests/SiteAssistantSessionFactoryTests.swift
@@ -1,0 +1,82 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+/// Actor-based capture, not a plain `var` mutated inside `Task { }` — the assistant-builder
+/// closure runs synchronously but needs to await the (async) snapshot provider, so the capture
+/// itself must be safe to mutate from that detached `Task`. Matches the `CapturingConversationalAssistant`
+/// idiom already used in `KnowledgeAugmentedAssistantTests`.
+private actor SnapshotCapture {
+    private(set) var received: SiteGraphExplorerSnapshot?
+    func capture(_ snapshot: SiteGraphExplorerSnapshot) { received = snapshot }
+}
+
+@Suite("SiteAssistantSessionFactory")
+@MainActor
+struct SiteAssistantSessionFactoryTests {
+    @Test("makeSession forwards the graph snapshot provider to the assistant builder")
+    func forwardsGraphSnapshotProvider() async throws {
+        let expected = SiteGraphExplorerSnapshot(
+            nodes: [SiteGraphNode(id: "n1", kind: .page, title: "Home", detail: nil, filePath: "src/pages/index.astro", route: "/")],
+            edges: []
+        )
+        let capture = SnapshotCapture()
+        var dependencies = SiteAssistantSessionFactory.Dependencies.live
+        dependencies.assistant = { _, _, _, _, _, graphSnapshotProvider in
+            Task {
+                let snapshot = await graphSnapshotProvider()
+                await capture.capture(snapshot)
+            }
+            return StubConversationalAssistant()
+        }
+
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        _ = SiteAssistantSessionFactory.makeSession(
+            siteID: "site-1",
+            sourceDirectory: root,
+            configDirectory: root,
+            mcpClient: { nil },
+            contentGraph: SiteContentGraph(),
+            knowledgeIndex: SiteKnowledgeIndex(),
+            semanticRanker: nil,
+            conventionsEngine: nil,
+            integrationService: IntegrationOperations.live(),
+            dependencies: dependencies,
+            graphSnapshotProvider: { expected }
+        )
+
+        while await capture.received == nil { await Task.yield() }
+        #expect(await capture.received == expected)
+    }
+}
+
+private actor StubConversationalAssistant: ConversationalAssistant {
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(
+            supportsStreaming: true, supportsStructuredOutput: false, supportsVision: false,
+            supportsTools: false, maxContextTokens: nil, providerName: "Stub"
+        )
+    }
+
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        AsyncStream { $0.finish() }
+    }
+
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+
+    #if compiler(>=6.4)
+    func generateStructured<T: Generable & Sendable>(prompt: String, context: AssistantContext, resultType: T.Type) async throws -> T {
+        throw AssistantError.unsupported("stub")
+    }
+    #endif
+
+    func cancel() async {}
+    func resetSession() async {}
+}

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -248,4 +248,61 @@ extension SiteWindowModelTests {
         #expect(!handled)
         #expect(model.mainPaneMode == .preview)
     }
+
+    /// Review finding: `revealCitationInGraph`'s deferred `Task` used to call `revealNode`
+    /// unconditionally, even when `showGraph()` aborted (e.g. an unresolved external-file
+    /// conflict), mutating `graphExplorer`'s selection/search state while the user was still
+    /// looking at the editor's conflict dialog. `showGraph()` now reports whether it actually
+    /// switched, and `revealCitationInGraph` only reveals the node when it did.
+    @Test("revealCitationInGraph doesn't touch graph state when showGraph aborts on an editor conflict")
+    func revealCitationInGraphSkipsRevealWhenShowGraphAborts() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let contentGraph = SiteContentGraph()
+        await contentGraph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date()
+            )],
+            posts: [], images: []
+        )
+        let model = makeModel(contentGraph: contentGraph)
+        model.graphExplorer.start(siteID: "site-1", sourceDirectory: root)
+        while model.graphExplorer.snapshot.nodes.isEmpty { await Task.yield() }
+
+        // A dirty editor whose file changed externally under it — `flushBeforeLeaving()`'s real
+        // conflict path (same technique as `EditableFileSessionTests`'s `writeExternally`).
+        let editedFile = root.appendingPathComponent("conflict.txt")
+        try Data("original".utf8).write(to: editedFile)
+        let fileRef = FileRef(url: editedFile, group: .components, name: "conflict.txt")
+        let editorModel = FileEditorModel(file: fileRef)
+        await editorModel.load()
+        editorModel.text = "dirty edit"
+        try Data("changed on disk".utf8).write(to: editedFile)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(2)], ofItemAtPath: editedFile.path
+        )
+        model.mainPaneMode = .editor(fileRef)
+        model.activeEditor = .text(editorModel)
+
+        let handled = model.revealCitationInGraph("src/pages/about.astro")
+        #expect(handled)
+
+        // Bounded poll (not unbounded) for the conflict to surface — the signal that
+        // `showGraph()`'s deferred Task has finished running and aborted.
+        var iterations = 0
+        while editorModel.conflictDiskContents == nil, iterations < 10_000 {
+            await Task.yield()
+            iterations += 1
+        }
+        guard editorModel.conflictDiskContents != nil else {
+            Issue.record("flushBeforeLeaving never surfaced the external conflict")
+            return
+        }
+
+        #expect(model.mainPaneMode == .editor(fileRef))
+        #expect(model.graphExplorer.selectedNodeID == nil)
+    }
 }

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -212,3 +212,40 @@ extension SiteWindowModelTests {
         #expect(model.contentActionError == nil)
     }
 }
+
+extension SiteWindowModelTests {
+    @Test("revealCitationInGraph returns true and switches to the graph pane for a matching path")
+    func revealCitationInGraphMatches() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let contentGraph = SiteContentGraph()
+        await contentGraph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date()
+            )],
+            posts: [], images: []
+        )
+        let model = makeModel(contentGraph: contentGraph)
+        model.graphExplorer.start(siteID: "site-1", sourceDirectory: root)
+        while model.graphExplorer.snapshot.nodes.isEmpty { await Task.yield() }
+
+        let handled = model.revealCitationInGraph("src/pages/about.astro")
+
+        #expect(handled)
+        while model.mainPaneMode != .graph { await Task.yield() }
+        #expect(model.graphExplorer.selectedNodeID == model.graphExplorer.snapshot.nodes.first?.id)
+    }
+
+    @Test("revealCitationInGraph returns false and does not switch panes for an unknown path")
+    func revealCitationInGraphNoMatch() {
+        let model = makeModel()
+
+        let handled = model.revealCitationInGraph("src/pages/unknown.astro")
+
+        #expect(!handled)
+        #expect(model.mainPaneMode == .preview)
+    }
+}

--- a/Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift
@@ -1,0 +1,199 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+private actor CapturingConversationalAssistant: ConversationalAssistant {
+    private(set) var prompts: [String] = []
+
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(
+            supportsStreaming: true,
+            supportsStructuredOutput: false,
+            supportsVision: false,
+            supportsTools: false,
+            maxContextTokens: nil,
+            providerName: "Capture"
+        )
+    }
+
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        prompts.append(prompt)
+        return AsyncStream { continuation in
+            continuation.yield(.started(model: "Capture", toolNames: []))
+            continuation.yield(.textDelta("ok"))
+            continuation.yield(.turnComplete(nil))
+            continuation.finish()
+        }
+    }
+
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        prompts.append(prompt)
+        return AsyncThrowingStream { continuation in
+            continuation.yield("ok")
+            continuation.finish()
+        }
+    }
+
+    #if compiler(>=6.4)
+    func generateStructured<T: Generable & Sendable>(
+        prompt: String,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        prompts.append(prompt)
+        throw AssistantError.unsupported("capture assistant does not generate structured values")
+    }
+    #endif
+
+    func cancel() async {}
+    func resetSession() async {}
+}
+
+@Suite("CombinedAugmentedAssistant")
+struct CombinedAugmentedAssistantTests {
+    private func node(
+        _ id: String,
+        kind: SiteGraphNodeKind = .component,
+        title: String,
+        filePath: String? = nil
+    ) -> SiteGraphNode {
+        SiteGraphNode(id: id, kind: kind, title: title, detail: nil, filePath: filePath, route: nil)
+    }
+
+    private func makeSite() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("combined-assistant-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("src/components"),
+            withIntermediateDirectories: true
+        )
+        return root
+    }
+
+    @Test("the content-index search runs against the original prompt, not a graph-enriched one")
+    func contentSearchUsesOriginalPrompt() async throws {
+        // A seed node whose title/facts would previously have polluted the content-index query
+        // if it were nested inside SiteGraphAugmentedAssistant's enriched text.
+        let header = node("c1", title: "Header", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [header], edges: [])
+
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "export const CTA = 'Book a consultation';\n".write(
+            to: root.appendingPathComponent("src/components/CTA.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(base: base, index: index, graphSnapshotProvider: { snapshot })
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        for await _ in try await assistant.converse(prompt: "How does the Header work with the CTA?", context: context) {}
+
+        // Both blocks must be present in the single prompt sent to `base` — proving the content
+        // search ran (it found the CTA excerpt) using the ORIGINAL question, not text mutated by
+        // the graph decorator first.
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Header") == true)
+        #expect(prompt?.contains("src/components/CTA.astro") == true)
+        #expect(prompt?.contains("User request:\nHow does the Header work with the CTA?") == true)
+    }
+
+    @Test("citations from both sources are merged into a single .citations event")
+    func mergesCitationsIntoOneEvent() async throws {
+        let header = node("c1", title: "Header", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [header], edges: [])
+
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "export const CTA = 'Book a consultation';\n".write(
+            to: root.appendingPathComponent("src/components/CTA.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(base: base, index: index, graphSnapshotProvider: { snapshot })
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "How does the Header work with the CTA?", context: context) {
+            events.append(event)
+        }
+
+        let citationEvents = events.filter { if case .citations = $0 { return true } else { return false } }
+        #expect(citationEvents.count == 1)
+        guard case .citations(let citations) = citationEvents.first else {
+            Issue.record("Expected exactly one .citations event")
+            return
+        }
+        #expect(citations.contains { $0.path == "src/components/Header.astro" })
+        #expect(citations.contains { $0.path == "src/components/CTA.astro" })
+    }
+
+    @Test("a path cited by both sources is only cited once, keeping the graph citation")
+    func dedupesCitationsByPath() async throws {
+        let cta = node("c1", title: "CTA", filePath: "src/components/CTA.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [cta], edges: [])
+
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "export const CTA = 'Book a consultation';\n".write(
+            to: root.appendingPathComponent("src/components/CTA.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(base: base, index: index, graphSnapshotProvider: { snapshot })
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "Tell me about the CTA component", context: context) {
+            events.append(event)
+        }
+
+        guard case .citations(let citations) = events.first else {
+            Issue.record("Expected first event to be .citations")
+            return
+        }
+        let ctaCitations = citations.filter { $0.path == "src/components/CTA.astro" }
+        #expect(ctaCitations.count == 1)
+        #expect(ctaCitations.first?.kind == .component)
+    }
+
+    @Test("neither source matching leaves the prompt untouched and skips citations")
+    func neitherMatchesLeavesPromptUntouched() async throws {
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(
+            base: base, index: index,
+            graphSnapshotProvider: { SiteGraphExplorerSnapshot(nodes: [], edges: []) }
+        )
+        let prompt = "Explain quantum entanglement"
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: prompt, context: AssistantContext(siteID: "site", siteDirectory: root)) {
+            events.append(event)
+        }
+
+        #expect(await base.prompts.first == prompt)
+        let hasCitations = events.contains { if case .citations = $0 { return true } else { return false } }
+        #expect(!hasCitations)
+    }
+}

--- a/Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift
@@ -4,6 +4,13 @@ import Foundation
 
 #if compiler(>=6.4)
 import FoundationModels
+
+/// A minimal `Generable` value for exercising `generateStructured`'s prompt-enrichment path.
+@Generable
+struct CombinedAugmentedAssistantStubResult: Equatable {
+    @Guide(description: "A generated title")
+    var title: String
+}
 #endif
 
 private actor CapturingConversationalAssistant: ConversationalAssistant {
@@ -224,6 +231,121 @@ struct CombinedAugmentedAssistantTests {
         }
 
         #expect(await base.prompts.first == prompt)
+        let hasCitations = events.contains { if case .citations = $0 { return true } else { return false } }
+        #expect(!hasCitations)
+    }
+
+    /// `converse` was the only entry point exercised so far; `generate` independently calls
+    /// `enrichedContext` too and could regress the original-prompt guarantee without either the
+    /// other tests or `converse`'s own passing noticing (review finding).
+    @Test("generate grounds the prompt against the original question, not a polluted one")
+    func generateUsesOriginalPrompt() async throws {
+        let header = node("c1", title: "Header", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [header], edges: [])
+
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "export const CTA = 'Book a consultation';\n".write(
+            to: root.appendingPathComponent("src/components/CTA.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+        // Same decoy technique as `contentSearchUsesOriginalPrompt` — vocabulary drawn only from
+        // the graph decorator's instruction sentence, absent from the real question.
+        try """
+        export const note = 'dependency dependency dependency invent invent invent \
+        injection graph specific facts answering built';
+        """.write(
+            to: root.appendingPathComponent("src/components/DepNotes.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(base: base, index: index, graphSnapshotProvider: { snapshot })
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        for try await _ in try await assistant.generate(prompt: "How does the Header work with the CTA?", context: context) {}
+
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Header") == true)
+        #expect(prompt?.contains("src/components/CTA.astro") == true)
+        #expect(prompt?.contains("DepNotes.astro") == false)
+    }
+
+    #if compiler(>=6.4)
+    /// Same guarantee as `generateUsesOriginalPrompt`, for the third `ContentAssistant` entry
+    /// point (review finding — `generateStructured` also independently calls `enrichedContext`).
+    @Test("generateStructured grounds the prompt against the original question, not a polluted one")
+    func generateStructuredUsesOriginalPrompt() async throws {
+        let header = node("c1", title: "Header", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [header], edges: [])
+
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "export const CTA = 'Book a consultation';\n".write(
+            to: root.appendingPathComponent("src/components/CTA.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        export const note = 'dependency dependency dependency invent invent invent \
+        injection graph specific facts answering built';
+        """.write(
+            to: root.appendingPathComponent("src/components/DepNotes.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(base: base, index: index, graphSnapshotProvider: { snapshot })
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        // `CapturingConversationalAssistant.generateStructured` always throws — this test only
+        // needs the prompt it recorded before doing so.
+        _ = try? await assistant.generateStructured(
+            prompt: "How does the Header work with the CTA?",
+            context: context,
+            resultType: CombinedAugmentedAssistantStubResult.self
+        )
+
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Header") == true)
+        #expect(prompt?.contains("src/components/CTA.astro") == true)
+        #expect(prompt?.contains("DepNotes.astro") == false)
+    }
+    #endif
+
+    /// Mirrors `SiteGraphAugmentedAssistantTests.nodeWithoutFilePathNotCited` but through the
+    /// merge path — a node without a `filePath` (e.g. `.collection`) should still ground the
+    /// answer via its facts block without producing a citation for it (review finding: this case
+    /// wasn't covered for the routed-through-`CombinedAugmentedAssistant` path, only the
+    /// standalone `SiteGraphAugmentedAssistant`).
+    @Test("a graph node without a file path grounds the answer but isn't cited, through the merge path")
+    func nodeWithoutFilePathNotCitedThroughMerge() async throws {
+        let collection = node("col1", kind: .collection, title: "Blog Collection")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [collection], edges: [])
+
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(base: base, index: index, graphSnapshotProvider: { snapshot })
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "What is the Blog Collection?", context: context) {
+            events.append(event)
+        }
+
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Blog Collection") == true)
         let hasCitations = events.contains { if case .citations = $0 { return true } else { return false } }
         #expect(!hasCitations)
     }

--- a/Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift
@@ -88,6 +88,24 @@ struct CombinedAugmentedAssistantTests {
             atomically: true,
             encoding: .utf8
         )
+        // A decoy document whose distinctive vocabulary ("dependency", "invent"...) comes only
+        // from SiteGraphAugmentedAssistant's graphBlock instruction sentence ("...its dependency
+        // graph. Do not invent details...") — never from the real user question below. `search`'s
+        // scoring is purely additive per matched query term with no dilution penalty, so if
+        // `enrichedContext` regressed to (bug-for-bug) feeding the graph-enriched blob into
+        // `contentBlock` instead of the raw prompt, those instruction words would become search
+        // terms and this decoy would be promoted into the citations/prompt. A single-candidate
+        // fixture (just the CTA doc) can't tell that regression apart from the fix, because the
+        // original prompt's words are still present as terms even in a polluted query — this
+        // decoy is what makes the distinction observable.
+        try """
+        export const note = 'dependency dependency dependency invent invent invent \
+        injection graph specific facts answering built';
+        """.write(
+            to: root.appendingPathComponent("src/components/DepNotes.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
         let index = SiteKnowledgeIndex()
         await index.rebuild(siteID: "site", projectRoot: root)
 
@@ -95,7 +113,10 @@ struct CombinedAugmentedAssistantTests {
         let assistant = CombinedAugmentedAssistant(base: base, index: index, graphSnapshotProvider: { snapshot })
         let context = AssistantContext(siteID: "site", siteDirectory: root)
 
-        for await _ in try await assistant.converse(prompt: "How does the Header work with the CTA?", context: context) {}
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "How does the Header work with the CTA?", context: context) {
+            events.append(event)
+        }
 
         // Both blocks must be present in the single prompt sent to `base` — proving the content
         // search ran (it found the CTA excerpt) using the ORIGINAL question, not text mutated by
@@ -104,6 +125,16 @@ struct CombinedAugmentedAssistantTests {
         #expect(prompt?.contains("Facts about Header") == true)
         #expect(prompt?.contains("src/components/CTA.astro") == true)
         #expect(prompt?.contains("User request:\nHow does the Header work with the CTA?") == true)
+
+        // The decoy must NOT be promoted: its terms only exist in the graph decorator's own
+        // instruction text, never in the user's real question. If it shows up here, the content
+        // search ran against a polluted query.
+        #expect(prompt?.contains("DepNotes.astro") == false)
+        let citationEvents = events.compactMap { event -> [RetrievedCitation]? in
+            if case .citations(let citations) = event { return citations }
+            return nil
+        }
+        #expect(citationEvents.flatMap { $0 }.contains { $0.path == "src/components/DepNotes.astro" } == false)
     }
 
     @Test("citations from both sources are merged into a single .citations event")

--- a/Tests/AnglesiteCoreTests/SiteGraphAugmentedAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphAugmentedAssistantTests.swift
@@ -162,6 +162,29 @@ struct SiteGraphAugmentedAssistantTests {
         #expect(!hasCitations)
     }
 
+    /// Speculative review finding: two distinct seed nodes sharing a `filePath` (not possible
+    /// from today's `SiteGraphExplorer.build`, but not structurally prevented either) shouldn't
+    /// cite the same file twice in one `.citations` event.
+    @Test("two seed nodes sharing a file path are cited once, not twice")
+    func duplicateFilePathCitedOnce() async throws {
+        let a = node("c1", title: "Header A", filePath: "src/components/Header.astro")
+        let b = node("c2", title: "Header B", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [a, b], edges: [])
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "Tell me about the Header components", context: context) {
+            events.append(event)
+        }
+
+        guard case .citations(let citations) = events.first else {
+            Issue.record("Expected .citations event")
+            return
+        }
+        #expect(citations.filter { $0.path == "src/components/Header.astro" }.count == 1)
+    }
+
     @Test("generate also grounds the prompt, matching converse")
     func generateGroundsPrompt() async throws {
         let header = node("c1", title: "Header", filePath: "src/components/Header.astro")

--- a/Tests/AnglesiteCoreTests/SiteGraphAugmentedAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphAugmentedAssistantTests.swift
@@ -1,0 +1,177 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+private actor CapturingConversationalAssistant: ConversationalAssistant {
+    private(set) var prompts: [String] = []
+
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(
+            supportsStreaming: true,
+            supportsStructuredOutput: false,
+            supportsVision: false,
+            supportsTools: false,
+            maxContextTokens: nil,
+            providerName: "Capture"
+        )
+    }
+
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        prompts.append(prompt)
+        return AsyncStream { continuation in
+            continuation.yield(.started(model: "Capture", toolNames: []))
+            continuation.yield(.textDelta("ok"))
+            continuation.yield(.turnComplete(nil))
+            continuation.finish()
+        }
+    }
+
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        prompts.append(prompt)
+        return AsyncThrowingStream { continuation in
+            continuation.yield("ok")
+            continuation.finish()
+        }
+    }
+
+    #if compiler(>=6.4)
+    func generateStructured<T: Generable & Sendable>(
+        prompt: String,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        prompts.append(prompt)
+        throw AssistantError.unsupported("capture assistant does not generate structured values")
+    }
+    #endif
+
+    func cancel() async {}
+    func resetSession() async {}
+}
+
+@Suite("SiteGraphAugmentedAssistant")
+struct SiteGraphAugmentedAssistantTests {
+    private func node(
+        _ id: String,
+        kind: SiteGraphNodeKind = .component,
+        title: String,
+        route: String? = nil,
+        filePath: String? = nil
+    ) -> SiteGraphNode {
+        SiteGraphNode(id: id, kind: kind, title: title, detail: nil, filePath: filePath, route: route)
+    }
+
+    private var context: AssistantContext {
+        AssistantContext(siteID: "site", siteDirectory: FileManager.default.temporaryDirectory)
+    }
+
+    @Test("converse grounds the prompt in a matching node's facts and cites its file")
+    func converseGroundsMatchingNode() async throws {
+        let header = node("c1", kind: .component, title: "Header", filePath: "src/components/Header.astro")
+        let home = node("p1", kind: .page, title: "Home", route: "/", filePath: "src/pages/index.astro")
+        let snapshot = SiteGraphExplorerSnapshot(
+            nodes: [header, home],
+            edges: [SiteGraphEdge(sourceID: "p1", targetID: "c1", kind: .imports)]
+        )
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "How does the Header work?", context: context) {
+            events.append(event)
+        }
+
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Header") == true)
+        #expect(prompt?.contains("src/components/Header.astro") == true)
+        #expect(prompt?.contains("User request:\nHow does the Header work?") == true)
+
+        guard case .citations(let citations) = events.first else {
+            Issue.record("Expected first event to be .citations, got \(events.first.debugDescription)")
+            return
+        }
+        #expect(citations.count == 1)
+        #expect(citations.first?.path == "src/components/Header.astro")
+        #expect(citations.first?.kind == .component)
+    }
+
+    @Test("converse with no matching node skips citations and leaves the prompt untouched")
+    func converseNoMatchLeavesPromptUntouched() async throws {
+        let header = node("c1", kind: .component, title: "Header", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [header], edges: [])
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+        let prompt = "Explain quantum entanglement"
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: prompt, context: context) {
+            events.append(event)
+        }
+
+        #expect(await base.prompts.first == prompt)
+        let hasCitations = events.contains { if case .citations = $0 { return true } else { return false } }
+        #expect(!hasCitations)
+    }
+
+    @Test("seed nodes are capped at 3, ranked by number of matched terms")
+    func seedNodesCappedAndRanked() async throws {
+        let exactMatch = node("c1", title: "Contact Form", filePath: "src/components/ContactForm.astro")
+        let partial1 = node("c2", title: "Contact Widget", filePath: "src/components/ContactWidget.astro")
+        let partial2 = node("c3", title: "Contact Banner", filePath: "src/components/ContactBanner.astro")
+        let extra = node("c4", title: "Contact Footer", filePath: "src/components/ContactFooter.astro")
+        let unrelated = node("c5", title: "Newsletter Signup", filePath: "src/components/Newsletter.astro")
+        let snapshot = SiteGraphExplorerSnapshot(
+            nodes: [exactMatch, partial1, partial2, extra, unrelated],
+            edges: []
+        )
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "Where is the contact form?", context: context) {
+            events.append(event)
+        }
+
+        guard case .citations(let citations) = events.first else {
+            Issue.record("Expected .citations event")
+            return
+        }
+        #expect(citations.count == 3)
+        #expect(!citations.contains { $0.path == "src/components/Newsletter.astro" })
+    }
+
+    @Test("a node with no file path is used for grounding but not cited")
+    func nodeWithoutFilePathNotCited() async throws {
+        let collection = node("col1", kind: .collection, title: "Blog Collection")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [collection], edges: [])
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "What is the Blog Collection?", context: context) {
+            events.append(event)
+        }
+
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Blog Collection") == true)
+        let hasCitations = events.contains { if case .citations = $0 { return true } else { return false } }
+        #expect(!hasCitations)
+    }
+
+    @Test("generate also grounds the prompt, matching converse")
+    func generateGroundsPrompt() async throws {
+        let header = node("c1", title: "Header", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [header], edges: [])
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+
+        for try await _ in try await assistant.generate(prompt: "Tell me about the Header", context: context) {}
+
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Header") == true)
+    }
+}

--- a/docs/superpowers/plans/2026-07-09-graph-augmented-chat.md
+++ b/docs/superpowers/plans/2026-07-09-graph-augmented-chat.md
@@ -998,6 +998,512 @@ git commit -m "feat: reveal-in-graph on chat citation click (#314)"
 
 ---
 
+### Task 6: Fix nested-decorator query pollution with `CombinedAugmentedAssistant`
+
+**Why:** The final whole-branch review (after Tasks 1-5) found that nesting
+`SiteGraphAugmentedAssistant(base: KnowledgeAugmentedAssistant(base: FoundationModelAssistant(...)))`
+(Task 3's wiring) means `KnowledgeAugmentedAssistant.enrichedContext` searches
+`SiteKnowledgeIndex` using the prompt `SiteGraphAugmentedAssistant` already rewrote — a blob of
+instructions and fact lines, not the user's actual question — degrading the content-index
+citations on exactly the structural questions this feature targets. Both decorators already
+compute `(prompt, context) -> (enrichedText, citations)` independently; the fix is to run both
+retrievals against the same, untouched prompt and merge once, instead of nesting.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift` (extract a reusable static retrieval step)
+- Modify: `Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift` (extract a reusable static retrieval step)
+- Create: `Sources/AnglesiteCore/CombinedAugmentedAssistant.swift`
+- Test: `Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift`
+- Modify: `Sources/AnglesiteApp/SiteAssistantSessionFactory.swift:67-82` (only the body of the `assistant` closure changes — the `AssistantBuilder` typealias and `makeSession` signature from Task 3 are unchanged)
+
+**Interfaces:**
+- Consumes: `SiteGraphExplainPrompt.facts(...)` (Task 1, unchanged), `SiteGraphAugmentedAssistant`'s existing static helpers (Task 2), `KnowledgeAugmentedAssistant.formatContext` (existing).
+- Produces: `SiteGraphAugmentedAssistant.graphBlock(prompt:snapshot:) -> (block: String, citations: [RetrievedCitation])?`, `KnowledgeAugmentedAssistant.contentBlock(prompt:context:index:) async -> (block: String, citations: [RetrievedCitation])?`, `public actor CombinedAugmentedAssistant: ConversationalAssistant` with `init(base:index:graphSnapshotProvider:)`.
+
+The extractions in Steps 1-2 are pure refactors — each decorator's OWN `enrichedContext` must
+keep producing byte-identical output to before, so `SiteGraphAugmentedAssistantTests` and
+`KnowledgeAugmentedAssistantTests` must both keep passing unchanged.
+
+- [ ] **Step 1: Extract `SiteGraphAugmentedAssistant.graphBlock(prompt:snapshot:)`**
+
+Run baseline: `swift test --filter SiteGraphAugmentedAssistant` — Expected: PASS (5/5, established baseline)
+
+In `Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift`, replace the `enrichedContext` method (current lines 82-109) with:
+
+```swift
+    private func enrichedContext(_ prompt: String) async -> (prompt: String, citations: [RetrievedCitation]) {
+        let snapshot = await snapshotProvider()
+        guard let (block, citations) = Self.graphBlock(prompt: prompt, snapshot: snapshot) else {
+            return (prompt, [])
+        }
+        let enriched = """
+        \(block)
+
+        User request:
+        \(prompt)
+        """
+        return (enriched, citations)
+    }
+
+    /// Builds the graph-facts block and citations for `prompt` against `snapshot`, or `nil` when
+    /// no node matches. Exposed (not `private`) so ``CombinedAugmentedAssistant`` can run this
+    /// retrieval directly against the original user question instead of a prompt another
+    /// decorator already rewrote (#314).
+    static func graphBlock(
+        prompt: String,
+        snapshot: SiteGraphExplorerSnapshot
+    ) -> (block: String, citations: [RetrievedCitation])? {
+        let seeds = seedNodes(for: prompt, in: snapshot)
+        guard !seeds.isEmpty else { return nil }
+
+        var blocks: [String] = []
+        var citations: [RetrievedCitation] = []
+        for node in seeds {
+            guard let impact = ImpactAnalysis.analyze(snapshot: snapshot, targetID: node.id) else { continue }
+            let (dependsOn, referencedBy) = neighbors(of: node, in: snapshot)
+            let facts = SiteGraphExplainPrompt.facts(node: node, impact: impact, dependsOn: dependsOn, referencedBy: referencedBy)
+            blocks.append("Facts about \(node.title):\n" + facts.joined(separator: "\n"))
+            if let citation = citation(for: node) { citations.append(citation) }
+        }
+        guard !blocks.isEmpty else { return nil }
+
+        let instructions = """
+        You are answering a question about how this Astro website is built, using only the \
+        facts below about specific files in its dependency graph. Do not invent details that \
+        are not in the facts, and cite file paths when you use a fact.
+        """
+        return (instructions + "\n\n" + blocks.joined(separator: "\n\n"), citations)
+    }
+```
+
+Run: `swift test --filter SiteGraphAugmentedAssistant`
+Expected: PASS (same 5/5, output unchanged — this is a pure extraction)
+
+- [ ] **Step 2: Extract `KnowledgeAugmentedAssistant.contentBlock(prompt:context:index:)`**
+
+Run baseline: `swift test --filter KnowledgeAugmentedAssistant` — Expected: PASS (established baseline)
+
+In `Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift`, replace the `enrichedContext` method (current lines 65-80) with:
+
+```swift
+    private func enrichedContext(_ prompt: String, context: AssistantContext) async -> (prompt: String, citations: [RetrievedCitation]) {
+        guard let (block, citations) = await Self.contentBlock(prompt: prompt, context: context, index: index) else {
+            return (prompt, [])
+        }
+        let enriched = """
+        \(block)
+
+        User request:
+        \(prompt)
+        """
+        return (enriched, citations)
+    }
+
+    /// Builds the content-search block and citations for `prompt`, or `nil` when nothing
+    /// matches. Exposed (not `private`) so ``CombinedAugmentedAssistant`` can run this retrieval
+    /// directly against the original user question instead of a prompt another decorator already
+    /// rewrote (#314).
+    static func contentBlock(
+        prompt: String,
+        context: AssistantContext,
+        index: SiteKnowledgeIndex
+    ) async -> (block: String, citations: [RetrievedCitation])? {
+        let results = await index.search(
+            siteID: context.siteID,
+            query: prompt,
+            options: context.searchOptions
+        )
+        guard !results.isEmpty else { return nil }
+        return (formatContext(results), results.map(RetrievedCitation.init))
+    }
+```
+
+(`formatContext` is already `private static` — leave it as-is, unchanged.)
+
+Run: `swift test --filter KnowledgeAugmentedAssistant`
+Expected: PASS (same as baseline, output unchanged — this is a pure extraction)
+
+- [ ] **Step 3: Write the failing tests for `CombinedAugmentedAssistant`**
+
+Create `Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+private actor CapturingConversationalAssistant: ConversationalAssistant {
+    private(set) var prompts: [String] = []
+
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(
+            supportsStreaming: true,
+            supportsStructuredOutput: false,
+            supportsVision: false,
+            supportsTools: false,
+            maxContextTokens: nil,
+            providerName: "Capture"
+        )
+    }
+
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        prompts.append(prompt)
+        return AsyncStream { continuation in
+            continuation.yield(.started(model: "Capture", toolNames: []))
+            continuation.yield(.textDelta("ok"))
+            continuation.yield(.turnComplete(nil))
+            continuation.finish()
+        }
+    }
+
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        prompts.append(prompt)
+        return AsyncThrowingStream { continuation in
+            continuation.yield("ok")
+            continuation.finish()
+        }
+    }
+
+    #if compiler(>=6.4)
+    func generateStructured<T: Generable & Sendable>(
+        prompt: String,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        prompts.append(prompt)
+        throw AssistantError.unsupported("capture assistant does not generate structured values")
+    }
+    #endif
+
+    func cancel() async {}
+    func resetSession() async {}
+}
+
+@Suite("CombinedAugmentedAssistant")
+struct CombinedAugmentedAssistantTests {
+    private func node(
+        _ id: String,
+        kind: SiteGraphNodeKind = .component,
+        title: String,
+        filePath: String? = nil
+    ) -> SiteGraphNode {
+        SiteGraphNode(id: id, kind: kind, title: title, detail: nil, filePath: filePath, route: nil)
+    }
+
+    private func makeSite() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("combined-assistant-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("src/components"),
+            withIntermediateDirectories: true
+        )
+        return root
+    }
+
+    @Test("the content-index search runs against the original prompt, not a graph-enriched one")
+    func contentSearchUsesOriginalPrompt() async throws {
+        // A seed node whose title/facts would previously have polluted the content-index query
+        // if it were nested inside SiteGraphAugmentedAssistant's enriched text.
+        let header = node("c1", title: "Header", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [header], edges: [])
+
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "export const CTA = 'Book a consultation';\n".write(
+            to: root.appendingPathComponent("src/components/CTA.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(base: base, index: index, graphSnapshotProvider: { snapshot })
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        for await _ in try await assistant.converse(prompt: "How does the Header work with the CTA?", context: context) {}
+
+        // Both blocks must be present in the single prompt sent to `base` — proving the content
+        // search ran (it found the CTA excerpt) using the ORIGINAL question, not text mutated by
+        // the graph decorator first.
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Header") == true)
+        #expect(prompt?.contains("src/components/CTA.astro") == true)
+        #expect(prompt?.contains("User request:\nHow does the Header work with the CTA?") == true)
+    }
+
+    @Test("citations from both sources are merged into a single .citations event")
+    func mergesCitationsIntoOneEvent() async throws {
+        let header = node("c1", title: "Header", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [header], edges: [])
+
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "export const CTA = 'Book a consultation';\n".write(
+            to: root.appendingPathComponent("src/components/CTA.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(base: base, index: index, graphSnapshotProvider: { snapshot })
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "How does the Header work with the CTA?", context: context) {
+            events.append(event)
+        }
+
+        let citationEvents = events.filter { if case .citations = $0 { return true } else { return false } }
+        #expect(citationEvents.count == 1)
+        guard case .citations(let citations) = citationEvents.first else {
+            Issue.record("Expected exactly one .citations event")
+            return
+        }
+        #expect(citations.contains { $0.path == "src/components/Header.astro" })
+        #expect(citations.contains { $0.path == "src/components/CTA.astro" })
+    }
+
+    @Test("a path cited by both sources is only cited once, keeping the graph citation")
+    func dedupesCitationsByPath() async throws {
+        let cta = node("c1", title: "CTA", filePath: "src/components/CTA.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [cta], edges: [])
+
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "export const CTA = 'Book a consultation';\n".write(
+            to: root.appendingPathComponent("src/components/CTA.astro"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(base: base, index: index, graphSnapshotProvider: { snapshot })
+        let context = AssistantContext(siteID: "site", siteDirectory: root)
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "Tell me about the CTA component", context: context) {
+            events.append(event)
+        }
+
+        guard case .citations(let citations) = events.first else {
+            Issue.record("Expected first event to be .citations")
+            return
+        }
+        let ctaCitations = citations.filter { $0.path == "src/components/CTA.astro" }
+        #expect(ctaCitations.count == 1)
+        #expect(ctaCitations.first?.kind == .component)
+    }
+
+    @Test("neither source matching leaves the prompt untouched and skips citations")
+    func neitherMatchesLeavesPromptUntouched() async throws {
+        let root = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "site", projectRoot: root)
+
+        let base = CapturingConversationalAssistant()
+        let assistant = CombinedAugmentedAssistant(
+            base: base, index: index,
+            graphSnapshotProvider: { SiteGraphExplorerSnapshot(nodes: [], edges: []) }
+        )
+        let prompt = "Explain quantum entanglement"
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: prompt, context: AssistantContext(siteID: "site", siteDirectory: root)) {
+            events.append(event)
+        }
+
+        #expect(await base.prompts.first == prompt)
+        let hasCitations = events.contains { if case .citations = $0 { return true } else { return false } }
+        #expect(!hasCitations)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `swift test --filter CombinedAugmentedAssistant`
+Expected: FAIL with "cannot find 'CombinedAugmentedAssistant' in scope"
+
+- [ ] **Step 5: Implement `CombinedAugmentedAssistant`**
+
+Create `Sources/AnglesiteCore/CombinedAugmentedAssistant.swift`:
+
+```swift
+import Foundation
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+/// Combines graph-structure grounding (``SiteGraphAugmentedAssistant``) and content-search
+/// grounding (``KnowledgeAugmentedAssistant``) into a single enrichment pass, both run against
+/// the same, untouched user prompt (#314).
+///
+/// Nesting the two decorators (each rewriting `prompt` and forwarding to the next) was the
+/// original approach and was rejected: the inner decorator's retrieval search then runs against
+/// the OUTER decorator's already-enriched prompt — a blob of instructions and fact lines, not
+/// the user's actual question — degrading exactly the citations this feature is meant to
+/// produce. Running both retrievals here, against the same original `prompt`, avoids that.
+public actor CombinedAugmentedAssistant: ConversationalAssistant {
+    private let base: any ConversationalAssistant
+    private let index: SiteKnowledgeIndex
+    private let graphSnapshotProvider: @Sendable () async -> SiteGraphExplorerSnapshot
+
+    public init(
+        base: any ConversationalAssistant,
+        index: SiteKnowledgeIndex,
+        graphSnapshotProvider: @escaping @Sendable () async -> SiteGraphExplorerSnapshot
+    ) {
+        self.base = base
+        self.index = index
+        self.graphSnapshotProvider = graphSnapshotProvider
+    }
+
+    public nonisolated var capabilities: AssistantCapabilities {
+        base.capabilities
+    }
+
+    public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        let (enriched, citations) = await enrichedContext(prompt, context: context)
+        let baseStream = try await base.converse(prompt: enriched, context: context)
+        guard !citations.isEmpty else { return baseStream }
+        return AsyncStream { continuation in
+            let task = Task {
+                continuation.yield(.citations(citations))
+                for await event in baseStream {
+                    continuation.yield(event)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    public func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        let (enriched, _) = await enrichedContext(prompt, context: context)
+        return try await base.generate(prompt: enriched, context: context)
+    }
+
+    #if compiler(>=6.4)
+    public func generateStructured<T: Generable & Sendable>(
+        prompt: String,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        let (enriched, _) = await enrichedContext(prompt, context: context)
+        return try await base.generateStructured(prompt: enriched, context: context, resultType: resultType)
+    }
+    #endif
+
+    public func cancel() async {
+        await base.cancel()
+    }
+
+    public func resetSession() async {
+        await base.resetSession()
+    }
+
+    private func enrichedContext(_ prompt: String, context: AssistantContext) async -> (prompt: String, citations: [RetrievedCitation]) {
+        let snapshot = await graphSnapshotProvider()
+        let graph = SiteGraphAugmentedAssistant.graphBlock(prompt: prompt, snapshot: snapshot)
+        let content = await KnowledgeAugmentedAssistant.contentBlock(prompt: prompt, context: context, index: index)
+
+        var blocks: [String] = []
+        var citations: [RetrievedCitation] = []
+        if let graph {
+            blocks.append(graph.block)
+            citations.append(contentsOf: graph.citations)
+        }
+        if let content {
+            blocks.append(content.block)
+            // A file that's both a matched graph node and a content-search hit is cited once —
+            // the graph citation (added first, above) already covers it and carries the more
+            // specific `SiteGraphNodeKind`-derived kind mapping.
+            let citedPaths = Set(citations.map(\.path))
+            citations.append(contentsOf: content.citations.filter { !citedPaths.contains($0.path) })
+        }
+        guard !blocks.isEmpty else { return (prompt, []) }
+
+        let enriched = """
+        \(blocks.joined(separator: "\n\n"))
+
+        User request:
+        \(prompt)
+        """
+        return (enriched, citations)
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `swift test --filter CombinedAugmentedAssistant`
+Expected: PASS (all 4 tests)
+
+Also re-run the two extraction targets to confirm no regression:
+
+Run: `swift test --filter SiteGraphAugmentedAssistant`
+Expected: PASS (5/5)
+
+Run: `swift test --filter KnowledgeAugmentedAssistant`
+Expected: PASS (established baseline count)
+
+- [ ] **Step 7: Wire `CombinedAugmentedAssistant` into `SiteAssistantSessionFactory`**
+
+In `Sources/AnglesiteApp/SiteAssistantSessionFactory.swift`, replace the `assistant` closure inside `Dependencies.live` (the one built in Task 3, currently constructing a nested `SiteGraphAugmentedAssistant(base: KnowledgeAugmentedAssistant(...))`) with:
+
+```swift
+            let assistant: AssistantBuilder = { editBridge, contentGraph, knowledgeIndex, semanticRanker, integrationService, graphSnapshotProvider in
+                CombinedAugmentedAssistant(
+                    base: FoundationModelAssistant(
+                        tier: .onDevice,
+                        editBridge: editBridge,
+                        contentGraph: contentGraph,
+                        knowledgeIndex: knowledgeIndex,
+                        semanticRanker: semanticRanker,
+                        integrationService: integrationService
+                    ),
+                    index: knowledgeIndex,
+                    graphSnapshotProvider: graphSnapshotProvider
+                )
+            }
+```
+
+The `AssistantBuilder` typealias and `makeSession`'s signature (both from Task 3) are unchanged — only this closure's body changes. `SiteAssistantSessionFactoryTests` (Task 3) stubs `Dependencies.assistant` entirely and never constructs the production closure, so it needs no changes and must still pass unchanged.
+
+- [ ] **Step 8: Run the full test suite and build to verify no regressions**
+
+Run: `swift test`
+Expected: PASS (every target, no regressions)
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift Sources/AnglesiteCore/CombinedAugmentedAssistant.swift Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
+git commit -m "fix: run graph and content RAG against the same original prompt (#314)
+
+Nesting SiteGraphAugmentedAssistant around KnowledgeAugmentedAssistant meant the
+inner content-index search ran against the outer decorator's already-enriched
+prompt instead of the user's actual question, degrading citations on exactly the
+structural questions #314 targets. CombinedAugmentedAssistant runs both
+retrievals against the same original prompt and merges once."
+```
+
+---
+
 ## Self-Review Notes
 
 - **Spec coverage:** Architecture (Task 2), Components (Tasks 1-2), Citations & navigation (Tasks 4-5), Error handling (no new task — verified by Task 2's existing-error-path tests inherited from the unchanged `FoundationModelAssistant`/`ChatModel` error surface), Testing (each task's own test file) — all spec sections have a task.

--- a/docs/superpowers/plans/2026-07-09-graph-augmented-chat.md
+++ b/docs/superpowers/plans/2026-07-09-graph-augmented-chat.md
@@ -1,0 +1,1005 @@
+# Free-form cross-node site Q&A (#314) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the Chat panel answer free-form, cross-node questions about how the site is built ("How is navigation generated?", "Why is this image appearing here?"), grounded in the site's dependency graph, with clickable citations that reveal the matching node in the Site Graph Explorer.
+
+**Architecture:** Add `SiteGraphAugmentedAssistant`, a new `ConversationalAssistant` decorator in `AnglesiteCore` that mirrors the existing `KnowledgeAugmentedAssistant` content-RAG pattern but grounds on the Site Graph Explorer's already-live `SiteGraphExplorerSnapshot` (nodes/edges + `ImpactAnalysis.Report`) instead of file text. Wire it into the existing per-site assistant chain in `SiteAssistantSessionFactory`, and extend the existing citation-chip UI so a click reveals the node in the Site Graph Explorer when possible, falling back to opening the file.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Suite`/`@Test`), SwiftUI, FoundationModels (gated `#if compiler(>=6.4)`).
+
+## Global Constraints
+
+- On-device Foundation Models only, no network fallback (LLM policy, #459) — this plan adds no new model calls; it only changes what gets prepended to the prompt `FoundationModelAssistant` already sends.
+- Every statement in an answer must be traceable to a cited source file (issue #314) — enforced by only injecting facts for nodes with a resolvable path, and instructing the model to cite them.
+- Follow the existing decorator pattern (`KnowledgeAugmentedAssistant`) rather than agentic tool-calling — tool-call results have no capture hook today (`FoundationModelAssistant.swift:229-230`), so front-loaded retrieval is the only path that can produce citations.
+- `SiteGraphExplainPrompt`'s existing single-node behavior (#614) must not change — `SiteGraphExplainPromptTests` must keep passing unchanged after the refactor in Task 1.
+
+---
+
+### Task 1: Extract `SiteGraphExplainPrompt.facts(...)` for reuse
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteGraphNodeExplainer.swift:40-72`
+- Test: `Tests/AnglesiteCoreTests/SiteGraphExplainPromptTests.swift` (existing — must keep passing unchanged)
+
+**Interfaces:**
+- Produces: `SiteGraphExplainPrompt.facts(node: SiteGraphNode, impact: ImpactAnalysis.Report, dependsOn: [SiteGraphNode], referencedBy: [SiteGraphNode]) -> [String]` — used by Task 2's `SiteGraphAugmentedAssistant`.
+
+This is a pure refactor (extract a helper, no behavior change), so the "test" step is confirming the existing characterization tests still pass before and after.
+
+- [ ] **Step 1: Run the existing tests to establish a passing baseline**
+
+Run: `swift test --filter SiteGraphExplainPrompt`
+Expected: PASS (all 8 tests in `SiteGraphExplainPromptTests`)
+
+- [ ] **Step 2: Extract the fact-building body into `facts(...)`**
+
+In `Sources/AnglesiteCore/SiteGraphNodeExplainer.swift`, replace the existing `prompt(...)` method (lines 40-72) with:
+
+```swift
+    static func facts(
+        node: SiteGraphNode,
+        impact: ImpactAnalysis.Report,
+        dependsOn: [SiteGraphNode],
+        referencedBy: [SiteGraphNode]
+    ) -> [String] {
+        // A neighbor reachable through several edge kinds (e.g. both `imports` and `usesLayout`)
+        // arrives once per edge — list it once, or the capped fact list fills with duplicates.
+        let uniqueDependsOn = deduplicated(dependsOn)
+        let uniqueReferencedBy = deduplicated(referencedBy)
+        var facts: [String] = []
+        facts.append("- This file: \(node.title) (a \(kindLabel(node.kind)) on the site)")
+        if let route = node.route { facts.append("- Its page address: \(route)") }
+        if let filePath = node.filePath { facts.append("- Its source file: \(filePath)") }
+        if !uniqueDependsOn.isEmpty {
+            facts.append("- Depends on: \(nameList(uniqueDependsOn, withKinds: true))")
+        }
+        if !uniqueReferencedBy.isEmpty {
+            facts.append("- Referenced by: \(nameList(uniqueReferencedBy, withKinds: true))")
+        }
+        facts.append(contentsOf: impactFacts(impact))
+        return facts
+    }
+
+    public static func prompt(
+        node: SiteGraphNode,
+        impact: ImpactAnalysis.Report,
+        dependsOn: [SiteGraphNode],
+        referencedBy: [SiteGraphNode]
+    ) -> String {
+        let factLines = facts(node: node, impact: impact, dependsOn: dependsOn, referencedBy: referencedBy)
+        return """
+        You are explaining one file in a static website's dependency graph to the site's owner, \
+        who is not a developer. Using only the facts below, write a short plain-language \
+        explanation (2 to 4 sentences) of this file's role on the site and what editing it would \
+        affect. Do not invent details that are not in the facts, and do not repeat the facts as a \
+        list — synthesize them.
+
+        Facts:
+        \(factLines.joined(separator: "\n"))
+        """
+    }
+```
+
+`facts` is deliberately not `public` — its only consumer (Task 2's `SiteGraphAugmentedAssistant`) lives in the same `AnglesiteCore` module.
+
+- [ ] **Step 3: Run the tests again to confirm no regression**
+
+Run: `swift test --filter SiteGraphExplainPrompt`
+Expected: PASS (same 8 tests, unchanged assertions, unchanged output)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
+git commit -m "refactor: extract SiteGraphExplainPrompt.facts for reuse (#314)"
+```
+
+---
+
+### Task 2: `SiteGraphAugmentedAssistant` — graph-grounded RAG decorator
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteGraphAugmentedAssistantTests.swift`
+
+**Interfaces:**
+- Consumes: `SiteGraphExplainPrompt.facts(node:impact:dependsOn:referencedBy:) -> [String]` (Task 1), `ImpactAnalysis.analyze(snapshot:targetID:) -> Report?`, `SiteGraphExplorerSnapshot`/`SiteGraphNode`/`SiteGraphNodeKind`, `RetrievedCitation`, `ConversationalAssistant`/`AssistantContext`/`AssistantEvent`.
+- Produces: `public actor SiteGraphAugmentedAssistant: ConversationalAssistant`, `public init(base: any ConversationalAssistant, snapshotProvider: @escaping @Sendable () async -> SiteGraphExplorerSnapshot)` — consumed by Task 3's `SiteAssistantSessionFactory`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/SiteGraphAugmentedAssistantTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+private actor CapturingConversationalAssistant: ConversationalAssistant {
+    private(set) var prompts: [String] = []
+
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(
+            supportsStreaming: true,
+            supportsStructuredOutput: false,
+            supportsVision: false,
+            supportsTools: false,
+            maxContextTokens: nil,
+            providerName: "Capture"
+        )
+    }
+
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        prompts.append(prompt)
+        return AsyncStream { continuation in
+            continuation.yield(.started(model: "Capture", toolNames: []))
+            continuation.yield(.textDelta("ok"))
+            continuation.yield(.turnComplete(nil))
+            continuation.finish()
+        }
+    }
+
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        prompts.append(prompt)
+        return AsyncThrowingStream { continuation in
+            continuation.yield("ok")
+            continuation.finish()
+        }
+    }
+
+    #if compiler(>=6.4)
+    func generateStructured<T: Generable & Sendable>(
+        prompt: String,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        prompts.append(prompt)
+        throw AssistantError.unsupported("capture assistant does not generate structured values")
+    }
+    #endif
+
+    func cancel() async {}
+    func resetSession() async {}
+}
+
+@Suite("SiteGraphAugmentedAssistant")
+struct SiteGraphAugmentedAssistantTests {
+    private func node(
+        _ id: String,
+        kind: SiteGraphNodeKind = .component,
+        title: String,
+        route: String? = nil,
+        filePath: String? = nil
+    ) -> SiteGraphNode {
+        SiteGraphNode(id: id, kind: kind, title: title, detail: nil, filePath: filePath, route: route)
+    }
+
+    private var context: AssistantContext {
+        AssistantContext(siteID: "site", siteDirectory: FileManager.default.temporaryDirectory)
+    }
+
+    @Test("converse grounds the prompt in a matching node's facts and cites its file")
+    func converseGroundsMatchingNode() async throws {
+        let header = node("c1", kind: .component, title: "Header", filePath: "src/components/Header.astro")
+        let home = node("p1", kind: .page, title: "Home", route: "/", filePath: "src/pages/index.astro")
+        let snapshot = SiteGraphExplorerSnapshot(
+            nodes: [header, home],
+            edges: [SiteGraphEdge(sourceID: "p1", targetID: "c1", kind: .imports)]
+        )
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "How does the Header work?", context: context) {
+            events.append(event)
+        }
+
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Header") == true)
+        #expect(prompt?.contains("src/components/Header.astro") == true)
+        #expect(prompt?.contains("User request:\nHow does the Header work?") == true)
+
+        guard case .citations(let citations) = events.first else {
+            Issue.record("Expected first event to be .citations, got \(events.first.debugDescription)")
+            return
+        }
+        #expect(citations.count == 1)
+        #expect(citations.first?.path == "src/components/Header.astro")
+        #expect(citations.first?.kind == .component)
+    }
+
+    @Test("converse with no matching node skips citations and leaves the prompt untouched")
+    func converseNoMatchLeavesPromptUntouched() async throws {
+        let header = node("c1", kind: .component, title: "Header", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [header], edges: [])
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+        let prompt = "Explain quantum entanglement"
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: prompt, context: context) {
+            events.append(event)
+        }
+
+        #expect(await base.prompts.first == prompt)
+        let hasCitations = events.contains { if case .citations = $0 { return true } else { return false } }
+        #expect(!hasCitations)
+    }
+
+    @Test("seed nodes are capped at 3, ranked by number of matched terms")
+    func seedNodesCappedAndRanked() async throws {
+        let exactMatch = node("c1", title: "Contact Form", filePath: "src/components/ContactForm.astro")
+        let partial1 = node("c2", title: "Contact Widget", filePath: "src/components/ContactWidget.astro")
+        let partial2 = node("c3", title: "Contact Banner", filePath: "src/components/ContactBanner.astro")
+        let extra = node("c4", title: "Contact Footer", filePath: "src/components/ContactFooter.astro")
+        let unrelated = node("c5", title: "Newsletter Signup", filePath: "src/components/Newsletter.astro")
+        let snapshot = SiteGraphExplorerSnapshot(
+            nodes: [exactMatch, partial1, partial2, extra, unrelated],
+            edges: []
+        )
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "Where is the contact form?", context: context) {
+            events.append(event)
+        }
+
+        guard case .citations(let citations) = events.first else {
+            Issue.record("Expected .citations event")
+            return
+        }
+        #expect(citations.count == 3)
+        #expect(!citations.contains { $0.path == "src/components/Newsletter.astro" })
+    }
+
+    @Test("a node with no file path is used for grounding but not cited")
+    func nodeWithoutFilePathNotCited() async throws {
+        let collection = node("col1", kind: .collection, title: "Blog Collection")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [collection], edges: [])
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "What is the Blog Collection?", context: context) {
+            events.append(event)
+        }
+
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Blog Collection") == true)
+        let hasCitations = events.contains { if case .citations = $0 { return true } else { return false } }
+        #expect(!hasCitations)
+    }
+
+    @Test("generate also grounds the prompt, matching converse")
+    func generateGroundsPrompt() async throws {
+        let header = node("c1", title: "Header", filePath: "src/components/Header.astro")
+        let snapshot = SiteGraphExplorerSnapshot(nodes: [header], edges: [])
+        let base = CapturingConversationalAssistant()
+        let assistant = SiteGraphAugmentedAssistant(base: base, snapshotProvider: { snapshot })
+
+        for try await _ in try await assistant.generate(prompt: "Tell me about the Header", context: context) {}
+
+        let prompt = await base.prompts.first
+        #expect(prompt?.contains("Facts about Header") == true)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --filter SiteGraphAugmentedAssistant`
+Expected: FAIL with "cannot find 'SiteGraphAugmentedAssistant' in scope" (the type doesn't exist yet)
+
+- [ ] **Step 3: Implement `SiteGraphAugmentedAssistant`**
+
+Create `Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift`:
+
+```swift
+import Foundation
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+/// Free-form, cross-node grounding for the Chat panel (#314). Mirrors
+/// ``KnowledgeAugmentedAssistant``'s content-search enrichment, but grounds on the Site Graph
+/// Explorer's dependency graph and ``ImpactAnalysis`` instead of file text — the facts needed to
+/// answer structural questions ("how is navigation generated", "why does this image appear
+/// here") that a text search over file contents can't answer.
+///
+/// Reuses #614's per-node fact list (``SiteGraphExplainPrompt/facts(node:impact:dependsOn:referencedBy:)``)
+/// for up to ``SiteGraphAugmentedAssistant/maxSeedNodes`` nodes matched against the question's
+/// words. Contributes nothing when no node matches, so unrelated chat turns are unaffected.
+public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
+    /// Largest number of matched nodes to ground a single question in — keeps the prompt within
+    /// the small on-device context window, matching the philosophy of
+    /// `SiteGraphExplainPrompt.maxListedNames`.
+    static let maxSeedNodes = 3
+
+    private let base: any ConversationalAssistant
+    private let snapshotProvider: @Sendable () async -> SiteGraphExplorerSnapshot
+
+    public init(
+        base: any ConversationalAssistant,
+        snapshotProvider: @escaping @Sendable () async -> SiteGraphExplorerSnapshot
+    ) {
+        self.base = base
+        self.snapshotProvider = snapshotProvider
+    }
+
+    public nonisolated var capabilities: AssistantCapabilities {
+        base.capabilities
+    }
+
+    public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        let (enriched, citations) = await enrichedContext(prompt)
+        let baseStream = try await base.converse(prompt: enriched, context: context)
+        guard !citations.isEmpty else { return baseStream }
+        // Prepended ahead of whatever `base` itself yields — if `base` is a
+        // `KnowledgeAugmentedAssistant`, its own `.citations` event (content-search sources)
+        // still arrives afterward as a second, separate "Sources" row. That's an accepted UX
+        // trade-off: two decorators, each contributing citations independently, is simpler and
+        // more honest than guessing how to merge two different kinds of retrieval.
+        return AsyncStream { continuation in
+            let task = Task {
+                continuation.yield(.citations(citations))
+                for await event in baseStream {
+                    continuation.yield(event)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    public func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        let (enriched, _) = await enrichedContext(prompt)
+        return try await base.generate(prompt: enriched, context: context)
+    }
+
+    #if compiler(>=6.4)
+    public func generateStructured<T: Generable & Sendable>(
+        prompt: String,
+        context: AssistantContext,
+        resultType: T.Type
+    ) async throws -> T {
+        let (enriched, _) = await enrichedContext(prompt)
+        return try await base.generateStructured(prompt: enriched, context: context, resultType: resultType)
+    }
+    #endif
+
+    public func cancel() async {
+        await base.cancel()
+    }
+
+    public func resetSession() async {
+        await base.resetSession()
+    }
+
+    private func enrichedContext(_ prompt: String) async -> (prompt: String, citations: [RetrievedCitation]) {
+        let snapshot = await snapshotProvider()
+        let seeds = Self.seedNodes(for: prompt, in: snapshot)
+        guard !seeds.isEmpty else { return (prompt, []) }
+
+        var blocks: [String] = []
+        var citations: [RetrievedCitation] = []
+        for node in seeds {
+            guard let impact = ImpactAnalysis.analyze(snapshot: snapshot, targetID: node.id) else { continue }
+            let (dependsOn, referencedBy) = Self.neighbors(of: node, in: snapshot)
+            let facts = SiteGraphExplainPrompt.facts(node: node, impact: impact, dependsOn: dependsOn, referencedBy: referencedBy)
+            blocks.append("Facts about \(node.title):\n" + facts.joined(separator: "\n"))
+            if let citation = Self.citation(for: node) { citations.append(citation) }
+        }
+        guard !blocks.isEmpty else { return (prompt, []) }
+
+        let enriched = """
+        You are answering a question about how this Astro website is built, using only the \
+        facts below about specific files in its dependency graph. Do not invent details that \
+        are not in the facts, and cite file paths when you use a fact.
+
+        \(blocks.joined(separator: "\n\n"))
+
+        User request:
+        \(prompt)
+        """
+        return (enriched, citations)
+    }
+
+    /// Scores every node's title/route/filePath against the question's words (case-insensitive
+    /// substring match, matching `SiteKnowledgeIndex`'s keyword-search style rather than
+    /// embeddings), and returns the top ``maxSeedNodes`` by match count. Ties break by title
+    /// (matching `ImpactAnalysis`'s stable sort), then id.
+    static func seedNodes(for question: String, in snapshot: SiteGraphExplorerSnapshot) -> [SiteGraphNode] {
+        let terms = queryTerms(question)
+        guard !terms.isEmpty else { return [] }
+        let scored: [(node: SiteGraphNode, score: Int)] = snapshot.nodes.compactMap { node in
+            let score = matchScore(node: node, terms: terms)
+            return score > 0 ? (node, score) : nil
+        }
+        return scored
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                let byTitle = lhs.node.title.localizedStandardCompare(rhs.node.title)
+                if byTitle != .orderedSame { return byTitle == .orderedAscending }
+                return lhs.node.id < rhs.node.id
+            }
+            .prefix(maxSeedNodes)
+            .map(\.node)
+    }
+
+    /// Direct neighbors of `node` (one hop each direction), matching what #614's
+    /// `SiteGraphExplorerModel.explainSelectedNode()` computes for the single-node case.
+    static func neighbors(
+        of node: SiteGraphNode,
+        in snapshot: SiteGraphExplorerSnapshot
+    ) -> (dependsOn: [SiteGraphNode], referencedBy: [SiteGraphNode]) {
+        let nodesByID = Dictionary(snapshot.nodes.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        var dependsOn: [SiteGraphNode] = []
+        var referencedBy: [SiteGraphNode] = []
+        for edge in snapshot.edges {
+            if edge.sourceID == node.id, let target = nodesByID[edge.targetID] { dependsOn.append(target) }
+            if edge.targetID == node.id, let source = nodesByID[edge.sourceID] { referencedBy.append(source) }
+        }
+        return (dependsOn, referencedBy)
+    }
+
+    /// `nil` when the node has no file path (e.g. a `.collection` node, which represents a
+    /// grouping rather than a single file) — it still grounds the answer via its facts block,
+    /// but there is nothing sensible to cite or open.
+    static func citation(for node: SiteGraphNode) -> RetrievedCitation? {
+        guard let path = node.filePath else { return nil }
+        return RetrievedCitation(
+            id: node.id,
+            path: path,
+            kind: documentKind(for: node.kind),
+            title: node.title,
+            lineRange: nil,
+            score: 1
+        )
+    }
+
+    static func documentKind(for kind: SiteGraphNodeKind) -> SiteKnowledgeIndex.Document.Kind {
+        switch kind {
+        case .page: return .page
+        case .layout: return .layout
+        case .component: return .component
+        case .collection, .contentEntry: return .content
+        case .asset: return .other
+        case .style: return .style
+        }
+    }
+
+    private static func matchScore(node: SiteGraphNode, terms: [String]) -> Int {
+        let haystack = [node.title, node.route, node.filePath]
+            .compactMap { $0 }
+            .joined(separator: " ")
+            .lowercased()
+        return terms.reduce(0) { count, term in haystack.contains(term) ? count + 1 : count }
+    }
+
+    /// Words of 3+ characters — short words ("is", "the", "of") match nearly every node and add
+    /// noise rather than signal.
+    private static func queryTerms(_ question: String) -> [String] {
+        question
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { $0.count > 2 }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --filter SiteGraphAugmentedAssistant`
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift Tests/AnglesiteCoreTests/SiteGraphAugmentedAssistantTests.swift
+git commit -m "feat: add SiteGraphAugmentedAssistant, graph-grounded RAG for chat (#314)"
+```
+
+---
+
+### Task 3: Wire `SiteGraphAugmentedAssistant` into the per-site assistant chain
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteAssistantSessionFactory.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift:1104-1114`
+- Test: `Tests/AnglesiteAppTests/SiteAssistantSessionFactoryTests.swift` (new)
+
+**Interfaces:**
+- Consumes: `SiteGraphAugmentedAssistant.init(base:snapshotProvider:)` (Task 2), `SiteWindowModel.graphExplorer.snapshot` (existing, `Sources/AnglesiteApp/SiteGraphExplorerModel.swift:22`).
+- Produces: `SiteAssistantSessionFactory.makeSession(..., graphSnapshotProvider:)` — the new required parameter every call site must supply.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteAppTests/SiteAssistantSessionFactoryTests.swift`:
+
+```swift
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// Actor-based capture, not a plain `var` mutated inside `Task { }` — the assistant-builder
+/// closure runs synchronously but needs to await the (async) snapshot provider, so the capture
+/// itself must be safe to mutate from that detached `Task`. Matches the `CapturingConversationalAssistant`
+/// idiom already used in `KnowledgeAugmentedAssistantTests`.
+private actor SnapshotCapture {
+    private(set) var received: SiteGraphExplorerSnapshot?
+    func capture(_ snapshot: SiteGraphExplorerSnapshot) { received = snapshot }
+}
+
+@Suite("SiteAssistantSessionFactory")
+@MainActor
+struct SiteAssistantSessionFactoryTests {
+    @Test("makeSession forwards the graph snapshot provider to the assistant builder")
+    func forwardsGraphSnapshotProvider() async throws {
+        let expected = SiteGraphExplorerSnapshot(
+            nodes: [SiteGraphNode(id: "n1", kind: .page, title: "Home", detail: nil, filePath: "src/pages/index.astro", route: "/")],
+            edges: []
+        )
+        let capture = SnapshotCapture()
+        var dependencies = SiteAssistantSessionFactory.Dependencies.live
+        dependencies.assistant = { _, _, _, _, _, graphSnapshotProvider in
+            Task {
+                let snapshot = await graphSnapshotProvider()
+                await capture.capture(snapshot)
+            }
+            return StubConversationalAssistant()
+        }
+
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        _ = SiteAssistantSessionFactory.makeSession(
+            siteID: "site-1",
+            sourceDirectory: root,
+            configDirectory: root,
+            mcpClient: { nil },
+            contentGraph: SiteContentGraph(),
+            knowledgeIndex: SiteKnowledgeIndex(),
+            semanticRanker: nil,
+            conventionsEngine: nil,
+            integrationService: IntegrationOperations.live(),
+            dependencies: dependencies,
+            graphSnapshotProvider: { expected }
+        )
+
+        while await capture.received == nil { await Task.yield() }
+        #expect(await capture.received == expected)
+    }
+}
+
+private actor StubConversationalAssistant: ConversationalAssistant {
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(
+            supportsStreaming: true, supportsStructuredOutput: false, supportsVision: false,
+            supportsTools: false, maxContextTokens: nil, providerName: "Stub"
+        )
+    }
+
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        AsyncStream { $0.finish() }
+    }
+
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+
+    #if compiler(>=6.4)
+    func generateStructured<T: Generable & Sendable>(prompt: String, context: AssistantContext, resultType: T.Type) async throws -> T {
+        throw AssistantError.unsupported("stub")
+    }
+    #endif
+
+    func cancel() async {}
+    func resetSession() async {}
+}
+```
+
+Note: if `IntegrationOperations.live()` or `ProjectConventionsEngine` construction requires arguments this test doesn't have handy, check their existing usages in `SiteWindowModelTests.swift` (`ProjectConventionsEngine()`) and reuse the same no-argument/lightweight construction — `conventionsEngine` in `makeSession` is optional (`ProjectConventionsEngine?`) per the factory's parameter list read in Task 3 Step 2 below, so passing `nil` there is valid.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter SiteAssistantSessionFactoryTests`
+Expected: FAIL to compile — `makeSession` has no `graphSnapshotProvider:` parameter and `Dependencies.assistant`'s closure type has no 6th parameter yet.
+
+- [ ] **Step 3: Update `SiteAssistantSessionFactory`**
+
+In `Sources/AnglesiteApp/SiteAssistantSessionFactory.swift`, replace the `AssistantBuilder` typealias (line 18-24) with:
+
+```swift
+    typealias GraphSnapshotProvider = @Sendable () async -> SiteGraphExplorerSnapshot
+    typealias AssistantBuilder = @Sendable (
+        _ editBridge: IntentEditBridge,
+        _ contentGraph: SiteContentGraph,
+        _ knowledgeIndex: SiteKnowledgeIndex,
+        _ semanticRanker: SemanticRanker?,
+        _ integrationService: any IntegrationOperationsService,
+        _ graphSnapshotProvider: @escaping GraphSnapshotProvider
+    ) -> any ConversationalAssistant
+```
+
+Replace the `assistant` closure inside `Dependencies.live` (lines 52-64) with:
+
+```swift
+            let assistant: AssistantBuilder = { editBridge, contentGraph, knowledgeIndex, semanticRanker, integrationService, graphSnapshotProvider in
+                SiteGraphAugmentedAssistant(
+                    base: KnowledgeAugmentedAssistant(
+                        base: FoundationModelAssistant(
+                            tier: .onDevice,
+                            editBridge: editBridge,
+                            contentGraph: contentGraph,
+                            knowledgeIndex: knowledgeIndex,
+                            semanticRanker: semanticRanker,
+                            integrationService: integrationService
+                        ),
+                        index: knowledgeIndex
+                    ),
+                    snapshotProvider: graphSnapshotProvider
+                )
+            }
+```
+
+Replace `makeSession`'s signature and body (lines 108-137) with:
+
+```swift
+    static func makeSession(
+        siteID: String,
+        sourceDirectory: URL,
+        configDirectory: URL,
+        mcpClient: @escaping MCPClientProvider,
+        contentGraph: SiteContentGraph,
+        knowledgeIndex: SiteKnowledgeIndex,
+        semanticRanker: SemanticRanker?,
+        conventionsEngine: ProjectConventionsEngine?,
+        integrationService: any IntegrationOperationsService,
+        dependencies: Dependencies = .live,
+        graphSnapshotProvider: @escaping GraphSnapshotProvider
+    ) -> SiteAssistantSession {
+        let editBridge = IntentEditBridge(routerProvider: dependencies.editRouterProvider)
+        let chat = ChatModel(
+            siteID: siteID,
+            siteDirectory: sourceDirectory,
+            configDirectory: configDirectory,
+            assistant: dependencies.assistant(
+                editBridge,
+                contentGraph,
+                knowledgeIndex,
+                semanticRanker,
+                integrationService,
+                graphSnapshotProvider
+            ),
+            annotationFeed: dependencies.annotationFeed(sourceDirectory),
+            annotationResolver: { [resolveAnnotation = dependencies.resolveAnnotation] id in
+                try await resolveAnnotation(sourceDirectory, id)
+            },
+            undoCommand: dependencies.undoCommand(mcpClient)
+        )
+
+        let altTextGenerator = dependencies.altTextGenerator(siteID, sourceDirectory, mcpClient, conventionsEngine)
+        let postProcessor: MCPApplyEditRouter.PostProcessor? = { reply, message in
+            await altTextGenerator.postProcess(reply: reply, message: message)
+        }
+
+        return SiteAssistantSession(
+            chat: chat,
+            editObserver: { [weak chat] reply in
+                Task { @MainActor in
+                    chat?.recordEdit(reply)
+                }
+            },
+            editPostProcessor: postProcessor
+        )
+    }
+```
+
+(Only the parameter list and the `dependencies.assistant(...)` call change — the doc comments above `SiteAssistantSession`/`editObserver` stay as they were.)
+
+- [ ] **Step 4: Update the `SiteWindowModel` call site**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, find the `SiteAssistantSessionFactory.makeSession(...)` call (around line 1104):
+
+```swift
+        let assistantSession = SiteAssistantSessionFactory.makeSession(
+            siteID: resolved.id,
+            sourceDirectory: resolved.sourceDirectory,
+            configDirectory: resolved.configDirectory,
+            mcpClient: mcpClient,
+            contentGraph: contentGraph,
+            knowledgeIndex: knowledgeIndex,
+            semanticRanker: semanticRanker,
+            conventionsEngine: conventionsEngine,
+            integrationService: integrationOps
+        )
+```
+
+Replace it with:
+
+```swift
+        let assistantSession = SiteAssistantSessionFactory.makeSession(
+            siteID: resolved.id,
+            sourceDirectory: resolved.sourceDirectory,
+            configDirectory: resolved.configDirectory,
+            mcpClient: mcpClient,
+            contentGraph: contentGraph,
+            knowledgeIndex: knowledgeIndex,
+            semanticRanker: semanticRanker,
+            conventionsEngine: conventionsEngine,
+            integrationService: integrationOps,
+            graphSnapshotProvider: { [weak self] in
+                guard let self else { return SiteGraphExplorerSnapshot(nodes: [], edges: []) }
+                return await MainActor.run { self.graphExplorer.snapshot }
+            }
+        )
+```
+
+- [ ] **Step 5: Run the test to verify it passes, then the full app test target to check for regressions**
+
+Run: `swift test --filter SiteAssistantSessionFactoryTests`
+Expected: PASS
+
+Run: `swift test --filter AnglesiteAppTests`
+Expected: PASS (no regressions in the rest of the suite)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteAssistantSessionFactory.swift Sources/AnglesiteApp/SiteWindowModel.swift Tests/AnglesiteAppTests/SiteAssistantSessionFactoryTests.swift
+git commit -m "feat: wire SiteGraphAugmentedAssistant into the chat assistant chain (#314)"
+```
+
+---
+
+### Task 4: `SiteWindowModel.revealCitationInGraph` — click-to-navigate
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift` (add method near `showGraph()`, line 213-217)
+- Test: `Tests/AnglesiteAppTests/SiteWindowModelTests.swift` (append a new `extension SiteWindowModelTests`)
+
+**Interfaces:**
+- Consumes: `SiteGraphExplorerModel.snapshot` (existing, read-only), `SiteGraphExplorerModel.revealNode(_:)` (existing, `Sources/AnglesiteApp/SiteGraphExplorerModel.swift:68-72`), `SiteWindowModel.showGraph() async` (existing, line 213).
+- Produces: `SiteWindowModel.revealCitationInGraph(_ path: String) -> Bool` — consumed by Task 5's `ChatView` wiring.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/AnglesiteAppTests/SiteWindowModelTests.swift`:
+
+```swift
+extension SiteWindowModelTests {
+    @Test("revealCitationInGraph returns true and switches to the graph pane for a matching path")
+    func revealCitationInGraphMatches() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let contentGraph = SiteContentGraph()
+        await contentGraph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date()
+            )],
+            posts: [], images: []
+        )
+        let model = makeModel(contentGraph: contentGraph)
+        model.graphExplorer.start(siteID: "site-1", sourceDirectory: root)
+        while model.graphExplorer.snapshot.nodes.isEmpty { await Task.yield() }
+
+        let handled = model.revealCitationInGraph("src/pages/about.astro")
+
+        #expect(handled)
+        while model.mainPaneMode != .graph { await Task.yield() }
+        #expect(model.graphExplorer.selectedNodeID == model.graphExplorer.snapshot.nodes.first?.id)
+    }
+
+    @Test("revealCitationInGraph returns false and does not switch panes for an unknown path")
+    func revealCitationInGraphNoMatch() {
+        let model = makeModel()
+
+        let handled = model.revealCitationInGraph("src/pages/unknown.astro")
+
+        #expect(!handled)
+        #expect(model.mainPaneMode == .preview)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --filter SiteWindowModelTests`
+Expected: FAIL to compile — `revealCitationInGraph` doesn't exist yet.
+
+- [ ] **Step 3: Implement `revealCitationInGraph`**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, add this method directly after `showGraph()` (line 217):
+
+```swift
+    /// Resolves a chat citation's file path to a Site Graph Explorer node and reveals it there
+    /// (#314): switches the main pane to Graph and selects the node. Returns `false` — and does
+    /// nothing — when the path doesn't match any node in the current snapshot, so the caller
+    /// (`ChatView`'s citation click handler) can fall back to opening the file directly.
+    ///
+    /// The pane switch and selection happen asynchronously (matching `setPaneSelection`'s
+    /// existing fire-and-forget `Task { await showGraph() }` pattern) — the `Bool` this returns
+    /// reflects only whether a matching node was found, not whether the navigation has finished.
+    @discardableResult
+    func revealCitationInGraph(_ path: String) -> Bool {
+        guard let node = graphExplorer.snapshot.nodes.first(where: { $0.filePath == path }) else {
+            return false
+        }
+        Task { [weak self] in
+            await self?.showGraph()
+            self?.graphExplorer.revealNode(node)
+        }
+        return true
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --filter SiteWindowModelTests`
+Expected: PASS (all tests in the file, including the two new ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteWindowModel.swift Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+git commit -m "feat: reveal chat citations in the Site Graph Explorer (#314)"
+```
+
+---
+
+### Task 5: Wire citation clicks in Chat to `revealCitationInGraph`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/CitationRowView.swift`
+- Modify: `Sources/AnglesiteApp/ChatView.swift` (the `ChatView` struct header and `MessageRow`'s citation branch)
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:187`
+
+**Interfaces:**
+- Consumes: `SiteWindowModel.revealCitationInGraph(_ path: String) -> Bool` (Task 4).
+
+This task is pure SwiftUI view wiring — threading an optional closure through three views and calling it in a button action. There is no independently-testable logic here beyond what Task 4 already covers (the closure's *behavior* is tested there; this task only wires it to a UI element). Verification is a manual GUI check, matching how this codebase already tracks other GUI-only wiring (e.g. #491, #586) rather than a synthetic automated test for a one-line button action.
+
+- [ ] **Step 1: Add the `revealCitation` parameter to `CitationRowView`**
+
+In `Sources/AnglesiteApp/CitationRowView.swift`, replace the struct's properties and the `CitationChip` call site (lines 7-23) with:
+
+```swift
+struct CitationRowView: View {
+    let citations: [RetrievedCitation]
+    let siteDirectory: URL
+    /// Resolves a citation's path to a Site Graph Explorer node and reveals it there; returns
+    /// `false` when the path isn't a graph node, so the click falls back to opening the file
+    /// (#314). `nil` in previews/tests that don't wire a graph explorer.
+    var revealCitation: ((String) -> Bool)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Sources")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+            FlowLayout(spacing: 6) {
+                ForEach(citations) { citation in
+                    CitationChip(citation: citation) {
+                        if revealCitation?(citation.path) == true { return }
+                        let url = siteDirectory.appendingPathComponent(citation.path)
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+            }
+        }
+```
+
+(The rest of the file — `.padding`/`.accessibilityElement` on the `VStack`, and all of `CitationChip`/`FlowLayout` below — is unchanged.)
+
+- [ ] **Step 2: Thread `revealCitation` through `ChatView` and `MessageRow`**
+
+In `Sources/AnglesiteApp/ChatView.swift`, add the property to `ChatView` right after `@Bindable var model: ChatModel` (line 17):
+
+```swift
+    @Bindable var model: ChatModel
+    /// Resolves a citation's path to a Site Graph Explorer node and reveals it there; returns
+    /// `false` when the path isn't a graph node, so the click falls back to opening the file
+    /// (#314). `nil` in previews/tests that don't wire a graph explorer.
+    var revealCitation: ((String) -> Bool)?
+```
+
+Update the `MessageRow` call site (line 97) from `MessageRow(message: message, model: model)` to:
+
+```swift
+                        MessageRow(message: message, model: model, revealCitation: revealCitation)
+```
+
+Update `MessageRow`'s properties and citation branch (lines 247-259) from:
+
+```swift
+private struct MessageRow: View {
+    let message: ChatModel.Message
+    let model: ChatModel
+
+    var body: some View {
+        if message.role == .edit {
+            editRow
+        } else if message.role == .annotation {
+            AnnotationRowView(message: message, model: model)
+        } else if message.role == .citation {
+            if let meta = message.citationMetadata {
+                CitationRowView(citations: meta.citations, siteDirectory: model.siteDirectoryURL)
+            }
+        } else {
+```
+
+to:
+
+```swift
+private struct MessageRow: View {
+    let message: ChatModel.Message
+    let model: ChatModel
+    var revealCitation: ((String) -> Bool)?
+
+    var body: some View {
+        if message.role == .edit {
+            editRow
+        } else if message.role == .annotation {
+            AnnotationRowView(message: message, model: model)
+        } else if message.role == .citation {
+            if let meta = message.citationMetadata {
+                CitationRowView(citations: meta.citations, siteDirectory: model.siteDirectoryURL, revealCitation: revealCitation)
+            }
+        } else {
+```
+
+- [ ] **Step 3: Wire the closure at the `ChatView` call site**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, replace line 187:
+
+```swift
+                            ChatView(model: chat)
+```
+
+with:
+
+```swift
+                            ChatView(model: chat, revealCitation: { path in model.revealCitationInGraph(path) })
+```
+
+(`model` here is the enclosing `SiteWindow`'s `SiteWindowModel`, already in scope — the same `model` used for `mainPane(for: site)` two lines above.)
+
+- [ ] **Step 4: Build**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 5: Manual GUI verification**
+
+Run the app (`open Anglesite.xcodeproj`, ⌘R), open a site with at least two pages where one imports a component (or open any existing test/sample site), open the Chat panel, and:
+
+1. Ask a question naming a specific file/component/page by title (e.g. "How does the Header component work?" or the title of any real component in the open site).
+2. Confirm a "Sources" chip row appears under the assistant's reply.
+3. Click a chip. Confirm the main pane switches to the Graph view and the corresponding node is selected/highlighted.
+4. Ask an unrelated question (e.g. "What's 2+2?"). Confirm no "Sources" row appears for that turn (or only the content-index one, if applicable) — the graph decorator should contribute nothing.
+5. Click a citation chip whose kind maps from a knowledge-index result (not a graph node) — e.g. from an ordinary content-search citation. Confirm it still falls back to opening the file (regression check on the existing `NSWorkspace.shared.open` path).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteApp/CitationRowView.swift Sources/AnglesiteApp/ChatView.swift Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat: reveal-in-graph on chat citation click (#314)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Architecture (Task 2), Components (Tasks 1-2), Citations & navigation (Tasks 4-5), Error handling (no new task — verified by Task 2's existing-error-path tests inherited from the unchanged `FoundationModelAssistant`/`ChatModel` error surface), Testing (each task's own test file) — all spec sections have a task.
+- **Type consistency checked:** `SiteGraphAugmentedAssistant.init(base:snapshotProvider:)` signature matches its Task 3 call site; `GraphSnapshotProvider`/`graphSnapshotProvider` naming is consistent across Tasks 2-3; `revealCitationInGraph(_:) -> Bool` signature matches its Task 5 closure usage `{ path in model.revealCitationInGraph(path) }`.
+- **No placeholders:** every step has complete code; Task 5's "no automated test" is an explicit, justified scope decision (documented inline), not a placeholder.

--- a/docs/superpowers/specs/2026-07-09-graph-augmented-chat-design.md
+++ b/docs/superpowers/specs/2026-07-09-graph-augmented-chat-design.md
@@ -1,0 +1,143 @@
+# Free-form cross-node site Q&A (#314)
+
+## Status
+
+Design for the remaining scope of #314 after #614 (shipped, PR #627) covered single-node
+"Explain this node" in the Site Graph Explorer. This design covers free-form, cross-node
+questions — e.g. "How is navigation generated?", "Why is this image appearing here?" — that
+require synthesizing facts from multiple graph nodes/edges, not just one selected node.
+
+## Problem
+
+The app's Chat panel (`ChatModel`/`ChatView`) already answers general questions using an
+on-device model (`FoundationModelAssistant`, per the #459 LLM policy: on-device first, no
+network fallback) enriched with content search over `SiteKnowledgeIndex`
+(`KnowledgeAugmentedAssistant`, `Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift`). That
+index does per-file *text* search — it can tell the model what a file says, but not how files
+relate: it has no notion of the dependency graph (`imports`, `usesLayout`, `referencesAsset`
+edges) or transitive impact that `SiteGraphExplorer`/`ImpactAnalysis` already compute for the
+Site Graph Explorer and #614's single-node explainer.
+
+Structural questions like "why is this image appearing here" or "how is navigation generated"
+need those graph facts, not file text, to answer accurately — and per the issue, every statement
+in the answer must cite its source file.
+
+## Non-goals
+
+- No new agentic tool-calling loop. `FoundationModelAssistant.converse` already supports
+  FoundationModels `Tool`s (e.g. `SearchContentTool`), but tool calls run opaquely inside
+  `LanguageModelSession.streamResponse` with no call-result telemetry exposed
+  (`FoundationModelAssistant.swift:229-230`) — there is no hook today to turn a tool's return
+  value into a `RetrievedCitation`. Front-loaded retrieval (classic RAG, matching the existing
+  `KnowledgeAugmentedAssistant` pattern) is simpler and keeps citations exact.
+- No new UI surface. Reuses the existing Chat panel end to end (see decision log below).
+- No semantic/vector search. `SiteKnowledgeIndex.search` is keyword/term-scored, not embeddings
+  (`SiteKnowledgeIndex.swift:102-131`); the new graph seed-matching step follows the same style
+  for consistency, not a new dependency.
+- No multi-hop graph traversal algorithm. `ImpactAnalysis.Report` is already a full
+  reverse-transitive closure from one target node (`ImpactAnalysis.swift:49`), so a single seed
+  node's impact facts already answer "what does this affect, however indirectly" without new
+  traversal code.
+
+## Design
+
+### Architecture
+
+Add a second decorator alongside the existing one, composed the same way:
+
+```
+SiteGraphAugmentedAssistant(
+    base: KnowledgeAugmentedAssistant(base: FoundationModelAssistant(...), index: knowledgeIndex),
+    snapshotProvider: { await MainActor.run { graphExplorer.snapshot } }
+)
+```
+
+`SiteGraphAugmentedAssistant` (new, `AnglesiteCore`, actor, conforms to `ConversationalAssistant`)
+runs before every turn, alongside (not instead of) the existing content-index enrichment:
+
+1. Read the live `SiteGraphExplorerSnapshot` via `snapshotProvider`. The snapshot is already
+   built once at window load (`SiteWindowModel.swift:1096`, `graphExplorer.start(...)`) and kept
+   current by file-watching (`SiteFileWatching`) — this step never rebuilds the graph, just reads
+   the window's existing copy.
+2. Score every node in the snapshot against the question's words (case-insensitive substring
+   match against `title`, `route`, `filePath`), take the top 3 scoring nodes as "seed nodes." Zero
+   matches → contribute nothing this turn (plain chat and content-only questions are unaffected).
+3. For each seed node, build its fact list — reusing `SiteGraphExplainPrompt`'s existing per-node
+   fact logic (direct `dependsOn`/`referencedBy` neighbors + `ImpactAnalysis.Report`, capped at
+   `maxListedNames` = 12 per group, same as #614) — and prepend a "Facts:" block per seed node to
+   the prompt, instructing the model to synthesize only from these facts and cite file paths.
+4. Emit one `RetrievedCitation` per seed node (`path` = node's `filePath`, `title` = node's
+   `title`, `kind` mapped from `SiteGraphNodeKind`, `score` = the match score).
+
+### Components
+
+- **`SiteGraphExplainPrompt` refactor** (`Sources/AnglesiteCore/SiteGraphNodeExplainer.swift`):
+  extract the per-node fact list into a reusable
+  `static func facts(node:impact:dependsOn:referencedBy:) -> [String]`, called by both the
+  existing single-node `prompt(...)` (unchanged behavior) and the new multi-node context builder.
+- **`SiteGraphAugmentedAssistant`** (new file, `Sources/AnglesiteCore/`): owns seed-node scoring,
+  fact assembly, and citation emission. Depends only on `SiteGraphExplorerSnapshot`,
+  `ImpactAnalysis`, and `SiteGraphExplainPrompt` — no FoundationModels import, so it stays
+  testable on any toolchain (matching the `#if compiler(>=6.4)` gating pattern used elsewhere).
+- **`SiteAssistantSessionFactory.makeSession`** (`Sources/AnglesiteApp/SiteAssistantSessionFactory.swift`):
+  gains a `graphSnapshotProvider: @Sendable () async -> SiteGraphExplorerSnapshot` parameter,
+  used to wrap the existing `assistant` chain with `SiteGraphAugmentedAssistant`.
+- **`SiteWindowModel`**: supplies the provider from its existing `graphExplorer` property
+  (`SiteWindowModel.swift:147`), and gains `revealCitationInGraph(path:) -> Bool` (see below).
+
+### Citations and navigation
+
+`RetrievedCitation` (`Sources/AnglesiteCore/RetrievedCitation.swift`) is unchanged — no new
+fields. `SiteGraphNodeKind` maps onto the existing `SiteKnowledgeIndex.Document.Kind` used by
+`RetrievedCitation.kind`:
+
+| `SiteGraphNodeKind` | `SiteKnowledgeIndex.Document.Kind` |
+|---|---|
+| `.page` | `.page` |
+| `.layout` | `.layout` |
+| `.component` | `.component` |
+| `.collection` | `.content` |
+| `.contentEntry` | `.content` |
+| `.asset` | `.other` |
+| `.style` | `.style` |
+
+Clicking a citation should reveal it in context, not just open the raw file. `ChatView` gains a
+`revealCitation: (String) -> Bool` closure param (mirroring the existing `onOpenNode` callback
+pattern already used for graph clicks, `SiteWindow.swift:690-692`), threaded down to
+`CitationRowView`/`CitationChip`. `SiteWindow` wires it to a new
+`SiteWindowModel.revealCitationInGraph(path:)`, which looks up a node with matching `filePath` in
+`graphExplorer.snapshot.nodes`; if found, it calls `showGraph()` then `graphExplorer.revealNode(node)`
+and returns `true`. `CitationChip`'s action tries this closure first; if it returns `false` (no
+matching node) or the closure is `nil` (tests/previews), it falls back to today's
+`NSWorkspace.shared.open`. This applies uniformly to every citation, not just graph-sourced ones —
+a content-index citation for a page gets "reveal in graph" too, for free, if that page happens to
+be a graph node.
+
+### Error handling
+
+`SiteGraphAugmentedAssistant` only reads an in-memory snapshot and never calls the model directly
+— it cannot itself throw `AssistantError.unavailable`. That error still originates solely from
+the underlying `FoundationModelAssistant` when Apple Intelligence is off, and is surfaced by
+Chat's existing error/unavailable UI unchanged.
+
+### Testing
+
+- Seed-node scoring: unit tests mirroring `SiteGraphExplainPromptTests.swift` — matches by title,
+  route, filePath; zero matches produce no graph facts and no citations; a tie-breaking/ordering
+  case; a cap-at-3 case.
+- `SiteGraphExplainPrompt.facts(...)` refactor: existing `SiteGraphExplainPromptTests` must keep
+  passing unchanged (pure extraction, no behavior change).
+- `SiteWindowModel.revealCitationInGraph`: matching path reveals + switches pane; non-matching
+  path returns `false`.
+- `ChatView`/`CitationRowView`: citation click calls `revealCitation` before falling back to
+  `NSWorkspace.shared.open` (existing `CitationRowView` has no tests today per the exploration —
+  add coverage for the new fallback branch specifically, not a full retrofit).
+
+## Decision log
+
+- **UI surface**: extend the existing Chat panel (not a new input box in the Site Graph
+  Explorer). Reuses all existing streaming/cancel/error chrome; avoids duplicating chat UI.
+- **Citation format**: inline clickable citations, using the existing `CitationRowView` chip UI
+  already shipped for content-index citations — no new rendering needed.
+- **Citation click action**: reveal the node in the Site Graph Explorer (switch pane + select),
+  falling back to opening the file when the path isn't a graph node.


### PR DESCRIPTION
## Summary
Closes #314. Extends the Chat panel to answer free-form, cross-node questions about how the site is built ("How is navigation generated?", "Why is this image appearing here?") — the remaining scope after #614 (which only explains one selected graph node).

- `SiteGraphAugmentedAssistant`: a graph-grounded RAG decorator that matches a question against the Site Graph Explorer's dependency graph, grounds on up to 3 matched nodes' `ImpactAnalysis.Report` + edges (reusing #614's fact-list builder), and produces citations.
- `CombinedAugmentedAssistant`: runs the graph retrieval and the existing content-index retrieval (`KnowledgeAugmentedAssistant`) against the *same* original user question and merges into one enriched prompt — added after a whole-branch review caught that naively nesting the two decorators fed the inner content search a polluted, already-enriched prompt instead of the user's real question.
- Citation clicks in Chat now try to reveal the matching node in the Site Graph Explorer first, falling back to opening the file (applies uniformly to all citations, not just graph-sourced ones).

Design: `docs/superpowers/specs/2026-07-09-graph-augmented-chat-design.md`
Plan: `docs/superpowers/plans/2026-07-09-graph-augmented-chat.md`

Built via subagent-driven development: 6 tasks, each independently implemented and task-reviewed, plus two whole-branch review passes (round 2 found only a stale doc comment, fixed directly).

## Test plan
- [x] `swift test` — full suite passes (1515+ tests, 5 targets, exit 0)
- [x] `xcodebuild -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [x] Manual GUI smoke test, performed live against the "Anglesite Tester" fixture site:
  - [x] Asked "How does the BookingWidget component work with BaseLayout?" — a "Sources" chip row appeared (COMPONENT BookingWidget.astro, LAYOUT BaseLayout.astro, COMPONENT Comments.astro), and the answer was correctly grounded: it stated only what the graph facts showed and said "There is no evidence... likely unrelated" rather than inventing a relationship
  - [x] Clicked citation chips (BookingWidget.astro, then Comments.astro) — each click switched the main pane to Graph view and selected/highlighted the matching node
  - [x] Asked "What's 2+2?" — no citations appeared at all, confirming the graph decorator stays silent on unrelated turns
  - [ ] Content-index-only citation → file-open fallback — **not verified live** (couldn't construct a citation that's a content-index hit but not a graph node from this fixture site); covered instead by `SiteWindowModelTests.revealCitationInGraphNoMatch` and the Task 5 code review's confirmation of the short-circuit logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)