### PR TITLE
fix(chat): proactively trim conversational session by token estimate (#657)

### DIFF
--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -641,15 +641,10 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     private static let transcriptBudgetHeadroom = 0.7
 
     /// Token ceiling a candidate transcript must fit under, derived from
-    /// ``transcriptBudgetHeadroom``. A stored-once computed property so
-    /// ``sessionFittingBudget(_:context:)`` doesn't recompute the multiplication on every candidate.
+    /// ``transcriptBudgetHeadroom``.
     private static var transcriptBudgetThreshold: Int {
         Int(Double(FoundationModelContextBudget.onDeviceTokenBudget) * transcriptBudgetHeadroom)
     }
-
-    /// Test-only: exposes ``transcriptBudgetThreshold`` so tests can compute the same token ceiling
-    /// without duplicating the headroom constant.
-    static var transcriptBudgetThresholdForTesting: Int { transcriptBudgetThreshold }
 
     /// Proactively shrinks `session`'s retained-turn window below ``maxRetainedTurns`` when its
     /// estimated token weight is already within reach of the on-device budget (#657). A heavy

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -312,7 +312,12 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         // it and keep history.)
         if activeDrains > 0 { session = nil }
 
-        let session = try conversationSession(for: context)
+        // Proactively trim *before* this turn extends the transcript further — a heavy attached
+        // tool set (#657) can already have pushed the cached session within reach of the on-device
+        // budget even though `maxRetainedTurns` hasn't been crossed, and the existing post-turn,
+        // turn-count-only trim below only protects *future* turns, not the one about to run.
+        let session = sessionFittingBudget(try conversationSession(for: context), context: context)
+        self.session = session
         let providerName = capabilities.providerName
         let toolNames = attachedToolNames
 
@@ -588,24 +593,88 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     /// compaction API (#456). Runs after each turn drains so the *next* turn (not the one that just
     /// finished) benefits from the smaller transcript. `current === session` guards against
     /// clobbering a session a newer turn already replaced while this drain was still in flight (see
-    /// `activeDrains` in ``converse(prompt:context:)``).
+    /// `activeDrains` in ``converse(prompt:context:)``). Pure turn-count: the pre-turn
+    /// ``sessionFittingBudget(_:context:)`` check (#657) is what protects the turn about to run
+    /// from a heavy tool set overflowing the budget before this ceiling is even crossed.
     private func trimSessionIfNeeded(current: LanguageModelSession, context: AssistantContext) {
         guard session === current else { return }
-        let transcript = current.transcript
+        guard let trimmed = Self.trimmedTranscript(current.transcript, retaining: maxRetainedTurns) else { return }
+        let tools = conversationTools(for: context, includeSpotlight: true)
+        session = LanguageModelSession(tools: tools, transcript: trimmed)
+    }
+
+    /// Rebuilds `transcript` keeping only its most recent `turns` `.prompt` entries (and everything
+    /// after the cutoff), plus the leading `.instructions` entry if present — so a trimmed session
+    /// still carries the route/page context and tool schemas it was created with. Returns `nil` when
+    /// `transcript` doesn't hold more than `turns` prompts (nothing to trim). Shared by the
+    /// turn-count trim (``trimSessionIfNeeded(current:context:)``) and the token-budget trim
+    /// (``sessionFittingBudget(_:context:)``, #657) so both rebuild a session identically.
+    private static func trimmedTranscript(_ transcript: Transcript, retaining turns: Int) -> Transcript? {
         let promptIndices = transcript.indices.filter {
             if case .prompt = transcript[$0] { return true }
             return false
         }
-        guard promptIndices.count > maxRetainedTurns else { return }
-        let cutoff = promptIndices[promptIndices.count - maxRetainedTurns]
+        guard promptIndices.count > turns else { return nil }
+        let cutoff = promptIndices[promptIndices.count - turns]
         var retained = Array(transcript[cutoff...])
-        // Keep the leading instructions entry so the trimmed session still carries the route/page
-        // context it was created with.
         if let first = transcript.first, case .instructions = first {
             retained.insert(first, at: 0)
         }
-        let tools = conversationTools(for: context, includeSpotlight: true)
-        session = LanguageModelSession(tools: tools, transcript: Transcript(entries: retained))
+        return Transcript(entries: retained)
+    }
+
+    /// Estimated token weight of a transcript's entries, including tool schemas baked into a
+    /// leading `.instructions` entry — `Transcript.Entry` is `CustomStringConvertible`, so its
+    /// `description` captures the actual segments/tool definitions sent to the model, letting this
+    /// reuse ``FoundationModelContextBudget``'s character-based token proxy rather than needing a
+    /// real on-device tokenizer.
+    private static func estimatedTranscriptTokens(_ transcript: Transcript) -> Int {
+        transcript.reduce(into: 0) { total, entry in
+            total += FoundationModelContextBudget.estimatedTokens(for: String(describing: entry))
+        }
+    }
+
+    /// Fraction of ``FoundationModelContextBudget/onDeviceTokenBudget`` the cached session is
+    /// allowed to reach before a turn proactively trims it further — kept below 1.0 so trimming
+    /// leaves headroom for the turn about to run (its own prompt plus the model's response),
+    /// rather than reacting only once the budget is already blown.
+    private static let transcriptBudgetHeadroom = 0.7
+
+    /// Token ceiling a candidate transcript must fit under, derived from
+    /// ``transcriptBudgetHeadroom``. A stored-once computed property so
+    /// ``sessionFittingBudget(_:context:)`` doesn't recompute the multiplication on every candidate.
+    private static var transcriptBudgetThreshold: Int {
+        Int(Double(FoundationModelContextBudget.onDeviceTokenBudget) * transcriptBudgetHeadroom)
+    }
+
+    /// Test-only: exposes ``transcriptBudgetThreshold`` so tests can compute the same token ceiling
+    /// without duplicating the headroom constant.
+    static var transcriptBudgetThresholdForTesting: Int { transcriptBudgetThreshold }
+
+    /// Proactively shrinks `session`'s retained-turn window below ``maxRetainedTurns`` when its
+    /// estimated token weight is already within reach of the on-device budget (#657). A heavy
+    /// attached tool set (11 tools, per the chat front door) can push a cached session's estimated
+    /// weight over budget well before ``maxRetainedTurns`` prompts accumulate — the existing
+    /// post-turn, count-only ``trimSessionIfNeeded(current:context:)`` can't prevent that, since it
+    /// only ever protects the turn *after* the one that overflowed. Shrinks the window one turn at a
+    /// time (rather than jumping straight to ``trimmedTranscript(_:retaining:)``'s single-shot cut)
+    /// so it stops as soon as the transcript fits, instead of over-trimming history that wasn't the
+    /// problem. Returns `session` unchanged once it fits, or once shrunk to a single retained turn —
+    /// the smallest useful window, past which the tool schemas (not history) are what dominate.
+    private func sessionFittingBudget(_ session: LanguageModelSession, context: AssistantContext) -> LanguageModelSession {
+        guard Self.estimatedTranscriptTokens(session.transcript) > Self.transcriptBudgetThreshold else {
+            return session
+        }
+        var window = maxRetainedTurns
+        while window > 1 {
+            window -= 1
+            guard let candidate = Self.trimmedTranscript(session.transcript, retaining: window) else { continue }
+            if window == 1 || Self.estimatedTranscriptTokens(candidate) <= Self.transcriptBudgetThreshold {
+                let tools = conversationTools(for: context, includeSpotlight: true)
+                return LanguageModelSession(tools: tools, transcript: candidate)
+            }
+        }
+        return session
     }
 
     /// Character cap on how much of ``AssistantContext/currentPageContent`` is folded into a

--- a/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
+++ b/Tests/AnglesiteCoreTests/FoundationModelAssistantTests.swift
@@ -490,6 +490,44 @@ struct FoundationModelAssistantTests {
         #expect(reply.localizedCaseInsensitiveContains("Falkor"))
     }
 
+    @Test("converse proactively trims once the transcript's estimated weight nears budget, even below maxRetainedTurns (#657)")
+    func converseProactivelyTrimsOverTokenBudget() async throws {
+        guard modelAvailable() else { return }
+        // maxRetainedTurns is high enough that the existing turn-count trim (#456) would never
+        // fire within this test — any shrinkage observed here is attributable only to the
+        // token-budget check added for #657.
+        let assistant = FoundationModelAssistant(maxRetainedTurns: 50)
+        let context = makeContext()
+
+        // Plant several bulky-but-bounded turns. Each is well within the real on-device budget on
+        // its own, but their combined weight (plus the always-attached Spotlight tool schema)
+        // crosses the proactive threshold well before 50 turns land — the #657 scenario, where a
+        // heavy attached tool set left little headroom for even a handful of turns.
+        let bulky = String(repeating: "The quick brown fox jumps over the lazy dog. ", count: 150)
+            + " Reply with just 'ok'."
+        for _ in 1...3 {
+            for await _ in try await assistant.converse(prompt: bulky, context: context) {}
+        }
+
+        // Without the proactive trim, this turn would extend an already-near-budget transcript and
+        // risk the hard "transcript exceeded the model's context size" failure reported in #657.
+        // With it, the cached session is shrunk *before* this turn runs, so it still completes.
+        var events: [AssistantEvent] = []
+        for await event in try await assistant.converse(prompt: "Reply with just 'ok'.", context: context) {
+            events.append(event)
+        }
+        guard case .turnComplete = events.last else {
+            Issue.record("Expected .turnComplete (proactive trim kept the turn within budget), got \(String(describing: events.last))")
+            return
+        }
+
+        // The count-based ceiling (50) was never reached, so any window smaller than the 4 turns
+        // submitted is attributable only to the token-budget check.
+        let promptCount = await assistant.promptCountForTesting
+        #expect(promptCount != nil)
+        if let promptCount { #expect(promptCount < 4) }
+    }
+
     @Test("cancel mid-stream yields .cancelled and ends the turn")
     func cancelMidStreamYieldsCancelled() async throws {
         guard modelAvailable() else { return }


### PR DESCRIPTION
## Summary
- The on-device chat's cached `LanguageModelSession` transcript was only trimmed once it held more than `maxRetainedTurns` (12) prompts, and only *after* a turn completed — so with the chat front door's ~11 attached tool schemas already consuming a large fraction of the 4,096-token window, the transcript could overflow well before 12 turns landed, and the post-turn trim only protected the *next* turn, not the one that failed.
- Adds `sessionFittingBudget`, which estimates the transcript's token weight (reusing `FoundationModelContextBudget`'s character-based proxy — `Transcript.Entry` is `CustomStringConvertible`, so its `description` captures tool schemas along with segments) and proactively shrinks the retained-turn window *before* a turn runs, once the estimate crosses 70% of budget.
- Factored the existing turn-count trim's rebuild step into a shared `trimmedTranscript(_:retaining:)` helper so both trims rebuild a session identically.

Closes #657.

## Test plan
- [x] `swift build --target AnglesiteCore` — clean
- [x] New live test `converseProactivelyTrimsOverTokenBudget` (gated on `modelAvailable()`) reproduces the #657 shape (many attached-tool-equivalent budget pressure via bulky turns under a high `maxRetainedTurns`) and asserts the turn still completes and the window shrank
- [x] Full `swift test` suite (1829 tests, 263 suites) passes, including the existing `converseTrimsTranscriptBeyondBudget` (#456) regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)