### PR TITLE
docs(qa): E2E acceptance criteria — launch, new site, edits, Cloudflare publish

### DIFF
--- a/docs/qa/e2e-acceptance-1-initial-launch.md
+++ b/docs/qa/e2e-acceptance-1-initial-launch.md
@@ -1,0 +1,117 @@
+# E2E Acceptance — Part 1: Initial Launch
+
+**Sequence:** Part 1 of 4 — see [e2e-acceptance-overview.md](e2e-acceptance-overview.md) for shared preconditions and the fresh-state reset.
+**Scope:** what a user experiences the very first time Anglesite launches: no recents, no bookmarks, no credentials, no sites.
+
+## Purpose
+
+Verify the first-run experience is the empty Sites launcher — no onboarding gates, no permission dialogs, no background provisioning — with every site-scoped command correctly disabled and sensible Settings defaults.
+
+## Preconditions
+
+- Fresh-state reset performed (overview doc).
+- Build launched normally (Finder/Xcode Run), not from a state-restoring session.
+
+## Acceptance Matrix
+
+| # | Case | Result | Notes |
+|---|---|---|---|
+| 1 | Launcher window with empty state |  |  |
+| 2 | No onboarding or permission dialogs |  |  |
+| 3 | Menu enablement with no site open |  |  |
+| 4 | Open Recent and Dock menu empty states |  |  |
+| 5 | Settings defaults |  |  |
+| 6 | Siri AI readiness tab |  |  |
+| 7 | No eager state or provisioning on disk |  |  |
+| 8 | Launcher error/drop affordances |  |  |
+
+## Test Cases
+
+### 1. Launcher window with empty state
+
+Launch the app.
+
+Expected:
+
+- Exactly one window opens: **"Sites"** (the launcher). No site window, no debug window.
+- Header: bold **"Sites"** title plus a borderless reload button (help text "Reload site list").
+- Empty state: `tray` symbol, headline **"No Anglesite sites found"**, body copy directing to **Add Site → Create new site…** / **Add Site → Import existing site…**.
+- Footer: an **"Add Site"** menu with exactly two items: **"Create new site…"** and **"Import existing site…"**.
+- No auto-open of any site (fresh install has no `lastOpenedSiteID`).
+
+Fail if a site window opens, the launcher shows a stale list, or the window appears blank for more than a moment (the "deciding" state must resolve).
+
+### 2. No onboarding or permission dialogs
+
+Observe the first 60 seconds after launch, then open Notification Center settings.
+
+Expected:
+
+- No welcome/onboarding/tour modal, no EULA, no sign-in gate.
+- **No notification permission prompt** — authorization is provisional and lazy (`CompletionNotifier`); it must never raise the system alert, at launch or later.
+- No container image/kernel provisioning UI or download activity at launch (runtime resolution is lazy, at site-open).
+
+Fail if any modal or system permission dialog appears before the user takes an action.
+
+### 3. Menu enablement with no site open
+
+Walk the menu bar with only the launcher open.
+
+Expected:
+
+- **File ▸ New ▸ Site** enabled (⇧⌘N). **New ▸ Page…** (⌘N), **Collection…**, **Post…**, **Component…** all disabled.
+- **File ▸ Open Site…** (⌘O) enabled; picking a non-package shows the "Couldn't open that site" alert.
+- **File ▸ Export Site Source…** disabled. **File ▸ Print…** inert.
+- **Site menu**: every item (Deploy ⇧⌘D, Recheck Deploy Readiness, Backup, Audit, Harden…, Domain…, Add Integration…, Siri AI Readiness…, dev-server controls, Open in Browser) disabled.
+- **View**: pane switches ⌘1–3, Chat ⌘K, Inspector ⌥⌘I inert; **"Show Debug Pane" (⌥⌘D) not visible** in a Release build until the Settings ▸ Advanced diagnostics toggle is on (visible by default in Debug builds).
+- **App menu ▸ About Anglesite** shows the custom panel with the `Phase <n> · macOS <version>` credits line.
+
+Fail if any site-scoped command is enabled with no site window focused.
+
+### 4. Open Recent and Dock menu empty states
+
+Expected:
+
+- **File ▸ Open Recent** shows a single disabled **"No Recent Sites"** item, with **"Import Site…"** below the divider (enabled).
+- The Dock icon's context menu shows only **"New Site"** (no recents). Selecting it activates the app and presents the New Site wizard on the launcher.
+
+### 5. Settings defaults
+
+Open Settings (⌘,).
+
+Expected — fixed-size window with three tabs:
+
+- **General**: "Auto-generate alt text for dropped images" **ON**; "Auto-suggest descriptions for new pages and posts" **ON**; "Notify when site operations finish" **ON**; "Announce live updates to VoiceOver" **ON**.
+- **Advanced**: plugin path override empty (placeholder "(use bundled plugin)"); Sites root empty (placeholder `~/Sites/`); Credentials section shows the Cloudflare API token row with **no stored token**; "Show Debug Pane menu item" **OFF**; LAN runtime section hidden in Release (no diagnostics opt-in yet).
+- No runtime-selection toggle exists anywhere (runtime choice is automatic).
+
+Fail if any default differs or a credential appears pre-populated after the fresh-state reset.
+
+### 6. Siri AI readiness tab
+
+Open Settings ▸ **Siri AI**.
+
+Expected:
+
+- An initial check runs on appear; rows for macOS runtime, App Intents registration, View annotations, Apple Foundation Models, System MCP bridge, each with a status color and remediation text where applicable (e.g. "Apple Intelligence is turned off" → System Settings pointer).
+- A **"Re-check"** button and last-checked timestamp.
+- Warnings here (e.g. Apple Intelligence off) do **not** block anything else in this run.
+
+### 7. No eager state or provisioning on disk
+
+After a few minutes idle, inspect the app container.
+
+Expected:
+
+- `recents.json` either absent or an empty list — no scan of `~/Sites/` happened (registry is authoritative, not a folder scan).
+- No container ext4/rootfs artifacts unpacked, no `com.apple.Virtualization` process running.
+
+### 8. Launcher error/drop affordances
+
+- Drag a valid `.anglesite` package from Finder onto the launcher list → it registers and its window opens (this seeds Part 2's "existing site" negative checks; use a throwaway package or defer to after Part 2).
+- Drag a non-package folder → ignored, no crash.
+- (If simulable) a corrupted `recents.json` shows the "Couldn't load sites" error state with a working **Retry**.
+
+## Exit state for Part 2
+
+The app is running with the empty launcher visible; Settings untouched apart from inspection; no sites registered (re-do the reset if case 8 registered a throwaway).

--- a/docs/qa/e2e-acceptance-2-new-website.md
+++ b/docs/qa/e2e-acceptance-2-new-website.md
@@ -1,0 +1,133 @@
+# E2E Acceptance — Part 2: Create a New Website
+
+**Sequence:** Part 2 of 4 — requires Part 1's exit state (running app, empty launcher).
+**Scope:** File ▸ New ▸ Site through a live previewing site window: wizard, scaffold on disk, container boot, first render.
+
+## Purpose
+
+Verify a user can create a `.anglesite` package end-to-end: the wizard collects name/type/look/content, the scaffold lands a complete git-initialized `Source/` **with a real initial commit** (#697), the site registers in recents, and the container runtime boots to a live preview of the owner's homepage without further user action.
+
+## Preconditions
+
+- Part 1 passed. Container artifacts provisioned and build entitled (overview doc) — otherwise every case from 7 on fails by design.
+- Test inputs used throughout: site name **"QA Bakery"**, type **business**, a non-default built-in theme, headline **"Fresh bread daily"**, domain choice **"Set this up later"**.
+
+## Acceptance Matrix
+
+| # | Case | Result | Notes |
+|---|---|---|---|
+| 1 | Wizard entry points |  |  |
+| 2 | Wizard steps, labels, validation |  |  |
+| 3 | Sandbox grant + save panel defaults |  |  |
+| 4 | Building checklist completes clean |  |  |
+| 5 | Package layout + marker on disk |  |  |
+| 6 | Git repo with initial commit (#697) |  |  |
+| 7 | Site window opens; dev server auto-boots |  |  |
+| 8 | Preview renders the owner's homepage |  |  |
+| 9 | Recents, window chrome, Finder behavior |  |  |
+| 10 | Window close tears down the runtime |  |  |
+| 11 | Negative: duplicate name / cancelled grant |  |  |
+| 12 | Negative: unprovisioned runtime messaging |  |  |
+
+## Test Cases
+
+### 1. Wizard entry points
+
+All three routes present the same wizard sheet on the launcher window:
+
+- **File ▸ New ▸ "Site"** (⇧⌘N) — note ⌘N is New Page, not New Site.
+- Dock menu **"New Site"**.
+- Launcher **Add Site → "Create new site…"**.
+
+### 2. Wizard steps, labels, validation
+
+Walk the six steps (fixed ~520×460 sheet; footer **Back / Cancel / Continue**):
+
+- **Details** ("Create a website"): "Website name" field; domain radio group **"Buy a domain"** / **"Transfer an existing domain"** / **"Set this up later"**. Selecting "Set this up later" shows the temporary-domain explanation. Continue is disabled until the name is non-empty and the slug untaken; Transfer additionally requires a valid domain.
+  - *Known gap:* the "later" copy promises a `<slug>.pages.dev` address; the actual deploy target is `*.workers.dev` (overview doc, candidate issue). Record the exact copy shown.
+- **Type** ("What kind of website are you creating?"): one card per site type; **business** is the default.
+- **Look** ("Pick a color scheme"): built-in theme grid plus a **Custom** card (primary/accent colors, "Upload Logo…"). Pick a non-default theme so case 8 can verify it applied.
+- **Content** ("First words"): "Homepage headline", optional short description; "Generate hero image…" appears only when Image Playground is available.
+- **Save**: leads to the save panel (case 3).
+- **Building**: case 4.
+
+Cancel at any pre-build step must dismiss with nothing on disk.
+
+### 3. Sandbox grant + save panel defaults
+
+Expected:
+
+- First creation on a sandboxed build raises the **"Grant Access"** open panel ("Choose your Sites folder so Anglesite can create the new site there."). Granting proceeds; it must not re-prompt for subsequent sites in the same root.
+- The save panel ("Save Your Website", prompt "Save") defaults to the Sites root (`~/Sites/` unless overridden) with filename **`qa-bakery.anglesite`**, and creates the directory if missing.
+
+### 4. Building checklist completes clean
+
+Expected, in order, all check off: created the website file → copied the template → applied your theme → wrote your words → installing → registering → done. On a clean build the wizard dismisses itself and the site window opens.
+
+- Warnings (⚠️ rows, e.g. "git init skipped", "Dependency baseline not saved") keep the wizard open with "…something above needs attention" and an **"Open Website Anyway"** button — record any warning verbatim; a clean run should have none.
+- Failures at *create folder*, *copy template*, or *register* are fatal and must roll back the half-written package (verify no orphan `qa-bakery.anglesite` remains after a forced failure, if simulated).
+
+### 5. Package layout + marker on disk
+
+Inspect `~/Sites/qa-bakery.anglesite/`:
+
+- `Info.plist` marker with format version 1, a stable site UUID, display name "QA Bakery", created date.
+- `Source/` — the Astro project: `package.json` (name `anglesite-site`), `astro.config.ts`, `src/`, `public/`, `scripts/`, `worker/`, `.site-config`.
+- `.site-config` contains the wizard answers: `SITE_NAME`, `SITE_TYPE`, `DOMAIN_CHOICE`, `THEME`, `TAGLINE`, and the real `ANGLESITE_VERSION` (not the `1.0.0` placeholder).
+- `Config/` exists beside `Source/` with the dependency baseline; `Config/` is **not** inside the git repo.
+- Excluded from the copy: `scripts/scaffold.sh`, `scripts/themes.ts`, `*.test.ts`, `integrations/`, `node_modules/`.
+
+### 6. Git repo with initial commit (#697)
+
+In `Source/`:
+
+```sh
+git -C ~/Sites/qa-bakery.anglesite/Source log --oneline
+git -C ~/Sites/qa-bakery.anglesite/Source status --porcelain
+```
+
+Expected:
+
+- Exactly one commit, message **"Initial commit"**, containing the scaffold *after* theme + homepage writes (working tree clean, or nearly — record any uncommitted paths).
+- No `.env` / `.env.*` files staged in the commit.
+- This is the regression guard for #697: a zero-commit repo makes the container's `git checkout HEAD` hydration fail and the site can never preview.
+
+### 7. Site window opens; dev server auto-boots
+
+Expected without any user action after the wizard:
+
+- The "QA Bakery" window opens (launcher dismisses) and the preview pane enters `.starting`: **"Starting dev server for QA Bakery…"** with a determinate progress bar walking "Starting dev server…" → "Building site…" → "Connecting to preview…", plus an ungated **"Show Logs"** affordance that opens the Debug window.
+- Debug logs show the container path: image import, VM boot, guest `git clone` of `Source/`, `npm install`, `astro dev`, MCP sidecar, vsock proxies. Record cold-start wall-clock time (first boot includes `npm install` — minutes is normal; a silent stall in "Building site…" beyond ~10 min is a fail).
+- The preview URL is loopback (`http://127.0.0.1:<os-assigned port>`) — never a guest IP.
+
+### 8. Preview renders the owner's homepage
+
+Expected once ready:
+
+- Homepage shows headline **"Fresh bread daily"** (not the template default "Welcome"); the chosen theme's colors are visibly applied.
+- `/about` renders the business-profile page; `/blog/` renders the empty state ("No posts yet…" with an RSS link); `/rss.xml` returns a feed.
+- The window's subtitle shows the live preview URL.
+
+### 9. Recents, window chrome, Finder behavior
+
+- The site appears in the launcher list (green check), **File ▸ Open Recent**, and the Dock menu.
+- Window title is "QA Bakery". Note whether a title-bar proxy icon appears (not currently wired — evidence for #680).
+- In Finder the package is a single opaque document ("Anglesite Site"); double-clicking it opens/focuses the site in Anglesite. `cd`, `git`, and an external editor still descend into `Source/` normally.
+- Quit and relaunch the app: the last-opened site auto-opens (MRU), skipping the launcher.
+
+### 10. Window close tears down the runtime
+
+Close the site window; within a few seconds no `com.apple.Virtualization` process remains, both vsock proxies are gone, and per-site ext4 artifacts are removed or accounted for (same bar as the container smoke doc).
+
+### 11. Negative: duplicate name / cancelled grant
+
+- Re-run the wizard with the name "QA Bakery" → Details step shows `A site named "qa-bakery" already exists.` and Continue stays disabled.
+- (Fresh sandbox state) Cancel the Grant Access panel → the wizard aborts without creating anything; record whether the abort is communicated or silent.
+
+### 12. Negative: unprovisioned runtime messaging
+
+On a build without vendored container artifacts (or with them deliberately removed), opening the site must settle to the failed pane — ⚠️ **"Can't preview QA Bakery"** with the missing artifacts named, **Retry** and **Show Logs**, and **no host-subprocess fallback** (no host Node/npm processes spawned).
+
+## Exit state for Part 3
+
+"QA Bakery" open with a ready preview; git log shows the single initial commit.

--- a/docs/qa/e2e-acceptance-3-basic-edits.md
+++ b/docs/qa/e2e-acceptance-3-basic-edits.md
@@ -1,0 +1,124 @@
+# E2E Acceptance — Part 3: Basic Edits
+
+**Sequence:** Part 3 of 4 — requires Part 2's exit state ("QA Bakery" open, preview ready).
+**Scope:** the everyday editing loop: navigator + inspector edits, in-preview click-to-edit and image drop, new page/post/component, rename/duplicate/delete, the Component Editor styles panel, save/undo/conflict semantics, and the git ledger.
+
+A PASS here (with evidence) closes the owed manual verifications **#586** (navigator content commands), **#491** (Component Editor slice-1 smoke), and — run on this sandboxed target with the git evidence recorded — **#656** (SwiftGit2 content-ops MAS smoke).
+
+## Purpose
+
+Verify the app's editing surfaces write to `Source/`, the preview hot-reloads, undo behaves per surface, and git stays the source of truth: per-operation commits for content ops and typed saves, working-tree-only writes (plus the hidden `anglesite/edits` undo branch) for overlay edits.
+
+## Layout orientation (case 1 verifies this inventory)
+
+- **Navigator** (sidebar): Pages, Posts, Collections, Components, Styles, Metadata groups; a Cleanup section once content exists.
+- **Center pane**: segmented **Preview / Editor / Graph** switcher pinned in the toolbar center (⌘1/⌘2/⌘3); the Editor tag only exists while a file editor is active.
+- **Inspector** (right, ⌥⌘I): metadata form for the selected page/post.
+- **Selection semantics — the key UX rule:** selecting a **page or post** keeps the center pane on **Preview** (navigating to that route) and loads its metadata into the **Inspector**; selecting a **component/style/metadata file** opens the center **Editor**. There is no center-pane document editor for pages/posts.
+- **Toolbar** defaults: Site Graph, Backup, Audit, Open in browser, Deploy (+health badge), Chat, Inspector.
+
+## Acceptance Matrix
+
+| # | Case | Result | Notes |
+|---|---|---|---|
+| 1 | Window layout + selection semantics |  |  |
+| 2 | Edit page metadata via inspector (⌘S, commit) |  |  |
+| 3 | In-preview click-to-edit text (+ ⌘Z undo) |  |  |
+| 4 | Image drop with auto alt text |  |  |
+| 5 | Save conflict: Keep My Changes / Reload |  |  |
+| 6 | New Page / New Post / New Component |  |  |
+| 7 | Rename (inline) |  |  |
+| 8 | Duplicate (⌘D) |  |  |
+| 9 | Delete (⌘⌫) with undo + redirect offer |  |  |
+| 10 | Component Editor: styles write round-trip |  |  |
+| 11 | Dev-server controls (Stop/Start/Restart) |  |  |
+| 12 | Git ledger matches the surface rules |  |  |
+| 13 | (Device-gated) Chat edit + unavailable copy |  |  |
+
+## Test Cases
+
+### 1. Window layout + selection semantics
+
+Verify the inventory above. Specifically: select the About page → center pane stays on Preview showing `/about`, inspector shows its metadata; select a component `.astro` file → center pane switches to Editor.
+
+### 2. Edit page metadata via inspector
+
+Select the About page; in the inspector change the title and a business field; observe the dirty indicator; press **⌘S** (File ▸ Save).
+
+Expected:
+
+- Save button/dot clears; the file under `Source/` reflects the change; the preview updates via Astro HMR without a manual reload.
+- Typed-entry saves **commit immediately**: `git log` gains an `anglesite: edit <type> <slug>` commit.
+- Navigate away with unsaved inspector edits → the buffer flushes to disk (autosave-on-leave), no data loss.
+- **File ▸ Revert to Saved** restores disk state after an unsaved change (with confirmation).
+
+### 3. In-preview click-to-edit text
+
+In the Preview pane, hover the homepage headline (blue outline), click, type a change, click elsewhere (blur).
+
+Expected:
+
+- The edit applies: the source file under `Source/` changes; preview keeps the new text after HMR.
+- The Chat panel records an `.edit` row with an inline **Undo**; **⌘Z** (Edit ▸ Undo) reverts the edit through the git `undo_edit` path — file and preview both revert. No redo is offered.
+- The edit is **not** committed on the working branch (see case 12) but is committed on the hidden `refs/heads/anglesite/edits` branch.
+
+### 4. Image drop with auto alt text
+
+Drag an image file from Finder onto an `<img>` in the preview.
+
+Expected: optimistic swap, then the server-returned asset (new `src`/`srcset`); the image file lands under `Source/`; with Apple Intelligence available and the General setting ON, alt text is generated. Failure/timeout (~30 s) reverts with a toast rather than leaving a broken image.
+
+### 5. Save conflict: Keep My Changes / Reload
+
+With a dirty inspector or file-editor buffer, edit the same file externally (e.g. `echo` an extra line via Terminal), then refocus the app window.
+
+Expected: the "`<file>` changed on disk" alert with **Keep My Changes** / **Reload from Disk**; each button does what it says; dismissing the dialog must not silently pick a side. Navigating away with a conflicted buffer surfaces the conflict instead of clobbering.
+
+### 6. New Page / New Post / New Component
+
+- **File ▸ New ▸ Page…** (⌘N): sheet with Title, auto-slugged editable route, template picker → creates `src/pages/<route>/index.astro`, commits `anglesite: add page …`, appears in the navigator, and selecting it previews the route once Astro rebuilds. Creating over an existing route is refused.
+- **File ▸ New ▸ Post…**: Title → markdown file in the posts collection, commits `anglesite: add posts …`; `/blog/` now lists it (empty state gone).
+- **File ▸ New ▸ Component…**: Name → PascalCase `src/components/<Name>.astro`, committed.
+
+### 7. Rename (inline)
+
+Context-menu **Rename** (or Return) on a page row → inline text field; Return/Tab/click-away commits, **Esc cancels**. Title rewrites in place; navigator and preview stay consistent.
+
+### 8. Duplicate (⌘D)
+
+Context menu or Edit ▸ Duplicate on a page → "<title> Copy" with a `-copy` slug appears, committed as `anglesite: duplicate …`.
+
+### 9. Delete (⌘⌫) with undo + redirect offer
+
+Delete the duplicate from case 8.
+
+Expected: confirmation dialog → row and file removed, committed `anglesite: delete …` → post-delete **Undo** alert restores it (commit `anglesite: restore …`) → delete again and this time check the **"Add Redirect?"** offer for the freed route. At no point may a file disappear without a commit recording it.
+
+### 10. Component Editor: styles write round-trip (#491 + slice 2)
+
+Open a component `.astro`; verify **Design/Source** toggle, outline → canvas → inspector selection sync, and props knobs. In the **Styles** panel edit a color value (color-picker scrub), add a declaration, and add a rule.
+
+Expected: each write lands in the component's scoped `<style>` in `Source/` and the canvas reflects it; edits carry `baseVersion` — editing the file externally mid-session produces the "changed outside Anglesite" banner + auto-reload, not a silent overwrite. An unparseable component degrades to Source with a diagnostic banner.
+
+### 11. Dev-server controls
+
+**Site ▸ Stop Dev Server** → preview parks at "Dev server stopped" with a Start button; **Start** recovers; **Restart** (⌥⌘R) cycles cleanly. Rapid re-clicks must not double-dispatch. After a forced failure, the failed pane's **Retry** works.
+
+### 12. Git ledger matches the surface rules
+
+Run `git -C …/Source log --oneline` and `git status --porcelain`, plus `git log anglesite/edits --oneline`.
+
+Expected:
+
+- Working-branch history shows the per-op commits from cases 2, 6–9 (`anglesite: add/edit/delete/duplicate/restore …`) on top of the initial commit.
+- Overlay/click-to-edit changes (case 3) and plain file-editor saves appear as **uncommitted working-tree changes** on the branch, and as commits on the hidden `anglesite/edits` branch.
+- Nothing under `Config/` is tracked.
+- (Out of the minimal loop: **Backup** requires an `origin` remote and refuses on `main`, so a fresh local-only site can't run it — do not treat that refusal as a failure. Remote backup under sandbox is #654/#655.)
+
+### 13. (Device-gated) Chat edit + unavailable copy
+
+With Apple Intelligence available: toolbar **Chat** (⌘K), ask for a small copy edit → same `.edit` row + Undo + ⌘Z semantics as case 3. Without it: the assistant surfaces "Apple Intelligence isn't available…" with the System Settings pointer. This case is optional for the run's PASS.
+
+## Exit state for Part 4
+
+"QA Bakery" previewing with several commits of real content history and a clean-enough working tree (commit or revert stray overlay edits if you want a tidy pre-publish state — the app itself does not require it).

--- a/docs/qa/e2e-acceptance-4-publish-cloudflare.md
+++ b/docs/qa/e2e-acceptance-4-publish-cloudflare.md
@@ -1,0 +1,119 @@
+# E2E Acceptance — Part 4: Publish to Cloudflare (no custom domain)
+
+**Sequence:** Part 4 of 4 — requires Part 3's exit state (edited site, preview ready).
+**Scope:** first deploy of the site to Cloudflare on the `*.workers.dev` subdomain only — the "Set this up later" domain path. Custom-domain attach, Harden, and Domain wizards are out of scope.
+
+## ⚠️ Known blockers (must land before this part can pass)
+
+Two app-side gaps mean a freshly scaffolded site **cannot currently complete this journey without manual intervention** (details + proposed issues in the [overview](e2e-acceptance-overview.md)):
+
+1. **No wrangler config is materialized.** `Source/` ships only `worker/wrangler.toml.template` with `{{SITE_NAME}}` unsubstituted; the app runs bare `npx wrangler deploy`, which aborts without a config. Until fixed, testers must hand-write `Source/wrangler.toml` (copy the template, set a unique `name`) — record that workaround in evidence.
+2. **`SITE_URL` is never written by the app deploy**, so the built site's canonical URLs/feeds carry `https://example.com` (case 8 documents the expected post-fix behavior).
+
+## Purpose
+
+Verify the deploy pipeline end-to-end: readiness gating, first-run Cloudflare token onboarding, build → pre-deploy scan → wrangler inside the container, the no-override blocked path, and a live `*.workers.dev` site surfaced in the deploy drawer.
+
+## Preconditions
+
+- Parts 1–3 passed on the same site; preview `.ready` (deploy runs **inside** the container — it is a hard dependency).
+- A Cloudflare account the tester controls; **no** token in Keychain and no `CLOUDFLARE_API_TOKEN` in the environment (fresh-state reset).
+- Network access from the guest.
+
+## Acceptance Matrix
+
+| # | Case | Result | Notes |
+|---|---|---|---|
+| 1 | Deploy affordance gating + tooltips |  |  |
+| 2 | Token onboarding: happy path |  |  |
+| 3 | Token onboarding: failure + cancel semantics |  |  |
+| 4 | Deploy progress drawer |  |  |
+| 5 | Blocked deploy: no override |  |  |
+| 6 | Success: live workers.dev URL |  |  |
+| 7 | Completion notification (quiet) |  |  |
+| 8 | Published-site content sanity |  |  |
+| 9 | Re-deploy idempotence |  |  |
+| 10 | Negative: container stopped / wrangler failure |  |  |
+| 11 | Second-site subdomain uniqueness |  |  |
+
+## Test Cases
+
+### 1. Deploy affordance gating + tooltips
+
+- Toolbar **Deploy** (paperplane, prominent, paired with the health badge) and **Site ▸ Deploy** (⇧⌘D) are enabled only when: site valid, preview runtime ready, and no backup/audit in flight.
+- Stop the dev server → Deploy disables with tooltip "Open the preview first to start the runtime before deploying". Restart it before continuing.
+- The button is labeled **Deploy** (not Publish — "Publish" is the separate GitHub feature).
+
+### 2. Token onboarding: happy path
+
+Click Deploy with no stored token.
+
+Expected:
+
+- The deploy parks and the **"Connect to Cloudflare"** sheet appears: three numbered steps (link "Open Cloudflare API tokens" → pre-filled token page; the "Anglesite" custom token with "Edit Cloudflare Workers" fallback; create-and-paste), a secure paste field, **Cancel** / **Connect & deploy** (disabled while empty or verifying).
+- Create the token in the dashboard, paste it, click **Connect & deploy**: spinner "Checking token…" → green **"Connected to <account>"** flash → sheet dismisses → **the parked deploy starts by itself** (no second Deploy click).
+- The token is written to Keychain **only after** successful verification (check Keychain afterwards); it never appears in any log line.
+
+### 3. Token onboarding: failure + cancel semantics
+
+- Paste a mangled token → red failure message ("That token didn't work…" template guidance); sheet stays open; Keychain untouched.
+- Empty/whitespace → "Paste your token first.", no verification attempt.
+- (Simulate offline) → "Couldn't reach Cloudflare…" copy.
+- **Cancel while a verification is in flight** → sheet closes, and no deploy may launch afterwards even if that verification later succeeds (the specifically-tested race). Re-clicking Deploy re-prompts.
+
+### 4. Deploy progress drawer
+
+On a running deploy, the slide-up drawer shows in order: **"Building site…"** → **"Running pre-deploy checks…"** → **"Deploying to production…"** → **"Finishing up…"**, with a live monospaced log tail (stderr in red, auto-scroll), a spinner header, and Dock-icon determinate progress. Deploy, Backup, and Audit remain mutually exclusive while running; double-clicking Deploy is a no-op.
+
+### 5. Blocked deploy: no override
+
+Seed a violation — e.g. paste a real-looking email address into page copy (PII scan) — and deploy.
+
+Expected:
+
+- The pipeline stops after the scan; **wrangler never runs**.
+- The blocked sheet lists categorized findings (e.g. "PII — email address") with file + remediation, and offers **only "Got it"** — there is no bypass/override control anywhere (hard product rule).
+- Remove the violation, redeploy → scan passes. Non-blocking warnings (e.g. OG-image absence) appear in the warnings section without stopping the deploy.
+
+### 6. Success: live workers.dev URL
+
+Expected on completion:
+
+- Drawer header becomes the deployed URL — shape `https://<name>.<account>.workers.dev` — subtitle "deployed in N.N s", with **Copy URL**, a ShareLink, and **Open in browser** (opens the default browser at the live site).
+- The drawer **never auto-dismisses**; it closes only via **Dismiss**.
+- Edge case to note: if wrangler exits 0 but the URL can't be parsed, the app reports "wrangler exited cleanly but no deployed URL was found in its output" — a deploy may be live despite this error (parser fragility, see overview).
+
+### 7. Completion notification (quiet)
+
+A deploy-finished notice arrives **provisionally** in Notification Center — no permission dialog is ever raised. Honors the General "Notify when site operations finish" toggle.
+
+### 8. Published-site content sanity
+
+Visit the live URL in a browser:
+
+- Homepage shows the Part 3 edits (headline, image); `/about` and `/blog/` (with the Part 3 post) render; `/rss.xml` serves.
+- No dev-only surfaces: `/keystatic` must not exist in production output.
+- Canonical URLs / feed self-links reference the deployed host — **currently expected to show `https://example.com`** until the `SITE_URL` blocker lands; record actual values.
+- The health badge reflects the passed scan ("Ready to deploy" green after a recheck).
+
+### 9. Re-deploy idempotence
+
+Make a small visible edit (Part 3, case 3 style), deploy again.
+
+Expected: no token prompt (Keychain hit); same URL; the edit is live after completion; drawer state from the prior run (logs, milestone) fully resets.
+
+### 10. Negative: container stopped / wrangler failure
+
+- Stop the dev server and attempt Site ▸ Deploy: it must refuse/disable rather than attempt a host-side deploy ("Container isn't running — open/start the site's preview first." if it reaches exec). There is **no host fallback** (host Node is retired).
+- Force a wrangler failure (e.g. revoke the token in the Cloudflare dashboard, then deploy): drawer shows "Deploy failed" + reason, red stderr lines, a **Copy log** button, and the on-device AI failure summary labeled "AI summary — verify against the log below" (summary is device-gated; its absence on non-AI hardware is not a fail).
+
+### 11. Second-site subdomain uniqueness
+
+Create a second site (Part 2 abbreviated) and deploy it.
+
+Expected: it must land on a **different** workers.dev subdomain than "QA Bakery" — not overwrite it. With the current placeholder/template gap, two sites sharing a hand-copied config name **will** clobber each other; this case is the acceptance test for the wrangler-config fix (per-site unique `name`).
+
+## Run closeout
+
+- File the evidence (matrix, timings, URL, screenshots) on the tracking issue for this run.
+- On full PASS: close #586, #491, and #656 with links to the Part 3 evidence; report Part 4 results on the wrangler-config and SITE_URL issues.

--- a/docs/qa/e2e-acceptance-4-publish-cloudflare.md
+++ b/docs/qa/e2e-acceptance-4-publish-cloudflare.md
@@ -5,10 +5,10 @@
 
 ## ⚠️ Known blockers (must land before this part can pass)
 
-Two app-side gaps mean a freshly scaffolded site **cannot currently complete this journey without manual intervention** (details + proposed issues in the [overview](e2e-acceptance-overview.md)):
+Two app-side gaps mean a freshly scaffolded site **cannot currently complete this journey without manual intervention** (details in the [overview](e2e-acceptance-overview.md)):
 
-1. **No wrangler config is materialized.** `Source/` ships only `worker/wrangler.toml.template` with `{{SITE_NAME}}` unsubstituted; the app runs bare `npx wrangler deploy`, which aborts without a config. Until fixed, testers must hand-write `Source/wrangler.toml` (copy the template, set a unique `name`) — record that workaround in evidence.
-2. **`SITE_URL` is never written by the app deploy**, so the built site's canonical URLs/feeds carry `https://example.com` (case 8 documents the expected post-fix behavior).
+1. **#701 — no wrangler config is materialized.** `Source/` ships only `worker/wrangler.toml.template` with `{{SITE_NAME}}` unsubstituted; the app runs bare `npx wrangler deploy`, which aborts without a config. Until fixed, testers must hand-write `Source/wrangler.toml` (copy the template, set a unique `name`) — record that workaround in evidence.
+2. **#702 — `SITE_URL` is never written by the app deploy**, so the built site's canonical URLs/feeds carry `https://example.com` (case 8 documents the expected post-fix behavior).
 
 ## Purpose
 
@@ -115,5 +115,5 @@ Expected: it must land on a **different** workers.dev subdomain than "QA Bakery"
 
 ## Run closeout
 
-- File the evidence (matrix, timings, URL, screenshots) on the tracking issue for this run.
-- On full PASS: close #586, #491, and #656 with links to the Part 3 evidence; report Part 4 results on the wrangler-config and SITE_URL issues.
+- File the evidence (matrix, timings, URL, screenshots) on the tracking issue for this run, #706.
+- On full PASS: close #586, #491, and #656 with links to the Part 3 evidence; report Part 4 results on #701 and #702.

--- a/docs/qa/e2e-acceptance-overview.md
+++ b/docs/qa/e2e-acceptance-overview.md
@@ -1,5 +1,6 @@
 # End-to-End QA Acceptance Run — Overview
 
+**Tracking issue:** [#706](https://github.com/Anglesite/Anglesite-app/issues/706) — record all evidence there.
 **Scope:** the core owner journey, first launch through first publish, as four sequential parts:
 
 | Part | Doc | Journey |
@@ -36,8 +37,8 @@ For each part: commit SHA + build config, macOS/Xcode versions, PASS/FAIL per ma
 
 ### Blockers — must land before the full run can pass
 
-- **Missing (file it): scaffolded sites have no deployable wrangler config.** The template ships only `Resources/Template/worker/wrangler.toml.template` with an unsubstituted `{{SITE_NAME}}` placeholder; neither `SiteScaffolder` nor the deploy pipeline renders it to `wrangler.toml`, `.site-config` gets no `CF_PROJECT_NAME`, and `DeployCommand` runs bare `npx wrangler deploy` — which aborts with no config. The plugin deploy SKILL (the retiring `claude --print` path, epic #459) is the only thing that ever wrote a Worker name, and it edits a `wrangler.jsonc` the template doesn't ship. Deterministic fix belongs in the scaffold (render the template with a slugified, uniquified site name) per the #459 "tool before brain" direction. Blocks Part 4 entirely.
-- **Missing (file it): app deploy never writes `SITE_URL`.** `astro.config.ts` reads `SITE_URL` from `.site-config` ("the deploy step writes the real domain… before build" — only the plugin skill did). On the no-custom-domain path the app should set it to the workers.dev URL (first deploy: after URL discovery; or derive from the Worker name pre-build). Until then, canonical URLs/feeds on a published site carry `https://example.com`. Blocks Part 4 case 8 (could be folded into the wrangler-config issue as one "app-native deploy config" issue).
+- **#701 — scaffolded sites have no deployable wrangler config.** The template ships only `Resources/Template/worker/wrangler.toml.template` with an unsubstituted `{{SITE_NAME}}` placeholder; neither `SiteScaffolder` nor the deploy pipeline renders it to `wrangler.toml`, `.site-config` gets no `CF_PROJECT_NAME`, and `DeployCommand` runs bare `npx wrangler deploy` — which aborts with no config. The plugin deploy SKILL (the retiring `claude --print` path, epic #459) is the only thing that ever wrote a Worker name, and it edits a `wrangler.jsonc` the template doesn't ship. Deterministic fix belongs in the scaffold (render the template with a slugified, uniquified site name) per the #459 "tool before brain" direction. Blocks Part 4 entirely.
+- **#702 — app deploy never writes `SITE_URL`.** `astro.config.ts` reads `SITE_URL` from `.site-config` ("the deploy step writes the real domain… before build" — only the plugin skill did). On the no-custom-domain path the app should set it to the workers.dev URL (first deploy: after URL discovery; or derive from the Worker name pre-build). Until then, canonical URLs/feeds on a published site carry `https://example.com`. Blocks Part 4 case 8.
 
 ### Open issues this run verifies (closable on PASS with evidence)
 
@@ -52,9 +53,9 @@ For each part: commit SHA + build config, macOS/Xcode versions, PASS/FAIL per ma
 - **#679 / #680** — keyboard-only pass and Mac-assed polish audit; overlap Part 1/3 surfaces but have their own checklists.
 - **#654 / #655** — GitHub publish / backup transport under sandbox: out of scope (Part 3 notes Backup is excluded from the minimal loop).
 
-### Smaller gaps observed while authoring (candidate issues / cleanups)
+### Smaller gaps observed while authoring (filed)
 
-- Wizard "Set this up later" copy and analytics-host fallbacks say **`<slug>.pages.dev`** (`NewSiteWizardModel.swift:51`, `PlistEditorModel.swift:286`) but the deploy target is **Workers → `*.workers.dev`**. User-visible copy inconsistency.
-- `DeployCommand.extractDeployedURL` anchors on wrangler's `Published` output line; a wrangler output-format change turns a successful deploy into "wrangler exited cleanly but no deployed URL was found". Robustness follow-up.
-- `ComponentEditorView` header comment still says "Read-only (slice 1)" though slice-2 style writes shipped — stale-comment cleanup.
-- No `representedURL`/proxy-icon wiring was found on the site window; verify in Part 2 case 9 and fold into #680 if missing.
+- **#703** — wizard "Set this up later" copy and analytics-host fallbacks say **`<slug>.pages.dev`** (`NewSiteWizardModel.swift:51`, `PlistEditorModel.swift:286`) but the deploy target is **Workers → `*.workers.dev`**.
+- **#704** — `DeployCommand.extractDeployedURL` anchors on wrangler's `Published` output line; a wrangler output-format change turns a successful deploy into "wrangler exited cleanly but no deployed URL was found".
+- **#705** — `ComponentEditorView` header comment still says "Read-only (slice 1)" though slice-2 style writes shipped.
+- No `representedURL`/proxy-icon wiring was found on the site window; verify in Part 2 case 9 and fold into #680 if missing (noted on #680).

--- a/docs/qa/e2e-acceptance-overview.md
+++ b/docs/qa/e2e-acceptance-overview.md
@@ -1,0 +1,60 @@
+# End-to-End QA Acceptance Run — Overview
+
+**Scope:** the core owner journey, first launch through first publish, as four sequential parts:
+
+| Part | Doc | Journey |
+|---|---|---|
+| 1 | [e2e-acceptance-1-initial-launch.md](e2e-acceptance-1-initial-launch.md) | Initial launch (fresh install, no prior state) |
+| 2 | [e2e-acceptance-2-new-website.md](e2e-acceptance-2-new-website.md) | Create a new website |
+| 3 | [e2e-acceptance-3-basic-edits.md](e2e-acceptance-3-basic-edits.md) | Basic edits on the website |
+| 4 | [e2e-acceptance-4-publish-cloudflare.md](e2e-acceptance-4-publish-cloudflare.md) | Publish to Cloudflare (no custom domain) |
+
+**Target:** the `Anglesite` scheme (single sandboxed Mac App Store target). Run the parts **in order on the same machine and the same site** — each part's exit state is the next part's precondition.
+
+## Shared preconditions
+
+- Apple Silicon Mac, macOS 26+ (macOS 27+ for the Siri AI probes to report green).
+- Xcode 27+ / Swift 6.4 toolchain; `xcodegen generate` run in the checkout.
+- Container boot artifacts provisioned (`scripts/vendor-container-image.sh` with `ANGLESITE_PLUGIN_SRC` set, plus `scripts/vendor-container-kernel.sh`) — see [local-container-runtime-smoke-test.md](local-container-runtime-smoke-test.md) §Artifact Provisioning. A checkout without them fails every preview by design (`UnavailableSiteRuntime`).
+- `scripts/copy-plugin.sh` run so `Resources/plugin/` is populated.
+- A build signed with `Resources/Anglesite.entitlements` (ad-hoc Debug is fine — the virtualization entitlement is unrestricted).
+- Network access (guest `npm install`, wrangler).
+- For Part 4: a Cloudflare account the tester controls, with no pre-existing token in Keychain or `CLOUDFLARE_API_TOKEN` in the environment.
+
+## Fresh-state reset (before Part 1)
+
+1. Quit Anglesite.
+2. Delete the app container: `~/Library/Containers/io.dwk.anglesite/` (sandboxed builds keep Application Support, preferences, and `recents.json` there). For non-container state, also check `~/Library/Application Support/Anglesite/`.
+3. Remove the Cloudflare token from Keychain (Keychain Access → search "Anglesite" / "Cloudflare") and ensure `CLOUDFLARE_API_TOKEN` is not exported in the launch environment.
+4. Move aside any existing `~/Sites/*.anglesite` packages (or use a Sites-root override pointed at an empty directory).
+
+## Evidence to record
+
+For each part: commit SHA + build config, macOS/Xcode versions, PASS/FAIL per matrix row, wall-clock timings where a case asks for them, and screenshots of any FAIL plus the Debug-pane log excerpt.
+
+## Issue map
+
+### Blockers — must land before the full run can pass
+
+- **Missing (file it): scaffolded sites have no deployable wrangler config.** The template ships only `Resources/Template/worker/wrangler.toml.template` with an unsubstituted `{{SITE_NAME}}` placeholder; neither `SiteScaffolder` nor the deploy pipeline renders it to `wrangler.toml`, `.site-config` gets no `CF_PROJECT_NAME`, and `DeployCommand` runs bare `npx wrangler deploy` — which aborts with no config. The plugin deploy SKILL (the retiring `claude --print` path, epic #459) is the only thing that ever wrote a Worker name, and it edits a `wrangler.jsonc` the template doesn't ship. Deterministic fix belongs in the scaffold (render the template with a slugified, uniquified site name) per the #459 "tool before brain" direction. Blocks Part 4 entirely.
+- **Missing (file it): app deploy never writes `SITE_URL`.** `astro.config.ts` reads `SITE_URL` from `.site-config` ("the deploy step writes the real domain… before build" — only the plugin skill did). On the no-custom-domain path the app should set it to the workers.dev URL (first deploy: after URL discovery; or derive from the Worker name pre-build). Until then, canonical URLs/feeds on a published site carry `https://example.com`. Blocks Part 4 case 8 (could be folded into the wrangler-config issue as one "app-native deploy config" issue).
+
+### Open issues this run verifies (closable on PASS with evidence)
+
+- **#586** — navigator content commands manual GUI verification → Part 3, cases 6–9.
+- **#491** — Component Editor slice-1 manual GUI smoke → Part 3, case 10.
+- **#656** — MAS-sandboxed GUI smoke of SwiftGit2 content ops (#649) → Part 3 run on a sandboxed build (this target is sandboxed, so the same pass counts; record git evidence).
+
+### Open issues adjacent, not required
+
+- **#81 / #617** — the real-signed App Store variant of this run and Phase 10.1 closeout; this run on ad-hoc Debug signing is the rehearsal.
+- **#616** — distribution-grade pinned container artifacts; dev vendoring suffices for this run.
+- **#679 / #680** — keyboard-only pass and Mac-assed polish audit; overlap Part 1/3 surfaces but have their own checklists.
+- **#654 / #655** — GitHub publish / backup transport under sandbox: out of scope (Part 3 notes Backup is excluded from the minimal loop).
+
+### Smaller gaps observed while authoring (candidate issues / cleanups)
+
+- Wizard "Set this up later" copy and analytics-host fallbacks say **`<slug>.pages.dev`** (`NewSiteWizardModel.swift:51`, `PlistEditorModel.swift:286`) but the deploy target is **Workers → `*.workers.dev`**. User-visible copy inconsistency.
+- `DeployCommand.extractDeployedURL` anchors on wrangler's `Published` output line; a wrangler output-format change turns a successful deploy into "wrangler exited cleanly but no deployed URL was found". Robustness follow-up.
+- `ComponentEditorView` header comment still says "Read-only (slice 1)" though slice-2 style writes shipped — stale-comment cleanup.
+- No `representedURL`/proxy-icon wiring was found on the site window; verify in Part 2 case 9 and fold into #680 if missing.


### PR DESCRIPTION
## Summary

Adds the four-part end-to-end QA acceptance run under `docs/qa/`, covering the core owner journey on the sandboxed MAS target:

1. **e2e-acceptance-1-initial-launch.md** — fresh-install launch: empty Sites launcher, no onboarding/permission dialogs, menu-enablement audit, Settings defaults, Siri AI readiness tab.
2. **e2e-acceptance-2-new-website.md** — New Site wizard through live preview: scaffold/package layout on disk, the #697 initial-commit regression guard, container boot progress, first render, Finder/package behavior, teardown, negative paths.
3. **e2e-acceptance-3-basic-edits.md** — the everyday editing loop: inspector-based page editing, in-preview click-to-edit + ⌘Z-through-git, image drop, new/rename/duplicate/delete, Component Editor style writes, conflict handling, and the git ledger rules (per-op commits vs. the hidden `anglesite/edits` branch).
4. **e2e-acceptance-4-publish-cloudflare.md** — first publish, no custom domain: deploy gating, Cloudflare token onboarding (incl. the cancel-mid-verify race), the no-override blocked sheet, deploy drawer, live `*.workers.dev` verification, re-deploy idempotence, second-site subdomain uniqueness.

**e2e-acceptance-overview.md** holds shared preconditions, the fresh-state reset, evidence rules, and the issue map.

## Issue wiring

- Tracking issue for running the QA: #706 (blocked by #701/#702).
- Blockers found while authoring (verified in source): #701 — scaffolded sites have no materialized wrangler config; #702 — the app deploy never writes `SITE_URL`.
- Smaller gaps filed: #703 (pages.dev vs workers.dev copy), #704 (`extractDeployedURL` fragility), #705 (stale read-only Component Editor comment).
- On a full PASS the run closes the owed manual verifications #586, #491, and #656.

## Notes for review

- Docs-only change; no code or template edits.
- Format follows the existing `docs/qa/` smoke-test house style (preconditions → matrix → cases with Expected/Fail).
- Part 4 leads with a "Known blockers" section so the run can start on Parts 1–3 now and document the manual `wrangler.toml` workaround if Part 4 is attempted before #701/#702 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)