### PR TITLE
Clarify SiteEntity.directory as package root, not source repo

### DIFF
--- a/Sources/AnglesiteIntents/SiteEntity.swift
+++ b/Sources/AnglesiteIntents/SiteEntity.swift
@@ -21,10 +21,11 @@ public struct SiteEntity: Sendable {
     /// The original display name used by `displayRepresentation` and `SiteEntityQuery`.
     public var displayName: String { name }
     /// The `.anglesite` **package root** (`SiteStore.Site.packageURL`) — NOT the `Source/` git
-    /// repo. Scaffolding, file scans, and git ops must not use this URL directly: derive
+    /// repo, so scaffolding, file scans, and git ops must not use this URL directly: derive
     /// `AnglesitePackage(url:).sourceURL` from it (see `ApplyThemeIntent`), or resolve the site
     /// by `id` via `SiteStore`/`SiteAccess.withScopedAccess`, which hands back `sourceDirectory`.
-    /// App-internal, not a schema property; nil only if AppIntents ever builds via the macro init.
+    /// App-internal rather than a schema `@Property`; nil only if AppIntents ever builds the
+    /// entity via the macro init.
     public var directory: URL?
 
     public var displayRepresentation: DisplayRepresentation {

--- a/Sources/AnglesiteIntents/SiteEntity.swift
+++ b/Sources/AnglesiteIntents/SiteEntity.swift
@@ -20,7 +20,11 @@ public struct SiteEntity: Sendable {
 
     /// The original display name used by `displayRepresentation` and `SiteEntityQuery`.
     public var displayName: String { name }
-    // App-internal, not a schema property; nil only if AppIntents ever builds via the macro init.
+    /// The `.anglesite` **package root** (`SiteStore.Site.packageURL`) — NOT the `Source/` git
+    /// repo. Scaffolding, file scans, and git ops must not use this URL directly: derive
+    /// `AnglesitePackage(url:).sourceURL` from it (see `ApplyThemeIntent`), or resolve the site
+    /// by `id` via `SiteStore`/`SiteAccess.withScopedAccess`, which hands back `sourceDirectory`.
+    /// App-internal, not a schema property; nil only if AppIntents ever builds via the macro init.
     public var directory: URL?
 
     public var displayRepresentation: DisplayRepresentation {


### PR DESCRIPTION
## Summary

- Expanded the `SiteEntity.directory` documentation to clarify that it points to the `.anglesite` **package root** (the `packageURL`), not the `Source/` git repo.
- Added guidance that scaffolding, file scans, and git operations must derive `sourceURL` via `AnglesitePackage(url:)` or resolve the site by `id` through `SiteStore`/`SiteAccess`, which provides the correct `sourceDirectory`.
- References `ApplyThemeIntent` as a concrete example of the correct pattern.

This prevents future confusion about the semantic difference between the package boundary and the editable source directory, aligning with the `.anglesite` package model (#242) and the principle that the app's working copy is not canonical — the git repo is.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite).

## Test plan

- N/A — documentation-only change to a public property comment.

https://claude.ai/code/session_01BpWY1SoRXGFBCvLMAAN9Wj