### PR TITLE
feat(port): AnglesiteBridgeCore split — webview-agnostic message schema

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,9 +75,19 @@ var packageTargets: [Target] = [
         path: "Sources/AnglesiteCore",
         swiftSettings: strictConcurrency + disableFoundationModelsAutolink
     ),
+    // Webview-agnostic message schema + overlay-bundle lookup (cross-platform port design §6
+    // "AnglesiteBridgeCore split") — no WebKit import, so it's portable off-Darwin. Each
+    // platform's webview adapter (AnglesiteBridge/WKWebView today; WebKitGTK/WebView2 later)
+    // wraps this in its own script-injection/message-handler API.
+    .target(
+        name: "AnglesiteBridgeCore",
+        dependencies: ["AnglesiteCore"],
+        path: "Sources/AnglesiteBridgeCore",
+        swiftSettings: strictConcurrency
+    ),
     .target(
         name: "AnglesiteBridge",
-        dependencies: ["AnglesiteCore"],
+        dependencies: ["AnglesiteCore", "AnglesiteBridgeCore"],
         path: "Sources/AnglesiteBridge",
         swiftSettings: strictConcurrency
     ),
@@ -120,6 +130,12 @@ var packageTargets: [Target] = [
         path: "Tests/AnglesiteCoreTests",
         swiftSettings: strictConcurrency,
         linkerSettings: weakLinkFoundationModels
+    ),
+    .testTarget(
+        name: "AnglesiteBridgeCoreTests",
+        dependencies: ["AnglesiteBridgeCore", "AnglesiteCore"],
+        path: "Tests/AnglesiteBridgeCoreTests",
+        swiftSettings: strictConcurrency
     ),
     .testTarget(
         name: "AnglesiteBridgeTests",
@@ -234,6 +250,7 @@ var packageProducts: [Product] = [
     .library(name: "AnglesiteSiteModel", targets: ["AnglesiteSiteModel"]),
     .library(name: "AnglesiteQuickLookSupport", targets: ["AnglesiteQuickLookSupport"]),
     .library(name: "AnglesiteCore", targets: ["AnglesiteCore"]),
+    .library(name: "AnglesiteBridgeCore", targets: ["AnglesiteBridgeCore"]),
     .library(name: "AnglesiteBridge", targets: ["AnglesiteBridge"]),
     .library(name: "AnglesiteIOS", targets: ["AnglesiteIOS"]),
     .library(name: "AnglesiteIntents", targets: ["AnglesiteIntents"])
@@ -261,6 +278,10 @@ if includeContainer {
 // URLSession.bytes(for:), CFGetTypeID, security-scoped bookmarks, vsock proxies, …) all grew
 // Platform/ seams or #if canImport gates (#566) — ANGLESITE_PORT_WIP no longer needs to opt it
 // back in. AnglesiteCoreTests is not yet in this set: its test files aren't purity-swept.
+// AnglesiteBridgeCore joined at phase 2 (#567): it's the webview-agnostic message-schema half
+// of the former AnglesiteBridge (no WebKit import), split out so the message dispatch logic —
+// and its tests — run on every platform; AnglesiteBridge itself (the WKWebView adapter) stays
+// Darwin-only.
 // Filtering by name here (rather than duplicating target definitions in per-platform
 // lists) keeps the single source of truth above.
 #if !canImport(Darwin)
@@ -268,6 +289,7 @@ let portableTargets: Set<String> = [
     "AnglesiteSiteModel", "AnglesiteSiteModelTests",
     "AnglesiteQuickLookSupport", "AnglesiteQuickLookSupportTests",
     "AnglesiteCore",
+    "AnglesiteBridgeCore", "AnglesiteBridgeCoreTests",
 ]
 packageTargets.removeAll { !portableTargets.contains($0.name) }
 // Every library product above is named after its single target, so the same name set

--- a/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
+++ b/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
@@ -1,36 +1,30 @@
 import Foundation
 import WebKit
 import AnglesiteCore
+import AnglesiteBridgeCore
 
-/// `WKScriptMessageHandler` for the `anglesite` namespace. Four message types ride this bridge:
-///
-/// 1. `anglesite:apply-edit` (an `EditMessage`) — routed through the injected `EditRouter`,
-///    reply delivered back to the WKWebView via `window.anglesite?._handleReply?.(<reply>)`.
-/// 2. `anglesite:visible-elements` (a `VisibleElementReport`, #145/B.1) — dispatched to the
-///    optional `onVisibleElements` callback. No reply; the JS side doesn't await one.
-/// 3. `anglesite:canvas-selection` (a `CanvasSelectionMessage`) — dispatched to the optional
-///    `onCanvasSelection` callback. Posted by the component-harness canvas overlay
-///    (`JS/edit-overlay/src/component-canvas.ts`) on click. No reply.
-/// 4. `anglesite:computed-styles` (a `ComputedStylesReport`) — dispatched to the optional
-///    `onComputedStyles` callback, posted alongside a canvas selection. No reply.
-///
-/// The interesting logic lives in `dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)`
-/// — it's unit-tested independent of `WKScriptMessage`, which has no public initializer and is
-/// awkward to fake.
+/// `WKScriptMessageHandler` adapter for the `anglesite` namespace — the WKWebView-specific thin
+/// layer over ``AnglesiteMessageDispatcher`` (cross-platform port design §6 "AnglesiteBridgeCore
+/// split"). All the message schema, decoding, and routing logic lives in the portable core; this
+/// class's own job is exactly two things `WKScriptMessage` requires: unwrap `message.body`/
+/// `.webView`, and evaluate the reply script back into the page.
 ///
 /// **API change vs prior versions:** the primary entry point is now
-/// `dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)`. All current
-/// callers are internal to this repo (the `WKScriptMessageHandler` impl below, the unit tests,
-/// and `PreviewView`'s production init) and use `dispatch` directly. The old `handle(body:via:)`
+/// `dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)` (forwarding to
+/// ``AnglesiteMessageDispatcher/dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)``).
+/// All current callers are internal to this repo (the `WKScriptMessageHandler` impl below, the
+/// unit tests — now in `AnglesiteBridgeCoreTests`, testing `AnglesiteMessageDispatcher` directly
+/// — and `PreviewView`'s production init) and use `dispatch` directly. The old `handle(body:via:)`
 /// signature is kept as a `@available(*, deprecated)` shim below — apply-edit only, matching its
 /// prior behavior — so a downstream framework consumer hitting this gets a fix-it instead of a
 /// cryptic missing-member error. The migration is mechanical: rename `handle` → `dispatch`, pass
 /// `nil` for the optional handlers to preserve the apply-edit-only behavior, and match on the
 /// richer `DispatchResult` enum instead of `Result<EditReply, EditMessage.DecodeError>`.
 public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
-    public typealias VisibleElementsHandler = @Sendable ([VisibleElement]) async -> Void
-    public typealias CanvasSelectionHandler = @Sendable (CanvasSelectionMessage) async -> Void
-    public typealias ComputedStylesHandler = @Sendable (ComputedStylesReport) async -> Void
+    public typealias VisibleElementsHandler = AnglesiteMessageDispatcher.VisibleElementsHandler
+    public typealias CanvasSelectionHandler = AnglesiteMessageDispatcher.CanvasSelectionHandler
+    public typealias ComputedStylesHandler = AnglesiteMessageDispatcher.ComputedStylesHandler
+    public typealias DispatchResult = AnglesiteMessageDispatcher.DispatchResult
 
     private let router: EditRouter
     private let onVisibleElements: VisibleElementsHandler?
@@ -53,41 +47,9 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         super.init()
     }
 
-    /// Outcome of dispatching one incoming message body. The script handler's
-    /// `userContentController` reads this to decide whether to emit a reply or log a rejection.
-    public enum DispatchResult: Sendable {
-        /// `anglesite:apply-edit` succeeded; emit the reply back to the WKWebView.
-        case editReply(EditReply)
-        /// `anglesite:visible-elements` was forwarded to the optional handler.
-        case visibleElementsHandled
-        /// `anglesite:visible-elements` arrived but no `onVisibleElements` handler is installed.
-        /// Useful for tests; in production the wiring is checked at handler-init time.
-        case visibleElementsDropped
-        /// `anglesite:canvas-selection` was forwarded to the optional handler.
-        case canvasSelectionHandled
-        /// `anglesite:canvas-selection` arrived but no `onCanvasSelection` handler is installed.
-        case canvasSelectionDropped
-        /// `anglesite:computed-styles` was forwarded to the optional handler.
-        case computedStylesHandled
-        /// `anglesite:computed-styles` arrived but no `onComputedStyles` handler is installed.
-        case computedStylesDropped
-        /// Body was undecodable. Log and move on.
-        case rejected(RejectionReason)
-
-        public enum RejectionReason: Sendable, Equatable {
-            case notAnObject
-            case missingType
-            case wrongType
-            case unknownType(String)
-            case editDecode(EditMessage.DecodeError)
-            case visibleElementsDecode(VisibleElementReport.DecodeError)
-            case canvasSelectionDecode(ComponentCanvasDecodeError)
-            case computedStylesDecode(ComponentCanvasDecodeError)
-        }
-    }
-
-    /// Peek at the `type` field, dispatch to the matching decoder, and route. Pure — no I/O
-    /// beyond the router call and the visible-elements handler call.
+    /// Forwards to ``AnglesiteMessageDispatcher/dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)``
+    /// — kept here so existing call sites (this class's own `userContentController`, and any
+    /// code written against the pre-split API) don't need to change.
     public static func dispatch(
         body: Any,
         via router: EditRouter,
@@ -95,53 +57,13 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         onCanvasSelection: CanvasSelectionHandler? = nil,
         onComputedStyles: ComputedStylesHandler? = nil
     ) async -> DispatchResult {
-        guard let dict = body as? [String: Any] else { return .rejected(.notAnObject) }
-        guard let rawType = dict["type"] else { return .rejected(.missingType) }
-        guard let typeStr = rawType as? String else { return .rejected(.wrongType) }
-
-        switch typeStr {
-        case EditMessage.MessageType.applyEdit.rawValue:
-            switch EditMessage.decode(from: body) {
-            case .success(let message):
-                let reply = await router.apply(message)
-                return .editReply(reply)
-            case .failure(let error):
-                return .rejected(.editDecode(error))
-            }
-
-        case VisibleElementReport.messageType:
-            switch VisibleElementReport.decode(from: body) {
-            case .success(let report):
-                guard let handler = onVisibleElements else { return .visibleElementsDropped }
-                await handler(report.elements)
-                return .visibleElementsHandled
-            case .failure(let error):
-                return .rejected(.visibleElementsDecode(error))
-            }
-
-        case CanvasSelectionMessage.messageType:
-            switch CanvasSelectionMessage.decode(from: body) {
-            case .success(let message):
-                guard let handler = onCanvasSelection else { return .canvasSelectionDropped }
-                await handler(message)
-                return .canvasSelectionHandled
-            case .failure(let error):
-                return .rejected(.canvasSelectionDecode(error))
-            }
-
-        case ComputedStylesReport.messageType:
-            switch ComputedStylesReport.decode(from: body) {
-            case .success(let report):
-                guard let handler = onComputedStyles else { return .computedStylesDropped }
-                await handler(report)
-                return .computedStylesHandled
-            case .failure(let error):
-                return .rejected(.computedStylesDecode(error))
-            }
-
-        default:
-            return .rejected(.unknownType(typeStr))
-        }
+        await AnglesiteMessageDispatcher.dispatch(
+            body: body,
+            via: router,
+            onVisibleElements: onVisibleElements,
+            onCanvasSelection: onCanvasSelection,
+            onComputedStyles: onComputedStyles
+        )
     }
 
     /// Deprecated forwarder for the old `handle(body:via:)` signature so out-of-tree adopters

--- a/Sources/AnglesiteBridge/WebViewBridge.swift
+++ b/Sources/AnglesiteBridge/WebViewBridge.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WebKit
 import AnglesiteCore
+import AnglesiteBridgeCore
 
 /// Bridges the WKWebView preview to the native edit pipeline.
 ///
@@ -8,7 +9,9 @@ import AnglesiteCore
 /// Step 2 (#16) registers the `anglesite` `WKScriptMessageHandler` on this same configuration to
 /// receive edit messages from the injected JS overlay.
 public enum WebViewBridge {
-    public static let scriptMessageNamespace = "anglesite"
+    /// The script-message namespace, shared with every platform adapter — see
+    /// ``AnglesiteMessageDispatcher/scriptMessageNamespace``.
+    public static let scriptMessageNamespace = AnglesiteMessageDispatcher.scriptMessageNamespace
 
     /// A `WKWebViewConfiguration` tuned for previewing a local Astro dev server. In Debug builds it
     /// uses a non-persistent data store so nothing is cached between launches (the dev server moves
@@ -42,12 +45,12 @@ public enum WebViewBridge {
 
     /// Loads the bundled edit overlay (built by `scripts/build-overlay.sh`) as a `WKUserScript`,
     /// or returns `nil` when the bundle hasn't been produced (e.g. `swift test`, or a build where
-    /// the prebuild script was skipped).
+    /// the prebuild script was skipped). The lookup + read is shared with every platform adapter
+    /// via ``AnglesiteOverlayBundle``; only the `WKUserScript` wrapping is WKWebView-specific.
     @MainActor
     public static func makeOverlayUserScript(in bundle: Bundle = .main) -> WKUserScript? {
-        guard let url = bundle.url(forResource: "overlay", withExtension: "js", subdirectory: "edit-overlay")
-        else { return nil }
-        return makeOverlayUserScript(from: url)
+        guard let source = AnglesiteOverlayBundle.source(in: bundle) else { return nil }
+        return WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
     }
 
     /// Reads `url` and wraps it as a `WKUserScript` at `atDocumentEnd`. Returns `nil` on read

--- a/Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift
+++ b/Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift
@@ -1,0 +1,123 @@
+import Foundation
+import AnglesiteCore
+
+/// Webview-agnostic message schema + routing for the `anglesite` script-message namespace
+/// (cross-platform port design, docs/superpowers/specs/2026-07-08-cross-platform-swift-port-
+/// design.md §6 "AnglesiteBridgeCore split"). Each platform's webview adapter (`WKWebView`
+/// today; WebKitGTK/WebView2 later) forwards the raw decoded message body here and gets back a
+/// `DispatchResult` describing what to do next — the adapter's only remaining job is shuttling
+/// bytes in and out of its native webview API.
+///
+/// Four message types ride this bridge:
+///
+/// 1. `anglesite:apply-edit` (an `EditMessage`) — routed through the injected `EditRouter`; the
+///    adapter delivers the reply back to the page (e.g. `window.anglesite?._handleReply?.(...)`
+///    on WKWebView).
+/// 2. `anglesite:visible-elements` (a `VisibleElementReport`, #145/B.1) — dispatched to the
+///    optional `onVisibleElements` callback. No reply; the JS side doesn't await one.
+/// 3. `anglesite:canvas-selection` (a `CanvasSelectionMessage`) — dispatched to the optional
+///    `onCanvasSelection` callback. Posted by the component-harness canvas overlay
+///    (`JS/edit-overlay/src/component-canvas.ts`) on click. No reply.
+/// 4. `anglesite:computed-styles` (a `ComputedStylesReport`) — dispatched to the optional
+///    `onComputedStyles` callback, posted alongside a canvas selection. No reply.
+public enum AnglesiteMessageDispatcher {
+    public typealias VisibleElementsHandler = @Sendable ([VisibleElement]) async -> Void
+    public typealias CanvasSelectionHandler = @Sendable (CanvasSelectionMessage) async -> Void
+    public typealias ComputedStylesHandler = @Sendable (ComputedStylesReport) async -> Void
+
+    /// The `WKUserContentController`/`WebKitUserContentManager`/WebView2 script-message name
+    /// every platform adapter registers its handler under — the JS overlay posts messages here
+    /// regardless of which native webview it's running in.
+    public static let scriptMessageNamespace = "anglesite"
+
+    /// Outcome of dispatching one incoming message body. The platform adapter reads this to
+    /// decide whether to emit a reply or log a rejection.
+    public enum DispatchResult: Sendable {
+        /// `anglesite:apply-edit` succeeded; the adapter should emit the reply back to the page.
+        case editReply(EditReply)
+        /// `anglesite:visible-elements` was forwarded to the optional handler.
+        case visibleElementsHandled
+        /// `anglesite:visible-elements` arrived but no `onVisibleElements` handler is installed.
+        /// Useful for tests; in production the wiring is checked at handler-init time.
+        case visibleElementsDropped
+        /// `anglesite:canvas-selection` was forwarded to the optional handler.
+        case canvasSelectionHandled
+        /// `anglesite:canvas-selection` arrived but no `onCanvasSelection` handler is installed.
+        case canvasSelectionDropped
+        /// `anglesite:computed-styles` was forwarded to the optional handler.
+        case computedStylesHandled
+        /// `anglesite:computed-styles` arrived but no `onComputedStyles` handler is installed.
+        case computedStylesDropped
+        /// Body was undecodable. Log and move on.
+        case rejected(RejectionReason)
+
+        public enum RejectionReason: Sendable, Equatable {
+            case notAnObject
+            case missingType
+            case wrongType
+            case unknownType(String)
+            case editDecode(EditMessage.DecodeError)
+            case visibleElementsDecode(VisibleElementReport.DecodeError)
+            case canvasSelectionDecode(ComponentCanvasDecodeError)
+            case computedStylesDecode(ComponentCanvasDecodeError)
+        }
+    }
+
+    /// Peek at the `type` field, dispatch to the matching decoder, and route. Pure — no I/O
+    /// beyond the router call and the optional handler calls.
+    public static func dispatch(
+        body: Any,
+        via router: EditRouter,
+        onVisibleElements: VisibleElementsHandler? = nil,
+        onCanvasSelection: CanvasSelectionHandler? = nil,
+        onComputedStyles: ComputedStylesHandler? = nil
+    ) async -> DispatchResult {
+        guard let dict = body as? [String: Any] else { return .rejected(.notAnObject) }
+        guard let rawType = dict["type"] else { return .rejected(.missingType) }
+        guard let typeStr = rawType as? String else { return .rejected(.wrongType) }
+
+        switch typeStr {
+        case EditMessage.MessageType.applyEdit.rawValue:
+            switch EditMessage.decode(from: body) {
+            case .success(let message):
+                let reply = await router.apply(message)
+                return .editReply(reply)
+            case .failure(let error):
+                return .rejected(.editDecode(error))
+            }
+
+        case VisibleElementReport.messageType:
+            switch VisibleElementReport.decode(from: body) {
+            case .success(let report):
+                guard let handler = onVisibleElements else { return .visibleElementsDropped }
+                await handler(report.elements)
+                return .visibleElementsHandled
+            case .failure(let error):
+                return .rejected(.visibleElementsDecode(error))
+            }
+
+        case CanvasSelectionMessage.messageType:
+            switch CanvasSelectionMessage.decode(from: body) {
+            case .success(let message):
+                guard let handler = onCanvasSelection else { return .canvasSelectionDropped }
+                await handler(message)
+                return .canvasSelectionHandled
+            case .failure(let error):
+                return .rejected(.canvasSelectionDecode(error))
+            }
+
+        case ComputedStylesReport.messageType:
+            switch ComputedStylesReport.decode(from: body) {
+            case .success(let report):
+                guard let handler = onComputedStyles else { return .computedStylesDropped }
+                await handler(report)
+                return .computedStylesHandled
+            case .failure(let error):
+                return .rejected(.computedStylesDecode(error))
+            }
+
+        default:
+            return .rejected(.unknownType(typeStr))
+        }
+    }
+}

--- a/Sources/AnglesiteBridgeCore/AnglesiteOverlayBundle.swift
+++ b/Sources/AnglesiteBridgeCore/AnglesiteOverlayBundle.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Locates the compiled edit-overlay JS (built by `scripts/build-overlay.sh`) inside an app
+/// bundle. Portable — every platform adapter (`WKUserScript` on WKWebView, the WebKitGTK/
+/// WebView2 equivalents later) wraps this same source string in its own native script-injection
+/// type; only the lookup + read is shared here.
+public enum AnglesiteOverlayBundle {
+    /// Reads the bundled overlay source, or `nil` when the bundle hasn't been produced (e.g.
+    /// `swift test`, or a build where the prebuild script was skipped) — non-fatal, callers
+    /// should just skip script injection.
+    public static func source(in bundle: Bundle = .main) -> String? {
+        guard let url = bundle.url(forResource: "overlay", withExtension: "js", subdirectory: "edit-overlay")
+        else { return nil }
+        return try? String(contentsOf: url, encoding: .utf8)
+    }
+}

--- a/Tests/AnglesiteBridgeCoreTests/AnglesiteMessageDispatcherTests.swift
+++ b/Tests/AnglesiteBridgeCoreTests/AnglesiteMessageDispatcherTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Testing
+@testable import AnglesiteBridgeCore
+import AnglesiteCore
+
+struct AnglesiteMessageDispatcherTests {
+    private func validEditBody() -> [String: Any] {
+        [
+            "id": "e-99",
+            "type": "anglesite:apply-edit",
+            "path": "/contact/",
+            "selector": [
+                "tag": "H1",
+                "classes": [] as [String],
+                "nthChild": 1,
+            ] as [String: Any],
+            "op": "replace-text",
+            "value": "New heading",
+        ]
+    }
+
+    private func validVisibleElementsBody() -> [String: Any] {
+        [
+            "type": "anglesite:visible-elements",
+            "elements": [
+                [
+                    "id": "v-1",
+                    "tag": "H1",
+                    "selector": [
+                        "tag": "H1",
+                        "classes": [] as [String],
+                        "nthChild": 1,
+                    ] as [String: Any],
+                    "rect": ["x": 0, "y": 0, "width": 100, "height": 40] as [String: Any],
+                    "text": "Heading",
+                ] as [String: Any]
+            ] as [Any],
+        ]
+    }
+
+    @Test("Dispatch routes apply-edit and returns reply") func dispatchRoutesApplyEdit() async {
+        let router = RecordingRouter(reply: EditReply(id: "e-99", status: .applied, message: "done"))
+        let result = await AnglesiteMessageDispatcher.dispatch(body: validEditBody(), via: router)
+        guard case .editReply(let reply) = result else {
+            Issue.record("expected .editReply, got \(result)")
+            return
+        }
+        #expect(reply.id == "e-99")
+        #expect(reply.status == .applied)
+        let received = await router.received
+        #expect(received.count == 1)
+        #expect(received.first?.id == "e-99")
+        #expect(received.first?.op == "replace-text")
+    }
+
+    @Test("Dispatch rejects unknown message type") func dispatchRejectsUnknownType() async {
+        var bad = validEditBody()
+        bad["type"] = "anglesite:not-real"
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteMessageDispatcher.dispatch(body: bad, via: router)
+        guard case .rejected(.unknownType(let t)) = result else {
+            Issue.record("expected .rejected(.unknownType), got \(result)")
+            return
+        }
+        #expect(t == "anglesite:not-real")
+        let received = await router.received
+        #expect(received.isEmpty, "router must not see undecodable input")
+    }
+
+    @Test("Dispatch rejects body that is not an object") func dispatchRejectsNonObject() async {
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteMessageDispatcher.dispatch(body: "string", via: router)
+        guard case .rejected(.notAnObject) = result else {
+            Issue.record("expected .rejected(.notAnObject), got \(result)")
+            return
+        }
+    }
+
+    @Test("Dispatch reports missing type as missingType") func dispatchReportsMissingType() async {
+        var body = validEditBody()
+        body.removeValue(forKey: "type")
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteMessageDispatcher.dispatch(body: body, via: router)
+        guard case .rejected(.missingType) = result else {
+            Issue.record("expected .rejected(.missingType), got \(result)")
+            return
+        }
+    }
+
+    @Test("Dispatch forwards visible-elements to handler") func dispatchForwardsVisibleElements() async {
+        let collector = ElementCollector()
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteMessageDispatcher.dispatch(
+            body: validVisibleElementsBody(),
+            via: router,
+            onVisibleElements: { elements in await collector.append(elements) }
+        )
+        guard case .visibleElementsHandled = result else {
+            Issue.record("expected .visibleElementsHandled, got \(result)")
+            return
+        }
+        let captured = await collector.batches
+        #expect(captured.count == 1)
+        #expect(captured.first?.count == 1)
+        #expect(captured.first?.first?.id == "v-1")
+        let received = await router.received
+        #expect(received.isEmpty, "router must not see a visible-elements message")
+    }
+
+    @Test("Dispatch drops visible-elements when no handler is installed") func dispatchDropsVisibleElementsWithoutHandler() async {
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteMessageDispatcher.dispatch(
+            body: validVisibleElementsBody(),
+            via: router,
+            onVisibleElements: nil
+        )
+        guard case .visibleElementsDropped = result else {
+            Issue.record("expected .visibleElementsDropped, got \(result)")
+            return
+        }
+    }
+
+    @Test("Dispatch surfaces visible-elements decode failures") func dispatchSurfacesVisibleElementsDecodeFailure() async {
+        var body = validVisibleElementsBody()
+        body.removeValue(forKey: "elements")
+        let collector = ElementCollector()
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let result = await AnglesiteMessageDispatcher.dispatch(
+            body: body,
+            via: router,
+            onVisibleElements: { elements in await collector.append(elements) }
+        )
+        guard case .rejected(.visibleElementsDecode(.missingField("elements"))) = result else {
+            Issue.record("expected .rejected(.visibleElementsDecode(.missingField(elements))), got \(result)")
+            return
+        }
+        let captured = await collector.batches
+        #expect(captured.isEmpty)
+    }
+
+    @Test("Dispatch routes canvas-selection to its handler") func dispatchRoutesCanvasSelection() async {
+        let router = RecordingRouter(reply: EditReply(id: "-", status: .failed, message: "unused"))
+        let received = LockIsolated<CanvasSelectionMessage?>(nil)
+        let result = await AnglesiteMessageDispatcher.dispatch(
+            body: ["type": "anglesite:canvas-selection", "file": "/f.astro", "line": 7, "column": 1],
+            via: router,
+            onCanvasSelection: { msg in received.setValue(msg) }
+        )
+        guard case .canvasSelectionHandled = result else {
+            Issue.record("expected .canvasSelectionHandled, got \(result)")
+            return
+        }
+        #expect(received.value?.line == 7)
+    }
+
+    @Test("Canvas messages without a handler are dropped, not rejected") func dispatchDropsUnhandledCanvas() async {
+        let router = RecordingRouter(reply: EditReply(id: "-", status: .failed, message: "unused"))
+        let result = await AnglesiteMessageDispatcher.dispatch(
+            body: ["type": "anglesite:computed-styles", "styles": ["display": "block"]],
+            via: router
+        )
+        guard case .computedStylesDropped = result else {
+            Issue.record("expected .computedStylesDropped, got \(result)")
+            return
+        }
+    }
+}
+
+private actor RecordingRouter: EditRouter {
+    private(set) var received: [EditMessage] = []
+    private let reply: EditReply
+    init(reply: EditReply) { self.reply = reply }
+    func apply(_ message: EditMessage) async -> EditReply {
+        received.append(message)
+        return reply
+    }
+}
+
+private actor ElementCollector {
+    private(set) var batches: [[VisibleElement]] = []
+    func append(_ batch: [VisibleElement]) { batches.append(batch) }
+}
+
+private final class LockIsolated<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: Value
+    init(_ value: Value) { self._value = value }
+    var value: Value {
+        lock.withLock { _value }
+    }
+    func setValue(_ new: Value) {
+        lock.withLock { _value = new }
+    }
+}

--- a/Tests/AnglesiteBridgeTests/AnglesiteScriptHandlerTests.swift
+++ b/Tests/AnglesiteBridgeTests/AnglesiteScriptHandlerTests.swift
@@ -3,6 +3,10 @@ import Testing
 @testable import AnglesiteBridge
 import AnglesiteCore
 
+// `AnglesiteScriptHandler.dispatch`'s routing logic is now `AnglesiteMessageDispatcher.dispatch`,
+// tested in `AnglesiteBridgeCoreTests` (portable). What's left here is `AnglesiteScriptHandler`'s
+// own remaining code: the deprecated `handle(body:via:)` back-compat shim, which only exists on
+// this WKWebView-specific type.
 struct AnglesiteScriptHandlerTests {
     private func validEditBody() -> [String: Any] {
         [
@@ -17,125 +21,6 @@ struct AnglesiteScriptHandlerTests {
             "op": "replace-text",
             "value": "New heading",
         ]
-    }
-
-    private func validVisibleElementsBody() -> [String: Any] {
-        [
-            "type": "anglesite:visible-elements",
-            "elements": [
-                [
-                    "id": "v-1",
-                    "tag": "H1",
-                    "selector": [
-                        "tag": "H1",
-                        "classes": [] as [String],
-                        "nthChild": 1,
-                    ] as [String: Any],
-                    "rect": ["x": 0, "y": 0, "width": 100, "height": 40] as [String: Any],
-                    "text": "Heading",
-                ] as [String: Any]
-            ] as [Any],
-        ]
-    }
-
-    @Test("Dispatch routes apply-edit and returns reply") func dispatchRoutesApplyEdit() async {
-        let router = RecordingRouter(reply: EditReply(id: "e-99", status: .applied, message: "done"))
-        let result = await AnglesiteScriptHandler.dispatch(body: validEditBody(), via: router)
-        guard case .editReply(let reply) = result else {
-            Issue.record("expected .editReply, got \(result)")
-            return
-        }
-        #expect(reply.id == "e-99")
-        #expect(reply.status == .applied)
-        let received = await router.received
-        #expect(received.count == 1)
-        #expect(received.first?.id == "e-99")
-        #expect(received.first?.op == "replace-text")
-    }
-
-    @Test("Dispatch rejects unknown message type") func dispatchRejectsUnknownType() async {
-        var bad = validEditBody()
-        bad["type"] = "anglesite:not-real"
-        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
-        let result = await AnglesiteScriptHandler.dispatch(body: bad, via: router)
-        guard case .rejected(.unknownType(let t)) = result else {
-            Issue.record("expected .rejected(.unknownType), got \(result)")
-            return
-        }
-        #expect(t == "anglesite:not-real")
-        let received = await router.received
-        #expect(received.isEmpty, "router must not see undecodable input")
-    }
-
-    @Test("Dispatch rejects body that is not an object") func dispatchRejectsNonObject() async {
-        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
-        let result = await AnglesiteScriptHandler.dispatch(body: "string", via: router)
-        guard case .rejected(.notAnObject) = result else {
-            Issue.record("expected .rejected(.notAnObject), got \(result)")
-            return
-        }
-    }
-
-    @Test("Dispatch reports missing type as missingType") func dispatchReportsMissingType() async {
-        var body = validEditBody()
-        body.removeValue(forKey: "type")
-        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
-        let result = await AnglesiteScriptHandler.dispatch(body: body, via: router)
-        guard case .rejected(.missingType) = result else {
-            Issue.record("expected .rejected(.missingType), got \(result)")
-            return
-        }
-    }
-
-    @Test("Dispatch forwards visible-elements to handler") func dispatchForwardsVisibleElements() async {
-        let collector = ElementCollector()
-        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
-        let result = await AnglesiteScriptHandler.dispatch(
-            body: validVisibleElementsBody(),
-            via: router,
-            onVisibleElements: { elements in await collector.append(elements) }
-        )
-        guard case .visibleElementsHandled = result else {
-            Issue.record("expected .visibleElementsHandled, got \(result)")
-            return
-        }
-        let captured = await collector.batches
-        #expect(captured.count == 1)
-        #expect(captured.first?.count == 1)
-        #expect(captured.first?.first?.id == "v-1")
-        let received = await router.received
-        #expect(received.isEmpty, "router must not see a visible-elements message")
-    }
-
-    @Test("Dispatch drops visible-elements when no handler is installed") func dispatchDropsVisibleElementsWithoutHandler() async {
-        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
-        let result = await AnglesiteScriptHandler.dispatch(
-            body: validVisibleElementsBody(),
-            via: router,
-            onVisibleElements: nil
-        )
-        guard case .visibleElementsDropped = result else {
-            Issue.record("expected .visibleElementsDropped, got \(result)")
-            return
-        }
-    }
-
-    @Test("Dispatch surfaces visible-elements decode failures") func dispatchSurfacesVisibleElementsDecodeFailure() async {
-        var body = validVisibleElementsBody()
-        body.removeValue(forKey: "elements")
-        let collector = ElementCollector()
-        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
-        let result = await AnglesiteScriptHandler.dispatch(
-            body: body,
-            via: router,
-            onVisibleElements: { elements in await collector.append(elements) }
-        )
-        guard case .rejected(.visibleElementsDecode(.missingField("elements"))) = result else {
-            Issue.record("expected .rejected(.visibleElementsDecode(.missingField(elements))), got \(result)")
-            return
-        }
-        let captured = await collector.batches
-        #expect(captured.isEmpty)
     }
 
     // The deprecated `handle(body:via:)` shim exists so out-of-tree adopters of the old
@@ -168,33 +53,6 @@ struct AnglesiteScriptHandlerTests {
     private func deprecatedHandle(body: Any, via router: EditRouter) async -> Result<EditReply, EditMessage.DecodeError> {
         await AnglesiteScriptHandler.handle(body: body, via: router)
     }
-
-    @Test("Dispatch routes canvas-selection to its handler") func dispatchRoutesCanvasSelection() async {
-        let router = RecordingRouter(reply: EditReply(id: "-", status: .failed, message: "unused"))
-        let received = LockIsolated<CanvasSelectionMessage?>(nil)
-        let result = await AnglesiteScriptHandler.dispatch(
-            body: ["type": "anglesite:canvas-selection", "file": "/f.astro", "line": 7, "column": 1],
-            via: router,
-            onCanvasSelection: { msg in received.setValue(msg) }
-        )
-        guard case .canvasSelectionHandled = result else {
-            Issue.record("expected .canvasSelectionHandled, got \(result)")
-            return
-        }
-        #expect(received.value?.line == 7)
-    }
-
-    @Test("Canvas messages without a handler are dropped, not rejected") func dispatchDropsUnhandledCanvas() async {
-        let router = RecordingRouter(reply: EditReply(id: "-", status: .failed, message: "unused"))
-        let result = await AnglesiteScriptHandler.dispatch(
-            body: ["type": "anglesite:computed-styles", "styles": ["display": "block"]],
-            via: router
-        )
-        guard case .computedStylesDropped = result else {
-            Issue.record("expected .computedStylesDropped, got \(result)")
-            return
-        }
-    }
 }
 
 private actor RecordingRouter: EditRouter {
@@ -204,22 +62,5 @@ private actor RecordingRouter: EditRouter {
     func apply(_ message: EditMessage) async -> EditReply {
         received.append(message)
         return reply
-    }
-}
-
-private actor ElementCollector {
-    private(set) var batches: [[VisibleElement]] = []
-    func append(_ batch: [VisibleElement]) { batches.append(batch) }
-}
-
-final class LockIsolated<Value>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var _value: Value
-    init(_ value: Value) { self._value = value }
-    var value: Value {
-        lock.withLock { _value }
-    }
-    func setValue(_ new: Value) {
-        lock.withLock { _value = new }
     }
 }


### PR DESCRIPTION
Phase 2 of the cross-platform port (#567), step 1 of 3 per the [design doc](docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md)'s phasing: "AnglesiteBridgeCore split → PodmanSiteRuntime → Adwaita shell".

## Changes

The `anglesite` script-message schema, decoding, and routing logic — previously living inside `AnglesiteScriptHandler` (a `WKScriptMessageHandler`, so the whole file needed WebKit) — moves into a new portable `AnglesiteBridgeCore` target with no WebKit import. Each platform's webview adapter (`AnglesiteBridge`/WKWebView today; WebKitGTK/WebView2 for the Linux/Windows shells later) becomes a thin wrapper: unwrap the native message body, call the shared dispatcher, apply the platform-specific reply mechanism.

- **New `AnglesiteBridgeCore` target**: `AnglesiteMessageDispatcher` (the `dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)` static method + `DispatchResult` enum + handler typealiases + the `scriptMessageNamespace = "anglesite"` constant every platform shares) and `AnglesiteOverlayBundle` (portable overlay.js lookup — locates + reads the compiled edit-overlay source from a `Bundle`; each platform adapter wraps the resulting `String` in its own native script-injection type).
- **`AnglesiteScriptHandler`** (stays in `AnglesiteBridge`, WKWebView-specific): keeps its exact public API (constructor, `dispatch`, the deprecated `handle` shim, the three handler typealiases) — all now forwarding to `AnglesiteMessageDispatcher` — so the existing app-target call sites (`PreviewView`, `ComponentEditorView`) need zero changes.
- **`WebViewBridge`**: `scriptMessageNamespace` and `makeOverlayUserScript(in:)` now source from the portable core instead of duplicating the logic.
- **Tests**: `AnglesiteScriptHandlerTests.swift`'s dispatch-logic cases move to `Tests/AnglesiteBridgeCoreTests/AnglesiteMessageDispatcherTests.swift` — they now run on every platform, per the design doc's "existing AnglesiteBridgeTests move to the core target and run on all platforms." The two `handle()` deprecated-shim tests stay in `AnglesiteBridgeTests` since that shim only exists on the WKWebView-specific class.
- **Package.swift**: new `AnglesiteBridgeCore` target + library product; `AnglesiteBridge` depends on it; `AnglesiteBridgeCoreTests` added to the off-Darwin portable target set.

## Verification

On the Linux dev box: clean `swift build` + `swift test` — 35 tests, 5 suites, 0 failures (26 pre-existing + 9 new `AnglesiteMessageDispatcherTests`).

**Could not verify the Darwin-only `AnglesiteBridge`/`AnglesiteApp` targets compile** — no Xcode/WebKit in this sandbox. Reviewed `AnglesiteScriptHandler.swift`/`WebViewBridge.swift` by hand for API-compatibility with their known call sites and confirmed no other file references the removed inline `DispatchResult`/`dispatch` implementations, but this PR's macOS CI legs (`build-test`, Xcode project sync) are the first real compile — please weight review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)