### PR TITLE
feat(port): AnglesiteLinux — Adwaita/GTK4 shell with WebKitGTK preview (#567)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -332,6 +332,41 @@ packageTargets.removeAll { !portableTargets.contains($0.name) }
 // filters products. (The container probe executable breaks that convention, but it is
 // Darwin-only and already excluded via includeContainer.)
 packageProducts.removeAll { !portableTargets.contains($0.name) }
+
+// Cross-platform port phase 2 (#567): the Linux shell — GTK4/libadwaita via Adwaita for Swift,
+// with a WebKitGTK preview (design §6). Opt-in via ANGLESITE_LINUX_SHELL=1 rather than
+// default-on: building it needs GTK system headers (libadwaita ≥ 1.7 for adwaita-swift main's
+// generated widgets, plus webkitgtk-6.0) that the Linux CI purity leg's swift:*-noble image
+// doesn't carry (noble caps libadwaita at 1.5), so — mirroring ANGLESITE_CONTAINER_TESTS —
+// the shell only enters the manifest when explicitly requested. Until a Flatpak-based CI lane
+// exists (the packaging item on #567), a GTK-provisioned Linux box is the real verification,
+// the same status PodmanContainerControl shipped with (#647).
+if ProcessInfo.processInfo.environment["ANGLESITE_LINUX_SHELL"] == "1" {
+    // Pinned to a commit, matching the SwiftGit2 policy above: adwaita-swift's only tag
+    // (0.1.0) predates its current API, and tracking main would silently pick up unreviewed
+    // commits. Bump deliberately. (Its own dependencies are branch-based, which SwiftPM
+    // permits under a revision pin.)
+    packageDependencies.append(
+        .package(url: "https://git.aparoksha.dev/aparoksha/adwaita-swift", revision: "15fe44efffa5c9ad5c2c5a703b104d0180c6af5e")
+    )
+    packageTargets.append(
+        .systemLibrary(name: "CWebKitGTK", path: "Sources/CWebKitGTK", pkgConfig: "webkitgtk-6.0")
+    )
+    packageTargets.append(
+        .executableTarget(
+            name: "AnglesiteLinux",
+            dependencies: [
+                "AnglesiteCore",
+                "AnglesiteBridgeCore",
+                "CWebKitGTK",
+                .product(name: "Adwaita", package: "adwaita-swift")
+            ],
+            path: "Sources/AnglesiteLinux",
+            swiftSettings: strictConcurrency
+        )
+    )
+    packageProducts.append(.executable(name: "anglesite-linux", targets: ["AnglesiteLinux"]))
+}
 #endif
 
 let package = Package(

--- a/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
+++ b/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
@@ -39,15 +39,23 @@ public struct PodmanContainerControl: LocalContainerControl {
 
     /// The production astro-dev guest command: hydrate deps from the image's baked toolchain
     /// (zero-install hardlink when the cloned site's lockfile matches the template; offline-first
-    /// npm ci otherwise), then serve. Matches `ContainerizationControl`'s guest command exactly.
+    /// npm ci otherwise), then serve. Matches `ContainerizationControl`'s guest command except
+    /// for the bind host: rootless podman's port publishing (pasta) forwards to the container's
+    /// eth0, NOT guest loopback, so a `127.0.0.1` bind (correct on macOS, where the guest-local
+    /// vsock proxies dial loopback from *inside* the guest) yields connection-reset on every
+    /// mapped port. Binding `0.0.0.0` here doesn't widen host exposure — `start()` publishes
+    /// both ports onto host loopback (`-p 127.0.0.1::…`), and the container's own interface
+    /// lives on pasta's private network. Verified against real podman on Linux (#567).
     public static let defaultAstroCommand =
-        "/usr/local/bin/anglesite-hydrate /workspace/site && cd /workspace/site && npx astro dev --port \(previewPort) --host 127.0.0.1"
+        "/usr/local/bin/anglesite-hydrate /workspace/site && cd /workspace/site && npx astro dev --port \(previewPort) --host 0.0.0.0"
 
     /// The production MCP-sidecar guest command: baked into the image at
     /// `/usr/local/lib/anglesite-mcp/` (scripts/vendor-container-image.sh stages the plugin's
-    /// `server/` dir). Config rides ENV, not flags — matches `ContainerizationControl` exactly.
+    /// `server/` dir). Config rides ENV, not flags — matches `ContainerizationControl` except
+    /// for `ANGLESITE_MCP_HOST=0.0.0.0` (the server's default is `127.0.0.1`), for the same
+    /// pasta port-forwarding reason as `defaultAstroCommand` above.
     public static let defaultMCPCommand =
-        "ANGLESITE_MCP_TRANSPORT=http ANGLESITE_MCP_PORT=\(mcpPort) ANGLESITE_PROJECT_ROOT=/workspace/site node /usr/local/lib/anglesite-mcp/server/index.mjs"
+        "ANGLESITE_MCP_TRANSPORT=http ANGLESITE_MCP_HOST=0.0.0.0 ANGLESITE_MCP_PORT=\(mcpPort) ANGLESITE_PROJECT_ROOT=/workspace/site node /usr/local/lib/anglesite-mcp/server/index.mjs"
 
     /// - Parameters:
     ///   - image: The OCI image reference `podman run` boots. Defaults to a locally-tagged image

--- a/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
+++ b/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
@@ -45,7 +45,10 @@ public struct PodmanContainerControl: LocalContainerControl {
     /// vsock proxies dial loopback from *inside* the guest) yields connection-reset on every
     /// mapped port. Binding `0.0.0.0` here doesn't widen host exposure — `start()` publishes
     /// both ports onto host loopback (`-p 127.0.0.1::…`), and the container's own interface
-    /// lives on pasta's private network. Verified against real podman on Linux (#567).
+    /// lives on pasta's private network. Verified live against real podman on Linux (#567,
+    /// PR #662 review): `ss -tlnp` shows pasta's host-side listener bound to `127.0.0.1:<port>`
+    /// (`podman port`'s `0.0.0.0:<port>` output is cosmetic reporting of the guest-side bind),
+    /// loopback connects, and a connect to the host's LAN address is refused.
     public static let defaultAstroCommand =
         "/usr/local/bin/anglesite-hydrate /workspace/site && cd /workspace/site && npx astro dev --port \(previewPort) --host 0.0.0.0"
 

--- a/Sources/AnglesiteLinux/AnglesiteLinuxApp.swift
+++ b/Sources/AnglesiteLinux/AnglesiteLinuxApp.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Adwaita
+import AnglesiteCore
+
+/// The Linux shell (cross-platform port phase 2, #567): a GTK4/libadwaita window that opens a
+/// `.anglesite` package, boots its site in a rootless-podman container
+/// (`LocalContainerSiteRuntime` over `PodmanContainerControl`, #647), and live-previews the
+/// containerized Astro dev server in an embedded WebKitGTK webview with the edit overlay
+/// injected. Deliberately thin (port design §6 risk containment): everything below the window
+/// chrome is `AnglesiteCore`/`AnglesiteBridgeCore` — the same portable stack the macOS shell
+/// composes.
+///
+/// Usage: `anglesite-linux [path/to/Site.anglesite]`, or open a package from the header-bar
+/// button. Requires podman and a loaded `localhost/anglesite-dev:latest` image.
+@main
+struct AnglesiteLinuxApp: App {
+    /// What the window shows. `.ready`'s payload feeds `PreviewWebView` directly.
+    enum PreviewStatus: Equatable {
+        case noSite
+        case starting(name: String)
+        case ready(name: String, url: String)
+        case failed(name: String, message: String)
+    }
+
+    var app = AdwaitaApp(id: "io.dwk.anglesite.linux")
+
+    let model = ShellModel()
+    let overlaySource = ShellModel.overlaySource()
+    @State private var status: PreviewStatus = .noSite
+    @State private var router: MCPApplyEditRouter?
+    @State private var openDialog: Signal = .init()
+    @State private var quitting = false
+
+    var scene: Scene {
+        Window(id: "main") { _ in
+            content
+                .topToolbar {
+                    HeaderBar.end {
+                        Button("Open Site…") { openDialog.signal() }
+                    }
+                    .headerBarTitle {
+                        Text(windowTitle)
+                    }
+                }
+                .folderImporter(open: openDialog) { url in
+                    open(packageURL: url)
+                }
+                .onAppear {
+                    // Logs are sacred: until the shell grows a debug pane, every supervised
+                    // subprocess line (container boot, git clone, astro dev, the MCP sidecar)
+                    // streams to the launching terminal's stderr.
+                    Task.detached {
+                        let subscription = await LogCenter.shared.subscribe()
+                        for await line in subscription.stream {
+                            FileHandle.standardError.write(Data("[\(line.source)] \(line.text)\n".utf8))
+                        }
+                    }
+                    // `anglesite-linux Foo.anglesite` — open straight into the site.
+                    if let path = CommandLine.arguments.dropFirst().first {
+                        open(packageURL: URL(fileURLWithPath: path))
+                    }
+                }
+        }
+        .defaultSize(width: 1200, height: 800)
+        .onClose {
+            // Never leak the site container: intercept the first close, stop the runtime
+            // (podman stop tears down the whole `--rm` guest), then quit for real. GTK's main
+            // loop keeps running during the async stop, so the window just stays up for the
+            // second or two the teardown takes.
+            if quitting { return .close }
+            quitting = true
+            Task {
+                await model.stopCurrent()
+                Idle { app.quit() }
+            }
+            return .cancel
+        }
+    }
+
+    var windowTitle: String {
+        switch status {
+        case .noSite: return "Anglesite"
+        case .starting(let name), .ready(let name, _), .failed(let name, _): return name
+        }
+    }
+
+    @ViewBuilder var content: Body {
+        switch status {
+        case .noSite:
+            StatusPage()
+                .title("No Site Open")
+                .description("Open a .anglesite package to start its preview.")
+                .iconName("folder-open-symbolic")
+        case .starting(let name):
+            StatusPage()
+                .title("Starting \(name)…")
+                .description("Booting the site container and dev server. First boot clones the site and installs dependencies.")
+                .child { Spinner() }
+        case .ready(_, let url):
+            PreviewWebView(
+                url: url,
+                router: router ?? MCPApplyEditRouter(mcpClient: { nil }),
+                overlaySource: overlaySource
+            )
+            .vexpand()
+            .hexpand()
+        case .failed(_, let message):
+            StatusPage()
+                .title("Preview Failed")
+                .description(message)
+                .iconName("dialog-error-symbolic")
+        }
+    }
+
+    /// Opens the package and forwards every runtime state transition onto the GTK main loop.
+    /// Errors surface as `.failed` on the status page rather than crashing the shell — the
+    /// Debug-pane equivalent (LogCenter) has the full container output.
+    func open(packageURL: URL) {
+        let site: ShellModel.OpenedSite
+        do {
+            site = try model.open(packageURL: packageURL)
+        } catch {
+            status = .failed(
+                name: packageURL.deletingPathExtension().lastPathComponent,
+                message: "Not an openable .anglesite package: \(error)"
+            )
+            return
+        }
+        router = site.router
+        status = .starting(name: site.displayName)
+
+        let name = site.displayName
+        let runtime = site.runtime
+        Task {
+            for await state in await runtime.observe() {
+                Idle {
+                    switch state {
+                    case .idle:
+                        break
+                    case .starting:
+                        status = .starting(name: name)
+                    case .ready(_, let url):
+                        status = .ready(name: name, url: url.absoluteString)
+                    case .failed(_, let message):
+                        status = .failed(name: name, message: message)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteLinux/AnglesiteLinuxApp.swift
+++ b/Sources/AnglesiteLinux/AnglesiteLinuxApp.swift
@@ -1,6 +1,8 @@
 import Foundation
+import Glibc
 import Adwaita
 import AnglesiteCore
+import CWebKitGTK
 
 /// The Linux shell (cross-platform port phase 2, #567): a GTK4/libadwaita window that opens a
 /// `.anglesite` package, boots its site in a rootless-podman container
@@ -30,6 +32,17 @@ struct AnglesiteLinuxApp: App {
     @State private var router: MCPApplyEditRouter?
     @State private var openDialog: Signal = .init()
     @State private var quitting = false
+    /// Monotonic count of `open(packageURL:)` calls. Every UI update an open's observation
+    /// task schedules is guarded on the generation it was spawned under, so a superseded
+    /// site's late transitions (e.g. its teardown settling after a site switch) can never
+    /// clobber the current site's `status`/title — even if an `Idle` closure was already
+    /// enqueued when the observation task got cancelled.
+    @State private var openGeneration = 0
+    /// The active open's observation task, cancelled on site switch and shutdown. Without
+    /// this, each "Open Site…" switch would park the previous `for await`-loop task (and the
+    /// runtime + MCP client it retains) for the rest of the process's life —
+    /// `SiteRuntime.observe()`'s stream only ends when the consumer cancels.
+    @State private var observation: Task<Void, Never>?
 
     var scene: Scene {
         Window(id: "main") { _ in
@@ -55,6 +68,10 @@ struct AnglesiteLinuxApp: App {
                             FileHandle.standardError.write(Data("[\(line.source)] \(line.text)\n".utf8))
                         }
                     }
+                    // Ctrl+C / kill must tear the container down exactly like the window
+                    // close-box does — `podman run -d` guests outlive this process otherwise.
+                    ShutdownSignals.handler = { beginShutdown() }
+                    ShutdownSignals.install()
                     // `anglesite-linux Foo.anglesite` — open straight into the site.
                     if let path = CommandLine.arguments.dropFirst().first {
                         open(packageURL: URL(fileURLWithPath: path))
@@ -63,16 +80,11 @@ struct AnglesiteLinuxApp: App {
         }
         .defaultSize(width: 1200, height: 800)
         .onClose {
-            // Never leak the site container: intercept the first close, stop the runtime
-            // (podman stop tears down the whole `--rm` guest), then quit for real. GTK's main
-            // loop keeps running during the async stop, so the window just stays up for the
-            // second or two the teardown takes.
-            if quitting { return .close }
-            quitting = true
-            Task {
-                await model.stopCurrent()
-                Idle { app.quit() }
-            }
+            // Never leak the site container: intercept close, stop the runtime (podman stop
+            // tears down the whole `--rm` guest), then quit for real. GTK's main loop keeps
+            // running during the async stop, so the window just stays up for the second or
+            // two the teardown takes.
+            beginShutdown()
             return .cancel
         }
     }
@@ -114,38 +126,86 @@ struct AnglesiteLinuxApp: App {
 
     /// Opens the package and forwards every runtime state transition onto the GTK main loop.
     /// Errors surface as `.failed` on the status page rather than crashing the shell — the
-    /// Debug-pane equivalent (LogCenter) has the full container output.
+    /// launching terminal (LogCenter → stderr) has the full container output. Always called
+    /// on the GTK main loop (folder importer, `onAppear`), so the cancel-then-replace of
+    /// `observation` and the generation bump are ordered without further synchronization.
     func open(packageURL: URL) {
-        let site: ShellModel.OpenedSite
-        do {
-            site = try model.open(packageURL: packageURL)
-        } catch {
-            status = .failed(
-                name: packageURL.deletingPathExtension().lastPathComponent,
-                message: "Not an openable .anglesite package: \(error)"
-            )
-            return
-        }
-        router = site.router
-        status = .starting(name: site.displayName)
+        if quitting { return }
+        openGeneration += 1
+        let generation = openGeneration
+        observation?.cancel()
 
-        let name = site.displayName
-        let runtime = site.runtime
-        Task {
-            for await state in await runtime.observe() {
+        let placeholderName = packageURL.deletingPathExtension().lastPathComponent
+        status = .starting(name: placeholderName)
+
+        observation = Task {
+            let site: ShellModel.OpenedSite
+            do {
+                site = try await model.open(packageURL: packageURL)
+            } catch {
                 Idle {
+                    guard openGeneration == generation else { return }
+                    status = .failed(
+                        name: placeholderName,
+                        message: "Not an openable .anglesite package: \(error)"
+                    )
+                }
+                return
+            }
+            Idle {
+                guard openGeneration == generation else { return }
+                router = site.router
+                status = .starting(name: site.displayName)
+            }
+            for await state in await site.runtime.observe() {
+                if Task.isCancelled { break }
+                Idle {
+                    guard openGeneration == generation else { return }
                     switch state {
                     case .idle:
                         break
                     case .starting:
-                        status = .starting(name: name)
+                        status = .starting(name: site.displayName)
                     case .ready(_, let url):
-                        status = .ready(name: name, url: url.absoluteString)
+                        status = .ready(name: site.displayName, url: url.absoluteString)
                     case .failed(_, let message):
-                        status = .failed(name: name, message: message)
+                        status = .failed(name: site.displayName, message: message)
                     }
                 }
             }
         }
+    }
+
+    /// Shared teardown for the window close-box and SIGINT/SIGTERM: stop the site container
+    /// (draining any in-flight site-switch teardowns first, see `ShellModel.stopCurrent`),
+    /// then quit the GTK app. Idempotent — a second close click or signal while teardown is
+    /// in flight is a no-op (and a second Ctrl+C hard-kills, since the signal source is
+    /// one-shot).
+    func beginShutdown() {
+        guard !quitting else { return }
+        quitting = true
+        observation?.cancel()
+        Task {
+            await model.stopCurrent()
+            Idle { app.quit() }
+        }
+    }
+}
+
+/// `g_unix_signal_add`'s callback is a captureless C function pointer, so the shutdown closure
+/// parks in this global. `nonisolated(unsafe)` is sound here: `handler` is written once from
+/// the GTK main loop (`onAppear`) before `install()` registers the sources, and GLib invokes
+/// unix-signal sources on that same main context — never from the raw signal handler.
+enum ShutdownSignals {
+    nonisolated(unsafe) static var handler: (() -> Void)?
+
+    static func install() {
+        let callback: @convention(c) (gpointer?) -> gboolean = { _ in
+            ShutdownSignals.handler?()
+            return 0 // G_SOURCE_REMOVE: the next signal falls through to default disposition,
+                     // so a second Ctrl+C force-kills a wedged teardown instead of being eaten.
+        }
+        _ = g_unix_signal_add(SIGINT, callback, nil)
+        _ = g_unix_signal_add(SIGTERM, callback, nil)
     }
 }

--- a/Sources/AnglesiteLinux/PreviewWebView.swift
+++ b/Sources/AnglesiteLinux/PreviewWebView.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Adwaita
+import AnglesiteCore
+import AnglesiteBridgeCore
+import CWebKitGTK
+
+/// WebKitGTK adapter for the preview + edit-overlay bridge — the Linux twin of
+/// `AnglesiteBridge`'s WKWebView stack (`WebViewBridge` + `AnglesiteScriptHandler`). All
+/// message schema, decoding, and routing live in the portable `AnglesiteMessageDispatcher`;
+/// this widget's only jobs are the WebKitGTK equivalents of the WKWebView adapter's:
+///
+/// - inject the compiled overlay bundle (`WebKitUserScript` at document-end, all frames —
+///   mirroring `WebViewBridge.makeOverlayUserScript`),
+/// - register the shared `anglesite` script-message namespace on the user-content manager and
+///   forward each `JSCValue` body (via its JSON projection) to the dispatcher,
+/// - evaluate apply-edit replies back into the page as `window.anglesite?._handleReply?.(...)`.
+///
+/// WebKitGTK's `WebKitUserContentManager` script-message API maps 1:1 onto the
+/// `WKScriptMessageHandler` pattern (port design §6), so the shape here deliberately follows
+/// `AnglesiteScriptHandler.userContentController(_:didReceive:)`.
+struct PreviewWebView: AdwaitaWidget {
+    /// The dev-server URL to display. Loaded on first render and re-loaded whenever it changes.
+    var url: String
+    /// Routes decoded `apply-edit` messages (production: `MCPApplyEditRouter` over the site's
+    /// MCP client).
+    var router: any EditRouter
+    /// The overlay JS to inject, or `nil` to preview without edit affordances (non-fatal,
+    /// matching the WKWebView adapter when the bundle wasn't produced).
+    var overlaySource: String?
+    var logCenter: LogCenter = .shared
+
+    func container<Data>(data: WidgetData, type: Data.Type) -> ViewStorage where Data: ViewRenderData {
+        guard let widget = webkit_web_view_new() else {
+            // webkit_web_view_new is infallible in practice (GObject construction aborts on
+            // OOM before returning nil); this guard is for the type system.
+            return ViewStorage(nil)
+        }
+        let storage = ViewStorage(OpaquePointer(widget))
+        // GObject downcast (GtkWidget* → WebKitWebView*): the parent instance is the first
+        // member, so rebinding the same address is the C-idiomatic WEBKIT_WEB_VIEW() cast.
+        let webView = UnsafeMutableRawPointer(widget).assumingMemoryBound(to: WebKitWebView.self)
+
+        // Inspector parity with `WebViewBridge.applyPreviewDefaults` (`isInspectable = true`):
+        // right-click → Inspect Element in every build configuration.
+        webkit_settings_set_enable_developer_extras(webkit_web_view_get_settings(webView), 1)
+
+        guard let ucm = webkit_web_view_get_user_content_manager(webView) else { return storage }
+        if let overlaySource {
+            let script = webkit_user_script_new(
+                overlaySource,
+                WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES,
+                WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_END,
+                nil,
+                nil
+            )
+            webkit_user_content_manager_add_script(ucm, script)
+            webkit_user_script_unref(script)
+        }
+
+        let namespace = AnglesiteMessageDispatcher.scriptMessageNamespace
+        webkit_user_content_manager_register_script_message_handler(ucm, namespace, nil)
+        let router = router
+        let logCenter = logCenter
+        // The reply hops threads (GTK signal → Swift concurrency → GTK idle), so the webview
+        // travels as a bit pattern rather than a non-Sendable pointer. Lifetime: the webview
+        // lives for the window's (and app's) whole run in this one-window shell, so the idle
+        // callback can't outlive it.
+        let webViewBits = UInt(bitPattern: UnsafeMutableRawPointer(webView))
+        storage.connectSignal(
+            name: "script-message-received::\(namespace)",
+            argCount: 1,
+            pointer: ucm
+        ) { args in
+            guard let raw = args.first as? UnsafeRawPointer else { return }
+            guard let jsonC = jsc_value_to_json(OpaquePointer(raw), 0) else { return }
+            let json = String(cString: jsonC)
+            g_free(jsonC)
+            guard let data = json.data(using: .utf8),
+                  let body = try? JSONSerialization.jsonObject(with: data)
+            else {
+                Task { await logCenter.append(source: "bridge-gtk", stream: .stderr, text: "undecodable script message: \(json)") }
+                return
+            }
+            Task {
+                switch await AnglesiteMessageDispatcher.dispatch(body: body, via: router) {
+                case .editReply(let reply):
+                    guard let encoded = try? JSONEncoder().encode(reply),
+                          let replyJSON = String(data: encoded, encoding: .utf8)
+                    else {
+                        await logCenter.append(source: "bridge-gtk", stream: .stderr, text: "failed to encode reply for id=\(reply.id)")
+                        return
+                    }
+                    let script = "window.anglesite?._handleReply?.(\(replyJSON))"
+                    Idle {
+                        let webView = UnsafeMutableRawPointer(bitPattern: webViewBits)?
+                            .assumingMemoryBound(to: WebKitWebView.self)
+                        webkit_web_view_evaluate_javascript(webView, script, -1, nil, nil, nil, nil, nil)
+                    }
+                case .visibleElementsHandled, .canvasSelectionHandled, .computedStylesHandled:
+                    return
+                case .visibleElementsDropped, .canvasSelectionDropped, .computedStylesDropped:
+                    // Expected in the MVP shell: no annotation/canvas consumers are wired yet
+                    // (they arrive with the component editor), so these land silently — unlike
+                    // the macOS adapter, where a drop means broken wiring and is logged.
+                    return
+                case .rejected(let reason):
+                    await logCenter.append(source: "bridge-gtk", stream: .stderr, text: "rejected message: \(reason)")
+                }
+            }
+        }
+
+        return storage
+    }
+
+    func update<Data>(_ storage: ViewStorage, data: WidgetData, updateProperties: Bool, type: Data.Type) where Data: ViewRenderData {
+        guard updateProperties else { return }
+        if !url.isEmpty, storage.fields["loaded-url"] as? String != url, let pointer = storage.opaquePointer {
+            storage.fields["loaded-url"] = url
+            webkit_web_view_load_uri(UnsafeMutablePointer<WebKitWebView>(pointer), url)
+        }
+        storage.previousState = self
+    }
+}

--- a/Sources/AnglesiteLinux/PreviewWebView.swift
+++ b/Sources/AnglesiteLinux/PreviewWebView.swift
@@ -70,9 +70,19 @@ struct PreviewWebView: AdwaitaWidget {
             name: "script-message-received::\(namespace)",
             argCount: 1,
             pointer: ucm
-        ) { args in
-            guard let raw = args.first as? UnsafeRawPointer else { return }
-            guard let jsonC = jsc_value_to_json(OpaquePointer(raw), 0) else { return }
+        ) { (args: [Any]) -> Void in
+            guard let raw = args.first as? UnsafeRawPointer else {
+                // A marshaling mismatch (e.g. Adwaita boxing the signal argument differently)
+                // would otherwise be a completely silent dead bridge — logs are sacred.
+                let got: String
+                if let first = args.first { got = String(describing: Swift.type(of: first)) } else { got = "nothing" }
+                Task { await logCenter.append(source: "bridge-gtk", stream: .stderr, text: "script-message signal argument was not a pointer (got \(got))") }
+                return
+            }
+            guard let jsonC = jsc_value_to_json(OpaquePointer(raw), 0) else {
+                Task { await logCenter.append(source: "bridge-gtk", stream: .stderr, text: "jsc_value_to_json returned NULL for a script message") }
+                return
+            }
             let json = String(cString: jsonC)
             g_free(jsonC)
             guard let data = json.data(using: .utf8),

--- a/Sources/AnglesiteLinux/ShellModel.swift
+++ b/Sources/AnglesiteLinux/ShellModel.swift
@@ -1,0 +1,79 @@
+import Foundation
+import AnglesiteCore
+
+/// Owns the site lifecycle behind the Linux shell: open a `.anglesite` package, compose the
+/// Linux runtime stack (`LocalContainerSiteRuntime` over `PodmanContainerControl`, per the
+/// cross-platform port design §7 and #647), and hand the UI everything it needs to render the
+/// preview and route overlay edits. One site at a time, matching the one-window MVP — opening
+/// a second package stops the first site's container.
+///
+/// UI-free by design: state reaches the shell through `SiteRuntime.observe()`, which the app
+/// layer drains and marshals onto the GTK main loop itself (`Idle`).
+final class ShellModel {
+    struct OpenedSite {
+        let displayName: String
+        let siteID: String
+        let runtime: LocalContainerSiteRuntime
+        let router: MCPApplyEditRouter
+    }
+
+    private var current: OpenedSite?
+
+    /// Reads the package marker (site identity, #242), stops any previously-open site, and
+    /// kicks off the container boot. Returns immediately — `start()` runs detached and the
+    /// caller watches `runtime.observe()` for `.starting` → `.ready`/`.failed`.
+    func open(packageURL: URL) throws -> OpenedSite {
+        let package = AnglesitePackage(url: packageURL)
+        let marker = try package.readMarker()
+
+        if let previous = current {
+            Task { await previous.runtime.stop() }
+        }
+
+        let client = MCPClient(supervisor: .shared)
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: PodmanContainerControl(),
+            mcpClient: client
+        )
+        let site = OpenedSite(
+            displayName: marker.displayName,
+            siteID: marker.siteID.uuidString,
+            runtime: runtime,
+            router: MCPApplyEditRouter(mcpClient: { client })
+        )
+        current = site
+
+        let sourceURL = package.sourceURL
+        Task { await runtime.start(siteID: site.siteID, siteDirectory: sourceURL) }
+        return site
+    }
+
+    /// Stops the open site's container, if any. Called on window close so quitting the shell
+    /// never leaks a running podman container (`podman stop` on a `--rm` container tears the
+    /// whole guest down, astro/MCP included).
+    func stopCurrent() async {
+        guard let site = current else { return }
+        current = nil
+        await site.runtime.stop()
+    }
+
+    /// The edit-overlay JS to inject into the preview. On macOS this rides the app bundle
+    /// (`AnglesiteOverlayBundle`); the Linux executable has no bundle yet (Flatpak packaging is
+    /// a separate #567 item), so resolution is: `ANGLESITE_OVERLAY_JS` env override first (dev
+    /// loop), then the repo-relative `scripts/build-overlay.sh` output beside the binary's cwd.
+    /// Missing overlay is non-fatal — the preview loads without edit affordances, matching
+    /// `WebViewBridge`'s behavior when the bundle wasn't produced.
+    static func overlaySource(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        let candidates = [
+            environment["ANGLESITE_OVERLAY_JS"],
+            "Resources/edit-overlay/overlay.js",
+        ]
+        for case let path? in candidates {
+            if let source = try? String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8) {
+                return source
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/AnglesiteLinux/ShellModel.swift
+++ b/Sources/AnglesiteLinux/ShellModel.swift
@@ -7,9 +7,15 @@ import AnglesiteCore
 /// preview and route overlay edits. One site at a time, matching the one-window MVP — opening
 /// a second package stops the first site's container.
 ///
+/// An `actor`, not `@MainActor`: `current`/`inFlightStop` are mutated from GTK callbacks *and*
+/// detached tasks, so they need real isolation — and on Linux `MainActor` rides the libdispatch
+/// main queue, which a GTK app's `g_main_loop`-parked main thread never drains, so main-actor
+/// work would starve. Actor isolation runs on the cooperative pool and is prompt regardless of
+/// what the main thread is doing.
+///
 /// UI-free by design: state reaches the shell through `SiteRuntime.observe()`, which the app
 /// layer drains and marshals onto the GTK main loop itself (`Idle`).
-final class ShellModel {
+actor ShellModel {
     struct OpenedSite {
         let displayName: String
         let siteID: String
@@ -19,15 +25,27 @@ final class ShellModel {
 
     private var current: OpenedSite?
 
+    /// The chain of not-yet-finished `runtime.stop()` calls from previous opens. Kept (rather
+    /// than fire-and-forgotten) for two reasons: `stopCurrent()` awaits it so process exit
+    /// can't race past an in-flight teardown and leak that container, and each new site's
+    /// `start()` is gated on it so re-opening the *same* package can't hit a podman
+    /// container-name collision with its own not-yet-removed predecessor.
+    private var inFlightStop: Task<Void, Never>?
+
     /// Reads the package marker (site identity, #242), stops any previously-open site, and
-    /// kicks off the container boot. Returns immediately — `start()` runs detached and the
-    /// caller watches `runtime.observe()` for `.starting` → `.ready`/`.failed`.
+    /// kicks off the container boot. Returns as soon as identity is known — `start()` runs
+    /// detached (gated on the previous teardown) and the caller watches `runtime.observe()`
+    /// for `.starting` → `.ready`/`.failed`.
     func open(packageURL: URL) throws -> OpenedSite {
         let package = AnglesitePackage(url: packageURL)
         let marker = try package.readMarker()
 
         if let previous = current {
-            Task { await previous.runtime.stop() }
+            let priorStops = inFlightStop
+            inFlightStop = Task {
+                await priorStops?.value
+                await previous.runtime.stop()
+            }
         }
 
         let client = MCPClient(supervisor: .shared)
@@ -45,14 +63,21 @@ final class ShellModel {
         current = site
 
         let sourceURL = package.sourceURL
-        Task { await runtime.start(siteID: site.siteID, siteDirectory: sourceURL) }
+        let stopGate = inFlightStop
+        Task {
+            await stopGate?.value
+            await runtime.start(siteID: site.siteID, siteDirectory: sourceURL)
+        }
         return site
     }
 
-    /// Stops the open site's container, if any. Called on window close so quitting the shell
-    /// never leaks a running podman container (`podman stop` on a `--rm` container tears the
-    /// whole guest down, astro/MCP included).
+    /// Stops the open site's container, if any, after draining any earlier in-flight
+    /// teardowns. Called on window close and on SIGINT/SIGTERM so quitting the shell never
+    /// leaks a running podman container (`podman stop` on a `--rm` container tears the whole
+    /// guest down, astro/MCP included) — even when the quit lands mid-site-switch.
     func stopCurrent() async {
+        await inFlightStop?.value
+        inFlightStop = nil
         guard let site = current else { return }
         current = nil
         await site.runtime.stop()

--- a/Sources/CWebKitGTK/module.modulemap
+++ b/Sources/CWebKitGTK/module.modulemap
@@ -1,0 +1,12 @@
+// WebKitGTK 6.0 (the GTK4-native API series) for the AnglesiteLinux preview. Header/linker
+// flags come from `pkgConfig: "webkitgtk-6.0"` in Package.swift — install libwebkitgtk-6.0-dev
+// (Debian/Ubuntu) or webkitgtk6.0-devel (Fedora) to build.
+//
+// This module includes the GTK headers a second time (Adwaita for Swift's CAdw is the first),
+// so its projections of shared GObject types are DISTINCT Swift types from CAdw's. That's fine
+// by construction: AnglesiteLinux exchanges widgets between the two worlds only as
+// OpaquePointer (Adwaita's ViewStorage currency), never as typed GObject pointers.
+module CWebKitGTK [system] {
+    header "shim.h"
+    export *
+}

--- a/Sources/CWebKitGTK/shim.h
+++ b/Sources/CWebKitGTK/shim.h
@@ -2,3 +2,6 @@
 // WebKitGTK's GTK4 API series. The umbrella header pulls in GTK4, GLib, and
 // JavaScriptCore (jsc_value_* — used to decode script-message bodies).
 #include <webkit/webkit.h>
+// g_unix_signal_add — SIGINT/SIGTERM sources dispatched on the GLib main loop,
+// used by the shell to tear down the site container on Ctrl+C/kill.
+#include <glib-unix.h>

--- a/Sources/CWebKitGTK/shim.h
+++ b/Sources/CWebKitGTK/shim.h
@@ -1,0 +1,4 @@
+#pragma once
+// WebKitGTK's GTK4 API series. The umbrella header pulls in GTK4, GLib, and
+// JavaScriptCore (jsc_value_* — used to decode script-message bodies).
+#include <webkit/webkit.h>


### PR DESCRIPTION
Phase 2 of the cross-platform port (#567), step 3 of 3 per the [design doc](docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md)'s phasing: "AnglesiteBridgeCore split (#641) → PodmanSiteRuntime (#647) → **Adwaita shell**". Stacks on both (merged).

## What this is

`anglesite-linux [Site.anglesite]` — a GTK4/libadwaita shell (Adwaita for Swift) that opens a `.anglesite` package, boots it with the already-shipping Linux runtime composition (`LocalContainerSiteRuntime(control: PodmanContainerControl())`), and live-previews the containerized Astro dev server in an embedded **WebKitGTK** webview with the edit-overlay bridge adapter wired up. Deliberately thin (spec §6 risk containment): everything below the window chrome is `AnglesiteCore`/`AnglesiteBridgeCore`.

- **`Sources/AnglesiteLinux/`** — `AnglesiteLinuxApp` (window, header bar, status pages, folder-importer open dialog, close-time container teardown, LogCenter → stderr because logs are sacred), `ShellModel` (marker read #242 → runtime composition → stop-previous-on-open), `PreviewWebView` (the WebKitGTK `AdwaitaWidget`).
- **`Sources/CWebKitGTK/`** — system-library target over `pkg-config webkitgtk-6.0`. GObject pointers cross the CAdw/CWebKitGTK module boundary only as `OpaquePointer` (ViewStorage's currency), so the double-import of GTK headers is harmless by construction.
- **`PreviewWebView`** mirrors `AnglesiteScriptHandler`/`WebViewBridge` 1:1: overlay injected as a `WebKitUserScript` at document-end, the shared `anglesite` script-message namespace registered on the user-content manager, bodies decoded via `jsc_value_to_json` → `AnglesiteMessageDispatcher.dispatch`, apply-edit replies evaluated back as `window.anglesite?._handleReply?.(...)`.

## A real #647 bug found and fixed by running the real image

`PodmanContainerControl`'s default guest commands bound **127.0.0.1** (copied from `ContainerizationControl`, where guest-local vsock proxies dial loopback from inside the guest — correct there). Rootless podman's port publishing (pasta) forwards to the container's **eth0**, not guest loopback, so every real boot timed out with connection-reset on the mapped ports. #647's integration tests masked this: their injectable fake guest commands didn't bind loopback. Fixed by binding `0.0.0.0` in the guest (`astro --host 0.0.0.0`, `ANGLESITE_MCP_HOST=0.0.0.0` — the sidecar already supports it); host exposure is unchanged since the publish side stays `127.0.0.1::`.

## Build gating

Opt-in via `ANGLESITE_LINUX_SHELL=1 swift build --product anglesite-linux`, mirroring the `ANGLESITE_CONTAINER_TESTS` pattern: adwaita-swift main requires libadwaita ≥ 1.7 (`adw_toggle_group_*`), but the Linux CI purity leg's `swift:*-noble` image caps at 1.5 — so the shell can't build there yet, the same zero-CI-coverage status `PodmanContainerControl` shipped with in #647. The eventual home is a Flatpak-based lane (the packaging item still open on #567). adwaita-swift is pinned to a commit, matching the SwiftGit2 policy.

## Verification (real Linux box: libadwaita 1.9, WebKitGTK 2.52.3, podman, GNOME)

- Built the **real** `anglesite-dev` image with podman from `Containers/anglesite-dev/` (plugin sidecar + template staged per `vendor-container-image.sh`), tagged `localhost/anglesite-dev:latest`.
- Full e2e from the GUI with a template-scaffolded `LinuxSmoke.anglesite`: open → `podman run` → guest `/etc/hosts` → clone → checkout → zero-install hydrate → `astro dev` + MCP sidecar up → runtime settles `.ready` → **WebKitGTK renders the live page** (AT-SPI tree shows `[document web] 'Welcome — Your New Anglesite Business Website'` with the Astro dev toolbar).
- Failure path: pre-fix boots surfaced the timeout `.failed` message on the status page with the window title still updating — the whole state pipeline works.
- Close teardown: clicking the window Close button (driven via AT-SPI) stops the runtime; `podman ps` confirms zero leaked containers.
- CI-leg equivalence with the flag **off**: portable `swift build` + `swift test --parallel` exit 0 (all 5 portable suites, 35 tests).
- Not exercised: an actual overlay apply-edit round-trip — the host has no node to build `overlay.js` (missing bundle is the documented non-fatal path, same as macOS). Overlay bundle packaging lands with Flatpak.

## Remaining on #567 after this

Multi-arch (linux/amd64) for the **vendored** image pipeline, Flatpak packaging (+ CI lane, overlay bundling), and the strict-concurrency `sending` warnings in the shell (Swift 5 warning tier, consistent with the repo's step-1 policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)