### PR TITLE
feat(git): move Backup to in-process SwiftGit2 push — sandbox-safe (#653)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -290,7 +290,7 @@ var packageDependencies: [Package.Dependency] = []
 // pinning to anglesite/main's tip would silently pick up unreviewed future commits. Bump
 // deliberately.
 packageDependencies.append(
-    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "49d2a87bcfa9c0e4f94862e7cfaa129d2adf64db")
+    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "7b24b5bf95600e30aef69e94f7c45d7e6341f302")
 )
 #endif
 

--- a/Package.swift
+++ b/Package.swift
@@ -290,7 +290,7 @@ var packageDependencies: [Package.Dependency] = []
 // pinning to anglesite/main's tip would silently pick up unreviewed future commits. Bump
 // deliberately.
 packageDependencies.append(
-    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "7b24b5bf95600e30aef69e94f7c45d7e6341f302")
+    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "65a16e39b09c16770a684ca29f3d5b242b9d0313")
 )
 #endif
 

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/accounts.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/accounts.html
@@ -13,7 +13,8 @@
 	<p class="lead">Connect your GitHub and Cloudflare accounts so Anglesite can back up and publish your site.</p>
 
 	<h2>GitHub</h2>
-	<p>Connecting your site to GitHub happens outside Anglesite. Your site's <code>Source</code> folder is an ordinary Git repository, so you can add a GitHub remote with the <code>gh</code> command-line tool or <code>git remote</code> in Terminal. Once the repository has an origin configured, Anglesite uses it to back up and publish your site.</p>
+	<p>Your site's <code>Source</code> folder is an ordinary Git repository, so you can add a GitHub remote with the <code>gh</code> command-line tool or <code>git remote</code> in Terminal. Once the repository has an origin configured, Anglesite uses it to back up and publish your site.</p>
+	<p>To let Anglesite push to GitHub, add a GitHub personal access token in <strong>Settings ▸ Advanced</strong>. Create a fine-grained token with <em>Contents: Read and write</em> access for your site's repository at <code>github.com/settings/tokens</code>.</p>
 
 	<h2>Cloudflare</h2>
 	<p>When Anglesite needs to deploy to Cloudflare, it will prompt you to provide a Cloudflare API token. You can create one in your Cloudflare dashboard.</p>

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -114,11 +114,13 @@ private struct AdvancedSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 #else
-                LabeledContent("GitHub") {
-                    Text("Uses your existing `git` credentials")
-                        .foregroundStyle(.secondary)
-                }
-                Text("The App Store build doesn't bundle `gh`. Anglesite uses whatever `git` credentials are already configured on your Mac (Keychain or SSH key) when pushing.")
+                KeychainTokenRow(
+                    title: "GitHub personal access token",
+                    read: { try KeychainStore().readGitHubToken() },
+                    write: { try KeychainStore().writeGitHubToken($0) },
+                    clear: { try KeychainStore().clearGitHubToken() }
+                )
+                Text("Used to push backups and publish sites to GitHub over HTTPS (the sandboxed app can't run `git` or `gh`, so it pushes in-process with this token). Create a fine-grained token with Contents read/write access at github.com/settings/tokens. Stored in the macOS Keychain under `io.dwk.anglesite` and never written to logs.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 #endif
@@ -170,11 +172,28 @@ private struct AdvancedSettingsView: View {
     }
 }
 
-/// Cloudflare API token row. Reads the current state from the Keychain on appear; saves a new
-/// value on commit; clears the slot on "Clear". The field stays a `SecureField` so the token
-/// doesn't appear in a screen share, but the actual secret bytes only round-trip when the user
-/// edits the field — appearing only redacts.
+/// Cloudflare API token row — the Keychain-token row bound to the Cloudflare slot.
 private struct CloudflareTokenRow: View {
+    var body: some View {
+        KeychainTokenRow(
+            title: "Cloudflare API token",
+            read: { try KeychainStore().readCloudflareToken() },
+            write: { try KeychainStore().writeCloudflareToken($0) },
+            clear: { try KeychainStore().clearCloudflareToken() }
+        )
+    }
+}
+
+/// Generic Keychain-backed token row (Cloudflare, GitHub). Reads the current state from the
+/// Keychain on appear; saves a new value on commit; clears the slot on "Clear". The field stays
+/// a `SecureField` so the token doesn't appear in a screen share, but the actual secret bytes
+/// only round-trip when the user edits the field — appearing only redacts.
+private struct KeychainTokenRow: View {
+    let title: String
+    let read: () throws -> String?
+    let write: (String) throws -> Void
+    let clear: () throws -> Void
+
     @State private var token: String = ""
     @State private var status: Status = .unknown
     @State private var savedMessage: String?
@@ -186,20 +205,18 @@ private struct CloudflareTokenRow: View {
         case error(String)
     }
 
-    private let store = KeychainStore()
-
     var body: some View {
-        LabeledContent("Cloudflare API token") {
+        LabeledContent(title) {
             VStack(alignment: .trailing, spacing: 6) {
                 HStack(spacing: 8) {
                     SecureField("paste token", text: $token, prompt: Text(promptText))
                         .textFieldStyle(.roundedBorder)
                         .frame(minWidth: 240)
-                        .accessibilityLabel("Cloudflare API token")
+                        .accessibilityLabel(title)
                         .accessibilityValue(statusDescription)
                     Button("Save") { save() }
                         .disabled(token.isEmpty)
-                    Button("Clear") { clear() }
+                    Button("Clear") { doClear() }
                         .disabled(status != .present)
                 }
                 if let savedMessage {
@@ -237,7 +254,7 @@ private struct CloudflareTokenRow: View {
 
     private func refreshStatus() {
         do {
-            status = (try store.readCloudflareToken() != nil) ? .present : .absent
+            status = (try read() != nil) ? .present : .absent
         } catch {
             status = .error("couldn't read keychain: \(error)")
         }
@@ -245,7 +262,7 @@ private struct CloudflareTokenRow: View {
 
     private func save() {
         do {
-            try store.writeCloudflareToken(token)
+            try write(token)
             token = ""
             status = .present
             savedMessage = "Saved."
@@ -255,9 +272,9 @@ private struct CloudflareTokenRow: View {
         }
     }
 
-    private func clear() {
+    private func doClear() {
         do {
-            try store.clearCloudflareToken()
+            try clear()
             token = ""
             status = .absent
             savedMessage = "Cleared."
@@ -269,8 +286,8 @@ private struct CloudflareTokenRow: View {
 }
 
 // The gh-backed GitHub panel is compiled out of the App Store build. A sandboxed app can't rely
-// on a user-installed `gh`; it uses the user's existing git credentials instead — see the #else
-// branch in the Credentials section above.
+// on a user-installed `gh` (nor spawn `git` at all, #640) — it stores its own GitHub token and
+// pushes in-process instead; see the KeychainTokenRow in the #else branch above (#653).
 #if !ANGLESITE_MAS
 /// "Connect GitHub" row. The app never sees the GitHub token — `gh` stores it in its own
 /// credential store. This row just launches the `gh auth login` device-code flow and

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -118,7 +118,22 @@ private struct AdvancedSettingsView: View {
                     title: "GitHub personal access token",
                     read: { try KeychainStore().readGitHubToken() },
                     write: { try KeychainStore().writeGitHubToken($0) },
-                    clear: { try KeychainStore().clearGitHubToken() }
+                    clear: {
+                        try KeychainStore().clearGitHubToken()
+                        AppSettings.shared.gitHubAccount = nil
+                    },
+                    verify: { token in
+                        switch await GitHubAPITokenVerifier().verify(token: token) {
+                        case .success(let account):
+                            AppSettings.shared.gitHubAccount = account
+                            return .success(.init(label: account.login, detail: account.name, avatarURL: account.avatarURL))
+                        case .failure(let error):
+                            return .failure(error.userMessage)
+                        }
+                    },
+                    cachedIdentity: {
+                        AppSettings.shared.gitHubAccount.map { .init(label: $0.login, detail: $0.name, avatarURL: $0.avatarURL) }
+                    }
                 )
                 Text("Used to push backups and publish sites to GitHub over HTTPS (the sandboxed app can't run `git` or `gh`, so it pushes in-process with this token). Create a fine-grained token with Contents read/write access at github.com/settings/tokens. Stored in the macOS Keychain under `io.dwk.anglesite` and never written to logs.")
                     .font(.caption)
@@ -172,14 +187,32 @@ private struct AdvancedSettingsView: View {
     }
 }
 
-/// Cloudflare API token row — the Keychain-token row bound to the Cloudflare slot.
+/// Cloudflare API token row — the Keychain-token row bound to the Cloudflare slot. Verifies
+/// against Cloudflare before persisting (same "verify then persist" shape `TokenOnboarding`
+/// uses at deploy time) so the row can surface the connected account, not just "token stored".
 private struct CloudflareTokenRow: View {
     var body: some View {
         KeychainTokenRow(
             title: "Cloudflare API token",
             read: { try KeychainStore().readCloudflareToken() },
             write: { try KeychainStore().writeCloudflareToken($0) },
-            clear: { try KeychainStore().clearCloudflareToken() }
+            clear: {
+                try KeychainStore().clearCloudflareToken()
+                AppSettings.shared.cloudflareAccount = nil
+            },
+            verify: { token in
+                // siteDirectory is vestigial on this protocol — verification is a pure API call.
+                switch await CloudflareAPITokenVerifier().verify(token: token, siteDirectory: FileManager.default.homeDirectoryForCurrentUser) {
+                case .success(let account):
+                    AppSettings.shared.cloudflareAccount = account
+                    return .success(.init(label: account.name ?? "Verified", detail: account.email, avatarURL: nil))
+                case .failure(let error):
+                    return .failure(error.userMessage)
+                }
+            },
+            cachedIdentity: {
+                AppSettings.shared.cloudflareAccount.map { .init(label: $0.name ?? "Verified", detail: $0.email, avatarURL: nil) }
+            }
         )
     }
 }
@@ -188,19 +221,49 @@ private struct CloudflareTokenRow: View {
 /// Keychain on appear; saves a new value on commit; clears the slot on "Clear". The field stays
 /// a `SecureField` so the token doesn't appear in a screen share, but the actual secret bytes
 /// only round-trip when the user edits the field — appearing only redacts.
+///
+/// When `verify` is supplied, `Save` checks the token against the provider's API first and, on
+/// success, surfaces the connected account — "Signed in as octocat" with an avatar for GitHub,
+/// a checkmark + account name for Cloudflare — instead of a bare "Saved." This mirrors Xcode's
+/// Accounts pane, which shows who you're signed in as rather than just "credential stored", and
+/// matches `GitHubAuthRow` below (the non-MAS `gh`-backed row already does this). `verify`
+/// defaults to `nil` — a future token slot with nothing to verify against just omits it and
+/// keeps the plain "Saved."/"Token stored" behavior.
 private struct KeychainTokenRow: View {
+    /// The identity to display after a token verifies. `detail` is a secondary line (e.g. a
+    /// GitHub display name, a Cloudflare account email) shown only when it differs from `label`.
+    struct Identity: Equatable {
+        let label: String
+        let detail: String?
+        let avatarURL: URL?
+    }
+
+    enum VerifyOutcome {
+        case success(Identity)
+        case failure(String)
+    }
+
     let title: String
     let read: () throws -> String?
     let write: (String) throws -> Void
     let clear: () throws -> Void
+    /// A plain `String` failure message, not `Error` — the verify closures wrap already-classified
+    /// provider errors (`GitHubTokenVerifyError.userMessage`, `TokenVerifyError.userMessage`) that
+    /// have nothing left to inspect, so there's no reason to make the row re-wrap a real `Error`.
+    var verify: ((String) async -> VerifyOutcome)? = nil
+    /// Reads back a previously verified identity (e.g. `AppSettings.shared.gitHubAccount`) so a
+    /// stored token still shows "Signed in as …" on the next launch without re-verifying eagerly.
+    var cachedIdentity: () -> Identity? = { nil }
 
     @State private var token: String = ""
     @State private var status: Status = .unknown
     @State private var savedMessage: String?
+    @State private var isBusy = false
 
     private enum Status: Equatable {
         case unknown
         case present
+        case connected(Identity)
         case absent
         case error(String)
     }
@@ -208,18 +271,25 @@ private struct KeychainTokenRow: View {
     var body: some View {
         LabeledContent(title) {
             VStack(alignment: .trailing, spacing: 6) {
+                if case .connected(let identity) = status {
+                    connectedLabel(identity)
+                }
                 HStack(spacing: 8) {
                     SecureField("paste token", text: $token, prompt: Text(promptText))
                         .textFieldStyle(.roundedBorder)
                         .frame(minWidth: 240)
+                        .disabled(isBusy)
                         .accessibilityLabel(title)
                         .accessibilityValue(statusDescription)
-                    Button("Save") { save() }
-                        .disabled(token.isEmpty)
+                    Button("Save") { Task { await save() } }
+                        .disabled(token.isEmpty || isBusy)
                     Button("Clear") { doClear() }
-                        .disabled(status != .present)
+                        .disabled(!isStored || isBusy)
                 }
-                if let savedMessage {
+                if isBusy {
+                    ProgressView().controlSize(.small)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                } else if let savedMessage {
                     Text(savedMessage)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -230,12 +300,48 @@ private struct KeychainTokenRow: View {
                 }
             }
         }
-        .task { refreshStatus() }
+        .task { await refreshStatus() }
+    }
+
+    private var isStored: Bool {
+        switch status {
+        case .present, .connected: return true
+        case .unknown, .absent, .error: return false
+        }
+    }
+
+    @ViewBuilder
+    private func connectedLabel(_ identity: Identity) -> some View {
+        HStack(spacing: 6) {
+            if let avatarURL = identity.avatarURL {
+                AsyncImage(url: avatarURL) { phase in
+                    if let image = phase.image {
+                        image.resizable().scaledToFill()
+                    } else {
+                        Circle().fill(Color.secondary.opacity(0.2))
+                    }
+                }
+                .frame(width: 18, height: 18)
+                .clipShape(Circle())
+            } else {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            }
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Signed in as \(identity.label)")
+                    .font(.caption)
+                if let detail = identity.detail, detail != identity.label {
+                    Text(detail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
     }
 
     private var promptText: String {
         switch status {
-        case .present: return "•••••••• (stored)"
+        case .present, .connected: return "•••••••• (stored)"
         case .absent:  return "paste token"
         case .unknown: return ""
         case .error:   return "paste token"
@@ -245,29 +351,72 @@ private struct KeychainTokenRow: View {
     /// Spoken status for VoiceOver — the redacted `SecureField` prompt isn't announced clearly.
     private var statusDescription: String {
         switch status {
-        case .present:           return "Token stored"
-        case .absent:            return "No token stored"
-        case .unknown:           return "Checking…"
-        case .error(let message): return "Error: \(message)"
+        case .present:                  return "Token stored"
+        case .connected(let identity):  return "Signed in as \(identity.label)"
+        case .absent:                   return "No token stored"
+        case .unknown:                  return "Checking…"
+        case .error(let message):       return "Error: \(message)"
         }
     }
 
-    private func refreshStatus() {
+    private func refreshStatus() async {
+        let stored: String?
         do {
-            status = (try read() != nil) ? .present : .absent
+            stored = try read()
         } catch {
             status = .error("couldn't read keychain: \(error)")
+            return
         }
+        guard let stored else {
+            status = .absent
+            return
+        }
+        if let cached = cachedIdentity() {
+            status = .connected(cached)
+            return
+        }
+        status = .present
+        guard let verify else { return }
+        // A token exists but nothing's cached yet — saved before this feature shipped, or via an
+        // env-var override some callers use. Best-effort silent backfill: a failure here just
+        // leaves the generic "stored" wording rather than surfacing a scary error for an ambient
+        // background check the user didn't ask for.
+        isBusy = true
+        if case .success(let identity) = await verify(stored) {
+            status = .connected(identity)
+        }
+        isBusy = false
     }
 
-    private func save() {
-        do {
-            try write(token)
-            token = ""
-            status = .present
-            savedMessage = "Saved."
-        } catch {
-            status = .error("couldn't save: \(error)")
+    private func save() async {
+        let candidate = token
+        guard let verify else {
+            do {
+                try write(candidate)
+                token = ""
+                status = .present
+                savedMessage = "Saved."
+            } catch {
+                status = .error("couldn't save: \(error)")
+                savedMessage = nil
+            }
+            return
+        }
+        isBusy = true
+        let outcome = await verify(candidate)
+        isBusy = false
+        switch outcome {
+        case .success(let identity):
+            do {
+                try write(candidate)
+                token = ""
+                status = .connected(identity)
+                savedMessage = nil
+            } catch {
+                status = .error("couldn't save: \(error)")
+            }
+        case .failure(let message):
+            status = .error(message)
             savedMessage = nil
         }
     }

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -26,6 +26,12 @@ public final class AppSettings: @unchecked Sendable {
         public static let announcesLiveUpdates = "anglesite.announcesLiveUpdates"
         public static let notifiesOnCompletion = "anglesite.notifiesOnCompletion"
         public static let didCleanLegacyChatBackendDefaults = "anglesite.didCleanLegacyChatBackendDefaults"
+        public static let gitHubAccountLogin = "anglesite.gitHubAccount.login"
+        public static let gitHubAccountName = "anglesite.gitHubAccount.name"
+        public static let gitHubAccountAvatarURL = "anglesite.gitHubAccount.avatarURL"
+        public static let cloudflareAccountVerified = "anglesite.cloudflareAccount.verified"
+        public static let cloudflareAccountName = "anglesite.cloudflareAccount.name"
+        public static let cloudflareAccountEmail = "anglesite.cloudflareAccount.email"
     }
 
     private enum LegacyKey {
@@ -198,6 +204,59 @@ public final class AppSettings: @unchecked Sendable {
                 defaults.removeObject(forKey: Key.lastOpenedSiteID)
             }
         }
+    }
+
+    /// Best-effort GitHub identity from the last successful token verification, shown in Settings
+    /// instead of a bare "token stored" — the same "who am I signed in as" surfacing Xcode's
+    /// Accounts pane does. Non-secret display fields only; the token itself lives in the Keychain,
+    /// never here. `nil` until a token verifies at least once (see `GitHubAPITokenVerifier`).
+    public var gitHubAccount: GitHubAccount? {
+        get {
+            guard let login = defaults.string(forKey: Key.gitHubAccountLogin), !login.isEmpty else { return nil }
+            let name = defaults.string(forKey: Key.gitHubAccountName)
+            let avatarURL = defaults.string(forKey: Key.gitHubAccountAvatarURL).flatMap(URL.init(string:))
+            return GitHubAccount(login: login, name: name, avatarURL: avatarURL)
+        }
+        set {
+            guard let account = newValue else {
+                defaults.removeObject(forKey: Key.gitHubAccountLogin)
+                defaults.removeObject(forKey: Key.gitHubAccountName)
+                defaults.removeObject(forKey: Key.gitHubAccountAvatarURL)
+                return
+            }
+            defaults.set(account.login, forKey: Key.gitHubAccountLogin)
+            setOptionalString(account.name, forKey: Key.gitHubAccountName)
+            setOptionalString(account.avatarURL?.absoluteString, forKey: Key.gitHubAccountAvatarURL)
+        }
+    }
+
+    /// Best-effort Cloudflare identity from the last successful token verification. A dedicated
+    /// "verified" flag (rather than inferring presence from `name`/`email`) distinguishes a
+    /// verified-but-uninformative token — a scoped token lacking `account:read` still verifies,
+    /// just with nothing to show — from a token that's never been checked at all.
+    public var cloudflareAccount: CloudflareAccount? {
+        get {
+            guard defaults.bool(forKey: Key.cloudflareAccountVerified) else { return nil }
+            return CloudflareAccount(
+                name: defaults.string(forKey: Key.cloudflareAccountName),
+                email: defaults.string(forKey: Key.cloudflareAccountEmail)
+            )
+        }
+        set {
+            guard let account = newValue else {
+                defaults.removeObject(forKey: Key.cloudflareAccountVerified)
+                defaults.removeObject(forKey: Key.cloudflareAccountName)
+                defaults.removeObject(forKey: Key.cloudflareAccountEmail)
+                return
+            }
+            defaults.set(true, forKey: Key.cloudflareAccountVerified)
+            setOptionalString(account.name, forKey: Key.cloudflareAccountName)
+            setOptionalString(account.email, forKey: Key.cloudflareAccountEmail)
+        }
+    }
+
+    private func setOptionalString(_ value: String?, forKey key: String) {
+        if let value { defaults.set(value, forKey: key) } else { defaults.removeObject(forKey: key) }
     }
 
     /// One-time cleanup for settings removed when chat became Foundation Models-only.

--- a/Sources/AnglesiteCore/BackupCommand.swift
+++ b/Sources/AnglesiteCore/BackupCommand.swift
@@ -255,10 +255,18 @@ public actor BackupCommand {
 
     // MARK: - Default production seams
 
+    #if canImport(Darwin)
+    /// Default `GitRunner`: in-process SwiftGit2 via `InProcessGit` (#653) — `/usr/bin/git`
+    /// cannot execute at all under the MAS App Sandbox (#640), so the old subprocess default
+    /// was dead code exactly where it mattered.
+    public static let defaultRunner: GitRunner = { siteDirectory, arguments in
+        await InProcessGit.run(siteDirectory: siteDirectory, arguments: arguments)
+    }
+    #else
     /// Default `GitRunner`: shells out to `git` via `ProcessSupervisor.shared.run(...)`.
     /// Uses `/usr/bin/env` so the user's shell-resolved `git` is used (matches what they'd
-    /// run in Terminal). Under the MAS sandbox this still spawns directly from the app, so
-    /// the per-site security-scoped grant is inherited.
+    /// run in Terminal). Off-Darwin there's no App Sandbox to route around, so subprocess
+    /// git remains correct here rather than a gap to fill.
     public static let defaultRunner: GitRunner = { siteDirectory, arguments in
         try await ProcessSupervisor.shared.run(
             executable: URL(fileURLWithPath: "/usr/bin/env"),
@@ -266,7 +274,17 @@ public actor BackupCommand {
             currentDirectoryURL: siteDirectory
         )
     }
+    #endif
 
+    #if canImport(Darwin)
+    /// Default `GitStreamer`: in-process SwiftGit2 via `InProcessGit` (#653). Step-level
+    /// progress lines land in `LogCenter` under `source` (so the drawer still narrates the
+    /// backup), and failure detail comes back directly as `stderr` — no subprocess, no
+    /// subscription dance.
+    public static let defaultStreamer: GitStreamer = { siteDirectory, arguments, source in
+        await InProcessGit.stream(siteDirectory: siteDirectory, arguments: arguments, source: source)
+    }
+    #else
     /// Default `GitStreamer`: launches `git` via `ProcessSupervisor.shared.launch(...)` so
     /// stdout/stderr flow into `LogCenter` line-by-line under `source`. Waits for exit and
     /// returns the code; `git push`'s auth-prompt back-and-forth is therefore visible in
@@ -310,8 +328,10 @@ public actor BackupCommand {
         case .retriesExhausted(let lastCode):   return (lastCode, stderr)
         }
     }
+    #endif
 }
 
+#if !canImport(Darwin)
 /// Accumulates streamed stderr lines for `BackupCommand.defaultStreamer`. An actor so the
 /// `@Sendable` collect Task can append without a lock.
 private actor StderrCollector {
@@ -319,3 +339,4 @@ private actor StderrCollector {
     func append(_ line: String) { lines.append(line) }
     func joined() -> String { lines.joined(separator: "\n") }
 }
+#endif

--- a/Sources/AnglesiteCore/GitHubAPITokenVerifier.swift
+++ b/Sources/AnglesiteCore/GitHubAPITokenVerifier.swift
@@ -1,0 +1,118 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// A GitHub account surfaced after a personal access token verifies — the identity Settings
+/// displays instead of a bare "token stored" (mirrors Xcode's Accounts pane, which shows who
+/// you're signed in as). `name` and `avatarURL` are best-effort niceties; `login` is always
+/// present on a valid token.
+public struct GitHubAccount: Sendable, Equatable {
+    public let login: String
+    public let name: String?
+    public let avatarURL: URL?
+
+    public init(login: String, name: String?, avatarURL: URL?) {
+        self.login = login
+        self.name = name
+        self.avatarURL = avatarURL
+    }
+}
+
+/// Why verifying a pasted GitHub token failed, with the user-facing copy Settings shows.
+public enum GitHubTokenVerifyError: Error, Equatable, Sendable {
+    /// The token was rejected by GitHub (bad/expired/revoked).
+    case invalidToken
+    /// We couldn't reach GitHub (DNS/connection failure).
+    case network
+    /// We couldn't check the token at all (rate limit, outage, unexpected response).
+    case unavailable(String)
+
+    public var userMessage: String {
+        switch self {
+        case .invalidToken:
+            return "That token didn’t work. Create a fine-grained token with Contents: Read and write access at github.com/settings/tokens and paste the whole token."
+        case .network:
+            return "Couldn’t reach GitHub. Check your connection and try again."
+        case .unavailable(let reason):
+            return reason
+        }
+    }
+}
+
+/// Verifies a GitHub personal access token before it's persisted, so a bad token is caught at
+/// the point of entry — and surfaces the connected identity for display, the same "verify then
+/// persist" shape as `TokenVerifying` (Cloudflare).
+public protocol GitHubTokenVerifying: Sendable {
+    func verify(token: String) async -> Result<GitHubAccount, GitHubTokenVerifyError>
+}
+
+/// Verifies a GitHub PAT by calling `GET /user` on the GitHub REST API directly. The HTTP step
+/// is injected (`Transport`) so the classification logic is unit-testable without real network —
+/// same seam philosophy as `CloudflareAPITokenVerifier`.
+public struct GitHubAPITokenVerifier: GitHubTokenVerifying {
+    /// Performs one authenticated GET and returns its body + response. Throws on connection failure.
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    private let baseURL: URL
+    private let transport: Transport
+
+    public init(
+        baseURL: URL = URL(string: "https://api.github.com")!,
+        transport: @escaping Transport = GitHubAPITokenVerifier.defaultTransport
+    ) {
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    public func verify(token: String) async -> Result<GitHubAccount, GitHubTokenVerifyError> {
+        var request = URLRequest(url: baseURL.appendingPathComponent("user"))
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+
+        let data: Data
+        let http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            return .failure(.network)
+        }
+
+        // 401 is an unambiguous bad/expired/revoked token. `/user` needs no specific scope, so a
+        // 403 is far more likely a rate limit than a genuinely invalid token — don't blame the
+        // user's token for it. 429/5xx are transient outages, same reasoning.
+        if http.statusCode == 401 {
+            return .failure(.invalidToken)
+        }
+        if http.statusCode == 403 || http.statusCode == 429 || http.statusCode >= 500 {
+            return .failure(.unavailable("GitHub is unavailable right now (HTTP \(http.statusCode)). Try again in a moment."))
+        }
+        guard (200..<300).contains(http.statusCode),
+              let user = try? JSONDecoder().decode(UserResponse.self, from: data)
+        else {
+            return .failure(.unavailable("GitHub returned an unexpected response while checking the token."))
+        }
+        return .success(GitHubAccount(login: user.login, name: user.name, avatarURL: user.avatarURLString.flatMap(URL.init(string:))))
+    }
+
+    /// Production transport: a plain `URLSession` GET.
+    public static let defaultTransport: Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+
+    private struct UserResponse: Decodable {
+        let login: String
+        let name: String?
+        let avatarURLString: String?
+
+        enum CodingKeys: String, CodingKey {
+            case login, name
+            case avatarURLString = "avatar_url"
+        }
+    }
+}

--- a/Sources/AnglesiteCore/InProcessGit.swift
+++ b/Sources/AnglesiteCore/InProcessGit.swift
@@ -1,0 +1,285 @@
+#if canImport(Darwin)
+import Foundation
+import SwiftGit2
+
+/// Executes `BackupCommand`'s git vocabulary in-process via SwiftGit2 (libgit2) — `/usr/bin/git`
+/// cannot execute at all under the MAS App Sandbox (#640/#653). This is deliberately an
+/// interpreter for the *exact* argument vectors `BackupCommand` issues, not a general git CLI
+/// shim: the vocabulary is closed (eight commands), both ends live in this module, and keeping
+/// the `GitRunner`/`GitStreamer` seams' shape means the command's orchestration — refusal
+/// ordering, cancellation guards, the #246 unpushed-commit check — and its entire test suite
+/// carry over unchanged. An argument vector outside the vocabulary fails loudly (exit 64)
+/// rather than guessing.
+///
+/// Exit codes are synthesized: 0 success, 1 generic failure, 128 "not a repository" (matching
+/// subprocess git's fatal exit), 64 unsupported usage. `BackupCommand` only branches on
+/// zero/non-zero; the codes exist for log readability.
+///
+/// libgit2 calls are blocking (push does real network I/O), so they run on a Dispatch global
+/// queue via `offPool` rather than on the cooperative pool. Like `NativeContentOperations`,
+/// each call opens its own `Repository` handle; cross-process/file-level git locking covers
+/// concurrent access the same way it does for two `git` processes.
+public enum InProcessGit {
+    /// Reads the GitHub personal access token used for HTTPS pushes. The default reads the
+    /// app-owned Keychain slot (`SecretAccounts.gitHubToken`); tests inject their own.
+    public typealias TokenProvider = @Sendable () throws -> String?
+
+    public static let defaultTokenProvider: TokenProvider = {
+        try PlatformSecretStore.make().readGitHubToken()
+    }
+
+    // MARK: - Introspection (BackupCommand.GitRunner shape)
+
+    /// Handles: `rev-parse --is-inside-work-tree`, `rev-parse --abbrev-ref HEAD`,
+    /// `rev-parse HEAD`, `remote get-url <name>`, `status --porcelain`,
+    /// `rev-list --count <upstream>..HEAD`.
+    public static func run(siteDirectory: URL, arguments: [String]) async -> ProcessSupervisor.RunResult {
+        await offPool { runSync(siteDirectory: siteDirectory, arguments: arguments) }
+    }
+
+    // MARK: - Mutations (BackupCommand.GitStreamer shape)
+
+    /// Handles: `add -A`, `commit -m <message>`, `push <remote> <branch>`. Step-level progress
+    /// and failure detail stream to `LogCenter` under `source` (logs are sacred); the returned
+    /// `stderr` carries the same failure detail so `BackupCommand` can surface it in the
+    /// `.failed` reason.
+    ///
+    /// Unlike the subprocess streamer there is no process to SIGTERM on cancellation:
+    /// `BackupCommand`'s between-step guards still apply, but an in-flight push runs to
+    /// completion — the #246 ahead-check recovers the "committed, cancelled before push
+    /// finished" case either way.
+    public static func stream(
+        siteDirectory: URL,
+        arguments: [String],
+        source: String,
+        tokenProvider: @escaping TokenProvider = InProcessGit.defaultTokenProvider
+    ) async -> (exitCode: Int32, stderr: String) {
+        let log = LogCenter.shared
+        // Narrate the slow step up front: everything else here is local and fast, but a push
+        // does network I/O, and the drawer should show "pushing…" while it happens — not a
+        // batch of lines after the fact.
+        if arguments.count == 3, arguments[0] == "push" {
+            await log.append(source: source, stream: .stdout, text: "pushing \(arguments[2]) to \(arguments[1])…")
+        }
+        let result = await offPool { streamSync(siteDirectory: siteDirectory, arguments: arguments, tokenProvider: tokenProvider) }
+        for line in result.stdoutLines {
+            await log.append(source: source, stream: .stdout, text: line)
+        }
+        if !result.stderr.isEmpty {
+            await log.append(source: source, stream: .stderr, text: result.stderr)
+        }
+        return (result.exitCode, result.stderr)
+    }
+
+    // MARK: - Introspection implementation
+
+    private static func runSync(siteDirectory: URL, arguments: [String]) -> ProcessSupervisor.RunResult {
+        SwiftGit2Bootstrap.ensureInitialized
+
+        func repository() -> Result<Repository, NSError> { Repository.at(siteDirectory) }
+
+        /// Opens the repo, runs `body`, and maps success stdout / failure stderr into a
+        /// `RunResult`. Failure exit is 1 — `BackupCommand` only branches on non-zero.
+        func withRepository(_ body: (Repository) -> Result<String, NSError>) -> ProcessSupervisor.RunResult {
+            switch repository().flatMap(body) {
+            case .success(let stdout):
+                return .init(stdout: stdout, stderr: "", exitCode: 0)
+            case .failure(let error):
+                return .init(stdout: "", stderr: errorText(error), exitCode: 1)
+            }
+        }
+
+        if arguments == ["rev-parse", "--is-inside-work-tree"] {
+            switch repository() {
+            case .success:
+                return .init(stdout: "true\n", stderr: "", exitCode: 0)
+            case .failure(let error):
+                return .init(stdout: "", stderr: errorText(error), exitCode: 128)
+            }
+        }
+
+        if arguments == ["rev-parse", "--abbrev-ref", "HEAD"] {
+            return withRepository { repo in
+                repo.HEAD().map { head in
+                    // A branch resolves to its short name; a detached HEAD prints "HEAD",
+                    // matching subprocess `rev-parse --abbrev-ref`.
+                    ((head as? Branch)?.name ?? "HEAD") + "\n"
+                }
+            }
+        }
+
+        if arguments == ["rev-parse", "HEAD"] {
+            return withRepository { repo in
+                repo.HEAD().map { $0.oid.description + "\n" }
+            }
+        }
+
+        if arguments.count == 3, arguments[0] == "remote", arguments[1] == "get-url" {
+            let name = arguments[2]
+            return withRepository { repo in
+                repo.remote(named: name).map { $0.URL + "\n" }
+            }
+        }
+
+        if arguments == ["status", "--porcelain"] {
+            return withRepository { repo in
+                repo.status().map { entries in
+                    entries.map { entry in
+                        let path = entry.indexToWorkDir?.newFile?.path
+                            ?? entry.headToIndex?.newFile?.path
+                            ?? entry.headToIndex?.oldFile?.path
+                            ?? "(unknown path)"
+                        return "?? \(path)"
+                    }
+                    .joined(separator: "\n")
+                }
+            }
+        }
+
+        if arguments.count == 3, arguments[0] == "rev-list", arguments[1] == "--count",
+           arguments[2].hasSuffix("..HEAD") {
+            let upstreamName = String(arguments[2].dropLast("..HEAD".count))
+            guard upstreamName.contains("/") else { return unsupported(arguments) }
+            return withRepository { repo in
+                repo.HEAD().flatMap { head in
+                    repo.remoteBranch(named: upstreamName).flatMap { upstream in
+                        repo.aheadBehind(local: head.oid, upstream: upstream.oid).map { "\($0.ahead)\n" }
+                    }
+                }
+            }
+        }
+
+        return unsupported(arguments)
+    }
+
+    // MARK: - Mutation implementation
+
+    private struct StreamOutcome {
+        var exitCode: Int32
+        var stderr: String
+        var stdoutLines: [String] = []
+    }
+
+    private static func streamSync(
+        siteDirectory: URL,
+        arguments: [String],
+        tokenProvider: TokenProvider
+    ) -> StreamOutcome {
+        SwiftGit2Bootstrap.ensureInitialized
+
+        let repo: Repository
+        switch Repository.at(siteDirectory) {
+        case .success(let opened): repo = opened
+        case .failure(let error): return .init(exitCode: 128, stderr: errorText(error))
+        }
+
+        if arguments == ["add", "-A"] {
+            switch repo.addAll() {
+            case .success:
+                return .init(exitCode: 0, stderr: "", stdoutLines: ["staged all changes (add -A)"])
+            case .failure(let error):
+                return .init(exitCode: 1, stderr: errorText(error))
+            }
+        }
+
+        if arguments.count == 3, arguments[0] == "commit", arguments[1] == "-m" {
+            let message = arguments[2]
+            let result = repo.defaultSignature().flatMap { signature in
+                repo.commit(message: message, signature: signature)
+            }
+            switch result {
+            case .success(let commit):
+                return .init(exitCode: 0, stderr: "", stdoutLines: ["committed \(commit.oid.description.prefix(7)): \(message)"])
+            case .failure(let error):
+                // The most likely failure is a missing identity (git's own "Please tell me who
+                // you are"): git_signature_default needs user.name/user.email, and the sandboxed
+                // app can't read ~/.gitconfig — only the site repo's local config.
+                let hint = errorText(error).lowercased().contains("config")
+                    ? " — set an identity in the site repository: `git config user.name \"You\"` and `git config user.email you@example.com` in \(siteDirectory.path)"
+                    : ""
+                return .init(exitCode: 1, stderr: errorText(error) + hint)
+            }
+        }
+
+        if arguments.count == 3, arguments[0] == "push" {
+            return push(remoteName: arguments[1], branch: arguments[2], in: repo, tokenProvider: tokenProvider)
+        }
+
+        let result = unsupported(arguments)
+        return .init(exitCode: result.exitCode, stderr: result.stderr)
+    }
+
+    private static func push(
+        remoteName: String,
+        branch: String,
+        in repo: Repository,
+        tokenProvider: TokenProvider
+    ) -> StreamOutcome {
+        let remoteURL: String
+        switch repo.remote(named: remoteName) {
+        case .success(let remote): remoteURL = remote.URL
+        case .failure(let error): return .init(exitCode: 1, stderr: errorText(error))
+        }
+
+        // HTTPS remotes authenticate with the app-owned GitHub token; anything else (file://
+        // test remotes, exotic setups) goes through libgit2's default credentials. A missing
+        // token fails fast with a remediation instead of a network round-trip that would end
+        // in an opaque libgit2 auth error.
+        let credentials: Credentials
+        if remoteURL.hasPrefix("https://") || remoteURL.hasPrefix("http://") {
+            let token: String?
+            do {
+                token = try tokenProvider()
+            } catch {
+                return .init(exitCode: 1, stderr: "couldn't read the GitHub token from the Keychain: \(error)")
+            }
+            guard let token, !token.isEmpty else {
+                return .init(
+                    exitCode: 1,
+                    stderr: "pushing to \(remoteURL) needs GitHub authentication — add a GitHub personal access token in Settings, then run Backup again."
+                )
+            }
+            credentials = .plaintext(username: "x-access-token", password: token)
+        } else {
+            credentials = .default
+        }
+
+        let refspec = "refs/heads/\(branch):refs/heads/\(branch)"
+        switch repo.push(remoteName: remoteName, refspec: refspec, credentials: credentials) {
+        case .success:
+            return .init(exitCode: 0, stderr: "", stdoutLines: ["push complete: \(branch) → \(remoteURL)"])
+        case .failure(let error):
+            var detail = errorText(error)
+            let lowered = detail.lowercased()
+            if remoteURL.hasPrefix("http"), lowered.contains("auth") || lowered.contains("credential") || lowered.contains("401") {
+                detail += " — your GitHub token may have expired or lack access to this repository; update it in Settings."
+            }
+            return .init(exitCode: 1, stderr: detail)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func unsupported(_ arguments: [String]) -> ProcessSupervisor.RunResult {
+        return .init(
+            stdout: "",
+            stderr: "unsupported in-process git invocation: git \(arguments.joined(separator: " "))",
+            exitCode: 64
+        )
+    }
+
+    private static func errorText(_ error: NSError) -> String {
+        error.localizedDescription
+    }
+
+    /// Runs blocking libgit2 work on a Dispatch global queue so a slow network push never
+    /// parks a cooperative-pool thread.
+    private static func offPool<T: Sendable>(_ work: @escaping @Sendable () -> T) async -> T {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: work())
+            }
+        }
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/InProcessGit.swift
+++ b/Sources/AnglesiteCore/InProcessGit.swift
@@ -5,11 +5,13 @@ import SwiftGit2
 /// Executes `BackupCommand`'s git vocabulary in-process via SwiftGit2 (libgit2) — `/usr/bin/git`
 /// cannot execute at all under the MAS App Sandbox (#640/#653). This is deliberately an
 /// interpreter for the *exact* argument vectors `BackupCommand` issues, not a general git CLI
-/// shim: the vocabulary is closed (eight commands), both ends live in this module, and keeping
-/// the `GitRunner`/`GitStreamer` seams' shape means the command's orchestration — refusal
-/// ordering, cancellation guards, the #246 unpushed-commit check — and its entire test suite
-/// carry over unchanged. An argument vector outside the vocabulary fails loudly (exit 64)
-/// rather than guessing.
+/// shim: the vocabulary is closed (nine shapes: `rev-parse --is-inside-work-tree`, `rev-parse
+/// --abbrev-ref HEAD`, `rev-parse HEAD`, `remote get-url <name>`, `status --porcelain`,
+/// `rev-list --count <upstream>..HEAD`, `add -A`, `commit -m <msg>`, `push <remote> <branch>`),
+/// both ends live in this module, and keeping the `GitRunner`/`GitStreamer` seams' shape means
+/// the command's orchestration — refusal ordering, cancellation guards, the #246 unpushed-commit
+/// check — and its entire test suite carry over unchanged. An argument vector outside the
+/// vocabulary fails loudly (exit 64) rather than guessing.
 ///
 /// Exit codes are synthesized: 0 success, 1 generic failure, 128 "not a repository" (matching
 /// subprocess git's fatal exit), 64 unsupported usage. `BackupCommand` only branches on
@@ -17,8 +19,19 @@ import SwiftGit2
 ///
 /// libgit2 calls are blocking (push does real network I/O), so they run on a Dispatch global
 /// queue via `offPool` rather than on the cooperative pool. Like `NativeContentOperations`,
-/// each call opens its own `Repository` handle; cross-process/file-level git locking covers
-/// concurrent access the same way it does for two `git` processes.
+/// each call opens its own `Repository` handle for the site directory it's given.
+///
+/// Concurrency: the fork's own test suite runs `.serialized` because uncoordinated concurrent
+/// libgit2 use is unsafe in general — but the risk that guards against (racing the process-wide,
+/// lazily-populated libgit2 config-search-path cache on first use) is already closed here by
+/// `SwiftGit2Bootstrap.ensureInitialized`'s `static let`: Swift guarantees a `static let`
+/// initializer runs exactly once even when first touched concurrently from multiple threads, so
+/// every caller blocks on the same one-time `SwiftGit2Init()` before any repository operation
+/// runs. Past that, two concurrent calls against *different* site directories each open their own
+/// `Repository` handle and don't share libgit2 state, so concurrent backups of different sites
+/// are safe. Two concurrent calls against the *same* site directory are not coordinated — the
+/// same class of hazard as two `git` processes racing on one working directory, not something new
+/// this port introduced.
 public enum InProcessGit {
     /// Reads the GitHub personal access token used for HTTPS pushes. The default reads the
     /// app-owned Keychain slot (`SecretAccounts.gitHubToken`); tests inject their own.
@@ -129,7 +142,7 @@ public enum InProcessGit {
                             ?? entry.headToIndex?.newFile?.path
                             ?? entry.headToIndex?.oldFile?.path
                             ?? "(unknown path)"
-                        return "?? \(path)"
+                        return "\(porcelainCode(for: entry.status)) \(path)"
                     }
                     .joined(separator: "\n")
                 }
@@ -270,6 +283,32 @@ public enum InProcessGit {
 
     private static func errorText(_ error: NSError) -> String {
         error.localizedDescription
+    }
+
+    /// Maps a libgit2 `Diff.Status` set to git's two-letter porcelain code (`git status
+    /// --porcelain`'s XY: index status, then worktree status) — real codes rather than a
+    /// fabricated `??` for every entry. `BackupCommand` only checks `.isEmpty` today, but a
+    /// future caller parsing codes (or a human reading `LogCenter`) should see the truth.
+    /// `conflicted` collapses every unmerged combination to `UU` — real git distinguishes which
+    /// side changed (`AA`, `DU`, `UD`, …), a distinction nothing here currently consumes.
+    private static func porcelainCode(for status: Diff.Status) -> String {
+        if status.contains(.conflicted) { return "UU" }
+        if status.contains(.workTreeNew) { return "??" }
+
+        var x: Character = " "
+        if status.contains(.indexNew) { x = "A" }
+        else if status.contains(.indexModified) { x = "M" }
+        else if status.contains(.indexDeleted) { x = "D" }
+        else if status.contains(.indexRenamed) { x = "R" }
+        else if status.contains(.indexTypeChange) { x = "T" }
+
+        var y: Character = " "
+        if status.contains(.workTreeModified) { y = "M" }
+        else if status.contains(.workTreeDeleted) { y = "D" }
+        else if status.contains(.workTreeTypeChange) { y = "T" }
+        else if status.contains(.workTreeRenamed) { y = "R" }
+
+        return "\(x)\(y)"
     }
 
     /// Runs blocking libgit2 work on a Dispatch global queue so a slow network push never

--- a/Sources/AnglesiteCore/Platform/KeychainStore.swift
+++ b/Sources/AnglesiteCore/Platform/KeychainStore.swift
@@ -19,8 +19,13 @@ import Security
 /// Security notes:
 /// - `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` keeps the token off iCloud Keychain and
 ///   inaccessible while the Mac is locked.
-/// - The token must never be logged. `DeployCommand` passes it via `environment` (which is opaque
-///   to the supervisor's stdout/stderr pump), so it does not end up in `LogCenter`.
+/// - The token must never be logged. `DeployCommand` passes the Cloudflare token via
+///   `environment` (which is opaque to the supervisor's stdout/stderr pump), so it never reaches
+///   `LogCenter`. The GitHub token (#653) takes a different path with the same invariant but a
+///   different mechanism: `InProcessGit` hands it to libgit2 through a `Credentials.plaintext`
+///   push callback — never interpolated into a URL, error string, or log line it constructs — so
+///   it likewise never reaches `LogCenter`, though its blast radius differs (an in-process
+///   credential callback vs. an opaque subprocess environment variable).
 public struct KeychainStore: SecretStore {
     public enum Error: Swift.Error, Equatable {
         /// `SecItemCopyMatching` / `SecItemAdd` / `SecItemUpdate` / `SecItemDelete` returned a

--- a/Sources/AnglesiteCore/Platform/SecretStore.swift
+++ b/Sources/AnglesiteCore/Platform/SecretStore.swift
@@ -29,6 +29,10 @@ public protocol SecretStore: Sendable {
 public enum SecretAccounts {
     /// The Cloudflare API token used by `wrangler deploy`.
     public static let cloudflareToken = "cloudflare-api-token"
+    /// The GitHub personal access token used for in-process git pushes (#653) and the GitHub
+    /// REST API (#654). The app owns this credential: the old `gh auth login` flow left the
+    /// token with `gh`, which the sandboxed app can neither spawn nor read.
+    public static let gitHubToken = "github-token"
 }
 
 public extension SecretStore {
@@ -45,6 +49,21 @@ public extension SecretStore {
     /// Clear the Cloudflare API token slot.
     func clearCloudflareToken() throws {
         try delete(account: SecretAccounts.cloudflareToken)
+    }
+
+    /// Read the GitHub personal access token under the shared account key.
+    func readGitHubToken() throws -> String? {
+        try read(account: SecretAccounts.gitHubToken)
+    }
+
+    /// Store the GitHub personal access token under the shared account key. Empty string clears.
+    func writeGitHubToken(_ token: String) throws {
+        try write(token, account: SecretAccounts.gitHubToken)
+    }
+
+    /// Clear the GitHub personal access token slot.
+    func clearGitHubToken() throws {
+        try delete(account: SecretAccounts.gitHubToken)
     }
 }
 

--- a/Tests/AnglesiteCoreTests/AppSettingsTests.swift
+++ b/Tests/AnglesiteCoreTests/AppSettingsTests.swift
@@ -155,4 +155,54 @@ final class AppSettingsTests {
     @Test("Debug menu revealed by option key in release") func debugMenuRevealedByOptionKeyInRelease() {
         #expect(DebugPaneVisibility.menuItemVisible(isDebugBuild: false, settingEnabled: false, optionHeldAtLaunch: true))
     }
+
+    // MARK: Cached verified-account identity (Settings "surfaced like Xcode does")
+
+    @Test("GitHub account defaults to nil") func gitHubAccountDefaultsToNil() {
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.gitHubAccount == nil)
+    }
+
+    @Test("GitHub account round trip, including a nil name/avatar") func gitHubAccountRoundTrip() {
+        let settings = AppSettings(defaults: defaults)
+        let account = GitHubAccount(login: "octocat", name: "The Octocat", avatarURL: URL(string: "https://example.com/a.png"))
+        settings.gitHubAccount = account
+        #expect(settings.gitHubAccount == account)
+
+        settings.gitHubAccount = GitHubAccount(login: "octocat2", name: nil, avatarURL: nil)
+        #expect(settings.gitHubAccount == GitHubAccount(login: "octocat2", name: nil, avatarURL: nil))
+    }
+
+    @Test("Clearing the GitHub account removes all its fields") func gitHubAccountClear() {
+        let settings = AppSettings(defaults: defaults)
+        settings.gitHubAccount = GitHubAccount(login: "octocat", name: "The Octocat", avatarURL: nil)
+        settings.gitHubAccount = nil
+        #expect(settings.gitHubAccount == nil)
+        #expect(defaults.string(forKey: AppSettings.Key.gitHubAccountName) == nil)
+    }
+
+    @Test("Cloudflare account defaults to nil") func cloudflareAccountDefaultsToNil() {
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.cloudflareAccount == nil)
+    }
+
+    @Test("Cloudflare account round trip, distinguishing a nameless-but-verified account from unset")
+    func cloudflareAccountRoundTrip() {
+        let settings = AppSettings(defaults: defaults)
+        settings.cloudflareAccount = CloudflareAccount(name: "Acme Corp", email: nil)
+        #expect(settings.cloudflareAccount == CloudflareAccount(name: "Acme Corp", email: nil))
+
+        // A verified token whose account lookup returned nothing still counts as "connected" —
+        // must not read back the same as "never verified".
+        settings.cloudflareAccount = CloudflareAccount(name: nil, email: nil)
+        #expect(settings.cloudflareAccount == CloudflareAccount(name: nil, email: nil))
+    }
+
+    @Test("Clearing the Cloudflare account removes all its fields") func cloudflareAccountClear() {
+        let settings = AppSettings(defaults: defaults)
+        settings.cloudflareAccount = CloudflareAccount(name: "Acme Corp", email: "a@example.com")
+        settings.cloudflareAccount = nil
+        #expect(settings.cloudflareAccount == nil)
+        #expect(defaults.string(forKey: AppSettings.Key.cloudflareAccountName) == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/BackupCommandInProcessTests.swift
+++ b/Tests/AnglesiteCoreTests/BackupCommandInProcessTests.swift
@@ -1,0 +1,128 @@
+#if canImport(Darwin)
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// End-to-end coverage for #653: `BackupCommand` with its **default** seams must run the whole
+/// add → commit → push flow via `InProcessGit` (SwiftGit2/libgit2) on Darwin — under the MAS
+/// App Sandbox `/usr/bin/git` can't execute at all, so the subprocess defaults these replaced
+/// were dead code there. Fixtures + independent verification use subprocess git (tests run
+/// unsandboxed); the subject under test is the default-wired command.
+///
+/// .serialized: libgit2 isn't safe for uncoordinated concurrent use.
+@Suite("BackupCommand in-process defaults", .serialized) struct BackupCommandInProcessTests {
+
+    private func makeTempDir(_ label: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("backup-e2e-\(label)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @discardableResult
+    private func git(_ arguments: [String], in dir: URL) async throws -> String {
+        let result = try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["git"] + arguments,
+            currentDirectoryURL: dir
+        )
+        guard result.exitCode == 0 else {
+            Issue.record("fixture git \(arguments.joined(separator: " ")) exited \(result.exitCode): \(result.stderr)")
+            throw FixtureError.gitFailed
+        }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private enum FixtureError: Error { case gitFailed }
+
+    @Test("default seams run the full backup — add, commit, push — in-process")
+    func backupEndToEndInProcess() async throws {
+        // Site repo on `draft` with identity, one commit, and a bare file:// origin.
+        let site = try makeTempDir("site")
+        try await git(["init", "-b", "draft"], in: site)
+        try await git(["config", "user.name", "Test"], in: site)
+        try await git(["config", "user.email", "test@example.com"], in: site)
+        try "hello".write(to: site.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: site)
+        try await git(["commit", "-m", "first"], in: site)
+        let remote = try makeTempDir("origin")
+        try await git(["init", "--bare"], in: remote)
+        try await git(["remote", "add", "origin", remote.absoluteString], in: site)
+        try await git(["push", "origin", "draft"], in: site)
+
+        // A change to back up.
+        try "hello v2".write(to: site.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
+
+        let siteID = "e2e-\(UUID().uuidString)"
+        let result = await BackupCommand().backup(siteID: siteID, siteDirectory: site)
+
+        guard case .succeeded(let sha, let branch, let remoteURL) = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        #expect(branch == "draft")
+        #expect(remoteURL == remote.absoluteString)
+
+        // Independent verification: subprocess git agrees the commit landed on the remote.
+        let remoteHEAD = try await git(["rev-parse", "draft"], in: remote)
+        #expect(remoteHEAD == sha)
+
+        // And the run went through the in-process path: its step lines — not subprocess git
+        // output — are what landed in LogCenter under this backup's source.
+        let lines = await LogCenter.shared.snapshot()
+            .filter { $0.source == "backup:\(siteID)" }
+            .map(\.text)
+        #expect(lines.contains { $0.contains("staged all changes (add -A)") })
+        #expect(lines.contains { $0.contains("push complete") })
+    }
+
+    @Test("default seams surface a clean tree with no unpushed commits as .noChanges")
+    func backupNoChangesInProcess() async throws {
+        let site = try makeTempDir("site")
+        try await git(["init", "-b", "draft"], in: site)
+        try await git(["config", "user.name", "Test"], in: site)
+        try await git(["config", "user.email", "test@example.com"], in: site)
+        try "hello".write(to: site.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: site)
+        try await git(["commit", "-m", "first"], in: site)
+        let remote = try makeTempDir("origin")
+        try await git(["init", "--bare"], in: remote)
+        try await git(["remote", "add", "origin", remote.absoluteString], in: site)
+        try await git(["push", "origin", "draft"], in: site)
+
+        let result = await BackupCommand().backup(siteID: "e2e-clean", siteDirectory: site)
+        #expect(result == .noChanges)
+    }
+
+    @Test("default seams push a stranded commit on a clean tree (#246)")
+    func backupPushesStrandedCommit() async throws {
+        let site = try makeTempDir("site")
+        try await git(["init", "-b", "draft"], in: site)
+        try await git(["config", "user.name", "Test"], in: site)
+        try await git(["config", "user.email", "test@example.com"], in: site)
+        try "hello".write(to: site.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: site)
+        try await git(["commit", "-m", "first"], in: site)
+        let remote = try makeTempDir("origin")
+        try await git(["init", "--bare"], in: remote)
+        try await git(["remote", "add", "origin", remote.absoluteString], in: site)
+        try await git(["push", "origin", "draft"], in: site)
+
+        // A committed-but-never-pushed change: clean tree, HEAD ahead of origin/draft.
+        try "stranded".write(to: site.appendingPathComponent("stranded.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: site)
+        try await git(["commit", "-m", "stranded"], in: site)
+        let localHEAD = try await git(["rev-parse", "HEAD"], in: site)
+
+        let result = await BackupCommand().backup(siteID: "e2e-stranded", siteDirectory: site)
+
+        guard case .succeeded(let sha, _, _) = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        #expect(sha == localHEAD)
+        let remoteHEAD = try await git(["rev-parse", "draft"], in: remote)
+        #expect(remoteHEAD == localHEAD)
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/GitHubAPITokenVerifierTests.swift
+++ b/Tests/AnglesiteCoreTests/GitHubAPITokenVerifierTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for the GitHub PAT verifier used to surface the connected account in Settings (#653
+/// follow-up: "surfaced like Xcode does" — Xcode's Accounts pane shows who you're signed in as,
+/// not just "token stored"). The HTTP step is injected, so classification is exercised without
+/// real network.
+struct GitHubAPITokenVerifierTests {
+    private static func transport(status: Int, json: String) -> GitHubAPITokenVerifier.Transport {
+        { request in
+            let http = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(json.utf8), http)
+        }
+    }
+
+    @Test("a valid token verifies and surfaces login, name, and avatar")
+    func validToken() async {
+        let verifier = GitHubAPITokenVerifier(transport: Self.transport(
+            status: 200,
+            json: #"{"login":"octocat","name":"The Octocat","avatar_url":"https://avatars.githubusercontent.com/u/1"}"#))
+        let result = await verifier.verify(token: "good")
+        #expect(result == .success(GitHubAccount(
+            login: "octocat",
+            name: "The Octocat",
+            avatarURL: URL(string: "https://avatars.githubusercontent.com/u/1"))))
+    }
+
+    @Test("a user with no display name still verifies, with a nil name")
+    func validTokenNoDisplayName() async {
+        let verifier = GitHubAPITokenVerifier(transport: Self.transport(
+            status: 200,
+            json: #"{"login":"octocat","name":null,"avatar_url":"https://avatars.githubusercontent.com/u/1"}"#))
+        let result = await verifier.verify(token: "good")
+        #expect(result == .success(GitHubAccount(
+            login: "octocat",
+            name: nil,
+            avatarURL: URL(string: "https://avatars.githubusercontent.com/u/1"))))
+    }
+
+    @Test("a 401 rejection maps to .invalidToken")
+    func rejectedToken() async {
+        let verifier = GitHubAPITokenVerifier(transport: Self.transport(
+            status: 401,
+            json: #"{"message":"Bad credentials"}"#))
+        let result = await verifier.verify(token: "bad")
+        #expect(result == .failure(.invalidToken))
+    }
+
+    @Test("a connection failure maps to .network")
+    func networkFailure() async {
+        let verifier = GitHubAPITokenVerifier(transport: { _ in throw URLError(.notConnectedToInternet) })
+        let result = await verifier.verify(token: "any")
+        #expect(result == .failure(.network))
+    }
+
+    @Test("a transient server error (5xx/429/403) maps to .unavailable, not .invalidToken")
+    func transientServerError() async {
+        let verifier = GitHubAPITokenVerifier(transport: Self.transport(
+            status: 503,
+            json: #"{"message":"Service unavailable"}"#))
+        let result = await verifier.verify(token: "any")
+        guard case .failure(.unavailable) = result else {
+            Issue.record("expected .unavailable, got \(result)")
+            return
+        }
+    }
+
+    @Test("a 403 (rate limit or fine-grained-scope quirk) maps to .unavailable, not .invalidToken")
+    func rateLimited() async {
+        // GET /user needs no specific token scope, so a 403 here is far more likely a rate limit
+        // than a genuinely bad token — must not be misreported as "your token is invalid".
+        let verifier = GitHubAPITokenVerifier(transport: Self.transport(
+            status: 403,
+            json: #"{"message":"API rate limit exceeded"}"#))
+        let result = await verifier.verify(token: "any")
+        guard case .failure(.unavailable) = result else {
+            Issue.record("expected .unavailable, got \(result)")
+            return
+        }
+    }
+
+    @Test("an unparseable body maps to .unavailable")
+    func unparseableBody() async {
+        let verifier = GitHubAPITokenVerifier(transport: Self.transport(status: 200, json: "not json"))
+        let result = await verifier.verify(token: "any")
+        guard case .failure(.unavailable) = result else {
+            Issue.record("expected .unavailable, got \(result)")
+            return
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/InProcessGitTests.swift
+++ b/Tests/AnglesiteCoreTests/InProcessGitTests.swift
@@ -117,6 +117,28 @@ import Foundation
         #expect(!dirty.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
 
+    @Test("status --porcelain reports real XY codes, not a fabricated ?? for everything")
+    func statusPorcelainRealCodes() async throws {
+        let repo = try await makeRepo()
+
+        // Untracked (no index side at all): "??".
+        try "new".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        // Modified in the worktree, not yet staged: " M".
+        try "hello v2".write(to: repo.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
+
+        let beforeStaging = await InProcessGit.run(siteDirectory: repo, arguments: ["status", "--porcelain"])
+        let beforeLines = Set(beforeStaging.stdout.split(separator: "\n").map(String.init))
+        #expect(beforeLines.contains("?? new.txt"))
+        #expect(beforeLines.contains(" M hello.txt"))
+
+        // Staged with subprocess git: the new file is "A ", the modification is "M ".
+        try await git(["add", "-A"], in: repo)
+        let afterStaging = await InProcessGit.run(siteDirectory: repo, arguments: ["status", "--porcelain"])
+        let afterLines = Set(afterStaging.stdout.split(separator: "\n").map(String.init))
+        #expect(afterLines.contains("A  new.txt"))
+        #expect(afterLines.contains("M  hello.txt"))
+    }
+
     @Test("rev-list --count origin/<branch>..HEAD counts unpushed commits, non-zero exit when the remote ref is unknown")
     func revListCount() async throws {
         let repo = try await makeRepo()
@@ -238,6 +260,24 @@ import Foundation
         #expect(exit != 0)
         #expect(stderr.contains("GitHub"))
         #expect(stderr.contains("Settings"))
+    }
+
+    @Test("a push failure's stderr never contains the raw token")
+    func pushFailureNeverLeaksToken() async throws {
+        let repo = try await makeRepo()
+        let secretToken = "ghp_SuperSecretTokenShouldNeverLeak12345"
+        // Port 1 refuses the connection immediately (nothing can bind it without root) — a real
+        // push attempt through libgit2's HTTPS transport that fails fast without a DNS timeout.
+        try await git(["remote", "add", "origin", "https://127.0.0.1:1/nonexistent.git"], in: repo)
+
+        let (exit, stderr) = await InProcessGit.stream(
+            siteDirectory: repo,
+            arguments: ["push", "origin", "draft"],
+            source: "test",
+            tokenProvider: { secretToken }
+        )
+        #expect(exit != 0)
+        #expect(!stderr.contains(secretToken), "push failure stderr must never echo the raw token: \(stderr)")
     }
 }
 #endif

--- a/Tests/AnglesiteCoreTests/InProcessGitTests.swift
+++ b/Tests/AnglesiteCoreTests/InProcessGitTests.swift
@@ -1,0 +1,243 @@
+#if canImport(Darwin)
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// `InProcessGit` executes `BackupCommand`'s exact git vocabulary via SwiftGit2 (in-process
+/// libgit2) so the deterministic backup path works under the MAS App Sandbox, where
+/// `/usr/bin/git` cannot execute at all (#640/#653).
+///
+/// These tests run unsandboxed, so fixtures are built — and results independently verified —
+/// with real subprocess `git`, while the subject under test is the in-process implementation.
+/// That cross-checks "InProcessGit matches subprocess git semantics" rather than the
+/// implementation against itself.
+///
+/// .serialized: libgit2 isn't safe for uncoordinated concurrent use (see the fork's specs).
+@Suite("InProcessGit", .serialized) struct InProcessGitTests {
+
+    // MARK: - Fixtures (subprocess git — tests are unsandboxed)
+
+    private func makeTempDir(_ label: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("inprocessgit-\(label)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @discardableResult
+    private func git(_ arguments: [String], in dir: URL) async throws -> String {
+        let result = try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["git"] + arguments,
+            currentDirectoryURL: dir
+        )
+        guard result.exitCode == 0 else {
+            Issue.record("fixture git \(arguments.joined(separator: " ")) exited \(result.exitCode): \(result.stderr)")
+            throw FixtureError.gitFailed
+        }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private enum FixtureError: Error { case gitFailed }
+
+    /// Repo on branch `draft` with local identity configured and one commit of `hello.txt`.
+    private func makeRepo() async throws -> URL {
+        let dir = try makeTempDir("work")
+        try await git(["init", "-b", "draft"], in: dir)
+        try await git(["config", "user.name", "Test"], in: dir)
+        try await git(["config", "user.email", "test@example.com"], in: dir)
+        try "hello".write(to: dir.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: dir)
+        try await git(["commit", "-m", "first"], in: dir)
+        return dir
+    }
+
+    /// Bare repo registered as `origin` of `repo`, with the current `draft` already pushed.
+    private func addPushedOrigin(to repo: URL) async throws -> URL {
+        let remote = try makeTempDir("origin")
+        try await git(["init", "--bare"], in: remote)
+        try await git(["remote", "add", "origin", remote.absoluteString], in: repo)
+        try await git(["push", "origin", "draft"], in: repo)
+        return remote
+    }
+
+    // MARK: - run (introspection commands)
+
+    @Test("rev-parse --is-inside-work-tree exits 0 in a repo, non-zero in a plain directory")
+    func isInsideWorkTree() async throws {
+        let repo = try await makeRepo()
+        let inRepo = await InProcessGit.run(siteDirectory: repo, arguments: ["rev-parse", "--is-inside-work-tree"])
+        #expect(inRepo.exitCode == 0)
+
+        let plain = try makeTempDir("plain")
+        let outside = await InProcessGit.run(siteDirectory: plain, arguments: ["rev-parse", "--is-inside-work-tree"])
+        #expect(outside.exitCode != 0)
+    }
+
+    @Test("rev-parse --abbrev-ref HEAD returns the current branch name")
+    func currentBranch() async throws {
+        let repo = try await makeRepo()
+        let result = await InProcessGit.run(siteDirectory: repo, arguments: ["rev-parse", "--abbrev-ref", "HEAD"])
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "draft")
+    }
+
+    @Test("rev-parse HEAD returns the commit SHA subprocess git agrees on")
+    func headSHA() async throws {
+        let repo = try await makeRepo()
+        let expected = try await git(["rev-parse", "HEAD"], in: repo)
+        let result = await InProcessGit.run(siteDirectory: repo, arguments: ["rev-parse", "HEAD"])
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == expected)
+    }
+
+    @Test("remote get-url origin returns the URL, or non-zero when unset")
+    func remoteGetURL() async throws {
+        let repo = try await makeRepo()
+        let missing = await InProcessGit.run(siteDirectory: repo, arguments: ["remote", "get-url", "origin"])
+        #expect(missing.exitCode != 0)
+
+        try await git(["remote", "add", "origin", "https://github.com/example/site.git"], in: repo)
+        let present = await InProcessGit.run(siteDirectory: repo, arguments: ["remote", "get-url", "origin"])
+        #expect(present.exitCode == 0)
+        #expect(present.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "https://github.com/example/site.git")
+    }
+
+    @Test("status --porcelain is empty on a clean tree, non-empty once a file changes")
+    func statusPorcelain() async throws {
+        let repo = try await makeRepo()
+        let clean = await InProcessGit.run(siteDirectory: repo, arguments: ["status", "--porcelain"])
+        #expect(clean.exitCode == 0)
+        #expect(clean.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+        try "changed".write(to: repo.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
+        try "new".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        let dirty = await InProcessGit.run(siteDirectory: repo, arguments: ["status", "--porcelain"])
+        #expect(dirty.exitCode == 0)
+        #expect(!dirty.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    @Test("rev-list --count origin/<branch>..HEAD counts unpushed commits, non-zero exit when the remote ref is unknown")
+    func revListCount() async throws {
+        let repo = try await makeRepo()
+
+        // No origin/draft ref yet: subprocess git exits non-zero here, and BackupCommand
+        // depends on that to preserve `.noChanges` (#246).
+        let unknown = await InProcessGit.run(siteDirectory: repo, arguments: ["rev-list", "--count", "origin/draft..HEAD"])
+        #expect(unknown.exitCode != 0)
+
+        _ = try await addPushedOrigin(to: repo)
+        let synced = await InProcessGit.run(siteDirectory: repo, arguments: ["rev-list", "--count", "origin/draft..HEAD"])
+        #expect(synced.exitCode == 0)
+        #expect(synced.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "0")
+
+        try "more".write(to: repo.appendingPathComponent("more.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: repo)
+        try await git(["commit", "-m", "unpushed"], in: repo)
+        let ahead = await InProcessGit.run(siteDirectory: repo, arguments: ["rev-list", "--count", "origin/draft..HEAD"])
+        #expect(ahead.exitCode == 0)
+        #expect(ahead.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "1")
+    }
+
+    @Test("an unsupported invocation fails loudly instead of guessing")
+    func unsupportedCommand() async throws {
+        let repo = try await makeRepo()
+        let result = await InProcessGit.run(siteDirectory: repo, arguments: ["stash"])
+        #expect(result.exitCode != 0)
+        #expect(result.stderr.contains("unsupported"))
+    }
+
+    // MARK: - stream (mutating commands)
+
+    @Test("add -A stages additions AND deletions like subprocess git")
+    func addAll() async throws {
+        let repo = try await makeRepo()
+        try "new".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        try FileManager.default.removeItem(at: repo.appendingPathComponent("hello.txt"))
+
+        let (exit, _) = await InProcessGit.stream(siteDirectory: repo, arguments: ["add", "-A"], source: "test")
+        #expect(exit == 0)
+
+        // Verify the staged state with subprocess git: both entries staged, none unstaged.
+        let status = try await git(["status", "--porcelain"], in: repo)
+        #expect(status.contains("A  new.txt"))
+        #expect(status.contains("D  hello.txt"))
+    }
+
+    @Test("commit -m creates the commit subprocess git can read back")
+    func commit() async throws {
+        let repo = try await makeRepo()
+        try "more".write(to: repo.appendingPathComponent("more.txt"), atomically: true, encoding: .utf8)
+        _ = await InProcessGit.stream(siteDirectory: repo, arguments: ["add", "-A"], source: "test")
+
+        let (exit, stderr) = await InProcessGit.stream(siteDirectory: repo, arguments: ["commit", "-m", "Backup 2026-07-10T12:00:00Z"], source: "test")
+        #expect(exit == 0, "commit failed: \(stderr)")
+        let subject = try await git(["log", "-1", "--format=%s"], in: repo)
+        #expect(subject == "Backup 2026-07-10T12:00:00Z")
+    }
+
+    @Test("push origin <branch> updates the remote and the remote-tracking ref")
+    func push() async throws {
+        let repo = try await makeRepo()
+        let remote = try await addPushedOrigin(to: repo)
+
+        try "more".write(to: repo.appendingPathComponent("more.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: repo)
+        try await git(["commit", "-m", "second"], in: repo)
+        let localHEAD = try await git(["rev-parse", "HEAD"], in: repo)
+
+        let (exit, stderr) = await InProcessGit.stream(siteDirectory: repo, arguments: ["push", "origin", "draft"], source: "test")
+        #expect(exit == 0, "push failed: \(stderr)")
+
+        // The remote moved…
+        let remoteHEAD = try await git(["rev-parse", "draft"], in: remote)
+        #expect(remoteHEAD == localHEAD)
+        // …and the local remote-tracking ref moved with it, so the next backup's
+        // ahead-count check (#246) sees a synced branch rather than phantom unpushed commits.
+        let trackingRef = try await git(["rev-parse", "origin/draft"], in: repo)
+        #expect(trackingRef == localHEAD)
+    }
+
+    @Test("a rejected push (non-fast-forward) exits non-zero with git's reason in stderr")
+    func pushRejected() async throws {
+        let repo = try await makeRepo()
+        let remote = try await addPushedOrigin(to: repo)
+
+        // Move the remote ahead behind our back, so our next push can't fast-forward.
+        let other = try makeTempDir("other")
+        try await git(["clone", remote.absoluteString, "checkout"], in: other)
+        let otherRepo = other.appendingPathComponent("checkout")
+        try await git(["config", "user.name", "Other"], in: otherRepo)
+        try await git(["config", "user.email", "other@example.com"], in: otherRepo)
+        try await git(["checkout", "draft"], in: otherRepo)
+        try "racing".write(to: otherRepo.appendingPathComponent("race.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: otherRepo)
+        try await git(["commit", "-m", "raced"], in: otherRepo)
+        try await git(["push", "origin", "draft"], in: otherRepo)
+
+        try "mine".write(to: repo.appendingPathComponent("mine.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: repo)
+        try await git(["commit", "-m", "mine"], in: repo)
+
+        let (exit, stderr) = await InProcessGit.stream(siteDirectory: repo, arguments: ["push", "origin", "draft"], source: "test")
+        #expect(exit != 0)
+        #expect(!stderr.isEmpty)
+    }
+
+    @Test("pushing to an HTTPS remote with no stored GitHub token fails fast with an actionable message")
+    func pushHTTPSWithoutToken() async throws {
+        let repo = try await makeRepo()
+        try await git(["remote", "add", "origin", "https://github.com/example/site.git"], in: repo)
+
+        let (exit, stderr) = await InProcessGit.stream(
+            siteDirectory: repo,
+            arguments: ["push", "origin", "draft"],
+            source: "test",
+            tokenProvider: { nil }
+        )
+        #expect(exit != 0)
+        #expect(stderr.contains("GitHub"))
+        #expect(stderr.contains("Settings"))
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/SecretStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SecretStoreTests.swift
@@ -41,6 +41,16 @@ struct SecretStoreTests {
         #expect(try store.readCloudflareToken() == nil)
     }
 
+    @Test("GitHub convenience methods address the shared SecretAccounts slot")
+    func gitHubConvenienceUsesSharedAccount() throws {
+        let store = InMemorySecretStore()
+        try store.writeGitHubToken("ghp_abc")
+        #expect(try store.read(account: SecretAccounts.gitHubToken) == "ghp_abc")
+        #expect(try store.readGitHubToken() == "ghp_abc")
+        try store.clearGitHubToken()
+        #expect(try store.readGitHubToken() == nil)
+    }
+
     @Test("UnavailableSecretStore reads nothing, deletes as no-op, and refuses writes")
     func unavailableStoreBehavior() throws {
         let store = UnavailableSecretStore()


### PR DESCRIPTION
Fixes #653.

`BackupCommand` ran its entire deterministic add → commit → push path through `/usr/bin/git` subprocesses, every one of which fails immediately under the MAS App Sandbox (`xcrun: error: cannot be used within an App Sandbox`, #640) — with the first preflight failure misdiagnosing a healthy repo as "not a git repository". This PR moves the whole path in-process, following the #649 SwiftGit2 pattern.

## What changed

**Paired fork PR (Anglesite/SwiftGit2, branch `anglesite/653-push`)** — new libgit2 wrappers:
- `push(remoteName:refspec:credentials:)` — `git_remote_push` with a credential callback and per-ref rejection capture (`push_update_reference`): a non-fast-forward is a `.failure`, never silent success.
- `addAll()` — true `git add -A` parity (`git_index_add_all` **+** `git_index_update_all`, so deletions stage).
- `aheadBehind(local:upstream:)` — `git_graph_ahead_behind`, for the #246 unpushed-commit check.
- `addRemote(named:url:)` and a `bare:` flag on `create(at:)` (local push targets must be bare).

**App:**
- `InProcessGit` (AnglesiteCore) — an interpreter for the exact eight git argument vectors `BackupCommand` issues, returning synthesized `RunResult`s / exit codes. Keeping the `GitRunner`/`GitStreamer` seam shape means the command's orchestration (refusal ordering, cancellation guards, #246) and its entire existing test suite carry over byte-for-byte. libgit2 calls run on a Dispatch global queue, not the cooperative pool; push step lines stream to `LogCenter` under `backup:<siteID>`.
- `BackupCommand.defaultRunner/defaultStreamer` now select `InProcessGit` on Darwin; off-Darwin keeps subprocess git (correct there — no sandbox to route around).
- **GitHub token**: the app now owns a GitHub PAT slot (`SecretAccounts.gitHubToken`) — the old `gh auth login` flow left credentials with `gh`, which the sandboxed app can neither spawn nor read. HTTPS pushes authenticate as `x-access-token:<PAT>`; a missing token fails fast with a remediation pointing at Settings instead of an opaque libgit2 auth error. Settings ▸ Advanced grows a "GitHub personal access token" row (the Cloudflare row generalized into a shared `KeychainTokenRow`), replacing the MAS branch's now-false "uses your existing git credentials" copy. Help Book updated to match.
- `Package.swift` pin bumped to the fork commit.

## Tests

- Fork: `AnglesitePushSpec` (6 tests) — bare create, add -A parity incl. deletions, ahead/behind counts, push moves the remote ref + fast-forward follow-up, non-fast-forward rejection (remote ref stays put), unknown-remote failure. All 140 fork tests pass.
- App: `InProcessGitTests` (12 tests) — every vocabulary command cross-verified against real subprocess git on real temp repos, including the remote-tracking-ref update after push that keeps #246 honest, rejected-push stderr, and the fast-fail missing-token path.
- App: `BackupCommandInProcessTests` (3 tests) — `BackupCommand` with **default** seams end-to-end against a file:// bare origin: full backup, `.noChanges`, and the #246 stranded-commit push, each independently verified with subprocess git.
- All pre-existing `BackupCommand*` orchestration tests pass unchanged.

## Known limits / follow-ups

- **Commit identity under sandbox**: `git_signature_default` reads git config, and the sandboxed app can't see `~/.gitconfig` — backup commits need `user.name`/`user.email` in the site repo's local config. The failure now carries that remediation; scaffolding new sites with a local identity would be the durable fix (same constraint already applies to #649's content-op commits).
- **SSH remotes**: libgit2's SSH-exec transport can't run under the sandbox; HTTPS remotes are the supported path and SSH failures surface libgit2's message.
- The signed, sandboxed real-`origin` smoke from the issue's acceptance criteria is owed as a manual step (like #656 for #649).
- #654 (Publish to GitHub) reuses this PR's fork push support + token slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
