### PR TITLE
feat(chat): warm SiteContentGraph at site-open, not just on content create/delete (#660)

### DIFF
--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1070,6 +1070,13 @@ final class SiteWindowModel {
         }
     }
 
+    /// Scan `sourceDirectory` and load the result into `contentGraph`. Called from `loadAndStart`
+    /// so the graph is warm (`isPopulated(siteID:) == true`) before the first chat turn, not just
+    /// after the first content create/delete (#660).
+    func refreshContentGraph(siteID: String, sourceDirectory: URL) async {
+        await contentGraph.rescan(siteID: siteID, projectRoot: sourceDirectory)
+    }
+
     func loadAndStart(siteID: String?, openSitesWindow: () -> Void, dismissSiteWindow: @escaping () -> Void) async {
         self.dismissSiteWindow = dismissSiteWindow
         // SwiftUI's NSPersistentUIManager will happily restore a WindowGroup with a
@@ -1161,6 +1168,18 @@ final class SiteWindowModel {
         // silently discarded by the runtime's fresh scan (#313).
         await styleGuide?.seedFromDisk()
         preview.open(siteID: resolved.id, siteDirectory: resolved.sourceDirectory)
+        // Warm the content graph now rather than waiting for the first create/delete (#660), so
+        // `SearchContentTool`'s `isPopulated` check is already reliable by the time the chat
+        // assistant is wired up below. Kicked off in the background (not awaited here) so its
+        // filesystem walk runs concurrently with the Navigator's and Graph Explorer's own,
+        // independent scans just below rather than serializing three full-tree walks; only
+        // awaited right before `SiteAssistantSessionFactory.makeSession` constructs
+        // `SearchContentTool`, the one thing that actually needs it done. Runs unconditionally —
+        // the scan is deterministic filesystem I/O, independent of whether a container runtime
+        // is available.
+        let contentGraphRefresh = Task {
+            await refreshContentGraph(siteID: resolved.id, sourceDirectory: resolved.sourceDirectory)
+        }
         // Scan from the package ROOT (not Source/): SiteFileTree's adaptive layout detects the
         // `.anglesite` package here and resolves Source/ for Components/Styles plus the sibling
         // Config/ + Info.plist for the Metadata group. Handing it Source/ would hide Metadata.
@@ -1192,6 +1211,7 @@ final class SiteWindowModel {
             guard let templateURL = TemplateRuntime.resolve().url else { return nil }
             return try? ThemeCatalog.load(templateURL: templateURL)
         }()
+        await contentGraphRefresh.value
         let assistantSession = SiteAssistantSessionFactory.makeSession(
             siteID: resolved.id,
             sourceDirectory: resolved.sourceDirectory,

--- a/Sources/AnglesiteCore/ContentScanner.swift
+++ b/Sources/AnglesiteCore/ContentScanner.swift
@@ -261,8 +261,13 @@ extension SiteContentGraph {
     /// `isPopulated` never lies about "scanned and empty" when the scan never actually ran.
     @discardableResult
     public func rescan(siteID: String, projectRoot: URL) async -> Bool {
-        let listing = await Task.detached(priority: .utility) { () -> ContentListing? in
+        let listing = await Task.detached(priority: .utility) { () async -> ContentListing? in
             guard (try? FileManager.default.contentsOfDirectory(atPath: projectRoot.path)) != nil else {
+                await LogCenter.shared.append(
+                    source: "content-graph:\(siteID)", stream: .stderr,
+                    text: "Couldn't list \(projectRoot.path) — leaving the content graph unpopulated "
+                        + "for this scan (stale bookmark, or the directory is missing/unmounted?)"
+                )
                 return nil
             }
             return ContentScanner.scan(projectRoot: projectRoot, siteID: siteID)

--- a/Sources/AnglesiteCore/ContentScanner.swift
+++ b/Sources/AnglesiteCore/ContentScanner.swift
@@ -249,3 +249,26 @@ public enum ContentScanner {
         return f
     }()
 }
+
+extension SiteContentGraph {
+    /// Scans `projectRoot` off the main actor and loads the result for `siteID` — the shared
+    /// "keep me in sync with disk" glue both `ContentCreationWorkflow`'s post-mutation rescan
+    /// and `SiteWindowModel`'s site-open scan (#660) need, kept off the actor itself per its
+    /// documented "no I/O surface" invariant.
+    ///
+    /// Returns `false` without touching `siteID`'s existing state if `projectRoot` can't even be
+    /// listed — a stale/revoked security-scoped bookmark, a deleted or unmounted directory — so
+    /// `isPopulated` never lies about "scanned and empty" when the scan never actually ran.
+    @discardableResult
+    public func rescan(siteID: String, projectRoot: URL) async -> Bool {
+        let listing = await Task.detached(priority: .utility) { () -> ContentListing? in
+            guard (try? FileManager.default.contentsOfDirectory(atPath: projectRoot.path)) != nil else {
+                return nil
+            }
+            return ContentScanner.scan(projectRoot: projectRoot, siteID: siteID)
+        }.value
+        guard let listing else { return false }
+        await load(siteID: siteID, pages: listing.pages, posts: listing.posts, images: listing.images)
+        return true
+    }
+}

--- a/Sources/AnglesiteCore/SiteContentGraph.swift
+++ b/Sources/AnglesiteCore/SiteContentGraph.swift
@@ -123,10 +123,9 @@ public actor SiteContentGraph {
     /// upsert (e.g. the navigator's rename path) proves one entry exists, not that the whole
     /// site has been enumerated, so it can't license "a search miss is reliable."
     ///
-    /// As of writing, the only production caller of `load` is a post-mutation rescan
-    /// (`ContentCreationWorkflow.refreshContentGraph`) — nothing calls it at site-open, so this
-    /// flag is `false` for most of a session until the user creates/deletes content. Tracked as
-    /// #660; until that lands, `isPopulated` is a correct but under-exercised signal in practice.
+    /// Populated both by a post-mutation rescan (`ContentCreationWorkflow.refreshContentGraph`)
+    /// and by `SiteWindowModel.refreshContentGraph` at site-open (#660), so this flag is normally
+    /// `true` shortly after a site finishes opening, well before the first chat turn.
     private var populatedSiteIDs: Set<String> = []
 
     /// Additive multi-subscriber broadcast for UI observers (the Site Navigator), keyed by a

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -306,3 +306,29 @@ extension SiteWindowModelTests {
         #expect(model.graphExplorer.selectedNodeID == nil)
     }
 }
+
+extension SiteWindowModelTests {
+    /// #660: `loadAndStart` should warm the content graph at site-open rather than leaving
+    /// `isPopulated` false until the first create/delete. This exercises the scan-and-load step
+    /// directly (bypassing `loadAndStart`'s `SiteStore.shared` dependency, same seam gap noted
+    /// throughout this file) against a real temp source directory.
+    @Test("refreshContentGraph scans a real source directory and marks the site's content graph populated")
+    func refreshContentGraphPopulatesFromSourceDirectory() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("site-window-model-\(UUID().uuidString)")
+        let pagesDir = root.appendingPathComponent("src/pages")
+        try FileManager.default.createDirectory(at: pagesDir, withIntermediateDirectories: true)
+        try Data().write(to: pagesDir.appendingPathComponent("about.astro"))
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let graph = SiteContentGraph()
+        let model = makeModel(contentGraph: graph)
+        #expect(await graph.isPopulated(siteID: "site-a") == false)
+
+        await model.refreshContentGraph(siteID: "site-a", sourceDirectory: root)
+
+        #expect(await graph.isPopulated(siteID: "site-a") == true)
+        let pages = await graph.pages(for: "site-a")
+        #expect(pages.map(\.route) == ["/about"])
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteContentGraphTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteContentGraphTests.swift
@@ -405,6 +405,41 @@ struct SiteContentGraphTests {
         #expect(await graph.isPopulated(siteID: Self.siteA) == false)
     }
 
+    // MARK: - rescan (#660)
+
+    @Test("rescan scans a real project root and populates the graph")
+    func rescanPopulatesFromRealProjectRoot() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("site-content-graph-\(UUID().uuidString)")
+        let pagesDir = root.appendingPathComponent("src/pages")
+        try FileManager.default.createDirectory(at: pagesDir, withIntermediateDirectories: true)
+        try Data().write(to: pagesDir.appendingPathComponent("about.astro"))
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let graph = SiteContentGraph()
+        let scanned = await graph.rescan(siteID: Self.siteA, projectRoot: root)
+
+        #expect(scanned == true)
+        #expect(await graph.isPopulated(siteID: Self.siteA) == true)
+        let pages = await graph.pages(for: Self.siteA)
+        #expect(pages.map(\.route) == ["/about"])
+    }
+
+    @Test("rescan against a project root that can't be listed leaves the site unpopulated")
+    func rescanUnreadableProjectRootDoesNotMarkPopulated() async {
+        // #660 follow-up: a stale/revoked security-scoped bookmark (MAS) or a deleted/unmounted
+        // source directory must not silently report "scanned and empty" — that would make
+        // `isPopulated` lie to `SearchContentTool`, which trusts it to mean "a miss is reliable."
+        let missingRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("site-content-graph-missing-\(UUID().uuidString)")
+
+        let graph = SiteContentGraph()
+        let scanned = await graph.rescan(siteID: Self.siteA, projectRoot: missingRoot)
+
+        #expect(scanned == false)
+        #expect(await graph.isPopulated(siteID: Self.siteA) == false)
+    }
+
     @Test("searchPages matches title and route case-insensitively")
     func searchPagesMatchesTitleAndRouteCaseInsensitive() async {
         let graph = SiteContentGraph()


### PR DESCRIPTION
## Summary

- Closes #660: `SiteContentGraph` is now populated during `SiteWindowModel.loadAndStart`, not only after the first content create/delete. `SearchContentTool`'s `isPopulated(siteID:)` check was `false` for most of a session before this, so an empty search almost always hedged ("index not loaded yet") instead of confidently telling the on-device assistant a miss is reliable.
- Extracted the scan+load sequence into `SiteContentGraph.rescan(siteID:projectRoot:)` (`Sources/AnglesiteCore/ContentScanner.swift`) — a shared home for the site-open scan and (as a future follow-up) `ContentCreationWorkflow`'s existing post-mutation rescan, which still has its own private copy of the same logic.
- `rescan` returns `false` and leaves `isPopulated` untouched when the project root can't actually be listed (stale/revoked MAS security-scoped bookmark, deleted/unmounted directory) — a code-review pass caught that the initial version would silently mark a site "populated" on a *failed* scan, which would have made `isPopulated` lie to `SearchContentTool` in exactly the situation #658/#660 exist to guard against.
- The scan now runs in the background (`Task { ... }` in `loadAndStart`, awaited right before `SiteAssistantSessionFactory.makeSession` needs it) instead of blocking synchronously — the initial version serialized it ahead of the Navigator's and Graph Explorer's own independent full-tree scans, adding avoidable site-open latency on large sites.
- Also closes stale #601 (LAN-reachable SiteRuntime) — both halves (guest side #604, host side #643) were already merged; the issue just hadn't been closed.

## Review notes

This branch went through a multi-angle code review (8 finder passes + verification) before landing. Two real findings were fixed here (see above); two were deliberately **not** fixed in this PR and are called out for the reviewer:

1. **Content-graph race condition (not fixed):** `SiteContentGraph.load` has no staleness/ordering guard, so the new site-open scan and the pre-existing App-Intents/Siri-Shortcuts-reachable `ContentCreationWorkflow.refreshContentGraph` path can race on the same `siteID` — if a Shortcut-driven create's rescan finishes and calls `load()` *before* a slower, earlier-started site-open scan's `load()` lands, the newer content is silently overwritten. Fixing this properly needs a monotonic per-siteID scan-generation guard on `SiteContentGraph.load` itself, touching both call sites — scoped as a separate follow-up rather than folded into #660.
2. **`loadAndStart` ordering has no test coverage:** nothing drives `loadAndStart` directly (it depends on the real `SiteStore.shared` singleton, a pre-existing, documented test-seam gap in this file), so a future refactor that reorders the new scan call relative to `SiteAssistantSessionFactory.makeSession` would silently reintroduce #660's bug without failing any test.

## Test plan

- [x] TDD: each behavior change (site-open scan, accessibility guard, `rescan` extraction) was written test-first and watched fail before implementing.
- [x] `swift test --package-path .` — full suite green, 1816+ tests across all bundles, no regressions.
- [x] `swift build` — clean (pre-existing warnings only, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)