### PR TITLE
feat(port): multi-arch dev-server image — linux/amd64 for PodmanSiteRuntime (#567)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,11 +58,12 @@ Resources/Template/.astro/
 Resources/container-image/
 !Resources/container-image/.gitkeep
 
-# Transient MCP sidecar staging dir (populated from the plugin by scripts/vendor-container-image.sh,
-# cleaned up on exit; never committed — plugin source lives in the sibling anglesite repo).
+# Transient MCP sidecar staging dir (populated from the plugin by scripts/vendor-container-image.sh
+# or scripts/build-podman-image.sh, cleaned up on exit; never committed — plugin source lives in
+# the sibling anglesite repo).
 Containers/anglesite-dev/mcp-sidecar/
 
-# Transient template + hydrate-script staging (populated by scripts/vendor-container-image.sh from
+# Transient template + hydrate-script staging (populated by the same two scripts from
 # Resources/Template/ and container/hydrate.sh, cleaned up on exit; never committed — both are
 # already tracked at their real, single-source locations).
 Containers/anglesite-dev/template/

--- a/Containers/anglesite-dev/Dockerfile
+++ b/Containers/anglesite-dev/Dockerfile
@@ -1,22 +1,35 @@
-# Anglesite local dev-server image (arm64 / Apple Silicon). Built and exported as an OCI layout by
-# scripts/vendor-container-image.sh, then bundled into AnglesiteContainer. Bakes Node + git + socat
-# (the vsock<->TCP bridge) + the app's MCP sidecar (the plugin's server/, npm ci'd for linux-arm64 so
-# sharp's native binary is correct) so a fresh container needs no in-guest install.
+# Anglesite local dev-server image. Two build paths consume this file:
+#   - scripts/vendor-container-image.sh (Apple `container` CLI, arm64 only — bundled into
+#     AnglesiteContainer for Apple Containerization, which is Apple-Silicon-only)
+#   - scripts/build-podman-image.sh (podman, native host arch — arm64 or amd64 — tagged
+#     localhost/anglesite-dev:latest for PodmanContainerControl on Linux)
+# Bakes Node + git + socat (the vsock<->TCP bridge, macOS path only) + the app's MCP sidecar
+# (the plugin's server/, npm ci'd for the build's native arch so sharp's native binary is
+# correct) so a fresh container needs no in-guest install.
 
-# Pinned to linux/arm64 digest for reproducible vendoring. Re-bump periodically for base security updates.
-FROM node:22-bookworm-slim@sha256:6db9be2ebb4bafb687a078ef5ba1b1dd256e8004d246a31fd210b6b848ab6be2
+# Per-arch digest pin (reproducible; re-bump periodically for base security updates). TARGETARCH
+# is set automatically by BuildKit/`container build`/podman when building for a given platform;
+# selecting the base by stage name (rather than a single floating digest) keeps the pin exact
+# for whichever arch is being built instead of only covering arm64.
+ARG TARGETARCH
+FROM node:22-bookworm-slim@sha256:6db9be2ebb4bafb687a078ef5ba1b1dd256e8004d246a31fd210b6b848ab6be2 AS base-arm64
+FROM node:22-bookworm-slim@sha256:a149cd71dccd68704a07d4e4ca3e610c27301852b0f556865cfdb6e2856f8bed AS base-amd64
+FROM base-${TARGETARCH} AS base
+
 # socat is the guest-side vsock<->TCP bridge: the host reaches astro/mcp (guest-local TCP) by
 # dialing AF_VSOCK ports that socat forwards to 127.0.0.1 (no vmnet on the sandboxed host, #60).
+# Unused on the podman path (port-mapping replaces vsock there) but harmless to install.
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates socat \
     && rm -rf /var/lib/apt/lists/*
-# MCP sidecar: staged by scripts/vendor-container-image.sh from the plugin's server/ dir.
-# npm ci runs on linux/arm64 → pulls @img/sharp-linux-arm64 (the native prebuilt) from the
+# MCP sidecar: staged by the build script from the plugin's server/ dir. npm ci runs on the
+# build's native arch → pulls the matching @img/sharp-linux-{arm64,x64} native prebuilt from the
 # lockfile. --omit=dev drops devDependencies. We intentionally do NOT pass --omit=optional
-# because @img/sharp-linux-arm64 is marked optional in the lockfile (platform-specific prebuilt);
-# npm's platform-cpu/os filters already skip macOS-only optionals like fsevents on linux/arm64.
+# because the sharp prebuilts are marked optional in the lockfile (platform-specific); npm's
+# platform-cpu/os filters already skip the other arch's prebuilt and macOS-only optionals like
+# fsevents.
 COPY mcp-sidecar/ /usr/local/lib/anglesite-mcp/
 # Playwright is an unused optionalDependency of the plugin. We keep `npm ci` (reproducible; lock-exact)
-# and cannot pass --omit=optional because @img/sharp-linux-arm64 is also optional (platform prebuilt).
+# and cannot pass --omit=optional because the sharp prebuilt is also optional (platform prebuilt).
 # ENV prevents playwright's postinstall from downloading ~300 MB of browsers; rm strips the pkg dirs.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 RUN cd /usr/local/lib/anglesite-mcp \

--- a/Containers/anglesite-dev/Dockerfile
+++ b/Containers/anglesite-dev/Dockerfile
@@ -7,11 +7,15 @@
 # (the plugin's server/, npm ci'd for the build's native arch so sharp's native binary is
 # correct) so a fresh container needs no in-guest install.
 
-# Per-arch digest pin (reproducible; re-bump periodically for base security updates). TARGETARCH
-# is set automatically by BuildKit/`container build`/podman when building for a given platform;
-# selecting the base by stage name (rather than a single floating digest) keeps the pin exact
-# for whichever arch is being built instead of only covering arm64.
-ARG TARGETARCH
+# Per-arch digest pin (reproducible; re-bump periodically for base security updates). Selecting
+# the base by stage name (rather than a single floating digest) keeps the pin exact for whichever
+# arch is being built instead of only covering arm64. scripts/vendor-container-image.sh and
+# scripts/build-podman-image.sh both pass `--build-arg TARGETARCH=<arch>` explicitly rather than
+# relying on the builder to inject it automatically. The default below covers building this file
+# directly (`podman build .` / `container build .`, e.g. manual testing or a future CI job that
+# doesn't go through either wrapper script) — it falls back to arm64, matching this image's
+# single-arch behavior before this change, rather than failing opaquely on an empty ARG.
+ARG TARGETARCH=arm64
 FROM node:22-bookworm-slim@sha256:6db9be2ebb4bafb687a078ef5ba1b1dd256e8004d246a31fd210b6b848ab6be2 AS base-arm64
 FROM node:22-bookworm-slim@sha256:a149cd71dccd68704a07d4e4ca3e610c27301852b0f556865cfdb6e2856f8bed AS base-amd64
 FROM base-${TARGETARCH} AS base

--- a/scripts/build-podman-image.sh
+++ b/scripts/build-podman-image.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Build the Anglesite local dev-server image with podman, tagged for PodmanContainerControl
+# (Sources/AnglesiteCore/Platform/PodmanContainerControl.swift) — the Linux SiteRuntime substrate.
+#
+# Unlike scripts/vendor-container-image.sh (Apple `container` CLI, macOS-only, arm64-only —
+# Apple Containerization only runs on Apple Silicon), this script builds NATIVELY for whatever
+# architecture the host running it is. No cross-arch emulation is needed: a Linux amd64 machine
+# produces an amd64 image, a Linux arm64 machine (or an Apple Silicon Mac with podman machine)
+# produces an arm64 image. This is what closes the "linux/amd64" gap in the vendored image
+# pipeline (design doc §7) — most Linux desktops are amd64, and there was previously no script
+# at all that provisioned the podman-consumed image for either architecture.
+#
+# The image is tagged into the local podman store only — it is not saved/exported anywhere,
+# unlike the macOS path's OCI-layout bundling, since PodmanContainerControl reads directly
+# from the local store (`podman build`/`podman load`, not a registry pull — see its doc comment).
+#
+# Requires podman (rootless is fine) on PATH.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "$ROOT/scripts/lib/stage-dev-image-context.sh"
+
+command -v podman >/dev/null 2>&1 || { echo "ERROR: podman not found on PATH." >&2; exit 1; }
+
+CTX="$ROOT/Containers/anglesite-dev"
+IMAGE_TAG="localhost/anglesite-dev:latest"
+
+stage_dev_image_context "$CTX"
+
+# podman's `--arch` defaults to the host's native architecture; TARGETARCH is passed explicitly
+# as a build-arg (matching vendor-container-image.sh) since it drives the Dockerfile's per-arch
+# base-image stage selection rather than relying on podman to inject it automatically.
+HOST_ARCH="$(podman info --format '{{.Host.Arch}}')"
+case "$HOST_ARCH" in
+    arm64|amd64) ;;
+    *)
+        echo "ERROR: unsupported host arch '$HOST_ARCH' (Dockerfile only pins arm64/amd64 bases)." >&2
+        exit 1
+        ;;
+esac
+
+echo "Building $IMAGE_TAG (linux/$HOST_ARCH, native)…"
+podman build \
+    --build-arg "TARGETARCH=$HOST_ARCH" \
+    --tag "$IMAGE_TAG" \
+    "$CTX"
+
+echo "Done. $IMAGE_TAG is in the local podman store:"
+podman images "$IMAGE_TAG"

--- a/scripts/lib/stage-dev-image-context.sh
+++ b/scripts/lib/stage-dev-image-context.sh
@@ -5,6 +5,11 @@
 # Stages the MCP sidecar (from the sibling plugin repo) and the website template's dependency
 # manifests into the build context, and registers a cleanup trap so the staged, gitignored
 # copies don't linger after the build. Source this file, then call stage_dev_image_context "$CTX".
+#
+# The EXIT trap it registers runs in the *caller's* shell (this function is sourced, not
+# subshelled) and overwrites any EXIT trap already set there — fine today since both callers
+# invoke this exactly once and set no other EXIT trap, but worth remembering if a future caller
+# needs its own EXIT cleanup too.
 
 stage_dev_image_context() {
     local ctx="$1"

--- a/scripts/lib/stage-dev-image-context.sh
+++ b/scripts/lib/stage-dev-image-context.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Shared staging step for scripts that build Containers/anglesite-dev/Dockerfile (the app's
+# local dev-server image), whichever tool builds it (Apple `container` CLI or podman).
+#
+# Stages the MCP sidecar (from the sibling plugin repo) and the website template's dependency
+# manifests into the build context, and registers a cleanup trap so the staged, gitignored
+# copies don't linger after the build. Source this file, then call stage_dev_image_context "$CTX".
+
+stage_dev_image_context() {
+    local ctx="$1"
+    local root
+    root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+    # Mirror scripts/copy-plugin.sh's resolution: honor $ANGLESITE_PLUGIN_SRC, default to
+    # ../anglesite (sibling under the same parent dir as this repo — wrong from inside a
+    # worktree, so set ANGLESITE_PLUGIN_SRC there).
+    local default_plugin_src="$(cd "$root/.." && pwd)/anglesite"
+    local plugin_src="${ANGLESITE_PLUGIN_SRC:-$default_plugin_src}"
+
+    if [[ ! -d "$plugin_src" ]]; then
+        echo "ERROR: plugin source not found at $plugin_src" >&2
+        echo "       Set ANGLESITE_PLUGIN_SRC or clone github.com/Anglesite/anglesite as a sibling." >&2
+        exit 1
+    fi
+    if [[ ! -f "$plugin_src/.claude-plugin/plugin.json" ]]; then
+        echo "ERROR: $plugin_src does not look like the Anglesite plugin (no .claude-plugin/plugin.json)" >&2
+        exit 1
+    fi
+
+    local sidecar_stage="$ctx/mcp-sidecar"
+    echo "Staging MCP sidecar from $plugin_src → $sidecar_stage"
+    rm -rf "$sidecar_stage"
+    mkdir -p "$sidecar_stage"
+
+    # Copy the plugin's server/ directory + package manifests (no node_modules, no .git).
+    rsync -a --delete \
+        --exclude='node_modules/' \
+        --exclude='.git/' \
+        "$plugin_src/server/" "$sidecar_stage/server/"
+    cp "$plugin_src/package.json" "$sidecar_stage/"
+    cp "$plugin_src/package-lock.json" "$sidecar_stage/"
+
+    echo "Sidecar staged: $(ls "$sidecar_stage")"
+
+    # Stage the website template's dependency manifests + the hydrate script into the build
+    # context, so the image can bake the template's full node_modules (design §5b, same pattern
+    # as container/Dockerfile). hydrate.sh is shared with the Cloudflare image —
+    # container/hydrate.sh is the single source.
+    local template_stage="$ctx/template"
+    echo "Staging template manifests from $root/Resources/Template → $template_stage"
+    rm -rf "$template_stage"
+    mkdir -p "$template_stage"
+    cp "$root/Resources/Template/package.json" "$template_stage/"
+    cp "$root/Resources/Template/package-lock.json" "$template_stage/"
+    cp "$root/container/hydrate.sh" "$ctx/hydrate.sh"
+
+    # Clean up the staged sidecar + template + hydrate script on exit (success or failure) so
+    # they don't accumulate in the build context. These are gitignored. The trap body is built
+    # as a string with the paths substituted now — `local`s go out of scope with this function's
+    # stack frame, so a trap naming them by variable (rather than value) would see them unbound
+    # by the time EXIT actually fires.
+    trap "rm -rf '$sidecar_stage' '$template_stage' '$ctx/hydrate.sh'" EXIT
+}

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -130,6 +130,7 @@ setup_linux() {
 
     if command -v podman >/dev/null 2>&1; then
         ok "podman $(podman --version | awk '{ print $NF }') (needed for the Linux MVP site runtime)"
+        note "provision the dev-server image PodmanContainerControl expects: scripts/build-podman-image.sh"
     else
         note "podman not found — not needed for the purity phase; required later for PodmanSiteRuntime (Linux MVP)"
     fi

--- a/scripts/vendor-container-image.sh
+++ b/scripts/vendor-container-image.sh
@@ -11,64 +11,13 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "$ROOT/scripts/lib/container-cli.sh"
+source "$ROOT/scripts/lib/stage-dev-image-context.sh"
 # Fail fast, before staging work: no point copying the sidecar/template if the CLI is missing.
 ensure_container_cli
 CTX="$ROOT/Containers/anglesite-dev"
 OUT="$ROOT/Resources/container-image"
 
-# ---------------------------------------------------------------------------
-# Stage the MCP sidecar source into the image build context.
-# The plugin source is outside the build context (sibling repo), so we copy
-# it in before building and clean up after. Mirror scripts/copy-plugin.sh's
-# resolution: honor $ANGLESITE_PLUGIN_SRC, default to ../anglesite (sibling
-# under the same parent dir as this repo).
-# ---------------------------------------------------------------------------
-DEFAULT_PLUGIN_SRC="$(cd "$ROOT/.." && pwd)/anglesite"
-PLUGIN_SRC="${ANGLESITE_PLUGIN_SRC:-$DEFAULT_PLUGIN_SRC}"
-
-if [[ ! -d "$PLUGIN_SRC" ]]; then
-    echo "ERROR: plugin source not found at $PLUGIN_SRC" >&2
-    echo "       Set ANGLESITE_PLUGIN_SRC or clone github.com/Anglesite/anglesite as a sibling." >&2
-    exit 1
-fi
-if [[ ! -f "$PLUGIN_SRC/.claude-plugin/plugin.json" ]]; then
-    echo "ERROR: $PLUGIN_SRC does not look like the Anglesite plugin (no .claude-plugin/plugin.json)" >&2
-    exit 1
-fi
-
-SIDECAR_STAGE="$CTX/mcp-sidecar"
-echo "Staging MCP sidecar from $PLUGIN_SRC → $SIDECAR_STAGE"
-rm -rf "$SIDECAR_STAGE"
-mkdir -p "$SIDECAR_STAGE"
-
-# Copy the plugin's server/ directory + package manifests (no node_modules, no .git).
-rsync -a --delete \
-    --exclude='node_modules/' \
-    --exclude='.git/' \
-    "$PLUGIN_SRC/server/" "$SIDECAR_STAGE/server/"
-cp "$PLUGIN_SRC/package.json" "$SIDECAR_STAGE/"
-cp "$PLUGIN_SRC/package-lock.json" "$SIDECAR_STAGE/"
-
-echo "Sidecar staged: $(ls "$SIDECAR_STAGE")"
-
-# ---------------------------------------------------------------------------
-# Stage the website template's dependency manifests + the hydrate script into
-# the build context, so the image can bake the template's full node_modules
-# (design §5b, same pattern as container/Dockerfile). hydrate.sh is shared
-# with the Cloudflare image — container/hydrate.sh is the single source.
-# ---------------------------------------------------------------------------
-TEMPLATE_STAGE="$CTX/template"
-echo "Staging template manifests from $ROOT/Resources/Template → $TEMPLATE_STAGE"
-rm -rf "$TEMPLATE_STAGE"
-mkdir -p "$TEMPLATE_STAGE"
-cp "$ROOT/Resources/Template/package.json" "$TEMPLATE_STAGE/"
-cp "$ROOT/Resources/Template/package-lock.json" "$TEMPLATE_STAGE/"
-cp "$ROOT/container/hydrate.sh" "$CTX/hydrate.sh"
-
-# Clean up the staged sidecar + template + hydrate script on exit (success or
-# failure) so they don't accumulate in the build context. These are gitignored.
-cleanup_sidecar() { rm -rf "$SIDECAR_STAGE" "$TEMPLATE_STAGE" "$CTX/hydrate.sh"; }
-trap cleanup_sidecar EXIT
+stage_dev_image_context "$CTX"
 
 echo "Building anglesite-dev:latest (linux/arm64)…"
 
@@ -86,8 +35,12 @@ mkdir -p "$OUT"
 # the store keeps anglesite-dev:latest between runs, so rebuilds are incremental — the same role
 # the old docker-container buildx builder's cache played.
 ARCHIVE="$OUT/image.tar"
+# --build-arg TARGETARCH is explicit rather than relying on the builder to auto-inject it
+# (unlike BuildKit, container CLI 1.1.0's docs don't confirm it sets platform ARGs
+# automatically) — the Dockerfile's per-arch base-image stage selection needs it either way.
 container build \
     --os linux --arch arm64 \
+    --build-arg TARGETARCH=arm64 \
     --tag anglesite-dev:latest \
     "$CTX"
 container image save --platform linux/arm64 --output "$ARCHIVE" anglesite-dev:latest


### PR DESCRIPTION
## Summary

Closes the "Multi-arch OCI image" checklist item on #567 (Cross-platform P2 — Linux MVP).

The vendored image was arm64-only, but the real gap wasn't `scripts/vendor-container-image.sh` — that script (Apple's `container` CLI) is permanently arm64-scoped since Apple Containerization only runs on Apple Silicon. The actual gap: there was **no build path at all** for the image `PodmanContainerControl` expects on Linux, where most desktops are amd64.

- `Containers/anglesite-dev/Dockerfile` now pins per-arch base-image digests (a `TARGETARCH`-selected build stage, defaulting to `arm64`) instead of a single arm64-only digest, so it builds correctly for either arch.
- New `scripts/build-podman-image.sh` builds the image natively via podman for whatever arch the Linux host is — no cross-arch emulation needed, since each host builds its own image (unlike the single-Mac Apple `container` CLI path, which needs Rosetta to cross-build).
- Staging logic (MCP sidecar + template manifests from the sibling plugin repo) shared between both build scripts via new `scripts/lib/stage-dev-image-context.sh`, rather than duplicated.
- `scripts/vendor-container-image.sh` gets an explicit `--build-arg TARGETARCH=arm64` rather than relying on unconfirmed automatic ARG injection from the Apple `container` CLI.
- Checked off `AnglesiteBridgeCore` split, multi-arch image, `PodmanSiteRuntime`, and `AnglesiteLinux` shell on #567's checklist — only Flatpak packaging remains.

## Verification

Built and booted `localhost/anglesite-dev:latest` for real with podman on an arm64 Linux box, against the actual sibling plugin checkout (`ANGLESITE_PLUGIN_SRC`):
- `node --version` → v22.23.1
- `git --version` → 2.39.5
- `socat` present
- MCP sidecar's `server/` files present under `/usr/local/lib/anglesite-mcp/`
- Baked template's `node_modules` present (451 packages)

Also found and fixed a real bug in the new shared staging lib: the cleanup `trap` referenced `local` variables that had already gone out of scope by the time `EXIT` fired (the trap body is now built as a string with the paths substituted immediately, rather than naming the variables).

Per review, verified the pinned **amd64** digest for real (not just resolving it via the registry API): `podman pull --arch amd64 node@sha256:a149c...` succeeds and `podman inspect` confirms `amd64 linux`. Also built `Containers/anglesite-dev/Dockerfile` through the `base` stage with `--arch amd64 --build-arg TARGETARCH=amd64` on this arm64 box — it correctly resolves `base-amd64`/pulls the right digest, then fails at the first `RUN` with "Exec format error", the expected failure mode without qemu binfmt registered here, not a problem with the stage-selection logic. A full `RUN`-through-completion amd64 build still can't be exercised without either an amd64 host or binfmt emulation set up on this box.

I could **not** verify the `scripts/vendor-container-image.sh` (Apple `container` CLI) path at all — that tool only runs on macOS and this work happened on a Linux box.

`swift build --target AnglesiteCore` still builds clean (no Swift source changes were needed — `PodmanContainerControl`'s default image tag `localhost/anglesite-dev:latest` already matched what the new script produces).

## Test plan

- [x] `scripts/build-podman-image.sh` run for real against the sibling plugin checkout on Linux/arm64 — image builds, tags, and boots correctly
- [x] `swift build --target AnglesiteCore` — clean build, no regressions
- [x] Pinned amd64 base digest confirmed real via `podman pull --arch amd64` + `podman inspect`; Dockerfile's `base` stage resolves correctly for amd64 (fails only at `RUN`, for lack of qemu binfmt on this box, not a stage-selection bug)
- [ ] Run `scripts/vendor-container-image.sh` on a real Apple-Silicon Mac to confirm the `--build-arg TARGETARCH=arm64` addition doesn't break the existing macOS vendoring path
- [ ] Full amd64 build (through `RUN` completion) on a real Linux amd64 host or with qemu binfmt emulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)