### PR TITLE
Slice 5: theme-apply wizard + design-interview conversation (#464)

### DIFF
--- a/Sources/AnglesiteApp/DesignInterviewPanel.swift
+++ b/Sources/AnglesiteApp/DesignInterviewPanel.swift
@@ -1,0 +1,110 @@
+// Sources/AnglesiteApp/DesignInterviewPanel.swift
+import SwiftUI
+import AnglesiteCore
+
+/// SwiftUI mirror of the `anglesite:design-interview` skill's conversation: a transcript column on
+/// the left, live axis sliders + apply confirmation on the right. Mutations to `draft.axes` route
+/// through `DesignInterviewModel.axisBinding(_:)` rather than `$model.draft.axes...` directly,
+/// since `draft`'s setter is `internal(set)` to AnglesiteCore.
+struct DesignInterviewPanel: View {
+    @Bindable var model: DesignInterviewModel
+    @State private var draftMessage = ""
+
+    var body: some View {
+        HSplitView {
+            transcriptColumn
+            axesColumn
+        }
+    }
+
+    private var transcriptColumn: some View {
+        VStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(Array(model.transcript.enumerated()), id: \.offset) { _, entry in
+                        transcriptBubble(entry)
+                    }
+                }
+                .padding()
+            }
+            HStack {
+                TextField("Describe what you're going for…", text: $draftMessage)
+                    .onSubmit { Task { await sendDraft() } }
+                Button("Send") { Task { await sendDraft() } }
+                    .disabled(draftMessage.isEmpty)
+            }
+            .padding()
+        }
+        .frame(minWidth: 320)
+    }
+
+    private func transcriptBubble(_ entry: (role: String, text: String)) -> some View {
+        let isUser = entry.role == "user"
+        return Text(entry.text)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isUser ? Color.accentColor.opacity(0.15) : Color.gray.opacity(0.12))
+            )
+            .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
+    }
+
+    private var axesColumn: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Design Axes").font(.headline)
+            axisSlider("Cool", "Warm", value: model.axisBinding(\.temperature))
+            axisSlider("Airy", "Dense", value: model.axisBinding(\.weight))
+            axisSlider("Playful", "Authoritative", value: model.axisBinding(\.register))
+            axisSlider("Classic", "Contemporary", value: model.axisBinding(\.time))
+            axisSlider("Subtle", "Bold", value: model.axisBinding(\.voice))
+
+            Spacer()
+
+            if model.draft.stage != .axisConfirmation && model.draft.stage != .done {
+                Button("Design It For Me") { model.skipToAxisConfirmation() }
+            }
+
+            if model.draft.stage == .axisConfirmation {
+                Button("Apply This Design") { Task { await model.confirmAndApply() } }
+                    .buttonStyle(.borderedProminent)
+            }
+
+            applyResultView
+        }
+        .padding()
+        .frame(minWidth: 260)
+    }
+
+    @ViewBuilder
+    private var applyResultView: some View {
+        switch model.applyResult {
+        case .none:
+            EmptyView()
+        case .success:
+            Label("Applied.", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .failure(let error):
+            Label("Couldn't apply that design: \(String(describing: error))", systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+        }
+    }
+
+    private func axisSlider(_ low: String, _ high: String, value: Binding<Double>) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(low).font(.caption).foregroundStyle(.secondary)
+                Spacer()
+                Text(high).font(.caption).foregroundStyle(.secondary)
+            }
+            Slider(value: value, in: 0...1)
+        }
+    }
+
+    private func sendDraft() async {
+        guard !draftMessage.isEmpty else { return }
+        let message = draftMessage
+        draftMessage = ""
+        await model.send(message)
+    }
+}

--- a/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
+++ b/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
@@ -20,7 +20,8 @@ enum SiteAssistantSessionFactory {
         _ contentGraph: SiteContentGraph,
         _ knowledgeIndex: SiteKnowledgeIndex,
         _ semanticRanker: SemanticRanker?,
-        _ integrationService: any IntegrationOperationsService
+        _ integrationService: any IntegrationOperationsService,
+        _ themeCatalog: ThemeCatalog?
     ) -> any ConversationalAssistant
 
     struct Dependencies {
@@ -49,7 +50,7 @@ enum SiteAssistantSessionFactory {
             let editRouterProvider: EditRouterProvider = { siteID in
                 await EditRouterRegistry.shared.router(for: siteID)
             }
-            let assistant: AssistantBuilder = { editBridge, contentGraph, knowledgeIndex, semanticRanker, integrationService in
+            let assistant: AssistantBuilder = { editBridge, contentGraph, knowledgeIndex, semanticRanker, integrationService, themeCatalog in
                 KnowledgeAugmentedAssistant(
                     base: FoundationModelAssistant(
                         tier: .onDevice,
@@ -57,7 +58,8 @@ enum SiteAssistantSessionFactory {
                         contentGraph: contentGraph,
                         knowledgeIndex: knowledgeIndex,
                         semanticRanker: semanticRanker,
-                        integrationService: integrationService
+                        integrationService: integrationService,
+                        themeCatalog: themeCatalog
                     ),
                     index: knowledgeIndex
                 )
@@ -115,6 +117,7 @@ enum SiteAssistantSessionFactory {
         semanticRanker: SemanticRanker?,
         conventionsEngine: ProjectConventionsEngine?,
         integrationService: any IntegrationOperationsService,
+        themeCatalog: ThemeCatalog? = nil,
         dependencies: Dependencies = .live
     ) -> SiteAssistantSession {
         let editBridge = IntentEditBridge(routerProvider: dependencies.editRouterProvider)
@@ -127,7 +130,8 @@ enum SiteAssistantSessionFactory {
                 contentGraph,
                 knowledgeIndex,
                 semanticRanker,
-                integrationService
+                integrationService,
+                themeCatalog
             ),
             annotationFeed: dependencies.annotationFeed(sourceDirectory),
             annotationResolver: { [resolveAnnotation = dependencies.resolveAnnotation] id in

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1101,6 +1101,13 @@ final class SiteWindowModel {
         let mcpClient: @Sendable () async -> MCPClient? = { [preview] in
             await preview.mcpClient()
         }
+        // Best-effort: SetupThemeTool only attaches to the chat assistant when a catalog loads
+        // successfully. A missing/unreadable template must not block opening the site — the
+        // assistant simply runs without the theme-apply tool, same as before this catalog existed.
+        let themeCatalog: ThemeCatalog? = {
+            guard let templateURL = TemplateRuntime.resolve().url else { return nil }
+            return try? ThemeCatalog.load(templateURL: templateURL)
+        }()
         let assistantSession = SiteAssistantSessionFactory.makeSession(
             siteID: resolved.id,
             sourceDirectory: resolved.sourceDirectory,
@@ -1110,7 +1117,8 @@ final class SiteWindowModel {
             knowledgeIndex: knowledgeIndex,
             semanticRanker: semanticRanker,
             conventionsEngine: conventionsEngine,
-            integrationService: integrationOps
+            integrationService: integrationOps,
+            themeCatalog: themeCatalog
         )
         chat = assistantSession.chat
         // The environment undo manager usually lands before the chat exists (cold open) —

--- a/Sources/AnglesiteApp/ThemeApplyWizard.swift
+++ b/Sources/AnglesiteApp/ThemeApplyWizard.swift
@@ -1,0 +1,152 @@
+// Sources/AnglesiteApp/ThemeApplyWizard.swift
+import SwiftUI
+import AnglesiteCore
+
+struct ThemeApplyWizard: View {
+    @Bindable var model: ThemeApplyWizardModel
+    @Environment(\.dismiss) private var dismiss
+
+    private let columns = [GridItem(.adaptive(minimum: 140, maximum: 180), spacing: 12)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Apply a Theme")
+                .font(.title2.bold())
+
+            Group {
+                switch model.step {
+                case .pickSource: pickSourceStep
+                case .pickBuiltIn: pickBuiltInStep
+                case .browseFreedesignmd: browseFreedesignmdStep
+                case .review: reviewStep
+                case .applying: applyingStep
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+            HStack {
+                if model.step != .pickSource, model.step != .applying {
+                    Button("Back") { model.back() }
+                }
+                Spacer()
+                if model.step == .review {
+                    Button("Apply") { Task { await model.apply() } }
+                        .buttonStyle(.borderedProminent)
+                } else if model.step != .applying {
+                    Button("Continue") { Task { await model.advance() } }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!model.canContinue)
+                }
+            }
+        }
+        .padding(20)
+        .frame(width: 480, height: 420)
+    }
+
+    private var pickSourceStep: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Picker("Source", selection: Binding(get: { model.source }, set: { model.source = $0 })) {
+                Text("Built-in themes").tag(ThemeApplyWizardModel.Source?.some(.builtIn))
+                Text("Browse freedesignmd.com").tag(ThemeApplyWizardModel.Source?.some(.freedesignmd))
+            }
+            .pickerStyle(.radioGroup)
+        }
+    }
+
+    private var pickBuiltInStep: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(model.catalog.themes) { theme in
+                    themeCard(theme)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private func themeCard(_ theme: Theme) -> some View {
+        let isSelected = model.selectedBuiltInID == theme.id
+        return Button {
+            model.selectedBuiltInID = theme.id
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 4) {
+                    ForEach(theme.swatch, id: \.self) { hex in
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color(hex: hex))
+                            .frame(width: 24, height: 24)
+                    }
+                }
+                Text(theme.name)
+                    .font(.subheadline.bold())
+                    .foregroundStyle(.primary)
+                Text(theme.blurb)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? Color.accentColor.opacity(0.15) : Color.gray.opacity(0.08))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var browseFreedesignmdStep: some View {
+        Group {
+            if let error = model.fetchError {
+                Text(error).foregroundStyle(.secondary)
+            } else if model.freedesignmdCandidates.isEmpty {
+                ProgressView("Searching freedesignmd.com…")
+            } else {
+                List(model.freedesignmdCandidates, selection: Binding(
+                    get: { model.selectedFreedesignmdSlug },
+                    set: { model.selectedFreedesignmdSlug = $0 }
+                )) { system in
+                    Text(system.name).tag(system.slug)
+                }
+            }
+        }
+    }
+
+    private var reviewStep: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            switch model.source {
+            case .builtIn:
+                if let theme = model.selectedBuiltInTheme {
+                    Text(theme.name).font(.headline)
+                    Text(theme.blurb).foregroundStyle(.secondary)
+                }
+            case .freedesignmd:
+                if let slug = model.selectedFreedesignmdSlug {
+                    Text(slug).font(.headline)
+                }
+            case nil: EmptyView()
+            }
+        }
+    }
+
+    private var applyingStep: some View {
+        VStack(spacing: 12) {
+            switch model.applyResult {
+            case .none:
+                ProgressView("Applying…")
+            case .success:
+                Label("Theme applied.", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                Button("Done") { dismiss() }
+            case .failure(let error):
+                Label("Couldn't apply that theme: \(String(describing: error))", systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteCore/DesignApplyService.swift
+++ b/Sources/AnglesiteCore/DesignApplyService.swift
@@ -79,25 +79,30 @@ public enum DesignApplyService {
         return .success(AppliedDesign(updatedVars: input.cssVars, writtenFiles: written))
     }
 
-    /// Replaces or appends `--<key>: <value>;` lines inside the first `:root { ... }` block,
-    /// leaving everything else in the file untouched. Returns `nil` if no `:root` block is found.
+    /// Replaces or appends `--<key>: <value>;` lines inside the top-level `:root { ... }` block,
+    /// leaving everything else in the file untouched. Returns `nil` if no top-level `:root` block
+    /// is found.
     static func upsertRootVars(_ vars: [String: String], in css: String) -> String? {
-        guard let rootRange = css.range(of: ":root"),
-              let openBrace = css.range(of: "{", range: rootRange.upperBound..<css.endIndex),
-              let closeBrace = css.range(of: "}", range: openBrace.upperBound..<css.endIndex)
-        else { return nil }
+        guard let (openBrace, closeBrace) = topLevelRootBlockRange(in: css) else { return nil }
 
-        var body = String(css[openBrace.upperBound..<closeBrace.lowerBound])
+        var body = String(css[openBrace..<closeBrace])
         var remaining = vars
 
         for key in vars.keys {
+            // Replace every occurrence, not just the first: a hand-edited `:root` block can
+            // declare the same custom property twice, and CSS gives the *last* declaration
+            // precedence — leaving an earlier duplicate stale would silently keep the old value
+            // in effect even though this function reports the var as updated.
             let pattern = #"(--\#(NSRegularExpression.escapedPattern(for: key))\s*:\s*)[^;]*;"#
             guard let re = try? NSRegularExpression(pattern: pattern) else { continue }
             let range = NSRange(body.startIndex..<body.endIndex, in: body)
-            if let match = re.firstMatch(in: body, range: range), let matchRange = Range(match.range, in: body) {
+            let matches = re.matches(in: body, range: range)
+            guard !matches.isEmpty else { continue }
+            for match in matches.reversed() {
+                guard let matchRange = Range(match.range, in: body) else { continue }
                 body.replaceSubrange(matchRange, with: "--\(key): \(vars[key]!);")
-                remaining.removeValue(forKey: key)
             }
+            remaining.removeValue(forKey: key)
         }
 
         if !remaining.isEmpty {
@@ -107,7 +112,54 @@ public enum DesignApplyService {
             body += additions + "\n"
         }
 
-        return String(css[css.startIndex..<openBrace.upperBound]) + body + String(css[closeBrace.lowerBound...])
+        return String(css[css.startIndex..<openBrace]) + body + String(css[closeBrace...])
+    }
+
+    /// Scans `css` for the first `:root { ... }` rule declared at the top level of the
+    /// stylesheet (brace depth 0), returning the range of its body (between the braces,
+    /// exclusive). Skips `:root` occurrences that are:
+    /// - part of a compound selector, e.g. `:root[data-theme="dark"]` (no `{` immediately
+    ///   after `:root`, modulo whitespace), or
+    /// - nested inside another block, e.g. a `:root` re-declared inside
+    ///   `@media (prefers-color-scheme: dark) { :root { ... } }` — a plain substring/regex
+    ///   search for `:root` can't tell this apart from the real top-level rule, and would
+    ///   silently upsert tokens into the wrong scope.
+    static func topLevelRootBlockRange(in css: String) -> (open: String.Index, close: String.Index)? {
+        var depth = 0
+        var i = css.startIndex
+        while i < css.endIndex {
+            let c = css[i]
+            if c == "{" {
+                depth += 1
+            } else if c == "}" {
+                depth -= 1
+            } else if depth == 0, css[i...].hasPrefix(":root") {
+                var j = css.index(i, offsetBy: 5)
+                while j < css.endIndex, css[j].isWhitespace { j = css.index(after: j) }
+                if j < css.endIndex, css[j] == "{" {
+                    guard let close = matchingCloseBrace(in: css, openingAt: j) else { return nil }
+                    return (css.index(after: j), close)
+                }
+            }
+            i = css.index(after: i)
+        }
+        return nil
+    }
+
+    /// Finds the index of the `}` that closes the `{` at `openBrace`, accounting for nested
+    /// braces inside the block.
+    private static func matchingCloseBrace(in css: String, openingAt openBrace: String.Index) -> String.Index? {
+        var depth = 1
+        var k = css.index(after: openBrace)
+        while k < css.endIndex {
+            if css[k] == "{" { depth += 1 }
+            else if css[k] == "}" {
+                depth -= 1
+                if depth == 0 { return k }
+            }
+            k = css.index(after: k)
+        }
+        return nil
     }
 }
 

--- a/Sources/AnglesiteCore/DesignApplyService.swift
+++ b/Sources/AnglesiteCore/DesignApplyService.swift
@@ -21,7 +21,7 @@ public struct AppliedDesign: Sendable, Equatable {
 public enum DesignApplyError: Error, Sendable, Equatable {
     case missingGlobalCSS
     case missingRootBlock
-    case writeFailed(String)
+    case writeFailed(message: String, partiallyWritten: [String])
 }
 
 /// The single writer for applying a design to a site's `Source/` directory — shared by the
@@ -64,7 +64,7 @@ public enum DesignApplyService {
             try (existingBrand + entry).write(to: brandURL, atomically: true, encoding: .utf8)
             written.append(brandRelativePath)
         } catch {
-            return .failure(.writeFailed((error as NSError).localizedDescription))
+            return .failure(.writeFailed(message: (error as NSError).localizedDescription, partiallyWritten: written))
         }
 
         return .success(AppliedDesign(updatedVars: input.cssVars, writtenFiles: written))

--- a/Sources/AnglesiteCore/DesignApplyService.swift
+++ b/Sources/AnglesiteCore/DesignApplyService.swift
@@ -37,19 +37,28 @@ public enum DesignApplyService {
         to sourceDirectory: URL,
         fileManager: FileManager = .default
     ) -> Result<AppliedDesign, DesignApplyError> {
-        let cssURL = sourceDirectory.appendingPathComponent(globalCSSRelativePath)
-        guard let original = try? String(contentsOf: cssURL, encoding: .utf8) else {
-            return .failure(.missingGlobalCSS)
-        }
-        guard let updatedCSS = upsertRootVars(input.cssVars, in: original) else {
-            return .failure(.missingRootBlock)
+        // An empty `cssVars` means the caller has no CSS tokens to write (e.g. the freedesignmd
+        // wizard flow, whose token translation is currently stubbed — see ThemeApplyWizardModel).
+        // Skip the global.css read/upsert/write entirely in that case: there is nothing to
+        // change, so this flow must not hard-fail just because global.css or its `:root` block
+        // is missing or malformed.
+        if !input.cssVars.isEmpty {
+            let cssURL = sourceDirectory.appendingPathComponent(globalCSSRelativePath)
+            guard let original = try? String(contentsOf: cssURL, encoding: .utf8) else {
+                return .failure(.missingGlobalCSS)
+            }
+            guard let updatedCSS = upsertRootVars(input.cssVars, in: original) else {
+                return .failure(.missingRootBlock)
+            }
+            do {
+                try updatedCSS.write(to: cssURL, atomically: true, encoding: .utf8)
+            } catch {
+                return .failure(.writeFailed(message: (error as NSError).localizedDescription, partiallyWritten: []))
+            }
         }
 
-        var written: [String] = []
+        var written: [String] = input.cssVars.isEmpty ? [] : [globalCSSRelativePath]
         do {
-            try updatedCSS.write(to: cssURL, atomically: true, encoding: .utf8)
-            written.append(globalCSSRelativePath)
-
             if let rationaleMarkdown = input.rationaleMarkdown {
                 let rationaleURL = sourceDirectory.appendingPathComponent(rationaleRelativePath)
                 try fileManager.createDirectory(at: rationaleURL.deletingLastPathComponent(), withIntermediateDirectories: true)

--- a/Sources/AnglesiteCore/DesignApplyService.swift
+++ b/Sources/AnglesiteCore/DesignApplyService.swift
@@ -101,3 +101,13 @@ public enum DesignApplyService {
         return String(css[css.startIndex..<openBrace.upperBound]) + body + String(css[closeBrace.lowerBound...])
     }
 }
+
+public extension DesignApplyService {
+    static func apply(
+        _ input: DesignApplyInput,
+        to package: AnglesitePackage,
+        fileManager: FileManager = .default
+    ) -> Result<AppliedDesign, DesignApplyError> {
+        apply(input, to: package.sourceURL, fileManager: fileManager)
+    }
+}

--- a/Sources/AnglesiteCore/DesignApplyService.swift
+++ b/Sources/AnglesiteCore/DesignApplyService.swift
@@ -1,0 +1,103 @@
+// Sources/AnglesiteCore/DesignApplyService.swift
+import Foundation
+
+public struct DesignApplyInput: Sendable {
+    public let cssVars: [String: String]
+    public let rationaleMarkdown: String?
+    public let brandSummary: String
+    public let sourceLabel: String
+
+    public init(cssVars: [String: String], rationaleMarkdown: String?, brandSummary: String, sourceLabel: String) {
+        self.cssVars = cssVars; self.rationaleMarkdown = rationaleMarkdown
+        self.brandSummary = brandSummary; self.sourceLabel = sourceLabel
+    }
+}
+
+public struct AppliedDesign: Sendable, Equatable {
+    public let updatedVars: [String: String]
+    public let writtenFiles: [String]
+}
+
+public enum DesignApplyError: Error, Sendable, Equatable {
+    case missingGlobalCSS
+    case missingRootBlock
+    case writeFailed(String)
+}
+
+/// The single writer for applying a design to a site's `Source/` directory — shared by the
+/// built-in/freedesignmd theme-apply wizard and (later) the design-interview conversation, so
+/// there is exactly one "write design to disk" implementation.
+public enum DesignApplyService {
+    static let globalCSSRelativePath = "src/styles/global.css"
+    static let rationaleRelativePath = "docs/DESIGN.md"
+    static let brandRelativePath = "docs/brand.md"
+
+    public static func apply(
+        _ input: DesignApplyInput,
+        to sourceDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> Result<AppliedDesign, DesignApplyError> {
+        let cssURL = sourceDirectory.appendingPathComponent(globalCSSRelativePath)
+        guard let original = try? String(contentsOf: cssURL, encoding: .utf8) else {
+            return .failure(.missingGlobalCSS)
+        }
+        guard let updatedCSS = upsertRootVars(input.cssVars, in: original) else {
+            return .failure(.missingRootBlock)
+        }
+
+        var written: [String] = []
+        do {
+            try updatedCSS.write(to: cssURL, atomically: true, encoding: .utf8)
+            written.append(globalCSSRelativePath)
+
+            if let rationaleMarkdown = input.rationaleMarkdown {
+                let rationaleURL = sourceDirectory.appendingPathComponent(rationaleRelativePath)
+                try fileManager.createDirectory(at: rationaleURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try rationaleMarkdown.write(to: rationaleURL, atomically: true, encoding: .utf8)
+                written.append(rationaleRelativePath)
+            }
+
+            let brandURL = sourceDirectory.appendingPathComponent(brandRelativePath)
+            try fileManager.createDirectory(at: brandURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let existingBrand = (try? String(contentsOf: brandURL, encoding: .utf8)) ?? ""
+            let entry = "\n## \(input.sourceLabel)\n\n\(input.brandSummary)\n"
+            try (existingBrand + entry).write(to: brandURL, atomically: true, encoding: .utf8)
+            written.append(brandRelativePath)
+        } catch {
+            return .failure(.writeFailed((error as NSError).localizedDescription))
+        }
+
+        return .success(AppliedDesign(updatedVars: input.cssVars, writtenFiles: written))
+    }
+
+    /// Replaces or appends `--<key>: <value>;` lines inside the first `:root { ... }` block,
+    /// leaving everything else in the file untouched. Returns `nil` if no `:root` block is found.
+    static func upsertRootVars(_ vars: [String: String], in css: String) -> String? {
+        guard let rootRange = css.range(of: ":root"),
+              let openBrace = css.range(of: "{", range: rootRange.upperBound..<css.endIndex),
+              let closeBrace = css.range(of: "}", range: openBrace.upperBound..<css.endIndex)
+        else { return nil }
+
+        var body = String(css[openBrace.upperBound..<closeBrace.lowerBound])
+        var remaining = vars
+
+        for key in vars.keys {
+            let pattern = #"(--\#(NSRegularExpression.escapedPattern(for: key))\s*:\s*)[^;]*;"#
+            guard let re = try? NSRegularExpression(pattern: pattern) else { continue }
+            let range = NSRange(body.startIndex..<body.endIndex, in: body)
+            if let match = re.firstMatch(in: body, range: range), let matchRange = Range(match.range, in: body) {
+                body.replaceSubrange(matchRange, with: "--\(key): \(vars[key]!);")
+                remaining.removeValue(forKey: key)
+            }
+        }
+
+        if !remaining.isEmpty {
+            let additions = remaining.sorted(by: { $0.key < $1.key })
+                .map { "  --\($0.key): \($0.value);" }.joined(separator: "\n")
+            if !body.hasSuffix("\n") { body += "\n" }
+            body += additions + "\n"
+        }
+
+        return String(css[css.startIndex..<openBrace.upperBound]) + body + String(css[closeBrace.lowerBound...])
+    }
+}

--- a/Sources/AnglesiteCore/DesignAxes.swift
+++ b/Sources/AnglesiteCore/DesignAxes.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Five design axes, each a float 0–1. Ported from the plugin's `scripts/design.ts`.
+public struct DesignAxes: Sendable, Equatable, Codable {
+    /// Cool (0) <-> Warm (1)
+    public var temperature: Double
+    /// Airy (0) <-> Dense (1)
+    public var weight: Double
+    /// Playful (0) <-> Authoritative (1)
+    public var register: Double
+    /// Classic (0) <-> Contemporary (1)
+    public var time: Double
+    /// Subtle (0) <-> Bold (1)
+    public var voice: Double
+
+    public init(temperature: Double, weight: Double, register: Double, time: Double, voice: Double) {
+        self.temperature = temperature; self.weight = weight; self.register = register
+        self.time = time; self.voice = voice
+    }
+}
+
+public enum DesignAxesCatalog {
+    public static let balanced = DesignAxes(temperature: 0.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4)
+
+    /// Business-type -> default axes. Verbatim port of `BUSINESS_AXES` in `scripts/design.ts`.
+    private static let byBusinessType: [String: DesignAxes] = [
+        "restaurant":   DesignAxes(temperature: 0.75, weight: 0.45, register: 0.3,  time: 0.4,  voice: 0.5),
+        "bakery":       DesignAxes(temperature: 0.8,  weight: 0.35, register: 0.25, time: 0.3,  voice: 0.45),
+        "brewery":      DesignAxes(temperature: 0.7,  weight: 0.55, register: 0.35, time: 0.45, voice: 0.55),
+        "hospitality":  DesignAxes(temperature: 0.7,  weight: 0.4,  register: 0.4,  time: 0.35, voice: 0.4),
+        "campground":   DesignAxes(temperature: 0.65, weight: 0.4,  register: 0.3,  time: 0.3,  voice: 0.45),
+        "accounting":   DesignAxes(temperature: 0.2,  weight: 0.4,  register: 0.8,  time: 0.3,  voice: 0.3),
+        "insurance":    DesignAxes(temperature: 0.25, weight: 0.45, register: 0.75, time: 0.35, voice: 0.3),
+        "credit-union": DesignAxes(temperature: 0.3,  weight: 0.4,  register: 0.7,  time: 0.4,  voice: 0.35),
+        "real-estate":  DesignAxes(temperature: 0.35, weight: 0.45, register: 0.65, time: 0.5,  voice: 0.45),
+        "healthcare":   DesignAxes(temperature: 0.35, weight: 0.3,  register: 0.6,  time: 0.6,  voice: 0.3),
+        "pharmacy":     DesignAxes(temperature: 0.3,  weight: 0.35, register: 0.65, time: 0.55, voice: 0.25),
+        "cleaning":     DesignAxes(temperature: 0.35, weight: 0.3,  register: 0.5,  time: 0.6,  voice: 0.35),
+        "grocery":      DesignAxes(temperature: 0.45, weight: 0.4,  register: 0.4,  time: 0.5,  voice: 0.4),
+        "fitness":      DesignAxes(temperature: 0.45, weight: 0.7,  register: 0.55, time: 0.7,  voice: 0.8),
+        "trades":       DesignAxes(temperature: 0.4,  weight: 0.65, register: 0.6,  time: 0.5,  voice: 0.7),
+        "auto-dealer":  DesignAxes(temperature: 0.35, weight: 0.7,  register: 0.6,  time: 0.6,  voice: 0.75),
+        "car-wash":     DesignAxes(temperature: 0.4,  weight: 0.6,  register: 0.5,  time: 0.6,  voice: 0.65),
+        "plumber":      DesignAxes(temperature: 0.4,  weight: 0.6,  register: 0.55, time: 0.5,  voice: 0.6),
+        "electrician":  DesignAxes(temperature: 0.35, weight: 0.6,  register: 0.55, time: 0.55, voice: 0.6),
+        "farm":         DesignAxes(temperature: 0.6,  weight: 0.45, register: 0.4,  time: 0.2,  voice: 0.4),
+        "florist":      DesignAxes(temperature: 0.6,  weight: 0.3,  register: 0.3,  time: 0.35, voice: 0.45),
+        "hardware":     DesignAxes(temperature: 0.5,  weight: 0.55, register: 0.5,  time: 0.3,  voice: 0.5),
+        "veterinarian": DesignAxes(temperature: 0.55, weight: 0.4,  register: 0.45, time: 0.4,  voice: 0.4),
+        "childcare":    DesignAxes(temperature: 0.7,  weight: 0.3,  register: 0.15, time: 0.6,  voice: 0.7),
+        "pet-services": DesignAxes(temperature: 0.65, weight: 0.35, register: 0.2,  time: 0.55, voice: 0.65),
+        "dance-studio": DesignAxes(temperature: 0.6,  weight: 0.3,  register: 0.2,  time: 0.65, voice: 0.7),
+        "youth-org":    DesignAxes(temperature: 0.6,  weight: 0.35, register: 0.25, time: 0.6,  voice: 0.6),
+        "entertainment": DesignAxes(temperature: 0.55, weight: 0.4, register: 0.2,  time: 0.65, voice: 0.75),
+        "salon":        DesignAxes(temperature: 0.4,  weight: 0.3,  register: 0.65, time: 0.7,  voice: 0.5),
+        "photography":  DesignAxes(temperature: 0.35, weight: 0.25, register: 0.6,  time: 0.7,  voice: 0.55),
+        "jewelry":      DesignAxes(temperature: 0.3,  weight: 0.25, register: 0.7,  time: 0.6,  voice: 0.45),
+        "community-theater": DesignAxes(temperature: 0.45, weight: 0.35, register: 0.55, time: 0.5, voice: 0.55),
+        "hotel":        DesignAxes(temperature: 0.4,  weight: 0.35, register: 0.7,  time: 0.55, voice: 0.4),
+        "nonprofit":    DesignAxes(temperature: 0.55, weight: 0.4,  register: 0.4,  time: 0.5,  voice: 0.45),
+        "house-of-worship": DesignAxes(temperature: 0.6, weight: 0.4, register: 0.45, time: 0.3, voice: 0.4),
+        "social-services": DesignAxes(temperature: 0.55, weight: 0.4, register: 0.45, time: 0.5, voice: 0.4),
+        "food-bank":    DesignAxes(temperature: 0.6,  weight: 0.4,  register: 0.35, time: 0.45, voice: 0.45),
+        "animal-shelter": DesignAxes(temperature: 0.6, weight: 0.35, register: 0.3, time: 0.5, voice: 0.5),
+    ]
+
+    /// Default axis positions for a business type. Falls back to ``balanced`` for unknown types.
+    /// Matches only on the substring before the first comma, lowercased and trimmed.
+    public static func defaults(forBusinessType businessType: String) -> DesignAxes {
+        guard !businessType.isEmpty else { return balanced }
+        let key = businessType.lowercased().split(separator: ",", maxSplits: 1)[0]
+            .trimmingCharacters(in: .whitespaces)
+        return byBusinessType[key] ?? balanced
+    }
+
+    /// Applies each delta to the named axis, clamping the result to [0, 1].
+    public static func adjusted(_ axes: DesignAxes, by deltas: [WritableKeyPath<DesignAxes, Double>: Double]) -> DesignAxes {
+        var result = axes
+        for (keyPath, delta) in deltas {
+            result[keyPath: keyPath] = max(0, min(1, result[keyPath: keyPath] + delta))
+        }
+        return result
+    }
+
+    public static func isValid(_ axes: DesignAxes) -> Bool {
+        [axes.temperature, axes.weight, axes.register, axes.time, axes.voice]
+            .allSatisfy { !$0.isNaN && $0 >= 0 && $0 <= 1 }
+    }
+}

--- a/Sources/AnglesiteCore/DesignConfigGenerator.swift
+++ b/Sources/AnglesiteCore/DesignConfigGenerator.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+public struct DesignTypography: Sendable, Equatable, Codable {
+    public let display: String
+    public let body: String
+    public let pairing: String
+    public init(display: String, body: String, pairing: String) { self.display = display; self.body = body; self.pairing = pairing }
+}
+
+public struct DesignSpacing: Sendable, Equatable, Codable {
+    public let xs, sm, md, lg, xl: String
+    public init(xs: String, sm: String, md: String, lg: String, xl: String) {
+        self.xs = xs; self.sm = sm; self.md = md; self.lg = lg; self.xl = xl
+    }
+}
+
+public struct DesignShape: Sendable, Equatable, Codable {
+    public let radiusSm, radiusMd, radiusLg, shadowSm, shadowMd: String
+    public init(radiusSm: String, radiusMd: String, radiusLg: String, shadowSm: String, shadowMd: String) {
+        self.radiusSm = radiusSm; self.radiusMd = radiusMd; self.radiusLg = radiusLg
+        self.shadowSm = shadowSm; self.shadowMd = shadowMd
+    }
+}
+
+public struct DesignConfig: Sendable, Equatable, Codable {
+    public let axes: DesignAxes
+    public let palette: DesignPalette
+    public let typography: DesignTypography
+    public let spacing: DesignSpacing
+    public let shape: DesignShape
+    public let siteType: String
+    public let brandColor: String?
+
+    public init(axes: DesignAxes, palette: DesignPalette, typography: DesignTypography,
+                spacing: DesignSpacing, shape: DesignShape, siteType: String, brandColor: String?) {
+        self.axes = axes; self.palette = palette; self.typography = typography
+        self.spacing = spacing; self.shape = shape; self.siteType = siteType; self.brandColor = brandColor
+    }
+}
+
+public enum DesignConfigGenerator {
+    private struct FontPairing {
+        let display: String
+        let body: String
+        let pairing: String
+        let score: (DesignAxes) -> Double
+    }
+
+    private static let fontPairings: [FontPairing] = [
+        FontPairing(display: #"Georgia, "Times New Roman", Times, serif"#,
+                    body: "system-ui, -apple-system, sans-serif",
+                    pairing: "classic-serif+modern-sans",
+                    score: { (1 - $0.time) * 2 + $0.register * 1.5 + (1 - $0.voice) * 0.5 }),
+        FontPairing(display: "system-ui, -apple-system, sans-serif",
+                    body: "system-ui, -apple-system, sans-serif",
+                    pairing: "modern-sans+modern-sans",
+                    score: { $0.time * 1.5 + (1 - $0.register) * 1 + $0.voice * 0.5 }),
+        FontPairing(display: #""Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif"#,
+                    body: #""Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif"#,
+                    pairing: "humanist-sans+humanist-sans",
+                    score: { $0.temperature * 1.5 + (1 - $0.register) * 1 + (1 - $0.voice) * 0.5 }),
+        FontPairing(display: #"Georgia, "Times New Roman", Times, serif"#,
+                    body: #""Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif"#,
+                    pairing: "classic-serif+humanist-sans",
+                    score: { (1 - $0.time) * 1.5 + $0.register * 1 + $0.temperature * 0.8 }),
+        FontPairing(display: "system-ui, -apple-system, sans-serif",
+                    body: #""Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif"#,
+                    pairing: "modern-sans+humanist-sans",
+                    score: { $0.time * 1 + $0.temperature * 0.8 + (1 - $0.register) * 0.8 }),
+    ]
+
+    public static func typography(for axes: DesignAxes) -> DesignTypography {
+        let best = fontPairings.max { $0.score(axes) < $1.score(axes) } ?? fontPairings[0]
+        return DesignTypography(display: best.display, body: best.body, pairing: best.pairing)
+    }
+
+    /// Airy (weight=0) -> generous spacing (1.2x). Dense (weight=1) -> tighter (0.8x).
+    public static func spacing(for axes: DesignAxes) -> DesignSpacing {
+        let m = 1.2 - axes.weight * 0.4
+        func fmt(_ v: Double) -> String { "\((v * 1000).rounded() / 1000)rem" }
+        return DesignSpacing(xs: fmt(0.25 * m), sm: fmt(0.5 * m), md: fmt(1 * m), lg: fmt(2 * m), xl: fmt(4 * m))
+    }
+
+    /// Playful (low register) + contemporary (high time) -> rounder. Bold (voice) -> stronger shadows.
+    public static func shape(for axes: DesignAxes) -> DesignShape {
+        let roundness = (1 - axes.register) * 0.6 + axes.time * 0.4
+        func fmt(_ v: Double) -> String { "\((v * 1000).rounded() / 1000)rem" }
+        let shadowAlpha = 0.06 + axes.voice * 0.08
+        let shadowSpread = 2 + axes.weight * 4
+        return DesignShape(
+            radiusSm: fmt(0.125 + roundness * 0.25),
+            radiusMd: fmt(0.25 + roundness * 0.5),
+            radiusLg: fmt(0.5 + roundness * 1.0),
+            shadowSm: "0 1px \(Int(shadowSpread.rounded()))px rgba(0, 0, 0, \(String(format: "%.2f", shadowAlpha)))",
+            shadowMd: "0 \(Int(shadowSpread.rounded()))px \(Int((shadowSpread * 3).rounded()))px rgba(0, 0, 0, \(String(format: "%.2f", shadowAlpha * 1.5)))"
+        )
+    }
+
+    public static func config(axes: DesignAxes, siteType: String, brandColor: String?) -> DesignConfig {
+        DesignConfig(
+            axes: axes,
+            palette: DesignPaletteGenerator.generate(axes: axes, brandColor: brandColor),
+            typography: typography(for: axes),
+            spacing: spacing(for: axes),
+            shape: shape(for: axes),
+            siteType: siteType,
+            brandColor: brandColor
+        )
+    }
+}

--- a/Sources/AnglesiteCore/DesignInterviewDraft.swift
+++ b/Sources/AnglesiteCore/DesignInterviewDraft.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+public enum ConversationStage: Int, Sendable, Equatable, CaseIterable {
+    case intent, mood, brandAnchor, axisConfirmation, done
+}
+
+/// A fixed nudge applied to one axis when the user's free text names a direction rather than a
+/// slider value (e.g. "make it warmer"). Each hint moves its axis by a flat 0.15, clamped to [0,1].
+public enum DesignAdjectiveHint: String, Sendable, CaseIterable {
+    case warmer, cooler, denser, airier, moreAuthoritative, morePlayful, moreClassic, moreContemporary, bolder, subtler
+
+    var keyPath: WritableKeyPath<DesignAxes, Double> {
+        switch self {
+        case .warmer, .cooler: return \.temperature
+        case .denser, .airier: return \.weight
+        case .moreAuthoritative, .morePlayful: return \.register
+        case .moreClassic, .moreContemporary: return \.time
+        case .bolder, .subtler: return \.voice
+        }
+    }
+
+    var delta: Double {
+        switch self {
+        case .warmer, .denser, .moreAuthoritative, .moreContemporary, .bolder: return 0.15
+        case .cooler, .airier, .morePlayful, .moreClassic, .subtler: return -0.15
+        }
+    }
+}
+
+public struct DesignInterviewDraft: Sendable, Equatable {
+    public var stage: ConversationStage
+    public var businessType: String
+    public var axes: DesignAxes
+    public var brandColorHex: String?
+    public var freeTextNotes: [String]
+
+    public init(businessType: String) {
+        self.stage = .intent
+        self.businessType = businessType
+        self.axes = DesignAxesCatalog.defaults(forBusinessType: businessType)
+        self.brandColorHex = nil
+        self.freeTextNotes = []
+    }
+
+    public mutating func advance() {
+        guard let next = ConversationStage(rawValue: stage.rawValue + 1) else { return }
+        stage = next
+    }
+
+    public mutating func applyAdjectiveHint(_ hint: DesignAdjectiveHint) {
+        axes = DesignAxesCatalog.adjusted(axes, by: [hint.keyPath: hint.delta])
+    }
+}

--- a/Sources/AnglesiteCore/DesignInterviewModel.swift
+++ b/Sources/AnglesiteCore/DesignInterviewModel.swift
@@ -60,6 +60,10 @@ public final class DesignInterviewModel: Identifiable {
             transcript.append((role: "assistant", text: "I couldn't respond just now — \(failureMessage)"))
             return
         }
+        guard !reply.isEmpty else {
+            transcript.append((role: "assistant", text: "The assistant didn't respond — try again."))
+            return
+        }
         transcript.append((role: "assistant", text: reply))
         draft.advance()
     }

--- a/Sources/AnglesiteCore/DesignInterviewModel.swift
+++ b/Sources/AnglesiteCore/DesignInterviewModel.swift
@@ -88,3 +88,45 @@ public final class DesignInterviewModel: Identifiable {
         }
     }
 }
+
+public extension DesignInterviewModel {
+    /// Applies a turn reply's optional per-axis deltas to `draft`, clamping via
+    /// `DesignAxesCatalog.adjusted`. Pure and toolchain-independent so it's testable without a
+    /// live FoundationModels session — the `@Generable` reply type that produces these values is
+    /// gated below.
+    nonisolated static func applyTurnReplyDeltas(
+        temperature: Double?, weight: Double?, register: Double?, time: Double?, voice: Double?,
+        brandColorHex: String?, to draft: inout DesignInterviewDraft
+    ) {
+        var deltas: [WritableKeyPath<DesignAxes, Double>: Double] = [:]
+        if let temperature { deltas[\.temperature] = temperature }
+        if let weight { deltas[\.weight] = weight }
+        if let register { deltas[\.register] = register }
+        if let time { deltas[\.time] = time }
+        if let voice { deltas[\.voice] = voice }
+        if !deltas.isEmpty { draft.axes = DesignAxesCatalog.adjusted(draft.axes, by: deltas) }
+        if let brandColorHex { draft.brandColorHex = brandColorHex }
+    }
+}
+
+#if compiler(>=6.4)
+import FoundationModels
+
+@Generable
+public struct DesignInterviewTurnReply: Sendable {
+    @Guide(description: "Your conversational reply to the owner, 1-2 sentences.")
+    public var replyText: String
+    @Guide(description: "Temperature axis change if the owner's message implies one, else omit.")
+    public var temperatureDelta: Double?
+    @Guide(description: "Weight axis change if the owner's message implies one, else omit.")
+    public var weightDelta: Double?
+    @Guide(description: "Register axis change if the owner's message implies one, else omit.")
+    public var registerDelta: Double?
+    @Guide(description: "Time axis change if the owner's message implies one, else omit.")
+    public var timeDelta: Double?
+    @Guide(description: "Voice axis change if the owner's message implies one, else omit.")
+    public var voiceDelta: Double?
+    @Guide(description: "Hex color if the owner mentioned a brand color, else omit.")
+    public var brandColorHex: String?
+}
+#endif

--- a/Sources/AnglesiteCore/DesignInterviewModel.swift
+++ b/Sources/AnglesiteCore/DesignInterviewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import SwiftUI
 import AnglesiteSiteModel
 
 /// Drives one design-interview conversation: prompts the current ``ConversationStage`` through an
@@ -65,6 +66,17 @@ public final class DesignInterviewModel: Identifiable {
 
     public func nudge(_ hint: DesignAdjectiveHint) {
         draft.applyAdjectiveHint(hint)
+    }
+
+    /// A two-way `Binding` into one axis of `draft.axes`, for GUI sliders. `draft`'s setter is
+    /// `internal(set)` (state changes are meant to flow through the model's own methods), so a
+    /// cross-module SwiftUI view can't write `$model.draft.axes.temperature` directly — this
+    /// routes the write back through the model instead of widening `draft`'s access.
+    public func axisBinding(_ keyPath: WritableKeyPath<DesignAxes, Double>) -> Binding<Double> {
+        Binding(
+            get: { self.draft.axes[keyPath: keyPath] },
+            set: { self.draft.axes[keyPath: keyPath] = $0 }
+        )
     }
 
     /// "Design it for me" escape hatch: skip straight to axis confirmation using the

--- a/Sources/AnglesiteCore/DesignInterviewModel.swift
+++ b/Sources/AnglesiteCore/DesignInterviewModel.swift
@@ -42,8 +42,22 @@ public final class DesignInterviewModel: Identifiable {
             return
         }
         var reply = ""
+        var failureMessage: String?
         for await event in stream {
-            if case .textDelta(let delta) = event { reply += delta }
+            switch event {
+            case .textDelta(let delta):
+                reply += delta
+            case .failed(let message):
+                failureMessage = message
+            case .cancelled:
+                failureMessage = "The response was cancelled — try again."
+            default:
+                break
+            }
+        }
+        if let failureMessage {
+            transcript.append((role: "assistant", text: "I couldn't respond just now — \(failureMessage)"))
+            return
         }
         transcript.append((role: "assistant", text: reply))
         draft.advance()
@@ -67,7 +81,10 @@ public final class DesignInterviewModel: Identifiable {
             brandSummary: "Generated from a design interview for a \(draft.businessType).",
             sourceLabel: "design-interview"
         )
-        applyResult = DesignApplyService.apply(input, to: package)
-        draft.stage = .done
+        let result = DesignApplyService.apply(input, to: package)
+        applyResult = result
+        if case .success = result {
+            draft.stage = .done
+        }
     }
 }

--- a/Sources/AnglesiteCore/DesignInterviewModel.swift
+++ b/Sources/AnglesiteCore/DesignInterviewModel.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Observation
+import AnglesiteSiteModel
+
+/// Drives one design-interview conversation: prompts the current ``ConversationStage`` through an
+/// injected ``ConversationalAssistant``, appends turns to a transcript, and — once the owner
+/// confirms the resulting ``DesignAxes`` — applies the generated design via ``DesignApplyService``.
+///
+/// Depends on the toolchain-independent ``ConversationalAssistant`` protocol (already used by
+/// `FoundationModelAssistant`'s conformance) rather than the concrete gated type directly, so the
+/// model itself stays testable on any toolchain with a fake assistant — the same seam
+/// `SiteGraphNodeExplaining` uses to decouple `SiteGraphExplainerFactory`'s consumers from the
+/// FoundationModels-gated implementation.
+@MainActor @Observable
+public final class DesignInterviewModel: Identifiable {
+    public let id = UUID()
+    public internal(set) var draft: DesignInterviewDraft
+    public internal(set) var transcript: [(role: String, text: String)] = []
+    public internal(set) var applyResult: Result<AppliedDesign, DesignApplyError>?
+
+    private let assistant: any ConversationalAssistant
+    private let package: AnglesitePackage
+    private let siteID: String
+
+    public init(businessType: String, assistant: any ConversationalAssistant, package: AnglesitePackage, siteID: String = "") {
+        self.draft = DesignInterviewDraft(businessType: businessType)
+        self.assistant = assistant
+        self.package = package
+        self.siteID = siteID
+    }
+
+    /// Sends one turn: appends the user's message, prompts the current stage, appends the
+    /// assistant's reply, then advances the conversation to the next stage. Structured
+    /// (`@Generable`) axis extraction from the reply is a follow-up refinement — v1 advances on
+    /// any reply and lets the user correct axes via ``nudge(_:)``.
+    public func send(_ userMessage: String) async {
+        transcript.append((role: "user", text: userMessage))
+        let prompt = DesignInterviewPrompts.prompt(for: draft.stage, draft: draft, userMessage: userMessage)
+        let context = AssistantContext(siteID: siteID, siteDirectory: package.sourceURL)
+        guard let stream = try? await assistant.converse(prompt: prompt, context: context) else {
+            transcript.append((role: "assistant", text: "I couldn't respond just now — try again in a moment."))
+            return
+        }
+        var reply = ""
+        for await event in stream {
+            if case .textDelta(let delta) = event { reply += delta }
+        }
+        transcript.append((role: "assistant", text: reply))
+        draft.advance()
+    }
+
+    public func nudge(_ hint: DesignAdjectiveHint) {
+        draft.applyAdjectiveHint(hint)
+    }
+
+    /// "Design it for me" escape hatch: skip straight to axis confirmation using the
+    /// business-type defaults already seeded in `draft.axes`.
+    public func skipToAxisConfirmation() {
+        draft.stage = .axisConfirmation
+    }
+
+    public func confirmAndApply() async {
+        let config = DesignConfigGenerator.config(axes: draft.axes, siteType: draft.businessType, brandColor: draft.brandColorHex)
+        let input = DesignApplyInput(
+            cssVars: DesignTokenWriter.templateCSSVars(for: config),
+            rationaleMarkdown: DesignTokenWriter.rationaleMarkdown(for: config),
+            brandSummary: "Generated from a design interview for a \(draft.businessType).",
+            sourceLabel: "design-interview"
+        )
+        applyResult = DesignApplyService.apply(input, to: package)
+        draft.stage = .done
+    }
+}

--- a/Sources/AnglesiteCore/DesignInterviewPrompts.swift
+++ b/Sources/AnglesiteCore/DesignInterviewPrompts.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Deterministic grounding-prompt builders for the design-interview conversation, one per
+/// ``ConversationStage``. Follows ``SiteGraphExplainPrompt``'s pattern: facts are assembled from
+/// typed data, never invented, and every prompt caps its own size to stay well under the
+/// on-device 4,096-token budget.
+public enum DesignInterviewPrompts {
+    public static func prompt(for stage: ConversationStage, draft: DesignInterviewDraft, userMessage: String) -> String {
+        switch stage {
+        case .intent: return intentPrompt(draft: draft, userMessage: userMessage)
+        case .mood: return moodPrompt(draft: draft, userMessage: userMessage)
+        case .brandAnchor: return brandAnchorPrompt(draft: draft, userMessage: userMessage)
+        case .axisConfirmation: return axisConfirmationPrompt(draft: draft, userMessage: userMessage)
+        case .done: return userMessage
+        }
+    }
+
+    private static func intentPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
+        """
+        You are interviewing the owner of a \(draft.businessType) website about what the site is \
+        for and who it's for. Ask one short, warm follow-up question to understand their intent — \
+        don't move to visual style yet. Owner said: "\(userMessage)"
+        """
+    }
+
+    private static func moodPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
+        """
+        You are helping the owner of a \(draft.businessType) website describe its visual mood. \
+        Current design axes (each 0 to 1): temperature \(draft.axes.temperature) (cool<->warm), \
+        weight \(draft.axes.weight) (airy<->dense), register \(draft.axes.register) \
+        (playful<->authoritative), time \(draft.axes.time) (classic<->contemporary), voice \
+        \(draft.axes.voice) (subtle<->bold). The owner described the mood they want as: \
+        "\(userMessage)". In one short sentence, reflect back how that mood shifts these axes.
+        """
+    }
+
+    private static func brandAnchorPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
+        """
+        Ask the owner of a \(draft.businessType) website if they have an existing brand color \
+        (hex code) or a reference site/brand whose look they like. Owner said: "\(userMessage)". \
+        If they gave a hex color or a clear reference, acknowledge it in one short sentence.
+        """
+    }
+
+    private static func axisConfirmationPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
+        """
+        Summarize this design in plain language for the owner of a \(draft.businessType) website, \
+        then ask them to confirm or adjust: temperature \(draft.axes.temperature), weight \
+        \(draft.axes.weight), register \(draft.axes.register), time \(draft.axes.time), voice \
+        \(draft.axes.voice). Owner's response: "\(userMessage)".
+        """
+    }
+}

--- a/Sources/AnglesiteCore/DesignInterviewPrompts.swift
+++ b/Sources/AnglesiteCore/DesignInterviewPrompts.swift
@@ -5,6 +5,18 @@ import Foundation
 /// typed data, never invented, and every prompt caps its own size to stay well under the
 /// on-device 4,096-token budget.
 public enum DesignInterviewPrompts {
+    /// Caps how much of the raw user message gets interpolated into a prompt template, mirroring
+    /// ``FoundationModelAssistant/maxPageContentCharacters``'s character-based proxy for the
+    /// on-device token budget (no on-device tokenizer is available to measure it directly).
+    static let maxUserMessageCharacters = 1_000
+
+    /// Truncates `message` to ``maxUserMessageCharacters``, appending "…" when truncated — same
+    /// shape as ``FoundationModelAssistant/truncatedPageContent(_:)``.
+    static func truncatedUserMessage(_ message: String) -> String {
+        guard message.count > maxUserMessageCharacters else { return message }
+        return String(message.prefix(maxUserMessageCharacters)) + "…"
+    }
+
     public static func prompt(for stage: ConversationStage, draft: DesignInterviewDraft, userMessage: String) -> String {
         switch stage {
         case .intent: return intentPrompt(draft: draft, userMessage: userMessage)
@@ -16,7 +28,8 @@ public enum DesignInterviewPrompts {
     }
 
     private static func intentPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
-        """
+        let userMessage = truncatedUserMessage(userMessage)
+        return """
         You are interviewing the owner of a \(draft.businessType) website about what the site is \
         for and who it's for. Ask one short, warm follow-up question to understand their intent — \
         don't move to visual style yet. Owner said: "\(userMessage)"
@@ -24,7 +37,8 @@ public enum DesignInterviewPrompts {
     }
 
     private static func moodPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
-        """
+        let userMessage = truncatedUserMessage(userMessage)
+        return """
         You are helping the owner of a \(draft.businessType) website describe its visual mood. \
         Current design axes (each 0 to 1): temperature \(draft.axes.temperature) (cool<->warm), \
         weight \(draft.axes.weight) (airy<->dense), register \(draft.axes.register) \
@@ -35,7 +49,8 @@ public enum DesignInterviewPrompts {
     }
 
     private static func brandAnchorPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
-        """
+        let userMessage = truncatedUserMessage(userMessage)
+        return """
         Ask the owner of a \(draft.businessType) website if they have an existing brand color \
         (hex code) or a reference site/brand whose look they like. Owner said: "\(userMessage)". \
         If they gave a hex color or a clear reference, acknowledge it in one short sentence.
@@ -43,7 +58,8 @@ public enum DesignInterviewPrompts {
     }
 
     private static func axisConfirmationPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
-        """
+        let userMessage = truncatedUserMessage(userMessage)
+        return """
         Summarize this design in plain language for the owner of a \(draft.businessType) website, \
         then ask them to confirm or adjust: temperature \(draft.axes.temperature), weight \
         \(draft.axes.weight), register \(draft.axes.register), time \(draft.axes.time), voice \

--- a/Sources/AnglesiteCore/DesignInterviewTool.swift
+++ b/Sources/AnglesiteCore/DesignInterviewTool.swift
@@ -1,0 +1,39 @@
+// Sources/AnglesiteCore/DesignInterviewTool.swift
+import Foundation
+
+#if compiler(>=6.4)
+import FoundationModels
+
+/// Chat entry point for the design interview. Unlike `SetupIntegrationTool`/`SetupThemeTool`
+/// (stateless plan-then-apply calls), the interview is inherently multi-turn — this tool's `call`
+/// starts or continues a session-scoped `DesignInterviewModel` the caller supplies, rather than
+/// owning conversation state itself.
+public struct DesignInterviewTool: Tool, Sendable {
+    public static let toolName = "designInterview"
+    public let name = DesignInterviewTool.toolName
+    public let description = "Have a short conversation to design or redesign a site's look and feel."
+
+    @Generable
+    public struct Arguments {
+        @Guide(description: "The owner's message in this turn of the design conversation.")
+        public var message: String
+        @Guide(description: "Set to true if the owner wants Anglesite to just pick a design for them.")
+        public var designForMe: Bool?
+    }
+
+    private let model: DesignInterviewModel
+    public init(model: DesignInterviewModel) { self.model = model }
+
+    public func call(arguments: Arguments) async throws -> String {
+        if arguments.designForMe == true {
+            let businessType = await MainActor.run { () -> String in
+                model.skipToAxisConfirmation()
+                return model.draft.businessType
+            }
+            return "I'll design it for you based on what a \(businessType) site usually needs. Review the axes and tell me to apply when you're happy."
+        }
+        await model.send(arguments.message)
+        return await MainActor.run { model.transcript.last?.text ?? "" }
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/DesignPaletteGenerator.swift
+++ b/Sources/AnglesiteCore/DesignPaletteGenerator.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Color tokens for a generated design. Ported from the plugin's `scripts/design.ts` `Palette`.
+public struct DesignPalette: Sendable, Equatable, Codable {
+    public let brand: String
+    public let accent: String
+    public let bg: String
+    public let surface: String
+    public let text: String
+    public let muted: String
+    public let border: String
+
+    public init(brand: String, accent: String, bg: String, surface: String, text: String, muted: String, border: String) {
+        self.brand = brand; self.accent = accent; self.bg = bg; self.surface = surface
+        self.text = text; self.muted = muted; self.border = border
+    }
+}
+
+public enum DesignPaletteGenerator {
+    /// Deterministic palette generation from design axes, ported verbatim from `generatePalette` in
+    /// `scripts/design.ts`. If `brandColor` is a valid hex, it becomes the brand color and the rest
+    /// is derived from it; otherwise the brand color is derived from `axes.temperature`.
+    public static func generate(axes: DesignAxes, brandColor: String?) -> DesignPalette {
+        let isDarkMode = axes.weight > 0.75 && axes.voice > 0.7
+
+        var brandH: Double, brandS: Double, brandL: Double
+        if let brandColor, let rgb = WCAGContrast.hexToRGB(brandColor) {
+            (brandH, brandS, brandL) = hexToHSL(rgb)
+        } else {
+            brandH = temperatureToHue(axes.temperature)
+            brandS = min(0.85, max(0.35, 0.45 + (1 - axes.register) * 0.2 + axes.voice * 0.15))
+            brandL = 0.42 - axes.register * 0.08
+        }
+        let brand = (brandColor.flatMap(WCAGContrast.hexToRGB) != nil) ? brandColor! : hslToHex(brandH, brandS, brandL)
+
+        let accentOffset: Double = axes.voice > 0.5 ? 180 : 40
+        let accentH = (brandH + accentOffset).truncatingRemainder(dividingBy: 360)
+        let accentS = min(0.8, brandS + 0.05)
+        let accentL = 0.45 + axes.voice * 0.1
+        let accent = hslToHex(accentH, accentS, accentL)
+
+        var bg: String, surface: String, text: String, muted: String, border: String
+        if isDarkMode {
+            bg = hslToHex(brandH, 0.15, 0.08 + axes.temperature * 0.04)
+            surface = hslToHex(brandH, 0.12, 0.12 + axes.temperature * 0.04)
+            text = hslToHex(brandH, 0.05, 0.92)
+            muted = hslToHex(brandH, 0.08, 0.6)
+            border = hslToHex(brandH, 0.1, 0.2)
+        } else {
+            let surfaceH = brandH
+            let surfaceS = 0.05 + axes.temperature * 0.1
+            bg = hslToHex(surfaceH, surfaceS, 0.99 - axes.temperature * 0.02)
+            surface = hslToHex(surfaceH, surfaceS + 0.02, 0.96 - axes.temperature * 0.02)
+            text = hslToHex(brandH, 0.1 + axes.temperature * 0.05, 0.1 + axes.weight * 0.03)
+            muted = hslToHex(brandH, 0.05, 0.42 + axes.weight * 0.05)
+            border = hslToHex(surfaceH, surfaceS + 0.03, 0.88 - axes.weight * 0.05)
+        }
+
+        text = WCAGContrast.suggestReadable(fg: text, bg: bg)
+        muted = WCAGContrast.suggestReadable(fg: muted, bg: bg)
+
+        return DesignPalette(brand: brand, accent: accent, bg: bg, surface: surface, text: text, muted: muted, border: border)
+    }
+
+    /// Cool (0) -> blue/teal (210), balanced (0.5) -> teal (160), warm (1) -> orange/terracotta (25).
+    static func temperatureToHue(_ t: Double) -> Double {
+        t <= 0.5 ? 210 - t * 100 : 160 - (t - 0.5) * 270
+    }
+
+    static func hslToHex(_ h: Double, _ s: Double, _ l: Double) -> String {
+        let hue = ((h.truncatingRemainder(dividingBy: 360)) + 360).truncatingRemainder(dividingBy: 360)
+        let a = s * min(l, 1 - l)
+        func f(_ n: Double) -> String {
+            let k = (n + hue / 30).truncatingRemainder(dividingBy: 12)
+            let color = l - a * max(min(min(k - 3, 9 - k), 1), -1)
+            let byte = Int((255 * max(0, min(1, color))).rounded())
+            return String(format: "%02x", byte)
+        }
+        return "#\(f(0))\(f(8))\(f(4))"
+    }
+
+    static func hexToHSL(_ rgb: RGBColor) -> (h: Double, s: Double, l: Double) {
+        let r = Double(rgb.r) / 255, g = Double(rgb.g) / 255, b = Double(rgb.b) / 255
+        let maxC = max(r, g, b), minC = min(r, g, b)
+        let l = (maxC + minC) / 2
+        if maxC == minC { return (0, 0, l) }
+        let d = maxC - minC
+        let s = l > 0.5 ? d / (2 - maxC - minC) : d / (maxC + minC)
+        var h: Double
+        if maxC == r { h = ((g - b) / d + (g < b ? 6 : 0)) * 60 }
+        else if maxC == g { h = ((b - r) / d + 2) * 60 }
+        else { h = ((r - g) / d + 4) * 60 }
+        return (h, s, l)
+    }
+}

--- a/Sources/AnglesiteCore/DesignTokenWriter.swift
+++ b/Sources/AnglesiteCore/DesignTokenWriter.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+public enum DesignTokenWriter {
+    /// Maps a generated ``DesignConfig`` onto the 12 CSS custom-property names
+    /// `Resources/Template/src/styles/global.css` already declares. Tokens the engine computes but
+    /// the template has no slot for (border, shadows, the xs/sm/lg/xl spacing steps) are dropped —
+    /// only `spacing.md` maps, to `--spacing-unit`.
+    public static func templateCSSVars(for config: DesignConfig) -> [String: String] {
+        [
+            "color-primary": config.palette.brand,
+            "color-accent": config.palette.accent,
+            "color-background": config.palette.bg,
+            "color-surface": config.palette.surface,
+            "color-text": config.palette.text,
+            "color-text-muted": config.palette.muted,
+            "font-heading": config.typography.display,
+            "font-body": config.typography.body,
+            "spacing-unit": config.spacing.md,
+            "radius-sm": config.shape.radiusSm,
+            "radius-md": config.shape.radiusMd,
+            "radius-lg": config.shape.radiusLg,
+        ]
+    }
+
+    /// A built-in ``Theme``'s `cssVars` already use the template's naming scheme (parsed from
+    /// `Resources/Template/scripts/themes.ts`) — pass through unchanged.
+    public static func templateCSSVars(for theme: Theme) -> [String: String] { theme.cssVars }
+
+    /// Human-readable `DESIGN.md` rationale, ported from `generateDesignRationale` in
+    /// `scripts/design.ts`.
+    public static func rationaleMarkdown(for config: DesignConfig) -> String {
+        let axes = config.axes
+        func describe(_ axis: String, _ value: Double, low: String, high: String) -> String {
+            if value <= 0.4 { return low }
+            if value >= 0.6 { return high }
+            return "between \(low) and \(high)"
+        }
+        let temperature = describe("temperature", axes.temperature, low: "cool", high: "warm")
+        let weight = describe("weight", axes.weight, low: "airy", high: "dense")
+        let register = describe("register", axes.register, low: "playful", high: "authoritative")
+        let time = describe("time", axes.time, low: "classic", high: "contemporary")
+        let voice = describe("voice", axes.voice, low: "subtle", high: "bold")
+        let moodWords = [temperature, weight, register, time, voice]
+            .reduce(into: [String]()) { if !$0.contains($1) { $0.append($1) } }
+
+        return """
+        # Your Design System
+
+        ## What we're going for
+
+        The feel is **\(moodWords.joined(separator: ", "))** — designed for a \(config.siteType.replacingOccurrences(of: "-", with: " ")).
+
+        ## Design axes
+
+        | Axis | Value | Reading |
+        |------|-------|---------|
+        | Temperature (cool <-> warm) | \(axes.temperature) | \(temperature) |
+        | Weight (airy <-> dense) | \(axes.weight) | \(weight) |
+        | Register (playful <-> authoritative) | \(axes.register) | \(register) |
+        | Time (classic <-> contemporary) | \(axes.time) | \(time) |
+        | Voice (subtle <-> bold) | \(axes.voice) | \(voice) |
+
+        ## Color
+
+        Your brand color is `\(config.palette.brand)`. The accent color `\(config.palette.accent)` provides contrast for calls to action. Text color `\(config.palette.text)` on background `\(config.palette.bg)` meets WCAG AA contrast requirements for readability.
+
+        ## Typography
+
+        Display font: `\(config.typography.display.split(separator: ",").first.map(String.init)?.replacingOccurrences(of: "\"", with: "") ?? config.typography.display)` — \(axes.register > 0.5 ? "conveys authority and expertise" : "feels approachable and friendly").
+
+        Body font: `\(config.typography.body.split(separator: ",").first.map(String.init)?.replacingOccurrences(of: "\"", with: "") ?? config.typography.body)` — optimized for comfortable reading at body text sizes.
+        """
+    }
+}

--- a/Sources/AnglesiteCore/DesignTokenWriter.swift
+++ b/Sources/AnglesiteCore/DesignTokenWriter.swift
@@ -43,6 +43,11 @@ public enum DesignTokenWriter {
         let moodWords = [temperature, weight, register, time, voice]
             .reduce(into: [String]()) { if !$0.contains($1) { $0.append($1) } }
 
+        let foundation = axes.temperature > 0.5 ? "warm" : "cool"
+        let pairing = config.typography.pairing
+            .replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: "+", with: " + ")
+
         return """
         # Your Design System
 
@@ -52,23 +57,41 @@ public enum DesignTokenWriter {
 
         ## Design axes
 
+        These five axes position your design. Each is a value from 0 to 1.
+
         | Axis | Value | Reading |
         |------|-------|---------|
-        | Temperature (cool <-> warm) | \(axes.temperature) | \(temperature) |
-        | Weight (airy <-> dense) | \(axes.weight) | \(weight) |
-        | Register (playful <-> authoritative) | \(axes.register) | \(register) |
-        | Time (classic <-> contemporary) | \(axes.time) | \(time) |
-        | Voice (subtle <-> bold) | \(axes.voice) | \(voice) |
+        | Temperature (cool ↔ warm) | \(axes.temperature) | \(temperature) |
+        | Weight (airy ↔ dense) | \(axes.weight) | \(weight) |
+        | Register (playful ↔ authoritative) | \(axes.register) | \(register) |
+        | Time (classic ↔ contemporary) | \(axes.time) | \(time) |
+        | Voice (subtle ↔ bold) | \(axes.voice) | \(voice) |
 
         ## Color
 
-        Your brand color is `\(config.palette.brand)`. The accent color `\(config.palette.accent)` provides contrast for calls to action. Text color `\(config.palette.text)` on background `\(config.palette.bg)` meets WCAG AA contrast requirements for readability.
+        Your brand color is `\(config.palette.brand)`. The accent color `\(config.palette.accent)` provides contrast for calls to action. The surface color `\(config.palette.surface)` and background `\(config.palette.bg)` set a \(foundation) foundation.
+
+        Text color `\(config.palette.text)` on background `\(config.palette.bg)` meets WCAG AA contrast requirements for readability.
 
         ## Typography
 
         Display font: `\(config.typography.display.split(separator: ",").first.map(String.init)?.replacingOccurrences(of: "\"", with: "") ?? config.typography.display)` — \(axes.register > 0.5 ? "conveys authority and expertise" : "feels approachable and friendly").
 
         Body font: `\(config.typography.body.split(separator: ",").first.map(String.init)?.replacingOccurrences(of: "\"", with: "") ?? config.typography.body)` — optimized for comfortable reading at body text sizes.
+
+        Pairing strategy: \(pairing).
+
+        ## To adjust
+
+        You can nudge these axes without re-running the full interview:
+
+        - Want it warmer? Increase `temperature` above \(axes.temperature).
+        - Want more authority? Increase `register` above \(axes.register).
+        - Want more whitespace? Decrease `weight` below \(axes.weight).
+        - Want it more modern? Increase `time` above \(axes.time).
+        - Want it louder? Increase `voice` above \(axes.voice).
+
+        Anglesite will regenerate these tokens the next time you apply a design.
         """
     }
 }

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -55,6 +55,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     private let knowledgeIndex: SiteKnowledgeIndex?
     private let semanticRanker: SemanticRanker?
     private let integrationService: (any IntegrationOperationsService)?
+    private let themeCatalog: ThemeCatalog?
     private let logger = Logger(subsystem: "io.dwk.anglesite", category: "FoundationModelAssistant")
     /// The current conversational turn's consumer-facing ``TurnRelay``, retained so ``cancel()`` can
     /// wind it down. Cancelling stops *delivery* only — it never cancels the model stream, because
@@ -90,6 +91,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         knowledgeIndex: SiteKnowledgeIndex? = nil,
         semanticRanker: SemanticRanker? = nil,
         integrationService: (any IntegrationOperationsService)? = nil,
+        themeCatalog: ThemeCatalog? = nil,
         maxRetainedTurns: Int = 12
     ) {
         self.tier = tier
@@ -98,6 +100,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         self.knowledgeIndex = knowledgeIndex
         self.semanticRanker = semanticRanker
         self.integrationService = integrationService
+        self.themeCatalog = themeCatalog
         // `trimSessionIfNeeded`'s cutoff indexing (`promptIndices.count - maxRetainedTurns`) assumes
         // at least 1: `<= 0` would index at or past the end of `promptIndices` and crash. Clamp
         // rather than crash so a caller passing e.g. `0` ("keep no history") degrades to the
@@ -335,6 +338,9 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         if integrationService != nil {
             names.append(SetupIntegrationTool.toolName)
         }
+        if themeCatalog != nil {
+            names.append(SetupThemeTool.toolName)
+        }
         return names
     }
 
@@ -411,6 +417,9 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         }
         if let integrationService {
             tools.append(SetupIntegrationTool(service: integrationService, siteID: context.siteID))
+        }
+        if let themeCatalog {
+            tools.append(SetupThemeTool(catalog: themeCatalog, sourceDirectory: context.siteDirectory))
         }
         return tools
     }

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -6,17 +6,45 @@ import OSLog
 /// Declared *outside* the `#if compiler(>=6.4)` gate because it has no `FoundationModels`
 /// dependency and can be referenced from package code compiled on older CI toolchains.
 ///
-/// - Important: The public `FoundationModels` framework is **on-device**. There is no
-///   caller-selectable Private Cloud Compute session; PCC is used transparently by some system
-///   APIs. `.privateCloudCompute` is therefore *modeled* here so future call sites can express
-///   intent, but **v1 backs it with the same on-device session**. The only observable difference
-///   today is the advertised ``AssistantCapabilities``.
+/// - Important: A 2026-07-10 feasibility spike
+///   (`docs/specs/2026-07-10-pcc-escalation-spike-notes.md`) found that a real, public
+///   `PrivateCloudComputeLanguageModel` API exists in the macOS 27 SDK's `FoundationModels`
+///   framework, conforming to `LanguageModel` and usable via `LanguageModelSession(model:)` —
+///   it is not aspirational or SPI. However, using it requires a manually-requested Apple
+///   developer entitlement this project has not yet obtained, plus undesigned quota- and
+///   availability-fallback handling (the type carries its own `QuotaUsage`/`Availability`
+///   states). `.privateCloudCompute` remains backed by the on-device session until that
+///   entitlement is granted and the integration is designed — this is a deliberate near-term
+///   scope choice, not an API limitation. The only observable difference today is the
+///   advertised ``AssistantCapabilities``.
 public enum FoundationModelTier: String, Sendable, Equatable, CaseIterable {
     /// `SystemLanguageModel.default` — the ~3B on-device model. Free, no network.
     case onDevice            = "onDevice"
     /// Reserved. Backed by the on-device session in v1 (see type note); advertises a larger
     /// context window via capabilities.
     case privateCloudCompute = "privateCloudCompute"
+}
+
+/// Deterministic context-budget helpers, usable without `FoundationModels`. Per the 2026-07-10
+/// spike (see ``FoundationModelTier``'s doc comment), real PCC escalation is not yet wired up, so
+/// "escalation" here means the caller (e.g. the design-interview conversation) should chunk or
+/// summarize a prompt deterministically before it overruns the on-device context window — there
+/// is no larger-model request to make yet.
+public extension FoundationModelAssistant {
+    /// Conservative characters-per-token proxy (~4 chars/token for English), matching the
+    /// existing character-based approach in `maxPageContentCharacters` — no on-device tokenizer
+    /// is available to measure the real count.
+    static let onDeviceTokenBudget = 4_096
+    private static let charsPerTokenEstimate = 4
+
+    static func estimatedTokens(for text: String) -> Int {
+        text.count / charsPerTokenEstimate
+    }
+
+    /// Whether a prompt is estimated to exceed the on-device context budget.
+    static func shouldEscalate(prompt: String) -> Bool {
+        estimatedTokens(for: prompt) > onDeviceTokenBudget
+    }
 }
 
 // Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -47,6 +47,13 @@ public enum FoundationModelContextBudget {
     }
 
     /// Whether a prompt is estimated to exceed the on-device context budget.
+    ///
+    /// - Note: this is currently unconsumed scaffolding — `DesignInterviewModel`/
+    ///   `DesignInterviewPrompts` don't call it yet; they apply their own independent, smaller
+    ///   character cap directly on the user's raw message instead (see
+    ///   `DesignInterviewPrompts.truncatedUserMessage`). Wiring this budget check into the actual
+    ///   conversation flow is tracked alongside design-interview's other app-integration gaps in
+    ///   Anglesite-app#631.
     public static func shouldEscalate(prompt: String) -> Bool {
         estimatedTokens(for: prompt) > onDeviceTokenBudget
     }

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -25,24 +25,29 @@ public enum FoundationModelTier: String, Sendable, Equatable, CaseIterable {
     case privateCloudCompute = "privateCloudCompute"
 }
 
-/// Deterministic context-budget helpers, usable without `FoundationModels`. Per the 2026-07-10
-/// spike (see ``FoundationModelTier``'s doc comment), real PCC escalation is not yet wired up, so
-/// "escalation" here means the caller (e.g. the design-interview conversation) should chunk or
-/// summarize a prompt deterministically before it overruns the on-device context window — there
-/// is no larger-model request to make yet.
-public extension FoundationModelAssistant {
+/// Deterministic context-budget helpers, usable without `FoundationModels`. Declared as a
+/// standalone type (not an extension on ``FoundationModelAssistant``) because that actor is
+/// declared inside the `#if compiler(>=6.4)` gate below and is therefore unavailable at this
+/// point in the file on older toolchains — extending it here would break compilation on CI's
+/// pre-6.4 `swift test` runners (#128).
+///
+/// Per the 2026-07-10 spike (see ``FoundationModelTier``'s doc comment), real PCC escalation is
+/// not yet wired up, so "escalation" here means the caller (e.g. the design-interview
+/// conversation) should chunk or summarize a prompt deterministically before it overruns the
+/// on-device context window — there is no larger-model request to make yet.
+public enum FoundationModelContextBudget {
     /// Conservative characters-per-token proxy (~4 chars/token for English), matching the
     /// existing character-based approach in `maxPageContentCharacters` — no on-device tokenizer
     /// is available to measure the real count.
-    static let onDeviceTokenBudget = 4_096
+    public static let onDeviceTokenBudget = 4_096
     private static let charsPerTokenEstimate = 4
 
-    static func estimatedTokens(for text: String) -> Int {
+    public static func estimatedTokens(for text: String) -> Int {
         text.count / charsPerTokenEstimate
     }
 
     /// Whether a prompt is estimated to exceed the on-device context budget.
-    static func shouldEscalate(prompt: String) -> Bool {
+    public static func shouldEscalate(prompt: String) -> Bool {
         estimatedTokens(for: prompt) > onDeviceTokenBudget
     }
 }

--- a/Sources/AnglesiteCore/FreedesignmdCatalog.swift
+++ b/Sources/AnglesiteCore/FreedesignmdCatalog.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+public struct FreedesignmdSystem: Sendable, Equatable, Identifiable {
+    public let slug: String
+    public let name: String
+    public var id: String { slug }
+    public init(slug: String, name: String) { self.slug = slug; self.name = name }
+}
+
+public struct FreedesignmdSystemDetail: Sendable, Equatable {
+    public let system: FreedesignmdSystem
+    public let description: String
+    public init(system: FreedesignmdSystem, description: String) { self.system = system; self.description = description }
+}
+
+public enum FreedesignmdCatalogError: Error, Sendable, Equatable {
+    case fetchFailed(String)
+    case parseFailed
+}
+
+/// Browses the freedesignmd.com catalog deterministically. The catalog page has no JSON API, but
+/// server-renders a JSON-LD `ItemList` with every system's slug/name — this parses that block
+/// directly rather than doing LLM-mediated page extraction (unlike the plugin's WebFetch-based
+/// `freedesignmd` skill), following `ThemeCatalog.parse(themesTS:)`'s tolerant-regex pattern.
+public enum FreedesignmdCatalog {
+    static let systemsURL = URL(string: "https://freedesignmd.com/systems")!
+    static func systemURL(slug: String) -> URL { URL(string: "https://freedesignmd.com/system/\(slug)")! }
+
+    private static let listItemPattern = #""url":"https://freedesignmd\.com/system/([a-z0-9-]+)","name":"([^"]+)""#
+    private static let descriptionPattern = #"name="description" content="([^"]*)""#
+
+    public static func parseSystemList(html: String) -> [FreedesignmdSystem] {
+        guard let re = try? NSRegularExpression(pattern: listItemPattern) else { return [] }
+        let ns = html as NSString
+        return re.matches(in: html, range: NSRange(location: 0, length: ns.length)).map {
+            FreedesignmdSystem(slug: ns.substring(with: $0.range(at: 1)), name: ns.substring(with: $0.range(at: 2)))
+        }
+    }
+
+    public static func parseDescription(html: String) -> String? {
+        guard let re = try? NSRegularExpression(pattern: descriptionPattern) else { return nil }
+        let ns = html as NSString
+        guard let match = re.firstMatch(in: html, range: NSRange(location: 0, length: ns.length)) else { return nil }
+        return ns.substring(with: match.range(at: 1))
+    }
+
+    public static func fetchSystemList(session: URLSession = .shared) async throws -> [FreedesignmdSystem] {
+        let (data, response) = try await session.data(from: systemsURL)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode,
+              let html = String(data: data, encoding: .utf8)
+        else { throw FreedesignmdCatalogError.fetchFailed("bad response from \(systemsURL)") }
+        let systems = parseSystemList(html: html)
+        guard !systems.isEmpty else { throw FreedesignmdCatalogError.parseFailed }
+        return systems
+    }
+
+    public static func fetchDescription(slug: String, session: URLSession = .shared) async throws -> String? {
+        let (data, response) = try await session.data(from: systemURL(slug: slug))
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode,
+              let html = String(data: data, encoding: .utf8)
+        else { throw FreedesignmdCatalogError.fetchFailed("bad response for \(slug)") }
+        return parseDescription(html: html)
+    }
+
+    /// Deterministic pre-filter: scores each system by how many whitespace-separated keywords from
+    /// `businessType` appear as a substring of its name (case-insensitive), descending. Ties keep
+    /// original catalog order (Swift's `sorted` is stable). Falls back to the original order when
+    /// `businessType` is empty or nothing matches.
+    public static func rank(_ systems: [FreedesignmdSystem], byKeywordsIn businessType: String) -> [FreedesignmdSystem] {
+        let keywords = businessType.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        guard !keywords.isEmpty else { return systems }
+        func score(_ system: FreedesignmdSystem) -> Int {
+            let name = system.name.lowercased()
+            return keywords.reduce(0) { $0 + (name.contains($1) ? 1 : 0) }
+        }
+        return systems.enumerated()
+            .sorted { a, b in
+                let (sa, sb) = (score(a.element), score(b.element))
+                return sa == sb ? a.offset < b.offset : sa > sb
+            }
+            .map(\.element)
+    }
+}

--- a/Sources/AnglesiteCore/FreedesignmdCatalog.swift
+++ b/Sources/AnglesiteCore/FreedesignmdCatalog.swift
@@ -44,6 +44,13 @@ public enum FreedesignmdCatalog {
         return ns.substring(with: match.range(at: 1))
     }
 
+    /// Fetches and parses the `/systems` catalog page's JSON-LD `ItemList`.
+    ///
+    /// - Important: As of 2026-07-10, the server-rendered `/systems` page's JSON-LD
+    ///   `itemListElement` only includes the first ~50 of the catalog's ~108 entries (per the
+    ///   JSON-LD's own `numberOfItems`); the remainder load via client-side pagination not
+    ///   present in this parse. This is a known constraint of the deterministic (non-LLM)
+    ///   parsing approach — callers should not assume completeness.
     public static func fetchSystemList(session: URLSession = .shared) async throws -> [FreedesignmdSystem] {
         let (data, response) = try await session.data(from: systemsURL)
         guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode,

--- a/Sources/AnglesiteCore/SetupThemeTool.swift
+++ b/Sources/AnglesiteCore/SetupThemeTool.swift
@@ -12,8 +12,12 @@ public enum SetupThemeArguments {
             return "I couldn't find this site's stylesheet, so I couldn't apply \(themeName)."
         case .failure(.missingRootBlock):
             return "This site's stylesheet doesn't have the expected structure, so I couldn't apply \(themeName)."
-        case .failure(.writeFailed(let message, _)):
-            return "Applying \(themeName) failed: \(message)."
+        case .failure(.writeFailed(let message, let partiallyWritten)):
+            guard !partiallyWritten.isEmpty else {
+                return "Applying \(themeName) failed: \(message)."
+            }
+            let files = partiallyWritten.joined(separator: ", ")
+            return "Applying \(themeName) failed partway through: \(message). Some files were already updated (\(files)) — the site may be in a mixed state until you try again."
         }
     }
 }

--- a/Sources/AnglesiteCore/SetupThemeTool.swift
+++ b/Sources/AnglesiteCore/SetupThemeTool.swift
@@ -1,0 +1,62 @@
+// Sources/AnglesiteCore/SetupThemeTool.swift
+import Foundation
+
+/// Pure, non-gated helpers so parse/reply logic is unit-testable on CI, mirroring
+/// `SetupIntegrationArguments`.
+public enum SetupThemeArguments {
+    public static func reply(for result: Result<AppliedDesign, DesignApplyError>, themeName: String) -> String {
+        switch result {
+        case .success:
+            return "Applied the \(themeName) theme."
+        case .failure(.missingGlobalCSS):
+            return "I couldn't find this site's stylesheet, so I couldn't apply \(themeName)."
+        case .failure(.missingRootBlock):
+            return "This site's stylesheet doesn't have the expected structure, so I couldn't apply \(themeName)."
+        case .failure(.writeFailed(let message, _)):
+            return "Applying \(themeName) failed: \(message)."
+        }
+    }
+}
+
+#if compiler(>=6.4)
+import FoundationModels
+
+public struct SetupThemeTool: Tool, Sendable {
+    public static let toolName = "setupTheme"
+    public let name = SetupThemeTool.toolName
+    public let description = "Apply one of the built-in visual themes to the current site."
+
+    @Generable
+    public struct Arguments {
+        @Guide(description: "The theme id to apply, e.g. 'warm', 'classic', 'bold'.")
+        public var themeID: String
+    }
+
+    private let catalog: ThemeCatalog
+    /// The site's `Source/` directory — the same value `AssistantContext.siteDirectory` carries,
+    /// which `DesignApplyService.apply(_:to:)`'s `URL` overload expects directly. (Not an
+    /// `AnglesitePackage`: the package-based overload re-derives `Source/` from a package root,
+    /// and the conversation context only ever hands tools the already-resolved source directory.)
+    private let sourceDirectory: URL
+
+    public init(catalog: ThemeCatalog, sourceDirectory: URL) {
+        self.catalog = catalog
+        self.sourceDirectory = sourceDirectory
+    }
+
+    public func call(arguments: Arguments) async throws -> String {
+        guard let theme = catalog.theme(id: arguments.themeID) else {
+            let names = catalog.themes.map(\.name).joined(separator: ", ")
+            return "I don't recognize that theme. Available themes: \(names)."
+        }
+        let input = DesignApplyInput(
+            cssVars: DesignTokenWriter.templateCSSVars(for: theme),
+            rationaleMarkdown: nil,
+            brandSummary: theme.blurb,
+            sourceLabel: "Built-in theme: \(theme.name)"
+        )
+        let result = DesignApplyService.apply(input, to: sourceDirectory)
+        return SetupThemeArguments.reply(for: result, themeName: theme.name)
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/ThemeApplyWizardModel.swift
+++ b/Sources/AnglesiteCore/ThemeApplyWizardModel.swift
@@ -1,0 +1,107 @@
+// Sources/AnglesiteCore/ThemeApplyWizardModel.swift
+import Foundation
+import Observation
+
+/// Drives the "apply a design" wizard: pick a source (built-in theme vs. a freedesignmd.com
+/// system), pick within that source, review, then apply via `DesignApplyService`. Shared by both
+/// the built-in theme gallery and the freedesignmd browsing flow so there is exactly one
+/// wizard-state machine rather than one per source.
+@MainActor @Observable
+public final class ThemeApplyWizardModel: Identifiable {
+    public enum Step: Int, CaseIterable { case pickSource, pickBuiltIn, browseFreedesignmd, review, applying }
+    public enum Source: Equatable { case builtIn, freedesignmd }
+
+    public let id = UUID()
+    public var step: Step = .pickSource
+    public var source: Source?
+    public var selectedBuiltInID: String?
+    public var freedesignmdCandidates: [FreedesignmdSystem] = []
+    public var selectedFreedesignmdSlug: String?
+    public var businessType: String
+    public internal(set) var applyResult: Result<AppliedDesign, DesignApplyError>?
+    public internal(set) var fetchError: String?
+
+    private let catalog: ThemeCatalog
+    private let package: AnglesitePackage
+
+    public init(catalog: ThemeCatalog, businessType: String, package: AnglesitePackage) {
+        self.catalog = catalog
+        self.businessType = businessType
+        self.package = package
+    }
+
+    public var selectedBuiltInTheme: Theme? {
+        selectedBuiltInID.flatMap(catalog.theme(id:))
+    }
+
+    public var canContinue: Bool {
+        switch step {
+        case .pickSource: return source != nil
+        case .pickBuiltIn: return selectedBuiltInID != nil
+        case .browseFreedesignmd: return selectedFreedesignmdSlug != nil
+        case .review: return true
+        case .applying: return false
+        }
+    }
+
+    public func advance() async {
+        guard canContinue else { return }
+        switch step {
+        case .pickSource:
+            step = source == .builtIn ? .pickBuiltIn : .browseFreedesignmd
+            if source == .freedesignmd { await loadFreedesignmdCandidates() }
+        case .pickBuiltIn, .browseFreedesignmd:
+            step = .review
+        case .review, .applying:
+            break
+        }
+    }
+
+    public func back() {
+        switch step {
+        case .pickBuiltIn, .browseFreedesignmd: step = .pickSource
+        case .review: step = source == .builtIn ? .pickBuiltIn : .browseFreedesignmd
+        case .pickSource, .applying: break
+        }
+    }
+
+    private func loadFreedesignmdCandidates() async {
+        do {
+            let all = try await FreedesignmdCatalog.fetchSystemList()
+            freedesignmdCandidates = Array(FreedesignmdCatalog.rank(all, byKeywordsIn: businessType).prefix(10))
+        } catch {
+            fetchError = "Couldn't reach freedesignmd.com — \((error as NSError).localizedDescription)"
+        }
+    }
+
+    public func apply() async {
+        step = .applying
+        switch source {
+        case .builtIn:
+            guard let theme = selectedBuiltInTheme else { return }
+            let input = DesignApplyInput(
+                cssVars: DesignTokenWriter.templateCSSVars(for: theme),
+                rationaleMarkdown: nil,
+                brandSummary: theme.blurb,
+                sourceLabel: "Built-in theme: \(theme.name)"
+            )
+            applyResult = DesignApplyService.apply(input, to: package)
+        case .freedesignmd:
+            guard let slug = selectedFreedesignmdSlug else { return }
+            let description = (try? await FreedesignmdCatalog.fetchDescription(slug: slug)) ?? nil
+            // freedesignmd's per-system CSS-token translation (mapping a fetched DESIGN.md's
+            // described tokens onto the template's 12 vars) is deliberately stubbed to `[:]` —
+            // see the plan's Task 8/9 note. This flow currently only records the description as
+            // brand rationale; it does not yet write new CSS vars.
+            let input = DesignApplyInput(
+                cssVars: [:],
+                rationaleMarkdown: nil,
+                brandSummary: description ?? "Applied from freedesignmd.com/system/\(slug).",
+                sourceLabel: "freedesignmd: \(slug)"
+            )
+            applyResult = DesignApplyService.apply(input, to: package)
+        case nil:
+            return
+        }
+    }
+}

--- a/Sources/AnglesiteCore/ThemeApplyWizardModel.swift
+++ b/Sources/AnglesiteCore/ThemeApplyWizardModel.swift
@@ -23,11 +23,15 @@ public final class ThemeApplyWizardModel: Identifiable {
 
     private let catalog: ThemeCatalog
     private let package: AnglesitePackage
+    private let session: URLSession
 
-    public init(catalog: ThemeCatalog, businessType: String, package: AnglesitePackage) {
+    public init(
+        catalog: ThemeCatalog, businessType: String, package: AnglesitePackage, session: URLSession = .shared
+    ) {
         self.catalog = catalog
         self.businessType = businessType
         self.package = package
+        self.session = session
     }
 
     public var selectedBuiltInTheme: Theme? {
@@ -67,7 +71,7 @@ public final class ThemeApplyWizardModel: Identifiable {
 
     private func loadFreedesignmdCandidates() async {
         do {
-            let all = try await FreedesignmdCatalog.fetchSystemList()
+            let all = try await FreedesignmdCatalog.fetchSystemList(session: session)
             freedesignmdCandidates = Array(FreedesignmdCatalog.rank(all, byKeywordsIn: businessType).prefix(10))
         } catch {
             fetchError = "Couldn't reach freedesignmd.com — \((error as NSError).localizedDescription)"
@@ -78,7 +82,10 @@ public final class ThemeApplyWizardModel: Identifiable {
         step = .applying
         switch source {
         case .builtIn:
-            guard let theme = selectedBuiltInTheme else { return }
+            guard let theme = selectedBuiltInTheme else {
+                applyResult = .failure(.writeFailed(message: "No theme selected to apply.", partiallyWritten: []))
+                return
+            }
             let input = DesignApplyInput(
                 cssVars: DesignTokenWriter.templateCSSVars(for: theme),
                 rationaleMarkdown: nil,
@@ -87,8 +94,11 @@ public final class ThemeApplyWizardModel: Identifiable {
             )
             applyResult = DesignApplyService.apply(input, to: package)
         case .freedesignmd:
-            guard let slug = selectedFreedesignmdSlug else { return }
-            let description = (try? await FreedesignmdCatalog.fetchDescription(slug: slug)) ?? nil
+            guard let slug = selectedFreedesignmdSlug else {
+                applyResult = .failure(.writeFailed(message: "No design system selected to apply.", partiallyWritten: []))
+                return
+            }
+            let description = (try? await FreedesignmdCatalog.fetchDescription(slug: slug, session: session)) ?? nil
             // freedesignmd's per-system CSS-token translation (mapping a fetched DESIGN.md's
             // described tokens onto the template's 12 vars) is deliberately stubbed to `[:]` —
             // see the plan's Task 8/9 note. This flow currently only records the description as
@@ -101,7 +111,7 @@ public final class ThemeApplyWizardModel: Identifiable {
             )
             applyResult = DesignApplyService.apply(input, to: package)
         case nil:
-            return
+            applyResult = .failure(.writeFailed(message: "No design source selected to apply.", partiallyWritten: []))
         }
     }
 }

--- a/Sources/AnglesiteCore/ThemeApplyWizardModel.swift
+++ b/Sources/AnglesiteCore/ThemeApplyWizardModel.swift
@@ -98,7 +98,10 @@ public final class ThemeApplyWizardModel: Identifiable {
                 applyResult = .failure(.writeFailed(message: "No design system selected to apply.", partiallyWritten: []))
                 return
             }
-            let description = (try? await FreedesignmdCatalog.fetchDescription(slug: slug, session: session)) ?? nil
+            // `try?` already flattens to `String??` -> `String?` (SE-0230); a fetch failure and a
+            // page with no `<meta description>` both land here as `nil` and get the same fallback
+            // brand summary below — that's an acceptable, intentional merge of the two cases.
+            let description = try? await FreedesignmdCatalog.fetchDescription(slug: slug, session: session)
             // freedesignmd's per-system CSS-token translation (mapping a fetched DESIGN.md's
             // described tokens onto the template's 12 vars) is deliberately stubbed to `[:]` —
             // see the plan's Task 8/9 note. This flow currently only records the description as

--- a/Sources/AnglesiteCore/ThemeApplyWizardModel.swift
+++ b/Sources/AnglesiteCore/ThemeApplyWizardModel.swift
@@ -21,7 +21,7 @@ public final class ThemeApplyWizardModel: Identifiable {
     public internal(set) var applyResult: Result<AppliedDesign, DesignApplyError>?
     public internal(set) var fetchError: String?
 
-    private let catalog: ThemeCatalog
+    public let catalog: ThemeCatalog
     private let package: AnglesitePackage
     private let session: URLSession
 

--- a/Sources/AnglesiteCore/WCAGContrast.swift
+++ b/Sources/AnglesiteCore/WCAGContrast.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// WCAG 2.2 contrast-ratio utilities, ported 1:1 from the plugin's `scripts/contrast.ts`.
+/// Pure, no I/O.
+public struct RGBColor: Sendable, Equatable {
+    public let r: Int
+    public let g: Int
+    public let b: Int
+    public init(r: Int, g: Int, b: Int) { self.r = r; self.g = g; self.b = b }
+}
+
+public enum WCAGContrast {
+    /// Parses a hex color (`#rgb` or `#rrggbb`, leading `#` optional). Returns `nil` for invalid input.
+    public static func hexToRGB(_ hex: String) -> RGBColor? {
+        var h = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        if h.count == 3, h.allSatisfy({ $0.isHexDigit }) {
+            h = h.map { "\($0)\($0)" }.joined()
+        }
+        guard h.count == 6, h.allSatisfy({ $0.isHexDigit }) else { return nil }
+        let scanner = Scanner(string: h)
+        var value: UInt64 = 0
+        guard scanner.scanHexInt64(&value) else { return nil }
+        return RGBColor(r: Int((value >> 16) & 0xFF), g: Int((value >> 8) & 0xFF), b: Int(value & 0xFF))
+    }
+
+    /// Relative luminance per WCAG 2.2 §1.4.3.
+    public static func relativeLuminance(_ rgb: RGBColor) -> Double {
+        func channel(_ c: Int) -> Double {
+            let s = Double(c) / 255
+            return s <= 0.04045 ? s / 12.92 : pow((s + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b)
+    }
+
+    /// Contrast ratio between two hex colors. `NaN` if either fails to parse.
+    public static func contrastRatio(_ hex1: String, _ hex2: String) -> Double {
+        guard let rgb1 = hexToRGB(hex1), let rgb2 = hexToRGB(hex2) else { return .nan }
+        let l1 = relativeLuminance(rgb1)
+        let l2 = relativeLuminance(rgb2)
+        let lighter = max(l1, l2)
+        let darker = min(l1, l2)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    public static func meetsAA(fg: String, bg: String) -> Bool { contrastRatio(fg, bg) >= 4.5 }
+    public static func meetsAALarge(fg: String, bg: String) -> Bool { contrastRatio(fg, bg) >= 3 }
+
+    private static func toHex(_ rgb: RGBColor) -> String {
+        func clamp(_ n: Int) -> String { String(format: "%02x", max(0, min(255, n))) }
+        return "#\(clamp(rgb.r))\(clamp(rgb.g))\(clamp(rgb.b))"
+    }
+
+    /// Darkens or lightens `fg` in 1-unit RGB steps until it meets AA against `bg`. Returns the
+    /// original hex, lowercased, if it already passes or if either color fails to parse.
+    public static func suggestReadable(fg: String, bg: String) -> String {
+        if meetsAA(fg: fg, bg: bg) { return fg }
+        guard let fgRGB = hexToRGB(fg), let bgRGB = hexToRGB(bg) else { return fg }
+        let shouldDarken = relativeLuminance(bgRGB) > 0.5
+        var best = fgRGB
+        for step in 1...255 {
+            let delta = shouldDarken ? -step : step
+            let candidate = RGBColor(
+                r: max(0, min(255, fgRGB.r + delta)),
+                g: max(0, min(255, fgRGB.g + delta)),
+                b: max(0, min(255, fgRGB.b + delta))
+            )
+            if meetsAA(fg: toHex(candidate), bg: toHex(bgRGB)) {
+                best = candidate
+                break
+            }
+        }
+        return toHex(best)
+    }
+}

--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -63,6 +63,22 @@ public enum AnglesiteIntents {
         AppDependencyManager.shared.add { () -> any DomainOperationsService in
             DomainOperations()
         }
+        // `ApplyThemeIntent` (ThemeIntents.swift) resolves `@Dependency private var catalog:
+        // ThemeCatalog` against whatever is registered here. `ThemeCatalog.load` parses the
+        // bundled template's scripts/themes.ts and can throw (missing/unreadable template),
+        // so — matching `SitesLauncherView.presentNewSite()`'s handling of the same call —
+        // fall back to an empty catalog rather than letting bootstrap throw or the intent trap
+        // on an unregistered dependency. `perform()` already has a "I don't recognize that
+        // theme" reply path for an empty/mismatched catalog.
+        let themeResolution = TemplateRuntime.resolve()
+        let themeCatalog: ThemeCatalog
+        if let templateURL = themeResolution.url, let loaded = try? ThemeCatalog.load(templateURL: templateURL) {
+            themeCatalog = loaded
+        } else {
+            log.error("ThemeCatalog load failed at bootstrap; ApplyThemeIntent will report no themes available")
+            themeCatalog = ThemeCatalog(themes: [])
+        }
+        AppDependencyManager.shared.add { () -> ThemeCatalog in themeCatalog }
         // `EditContentIntent` (B.5 / #149) routes natural-language edits through
         // `IntentEditBridge`, which asks `EditRouterRegistry.shared` for the live edit router of
         // the requested site. The registry is populated by `PreviewModel.open()` and cleared by

--- a/Sources/AnglesiteIntents/DesignInterviewIntents.swift
+++ b/Sources/AnglesiteIntents/DesignInterviewIntents.swift
@@ -1,0 +1,30 @@
+import AppIntents
+import AnglesiteCore
+import Foundation
+
+/// Opens chat pre-seeded to start (or resume) the design interview for a site. The interview
+/// itself runs in chat/GUI, not as a multi-turn App Intent — Siri's role is only the entry point.
+///
+/// **Known gap:** `perform()` below only returns a dialog — it does not yet navigate the app to a
+/// pre-seeded chat/`DesignInterviewModel` instance for `site`. None of the existing
+/// `openAppWhenRun` intents in `AnglesiteIntents` (e.g. `IntegrationIntents`'s siblings) hand off
+/// to a specific chat/view via a URL or scene-storage convention that this intent could reuse —
+/// that routing mechanism doesn't exist yet in this module, so wiring it is left as a follow-up
+/// for whoever owns the app-shell's scene/URL routing, not silently faked here.
+public struct StartDesignInterviewIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Start Design Interview"
+    public static let description = IntentDescription("Start a conversation to design your site's look and feel.")
+    public static let openAppWhenRun = true
+
+    @Parameter(title: "Site") public var site: SiteEntity
+
+    public init() {}
+
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Start a design interview for \(\.$site)")
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        .result(dialog: IntentDialog(stringLiteral: "Let's design \(site.displayName). Opening chat…"))
+    }
+}

--- a/Sources/AnglesiteIntents/ThemeIntents.swift
+++ b/Sources/AnglesiteIntents/ThemeIntents.swift
@@ -1,0 +1,48 @@
+// Sources/AnglesiteIntents/ThemeIntents.swift
+import AppIntents
+import AnglesiteCore
+import Foundation
+
+/// Siri/Shortcuts front door for applying a built-in visual theme to a site.
+///
+/// `SiteEntity.directory` (set from `SiteStore.Site.packageURL` — see `SiteEntity.swift`) is the
+/// `.anglesite` package root, not the `Source/` git directory. So this intent builds a real
+/// `AnglesitePackage(url:)` from it and uses the package-based `DesignApplyService.apply`
+/// overload, which re-derives `Source/` internally. (Contrast `SetupThemeTool` in
+/// `AnglesiteCore`, which is handed an already-resolved `Source/` directory by the conversation
+/// context and calls the `URL` overload directly — there is no phantom
+/// `AnglesitePackage(sourceDirectory:)` initializer; it does not exist.)
+public struct ApplyThemeIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Apply Theme"
+    public static let description = IntentDescription("Apply a built-in visual theme to a site.")
+
+    @Parameter(title: "Site") public var site: SiteEntity
+    @Parameter(title: "Theme", description: "e.g. warm, classic, bold, elegant.") public var themeID: String
+    @Dependency private var catalog: ThemeCatalog
+
+    public init() {}
+
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Apply \(\.$themeID) theme to \(\.$site)")
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        guard let theme = catalog.theme(id: themeID) else {
+            let names = catalog.themes.map(\.name).joined(separator: ", ")
+            return .result(dialog: IntentDialog(stringLiteral: "I don't recognize that theme. Available: \(names)."))
+        }
+        guard let packageURL = site.directory else {
+            return .result(dialog: IntentDialog(stringLiteral: "I couldn't find \(site.displayName)'s location."))
+        }
+        try await requestConfirmation(dialog: "Apply the \(theme.name) theme to \(site.displayName)?")
+        let package = AnglesitePackage(url: packageURL)
+        let input = DesignApplyInput(
+            cssVars: DesignTokenWriter.templateCSSVars(for: theme),
+            rationaleMarkdown: nil,
+            brandSummary: theme.blurb,
+            sourceLabel: "Built-in theme: \(theme.name)"
+        )
+        let result = DesignApplyService.apply(input, to: package)
+        return .result(dialog: IntentDialog(stringLiteral: SetupThemeArguments.reply(for: result, themeName: theme.name)))
+    }
+}

--- a/Sources/AnglesiteSiteModel/AnglesitePackage.swift
+++ b/Sources/AnglesiteSiteModel/AnglesitePackage.swift
@@ -17,15 +17,29 @@ public struct AnglesitePackage: Sendable, Equatable {
 
     /// The package directory (`…/Name.anglesite`).
     public let url: URL
+    /// For synthetic test packages created via `init(sourceDirectory:)`, this is set to the
+    /// source directory itself. For normal packages, this is `nil`.
+    private let syntheticSourceDirectory: URL?
 
     public init(url: URL) {
         self.url = url
+        self.syntheticSourceDirectory = nil
+    }
+
+    /// Convenience initializer for test-friendly wrapping of a bare source directory.
+    /// Constructs a synthetic package pointing to a directory that acts as the source location,
+    /// without requiring a full `.anglesite` package structure on disk.
+    public init(sourceDirectory: URL) {
+        self.url = sourceDirectory
+        self.syntheticSourceDirectory = sourceDirectory
     }
 
     // MARK: - Layout
 
     public var infoPlistURL: URL { url.appendingPathComponent("Info.plist", isDirectory: false) }
-    public var sourceURL: URL { url.appendingPathComponent("Source", isDirectory: true) }
+    public var sourceURL: URL {
+        syntheticSourceDirectory ?? url.appendingPathComponent("Source", isDirectory: true)
+    }
     public var configURL: URL { url.appendingPathComponent("Config", isDirectory: true) }
 
     /// App-owned sync state, inside `Config/` (never in the `Source/` git repo).

--- a/Sources/AnglesiteSiteModel/AnglesitePackage.swift
+++ b/Sources/AnglesiteSiteModel/AnglesitePackage.swift
@@ -17,29 +17,15 @@ public struct AnglesitePackage: Sendable, Equatable {
 
     /// The package directory (`…/Name.anglesite`).
     public let url: URL
-    /// For synthetic test packages created via `init(sourceDirectory:)`, this is set to the
-    /// source directory itself. For normal packages, this is `nil`.
-    private let syntheticSourceDirectory: URL?
 
     public init(url: URL) {
         self.url = url
-        self.syntheticSourceDirectory = nil
-    }
-
-    /// Convenience initializer for test-friendly wrapping of a bare source directory.
-    /// Constructs a synthetic package pointing to a directory that acts as the source location,
-    /// without requiring a full `.anglesite` package structure on disk.
-    public init(sourceDirectory: URL) {
-        self.url = sourceDirectory
-        self.syntheticSourceDirectory = sourceDirectory
     }
 
     // MARK: - Layout
 
     public var infoPlistURL: URL { url.appendingPathComponent("Info.plist", isDirectory: false) }
-    public var sourceURL: URL {
-        syntheticSourceDirectory ?? url.appendingPathComponent("Source", isDirectory: true)
-    }
+    public var sourceURL: URL { url.appendingPathComponent("Source", isDirectory: true) }
     public var configURL: URL { url.appendingPathComponent("Config", isDirectory: true) }
 
     /// App-owned sync state, inside `Config/` (never in the `Source/` git repo).

--- a/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
@@ -178,6 +178,85 @@ import Foundation
         #expect(css == originalCSS)
     }
 
+    @Test func ignoresAttributeSelectorRootAndUpdatesTheBareRootBlock() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = dir.appendingPathComponent("src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        let css = """
+        :root[data-theme="dark"] {
+          --color-primary: #000000;
+        }
+
+        :root {
+          --color-primary: #2563eb;
+        }
+        """
+        try css.write(to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+
+        let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
+                                     brandSummary: "x", sourceLabel: "x")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .success = result else { Issue.record("expected success"); return }
+        let updated = try String(contentsOf: stylesDir.appendingPathComponent("global.css"), encoding: .utf8)
+        // The attribute-selector block must be left untouched — only the bare `:root` block updates.
+        #expect(updated.contains("[data-theme=\"dark\"] {\n  --color-primary: #000000;"))
+        #expect(updated.contains(":root {\n  --color-primary: #ff0000;"))
+    }
+
+    @Test func skipsRootBlockNestedInsideAMediaQueryAndUpdatesTheTopLevelOne() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = dir.appendingPathComponent("src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        let css = """
+        @media (prefers-color-scheme: dark) {
+          :root {
+            --color-primary: #000000;
+          }
+        }
+
+        :root {
+          --color-primary: #2563eb;
+        }
+        """
+        try css.write(to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+
+        let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
+                                     brandSummary: "x", sourceLabel: "x")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .success = result else { Issue.record("expected success"); return }
+        let updated = try String(contentsOf: stylesDir.appendingPathComponent("global.css"), encoding: .utf8)
+        // The @media-nested :root must be left untouched — only the top-level block updates.
+        #expect(updated.contains("@media (prefers-color-scheme: dark) {\n  :root {\n    --color-primary: #000000;"))
+        #expect(updated.contains("\n:root {\n  --color-primary: #ff0000;"))
+    }
+
+    @Test func updatesEveryDuplicateDeclarationOfTheSameProperty() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = dir.appendingPathComponent("src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        // A hand-edited :root block declaring --color-primary twice — CSS gives the LAST
+        // declaration precedence, so both must be rewritten or the stale first one would look
+        // "updated" in isolation while the real, cascading value stayed old.
+        let css = """
+        :root {
+          --color-primary: #111111;
+          --color-accent: #f59e0b;
+          --color-primary: #222222;
+        }
+        """
+        try css.write(to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+
+        let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
+                                     brandSummary: "x", sourceLabel: "x")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .success = result else { Issue.record("expected success"); return }
+        let updated = try String(contentsOf: stylesDir.appendingPathComponent("global.css"), encoding: .utf8)
+        #expect(updated.components(separatedBy: "--color-primary: #111111;").count == 1) // gone
+        #expect(updated.components(separatedBy: "--color-primary: #222222;").count == 1) // gone
+        #expect(updated.components(separatedBy: "--color-primary: #ff0000;").count == 3) // both replaced
+        #expect(updated.contains("--color-accent: #f59e0b;")) // untouched var preserved
+    }
+
     @Test func writeFailureAfterGlobalCSSReportsPartiallyWrittenFiles() throws {
         let dir = try makeSite()
         let failingManager = FailingFileManager(failingPathSubstring: "docs")

--- a/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
@@ -84,4 +84,71 @@ import Foundation
         let result = DesignApplyService.apply(input, to: dir)
         guard case .failure(.missingGlobalCSS) = result else { Issue.record("expected .missingGlobalCSS"); return }
     }
+
+    @Test func failsWithMissingRootBlockWhenGlobalCSSHasNoRoot() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = dir.appendingPathComponent("src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        let css = "* { box-sizing: border-box; }\n"
+        try css.write(to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+
+        let input = DesignApplyInput(cssVars: ["color-primary": "#fff"], rationaleMarkdown: nil, brandSummary: "x", sourceLabel: "x")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .failure(.missingRootBlock) = result else { Issue.record("expected .missingRootBlock"); return }
+    }
+
+    @Test func appendsBrandSummaryAcrossMultipleApplies() throws {
+        let dir = try makeSite()
+        let firstInput = DesignApplyInput(cssVars: [:], rationaleMarkdown: nil, brandSummary: "First brand summary.", sourceLabel: "Built-in theme: Warm")
+        _ = DesignApplyService.apply(firstInput, to: dir)
+        let secondInput = DesignApplyInput(cssVars: [:], rationaleMarkdown: nil, brandSummary: "Second brand summary.", sourceLabel: "Built-in theme: Cool")
+        _ = DesignApplyService.apply(secondInput, to: dir)
+
+        let brand = try String(contentsOf: dir.appendingPathComponent("docs/brand.md"), encoding: .utf8)
+        #expect(brand.contains("Built-in theme: Warm"))
+        #expect(brand.contains("First brand summary."))
+        #expect(brand.contains("Built-in theme: Cool"))
+        #expect(brand.contains("Second brand summary."))
+    }
+
+    /// A `FileManager` subclass that fails `createDirectory` once a target path matches a
+    /// given substring, used to force a partial-write failure partway through `apply`.
+    private final class FailingFileManager: FileManager, @unchecked Sendable {
+        let failingPathSubstring: String
+
+        init(failingPathSubstring: String) {
+            self.failingPathSubstring = failingPathSubstring
+            super.init()
+        }
+
+        override func createDirectory(
+            at url: URL,
+            withIntermediateDirectories createIntermediates: Bool,
+            attributes: [FileAttributeKey: Any]? = nil
+        ) throws {
+            if url.path.contains(failingPathSubstring) {
+                throw NSError(domain: "DesignApplyServiceTests", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "forced failure creating \(url.path)",
+                ])
+            }
+            try super.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attributes)
+        }
+    }
+
+    @Test func writeFailureAfterGlobalCSSReportsPartiallyWrittenFiles() throws {
+        let dir = try makeSite()
+        let failingManager = FailingFileManager(failingPathSubstring: "docs")
+        let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
+                                     brandSummary: "A test brand.", sourceLabel: "Test")
+        let result = DesignApplyService.apply(input, to: dir, fileManager: failingManager)
+
+        guard case .failure(.writeFailed(_, let partiallyWritten)) = result else {
+            Issue.record("expected .writeFailed"); return
+        }
+        #expect(partiallyWritten == ["src/styles/global.css"])
+
+        // The CSS write itself succeeded on disk even though the overall apply failed.
+        let css = try String(contentsOf: dir.appendingPathComponent("src/styles/global.css"), encoding: .utf8)
+        #expect(css.contains("--color-primary: #ff0000;"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
@@ -152,3 +152,17 @@ import Foundation
         #expect(css.contains("--color-primary: #ff0000;"))
     }
 }
+
+extension DesignApplyServiceTests {
+    @Test func packageOverloadDelegatesToSourceDirectory() throws {
+        let dir = try makeSite()
+        // AnglesitePackage(sourceDirectory:) is the existing test-friendly initializer used
+        // elsewhere in AnglesiteCoreTests (see AnglesiteSiteModelTests) — wraps a bare directory
+        // without requiring a full .anglesite package on disk.
+        let package = AnglesitePackage(sourceDirectory: dir)
+        let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
+                                     brandSummary: "x", sourceLabel: "x")
+        let result = DesignApplyService.apply(input, to: package)
+        guard case .success = result else { Issue.record("expected success"); return }
+    }
+}

--- a/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
@@ -154,15 +154,34 @@ import Foundation
 }
 
 extension DesignApplyServiceTests {
+    /// Builds a real `.anglesite` package layout: a package root containing a `Source/`
+    /// subdirectory with the `src/styles/global.css` fixture nested underneath, matching
+    /// `AnglesitePackage.sourceURL`'s real `url/Source` invariant (not a synthetic wrapper).
+    private func makePackageRoot() throws -> URL {
+        let packageRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = packageRoot.appendingPathComponent("Source/src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        let css = """
+        :root {
+          --color-primary: #2563eb;
+          --color-accent: #f59e0b;
+          --font-heading: system-ui, -apple-system, sans-serif;
+        }
+
+        * { box-sizing: border-box; }
+        """
+        try css.write(to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+        return packageRoot
+    }
+
     @Test func packageOverloadDelegatesToSourceDirectory() throws {
-        let dir = try makeSite()
-        // AnglesitePackage(sourceDirectory:) is the existing test-friendly initializer used
-        // elsewhere in AnglesiteCoreTests (see AnglesiteSiteModelTests) — wraps a bare directory
-        // without requiring a full .anglesite package on disk.
-        let package = AnglesitePackage(sourceDirectory: dir)
+        let packageRoot = try makePackageRoot()
+        let package = AnglesitePackage(url: packageRoot)
         let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
                                      brandSummary: "x", sourceLabel: "x")
         let result = DesignApplyService.apply(input, to: package)
         guard case .success = result else { Issue.record("expected success"); return }
+        let css = try String(contentsOf: packageRoot.appendingPathComponent("Source/src/styles/global.css"), encoding: .utf8)
+        #expect(css.contains("--color-primary: #ff0000;"))
     }
 }

--- a/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
@@ -1,0 +1,87 @@
+// Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct DesignApplyServiceTests {
+    private func makeSite() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = dir.appendingPathComponent("src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        let css = """
+        :root {
+          --color-primary: #2563eb;
+          --color-accent: #f59e0b;
+          --font-heading: system-ui, -apple-system, sans-serif;
+        }
+
+        * { box-sizing: border-box; }
+        """
+        try css.write(to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+        return dir
+    }
+
+    @Test func updatesExistingVarsInRootBlock() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
+                                     brandSummary: "A test brand.", sourceLabel: "Test")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .success = result else { Issue.record("expected success"); return }
+        let css = try String(contentsOf: dir.appendingPathComponent("src/styles/global.css"), encoding: .utf8)
+        #expect(css.contains("--color-primary: #ff0000;"))
+        #expect(css.contains("--color-accent: #f59e0b;")) // untouched var preserved
+    }
+
+    @Test func addsNewVarsNotPreviouslyInRootBlock() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: ["color-surface": "#eeeeee"], rationaleMarkdown: nil,
+                                     brandSummary: "A test brand.", sourceLabel: "Test")
+        _ = DesignApplyService.apply(input, to: dir)
+        let css = try String(contentsOf: dir.appendingPathComponent("src/styles/global.css"), encoding: .utf8)
+        #expect(css.contains("--color-surface: #eeeeee;"))
+    }
+
+    @Test func preservesEverythingOutsideRootBlock() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
+                                     brandSummary: "A test brand.", sourceLabel: "Test")
+        _ = DesignApplyService.apply(input, to: dir)
+        let css = try String(contentsOf: dir.appendingPathComponent("src/styles/global.css"), encoding: .utf8)
+        #expect(css.contains("* { box-sizing: border-box; }"))
+    }
+
+    @Test func writesRationaleWhenProvided() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: [:], rationaleMarkdown: "# Design", brandSummary: "A test brand.", sourceLabel: "Test")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .success(let applied) = result else { Issue.record("expected success"); return }
+        #expect(applied.writtenFiles.contains("docs/DESIGN.md"))
+        let md = try String(contentsOf: dir.appendingPathComponent("docs/DESIGN.md"), encoding: .utf8)
+        #expect(md == "# Design")
+    }
+
+    @Test func skipsRationaleFileWhenNil() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: [:], rationaleMarkdown: nil, brandSummary: "A test brand.", sourceLabel: "Test")
+        guard case .success(let applied) = DesignApplyService.apply(input, to: dir) else { Issue.record("expected success"); return }
+        #expect(!applied.writtenFiles.contains("docs/DESIGN.md"))
+        #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent("docs/DESIGN.md").path))
+    }
+
+    @Test func appendsBrandSummaryToNewBrandMd() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: [:], rationaleMarkdown: nil, brandSummary: "A test brand.", sourceLabel: "Built-in theme: Warm")
+        _ = DesignApplyService.apply(input, to: dir)
+        let brand = try String(contentsOf: dir.appendingPathComponent("docs/brand.md"), encoding: .utf8)
+        #expect(brand.contains("Built-in theme: Warm"))
+        #expect(brand.contains("A test brand."))
+    }
+
+    @Test func failsWhenGlobalCSSMissing() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let input = DesignApplyInput(cssVars: ["color-primary": "#fff"], rationaleMarkdown: nil, brandSummary: "x", sourceLabel: "x")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .failure(.missingGlobalCSS) = result else { Issue.record("expected .missingGlobalCSS"); return }
+    }
+}

--- a/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
@@ -135,6 +135,49 @@ import Foundation
         }
     }
 
+    @Test func emptyCSSVarsSkipsGlobalCSSAndSucceedsWithNoCSSFileAtAll() throws {
+        // No src/styles directory at all — not even a malformed global.css.
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let input = DesignApplyInput(
+            cssVars: [:], rationaleMarkdown: "# Design", brandSummary: "freedesignmd description.",
+            sourceLabel: "freedesignmd: acme"
+        )
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .success(let applied) = result else { Issue.record("expected success"); return }
+
+        #expect(!applied.writtenFiles.contains("src/styles/global.css"))
+        #expect(applied.writtenFiles.contains("docs/DESIGN.md"))
+        #expect(applied.writtenFiles.contains("docs/brand.md"))
+        #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent("src/styles/global.css").path))
+
+        let brand = try String(contentsOf: dir.appendingPathComponent("docs/brand.md"), encoding: .utf8)
+        #expect(brand.contains("freedesignmd: acme"))
+        #expect(brand.contains("freedesignmd description."))
+        let rationale = try String(contentsOf: dir.appendingPathComponent("docs/DESIGN.md"), encoding: .utf8)
+        #expect(rationale == "# Design")
+    }
+
+    @Test func emptyCSSVarsSkipsGlobalCSSAndSucceedsWithMalformedGlobalCSS() throws {
+        // A global.css that exists but has no `:root` block — would normally trip
+        // .missingRootBlock, but must not for an empty-cssVars caller.
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = dir.appendingPathComponent("src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        let originalCSS = "* { box-sizing: border-box; }\n"
+        try originalCSS.write(to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+
+        let input = DesignApplyInput(cssVars: [:], rationaleMarkdown: nil, brandSummary: "x", sourceLabel: "freedesignmd: acme")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .success(let applied) = result else { Issue.record("expected success"); return }
+        #expect(!applied.writtenFiles.contains("src/styles/global.css"))
+
+        // global.css itself is untouched.
+        let css = try String(contentsOf: stylesDir.appendingPathComponent("global.css"), encoding: .utf8)
+        #expect(css == originalCSS)
+    }
+
     @Test func writeFailureAfterGlobalCSSReportsPartiallyWrittenFiles() throws {
         let dir = try makeSite()
         let failingManager = FailingFileManager(failingPathSubstring: "docs")

--- a/Tests/AnglesiteCoreTests/DesignAxesTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignAxesTests.swift
@@ -1,0 +1,43 @@
+// Tests/AnglesiteCoreTests/DesignAxesTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignAxesTests {
+    @Test func defaultsForKnownBusinessType() {
+        let axes = DesignAxesCatalog.defaults(forBusinessType: "restaurant")
+        #expect(axes.temperature == 0.75)
+        #expect(axes.weight == 0.45)
+        #expect(axes.register == 0.3)
+        #expect(axes.time == 0.4)
+        #expect(axes.voice == 0.5)
+    }
+
+    @Test func defaultsForUnknownBusinessTypeFallsBackToBalanced() {
+        let axes = DesignAxesCatalog.defaults(forBusinessType: "spaceship-repair")
+        #expect(axes == DesignAxes(temperature: 0.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4))
+    }
+
+    @Test func defaultsAreCaseAndCommaInsensitive() {
+        let axes = DesignAxesCatalog.defaults(forBusinessType: "Restaurant, fine-dining")
+        #expect(axes.temperature == 0.75)
+    }
+
+    @Test func adjustedClampsToUnitRange() {
+        let axes = DesignAxes(temperature: 0.9, weight: 0.1, register: 0.5, time: 0.5, voice: 0.5)
+        let result = DesignAxesCatalog.adjusted(axes, by: [\.temperature: 0.5, \.weight: -0.5])
+        #expect(result.temperature == 1.0)
+        #expect(result.weight == 0.0)
+    }
+
+    @Test func adjustedLeavesUntouchedAxesAlone() {
+        let axes = DesignAxes(temperature: 0.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4)
+        let result = DesignAxesCatalog.adjusted(axes, by: [\.register: 0.1])
+        #expect(result.temperature == 0.5)
+        #expect(result.register == 0.6)
+    }
+
+    @Test func isValidRejectsOutOfRange() {
+        #expect(DesignAxesCatalog.isValid(DesignAxes(temperature: 1.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4)) == false)
+        #expect(DesignAxesCatalog.isValid(DesignAxes(temperature: 0.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4)) == true)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DesignConfigGeneratorTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignConfigGeneratorTests.swift
@@ -32,6 +32,31 @@ import Testing
         #expect(config.brandColor == nil)
     }
 
+    @Test func warmLowRegisterAxesPickHumanistSansPairing() {
+        // Index 2: humanist-sans+humanist-sans wins when temperature is high,
+        // register is low, voice is low. Score formula: temp*1.5 + (1-reg)*1 + (1-voice)*0.5
+        let axes = DesignAxes(temperature: 1.0, weight: 0.5, register: 0.0, time: 0.5, voice: 0.0)
+        let result = DesignConfigGenerator.typography(for: axes)
+        #expect(result.pairing == "humanist-sans+humanist-sans")
+    }
+
+    @Test func classicAuthorityWithWarmTemperaturePicksClassicSerifHumanistSansPairing() {
+        // Index 3: classic-serif+humanist-sans wins with low time, high register, high temperature.
+        // Score formula: (1-time)*1.5 + register*1 + temp*0.8
+        let axes = DesignAxes(temperature: 1.0, weight: 0.5, register: 0.8, time: 0.21, voice: 1.0)
+        let result = DesignConfigGenerator.typography(for: axes)
+        #expect(result.pairing == "classic-serif+humanist-sans")
+    }
+
+    @Test func contemporaryHighRegisterAxesPickModernSansHumanistSansPairing() {
+        // Index 4: modern-sans+humanist-sans wins with high time, high temperature, high register.
+        // Score formula: time*1 + temp*0.8 + (1-register)*0.8
+        // With high register, (1-register)*0.8 is small, allowing time and temp to dominate.
+        let axes = DesignAxes(temperature: 0.95, weight: 0.5, register: 0.9, time: 0.95, voice: 0.5)
+        let result = DesignConfigGenerator.typography(for: axes)
+        #expect(result.pairing == "modern-sans+humanist-sans")
+    }
+
     private func parseRem(_ value: String) -> Double {
         Double(value.replacingOccurrences(of: "rem", with: "")) ?? 0
     }

--- a/Tests/AnglesiteCoreTests/DesignConfigGeneratorTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignConfigGeneratorTests.swift
@@ -1,0 +1,38 @@
+// Tests/AnglesiteCoreTests/DesignConfigGeneratorTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignConfigGeneratorTests {
+    @Test func contemporaryAxesPickModernSansPairing() {
+        let axes = DesignAxes(temperature: 0.5, weight: 0.4, register: 0.2, time: 1.0, voice: 0.5)
+        #expect(DesignConfigGenerator.typography(for: axes).pairing == "modern-sans+modern-sans")
+    }
+
+    @Test func classicAuthoritativeAxesPickClassicSerifPairing() {
+        let axes = DesignAxes(temperature: 0.5, weight: 0.4, register: 1.0, time: 0.0, voice: 0.1)
+        #expect(DesignConfigGenerator.typography(for: axes).pairing == "classic-serif+modern-sans")
+    }
+
+    @Test func airyWeightProducesLargerSpacingThanDense() {
+        let airy = DesignConfigGenerator.spacing(for: DesignAxes(temperature: 0.5, weight: 0.0, register: 0.5, time: 0.5, voice: 0.4))
+        let dense = DesignConfigGenerator.spacing(for: DesignAxes(temperature: 0.5, weight: 1.0, register: 0.5, time: 0.5, voice: 0.4))
+        #expect(parseRem(airy.md) > parseRem(dense.md))
+    }
+
+    @Test func playfulContemporaryAxesProduceRounderShapeThanAuthoritativeClassic() {
+        let playful = DesignConfigGenerator.shape(for: DesignAxes(temperature: 0.5, weight: 0.4, register: 0.0, time: 1.0, voice: 0.4))
+        let authoritative = DesignConfigGenerator.shape(for: DesignAxes(temperature: 0.5, weight: 0.4, register: 1.0, time: 0.0, voice: 0.4))
+        #expect(parseRem(playful.radiusMd) > parseRem(authoritative.radiusMd))
+    }
+
+    @Test func configAssemblesAllParts() {
+        let config = DesignConfigGenerator.config(axes: DesignAxesCatalog.balanced, siteType: "bakery", brandColor: nil)
+        #expect(config.siteType == "bakery")
+        #expect(config.axes == DesignAxesCatalog.balanced)
+        #expect(config.brandColor == nil)
+    }
+
+    private func parseRem(_ value: String) -> Double {
+        Double(value.replacingOccurrences(of: "rem", with: "")) ?? 0
+    }
+}

--- a/Tests/AnglesiteCoreTests/DesignInterviewDraftTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewDraftTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignInterviewDraftTests {
+    @Test func initSeedsAxesFromBusinessType() {
+        let draft = DesignInterviewDraft(businessType: "restaurant")
+        #expect(draft.axes == DesignAxesCatalog.defaults(forBusinessType: "restaurant"))
+        #expect(draft.stage == .intent)
+    }
+
+    @Test func advanceStepsThroughAllStagesInOrder() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let expected: [ConversationStage] = [.mood, .brandAnchor, .axisConfirmation, .done]
+        for stage in expected {
+            draft.advance()
+            #expect(draft.stage == stage)
+        }
+    }
+
+    @Test func advancePastDoneStaysAtDone() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        for _ in 0..<10 { draft.advance() }
+        #expect(draft.stage == .done)
+    }
+
+    @Test func adjectiveHintNudgesTheRightAxis() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.temperature
+        draft.applyAdjectiveHint(.warmer)
+        #expect(draft.axes.temperature > before)
+    }
+
+    @Test func adjectiveHintClampsAtOne() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        for _ in 0..<20 { draft.applyAdjectiveHint(.bolder) }
+        #expect(draft.axes.voice == 1.0)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DesignInterviewDraftTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewDraftTests.swift
@@ -35,4 +35,60 @@ import Testing
         for _ in 0..<20 { draft.applyAdjectiveHint(.bolder) }
         #expect(draft.axes.voice == 1.0)
     }
+
+    @Test func adjectiveHintCoolerDecreasesTemperature() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.temperature
+        draft.applyAdjectiveHint(.cooler)
+        #expect(draft.axes.temperature < before)
+    }
+
+    @Test func adjectiveHintDenserIncreasesWeight() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.weight
+        draft.applyAdjectiveHint(.denser)
+        #expect(draft.axes.weight > before)
+    }
+
+    @Test func adjectiveHintAiriestDecreasesWeight() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.weight
+        draft.applyAdjectiveHint(.airier)
+        #expect(draft.axes.weight < before)
+    }
+
+    @Test func adjectiveHintMoreAuthoritativeIncreasesRegister() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.register
+        draft.applyAdjectiveHint(.moreAuthoritative)
+        #expect(draft.axes.register > before)
+    }
+
+    @Test func adjectiveHintMorePlayfulDecreasesRegister() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.register
+        draft.applyAdjectiveHint(.morePlayful)
+        #expect(draft.axes.register < before)
+    }
+
+    @Test func adjectiveHintMoreClassicDecreasesTime() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.time
+        draft.applyAdjectiveHint(.moreClassic)
+        #expect(draft.axes.time < before)
+    }
+
+    @Test func adjectiveHintMoreContemporaryIncreasesTime() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.time
+        draft.applyAdjectiveHint(.moreContemporary)
+        #expect(draft.axes.time > before)
+    }
+
+    @Test func adjectiveHintSubtlerDecreasesVoice() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.voice
+        draft.applyAdjectiveHint(.subtler)
+        #expect(draft.axes.voice < before)
+    }
 }

--- a/Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
@@ -10,6 +10,14 @@ import FoundationModels
 /// Minimal fake — echoes a fixed reply as a single `.textDelta` then `.turnComplete`, so tests
 /// can assert on stage progression and draft state without a real FoundationModels session.
 private actor FakeConversationalAssistant: ConversationalAssistant {
+    /// When set, `converse` yields `.failed(message:)` instead of a successful reply — used to
+    /// exercise `DesignInterviewModel.send(_:)`'s in-band-failure path.
+    private let failureMessage: String?
+
+    init(failureMessage: String? = nil) {
+        self.failureMessage = failureMessage
+    }
+
     nonisolated var capabilities: AssistantCapabilities {
         AssistantCapabilities(supportsStreaming: true, supportsStructuredOutput: false, supportsVision: false,
                               supportsTools: false, maxContextTokens: 4096, providerName: "Fake")
@@ -23,10 +31,15 @@ private actor FakeConversationalAssistant: ConversationalAssistant {
     }
     #endif
     func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
-        AsyncStream { continuation in
+        let failureMessage = failureMessage
+        return AsyncStream { continuation in
             continuation.yield(.started(model: "Fake", toolNames: []))
-            continuation.yield(.textDelta("Got it."))
-            continuation.yield(.turnComplete(nil))
+            if let failureMessage {
+                continuation.yield(.failed(message: failureMessage))
+            } else {
+                continuation.yield(.textDelta("Got it."))
+                continuation.yield(.turnComplete(nil))
+            }
             continuation.finish()
         }
     }
@@ -44,6 +57,15 @@ private actor FakeConversationalAssistant: ConversationalAssistant {
         try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
         try ":root {\n  --color-primary: #000000;\n}\n".write(
             to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+        return AnglesitePackage(url: packageRoot)
+    }
+
+    /// A package whose `Source/` exists but has no `src/styles/global.css` at all, so
+    /// `DesignApplyService.apply` fails with `.missingGlobalCSS` rather than writing anything.
+    private func makeSiteWithoutGlobalCSS() throws -> AnglesitePackage {
+        let packageRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: packageRoot.appendingPathComponent("Source"), withIntermediateDirectories: true)
         return AnglesitePackage(url: packageRoot)
     }
 
@@ -77,5 +99,48 @@ private actor FakeConversationalAssistant: ConversationalAssistant {
         guard case .success(let applied) = model.applyResult else { Issue.record("expected success"); return }
         #expect(applied.writtenFiles.contains("src/styles/global.css"))
         #expect(model.draft.stage == .done)
+    }
+
+    @Test @MainActor func sendOnInBandFailureAppendsErrorAndDoesNotAdvanceStage() async throws {
+        let model = DesignInterviewModel(
+            businessType: "bakery",
+            assistant: FakeConversationalAssistant(failureMessage: "model unavailable"),
+            package: try makeSite())
+        #expect(model.draft.stage == .intent)
+        await model.send("It's a cozy neighborhood bakery.")
+        #expect(model.draft.stage == .intent, "stage must not advance when the assistant reports .failed")
+        guard let lastAssistantTurn = model.transcript.last(where: { $0.role == "assistant" }) else {
+            Issue.record("expected an assistant transcript entry")
+            return
+        }
+        #expect(!lastAssistantTurn.text.isEmpty)
+        #expect(lastAssistantTurn.text.contains("model unavailable"))
+    }
+
+    @Test @MainActor func sendAdvancesThroughAllStagesAcrossMultipleTurns() async throws {
+        let model = DesignInterviewModel(businessType: "bakery", assistant: FakeConversationalAssistant(), package: try makeSite())
+        #expect(model.draft.stage == .intent)
+
+        await model.send("It's a cozy neighborhood bakery.")
+        #expect(model.draft.stage == .mood)
+
+        await model.send("Warm and inviting, but still modern.")
+        #expect(model.draft.stage == .brandAnchor)
+
+        await model.send("Think a warm oat-milk latte color.")
+        #expect(model.draft.stage == .axisConfirmation)
+
+        await model.send("That all sounds right.")
+        #expect(model.draft.stage == .done)
+    }
+
+    @Test @MainActor func confirmAndApplyOnFailureLeavesStageAtAxisConfirmation() async throws {
+        let model = DesignInterviewModel(
+            businessType: "bakery", assistant: FakeConversationalAssistant(), package: try makeSiteWithoutGlobalCSS())
+        model.skipToAxisConfirmation()
+        await model.confirmAndApply()
+        guard case .failure(let error) = model.applyResult else { Issue.record("expected failure"); return }
+        #expect(error == .missingGlobalCSS)
+        #expect(model.draft.stage == .axisConfirmation, "stage must not become .done when apply fails")
     }
 }

--- a/Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
@@ -13,9 +13,14 @@ private actor FakeConversationalAssistant: ConversationalAssistant {
     /// When set, `converse` yields `.failed(message:)` instead of a successful reply — used to
     /// exercise `DesignInterviewModel.send(_:)`'s in-band-failure path.
     private let failureMessage: String?
+    /// When true, `converse` yields only `.started`/`.turnComplete` with no `.textDelta` in
+    /// between — used to exercise `DesignInterviewModel.send(_:)`'s empty-reply path (a terminal
+    /// event shape distinct from `.failed`/`.cancelled`).
+    private let emitsEmptyReply: Bool
 
-    init(failureMessage: String? = nil) {
+    init(failureMessage: String? = nil, emitsEmptyReply: Bool = false) {
         self.failureMessage = failureMessage
+        self.emitsEmptyReply = emitsEmptyReply
     }
 
     nonisolated var capabilities: AssistantCapabilities {
@@ -32,10 +37,13 @@ private actor FakeConversationalAssistant: ConversationalAssistant {
     #endif
     func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
         let failureMessage = failureMessage
+        let emitsEmptyReply = emitsEmptyReply
         return AsyncStream { continuation in
             continuation.yield(.started(model: "Fake", toolNames: []))
             if let failureMessage {
                 continuation.yield(.failed(message: failureMessage))
+            } else if emitsEmptyReply {
+                continuation.yield(.turnComplete(nil))
             } else {
                 continuation.yield(.textDelta("Got it."))
                 continuation.yield(.turnComplete(nil))
@@ -115,6 +123,21 @@ private actor FakeConversationalAssistant: ConversationalAssistant {
         }
         #expect(!lastAssistantTurn.text.isEmpty)
         #expect(lastAssistantTurn.text.contains("model unavailable"))
+    }
+
+    @Test @MainActor func sendOnEmptyReplyAppendsErrorAndDoesNotAdvanceStage() async throws {
+        let model = DesignInterviewModel(
+            businessType: "bakery",
+            assistant: FakeConversationalAssistant(emitsEmptyReply: true),
+            package: try makeSite())
+        #expect(model.draft.stage == .intent)
+        await model.send("It's a cozy neighborhood bakery.")
+        #expect(model.draft.stage == .intent, "stage must not advance when the assistant sends no text")
+        guard let lastAssistantTurn = model.transcript.last(where: { $0.role == "assistant" }) else {
+            Issue.record("expected an assistant transcript entry")
+            return
+        }
+        #expect(!lastAssistantTurn.text.isEmpty)
     }
 
     @Test @MainActor func sendAdvancesThroughAllStagesAcrossMultipleTurns() async throws {

--- a/Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
@@ -144,3 +144,26 @@ private actor FakeConversationalAssistant: ConversationalAssistant {
         #expect(model.draft.stage == .axisConfirmation, "stage must not become .done when apply fails")
     }
 }
+
+extension DesignInterviewModelTests {
+    @Test func applyingTurnReplyDeltasNudgesAxesAndCapturesBrandColor() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.temperature
+        DesignInterviewModel.applyTurnReplyDeltas(
+            temperature: 0.1, weight: nil, register: nil, time: nil, voice: nil,
+            brandColorHex: "#ff6600", to: &draft
+        )
+        #expect(draft.axes.temperature == before + 0.1)
+        #expect(draft.brandColorHex == "#ff6600")
+    }
+
+    @Test func applyingNilDeltasLeavesAxesUnchanged() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes
+        DesignInterviewModel.applyTurnReplyDeltas(
+            temperature: nil, weight: nil, register: nil, time: nil, voice: nil,
+            brandColorHex: nil, to: &draft
+        )
+        #expect(draft.axes == before)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteSiteModel
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+/// Minimal fake — echoes a fixed reply as a single `.textDelta` then `.turnComplete`, so tests
+/// can assert on stage progression and draft state without a real FoundationModels session.
+private actor FakeConversationalAssistant: ConversationalAssistant {
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(supportsStreaming: true, supportsStructuredOutput: false, supportsVision: false,
+                              supportsTools: false, maxContextTokens: 4096, providerName: "Fake")
+    }
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.yield("echo: \(prompt)"); $0.finish() }
+    }
+    #if compiler(>=6.4)
+    func generateStructured<T: Generable & Sendable>(prompt: String, context: AssistantContext, resultType: T.Type) async throws -> T {
+        fatalError("not used by DesignInterviewModelTests")
+    }
+    #endif
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        AsyncStream { continuation in
+            continuation.yield(.started(model: "Fake", toolNames: []))
+            continuation.yield(.textDelta("Got it."))
+            continuation.yield(.turnComplete(nil))
+            continuation.finish()
+        }
+    }
+    func cancel() async {}
+    func resetSession() async {}
+}
+
+@Suite struct DesignInterviewModelTests {
+    /// Builds a real `.anglesite` package layout: a package root containing a `Source/`
+    /// subdirectory with the `src/styles/global.css` fixture nested underneath, matching
+    /// `AnglesitePackage.sourceURL`'s real `url/Source` invariant (not a synthetic wrapper).
+    private func makeSite() throws -> AnglesitePackage {
+        let packageRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = packageRoot.appendingPathComponent("Source/src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        try ":root {\n  --color-primary: #000000;\n}\n".write(
+            to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+        return AnglesitePackage(url: packageRoot)
+    }
+
+    @Test @MainActor func sendAppendsToTranscriptAndAdvancesStage() async throws {
+        let model = DesignInterviewModel(businessType: "bakery", assistant: FakeConversationalAssistant(), package: try makeSite())
+        #expect(model.draft.stage == .intent)
+        await model.send("It's a cozy neighborhood bakery.")
+        #expect(model.draft.stage == .mood)
+        #expect(model.transcript.contains { $0.role == "user" && $0.text == "It's a cozy neighborhood bakery." })
+        #expect(model.transcript.contains { $0.role == "assistant" && $0.text == "Got it." })
+    }
+
+    @Test @MainActor func nudgeAdjustsAxesWithoutAdvancingStage() async throws {
+        let model = DesignInterviewModel(businessType: "bakery", assistant: FakeConversationalAssistant(), package: try makeSite())
+        let before = model.draft.axes.temperature
+        model.nudge(.warmer)
+        #expect(model.draft.axes.temperature > before)
+        #expect(model.draft.stage == .intent)
+    }
+
+    @Test @MainActor func skipToAxisConfirmationJumpsStage() async throws {
+        let model = DesignInterviewModel(businessType: "bakery", assistant: FakeConversationalAssistant(), package: try makeSite())
+        model.skipToAxisConfirmation()
+        #expect(model.draft.stage == .axisConfirmation)
+    }
+
+    @Test @MainActor func confirmAndApplyWritesThroughDesignApplyService() async throws {
+        let model = DesignInterviewModel(businessType: "bakery", assistant: FakeConversationalAssistant(), package: try makeSite())
+        model.skipToAxisConfirmation()
+        await model.confirmAndApply()
+        guard case .success(let applied) = model.applyResult else { Issue.record("expected success"); return }
+        #expect(applied.writtenFiles.contains("src/styles/global.css"))
+        #expect(model.draft.stage == .done)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DesignInterviewPromptsTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewPromptsTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignInterviewPromptsTests {
+    @Test func intentPromptAsksAboutPurpose() {
+        let draft = DesignInterviewDraft(businessType: "bakery")
+        let prompt = DesignInterviewPrompts.prompt(for: .intent, draft: draft, userMessage: "It's a cozy neighborhood bakery.")
+        #expect(prompt.contains("bakery"))
+        #expect(prompt.contains("It's a cozy neighborhood bakery."))
+    }
+
+    @Test func moodPromptIncludesCurrentAxes() {
+        let draft = DesignInterviewDraft(businessType: "bakery")
+        let prompt = DesignInterviewPrompts.prompt(for: .mood, draft: draft, userMessage: "warmer and more playful")
+        #expect(prompt.contains("temperature"))
+        #expect(prompt.contains(String(draft.axes.temperature)))
+    }
+
+    @Test func brandAnchorPromptAsksForColorOrReference() {
+        let draft = DesignInterviewDraft(businessType: "bakery")
+        let prompt = DesignInterviewPrompts.prompt(for: .brandAnchor, draft: draft, userMessage: "our brand color is #ff6600")
+        #expect(prompt.lowercased().contains("brand color") || prompt.lowercased().contains("hex"))
+    }
+
+    @Test func axisConfirmationPromptSummarizesFinalAxes() {
+        let draft = DesignInterviewDraft(businessType: "bakery")
+        let prompt = DesignInterviewPrompts.prompt(for: .axisConfirmation, draft: draft, userMessage: "looks good")
+        for axisName in ["temperature", "weight", "register", "time", "voice"] {
+            #expect(prompt.contains(axisName))
+        }
+    }
+
+    @Test func donePassesUserMessageThrough() {
+        let draft = DesignInterviewDraft(businessType: "bakery")
+        let prompt = DesignInterviewPrompts.prompt(for: .done, draft: draft, userMessage: "thanks!")
+        #expect(prompt == "thanks!")
+    }
+
+    @Test func promptsStayUnderOnDeviceBudgetEstimate() {
+        let draft = DesignInterviewDraft(businessType: "restaurant")
+        for stage in ConversationStage.allCases where stage != .done {
+            let prompt = DesignInterviewPrompts.prompt(for: stage, draft: draft, userMessage: String(repeating: "word ", count: 50))
+            // Conservative proxy matching FoundationModelAssistant.maxPageContentCharacters' approach:
+            // no single turn prompt should exceed ~2000 characters, leaving room for history + reply.
+            #expect(prompt.count < 2000)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/DesignInterviewPromptsTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewPromptsTests.swift
@@ -45,4 +45,27 @@ import Testing
             #expect(prompt.count < 2000)
         }
     }
+
+    @Test func promptsTruncatePathologicallyLongUserMessage() {
+        let draft = DesignInterviewDraft(businessType: "restaurant")
+        let pathologicalMessage = String(repeating: "word ", count: 2_000) // 10,000 characters
+        for stage in ConversationStage.allCases where stage != .done {
+            let prompt = DesignInterviewPrompts.prompt(for: stage, draft: draft, userMessage: pathologicalMessage)
+            // A genuinely pathological input must still be capped well under the on-device
+            // context budget, not just the fixed-size input the estimate test above uses.
+            #expect(prompt.count < 2000)
+        }
+    }
+
+    @Test func truncatedUserMessageCapsLengthAndMarksTruncation() {
+        let longMessage = String(repeating: "a", count: 5_000)
+        let truncated = DesignInterviewPrompts.truncatedUserMessage(longMessage)
+        #expect(truncated.count == DesignInterviewPrompts.maxUserMessageCharacters + 1)
+        #expect(truncated.hasSuffix("…"))
+    }
+
+    @Test func truncatedUserMessageLeavesShortMessageUnchanged() {
+        let shortMessage = "our brand color is #ff6600"
+        #expect(DesignInterviewPrompts.truncatedUserMessage(shortMessage) == shortMessage)
+    }
 }

--- a/Tests/AnglesiteCoreTests/DesignPaletteGeneratorTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignPaletteGeneratorTests.swift
@@ -1,0 +1,41 @@
+// Tests/AnglesiteCoreTests/DesignPaletteGeneratorTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignPaletteGeneratorTests {
+    @Test func generatesAllSevenTokens() {
+        let palette = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: nil)
+        for hex in [palette.brand, palette.accent, palette.bg, palette.surface, palette.text, palette.muted, palette.border] {
+            #expect(WCAGContrast.hexToRGB(hex) != nil)
+        }
+    }
+
+    @Test func honorsExplicitBrandColor() {
+        let palette = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: "#ff0000")
+        #expect(palette.brand == "#ff0000")
+    }
+
+    @Test func ignoresInvalidBrandColorAndDerivesInstead() {
+        let derived = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: "not-a-color")
+        #expect(derived.brand != "not-a-color")
+        #expect(WCAGContrast.hexToRGB(derived.brand) != nil)
+    }
+
+    @Test func textMeetsAAAgainstBackground() {
+        let palette = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: nil)
+        #expect(WCAGContrast.meetsAA(fg: palette.text, bg: palette.bg))
+    }
+
+    @Test func mutedMeetsAAAgainstBackground() {
+        let palette = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: nil)
+        #expect(WCAGContrast.meetsAA(fg: palette.muted, bg: palette.bg))
+    }
+
+    @Test func warmTemperatureProducesDifferentBrandHueThanCool() {
+        let warm = DesignPaletteGenerator.generate(
+            axes: DesignAxes(temperature: 1.0, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4), brandColor: nil)
+        let cool = DesignPaletteGenerator.generate(
+            axes: DesignAxes(temperature: 0.0, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4), brandColor: nil)
+        #expect(warm.brand != cool.brand)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DesignPaletteGeneratorTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignPaletteGeneratorTests.swift
@@ -38,4 +38,28 @@ import Testing
             axes: DesignAxes(temperature: 0.0, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4), brandColor: nil)
         #expect(warm.brand != cool.brand)
     }
+
+    @Test func goldenValueForBalancedAxesWithNoBrandColor() {
+        let palette = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: nil)
+        #expect(palette.brand == "#269c75")
+        #expect(palette.accent == "#2a98cf")
+        #expect(palette.bg == "#f9fafa")
+        #expect(palette.surface == "#f1f4f3")
+        #expect(palette.text == "#19201e")
+        #expect(palette.muted == "#6b7672")
+        #expect(palette.border == "#d7e0dd")
+    }
+
+    @Test func goldenValueForDarkModeAxesWithNoBrandColor() {
+        let palette = DesignPaletteGenerator.generate(
+            axes: DesignAxes(temperature: 0.6, weight: 0.9, register: 0.5, time: 0.5, voice: 0.9),
+            brandColor: nil)
+        #expect(palette.brand == "#1fa33b")
+        #expect(palette.accent == "#e033bb")
+        #expect(palette.bg == "#171e18")
+        #expect(palette.surface == "#202922")
+        #expect(palette.text == "#eaecea")
+        #expect(palette.muted == "#91a194")
+        #expect(palette.border == "#2e3830")
+    }
 }

--- a/Tests/AnglesiteCoreTests/DesignTokenWriterTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignTokenWriterTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignTokenWriterTests {
+    @Test func mapsConfigToExactlyTheTemplateTwelveVars() {
+        let config = DesignConfigGenerator.config(axes: DesignAxesCatalog.balanced, siteType: "bakery", brandColor: nil)
+        let vars = DesignTokenWriter.templateCSSVars(for: config)
+        #expect(Set(vars.keys) == Set([
+            "color-primary", "color-accent", "color-background", "color-surface",
+            "color-text", "color-text-muted", "font-heading", "font-body",
+            "spacing-unit", "radius-sm", "radius-md", "radius-lg",
+        ]))
+    }
+
+    @Test func configColorPrimaryComesFromPaletteBrand() {
+        let config = DesignConfigGenerator.config(axes: DesignAxesCatalog.balanced, siteType: "bakery", brandColor: "#ff0000")
+        let vars = DesignTokenWriter.templateCSSVars(for: config)
+        #expect(vars["color-primary"] == "#ff0000")
+    }
+
+    @Test func themeVarsPassThroughUnchanged() {
+        let theme = Theme(id: "warm", name: "Warm", blurb: "cozy", swatch: ["#111", "#222"],
+                          cssVars: ["color-primary": "#111", "font-heading": "Georgia"])
+        let vars = DesignTokenWriter.templateCSSVars(for: theme)
+        #expect(vars["color-primary"] == "#111")
+        #expect(vars["font-heading"] == "Georgia")
+    }
+
+    @Test func rationaleIncludesAllFiveAxesAndBothColors() {
+        let config = DesignConfigGenerator.config(axes: DesignAxesCatalog.balanced, siteType: "bakery", brandColor: nil)
+        let md = DesignTokenWriter.rationaleMarkdown(for: config)
+        for axisName in ["Temperature", "Weight", "Register", "Time", "Voice"] {
+            #expect(md.contains(axisName))
+        }
+        #expect(md.contains(config.palette.brand))
+        #expect(md.contains(config.palette.accent))
+    }
+}

--- a/Tests/AnglesiteCoreTests/DesignTokenWriterTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignTokenWriterTests.swift
@@ -35,4 +35,46 @@ import Testing
         #expect(md.contains(config.palette.brand))
         #expect(md.contains(config.palette.accent))
     }
+
+    @Test func rationaleIncludesSurfaceFoundationPairingAndAdjustSection() {
+        let config = DesignConfigGenerator.config(axes: DesignAxesCatalog.balanced, siteType: "bakery", brandColor: nil)
+        let md = DesignTokenWriter.rationaleMarkdown(for: config)
+
+        #expect(md.contains("These five axes position your design. Each is a value from 0 to 1."))
+
+        #expect(md.contains(config.palette.surface))
+        #expect(md.contains("set a cool foundation."))
+
+        let expectedPairing = config.typography.pairing
+            .replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: "+", with: " + ")
+        #expect(md.contains("Pairing strategy: \(expectedPairing)."))
+
+        #expect(md.contains("## To adjust"))
+        #expect(md.contains("Want it warmer? Increase `temperature` above"))
+        #expect(md.contains("Want more authority? Increase `register` above"))
+        #expect(md.contains("Want more whitespace? Decrease `weight` below"))
+        #expect(md.contains("Want it more modern? Increase `time` above"))
+        #expect(md.contains("Want it louder? Increase `voice` above"))
+        #expect(md.contains("Anglesite will regenerate these tokens the next time you apply a design."))
+
+        #expect(md.contains("Temperature (cool ↔ warm)"))
+        #expect(md.contains("Weight (airy ↔ dense)"))
+        #expect(md.contains("Register (playful ↔ authoritative)"))
+        #expect(md.contains("Time (classic ↔ contemporary)"))
+        #expect(md.contains("Voice (subtle ↔ bold)"))
+        #expect(!md.contains("<->"))
+    }
+
+    @Test func rationaleUsesHighAxisWordingForHighValueAxes() {
+        let axes = DesignAxes(temperature: 0.7, weight: 0.65, register: 0.8, time: 0.65, voice: 0.65)
+        let config = DesignConfigGenerator.config(axes: axes, siteType: "bakery", brandColor: nil)
+        let md = DesignTokenWriter.rationaleMarkdown(for: config)
+
+        #expect(md.contains("warm"))
+        #expect(md.contains("authoritative"))
+        #expect(md.contains("conveys authority and expertise"))
+        #expect(!md.contains("feels approachable and friendly"))
+        #expect(md.contains("set a warm foundation."))
+    }
 }

--- a/Tests/AnglesiteCoreTests/FoundationModelAssistantEscalationTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelAssistantEscalationTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct FoundationModelAssistantEscalationTests {
+    @Test func estimatedTokensUsesCharacterProxy() {
+        // Matches FoundationModelAssistant.maxPageContentCharacters' existing character-based
+        // proxy approach (no on-device tokenizer is available).
+        let text = String(repeating: "a", count: 20_000)
+        #expect(FoundationModelAssistant.estimatedTokens(for: text) > FoundationModelAssistant.onDeviceTokenBudget)
+    }
+
+    @Test func shouldEscalateWhenOverBudget() {
+        let longPrompt = String(repeating: "word ", count: 5_000)
+        #expect(FoundationModelAssistant.shouldEscalate(prompt: longPrompt) == true)
+    }
+
+    @Test func shouldNotEscalateWhenUnderBudget() {
+        #expect(FoundationModelAssistant.shouldEscalate(prompt: "short prompt") == false)
+    }
+}

--- a/Tests/AnglesiteCoreTests/FoundationModelAssistantEscalationTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelAssistantEscalationTests.swift
@@ -6,15 +6,15 @@ import Testing
         // Matches FoundationModelAssistant.maxPageContentCharacters' existing character-based
         // proxy approach (no on-device tokenizer is available).
         let text = String(repeating: "a", count: 20_000)
-        #expect(FoundationModelAssistant.estimatedTokens(for: text) > FoundationModelAssistant.onDeviceTokenBudget)
+        #expect(FoundationModelContextBudget.estimatedTokens(for: text) > FoundationModelContextBudget.onDeviceTokenBudget)
     }
 
     @Test func shouldEscalateWhenOverBudget() {
         let longPrompt = String(repeating: "word ", count: 5_000)
-        #expect(FoundationModelAssistant.shouldEscalate(prompt: longPrompt) == true)
+        #expect(FoundationModelContextBudget.shouldEscalate(prompt: longPrompt) == true)
     }
 
     @Test func shouldNotEscalateWhenUnderBudget() {
-        #expect(FoundationModelAssistant.shouldEscalate(prompt: "short prompt") == false)
+        #expect(FoundationModelContextBudget.shouldEscalate(prompt: "short prompt") == false)
     }
 }

--- a/Tests/AnglesiteCoreTests/FreedesignmdCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/FreedesignmdCatalogTests.swift
@@ -1,7 +1,40 @@
+import Foundation
 import Testing
 @testable import AnglesiteCore
 
-@Suite struct FreedesignmdCatalogTests {
+/// Stub `URLProtocol` that returns a canned status/body for every request, so
+/// `fetchSystemList`/`fetchDescription` can be exercised without a real network call.
+private final class FreedesignmdStubURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var statusCode = 200
+    nonisolated(unsafe) static var body = ""
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(Self.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FreedesignmdStubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+// .serialized: fetchSystemList/fetchDescription tests share FreedesignmdStubURLProtocol's
+// mutable static status/body, which would race under Swift Testing's default parallel execution.
+@Suite(.serialized) struct FreedesignmdCatalogTests {
     private let sampleListHTML = """
     <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"BreadcrumbList"},{"@type":"CollectionPage","mainEntity":{"@type":"ItemList","numberOfItems":3,"itemListElement":[{"@type":"ListItem","position":1,"url":"https://freedesignmd.com/system/linear-orbit","name":"Linear Orbit"},{"@type":"ListItem","position":2,"url":"https://freedesignmd.com/system/devshell-mono","name":"Devshell Mono"},{"@type":"ListItem","position":3,"url":"https://freedesignmd.com/system/vinyl-noir","name":"Vinyl Noir"}]}}]}</script>
     """
@@ -40,5 +73,45 @@ import Testing
         let systems = FreedesignmdCatalog.parseSystemList(html: sampleListHTML)
         let ranked = FreedesignmdCatalog.rank(systems, byKeywordsIn: "")
         #expect(ranked == systems)
+    }
+
+    @Test func rankKeepsOriginalRelativeOrderForEqualNonzeroScores() {
+        // Both "mono-alpha" and "mono-beta" match "mono" exactly once (score 1), so they tie;
+        // "solo-gamma" doesn't match at all (score 0). Only the *relative* order of the tied
+        // pair is asserted here — the earlier test only checked `ranked.first`.
+        let systems = [
+            FreedesignmdSystem(slug: "mono-alpha", name: "Mono Alpha"),
+            FreedesignmdSystem(slug: "solo-gamma", name: "Solo Gamma"),
+            FreedesignmdSystem(slug: "mono-beta", name: "Mono Beta"),
+        ]
+        let ranked = FreedesignmdCatalog.rank(systems, byKeywordsIn: "mono")
+        #expect(ranked.map(\.slug) == ["mono-alpha", "mono-beta", "solo-gamma"])
+    }
+
+    @Test func fetchSystemListThrowsFetchFailedOnNon2xxStatus() async {
+        FreedesignmdStubURLProtocol.statusCode = 404
+        FreedesignmdStubURLProtocol.body = "not found"
+        let session = FreedesignmdStubURLProtocol.makeSession()
+        await #expect(throws: FreedesignmdCatalogError.fetchFailed("bad response from \(FreedesignmdCatalog.systemsURL)")) {
+            _ = try await FreedesignmdCatalog.fetchSystemList(session: session)
+        }
+    }
+
+    @Test func fetchSystemListThrowsParseFailedOnEmptyCatalog() async {
+        FreedesignmdStubURLProtocol.statusCode = 200
+        FreedesignmdStubURLProtocol.body = "<html><body>no systems here</body></html>"
+        let session = FreedesignmdStubURLProtocol.makeSession()
+        await #expect(throws: FreedesignmdCatalogError.parseFailed) {
+            _ = try await FreedesignmdCatalog.fetchSystemList(session: session)
+        }
+    }
+
+    @Test func fetchDescriptionThrowsFetchFailedOnNon2xxStatus() async {
+        FreedesignmdStubURLProtocol.statusCode = 500
+        FreedesignmdStubURLProtocol.body = "server error"
+        let session = FreedesignmdStubURLProtocol.makeSession()
+        await #expect(throws: FreedesignmdCatalogError.fetchFailed("bad response for linear-orbit")) {
+            _ = try await FreedesignmdCatalog.fetchDescription(slug: "linear-orbit", session: session)
+        }
     }
 }

--- a/Tests/AnglesiteCoreTests/FreedesignmdCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/FreedesignmdCatalogTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct FreedesignmdCatalogTests {
+    private let sampleListHTML = """
+    <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"BreadcrumbList"},{"@type":"CollectionPage","mainEntity":{"@type":"ItemList","numberOfItems":3,"itemListElement":[{"@type":"ListItem","position":1,"url":"https://freedesignmd.com/system/linear-orbit","name":"Linear Orbit"},{"@type":"ListItem","position":2,"url":"https://freedesignmd.com/system/devshell-mono","name":"Devshell Mono"},{"@type":"ListItem","position":3,"url":"https://freedesignmd.com/system/vinyl-noir","name":"Vinyl Noir"}]}}]}</script>
+    """
+
+    private let sampleDetailHTML = """
+    <meta name="description" content="Hairline-thin product workspace. Cool off-white surfaces, Inter Display with tight tracking."/>
+    """
+
+    @Test func parsesAllListItems() {
+        let systems = FreedesignmdCatalog.parseSystemList(html: sampleListHTML)
+        #expect(systems.count == 3)
+        #expect(systems[0] == FreedesignmdSystem(slug: "linear-orbit", name: "Linear Orbit"))
+        #expect(systems[2] == FreedesignmdSystem(slug: "vinyl-noir", name: "Vinyl Noir"))
+    }
+
+    @Test func parseSystemListReturnsEmptyForUnrecognizedHTML() {
+        #expect(FreedesignmdCatalog.parseSystemList(html: "<html><body>nothing here</body></html>").isEmpty)
+    }
+
+    @Test func parsesDescriptionMetaTag() {
+        let description = FreedesignmdCatalog.parseDescription(html: sampleDetailHTML)
+        #expect(description == "Hairline-thin product workspace. Cool off-white surfaces, Inter Display with tight tracking.")
+    }
+
+    @Test func parseDescriptionReturnsNilWhenAbsent() {
+        #expect(FreedesignmdCatalog.parseDescription(html: "<html></html>") == nil)
+    }
+
+    @Test func rankPrioritizesNameSubstringMatches() {
+        let systems = FreedesignmdCatalog.parseSystemList(html: sampleListHTML)
+        let ranked = FreedesignmdCatalog.rank(systems, byKeywordsIn: "mono developer tools")
+        #expect(ranked.first == FreedesignmdSystem(slug: "devshell-mono", name: "Devshell Mono"))
+    }
+
+    @Test func rankFallsBackToOriginalOrderWithNoMatches() {
+        let systems = FreedesignmdCatalog.parseSystemList(html: sampleListHTML)
+        let ranked = FreedesignmdCatalog.rank(systems, byKeywordsIn: "")
+        #expect(ranked == systems)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SetupThemeToolTests.swift
+++ b/Tests/AnglesiteCoreTests/SetupThemeToolTests.swift
@@ -16,10 +16,21 @@ import Testing
 
     @Test func replyForWriteFailedIncludesMessage() {
         let reply = SetupThemeArguments.reply(
+            for: .failure(.writeFailed(message: "disk full", partiallyWritten: [])),
+            themeName: "Warm"
+        )
+        #expect(reply.contains("disk full"))
+    }
+
+    @Test func replyForPartialWriteFailureNamesTheFilesAlreadyWritten() {
+        let reply = SetupThemeArguments.reply(
             for: .failure(.writeFailed(message: "disk full", partiallyWritten: ["src/styles/global.css"])),
             themeName: "Warm"
         )
         #expect(reply.contains("disk full"))
+        #expect(reply.contains("src/styles/global.css"))
+        // Must not read like nothing happened — the CSS write already landed on disk.
+        #expect(reply.contains("already updated") || reply.contains("mixed state"))
     }
 
     @Test func replyForMissingRootBlockExplainsWhatWentWrong() {

--- a/Tests/AnglesiteCoreTests/SetupThemeToolTests.swift
+++ b/Tests/AnglesiteCoreTests/SetupThemeToolTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct SetupThemeToolTests {
+    @Test func replyForSuccessNamesTheTheme() {
+        let applied = AppliedDesign(updatedVars: [:], writtenFiles: ["src/styles/global.css"])
+        let reply = SetupThemeArguments.reply(for: .success(applied), themeName: "Warm")
+        #expect(reply.contains("Warm"))
+    }
+
+    @Test func replyForFailureExplainsWhatWentWrong() {
+        let reply = SetupThemeArguments.reply(for: .failure(.missingGlobalCSS), themeName: "Warm")
+        #expect(!reply.isEmpty)
+        #expect(reply != SetupThemeArguments.reply(for: .success(AppliedDesign(updatedVars: [:], writtenFiles: [])), themeName: "Warm"))
+    }
+
+    @Test func replyForWriteFailedIncludesMessage() {
+        let reply = SetupThemeArguments.reply(
+            for: .failure(.writeFailed(message: "disk full", partiallyWritten: ["src/styles/global.css"])),
+            themeName: "Warm"
+        )
+        #expect(reply.contains("disk full"))
+    }
+
+    @Test func replyForMissingRootBlockExplainsWhatWentWrong() {
+        let reply = SetupThemeArguments.reply(for: .failure(.missingRootBlock), themeName: "Warm")
+        #expect(!reply.isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/ThemeApplyWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/ThemeApplyWizardModelTests.swift
@@ -1,0 +1,63 @@
+// Tests/AnglesiteCoreTests/ThemeApplyWizardModelTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct ThemeApplyWizardModelTests {
+    private func makeSite() throws -> AnglesitePackage {
+        let packageRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = packageRoot.appendingPathComponent("Source/src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        try ":root {\n  --color-primary: #000000;\n}\n".write(
+            to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+        return AnglesitePackage(url: packageRoot)
+    }
+
+    private var testCatalog: ThemeCatalog {
+        ThemeCatalog(themes: [Theme(id: "warm", name: "Warm", blurb: "cozy", swatch: ["#a11", "#a22"],
+                                    cssVars: ["color-primary": "#a11111", "color-accent": "#a22222"])])
+    }
+
+    @Test @MainActor func picksBuiltInFlowAndApplies() async throws {
+        let package = try makeSite()
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery", package: package)
+        model.source = .builtIn
+        await model.advance() // pickSource -> pickBuiltIn
+        #expect(model.step == .pickBuiltIn)
+        model.selectedBuiltInID = "warm"
+        await model.advance() // pickBuiltIn -> review
+        #expect(model.step == .review)
+        #expect(model.canContinue)
+        await model.apply()
+        #expect(model.step == .applying)
+        guard case .success(let applied) = model.applyResult else { Issue.record("expected success"); return }
+        #expect(applied.updatedVars["color-primary"] == "#a11111")
+    }
+
+    @Test @MainActor func canContinueRequiresSourceChoiceFirst() {
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery",
+                                          package: AnglesitePackage(url: FileManager.default.temporaryDirectory))
+        #expect(model.canContinue == false)
+        model.source = .builtIn
+        #expect(model.canContinue)
+    }
+
+    @Test @MainActor func canContinueRequiresBuiltInSelection() async {
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery",
+                                          package: AnglesitePackage(url: FileManager.default.temporaryDirectory))
+        model.source = .builtIn
+        await model.advance()
+        #expect(model.canContinue == false)
+        model.selectedBuiltInID = "warm"
+        #expect(model.canContinue)
+    }
+
+    @Test @MainActor func backReturnsToPickSource() async {
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery",
+                                          package: AnglesitePackage(url: FileManager.default.temporaryDirectory))
+        model.source = .builtIn
+        await model.advance()
+        model.back()
+        #expect(model.step == .pickSource)
+    }
+}

--- a/Tests/AnglesiteCoreTests/ThemeApplyWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/ThemeApplyWizardModelTests.swift
@@ -3,7 +3,41 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
-@Suite struct ThemeApplyWizardModelTests {
+/// Stub `URLProtocol` that returns a canned status/body for every request, so the
+/// freedesignmd branch of `ThemeApplyWizardModel` can be exercised without a real network
+/// call. Mirrors `FreedesignmdStubURLProtocol` in FreedesignmdCatalogTests.swift, kept
+/// separate/private here to avoid cross-file coupling on a `private` type.
+private final class WizardFreedesignmdStubURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var statusCode = 200
+    nonisolated(unsafe) static var body = ""
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(Self.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [WizardFreedesignmdStubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+// .serialized: the freedesignmd tests share WizardFreedesignmdStubURLProtocol's mutable
+// static status/body, which would race under Swift Testing's default parallel execution.
+@Suite(.serialized) struct ThemeApplyWizardModelTests {
     private func makeSite() throws -> AnglesitePackage {
         let packageRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let stylesDir = packageRoot.appendingPathComponent("Source/src/styles")
@@ -59,5 +93,101 @@ import Foundation
         await model.advance()
         model.back()
         #expect(model.step == .pickSource)
+    }
+
+    // MARK: - Fix 1: apply() must not leave applyResult nil when there's nothing to apply
+
+    @Test @MainActor func applyFailsExplicitlyWhenBuiltInSelectionMissing() async {
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery",
+                                          package: AnglesitePackage(url: FileManager.default.temporaryDirectory))
+        model.source = .builtIn
+        // No selectedBuiltInID set — simulate a caller reaching `.review` then clearing the
+        // selection and calling apply() directly, bypassing canContinue's advance() gate.
+        await model.apply()
+        #expect(model.step == .applying)
+        guard case .failure = model.applyResult else {
+            Issue.record("expected apply() to surface a failure, not leave applyResult nil")
+            return
+        }
+    }
+
+    @Test @MainActor func applyFailsExplicitlyWhenFreedesignmdSelectionMissing() async {
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery",
+                                          package: AnglesitePackage(url: FileManager.default.temporaryDirectory))
+        model.source = .freedesignmd
+        // No selectedFreedesignmdSlug set.
+        await model.apply()
+        #expect(model.step == .applying)
+        guard case .failure = model.applyResult else {
+            Issue.record("expected apply() to surface a failure, not leave applyResult nil")
+            return
+        }
+    }
+
+    @Test @MainActor func applyFailsExplicitlyWhenSourceMissing() async {
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery",
+                                          package: AnglesitePackage(url: FileManager.default.temporaryDirectory))
+        // source is nil.
+        await model.apply()
+        guard case .failure = model.applyResult else {
+            Issue.record("expected apply() to surface a failure, not leave applyResult nil")
+            return
+        }
+    }
+
+    // MARK: - Fix 2: freedesignmd branch coverage
+
+    private let sampleListHTML = """
+    <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"BreadcrumbList"},{"@type":"CollectionPage","mainEntity":{"@type":"ItemList","numberOfItems":2,"itemListElement":[{"@type":"ListItem","position":1,"url":"https://freedesignmd.com/system/linear-orbit","name":"Linear Orbit"},{"@type":"ListItem","position":2,"url":"https://freedesignmd.com/system/vinyl-noir","name":"Vinyl Noir"}]}}]}</script>
+    """
+
+    private let sampleDetailHTML = """
+    <meta name="description" content="Hairline-thin product workspace."/>
+    """
+
+    @Test @MainActor func picksFreedesignmdFlowAndPopulatesCandidates() async throws {
+        WizardFreedesignmdStubURLProtocol.statusCode = 200
+        WizardFreedesignmdStubURLProtocol.body = sampleListHTML
+        let session = WizardFreedesignmdStubURLProtocol.makeSession()
+        let package = try makeSite()
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery", package: package,
+                                          session: session)
+        model.source = .freedesignmd
+        await model.advance() // pickSource -> browseFreedesignmd, loads candidates
+        #expect(model.step == .browseFreedesignmd)
+        #expect(model.fetchError == nil)
+        #expect(model.freedesignmdCandidates.map(\.slug) == ["linear-orbit", "vinyl-noir"])
+    }
+
+    @Test @MainActor func loadFreedesignmdCandidatesSetsFetchErrorOnHTTPFailure() async {
+        WizardFreedesignmdStubURLProtocol.statusCode = 500
+        WizardFreedesignmdStubURLProtocol.body = "server error"
+        let session = WizardFreedesignmdStubURLProtocol.makeSession()
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery",
+                                          package: AnglesitePackage(url: FileManager.default.temporaryDirectory),
+                                          session: session)
+        model.source = .freedesignmd
+        await model.advance() // pickSource -> browseFreedesignmd, load fails
+        #expect(model.step == .browseFreedesignmd)
+        #expect(model.freedesignmdCandidates.isEmpty)
+        #expect(model.fetchError != nil)
+    }
+
+    @Test @MainActor func appliesFreedesignmdSelection() async throws {
+        WizardFreedesignmdStubURLProtocol.statusCode = 200
+        WizardFreedesignmdStubURLProtocol.body = sampleDetailHTML
+        let session = WizardFreedesignmdStubURLProtocol.makeSession()
+        let package = try makeSite()
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery", package: package,
+                                          session: session)
+        model.source = .freedesignmd
+        model.selectedFreedesignmdSlug = "linear-orbit"
+        model.step = .review
+        await model.apply()
+        #expect(model.step == .applying)
+        guard case .success(let applied) = model.applyResult else {
+            Issue.record("expected success"); return
+        }
+        #expect(applied.writtenFiles.isEmpty == false)
     }
 }

--- a/Tests/AnglesiteCoreTests/ThemeApplyWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/ThemeApplyWizardModelTests.swift
@@ -189,5 +189,13 @@ private final class WizardFreedesignmdStubURLProtocol: URLProtocol, @unchecked S
             Issue.record("expected success"); return
         }
         #expect(applied.writtenFiles.isEmpty == false)
+        #expect(applied.writtenFiles.contains("docs/brand.md"))
+        // The freedesignmd flow writes no CSS vars — the global.css upsert step must be skipped.
+        #expect(!applied.writtenFiles.contains("src/styles/global.css"))
+
+        let brandURL = package.sourceURL.appendingPathComponent("docs/brand.md")
+        let brand = try String(contentsOf: brandURL, encoding: .utf8)
+        #expect(brand.contains("freedesignmd: linear-orbit"))
+        #expect(brand.contains("Hairline-thin product workspace."))
     }
 }

--- a/Tests/AnglesiteCoreTests/WCAGContrastTests.swift
+++ b/Tests/AnglesiteCoreTests/WCAGContrastTests.swift
@@ -1,0 +1,45 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct WCAGContrastTests {
+    @Test func hexToRGBParsesSixDigit() {
+        #expect(WCAGContrast.hexToRGB("#2563eb") == RGBColor(r: 0x25, g: 0x63, b: 0xeb))
+    }
+
+    @Test func hexToRGBExpandsThreeDigit() {
+        #expect(WCAGContrast.hexToRGB("#f00") == RGBColor(r: 0xff, g: 0x00, b: 0x00))
+    }
+
+    @Test func hexToRGBRejectsInvalid() {
+        #expect(WCAGContrast.hexToRGB("not-a-color") == nil)
+    }
+
+    @Test func contrastRatioBlackOnWhiteIsMax() {
+        let ratio = WCAGContrast.contrastRatio("#000000", "#ffffff")
+        #expect(abs(ratio - 21.0) < 0.01)
+    }
+
+    @Test func contrastRatioIsOrderIndependent() {
+        #expect(WCAGContrast.contrastRatio("#123456", "#abcdef") ==
+                WCAGContrast.contrastRatio("#abcdef", "#123456"))
+    }
+
+    @Test func meetsAAThreshold() {
+        #expect(WCAGContrast.meetsAA(fg: "#000000", bg: "#ffffff") == true)
+        #expect(WCAGContrast.meetsAA(fg: "#777777", bg: "#888888") == false)
+    }
+
+    @Test func suggestReadableReturnsOriginalWhenAlreadyPassing() {
+        #expect(WCAGContrast.suggestReadable(fg: "#000000", bg: "#ffffff") == "#000000")
+    }
+
+    @Test func suggestReadableDarkensOnLightBackground() {
+        let fixed = WCAGContrast.suggestReadable(fg: "#aaaaaa", bg: "#ffffff")
+        #expect(WCAGContrast.meetsAA(fg: fixed, bg: "#ffffff"))
+    }
+
+    @Test func suggestReadableLightensOnDarkBackground() {
+        let fixed = WCAGContrast.suggestReadable(fg: "#333333", bg: "#000000")
+        #expect(WCAGContrast.meetsAA(fg: fixed, bg: "#000000"))
+    }
+}

--- a/docs/specs/2026-07-10-pcc-escalation-spike-notes.md
+++ b/docs/specs/2026-07-10-pcc-escalation-spike-notes.md
@@ -1,0 +1,275 @@
+# PCC escalation feasibility spike — findings (2026-07-10)
+
+**Task:** Task 1 of the design-interview conversation plan (issue #464 line of work). Investigation
+only — no code changed. Goal: verify whether the on-device `FoundationModels` framework exposes any
+caller-selectable Private Cloud Compute (PCC) path, before Task 4 of the plan builds against it.
+
+**Existing internal claim under test** (`Sources/AnglesiteCore/FoundationModelAssistant.swift:9-13`):
+
+> The public `FoundationModels` framework is **on-device**. There is no caller-selectable Private
+> Cloud Compute session; PCC is used transparently by some system APIs. `.privateCloudCompute` is
+> therefore *modeled* here so future call sites can express intent, but **v1 backs it with the same
+> on-device session**.
+
+## Outcome (up front)
+
+**PCC-reachable — the existing code comment is now stale, not confirmed.** The macOS 27 /
+Xcode 27 SDK (Xcode-beta.app, build 27A5209h, targeting macOS 26A5378j — the toolchain this project
+already builds against per CLAUDE.md) ships a genuine, app-facing
+`PrivateCloudComputeLanguageModel` class in `FoundationModels`, introduced at
+`@available(iOS 27.0, macOS 27.0, *)`. It is a real API, not a rumor or WWDC-notes inference — the
+module's compiled Swift interface was synthesized directly from the installed SDK and inspected
+below. See "Decision gate" for what this changes and does not change for the plan.
+
+## Step 1: check the public API surface for PCC symbols
+
+The brief's exact command uses `swift-ide-test`, which does not exist in this Xcode 27 beta
+toolchain:
+
+```
+$ DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcrun swift-ide-test \
+  -print-module -module-to-print=FoundationModels -source-filename x \
+  -target arm64-apple-macos27.0 2>/dev/null | grep -i "cloud\|pcc\|remote"
+```
+```
+xcrun: error: sh -c '.../xcodebuild -sdk .../MacOSX27.0.sdk -find swift-ide-test 2> /dev/null' failed
+xcrun: error: unable to find utility "swift-ide-test", not a developer tool or in PATH
+```
+
+`swift-ide-test` has been removed from this toolchain's `usr/bin` (it ships `swift-symbolgraph-extract`,
+`swift-synthesize-interface`, etc. instead). Substituted the toolchain's `swift-synthesize-interface`
+(the direct successor for this exact purpose — printing a module's public Swift interface from a
+binary SDK module) to get equivalent output:
+
+```
+$ DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
+  /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-synthesize-interface \
+  -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX27.0.sdk \
+  -target arm64-apple-macos27.0 -module-name FoundationModels \
+  -o /tmp/FoundationModels.swiftinterface
+$ echo $?
+0
+$ wc -l /tmp/FoundationModels.swiftinterface
+9210 /tmp/FoundationModels.swiftinterface
+```
+
+Grep for cloud/pcc/remote symbols in the synthesized interface:
+
+```
+$ grep -ni "cloud\|pcc\|remote" /tmp/FoundationModels.swiftinterface
+```
+
+Relevant excerpt (full match list is ~90 lines, all inside one type's declaration):
+
+```swift
+/// A variant of Apple Foundation Models that runs on Private Cloud Compute to provide enhanced
+/// capabilities while maintaining privacy guarantees.
+///
+/// To use the server-based model that powers Apple Intelligence, you change a single line of code
+/// that you apply when creating your ``LanguageModelSession``.
+///
+/// ```swift
+/// // Create a session with the server-side model.
+/// let session = LanguageModelSession(model: PrivateCloudComputeLanguageModel())
+/// let response = try await session.respond(to: "Analyze this document...")
+/// ```
+///
+/// Before you use the model, you'll need to verify its ``availability``. Model
+/// availability depends on device factors like:
+///
+/// * The device must support Apple Intelligence.
+/// * Apple Intelligence must be turned on in Settings.
+///
+/// > Important: To develop with PCC you must meet certain eligibility requirements.
+/// To learn more and request access to the manage entitlement, sign in to your Developer
+/// account and complete the
+/// [entitlement request form](https://developer.apple.com/contact/request/private-cloud-compute/).
+@available(iOS 27.0, macOS 27.0, watchOS 27.0, *)
+@available(tvOS, unavailable)
+final public class PrivateCloudComputeLanguageModel : Sendable {
+    @objc deinit
+}
+
+extension PrivateCloudComputeLanguageModel {
+    final public var availability: PrivateCloudComputeLanguageModel.Availability { get }
+    final public var quotaUsage: PrivateCloudComputeLanguageModel.QuotaUsage { get }
+    final public var isAvailable: Bool { get }
+}
+
+extension PrivateCloudComputeLanguageModel {
+    /// Creates a new Private Cloud Compute language model instance.
+    public convenience init()
+}
+
+extension PrivateCloudComputeLanguageModel {
+    @frozen public enum Availability : Equatable, Sendable {
+        case available
+        case unavailable(PrivateCloudComputeLanguageModel.Availability.UnavailableReason)
+    }
+}
+
+extension PrivateCloudComputeLanguageModel : nonisolated Observable {}
+
+extension PrivateCloudComputeLanguageModel : LanguageModel {
+    final public var capabilities: LanguageModelCapabilities { get }
+    final public var executorConfiguration: PrivateCloudComputeLanguageModel.Executor.Configuration { get }
+}
+
+extension PrivateCloudComputeLanguageModel {
+    /// Returns the maximum context size (in tokens) supported by the model.
+    nonisolated(nonsending) final public var contextSize: Int { get async throws }
+}
+
+extension PrivateCloudComputeLanguageModel {
+    public struct Executor : LanguageModelExecutor { /* ... */ }
+}
+
+extension PrivateCloudComputeLanguageModel {
+    /// Errors that may occur when using Private Cloud Compute.
+    public enum Error : Error, LocalizedError {
+        case networkFailure(PrivateCloudComputeLanguageModel.Error.NetworkFailure)
+        case quotaLimitReached(PrivateCloudComputeLanguageModel.Error.QuotaLimitReached)
+        case serviceUnavailable(PrivateCloudComputeLanguageModel.Error.ServiceUnavailable)
+    }
+
+    /// The usage quota state for a Private Cloud Compute language model.
+    ///
+    /// Quotas are orthogonal to a model's availability — a model can be available even after its
+    /// usage limit has been reached.
+    public struct QuotaUsage : Sendable {
+        public var status: PrivateCloudComputeLanguageModel.QuotaUsage.Status
+        public var limitIncreaseSuggestion: PrivateCloudComputeLanguageModel.QuotaUsage.LimitIncreaseSuggestion?
+        public var resetDate: Date?
+    }
+}
+```
+
+Confirmed `PrivateCloudComputeLanguageModel` genuinely satisfies `LanguageModel`, and that
+`LanguageModelSession` has a generic initializer that accepts it (not just the `SystemLanguageModel`-typed
+convenience initializers):
+
+```
+$ grep -n "public convenience init<Failure>(model: some LanguageModel" /tmp/FoundationModels.swiftinterface
+4205:    public convenience init<Failure>(model: some LanguageModel, tools: [any Tool] = [], @InstructionsBuilder instructions: () throws(Failure) -> Instructions) throws(Failure) where Failure : Error
+```
+
+So the doc comment's own sample code (`LanguageModelSession(model: PrivateCloudComputeLanguageModel())`)
+is not aspirational marketing copy — it type-checks against the declared API surface.
+
+## Step 2: public developer documentation / WWDC session search
+
+**Not performed with independent evidence.** This environment has no `WebSearch`/`WebFetch` tool
+available to this agent, so I cannot fetch developer.apple.com/documentation/foundationmodels or
+WWDC session transcripts live. I am not fabricating a documentation search. Everything above and
+below is derived solely from the doc comments embedded in the installed Xcode 27 beta SDK's compiled
+module (which does typically mirror what ends up on developer.apple.com, but that mirroring itself
+is unverified here). If a live web check is wanted for confirmation, this step should be re-run with
+a `WebFetch`-capable session against
+`https://developer.apple.com/documentation/foundationmodels/privatecloudcomputelanguagemodel`.
+
+## Step 3: probe `SystemLanguageModel` for a size/tier selector
+
+```
+$ grep -n "class SystemLanguageModel\|struct SystemLanguageModel" /tmp/FoundationModels.swiftinterface
+6469:final public class SystemLanguageModel : Sendable {
+```
+
+`SystemLanguageModel` itself exposes only a `UseCase` selector (`.general`, `.contentTagging`) — no
+size/tier axis:
+
+```swift
+public struct UseCase : Sendable, Equatable {
+    /// A use case for general prompting. This is the default use case for the base version of the model.
+    public static let general: SystemLanguageModel.UseCase
+    /// A use case for content tagging.
+    public static let contentTagging: SystemLanguageModel.UseCase
+}
+```
+
+and a plain `contextSize: Int` (synchronous, on-device):
+
+```swift
+extension SystemLanguageModel {
+    /// Returns the maximum context size (in tokens) supported by the model.
+    @backDeployed(before: iOS 26.4, macOS 26.4, visionOS 26.4)
+    final public var contextSize: Int { get }
+}
+```
+
+So there is no "large on-device model" tier hidden inside `SystemLanguageModel` — the only larger
+context window available is the separate `PrivateCloudComputeLanguageModel` type (async `contextSize`,
+consistent with it being a network-backed model rather than an in-process one).
+
+## Decision gate
+
+**PCC-reachable**, with an important caveat: it is not *freely* reachable. Concretely:
+
+- `PrivateCloudComputeLanguageModel()` is a genuine, public, documented, `Sendable`,
+  `Observable`-conforming class that conforms to the same `LanguageModel` protocol
+  `SystemLanguageModel` conforms to, and `LanguageModelSession` has a generic initializer
+  (`init<Failure>(model: some LanguageModel, ...)`) that accepts it directly — not a private/SPI
+  symbol, not something only reachable via a system-only entry point.
+- It requires `iOS 27.0 / macOS 27.0`, which matches this project's minimum deployment target
+  (`Package.swift` declares `.macOS("27.0")`), so no additional OS-version bump would be needed.
+- **It is gated behind a manual Apple entitlement request**, per the type's own doc comment: *"To
+  develop with PCC you must meet certain eligibility requirements. To learn more and request access
+  to the manage entitlement, sign in to your Developer account and complete the [entitlement request
+  form]."* This is the same shape as other restricted entitlements (e.g. NFC tag-writing,
+  driver extensions) — approval is not guaranteed, is out of this repo's control, and would need to
+  be requested and granted before any code depending on it could ship, even in TestFlight.
+- It also carries its own **usage quota** (`QuotaUsage`, `.limitReached` status,
+  `limitIncreaseSuggestion`) and **availability preconditions** (device supports Apple Intelligence,
+  Apple Intelligence enabled in Settings) — so even once entitled, it is not an unconditionally
+  available "just ask for more tokens" path; call sites must handle `.unavailable` and quota-exhausted
+  states as first-class outcomes, same as this codebase's existing `SystemLanguageModel.availability`
+  handling pattern.
+
+### Two next-step paths, per the brief's decision gate
+
+- **If PCC-reachable (this spike's actual finding):** Task 4 can build against the real
+  `PrivateCloudComputeLanguageModel` API — `import FoundationModels`, construct
+  `PrivateCloudComputeLanguageModel()`, gate on `.isAvailable`/`.availability` and `.quotaUsage`
+  before use, and pass it to `LanguageModelSession(model:)`'s generic initializer instead of the
+  `SystemLanguageModel`-typed convenience initializer `FoundationModelAssistant` uses today. This
+  requires (a) actually filing and getting approved the PCC entitlement request at
+  `developer.apple.com/contact/request/private-cloud-compute/` — an out-of-band, non-code
+  prerequisite with unknown timeline — and (b) designing quota/availability fallback behavior (revert
+  to the on-device session, surface a user-facing message) for when PCC is entitled-but-unavailable
+  or entitled-but-quota-exhausted. Given the entitlement is not yet requested/granted, Task 4 should
+  **not** assume PCC is usable by default; it should be built as an optional escalation path behind a
+  capability check that degrades gracefully to the on-device session, exactly as `FoundationModelTier`
+  already models it structurally.
+- **If PCC-not-reachable:** (documented for completeness, since the brief asked for both paths, even
+  though this is not what was found) Task 4 would implement deterministic context-budget escalation
+  instead — chunk/summarize grounding prompts deterministically when they would exceed the 4,096-token
+  budget, rather than claim a larger model is available.
+
+Given the entitlement-gated nature of the real finding, the **pragmatic recommendation for this
+plan** is closer to the second path in the near term: implement Task 4 as deterministic
+context-budget management now (no entitlement dependency, ships immediately), and track the real
+`PrivateCloudComputeLanguageModel` integration as a separate, explicitly-gated follow-up once the PCC
+entitlement request has actually been filed and approved. This avoids blocking the design-interview
+feature on an Apple approval process with no committed timeline.
+
+### `FoundationModelTier` doc comment
+
+`Sources/AnglesiteCore/FoundationModelAssistant.swift:9-13`'s comment ("There is no caller-selectable
+Private Cloud Compute session") is now **factually stale** as of the macOS 27 / Xcode 27 SDK: a
+caller-selectable session does exist as public API, gated by a separate Apple entitlement approval
+rather than by API availability. The comment should be corrected (in a follow-up code change, not in
+this investigation-only task) to state:
+
+- `PrivateCloudComputeLanguageModel` is real, public API (cite this spike/doc), conforming to
+  `LanguageModel` and usable via `LanguageModelSession(model:)`.
+- `.privateCloudCompute` remains **unimplemented in this codebase**, not because no API exists, but
+  because (a) it requires a manually-requested-and-approved Apple entitlement this project has not
+  yet obtained, and (b) it introduces network dependency, quota, and availability-fallback complexity
+  not yet designed. v1 continues to back `.privateCloudCompute` with the same on-device session until
+  that entitlement/design work happens.
+
+## Toolchain note for future spikes
+
+`swift-ide-test` is not present in this Xcode 27 beta's toolchain bin (`Toolchains/XcodeDefault.xctoolchain/usr/bin`
+has `swift-symbolgraph-extract` and `swift-synthesize-interface` but not `swift-ide-test`). Use
+`swift-synthesize-interface -sdk <SDK> -target <triple> -module-name <Module> -o <out>` as the
+equivalent module-interface-printing tool on this toolchain going forward.

--- a/docs/superpowers/plans/2026-07-10-design-interview-pcc-plan.md
+++ b/docs/superpowers/plans/2026-07-10-design-interview-pcc-plan.md
@@ -1,0 +1,961 @@
+# design-interview Conversation + PCC Escalation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the design-interview conversation (Intent → Mood → Brand → Axis confirmation) as an on-device-FM-backed chat flow with a live GUI mirror, converging on the same `DesignApplyService` write path as the theme-apply wizard, and give `FoundationModelAssistant`'s `.privateCloudCompute` tier a real escalation path instead of its current on-device stub.
+
+**Architecture:** `DesignInterviewModel` drives a `ConversationStage` state machine over `FoundationModelAssistant.converse()`, using `@Generable` structured replies so each turn updates a typed `DesignInterviewDraft` rather than parsing free text. Stage-specific grounding prompts are pure, deterministic, unit-testable builders (mirroring `SiteGraphExplainPrompt`). The escalation mechanism is gated behind **Task 1, a feasibility spike** — this plan does not assume PCC escalation is achievable through Apple's public `FoundationModels` API until that's verified.
+
+**Tech Stack:** Swift 6.4, FoundationModels (`#if compiler(>=6.4)`), SwiftUI, Swift Testing.
+
+## Global Constraints
+
+- Same toolchain/testing constraints as the theme-apply plan (`DEVELOPER_DIR=/Applications/Xcode-beta.app/...`, hosted UI tests don't run on CI).
+- **This plan depends on the theme-apply plan's `DesignApplyService`/`DesignApplyInput`/`AppliedDesign`/`DesignApplyError` (Tasks 6-7 there) and `DesignAxes`/`DesignConfigGenerator`/`DesignTokenWriter` (Tasks 2-5 there) already being merged.** Do not re-implement them.
+- `FoundationModelAssistant`'s existing `AssistantError/unavailable(_:)` semantics apply: no network fallback when Apple Intelligence is off — the feature goes unavailable, never degrades to a cloud call outside Apple's own PCC path (per the LLM policy, #459 §8).
+- On-device context budget is 4,096 tokens (`AssistantCapabilities.maxContextTokens`). Grounding prompts must stay well under this — cap list/history sizes the way `SiteGraphExplainPrompt.maxListedNames` does.
+- No new third-party dependencies.
+
+---
+
+### Task 1: PCC feasibility spike (investigation, not implementation)
+
+**Files:** none created — this is a documented investigation with a pass/fail decision gate. Record findings in a new file `docs/specs/2026-07-10-pcc-escalation-spike-notes.md`.
+
+**Why this is Task 1, not deferred:** `Sources/AnglesiteCore/FoundationModelAssistant.swift:9-13` already documents that "the public `FoundationModels` framework is on-device. There is no caller-selectable Private Cloud Compute session; PCC is used transparently by some system APIs." That comment is the strongest existing evidence that a caller-initiated PCC escalation may not be buildable at all through public API — Tasks 4-5 of this plan branch on what this spike actually finds, so it must run first.
+
+- [ ] **Step 1: Check Apple's current public API surface for PCC**
+
+On the Xcode 27 toolchain, inspect the `FoundationModels` module interface for any PCC-related symbol:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcrun swift-ide-test \
+  -print-module -module-to-print=FoundationModels -source-filename x \
+  -target arm64-apple-macos27.0 2>/dev/null | grep -i "cloud\|pcc\|remote"
+```
+
+Record every match (symbol name, availability annotation, doc comment) in the spike notes file. If this returns nothing, that's a strong (not yet conclusive) signal against a caller-selectable PCC path.
+
+- [ ] **Step 2: Check Apple's current developer documentation**
+
+Search Apple's FoundationModels documentation (developer.apple.com/documentation/foundationmodels) and WWDC 2026/2027 session notes for "Private Cloud Compute", "PCC", or "larger model" in the context of `LanguageModelSession`/`SystemLanguageModel`. Record what's found — specifically whether there's any documented way for an app to *request* a larger/cloud-backed model, versus PCC being purely an OS-internal implementation detail invoked transparently for unrelated system features (e.g. Siri, Visual Intelligence) with no app-facing hook.
+
+- [ ] **Step 3: Probe for a larger on-device model tier**
+
+Check whether `SystemLanguageModel` exposes any variant/size selector at all (some Apple platforms expose a "large" vs "default" adapter). Look for `SystemLanguageModel.Use case`, custom adapters, or any initializer beyond `.default`:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcrun swift-ide-test \
+  -print-module -module-to-print=FoundationModels -source-filename x \
+  -target arm64-apple-macos27.0 2>/dev/null | grep -A3 "class SystemLanguageModel\|struct SystemLanguageModel"
+```
+
+- [ ] **Step 4: Decision gate — record the outcome and pick a path**
+
+Write the finding as one of two outcomes in `docs/specs/2026-07-10-pcc-escalation-spike-notes.md`:
+
+- **PCC-reachable**: a genuine app-facing API exists to request a larger/cloud-backed session. Record the exact API surface found. → Continue to Task 4 as written (real escalation).
+- **PCC-not-reachable** (the expected outcome, given the existing code comment): no public API lets an app request PCC or a larger model. → Skip Task 4's "real PCC call" and implement Task 4 as **deterministic context-budget escalation** instead: when a stage's grounding prompt would exceed the 4,096-token budget, chunk/summarize deterministically rather than claim a larger model is available. Update `FoundationModelTier`'s doc comment to state plainly that `.privateCloudCompute` remains aspirational/unimplemented pending a future Apple API, rather than leaving the current misleading "reserved for future use" framing. This is not a failure of the plan — it's the honest outcome the design spec's own risk section (§8) anticipated, and it's why this spike is Task 1 rather than an assumption baked into the design.
+
+- [ ] **Step 5: Commit the spike notes**
+
+```bash
+git add docs/specs/2026-07-10-pcc-escalation-spike-notes.md
+git commit -m "docs: PCC escalation feasibility spike findings (#464)"
+```
+
+---
+
+### Task 2: DesignInterviewDraft + ConversationStage (deterministic types)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DesignInterviewDraft.swift`
+- Test: `Tests/AnglesiteCoreTests/DesignInterviewDraftTests.swift`
+
+**Interfaces:**
+- Consumes: `DesignAxes`, `DesignAxesCatalog` (from the theme-apply plan).
+- Produces:
+```swift
+public enum ConversationStage: Int, Sendable, Equatable, CaseIterable { case intent, mood, brandAnchor, axisConfirmation, done }
+public struct DesignInterviewDraft: Sendable, Equatable {
+    public var stage: ConversationStage
+    public var businessType: String
+    public var axes: DesignAxes
+    public var brandColorHex: String?
+    public var freeTextNotes: [String]
+    public init(businessType: String)
+    public mutating func advance()
+    public mutating func applyAdjectiveHint(_ hint: DesignAdjectiveHint)
+}
+public enum DesignAdjectiveHint: String, Sendable, CaseIterable {
+    case warmer, cooler, denser, airier, moreAuthoritative, morePlayful, moreClassic, moreContemporary, bolder, subtler
+}
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/DesignInterviewDraftTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignInterviewDraftTests {
+    @Test func initSeedsAxesFromBusinessType() {
+        let draft = DesignInterviewDraft(businessType: "restaurant")
+        #expect(draft.axes == DesignAxesCatalog.defaults(forBusinessType: "restaurant"))
+        #expect(draft.stage == .intent)
+    }
+
+    @Test func advanceStepsThroughAllStagesInOrder() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let expected: [ConversationStage] = [.mood, .brandAnchor, .axisConfirmation, .done]
+        for stage in expected {
+            draft.advance()
+            #expect(draft.stage == stage)
+        }
+    }
+
+    @Test func advancePastDoneStaysAtDone() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        for _ in 0..<10 { draft.advance() }
+        #expect(draft.stage == .done)
+    }
+
+    @Test func adjectiveHintNudgesTheRightAxis() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.temperature
+        draft.applyAdjectiveHint(.warmer)
+        #expect(draft.axes.temperature > before)
+    }
+
+    @Test func adjectiveHintClampsAtOne() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        for _ in 0..<20 { draft.applyAdjectiveHint(.bolder) }
+        #expect(draft.axes.voice == 1.0)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignInterviewDraftTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/DesignInterviewDraft.swift
+import Foundation
+
+public enum ConversationStage: Int, Sendable, Equatable, CaseIterable {
+    case intent, mood, brandAnchor, axisConfirmation, done
+}
+
+/// A fixed nudge applied to one axis when the user's free text names a direction rather than a
+/// slider value (e.g. "make it warmer"). Each hint moves its axis by a flat 0.15, clamped to [0,1].
+public enum DesignAdjectiveHint: String, Sendable, CaseIterable {
+    case warmer, cooler, denser, airier, moreAuthoritative, morePlayful, moreClassic, moreContemporary, bolder, subtler
+
+    var keyPath: WritableKeyPath<DesignAxes, Double> {
+        switch self {
+        case .warmer, .cooler: return \.temperature
+        case .denser, .airier: return \.weight
+        case .moreAuthoritative, .morePlayful: return \.register
+        case .moreClassic, .moreContemporary: return \.time
+        case .bolder, .subtler: return \.voice
+        }
+    }
+
+    var delta: Double {
+        switch self {
+        case .warmer, .denser, .moreAuthoritative, .moreContemporary, .bolder: return 0.15
+        case .cooler, .airier, .morePlayful, .moreClassic, .subtler: return -0.15
+        }
+    }
+}
+
+public struct DesignInterviewDraft: Sendable, Equatable {
+    public var stage: ConversationStage
+    public var businessType: String
+    public var axes: DesignAxes
+    public var brandColorHex: String?
+    public var freeTextNotes: [String]
+
+    public init(businessType: String) {
+        self.stage = .intent
+        self.businessType = businessType
+        self.axes = DesignAxesCatalog.defaults(forBusinessType: businessType)
+        self.brandColorHex = nil
+        self.freeTextNotes = []
+    }
+
+    public mutating func advance() {
+        guard let next = ConversationStage(rawValue: stage.rawValue + 1) else { return }
+        stage = next
+    }
+
+    public mutating func applyAdjectiveHint(_ hint: DesignAdjectiveHint) {
+        axes = DesignAxesCatalog.adjusted(axes, by: [hint.keyPath: hint.delta])
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignInterviewDraftTests`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignInterviewDraft.swift Tests/AnglesiteCoreTests/DesignInterviewDraftTests.swift
+git commit -m "feat(core): add DesignInterviewDraft + ConversationStage state machine"
+```
+
+---
+
+### Task 3: Stage grounding prompts (deterministic prompt builders)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DesignInterviewPrompts.swift`
+- Test: `Tests/AnglesiteCoreTests/DesignInterviewPromptsTests.swift`
+
+**Interfaces:**
+- Consumes: `DesignInterviewDraft`, `ConversationStage` (Task 2).
+- Produces: `enum DesignInterviewPrompts { static func prompt(for stage: ConversationStage, draft: DesignInterviewDraft, userMessage: String) -> String }`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/DesignInterviewPromptsTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignInterviewPromptsTests {
+    @Test func intentPromptAsksAboutPurpose() {
+        let draft = DesignInterviewDraft(businessType: "bakery")
+        let prompt = DesignInterviewPrompts.prompt(for: .intent, draft: draft, userMessage: "It's a cozy neighborhood bakery.")
+        #expect(prompt.contains("bakery"))
+        #expect(prompt.contains("It's a cozy neighborhood bakery."))
+    }
+
+    @Test func moodPromptIncludesCurrentAxes() {
+        let draft = DesignInterviewDraft(businessType: "bakery")
+        let prompt = DesignInterviewPrompts.prompt(for: .mood, draft: draft, userMessage: "warmer and more playful")
+        #expect(prompt.contains("temperature"))
+        #expect(prompt.contains(String(draft.axes.temperature)))
+    }
+
+    @Test func brandAnchorPromptAsksForColorOrReference() {
+        let draft = DesignInterviewDraft(businessType: "bakery")
+        let prompt = DesignInterviewPrompts.prompt(for: .brandAnchor, draft: draft, userMessage: "our brand color is #ff6600")
+        #expect(prompt.lowercased().contains("brand color") || prompt.lowercased().contains("hex"))
+    }
+
+    @Test func axisConfirmationPromptSummarizesFinalAxes() {
+        let draft = DesignInterviewDraft(businessType: "bakery")
+        let prompt = DesignInterviewPrompts.prompt(for: .axisConfirmation, draft: draft, userMessage: "looks good")
+        for axisName in ["temperature", "weight", "register", "time", "voice"] {
+            #expect(prompt.contains(axisName))
+        }
+    }
+
+    @Test func promptsStayUnderOnDeviceBudgetEstimate() {
+        let draft = DesignInterviewDraft(businessType: "restaurant")
+        for stage in ConversationStage.allCases where stage != .done {
+            let prompt = DesignInterviewPrompts.prompt(for: stage, draft: draft, userMessage: String(repeating: "word ", count: 50))
+            // Conservative proxy matching FoundationModelAssistant.maxPageContentCharacters' approach:
+            // no single turn prompt should exceed ~2000 characters, leaving room for history + reply.
+            #expect(prompt.count < 2000)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignInterviewPromptsTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/DesignInterviewPrompts.swift
+import Foundation
+
+/// Deterministic grounding-prompt builders for the design-interview conversation, one per
+/// ``ConversationStage``. Follows ``SiteGraphExplainPrompt``'s pattern: facts are assembled from
+/// typed data, never invented, and every prompt caps its own size to stay well under the
+/// on-device 4,096-token budget.
+public enum DesignInterviewPrompts {
+    public static func prompt(for stage: ConversationStage, draft: DesignInterviewDraft, userMessage: String) -> String {
+        switch stage {
+        case .intent: return intentPrompt(draft: draft, userMessage: userMessage)
+        case .mood: return moodPrompt(draft: draft, userMessage: userMessage)
+        case .brandAnchor: return brandAnchorPrompt(draft: draft, userMessage: userMessage)
+        case .axisConfirmation: return axisConfirmationPrompt(draft: draft, userMessage: userMessage)
+        case .done: return userMessage
+        }
+    }
+
+    private static func intentPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
+        """
+        You are interviewing the owner of a \(draft.businessType) website about what the site is \
+        for and who it's for. Ask one short, warm follow-up question to understand their intent — \
+        don't move to visual style yet. Owner said: "\(userMessage)"
+        """
+    }
+
+    private static func moodPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
+        """
+        You are helping the owner of a \(draft.businessType) website describe its visual mood. \
+        Current design axes (each 0 to 1): temperature \(draft.axes.temperature) (cool<->warm), \
+        weight \(draft.axes.weight) (airy<->dense), register \(draft.axes.register) \
+        (playful<->authoritative), time \(draft.axes.time) (classic<->contemporary), voice \
+        \(draft.axes.voice) (subtle<->bold). The owner described the mood they want as: \
+        "\(userMessage)". In one short sentence, reflect back how that mood shifts these axes.
+        """
+    }
+
+    private static func brandAnchorPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
+        """
+        Ask the owner of a \(draft.businessType) website if they have an existing brand color \
+        (hex code) or a reference site/brand whose look they like. Owner said: "\(userMessage)". \
+        If they gave a hex color or a clear reference, acknowledge it in one short sentence.
+        """
+    }
+
+    private static func axisConfirmationPrompt(draft: DesignInterviewDraft, userMessage: String) -> String {
+        """
+        Summarize this design in plain language for the owner of a \(draft.businessType) website, \
+        then ask them to confirm or adjust: temperature \(draft.axes.temperature), weight \
+        \(draft.axes.weight), register \(draft.axes.register), time \(draft.axes.time), voice \
+        \(draft.axes.voice). Owner's response: "\(userMessage)".
+        """
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignInterviewPromptsTests`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignInterviewPrompts.swift Tests/AnglesiteCoreTests/DesignInterviewPromptsTests.swift
+git commit -m "feat(core): add deterministic design-interview grounding prompts"
+```
+
+---
+
+### Task 4: Escalation seam in FoundationModelAssistant (branches on Task 1's finding)
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/FoundationModelAssistant.swift`
+- Test: `Tests/AnglesiteCoreTests/FoundationModelAssistantEscalationTests.swift` (new file)
+
+**Interfaces:**
+- Produces: `extension FoundationModelAssistant { func escalate(reason: EscalationReason) async -> FoundationModelTier }`, `enum EscalationReason: Sendable, Equatable { case contextBudgetExceeded(estimatedTokens: Int), userRequestedBetter }`
+
+**This task has two implementations depending on Task 1's outcome — implement only the branch that spike found true, and delete the other's code block from this task before starting:**
+
+**If Task 1 found PCC-reachable:** implement `escalate(reason:)` to actually construct a session against the real API surface Task 1 documented, returning `.privateCloudCompute` on success and logging + returning `.onDevice` on failure (never throwing — escalation failure degrades to on-device, it doesn't fail the turn). Write this task's tests and implementation from that documented API once known; it can't be pre-written here since the API doesn't exist yet in verified form.
+
+**If Task 1 found PCC-not-reachable (expected):** implement `escalate(reason:)` as deterministic context-budget management, not a real tier switch — this is the realistic version to build now:
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/FoundationModelAssistantEscalationTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct FoundationModelAssistantEscalationTests {
+    @Test func estimatedTokensUsesCharacterProxy() {
+        // Matches FoundationModelAssistant.maxPageContentCharacters' existing character-based
+        // proxy approach (no on-device tokenizer is available).
+        let text = String(repeating: "a", count: 4000)
+        #expect(FoundationModelAssistant.estimatedTokens(for: text) > FoundationModelAssistant.onDeviceTokenBudget)
+    }
+
+    @Test func shouldEscalateWhenOverBudget() {
+        let longPrompt = String(repeating: "word ", count: 2000)
+        #expect(FoundationModelAssistant.shouldEscalate(prompt: longPrompt) == true)
+    }
+
+    @Test func shouldNotEscalateWhenUnderBudget() {
+        #expect(FoundationModelAssistant.shouldEscalate(prompt: "short prompt") == false)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter FoundationModelAssistantEscalationTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Appended to Sources/AnglesiteCore/FoundationModelAssistant.swift, above the `#if compiler(>=6.4)` guard
+// so the budget helpers are usable (and testable) on toolchains without FoundationModels too.
+
+public extension FoundationModelAssistant {
+    /// Conservative characters-per-token proxy (~4 chars/token for English), matching the existing
+    /// character-based approach in `maxPageContentCharacters` — no on-device tokenizer is available
+    /// to measure the real count.
+    static let onDeviceTokenBudget = 4_096
+    private static let charsPerTokenEstimate = 4
+
+    static func estimatedTokens(for text: String) -> Int {
+        text.count / charsPerTokenEstimate
+    }
+
+    /// Whether a prompt is estimated to exceed the on-device context budget. Per Task 1's spike
+    /// finding (PCC not reachable via public API as of macOS 27), "escalation" here means the
+    /// caller (``DesignInterviewModel``) should chunk/summarize deterministically rather than
+    /// request a genuinely larger model — there is no such request to make.
+    static func shouldEscalate(prompt: String) -> Bool {
+        estimatedTokens(for: prompt) > onDeviceTokenBudget
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter FoundationModelAssistantEscalationTests`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Update `FoundationModelTier`'s doc comment to stop implying a future PCC call is imminent**
+
+Modify the doc comment at `Sources/AnglesiteCore/FoundationModelAssistant.swift:9-13` (the `Important:` block above `FoundationModelTier`) to state the spike's finding plainly — e.g. append: "A 2026-07-10 feasibility spike (`docs/specs/2026-07-10-pcc-escalation-spike-notes.md`) found no public API for an app to request a larger/cloud-backed session; `.privateCloudCompute` remains aspirational until Apple ships one." Do not silently leave the old wording, which reads as "not yet implemented" rather than "not currently possible."
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/FoundationModelAssistant.swift Tests/AnglesiteCoreTests/FoundationModelAssistantEscalationTests.swift
+git commit -m "feat(core): add context-budget escalation seam; document PCC spike finding"
+```
+
+---
+
+### Task 5: DesignInterviewModel — the conversation driver
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DesignInterviewModel.swift`
+- Test: `Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift`
+
+**Interfaces:**
+- Consumes: `DesignInterviewDraft`, `ConversationStage`, `DesignAdjectiveHint` (Task 2), `DesignInterviewPrompts` (Task 3), `FoundationModelAssistant.shouldEscalate` (Task 4), `DesignApplyService`/`DesignApplyInput`/`AppliedDesign` (theme-apply plan), `DesignConfigGenerator`/`DesignTokenWriter` (theme-apply plan), `ConversationalAssistant`/`AssistantContext`/`AssistantEvent` (existing `ContentAssistant` protocol family).
+- Produces:
+```swift
+@MainActor @Observable
+public final class DesignInterviewModel: Identifiable {
+    public let id = UUID()
+    public internal(set) var draft: DesignInterviewDraft
+    public internal(set) var transcript: [(role: String, text: String)] = []
+    public internal(set) var applyResult: Result<AppliedDesign, DesignApplyError>?
+    public init(businessType: String, assistant: any ConversationalAssistant, package: AnglesitePackage)
+    public func send(_ userMessage: String) async
+    public func nudge(_ hint: DesignAdjectiveHint)
+    public func skipToAxisConfirmation() // "design it for me" escape hatch
+    public func confirmAndApply() async
+}
+```
+
+Since `FoundationModelAssistant` is gated `#if compiler(>=6.4)`, `DesignInterviewModel` depends on the toolchain-independent `ConversationalAssistant` protocol (already used by `FoundationModelAssistant`'s conformance) rather than the concrete type directly — this keeps the model itself testable on any toolchain with a fake assistant, matching how `SiteGraphNodeExplaining` decouples `SiteGraphExplainerFactory`'s consumers from the gated implementation.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Minimal fake — echoes the prompt back as a single `.textDelta` then `.turnComplete`, so tests
+/// can assert on stage progression and draft state without a real FoundationModels session.
+private actor FakeConversationalAssistant: ConversationalAssistant {
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(supportsStreaming: true, supportsStructuredOutput: false, supportsVision: false,
+                              supportsTools: false, maxContextTokens: 4096, providerName: "Fake")
+    }
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.yield("echo: \(prompt)"); $0.finish() }
+    }
+    func generateStructured<T: Generable & Sendable>(prompt: String, context: AssistantContext, resultType: T.Type) async throws -> T {
+        fatalError("not used by DesignInterviewModelTests")
+    }
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        AsyncStream { continuation in
+            continuation.yield(.started(model: "Fake", toolNames: []))
+            continuation.yield(.textDelta("Got it."))
+            continuation.yield(.turnComplete(nil))
+            continuation.finish()
+        }
+    }
+    func cancel() async {}
+    func resetSession() async {}
+}
+
+@Suite struct DesignInterviewModelTests {
+    private func makeSite() throws -> AnglesitePackage {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = dir.appendingPathComponent("src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        try ":root {\n  --color-primary: #000000;\n}\n".write(
+            to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+        return AnglesitePackage(sourceDirectory: dir)
+    }
+
+    @Test @MainActor func sendAppendsToTranscriptAndAdvancesStage() async throws {
+        let model = DesignInterviewModel(businessType: "bakery", assistant: FakeConversationalAssistant(), package: try makeSite())
+        #expect(model.draft.stage == .intent)
+        await model.send("It's a cozy neighborhood bakery.")
+        #expect(model.draft.stage == .mood)
+        #expect(model.transcript.contains { $0.role == "user" && $0.text == "It's a cozy neighborhood bakery." })
+        #expect(model.transcript.contains { $0.role == "assistant" && $0.text == "Got it." })
+    }
+
+    @Test @MainActor func nudgeAdjustsAxesWithoutAdvancingStage() async throws {
+        let model = DesignInterviewModel(businessType: "bakery", assistant: FakeConversationalAssistant(), package: try makeSite())
+        let before = model.draft.axes.temperature
+        model.nudge(.warmer)
+        #expect(model.draft.axes.temperature > before)
+        #expect(model.draft.stage == .intent)
+    }
+
+    @Test @MainActor func skipToAxisConfirmationJumpsStage() async throws {
+        let model = DesignInterviewModel(businessType: "bakery", assistant: FakeConversationalAssistant(), package: try makeSite())
+        model.skipToAxisConfirmation()
+        #expect(model.draft.stage == .axisConfirmation)
+    }
+
+    @Test @MainActor func confirmAndApplyWritesThroughDesignApplyService() async throws {
+        let model = DesignInterviewModel(businessType: "bakery", assistant: FakeConversationalAssistant(), package: try makeSite())
+        model.skipToAxisConfirmation()
+        await model.confirmAndApply()
+        guard case .success(let applied) = model.applyResult else { Issue.record("expected success"); return }
+        #expect(applied.writtenFiles.contains("src/styles/global.css"))
+        #expect(model.draft.stage == .done)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignInterviewModelTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/DesignInterviewModel.swift
+import Foundation
+import Observation
+
+@MainActor @Observable
+public final class DesignInterviewModel: Identifiable {
+    public let id = UUID()
+    public internal(set) var draft: DesignInterviewDraft
+    public internal(set) var transcript: [(role: String, text: String)] = []
+    public internal(set) var applyResult: Result<AppliedDesign, DesignApplyError>?
+
+    private let assistant: any ConversationalAssistant
+    private let package: AnglesitePackage
+    private let siteID: String
+
+    public init(businessType: String, assistant: any ConversationalAssistant, package: AnglesitePackage, siteID: String = "") {
+        self.draft = DesignInterviewDraft(businessType: businessType)
+        self.assistant = assistant
+        self.package = package
+        self.siteID = siteID
+    }
+
+    /// Sends one turn: appends the user's message, prompts the current stage, appends the
+    /// assistant's reply, then advances the conversation to the next stage. Structured
+    /// (`@Generable`) axis extraction from the reply is a follow-up refinement (see plan note below)
+    /// — v1 advances on any reply and lets the user correct axes via ``nudge(_:)``.
+    public func send(_ userMessage: String) async {
+        transcript.append((role: "user", text: userMessage))
+        let prompt = DesignInterviewPrompts.prompt(for: draft.stage, draft: draft, userMessage: userMessage)
+        let context = AssistantContext(siteID: siteID, siteDirectory: package.sourceDirectory)
+        guard let stream = try? await assistant.converse(prompt: prompt, context: context) else {
+            transcript.append((role: "assistant", text: "I couldn't respond just now — try again in a moment."))
+            return
+        }
+        var reply = ""
+        for await event in stream {
+            if case .textDelta(let delta) = event { reply += delta }
+        }
+        transcript.append((role: "assistant", text: reply))
+        draft.advance()
+    }
+
+    public func nudge(_ hint: DesignAdjectiveHint) {
+        draft.applyAdjectiveHint(hint)
+    }
+
+    /// "Design it for me" escape hatch: skip straight to axis confirmation using the
+    /// business-type defaults already seeded in `draft.axes`.
+    public func skipToAxisConfirmation() {
+        draft.stage = .axisConfirmation
+    }
+
+    public func confirmAndApply() async {
+        let config = DesignConfigGenerator.config(axes: draft.axes, siteType: draft.businessType, brandColor: draft.brandColorHex)
+        let input = DesignApplyInput(
+            cssVars: DesignTokenWriter.templateCSSVars(for: config),
+            rationaleMarkdown: DesignTokenWriter.rationaleMarkdown(for: config),
+            brandSummary: "Generated from a design interview for a \(draft.businessType).",
+            sourceLabel: "design-interview"
+        )
+        applyResult = DesignApplyService.apply(input, to: package)
+        draft.stage = .done
+    }
+}
+```
+
+**Note for the implementer:** `send(_:)` currently advances the stage on any reply rather than parsing the assistant's response into a structured `@Generable` update (e.g. detecting an adjective hint or brand-color mention automatically). The design called for structured replies driving live axis updates from the conversation itself; this task ships the simpler "advance + let the user `nudge()` explicitly" version first, working and testable end-to-end, with structured-reply parsing as a clearly-scoped follow-up (Task 6 below) rather than something silently missing.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignInterviewModelTests`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignInterviewModel.swift Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
+git commit -m "feat(core): add DesignInterviewModel conversation driver"
+```
+
+---
+
+### Task 6: Structured per-turn axis extraction (upgrade `send` from echo-advance to `@Generable`)
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/DesignInterviewModel.swift`
+- Modify: `Sources/AnglesiteCore/DesignInterviewPrompts.swift` (prompts must ask for structured output)
+- Test: append to `Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift`
+
+**Interfaces:**
+- Produces (gated `#if compiler(>=6.4)`): `@Generable public struct DesignInterviewTurnReply { @Guide var replyText: String; @Guide var temperatureDelta: Double?; @Guide var weightDelta: Double?; @Guide var registerDelta: Double?; @Guide var timeDelta: Double?; @Guide var voiceDelta: Double?; @Guide var brandColorHex: String? }`
+
+This task requires a live FoundationModels session to exercise meaningfully (structured generation can't be faked through the `ConversationalAssistant` protocol's untyped `converse`, since `@Generable` guided generation is a `FoundationModelAssistant`-specific capability reached via `generateStructured`, not `converse`). Because of that, this task's test coverage is necessarily thinner than Task 5's — cover the deterministic glue (applying a decoded `DesignInterviewTurnReply`'s deltas to a `DesignInterviewDraft`) with a real unit test, and leave the actual FM call to manual GUI smoke, consistent with the design spec's testing strategy.
+
+- [ ] **Step 1: Write the failing test for the deterministic glue**
+
+```swift
+// Appended to Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
+extension DesignInterviewModelTests {
+    @Test func applyingTurnReplyDeltasNudgesAxesAndCapturesBrandColor() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes.temperature
+        DesignInterviewModel.applyTurnReplyDeltas(
+            temperature: 0.1, weight: nil, register: nil, time: nil, voice: nil,
+            brandColorHex: "#ff6600", to: &draft
+        )
+        #expect(draft.axes.temperature == before + 0.1)
+        #expect(draft.brandColorHex == "#ff6600")
+    }
+
+    @Test func applyingNilDeltasLeavesAxesUnchanged() {
+        var draft = DesignInterviewDraft(businessType: "bakery")
+        let before = draft.axes
+        DesignInterviewModel.applyTurnReplyDeltas(
+            temperature: nil, weight: nil, register: nil, time: nil, voice: nil,
+            brandColorHex: nil, to: &draft
+        )
+        #expect(draft.axes == before)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignInterviewModelTests`
+Expected: FAIL (compile error — `applyTurnReplyDeltas` doesn't exist yet)
+
+- [ ] **Step 3: Implement the deterministic glue (non-gated) and the `@Generable` type (gated)**
+
+```swift
+// Appended to Sources/AnglesiteCore/DesignInterviewModel.swift, outside the compiler gate
+public extension DesignInterviewModel {
+    /// Applies a turn reply's optional per-axis deltas to `draft`, clamping via
+    /// `DesignAxesCatalog.adjusted`. Pure and toolchain-independent so it's testable without a
+    /// live FoundationModels session — the `@Generable` reply type that produces these values is
+    /// gated below.
+    static func applyTurnReplyDeltas(
+        temperature: Double?, weight: Double?, register: Double?, time: Double?, voice: Double?,
+        brandColorHex: String?, to draft: inout DesignInterviewDraft
+    ) {
+        var deltas: [WritableKeyPath<DesignAxes, Double>: Double] = [:]
+        if let temperature { deltas[\.temperature] = temperature }
+        if let weight { deltas[\.weight] = weight }
+        if let register { deltas[\.register] = register }
+        if let time { deltas[\.time] = time }
+        if let voice { deltas[\.voice] = voice }
+        if !deltas.isEmpty { draft.axes = DesignAxesCatalog.adjusted(draft.axes, by: deltas) }
+        if let brandColorHex { draft.brandColorHex = brandColorHex }
+    }
+}
+
+#if compiler(>=6.4)
+import FoundationModels
+
+@Generable
+public struct DesignInterviewTurnReply: Sendable {
+    @Guide(description: "Your conversational reply to the owner, 1-2 sentences.")
+    public var replyText: String
+    @Guide(description: "Temperature axis change if the owner's message implies one, else omit.")
+    public var temperatureDelta: Double?
+    @Guide(description: "Weight axis change if the owner's message implies one, else omit.")
+    public var weightDelta: Double?
+    @Guide(description: "Register axis change if the owner's message implies one, else omit.")
+    public var registerDelta: Double?
+    @Guide(description: "Time axis change if the owner's message implies one, else omit.")
+    public var timeDelta: Double?
+    @Guide(description: "Voice axis change if the owner's message implies one, else omit.")
+    public var voiceDelta: Double?
+    @Guide(description: "Hex color if the owner mentioned a brand color, else omit.")
+    public var brandColorHex: String?
+}
+#endif
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignInterviewModelTests`
+Expected: PASS (6 tests total, 2 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignInterviewModel.swift Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
+git commit -m "feat(core): add structured per-turn axis extraction for design-interview"
+```
+
+**Note for the implementer:** wiring `send(_:)` to actually call `generateStructured(prompt:context:resultType: DesignInterviewTurnReply.self)` instead of `converse`'s free-text stream, and to call `applyTurnReplyDeltas` with the decoded result, is a small follow-up left undone here — flag it explicitly rather than silently leaving `send` on the Task 5 echo-advance behavior forever. This also means `send` moves off the generic `ConversationalAssistant` protocol onto `FoundationModelAssistant` directly (structured generation isn't part of that protocol's `converse` surface), which is a real API shape change worth calling out before implementing.
+
+---
+
+### Task 7: GUI mirror panel
+
+**Files:**
+- Create: `Sources/AnglesiteApp/DesignInterviewPanel.swift`
+
+**Interfaces:**
+- Consumes: `DesignInterviewModel` (Task 5).
+
+No isolated unit test (SwiftUI view, same rationale as the theme-apply wizard's Task 10) — covered by manual GUI smoke.
+
+- [ ] **Step 1: Implement**
+
+```swift
+// Sources/AnglesiteApp/DesignInterviewPanel.swift
+import SwiftUI
+import AnglesiteCore
+
+struct DesignInterviewPanel: View {
+    @Bindable var model: DesignInterviewModel
+    @State private var draftMessage = ""
+
+    var body: some View {
+        HSplitView {
+            transcriptColumn
+            axesColumn
+        }
+    }
+
+    private var transcriptColumn: some View {
+        VStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(Array(model.transcript.enumerated()), id: \.offset) { _, entry in
+                        Text(entry.text)
+                            .frame(maxWidth: .infinity, alignment: entry.role == "user" ? .trailing : .leading)
+                    }
+                }
+                .padding()
+            }
+            HStack {
+                TextField("Describe what you're going for…", text: $draftMessage)
+                    .onSubmit { Task { await sendDraft() } }
+                Button("Send") { Task { await sendDraft() } }
+                    .disabled(draftMessage.isEmpty)
+            }
+            .padding()
+        }
+        .frame(minWidth: 320)
+    }
+
+    private var axesColumn: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Design Axes").font(.headline)
+            axisSlider("Cool", "Warm", value: $model.draft.axes.temperature)
+            axisSlider("Airy", "Dense", value: $model.draft.axes.weight)
+            axisSlider("Playful", "Authoritative", value: $model.draft.axes.register)
+            axisSlider("Classic", "Contemporary", value: $model.draft.axes.time)
+            axisSlider("Subtle", "Bold", value: $model.draft.axes.voice)
+
+            Spacer()
+
+            if model.draft.stage == .axisConfirmation {
+                Button("Apply This Design") { Task { await model.confirmAndApply() } }
+                    .buttonStyle(.borderedProminent)
+            }
+
+            if case .success = model.applyResult {
+                Label("Applied.", systemImage: "checkmark.circle.fill").foregroundStyle(.green)
+            }
+        }
+        .padding()
+        .frame(minWidth: 260)
+    }
+
+    private func axisSlider(_ low: String, _ high: String, value: Binding<Double>) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(low).font(.caption).foregroundStyle(.secondary)
+                Spacer()
+                Text(high).font(.caption).foregroundStyle(.secondary)
+            }
+            Slider(value: value, in: 0...1)
+        }
+    }
+
+    private func sendDraft() async {
+        guard !draftMessage.isEmpty else { return }
+        let message = draftMessage
+        draftMessage = ""
+        await model.send(message)
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DesignInterviewPanel.swift
+git commit -m "feat(app): add DesignInterviewPanel GUI mirror for the design interview"
+```
+
+---
+
+### Task 8: Front doors — FM tool and Siri intent
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DesignInterviewTool.swift`
+- Create: `Sources/AnglesiteIntents/DesignInterviewIntents.swift`
+
+**Interfaces:**
+- Consumes: `DesignInterviewModel` (Task 5), `SiteEntity` (existing).
+
+No isolated unit tests — both are thin front-door wiring over an already-tested model, matching `SetupIntegrationTool`/`IntegrationIntents.swift`'s own untested-glue precedent for the `AppIntents`-runtime-dependent half.
+
+- [ ] **Step 1: Implement the Siri entry point**
+
+```swift
+// Sources/AnglesiteIntents/DesignInterviewIntents.swift
+import AppIntents
+import AnglesiteCore
+import Foundation
+
+/// Opens chat pre-seeded to start (or resume) the design interview for a site. The interview
+/// itself runs in chat/GUI, not as a multi-turn App Intent — Siri's role is only the entry point.
+public struct StartDesignInterviewIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Start Design Interview"
+    public static let description = IntentDescription("Start a conversation to design your site's look and feel.")
+    public static let openAppWhenRun = true
+
+    @Parameter(title: "Site") public var site: SiteEntity
+
+    public init() {}
+
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Start a design interview for \(\.$site)")
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        // Navigation into the chat surface, pre-seeded at .intent stage, is handled by the app's
+        // existing URL/scene-routing (same mechanism IntegrationIntents' siblings use to land on a
+        // specific site) — wiring that route is a small follow-up left to the app-shell owner
+        // rather than duplicated here.
+        .result(dialog: IntentDialog(stringLiteral: "Let's design \(site.displayName). Opening chat…"))
+    }
+}
+```
+
+**Note for the implementer:** the comment above flags a real gap — this intent returns a dialog but doesn't yet navigate the app to a pre-seeded chat/`DesignInterviewModel` instance. Wiring that requires knowing this app's scene/URL-routing convention for landing on a specific site + chat state, which wasn't in scope to reverse-engineer for this plan; grep for how other `openAppWhenRun` intents in `AnglesiteIntents` hand off to a specific view before implementing, and complete the handoff rather than leaving the dialog as the whole feature.
+
+- [ ] **Step 2: Implement the FM chat tool**
+
+```swift
+// Sources/AnglesiteCore/DesignInterviewTool.swift
+import Foundation
+
+#if compiler(>=6.4)
+import FoundationModels
+
+/// Chat entry point for the design interview. Unlike `SetupIntegrationTool`/`SetupThemeTool`
+/// (stateless plan-then-apply calls), the interview is inherently multi-turn — this tool's `call`
+/// starts or continues a session-scoped `DesignInterviewModel` the caller supplies, rather than
+/// owning conversation state itself.
+public struct DesignInterviewTool: Tool, Sendable {
+    public static let toolName = "designInterview"
+    public let name = DesignInterviewTool.toolName
+    public let description = "Have a short conversation to design or redesign a site's look and feel."
+
+    @Generable
+    public struct Arguments {
+        @Guide(description: "The owner's message in this turn of the design conversation.")
+        public var message: String
+        @Guide(description: "Set to true if the owner wants Anglesite to just pick a design for them.")
+        public var designForMe: Bool?
+    }
+
+    private let model: DesignInterviewModel
+    public init(model: DesignInterviewModel) { self.model = model }
+
+    public func call(arguments: Arguments) async throws -> String {
+        if arguments.designForMe == true {
+            await MainActor.run { model.skipToAxisConfirmation() }
+            return "I'll design it for you based on what a \(await MainActor.run { model.draft.businessType }) site usually needs. Review the axes and tell me to apply when you're happy."
+        }
+        await model.send(arguments.message)
+        return await MainActor.run { model.transcript.last?.text ?? "" }
+    }
+}
+#endif
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignInterviewTool.swift Sources/AnglesiteIntents/DesignInterviewIntents.swift
+git commit -m "feat: add design-interview FM chat tool and Siri entry point"
+```
+
+**Note for the implementer:** `DesignInterviewTool` takes a `DesignInterviewModel` instance at construction, unlike `SetupIntegrationTool`'s stateless `service`/`siteID` pair — this means `FoundationModelAssistant.conversationTools(for:includeSpotlight:)` needs a per-conversation `DesignInterviewModel` available at tool-construction time, not just a stateless service. Wiring this into `FoundationModelAssistant.init`/`conversationTools` (mirroring the `SetupIntegrationTool` wiring note in the theme-apply plan's Task 11) is left for whoever integrates both front doors together — flag it, don't skip it.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** conversation stages (Tasks 2-3), FM-backed turns with structured axis extraction (Tasks 5-6), GUI mirror (Task 7), chat-first front door + Siri entry (Task 8), shared write path via `DesignApplyService` (Task 5's `confirmAndApply`), PCC escalation (Task 1 spike + Task 4, honestly branched rather than assumed) — all covered.
+- **Known gaps surfaced to the implementer, not hidden:** (1) Task 1's outcome determines which Task 4 branch to build — this plan does not pretend PCC escalation is definitely buildable; (2) Task 6's structured-reply wiring into `send()` is left as an explicit follow-up rather than silently completed; (3) Siri's chat hand-off (Task 8) and (4) `DesignInterviewTool`'s wiring into `FoundationModelAssistant` (Task 8) are both flagged rather than faked.
+- **Type consistency:** `DesignInterviewDraft`/`ConversationStage`/`DesignAdjectiveHint` (Task 2) are used identically across Tasks 3, 5, 6, 7. `DesignInterviewModel.confirmAndApply()` (Task 5) reuses `DesignApplyInput`/`AppliedDesign`/`DesignApplyError` from the theme-apply plan without redefinition, per the design spec's "one shared write path" requirement.
+- **Dependency on the other plan:** this plan cannot start before the theme-apply plan's Tasks 2-7 are merged (`DesignAxes`, `DesignConfigGenerator`, `DesignTokenWriter`, `DesignApplyService` are consumed, not redefined, throughout).

--- a/docs/superpowers/plans/2026-07-10-theme-apply-wizard-plan.md
+++ b/docs/superpowers/plans/2026-07-10-theme-apply-wizard-plan.md
@@ -1,0 +1,1942 @@
+# Theme Apply Wizard + Design Token Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a deterministic, Claude-free way to apply a visual theme to an existing `.anglesite` site — either one of the 9 built-in quick-picks or a freedesignmd catalog system — through GUI, App Intent, and FM-chat front doors alike.
+
+**Architecture:** A pure Swift design-token engine (ported 1:1 from the plugin's `scripts/design.ts` + `scripts/contrast.ts`) computes CSS custom-property values; a single `DesignApplyService` writes them into the site's `global.css` `:root` block plus `docs/brand.md`. `ThemeApplyWizardModel` drives the built-in/freedesignmd choice through this shared write path, following the existing `IntegrationWizardModel` triad (GUI sheet, App Intent, FM chat tool).
+
+**Tech Stack:** Swift 6.4, SwiftUI, Swift Testing, Foundation (`URLSession`, `NSRegularExpression`), FoundationModels (optional FM-assist step only, `#if compiler(>=6.4)`).
+
+## Global Constraints
+
+- Target macOS 27+, Swift 6.4 toolchain (`DEVELOPER_DIR=/Applications/Xcode-beta.app/...` for `swift test`, per project memory).
+- No third-party dependencies — Apple frameworks only.
+- All file writes go through `AnglesiteCore`; no view ever calls `Process()` or writes files directly.
+- CSS custom-property names written by this feature MUST match the **12 names already used by `Resources/Template/src/styles/global.css`**: `--color-primary`, `--color-accent`, `--color-background`, `--color-surface`, `--color-text`, `--color-text-muted`, `--font-heading`, `--font-body`, `--spacing-unit`, `--radius-sm`, `--radius-md`, `--radius-lg`. Do not introduce new var names (e.g. `--color-brand`, `--color-bg`, `--shadow-*`, `--space-xs`) — the plugin's `design.ts` uses a different, newer naming scheme than the shipped template; this plan's engine output must be mapped onto the template's existing schema, not the plugin's.
+- Every new type is `Sendable`; models that touch SwiftUI state are `@MainActor @Observable`, following `IntegrationWizardModel`.
+- No FM dependency in Tasks 1–7 — those are pure, CI-testable. FM is used only in Task 8 (optional catalog re-rank), gated `#if compiler(>=6.4)`.
+
+---
+
+## File Structure
+
+```
+Sources/AnglesiteCore/
+  WCAGContrast.swift            # Task 1 — hex/RGB/luminance/contrast-ratio math
+  DesignAxes.swift               # Task 2 — DesignAxes struct, business-type defaults, adjustAxes
+  DesignPaletteGenerator.swift   # Task 3 — HSL color math, generatePalette
+  DesignConfigGenerator.swift    # Task 4 — Typography/Spacing/Shape + DesignConfig assembly
+  DesignTokenWriter.swift        # Task 5 — CSS-var mapping (engine output -> template's 12 vars) + DESIGN.md rationale text
+  DesignApplyService.swift       # Task 6 — writes global.css :root + docs/brand.md
+  FreedesignmdCatalog.swift      # Task 8 — fetch + parse the systems list, per-system description
+  ThemeApplyWizardModel.swift    # Task 9 — @MainActor @Observable wizard model
+  SetupThemeTool.swift           # Task 11 — FM chat tool
+
+Sources/AnglesiteApp/
+  ThemeApplyWizard.swift         # Task 10 — SwiftUI sheet
+
+Sources/AnglesiteIntents/
+  ThemeIntents.swift             # Task 12 — ApplyThemeIntent
+
+Tests/AnglesiteCoreTests/
+  WCAGContrastTests.swift
+  DesignAxesTests.swift
+  DesignPaletteGeneratorTests.swift
+  DesignConfigGeneratorTests.swift
+  DesignTokenWriterTests.swift
+  DesignApplyServiceTests.swift
+  FreedesignmdCatalogTests.swift
+  ThemeApplyWizardModelTests.swift
+  SetupThemeToolTests.swift
+```
+
+`ThemeCatalog.swift` (existing) is reused unchanged for the 9 built-ins — no modification needed.
+
+---
+
+### Task 1: WCAG contrast math
+
+**Files:**
+- Create: `Sources/AnglesiteCore/WCAGContrast.swift`
+- Test: `Tests/AnglesiteCoreTests/WCAGContrastTests.swift`
+
+**Interfaces:**
+- Produces: `struct RGBColor: Sendable, Equatable { let r, g, b: Int }`, `enum WCAGContrast { static func hexToRGB(_ hex: String) -> RGBColor?; static func relativeLuminance(_ rgb: RGBColor) -> Double; static func contrastRatio(_ hex1: String, _ hex2: String) -> Double; static func meetsAA(fg: String, bg: String) -> Bool; static func meetsAALarge(fg: String, bg: String) -> Bool; static func suggestReadable(fg: String, bg: String) -> String }`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/WCAGContrastTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct WCAGContrastTests {
+    @Test func hexToRGBParsesSixDigit() {
+        #expect(WCAGContrast.hexToRGB("#2563eb") == RGBColor(r: 0x25, g: 0x63, b: 0xeb))
+    }
+
+    @Test func hexToRGBExpandsThreeDigit() {
+        #expect(WCAGContrast.hexToRGB("#f00") == RGBColor(r: 0xff, g: 0x00, b: 0x00))
+    }
+
+    @Test func hexToRGBRejectsInvalid() {
+        #expect(WCAGContrast.hexToRGB("not-a-color") == nil)
+    }
+
+    @Test func contrastRatioBlackOnWhiteIsMax() {
+        let ratio = WCAGContrast.contrastRatio("#000000", "#ffffff")
+        #expect(abs(ratio - 21.0) < 0.01)
+    }
+
+    @Test func contrastRatioIsOrderIndependent() {
+        #expect(WCAGContrast.contrastRatio("#123456", "#abcdef") ==
+                WCAGContrast.contrastRatio("#abcdef", "#123456"))
+    }
+
+    @Test func meetsAAThreshold() {
+        #expect(WCAGContrast.meetsAA(fg: "#000000", bg: "#ffffff") == true)
+        #expect(WCAGContrast.meetsAA(fg: "#777777", bg: "#888888") == false)
+    }
+
+    @Test func suggestReadableReturnsOriginalWhenAlreadyPassing() {
+        #expect(WCAGContrast.suggestReadable(fg: "#000000", bg: "#ffffff") == "#000000")
+    }
+
+    @Test func suggestReadableDarkensOnLightBackground() {
+        let fixed = WCAGContrast.suggestReadable(fg: "#aaaaaa", bg: "#ffffff")
+        #expect(WCAGContrast.meetsAA(fg: fixed, bg: "#ffffff"))
+    }
+
+    @Test func suggestReadableLightensOnDarkBackground() {
+        let fixed = WCAGContrast.suggestReadable(fg: "#333333", bg: "#000000")
+        #expect(WCAGContrast.meetsAA(fg: fixed, bg: "#000000"))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter WCAGContrastTests`
+Expected: FAIL (compile error — `WCAGContrast`/`RGBColor` don't exist yet)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/WCAGContrast.swift
+import Foundation
+
+/// WCAG 2.2 contrast-ratio utilities, ported 1:1 from the plugin's `scripts/contrast.ts`.
+/// Pure, no I/O.
+public struct RGBColor: Sendable, Equatable {
+    public let r: Int
+    public let g: Int
+    public let b: Int
+    public init(r: Int, g: Int, b: Int) { self.r = r; self.g = g; self.b = b }
+}
+
+public enum WCAGContrast {
+    /// Parses a hex color (`#rgb` or `#rrggbb`, leading `#` optional). Returns `nil` for invalid input.
+    public static func hexToRGB(_ hex: String) -> RGBColor? {
+        var h = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        if h.count == 3, h.allSatisfy({ $0.isHexDigit }) {
+            h = h.map { "\($0)\($0)" }.joined()
+        }
+        guard h.count == 6, h.allSatisfy({ $0.isHexDigit }) else { return nil }
+        let scanner = Scanner(string: h)
+        var value: UInt64 = 0
+        guard scanner.scanHexInt64(&value) else { return nil }
+        return RGBColor(r: Int((value >> 16) & 0xFF), g: Int((value >> 8) & 0xFF), b: Int(value & 0xFF))
+    }
+
+    /// Relative luminance per WCAG 2.2 §1.4.3.
+    public static func relativeLuminance(_ rgb: RGBColor) -> Double {
+        func channel(_ c: Int) -> Double {
+            let s = Double(c) / 255
+            return s <= 0.04045 ? s / 12.92 : pow((s + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b)
+    }
+
+    /// Contrast ratio between two hex colors. `NaN` if either fails to parse.
+    public static func contrastRatio(_ hex1: String, _ hex2: String) -> Double {
+        guard let rgb1 = hexToRGB(hex1), let rgb2 = hexToRGB(hex2) else { return .nan }
+        let l1 = relativeLuminance(rgb1)
+        let l2 = relativeLuminance(rgb2)
+        let lighter = max(l1, l2)
+        let darker = min(l1, l2)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    public static func meetsAA(fg: String, bg: String) -> Bool { contrastRatio(fg, bg) >= 4.5 }
+    public static func meetsAALarge(fg: String, bg: String) -> Bool { contrastRatio(fg, bg) >= 3 }
+
+    private static func toHex(_ rgb: RGBColor) -> String {
+        func clamp(_ n: Int) -> String { String(format: "%02x", max(0, min(255, n))) }
+        return "#\(clamp(rgb.r))\(clamp(rgb.g))\(clamp(rgb.b))"
+    }
+
+    /// Darkens or lightens `fg` in 1-unit RGB steps until it meets AA against `bg`. Returns the
+    /// original hex, lowercased, if it already passes or if either color fails to parse.
+    public static func suggestReadable(fg: String, bg: String) -> String {
+        if meetsAA(fg: fg, bg: bg) { return fg }
+        guard let fgRGB = hexToRGB(fg), let bgRGB = hexToRGB(bg) else { return fg }
+        let shouldDarken = relativeLuminance(bgRGB) > 0.5
+        var best = fgRGB
+        for step in 1...255 {
+            let delta = shouldDarken ? -step : step
+            let candidate = RGBColor(
+                r: max(0, min(255, fgRGB.r + delta)),
+                g: max(0, min(255, fgRGB.g + delta)),
+                b: max(0, min(255, fgRGB.b + delta))
+            )
+            if meetsAA(fg: toHex(candidate), bg: toHex(bgRGB)) {
+                best = candidate
+                break
+            }
+        }
+        return toHex(best)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter WCAGContrastTests`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WCAGContrast.swift Tests/AnglesiteCoreTests/WCAGContrastTests.swift
+git commit -m "feat(core): port WCAG contrast utilities from plugin contrast.ts"
+```
+
+---
+
+### Task 2: Design axes + business-type defaults
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DesignAxes.swift`
+- Test: `Tests/AnglesiteCoreTests/DesignAxesTests.swift`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `struct DesignAxes: Sendable, Equatable, Codable { var temperature, weight, register, time, voice: Double }`, `enum DesignAxesCatalog { static func defaults(forBusinessType: String) -> DesignAxes; static func adjusted(_ axes: DesignAxes, by deltas: [WritableKeyPath<DesignAxes, Double>: Double]) -> DesignAxes; static func isValid(_ axes: DesignAxes) -> Bool }`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/DesignAxesTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignAxesTests {
+    @Test func defaultsForKnownBusinessType() {
+        let axes = DesignAxesCatalog.defaults(forBusinessType: "restaurant")
+        #expect(axes.temperature == 0.75)
+        #expect(axes.weight == 0.45)
+        #expect(axes.register == 0.3)
+        #expect(axes.time == 0.4)
+        #expect(axes.voice == 0.5)
+    }
+
+    @Test func defaultsForUnknownBusinessTypeFallsBackToBalanced() {
+        let axes = DesignAxesCatalog.defaults(forBusinessType: "spaceship-repair")
+        #expect(axes == DesignAxes(temperature: 0.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4))
+    }
+
+    @Test func defaultsAreCaseAndCommaInsensitive() {
+        let axes = DesignAxesCatalog.defaults(forBusinessType: "Restaurant, fine-dining")
+        #expect(axes.temperature == 0.75)
+    }
+
+    @Test func adjustedClampsToUnitRange() {
+        let axes = DesignAxes(temperature: 0.9, weight: 0.1, register: 0.5, time: 0.5, voice: 0.5)
+        let result = DesignAxesCatalog.adjusted(axes, by: [\.temperature: 0.5, \.weight: -0.5])
+        #expect(result.temperature == 1.0)
+        #expect(result.weight == 0.0)
+    }
+
+    @Test func adjustedLeavesUntouchedAxesAlone() {
+        let axes = DesignAxes(temperature: 0.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4)
+        let result = DesignAxesCatalog.adjusted(axes, by: [\.register: 0.1])
+        #expect(result.temperature == 0.5)
+        #expect(result.register == 0.6)
+    }
+
+    @Test func isValidRejectsOutOfRange() {
+        #expect(DesignAxesCatalog.isValid(DesignAxes(temperature: 1.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4)) == false)
+        #expect(DesignAxesCatalog.isValid(DesignAxes(temperature: 0.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4)) == true)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignAxesTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/DesignAxes.swift
+import Foundation
+
+/// Five design axes, each a float 0–1. Ported from the plugin's `scripts/design.ts`.
+public struct DesignAxes: Sendable, Equatable, Codable {
+    /// Cool (0) <-> Warm (1)
+    public var temperature: Double
+    /// Airy (0) <-> Dense (1)
+    public var weight: Double
+    /// Playful (0) <-> Authoritative (1)
+    public var register: Double
+    /// Classic (0) <-> Contemporary (1)
+    public var time: Double
+    /// Subtle (0) <-> Bold (1)
+    public var voice: Double
+
+    public init(temperature: Double, weight: Double, register: Double, time: Double, voice: Double) {
+        self.temperature = temperature; self.weight = weight; self.register = register
+        self.time = time; self.voice = voice
+    }
+}
+
+public enum DesignAxesCatalog {
+    public static let balanced = DesignAxes(temperature: 0.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4)
+
+    /// Business-type -> default axes. Verbatim port of `BUSINESS_AXES` in `scripts/design.ts`.
+    private static let byBusinessType: [String: DesignAxes] = [
+        "restaurant":   DesignAxes(temperature: 0.75, weight: 0.45, register: 0.3,  time: 0.4,  voice: 0.5),
+        "bakery":       DesignAxes(temperature: 0.8,  weight: 0.35, register: 0.25, time: 0.3,  voice: 0.45),
+        "brewery":      DesignAxes(temperature: 0.7,  weight: 0.55, register: 0.35, time: 0.45, voice: 0.55),
+        "hospitality":  DesignAxes(temperature: 0.7,  weight: 0.4,  register: 0.4,  time: 0.35, voice: 0.4),
+        "campground":   DesignAxes(temperature: 0.65, weight: 0.4,  register: 0.3,  time: 0.3,  voice: 0.45),
+        "accounting":   DesignAxes(temperature: 0.2,  weight: 0.4,  register: 0.8,  time: 0.3,  voice: 0.3),
+        "insurance":    DesignAxes(temperature: 0.25, weight: 0.45, register: 0.75, time: 0.35, voice: 0.3),
+        "credit-union": DesignAxes(temperature: 0.3,  weight: 0.4,  register: 0.7,  time: 0.4,  voice: 0.35),
+        "real-estate":  DesignAxes(temperature: 0.35, weight: 0.45, register: 0.65, time: 0.5,  voice: 0.45),
+        "healthcare":   DesignAxes(temperature: 0.35, weight: 0.3,  register: 0.6,  time: 0.6,  voice: 0.3),
+        "pharmacy":     DesignAxes(temperature: 0.3,  weight: 0.35, register: 0.65, time: 0.55, voice: 0.25),
+        "cleaning":     DesignAxes(temperature: 0.35, weight: 0.3,  register: 0.5,  time: 0.6,  voice: 0.35),
+        "grocery":      DesignAxes(temperature: 0.45, weight: 0.4,  register: 0.4,  time: 0.5,  voice: 0.4),
+        "fitness":      DesignAxes(temperature: 0.45, weight: 0.7,  register: 0.55, time: 0.7,  voice: 0.8),
+        "trades":       DesignAxes(temperature: 0.4,  weight: 0.65, register: 0.6,  time: 0.5,  voice: 0.7),
+        "auto-dealer":  DesignAxes(temperature: 0.35, weight: 0.7,  register: 0.6,  time: 0.6,  voice: 0.75),
+        "car-wash":     DesignAxes(temperature: 0.4,  weight: 0.6,  register: 0.5,  time: 0.6,  voice: 0.65),
+        "plumber":      DesignAxes(temperature: 0.4,  weight: 0.6,  register: 0.55, time: 0.5,  voice: 0.6),
+        "electrician":  DesignAxes(temperature: 0.35, weight: 0.6,  register: 0.55, time: 0.55, voice: 0.6),
+        "farm":         DesignAxes(temperature: 0.6,  weight: 0.45, register: 0.4,  time: 0.2,  voice: 0.4),
+        "florist":      DesignAxes(temperature: 0.6,  weight: 0.3,  register: 0.3,  time: 0.35, voice: 0.45),
+        "hardware":     DesignAxes(temperature: 0.5,  weight: 0.55, register: 0.5,  time: 0.3,  voice: 0.5),
+        "veterinarian": DesignAxes(temperature: 0.55, weight: 0.4,  register: 0.45, time: 0.4,  voice: 0.4),
+        "childcare":    DesignAxes(temperature: 0.7,  weight: 0.3,  register: 0.15, time: 0.6,  voice: 0.7),
+        "pet-services": DesignAxes(temperature: 0.65, weight: 0.35, register: 0.2,  time: 0.55, voice: 0.65),
+        "dance-studio": DesignAxes(temperature: 0.6,  weight: 0.3,  register: 0.2,  time: 0.65, voice: 0.7),
+        "youth-org":    DesignAxes(temperature: 0.6,  weight: 0.35, register: 0.25, time: 0.6,  voice: 0.6),
+        "entertainment": DesignAxes(temperature: 0.55, weight: 0.4, register: 0.2,  time: 0.65, voice: 0.75),
+        "salon":        DesignAxes(temperature: 0.4,  weight: 0.3,  register: 0.65, time: 0.7,  voice: 0.5),
+        "photography":  DesignAxes(temperature: 0.35, weight: 0.25, register: 0.6,  time: 0.7,  voice: 0.55),
+        "jewelry":      DesignAxes(temperature: 0.3,  weight: 0.25, register: 0.7,  time: 0.6,  voice: 0.45),
+        "community-theater": DesignAxes(temperature: 0.45, weight: 0.35, register: 0.55, time: 0.5, voice: 0.55),
+        "hotel":        DesignAxes(temperature: 0.4,  weight: 0.35, register: 0.7,  time: 0.55, voice: 0.4),
+        "nonprofit":    DesignAxes(temperature: 0.55, weight: 0.4,  register: 0.4,  time: 0.5,  voice: 0.45),
+        "house-of-worship": DesignAxes(temperature: 0.6, weight: 0.4, register: 0.45, time: 0.3, voice: 0.4),
+        "social-services": DesignAxes(temperature: 0.55, weight: 0.4, register: 0.45, time: 0.5, voice: 0.4),
+        "food-bank":    DesignAxes(temperature: 0.6,  weight: 0.4,  register: 0.35, time: 0.45, voice: 0.45),
+        "animal-shelter": DesignAxes(temperature: 0.6, weight: 0.35, register: 0.3, time: 0.5, voice: 0.5),
+    ]
+
+    /// Default axis positions for a business type. Falls back to ``balanced`` for unknown types.
+    /// Matches only on the substring before the first comma, lowercased and trimmed.
+    public static func defaults(forBusinessType businessType: String) -> DesignAxes {
+        guard !businessType.isEmpty else { return balanced }
+        let key = businessType.lowercased().split(separator: ",", maxSplits: 1)[0]
+            .trimmingCharacters(in: .whitespaces)
+        return byBusinessType[key] ?? balanced
+    }
+
+    /// Applies each delta to the named axis, clamping the result to [0, 1].
+    public static func adjusted(_ axes: DesignAxes, by deltas: [WritableKeyPath<DesignAxes, Double>: Double]) -> DesignAxes {
+        var result = axes
+        for (keyPath, delta) in deltas {
+            result[keyPath: keyPath] = max(0, min(1, result[keyPath: keyPath] + delta))
+        }
+        return result
+    }
+
+    public static func isValid(_ axes: DesignAxes) -> Bool {
+        [axes.temperature, axes.weight, axes.register, axes.time, axes.voice]
+            .allSatisfy { !$0.isNaN && $0 >= 0 && $0 <= 1 }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignAxesTests`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignAxes.swift Tests/AnglesiteCoreTests/DesignAxesTests.swift
+git commit -m "feat(core): port DesignAxes + business-type defaults from plugin design.ts"
+```
+
+---
+
+### Task 3: Palette generation (HSL color math)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DesignPaletteGenerator.swift`
+- Test: `Tests/AnglesiteCoreTests/DesignPaletteGeneratorTests.swift`
+
+**Interfaces:**
+- Consumes: `DesignAxes` (Task 2), `WCAGContrast.suggestReadable`/`hexToRGB` (Task 1).
+- Produces: `struct DesignPalette: Sendable, Equatable, Codable { let brand, accent, bg, surface, text, muted, border: String }`, `enum DesignPaletteGenerator { static func generate(axes: DesignAxes, brandColor: String?) -> DesignPalette }`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/DesignPaletteGeneratorTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignPaletteGeneratorTests {
+    @Test func generatesAllSevenTokens() {
+        let palette = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: nil)
+        for hex in [palette.brand, palette.accent, palette.bg, palette.surface, palette.text, palette.muted, palette.border] {
+            #expect(WCAGContrast.hexToRGB(hex) != nil)
+        }
+    }
+
+    @Test func honorsExplicitBrandColor() {
+        let palette = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: "#ff0000")
+        #expect(palette.brand == "#ff0000")
+    }
+
+    @Test func ignoresInvalidBrandColorAndDerivesInstead() {
+        let derived = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: "not-a-color")
+        #expect(derived.brand != "not-a-color")
+        #expect(WCAGContrast.hexToRGB(derived.brand) != nil)
+    }
+
+    @Test func textMeetsAAAgainstBackground() {
+        let palette = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: nil)
+        #expect(WCAGContrast.meetsAA(fg: palette.text, bg: palette.bg))
+    }
+
+    @Test func mutedMeetsAAAgainstBackground() {
+        let palette = DesignPaletteGenerator.generate(axes: DesignAxesCatalog.balanced, brandColor: nil)
+        #expect(WCAGContrast.meetsAA(fg: palette.muted, bg: palette.bg))
+    }
+
+    @Test func warmTemperatureProducesDifferentBrandHueThanCool() {
+        let warm = DesignPaletteGenerator.generate(
+            axes: DesignAxes(temperature: 1.0, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4), brandColor: nil)
+        let cool = DesignPaletteGenerator.generate(
+            axes: DesignAxes(temperature: 0.0, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4), brandColor: nil)
+        #expect(warm.brand != cool.brand)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignPaletteGeneratorTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/DesignPaletteGenerator.swift
+import Foundation
+
+/// Color tokens for a generated design. Ported from the plugin's `scripts/design.ts` `Palette`.
+public struct DesignPalette: Sendable, Equatable, Codable {
+    public let brand: String
+    public let accent: String
+    public let bg: String
+    public let surface: String
+    public let text: String
+    public let muted: String
+    public let border: String
+
+    public init(brand: String, accent: String, bg: String, surface: String, text: String, muted: String, border: String) {
+        self.brand = brand; self.accent = accent; self.bg = bg; self.surface = surface
+        self.text = text; self.muted = muted; self.border = border
+    }
+}
+
+public enum DesignPaletteGenerator {
+    /// Deterministic palette generation from design axes, ported verbatim from `generatePalette` in
+    /// `scripts/design.ts`. If `brandColor` is a valid hex, it becomes the brand color and the rest
+    /// is derived from it; otherwise the brand color is derived from `axes.temperature`.
+    public static func generate(axes: DesignAxes, brandColor: String?) -> DesignPalette {
+        let isDarkMode = axes.weight > 0.75 && axes.voice > 0.7
+
+        var brandH: Double, brandS: Double, brandL: Double
+        if let brandColor, let rgb = WCAGContrast.hexToRGB(brandColor) {
+            (brandH, brandS, brandL) = hexToHSL(rgb)
+        } else {
+            brandH = temperatureToHue(axes.temperature)
+            brandS = min(0.85, max(0.35, 0.45 + (1 - axes.register) * 0.2 + axes.voice * 0.15))
+            brandL = 0.42 - axes.register * 0.08
+        }
+        let brand = (brandColor.flatMap(WCAGContrast.hexToRGB) != nil) ? brandColor! : hslToHex(brandH, brandS, brandL)
+
+        let accentOffset: Double = axes.voice > 0.5 ? 180 : 40
+        let accentH = (brandH + accentOffset).truncatingRemainder(dividingBy: 360)
+        let accentS = min(0.8, brandS + 0.05)
+        let accentL = 0.45 + axes.voice * 0.1
+        let accent = hslToHex(accentH, accentS, accentL)
+
+        var bg: String, surface: String, text: String, muted: String, border: String
+        if isDarkMode {
+            bg = hslToHex(brandH, 0.15, 0.08 + axes.temperature * 0.04)
+            surface = hslToHex(brandH, 0.12, 0.12 + axes.temperature * 0.04)
+            text = hslToHex(brandH, 0.05, 0.92)
+            muted = hslToHex(brandH, 0.08, 0.6)
+            border = hslToHex(brandH, 0.1, 0.2)
+        } else {
+            let surfaceH = brandH
+            let surfaceS = 0.05 + axes.temperature * 0.1
+            bg = hslToHex(surfaceH, surfaceS, 0.99 - axes.temperature * 0.02)
+            surface = hslToHex(surfaceH, surfaceS + 0.02, 0.96 - axes.temperature * 0.02)
+            text = hslToHex(brandH, 0.1 + axes.temperature * 0.05, 0.1 + axes.weight * 0.03)
+            muted = hslToHex(brandH, 0.05, 0.42 + axes.weight * 0.05)
+            border = hslToHex(surfaceH, surfaceS + 0.03, 0.88 - axes.weight * 0.05)
+        }
+
+        text = WCAGContrast.suggestReadable(fg: text, bg: bg)
+        muted = WCAGContrast.suggestReadable(fg: muted, bg: bg)
+
+        return DesignPalette(brand: brand, accent: accent, bg: bg, surface: surface, text: text, muted: muted, border: border)
+    }
+
+    /// Cool (0) -> blue/teal (210), balanced (0.5) -> teal (160), warm (1) -> orange/terracotta (25).
+    static func temperatureToHue(_ t: Double) -> Double {
+        t <= 0.5 ? 210 - t * 100 : 160 - (t - 0.5) * 270
+    }
+
+    static func hslToHex(_ h: Double, _ s: Double, _ l: Double) -> String {
+        let hue = ((h.truncatingRemainder(dividingBy: 360)) + 360).truncatingRemainder(dividingBy: 360)
+        let a = s * min(l, 1 - l)
+        func f(_ n: Double) -> String {
+            let k = (n + hue / 30).truncatingRemainder(dividingBy: 12)
+            let color = l - a * max(min(min(k - 3, 9 - k), 1), -1)
+            let byte = Int((255 * max(0, min(1, color))).rounded())
+            return String(format: "%02x", byte)
+        }
+        return "#\(f(0))\(f(8))\(f(4))"
+    }
+
+    static func hexToHSL(_ rgb: RGBColor) -> (h: Double, s: Double, l: Double) {
+        let r = Double(rgb.r) / 255, g = Double(rgb.g) / 255, b = Double(rgb.b) / 255
+        let maxC = max(r, g, b), minC = min(r, g, b)
+        let l = (maxC + minC) / 2
+        if maxC == minC { return (0, 0, l) }
+        let d = maxC - minC
+        let s = l > 0.5 ? d / (2 - maxC - minC) : d / (maxC + minC)
+        var h: Double
+        if maxC == r { h = ((g - b) / d + (g < b ? 6 : 0)) * 60 }
+        else if maxC == g { h = ((b - r) / d + 2) * 60 }
+        else { h = ((r - g) / d + 4) * 60 }
+        return (h, s, l)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignPaletteGeneratorTests`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignPaletteGenerator.swift Tests/AnglesiteCoreTests/DesignPaletteGeneratorTests.swift
+git commit -m "feat(core): port HSL palette generator from plugin design.ts"
+```
+
+---
+
+### Task 4: Typography, spacing, shape + DesignConfig assembly
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DesignConfigGenerator.swift`
+- Test: `Tests/AnglesiteCoreTests/DesignConfigGeneratorTests.swift`
+
+**Interfaces:**
+- Consumes: `DesignAxes` (Task 2), `DesignPalette`/`DesignPaletteGenerator.generate` (Task 3).
+- Produces: `struct DesignTypography: Sendable, Equatable, Codable { let display, body, pairing: String }`, `struct DesignSpacing: Sendable, Equatable, Codable { let xs, sm, md, lg, xl: String }`, `struct DesignShape: Sendable, Equatable, Codable { let radiusSm, radiusMd, radiusLg, shadowSm, shadowMd: String }`, `struct DesignConfig: Sendable, Equatable, Codable { let axes: DesignAxes; let palette: DesignPalette; let typography: DesignTypography; let spacing: DesignSpacing; let shape: DesignShape; let siteType: String; let brandColor: String? }`, `enum DesignConfigGenerator { static func typography(for axes: DesignAxes) -> DesignTypography; static func spacing(for axes: DesignAxes) -> DesignSpacing; static func shape(for axes: DesignAxes) -> DesignShape; static func config(axes: DesignAxes, siteType: String, brandColor: String?) -> DesignConfig }`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/DesignConfigGeneratorTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignConfigGeneratorTests {
+    @Test func contemporaryAxesPickModernSansPairing() {
+        let axes = DesignAxes(temperature: 0.5, weight: 0.4, register: 0.2, time: 1.0, voice: 0.5)
+        #expect(DesignConfigGenerator.typography(for: axes).pairing == "modern-sans+modern-sans")
+    }
+
+    @Test func classicAuthoritativeAxesPickClassicSerifPairing() {
+        let axes = DesignAxes(temperature: 0.5, weight: 0.4, register: 1.0, time: 0.0, voice: 0.1)
+        #expect(DesignConfigGenerator.typography(for: axes).pairing == "classic-serif+modern-sans")
+    }
+
+    @Test func airyWeightProducesLargerSpacingThanDense() {
+        let airy = DesignConfigGenerator.spacing(for: DesignAxes(temperature: 0.5, weight: 0.0, register: 0.5, time: 0.5, voice: 0.4))
+        let dense = DesignConfigGenerator.spacing(for: DesignAxes(temperature: 0.5, weight: 1.0, register: 0.5, time: 0.5, voice: 0.4))
+        #expect(parseRem(airy.md) > parseRem(dense.md))
+    }
+
+    @Test func playfulContemporaryAxesProduceRounderShapeThanAuthoritativeClassic() {
+        let playful = DesignConfigGenerator.shape(for: DesignAxes(temperature: 0.5, weight: 0.4, register: 0.0, time: 1.0, voice: 0.4))
+        let authoritative = DesignConfigGenerator.shape(for: DesignAxes(temperature: 0.5, weight: 0.4, register: 1.0, time: 0.0, voice: 0.4))
+        #expect(parseRem(playful.radiusMd) > parseRem(authoritative.radiusMd))
+    }
+
+    @Test func configAssemblesAllParts() {
+        let config = DesignConfigGenerator.config(axes: DesignAxesCatalog.balanced, siteType: "bakery", brandColor: nil)
+        #expect(config.siteType == "bakery")
+        #expect(config.axes == DesignAxesCatalog.balanced)
+        #expect(config.brandColor == nil)
+    }
+
+    private func parseRem(_ value: String) -> Double {
+        Double(value.replacingOccurrences(of: "rem", with: "")) ?? 0
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignConfigGeneratorTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/DesignConfigGenerator.swift
+import Foundation
+
+public struct DesignTypography: Sendable, Equatable, Codable {
+    public let display: String
+    public let body: String
+    public let pairing: String
+    public init(display: String, body: String, pairing: String) { self.display = display; self.body = body; self.pairing = pairing }
+}
+
+public struct DesignSpacing: Sendable, Equatable, Codable {
+    public let xs, sm, md, lg, xl: String
+    public init(xs: String, sm: String, md: String, lg: String, xl: String) {
+        self.xs = xs; self.sm = sm; self.md = md; self.lg = lg; self.xl = xl
+    }
+}
+
+public struct DesignShape: Sendable, Equatable, Codable {
+    public let radiusSm, radiusMd, radiusLg, shadowSm, shadowMd: String
+    public init(radiusSm: String, radiusMd: String, radiusLg: String, shadowSm: String, shadowMd: String) {
+        self.radiusSm = radiusSm; self.radiusMd = radiusMd; self.radiusLg = radiusLg
+        self.shadowSm = shadowSm; self.shadowMd = shadowMd
+    }
+}
+
+public struct DesignConfig: Sendable, Equatable, Codable {
+    public let axes: DesignAxes
+    public let palette: DesignPalette
+    public let typography: DesignTypography
+    public let spacing: DesignSpacing
+    public let shape: DesignShape
+    public let siteType: String
+    public let brandColor: String?
+
+    public init(axes: DesignAxes, palette: DesignPalette, typography: DesignTypography,
+                spacing: DesignSpacing, shape: DesignShape, siteType: String, brandColor: String?) {
+        self.axes = axes; self.palette = palette; self.typography = typography
+        self.spacing = spacing; self.shape = shape; self.siteType = siteType; self.brandColor = brandColor
+    }
+}
+
+public enum DesignConfigGenerator {
+    private struct FontPairing {
+        let display: String
+        let body: String
+        let pairing: String
+        let score: (DesignAxes) -> Double
+    }
+
+    private static let fontPairings: [FontPairing] = [
+        FontPairing(display: #"Georgia, "Times New Roman", Times, serif"#,
+                    body: "system-ui, -apple-system, sans-serif",
+                    pairing: "classic-serif+modern-sans",
+                    score: { (1 - $0.time) * 2 + $0.register * 1.5 + (1 - $0.voice) * 0.5 }),
+        FontPairing(display: "system-ui, -apple-system, sans-serif",
+                    body: "system-ui, -apple-system, sans-serif",
+                    pairing: "modern-sans+modern-sans",
+                    score: { $0.time * 1.5 + (1 - $0.register) * 1 + $0.voice * 0.5 }),
+        FontPairing(display: #""Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif"#,
+                    body: #""Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif"#,
+                    pairing: "humanist-sans+humanist-sans",
+                    score: { $0.temperature * 1.5 + (1 - $0.register) * 1 + (1 - $0.voice) * 0.5 }),
+        FontPairing(display: #"Georgia, "Times New Roman", Times, serif"#,
+                    body: #""Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif"#,
+                    pairing: "classic-serif+humanist-sans",
+                    score: { (1 - $0.time) * 1.5 + $0.register * 1 + $0.temperature * 0.8 }),
+        FontPairing(display: "system-ui, -apple-system, sans-serif",
+                    body: #""Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif"#,
+                    pairing: "modern-sans+humanist-sans",
+                    score: { $0.time * 1 + $0.temperature * 0.8 + (1 - $0.register) * 0.8 }),
+    ]
+
+    public static func typography(for axes: DesignAxes) -> DesignTypography {
+        let best = fontPairings.max { $0.score(axes) < $1.score(axes) } ?? fontPairings[0]
+        return DesignTypography(display: best.display, body: best.body, pairing: best.pairing)
+    }
+
+    /// Airy (weight=0) -> generous spacing (1.2x). Dense (weight=1) -> tighter (0.8x).
+    public static func spacing(for axes: DesignAxes) -> DesignSpacing {
+        let m = 1.2 - axes.weight * 0.4
+        func fmt(_ v: Double) -> String { "\((v * 1000).rounded() / 1000)rem" }
+        return DesignSpacing(xs: fmt(0.25 * m), sm: fmt(0.5 * m), md: fmt(1 * m), lg: fmt(2 * m), xl: fmt(4 * m))
+    }
+
+    /// Playful (low register) + contemporary (high time) -> rounder. Bold (voice) -> stronger shadows.
+    public static func shape(for axes: DesignAxes) -> DesignShape {
+        let roundness = (1 - axes.register) * 0.6 + axes.time * 0.4
+        func fmt(_ v: Double) -> String { "\((v * 1000).rounded() / 1000)rem" }
+        let shadowAlpha = 0.06 + axes.voice * 0.08
+        let shadowSpread = 2 + axes.weight * 4
+        return DesignShape(
+            radiusSm: fmt(0.125 + roundness * 0.25),
+            radiusMd: fmt(0.25 + roundness * 0.5),
+            radiusLg: fmt(0.5 + roundness * 1.0),
+            shadowSm: "0 1px \(Int(shadowSpread.rounded()))px rgba(0, 0, 0, \(String(format: "%.2f", shadowAlpha)))",
+            shadowMd: "0 \(Int(shadowSpread.rounded()))px \(Int((shadowSpread * 3).rounded()))px rgba(0, 0, 0, \(String(format: "%.2f", shadowAlpha * 1.5)))"
+        )
+    }
+
+    public static func config(axes: DesignAxes, siteType: String, brandColor: String?) -> DesignConfig {
+        DesignConfig(
+            axes: axes,
+            palette: DesignPaletteGenerator.generate(axes: axes, brandColor: brandColor),
+            typography: typography(for: axes),
+            spacing: spacing(for: axes),
+            shape: shape(for: axes),
+            siteType: siteType,
+            brandColor: brandColor
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignConfigGeneratorTests`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignConfigGenerator.swift Tests/AnglesiteCoreTests/DesignConfigGeneratorTests.swift
+git commit -m "feat(core): port typography/spacing/shape generators + DesignConfig assembly"
+```
+
+---
+
+### Task 5: Map engine output onto the template's CSS vars + DESIGN.md rationale
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DesignTokenWriter.swift`
+- Test: `Tests/AnglesiteCoreTests/DesignTokenWriterTests.swift`
+
+**Interfaces:**
+- Consumes: `DesignConfig`/`DesignPalette`/`DesignTypography` (Task 4), `Theme` (existing `ThemeCatalog.swift`).
+- Produces: `enum DesignTokenWriter { static func templateCSSVars(for config: DesignConfig) -> [String: String]; static func templateCSSVars(for theme: Theme) -> [String: String]; static func rationaleMarkdown(for config: DesignConfig) -> String }`
+
+Per the Global Constraints, output var names are the template's existing 12: `color-primary`, `color-accent`, `color-background`, `color-surface`, `color-text`, `color-text-muted`, `font-heading`, `font-body`, `spacing-unit`, `radius-sm`, `radius-md`, `radius-lg`. The engine's `border`/`shadow-*`/per-step spacing scale have no template slot yet and are intentionally dropped here (out of scope — see design spec §5).
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/DesignTokenWriterTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DesignTokenWriterTests {
+    @Test func mapsConfigToExactlyTheTemplateTwelveVars() {
+        let config = DesignConfigGenerator.config(axes: DesignAxesCatalog.balanced, siteType: "bakery", brandColor: nil)
+        let vars = DesignTokenWriter.templateCSSVars(for: config)
+        #expect(Set(vars.keys) == Set([
+            "color-primary", "color-accent", "color-background", "color-surface",
+            "color-text", "color-text-muted", "font-heading", "font-body",
+            "spacing-unit", "radius-sm", "radius-md", "radius-lg",
+        ]))
+    }
+
+    @Test func configColorPrimaryComesFromPaletteBrand() {
+        let config = DesignConfigGenerator.config(axes: DesignAxesCatalog.balanced, siteType: "bakery", brandColor: "#ff0000")
+        let vars = DesignTokenWriter.templateCSSVars(for: config)
+        #expect(vars["color-primary"] == "#ff0000")
+    }
+
+    @Test func themeVarsPassThroughUnchanged() {
+        let theme = Theme(id: "warm", name: "Warm", blurb: "cozy", swatch: ["#111", "#222"],
+                          cssVars: ["color-primary": "#111", "font-heading": "Georgia"])
+        let vars = DesignTokenWriter.templateCSSVars(for: theme)
+        #expect(vars["color-primary"] == "#111")
+        #expect(vars["font-heading"] == "Georgia")
+    }
+
+    @Test func rationaleIncludesAllFiveAxesAndBothColors() {
+        let config = DesignConfigGenerator.config(axes: DesignAxesCatalog.balanced, siteType: "bakery", brandColor: nil)
+        let md = DesignTokenWriter.rationaleMarkdown(for: config)
+        for axisName in ["Temperature", "Weight", "Register", "Time", "Voice"] {
+            #expect(md.contains(axisName))
+        }
+        #expect(md.contains(config.palette.brand))
+        #expect(md.contains(config.palette.accent))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignTokenWriterTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/DesignTokenWriter.swift
+import Foundation
+
+public enum DesignTokenWriter {
+    /// Maps a generated ``DesignConfig`` onto the 12 CSS custom-property names
+    /// `Resources/Template/src/styles/global.css` already declares. Tokens the engine computes but
+    /// the template has no slot for (border, shadows, the xs/sm/lg/xl spacing steps) are dropped —
+    /// only `spacing.md` maps, to `--spacing-unit`.
+    public static func templateCSSVars(for config: DesignConfig) -> [String: String] {
+        [
+            "color-primary": config.palette.brand,
+            "color-accent": config.palette.accent,
+            "color-background": config.palette.bg,
+            "color-surface": config.palette.surface,
+            "color-text": config.palette.text,
+            "color-text-muted": config.palette.muted,
+            "font-heading": config.typography.display,
+            "font-body": config.typography.body,
+            "spacing-unit": config.spacing.md,
+            "radius-sm": config.shape.radiusSm,
+            "radius-md": config.shape.radiusMd,
+            "radius-lg": config.shape.radiusLg,
+        ]
+    }
+
+    /// A built-in ``Theme``'s `cssVars` already use the template's naming scheme (parsed from
+    /// `Resources/Template/scripts/themes.ts`) — pass through unchanged.
+    public static func templateCSSVars(for theme: Theme) -> [String: String] { theme.cssVars }
+
+    /// Human-readable `DESIGN.md` rationale, ported from `generateDesignRationale` in
+    /// `scripts/design.ts`.
+    public static func rationaleMarkdown(for config: DesignConfig) -> String {
+        let axes = config.axes
+        func describe(_ axis: String, _ value: Double, low: String, high: String) -> String {
+            if value <= 0.4 { return low }
+            if value >= 0.6 { return high }
+            return "between \(low) and \(high)"
+        }
+        let temperature = describe("temperature", axes.temperature, low: "cool", high: "warm")
+        let weight = describe("weight", axes.weight, low: "airy", high: "dense")
+        let register = describe("register", axes.register, low: "playful", high: "authoritative")
+        let time = describe("time", axes.time, low: "classic", high: "contemporary")
+        let voice = describe("voice", axes.voice, low: "subtle", high: "bold")
+        let moodWords = [temperature, weight, register, time, voice]
+            .reduce(into: [String]()) { if !$0.contains($1) { $0.append($1) } }
+
+        return """
+        # Your Design System
+
+        ## What we're going for
+
+        The feel is **\(moodWords.joined(separator: ", "))** — designed for a \(config.siteType.replacingOccurrences(of: "-", with: " ")).
+
+        ## Design axes
+
+        | Axis | Value | Reading |
+        |------|-------|---------|
+        | Temperature (cool <-> warm) | \(axes.temperature) | \(temperature) |
+        | Weight (airy <-> dense) | \(axes.weight) | \(weight) |
+        | Register (playful <-> authoritative) | \(axes.register) | \(register) |
+        | Time (classic <-> contemporary) | \(axes.time) | \(time) |
+        | Voice (subtle <-> bold) | \(axes.voice) | \(voice) |
+
+        ## Color
+
+        Your brand color is `\(config.palette.brand)`. The accent color `\(config.palette.accent)` provides contrast for calls to action. Text color `\(config.palette.text)` on background `\(config.palette.bg)` meets WCAG AA contrast requirements for readability.
+
+        ## Typography
+
+        Display font: `\(config.typography.display.split(separator: ",").first.map(String.init)?.replacingOccurrences(of: "\"", with: "") ?? config.typography.display)` — \(axes.register > 0.5 ? "conveys authority and expertise" : "feels approachable and friendly").
+
+        Body font: `\(config.typography.body.split(separator: ",").first.map(String.init)?.replacingOccurrences(of: "\"", with: "") ?? config.typography.body)` — optimized for comfortable reading at body text sizes.
+        """
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignTokenWriterTests`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignTokenWriter.swift Tests/AnglesiteCoreTests/DesignTokenWriterTests.swift
+git commit -m "feat(core): map design engine output onto the template's 12 CSS vars"
+```
+
+---
+
+### Task 6: DesignApplyService — the shared write path
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DesignApplyService.swift`
+- Test: `Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift`
+
+**Interfaces:**
+- Consumes: nothing new — takes a plain `[String: String]` of CSS vars plus text content, so it has no dependency on `DesignConfig`/`Theme` directly (keeps it reusable from Task 9's wizard and, later, `DesignInterviewModel`).
+- Produces:
+```swift
+public struct DesignApplyInput: Sendable {
+    public let cssVars: [String: String]      // property name (no leading --) -> value
+    public let rationaleMarkdown: String?      // written to docs/DESIGN.md when non-nil
+    public let brandSummary: String            // one paragraph, appended to docs/brand.md
+    public let sourceLabel: String             // e.g. "Built-in theme: Warm"
+    public init(cssVars: [String: String], rationaleMarkdown: String?, brandSummary: String, sourceLabel: String)
+}
+public struct AppliedDesign: Sendable, Equatable { public let updatedVars: [String: String]; public let writtenFiles: [String] }
+public enum DesignApplyError: Error, Sendable, Equatable { case missingGlobalCSS, missingRootBlock, writeFailed(String) }
+public enum DesignApplyService {
+    public static func apply(_ input: DesignApplyInput, to sourceDirectory: URL, fileManager: FileManager = .default) -> Result<AppliedDesign, DesignApplyError>
+}
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct DesignApplyServiceTests {
+    private func makeSite() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = dir.appendingPathComponent("src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        let css = """
+        :root {
+          --color-primary: #2563eb;
+          --color-accent: #f59e0b;
+          --font-heading: system-ui, -apple-system, sans-serif;
+        }
+
+        * { box-sizing: border-box; }
+        """
+        try css.write(to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+        return dir
+    }
+
+    @Test func updatesExistingVarsInRootBlock() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
+                                     brandSummary: "A test brand.", sourceLabel: "Test")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .success = result else { Issue.record("expected success"); return }
+        let css = try String(contentsOf: dir.appendingPathComponent("src/styles/global.css"), encoding: .utf8)
+        #expect(css.contains("--color-primary: #ff0000;"))
+        #expect(css.contains("--color-accent: #f59e0b;")) // untouched var preserved
+    }
+
+    @Test func addsNewVarsNotPreviouslyInRootBlock() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: ["color-surface": "#eeeeee"], rationaleMarkdown: nil,
+                                     brandSummary: "A test brand.", sourceLabel: "Test")
+        _ = DesignApplyService.apply(input, to: dir)
+        let css = try String(contentsOf: dir.appendingPathComponent("src/styles/global.css"), encoding: .utf8)
+        #expect(css.contains("--color-surface: #eeeeee;"))
+    }
+
+    @Test func preservesEverythingOutsideRootBlock() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
+                                     brandSummary: "A test brand.", sourceLabel: "Test")
+        _ = DesignApplyService.apply(input, to: dir)
+        let css = try String(contentsOf: dir.appendingPathComponent("src/styles/global.css"), encoding: .utf8)
+        #expect(css.contains("* { box-sizing: border-box; }"))
+    }
+
+    @Test func writesRationaleWhenProvided() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: [:], rationaleMarkdown: "# Design", brandSummary: "A test brand.", sourceLabel: "Test")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .success(let applied) = result else { Issue.record("expected success"); return }
+        #expect(applied.writtenFiles.contains("docs/DESIGN.md"))
+        let md = try String(contentsOf: dir.appendingPathComponent("docs/DESIGN.md"), encoding: .utf8)
+        #expect(md == "# Design")
+    }
+
+    @Test func skipsRationaleFileWhenNil() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: [:], rationaleMarkdown: nil, brandSummary: "A test brand.", sourceLabel: "Test")
+        guard case .success(let applied) = DesignApplyService.apply(input, to: dir) else { Issue.record("expected success"); return }
+        #expect(!applied.writtenFiles.contains("docs/DESIGN.md"))
+        #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent("docs/DESIGN.md").path))
+    }
+
+    @Test func appendsBrandSummaryToNewBrandMd() throws {
+        let dir = try makeSite()
+        let input = DesignApplyInput(cssVars: [:], rationaleMarkdown: nil, brandSummary: "A test brand.", sourceLabel: "Built-in theme: Warm")
+        _ = DesignApplyService.apply(input, to: dir)
+        let brand = try String(contentsOf: dir.appendingPathComponent("docs/brand.md"), encoding: .utf8)
+        #expect(brand.contains("Built-in theme: Warm"))
+        #expect(brand.contains("A test brand."))
+    }
+
+    @Test func failsWhenGlobalCSSMissing() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let input = DesignApplyInput(cssVars: ["color-primary": "#fff"], rationaleMarkdown: nil, brandSummary: "x", sourceLabel: "x")
+        let result = DesignApplyService.apply(input, to: dir)
+        guard case .failure(.missingGlobalCSS) = result else { Issue.record("expected .missingGlobalCSS"); return }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignApplyServiceTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/DesignApplyService.swift
+import Foundation
+
+public struct DesignApplyInput: Sendable {
+    public let cssVars: [String: String]
+    public let rationaleMarkdown: String?
+    public let brandSummary: String
+    public let sourceLabel: String
+
+    public init(cssVars: [String: String], rationaleMarkdown: String?, brandSummary: String, sourceLabel: String) {
+        self.cssVars = cssVars; self.rationaleMarkdown = rationaleMarkdown
+        self.brandSummary = brandSummary; self.sourceLabel = sourceLabel
+    }
+}
+
+public struct AppliedDesign: Sendable, Equatable {
+    public let updatedVars: [String: String]
+    public let writtenFiles: [String]
+}
+
+public enum DesignApplyError: Error, Sendable, Equatable {
+    case missingGlobalCSS
+    case missingRootBlock
+    case writeFailed(String)
+}
+
+/// The single writer for applying a design to a site's `Source/` directory — shared by the
+/// built-in/freedesignmd theme-apply wizard and (later) the design-interview conversation, so
+/// there is exactly one "write design to disk" implementation.
+public enum DesignApplyService {
+    static let globalCSSRelativePath = "src/styles/global.css"
+    static let rationaleRelativePath = "docs/DESIGN.md"
+    static let brandRelativePath = "docs/brand.md"
+
+    public static func apply(
+        _ input: DesignApplyInput,
+        to sourceDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> Result<AppliedDesign, DesignApplyError> {
+        let cssURL = sourceDirectory.appendingPathComponent(globalCSSRelativePath)
+        guard let original = try? String(contentsOf: cssURL, encoding: .utf8) else {
+            return .failure(.missingGlobalCSS)
+        }
+        guard let updatedCSS = upsertRootVars(input.cssVars, in: original) else {
+            return .failure(.missingRootBlock)
+        }
+
+        var written: [String] = []
+        do {
+            try updatedCSS.write(to: cssURL, atomically: true, encoding: .utf8)
+            written.append(globalCSSRelativePath)
+
+            if let rationaleMarkdown = input.rationaleMarkdown {
+                let rationaleURL = sourceDirectory.appendingPathComponent(rationaleRelativePath)
+                try fileManager.createDirectory(at: rationaleURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try rationaleMarkdown.write(to: rationaleURL, atomically: true, encoding: .utf8)
+                written.append(rationaleRelativePath)
+            }
+
+            let brandURL = sourceDirectory.appendingPathComponent(brandRelativePath)
+            try fileManager.createDirectory(at: brandURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let existingBrand = (try? String(contentsOf: brandURL, encoding: .utf8)) ?? ""
+            let entry = "\n## \(input.sourceLabel)\n\n\(input.brandSummary)\n"
+            try (existingBrand + entry).write(to: brandURL, atomically: true, encoding: .utf8)
+            written.append(brandRelativePath)
+        } catch {
+            return .failure(.writeFailed((error as NSError).localizedDescription))
+        }
+
+        return .success(AppliedDesign(updatedVars: input.cssVars, writtenFiles: written))
+    }
+
+    /// Replaces or appends `--<key>: <value>;` lines inside the first `:root { ... }` block,
+    /// leaving everything else in the file untouched. Returns `nil` if no `:root` block is found.
+    static func upsertRootVars(_ vars: [String: String], in css: String) -> String? {
+        guard let rootRange = css.range(of: ":root"),
+              let openBrace = css.range(of: "{", range: rootRange.upperBound..<css.endIndex),
+              let closeBrace = css.range(of: "}", range: openBrace.upperBound..<css.endIndex)
+        else { return nil }
+
+        var body = String(css[openBrace.upperBound..<closeBrace.lowerBound])
+        var remaining = vars
+
+        for key in vars.keys {
+            let pattern = #"(--\#(NSRegularExpression.escapedPattern(for: key))\s*:\s*)[^;]*;"#
+            guard let re = try? NSRegularExpression(pattern: pattern) else { continue }
+            let range = NSRange(body.startIndex..<body.endIndex, in: body)
+            if let match = re.firstMatch(in: body, range: range), let matchRange = Range(match.range, in: body) {
+                body.replaceSubrange(matchRange, with: "--\(key): \(vars[key]!);")
+                remaining.removeValue(forKey: key)
+            }
+        }
+
+        if !remaining.isEmpty {
+            let additions = remaining.sorted(by: { $0.key < $1.key })
+                .map { "  --\($0.key): \($0.value);" }.joined(separator: "\n")
+            if !body.hasSuffix("\n") { body += "\n" }
+            body += additions + "\n"
+        }
+
+        return String(css[css.startIndex..<openBrace.upperBound]) + body + String(css[closeBrace.lowerBound...])
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignApplyServiceTests`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignApplyService.swift Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+git commit -m "feat(core): add DesignApplyService, the shared design write path"
+```
+
+---
+
+### Task 7: `AnglesitePackage` convenience for DesignApplyService
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/DesignApplyService.swift`
+- Test: `Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift`
+
+**Interfaces:**
+- Consumes: `AnglesitePackage.sourceDirectory` (existing, from `AnglesiteSiteModel`, re-exported by `AnglesiteCore` per CLAUDE.md).
+- Produces: `extension DesignApplyService { static func apply(_ input: DesignApplyInput, to package: AnglesitePackage, fileManager: FileManager = .default) -> Result<AppliedDesign, DesignApplyError> }`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// Appended to Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+extension DesignApplyServiceTests {
+    @Test func packageOverloadDelegatesToSourceDirectory() throws {
+        let dir = try makeSite()
+        // AnglesitePackage(sourceDirectory:) is the existing test-friendly initializer used
+        // elsewhere in AnglesiteCoreTests (see AnglesiteSiteModelTests) — wraps a bare directory
+        // without requiring a full .anglesite package on disk.
+        let package = AnglesitePackage(sourceDirectory: dir)
+        let input = DesignApplyInput(cssVars: ["color-primary": "#ff0000"], rationaleMarkdown: nil,
+                                     brandSummary: "x", sourceLabel: "x")
+        let result = DesignApplyService.apply(input, to: package)
+        guard case .success = result else { Issue.record("expected success"); return }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignApplyServiceTests/packageOverloadDelegatesToSourceDirectory`
+Expected: FAIL (compile error — no such overload)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Appended to Sources/AnglesiteCore/DesignApplyService.swift
+public extension DesignApplyService {
+    static func apply(
+        _ input: DesignApplyInput,
+        to package: AnglesitePackage,
+        fileManager: FileManager = .default
+    ) -> Result<AppliedDesign, DesignApplyError> {
+        apply(input, to: package.sourceDirectory, fileManager: fileManager)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DesignApplyServiceTests`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DesignApplyService.swift Tests/AnglesiteCoreTests/DesignApplyServiceTests.swift
+git commit -m "feat(core): add AnglesitePackage overload for DesignApplyService.apply"
+```
+
+---
+
+### Task 8: freedesignmd catalog fetch + parse + deterministic pre-filter
+
+**Files:**
+- Create: `Sources/AnglesiteCore/FreedesignmdCatalog.swift`
+- Test: `Tests/AnglesiteCoreTests/FreedesignmdCatalogTests.swift`
+
+**Interfaces:**
+- Consumes: nothing from prior tasks.
+- Produces:
+```swift
+public struct FreedesignmdSystem: Sendable, Equatable, Identifiable { public let slug: String; public let name: String; public var id: String { slug } }
+public struct FreedesignmdSystemDetail: Sendable, Equatable { public let system: FreedesignmdSystem; public let description: String }
+public enum FreedesignmdCatalogError: Error, Sendable, Equatable { case fetchFailed(String), parseFailed }
+public enum FreedesignmdCatalog {
+    public static func parseSystemList(html: String) -> [FreedesignmdSystem]
+    public static func parseDescription(html: String) -> String?
+    public static func fetchSystemList(session: URLSession = .shared) async throws -> [FreedesignmdSystem]
+    public static func fetchDescription(slug: String, session: URLSession = .shared) async throws -> String?
+    public static func rank(_ systems: [FreedesignmdSystem], byKeywordsIn businessType: String) -> [FreedesignmdSystem]
+}
+```
+
+**Verified real structure** (fetched 2026-07-10 from `https://freedesignmd.com/systems`): the page embeds a JSON-LD `<script type="application/ld+json">` block containing `"@type":"ItemList"` with `itemListElement` entries shaped `{"@type":"ListItem","position":N,"url":"https://freedesignmd.com/system/<slug>","name":"<Display Name>"}`. Individual system pages (`https://freedesignmd.com/system/<slug>`) carry a standard `<meta name="description" content="...">` tag with a one-line description. Both are parsed with a tolerant regex, following the existing pattern in `ThemeCatalog.parse(themesTS:)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/FreedesignmdCatalogTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct FreedesignmdCatalogTests {
+    private let sampleListHTML = """
+    <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"BreadcrumbList"},{"@type":"CollectionPage","mainEntity":{"@type":"ItemList","numberOfItems":3,"itemListElement":[{"@type":"ListItem","position":1,"url":"https://freedesignmd.com/system/linear-orbit","name":"Linear Orbit"},{"@type":"ListItem","position":2,"url":"https://freedesignmd.com/system/devshell-mono","name":"Devshell Mono"},{"@type":"ListItem","position":3,"url":"https://freedesignmd.com/system/vinyl-noir","name":"Vinyl Noir"}]}}]}</script>
+    """
+
+    private let sampleDetailHTML = """
+    <meta name="description" content="Hairline-thin product workspace. Cool off-white surfaces, Inter Display with tight tracking."/>
+    """
+
+    @Test func parsesAllListItems() {
+        let systems = FreedesignmdCatalog.parseSystemList(html: sampleListHTML)
+        #expect(systems.count == 3)
+        #expect(systems[0] == FreedesignmdSystem(slug: "linear-orbit", name: "Linear Orbit"))
+        #expect(systems[2] == FreedesignmdSystem(slug: "vinyl-noir", name: "Vinyl Noir"))
+    }
+
+    @Test func parseSystemListReturnsEmptyForUnrecognizedHTML() {
+        #expect(FreedesignmdCatalog.parseSystemList(html: "<html><body>nothing here</body></html>").isEmpty)
+    }
+
+    @Test func parsesDescriptionMetaTag() {
+        let description = FreedesignmdCatalog.parseDescription(html: sampleDetailHTML)
+        #expect(description == "Hairline-thin product workspace. Cool off-white surfaces, Inter Display with tight tracking.")
+    }
+
+    @Test func parseDescriptionReturnsNilWhenAbsent() {
+        #expect(FreedesignmdCatalog.parseDescription(html: "<html></html>") == nil)
+    }
+
+    @Test func rankPrioritizesNameSubstringMatches() {
+        let systems = FreedesignmdCatalog.parseSystemList(html: sampleListHTML)
+        let ranked = FreedesignmdCatalog.rank(systems, byKeywordsIn: "mono developer tools")
+        #expect(ranked.first == FreedesignmdSystem(slug: "devshell-mono", name: "Devshell Mono"))
+    }
+
+    @Test func rankFallsBackToOriginalOrderWithNoMatches() {
+        let systems = FreedesignmdCatalog.parseSystemList(html: sampleListHTML)
+        let ranked = FreedesignmdCatalog.rank(systems, byKeywordsIn: "")
+        #expect(ranked == systems)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter FreedesignmdCatalogTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/FreedesignmdCatalog.swift
+import Foundation
+
+public struct FreedesignmdSystem: Sendable, Equatable, Identifiable {
+    public let slug: String
+    public let name: String
+    public var id: String { slug }
+    public init(slug: String, name: String) { self.slug = slug; self.name = name }
+}
+
+public struct FreedesignmdSystemDetail: Sendable, Equatable {
+    public let system: FreedesignmdSystem
+    public let description: String
+    public init(system: FreedesignmdSystem, description: String) { self.system = system; self.description = description }
+}
+
+public enum FreedesignmdCatalogError: Error, Sendable, Equatable {
+    case fetchFailed(String)
+    case parseFailed
+}
+
+/// Browses the freedesignmd.com catalog deterministically. The catalog page has no JSON API, but
+/// server-renders a JSON-LD `ItemList` with every system's slug/name — this parses that block
+/// directly rather than doing LLM-mediated page extraction (unlike the plugin's WebFetch-based
+/// `freedesignmd` skill), following `ThemeCatalog.parse(themesTS:)`'s tolerant-regex pattern.
+public enum FreedesignmdCatalog {
+    static let systemsURL = URL(string: "https://freedesignmd.com/systems")!
+    static func systemURL(slug: String) -> URL { URL(string: "https://freedesignmd.com/system/\(slug)")! }
+
+    private static let listItemPattern = #""url":"https://freedesignmd\.com/system/([a-z0-9-]+)","name":"([^"]+)""#
+    private static let descriptionPattern = #"name="description" content="([^"]*)""#
+
+    public static func parseSystemList(html: String) -> [FreedesignmdSystem] {
+        guard let re = try? NSRegularExpression(pattern: listItemPattern) else { return [] }
+        let ns = html as NSString
+        return re.matches(in: html, range: NSRange(location: 0, length: ns.length)).map {
+            FreedesignmdSystem(slug: ns.substring(with: $0.range(at: 1)), name: ns.substring(with: $0.range(at: 2)))
+        }
+    }
+
+    public static func parseDescription(html: String) -> String? {
+        guard let re = try? NSRegularExpression(pattern: descriptionPattern) else { return nil }
+        let ns = html as NSString
+        guard let match = re.firstMatch(in: html, range: NSRange(location: 0, length: ns.length)) else { return nil }
+        return ns.substring(with: match.range(at: 1))
+    }
+
+    public static func fetchSystemList(session: URLSession = .shared) async throws -> [FreedesignmdSystem] {
+        let (data, response) = try await session.data(from: systemsURL)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode,
+              let html = String(data: data, encoding: .utf8)
+        else { throw FreedesignmdCatalogError.fetchFailed("bad response from \(systemsURL)") }
+        let systems = parseSystemList(html: html)
+        guard !systems.isEmpty else { throw FreedesignmdCatalogError.parseFailed }
+        return systems
+    }
+
+    public static func fetchDescription(slug: String, session: URLSession = .shared) async throws -> String? {
+        let (data, response) = try await session.data(from: systemURL(slug: slug))
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode,
+              let html = String(data: data, encoding: .utf8)
+        else { throw FreedesignmdCatalogError.fetchFailed("bad response for \(slug)") }
+        return parseDescription(html: html)
+    }
+
+    /// Deterministic pre-filter: scores each system by how many whitespace-separated keywords from
+    /// `businessType` appear as a substring of its name (case-insensitive), descending. Ties keep
+    /// original catalog order (Swift's `sorted` is stable). Falls back to the original order when
+    /// `businessType` is empty or nothing matches.
+    public static func rank(_ systems: [FreedesignmdSystem], byKeywordsIn businessType: String) -> [FreedesignmdSystem] {
+        let keywords = businessType.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        guard !keywords.isEmpty else { return systems }
+        func score(_ system: FreedesignmdSystem) -> Int {
+            let name = system.name.lowercased()
+            return keywords.reduce(0) { $0 + (name.contains($1) ? 1 : 0) }
+        }
+        return systems.enumerated()
+            .sorted { a, b in
+                let (sa, sb) = (score(a.element), score(b.element))
+                return sa == sb ? a.offset < b.offset : sa > sb
+            }
+            .map(\.element)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter FreedesignmdCatalogTests`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/FreedesignmdCatalog.swift Tests/AnglesiteCoreTests/FreedesignmdCatalogTests.swift
+git commit -m "feat(core): add deterministic freedesignmd catalog fetch/parse/rank"
+```
+
+---
+
+### Task 9: ThemeApplyWizardModel
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ThemeApplyWizardModel.swift`
+- Test: `Tests/AnglesiteCoreTests/ThemeApplyWizardModelTests.swift`
+
+**Interfaces:**
+- Consumes: `ThemeCatalog`/`Theme` (existing), `FreedesignmdCatalog` (Task 8), `DesignApplyService`/`DesignApplyInput`/`AppliedDesign`/`DesignApplyError` (Tasks 6-7), `DesignTokenWriter.templateCSSVars(for:)` (Task 5).
+- Produces:
+```swift
+@MainActor @Observable
+public final class ThemeApplyWizardModel: Identifiable {
+    public enum Step: Int, CaseIterable { case pickSource, pickBuiltIn, browseFreedesignmd, review, applying }
+    public enum Source: Equatable { case builtIn, freedesignmd }
+    public let id = UUID()
+    public var step: Step = .pickSource
+    public var source: Source?
+    public var selectedBuiltInID: String?
+    public var freedesignmdCandidates: [FreedesignmdSystem] = []
+    public var selectedFreedesignmdSlug: String?
+    public var businessType: String
+    public internal(set) var applyResult: Result<AppliedDesign, DesignApplyError>?
+    public init(catalog: ThemeCatalog, businessType: String, package: AnglesitePackage)
+    public var canContinue: Bool { get }
+    public func advance() async
+    public func back()
+    public func apply() async
+}
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/ThemeApplyWizardModelTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct ThemeApplyWizardModelTests {
+    private func makeSite() throws -> AnglesitePackage {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let stylesDir = dir.appendingPathComponent("src/styles")
+        try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+        try ":root {\n  --color-primary: #000000;\n}\n".write(
+            to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+        return AnglesitePackage(sourceDirectory: dir)
+    }
+
+    private var testCatalog: ThemeCatalog {
+        ThemeCatalog(themes: [Theme(id: "warm", name: "Warm", blurb: "cozy", swatch: ["#a11", "#a22"],
+                                    cssVars: ["color-primary": "#a11111", "color-accent": "#a22222"])])
+    }
+
+    @Test @MainActor func picksBuiltInFlowAndApplies() async throws {
+        let package = try makeSite()
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery", package: package)
+        model.source = .builtIn
+        await model.advance() // pickSource -> pickBuiltIn
+        #expect(model.step == .pickBuiltIn)
+        model.selectedBuiltInID = "warm"
+        await model.advance() // pickBuiltIn -> review
+        #expect(model.step == .review)
+        #expect(model.canContinue)
+        await model.apply()
+        #expect(model.step == .applying)
+        guard case .success(let applied) = model.applyResult else { Issue.record("expected success"); return }
+        #expect(applied.updatedVars["color-primary"] == "#a11111")
+    }
+
+    @Test @MainActor func canContinueRequiresSourceChoiceFirst() {
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery",
+                                          package: AnglesitePackage(sourceDirectory: FileManager.default.temporaryDirectory))
+        #expect(model.canContinue == false)
+        model.source = .builtIn
+        #expect(model.canContinue)
+    }
+
+    @Test @MainActor func canContinueRequiresBuiltInSelection() async {
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery",
+                                          package: AnglesitePackage(sourceDirectory: FileManager.default.temporaryDirectory))
+        model.source = .builtIn
+        await model.advance()
+        #expect(model.canContinue == false)
+        model.selectedBuiltInID = "warm"
+        #expect(model.canContinue)
+    }
+
+    @Test @MainActor func backReturnsToPickSource() async {
+        let model = ThemeApplyWizardModel(catalog: testCatalog, businessType: "bakery",
+                                          package: AnglesitePackage(sourceDirectory: FileManager.default.temporaryDirectory))
+        model.source = .builtIn
+        await model.advance()
+        model.back()
+        #expect(model.step == .pickSource)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ThemeApplyWizardModelTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/ThemeApplyWizardModel.swift
+import Foundation
+import Observation
+
+@MainActor @Observable
+public final class ThemeApplyWizardModel: Identifiable {
+    public enum Step: Int, CaseIterable { case pickSource, pickBuiltIn, browseFreedesignmd, review, applying }
+    public enum Source: Equatable { case builtIn, freedesignmd }
+
+    public let id = UUID()
+    public var step: Step = .pickSource
+    public var source: Source?
+    public var selectedBuiltInID: String?
+    public var freedesignmdCandidates: [FreedesignmdSystem] = []
+    public var selectedFreedesignmdSlug: String?
+    public var businessType: String
+    public internal(set) var applyResult: Result<AppliedDesign, DesignApplyError>?
+    public internal(set) var fetchError: String?
+
+    private let catalog: ThemeCatalog
+    private let package: AnglesitePackage
+
+    public init(catalog: ThemeCatalog, businessType: String, package: AnglesitePackage) {
+        self.catalog = catalog
+        self.businessType = businessType
+        self.package = package
+    }
+
+    public var selectedBuiltInTheme: Theme? {
+        selectedBuiltInID.flatMap(catalog.theme(id:))
+    }
+
+    public var canContinue: Bool {
+        switch step {
+        case .pickSource: return source != nil
+        case .pickBuiltIn: return selectedBuiltInID != nil
+        case .browseFreedesignmd: return selectedFreedesignmdSlug != nil
+        case .review: return true
+        case .applying: return false
+        }
+    }
+
+    public func advance() async {
+        guard canContinue else { return }
+        switch step {
+        case .pickSource:
+            step = source == .builtIn ? .pickBuiltIn : .browseFreedesignmd
+            if source == .freedesignmd { await loadFreedesignmdCandidates() }
+        case .pickBuiltIn, .browseFreedesignmd:
+            step = .review
+        case .review, .applying:
+            break
+        }
+    }
+
+    public func back() {
+        switch step {
+        case .pickBuiltIn, .browseFreedesignmd: step = .pickSource
+        case .review: step = source == .builtIn ? .pickBuiltIn : .browseFreedesignmd
+        case .pickSource, .applying: break
+        }
+    }
+
+    private func loadFreedesignmdCandidates() async {
+        do {
+            let all = try await FreedesignmdCatalog.fetchSystemList()
+            freedesignmdCandidates = Array(FreedesignmdCatalog.rank(all, byKeywordsIn: businessType).prefix(10))
+        } catch {
+            fetchError = "Couldn't reach freedesignmd.com — \((error as NSError).localizedDescription)"
+        }
+    }
+
+    public func apply() async {
+        step = .applying
+        switch source {
+        case .builtIn:
+            guard let theme = selectedBuiltInTheme else { return }
+            let input = DesignApplyInput(
+                cssVars: DesignTokenWriter.templateCSSVars(for: theme),
+                rationaleMarkdown: nil,
+                brandSummary: theme.blurb,
+                sourceLabel: "Built-in theme: \(theme.name)"
+            )
+            applyResult = DesignApplyService.apply(input, to: package)
+        case .freedesignmd:
+            guard let slug = selectedFreedesignmdSlug else { return }
+            let description = (try? await FreedesignmdCatalog.fetchDescription(slug: slug)) ?? nil
+            let input = DesignApplyInput(
+                cssVars: [:], // token translation from a fetched DESIGN.md is out of scope here (see plan Task 8 note)
+                rationaleMarkdown: nil,
+                brandSummary: description ?? "Applied from freedesignmd.com/system/\(slug).",
+                sourceLabel: "freedesignmd: \(slug)"
+            )
+            applyResult = DesignApplyService.apply(input, to: package)
+        case nil:
+            return
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter ThemeApplyWizardModelTests`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ThemeApplyWizardModel.swift Tests/AnglesiteCoreTests/ThemeApplyWizardModelTests.swift
+git commit -m "feat(core): add ThemeApplyWizardModel driving built-in + freedesignmd flows"
+```
+
+**Note for the implementer:** freedesignmd's per-system CSS-token translation (mapping a fetched `DESIGN.md`'s described tokens onto the template's 12 vars) is deliberately stubbed to `[:]` here — the plugin skill does this translation via LLM judgment over unstructured markdown, which this plan doesn't attempt to replicate deterministically. Flag this gap to the user before merging: freedesignmd selection currently only writes `docs/brand.md` (the description/rationale), not new CSS vars. Closing that gap is follow-up work, tracked as a fast-follow to this plan rather than silently shipped as feature-complete.
+
+---
+
+### Task 10: ThemeApplyWizard SwiftUI sheet
+
+**Files:**
+- Create: `Sources/AnglesiteApp/ThemeApplyWizard.swift`
+
+**Interfaces:**
+- Consumes: `ThemeApplyWizardModel` (Task 9), `ThemeCatalog`/`Theme` (existing).
+- Produces: `struct ThemeApplyWizard: View { init(model: ThemeApplyWizardModel) }`
+
+This task has no isolated unit test — SwiftUI view bodies aren't unit-testable, and hosted UI tests can't run on CI (per Global Constraints / project memory). It's covered by the manual GUI smoke pass noted in the design spec. Mirror `IntegrationWizard.swift`'s structure (a `switch model.step` producing per-step content, Back/Continue buttons wired to `model.back()`/`model.advance()`, a final `.applying` step showing a progress spinner then the result).
+
+- [ ] **Step 1: Implement**
+
+```swift
+// Sources/AnglesiteApp/ThemeApplyWizard.swift
+import SwiftUI
+import AnglesiteCore
+
+struct ThemeApplyWizard: View {
+    @Bindable var model: ThemeApplyWizardModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Apply a Theme")
+                .font(.title2.bold())
+
+            Group {
+                switch model.step {
+                case .pickSource: pickSourceStep
+                case .pickBuiltIn: pickBuiltInStep
+                case .browseFreedesignmd: browseFreedesignmdStep
+                case .review: reviewStep
+                case .applying: applyingStep
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+            HStack {
+                if model.step != .pickSource, model.step != .applying {
+                    Button("Back") { model.back() }
+                }
+                Spacer()
+                if model.step == .review {
+                    Button("Apply") { Task { await model.apply() } }
+                        .buttonStyle(.borderedProminent)
+                } else if model.step != .applying {
+                    Button("Continue") { Task { await model.advance() } }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!model.canContinue)
+                }
+            }
+        }
+        .padding(20)
+        .frame(width: 480, height: 360)
+    }
+
+    private var pickSourceStep: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Picker("Source", selection: Binding(get: { model.source }, set: { model.source = $0 })) {
+                Text("Built-in themes").tag(ThemeApplyWizardModel.Source?.some(.builtIn))
+                Text("Browse freedesignmd.com").tag(ThemeApplyWizardModel.Source?.some(.freedesignmd))
+            }
+            .pickerStyle(.radioGroup)
+        }
+    }
+
+    private var pickBuiltInStep: some View {
+        List(model.selectedBuiltInID.map { _ in [] } ?? [], id: \.self) { (_: String) in EmptyView() }
+            .overlay { EmptyView() } // placeholder overlay removed below by real catalog binding
+    }
+
+    private var browseFreedesignmdStep: some View {
+        Group {
+            if let error = model.fetchError {
+                Text(error).foregroundStyle(.secondary)
+            } else if model.freedesignmdCandidates.isEmpty {
+                ProgressView("Searching freedesignmd.com…")
+            } else {
+                List(model.freedesignmdCandidates, selection: Binding(
+                    get: { model.selectedFreedesignmdSlug },
+                    set: { model.selectedFreedesignmdSlug = $0 }
+                )) { system in
+                    Text(system.name).tag(system.slug)
+                }
+            }
+        }
+    }
+
+    private var reviewStep: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            switch model.source {
+            case .builtIn:
+                if let theme = model.selectedBuiltInTheme {
+                    Text(theme.name).font(.headline)
+                    Text(theme.blurb).foregroundStyle(.secondary)
+                }
+            case .freedesignmd:
+                if let slug = model.selectedFreedesignmdSlug {
+                    Text(slug).font(.headline)
+                }
+            case nil: EmptyView()
+            }
+        }
+    }
+
+    private var applyingStep: some View {
+        VStack(spacing: 12) {
+            switch model.applyResult {
+            case .none:
+                ProgressView("Applying…")
+            case .success:
+                Label("Theme applied.", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                Button("Done") { dismiss() }
+            case .failure(let error):
+                Label("Couldn't apply that theme: \(String(describing: error))", systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+}
+```
+
+**Note for the implementer:** `pickBuiltInStep` above is intentionally left as a minimal placeholder pending a small follow-up: it needs a `ThemeCatalog` instance threaded into the view (not currently exposed by the model) to render the actual 9-theme picker grid. Before merging, either add a `catalog` property to `ThemeApplyWizardModel` (exposing `catalog.themes` read-only) or pass `ThemeCatalog` into `ThemeApplyWizard`'s initializer directly, then replace this step with a `LazyVGrid` of theme swatches bound to `model.selectedBuiltInID`, mirroring `IntegrationWizard.swift`'s picker step. Flag this to the user rather than silently shipping the placeholder.
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ThemeApplyWizard.swift
+git commit -m "feat(app): add ThemeApplyWizard SwiftUI sheet"
+```
+
+---
+
+### Task 11: SetupThemeTool (FM chat front door)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/SetupThemeTool.swift`
+- Test: `Tests/AnglesiteCoreTests/SetupThemeToolTests.swift`
+
+**Interfaces:**
+- Consumes: `ThemeCatalog` (existing), `DesignApplyService`/`DesignTokenWriter` (Tasks 5-7).
+- Produces: `enum SetupThemeArguments { static func reply(for result: Result<AppliedDesign, DesignApplyError>, themeName: String) -> String }`, and (gated `#if compiler(>=6.4)`) `struct SetupThemeTool: Tool, Sendable`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/SetupThemeToolTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct SetupThemeToolTests {
+    @Test func replyForSuccessNamesTheTheme() {
+        let applied = AppliedDesign(updatedVars: [:], writtenFiles: ["src/styles/global.css"])
+        let reply = SetupThemeArguments.reply(for: .success(applied), themeName: "Warm")
+        #expect(reply.contains("Warm"))
+    }
+
+    @Test func replyForFailureExplainsWhatWentWrong() {
+        let reply = SetupThemeArguments.reply(for: .failure(.missingGlobalCSS), themeName: "Warm")
+        #expect(!reply.isEmpty)
+        #expect(reply != SetupThemeArguments.reply(for: .success(AppliedDesign(updatedVars: [:], writtenFiles: [])), themeName: "Warm"))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SetupThemeToolTests`
+Expected: FAIL (compile error)
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/SetupThemeTool.swift
+import Foundation
+
+/// Pure, non-gated helpers so parse/reply logic is unit-testable on CI, mirroring
+/// `SetupIntegrationArguments`.
+public enum SetupThemeArguments {
+    public static func reply(for result: Result<AppliedDesign, DesignApplyError>, themeName: String) -> String {
+        switch result {
+        case .success:
+            return "Applied the \(themeName) theme."
+        case .failure(.missingGlobalCSS):
+            return "I couldn't find this site's stylesheet, so I couldn't apply \(themeName)."
+        case .failure(.missingRootBlock):
+            return "This site's stylesheet doesn't have the expected structure, so I couldn't apply \(themeName)."
+        case .failure(.writeFailed(let message)):
+            return "Applying \(themeName) failed: \(message)."
+        }
+    }
+}
+
+#if compiler(>=6.4)
+import FoundationModels
+
+public struct SetupThemeTool: Tool, Sendable {
+    public static let toolName = "setupTheme"
+    public let name = SetupThemeTool.toolName
+    public let description = "Apply one of the built-in visual themes to the current site."
+
+    @Generable
+    public struct Arguments {
+        @Guide(description: "The theme id to apply, e.g. 'warm', 'classic', 'bold'.")
+        public var themeID: String
+    }
+
+    private let catalog: ThemeCatalog
+    private let package: AnglesitePackage
+    public init(catalog: ThemeCatalog, package: AnglesitePackage) {
+        self.catalog = catalog; self.package = package
+    }
+
+    public func call(arguments: Arguments) async throws -> String {
+        guard let theme = catalog.theme(id: arguments.themeID) else {
+            let names = catalog.themes.map(\.name).joined(separator: ", ")
+            return "I don't recognize that theme. Available themes: \(names)."
+        }
+        let input = DesignApplyInput(
+            cssVars: DesignTokenWriter.templateCSSVars(for: theme),
+            rationaleMarkdown: nil,
+            brandSummary: theme.blurb,
+            sourceLabel: "Built-in theme: \(theme.name)"
+        )
+        let result = DesignApplyService.apply(input, to: package)
+        return SetupThemeArguments.reply(for: result, themeName: theme.name)
+    }
+}
+#endif
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SetupThemeToolTests`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SetupThemeTool.swift Tests/AnglesiteCoreTests/SetupThemeToolTests.swift
+git commit -m "feat(core): add SetupThemeTool FM chat front door for theme apply"
+```
+
+**Note for the implementer:** wire `SetupThemeTool` into `FoundationModelAssistant.conversationTools(for:includeSpotlight:)` (`Sources/AnglesiteCore/FoundationModelAssistant.swift:389`) the same way `SetupIntegrationTool` is wired, adding a `themeApplyService`-shaped dependency (or reuse a `ThemeCatalog`/`AnglesitePackage` pair) to `FoundationModelAssistant.init` and `attachedToolNames`. Not spelled out as its own task here because it's a small, mechanical addition to an existing file — but don't skip it, or the chat front door never actually attaches.
+
+---
+
+### Task 12: ApplyThemeIntent (Siri/Shortcuts front door)
+
+**Files:**
+- Create: `Sources/AnglesiteIntents/ThemeIntents.swift`
+
+**Interfaces:**
+- Consumes: `ThemeCatalog`, `DesignApplyService`/`DesignTokenWriter`, `SiteEntity` (existing, same as `IntegrationIntents.swift`).
+
+This task has no isolated unit test — `AppIntents` types aren't testable without the AppIntents runtime, matching `IntegrationIntents.swift`'s existing pattern (which relies on `confirmAndApplyForTesting()` seams tested at the `AnglesiteIntentsTests` target, not here). Follow that same seam pattern.
+
+- [ ] **Step 1: Implement**
+
+```swift
+// Sources/AnglesiteIntents/ThemeIntents.swift
+import AppIntents
+import AnglesiteCore
+import Foundation
+
+public struct ApplyThemeIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Apply Theme"
+    public static let description = IntentDescription("Apply a built-in visual theme to a site.")
+
+    @Parameter(title: "Site") public var site: SiteEntity
+    @Parameter(title: "Theme", description: "e.g. warm, classic, bold, elegant.") public var themeID: String
+    @Dependency private var catalog: ThemeCatalog
+
+    public init() {}
+
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Apply \(\.$themeID) theme to \(\.$site)")
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        guard let theme = catalog.theme(id: themeID) else {
+            let names = catalog.themes.map(\.name).joined(separator: ", ")
+            return .result(dialog: IntentDialog(stringLiteral: "I don't recognize that theme. Available: \(names)."))
+        }
+        try await requestConfirmation(dialog: "Apply the \(theme.name) theme to \(site.displayName)?")
+        let package = AnglesitePackage(sourceDirectory: site.sourceDirectory)
+        let input = DesignApplyInput(
+            cssVars: DesignTokenWriter.templateCSSVars(for: theme),
+            rationaleMarkdown: nil,
+            brandSummary: theme.blurb,
+            sourceLabel: "Built-in theme: \(theme.name)"
+        )
+        let result = DesignApplyService.apply(input, to: package)
+        return .result(dialog: IntentDialog(stringLiteral: SetupThemeArguments.reply(for: result, themeName: theme.name)))
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteIntents/ThemeIntents.swift
+git commit -m "feat(intents): add ApplyThemeIntent for Siri/Shortcuts theme apply"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** built-in wizard (Tasks 9-10), freedesignmd browse (Task 8, with the token-translation gap explicitly flagged rather than faked), GUI+Siri+chat front-door parity (Tasks 10-12), shared deterministic write path (Tasks 5-7), design-engine port from real plugin source (Tasks 1-5) — all covered. FM-assist re-ranking (design spec's optional step) is implemented as `FreedesignmdCatalog.rank` (deterministic keyword match); a true on-device FM re-rank on top of it is a small follow-up, not blocking this plan's independently-shippable deliverable (the deterministic wizard).
+- **Known gaps surfaced to the implementer, not hidden:** (1) freedesignmd CSS-token translation from a fetched `DESIGN.md` (Task 9 note), (2) `pickBuiltInStep`'s theme-grid wiring (Task 10 note), (3) `SetupThemeTool` wiring into `FoundationModelAssistant` (Task 11 note). Each is a small, well-scoped addition — flagged explicitly rather than silently shipped incomplete.
+- **Type consistency:** `DesignApplyInput`/`AppliedDesign`/`DesignApplyError` (Task 6) are used identically by `ThemeApplyWizardModel` (Task 9), `SetupThemeTool` (Task 11), and `ApplyThemeIntent` (Task 12) — one shared write path as the design spec required.

--- a/docs/superpowers/specs/2026-07-10-theme-design-interview-slice5-design.md
+++ b/docs/superpowers/specs/2026-07-10-theme-design-interview-slice5-design.md
@@ -1,0 +1,90 @@
+# Slice 5 (#464): Theme apply + design-interview on FM/PCC
+
+**Status:** Approved design, not yet implemented.
+**Epic:** Claude Code removal (#459), Slice 5 (P3).
+**Spec reference:** [`2026-06-20-claude-code-removal-roadmap-design.md`](2026-06-20-claude-code-removal-roadmap-design.md) §6 Slice 5, §5 Bucket 3 & Bucket 5, §8 PCC risk.
+
+## Scope
+
+This slice covers two related but architecturally distinct capabilities from the plugin's `themes`/`freedesignmd`/`design-interview` skills:
+
+1. **Theme apply** (Bucket 3 — deterministic): choosing and applying a built-in or freedesignmd theme to an existing site.
+2. **design-interview** (Bucket 5 — hybrid): a multi-turn conversation that derives a bespoke `DesignAxes`/palette, generative where the plugin skill used free-form LLM reasoning.
+
+Both converge on the same deterministic write path, so they're designed together even though their front doors and testability differ sharply.
+
+**Explicitly out of scope for this slice:**
+- `design-import` (scraping/inferring design from an external site) — separate skill, not touched here.
+- Favicon/manifest/`ai-images` regeneration, which the plugin's `design-interview` also performs — this slice covers axes/palette/tokens/`DESIGN.md`/`brand.md` only.
+- Retiring the plugin skills — that happens in Slice 7 (#466), once both Swift front doors are Claude-free.
+
+## Data model
+
+New types, ported from the plugin's `scripts/design.ts` (no Swift equivalents exist today):
+
+- `DesignAxes` — `Codable` struct of 0–1 sliders (formality, energy, density, etc.), mirroring the skill's axis vocabulary.
+- `DesignPalette` — colors/fonts derived from axes and/or freedesignmd tokens.
+- `DesignDraft` — `{ axes: DesignAxes, palette: DesignPalette, rationale: String?, sourceThemeID: String? }`. The convergence point for both flows.
+- `Theme` — already exists (`Sources/AnglesiteCore/ThemeCatalog.swift`), reused unchanged for the 9 built-in quick-picks.
+
+`DesignApplyService` (new, `AnglesiteCore`): `apply(_ draft: DesignDraft, to site: AnglesitePackage) -> Result<AppliedDesign, DesignApplyError>`. Ports `designToTokensCss()`, `createDesignConfig()`, the contrast check, and the `docs/brand.md` update from the skill. Pure and synchronous — no FoundationModels dependency, fully unit-testable, and shared by both flows below so there is exactly one "write design to disk" implementation.
+
+## Theme-apply wizard (Bucket 3)
+
+`ThemeApplyWizardModel` (`@MainActor @Observable`, `AnglesiteCore`), following the shape of the existing `IntegrationWizardModel` (PR #283):
+
+```swift
+enum Step {
+    case pickSource       // built-in quick-picks vs. freedesignmd catalog
+    case pickBuiltIn      // existing ThemeCatalog entries
+    case browseFreedesignmd
+    case fmAssist          // optional, only if FoundationModelAssistant reports .available
+    case review
+    case applying
+}
+```
+
+- **pickBuiltIn**: unchanged, reuses `ThemeCatalog`.
+- **browseFreedesignmd**: deterministic tag filter over the freedesignmd catalog (121 entries). The business-type → tag table is ported from the skill as static Swift data. The catalog JSON itself is fetched and cached; the *filter* over it is pure decision-tree logic, no LLM.
+- **fmAssist** (optional): if `FoundationModelAssistant` availability is `.available`, offer a free-text "describe your vibe" box that re-ranks the already tag-filtered shortlist via one on-device FM call. This is bounded ranking over a short list — always fits the on-device 4K context, never escalates to PCC.
+- **review**: shows the resolved `DesignDraft` (theme → axes/palette translation) before writing.
+- **applying**: calls `DesignApplyService.apply`.
+
+**Front-door parity**, mirroring the integration-wizard triad:
+- GUI: `ThemeApplyWizard.swift` (SwiftUI sheet, `AnglesiteApp`), mirrors `IntegrationWizard.swift`.
+- App Intent: `ApplyThemeIntent`.
+- Chat: `SetupThemeTool`, an FM `Tool` using the same confirm-then-apply pattern as `SetupIntegrationTool` (plan, present, re-invoke with `apply: true`).
+
+## design-interview conversation (Bucket 5)
+
+`DesignInterviewModel` (`@MainActor`, wraps a `FoundationModelAssistant` session):
+
+```swift
+enum ConversationStage { case intent, mood, brandAnchor, axisConfirmation, done }
+```
+
+- Each stage is a `converse()` turn against a stage-specific, deterministically-built grounding prompt (following the `SiteGraphExplainPrompt` pattern — prompts are built from typed data, not ad-hoc string concatenation).
+- The assistant replies with a structured (`@Generable`) type, not free text, which updates a live `DesignDraft`. A GUI slider/palette-preview panel observes the same `DesignDraft` and lets the user nudge sliders directly; a direct nudge re-seeds the next turn's grounding prompt.
+- **"design it for me" escape hatch**: skips straight to `axisConfirmation` using FM-inferred defaults from business-type plus any free text supplied.
+- `axisConfirmation` hands the finished `DesignDraft` to `DesignApplyService.apply` (the same call the wizard uses), plus one more on-device FM call to produce `generateDesignRationale()`'s prose — this is summarizing an already-bounded draft, not open brand generation, so it stays on-device.
+
+**Front-door parity**: chat-first — the FM tool *is* the primary interface. The GUI panel mirrors state live rather than being a separate flow. Siri gets a single `StartDesignInterviewIntent` that opens chat pre-seeded at the `intent` stage.
+
+### PCC escalation (real implementation, not the existing stub)
+
+`FoundationModelAssistant.FoundationModelTier.privateCloudCompute` currently just runs on-device with a log message — no real escalation exists anywhere in the codebase. This slice implements it for real:
+
+- `FoundationModelAssistant` gains an `escalate(reason:)` path.
+- Triggers: (a) the brand-anchor stage's cumulative context would exceed the on-device 4096-token ceiling, or (b) the user explicitly requests "better"/more creative results.
+- **Before the real implementation lands**, a validation spike confirms Apple's PCC round-trip is actually callable from both DevID and MAS builds (§8 risk in the roadmap spec). This spike is the first task in the implementation plan, not a deferred follow-up — if PCC isn't reachable, the escalation design needs to change before the rest of this slice is built on top of it.
+
+## Testing strategy
+
+- `DesignApplyService`, `DesignAxes`/`DesignPalette` transforms, freedesignmd tag-filter matching, and theme→axes translation: full Swift Testing unit coverage, no FM dependency, runs on CI.
+- `FoundationModelAssistant`'s prompt-builders and response-parsing: unit-testable via fake `LanguageModelSession` responses, following the existing `#if compiler(>=6.4)` gating pattern.
+- The live conversation loop, slider↔chat state mirroring, and actual FM/PCC calls: not testable on CI (hosted-app tests can't launch on CI's macOS-15 runners). Covered by manual GUI smoke pre-release, paired with the still-owed #491 smoke test in one manual pass.
+- PCC round-trip validation: the spike itself is the acceptance test for that piece.
+
+## Architecture rationale
+
+Two focused models (`ThemeApplyWizardModel`, `DesignInterviewModel`) funneling into one shared `DesignApplyService`, rather than a single unified state machine. This keeps the deterministic half (theme-apply) independently testable and simple, while the generative half (design-interview) isn't forced into a flat wizard `Step` enum it doesn't fit. The cost is two models instead of one, but they share the one piece that actually matters for correctness — the write path.


### PR DESCRIPTION
## Summary

Implements Slice 5 of the Claude Code removal epic (#459): moving `themes`/`freedesignmd`/`design-interview` off the Claude plugin onto deterministic Swift + on-device FoundationModels, per the design spec at `docs/superpowers/specs/2026-07-10-theme-design-interview-slice5-design.md`.

Two implementation plans, executed via subagent-driven development with a task review after every task (several went through a fix round) and a whole-branch review at the end of each plan:

**Plan 1 — Theme apply wizard** (`docs/superpowers/plans/2026-07-10-theme-apply-wizard-plan.md`)
- Deterministic design-token engine ported 1:1 from the plugin's real `design.ts`/`contrast.ts` (palette generation, typography pairing, spacing/shape, WCAG contrast)
- `DesignApplyService` — the single shared write path (global.css `:root` upsert + `docs/DESIGN.md`/`docs/brand.md`), with partial-write visibility on failure
- `FreedesignmdCatalog` — deterministic JSON-LD catalog parsing (verified against the live site; no LLM-mediated extraction)
- `ThemeApplyWizardModel` + three front doors: SwiftUI wizard sheet, FoundationModels chat tool (`SetupThemeTool`), Siri/Shortcuts intent (`ApplyThemeIntent`)
- Whole-branch review (2 rounds) caught the chat tool being wired internally but never attached to the real assistant factory — fixed, along with the freedesignmd flow hard-failing when it had no CSS to write

**Plan 2 — Design-interview conversation** (`docs/superpowers/plans/2026-07-10-design-interview-pcc-plan.md`)
- `DesignInterviewDraft`/`ConversationStage` state machine, deterministic grounding prompts (with a real length cap after review found none existed)
- A PCC (Private Cloud Compute) feasibility spike — found a real, public `PrivateCloudComputeLanguageModel` API exists in the macOS 27 SDK, but it's gated behind an unobtained Apple entitlement, so `FoundationModelTier`'s doc comment was corrected and Task 4 implements deterministic context-budget management instead of real PCC escalation for now
- `DesignInterviewModel` conversation driver, GUI mirror panel, and two front doors (chat tool, Siri intent)
- Whole-branch review found the feature ships fully tested but with **no reachable entry point** (GUI panel never instantiated, chat tool never attached, Siri intent doesn't navigate) — tracked as a required follow-up in #631 rather than built in this PR, since the gaps are honestly documented in-source rather than falsely claimed complete

## Notable things a reviewer should know

- `AnglesitePackage(sourceDirectory:)` was briefly added then fully reverted early in this branch (it broke the Source/Config separation invariant) — every construction site correctly uses the real `AnglesitePackage(url:)`.
- `DesignApplyError.writeFailed` changed from a single-`String` case to `.writeFailed(message:partiallyWritten:)` partway through — every call site uses the current form.
- Two implementer subagents stalled silently mid-session after finishing their work (stuck on a background test run); both were caught via fallback checks, verified, and committed on their behalf with a reconstructed report flagging the missing self-review for extra reviewer scrutiny.
- Design-interview's feature-reachability gap is real and intentional to leave for a follow-up (#631) — this PR ships a correct, tested foundation, not a user-reachable feature yet.

## Test plan

- [x] `swift test` — all new/changed suites pass (WCAGContrast, DesignAxes, DesignPaletteGenerator, DesignConfigGenerator, DesignTokenWriter, DesignApplyService, FreedesignmdCatalog, ThemeApplyWizardModel, DesignInterviewDraft, DesignInterviewPrompts, FoundationModelAssistantEscalation, DesignInterviewModel)
- [x] `xcodebuild -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED at every SwiftUI/AppIntents task and at both final whole-branch checkpoints
- [ ] Manual GUI smoke (theme-apply wizard sheet, design-interview panel) — not yet done, no CI-runnable UI tests exist for this project

🤖 Generated with [Claude Code](https://claude.com/claude-code)