### PR TITLE
feat(git): move content-op git writes to in-process SwiftGit2 (#640)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -273,7 +273,7 @@ var packageDependencies: [Package.Dependency] = []
 // pinning to anglesite/main's tip would silently pick up unreviewed future commits. Bump
 // deliberately.
 packageDependencies.append(
-    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "ac0acfed2fe1b963005663821e96e1464a178854")
+    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "838fd896027a83731297e965a2ba879371d32719")
 )
 #endif
 

--- a/Package.swift
+++ b/Package.swift
@@ -57,6 +57,15 @@ let includeContainer = false
 // runtime of GH's `macos-15` runner (which currently caps at Xcode 26.3).
 // Locally on Xcode 27 the tests build + run normally; on the older toolchain
 // we drop them so `swift test` still passes. Tracking removal in #128.
+// SwiftGit2 (Anglesite's patched fork — see #640) is Darwin-only: it has no Linux platform
+// entry, and the App Sandbox problem it solves doesn't exist off-macOS in the first place.
+// GitInitRunner/NativeContentOperations keep the plain subprocess-git path as their
+// #if !canImport(Darwin) branch, which is correct there, not just a fallback.
+var anglesiteCoreDependencies: [Target.Dependency] = ["AnglesiteSiteModel"]
+#if canImport(Darwin)
+anglesiteCoreDependencies.append(.product(name: "SwiftGit2", package: "SwiftGit2"))
+#endif
+
 var packageTargets: [Target] = [
     .target(
         name: "AnglesiteSiteModel",
@@ -71,7 +80,7 @@ var packageTargets: [Target] = [
     ),
     .target(
         name: "AnglesiteCore",
-        dependencies: ["AnglesiteSiteModel"],
+        dependencies: anglesiteCoreDependencies,
         path: "Sources/AnglesiteCore",
         swiftSettings: strictConcurrency + disableFoundationModelsAutolink
     ),
@@ -257,6 +266,16 @@ var packageProducts: [Product] = [
 ]
 
 var packageDependencies: [Package.Dependency] = []
+
+#if canImport(Darwin)
+// Anglesite's patched fork of mbernson/SwiftGit2 — see #640 and Spikes/GitPackageSpike. Pinned
+// to a commit rather than a tag or branch: SwiftGit2 upstream has no tagged SPM release yet, and
+// pinning to anglesite/main's tip would silently pick up unreviewed future commits. Bump
+// deliberately.
+packageDependencies.append(
+    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "ac0acfed2fe1b963005663821e96e1464a178854")
+)
+#endif
 
 // Keep the AnglesiteContainer product and its native dependency together with the target above:
 // excluded as one unit under ANGLESITE_SKIP_CONTAINER=1 so the manifest never references a missing

--- a/Package.swift
+++ b/Package.swift
@@ -273,7 +273,7 @@ var packageDependencies: [Package.Dependency] = []
 // pinning to anglesite/main's tip would silently pick up unreviewed future commits. Bump
 // deliberately.
 packageDependencies.append(
-    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "838fd896027a83731297e965a2ba879371d32719")
+    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "49d2a87bcfa9c0e4f94862e7cfaa129d2adf64db")
 )
 #endif
 

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -366,17 +366,12 @@ struct SitesLauncherView: View {
                 try await ProcessSupervisor.shared.run(executable: exe, arguments: args, currentDirectoryURL: cwd)
             },
             gitInit: { sourceDir in
-                // Route through GitInitRunner so a nonzero exit throws (with stderr) instead of
-                // being discarded — see #548, where this used to `_ = try await ...run(...)` and
-                // silently kept a Source/ with no .git that could never preview.
-                try await GitInitRunner.run(in: sourceDir) { exe, args, cwd in
-                    let result = try await ProcessSupervisor.shared.run(executable: exe, arguments: args, currentDirectoryURL: cwd)
-                    // Logs are sacred: this is a one-shot `run`, not a streamed `launch`, so forward
-                    // its captured output to the debug pane ourselves.
-                    if !result.stdout.isEmpty { await LogCenter.shared.append(source: "git-init", stream: .stdout, text: result.stdout) }
-                    if !result.stderr.isEmpty { await LogCenter.shared.append(source: "git-init", stream: .stderr, text: result.stderr) }
-                    return result
-                }
+                // Route through GitInitRunner so a failure throws instead of being discarded —
+                // see #548, where this used to `_ = try await ...run(...)` and silently kept a
+                // Source/ with no .git that could never preview. SwiftGit2 (in-process libgit2,
+                // #640) rather than a /usr/bin/git subprocess, so there's no subprocess output to
+                // forward to LogCenter here.
+                try GitInitRunner.run(in: sourceDir)
             },
             register: { package in
                 let site = try await SiteStore.shared.record(package)

--- a/Sources/AnglesiteCore/GitInitRunner.swift
+++ b/Sources/AnglesiteCore/GitInitRunner.swift
@@ -1,24 +1,47 @@
 import Foundation
+#if canImport(Darwin)
+import SwiftGit2
+#endif
 
-/// `git init`'s nonzero exit must not be discarded: it previously was in `SitesLauncherView`'s
+/// `git init`'s failure must not be discarded: it previously was in `SitesLauncherView`'s
 /// production wiring (`_ = try await ProcessSupervisor...run(...)`), which meant a failing `git
 /// init` never even reached `SiteScaffolder`'s `.warning` step — the new site silently kept a
 /// `Source/` with no `.git`, and could never preview (#548).
 public enum GitInitError: LocalizedError, Sendable, Equatable {
+    #if canImport(Darwin)
+    case failed(message: String)
+    #else
     case failed(exitCode: Int32, stderr: String)
+    #endif
 
     public var errorDescription: String? {
         switch self {
+        #if canImport(Darwin)
+        case .failed(let message):
+            return "git init failed: \(message)"
+        #else
         case .failed(let exitCode, let stderr):
             let detail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             return detail.isEmpty ? "git init exited \(exitCode)." : "git init exited \(exitCode): \(detail)"
+        #endif
         }
     }
 }
 
 public enum GitInitRunner {
+    #if canImport(Darwin)
+    /// Initializes a git repository at `sourceDirectory` via SwiftGit2 (in-process libgit2, no
+    /// subprocess) — `/usr/bin/git` cannot execute at all under App Sandbox (#640).
+    public static func run(in sourceDirectory: URL) throws {
+        SwiftGit2Bootstrap.ensureInitialized
+        if case .failure(let error) = Repository.create(at: sourceDirectory) {
+            throw GitInitError.failed(message: error.localizedDescription)
+        }
+    }
+    #else
     /// Runs `git init` in `sourceDirectory` via `run`, throwing `GitInitError` (carrying stderr) on
-    /// a nonzero exit instead of discarding the result.
+    /// a nonzero exit instead of discarding the result. Off-Darwin there's no App Sandbox to route
+    /// around, so plain subprocess git remains correct here rather than a gap to fill.
     public static func run(
         in sourceDirectory: URL,
         using run: @Sendable (_ executable: URL, _ arguments: [String], _ cwd: URL?) async throws -> ProcessSupervisor.RunResult
@@ -29,4 +52,5 @@ public enum GitInitRunner {
             throw GitInitError.failed(exitCode: result.exitCode, stderr: result.stderr)
         }
     }
+    #endif
 }

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -1,5 +1,8 @@
 // Sources/AnglesiteCore/NativeContentOperations.swift
 import Foundation
+#if canImport(Darwin)
+import SwiftGit2
+#endif
 
 /// Native, in-process `create_page` / `create_post`. Byte-faithful to the Node sidecar's
 /// `create-content.mjs` (see `ContentScaffold`), but writes the file with `FileManager` and
@@ -368,9 +371,36 @@ public struct NativeContentOperations: ContentOperationsService {
         try contents.write(to: abs, atomically: true, encoding: .utf8)
     }
 
+    #if canImport(Darwin)
+    /// Stage and commit exactly `relPath` on the current branch. Returns the new HEAD SHA, or
+    /// nil on any failure (not a repo, no configured git identity) — best-effort, mirroring the
+    /// Node sidecar's `commitFile`. Via SwiftGit2 (in-process libgit2, #640): `/usr/bin/git`
+    /// cannot execute at all under App Sandbox.
+    ///
+    /// Two behavioral differences from the subprocess-git version this replaced, both judged
+    /// acceptable for this app's single-user, one-operation-at-a-time usage:
+    ///  - Commits whatever is currently staged, not scoped to just `relPath` the way `git commit
+    ///    -- relPath` was — there's no equivalent path-scoped commit in SwiftGit2's public API.
+    ///    Since every call site here does add-then-commit for one file with nothing else staged
+    ///    in between, this doesn't currently observably differ.
+    ///  - Does not run `.git/hooks/pre-commit`/`commit-msg` — libgit2 never invokes shell hooks
+    ///    (that's a porcelain-layer concept). Nothing in this app currently relies on commit-time
+    ///    hooks firing for content-op commits (unlike `pre-deploy-check.sh`, which is a separate,
+    ///    still-enforced deploy-time gate — see CLAUDE.md's "app cannot bypass plugin security
+    ///    hooks").
+    @Sendable public static func processGitCommit(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
+        SwiftGit2Bootstrap.ensureInitialized
+        guard case .success(let repo) = Repository.at(projectRoot) else { return nil }
+        guard case .success = repo.add(path: relPath) else { return nil }
+        guard case .success(let signature) = repo.defaultSignature() else { return nil }
+        guard case .success(let commit) = repo.commit(message: message, signature: signature) else { return nil }
+        return commit.oid.description
+    }
+    #else
     /// Stage and commit exactly `relPath` on the current branch. Returns the new HEAD SHA,
     /// or nil on any failure (not a repo, rejecting hook, git missing) — best-effort, mirroring
-    /// the Node sidecar's `commitFile`.
+    /// the Node sidecar's `commitFile`. Off-Darwin there's no App Sandbox to route around, so
+    /// plain subprocess git remains correct here rather than a gap to fill.
     @Sendable public static func processGitCommit(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
         let git = URL(fileURLWithPath: "/usr/bin/git")
         func run(_ args: [String]) async -> ProcessSupervisor.RunResult? {
@@ -384,12 +414,34 @@ public struct NativeContentOperations: ContentOperationsService {
               let head = await run(["rev-parse", "HEAD"]) else { return nil }
         return head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+    #endif
 
     /// Stage-delete and commit exactly `relPath` on the current branch (`git rm` + `git commit`).
     /// Returns the new HEAD SHA, or nil on any failure (not a repo, dirty tree, rejecting hook,
     /// git missing, no HEAD copy) — best-effort, mirroring `processGitCommit`'s shape exactly.
     /// Git history is the sole undo/archive mechanism for this delete; there is no separate
     /// trash/archive path.
+    ///
+    /// STILL SUBPROCESS-GIT ON DARWIN TOO (#640 follow-up) — deliberately not yet converted to
+    /// SwiftGit2 alongside `processGitCommit`, unlike everything else in this file. Converting it
+    /// safely needs three capabilities SwiftGit2's public API doesn't have yet, all upstream of
+    /// this method's actual safety property (a failed commit after a successful `rm` must roll
+    /// back cleanly — there's no separate trash, so a bug here is a silent, permanent data-loss
+    /// path):
+    ///   1. `git rm` equivalent — `git_index_remove_bypath` + unlinking the working-tree file.
+    ///      No `Repository.remove(path:)` exists (mirror of `add(path:)`, which does exist).
+    ///   2. The `cat-file -e HEAD:relPath` precondition — checking a path exists in HEAD's tree
+    ///      without a full checkout. Needs `git_object_lookup_bypath`, unwrapped anywhere.
+    ///   3. The `checkout HEAD -- relPath` rollback — restoring exactly one path from a tree,
+    ///      not the whole working copy. `Repository.checkout` only takes a whole-repo strategy;
+    ///      libgit2's `git_checkout_options.paths` (a path-scoped `git_strarray` filter) isn't
+    ///      exposed.
+    /// Each is a small, self-contained libgit2 wrapper addition (same shape as `add(path:)` /
+    /// `defaultSignature()` on anglesite/SwiftGit2), but rolling all three into one commit-message-
+    /// sized patch and getting the rollback interaction right deserves its own change, not a
+    /// footnote inside this one. Until then: deletes still fail under App Sandbox exactly as
+    /// #640 originally found (creates now work; deletes remain broken there) — an incomplete but
+    /// honest intermediate state, not a silent regression.
     @Sendable public static func processGitDelete(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
         let git = URL(fileURLWithPath: "/usr/bin/git")
         func run(_ args: [String]) async -> ProcessSupervisor.RunResult? {

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -416,32 +416,59 @@ public struct NativeContentOperations: ContentOperationsService {
     }
     #endif
 
+    #if canImport(Darwin)
+    /// Stage-delete and commit exactly `relPath` on the current branch (`git rm` + `git commit`
+    /// equivalent). Returns the new HEAD SHA, or nil on any failure (not a repo, no configured
+    /// git identity, no HEAD copy) — best-effort, mirroring `processGitCommit`'s shape exactly.
+    /// Git history is the sole undo/archive mechanism for this delete; there is no separate
+    /// trash/archive path. Via SwiftGit2 (in-process libgit2, #640): `/usr/bin/git` cannot
+    /// execute at all under App Sandbox. Uses three fork-specific additions —
+    /// `headHasEntry(atPath:)`, `remove(path:)`, `restorePathFromHEAD(_:)` — landed on
+    /// `anglesite/SwiftGit2` specifically for this conversion.
+    @Sendable public static func processGitDelete(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
+        SwiftGit2Bootstrap.ensureInitialized
+        guard case .success(let repo) = Repository.at(projectRoot) else { return nil }
+        // Require a HEAD copy before touching anything: if the commit below fails after the
+        // remove already succeeds, the only safe rollback is restoring from HEAD, which needs
+        // HEAD to actually have the file. A staged-but-never-committed file would otherwise risk
+        // ending up gone from both the index and the working tree with no way back — refusing up
+        // front is a clean, side-effect-free failure instead.
+        guard repo.headHasEntry(atPath: relPath) else { return nil }
+        guard case .success = repo.remove(path: relPath) else { return nil }
+
+        let commitResult = repo.defaultSignature().flatMap { signature in
+            repo.commit(message: message, signature: signature)
+        }
+        guard case .success(let commit) = commitResult else {
+            // remove(path:) already removed the file from the index and working tree before the
+            // commit failed (no identity configured, etc.) — restore both from HEAD so a failed
+            // delete never leaves the file gone without a commit. Same "never a raw
+            // non-git-recoverable delete" safety property the happy path relies on, applied to
+            // the failure path too.
+            // This second failure (the rollback itself also failing) has no regression test: by
+            // this point the `headHasEntry` guard above has already confirmed HEAD has the file,
+            // so the restore failing here means something environmental went wrong between that
+            // check and this line (disk full, permissions revoked mid-flight) — genuinely hard to
+            // construct reliably/portably in a test, and narrower than it looks since the
+            // precondition above already rules out the most common cause (no HEAD copy). Logged
+            // rather than silently swallowed so it's at least diagnosable if it ever fires for
+            // real.
+            if case .failure = repo.restorePathFromHEAD(relPath) {
+                await LogCenter.shared.append(
+                    source: "dead-assets:delete", stream: .stderr,
+                    text: "processGitDelete: commit failed for \(relPath) AND rollback (restorePathFromHEAD) also failed — the file may be missing from disk with no commit recording its removal. Manual recovery may be needed in \(projectRoot.path).")
+            }
+            return nil
+        }
+        return commit.oid.description
+    }
+    #else
     /// Stage-delete and commit exactly `relPath` on the current branch (`git rm` + `git commit`).
     /// Returns the new HEAD SHA, or nil on any failure (not a repo, dirty tree, rejecting hook,
     /// git missing, no HEAD copy) — best-effort, mirroring `processGitCommit`'s shape exactly.
     /// Git history is the sole undo/archive mechanism for this delete; there is no separate
-    /// trash/archive path.
-    ///
-    /// STILL SUBPROCESS-GIT ON DARWIN TOO (#640 follow-up) — deliberately not yet converted to
-    /// SwiftGit2 alongside `processGitCommit`, unlike everything else in this file. Converting it
-    /// safely needs three capabilities SwiftGit2's public API doesn't have yet, all upstream of
-    /// this method's actual safety property (a failed commit after a successful `rm` must roll
-    /// back cleanly — there's no separate trash, so a bug here is a silent, permanent data-loss
-    /// path):
-    ///   1. `git rm` equivalent — `git_index_remove_bypath` + unlinking the working-tree file.
-    ///      No `Repository.remove(path:)` exists (mirror of `add(path:)`, which does exist).
-    ///   2. The `cat-file -e HEAD:relPath` precondition — checking a path exists in HEAD's tree
-    ///      without a full checkout. Needs `git_object_lookup_bypath`, unwrapped anywhere.
-    ///   3. The `checkout HEAD -- relPath` rollback — restoring exactly one path from a tree,
-    ///      not the whole working copy. `Repository.checkout` only takes a whole-repo strategy;
-    ///      libgit2's `git_checkout_options.paths` (a path-scoped `git_strarray` filter) isn't
-    ///      exposed.
-    /// Each is a small, self-contained libgit2 wrapper addition (same shape as `add(path:)` /
-    /// `defaultSignature()` on anglesite/SwiftGit2), but rolling all three into one commit-message-
-    /// sized patch and getting the rollback interaction right deserves its own change, not a
-    /// footnote inside this one. Until then: deletes still fail under App Sandbox exactly as
-    /// #640 originally found (creates now work; deletes remain broken there) — an incomplete but
-    /// honest intermediate state, not a silent regression.
+    /// trash/archive path. Off-Darwin there's no App Sandbox to route around, so plain subprocess
+    /// git remains correct here rather than a gap to fill.
     @Sendable public static func processGitDelete(_ projectRoot: URL, _ relPath: String, _ message: String) async -> String? {
         let git = URL(fileURLWithPath: "/usr/bin/git")
         func run(_ args: [String]) async -> ProcessSupervisor.RunResult? {
@@ -482,4 +509,5 @@ public struct NativeContentOperations: ContentOperationsService {
         guard let head = await run(["rev-parse", "HEAD"]) else { return nil }
         return head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+    #endif
 }

--- a/Sources/AnglesiteCore/SwiftGit2Bootstrap.swift
+++ b/Sources/AnglesiteCore/SwiftGit2Bootstrap.swift
@@ -1,0 +1,15 @@
+#if canImport(Darwin)
+import SwiftGit2
+
+/// SwiftGit2 (in-process libgit2, #640) requires `SwiftGit2Init()` before any repository
+/// operation — an uninitialized call fails with "library has not been initialized" rather than
+/// doing the operation. `static let` initializers run exactly once, lazily, thread-safely, on
+/// first access, so every git-touching call site references `ensureInitialized` first instead of
+/// each reimplementing its own once-only guard. There's no matching `SwiftGit2Shutdown()` call:
+/// the app process lives for the app's lifetime, so there's nothing to release it before.
+enum SwiftGit2Bootstrap {
+    static let ensureInitialized: Void = {
+        _ = SwiftGit2Init()
+    }()
+}
+#endif

--- a/Spikes/GitPackageSpike/.gitignore
+++ b/Spikes/GitPackageSpike/.gitignore
@@ -1,0 +1,3 @@
+results/
+.build/
+.vendor/

--- a/Spikes/GitPackageSpike/Entitlements/Info.plist
+++ b/Spikes/GitPackageSpike/Entitlements/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>GitPackageSpike</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.dwk.anglesite.spikes.gitpackage</string>
+	<key>CFBundleName</key>
+	<string>GitPackageSpike</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<!-- Runs headless (no dock icon/menu bar) — this is a CLI probe wrapped in just enough
+	     bundle structure for sandboxd to compute a container path, per #640's own repro
+	     methodology and Spikes/ContainerSpike's prior finding that a bare Mach-O binary
+	     with no real .app bundle makes sandboxd hang instead of attaching a container. -->
+	<key>LSUIElement</key>
+	<true/>
+</dict>
+</plist>

--- a/Spikes/GitPackageSpike/Entitlements/sandboxed.plist
+++ b/Spikes/GitPackageSpike/Entitlements/sandboxed.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Mirrors Resources/Anglesite.entitlements' sandbox posture (minus virtualization/network,
+	     which are irrelevant to this probe). -->
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+</dict>
+</plist>

--- a/Spikes/GitPackageSpike/Package.swift
+++ b/Spikes/GitPackageSpike/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 6.0
+// GitPackageSpike — empirical harness for #640: does a Swift-native libgit2 binding
+// (in-process, no subprocess) sidestep the App Sandbox block that traps `/usr/bin/git`?
+//
+// Depends on github.com/Anglesite/SwiftGit2 — Anglesite's fork of mbernson/SwiftGit2, carrying
+// the one patch this spike's earlier runs proved was needed: Repository.commit(message:signature:)
+// now handles the first commit on a freshly `git init`'d (unborn HEAD) repo. See the fork's own
+// README and https://github.com/SwiftGit2/SwiftGit2/issues/174 for the upstream bug this fixes.
+//
+// Pinned to an exact commit on the `anglesite/main` branch rather than the branch itself, for
+// reproducibility — bump deliberately when the fork gets new commits.
+//
+// See ../README.md for the run procedure.
+
+import PackageDescription
+
+let package = Package(
+    name: "GitPackageSpike",
+    platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "d06cd7e5e2c5cc83d69fcb9d9beac51a53fc9014"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "GitPackageSpike",
+            dependencies: [
+                .product(name: "SwiftGit2", package: "SwiftGit2"),
+            ]
+        )
+    ]
+)

--- a/Spikes/GitPackageSpike/README.md
+++ b/Spikes/GitPackageSpike/README.md
@@ -1,0 +1,122 @@
+# GitPackageSpike
+
+Empirical harness for [#640](https://github.com/Anglesite/Anglesite-app/issues/640): does a
+Swift-native, in-process libgit2 binding work from inside a real App Sandbox container, where
+`/usr/bin/git` refuses to execute at all (`xcrun: error: cannot be used within an App Sandbox.`)?
+
+Depends on [github.com/Anglesite/SwiftGit2](https://github.com/Anglesite/SwiftGit2) — Anglesite's
+fork of [mbernson/SwiftGit2](https://github.com/mbernson/SwiftGit2), carrying the one patch this
+spike's own runs proved was needed (see "Result" below and the fork's own README).
+
+```sh
+Spikes/GitPackageSpike/scripts/build-and-run.sh
+```
+
+Output lands in `results/{control,sandboxed}-result.json`.
+
+## What it tests
+
+One binary, run twice: once unsigned/unsandboxed as a control, once wrapped in a real `.app`
+bundle, ad-hoc signed with `com.apple.security.app-sandbox` + file entitlements mirroring
+`Resources/Anglesite.entitlements`, and launched via `open` — the same methodology #640's own
+repro used, and required per `Spikes/ContainerSpike`'s prior finding that a bare Mach-O binary
+with no real `.app` bundle makes `sandboxd` hang instead of attaching a container.
+
+Two tiers, matching the shapes of git write this app performs:
+
+| Tier | What it exercises | Maps to |
+|---|---|---|
+| A | `Repository.create` + `add` + `commit(message:signature:)` on a **brand-new, unborn-HEAD repo**, using the *unmodified* public API — the fork's patch lives inside `commit(message:signature:)` itself, so callers don't do anything differently | `NativeContentOperations.processGitCommit`'s *first-ever* call for a freshly scaffolded site (see "Does SiteScaffolder avoid this?" below) |
+| B | `add` + `commit` on a repo **pre-seeded with one commit** (via real `git`, run unsandboxed by the driver script, before the sandboxed binary launches) | `NativeContentOperations.processGitCommit` — every commit *after* a site's first, which already has history |
+
+Tier B's repo is pre-seeded *outside* the sandbox because the sandboxed binary's own git writes
+are exactly what's under test — seeding it via a subprocess `git` call from inside the sandboxed
+process would just re-trigger #640's bug. Pre-seeding works because the sandbox container
+directory (`~/Library/Containers/<bundle-id>/Data/tmp/`) is an ordinary folder any process
+running as the same user can write to ahead of time; the sandbox only restricts what the
+*sandboxed app itself* can reach at runtime, not what set up its container beforehand.
+
+Since a GUI-launched (`open`) process has no attached terminal, the binary writes a JSON result
+array to `FileManager.default.temporaryDirectory` (which resolves inside the sandbox container
+when sandboxed) instead of printing to stdout; the driver script polls for that file and prints
+it back out.
+
+## Does `SiteScaffolder` avoid the unborn-HEAD case?
+
+No — checked directly. [`SiteScaffolder.runPipeline`](../../Sources/AnglesiteCore/SiteScaffolder.swift)
+runs `git init` (step 2b) and then only writes files to the working tree — theme, homepage, logo,
+`.site-config` — it never commits. [`scaffold.sh`](../../Resources/Template/scripts/scaffold.sh)
+is a plain `rsync` of the template tree; it doesn't touch git at all. So a freshly scaffolded site
+has an initialized-but-commit-less repo until the owner's *first* New Post/Page/Component, at
+which point [`NativeContentOperations.processGitCommit`](../../Sources/AnglesiteCore/NativeContentOperations.swift#L374)
+runs `git commit` against a genuinely unborn `HEAD`. Real `/usr/bin/git` handles that transparently
+(it's normal git behavior — nobody special-cased it because there was nothing to special-case), so
+this gap only exists in SwiftGit2's *public* API surface, not in the app's design.
+
+**Pre-baking a `.git` into `Resources/Template/` (the "repo already initialized in the template"
+idea) doesn't fix this and adds a real footgun**: `Resources/Template/` is itself tracked inside
+Anglesite-app's own git repo, and a nested `.git/` directory under a tracked tree is a gitlink/
+submodule boundary — clones, CI, and diff tooling won't reproduce it the way a plain file would.
+It also wouldn't remove the need for an unborn-HEAD-safe commit: `gitInit` runs *before* the
+theme/homepage/logo/config writes, so even with a pre-baked initial commit, that first real
+content-write would still need to land as a new commit on top — Tier A's problem just moves to a
+different commit, it doesn't disappear. Every scaffolded site would also end up sharing byte-
+identical initial-commit objects, which is a smell of its own.
+
+## Prior art: this was a known, long-open upstream bug
+
+[SwiftGit2/SwiftGit2#174 "First commit in an empty repo."](https://github.com/SwiftGit2/SwiftGit2/issues/174)
+(filed 2020-06-03, still open upstream) is the exact same bug, same error string
+(`reference 'refs/heads/master' not found`). Two things from that thread carried forward into the
+real fix:
+
+- A 2020-08-22 comment independently landed on the same workaround this investigation considered
+  and rejected — "copying an initialized repo into the folder" — so it's a known, if awkward,
+  community pattern, not something dismissed unfairly here.
+- A 2020-10-07 comment from `stevengharris` had the fix's actual shape: patch
+  `commit(message:signature:)` itself to detect a zero `parentID` OID (i.e. unborn HEAD) after
+  `git_reference_name_to_id` fails, and fall through to `commit(tree:parents:[],...)` in that
+  case. That keeps the existing public API surface unchanged — callers keep calling
+  `commit(message:signature:)` exactly as before. No PR was ever opened against the issue in the
+  5 years since; [Anglesite/SwiftGit2@d06cd7e](https://github.com/Anglesite/SwiftGit2/commit/d06cd7e5e2c5cc83d69fcb9d9beac51a53fc9014)
+  applies that exact shape as a real patch, on Anglesite's fork.
+
+## Result (2026-07-10, actually run in this worktree)
+
+**Both tiers succeed, in the real signed, sandboxed `.app`, against the unmodified public API:**
+
+- **Tier A (fresh repo, first commit)**: `create` → `add` → `commit(message:signature:)` → `HEAD`
+  all succeed — a real root commit, zero parents, `HEAD` resolving to `refs/heads/master`. Before
+  the fork's patch landed, this step failed identically in both an unsandboxed control run and
+  the signed sandboxed run (`reference 'refs/heads/master' not found` / `'refs/heads/main' not
+  found`) — same failure in both, which was itself the useful earlier signal that the gap was a
+  **binding limitation, not a sandbox effect**: SwiftGit2's public `commit(message:signature:)`
+  called `git_reference_name_to_id(..., "HEAD")` unconditionally, which errors on an unborn
+  branch, even though the low-level `commit(tree:parents:message:signature:)` overload never
+  needed HEAD to exist at all (`git_commit_create` creates the first ref from scratch — that's how
+  `git commit` on an empty repo has always worked at the libgit2 level).
+- **Tier B (commit onto existing history)**: `open-preseeded-repo` → `add` → `commit-with-parent`
+  → `HEAD-after-commit` all completed normally, producing a real commit object (correct oid, tree,
+  parent chain, author/committer) and a `HEAD` resolving to `refs/heads/main`. This covers the
+  majority real-world path — every commit after a site's first is onto existing history — and
+  confirms the core #640 hypothesis: an in-process libgit2 binding has no subprocess to trip App
+  Sandbox's container-init block, unlike `/usr/bin/git`.
+
+Raw output in `results/{control,sandboxed}-result.json`.
+
+## Follow-ups if this direction is pursued for real
+
+1. Confirm this on a signed build with the actual `io.dwk.anglesite` bundle id / provisioning,
+   not just ad-hoc.
+2. Consider upstreaming the fork's patch to `mbernson/SwiftGit2` as a real PR (small,
+   self-contained, no API breaks) rather than only carrying it on Anglesite's fork indefinitely —
+   would reduce the fork-maintenance surface. Not required before adopting the fork; the fork
+   README documents the patch and links back to the upstream issue for whoever eventually does.
+3. Push/fetch over HTTPS with a token (for `RepoBootstrap`'s "Publish to GitHub" flow) isn't
+   exercised here — SwiftGit2's `Remotes.swift`/`Credentials.swift` look adequate but are
+   unverified by this spike.
+4. #640's Option 1 (a vendored, non-Apple git binary run as a subprocess) was also spiked — see
+   `../VendoredGitSpike` — and worked with *no* binding patch needed at all, but raises a GPLv2
+   distribution question for a Mac App Store app that this option (MIT SwiftGit2 / GPLv2-with-
+   linking-exception libgit2) doesn't. That trade-off was the deciding factor for picking this
+   direction — see the issue/PR discussion for the full comparison.

--- a/Spikes/GitPackageSpike/Sources/GitPackageSpike/main.swift
+++ b/Spikes/GitPackageSpike/Sources/GitPackageSpike/main.swift
@@ -1,0 +1,114 @@
+// GitPackageSpike — probes whether SwiftGit2 (libgit2 vendored + compiled in-process, no
+// subprocess) can perform git operations from inside a real App-Sandbox container, where
+// #640 found `/usr/bin/git` refuses to execute at all.
+//
+// Two tiers, mirroring the two shapes of git write this app actually performs. Depends on
+// github.com/Anglesite/SwiftGit2 (a fork of mbernson/SwiftGit2), which carries the patch this
+// spike's earlier run proved was needed — see ../README.md "Result" and the fork's own README
+// for the fix itself and https://github.com/SwiftGit2/SwiftGit2/issues/174 for the upstream bug.
+//   A. `git init` + first-ever commit in a brand-new repo (SiteScaffolder's path). This
+//      exercises `Repository.create` + `add` + `commit(message:signature:)` — the *unmodified*
+//      public API, which now handles the unborn-HEAD case directly thanks to the fork's patch.
+//   B. A commit on top of an already-existing history (NativeContentOperations' path — New
+//      Post/Page/Component, Duplicate, Delete/Undo all commit into a repo that already has at
+//      least one commit). The repo is pre-seeded by the *unsandboxed* driver script using the
+//      real git CLI, then this sandboxed binary opens it and commits into it.
+//
+// Both tiers write a JSON result line to a fixed path under the process's own sandbox
+// container tmp dir, since a GUI-launched (`open`) process has no terminal to print to. The
+// driver script polls that path and prints it back out.
+
+import Foundation
+import SwiftGit2
+
+struct TierResult: Codable {
+    let tier: String
+    let step: String
+    let ok: Bool
+    let detail: String
+}
+
+// Top-level code in a Swift 6 executable is implicitly @MainActor-isolated; `results` is only
+// ever mutated from this top-level scope, so a plain local var (not a global) keeps everything
+// on the same isolation domain without needing explicit @MainActor annotations.
+var results: [TierResult] = []
+
+func makeResult(_ tier: String, _ step: String, _ result: Result<some Any, NSError>) -> TierResult {
+    switch result {
+    case .success(let value):
+        return TierResult(tier: tier, step: step, ok: true, detail: String(describing: value))
+    case .failure(let error):
+        return TierResult(tier: tier, step: step, ok: false, detail: error.localizedDescription)
+    }
+}
+
+func writeResultsAndExit(_ results: [TierResult]) -> Never {
+    let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("gitpackagespike-result.json")
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    do {
+        let data = try encoder.encode(results)
+        try data.write(to: outputURL, options: .atomic)
+    } catch {
+        // Best-effort fallback so the driver script's poll loop still has *something* to read.
+        try? "encode/write failed: \(error)".write(to: outputURL, atomically: true, encoding: .utf8)
+    }
+    exit(0)
+}
+
+let signature = Signature(name: "GitPackageSpike", email: "spike@anglesite.local")
+
+// SwiftGit2's develop branch requires explicit init/shutdown of the underlying libgit2 state.
+_ = SwiftGit2Init()
+defer { _ = SwiftGit2Shutdown() }
+
+// MARK: - Tier A: fresh `git init` + first commit (SiteScaffolder's path)
+
+let tierADir = FileManager.default.temporaryDirectory.appendingPathComponent("gitpackagespike-tierA-\(UUID().uuidString)")
+try? FileManager.default.createDirectory(at: tierADir, withIntermediateDirectories: true)
+
+let tierACreate = Repository.create(at: tierADir)
+results.append(makeResult("A", "create", tierACreate))
+
+if case .success(let repoA) = tierACreate {
+    let fileURL = tierADir.appendingPathComponent("hello.txt")
+    try? "hello from GitPackageSpike tier A".write(to: fileURL, atomically: true, encoding: .utf8)
+
+    let addA = repoA.add(path: "hello.txt")
+    results.append(makeResult("A", "add", addA))
+
+    let commitA = repoA.commit(message: "Tier A: first commit in a fresh repo", signature: signature)
+    results.append(makeResult("A", "commit-on-unborn-HEAD", commitA))
+
+    if case .success = commitA {
+        results.append(makeResult("A", "HEAD-after-commit", repoA.HEAD()))
+    }
+}
+
+// MARK: - Tier B: commit on top of pre-existing history (NativeContentOperations' path)
+//
+// CLI arg 1 is the pre-seeded repo path, written by the unsandboxed driver script using the
+// real `git` CLI (outside the sandbox) before this binary was launched via `open`.
+
+if CommandLine.arguments.count > 1 {
+    let tierBDir = URL(fileURLWithPath: CommandLine.arguments[1])
+    let tierBOpen = Repository.at(tierBDir)
+    results.append(makeResult("B", "open-preseeded-repo", tierBOpen))
+
+    if case .success(let repoB) = tierBOpen {
+        let fileURL = tierBDir.appendingPathComponent("second-file.txt")
+        try? "hello from GitPackageSpike tier B".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let addB = repoB.add(path: "second-file.txt")
+        results.append(makeResult("B", "add", addB))
+
+        let commitB = repoB.commit(message: "Tier B: commit on top of existing history", signature: signature)
+        results.append(makeResult("B", "commit-with-parent", commitB))
+
+        results.append(makeResult("B", "HEAD-after-commit", repoB.HEAD()))
+    }
+} else {
+    results.append(TierResult(tier: "B", step: "skipped", ok: false, detail: "no pre-seeded repo path passed as argv[1]"))
+}
+
+writeResultsAndExit(results)

--- a/Spikes/GitPackageSpike/scripts/build-and-run.sh
+++ b/Spikes/GitPackageSpike/scripts/build-and-run.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Build GitPackageSpike, wrap it in a real .app bundle, ad-hoc sign it with app-sandbox
+# entitlements, and run it via `open` — the same methodology #640 itself used to get a real
+# sandbox container attached (a bare Mach-O CLI binary makes sandboxd hang instead, per
+# Spikes/ContainerSpike's prior finding).
+#
+# Also runs the identical binary unsigned/unsandboxed first, as a control.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+SPIKE_DIR="$PWD"
+RESULTS_DIR="$SPIKE_DIR/results"
+BUNDLE_ID="io.dwk.anglesite.spikes.gitpackage"
+CONTAINER_DIR="$HOME/Library/Containers/$BUNDLE_ID"
+mkdir -p "$RESULTS_DIR"
+
+echo "==> swift build"
+swift build -c release --arch arm64
+
+BIN="$(swift build -c release --arch arm64 --show-bin-path)/GitPackageSpike"
+[[ -x "$BIN" ]] || { echo "FATAL: binary not at $BIN — did the build succeed?" >&2; exit 1; }
+
+echo
+echo "==> control: unsigned, unsandboxed run (tier B has no pre-seeded repo, so it's skipped)"
+"$BIN" \
+    > "$RESULTS_DIR/control.stdout.txt" \
+    2> "$RESULTS_DIR/control.stderr.txt" \
+    || echo "(exit $?)" >> "$RESULTS_DIR/control.stderr.txt"
+CONTROL_RESULT="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'gitpackagespike-result.json' -print -quit 2>/dev/null || true)"
+if [[ -n "$CONTROL_RESULT" ]]; then
+    cp "$CONTROL_RESULT" "$RESULTS_DIR/control-result.json"
+    echo "control result:"
+    cat "$RESULTS_DIR/control-result.json"
+    rm -f "$CONTROL_RESULT"
+else
+    echo "control: no result file found at ${TMPDIR:-/tmp}/gitpackagespike-result.json" >&2
+fi
+
+echo
+echo "==> building .app bundle"
+APP="$RESULTS_DIR/GitPackageSpike.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS"
+cp "$BIN" "$APP/Contents/MacOS/GitPackageSpike"
+cp "$SPIKE_DIR/Entitlements/Info.plist" "$APP/Contents/Info.plist"
+
+echo "==> pre-seeding tier B repo (real git, unsandboxed) inside the sandbox container's tmp dir"
+# The container dir is a normal folder any process running as this user can write to — sandbox
+# restricts what the *sandboxed app itself* can reach, not what other processes do to its
+# container ahead of time. This lets tier B test the steady-state "commit onto existing
+# history" path (NativeContentOperations) without routing through the very subprocess-git
+# call #640 found broken.
+CONTAINER_TMP="$CONTAINER_DIR/Data/tmp"
+mkdir -p "$CONTAINER_TMP"
+TIER_B_REPO="$CONTAINER_TMP/gitpackagespike-tierB-preseeded"
+rm -rf "$TIER_B_REPO"
+mkdir -p "$TIER_B_REPO"
+git -C "$TIER_B_REPO" init -q
+git -C "$TIER_B_REPO" config user.email "spike@anglesite.local"
+git -C "$TIER_B_REPO" config user.name "GitPackageSpike setup"
+echo "first file" > "$TIER_B_REPO/first-file.txt"
+git -C "$TIER_B_REPO" add first-file.txt
+git -C "$TIER_B_REPO" commit -q -m "Pre-seeded initial commit (real git, outside the sandbox)"
+
+echo "==> ad-hoc signing with sandbox entitlements"
+codesign --force --deep --sign - --entitlements "$SPIKE_DIR/Entitlements/sandboxed.plist" "$APP"
+codesign -d --entitlements - "$APP" 2>&1 | grep -A2 app-sandbox || true
+
+RESULT_JSON="$CONTAINER_TMP/gitpackagespike-result.json"
+rm -f "$RESULT_JSON"
+
+echo
+echo "==> launching sandboxed .app via 'open' (mirrors #640's own repro methodology)"
+open -W -a "$APP" --args "$TIER_B_REPO"
+
+echo "==> polling for result file at $RESULT_JSON"
+for _ in $(seq 1 20); do
+    [[ -f "$RESULT_JSON" ]] && break
+    sleep 0.5
+done
+
+if [[ -f "$RESULT_JSON" ]]; then
+    cp "$RESULT_JSON" "$RESULTS_DIR/sandboxed-result.json"
+    echo
+    echo "==> sandboxed result:"
+    cat "$RESULTS_DIR/sandboxed-result.json"
+else
+    echo "FATAL: no result file appeared at $RESULT_JSON after 10s — the sandboxed process" >&2
+    echo "likely crashed or was blocked before it could write output. Check Console.app for" >&2
+    echo "'GitPackageSpike' crash/sandbox-violation logs." >&2
+    exit 1
+fi
+
+echo
+echo "Saved to $RESULTS_DIR/{control,sandboxed}-result.json"

--- a/Spikes/VendoredGitSpike/.gitignore
+++ b/Spikes/VendoredGitSpike/.gitignore
@@ -1,0 +1,3 @@
+results/
+.build/
+vendor/

--- a/Spikes/VendoredGitSpike/Entitlements/Info.plist
+++ b/Spikes/VendoredGitSpike/Entitlements/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>VendoredGitSpike</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.dwk.anglesite.spikes.vendoredgit</string>
+	<key>CFBundleName</key>
+	<string>VendoredGitSpike</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<!-- Headless probe, per #640's own repro methodology and Spikes/ContainerSpike's finding
+	     that a bare Mach-O binary with no real .app bundle makes sandboxd hang. -->
+	<key>LSUIElement</key>
+	<true/>
+</dict>
+</plist>

--- a/Spikes/VendoredGitSpike/Entitlements/sandboxed.plist
+++ b/Spikes/VendoredGitSpike/Entitlements/sandboxed.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Mirrors Resources/Anglesite.entitlements' sandbox posture (minus virtualization/network,
+	     which are irrelevant to this probe). Deliberately NOT adding any exec-related
+	     temporary-exception entitlement — the whole point is testing whether a vendored binary
+	     needs one at all, or whether plain app-sandbox is sufficient like it is for any other
+	     bundled helper tool. -->
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+</dict>
+</plist>

--- a/Spikes/VendoredGitSpike/Package.swift
+++ b/Spikes/VendoredGitSpike/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.0
+// VendoredGitSpike — empirical harness for #640's Option 1: does a *vendored, non-Apple* git
+// binary (no Xcode Command Line Tools license-gate) execute as a subprocess from inside a real
+// App Sandbox container, where Apple's own `/usr/bin/git` refuses to run at all?
+//
+// See ../README.md for the run procedure and how this differs from ../GitPackageSpike (Option 2,
+// the SwiftGit2 in-process binding).
+
+import PackageDescription
+
+let package = Package(
+    name: "VendoredGitSpike",
+    platforms: [.macOS(.v13)],
+    targets: [
+        .executableTarget(name: "VendoredGitSpike")
+    ]
+)

--- a/Spikes/VendoredGitSpike/README.md
+++ b/Spikes/VendoredGitSpike/README.md
@@ -1,0 +1,116 @@
+# VendoredGitSpike
+
+Empirical harness for [#640](https://github.com/Anglesite/Anglesite-app/issues/640)'s Option 1:
+does a **vendored, non-Apple** git binary (no Xcode Command Line Tools license-gate) execute as a
+subprocess from inside a real App Sandbox container, where Apple's own `/usr/bin/git` refuses to
+run at all (`xcrun: error: cannot be used within an App Sandbox.`)?
+
+Companion to [`../GitPackageSpike`](../GitPackageSpike) (Option 2 — SwiftGit2, an in-process
+libgit2 binding). This spike tests the other branch of #640's "Suggested direction."
+
+```sh
+brew install git   # if not already installed — the vendor source
+Spikes/VendoredGitSpike/scripts/build-and-run.sh
+```
+
+Output lands in `results/sandboxed-result.json`.
+
+## What it tests
+
+One `.app` bundle, wrapped and ad-hoc signed with `com.apple.security.app-sandbox` (mirroring
+`Resources/Anglesite.entitlements`) and launched via `open` — same methodology #640 itself used,
+and required per `Spikes/ContainerSpike`'s prior finding that a bare Mach-O binary with no real
+`.app` bundle makes `sandboxd` hang instead of attaching a container.
+
+Deliberately **no extra entitlement** beyond plain `app-sandbox` + the file entitlements — the
+question is whether a vendored binary needs anything special at all, the same as any other
+bundled helper tool a sandboxed Mac app ships.
+
+Inside that one sandboxed process, the same `init` → `rev-parse --git-dir` → `add` → `commit` →
+`rev-parse HEAD` sequence (mirroring #640's own repro exactly) runs through **two** git binaries,
+back to back, for a direct comparison:
+
+| Tier | Binary | Purpose |
+|---|---|---|
+| V-vendored | Homebrew-built `git` (`/opt/homebrew/opt/git/bin/git`), copied into `Contents/Resources/git-vendor/`, `install_name_tool`-rewritten to `@executable_path`-relative dylib paths, and re-signed — fully self-contained, no dependency on `/opt/homebrew` existing on the target machine | The actual proposal: a git binary genuinely bundled inside the app |
+| S-system | Apple's `/usr/bin/git`, run unmodified | In-harness reproduction of #640, for a same-process, same-run comparison rather than trusting the issue's own repro on faith |
+
+Homebrew's `git` links only two non-system dylibs (`libpcre2-8.0.dylib`, `libintl.8.dylib` — both
+vendored alongside it); `init`/`add`/`commit`/`rev-parse` are all compiled-in builtins in the git
+binary itself (confirmed via `ls -li`: `libexec/git-core/git-{init,add,commit,rev-parse}` are all
+symlinks to the same `bin/git`), so no separate helper-script dispatch is needed for this
+sequence — the vendored `libexec/git-core/` symlink farm is just for shape-parity with a real git
+install, not functionally required here.
+
+## Result (2026-07-10, actually run in this worktree)
+
+**Tier V-vendored: full success.** All five steps passed, including a real root-commit:
+
+```
+init                  → "Initialized empty Git repository in .../vendoredgitspike-V-vendored-.../.git/"
+rev-parse --git-dir   → ".git"
+add                    → (silent success)
+commit                 → "[master (root-commit) 6e12d7b] Tier V-vendored: first commit"
+rev-parse HEAD         → "6e12d7bb2f3880ad806f33253a4747f7596f578a"
+```
+
+Notably, `commit` succeeded on a genuinely unborn `HEAD` (first-ever commit in a fresh repo) with
+**zero special-casing** — real git has always handled that case natively. This is the exact
+scenario `GitPackageSpike`'s Tier A found SwiftGit2's public API couldn't do without a patch.
+
+**Tier S-system: reproduces #640 exactly**, in the same process, same run: `init` fails
+immediately with `xcrun: error: cannot be used within an App Sandbox.`
+
+**The first run surfaced a real, informative side note**, not a sandbox blocker: Tier V initially
+failed too, but with a completely different error — `fatal: unable to access
+'/opt/homebrew/etc/gitconfig': Operation not permitted`. Homebrew's git build has a compile-time
+default *system* config path baked in (`/opt/homebrew/etc/gitconfig`), which sits outside the
+sandbox container and is unreadable — an ordinary sandbox file-read restriction, unrelated to
+`xcrun`/CLT gating. Setting `GIT_CONFIG_NOSYSTEM=1` (skip system config entirely) fixed it
+immediately. A binary actually built for vendoring (statically, with no baked-in external default
+paths) wouldn't hit this at all — Homebrew's build just happens to bake in a path that assumes a
+normal, non-sandboxed Homebrew install. Worth remembering as the class of gotcha to expect when
+building the real vendored binary (any compile-time default path — templates, system config,
+`.gitattributes` macros — needs to either not exist or resolve inside the bundle).
+
+## Why this succeeds where Apple's git fails
+
+`/usr/bin/git`'s failure is specific to Apple's own toolchain distribution: the error text
+(`xcrun: error: ...`) is characteristic of Xcode Command Line Tools' license-gating IPC, which
+Apple's own dev-tools binaries (git, clang, swift, etc.) are wired into regardless of what
+`file`/`strings` reports about the binary itself (see #640's own investigation, which ruled out a
+literal xcrun *stub* but still hit an xcrun-originated error). That gate is not a general "App
+Sandbox blocks all subprocess exec" rule — sandboxed Mac apps routinely bundle and exec their own
+helper tools (that's the *entire premise* of Option 1). A git binary with no relationship to
+Apple's CLT distribution simply never touches that gate.
+
+## Comparison with GitPackageSpike (Option 2)
+
+| | Option 1: vendored git binary | Option 2: SwiftGit2 (in-process) |
+|---|---|---|
+| Sandbox result | ✅ full success, no patch needed | ✅ success, but needs a ~15-line patch for first-commit ([SwiftGit2/SwiftGit2#174](https://github.com/SwiftGit2/SwiftGit2/issues/174), open since 2020) |
+| Unborn-HEAD first commit | Works natively — real git has always handled this | Requires the patch above |
+| Feature parity | Full real git (SSH, hooks, worktrees, LFS if ever needed) | Whatever SwiftGit2's API surface covers; SSH untested/likely absent in the pinned fork |
+| Ongoing maintenance surface | A vendored binary + build/update pipeline (like `container-image`/`container-kernel` already are) | A patch carried against a small (8★), single-maintainer Swift binding |
+| Integration shape | Subprocess — `ProcessSupervisor`/`GitInitRunner`/`NativeContentOperations` keep their current shape almost unchanged (just point at a bundled path instead of `/usr/bin/git`) | Rewrite of every git call site to libgit2 API calls |
+| Gotchas found | Compile-time default paths (system gitconfig) must be neutralized for a sandboxed bundle | Public API gap on unborn HEAD |
+
+## Follow-ups if this direction is pursued for real
+
+1. Don't ship Homebrew's build as-is — it bakes in `/opt/homebrew` assumptions (system config
+   path, likely others under load). Build git from source with `--prefix` pointed at a bundle-
+   relative path (or otherwise verify no other baked-in absolute paths survive), the way
+   `Resources/container-image/`, `Resources/container-kernel/` are already vendored via
+   `scripts/vendor-container-image.sh`/`scripts/vendor-container-kernel.sh`.
+2. Confirm this on a signed build with the actual `io.dwk.anglesite` bundle id / provisioning,
+   not just ad-hoc.
+3. `NativeContentOperations`/`GitInitRunner` already shell out via `ProcessSupervisor` with an
+   injected `executable: URL` — swapping `/usr/bin/git` for a bundled path is a small, contained
+   change to those call sites, not a rewrite.
+4. Binary size/build-time cost: a statically-linked git (with zlib/pcre2/iconv/gettext) adds
+   real weight to the app bundle — worth measuring against SwiftGit2's compiled-libgit2 footprint
+   (`Spikes/GitPackageSpike` already builds that for comparison).
+5. Licensing: git is GPLv2. Bundling a GPLv2 binary inside a Mac App Store app has real license
+   implications (distribution terms, source-availability obligations) that need review before
+   this direction is chosen for real — unlike SwiftGit2/libgit2, which is MIT/GPLv2-with-linking-
+   exception respectively and was already the less legally-encumbered path.

--- a/Spikes/VendoredGitSpike/Sources/VendoredGitSpike/main.swift
+++ b/Spikes/VendoredGitSpike/Sources/VendoredGitSpike/main.swift
@@ -1,0 +1,134 @@
+// VendoredGitSpike — probes whether a *vendored, non-Apple* git binary (built by Homebrew, no
+// Xcode Command Line Tools license-gate) can run as a subprocess from inside a real App-Sandbox
+// container, where #640 found Apple's own `/usr/bin/git` refuses to execute at all
+// (`xcrun: error: cannot be used within an App Sandbox.`).
+//
+// Runs the same command sequence through TWO binaries, side by side, in the same sandboxed
+// process, for a direct in-harness comparison:
+//   Tier V (vendored): the bundled Homebrew-built git at Resources/git-vendor/bin/git
+//   Tier S (system):   Apple's /usr/bin/git — expected to reproduce #640's failure right here
+//
+// Both write a JSON result array to the process's own sandbox container tmp dir, since a
+// GUI-launched (`open`) process has no terminal to print to. The driver script polls for that
+// file and prints it back out.
+
+import Foundation
+
+struct StepResult: Codable {
+    let tier: String
+    let step: String
+    let ok: Bool
+    let detail: String
+}
+
+var results: [StepResult] = []
+
+func run(_ executable: URL, _ arguments: [String], cwd: URL, env: [String: String]) -> (exitCode: Int32, stdout: String, stderr: String) {
+    let process = Process()
+    process.executableURL = executable
+    process.arguments = arguments
+    process.currentDirectoryURL = cwd
+    process.environment = env
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+
+    do {
+        try process.run()
+    } catch {
+        return (-1, "", "Process.run() threw: \(error)")
+    }
+    process.waitUntilExit()
+
+    let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+    return (
+        process.terminationStatus,
+        String(data: stdoutData, encoding: .utf8) ?? "",
+        String(data: stderrData, encoding: .utf8) ?? ""
+    )
+}
+
+/// Runs `git init` → write a file → `add` → `commit` → `rev-parse --git-dir` → `rev-parse HEAD`
+/// through the given git executable, recording one StepResult per step. Mirrors #640's own
+/// repro sequence exactly (including the leading read-only `rev-parse --git-dir` check).
+func probe(tier: String, gitExecutable: URL, env: [String: String]) -> [StepResult] {
+    var stepResults: [StepResult] = []
+    let workDir = FileManager.default.temporaryDirectory.appendingPathComponent("vendoredgitspike-\(tier)-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+
+    func step(_ name: String, _ args: [String]) -> Bool {
+        let result = run(gitExecutable, args, cwd: workDir, env: env)
+        let ok = result.exitCode == 0
+        let detail = ok
+            ? result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            : "exit \(result.exitCode): \(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))"
+        stepResults.append(StepResult(tier: tier, step: name, ok: ok, detail: detail))
+        return ok
+    }
+
+    guard step("init", ["init"]) else { return stepResults }
+    guard step("rev-parse --git-dir", ["rev-parse", "--git-dir"]) else { return stepResults }
+
+    let fileURL = workDir.appendingPathComponent("hello.txt")
+    try? "hello from VendoredGitSpike tier \(tier)".write(to: fileURL, atomically: true, encoding: .utf8)
+
+    guard step("add", ["add", "--", "hello.txt"]) else { return stepResults }
+    guard step(
+        "commit",
+        ["-c", "user.email=spike@anglesite.local", "-c", "user.name=VendoredGitSpike", "commit", "-m", "Tier \(tier): first commit"]
+    ) else { return stepResults }
+    _ = step("rev-parse HEAD", ["rev-parse", "HEAD"])
+
+    return stepResults
+}
+
+func writeResultsAndExit(_ results: [StepResult]) -> Never {
+    let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("vendoredgitspike-result.json")
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    do {
+        let data = try encoder.encode(results)
+        try data.write(to: outputURL, options: .atomic)
+    } catch {
+        try? "encode/write failed: \(error)".write(to: outputURL, atomically: true, encoding: .utf8)
+    }
+    exit(0)
+}
+
+// MARK: - Tier V: vendored, non-Apple git (bundled inside this .app, resolved via Bundle.main)
+
+let vendorEnv: [String: String] = [
+    "HOME": FileManager.default.temporaryDirectory.path,
+    "TMPDIR": FileManager.default.temporaryDirectory.path,
+]
+
+if let resourceURL = Bundle.main.resourceURL {
+    let vendoredGit = resourceURL.appendingPathComponent("git-vendor/bin/git")
+    if FileManager.default.isExecutableFile(atPath: vendoredGit.path) {
+        var env = vendorEnv
+        env["GIT_EXEC_PATH"] = resourceURL.appendingPathComponent("git-vendor/libexec/git-core").path
+        env["DYLD_LIBRARY_PATH"] = resourceURL.appendingPathComponent("git-vendor/lib").path
+        // Homebrew's git has a build-time default system-config path (/opt/homebrew/etc/gitconfig)
+        // baked in, which is outside the sandbox container and unreadable — a plain sandbox
+        // file-read restriction, not the xcrun CLT-gate #640 hit. A real vendored/statically-built
+        // git for production would carry no such external default; NOSYSTEM here just neutralizes
+        // Homebrew's specific build config so this spike measures the CLT-gate question in
+        // isolation.
+        env["GIT_CONFIG_NOSYSTEM"] = "1"
+        results.append(contentsOf: probe(tier: "V-vendored", gitExecutable: vendoredGit, env: env))
+    } else {
+        results.append(StepResult(tier: "V-vendored", step: "locate-binary", ok: false, detail: "not found/executable at \(vendoredGit.path)"))
+    }
+} else {
+    results.append(StepResult(tier: "V-vendored", step: "locate-bundle", ok: false, detail: "Bundle.main.resourceURL is nil"))
+}
+
+// MARK: - Tier S: Apple's system git, run through the identical sequence in the same sandboxed
+// process — an in-harness reproduction of #640, for direct side-by-side comparison.
+
+results.append(contentsOf: probe(tier: "S-system", gitExecutable: URL(fileURLWithPath: "/usr/bin/git"), env: vendorEnv))
+
+writeResultsAndExit(results)

--- a/Spikes/VendoredGitSpike/scripts/build-and-run.sh
+++ b/Spikes/VendoredGitSpike/scripts/build-and-run.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Build VendoredGitSpike, vendor a non-Apple (Homebrew-built) git binary + its two dylib deps
+# into a real .app bundle, ad-hoc sign it with app-sandbox entitlements, and run it via `open` —
+# the same methodology #640 itself used to get a real sandbox container attached.
+#
+# The probe binary runs the identical init/add/commit/rev-parse sequence through BOTH the
+# vendored git and Apple's system /usr/bin/git, in the same sandboxed process, for a direct
+# side-by-side comparison.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+SPIKE_DIR="$PWD"
+RESULTS_DIR="$SPIKE_DIR/results"
+VENDOR_DIR="$SPIKE_DIR/vendor"
+BUNDLE_ID="io.dwk.anglesite.spikes.vendoredgit"
+mkdir -p "$RESULTS_DIR"
+
+BREW_GIT_PREFIX="$(brew --prefix git 2>/dev/null || true)"
+if [[ -z "$BREW_GIT_PREFIX" || ! -x "$BREW_GIT_PREFIX/bin/git" ]]; then
+    echo "FATAL: Homebrew git not found. Run 'brew install git' first (this spike needs a" >&2
+    echo "non-Apple git build — the point is testing a binary NOT gated by Xcode CLT licensing)." >&2
+    exit 1
+fi
+echo "==> using vendor source: $BREW_GIT_PREFIX/bin/git ($("$BREW_GIT_PREFIX/bin/git" --version))"
+
+echo "==> swift build"
+swift build -c release --arch arm64
+
+BIN="$(swift build -c release --arch arm64 --show-bin-path)/VendoredGitSpike"
+[[ -x "$BIN" ]] || { echo "FATAL: binary not at $BIN — did the build succeed?" >&2; exit 1; }
+
+echo
+echo "==> assembling vendored git payload in $VENDOR_DIR"
+rm -rf "$VENDOR_DIR"
+mkdir -p "$VENDOR_DIR/bin" "$VENDOR_DIR/lib" "$VENDOR_DIR/libexec/git-core"
+
+cp "$BREW_GIT_PREFIX/bin/git" "$VENDOR_DIR/bin/git"
+PCRE2_DYLIB="$(otool -L "$BREW_GIT_PREFIX/bin/git" | awk '/libpcre2/{print $1}')"
+INTL_DYLIB="$(otool -L "$BREW_GIT_PREFIX/bin/git" | awk '/libintl/{print $1}')"
+cp "$PCRE2_DYLIB" "$VENDOR_DIR/lib/$(basename "$PCRE2_DYLIB")"
+cp "$INTL_DYLIB" "$VENDOR_DIR/lib/$(basename "$INTL_DYLIB")"
+# libintl itself depends on libiconv, which is a stable /usr/lib system dylib on every macOS
+# version — no need to vendor it.
+
+chmod u+w "$VENDOR_DIR/bin/git" "$VENDOR_DIR/lib/"*.dylib
+
+echo "==> rewriting dylib load paths to be self-contained (@executable_path-relative)"
+install_name_tool -change "$PCRE2_DYLIB" "@executable_path/../lib/$(basename "$PCRE2_DYLIB")" "$VENDOR_DIR/bin/git"
+install_name_tool -change "$INTL_DYLIB" "@executable_path/../lib/$(basename "$INTL_DYLIB")" "$VENDOR_DIR/bin/git"
+install_name_tool -id "@executable_path/../lib/$(basename "$PCRE2_DYLIB")" "$VENDOR_DIR/lib/$(basename "$PCRE2_DYLIB")"
+install_name_tool -id "@executable_path/../lib/$(basename "$INTL_DYLIB")" "$VENDOR_DIR/lib/$(basename "$INTL_DYLIB")"
+
+echo "==> re-signing vendored payload (install_name_tool invalidates existing signatures)"
+codesign --force --sign - "$VENDOR_DIR/lib/"*.dylib
+codesign --force --sign - "$VENDOR_DIR/bin/git"
+
+# git's builtins (init/add/commit/rev-parse) don't need libexec/git-core dispatch, but a
+# GIT_EXEC_PATH that resolves to something real avoids startup warnings — symlink farm back to
+# the one vendored binary, exactly matching Homebrew's own layout shape.
+for cmd in git git-init git-add git-commit git-rev-parse; do
+    ln -sf ../../bin/git "$VENDOR_DIR/libexec/git-core/$cmd"
+done
+
+echo "==> verifying vendored binary now only references system + self-contained libs"
+otool -L "$VENDOR_DIR/bin/git"
+
+echo
+echo "==> building .app bundle"
+APP="$RESULTS_DIR/VendoredGitSpike.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+cp "$BIN" "$APP/Contents/MacOS/VendoredGitSpike"
+cp "$SPIKE_DIR/Entitlements/Info.plist" "$APP/Contents/Info.plist"
+cp -R "$VENDOR_DIR" "$APP/Contents/Resources/git-vendor"
+
+echo "==> ad-hoc signing the whole bundle with sandbox entitlements"
+codesign --force --deep --sign - --entitlements "$SPIKE_DIR/Entitlements/sandboxed.plist" "$APP"
+codesign -d --entitlements - "$APP" 2>&1 | grep -A2 app-sandbox || true
+
+RESULT_JSON="$HOME/Library/Containers/$BUNDLE_ID/Data/tmp/vendoredgitspike-result.json"
+rm -f "$RESULT_JSON"
+
+echo
+echo "==> launching sandboxed .app via 'open' (mirrors #640's own repro methodology)"
+open -W -a "$APP"
+
+echo "==> polling for result file at $RESULT_JSON"
+for _ in $(seq 1 20); do
+    [[ -f "$RESULT_JSON" ]] && break
+    sleep 0.5
+done
+
+if [[ -f "$RESULT_JSON" ]]; then
+    cp "$RESULT_JSON" "$RESULTS_DIR/sandboxed-result.json"
+    echo
+    echo "==> sandboxed result:"
+    cat "$RESULTS_DIR/sandboxed-result.json"
+else
+    echo "FATAL: no result file appeared at $RESULT_JSON after 10s." >&2
+    exit 1
+fi
+
+echo
+echo "Saved to $RESULTS_DIR/sandboxed-result.json"

--- a/Tests/AnglesiteCoreTests/GitInitRunnerTests.swift
+++ b/Tests/AnglesiteCoreTests/GitInitRunnerTests.swift
@@ -2,39 +2,41 @@ import XCTest
 @testable import AnglesiteCore
 
 /// Regression coverage for #548: production wiring in `SitesLauncherView` used to discard the
-/// `RunResult` of `git init` entirely (`_ = try await ...run(...)`), so a nonzero exit code never
-/// surfaced as an error or even a warning — the scaffolder's "non-fatal" git-init step silently
-/// believed it had succeeded. `GitInitRunner` centralizes the exit-code check so it can't regress.
+/// result of `git init` entirely (`_ = try await ...run(...)`), so a failure never surfaced as an
+/// error or even a warning — the scaffolder's "non-fatal" git-init step silently believed it had
+/// succeeded. `GitInitRunner` centralizes the failure check so it can't regress.
+///
+/// Runs against SwiftGit2 (in-process libgit2, #640) rather than a subprocess — there's no
+/// injectable command runner to fake exit codes with anymore, so these exercise the real thing
+/// against real temp directories.
 final class GitInitRunnerTests: XCTestCase {
 
-    func testThrowsWithStderrOnNonzeroExit() async {
-        let dir = URL(fileURLWithPath: "/tmp/some-site")
-        do {
-            try await GitInitRunner.run(in: dir) { _, _, _ in
-                ProcessSupervisor.RunResult(stdout: "", stderr: "fatal: not a valid path", exitCode: 128)
-            }
-            XCTFail("expected GitInitError to be thrown")
-        } catch let error as GitInitError {
-            guard case .failed(let exitCode, let stderr) = error else { return XCTFail("wrong case") }
-            XCTAssertEqual(exitCode, 128)
-            XCTAssertEqual(stderr, "fatal: not a valid path")
-            XCTAssertEqual(error.errorDescription, "git init exited 128: fatal: not a valid path")
-        } catch {
-            XCTFail("expected GitInitError, got \(error)")
-        }
+    func testSucceedsAndCreatesAGitDirectory() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("gitinitrunner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try GitInitRunner.run(in: dir)
+
+        var isDirectory: ObjCBool = false
+        let gitDirExists = FileManager.default.fileExists(atPath: dir.appendingPathComponent(".git").path, isDirectory: &isDirectory)
+        XCTAssertTrue(gitDirExists)
+        XCTAssertTrue(isDirectory.boolValue)
     }
 
-    func testSucceedsOnZeroExit() async throws {
-        let dir = URL(fileURLWithPath: "/tmp/some-site")
-        var capturedArgs: [String] = []
-        var capturedCwd: URL?
-        try await GitInitRunner.run(in: dir) { executable, args, cwd in
-            capturedArgs = args
-            capturedCwd = cwd
-            XCTAssertEqual(executable.path, "/usr/bin/git")
-            return ProcessSupervisor.RunResult(stdout: "Initialized empty Git repository", stderr: "", exitCode: 0)
+    func testThrowsGitInitErrorWhenTargetIsNotADirectory() throws {
+        // git_repository_init requires a directory; pointing it at a plain file must fail.
+        let file = FileManager.default.temporaryDirectory.appendingPathComponent("gitinitrunner-\(UUID().uuidString)-not-a-dir")
+        try Data("not a directory".utf8).write(to: file)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        XCTAssertThrowsError(try GitInitRunner.run(in: file)) { error in
+            guard let gitError = error as? GitInitError else {
+                return XCTFail("expected GitInitError, got \(error)")
+            }
+            guard case .failed(let message) = gitError else { return XCTFail("wrong case") }
+            XCTAssertFalse(message.isEmpty)
+            XCTAssertEqual(gitError.errorDescription, "git init failed: \(message)")
         }
-        XCTAssertEqual(capturedArgs, ["init"])
-        XCTAssertEqual(capturedCwd, dir)
     }
 }

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -215,6 +215,35 @@ struct NativeContentOperationsTests {
         #expect(sha?.count == 40)
     }
 
+    @Test("processGitCommit returns nil when the configured git identity can't be resolved")
+    func realGitNoIdentity() async throws {
+        // Forcing "genuinely no user.name/user.email anywhere in the config chain" isn't
+        // reliably constructible here: SwiftGit2's resolution goes through libgit2's own
+        // process-global config-search-path cache (populated once, at first SwiftGit2Init()), so
+        // mutating HOME/XDG_CONFIG_HOME mid-test doesn't retroactively affect it. Making the local
+        // repo config merely unreadable doesn't work either — empirically verified: libgit2
+        // silently skips an inaccessible local config and falls through to this dev/CI machine's
+        // real ambient global config instead of failing. What *does* reliably fail is malformed
+        // config syntax: a config file libgit2 can open but not parse is a hard error, not a
+        // silently-skipped level. This is a different trigger than "no identity configured
+        // anywhere" but exercises the exact thing this test actually cares about: a
+        // `defaultSignature()` failure, for any reason, must make `processGitCommit` return nil
+        // rather than crash or silently misbehave (finding #2 in PR #649's review).
+        let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        _ = try await ProcessSupervisor.shared.run(executable: git, arguments: ["init"], currentDirectoryURL: repo)
+        // Deliberately no `git config user.email`/`user.name` this time — and the config file's
+        // contents are overwritten with unparseable garbage below, so it can't fall back to
+        // whatever `git init` itself wrote there either.
+        let configPath = repo.appendingPathComponent(".git/config")
+        try "[core\nthis is not valid git-config syntax".write(to: configPath, atomically: true, encoding: .utf8)
+
+        try "page".write(to: repo.appendingPathComponent("p.astro"), atomically: true, encoding: .utf8)
+        let sha = await NativeContentOperations.processGitCommit(repo, "p.astro", "anglesite: add page /p")
+        #expect(sha == nil)
+    }
+
     @Test("processGitDelete removes and commits the file, nil outside a repo")
     func realGitDelete() async throws {
         // Outside a repo → nil (best-effort), file untouched.

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -253,11 +253,16 @@ struct NativeContentOperationsTests {
         try "<div>original</div>".write(to: filePath, atomically: true, encoding: .utf8)
         _ = await NativeContentOperations.processGitCommit(repo, "unused.astro", "add unused.astro")
 
-        // Install a pre-commit hook that always rejects, so `git commit` fails after `git rm`
-        // has already removed the file from the index and working tree.
-        let hookPath = repo.appendingPathComponent(".git/hooks/pre-commit")
-        try "#!/bin/sh\nexit 1\n".write(to: hookPath, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hookPath.path)
+        // Force the commit step to fail after the remove already succeeds: make the object
+        // database unwritable, so writing the new tree/commit objects fails. This used to be a
+        // rejecting `.git/hooks/pre-commit` hook, but SwiftGit2/libgit2 never runs shell hooks —
+        // a documented, accepted difference from the subprocess-git implementation this replaced
+        // (see processGitCommit's doc comment) — so a hook no longer exercises this path at all.
+        // Read access is untouched (0o555), so the rollback's restore-from-HEAD (which only reads
+        // existing objects, not writes new ones) still works.
+        let objectsDir = repo.appendingPathComponent(".git/objects")
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: objectsDir.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: objectsDir.path) }
 
         let sha = await NativeContentOperations.processGitDelete(repo, "unused.astro", "Remove unused.astro")
         #expect(sha == nil)


### PR DESCRIPTION
## Summary

- App Sandbox blocks `/usr/bin/git` from executing at all (Apple's Xcode CLT license gate rejects it outright, even for read-only calls) — silently breaking every git write `NativeContentOperations`/`GitInitRunner` made once Anglesite became MAS-sandboxed-only. See #640 for the original repro.
- Spiked both of #640's suggested directions before picking one — `Spikes/GitPackageSpike` (in-process libgit2 binding) and `Spikes/VendoredGitSpike` (a vendored non-Apple git binary run as a subprocess). Both work under sandbox; went with the libgit2 binding because bundling GPLv2 git inside a Mac App Store app raises real distribution-license questions (see full writeup on #640) that a permissively-licensed binding avoids.
- Wires [github.com/Anglesite/SwiftGit2](https://github.com/Anglesite/SwiftGit2) — Anglesite's fork of `mbernson/SwiftGit2`, carrying four small patches:
  - A fix for [SwiftGit2/SwiftGit2#174](https://github.com/SwiftGit2/SwiftGit2/issues/174) (open since 2020): the first commit into a freshly `git init`'d repo failed on unborn HEAD.
  - `Repository.defaultSignature()`, wrapping `git_signature_default` — SwiftGit2 had no way to resolve the caller's configured git identity (`user.name`/`user.email`), which subprocess git did automatically.
  - `Repository.remove(path:)`, `headHasEntry(atPath:)`, `restorePathFromHEAD(_:)` — `git rm`, `cat-file -e HEAD:path`, and `checkout HEAD -- path` equivalents, needed for `processGitDelete`'s rollback safety (see below).
- `GitInitRunner` now calls `Repository.create(at:)` instead of spawning `git init`.
- `NativeContentOperations.processGitCommit` now does `add` → `defaultSignature()` → `commit` via SwiftGit2 instead of shelling out to `git add`/`git commit`/`git rev-parse`.
- `NativeContentOperations.processGitDelete` now does the same via `headHasEntry` → `remove(path:)` → `defaultSignature()` → `commit`, with `restorePathFromHEAD(_:)` on the rollback path if the commit fails after the remove succeeds — same safety property the subprocess version had (this is the sole undo/archive mechanism for content deletion; there's no separate trash).

## Portability

All of it is gated behind `#if canImport(Darwin)`. `AnglesiteCore` is in the portable target set (#571) and SwiftGit2 is Darwin-only, so non-Darwin platforms keep the plain subprocess-git path — which is correct there, since App Sandbox doesn't exist off-macOS. `Package.swift`'s SwiftGit2 dependency is added under the same gate.

## Test plan

- [x] `GitInitRunnerTests` (2 tests, rewritten for the new API — real temp-dir git init, success + not-a-directory failure)
- [x] `NativeContentOperationsTests` + sibling suites (37 tests) — full pass, including `processGitCommit`/`processGitDelete`'s real-repo integration tests now exercising the SwiftGit2 path
- [x] `rollbackOnCommitFailure`'s failure-injection mechanism changed: it used to install a rejecting `.git/hooks/pre-commit` hook, but libgit2 never runs shell hooks (a documented difference from subprocess git), so that hook silently stopped doing anything and the test was passing for the wrong reason. Replaced with making `.git/objects` temporarily unwritable, which fails the object write at the libgit2 level regardless of backend.
- [x] `anglesite/SwiftGit2`'s three new methods (`remove`/`headHasEntry`/`restorePathFromHEAD`) have their own coverage: `Tests/SwiftGit2Tests/AnglesiteDeleteSpec.swift` (5 tests, `.serialized` — libgit2 isn't safe for uncoordinated concurrent use across threads, which Swift Testing's default parallel pool triggered)
- [x] `swift build --build-tests` — clean full build
- [ ] Full unfiltered `AnglesiteCoreTests` run hit a pre-existing slow/hanging spot unrelated to this diff (known e2e-test flakiness in this repo per prior sessions) — relied on the targeted, comprehensive filtered run instead. Worth CI confirming.
- [ ] Not yet verified on a signed, sandboxed build of the actual `Anglesite` app target (only verified via the `Spikes/GitPackageSpike` harness's own signed `.app`) — worth a manual GUI smoke (New Post/Page/Component/Delete/Undo under a real MAS-entitled build) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
