### PR TITLE
feat(chat): wire DesignInterviewTool into FoundationModelAssistant's chat tools (#665)

### DIFF
--- a/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
+++ b/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
@@ -25,6 +25,7 @@ enum SiteAssistantSessionFactory {
         _ conventionsEngine: ProjectConventionsEngine?,
         _ conventionsStore: ProjectConventionsStore,
         _ themeCatalog: ThemeCatalog?,
+        _ designInterviewFactory: (@Sendable () async -> DesignInterviewModel)?,
         _ graphSnapshotProvider: @escaping GraphSnapshotProvider
     ) -> any ConversationalAssistant
 
@@ -54,7 +55,7 @@ enum SiteAssistantSessionFactory {
             let editRouterProvider: EditRouterProvider = { siteID in
                 await EditRouterRegistry.shared.router(for: siteID)
             }
-            let assistant: AssistantBuilder = { editBridge, contentGraph, knowledgeIndex, semanticRanker, integrationService, conventionsEngine, conventionsStore, themeCatalog, graphSnapshotProvider in
+            let assistant: AssistantBuilder = { editBridge, contentGraph, knowledgeIndex, semanticRanker, integrationService, conventionsEngine, conventionsStore, themeCatalog, designInterviewFactory, graphSnapshotProvider in
                 CombinedAugmentedAssistant(
                     base: FoundationModelAssistant(
                         tier: .onDevice,
@@ -68,7 +69,8 @@ enum SiteAssistantSessionFactory {
                         copyEditAuditor: CopyEditAuditorFactory.makeDefault(),
                         socialMediaPlanner: SocialMediaPlannerFactory.makeDefault(),
                         postRepurposer: PostRepurposerFactory.makeDefault(),
-                        themeCatalog: themeCatalog
+                        themeCatalog: themeCatalog,
+                        designInterviewFactory: designInterviewFactory
                     ),
                     index: knowledgeIndex,
                     graphSnapshotProvider: graphSnapshotProvider
@@ -121,6 +123,7 @@ enum SiteAssistantSessionFactory {
         siteID: String,
         sourceDirectory: URL,
         configDirectory: URL,
+        packageURL: URL? = nil,
         mcpClient: @escaping MCPClientProvider,
         contentGraph: SiteContentGraph,
         knowledgeIndex: SiteKnowledgeIndex,
@@ -139,6 +142,24 @@ enum SiteAssistantSessionFactory {
         // the engine's merged snapshot to whichever store instance they hold, so a second store
         // pointed at the same `conventions.json` never observes a stale value.
         let conventionsStore = ProjectConventionsStore(configDirectory: configDirectory)
+        // The chat front door's design-interview factory (#665), invoked lazily by
+        // `FoundationModelAssistant` on `DesignInterviewTool`'s first call. Mirrors
+        // `SiteWindowModel.presentDesignInterview()`: a **standalone** on-device assistant, because
+        // the interview is its own model conversation — routing it through the hosting chat
+        // assistant would both append interview turns to the chat session's transcript and
+        // re-enter that actor's single-flight session mid-drain.
+        let designInterviewFactory: (@Sendable () async -> DesignInterviewModel)? = packageURL.map { packageURL in
+            {
+                await MainActor.run {
+                    DesignInterviewModel(
+                        businessType: SiteBusinessType.read(sourceDirectory: sourceDirectory) ?? "",
+                        assistant: FoundationModelAssistant(tier: .onDevice),
+                        package: AnglesitePackage(url: packageURL),
+                        siteID: siteID
+                    )
+                }
+            }
+        }
         let chat = ChatModel(
             siteID: siteID,
             siteDirectory: sourceDirectory,
@@ -152,6 +173,7 @@ enum SiteAssistantSessionFactory {
                 conventionsEngine,
                 conventionsStore,
                 themeCatalog,
+                designInterviewFactory,
                 graphSnapshotProvider
             ),
             annotationFeed: dependencies.annotationFeed(sourceDirectory),

--- a/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
+++ b/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
@@ -25,7 +25,7 @@ enum SiteAssistantSessionFactory {
         _ conventionsEngine: ProjectConventionsEngine?,
         _ conventionsStore: ProjectConventionsStore,
         _ themeCatalog: ThemeCatalog?,
-        _ designInterviewFactory: (@Sendable () async -> DesignInterviewModel)?,
+        _ designInterviewFactory: FoundationModelAssistant.DesignInterviewModelFactory?,
         _ graphSnapshotProvider: @escaping GraphSnapshotProvider
     ) -> any ConversationalAssistant
 
@@ -148,11 +148,14 @@ enum SiteAssistantSessionFactory {
         // the interview is its own model conversation — routing it through the hosting chat
         // assistant would both append interview turns to the chat session's transcript and
         // re-enter that actor's single-flight session mid-drain.
-        let designInterviewFactory: (@Sendable () async -> DesignInterviewModel)? = packageURL.map { packageURL in
+        let designInterviewFactory: FoundationModelAssistant.DesignInterviewModelFactory? = packageURL.map { packageURL in
             {
-                await MainActor.run {
+                // Read off the main actor — only DesignInterviewModel's init needs MainActor,
+                // and `.site-config` may live on slow (e.g. iCloud-backed) storage.
+                let businessType = SiteBusinessType.read(sourceDirectory: sourceDirectory) ?? ""
+                return await MainActor.run {
                     DesignInterviewModel(
-                        businessType: SiteBusinessType.read(sourceDirectory: sourceDirectory) ?? "",
+                        businessType: businessType,
                         assistant: FoundationModelAssistant(tier: .onDevice),
                         package: AnglesitePackage(url: packageURL),
                         siteID: siteID

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1246,6 +1246,7 @@ final class SiteWindowModel {
             siteID: resolved.id,
             sourceDirectory: resolved.sourceDirectory,
             configDirectory: resolved.configDirectory,
+            packageURL: resolved.packageURL,
             mcpClient: mcpClient,
             contentGraph: contentGraph,
             knowledgeIndex: knowledgeIndex,

--- a/Sources/AnglesiteCore/DesignInterviewTool.swift
+++ b/Sources/AnglesiteCore/DesignInterviewTool.swift
@@ -21,10 +21,18 @@ public struct DesignInterviewTool: Tool, Sendable {
         public var designForMe: Bool?
     }
 
-    private let model: DesignInterviewModel
-    public init(model: DesignInterviewModel) { self.model = model }
+    /// Resolves the conversation's model on each call. Front doors that already hold a model
+    /// (the GUI sheet) wrap it in a constant closure via ``init(model:)``; the chat front door
+    /// (#665) passes ``FoundationModelAssistant``'s lazy, session-cached accessor instead, so the
+    /// interview isn't built until the assistant actually invokes the tool.
+    public typealias ModelProvider = @Sendable () async -> DesignInterviewModel
+
+    private let provider: ModelProvider
+    public init(model: DesignInterviewModel) { self.provider = { model } }
+    public init(provider: @escaping ModelProvider) { self.provider = provider }
 
     public func call(arguments: Arguments) async throws -> String {
+        let model = await provider()
         if arguments.designForMe == true {
             let businessType = await MainActor.run { () -> String in
                 model.skipToAxisConfirmation()

--- a/Sources/AnglesiteCore/DesignInterviewTool.swift
+++ b/Sources/AnglesiteCore/DesignInterviewTool.swift
@@ -24,15 +24,17 @@ public struct DesignInterviewTool: Tool, Sendable {
     /// Resolves the conversation's model on each call. Front doors that already hold a model
     /// (the GUI sheet) wrap it in a constant closure via ``init(model:)``; the chat front door
     /// (#665) passes ``FoundationModelAssistant``'s lazy, session-cached accessor instead, so the
-    /// interview isn't built until the assistant actually invokes the tool.
-    public typealias ModelProvider = @Sendable () async -> DesignInterviewModel
+    /// interview isn't built until the assistant actually invokes the tool. Throwing so a
+    /// provider whose backing state is gone fails the tool call loudly rather than silently
+    /// handing back a fresh interview with no history.
+    public typealias ModelProvider = @Sendable () async throws -> DesignInterviewModel
 
     private let provider: ModelProvider
     public init(model: DesignInterviewModel) { self.provider = { model } }
     public init(provider: @escaping ModelProvider) { self.provider = provider }
 
     public func call(arguments: Arguments) async throws -> String {
-        let model = await provider()
+        let model = try await provider()
         if arguments.designForMe == true {
             let businessType = await MainActor.run { () -> String in
                 model.skipToAxisConfirmation()

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -388,7 +388,10 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         if let designInterviewModel { return designInterviewModel }
         let created = await designInterviewFactory()
         // Actor reentrancy: a concurrent tool call may have built one while the factory ran —
-        // first writer wins so both calls continue the same interview.
+        // first writer wins so both calls continue the same interview. The losing build is
+        // discarded outright; that's intentional and cheap while `DesignInterviewModel.init` is
+        // plain property assignment — keep the factory free of heavy work (I/O is fine, it's
+        // rare) or add dedup before the `await` if that ever changes.
         if let existing = designInterviewModel { return existing }
         designInterviewModel = created
         return created

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -102,6 +102,15 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     private let socialMediaPlanner: (any SocialMediaPlanning)?
     private let postRepurposer: (any PostRepurposing)?
     private let themeCatalog: ThemeCatalog?
+    private let designInterviewFactory: (@Sendable () async -> DesignInterviewModel)?
+    /// The chat session's design interview, built lazily by ``currentDesignInterviewModel()`` on
+    /// the tool's first call. One interview per chat session: unlike every other tool dependency
+    /// on this actor (window-lifetime, stateless), the interview is conversation-lifetime mutable
+    /// state (#665) — it survives session trims (``trimSessionIfNeeded(current:context:)`` must
+    /// not reset an in-flight interview) and is cleared only by ``resetSession()``. Deliberately
+    /// a *separate* instance from the GUI sheet's `SiteWindowModel.designInterviewModel`: each
+    /// front door owns its own conversation, and sharing would pop the sheet from a chat turn.
+    private var designInterviewModel: DesignInterviewModel?
     private let logger = Logger(subsystem: "io.dwk.anglesite", category: "FoundationModelAssistant")
     /// The current conversational turn's consumer-facing ``TurnRelay``, retained so ``cancel()`` can
     /// wind it down. Cancelling stops *delivery* only — it never cancels the model stream, because
@@ -143,6 +152,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         socialMediaPlanner: (any SocialMediaPlanning)? = nil,
         postRepurposer: (any PostRepurposing)? = nil,
         themeCatalog: ThemeCatalog? = nil,
+        designInterviewFactory: (@Sendable () async -> DesignInterviewModel)? = nil,
         maxRetainedTurns: Int = 12
     ) {
         self.tier = tier
@@ -157,6 +167,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         self.socialMediaPlanner = socialMediaPlanner
         self.postRepurposer = postRepurposer
         self.themeCatalog = themeCatalog
+        self.designInterviewFactory = designInterviewFactory
         // `trimSessionIfNeeded`'s cutoff indexing (`promptIndices.count - maxRetainedTurns`) assumes
         // at least 1: `<= 0` would index at or past the end of `promptIndices` and crash. Clamp
         // rather than crash so a caller passing e.g. `0` ("keep no history") degrades to the
@@ -357,6 +368,25 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         activeRelay?.cancel()
         activeRelay = nil
         session = nil
+        // Resetting the chat also starts a fresh design interview (#665) — the interview is
+        // conversation-lifetime state, and "reset" means the whole conversation to the user.
+        designInterviewModel = nil
+    }
+
+    /// Returns the chat session's ``DesignInterviewModel``, lazily building it via the injected
+    /// `designInterviewFactory` on first use, or `nil` when no factory was supplied. Cached so
+    /// every ``DesignInterviewTool`` call within one chat session continues the same interview;
+    /// ``resetSession()`` clears it. See `designInterviewModel`'s doc comment for the lifetime
+    /// rationale (#665).
+    func currentDesignInterviewModel() async -> DesignInterviewModel? {
+        guard let designInterviewFactory else { return nil }
+        if let designInterviewModel { return designInterviewModel }
+        let created = await designInterviewFactory()
+        // Actor reentrancy: a concurrent tool call may have built one while the factory ran —
+        // first writer wins so both calls continue the same interview.
+        if let existing = designInterviewModel { return existing }
+        designInterviewModel = created
+        return created
     }
 
     /// Test-only: the clamped ``maxRetainedTurns`` actually stored, so tests can assert `init`
@@ -385,7 +415,8 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     /// `ReviewCopyTool` is added when a `copyEditAuditor` is provided. `PlanSocialMediaTool` is
     /// added when a `socialMediaPlanner` is provided. `RepurposePostTool`/`SaveSyndicationTool` are
     /// added together when a `postRepurposer` is provided. `SetupThemeTool` is added when a
-    /// `themeCatalog` is provided.
+    /// `themeCatalog` is provided. `DesignInterviewTool` is added when a
+    /// `designInterviewFactory` is provided (#665).
     private var attachedToolNames: [String] {
         var names = [Self.spotlightToolDisplayName]
         if editBridge != nil && contentGraph != nil {
@@ -415,7 +446,20 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         if themeCatalog != nil {
             names.append(SetupThemeTool.toolName)
         }
+        if designInterviewFactory != nil {
+            names.append(DesignInterviewTool.toolName)
+        }
         return names
+    }
+
+    /// Test-only: exposes ``attachedToolNames`` so tests can assert optional-tool advertising
+    /// without a live model turn (the production surface is the `.started` event).
+    var attachedToolNamesForTesting: [String] { attachedToolNames }
+
+    /// Test-only: exposes ``conversationTools(for:includeSpotlight:)`` so tests can assert which
+    /// tool types a conversational session would carry without constructing a live session.
+    func conversationToolsForTesting(for context: AssistantContext) -> [any Tool] {
+        conversationTools(for: context, includeSpotlight: false)
     }
 
     /// Returns the cached conversational session, lazily creating it from `context` on first use.
@@ -513,6 +557,16 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         }
         if let themeCatalog {
             tools.append(SetupThemeTool(catalog: themeCatalog, sourceDirectory: context.siteDirectory))
+        }
+        if let designInterviewFactory {
+            // The provider routes through the actor's cache so every call in this chat session
+            // continues one interview (#665). `[weak self]` because the actor retains the
+            // session, the session retains its tools, and a strong capture would close a
+            // self-retain cycle; the factory fallback only runs if the actor is already gone.
+            tools.append(DesignInterviewTool(provider: { [weak self] in
+                if let self, let model = await self.currentDesignInterviewModel() { return model }
+                return await designInterviewFactory()
+            }))
         }
         return tools
     }

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -101,8 +101,13 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     private let copyEditAuditor: (any CopyEditAuditing)?
     private let socialMediaPlanner: (any SocialMediaPlanning)?
     private let postRepurposer: (any PostRepurposing)?
+    /// Builds a fresh ``DesignInterviewModel`` for the chat front door (#665). Infallible —
+    /// distinct from ``DesignInterviewTool/ModelProvider``, which may throw when its backing
+    /// state is gone. Named so the app-side wiring and this actor spell one type.
+    public typealias DesignInterviewModelFactory = @Sendable () async -> DesignInterviewModel
+
     private let themeCatalog: ThemeCatalog?
-    private let designInterviewFactory: (@Sendable () async -> DesignInterviewModel)?
+    private let designInterviewFactory: DesignInterviewModelFactory?
     /// The chat session's design interview, built lazily by ``currentDesignInterviewModel()`` on
     /// the tool's first call. One interview per chat session: unlike every other tool dependency
     /// on this actor (window-lifetime, stateless), the interview is conversation-lifetime mutable
@@ -152,7 +157,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         socialMediaPlanner: (any SocialMediaPlanning)? = nil,
         postRepurposer: (any PostRepurposing)? = nil,
         themeCatalog: ThemeCatalog? = nil,
-        designInterviewFactory: (@Sendable () async -> DesignInterviewModel)? = nil,
+        designInterviewFactory: DesignInterviewModelFactory? = nil,
         maxRetainedTurns: Int = 12
     ) {
         self.tier = tier
@@ -558,14 +563,18 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         if let themeCatalog {
             tools.append(SetupThemeTool(catalog: themeCatalog, sourceDirectory: context.siteDirectory))
         }
-        if let designInterviewFactory {
+        if designInterviewFactory != nil {
             // The provider routes through the actor's cache so every call in this chat session
             // continues one interview (#665). `[weak self]` because the actor retains the
             // session, the session retains its tools, and a strong capture would close a
-            // self-retain cycle; the factory fallback only runs if the actor is already gone.
+            // self-retain cycle. A nil `self` means the tool outlived its actor — unreachable
+            // today (the session's lifetime is bounded by the actor's); fail the call loudly
+            // rather than silently fabricating an uncached interview with no history.
             tools.append(DesignInterviewTool(provider: { [weak self] in
-                if let self, let model = await self.currentDesignInterviewModel() { return model }
-                return await designInterviewFactory()
+                guard let self, let model = await self.currentDesignInterviewModel() else {
+                    throw CancellationError()
+                }
+                return model
             }))
         }
         return tools

--- a/Tests/AnglesiteAppTests/SiteAssistantSessionFactoryTests.swift
+++ b/Tests/AnglesiteAppTests/SiteAssistantSessionFactoryTests.swift
@@ -27,7 +27,7 @@ struct SiteAssistantSessionFactoryTests {
         )
         let capture = SnapshotCapture()
         var dependencies = SiteAssistantSessionFactory.Dependencies.live
-        dependencies.assistant = { _, _, _, _, _, _, _, _, graphSnapshotProvider in
+        dependencies.assistant = { _, _, _, _, _, _, _, _, _, graphSnapshotProvider in
             Task {
                 let snapshot = await graphSnapshotProvider()
                 await capture.capture(snapshot)
@@ -52,6 +52,47 @@ struct SiteAssistantSessionFactoryTests {
 
         while await capture.received == nil { await Task.yield() }
         #expect(await capture.received == expected)
+    }
+
+    /// Runs `makeSession` with a builder that only records whether a design-interview factory
+    /// arrived, returning that observation (#665).
+    private func interviewFactoryPresence(packageURL: URL?) -> Bool {
+        // The builder closure is `@Sendable`, so it can't mutate a captured local directly —
+        // but it runs synchronously inside `makeSession`, so an unchecked box is race-free here.
+        final class Observed: @unchecked Sendable { var factoryPresent = false }
+        let observed = Observed()
+        var dependencies = SiteAssistantSessionFactory.Dependencies.live
+        dependencies.assistant = { _, _, _, _, _, _, _, _, designInterviewFactory, _ in
+            observed.factoryPresent = designInterviewFactory != nil
+            return StubConversationalAssistant()
+        }
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        _ = SiteAssistantSessionFactory.makeSession(
+            siteID: "site-1",
+            sourceDirectory: root,
+            configDirectory: root,
+            packageURL: packageURL,
+            mcpClient: { nil },
+            contentGraph: SiteContentGraph(),
+            knowledgeIndex: SiteKnowledgeIndex(),
+            semanticRanker: nil,
+            conventionsEngine: nil,
+            integrationService: IntegrationOperations.live(),
+            dependencies: dependencies,
+            graphSnapshotProvider: { SiteGraphExplorerSnapshot(nodes: [], edges: []) }
+        )
+        return observed.factoryPresent
+    }
+
+    @Test("a packageURL yields a design-interview factory for the chat assistant (#665)")
+    func packageURLYieldsDesignInterviewFactory() {
+        let packageURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        #expect(interviewFactoryPresence(packageURL: packageURL))
+    }
+
+    @Test("no packageURL means no design-interview factory (#665)")
+    func missingPackageURLMeansNoFactory() {
+        #expect(!interviewFactoryPresence(packageURL: nil))
     }
 }
 

--- a/Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewModelTests.swift
@@ -7,53 +7,8 @@ import Foundation
 import FoundationModels
 #endif
 
-/// Minimal fake — echoes a fixed reply as a single `.textDelta` then `.turnComplete`, so tests
-/// can assert on stage progression and draft state without a real FoundationModels session.
-private actor FakeConversationalAssistant: ConversationalAssistant {
-    /// When set, `converse` yields `.failed(message:)` instead of a successful reply — used to
-    /// exercise `DesignInterviewModel.send(_:)`'s in-band-failure path.
-    private let failureMessage: String?
-    /// When true, `converse` yields only `.started`/`.turnComplete` with no `.textDelta` in
-    /// between — used to exercise `DesignInterviewModel.send(_:)`'s empty-reply path (a terminal
-    /// event shape distinct from `.failed`/`.cancelled`).
-    private let emitsEmptyReply: Bool
-
-    init(failureMessage: String? = nil, emitsEmptyReply: Bool = false) {
-        self.failureMessage = failureMessage
-        self.emitsEmptyReply = emitsEmptyReply
-    }
-
-    nonisolated var capabilities: AssistantCapabilities {
-        AssistantCapabilities(supportsStreaming: true, supportsStructuredOutput: false, supportsVision: false,
-                              supportsTools: false, maxContextTokens: 4096, providerName: "Fake")
-    }
-    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
-        AsyncThrowingStream { $0.yield("echo: \(prompt)"); $0.finish() }
-    }
-    #if compiler(>=6.4)
-    func generateStructured<T: Generable & Sendable>(prompt: String, context: AssistantContext, resultType: T.Type) async throws -> T {
-        fatalError("not used by DesignInterviewModelTests")
-    }
-    #endif
-    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
-        let failureMessage = failureMessage
-        let emitsEmptyReply = emitsEmptyReply
-        return AsyncStream { continuation in
-            continuation.yield(.started(model: "Fake", toolNames: []))
-            if let failureMessage {
-                continuation.yield(.failed(message: failureMessage))
-            } else if emitsEmptyReply {
-                continuation.yield(.turnComplete(nil))
-            } else {
-                continuation.yield(.textDelta("Got it."))
-                continuation.yield(.turnComplete(nil))
-            }
-            continuation.finish()
-        }
-    }
-    func cancel() async {}
-    func resetSession() async {}
-}
+// The shared `FakeConversationalAssistant` (FakeConversationalAssistant.swift) provides the
+// canned "Got it." reply plus the failure/empty-reply variants these tests exercise.
 
 @Suite struct DesignInterviewModelTests {
     /// Builds a real `.anglesite` package layout: a package root containing a `Source/`

--- a/Tests/AnglesiteCoreTests/DesignInterviewToolTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewToolTests.swift
@@ -7,31 +7,8 @@ import Foundation
 #if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
-/// Minimal fake — echoes a fixed reply as a single `.textDelta` then `.turnComplete`, so the
-/// tool's call path can be exercised without a real FoundationModels session (same shape as
-/// `DesignInterviewModelTests`' fake, private to that file).
-private actor FakeConversationalAssistant: ConversationalAssistant {
-    nonisolated var capabilities: AssistantCapabilities {
-        AssistantCapabilities(supportsStreaming: true, supportsStructuredOutput: false, supportsVision: false,
-                              supportsTools: false, maxContextTokens: 4096, providerName: "Fake")
-    }
-    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
-        AsyncThrowingStream { $0.yield("echo: \(prompt)"); $0.finish() }
-    }
-    func generateStructured<T: Generable & Sendable>(prompt: String, context: AssistantContext, resultType: T.Type) async throws -> T {
-        fatalError("not used by DesignInterviewToolTests")
-    }
-    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
-        AsyncStream { continuation in
-            continuation.yield(.started(model: "Fake", toolNames: []))
-            continuation.yield(.textDelta("Got it."))
-            continuation.yield(.turnComplete(nil))
-            continuation.finish()
-        }
-    }
-    func cancel() async {}
-    func resetSession() async {}
-}
+// Uses the shared `FakeConversationalAssistant` (FakeConversationalAssistant.swift) for the
+// canned "Got it." reply, so the tool's call path runs without a real FoundationModels session.
 
 @Suite struct DesignInterviewToolTests {
     /// A real `.anglesite` package layout (root + `Source/`), matching

--- a/Tests/AnglesiteCoreTests/DesignInterviewToolTests.swift
+++ b/Tests/AnglesiteCoreTests/DesignInterviewToolTests.swift
@@ -1,0 +1,96 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteSiteModel
+
+// Gated like the type under test (#128): `DesignInterviewTool` is FoundationModels-only.
+#if compiler(>=6.4) && canImport(FoundationModels)
+import FoundationModels
+
+/// Minimal fake — echoes a fixed reply as a single `.textDelta` then `.turnComplete`, so the
+/// tool's call path can be exercised without a real FoundationModels session (same shape as
+/// `DesignInterviewModelTests`' fake, private to that file).
+private actor FakeConversationalAssistant: ConversationalAssistant {
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(supportsStreaming: true, supportsStructuredOutput: false, supportsVision: false,
+                              supportsTools: false, maxContextTokens: 4096, providerName: "Fake")
+    }
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.yield("echo: \(prompt)"); $0.finish() }
+    }
+    func generateStructured<T: Generable & Sendable>(prompt: String, context: AssistantContext, resultType: T.Type) async throws -> T {
+        fatalError("not used by DesignInterviewToolTests")
+    }
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        AsyncStream { continuation in
+            continuation.yield(.started(model: "Fake", toolNames: []))
+            continuation.yield(.textDelta("Got it."))
+            continuation.yield(.turnComplete(nil))
+            continuation.finish()
+        }
+    }
+    func cancel() async {}
+    func resetSession() async {}
+}
+
+@Suite struct DesignInterviewToolTests {
+    /// A real `.anglesite` package layout (root + `Source/`), matching
+    /// `AnglesitePackage.sourceURL`'s invariant — no CSS fixture needed since these tests never
+    /// reach `confirmAndApply`.
+    private func makePackage() throws -> AnglesitePackage {
+        let packageRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: packageRoot.appendingPathComponent("Source"), withIntermediateDirectories: true)
+        return AnglesitePackage(url: packageRoot)
+    }
+
+    @MainActor
+    private func makeModel(businessType: String = "bakery") throws -> DesignInterviewModel {
+        DesignInterviewModel(
+            businessType: businessType,
+            assistant: FakeConversationalAssistant(),
+            package: try makePackage(),
+            siteID: "site-1"
+        )
+    }
+
+    @Test("provider init routes the message into the provided model and returns its reply (#665)")
+    @MainActor func providerInitRoutesMessageIntoModel() async throws {
+        let model = try makeModel()
+        let tool = DesignInterviewTool(provider: { model })
+        let reply = try await tool.call(arguments: .init(message: "I run a bakery", designForMe: nil))
+        #expect(reply == "Got it.")
+        #expect(model.transcript.count == 2)
+        #expect(model.transcript.first?.role == "user")
+        #expect(model.transcript.first?.text == "I run a bakery")
+    }
+
+    @Test("successive calls through the provider continue one conversation (#665)")
+    @MainActor func successiveCallsContinueOneConversation() async throws {
+        let model = try makeModel()
+        let tool = DesignInterviewTool(provider: { model })
+        _ = try await tool.call(arguments: .init(message: "first turn", designForMe: nil))
+        _ = try await tool.call(arguments: .init(message: "second turn", designForMe: nil))
+        #expect(model.transcript.count == 4)
+        #expect(model.draft.stage == .brandAnchor)  // advanced twice from .intent
+    }
+
+    @Test("designForMe skips to axis confirmation through the provider path (#665)")
+    @MainActor func designForMeSkipsToAxisConfirmation() async throws {
+        let model = try makeModel(businessType: "bakery")
+        let tool = DesignInterviewTool(provider: { model })
+        let reply = try await tool.call(arguments: .init(message: "just pick for me", designForMe: true))
+        #expect(reply.contains("bakery"))
+        #expect(model.draft.stage == .axisConfirmation)
+    }
+
+    @Test("the existing model-based init still drives the same conversation flow")
+    @MainActor func modelInitStillWorks() async throws {
+        let model = try makeModel()
+        let tool = DesignInterviewTool(model: model)
+        let reply = try await tool.call(arguments: .init(message: "hello", designForMe: nil))
+        #expect(reply == "Got it.")
+        #expect(model.transcript.count == 2)
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/FakeConversationalAssistant.swift
+++ b/Tests/AnglesiteCoreTests/FakeConversationalAssistant.swift
@@ -1,0 +1,55 @@
+import Foundation
+@testable import AnglesiteCore
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+/// Minimal fake — echoes a fixed reply as a single `.textDelta` then `.turnComplete`, so tests
+/// can assert on conversation flow (stage progression, transcript, tool replies) without a real
+/// FoundationModels session. Shared by `DesignInterviewModelTests` and `DesignInterviewToolTests`.
+actor FakeConversationalAssistant: ConversationalAssistant {
+    /// When set, `converse` yields `.failed(message:)` instead of a successful reply — used to
+    /// exercise `DesignInterviewModel.send(_:)`'s in-band-failure path.
+    private let failureMessage: String?
+    /// When true, `converse` yields only `.started`/`.turnComplete` with no `.textDelta` in
+    /// between — used to exercise `DesignInterviewModel.send(_:)`'s empty-reply path (a terminal
+    /// event shape distinct from `.failed`/`.cancelled`).
+    private let emitsEmptyReply: Bool
+
+    init(failureMessage: String? = nil, emitsEmptyReply: Bool = false) {
+        self.failureMessage = failureMessage
+        self.emitsEmptyReply = emitsEmptyReply
+    }
+
+    nonisolated var capabilities: AssistantCapabilities {
+        AssistantCapabilities(supportsStreaming: true, supportsStructuredOutput: false, supportsVision: false,
+                              supportsTools: false, maxContextTokens: 4096, providerName: "Fake")
+    }
+    func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.yield("echo: \(prompt)"); $0.finish() }
+    }
+    #if compiler(>=6.4)
+    func generateStructured<T: Generable & Sendable>(prompt: String, context: AssistantContext, resultType: T.Type) async throws -> T {
+        fatalError("not used by fake-backed tests")
+    }
+    #endif
+    func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
+        let failureMessage = failureMessage
+        let emitsEmptyReply = emitsEmptyReply
+        return AsyncStream { continuation in
+            continuation.yield(.started(model: "Fake", toolNames: []))
+            if let failureMessage {
+                continuation.yield(.failed(message: failureMessage))
+            } else if emitsEmptyReply {
+                continuation.yield(.turnComplete(nil))
+            } else {
+                continuation.yield(.textDelta("Got it."))
+                continuation.yield(.turnComplete(nil))
+            }
+            continuation.finish()
+        }
+    }
+    func cancel() async {}
+    func resetSession() async {}
+}

--- a/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
@@ -4,6 +4,7 @@ import CoreGraphics
 import ImageIO
 import UniformTypeIdentifiers
 @testable import AnglesiteCore
+import AnglesiteSiteModel
 
 // Gated like the type under test (#128). Capability/tier assertions run on any toolchain≥6.4;
 // the generate/generateStructured tests are live-model and skip when unavailable.
@@ -64,6 +65,67 @@ struct FoundationModelAssistantTests {
         #expect(FoundationModelAssistant(maxRetainedTurns: 0).maxRetainedTurnsForTesting == 1)
         #expect(FoundationModelAssistant(maxRetainedTurns: -5).maxRetainedTurnsForTesting == 1)
         #expect(FoundationModelAssistant(maxRetainedTurns: 3).maxRetainedTurnsForTesting == 3)
+    }
+
+    // MARK: Design-interview chat tool (#665) — no model required
+
+    /// Counts factory invocations from a `@Sendable` closure without data races.
+    private actor InvocationCounter {
+        var count = 0
+        func increment() { count += 1 }
+    }
+
+    /// A design-interview factory whose inner assistant is never exercised — these tests only
+    /// cover the hosting actor's lazy-build/cache/reset lifecycle, not the interview itself.
+    private func makeInterviewFactory(counting counter: InvocationCounter) -> @Sendable () async -> DesignInterviewModel {
+        {
+            await counter.increment()
+            return await MainActor.run {
+                DesignInterviewModel(
+                    businessType: "bakery",
+                    assistant: FoundationModelAssistant(tier: .onDevice),
+                    package: AnglesitePackage(url: FileManager.default.temporaryDirectory
+                        .appendingPathComponent(UUID().uuidString)),
+                    siteID: "site-1"
+                )
+            }
+        }
+    }
+
+    @Test("design-interview model is built lazily, cached across calls, and cleared by resetSession (#665)")
+    func designInterviewModelLifecycle() async throws {
+        let counter = InvocationCounter()
+        let assistant = FoundationModelAssistant(designInterviewFactory: makeInterviewFactory(counting: counter))
+        // Lazy: nothing built at init.
+        #expect(await counter.count == 0)
+        let first = try #require(await assistant.currentDesignInterviewModel())
+        let second = try #require(await assistant.currentDesignInterviewModel())
+        // Cached: one interview per chat session, not one per turn.
+        #expect(first === second)
+        #expect(await counter.count == 1)
+        // resetSession starts a fresh interview along with the fresh chat.
+        await assistant.resetSession()
+        let third = try #require(await assistant.currentDesignInterviewModel())
+        #expect(third !== first)
+        #expect(await counter.count == 2)
+    }
+
+    @Test("no factory means no design-interview model and no advertised tool (#665)")
+    func designInterviewAbsentWithoutFactory() async {
+        let assistant = FoundationModelAssistant()
+        #expect(await assistant.currentDesignInterviewModel() == nil)
+        #expect(await !assistant.attachedToolNamesForTesting.contains(DesignInterviewTool.toolName))
+    }
+
+    @Test("a supplied factory attaches DesignInterviewTool to the conversational session (#665)")
+    func designInterviewToolAttachedWithFactory() async {
+        let counter = InvocationCounter()
+        let assistant = FoundationModelAssistant(designInterviewFactory: makeInterviewFactory(counting: counter))
+        #expect(await assistant.attachedToolNamesForTesting.contains(DesignInterviewTool.toolName))
+        let tools = await assistant.conversationToolsForTesting(for: makeContext())
+        #expect(tools.contains { $0 is DesignInterviewTool })
+        // Attaching the tool must not eagerly build the interview model.
+        #expect(await counter.count == 0)
     }
 
     @Test("PCC-tier assistant constructs and remains usable (falls back to on-device)")

--- a/docs/superpowers/specs/2026-07-12-design-interview-chat-tool-design.md
+++ b/docs/superpowers/specs/2026-07-12-design-interview-chat-tool-design.md
@@ -1,0 +1,79 @@
+# Design Interview chat tool wiring (#665) — design note
+
+**Issue:** #665 — wire `DesignInterviewTool` into `FoundationModelAssistant`'s per-conversation
+chat tools, completing the third front door deferred out of #631 (GUI sheet and Siri intent
+shipped in PR #667).
+
+## The problem
+
+`DesignInterviewTool.init(model:)` needs a conversation-lifetime, mutable,
+`@MainActor`-isolated `DesignInterviewModel`. `FoundationModelAssistant` is a plain
+(non-`MainActor`) actor whose `conversationTools(for:includeSpotlight:)` builds every other
+tool from stateless, window-lifetime dependencies stored at init (`themeCatalog`,
+`integrationService`, …). Three constraints shape the answer:
+
+1. `conversationTools` is synchronous and called from two synchronous paths
+   (`makeSession(context:includeSpotlight:)` and `trimSessionIfNeeded(current:context:)`).
+   Making it `async` ripples through session construction and the trim path.
+2. `trimSessionIfNeeded` rebuilds the tool array mid-conversation (#456). Any design that
+   constructs a *fresh* interview model per tool-array build silently resets an in-flight
+   interview when the transcript gets trimmed.
+3. The GUI sheet binds `.sheet(item: $model.designInterviewModel)` (`SiteWindow.swift`), so
+   sharing `SiteWindowModel`'s instance with chat would pop the sheet open mid-chat — and
+   would couple `AnglesiteCore` to app-layer window state.
+
+## Decision: actor-cached lazy provider
+
+- **`DesignInterviewTool`** gains a provider-based initializer,
+  `init(provider: @escaping @Sendable () async -> DesignInterviewModel)`, alongside the
+  existing `init(model:)` (which becomes a trivial wrapper). `call` awaits the provider each
+  turn. Awaiting is free for the direct-model case and gives the chat path its lazy hook.
+- **`FoundationModelAssistant`** gains an optional init dependency,
+  `designInterviewFactory: (@Sendable () async -> DesignInterviewModel)? = nil`, plus actor
+  state `private var designInterviewModel: DesignInterviewModel?`. An internal
+  `currentDesignInterviewModel()` lazily invokes the factory once and caches (with an
+  actor-reentrancy re-check after the `await`, first-writer-wins). `conversationTools`
+  stays synchronous: when a factory is present it appends
+  `DesignInterviewTool(provider: { [weak self] … })`, where the provider calls back into
+  the actor. The capture is weak because the actor retains the session, the session retains
+  its tools, and a strong capture would close a self-retain cycle.
+- **Lifetime: one interview per chat session.** The cached model survives session trims
+  (constraint 2) and is cleared by `resetSession()` — resetting the chat also starts a
+  fresh interview, matching the user-visible meaning of "reset". `cancel()` does not clear
+  it. The chat interview is deliberately a *separate* conversation from the GUI sheet's
+  (constraint 3): each front door owns its own `DesignInterviewModel`, exactly as
+  `presentDesignInterview()` already builds a standalone one per sheet presentation.
+- **App wiring.** `SiteAssistantSessionFactory.makeSession` gains a `packageURL: URL?`
+  parameter (`SiteWindowModel` passes `site.packageURL`). The factory closure mirrors
+  `presentDesignInterview()`: `SiteBusinessType.read` for the business type, a **standalone**
+  `FoundationModelAssistant(tier: .onDevice)` as the interview's assistant (the interview is
+  its own model conversation, not turns appended to the hosting chat session — and using the
+  hosting actor would re-enter its single-flight session mid-drain), and
+  `AnglesitePackage(url: packageURL)`. `AssistantBuilder` grows a matching
+  `designInterviewFactory` parameter threaded into `FoundationModelAssistant`.
+- `attachedToolNames` advertises `DesignInterviewTool.toolName` when a factory is present,
+  so the chat UI's `.started` event reflects the wiring like every other optional tool.
+
+## Alternatives rejected
+
+- **Share `SiteWindowModel.designInterviewModel` across front doors** — pops the GUI sheet
+  from a chat turn (sheet(item:) binding) and inverts the layering (core actor reaching
+  into app window state).
+- **Fresh model per session build (async `conversationTools`)** — resets in-flight
+  interviews on transcript trim; async ripple through `makeSession`/`trimSessionIfNeeded`.
+
+## Testing
+
+All new behavior is testable without the live on-device model:
+
+- `DesignInterviewTool` provider init: `call` routes the message into the provided model
+  (fake `ConversationalAssistant`) and returns the model's last transcript entry; the
+  `designForMe` fast path works through the provider too.
+- `FoundationModelAssistant.currentDesignInterviewModel()`: lazy (factory not invoked until
+  first call), cached (same instance across calls, factory invoked once), and reset
+  (`resetSession()` clears it; next call builds a new instance).
+- `attachedToolNames` (internal-for-testing, same pattern as `instructions`/`turnPrompt`):
+  includes `designInterview` only when a factory is supplied.
+
+Hosted-app-target wiring (`SiteAssistantSessionFactory`/`SiteWindowModel`) stays thin per
+the CLAUDE.md CI policy; the testable logic lives in `AnglesiteCore`.


### PR DESCRIPTION
Fixes #665 — the third front door deliberately deferred out of #631 (GUI sheet + Siri intent shipped in PR #667). The on-device chat assistant can now start and continue a design interview mid-conversation.

## Design (documented in `docs/superpowers/specs/2026-07-12-design-interview-chat-tool-design.md`)

**Actor-cached lazy provider.** `DesignInterviewTool` needs a conversation-lifetime, `@MainActor` `DesignInterviewModel`, but `FoundationModelAssistant` is a plain actor whose synchronous `conversationTools` is also called from the session-trim path. So:

- `DesignInterviewTool` gains `init(provider: @Sendable () async -> DesignInterviewModel)`; the existing `init(model:)` becomes a constant-closure wrapper. `call` resolves the model per turn.
- `FoundationModelAssistant` gains an optional `designInterviewFactory` init dependency and an internal `currentDesignInterviewModel()` that lazily builds **one interview per chat session** on the tool's first call (actor-reentrancy-safe, first writer wins). The cached model **survives session trims** (#456 rebuilds must not reset an in-flight interview) and is cleared by `resetSession()` — resetting the chat starts a fresh interview. The tool's provider captures the actor weakly (actor → session → tools would otherwise self-retain).
- `attachedToolNames` advertises `designInterview` when wired, like every other optional tool.
- App side stays thin per the CI policy: `SiteAssistantSessionFactory.makeSession` gains `packageURL:`, builds the factory mirroring `presentDesignInterview()` — a **standalone** `FoundationModelAssistant(tier: .onDevice)` as the interview's assistant, because the interview is its own model conversation and must not append turns to (or re-enter) the hosting chat session. `SiteWindowModel` passes `resolved.packageURL`.

**Session lifetime decision:** one interview per chat session per window, distinct from the GUI sheet's instance — sharing `SiteWindowModel.designInterviewModel` would pop the sheet from a chat turn (`.sheet(item:)` binding) and invert the core/app layering. Each front door owns its own conversation.

## Test plan
- [x] New `DesignInterviewToolTests`: provider init routes messages into the model, successive calls continue one conversation (stage advances), `designForMe` fast path, existing `init(model:)` unchanged.
- [x] `FoundationModelAssistantTests`: factory is lazy (not invoked at init or tool attachment), cached across calls, cleared by `resetSession()`; no factory → no model, no advertised tool; factory → `DesignInterviewTool` present in `conversationTools`.
- [x] `SiteAssistantSessionFactoryTests`: `packageURL` ⇒ factory reaches the assistant builder; no `packageURL` ⇒ nil.
- [x] Full `swift test` — 2,178 tests across all 7 targets, 0 failures (exit 0), including the live on-device FoundationModels suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)