### PR TITLE
fix(chat): guard SiteContentGraph.load against slower, earlier-started scans (#666)

### DIFF
--- a/Sources/AnglesiteCore/ContentCreationWorkflow.swift
+++ b/Sources/AnglesiteCore/ContentCreationWorkflow.swift
@@ -222,6 +222,10 @@ public struct ContentCreationWorkflow: ContentOperationsService {
     private func refreshContentGraph(siteID: String, indexFilePath: String? = nil) async {
         guard let root = await siteDirectory(siteID) else { return }
         if let contentGraph {
+            // Claim a scan generation (#666) before the filesystem walk starts, so a slower
+            // rescan racing against a faster, newer one — e.g. the site-open scan in
+            // `SiteContentGraph.rescan` — never clobbers the newer result.
+            let generation = await contentGraph.beginScan(siteID: siteID)
             let listing = await Task.detached(priority: .utility) {
                 ContentScanner.scan(projectRoot: root, siteID: siteID)
             }.value
@@ -229,7 +233,8 @@ public struct ContentCreationWorkflow: ContentOperationsService {
                 siteID: siteID,
                 pages: listing.pages,
                 posts: listing.posts,
-                images: listing.images
+                images: listing.images,
+                generation: generation
             )
         }
         if let indexFilePath {

--- a/Sources/AnglesiteCore/ContentScanner.swift
+++ b/Sources/AnglesiteCore/ContentScanner.swift
@@ -259,8 +259,13 @@ extension SiteContentGraph {
     /// Returns `false` without touching `siteID`'s existing state if `projectRoot` can't even be
     /// listed — a stale/revoked security-scoped bookmark, a deleted or unmounted directory — so
     /// `isPopulated` never lies about "scanned and empty" when the scan never actually ran.
+    ///
+    /// Claims a scan generation (#666) before the filesystem walk starts, so a slower rescan
+    /// racing against a faster, newer one from another call site (`ContentCreationWorkflow`'s
+    /// post-mutation rescan) never clobbers the newer result.
     @discardableResult
     public func rescan(siteID: String, projectRoot: URL) async -> Bool {
+        let generation = beginScan(siteID: siteID)
         let listing = await Task.detached(priority: .utility) { () async -> ContentListing? in
             guard (try? FileManager.default.contentsOfDirectory(atPath: projectRoot.path)) != nil else {
                 await LogCenter.shared.append(
@@ -273,7 +278,13 @@ extension SiteContentGraph {
             return ContentScanner.scan(projectRoot: projectRoot, siteID: siteID)
         }.value
         guard let listing else { return false }
-        await load(siteID: siteID, pages: listing.pages, posts: listing.posts, images: listing.images)
+        await load(
+            siteID: siteID,
+            pages: listing.pages,
+            posts: listing.posts,
+            images: listing.images,
+            generation: generation
+        )
         return true
     }
 }

--- a/Sources/AnglesiteCore/SiteContentGraph.swift
+++ b/Sources/AnglesiteCore/SiteContentGraph.swift
@@ -133,7 +133,27 @@ public actor SiteContentGraph {
     /// these are fire-and-forget siteID feeds. Pruned via the stream's `onTermination`.
     private var changeStreamContinuations: [UUID: AsyncStream<String>.Continuation] = [:]
 
+    /// Per-siteID monotonic counter guarding `load` against a slower, earlier-started scan
+    /// landing after (and clobbering) a faster, newer one (#666). Keyed per siteID so two
+    /// sites' scans never interfere with each other's fencing.
+    private var scanGenerations: [String: Int] = [:]
+
     public init() {}
+
+    /// Claims a new scan generation for `siteID`. Call this *before* starting a filesystem
+    /// walk, then pass the returned token to `load(siteID:pages:posts:images:generation:)`
+    /// when the scan completes.
+    ///
+    /// First-started, not first-finished, wins: if another `beginScan` call claims a newer
+    /// generation for the same siteID before this scan's `load` lands, that `load` call is
+    /// silently discarded — a later-started scan reflects a filesystem state that already
+    /// accounts for whatever mutation triggered it, so an earlier-started scan's result is
+    /// stale by definition, however long it takes to complete (#666).
+    public func beginScan(siteID: String) -> Int {
+        let next = (scanGenerations[siteID] ?? 0) + 1
+        scanGenerations[siteID] = next
+        return next
+    }
 
     public func setChangeHandler(_ handler: ChangeHandler?) {
         changeHandler = handler
@@ -170,13 +190,24 @@ public actor SiteContentGraph {
     // MARK: - Bulk load
 
     /// Replaces all entries for `siteID` with the supplied payload. Existing entries for
-    /// other siteIDs are untouched. Always emits a change for `siteID`.
+    /// other siteIDs are untouched. Always emits a change for `siteID`, unless discarded by
+    /// the `generation` guard below.
+    ///
+    /// - Parameter generation: A token from `beginScan(siteID:)`. When provided, this call is
+    ///   silently discarded (no state change, no emit) if a newer scan has since claimed a
+    ///   later generation for `siteID` — see `beginScan` (#666). `nil` (the default) skips the
+    ///   guard entirely, applying unconditionally; used by incremental/test callers that don't
+    ///   participate in the scan-race fence.
     public func load(
         siteID: String,
         pages: [Page],
         posts: [Post],
-        images: [Image]
+        images: [Image],
+        generation: Int? = nil
     ) async {
+        if let generation, scanGenerations[siteID] != generation {
+            return
+        }
         for key in self.pages.compactMap({ $0.value.siteID == siteID ? $0.key : nil }) {
             self.pages.removeValue(forKey: key)
         }

--- a/Tests/AnglesiteCoreTests/SiteContentGraphTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteContentGraphTests.swift
@@ -440,6 +440,91 @@ struct SiteContentGraphTests {
         #expect(await graph.isPopulated(siteID: Self.siteA) == false)
     }
 
+    // MARK: - scan generation guard (#666)
+
+    @Test("beginScan returns increasing tokens per siteID, starting at 1")
+    func beginScanReturnsIncreasingTokens() async {
+        let graph = SiteContentGraph()
+        let first = await graph.beginScan(siteID: Self.siteA)
+        let second = await graph.beginScan(siteID: Self.siteA)
+        #expect(first == 1)
+        #expect(second == 2)
+    }
+
+    @Test("load without a generation token bypasses the freshness guard (back-compat default)")
+    func loadWithoutGenerationAlwaysApplies() async {
+        let graph = SiteContentGraph()
+        _ = await graph.beginScan(siteID: Self.siteA)
+        await graph.load(siteID: Self.siteA, pages: [Self.page()], posts: [], images: [])
+        let pages = await graph.pages(for: Self.siteA)
+        #expect(pages.count == 1)
+    }
+
+    @Test("load with the current generation applies normally")
+    func loadWithCurrentGenerationApplies() async {
+        let graph = SiteContentGraph()
+        let gen = await graph.beginScan(siteID: Self.siteA)
+        await graph.load(siteID: Self.siteA, pages: [Self.page()], posts: [], images: [], generation: gen)
+        let pages = await graph.pages(for: Self.siteA)
+        #expect(pages.count == 1)
+        #expect(await graph.isPopulated(siteID: Self.siteA) == true)
+    }
+
+    @Test("""
+    simulates the #666 race: a slower site-open scan started first must not clobber a \
+    faster, newer create-triggered rescan
+    """)
+    func staleGenerationLoadIsDiscarded() async {
+        let graph = SiteContentGraph()
+
+        // Site-open scan starts first (older generation)...
+        let openScanGeneration = await graph.beginScan(siteID: Self.siteA)
+
+        // ...but a Shortcut creates a page and its rescan starts — and finishes — while the
+        // site-open scan is still walking the filesystem.
+        let createRescanGeneration = await graph.beginScan(siteID: Self.siteA)
+        await graph.load(
+            siteID: Self.siteA,
+            pages: [Self.page(route: "/new-from-shortcut")],
+            posts: [],
+            images: [],
+            generation: createRescanGeneration
+        )
+
+        // The slower site-open scan finally finishes and calls load with its stale snapshot,
+        // captured before the Shortcut's page existed — this must be discarded, not applied.
+        await graph.load(
+            siteID: Self.siteA,
+            pages: [Self.page(route: "/about")],
+            posts: [],
+            images: [],
+            generation: openScanGeneration
+        )
+
+        let routes = await graph.pages(for: Self.siteA).map(\.route)
+        #expect(routes == ["/new-from-shortcut"])
+    }
+
+    @Test("scan generations are tracked independently per siteID, not a single shared counter")
+    func scanGenerationsArePerSiteIsolated() async {
+        let graph = SiteContentGraph()
+        let siteAGeneration = await graph.beginScan(siteID: Self.siteA)
+        // Advance siteB's counter ahead of siteA's — if generations were a single shared
+        // counter instead of keyed per siteID, siteA's load below would be wrongly discarded.
+        _ = await graph.beginScan(siteID: Self.siteB)
+        _ = await graph.beginScan(siteID: Self.siteB)
+
+        await graph.load(
+            siteID: Self.siteA,
+            pages: [Self.page(site: Self.siteA)],
+            posts: [],
+            images: [],
+            generation: siteAGeneration
+        )
+
+        #expect(await graph.pages(for: Self.siteA).count == 1)
+    }
+
     @Test("searchPages matches title and route case-insensitively")
     func searchPagesMatchesTitleAndRouteCaseInsensitive() async {
         let graph = SiteContentGraph()


### PR DESCRIPTION
## Summary
- `SiteContentGraph.load` unconditionally replaced all entries for a `siteID`, so whichever of two concurrent scans *finished* last won — even if it *started* first and reflects staler disk state (#666). Concretely: a slow site-open scan could land after a fast create/delete rescan and silently revert a just-created page/post out of the graph, with `isPopulated` staying `true` and no error signal — the chat assistant would then confidently tell the user a page doesn't exist.
- Adds a per-siteID monotonic scan generation: `beginScan(siteID:)` claims a token before a filesystem walk starts, and `load(..., generation:)` discards its own result if a newer scan has since claimed a later generation for that siteID. First-started, not first-finished, wins.
- Both production call sites now thread a generation token: `SiteContentGraph.rescan` (site-open scan, `ContentScanner.swift`) and `ContentCreationWorkflow.refreshContentGraph` (post-create/delete rescan).
- `generation` defaults to `nil` (no guard), so the many existing direct `load(...)` test call sites and incremental upserts are unaffected.

## Test plan
- [x] New unit tests in `SiteContentGraphTests.swift` covering `beginScan` token issuance, the back-compat `nil` default, normal apply with a current generation, per-siteID isolation of the counter, and a regression test that directly simulates the #666 race (slower-started scan landing after a faster, newer one is discarded).
- [x] `swift test --package-path .` — full suite passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)