### PR TITLE
feat(port): AssistantBackend + EmbeddingProvider seam — canImport-gate FoundationModels/NaturalLanguage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -256,9 +256,15 @@ if includeContainer {
 // swift-port-design.md §10): off-Darwin, expose only the targets that actually compile
 // there, so `swift build && swift test` stays green on the Linux CI leg and the compiler is
 // the purity lint as seam PRs expand the portable set. Today that's AnglesiteSiteModel
-// and AnglesiteQuickLookSupport (both pure Foundation). AnglesiteCore still has Apple-only imports (FoundationModels, OSLog,
-// Security, …); ANGLESITE_PORT_WIP=1 opts it back in so in-flight seam work can
-// compile-check it locally before the final purity PR flips it on unconditionally.
+// and AnglesiteQuickLookSupport (both pure Foundation). The FoundationModels/NaturalLanguage/
+// SwiftUI/SecretStore/SiteFileWatching seams are done (all gated behind `canImport`), but
+// AnglesiteCore still doesn't compile off-Darwin: SecurityScopedBookmark.swift/SiteStore.swift
+// (security-scoped bookmarks), BundleSync.swift/EditUndoCoordinator.swift (NSFileCoordinator/
+// UndoManager), HTTPTransport.swift/MCPClient.swift/PlistDocumentIO.swift (URLSession.bytes(for:)
+// + CFGetTypeID, absent from FoundationNetworking/CoreFoundation on Linux), and
+// VsockTCPProxy.swift (a Glibc socket-type mismatch) are the remaining seams. ANGLESITE_PORT_WIP=1
+// opts AnglesiteCore back into the manifest so in-flight seam work can compile-check it locally
+// before the final purity PR (once all of the above are gated/ported) flips it on unconditionally.
 // Filtering by name here (rather than duplicating target definitions in per-platform
 // lists) keeps the single source of truth above.
 #if !canImport(Darwin)

--- a/Sources/AnglesiteCore/AltTextGenerator.swift
+++ b/Sources/AnglesiteCore/AltTextGenerator.swift
@@ -1,8 +1,9 @@
 import Foundation
 
 // Gated to the Xcode-27 toolchain — `GeneratedAltText` is `@Generable` (FoundationModels), absent
-// at runtime on CI (#128). Same pattern as FoundationModelAssistant.swift / GenerableTypes.swift.
-#if compiler(>=6.4)
+// at runtime on CI (#128) — and to canImport for genuine off-Darwin portability (cross-platform
+// port design §5). Same pattern as FoundationModelAssistant.swift / GenerableTypes.swift.
+#if compiler(>=6.4) && canImport(FoundationModels)
 
 /// Post-processes a successful image-drop edit by generating alt text with the on-device vision
 /// model and applying it to the `<img>` (C.7, #157).

--- a/Sources/AnglesiteCore/ApplyEditTool.swift
+++ b/Sources/AnglesiteCore/ApplyEditTool.swift
@@ -1,8 +1,9 @@
 import Foundation
 
-// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).
-// Same pattern as FoundationModelAssistant.swift / GenerableTypes.swift.
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5). Same pattern as
+// FoundationModelAssistant.swift / GenerableTypes.swift.
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 /// A FoundationModels ``Tool`` that lets the on-device model apply a structured edit to an element

--- a/Sources/AnglesiteCore/CSSColor.swift
+++ b/Sources/AnglesiteCore/CSSColor.swift
@@ -1,3 +1,6 @@
+// SwiftUI is Darwin-only; this bridge exists purely for the (Darwin-only) Styles panel's
+// ColorPicker, so it compiles out cleanly on the portable core (cross-platform port design §5).
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// Best-effort CSS <color> <-> SwiftUI Color bridge for the Styles panel's ColorPicker.
@@ -42,3 +45,4 @@ public enum CSSColor {
         "border-top-color", "border-right-color", "border-bottom-color", "border-left-color",
     ]
 }
+#endif

--- a/Sources/AnglesiteCore/CombinedAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/CombinedAugmentedAssistant.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -53,7 +55,7 @@ public actor CombinedAugmentedAssistant: ConversationalAssistant {
         return try await base.generate(prompt: enriched, context: context)
     }
 
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     public func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,

--- a/Sources/AnglesiteCore/ContentAssistant.swift
+++ b/Sources/AnglesiteCore/ContentAssistant.swift
@@ -4,8 +4,9 @@ import Foundation
 // runner at *runtime* — linking it into the package makes the whole test bundle fail to
 // `dlopen`. Gate it behind the Xcode-27 toolchain (Swift 6.4) so CI on Xcode 26.3 builds
 // and loads the reduced surface, while production (always Xcode 27) gets the full protocol.
+// Also gate on canImport for genuine off-Darwin portability (cross-platform port design §5).
 // Same pattern + tracking as the long-running-intent guards — see #128.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -35,7 +36,7 @@ public protocol ContentAssistant: Sendable {
     ///   `nonisolated` boundary without a data-race warning. Tightening a `public` requirement is
     ///   technically source-breaking for out-of-module conformers, but every conformer is internal
     ///   to this app, and all `@Generable` result types already conform to `Sendable`.
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,

--- a/Sources/AnglesiteCore/FindLinkOpportunitiesTool.swift
+++ b/Sources/AnglesiteCore/FindLinkOpportunitiesTool.swift
@@ -1,7 +1,9 @@
 // Sources/AnglesiteCore/FindLinkOpportunitiesTool.swift
 import Foundation
 
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 /// Foundation Models tool that audits a site's internal linking structure: orphan pages,

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OSLog
 
 /// Which Apple model substrate a ``FoundationModelAssistant`` targets.
 ///
@@ -19,11 +18,13 @@ public enum FoundationModelTier: String, Sendable, Equatable, CaseIterable {
     case privateCloudCompute = "privateCloudCompute"
 }
 
-// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).
-// See ContentAssistant.swift for the same pattern.
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128) — and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5). See
+// ContentAssistant.swift for the same pattern.
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 import CoreSpotlight
+import OSLog
 
 /// A ``ContentAssistant`` backed by Apple's on-device `FoundationModels`. Streams free-form text
 /// and produces ``Generable`` structured output via guided generation.

--- a/Sources/AnglesiteCore/FoundationModelDeploySummarizer.swift
+++ b/Sources/AnglesiteCore/FoundationModelDeploySummarizer.swift
@@ -4,7 +4,7 @@ import Foundation
 /// can default its dependency without importing FoundationModels.
 public enum DeploySummarizerFactory {
     public static func makeDefault() -> any DeployFailureSummarizing {
-        #if compiler(>=6.4)
+        #if compiler(>=6.4) && canImport(FoundationModels)
         return FoundationModelDeploySummarizer()
         #else
         return NoopDeploySummarizer()
@@ -12,7 +12,9 @@ public enum DeploySummarizerFactory {
     }
 }
 
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 import os
 

--- a/Sources/AnglesiteCore/FoundationModelEditInterpreter.swift
+++ b/Sources/AnglesiteCore/FoundationModelEditInterpreter.swift
@@ -1,4 +1,6 @@
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import Foundation
 import FoundationModels
 

--- a/Sources/AnglesiteCore/FoundationModelPageCopyGenerator.swift
+++ b/Sources/AnglesiteCore/FoundationModelPageCopyGenerator.swift
@@ -4,7 +4,7 @@ import Foundation
 /// can default its dependency without importing FoundationModels.
 public enum PageCopyGeneratorFactory {
     public static func makeDefault() -> any PageCopyGenerating {
-        #if compiler(>=6.4)
+        #if compiler(>=6.4) && canImport(FoundationModels)
         return FoundationModelPageCopyGenerator()
         #else
         return NoopPageCopyGenerator()
@@ -12,7 +12,9 @@ public enum PageCopyGeneratorFactory {
     }
 }
 
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 /// On-device short-copy generator: suggests an SEO meta description for a new page/post title

--- a/Sources/AnglesiteCore/GenerableTypes.swift
+++ b/Sources/AnglesiteCore/GenerableTypes.swift
@@ -3,9 +3,10 @@ import Foundation
 // `FoundationModels` ships in the macOS 26 SDK but is absent from GitHub's `macos-15`
 // runner at *runtime* — linking it into the package makes the whole test bundle fail to
 // `dlopen`. Gate it behind the Xcode-27 toolchain (Swift 6.4) so CI on Xcode 26.3 builds
-// without it, while production (always Xcode 27) gets these types. See #128 and
+// without it, while production (always Xcode 27) gets these types. Also gate on canImport
+// for genuine off-Darwin portability (cross-platform port design §5). See #128 and
 // ContentAssistant.swift for the same pattern.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 /// The kind of mutation a ``GeneratedEditCommand`` performs. The cases correspond 1:1 to

--- a/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -39,7 +41,7 @@ public actor KnowledgeAugmentedAssistant: ConversationalAssistant {
         return try await base.generate(prompt: enriched, context: context)
     }
 
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     public func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,

--- a/Sources/AnglesiteCore/NLContextualEmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/NLContextualEmbeddingProvider.swift
@@ -1,4 +1,8 @@
 import Foundation
+
+// NaturalLanguage is Darwin-only (cross-platform port design §5); off-Darwin, callers fall back
+// to ``LexicalEmbeddingProvider``.
+#if canImport(NaturalLanguage)
 import NaturalLanguage
 import os
 
@@ -69,3 +73,4 @@ public struct NLContextualEmbeddingProvider: EmbeddingProvider {
         return recognizer.dominantLanguage
     }
 }
+#endif

--- a/Sources/AnglesiteCore/NLEmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/NLEmbeddingProvider.swift
@@ -1,4 +1,8 @@
 import Foundation
+
+// NaturalLanguage is Darwin-only (cross-platform port design §5); off-Darwin, callers fall back
+// to ``LexicalEmbeddingProvider``.
+#if canImport(NaturalLanguage)
 import NaturalLanguage
 
 /// Production ``EmbeddingProvider`` backed by Apple's on-device `NLEmbedding.sentenceEmbedding`.
@@ -30,3 +34,4 @@ public struct NLEmbeddingProvider: EmbeddingProvider {
         return floats.map { $0 / magnitude }
     }
 }
+#endif

--- a/Sources/AnglesiteCore/Platform/LexicalEmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/Platform/LexicalEmbeddingProvider.swift
@@ -22,6 +22,11 @@ public struct LexicalEmbeddingProvider: EmbeddingProvider {
             vector[Self.bucket(for: word, dimension: dimension)] += 1
         }
         let magnitude = (vector.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        // Reachable, not just defensive: `tokens(of:)` filters to alphanumeric words, so
+        // non-empty, non-whitespace input that's entirely punctuation/symbols/emoji (e.g. "—",
+        // "😀😀") tokenizes to `[]` and lands here. `.modelUnavailable` is the closest existing
+        // case for "no lexical content found to embed" — there's no separate case for it and
+        // adding one isn't worth it for a fallback provider that's never the sole embedding path.
         guard magnitude > 0 else { throw EmbeddingError.modelUnavailable }
         return vector.map { $0 / magnitude }
     }
@@ -36,7 +41,6 @@ public struct LexicalEmbeddingProvider: EmbeddingProvider {
     }
 
     static func bucket(for word: String, dimension: Int) -> Int {
-        let hash = UInt64(VectorMath.stableHash(word), radix: 16) ?? 0
-        return Int(hash % UInt64(dimension))
+        Int(VectorMath.stableHashValue(word) % UInt64(dimension))
     }
 }

--- a/Sources/AnglesiteCore/Platform/LexicalEmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/Platform/LexicalEmbeddingProvider.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Portable, deterministic ``EmbeddingProvider`` fallback for platforms without an on-device
+/// embedding model (``NLEmbeddingProvider``/``NLContextualEmbeddingProvider``, both Darwin-only
+/// via NaturalLanguage — see ``PlatformCapabilities/hasEmbeddings``). Hashes lowercased word
+/// tokens into a fixed-dimension bag-of-words vector via ``VectorMath/stableHash(_:)``, so texts
+/// sharing vocabulary land closer together under cosine similarity — a real (if crude)
+/// lexical-overlap signal for ``SemanticRanker``, unlike ``FakeEmbeddingProvider``'s
+/// character-level projection (test-only, tuned for stability rather than usefulness).
+public struct LexicalEmbeddingProvider: EmbeddingProvider {
+    public let dimension: Int
+
+    public init(dimension: Int = 256) {
+        self.dimension = max(1, dimension)
+    }
+
+    public func embed(_ text: String) async throws -> [Float] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw EmbeddingError.emptyText }
+        var vector = [Float](repeating: 0, count: dimension)
+        for word in Self.tokens(of: trimmed) {
+            vector[Self.bucket(for: word, dimension: dimension)] += 1
+        }
+        let magnitude = (vector.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        guard magnitude > 0 else { throw EmbeddingError.modelUnavailable }
+        return vector.map { $0 / magnitude }
+    }
+
+    /// Lowercased alphanumeric word tokens. Unlike the short-word filter in
+    /// `SiteGraphAugmentedAssistant.queryTerms` (a query-matching heuristic), every token counts
+    /// here — this is a general-purpose embedder, not a search filter.
+    static func tokens(of text: String) -> [String] {
+        text.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+    }
+
+    static func bucket(for word: String, dimension: Int) -> Int {
+        let hash = UInt64(VectorMath.stableHash(word), radix: 16) ?? 0
+        return Int(hash % UInt64(dimension))
+    }
+}

--- a/Sources/AnglesiteCore/Platform/PlatformCapabilities.swift
+++ b/Sources/AnglesiteCore/Platform/PlatformCapabilities.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Static description of which on-device AI capabilities this build supports, computed once via
+/// `canImport`/`compiler` checks so callers (routing, UI, diagnostics) check a flag instead of
+/// scattering `#if canImport(FoundationModels)` throughout `AnglesiteApp` (cross-platform port
+/// design §5/§10).
+public enum PlatformCapabilities {
+    /// Whether a `FoundationModelAssistant` (and the FoundationModels-backed tools alongside it)
+    /// can exist in this build. `false` off-Darwin, and on Darwin builds using a pre-Xcode-27
+    /// toolchain where `FoundationModels` is absent at runtime (#128).
+    public static let hasAssistant: Bool = {
+        #if compiler(>=6.4) && canImport(FoundationModels)
+        return true
+        #else
+        return false
+        #endif
+    }()
+
+    /// Whether an on-device NaturalLanguage embedding model (``NLEmbeddingProvider`` /
+    /// ``NLContextualEmbeddingProvider``) is available. `false` off-Darwin, where
+    /// ``SemanticRanker`` callers fall back to ``LexicalEmbeddingProvider``.
+    public static let hasEmbeddings: Bool = {
+        #if canImport(NaturalLanguage)
+        return true
+        #else
+        return false
+        #endif
+    }()
+
+    /// Coarse label for the AI backend this build falls back to — diagnostics/telemetry only;
+    /// routing decisions should check ``hasAssistant``/``hasEmbeddings`` directly.
+    public enum ModelTier: String, Sendable, Equatable {
+        /// Apple's on-device FoundationModels + NaturalLanguage are available.
+        case onDevice
+        /// Neither is available; callers use ``LexicalEmbeddingProvider`` and hide
+        /// assistant-dependent features rather than degrade to a cloud call (LLM policy, #459).
+        case unavailable
+    }
+
+    public static var modelTier: ModelTier {
+        hasAssistant ? .onDevice : .unavailable
+    }
+}

--- a/Sources/AnglesiteCore/ProjectConventionsEnricherFactory.swift
+++ b/Sources/AnglesiteCore/ProjectConventionsEnricherFactory.swift
@@ -7,7 +7,7 @@ import Foundation
 /// identically (just without tone/brand enrichment) on the reduced CI toolchain.
 public enum ProjectConventionsEnricherFactory {
     public static func makeDefault() -> ProjectConventionsEngine.ConventionsEnricher? {
-        #if compiler(>=6.4)
+        #if compiler(>=6.4) && canImport(FoundationModels)
         return { sampleText, context in
             let result = try await FoundationModelAssistant(tier: .onDevice).generateStructured(
                 prompt: """

--- a/Sources/AnglesiteCore/SearchContentTool.swift
+++ b/Sources/AnglesiteCore/SearchContentTool.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 /// A FoundationModels ``Tool`` that lets the on-device model search the current site's pages and

--- a/Sources/AnglesiteCore/SearchKnowledgeTool.swift
+++ b/Sources/AnglesiteCore/SearchKnowledgeTool.swift
@@ -1,8 +1,10 @@
 import Foundation
-import os
 
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
+import os
 
 /// FoundationModels tool for retrieving ranked excerpts from the current site's local knowledge
 /// index. Complements ``SearchContentTool``: content graph search finds known pages/posts by

--- a/Sources/AnglesiteCore/SetupIntegrationTool.swift
+++ b/Sources/AnglesiteCore/SetupIntegrationTool.swift
@@ -57,7 +57,9 @@ public enum SetupIntegrationArguments {
     }
 }
 
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 public struct SetupIntegrationTool: Tool, Sendable {

--- a/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -62,7 +64,7 @@ public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
         return try await base.generate(prompt: enriched, context: context)
     }
 
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     public func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,

--- a/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
+++ b/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
@@ -21,7 +21,7 @@ public protocol SiteGraphNodeExplaining: Sendable {
 /// ``AssistantError/unavailable(_:)`` ("backend exists, Apple Intelligence is off").
 public enum SiteGraphExplainerFactory {
     public static func makeDefault() -> (any SiteGraphNodeExplaining)? {
-        #if compiler(>=6.4)
+        #if compiler(>=6.4) && canImport(FoundationModels)
         return FoundationModelSiteGraphExplainer()
         #else
         return nil
@@ -133,9 +133,10 @@ public enum SiteGraphExplainPrompt {
     }
 }
 
-// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
 // See FoundationModelAssistant.swift for the pattern.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 /// On-device explainer: streams ``FoundationModelAssistant``'s one-shot `generate` output. A host
 /// without Apple Intelligence throws ``AssistantError/unavailable(_:)`` from `generate` before
 /// the stream opens — surfaced by the UI as its "unavailable" state, never a cloud fallback.

--- a/Sources/AnglesiteCore/SuggestLinksTool.swift
+++ b/Sources/AnglesiteCore/SuggestLinksTool.swift
@@ -1,8 +1,10 @@
 import Foundation
-import os
 
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain (FoundationModels absent at runtime on CI, #128) and to
+// canImport for genuine off-Darwin portability (cross-platform port design §5).
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
+import os
 
 /// Foundation Models tool that suggests internal pages to link to from a given page. Uses
 /// semantic similarity (``SemanticRanker.related``) filtered by existing links (``LinkGraph``).

--- a/Sources/AnglesiteCore/VectorMath.swift
+++ b/Sources/AnglesiteCore/VectorMath.swift
@@ -16,14 +16,21 @@ public enum VectorMath {
         return dot / (magA.squareRoot() * magB.squareRoot())
     }
 
-    /// FNV-1a 64-bit hash as hex. Stable across process runs (unlike `Hasher`), so it is safe
-    /// as a cache-invalidation key for embedded text.
-    public static func stableHash(_ text: String) -> String {
+    /// FNV-1a 64-bit hash. Stable across process runs (unlike `Hasher`). Callers that need the
+    /// raw numeric hash (e.g. `LexicalEmbeddingProvider`'s bucketing) should use this directly
+    /// rather than round-tripping through `stableHash`'s hex `String`.
+    public static func stableHashValue(_ text: String) -> UInt64 {
         var hash: UInt64 = 0xcbf29ce484222325
         for byte in text.utf8 {
             hash ^= UInt64(byte)
             hash = hash &* 0x100000001b3
         }
-        return String(hash, radix: 16)
+        return hash
+    }
+
+    /// FNV-1a 64-bit hash as hex. Stable across process runs (unlike `Hasher`), so it is safe
+    /// as a cache-invalidation key for embedded text.
+    public static func stableHash(_ text: String) -> String {
+        String(stableHashValue(text), radix: 16)
     }
 }

--- a/Tests/AnglesiteCoreTests/AltTextGeneratorTests.swift
+++ b/Tests/AnglesiteCoreTests/AltTextGeneratorTests.swift
@@ -4,7 +4,7 @@ import Foundation
 
 // Gated like the type under test — `AltTextGenerator` references `GeneratedAltText` (`@Generable`,
 // Xcode-27 only). The logic here is model-free: the vision call is injected as a closure.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 
 @Suite("AltTextGenerator")
 struct AltTextGeneratorTests {

--- a/Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/CombinedAugmentedAssistantTests.swift
@@ -2,7 +2,7 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 /// A minimal `Generable` value for exercising `generateStructured`'s prompt-enrichment path.
@@ -45,7 +45,7 @@ private actor CapturingConversationalAssistant: ConversationalAssistant {
         }
     }
 
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,
@@ -275,7 +275,7 @@ struct CombinedAugmentedAssistantTests {
         #expect(prompt?.contains("DepNotes.astro") == false)
     }
 
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     /// Same guarantee as `generateUsesOriginalPrompt`, for the third `ContentAssistant` entry
     /// point (review finding — `generateStructured` also independently calls `enrichedContext`).
     @Test("generateStructured grounds the prompt against the original question, not a polluted one")

--- a/Tests/AnglesiteCoreTests/ContentAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentAssistantTests.swift
@@ -4,7 +4,7 @@ import Foundation
 
 // FoundationModels (and thus the `generateStructured` / `Generable` surface) is only
 // available on the Xcode-27 toolchain — see ContentAssistant.swift and #128.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 /// A minimal `Generable` value used to exercise the protocol's structured-output surface.
@@ -27,7 +27,7 @@ struct UnrelatedGeneratedResult: Equatable {
 private struct StubAssistant: ContentAssistant {
     let chunks: [String]
     let capabilities: AssistantCapabilities
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     let structured: StubGeneratedResult
     #endif
 
@@ -38,7 +38,7 @@ private struct StubAssistant: ContentAssistant {
         }
     }
 
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     func generateStructured<T: Generable>(
         prompt: String,
         context: AssistantContext,
@@ -66,7 +66,7 @@ struct ContentAssistantTests {
     )
 
     private func makeAssistant(chunks: [String] = []) -> StubAssistant {
-        #if compiler(>=6.4)
+        #if compiler(>=6.4) && canImport(FoundationModels)
         StubAssistant(chunks: chunks, capabilities: Self.testCapabilities, structured: StubGeneratedResult(title: "x"))
         #else
         StubAssistant(chunks: chunks, capabilities: Self.testCapabilities)
@@ -102,7 +102,7 @@ struct ContentAssistantTests {
         #expect(collected == "Hello, world!")
     }
 
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     @Test("generateStructured returns the requested Generable type")
     func structuredReturnsTypedValue() async throws {
         let expected = StubGeneratedResult(title: "Generated")

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -515,9 +515,15 @@ struct DeployCommandTests {
         try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: configDir) }
         try? DeployedRoutesSnapshot.save(["/about", "/old-page"], to: configDir)
-        try? RedirectsStore(sourceDirectory: tmpDir).save(
+        // A private site directory, NOT the shared `tmpDir`: this test's redirects.json must not
+        // be visible to `orphanedRouteAddsWarning`, which reads redirects from its own
+        // `siteDirectory` concurrently (suite tests run in parallel).
+        let siteDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DeployCommandTests-site-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: siteDir) }
+        try? RedirectsStore(sourceDirectory: siteDir).save(
             [RedirectsStore.RedirectEntry(source: "/old-page", destination: "/about", code: .permanent)])
-        defer { try? FileManager.default.removeItem(at: tmpDir.appendingPathComponent("redirects.json")) }
 
         let exec = FakeExecutor()
             .set(.build, exitCode: 0, output: "building…")
@@ -526,7 +532,7 @@ struct DeployCommandTests {
         let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
         let outcomes = Locked<[PreDeployCheck.Outcome]>([])
         _ = await cmd.deploy(
-            siteID: "s", siteDirectory: tmpDir,
+            siteID: "s", siteDirectory: siteDir,
             configDirectory: configDir, currentRoutes: ["/about"],
             onPreflight: { outcomes.append($0) })
 

--- a/Tests/AnglesiteCoreTests/FindLinkOpportunitiesToolTests.swift
+++ b/Tests/AnglesiteCoreTests/FindLinkOpportunitiesToolTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import AnglesiteCore
 
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 @Suite("FindLinkOpportunitiesTool")
 struct FindLinkOpportunitiesToolTests {
     private func doc(

--- a/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
@@ -8,7 +8,7 @@ import UniformTypeIdentifiers
 // Gated like the type under test (#128). Capability/tier assertions run on any toolchain≥6.4;
 // the generate/generateStructured tests are live-model and skip when unavailable.
 // TODO(#104/#161): migrate the live tests to the mock LanguageModel session once #104 lands.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 @Suite("FoundationModelAssistant")

--- a/Tests/AnglesiteCoreTests/FoundationModelDeploySummarizerTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelDeploySummarizerTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import AnglesiteCore
 
 // FoundationModels is absent on the CI runner; these only compile/run under Xcode 27.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 @Suite struct FoundationModelDeploySummarizerTests {
     @Test func promptIncludesTheLog() {
         let prompt = FoundationModelDeploySummarizer.prompt(for: "✘ [ERROR] Could not resolve \"./x\"")

--- a/Tests/AnglesiteCoreTests/FoundationModelEditInterpreterTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelEditInterpreterTests.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import Testing
 @testable import AnglesiteCore
 

--- a/Tests/AnglesiteCoreTests/FoundationModelPageCopyGeneratorTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelPageCopyGeneratorTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import AnglesiteCore
 
 // FoundationModels is absent on the CI runner; these only compile/run under Xcode 27.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 @Suite struct FoundationModelPageCopyGeneratorTests {
     @Test func promptIncludesTheTitle() {
         let prompt = FoundationModelPageCopyGenerator.prompt(for: "About Us")

--- a/Tests/AnglesiteCoreTests/GenerableTypesTests.swift
+++ b/Tests/AnglesiteCoreTests/GenerableTypesTests.swift
@@ -6,7 +6,7 @@ import Foundation
 // runtime on CI (#128). These are live-model round-trip tests; they skip when the on-device
 // model isn't present so they never produce spurious CI failures.
 // TODO(#104/#161): migrate to the mock LanguageModel session once #104 lands.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 @Suite("GenerableTypes round-trips")

--- a/Tests/AnglesiteCoreTests/KnowledgeAugmentedAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/KnowledgeAugmentedAssistantTests.swift
@@ -2,7 +2,7 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -38,7 +38,7 @@ private actor CapturingConversationalAssistant: ConversationalAssistant {
         }
     }
 
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,

--- a/Tests/AnglesiteCoreTests/LexicalEmbeddingProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/LexicalEmbeddingProviderTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("LexicalEmbeddingProvider")
+struct LexicalEmbeddingProviderTests {
+    @Test("identical text embeds to an identical, unit-normalized vector")
+    func deterministicNormalized() async throws {
+        let provider = LexicalEmbeddingProvider(dimension: 64)
+        let a = try await provider.embed("pricing plans for teams")
+        let b = try await provider.embed("pricing plans for teams")
+        #expect(a == b)
+        #expect(a.count == 64)
+        let magnitude = (a.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        #expect(abs(magnitude - 1.0) < 0.0001)
+    }
+
+    @Test("vocabulary overlap ranks closer than disjoint text under cosine")
+    func lexicalOverlapSignal() async throws {
+        let provider = LexicalEmbeddingProvider()
+        let query = try await provider.embed("pricing plans for small teams")
+        let overlapping = try await provider.embed("compare pricing plans")
+        let disjoint = try await provider.embed("uploading vacation photographs")
+        #expect(VectorMath.cosine(query, overlapping) > VectorMath.cosine(query, disjoint))
+    }
+
+    @Test("tokenization is case-insensitive and ignores punctuation")
+    func caseAndPunctuation() async throws {
+        let provider = LexicalEmbeddingProvider()
+        let a = try await provider.embed("Pricing, Plans!")
+        let b = try await provider.embed("pricing plans")
+        #expect(a == b)
+    }
+
+    @Test("blank text throws emptyText")
+    func blankThrows() async {
+        let provider = LexicalEmbeddingProvider()
+        await #expect(throws: EmbeddingError.emptyText) {
+            _ = try await provider.embed("  \n\t ")
+        }
+    }
+
+    @Test("text with no alphanumeric tokens throws modelUnavailable, not a zero vector")
+    func noTokensThrows() async {
+        let provider = LexicalEmbeddingProvider()
+        await #expect(throws: EmbeddingError.modelUnavailable) {
+            _ = try await provider.embed("!!! --- ???")
+        }
+    }
+
+    @Test("dimension is clamped to at least 1 and buckets stay in range",
+          arguments: [-4, 0, 1, 2, 256])
+    func bucketRange(dimension: Int) throws {
+        let provider = LexicalEmbeddingProvider(dimension: dimension)
+        #expect(provider.dimension >= 1)
+        for word in ["a", "pricing", "🎉emoji🎉", String(repeating: "z", count: 300)] {
+            let bucket = LexicalEmbeddingProvider.bucket(for: word, dimension: provider.dimension)
+            #expect((0..<provider.dimension).contains(bucket))
+        }
+    }
+
+    @Test("tokens(of:) splits on non-alphanumerics and lowercases")
+    func tokens() {
+        #expect(LexicalEmbeddingProvider.tokens(of: "Hello, wide-open World_2") ==
+            ["hello", "wide", "open", "world", "2"])
+        #expect(LexicalEmbeddingProvider.tokens(of: "...").isEmpty)
+    }
+
+    @Test("bucket parses every stableHash value — repeated words accumulate weight")
+    func repeatedWordsAccumulate() async throws {
+        let provider = LexicalEmbeddingProvider(dimension: 512)
+        let once = try await provider.embed("pricing details")
+        let repeated = try await provider.embed("pricing pricing pricing details")
+        // More mass on "pricing"'s bucket after normalization → vectors differ.
+        #expect(once != repeated)
+        // But they still share all vocabulary, so similarity stays high.
+        #expect(VectorMath.cosine(once, repeated) > 0.7)
+    }
+}

--- a/Tests/AnglesiteCoreTests/LexicalEmbeddingProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/LexicalEmbeddingProviderTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("LexicalEmbeddingProvider")
+struct LexicalEmbeddingProviderTests {
+    @Test("deterministic and unit-normalized")
+    func deterministicNormalized() async throws {
+        let provider = LexicalEmbeddingProvider(dimension: 256)
+        let a = try await provider.embed("pricing plans for teams")
+        let b = try await provider.embed("pricing plans for teams")
+        #expect(a == b)
+        #expect(a.count == 256)
+        let magnitude = (a.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        #expect(abs(magnitude - 1.0) < 0.0001)
+    }
+
+    @Test("blank text throws emptyText")
+    func blankThrows() async {
+        let provider = LexicalEmbeddingProvider(dimension: 256)
+        await #expect(throws: EmbeddingError.emptyText) {
+            _ = try await provider.embed("   ")
+        }
+    }
+
+    @Test("shared vocabulary ranks closer than unrelated text")
+    func sharedVocabularyRanksCloser() async throws {
+        let provider = LexicalEmbeddingProvider(dimension: 256)
+        let pricing = try await provider.embed("our pricing and subscription plans")
+        let plans = try await provider.embed("subscription pricing tiers")
+        let weather = try await provider.embed("today's weather forecast")
+        #expect(VectorMath.cosine(pricing, plans) > VectorMath.cosine(pricing, weather))
+    }
+}

--- a/Tests/AnglesiteCoreTests/NLContextualEmbeddingProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/NLContextualEmbeddingProviderTests.swift
@@ -1,7 +1,11 @@
 import Foundation
-import NaturalLanguage
 import Testing
 @testable import AnglesiteCore
+
+// Gated for the same reason as the type under test — NaturalLanguage is a Darwin-only
+// framework (see NLContextualEmbeddingProvider.swift's canImport(NaturalLanguage) guard).
+#if canImport(NaturalLanguage)
+import NaturalLanguage
 
 @Suite("NLContextualEmbeddingProvider")
 struct NLContextualEmbeddingProviderTests {
@@ -20,3 +24,4 @@ struct NLContextualEmbeddingProviderTests {
         #expect(VectorMath.cosine(pricing, plans) > VectorMath.cosine(pricing, weather))
     }
 }
+#endif

--- a/Tests/AnglesiteCoreTests/NLEmbeddingProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/NLEmbeddingProviderTests.swift
@@ -1,7 +1,11 @@
 import Foundation
-import NaturalLanguage
 import Testing
 @testable import AnglesiteCore
+
+// Gated for the same reason as the type under test — NaturalLanguage is a Darwin-only
+// framework (see NLEmbeddingProvider.swift's canImport(NaturalLanguage) guard).
+#if canImport(NaturalLanguage)
+import NaturalLanguage
 
 @Suite("NLEmbeddingProvider")
 struct NLEmbeddingProviderTests {
@@ -19,3 +23,4 @@ struct NLEmbeddingProviderTests {
         #expect(VectorMath.cosine(pricing, plans) > VectorMath.cosine(pricing, weather))
     }
 }
+#endif

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -4,7 +4,7 @@ import Foundation
 
 // Gated like the types under test — FoundationModels is unavailable at runtime on CI (#128).
 // These tests need no live model: the tools' `call(...)` is pure mapping/routing/query logic.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 /// Records the EditMessage it receives and returns a canned reply.

--- a/Tests/AnglesiteCoreTests/PlatformCapabilitiesTests.swift
+++ b/Tests/AnglesiteCoreTests/PlatformCapabilitiesTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("PlatformCapabilities")
+struct PlatformCapabilitiesTests {
+    @Test("modelTier is derived from hasAssistant")
+    func tierMatchesAssistant() {
+        let expected: PlatformCapabilities.ModelTier =
+            PlatformCapabilities.hasAssistant ? .onDevice : .unavailable
+        #expect(PlatformCapabilities.modelTier == expected)
+    }
+
+    @Test("capability flags match this build's actual imports")
+    func flagsMatchBuild() {
+        #if canImport(NaturalLanguage)
+        #expect(PlatformCapabilities.hasEmbeddings)
+        #else
+        #expect(!PlatformCapabilities.hasEmbeddings)
+        #endif
+
+        #if compiler(>=6.4) && canImport(FoundationModels)
+        #expect(PlatformCapabilities.hasAssistant)
+        #else
+        #expect(!PlatformCapabilities.hasAssistant)
+        #endif
+    }
+}

--- a/Tests/AnglesiteCoreTests/SearchKnowledgeToolHybridTests.swift
+++ b/Tests/AnglesiteCoreTests/SearchKnowledgeToolHybridTests.swift
@@ -5,7 +5,7 @@ import Testing
 // Gated like the type under test — FoundationModels (and thus SearchKnowledgeTool) is only
 // compiled under the Xcode-27 toolchain (#128). The hybrid path needs no live model: the
 // embedding providers below are deterministic test doubles.
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
 @Suite("SearchKnowledgeTool hybrid")

--- a/Tests/AnglesiteCoreTests/SiteGraphAugmentedAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphAugmentedAssistantTests.swift
@@ -2,7 +2,7 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -38,7 +38,7 @@ private actor CapturingConversationalAssistant: ConversationalAssistant {
         }
     }
 
-    #if compiler(>=6.4)
+    #if compiler(>=6.4) && canImport(FoundationModels)
     func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,

--- a/Tests/AnglesiteCoreTests/SuggestLinksToolTests.swift
+++ b/Tests/AnglesiteCoreTests/SuggestLinksToolTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import AnglesiteCore
 
-#if compiler(>=6.4)
+#if compiler(>=6.4) && canImport(FoundationModels)
 @Suite("SuggestLinksTool")
 struct SuggestLinksToolTests {
     private func doc(


### PR DESCRIPTION
## Summary
- Part of the cross-platform Swift port (#571), phase P1 "Core purity" (#566). Every `FoundationModels`/`NaturalLanguage`-dependent file in `AnglesiteCore` was gated only on `#if compiler(>=6.4)` — a proxy for the macOS-15 CI-runner issue (#128), not real off-Darwin portability, since a future Linux Swift 6.4+ toolchain would still fail to `import FoundationModels`. Strengthened all 20 gates to `compiler(>=6.4) && canImport(FoundationModels)`, and gated the two NaturalLanguage embedding providers and the SwiftUI-only `CSSColor` bridge behind their own `canImport` checks (plus fixed a few `os`/`OSLog` imports that had leaked outside their gate).
- Added `PlatformCapabilities` (`hasAssistant`/`hasEmbeddings`/`modelTier`) and `LexicalEmbeddingProvider`, a portable deterministic bag-of-words embedding fallback for platforms without NaturalLanguage — both called for in #566's checklist.
- Updated `Package.swift`'s off-Darwin comment with the current, verified list of what's still blocking `AnglesiteCore` from compiling on Linux (unrelated to this seam): security-scoped bookmarks, `NSFileCoordinator`/`UndoManager`, an HTTP-transport/CFType cluster, and a vsock socket-type mismatch. Follow-up tracked separately.

## Review follow-ups
- Added `LexicalEmbeddingProviderTests.swift` for test parity with the other `EmbeddingProvider` conformers (determinism, unit-normalization, empty-text, and shared-vocabulary-ranks-closer via `VectorMath.cosine`).
- **`PlatformCapabilities`/`LexicalEmbeddingProvider` are intentionally not wired into `AppDelegate.makeEmbeddingProvider()` in this PR.** That call site already documents (AnglesiteApp.swift:14-16) that a `nil` `SemanticRanker` deliberately degrades to `SiteKnowledgeIndex`'s own lexical search rather than blending in a non-meaningful vector. `SearchKnowledgeTool` blends `SemanticRanker`'s output at 60% weight against that same lexical index, and a hash-based bag-of-words carries no information the lexical index doesn't already have (no IDF, no fielding) — wiring it in there would dilute an already-good signal, not add real semantic coverage, so I didn't take that regression risk just to give this seam an immediate caller. The intended first caller is the Linux/Windows app shell (P2 #567, P4 #569), where there's no NL alternative at all and a crude lexical signal is strictly better than none. Both stay unreferenced-but-tested infrastructure until that shell exists, same as `SecretStore`'s libsecret impl before #567.

## Test plan
- [x] `ANGLESITE_PORT_WIP=1 swift build --target AnglesiteCore` on Linux (swift:6.3.3 toolchain): confirmed zero errors remain from FoundationModels/NaturalLanguage/SwiftUI; remaining errors are the four unrelated pre-existing seams noted above (error set identical before/after this change — no regressions introduced).
- [x] `swift build && swift test` (default, non-WIP Linux path — `AnglesiteSiteModel`/`AnglesiteQuickLookSupport`): builds clean, all 26 tests pass.
- [x] `LexicalEmbeddingProviderTests` logic verified against a standalone script on the same Linux toolchain (can't run the real `AnglesiteCoreTests` target here — it isn't in the Linux-portable set yet).
- [x] macOS `xcodebuild`/`swift test` (Darwin path) — not run in this sandbox; the gate change is compile-time-only and `canImport(FoundationModels)` is always true whenever `compiler(>=6.4)` is true on a real Xcode-27 toolchain, so no behavior change is expected, but CI should confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
