### PR TITLE
fix(scaffold): land a real initial commit when creating a new site

### DIFF
--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -373,6 +373,11 @@ struct SitesLauncherView: View {
                 // forward to LogCenter here.
                 try GitInitRunner.run(in: sourceDir)
             },
+            gitCommit: { sourceDir in
+                // Local init+commit only (no GitHub) — lands a real initial commit so the site
+                // has a HEAD immediately and can be cloned into a container runtime for preview.
+                try await RepoBootstrap.live().commitAll(source: sourceDir)
+            },
             register: { package in
                 let site = try await SiteStore.shared.record(package)
                 #if ANGLESITE_MAS

--- a/Sources/AnglesiteCore/RepoBootstrap.swift
+++ b/Sources/AnglesiteCore/RepoBootstrap.swift
@@ -181,6 +181,15 @@ public actor RepoBootstrap {
     }
     #endif
 
+    /// Local git init+commit only — no GitHub involved. Reuses the same staging/secret-file/
+    /// identity checks as `publish`'s preflight. Entry point for the new-site scaffold, which
+    /// must land a real initial commit before the site can be cloned into a container runtime
+    /// (an empty, commit-less repo fails `git checkout HEAD`) — see CLAUDE.md's "Git is the
+    /// source of truth" (#72).
+    public func commitAll(source: URL) async throws {
+        try await ensureCommittable(source: source, emit: { _ in })
+    }
+
     /// Detect → (auth) → ensure committable → create + push. Streams progress; settles to
     /// `.published` / `.needsAuth` / `.failed`. Idempotent: an already-published site yields
     /// `.published(existing)` with no side effects.

--- a/Sources/AnglesiteCore/SiteScaffolder.swift
+++ b/Sources/AnglesiteCore/SiteScaffolder.swift
@@ -18,12 +18,16 @@ public actor SiteScaffolder {
     public typealias Register = @Sendable (_ package: AnglesitePackage) async throws -> SiteStore.Site
     /// Initialize a git repo in the source dir (production: `git init` via ProcessSupervisor).
     public typealias GitInit = @Sendable (_ sourceDirectory: URL) async throws -> Void
+    /// Land the initial commit once template/theme/content are all written (production:
+    /// `RepoBootstrap.commitAll` — local init+commit only, no GitHub).
+    public typealias GitCommit = @Sendable (_ sourceDirectory: URL) async throws -> Void
 
     private let sitesRoot: URL
     private let templateURL: URL
     private let catalog: ThemeCatalog
     private let run: CommandRunner
     private let gitInit: GitInit
+    private let gitCommit: GitCommit
     private let register: Register
     private let fileManager: FileManager
     private let appVersion: @Sendable () -> String?
@@ -34,6 +38,7 @@ public actor SiteScaffolder {
     /// has no `CFBundleShortVersionString`.
     public init(sitesRoot: URL, templateURL: URL, catalog: ThemeCatalog,
                 run: @escaping CommandRunner, gitInit: @escaping GitInit,
+                gitCommit: @escaping GitCommit,
                 register: @escaping Register, fileManager: FileManager = .default,
                 appVersion: @escaping @Sendable () -> String? = { AppVersion.current() }) {
         self.sitesRoot = sitesRoot
@@ -41,6 +46,7 @@ public actor SiteScaffolder {
         self.catalog = catalog
         self.run = run
         self.gitInit = gitInit
+        self.gitCommit = gitCommit
         self.register = register
         self.fileManager = fileManager
         self.appVersion = appVersion
@@ -147,6 +153,13 @@ public actor SiteScaffolder {
                 emit(.warning(step: "writingContent", message: "Hero image not added: \(humanize(error))"))
             }
         }
+
+        // 4c. Initial commit, once all template/theme/content writes above have landed (non-fatal,
+        // matching git init's handling above). Without this, a freshly scaffolded site has no
+        // commits, so a container runtime that clones it and runs `git checkout HEAD` fails and
+        // the site can never preview.
+        do { try await gitCommit(siteDir) }
+        catch { emit(.warning(step: "writingContent", message: "Initial commit skipped: \(humanize(error))")) }
 
         // 5. Dependency install is handled by the selected runtime after scaffold.
         emit(.installing)

--- a/Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
@@ -93,6 +93,7 @@ final class NewSiteWizardModelTests: XCTestCase {
                 return ProcessSupervisor.RunResult(stdout: "", stderr: "", exitCode: 0)
             },
             gitInit: { _ in throw CocoaError(.fileWriteUnknown) },
+            gitCommit: { _ in },
             register: { pkg in SiteStore.Site(id: pkg.url.path, name: pkg.url.lastPathComponent, packageURL: pkg.url, isValid: true, missingSentinels: []) }
         )
     }

--- a/Tests/AnglesiteCoreTests/SiteScaffolderPackageTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteScaffolderPackageTests.swift
@@ -10,16 +10,18 @@ struct SiteScaffolderPackageTests {
         return d
     }
 
-    @Test("scaffold creates a package and runs the template + git init inside Source/")
+    @Test("scaffold creates a package and runs the template + git init + initial commit inside Source/")
     func scaffoldsIntoSource() async throws {
         let root = try tempDir(); defer { try? FileManager.default.removeItem(at: root) }
         let template = root.appendingPathComponent("Template", isDirectory: true)
         try FileManager.default.createDirectory(at: template.appendingPathComponent("scripts"), withIntermediateDirectories: true)
 
-        // Record the cwd each injected command was run in, and which dir got `git init`.
-        actor Spy { var cwds: [URL] = []; var gitInits: [URL] = []
+        // Record the cwd each injected command was run in, which dir got `git init`, and which
+        // dir got the initial commit.
+        actor Spy { var cwds: [URL] = []; var gitInits: [URL] = []; var gitCommits: [URL] = []
             func cwd(_ u: URL?) { if let u { cwds.append(u) } }
             func git(_ u: URL) { gitInits.append(u) }
+            func commit(_ u: URL) { gitCommits.append(u) }
         }
         let spy = Spy()
 
@@ -29,6 +31,7 @@ struct SiteScaffolderPackageTests {
             catalog: ThemeCatalog(themes: []),
             run: { _, _, cwd in await spy.cwd(cwd); return .init(stdout: "", stderr: "", exitCode: 0) },
             gitInit: { src in await spy.git(src) },
+            gitCommit: { src in await spy.commit(src) },
             register: { pkg in try SiteStore.Site.make(package: pkg) }
         )
 
@@ -45,5 +48,7 @@ struct SiteScaffolderPackageTests {
         // Template scaffold + npm install ran with cwd == Source/, and git init targeted Source/.
         #expect(await spy.cwds.allSatisfy { $0 == pkg.sourceURL })
         #expect(await spy.gitInits == [pkg.sourceURL])
+        // The initial commit also targeted Source/, after git init.
+        #expect(await spy.gitCommits == [pkg.sourceURL])
     }
 }

--- a/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
@@ -22,6 +22,7 @@ final class SiteScaffolderTests: XCTestCase {
             catalog: ThemeCatalog(themes: [theme]),
             run: fakeRunner(calls: calls),
             gitInit: { _ in },
+            gitCommit: { _ in },
             register: { pkg in try SiteStore.Site.make(package: pkg) }
         )
     }
@@ -155,6 +156,7 @@ final class SiteScaffolderTests: XCTestCase {
             sitesRoot: root, templateURL: URL(fileURLWithPath: "/template"), catalog: ThemeCatalog(themes: [theme]),
             run: fakeRunner(scaffoldExit: 1, calls: CallRecorder()),
             gitInit: { _ in },
+            gitCommit: { _ in },
             register: { _ in XCTFail("must not register on scaffold failure"); fatalError() }
         )
         var steps: [SiteScaffolder.ScaffoldStep] = []
@@ -173,6 +175,7 @@ final class SiteScaffolderTests: XCTestCase {
             sitesRoot: root, templateURL: templateURL, catalog: ThemeCatalog(themes: [theme]),
             run: fakeRunner(calls: calls),
             gitInit: { _ in },
+            gitCommit: { _ in },
             register: { pkg in try SiteStore.Site.make(package: pkg) },
             appVersion: { "9.9.9" }
         )
@@ -251,6 +254,7 @@ final class SiteScaffolderTests: XCTestCase {
             sitesRoot: root, templateURL: URL(fileURLWithPath: "/template"), catalog: ThemeCatalog(themes: [theme]),
             run: fakeRunner(calls: CallRecorder()),
             gitInit: { _ in throw CocoaError(.fileWriteUnknown) },
+            gitCommit: { _ in },
             register: { pkg in
                 registered.withLock { $0 = true }
                 return try SiteStore.Site.make(package: pkg)
@@ -261,6 +265,65 @@ final class SiteScaffolderTests: XCTestCase {
         XCTAssertTrue(registered.withLock { $0 }, "git init failure should not block registration")
         XCTAssertTrue(steps.contains { if case .warning(let s, _) = $0 { return s == "copyingTemplate" }; return false })
         guard case .done? = steps.last else { return XCTFail("expected .done despite git init failure") }
+    }
+
+    func testGitCommitFailureIsNonFatalAndStillRegisters() async throws {
+        let root = tmpDir()
+        let registered = OSAllocatedUnfairLock<Bool>(initialState: false)
+        let scaffolder = SiteScaffolder(
+            sitesRoot: root, templateURL: URL(fileURLWithPath: "/template"), catalog: ThemeCatalog(themes: [theme]),
+            run: fakeRunner(calls: CallRecorder()),
+            gitInit: { _ in },
+            gitCommit: { _ in throw CocoaError(.fileWriteUnknown) },
+            register: { pkg in
+                registered.withLock { $0 = true }
+                return try SiteStore.Site.make(package: pkg)
+            }
+        )
+        var steps: [SiteScaffolder.ScaffoldStep] = []
+        for await s in scaffolder.scaffold(makeDraft()) { steps.append(s) }
+        XCTAssertTrue(registered.withLock { $0 }, "initial-commit failure should not block registration")
+        XCTAssertTrue(steps.contains { if case .warning(let s, let m) = $0 { return s == "writingContent" && m.contains("Initial commit skipped") }; return false })
+        guard case .done? = steps.last else { return XCTFail("expected .done despite initial-commit failure") }
+    }
+
+    /// Regression coverage for the missing-initial-commit bug: a brand-new site's `gitInit`
+    /// closure creates a real `.git` (via `GitInitRunner`, same as production) and `gitCommit`
+    /// creates a real commit (via `RepoBootstrap.commitAll`, same as production) — asserting the
+    /// scaffolded repo actually has a `HEAD` afterward, not just that the closures were called.
+    /// Without the fix, `Source/` had a `.git` but zero commits, so a container runtime cloning
+    /// it and running `git checkout HEAD` failed and the site could never preview.
+    func testHappyPathLandsARealInitialCommit() async throws {
+        let root = tmpDir()
+        let scaffolder = SiteScaffolder(
+            sitesRoot: root, templateURL: URL(fileURLWithPath: "/template"), catalog: ThemeCatalog(themes: [theme]),
+            run: fakeRunner(calls: CallRecorder()),
+            gitInit: { sourceDir in
+                try GitInitRunner.run(in: sourceDir)
+                // Deterministic local identity so RepoBootstrap.commitAll's defaultSignature()
+                // doesn't depend on ambient global git config (which CI runners may not have) —
+                // same fixture pattern as RepoBootstrapTests.makeSourceDir.
+                let git = URL(fileURLWithPath: "/usr/bin/git")
+                _ = try await ProcessSupervisor.shared.run(
+                    executable: git, arguments: ["config", "user.email", "t@t.io"], currentDirectoryURL: sourceDir)
+                _ = try await ProcessSupervisor.shared.run(
+                    executable: git, arguments: ["config", "user.name", "t"], currentDirectoryURL: sourceDir)
+            },
+            gitCommit: { sourceDir in try await RepoBootstrap.live().commitAll(source: sourceDir) },
+            register: { pkg in try SiteStore.Site.make(package: pkg) }
+        )
+        var steps: [SiteScaffolder.ScaffoldStep] = []
+        for await s in scaffolder.scaffold(makeDraft()) { steps.append(s) }
+        guard case .done? = steps.last else { return XCTFail("expected .done, got \(String(describing: steps.last))") }
+
+        let pkgURL = root.appendingPathComponent("acme-co.anglesite")
+        let sourceDir = pkgURL.appendingPathComponent("Source")
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        let log = try await ProcessSupervisor.shared.run(
+            executable: git, arguments: ["log", "--oneline"], currentDirectoryURL: sourceDir)
+        XCTAssertEqual(log.exitCode, 0, "git log failed — no initial commit was created: \(log.stderr)")
+        XCTAssertFalse(log.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                       "expected at least one commit in the freshly scaffolded Source/ repo")
     }
 }
 


### PR DESCRIPTION
## Summary
- New-site creation (File ▸ New ▸ Site) ran `git init` in the scaffolded `Source/` directory but never committed, leaving every fresh site with a `.git` and zero commits.
- Container runtimes clone the repo and run `git checkout HEAD`, which fails with `pathspec 'HEAD' did not match any file(s)` against a commit-less repo — new sites could never preview (surfaced in the app as `cloneFailed(...)`).
- Adds `RepoBootstrap.commitAll(source:)`, a thin wrapper around the existing (well-tested) local init+commit logic already used by "Publish to GitHub", and wires `SiteScaffolder` to call it once template/theme/content writes have landed, right before registering the site. Failure is non-fatal and surfaces as a wizard warning, matching `git init`'s existing handling.

## Test plan
- [x] `swift test --package-path .` — full suite (1829 tests) passes, including new regression coverage:
  - `testHappyPathLandsARealInitialCommit` — exercises the real `GitInitRunner` + `RepoBootstrap.commitAll` (not mocks) and asserts `git log --oneline` returns a commit after scaffolding.
  - `testGitCommitFailureIsNonFatalAndStillRegisters`
  - `SiteScaffolderPackageTests.scaffoldsIntoSource` extended to assert the commit closure fires targeting `Source/`.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)