### PR TITLE
Test coverage for App Intents + CI build caching/path filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,17 +30,21 @@ jobs:
     outputs:
       swift: ${{ steps.filter.outputs.swift }}
       js: ${{ steps.filter.outputs.js }}
+      helpBook: ${{ steps.filter.outputs.helpBook }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # push events (merges to main) diff against the prior commit; PR events use the
-          # GitHub API diff instead and ignore this, but fetch-depth 1 wouldn't have a
-          # previous commit to compare against for the push case.
-          fetch-depth: 2
+          # Full history. `dorny/paths-filter` diffs push events against `github.event.before`,
+          # the tip of `main` before the push — which can be more than one commit back (this
+          # repo allows merge-commit and rebase-merge, and has no branch protection stopping a
+          # direct multi-commit push), so a shallow `before`-sized depth can undershoot and fail
+          # the diff. The repo is ~9MB/474 commits, so a full clone here is still fast — cheap
+          # insurance against a job that gates every other job in this workflow.
+          fetch-depth: 0
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
-          # `.github/workflows/ci.yml` is in both groups: a change to this file should never
+          # `.github/workflows/ci.yml` is in every group: a change to this file should never
           # cause a job to go unevaluated just because we're the ones who touched the filters.
           filters: |
             swift:
@@ -54,8 +58,10 @@ jobs:
               - '.github/workflows/ci.yml'
             js:
               - 'JS/edit-overlay/**'
-              - 'Resources/Anglesite.help/**'
               - 'scripts/node-version.txt'
+              - '.github/workflows/ci.yml'
+            helpBook:
+              - 'Resources/Anglesite.help/**'
               - 'scripts/check-help-links.sh'
               - '.github/workflows/ci.yml'
 
@@ -81,10 +87,18 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm test
-      # Unrelated to the overlay, but this is the cheap ubuntu lint lane: verify every
-      # intra-book link/asset in the Apple Help Book resolves (plain bash+grep, no deps).
+
+  help-book-links:
+    name: Help Book links
+    needs: changes
+    if: needs.changes.outputs.helpBook == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Split out of edit-overlay: a Help Book-only change shouldn't pay for a full npm
+    # install/lint/typecheck/test cycle just to reach this check. Plain bash+grep, no deps.
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check Help Book links
-        working-directory: ${{ github.workspace }}
         run: scripts/check-help-links.sh
 
   linux-build-test:
@@ -384,3 +398,35 @@ jobs:
         # required schema member (verified locally) fails the build with a "Missing required
         # property … from AppSchemaEntity …" halting error.
         run: xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteIntents -configuration Debug build
+
+  ci:
+    name: CI required checks
+    # Every job above is conditionally skipped by the `changes` path filter, so no single
+    # existing job name is a reliable "did CI actually run" signal — a future branch-protection
+    # rule should require this one instead. `always()` so it still runs (and can still fail)
+    # when an upstream job was skipped or failed, rather than being skipped itself.
+    if: always()
+    needs:
+      - changes
+      - edit-overlay
+      - help-book-links
+      - linux-build-test
+      - build-test
+      - relay-tsan
+      - xcodeproj-sync
+      - appintents-schema
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify path detection succeeded and no required job failed
+        # `needs.changes.result != 'success'` catches the case this job exists for: if `changes`
+        # itself errors (flaky API call, upstream Action regression), every other job's `if:`
+        # condition reads an empty output and quietly resolves to "skipped" rather than
+        # "failed" — this job is `always()`, so it still runs and turns that into a loud
+        # failure instead of a workflow that looks CI-clean with zero tests actually run.
+        # `contains(needs.*.result, 'failure')` catches ordinary job failures too, so this one
+        # job is a complete required-check signal on its own.
+        if: needs.changes.result != 'success' || contains(needs.*.result, 'failure')
+        run: |
+          echo "::error::One or more required jobs did not succeed, or path detection itself failed (which silently skips everything downstream instead of failing it)."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,49 @@ env:
   ANGLESITE_SKIP_CONTAINER: '1'
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      swift: ${{ steps.filter.outputs.swift }}
+      js: ${{ steps.filter.outputs.js }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # push events (merges to main) diff against the prior commit; PR events use the
+          # GitHub API diff instead and ignore this, but fetch-depth 1 wouldn't have a
+          # previous commit to compare against for the push case.
+          fetch-depth: 2
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          # `.github/workflows/ci.yml` is in both groups: a change to this file should never
+          # cause a job to go unevaluated just because we're the ones who touched the filters.
+          filters: |
+            swift:
+              - 'Package.swift'
+              - 'Package.resolved'
+              - 'project.yml'
+              - 'Sources/**'
+              - 'Tests/**'
+              - 'Resources/Template/**'
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
+            js:
+              - 'JS/edit-overlay/**'
+              - 'Resources/Anglesite.help/**'
+              - 'scripts/node-version.txt'
+              - 'scripts/check-help-links.sh'
+              - '.github/workflows/ci.yml'
+
   edit-overlay:
     name: JS edit-overlay (lint/typecheck/test)
+    needs: changes
+    if: needs.changes.outputs.js == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:
@@ -48,6 +89,8 @@ jobs:
 
   linux-build-test:
     name: Linux (portable SwiftPM targets)
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Cross-platform port, phase 1 "purity" (2026-07-08 design §9/§10): the compiler is the
@@ -64,6 +107,21 @@ jobs:
       - name: Show toolchain versions
         run: swift --version
 
+      # Keyed on the swift:6.3.3-noble image (a different image tag would need a different
+      # cache) + Package.resolved (dependency changes shouldn't reuse a stale checkout) +
+      # commit SHA (so every run saves fresh; restore-keys below fall back to the closest
+      # match instead of requiring an exact one). SwiftPM's own incremental build tracking
+      # handles the rest — a partial-match restore never produces wrong output, only a
+      # partially-warm cache.
+      - name: Cache SwiftPM build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .build
+          key: swiftpm-linux-6.3.3-noble-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          restore-keys: |
+            swiftpm-linux-6.3.3-noble-${{ hashFiles('Package.resolved') }}-
+            swiftpm-linux-6.3.3-noble-
+
       - name: Build (debug)
         run: swift build -c debug
 
@@ -77,6 +135,8 @@ jobs:
     # an allocation pattern in the compiled binary, not any specific test, so any PR can trip
     # it. macOS 26.4's runtime (Swift 6.3+) has the fix; verified by running #644's exact head
     # green on macos-26 (PR #646) while it failed 5/5 on macos-15.
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
     runs-on: macos-26
     timeout-minutes: 15
     steps:
@@ -114,6 +174,7 @@ jobs:
         # target). #104 moves the App Intents into a SwiftPM library and surfaces the gap.
         # Pick the newest Xcode pre-installed on the runner; the runner image determines what's
         # available (macos-15 typically ships Xcode 16/26 betas).
+        id: xcode
         run: |
           set -euo pipefail
           ls -d /Applications/Xcode*.app 2>/dev/null | sort -V
@@ -125,12 +186,27 @@ jobs:
           LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | grep -vE '/Xcode_26\.3(\.app|\.[0-9]+\.app)$' | tail -1)
           echo "Selecting: $LATEST"
           sudo xcode-select -s "$LATEST"
+          # Cache-key input: a runner-image bump that changes which Xcode is "latest" must not
+          # reuse a build cache from a different toolchain.
+          echo "version=$(basename "$LATEST")" >> "$GITHUB_OUTPUT"
 
       - name: Show toolchain versions
         run: |
           swift --version
           xcodebuild -version
           node --version
+
+      # See the linux-build-test cache step for the key-scheme rationale. Namespaced by the
+      # selected Xcode build so a runner-image toolchain bump can't restore incompatible
+      # object files.
+      - name: Cache SwiftPM build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .build
+          key: swiftpm-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          restore-keys: |
+            swiftpm-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-
+            swiftpm-macos-${{ steps.xcode.outputs.version }}-
 
       - name: Build (debug)
         run: swift build -c debug
@@ -148,6 +224,8 @@ jobs:
     # macos-26 for the same OS-runtime reason as build-test: this lane runs Swift concurrency
     # suites against the host's libswift_Concurrency, so it has the same exposure to the
     # macos-15 image's Swift 6.2.x task-allocator bug.
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
     runs-on: macos-26
     timeout-minutes: 15
     # The relay suites (TurnRelay/TextStreamRelay) have no plugin/Node dependency, so this lane
@@ -158,6 +236,7 @@ jobs:
 
       - name: Select latest available Xcode
         # Same toolchain rationale as build-test: CLAUDE.md mandates Xcode 27+.
+        id: xcode
         run: |
           set -euo pipefail
           # Skip Xcode 26.3 on the current runner image: its toolchain builds test targets that
@@ -168,15 +247,30 @@ jobs:
           LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | grep -vE '/Xcode_26\.3(\.app|\.[0-9]+\.app)$' | tail -1)
           echo "Selecting: $LATEST"
           sudo xcode-select -s "$LATEST"
+          echo "version=$(basename "$LATEST")" >> "$GITHUB_OUTPUT"
 
       - name: Show toolchain versions
         run: swift --version
+
+      # A distinct key namespace (`swiftpm-tsan-...`, not `swiftpm-macos-...`) — `--sanitize
+      # thread` recompiles every unit with different flags, so sharing a cache with the plain
+      # debug build would mean this lane can never hit and just pays the upload for nothing.
+      - name: Cache SwiftPM build (ThreadSanitizer)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .build
+          key: swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          restore-keys: |
+            swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-
+            swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-
 
       - name: Run relay suites under ThreadSanitizer
         run: scripts/test-relay-tsan.sh
 
   xcodeproj-sync:
     name: Anglesite.xcodeproj ↔ project.yml in sync
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
     runs-on: macos-15
     timeout-minutes: 10
     permissions:
@@ -213,6 +307,8 @@ jobs:
     name: AppIntents schema conformance (metadata processor)
     # macOS 27 / Xcode 27 runner: the AppSchema.WordProcessor surface and its
     # validator are macOS-27 symbols. macos-15 (Xcode 16/26) cannot run this.
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
     runs-on: macos-26
     timeout-minutes: 15
     permissions:

--- a/Sources/AnglesiteIntents/ContentHelpIntents.swift
+++ b/Sources/AnglesiteIntents/ContentHelpIntents.swift
@@ -26,16 +26,20 @@ public struct ReviewCopyIntent: AppIntent {
     }
 
     public func perform() async throws -> some IntentResult & ProvidesDialog {
+        .result(dialog: IntentDialog(stringLiteral: try await run()))
+    }
+
+    private func run() async throws -> String {
         // `SiteEntity.directory` is the `.anglesite` PACKAGE root (see its init from
         // `SiteStore.Site`), not the `Source/` git repo the auditor needs to read — derive the
         // actual source directory via `AnglesitePackage` here rather than changing the entity's
         // established (and elsewhere-relied-on) semantics.
         guard let packageURL = site.directory else {
-            return .result(dialog: "\(IntegrationDialogs.failed(reason: "site folder unavailable", siteName: site.displayName))")
+            return IntegrationDialogs.failed(reason: "site folder unavailable", siteName: site.displayName)
         }
         let sourceDirectory = AnglesitePackage(url: packageURL).sourceURL
         guard let auditor = CopyEditAuditorFactory.makeDefault() else {
-            return .result(dialog: "\(ContentHelpDialogs.assistantUnavailable(feature: "Copy review"))")
+            return ContentHelpDialogs.assistantUnavailable(feature: "Copy review")
         }
         let chunks = SiteContentChunker.chunks(sourceDirectory: sourceDirectory)
         let preamble = BrandVoiceGuidance.preamble(
@@ -43,9 +47,22 @@ public struct ReviewCopyIntent: AppIntent {
         let report = await auditor.audit(
             chunks: chunks, preamble: preamble, siteID: site.id, siteDirectory: sourceDirectory)
         if let unavailableMessage = report.unavailableMessage {
-            return .result(dialog: "\(unavailableMessage)")
+            return unavailableMessage
         }
-        return .result(dialog: "\(ContentHelpDialogs.copyReview(findingCount: report.findings.count, pageCount: report.auditedCount, skippedCount: report.skippedRoutes.count, siteName: site.displayName))")
+        return ContentHelpDialogs.copyReview(findingCount: report.findings.count, pageCount: report.auditedCount, skippedCount: report.skippedRoutes.count, siteName: site.displayName)
+    }
+}
+
+// MARK: - Test-only helpers
+
+extension ReviewCopyIntent {
+    /// Drives `perform`'s dialog logic directly, bypassing the AppIntents runtime (`IntentDialog`
+    /// exposes no way to read its text back out, so tests can't inspect `perform()`'s return
+    /// value directly — mirrors `ListDNSRecordsIntent.performForTesting()`). Safe for the
+    /// site-folder-unavailable guard; reaching further calls the real `CopyEditAuditorFactory`
+    /// (no test-only override exists for it).
+    func performForTesting() async throws -> String {
+        try await run()
     }
 }
 
@@ -72,14 +89,18 @@ public struct PlanSocialMediaIntent: AppIntent {
     }
 
     public func perform() async throws -> some IntentResult & ProvidesDialog {
+        .result(dialog: IntentDialog(stringLiteral: try await run()))
+    }
+
+    private func run() async throws -> String {
         // Same `SiteEntity.directory` ground truth as `ReviewCopyIntent`: it's the package root,
         // not `Source/` — derive the source directory via `AnglesitePackage`.
         guard let packageURL = site.directory else {
-            return .result(dialog: "\(IntegrationDialogs.failed(reason: "site folder unavailable", siteName: site.displayName))")
+            return IntegrationDialogs.failed(reason: "site folder unavailable", siteName: site.displayName)
         }
         let sourceDirectory = AnglesitePackage(url: packageURL).sourceURL
         guard let planner = SocialMediaPlannerFactory.makeDefault() else {
-            return .result(dialog: "\(ContentHelpDialogs.assistantUnavailable(feature: "Social planning"))")
+            return ContentHelpDialogs.assistantUnavailable(feature: "Social planning")
         }
         let businessType = SiteBusinessType.read(sourceDirectory: sourceDirectory)
         let siteName = SiteConfigValues.siteName(sourceDirectory: sourceDirectory) ?? site.displayName
@@ -88,13 +109,25 @@ public struct PlanSocialMediaIntent: AppIntent {
             siteName: siteName, businessType: businessType,
             preamble: BrandVoiceGuidance.preamble(conventions: nil, businessType: businessType),
             weeks: clamped, startDate: Date(), siteID: site.id, siteDirectory: sourceDirectory) else {
-            return .result(dialog: "\(ContentHelpDialogs.assistantUnavailable(feature: "Social planning"))")
+            return ContentHelpDialogs.assistantUnavailable(feature: "Social planning")
         }
         // Writing a docs file into the site repo: confirm like AddBookingIntent confirms writes.
         try await requestConfirmation(dialog: "Save a \(plan.weeks.count)-week social plan to \(site.displayName)'s docs/social-calendar.md?")
         let markdown = SocialCalendarMarkdown.render(plan: plan, siteName: siteName)
         try SocialCalendarMarkdown.write(markdown: markdown, sourceDirectory: sourceDirectory)
-        return .result(dialog: "\(ContentHelpDialogs.socialPlanSaved(weeks: plan.weeks.count, siteName: site.displayName))")
+        return ContentHelpDialogs.socialPlanSaved(weeks: plan.weeks.count, siteName: site.displayName)
+    }
+}
+
+// MARK: - Test-only helpers
+
+extension PlanSocialMediaIntent {
+    /// Drives `perform`'s dialog logic directly, bypassing the AppIntents runtime — see
+    /// `ReviewCopyIntent.performForTesting()`. Safe for the site-folder-unavailable guard;
+    /// reaching further calls the real `SocialMediaPlannerFactory` and, on success, a real
+    /// `requestConfirmation` (no test-only override exists for either).
+    func performForTesting() async throws -> String {
+        try await run()
     }
 }
 
@@ -121,17 +154,22 @@ public struct RepurposePostIntent: AppIntent {
     }
 
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<String> {
+        let (value, dialog) = try await run()
+        return .result(value: value, dialog: IntentDialog(stringLiteral: dialog))
+    }
+
+    private func run() async throws -> (value: String, dialog: String) {
         // Same `SiteEntity.directory` ground truth as `ReviewCopyIntent`/`PlanSocialMediaIntent`:
         // it's the package root, not `Source/` — derive the source directory via `AnglesitePackage`.
         guard let packageURL = site.directory else {
-            return .result(value: "", dialog: "\(IntegrationDialogs.failed(reason: "site folder unavailable", siteName: site.displayName))")
+            return ("", IntegrationDialogs.failed(reason: "site folder unavailable", siteName: site.displayName))
         }
         let sourceDirectory = AnglesitePackage(url: packageURL).sourceURL
         guard let repurposer = PostRepurposerFactory.makeDefault() else {
-            return .result(value: "", dialog: "\(ContentHelpDialogs.assistantUnavailable(feature: "Repurposing"))")
+            return ("", ContentHelpDialogs.assistantUnavailable(feature: "Repurposing"))
         }
         guard let post = PostSource.load(slug: slug, sourceDirectory: sourceDirectory) else {
-            return .result(value: "", dialog: "\(IntegrationDialogs.failed(reason: "no post named \(slug)", siteName: site.displayName))")
+            return ("", IntegrationDialogs.failed(reason: "no post named \(slug)", siteName: site.displayName))
         }
         // Domain resolution mirrors `RepurposePostTool`/`RepurposeModel`: the app writes `DOMAIN`
         // (not `SITE_DOMAIN`) into `.site-config`, so this reads it via `WebsiteAnalyticsAsset.bestHost`.
@@ -150,6 +188,18 @@ public struct RepurposePostIntent: AppIntent {
         let summary = ContentHelpDialogs.repurposeSummary(
             postTitle: post.title, platformCount: variants.count - failed, failedCount: failed)
         let dialog = domain.isEmpty ? "\(RepurposeReply.missingDomainWarning) \(summary)" : summary
-        return .result(value: block, dialog: "\(dialog)")
+        return (block, dialog)
+    }
+}
+
+// MARK: - Test-only helpers
+
+extension RepurposePostIntent {
+    /// Drives `perform`'s dialog logic directly, bypassing the AppIntents runtime — see
+    /// `ReviewCopyIntent.performForTesting()`. Safe for the site-folder-unavailable guard;
+    /// reaching further calls the real `PostRepurposerFactory` (no test-only override exists
+    /// for it).
+    func performForTesting() async throws -> (value: String, dialog: String) {
+        try await run()
     }
 }

--- a/Sources/AnglesiteIntents/ThemeCatalogOverride.swift
+++ b/Sources/AnglesiteIntents/ThemeCatalogOverride.swift
@@ -1,0 +1,10 @@
+import AnglesiteCore
+
+/// Test-only escape hatch around `@Dependency` resolution of `ThemeCatalog`, mirroring
+/// `ContentOperationsOverride`. `@Dependency` is gated to the AppIntents perform flow; direct
+/// `intent.perform()` calls from unit tests crash without it. Tests bind this `@TaskLocal` to a
+/// fake catalog before invoking `ApplyThemeIntent`, which reads
+/// `ThemeCatalogOverride.scoped ?? self.catalog`, so production flows through `@Dependency`.
+public enum ThemeCatalogOverride {
+    @TaskLocal public static var scoped: ThemeCatalog?
+}

--- a/Sources/AnglesiteIntents/ThemeIntents.swift
+++ b/Sources/AnglesiteIntents/ThemeIntents.swift
@@ -27,14 +27,24 @@ public struct ApplyThemeIntent: AppIntent {
     }
 
     public func perform() async throws -> some IntentResult & ProvidesDialog {
-        guard let theme = catalog.theme(id: themeID) else {
-            let names = catalog.themes.map(\.name).joined(separator: ", ")
-            return .result(dialog: IntentDialog(stringLiteral: "I don't recognize that theme. Available: \(names)."))
+        .result(dialog: IntentDialog(stringLiteral: try await run()))
+    }
+
+    private func run() async throws -> String {
+        // Tests bind ThemeCatalogOverride.scoped; production goes through @Dependency.
+        let themeCatalog = ThemeCatalogOverride.scoped ?? catalog
+        guard let theme = themeCatalog.theme(id: themeID) else {
+            let names = themeCatalog.themes.map(\.name).joined(separator: ", ")
+            return "I don't recognize that theme. Available: \(names)."
         }
         guard let packageURL = site.directory else {
-            return .result(dialog: IntentDialog(stringLiteral: "I couldn't find \(site.displayName)'s location."))
+            return "I couldn't find \(site.displayName)'s location."
         }
-        try await requestConfirmation(dialog: "Apply the \(theme.name) theme to \(site.displayName)?")
+        // A bound override means we're under test — skip the real Siri confirmation UI, which
+        // isn't introspectable under `swift test` (mirrors AddDNSRecordIntent/DeleteDNSRecordIntent).
+        if ThemeCatalogOverride.scoped == nil {
+            try await requestConfirmation(dialog: "Apply the \(theme.name) theme to \(site.displayName)?")
+        }
         let package = AnglesitePackage(url: packageURL)
         let input = DesignApplyInput(
             cssVars: DesignTokenWriter.templateCSSVars(for: theme),
@@ -43,6 +53,20 @@ public struct ApplyThemeIntent: AppIntent {
             sourceLabel: "Built-in theme: \(theme.name)"
         )
         let result = DesignApplyService.apply(input, to: package)
-        return .result(dialog: IntentDialog(stringLiteral: SetupThemeArguments.reply(for: result, themeName: theme.name)))
+        return SetupThemeArguments.reply(for: result, themeName: theme.name)
+    }
+}
+
+// MARK: - Test-only helpers
+
+extension ApplyThemeIntent {
+    /// Drives `perform`'s dialog logic directly, bypassing the AppIntents `@Dependency` gate and
+    /// (since a bound override also skips `requestConfirmation`) the confirmation gate too.
+    /// Only callable when `ThemeCatalogOverride.scoped` is bound.
+    func performForTesting() async throws -> String {
+        guard ThemeCatalogOverride.scoped != nil else {
+            fatalError("performForTesting requires a bound ThemeCatalogOverride.scoped")
+        }
+        return try await run()
     }
 }

--- a/Tests/AnglesiteIntentsTests/ContentHelpIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ContentHelpIntentsTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+/// Covers the site-folder-unavailable guard shared by all three content-help intents (#465).
+/// The success paths call the real `CopyEditAuditorFactory`/`SocialMediaPlannerFactory`/
+/// `PostRepurposerFactory` (no test-only override exists for any of them yet, unlike
+/// `DomainOperationsOverride` et al.), so they aren't exercised here.
+extension AppIntentsTests {
+    @Suite("ContentHelpIntents")
+    struct ContentHelpIntentsTests {
+        private func entity(directory: URL? = nil) -> SiteEntity {
+            SiteEntity(id: "s1", name: "Portfolio", creationDate: nil, modificationDate: nil, directory: directory)
+        }
+
+        @Test("ReviewCopyIntent reports a missing site folder instead of crashing")
+        func reviewCopyReportsMissingSiteFolder() async throws {
+            var intent = ReviewCopyIntent()
+            intent.site = entity(directory: nil)
+
+            let dialog = try await intent.performForTesting()
+
+            #expect(dialog.contains("site folder unavailable"))
+            #expect(dialog.contains("Portfolio"))
+        }
+
+        @Test("PlanSocialMediaIntent reports a missing site folder instead of crashing")
+        func planSocialMediaReportsMissingSiteFolder() async throws {
+            var intent = PlanSocialMediaIntent()
+            intent.site = entity(directory: nil)
+            intent.weeks = 4
+
+            let dialog = try await intent.performForTesting()
+
+            #expect(dialog.contains("site folder unavailable"))
+            #expect(dialog.contains("Portfolio"))
+        }
+
+        @Test("RepurposePostIntent reports a missing site folder instead of crashing, with an empty value")
+        func repurposePostReportsMissingSiteFolder() async throws {
+            var intent = RepurposePostIntent()
+            intent.site = entity(directory: nil)
+            intent.slug = "coast-trip"
+
+            let (value, dialog) = try await intent.performForTesting()
+
+            #expect(value.isEmpty)
+            #expect(dialog.contains("site folder unavailable"))
+            #expect(dialog.contains("Portfolio"))
+        }
+    }
+}

--- a/Tests/AnglesiteIntentsTests/ThemeIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ThemeIntentsTests.swift
@@ -1,0 +1,93 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+@testable import AnglesiteIntents
+
+extension AppIntentsTests {
+    @Suite("ApplyThemeIntent")
+    struct ThemeIntentsTests {
+        private static let sunset = Theme(
+            id: "sunset", name: "Sunset", blurb: "warm hues",
+            swatch: ["#ff0000", "#00ff00"], cssVars: ["color-primary": "#ff0000"])
+        private static let catalog = ThemeCatalog(themes: [sunset])
+
+        /// A throwaway `.anglesite` package with a `Source/src/styles/global.css` containing a
+        /// `:root` block, so `DesignApplyService.apply` can actually write into it.
+        private func makePackage() throws -> URL {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("apply-theme-tests-\(UUID().uuidString).anglesite", isDirectory: true)
+            let stylesDir = root.appendingPathComponent("Source/src/styles", isDirectory: true)
+            try FileManager.default.createDirectory(at: stylesDir, withIntermediateDirectories: true)
+            try "html { color: black; }\n:root {\n  --color-primary: #000000;\n}\n"
+                .write(to: stylesDir.appendingPathComponent("global.css"), atomically: true, encoding: .utf8)
+            return root
+        }
+
+        private func entity(directory: URL?) -> SiteEntity {
+            SiteEntity(id: "s1", name: "Portfolio", creationDate: nil, modificationDate: nil, directory: directory)
+        }
+
+        @Test("an unrecognized theme id lists the available themes instead of applying anything")
+        func unknownThemeListsAvailableThemes() async throws {
+            var intent = ApplyThemeIntent()
+            intent.site = entity(directory: URL(fileURLWithPath: "/tmp/unused"))
+            intent.themeID = "does-not-exist"
+
+            let dialog = try await ThemeCatalogOverride.$scoped.withValue(Self.catalog) {
+                try await intent.performForTesting()
+            }
+
+            #expect(dialog.contains("I don't recognize that theme"))
+            #expect(dialog.contains("Sunset"))
+        }
+
+        @Test("a site with no resolvable location reports it can't be found")
+        func missingDirectoryReportsNotFound() async throws {
+            var intent = ApplyThemeIntent()
+            intent.site = entity(directory: nil)
+            intent.themeID = Self.sunset.id
+
+            let dialog = try await ThemeCatalogOverride.$scoped.withValue(Self.catalog) {
+                try await intent.performForTesting()
+            }
+
+            #expect(dialog.contains("couldn't find"))
+        }
+
+        @Test("applies the theme's CSS vars to the site's stylesheet and reports success")
+        func appliesThemeVars() async throws {
+            let package = try makePackage()
+            defer { try? FileManager.default.removeItem(at: package) }
+            let cssURL = package.appendingPathComponent("Source/src/styles/global.css")
+
+            var intent = ApplyThemeIntent()
+            intent.site = entity(directory: package)
+            intent.themeID = Self.sunset.id
+
+            let dialog = try await ThemeCatalogOverride.$scoped.withValue(Self.catalog) {
+                try await intent.performForTesting()
+            }
+
+            #expect(dialog.contains("Applied the Sunset theme"))
+            #expect(try String(contentsOf: cssURL, encoding: .utf8).contains("--color-primary: #ff0000;"))
+        }
+
+        @Test("a site missing its stylesheet reports the failure instead of throwing")
+        func missingStylesheetReportsFailure() async throws {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("apply-theme-tests-\(UUID().uuidString).anglesite", isDirectory: true)
+            try FileManager.default.createDirectory(at: root.appendingPathComponent("Source"), withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            var intent = ApplyThemeIntent()
+            intent.site = entity(directory: root)
+            intent.themeID = Self.sunset.id
+
+            let dialog = try await ThemeCatalogOverride.$scoped.withValue(Self.catalog) {
+                try await intent.performForTesting()
+            }
+
+            #expect(dialog.contains("couldn't find this site's stylesheet"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add missing test suites for `ApplyThemeIntent` and the Slice 6 content-help intents (`ReviewCopyIntent`, `PlanSocialMediaIntent`, `RepurposePostIntent`) — all four shipped with no test file, breaking this codebase's one-suite-per-intent convention. Refactored each `perform()` into a private `String`-returning `run()` (matching the existing `DomainIntents.swift` idiom — `IntentDialog` has no public accessor to read its text back, which is why that idiom exists) so tests can drive the dialog logic directly. No behavior change.
- Add `ThemeCatalogOverride` (mirrors `ContentOperationsOverride` et al.) so `ApplyThemeIntent`'s `@Dependency` and confirmation gate can be bypassed under `swift test`, the same way the existing `Domain*`/`Content*` intents already are.
- Cache SwiftPM `.build` in CI (`linux-build-test`, `build-test`, `relay-tsan`) — every job previously did a fully cold build on every push with zero caching anywhere in the workflow.
- Skip CI jobs unaffected by the changed paths via a new `changes` job (`dorny/paths-filter`) — previously all 6 jobs ran unconditionally regardless of diff (a docs-only PR still ran the full Swift build/test matrix).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change needs a paired PR in `Anglesite/anglesite`.

## Notes for reviewers

- `ReviewCopyIntent`/`PlanSocialMediaIntent`/`RepurposePostIntent`'s success paths still call the real `CopyEditAuditorFactory`/`SocialMediaPlannerFactory`/`PostRepurposerFactory` directly — no test-only override seam exists for them yet, so only the shared site-folder-unavailable guard is covered. Deeper coverage would mean adding DI overrides for those three factories, which felt like a separate, larger decision.
- Confirmed `main` has no required-status-checks configured, so a job going from "run" to "skipped" on an unaffected-path PR won't block merges.
- Both new third-party actions are SHA-pinned against their actual release tags (`actions/cache` v6.1.0, `dorny/paths-filter` v4.0.2), matching this workflow's existing pinning convention.
- CI cache/path-filter behavior can only really be proven by watching the next few Actions runs on this PR — I validated the YAML with `actionlint` + a plain parse, but there's no local way to dry-run GitHub-hosted execution.

## Test plan

- [x] `swift build --target AnglesiteIntents`
- [x] `swift test --package-path . --filter "AnglesiteIntentsTests"` (248 tests, 43 suites, all passing)
- [x] `swift test --package-path . --enable-code-coverage` (full suite, prior to these changes, all green)
- [x] `actionlint .github/workflows/ci.yml` + YAML parse (no errors; only pre-existing shellcheck info-level notes unrelated to this diff)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`