### PR TITLE
fix(port): gate newly-landed Darwin-only imports (SwiftUI/NaturalLanguage/os)

### DIFF
--- a/Sources/AnglesiteCore/CSSColor.swift
+++ b/Sources/AnglesiteCore/CSSColor.swift
@@ -1,3 +1,6 @@
+// SwiftUI (and the AppKit/UIKit color types it bridges to) is a Darwin-only framework, so this
+// bridge — used only by the app target's Styles panel ColorPicker — compiles out elsewhere.
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// Best-effort CSS <color> <-> SwiftUI Color bridge for the Styles panel's ColorPicker.
@@ -42,3 +45,4 @@ public enum CSSColor {
         "border-top-color", "border-right-color", "border-bottom-color", "border-left-color",
     ]
 }
+#endif

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OSLog
 
 /// Which Apple model substrate a ``FoundationModelAssistant`` targets.
 ///
@@ -19,11 +18,14 @@ public enum FoundationModelTier: String, Sendable, Equatable, CaseIterable {
     case privateCloudCompute = "privateCloudCompute"
 }
 
-// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128).
-// See ContentAssistant.swift for the same pattern.
-#if compiler(>=6.4)
+// Gated to the Xcode-27 toolchain — FoundationModels is absent at runtime on CI (#128) — and to
+// canImport(FoundationModels) so a future Linux 6.4+ toolchain doesn't pull this in (the module,
+// and OSLog which this file's Logger also needs, are Darwin-only regardless of Swift version).
+// See ContentAssistant.swift for the same compiler(>=6.4) pattern.
+#if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 import CoreSpotlight
+import OSLog
 
 /// A ``ContentAssistant`` backed by Apple's on-device `FoundationModels`. Streams free-form text
 /// and produces ``Generable`` structured output via guided generation.

--- a/Sources/AnglesiteCore/NLContextualEmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/NLContextualEmbeddingProvider.swift
@@ -1,3 +1,6 @@
+// NaturalLanguage is a Darwin-only framework, so this provider compiles out elsewhere; the
+// EmbeddingProvider protocol itself stays portable (see EmbeddingProvider.swift).
+#if canImport(NaturalLanguage)
 import Foundation
 import NaturalLanguage
 import os
@@ -69,3 +72,4 @@ public struct NLContextualEmbeddingProvider: EmbeddingProvider {
         return recognizer.dominantLanguage
     }
 }
+#endif

--- a/Sources/AnglesiteCore/NLEmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/NLEmbeddingProvider.swift
@@ -1,3 +1,6 @@
+// NaturalLanguage is a Darwin-only framework, so this provider compiles out elsewhere; the
+// EmbeddingProvider protocol itself stays portable (see EmbeddingProvider.swift).
+#if canImport(NaturalLanguage)
 import Foundation
 import NaturalLanguage
 
@@ -30,3 +33,4 @@ public struct NLEmbeddingProvider: EmbeddingProvider {
         return floats.map { $0 / magnitude }
     }
 }
+#endif

--- a/Sources/AnglesiteCore/SearchKnowledgeTool.swift
+++ b/Sources/AnglesiteCore/SearchKnowledgeTool.swift
@@ -1,8 +1,8 @@
 import Foundation
-import os
 
 #if compiler(>=6.4)
 import FoundationModels
+import os
 
 /// FoundationModels tool for retrieving ranked excerpts from the current site's local knowledge
 /// index. Complements ``SearchContentTool``: content graph search finds known pages/posts by

--- a/Sources/AnglesiteCore/SuggestLinksTool.swift
+++ b/Sources/AnglesiteCore/SuggestLinksTool.swift
@@ -1,8 +1,8 @@
 import Foundation
-import os
 
 #if compiler(>=6.4)
 import FoundationModels
+import os
 
 /// Foundation Models tool that suggests internal pages to link to from a given page. Uses
 /// semantic similarity (``SemanticRanker.related``) filtered by existing links (``LinkGraph``).


### PR DESCRIPTION
Part of the #566 Linux-build cleanup — this is the "cluster 0" fix that had to land before any of the four originally-scoped clusters could even be checked, since it stalls the whole-module build.

## Changes

Since the last `ANGLESITE_PORT_WIP=1 swift build --target AnglesiteCore` verification, several files landed on `main` with unconditional Darwin-only framework imports that a whole-module Linux build fails on before reporting anything else:

- **CSSColor.swift** (#628, Component Editor Styles panel): `import SwiftUI` unconditional — gated `#if canImport(SwiftUI)`.
- **NLEmbeddingProvider.swift** / **NLContextualEmbeddingProvider.swift** (#312, i18n embeddings): `import NaturalLanguage` unconditional — gated `#if canImport(NaturalLanguage)`.
- **FoundationModelAssistant.swift**: `import OSLog` sat outside the file's `#if compiler(>=6.4)` gate even though its only use (`Logger`) is inside it. Moved inside, and the gate now also requires `canImport(FoundationModels)` (matching the established pattern elsewhere in the file, per the AssistantBackend seam) so a future Linux 6.4+ toolchain doesn't pull it in either.
- **SearchKnowledgeTool.swift** / **SuggestLinksTool.swift**: same `import os` outside its FoundationModels gate, same fix.

## Verification

`ANGLESITE_PORT_WIP=1 swift build --target AnglesiteCore` on the Linux dev box: these were the only errors blocking the build from reaching the four originally-tracked clusters (security-scoped bookmarks, NSFileCoordinator/UndoManager, HTTP/CFType, VsockTCPProxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)