### PR TITLE
fix(app): Component Editor fast-follows — debounce, +encoding, testable fileMatches, friendlier errors

### DIFF
--- a/JS/edit-overlay/src/component-canvas.ts
+++ b/JS/edit-overlay/src/component-canvas.ts
@@ -8,6 +8,7 @@
 const HARNESS_PREFIX = "/_anglesite/component/";
 const RING_CLASS = "anglesite-canvas-ring";
 const SCRUB_STYLE_ID = "anglesite-scrub";
+const INSTALLED_FLAG = "__anglesiteComponentCanvasInstalled" as const;
 
 // Curated list shown in the inspector's Computed section.
 const REPORTED_PROPERTIES = [
@@ -42,8 +43,12 @@ export function sourceLoc(el: Element): SourceLoc | null {
   return null;
 }
 
+/** Mount the component canvas onto `window`/`document`. Safe to call more than once. */
 export function installComponentCanvas(): void {
   if (!isHarnessPage()) return;
+  const win = window as unknown as { [INSTALLED_FLAG]?: boolean };
+  if (win[INSTALLED_FLAG]) return;
+  win[INSTALLED_FLAG] = true;
   document.addEventListener("click", onClick, true);
   (window as unknown as Record<string, unknown>).anglesiteCanvas = {
     highlight(line: number, column: number): void {

--- a/JS/edit-overlay/test/component-canvas.test.ts
+++ b/JS/edit-overlay/test/component-canvas.test.ts
@@ -18,6 +18,7 @@ describe("component canvas", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
     delete (window as any).anglesiteCanvas;
+    delete (window as any).__anglesiteComponentCanvasInstalled;
   });
 
   it("isHarnessPage gates on the harness path prefix", () => {
@@ -121,5 +122,19 @@ describe("component canvas", () => {
     setPath("/_anglesite/component/Card");
     installComponentCanvas();
     expect(() => (window as any).anglesiteCanvas.clearScrub()).not.toThrow();
+  });
+
+  it("is idempotent: repeated installs don't double-register the click listener", () => {
+    setPath("/_anglesite/component/Card");
+    const posts = capturePosts();
+    document.body.innerHTML =
+      `<article data-astro-source-file="/f.astro" data-astro-source-loc="7:1">hi</article>`;
+    installComponentCanvas();
+    installComponentCanvas();
+    installComponentCanvas();
+    (document.querySelector("article") as HTMLElement).dispatchEvent(
+      new MouseEvent("click", { bubbles: true }),
+    );
+    expect(posts.filter((p: any) => p.type === "anglesite:canvas-selection")).toHaveLength(1);
   });
 });

--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -26,10 +26,13 @@ final class ComponentEditorModel {
 
     /// Distinguishes "dev server/MCP client isn't up yet" (retryable, not a
     /// real failure — `ComponentEditorView`'s `loadKey` re-triggers `load()`
-    /// once `context.baseURL`/the client become available) from a genuine
-    /// load failure worth showing as an error page.
+    /// once `context.baseURL`/the client become available) from an
+    /// unparseable component (design spec §5: degrade to the Source tab with
+    /// the compiler diagnostic in a banner, never a dead end) from any other
+    /// genuine load failure worth showing as a full-pane error.
     enum LoadErrorReason: Equatable {
         case notConnected
+        case unparseable
         case other
     }
 
@@ -100,32 +103,22 @@ final class ComponentEditorModel {
                     ($0.name, KnobDefaults.value(for: $0))
                 }
             )
-        } catch ComponentModelClient.ModelError.notConnected {
-            loadError = "Site is not running yet."
-            loadErrorReason = .notConnected
+        } catch let error as ComponentModelClient.ModelError {
+            loadError = error.friendlyMessage
+            switch error {
+            case .notConnected: loadErrorReason = .notConnected
+            case .toolFailed(let reason, _): loadErrorReason = reason == "parse-failed" ? .unparseable : .other
+            case .decodeFailed: loadErrorReason = .other
+            }
         } catch {
-            loadError = String(describing: error)
+            loadError = "Couldn't load this component: \(error.localizedDescription)"
             loadErrorReason = .other
         }
     }
 
-    /// True when a canvas selection's `message.file` refers to the component
-    /// currently being edited. The annotation file is vite-rooted (e.g.
-    /// "/src/components/Card.astro" or an absolute filesystem path ending in
-    /// that), while `relativePath` is project-relative (e.g.
-    /// "src/components/Card.astro") — so compare via suffix, not equality.
-    /// A selection elsewhere in the harness page (chrome, a nested child
-    /// component's own markup) must not be line-matched against this
-    /// component's outline.
-    private func fileMatches(_ file: String?) -> Bool {
-        guard let file, !file.isEmpty else { return false }
-        let normalized = file.hasPrefix("/") ? String(file.dropFirst()) : file
-        return normalized == relativePath || normalized.hasSuffix("/" + relativePath)
-    }
-
     func canvasSelected(_ message: CanvasSelectionMessage) {
         guard let model,
-              fileMatches(message.file),
+              ComponentOutline.fileMatches(message.file, relativePath: relativePath),
               let line = message.line,
               let column = message.column
         else {

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -66,10 +66,7 @@ struct ComponentEditorView: View {
             Divider()
             switch mode {
             case .design: designPane
-            case .source:
-                TextEditor(text: $fileEditor.text)
-                    .font(.system(.body, design: .monospaced))
-                    .scrollContentBackground(.hidden)
+            case .source: sourcePane
             }
         }
         .task(id: loadKey) {
@@ -80,6 +77,40 @@ struct ComponentEditorView: View {
         .onChange(of: model?.selectedNodeID) { _, newValue in
             highlightInCanvas(nodeID: newValue)
         }
+        .onChange(of: model?.loadErrorReason) { _, newValue in
+            // Design spec §5: an unparseable component degrades to the Source tab with the
+            // compiler diagnostic in a banner, rather than a dead-end full-pane error — fixing
+            // the syntax error in source is the only way out, so land the user where they can.
+            if newValue == .unparseable { mode = .source }
+        }
+    }
+
+    @ViewBuilder private var sourcePane: some View {
+        VStack(spacing: 0) {
+            if let model, model.loadErrorReason == .unparseable, let error = model.loadError {
+                parseErrorBanner(message: error)
+                Divider()
+            }
+            TextEditor(text: $fileEditor.text)
+                .font(.system(.body, design: .monospaced))
+                .scrollContentBackground(.hidden)
+        }
+    }
+
+    /// Compiler diagnostic banner shown atop the Source tab when the Design pane couldn't parse
+    /// the component (see `sourcePane`). Unlike `conflictBanner`/`writeErrorBanner` it has no
+    /// dismiss button — it stays until the underlying syntax error is fixed and the component
+    /// reloads clean.
+    private func parseErrorBanner(message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle").foregroundStyle(.red)
+            Text(message)
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+            Spacer()
+        }
+        .padding(8)
+        .background(.red.opacity(0.12))
     }
 
     @ViewBuilder private var designPane: some View {
@@ -507,8 +538,14 @@ private struct ComponentCanvasView: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
+    @MainActor
     final class Coordinator {
         var loadedURL: URL?
+        /// Debounces reloads triggered by rapid `url` changes (e.g. a knob TextField's
+        /// per-keystroke `harnessURL`, which folds prop edits into the query string) so each
+        /// keystroke doesn't fire a full `webView.load()`. Cancelled and restarted on every
+        /// further change; only the settled URL after a short pause actually reloads.
+        var pendingReload: Task<Void, Never>?
     }
 
     func makeNSView(context: Context) -> WKWebView {
@@ -530,7 +567,15 @@ private struct ComponentCanvasView: NSViewRepresentable {
 
     func updateNSView(_ webView: WKWebView, context: Context) {
         guard context.coordinator.loadedURL != url else { return }
-        context.coordinator.loadedURL = url
-        webView.load(URLRequest(url: url))
+        let targetURL = url
+        let coordinator = context.coordinator
+        coordinator.pendingReload?.cancel()
+        coordinator.pendingReload = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            coordinator.loadedURL = targetURL
+            coordinator.pendingReload = nil
+            webView.load(URLRequest(url: targetURL))
+        }
     }
 }

--- a/Sources/AnglesiteCore/ComponentModelClient.swift
+++ b/Sources/AnglesiteCore/ComponentModelClient.swift
@@ -20,20 +20,58 @@ public struct ComponentModelClient: Sendable {
     }
 
     public enum ModelError: Error, Equatable {
+        /// `reason` is the plugin's machine-readable code (`"parse-failed"`, `"read-failed"`,
+        /// `"invalid-input"`, `"internal-error"`) from its `anglesite:component-model-failed`
+        /// envelope; `"unknown"` if the tool result didn't decode as that envelope at all.
+        /// `detail` is the plugin's human-readable message.
         case notConnected
-        case toolFailed(String)
+        case toolFailed(reason: String, detail: String)
         case decodeFailed(String)
+    }
+
+    /// Wire shape of `get_component_model`'s error content: `{type, reason, detail}`.
+    private struct FailureEnvelope: Decodable {
+        let reason: String
+        let detail: String
     }
 
     public func fetch(path: String) async throws -> ComponentModel {
         let result = try await toolCaller("get_component_model", .object(["path": .string(path)]))
         let text = result.content.compactMap(\.text).joined(separator: "\n")
-        guard !result.isError else { throw ModelError.toolFailed(text) }
+        guard !result.isError else {
+            if let data = text.data(using: .utf8),
+               let envelope = try? JSONDecoder().decode(FailureEnvelope.self, from: data) {
+                throw ModelError.toolFailed(reason: envelope.reason, detail: envelope.detail)
+            }
+            throw ModelError.toolFailed(reason: "unknown", detail: text)
+        }
         guard let data = text.data(using: .utf8) else { throw ModelError.decodeFailed("non-utf8 payload") }
         do {
             return try JSONDecoder().decode(ComponentModel.self, from: data)
         } catch {
             throw ModelError.decodeFailed(String(describing: error))
+        }
+    }
+}
+
+extension ComponentModelClient.ModelError {
+    /// User-facing summary for `ComponentEditorModel.loadError`. Parse failures carry the
+    /// compiler's own diagnostic through as-is (spec §5: shown in a banner, editor degrades to
+    /// the Source tab); other reasons get a short, reason-specific sentence instead of a raw
+    /// Swift error dump.
+    public var friendlyMessage: String {
+        switch self {
+        case .notConnected:
+            return "Site is not running yet."
+        case .toolFailed(let reason, let detail):
+            switch reason {
+            case "parse-failed": return detail
+            case "read-failed": return "Couldn't read this component file: \(detail)"
+            case "invalid-input": return detail
+            default: return "Something went wrong loading this component: \(detail)"
+            }
+        case .decodeFailed:
+            return "Anglesite couldn't understand the component model returned by the plugin. Try updating the bundled plugin."
         }
     }
 }

--- a/Sources/AnglesiteCore/ComponentOutline.swift
+++ b/Sources/AnglesiteCore/ComponentOutline.swift
@@ -61,6 +61,18 @@ public enum ComponentOutline {
 
         return exact ?? bestOffset
     }
+
+    /// True when a canvas selection's `file` (vite-rooted, e.g.
+    /// "/src/components/Card.astro", or an absolute filesystem path ending in
+    /// that) refers to the component at `relativePath` (project-relative,
+    /// e.g. "src/components/Card.astro") — compared via suffix, not equality,
+    /// so a selection elsewhere in the harness page (chrome, a nested child
+    /// component's own markup) never line-matches against the wrong outline.
+    public static func fileMatches(_ file: String?, relativePath: String) -> Bool {
+        guard let file, !file.isEmpty else { return false }
+        let normalized = file.hasPrefix("/") ? String(file.dropFirst()) : file
+        return normalized == relativePath || normalized.hasSuffix("/" + relativePath)
+    }
 }
 
 /// Builds harness-route URLs for the component canvas (route injected by the
@@ -77,7 +89,15 @@ public enum HarnessURL {
         if !props.isEmpty,
            let data = try? JSONSerialization.data(withJSONObject: props, options: [.sortedKeys]),
            let json = String(data: data, encoding: .utf8) {
-            components.queryItems = [URLQueryItem(name: "props", value: json)]
+            // `URLComponents.queryItems` percent-encodes via `.urlQueryAllowed`, which treats `+`
+            // as unreserved and leaves it literal — but the harness decodes the query with
+            // `URLSearchParams`, which follows form-encoding semantics and turns an unescaped `+`
+            // into a space. Percent-encode `+` explicitly so a prop value containing one survives
+            // the round-trip intact.
+            var allowedCharacters = CharacterSet.urlQueryAllowed
+            allowedCharacters.remove(charactersIn: "+")
+            guard let encodedJSON = json.addingPercentEncoding(withAllowedCharacters: allowedCharacters) else { return nil }
+            components.percentEncodedQuery = "props=" + encodedJSON
         }
         return components.url
     }

--- a/Sources/AnglesiteCore/ComponentOutline.swift
+++ b/Sources/AnglesiteCore/ComponentOutline.swift
@@ -89,13 +89,15 @@ public enum HarnessURL {
         if !props.isEmpty,
            let data = try? JSONSerialization.data(withJSONObject: props, options: [.sortedKeys]),
            let json = String(data: data, encoding: .utf8) {
-            // `URLComponents.queryItems` percent-encodes via `.urlQueryAllowed`, which treats `+`
-            // as unreserved and leaves it literal — but the harness decodes the query with
-            // `URLSearchParams`, which follows form-encoding semantics and turns an unescaped `+`
-            // into a space. Percent-encode `+` explicitly so a prop value containing one survives
-            // the round-trip intact.
-            var allowedCharacters = CharacterSet.urlQueryAllowed
-            allowedCharacters.remove(charactersIn: "+")
+            // `URLComponents.queryItems` percent-encodes via `.urlQueryAllowed`, which treats RFC
+            // 3986 sub-delims (`+`, `&`, `=`, `;`, …) as unreserved and leaves them literal — but
+            // the harness decodes the query with `URLSearchParams`, which follows form-encoding
+            // semantics: an unescaped `+` becomes a space, and `&`/`=` are parsed as extra
+            // parameter delimiters, corrupting the JSON payload. Percent-encode everything except
+            // RFC 3986 unreserved characters (unlike `.urlQueryAllowed`, this doesn't special-case
+            // "query-safe" delimiters) so any prop value survives the round-trip intact.
+            var allowedCharacters = CharacterSet.alphanumerics
+            allowedCharacters.insert(charactersIn: "-._~")
             guard let encodedJSON = json.addingPercentEncoding(withAllowedCharacters: allowedCharacters) else { return nil }
             components.percentEncodedQuery = "props=" + encodedJSON
         }

--- a/Tests/AnglesiteCoreTests/ComponentModelClientTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentModelClientTests.swift
@@ -17,12 +17,28 @@ struct ComponentModelClientTests {
         #expect(model.path == "src/components/Card.astro")
     }
 
-    @Test("Tool errors surface as toolFailed") func toolErrors() async {
+    @Test("Tool errors decode the plugin's reason/detail envelope into toolFailed") func toolErrors() async throws {
         let client = ComponentModelClient { _, _ in
-            self.result(text: #"{"type":"anglesite:component-model-failed","reason":"read-failed"}"#, isError: true)
+            self.result(
+                text: #"{"type":"anglesite:component-model-failed","reason":"parse-failed","detail":"parse Card.astro: Unexpected token"}"#,
+                isError: true
+            )
         }
-        await #expect(throws: ComponentModelClient.ModelError.self) {
+        do {
             _ = try await client.fetch(path: "src/components/Nope.astro")
+            Issue.record("expected throw")
+        } catch let error as ComponentModelClient.ModelError {
+            #expect(error == .toolFailed(reason: "parse-failed", detail: "parse Card.astro: Unexpected token"))
+        }
+    }
+
+    @Test("A tool error whose text isn't the plugin's envelope falls back to reason \"unknown\"") func toolErrorFallback() async throws {
+        let client = ComponentModelClient { _, _ in self.result(text: "boom", isError: true) }
+        do {
+            _ = try await client.fetch(path: "x.astro")
+            Issue.record("expected throw")
+        } catch let error as ComponentModelClient.ModelError {
+            #expect(error == .toolFailed(reason: "unknown", detail: "boom"))
         }
     }
 
@@ -39,5 +55,19 @@ struct ComponentModelClientTests {
         } catch {
             Issue.record("unexpected error type \(error)")
         }
+    }
+
+    @Test("friendlyMessage passes a parse-failed diagnostic through verbatim, for the Source-tab banner") func friendlyMessageParseFailed() {
+        let error = ComponentModelClient.ModelError.toolFailed(reason: "parse-failed", detail: "parse Card.astro: Unexpected token")
+        #expect(error.friendlyMessage == "parse Card.astro: Unexpected token")
+    }
+
+    @Test("friendlyMessage summarizes other reasons instead of dumping the raw error") func friendlyMessageOtherReasons() {
+        #expect(ComponentModelClient.ModelError.notConnected.friendlyMessage == "Site is not running yet.")
+        #expect(ComponentModelClient.ModelError.toolFailed(reason: "read-failed", detail: "permission denied").friendlyMessage
+            == "Couldn't read this component file: permission denied")
+        #expect(ComponentModelClient.ModelError.toolFailed(reason: "internal-error", detail: "boom").friendlyMessage
+            == "Something went wrong loading this component: boom")
+        #expect(!ComponentModelClient.ModelError.decodeFailed("keyNotFound(...)").friendlyMessage.contains("keyNotFound"))
     }
 }

--- a/Tests/AnglesiteCoreTests/ComponentOutlineTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentOutlineTests.swift
@@ -62,6 +62,28 @@ struct ComponentOutlineTests {
         #expect(HarnessURL.build(base: base, componentPath: "src/pages/index.astro", props: [:]) == nil)
     }
 
+    @Test("Harness URL percent-encodes + in prop values instead of leaving it literal") func harnessURLPlusEncoding() throws {
+        let base = URL(string: "http://localhost:4321")!
+        let url = try #require(HarnessURL.build(base: base, componentPath: "src/components/Card.astro", props: ["title": "1 + 1"]))
+        // A literal `+` in the query is decoded as a space by `URLSearchParams` on the harness
+        // side, so the raw query string must carry it percent-encoded, not literal.
+        #expect(url.query(percentEncoded: true)?.contains("+") == false)
+        // And the round trip through URLComponents' own decoding recovers the original value.
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let propsJSON = try #require(components.queryItems?.first(where: { $0.name == "props" })?.value)
+        let decoded = try JSONDecoder().decode([String: String].self, from: Data(propsJSON.utf8))
+        #expect(decoded["title"] == "1 + 1")
+    }
+
+    @Test("fileMatches compares the harness's vite-rooted file against the project-relative path") func fileMatchesTest() {
+        #expect(ComponentOutline.fileMatches("/src/components/Card.astro", relativePath: "src/components/Card.astro"))
+        #expect(ComponentOutline.fileMatches("src/components/Card.astro", relativePath: "src/components/Card.astro"))
+        #expect(ComponentOutline.fileMatches("/Users/dev/site/src/components/Card.astro", relativePath: "src/components/Card.astro"))
+        #expect(!ComponentOutline.fileMatches("/src/components/Other.astro", relativePath: "src/components/Card.astro"))
+        #expect(!ComponentOutline.fileMatches(nil, relativePath: "src/components/Card.astro"))
+        #expect(!ComponentOutline.fileMatches("", relativePath: "src/components/Card.astro"))
+    }
+
     @Test("Knob defaults prefer declared defaults, else type samples") func knobDefaults() {
         #expect(KnobDefaults.value(for: .init(name: "n", type: "number", optional: true, defaultValue: "1")) == "1")
         #expect(KnobDefaults.value(for: .init(name: "t", type: "string", optional: false, defaultValue: "\"Hello\"")) == "Hello")

--- a/Tests/AnglesiteCoreTests/ComponentOutlineTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentOutlineTests.swift
@@ -75,6 +75,21 @@ struct ComponentOutlineTests {
         #expect(decoded["title"] == "1 + 1")
     }
 
+    @Test("Harness URL percent-encodes & and = in prop values instead of leaving them literal") func harnessURLAmpersandEqualsEncoding() throws {
+        let base = URL(string: "http://localhost:4321")!
+        let url = try #require(HarnessURL.build(base: base, componentPath: "src/components/Card.astro", props: ["title": "Save & Close = done"]))
+        // `.urlQueryAllowed` treats RFC 3986 sub-delims like `&` and `=` as unreserved, but they're
+        // parameter/key-value delimiters to `URLSearchParams` on the harness side — left literal,
+        // they'd split the query into bogus extra parameters and corrupt the JSON payload.
+        let rawQuery = try #require(url.query(percentEncoded: true))
+        #expect(!rawQuery.dropFirst("props=".count).contains("&"))
+        #expect(!rawQuery.dropFirst("props=".count).contains("="))
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let propsJSON = try #require(components.queryItems?.first(where: { $0.name == "props" })?.value)
+        let decoded = try JSONDecoder().decode([String: String].self, from: Data(propsJSON.utf8))
+        #expect(decoded["title"] == "Save & Close = done")
+    }
+
     @Test("fileMatches compares the harness's vite-rooted file against the project-relative path") func fileMatchesTest() {
         #expect(ComponentOutline.fileMatches("/src/components/Card.astro", relativePath: "src/components/Card.astro"))
         #expect(ComponentOutline.fileMatches("src/components/Card.astro", relativePath: "src/components/Card.astro"))


### PR DESCRIPTION
## Summary

Clears the 5 fast-follow items filed against slice 1's final review (#487), so they don't accumulate underneath the rest of the Component Editor epic (#496):

- **Debounce knob-edit canvas reloads** — `ComponentCanvasView.updateNSView` fired a full `webView.load()` on every keystroke in a knob `TextField` (each edit changes `harnessURL`'s query string). Now debounces 300ms via a cancel-and-reschedule `Task` on the coordinator, matching the existing `ColorPicker` debounce pattern in this file.
- **`+` becomes a space in knob values** — `HarnessURL.build` used `URLComponents.queryItems`, which percent-encodes via `.urlQueryAllowed` and leaves `+` literal; the harness then decodes the query with `URLSearchParams`, which treats an unescaped `+` as a space (form-encoding semantics). Now builds `percentEncodedQuery` directly with `+` explicitly encoded.
- **`fileMatches` moved to AnglesiteCore** — was private string-matching logic on `ComponentEditorModel` (app target); moved to `ComponentOutline.fileMatches`, next to the outline logic it composes with in `canvasSelected`, and covered directly by a `ComponentOutlineTests` case.
- **Friendlier load errors** — `ComponentModelClient.ModelError.toolFailed` now carries the plugin's parsed `(reason, detail)` from its `anglesite:component-model-failed` envelope instead of a flat opaque string. A `parse-failed` load now degrades the Component Editor to the Source tab with the compiler diagnostic in a banner (design spec §5), instead of a dead-end full-pane `ContentUnavailableView`. Other failure reasons get a short, reason-specific message instead of a raw Swift error dump.
- **`installComponentCanvas()` idempotency guard** — added the same `INSTALLED_FLAG` pattern already used by `overlay.ts`/`visible-elements.ts`, so re-injection can't double-register the click listener.

Closes #489.

## Test plan

- [x] `swift build` — clean
- [x] `swift test --filter "AnglesiteCoreTests.ComponentOutlineTests|AnglesiteCoreTests.ComponentModelClientTests"` — 15/15 pass (added 5 new cases: `+`-encoding round-trip, `fileMatches`, envelope decode, envelope fallback, `friendlyMessage`)
- [x] `swift test --filter AnglesiteAppTests` — 53/53 pass (unaffected app-target coverage still green)
- [x] `npx vitest run` in `JS/edit-overlay` — 60/60 pass (added an idempotency case to `component-canvas.test.ts`)
- [x] `npm run typecheck && npm run lint && npm run build` in `JS/edit-overlay` — clean
- [ ] Manual GUI smoke of the knob debounce and Source-tab degrade (no real hardware access in this session — flagging per repo convention rather than claiming it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)