### PR TITLE
Add ESI Astro components + local fallback preview toggle

### DIFF
--- a/Resources/Template/src/components/esi/EsiComment.astro
+++ b/Resources/Template/src/components/esi/EsiComment.astro
@@ -1,0 +1,12 @@
+---
+import { buildEsiCommentTag } from "./esi-markup";
+
+export interface Props {
+  /** Authoring note dropped by the `@dwk/esi` processor — never reaches a client, in dev or prod. */
+  text: string;
+}
+
+const { text } = Astro.props;
+const tag = buildEsiCommentTag(text);
+---
+<Fragment set:html={tag} />

--- a/Resources/Template/src/components/esi/EsiInclude.astro
+++ b/Resources/Template/src/components/esi/EsiInclude.astro
@@ -29,7 +29,7 @@ const tag = buildEsiIncludeTag({ src, alt, onerror });
   <script>
     import { resolveEsiFragments, esiPreviewIsUnprocessed } from "./esi-dev-shim";
     if (!esiPreviewIsUnprocessed(location.search)) {
-      resolveEsiFragments(document, (url) => fetch(url));
+      resolveEsiFragments(document, (url, signal) => fetch(url, { signal }));
     }
   </script>
 )}

--- a/Resources/Template/src/components/esi/EsiInclude.astro
+++ b/Resources/Template/src/components/esi/EsiInclude.astro
@@ -1,0 +1,35 @@
+---
+import { buildEsiIncludeTag } from "./esi-markup";
+
+export interface Props {
+  /**
+   * URL to fetch and splice in place of this tag at the edge. Routed through `@dwk/esi`'s
+   * safeFetch-backed resolver in production, so an attacker- or user-supplied URL is safe here.
+   * In local dev preview, fetched client-side instead — a cross-origin `src` needs that origin's
+   * own CORS headers to resolve in preview (production has no such restriction). Pair with
+   * `EsiRemove` for fallback markup shown when nothing ESI-aware processes this page:
+   *
+   * ```astro
+   * <EsiInclude src="/fragments/count" onerror="continue" />
+   * <EsiRemove><span class="count-fallback">—</span></EsiRemove>
+   * ```
+   */
+  src: string;
+  /** Fallback URL retried once if `src` fails (only when `onerror` is unset). */
+  alt?: string;
+  /** `"continue"`: drop this fragment silently on failure instead of retrying `alt`. */
+  onerror?: "continue";
+}
+
+const { src, alt, onerror } = Astro.props;
+const tag = buildEsiIncludeTag({ src, alt, onerror });
+---
+<Fragment set:html={tag} />
+{import.meta.env.DEV && (
+  <script>
+    import { resolveEsiFragments, esiPreviewIsUnprocessed } from "./esi-dev-shim";
+    if (!esiPreviewIsUnprocessed(location.search)) {
+      resolveEsiFragments(document, (url) => fetch(url));
+    }
+  </script>
+)}

--- a/Resources/Template/src/components/esi/EsiRemove.astro
+++ b/Resources/Template/src/components/esi/EsiRemove.astro
@@ -1,0 +1,7 @@
+---
+---
+{/* Fallback markup shown only when nothing ESI-aware processes this page — see EsiInclude's
+    doc comment for the idiomatic EsiInclude/EsiRemove sibling pairing. */}
+<Fragment set:html="<esi:remove>" />
+<slot />
+<Fragment set:html="</esi:remove>" />

--- a/Resources/Template/src/components/esi/EsiRemove.astro
+++ b/Resources/Template/src/components/esi/EsiRemove.astro
@@ -1,7 +1,9 @@
 ---
+const openTag = "<esi:remove>";
+const closeTag = "</esi:remove>";
 ---
 {/* Fallback markup shown only when nothing ESI-aware processes this page — see EsiInclude's
     doc comment for the idiomatic EsiInclude/EsiRemove sibling pairing. */}
-<Fragment set:html="<esi:remove>" />
+<Fragment set:html={openTag} />
 <slot />
-<Fragment set:html="</esi:remove>" />
+<Fragment set:html={closeTag} />

--- a/Resources/Template/src/components/esi/esi-components.build.test.ts
+++ b/Resources/Template/src/components/esi/esi-components.build.test.ts
@@ -1,7 +1,7 @@
 // Resources/Template/src/components/esi/esi-components.build.test.ts
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, cp, writeFile, readFile, rm } from "node:fs/promises";
+import { mkdtemp, cp, writeFile, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -46,8 +46,20 @@ import EsiRemove from "../components/esi/EsiRemove.astro";
     assert.match(html, /<esi:comment text="build fixture"\/>/);
     assert.match(html, /<esi:remove><span class="fallback">—<\/span><\/esi:remove>/);
 
-    // The dev-only fetch shim must not ship to production at all — not just be inert.
-    assert.ok(!html.includes("resolveEsiFragments"), "dev shim script leaked into production build");
+    // The dev-only fetch shim must not ship to production at all — not just be inert. `index.html`
+    // alone isn't enough: Astro hoists client <script> blocks into separately bundled
+    // `dist/_astro/*.js` chunks, so a leaked shim could land there even with no trace in the page
+    // HTML. Walk the whole `dist/` tree.
+    const distFiles = await readdir(join(fixtureDir, "dist"), { recursive: true, withFileTypes: true });
+    for (const entry of distFiles) {
+      if (!entry.isFile()) continue;
+      const filePath = join(entry.parentPath ?? entry.path, entry.name);
+      const contents = await readFile(filePath, "utf8").catch(() => "");
+      assert.ok(
+        !contents.includes("resolveEsiFragments"),
+        `dev shim script leaked into production build: ${filePath}`
+      );
+    }
   } finally {
     await rm(fixtureDir, { recursive: true, force: true });
   }

--- a/Resources/Template/src/components/esi/esi-components.build.test.ts
+++ b/Resources/Template/src/components/esi/esi-components.build.test.ts
@@ -1,0 +1,54 @@
+// Resources/Template/src/components/esi/esi-components.build.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, cp, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+// Resources/Template/ — three `..` up from src/components/esi/
+const TEMPLATE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+const EXCLUDED = /(^|\/)(node_modules|dist|\.astro|\.wrangler)(\/|$)/;
+
+test("EsiInclude/EsiComment/EsiRemove survive an astro build byte-for-byte", async () => {
+  const fixtureDir = await mkdtemp(join(tmpdir(), "anglesite-esi-fixture-"));
+  try {
+    await cp(TEMPLATE_ROOT, fixtureDir, {
+      recursive: true,
+      filter: (src) => !EXCLUDED.test(src.slice(TEMPLATE_ROOT.length)),
+    });
+
+    const fixturePage = `---
+import EsiInclude from "../components/esi/EsiInclude.astro";
+import EsiComment from "../components/esi/EsiComment.astro";
+import EsiRemove from "../components/esi/EsiRemove.astro";
+---
+<EsiInclude src="/fragments/count" alt="/fragments/count-fallback" onerror="continue" />
+<EsiComment text="build fixture" />
+<EsiRemove><span class="fallback">—</span></EsiRemove>
+`;
+    await writeFile(join(fixtureDir, "src/pages/esi-build-fixture.astro"), fixturePage, "utf8");
+
+    execFileSync("npm", ["install", "--no-audit", "--no-fund", "--prefer-offline"], {
+      cwd: fixtureDir,
+      stdio: "inherit",
+    });
+    execFileSync("npx", ["astro", "build"], { cwd: fixtureDir, stdio: "inherit" });
+
+    const html = await readFile(join(fixtureDir, "dist/esi-build-fixture/index.html"), "utf8");
+
+    assert.match(
+      html,
+      /<esi:include src="\/fragments\/count" alt="\/fragments\/count-fallback" onerror="continue"><\/esi:include>/
+    );
+    assert.match(html, /<esi:comment text="build fixture"\/>/);
+    assert.match(html, /<esi:remove><span class="fallback">—<\/span><\/esi:remove>/);
+
+    // The dev-only fetch shim must not ship to production at all — not just be inert.
+    assert.ok(!html.includes("resolveEsiFragments"), "dev shim script leaked into production build");
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/Resources/Template/src/components/esi/esi-dev-shim.test.ts
+++ b/Resources/Template/src/components/esi/esi-dev-shim.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveEsiFragments, esiPreviewIsUnprocessed, type EsiFragmentElement, type EsiFragmentDocument } from "./esi-dev-shim";
+
+function makeElement(attrs: Record<string, string>): EsiFragmentElement & { innerHTML: string } {
+  const attributes = { ...attrs };
+  return {
+    getAttribute: (name) => attributes[name] ?? null,
+    setAttribute: (name, value) => { attributes[name] = value; },
+    hasAttribute: (name) => name in attributes,
+    innerHTML: "",
+  };
+}
+
+test("resolveEsiFragments: fetches src and fills innerHTML on success", async () => {
+  const el = makeElement({ src: "/fragments/count" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  await resolveEsiFragments(doc, async () => new Response("42", { status: 200 }));
+  assert.equal(el.innerHTML, "42");
+  assert.equal(el.hasAttribute("data-esi-dev-resolved"), true);
+});
+
+test("resolveEsiFragments: falls back to alt once when src fails and no onerror is set", async () => {
+  const el = makeElement({ src: "/fragments/count", alt: "/fragments/fallback" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  await resolveEsiFragments(doc, async (url) =>
+    url === "/fragments/count" ? new Response("", { status: 500 }) : new Response("fallback-text", { status: 200 })
+  );
+  assert.equal(el.innerHTML, "fallback-text");
+});
+
+test("resolveEsiFragments: onerror=continue drops silently, never tries alt", async () => {
+  const el = makeElement({ src: "/fragments/count", alt: "/fragments/fallback", onerror: "continue" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  let altCalled = false;
+  await resolveEsiFragments(doc, async (url) => {
+    if (url === "/fragments/fallback") altCalled = true;
+    return new Response("", { status: 500 });
+  });
+  assert.equal(el.innerHTML, "");
+  assert.equal(altCalled, false);
+});
+
+test("resolveEsiFragments: no alt and src fails leaves the element empty", async () => {
+  const el = makeElement({ src: "/fragments/count" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  await resolveEsiFragments(doc, async () => new Response("", { status: 500 }));
+  assert.equal(el.innerHTML, "");
+  assert.equal(el.hasAttribute("data-esi-dev-resolved"), true);
+});
+
+test("resolveEsiFragments: skips elements already marked resolved", async () => {
+  const el = makeElement({ src: "/fragments/count", "data-esi-dev-resolved": "true" });
+  el.innerHTML = "cached";
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  let called = false;
+  await resolveEsiFragments(doc, async () => {
+    called = true;
+    return new Response("42");
+  });
+  assert.equal(called, false);
+  assert.equal(el.innerHTML, "cached");
+});
+
+test("esiPreviewIsUnprocessed: true only for ?esiPreview=unprocessed", () => {
+  assert.equal(esiPreviewIsUnprocessed("?esiPreview=unprocessed"), true);
+  assert.equal(esiPreviewIsUnprocessed(""), false);
+  assert.equal(esiPreviewIsUnprocessed("?esiPreview=live"), false);
+  assert.equal(esiPreviewIsUnprocessed("?other=1&esiPreview=unprocessed"), true);
+});

--- a/Resources/Template/src/components/esi/esi-dev-shim.test.ts
+++ b/Resources/Template/src/components/esi/esi-dev-shim.test.ts
@@ -62,6 +62,31 @@ test("resolveEsiFragments: skips elements already marked resolved", async () => 
   assert.equal(el.innerHTML, "cached");
 });
 
+test("resolveEsiFragments: no src attribute marks resolved without fetching", async () => {
+  const el = makeElement({});
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  let called = false;
+  await assert.doesNotReject(
+    resolveEsiFragments(doc, async () => {
+      called = true;
+      return new Response("42");
+    })
+  );
+  assert.equal(called, false);
+  assert.equal(el.innerHTML, "");
+  assert.equal(el.hasAttribute("data-esi-dev-resolved"), true);
+});
+
+test("resolveEsiFragments: fetchImpl throwing leaves the element empty and resolved", async () => {
+  const el = makeElement({ src: "/fragments/count" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  await resolveEsiFragments(doc, async () => {
+    throw new Error("network down");
+  });
+  assert.equal(el.innerHTML, "");
+  assert.equal(el.hasAttribute("data-esi-dev-resolved"), true);
+});
+
 test("esiPreviewIsUnprocessed: true only for ?esiPreview=unprocessed", () => {
   assert.equal(esiPreviewIsUnprocessed("?esiPreview=unprocessed"), true);
   assert.equal(esiPreviewIsUnprocessed(""), false);

--- a/Resources/Template/src/components/esi/esi-dev-shim.test.ts
+++ b/Resources/Template/src/components/esi/esi-dev-shim.test.ts
@@ -87,6 +87,41 @@ test("resolveEsiFragments: fetchImpl throwing leaves the element empty and resol
   assert.equal(el.hasAttribute("data-esi-dev-resolved"), true);
 });
 
+test("resolveEsiFragments: passes an AbortSignal to fetchImpl, so a hanging fetch can be timed out", async () => {
+  const el = makeElement({ src: "/fragments/count", alt: "/fragments/fallback" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  let receivedSignal: AbortSignal | undefined;
+  await resolveEsiFragments(doc, async (url, signal) => {
+    if (url === "/fragments/count") {
+      receivedSignal = signal;
+      // Simulates AbortSignal.timeout() firing: fetch rejects once its signal aborts.
+      throw new Error("simulated timeout abort");
+    }
+    return new Response("fallback-text", { status: 200 });
+  });
+  assert.ok(receivedSignal instanceof AbortSignal, "fetchImpl must receive a real AbortSignal");
+  // A timed-out src falls through to alt exactly like any other failure.
+  assert.equal(el.innerHTML, "fallback-text");
+});
+
+test("resolveEsiFragments: two concurrent invocations on the same element only fetch once", async () => {
+  const el = makeElement({ src: "/fragments/count" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  let fetchCount = 0;
+  const fetchImpl = async () => {
+    fetchCount++;
+    return new Response("42", { status: 200 });
+  };
+  // Two script instances resolving the same page in the same tick (e.g. two EsiInclude
+  // components, if Astro doesn't dedupe the client script) must not both fire a fetch for the
+  // same element — RESOLVED_ATTR is claimed synchronously before either awaits.
+  const first = resolveEsiFragments(doc, fetchImpl);
+  const second = resolveEsiFragments(doc, fetchImpl);
+  await Promise.all([first, second]);
+  assert.equal(fetchCount, 1);
+  assert.equal(el.innerHTML, "42");
+});
+
 test("esiPreviewIsUnprocessed: true only for ?esiPreview=unprocessed", () => {
   assert.equal(esiPreviewIsUnprocessed("?esiPreview=unprocessed"), true);
   assert.equal(esiPreviewIsUnprocessed(""), false);

--- a/Resources/Template/src/components/esi/esi-dev-shim.ts
+++ b/Resources/Template/src/components/esi/esi-dev-shim.ts
@@ -14,26 +14,35 @@ export interface EsiFragmentDocument {
 
 const RESOLVED_ATTR = "data-esi-dev-resolved";
 
+/** Fragment fetches abort after this long, falling through to `alt`/drop the same way a non-2xx
+ *  response does — otherwise a hanging endpoint would leave an `<esi:include>` blank forever. */
+const FETCH_TIMEOUT_MS = 5000;
+
 /**
  * Dev-preview approximation of `@dwk/esi`'s fragment resolution: fetches each unresolved
  * `<esi:include>` element's `src`, applying the same onerror/alt rules the real processor uses
  * (`docs/superpowers/specs/2026-07-13-esi-astro-component-design.md` §4), so local preview shows
  * something close to what production will. Dev-only — never bundled into a production build
  * (see `EsiInclude.astro`'s `{import.meta.env.DEV && (...)}` guard).
+ *
+ * Safe to invoke redundantly if more than one `<script>` copy of this module ends up on the same
+ * page (e.g. Astro not deduplicating a client script shared by multiple `EsiInclude` instances):
+ * each element is claimed via `RESOLVED_ATTR` *synchronously*, before any `await`, so a second
+ * invocation racing the first sees the claim immediately rather than only after the first
+ * invocation's fetch settles.
  */
 export async function resolveEsiFragments(
   doc: EsiFragmentDocument,
-  fetchImpl: (url: string) => Promise<Response>
+  fetchImpl: (url: string, signal: AbortSignal) => Promise<Response>
 ): Promise<void> {
   const elements = Array.from(doc.querySelectorAll("esi\\:include"));
   await Promise.all(
     elements.map(async (el) => {
       if (el.hasAttribute(RESOLVED_ATTR)) return;
+      el.setAttribute(RESOLVED_ATTR, "true");
+
       const src = el.getAttribute("src");
-      if (!src) {
-        el.setAttribute(RESOLVED_ATTR, "true");
-        return;
-      }
+      if (!src) return;
       const onerror = el.getAttribute("onerror");
       const alt = el.getAttribute("alt");
 
@@ -42,17 +51,16 @@ export async function resolveEsiFragments(
         body = await fetchFragmentBody(alt, fetchImpl);
       }
       if (body !== null) el.innerHTML = body;
-      el.setAttribute(RESOLVED_ATTR, "true");
     })
   );
 }
 
 async function fetchFragmentBody(
   url: string,
-  fetchImpl: (url: string) => Promise<Response>
+  fetchImpl: (url: string, signal: AbortSignal) => Promise<Response>
 ): Promise<string | null> {
   try {
-    const res = await fetchImpl(url);
+    const res = await fetchImpl(url, AbortSignal.timeout(FETCH_TIMEOUT_MS));
     if (!res.ok) return null;
     return await res.text();
   } catch {

--- a/Resources/Template/src/components/esi/esi-dev-shim.ts
+++ b/Resources/Template/src/components/esi/esi-dev-shim.ts
@@ -1,0 +1,67 @@
+/** Structural subset of `Element` this module needs — lets tests pass a hand-rolled fake
+ *  instead of pulling in a DOM-emulation dependency this template toolchain doesn't otherwise use. */
+export interface EsiFragmentElement {
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): void;
+  hasAttribute(name: string): boolean;
+  innerHTML: string;
+}
+
+/** Structural subset of `Document` this module needs. */
+export interface EsiFragmentDocument {
+  querySelectorAll(selector: string): ArrayLike<EsiFragmentElement>;
+}
+
+const RESOLVED_ATTR = "data-esi-dev-resolved";
+
+/**
+ * Dev-preview approximation of `@dwk/esi`'s fragment resolution: fetches each unresolved
+ * `<esi:include>` element's `src`, applying the same onerror/alt rules the real processor uses
+ * (`docs/superpowers/specs/2026-07-13-esi-astro-component-design.md` §4), so local preview shows
+ * something close to what production will. Dev-only — never bundled into a production build
+ * (see `EsiInclude.astro`'s `{import.meta.env.DEV && (...)}` guard).
+ */
+export async function resolveEsiFragments(
+  doc: EsiFragmentDocument,
+  fetchImpl: (url: string) => Promise<Response>
+): Promise<void> {
+  const elements = Array.from(doc.querySelectorAll("esi\\:include"));
+  await Promise.all(
+    elements.map(async (el) => {
+      if (el.hasAttribute(RESOLVED_ATTR)) return;
+      const src = el.getAttribute("src");
+      if (!src) {
+        el.setAttribute(RESOLVED_ATTR, "true");
+        return;
+      }
+      const onerror = el.getAttribute("onerror");
+      const alt = el.getAttribute("alt");
+
+      let body = await fetchFragmentBody(src, fetchImpl);
+      if (body === null && onerror !== "continue" && alt) {
+        body = await fetchFragmentBody(alt, fetchImpl);
+      }
+      if (body !== null) el.innerHTML = body;
+      el.setAttribute(RESOLVED_ATTR, "true");
+    })
+  );
+}
+
+async function fetchFragmentBody(
+  url: string,
+  fetchImpl: (url: string) => Promise<Response>
+): Promise<string | null> {
+  try {
+    const res = await fetchImpl(url);
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+/** Reads the query-parameter toggle the app's Debug Pane Server section appends to the preview
+ *  URL when "Unprocessed" mode is selected (spec §4a). */
+export function esiPreviewIsUnprocessed(search: string): boolean {
+  return new URLSearchParams(search).get("esiPreview") === "unprocessed";
+}

--- a/Resources/Template/src/components/esi/esi-markup.test.ts
+++ b/Resources/Template/src/components/esi/esi-markup.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { escapeAttribute, buildEsiIncludeTag, buildEsiCommentTag } from "./esi-markup";
+
+test("escapeAttribute escapes & and \"", () => {
+  assert.equal(escapeAttribute(`a & b "c"`), `a &amp; b &quot;c&quot;`);
+});
+
+test("escapeAttribute leaves plain text untouched", () => {
+  assert.equal(escapeAttribute("/fragments/count"), "/fragments/count");
+});
+
+test("buildEsiIncludeTag: src only", () => {
+  assert.equal(
+    buildEsiIncludeTag({ src: "/fragments/count" }),
+    `<esi:include src="/fragments/count"></esi:include>`
+  );
+});
+
+test("buildEsiIncludeTag: src + alt + onerror", () => {
+  assert.equal(
+    buildEsiIncludeTag({ src: "/a", alt: "/b", onerror: "continue" }),
+    `<esi:include src="/a" alt="/b" onerror="continue"></esi:include>`
+  );
+});
+
+test("buildEsiIncludeTag: escapes quotes and ampersands in attribute values", () => {
+  assert.equal(
+    buildEsiIncludeTag({ src: '/a?x="y"&z=1' }),
+    `<esi:include src="/a?x=&quot;y&quot;&amp;z=1"></esi:include>`
+  );
+});
+
+test("buildEsiCommentTag", () => {
+  assert.equal(
+    buildEsiCommentTag(`hello & "world"`),
+    `<esi:comment text="hello &amp; &quot;world&quot;"/>`
+  );
+});

--- a/Resources/Template/src/components/esi/esi-markup.ts
+++ b/Resources/Template/src/components/esi/esi-markup.ts
@@ -1,0 +1,24 @@
+/** Escapes the two characters that matter inside a double-quoted HTML attribute value. */
+export function escapeAttribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+export interface EsiIncludeProps {
+  src: string;
+  alt?: string;
+  onerror?: "continue";
+}
+
+/** Builds the literal `<esi:include ...></esi:include>` tag `@dwk/esi`'s tokenizer expects. */
+export function buildEsiIncludeTag(props: EsiIncludeProps): string {
+  let tag = `<esi:include src="${escapeAttribute(props.src)}"`;
+  if (props.alt) tag += ` alt="${escapeAttribute(props.alt)}"`;
+  if (props.onerror) tag += ` onerror="${escapeAttribute(props.onerror)}"`;
+  tag += "></esi:include>";
+  return tag;
+}
+
+/** Builds the literal `<esi:comment text="…"/>` tag. */
+export function buildEsiCommentTag(text: string): string {
+  return `<esi:comment text="${escapeAttribute(text)}"/>`;
+}

--- a/Resources/Template/src/components/esi/esi-markup.ts
+++ b/Resources/Template/src/components/esi/esi-markup.ts
@@ -1,4 +1,14 @@
-/** Escapes the two characters that matter inside a double-quoted HTML attribute value. */
+/**
+ * Escapes the two characters that matter inside a double-quoted HTML attribute value — correct
+ * and sufficient for a browser parsing this as HTML.
+ *
+ * Forward-looking caveat: `@dwk/esi`'s edge-side tokenizer doesn't exist as code yet (the design
+ * this hinges on emitting exact literal bytes that tokenizer expects). If it ends up being a
+ * lightweight/regex-based parser rather than a full HTML parser, an unescaped `>` in `src`/`alt`
+ * (e.g. `src="/a>injected"`) could prematurely terminate the tag from that parser's point of view
+ * even though it's valid to a browser. Revisit once that tokenizer lands and its actual parsing
+ * behavior can be verified against.
+ */
 export function escapeAttribute(value: string): string {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
 }

--- a/Sources/AnglesiteApp/DebugPaneView.swift
+++ b/Sources/AnglesiteApp/DebugPaneView.swift
@@ -17,6 +17,7 @@ struct DebugPaneView: View {
     @State private var searchQuery: String = ""
     @State private var autoScroll: Bool = true
     @State private var subscriberTask: Task<Void, Never>?
+    @AppStorage(AppSettings.Key.esiPreviewUnprocessed) private var esiPreviewUnprocessed: Bool = false
 
     private static let allSourcesTag = "All"
     private let center: LogCenter
@@ -30,6 +31,10 @@ struct DebugPaneView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             toolbar
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            Divider()
+            serverSection
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
             Divider()
@@ -97,6 +102,23 @@ struct DebugPaneView: View {
             }
             Button("Copy") { copyVisibleToClipboard() }
             Button("Save…") { saveVisibleToFile() }
+        }
+    }
+
+    /// Production-behavior controls, distinct from the log-filtering toolbar above. ESI's
+    /// Live/Unprocessed toggle is the first control here — see
+    /// docs/superpowers/specs/2026-07-13-esi-astro-component-design.md §4a; broader controls
+    /// (running a composed Worker locally, viewing worker/analytics logs) are tracked in #699.
+    private var serverSection: some View {
+        HStack(spacing: 12) {
+            Text("Server").font(.headline)
+            Picker("ESI Fragments", selection: $esiPreviewUnprocessed) {
+                Text("Live").tag(false)
+                Text("Unprocessed (show fallbacks)").tag(true)
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 320)
+            Spacer()
         }
     }
 

--- a/Sources/AnglesiteApp/DebugPaneView.swift
+++ b/Sources/AnglesiteApp/DebugPaneView.swift
@@ -17,7 +17,7 @@ struct DebugPaneView: View {
     @State private var searchQuery: String = ""
     @State private var autoScroll: Bool = true
     @State private var subscriberTask: Task<Void, Never>?
-    @AppStorage(AppSettings.Key.esiPreviewUnprocessed) private var esiPreviewUnprocessed: Bool = false
+    @Bindable private var esiPreviewMode = EsiPreviewMode.shared
 
     private static let allSourcesTag = "All"
     private let center: LogCenter
@@ -112,7 +112,7 @@ struct DebugPaneView: View {
     private var serverSection: some View {
         HStack(spacing: 12) {
             Text("Server").font(.headline)
-            Picker("ESI Fragments", selection: $esiPreviewUnprocessed) {
+            Picker("ESI Fragments", selection: $esiPreviewMode.unprocessed) {
                 Text("Live").tag(false)
                 Text("Unprocessed (show fallbacks)").tag(true)
             }

--- a/Sources/AnglesiteApp/EsiPreviewMode.swift
+++ b/Sources/AnglesiteApp/EsiPreviewMode.swift
@@ -1,0 +1,31 @@
+import Observation
+import AnglesiteCore
+
+/// Observable wrapper around `AppSettings.esiPreviewUnprocessed` so a Debug Pane toggle flip
+/// actually propagates to open `SiteWindow`s via Swift's Observation tracking.
+///
+/// A plain `UserDefaults`/`@AppStorage` read inside `PreviewModel.displayURL` (an `@Observable`
+/// class) does not register as a tracked dependency — Observation only tracks reads of
+/// properties backed by its own tracking machinery — so `SiteWindow`'s body never re-evaluated
+/// on change and the toggle was inert (found in final review of
+/// docs/superpowers/specs/2026-07-13-esi-astro-component-design.md §4a). `DebugPaneView` (the
+/// writer) and `PreviewModel` (the reader) both reference this single shared instance directly
+/// instead, so a change genuinely propagates through Observation.
+@MainActor
+@Observable
+final class EsiPreviewMode {
+    static let shared = EsiPreviewMode()
+
+    /// Mirrors `AppSettings.shared.esiPreviewUnprocessed` for persistence across relaunches —
+    /// this property, not the underlying default, is what views should read/bind to.
+    var unprocessed: Bool {
+        didSet {
+            guard unprocessed != oldValue else { return }
+            AppSettings.shared.esiPreviewUnprocessed = unprocessed
+        }
+    }
+
+    private init() {
+        unprocessed = AppSettings.shared.esiPreviewUnprocessed
+    }
+}

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -312,7 +312,7 @@ final class PreviewModel {
     var displayURL: URL? {
         guard let base = readyURL else { return nil }
         let target = activeRoute.map { PreviewNavigation.targetURL(base: base, route: $0) } ?? base
-        return PreviewNavigation.applyingEsiPreviewMode(target, unprocessed: AppSettings.shared.esiPreviewUnprocessed)
+        return PreviewNavigation.applyingEsiPreviewMode(target, unprocessed: EsiPreviewMode.shared.unprocessed)
     }
 
     /// Open the Web Inspector for the live preview. No-ops when the weak `webView` is nil

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -307,10 +307,12 @@ final class PreviewModel {
 
     /// The URL the preview WKWebView should load: the active page route against the ready base
     /// URL, or the base URL itself when no route is active. `nil` until the runtime is `.ready`.
+    /// Also carries the Debug Pane's global ESI preview mode (spec §4a) as a query parameter, so
+    /// `EsiInclude`'s dev shim can read it.
     var displayURL: URL? {
         guard let base = readyURL else { return nil }
-        guard let route = activeRoute else { return base }
-        return PreviewNavigation.targetURL(base: base, route: route)
+        let target = activeRoute.map { PreviewNavigation.targetURL(base: base, route: $0) } ?? base
+        return PreviewNavigation.applyingEsiPreviewMode(target, unprocessed: AppSettings.shared.esiPreviewUnprocessed)
     }
 
     /// Open the Web Inspector for the live preview. No-ops when the weak `webView` is nil

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -19,6 +19,7 @@ public final class AppSettings: @unchecked Sendable {
         public static let lanRuntimePreviewPort = "anglesite.lanRuntimePreviewPort"
         public static let lanRuntimeMCPPort     = "anglesite.lanRuntimeMCPPort"
         public static let debugPaneEnabled   = "anglesite.debugPaneEnabled"
+        public static let esiPreviewUnprocessed = "anglesite.esiPreviewUnprocessed"
         public static let lastOpenedSiteID   = "anglesite.lastOpenedSiteID"
         public static let sitesRootBookmark  = "anglesite.sitesRootBookmark"
         public static let autoGenerateAltText = "anglesite.autoGenerateAltText"
@@ -127,6 +128,16 @@ public final class AppSettings: @unchecked Sendable {
     public var debugPaneEnabled: Bool {
         get { defaults.bool(forKey: Key.debugPaneEnabled) }
         set { defaults.set(newValue, forKey: Key.debugPaneEnabled) }
+    }
+
+    /// Forces local preview to skip `EsiInclude`'s dev-only fetch shim, so `EsiRemove`'s fallback
+    /// content can be previewed on demand instead of only by sabotaging the fragment URL
+    /// (docs/superpowers/specs/2026-07-13-esi-astro-component-design.md §4a). Global rather than
+    /// per-site: the Debug Pane this control lives in has no per-site scoping today. Defaults to
+    /// `false` (live/resolved preview, today's existing behavior).
+    public var esiPreviewUnprocessed: Bool {
+        get { defaults.bool(forKey: Key.esiPreviewUnprocessed) }
+        set { defaults.set(newValue, forKey: Key.esiPreviewUnprocessed) }
     }
 
     /// Security-scoped bookmark for the sites root, persisted so the sandboxed (MAS) build only

--- a/Sources/AnglesiteCore/PreviewNavigation.swift
+++ b/Sources/AnglesiteCore/PreviewNavigation.swift
@@ -20,4 +20,20 @@ public enum PreviewNavigation {
         comps.fragment = routeComps.fragment
         return comps.url ?? base
     }
+
+    /// Query-parameter key the app appends to force `EsiInclude`'s dev-preview shim into the
+    /// "unprocessed" state (spec §4a) — must match `esi-dev-shim.ts`'s `esiPreviewIsUnprocessed`.
+    public static let esiPreviewQueryKey = "esiPreview"
+    public static let esiPreviewUnprocessedValue = "unprocessed"
+
+    /// Appends (or replaces) the `esiPreview=unprocessed` query item on `url` when `unprocessed`
+    /// is `true`; returns `url` unchanged when `false`. Existing query items are preserved.
+    public static func applyingEsiPreviewMode(_ url: URL, unprocessed: Bool) -> URL {
+        guard unprocessed else { return url }
+        guard var comps = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        var items = (comps.queryItems ?? []).filter { $0.name != esiPreviewQueryKey }
+        items.append(URLQueryItem(name: esiPreviewQueryKey, value: esiPreviewUnprocessedValue))
+        comps.queryItems = items
+        return comps.url ?? url
+    }
 }

--- a/Tests/AnglesiteCoreTests/PreviewNavigationTests.swift
+++ b/Tests/AnglesiteCoreTests/PreviewNavigationTests.swift
@@ -48,4 +48,35 @@ struct PreviewNavigationTests {
         #expect(PreviewNavigation.targetURL(base: Self.base, route: "/about#top")
                 == URL(string: "http://localhost:4321/about#top")!)
     }
+
+    @Test("applyingEsiPreviewMode: unprocessed=false leaves the URL untouched")
+    func esiPreviewModeOffIsNoop() {
+        #expect(PreviewNavigation.applyingEsiPreviewMode(Self.base, unprocessed: false) == Self.base)
+    }
+
+    @Test("applyingEsiPreviewMode: unprocessed=true appends the query parameter")
+    func esiPreviewModeOnAppendsQuery() {
+        #expect(PreviewNavigation.applyingEsiPreviewMode(Self.base, unprocessed: true)
+                == URL(string: "http://localhost:4321/?esiPreview=unprocessed")!)
+    }
+
+    @Test("applyingEsiPreviewMode: preserves an existing query item")
+    func esiPreviewModePreservesExistingQuery() {
+        let withQuery = URL(string: "http://localhost:4321/about?preview=1")!
+        let result = PreviewNavigation.applyingEsiPreviewMode(withQuery, unprocessed: true)
+        let comps = URLComponents(url: result, resolvingAgainstBaseURL: false)!
+        let items = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value) })
+        #expect(items["preview"] == "1")
+        #expect(items["esiPreview"] == "unprocessed")
+    }
+
+    @Test("applyingEsiPreviewMode: replaces a stale esiPreview value rather than duplicating it")
+    func esiPreviewModeReplacesStaleValue() {
+        let stale = URL(string: "http://localhost:4321/?esiPreview=live")!
+        let result = PreviewNavigation.applyingEsiPreviewMode(stale, unprocessed: true)
+        let comps = URLComponents(url: result, resolvingAgainstBaseURL: false)!
+        let matches = (comps.queryItems ?? []).filter { $0.name == "esiPreview" }
+        #expect(matches.count == 1)
+        #expect(matches.first?.value == "unprocessed")
+    }
 }

--- a/docs/superpowers/plans/2026-07-13-esi-astro-component.md
+++ b/docs/superpowers/plans/2026-07-13-esi-astro-component.md
@@ -1,0 +1,783 @@
+# ESI Astro Components + Local Fallback Preview — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship three Astro template components (`EsiInclude`, `EsiComment`, `EsiRemove`) that let a site owner author Edge Side Includes markup, plus a global Live/Unprocessed preview toggle in the app's Debug Pane so the fallback state can be previewed on demand.
+
+**Architecture:** Three `.astro` components under `Resources/Template/src/components/esi/` build their literal `esi:*` markup via `<Fragment set:html={...}>` from small, unit-tested pure TS helpers (`esi-markup.ts`), sidestepping any risk in Astro's compiler handling colon-containing tag names. `EsiInclude` also carries a dev-only client-side fetch shim (`esi-dev-shim.ts`) that approximates edge resolution in local preview. A new global `AppSettings` key drives a Live/Unprocessed picker in the existing Debug Pane; `PreviewNavigation` (already `AnglesiteCore`-pure and unit-tested) grows one function to translate that setting into a query parameter on the preview URL, which the dev shim reads to skip its fetch when in Unprocessed mode.
+
+**Tech Stack:** Astro 6 (`.astro` components, template-level conditionals), plain TypeScript (`node:test` + `tsx`, this repo's existing template-test convention — no vitest/jsdom in this part of the codebase), Swift 6 / SwiftUI (`AnglesiteCore` pure logic + `AppSettings`/`UserDefaults`, `AnglesiteApp` SwiftUI view), Swift Testing for the Swift-side test.
+
+## Global Constraints
+
+- Every new `SiteSettings`-style field must stay optional — **not applicable here**: this plan does not touch `SiteConfigStore`/`SiteSettings` (see spec §4a's correction — the toggle is global via `AppSettings`, not per-site).
+- Template `.test.ts` files run via `cd Resources/Template && npx tsx --test <file>.test.ts` — this repo's established convention (no vitest/jsdom for template code); match it exactly, do not introduce a new template test runner.
+- New `AnglesiteCore` logic must stay platform-pure and unit-tested there; `AnglesiteApp`-target SwiftUI view code has no CI coverage in this repo today (per CLAUDE.md) — don't invent a test harness for `DebugPaneView` that doesn't already exist.
+- `esi:include`/`esi:comment`/`esi:remove` markup must be emitted via `set:html` with hand-escaped attribute values, never via literal `<esi:include src={src} />` template syntax (spec §3 — unverified compiler round-trip risk for colon tag names).
+- No Component Editor Swift code in this plan — `EsiRemove`'s `<slot />` and the other two components' props are picked up for free once #493/#494 ship; the refinement comments those two issues needed were already posted during brainstorming (not implementation work).
+- **Task ordering note:** `esi-dev-shim.ts` (Task 2) must exist before the three components (Task 3), because `EsiInclude.astro` imports from it — and the build-fixture spike (Task 4) runs a real `astro build`, which would fail on a missing module if the shim didn't exist yet. Do not reorder Tasks 2–4.
+
+---
+
+## Task 1: `esi-markup.ts` — pure ESI tag-string builders
+
+**Files:**
+- Create: `Resources/Template/src/components/esi/esi-markup.ts`
+- Create: `Resources/Template/src/components/esi/esi-markup.test.ts`
+
+**Interfaces:**
+- Produces: `escapeAttribute(value: string): string`, `buildEsiIncludeTag(props: { src: string; alt?: string; onerror?: "continue" }): string`, `buildEsiCommentTag(text: string): string` — consumed by Task 3's `.astro` components.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// Resources/Template/src/components/esi/esi-markup.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { escapeAttribute, buildEsiIncludeTag, buildEsiCommentTag } from "./esi-markup";
+
+test("escapeAttribute escapes & and \"", () => {
+  assert.equal(escapeAttribute(`a & b "c"`), `a &amp; b &quot;c&quot;`);
+});
+
+test("escapeAttribute leaves plain text untouched", () => {
+  assert.equal(escapeAttribute("/fragments/count"), "/fragments/count");
+});
+
+test("buildEsiIncludeTag: src only", () => {
+  assert.equal(
+    buildEsiIncludeTag({ src: "/fragments/count" }),
+    `<esi:include src="/fragments/count"></esi:include>`
+  );
+});
+
+test("buildEsiIncludeTag: src + alt + onerror", () => {
+  assert.equal(
+    buildEsiIncludeTag({ src: "/a", alt: "/b", onerror: "continue" }),
+    `<esi:include src="/a" alt="/b" onerror="continue"></esi:include>`
+  );
+});
+
+test("buildEsiIncludeTag: escapes quotes and ampersands in attribute values", () => {
+  assert.equal(
+    buildEsiIncludeTag({ src: '/a?x="y"&z=1' }),
+    `<esi:include src="/a?x=&quot;y&quot;&amp;z=1"></esi:include>`
+  );
+});
+
+test("buildEsiCommentTag", () => {
+  assert.equal(
+    buildEsiCommentTag(`hello & "world"`),
+    `<esi:comment text="hello &amp; &quot;world&quot;"/>`
+  );
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd Resources/Template && npx tsx --test src/components/esi/esi-markup.test.ts`
+Expected: FAIL — `Cannot find module './esi-markup'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```ts
+// Resources/Template/src/components/esi/esi-markup.ts
+
+/** Escapes the two characters that matter inside a double-quoted HTML attribute value. */
+export function escapeAttribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+export interface EsiIncludeProps {
+  src: string;
+  alt?: string;
+  onerror?: "continue";
+}
+
+/** Builds the literal `<esi:include ...></esi:include>` tag `@dwk/esi`'s tokenizer expects. */
+export function buildEsiIncludeTag(props: EsiIncludeProps): string {
+  let tag = `<esi:include src="${escapeAttribute(props.src)}"`;
+  if (props.alt) tag += ` alt="${escapeAttribute(props.alt)}"`;
+  if (props.onerror) tag += ` onerror="${escapeAttribute(props.onerror)}"`;
+  tag += "></esi:include>";
+  return tag;
+}
+
+/** Builds the literal `<esi:comment text="…"/>` tag. */
+export function buildEsiCommentTag(text: string): string {
+  return `<esi:comment text="${escapeAttribute(text)}"/>`;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd Resources/Template && npx tsx --test src/components/esi/esi-markup.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Resources/Template/src/components/esi/esi-markup.ts Resources/Template/src/components/esi/esi-markup.test.ts
+git commit -m "feat(template): add ESI tag-string builders"
+```
+
+---
+
+## Task 2: `esi-dev-shim.ts` — dev-preview fetch logic
+
+Written before the components (Task 3) because `EsiInclude.astro` imports from this module — see the Global Constraints ordering note.
+
+**Files:**
+- Create: `Resources/Template/src/components/esi/esi-dev-shim.ts`
+- Create: `Resources/Template/src/components/esi/esi-dev-shim.test.ts`
+
+**Interfaces:**
+- Produces: `resolveEsiFragments(doc: EsiFragmentDocument, fetchImpl: (url: string) => Promise<Response>): Promise<void>`, `esiPreviewIsUnprocessed(search: string): boolean` — both imported by `EsiInclude.astro` (Task 3).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// Resources/Template/src/components/esi/esi-dev-shim.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveEsiFragments, esiPreviewIsUnprocessed, type EsiFragmentElement, type EsiFragmentDocument } from "./esi-dev-shim";
+
+function makeElement(attrs: Record<string, string>): EsiFragmentElement & { innerHTML: string } {
+  const attributes = { ...attrs };
+  return {
+    getAttribute: (name) => attributes[name] ?? null,
+    setAttribute: (name, value) => { attributes[name] = value; },
+    hasAttribute: (name) => name in attributes,
+    innerHTML: "",
+  };
+}
+
+test("resolveEsiFragments: fetches src and fills innerHTML on success", async () => {
+  const el = makeElement({ src: "/fragments/count" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  await resolveEsiFragments(doc, async () => new Response("42", { status: 200 }));
+  assert.equal(el.innerHTML, "42");
+  assert.equal(el.hasAttribute("data-esi-dev-resolved"), true);
+});
+
+test("resolveEsiFragments: falls back to alt once when src fails and no onerror is set", async () => {
+  const el = makeElement({ src: "/fragments/count", alt: "/fragments/fallback" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  await resolveEsiFragments(doc, async (url) =>
+    url === "/fragments/count" ? new Response("", { status: 500 }) : new Response("fallback-text", { status: 200 })
+  );
+  assert.equal(el.innerHTML, "fallback-text");
+});
+
+test("resolveEsiFragments: onerror=continue drops silently, never tries alt", async () => {
+  const el = makeElement({ src: "/fragments/count", alt: "/fragments/fallback", onerror: "continue" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  let altCalled = false;
+  await resolveEsiFragments(doc, async (url) => {
+    if (url === "/fragments/fallback") altCalled = true;
+    return new Response("", { status: 500 });
+  });
+  assert.equal(el.innerHTML, "");
+  assert.equal(altCalled, false);
+});
+
+test("resolveEsiFragments: no alt and src fails leaves the element empty", async () => {
+  const el = makeElement({ src: "/fragments/count" });
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  await resolveEsiFragments(doc, async () => new Response("", { status: 500 }));
+  assert.equal(el.innerHTML, "");
+  assert.equal(el.hasAttribute("data-esi-dev-resolved"), true);
+});
+
+test("resolveEsiFragments: skips elements already marked resolved", async () => {
+  const el = makeElement({ src: "/fragments/count", "data-esi-dev-resolved": "true" });
+  el.innerHTML = "cached";
+  const doc: EsiFragmentDocument = { querySelectorAll: () => [el] };
+  let called = false;
+  await resolveEsiFragments(doc, async () => {
+    called = true;
+    return new Response("42");
+  });
+  assert.equal(called, false);
+  assert.equal(el.innerHTML, "cached");
+});
+
+test("esiPreviewIsUnprocessed: true only for ?esiPreview=unprocessed", () => {
+  assert.equal(esiPreviewIsUnprocessed("?esiPreview=unprocessed"), true);
+  assert.equal(esiPreviewIsUnprocessed(""), false);
+  assert.equal(esiPreviewIsUnprocessed("?esiPreview=live"), false);
+  assert.equal(esiPreviewIsUnprocessed("?other=1&esiPreview=unprocessed"), true);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd Resources/Template && npx tsx --test src/components/esi/esi-dev-shim.test.ts`
+Expected: FAIL — `Cannot find module './esi-dev-shim'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```ts
+// Resources/Template/src/components/esi/esi-dev-shim.ts
+
+/** Structural subset of `Element` this module needs — lets tests pass a hand-rolled fake
+ *  instead of pulling in a DOM-emulation dependency this template toolchain doesn't otherwise use. */
+export interface EsiFragmentElement {
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): void;
+  hasAttribute(name: string): boolean;
+  innerHTML: string;
+}
+
+/** Structural subset of `Document` this module needs. */
+export interface EsiFragmentDocument {
+  querySelectorAll(selector: string): ArrayLike<EsiFragmentElement>;
+}
+
+const RESOLVED_ATTR = "data-esi-dev-resolved";
+
+/**
+ * Dev-preview approximation of `@dwk/esi`'s fragment resolution: fetches each unresolved
+ * `<esi:include>` element's `src`, applying the same onerror/alt rules the real processor uses
+ * (`docs/superpowers/specs/2026-07-13-esi-astro-component-design.md` §4), so local preview shows
+ * something close to what production will. Dev-only — never bundled into a production build
+ * (see `EsiInclude.astro`'s `{import.meta.env.DEV && (...)}` guard).
+ */
+export async function resolveEsiFragments(
+  doc: EsiFragmentDocument,
+  fetchImpl: (url: string) => Promise<Response>
+): Promise<void> {
+  const elements = Array.from(doc.querySelectorAll("esi\\:include"));
+  await Promise.all(
+    elements.map(async (el) => {
+      if (el.hasAttribute(RESOLVED_ATTR)) return;
+      const src = el.getAttribute("src");
+      if (!src) {
+        el.setAttribute(RESOLVED_ATTR, "true");
+        return;
+      }
+      const onerror = el.getAttribute("onerror");
+      const alt = el.getAttribute("alt");
+
+      let body = await fetchFragmentBody(src, fetchImpl);
+      if (body === null && onerror !== "continue" && alt) {
+        body = await fetchFragmentBody(alt, fetchImpl);
+      }
+      if (body !== null) el.innerHTML = body;
+      el.setAttribute(RESOLVED_ATTR, "true");
+    })
+  );
+}
+
+async function fetchFragmentBody(
+  url: string,
+  fetchImpl: (url: string) => Promise<Response>
+): Promise<string | null> {
+  try {
+    const res = await fetchImpl(url);
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+/** Reads the query-parameter toggle the app's Debug Pane Server section appends to the preview
+ *  URL when "Unprocessed" mode is selected (spec §4a). */
+export function esiPreviewIsUnprocessed(search: string): boolean {
+  return new URLSearchParams(search).get("esiPreview") === "unprocessed";
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd Resources/Template && npx tsx --test src/components/esi/esi-dev-shim.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Resources/Template/src/components/esi/esi-dev-shim.ts Resources/Template/src/components/esi/esi-dev-shim.test.ts
+git commit -m "feat(template): add EsiInclude dev-preview fetch shim"
+```
+
+---
+
+## Task 3: The three ESI components
+
+**Files:**
+- Create: `Resources/Template/src/components/esi/EsiInclude.astro`
+- Create: `Resources/Template/src/components/esi/EsiComment.astro`
+- Create: `Resources/Template/src/components/esi/EsiRemove.astro`
+
+**Interfaces:**
+- Consumes: `buildEsiIncludeTag`, `buildEsiCommentTag` (Task 1); `resolveEsiFragments`, `esiPreviewIsUnprocessed` (Task 2).
+- Produces: three importable Astro components, exercised by Task 4's build-fixture spike.
+
+- [ ] **Step 1: Write `EsiComment.astro`** (simplest — no children, no dev shim)
+
+```astro
+---
+import { buildEsiCommentTag } from "./esi-markup";
+
+export interface Props {
+  /** Authoring note dropped by the `@dwk/esi` processor — never reaches a client, in dev or prod. */
+  text: string;
+}
+
+const { text } = Astro.props;
+const tag = buildEsiCommentTag(text);
+---
+<Fragment set:html={tag} />
+```
+
+- [ ] **Step 2: Write `EsiRemove.astro`** (children via `<slot />`, no props)
+
+```astro
+---
+---
+{/* Fallback markup shown only when nothing ESI-aware processes this page — see EsiInclude's
+    doc comment for the idiomatic EsiInclude/EsiRemove sibling pairing. */}
+<Fragment set:html="<esi:remove>" />
+<slot />
+<Fragment set:html="</esi:remove>" />
+```
+
+- [ ] **Step 3: Write `EsiInclude.astro`**
+
+```astro
+---
+import { buildEsiIncludeTag } from "./esi-markup";
+
+export interface Props {
+  /**
+   * URL to fetch and splice in place of this tag at the edge. Routed through `@dwk/esi`'s
+   * safeFetch-backed resolver in production, so an attacker- or user-supplied URL is safe here.
+   * In local dev preview, fetched client-side instead — a cross-origin `src` needs that origin's
+   * own CORS headers to resolve in preview (production has no such restriction). Pair with
+   * `EsiRemove` for fallback markup shown when nothing ESI-aware processes this page:
+   *
+   * ```astro
+   * <EsiInclude src="/fragments/count" onerror="continue" />
+   * <EsiRemove><span class="count-fallback">—</span></EsiRemove>
+   * ```
+   */
+  src: string;
+  /** Fallback URL retried once if `src` fails (only when `onerror` is unset). */
+  alt?: string;
+  /** `"continue"`: drop this fragment silently on failure instead of retrying `alt`. */
+  onerror?: "continue";
+}
+
+const { src, alt, onerror } = Astro.props;
+const tag = buildEsiIncludeTag({ src, alt, onerror });
+---
+<Fragment set:html={tag} />
+{import.meta.env.DEV && (
+  <script>
+    import { resolveEsiFragments, esiPreviewIsUnprocessed } from "./esi-dev-shim";
+    if (!esiPreviewIsUnprocessed(location.search)) {
+      resolveEsiFragments(document, (url) => fetch(url));
+    }
+  </script>
+)}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Resources/Template/src/components/esi/EsiInclude.astro Resources/Template/src/components/esi/EsiComment.astro Resources/Template/src/components/esi/EsiRemove.astro
+git commit -m "feat(template): add EsiInclude/EsiComment/EsiRemove components"
+```
+
+---
+
+## Task 4: Astro build fixture test — the empirical spike
+
+This is the empirical check the design doc calls out (spec §3/§7): confirm Astro's static build emits the `set:html`-injected literal `esi:*` markup byte-for-byte unchanged, and that the dev-only shim script is entirely absent from a production build's output. No existing test in this repo runs a real `astro build` (checked: no CI job or npm script does this for `Resources/Template`) — this is new, heavier ground, expected to take **30–90 seconds** (a real `npm install` + `astro build` in a temp directory) and needs network access for the install. It is not wired into CI (matching the existing, unwired state of every other `Resources/Template/**/*.test.ts` file in this repo) — run it manually during this task and again before opening the PR.
+
+This is the gate before starting the Swift-side tasks (5–8): if the literal-markup assertions fail here, stop and reconsider the `set:html` approach (spec §3) rather than continuing to build on it.
+
+**Files:**
+- Create: `Resources/Template/src/components/esi/esi-components.build.test.ts`
+
+**Interfaces:**
+- Consumes: the three components (Task 3), which in turn pull in Task 1 and Task 2's modules.
+- Produces: nothing consumed by later tasks — this is a standalone validation gate.
+
+- [ ] **Step 1: Write the test**
+
+```ts
+// Resources/Template/src/components/esi/esi-components.build.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, cp, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+// Resources/Template/ — three `..` up from src/components/esi/
+const TEMPLATE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+const EXCLUDED = /(^|\/)(node_modules|dist|\.astro|\.wrangler)(\/|$)/;
+
+test("EsiInclude/EsiComment/EsiRemove survive an astro build byte-for-byte", async () => {
+  const fixtureDir = await mkdtemp(join(tmpdir(), "anglesite-esi-fixture-"));
+  try {
+    await cp(TEMPLATE_ROOT, fixtureDir, {
+      recursive: true,
+      filter: (src) => !EXCLUDED.test(src.slice(TEMPLATE_ROOT.length)),
+    });
+
+    const fixturePage = `---
+import EsiInclude from "../components/esi/EsiInclude.astro";
+import EsiComment from "../components/esi/EsiComment.astro";
+import EsiRemove from "../components/esi/EsiRemove.astro";
+---
+<EsiInclude src="/fragments/count" alt="/fragments/count-fallback" onerror="continue" />
+<EsiComment text="build fixture" />
+<EsiRemove><span class="fallback">—</span></EsiRemove>
+`;
+    await writeFile(join(fixtureDir, "src/pages/esi-build-fixture.astro"), fixturePage, "utf8");
+
+    execFileSync("npm", ["install", "--no-audit", "--no-fund", "--prefer-offline"], {
+      cwd: fixtureDir,
+      stdio: "inherit",
+    });
+    execFileSync("npx", ["astro", "build"], { cwd: fixtureDir, stdio: "inherit" });
+
+    const html = await readFile(join(fixtureDir, "dist/esi-build-fixture/index.html"), "utf8");
+
+    assert.match(
+      html,
+      /<esi:include src="\/fragments\/count" alt="\/fragments\/count-fallback" onerror="continue"><\/esi:include>/
+    );
+    assert.match(html, /<esi:comment text="build fixture"\/>/);
+    assert.match(html, /<esi:remove><span class="fallback">—<\/span><\/esi:remove>/);
+
+    // The dev-only fetch shim must not ship to production at all — not just be inert.
+    assert.ok(!html.includes("resolveEsiFragments"), "dev shim script leaked into production build");
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd Resources/Template && npx tsx --test src/components/esi/esi-components.build.test.ts`
+Expected: PASS after ~30-90s. If it fails specifically on the `<esi:include>`/`<esi:comment>`/`<esi:remove>` assertions (not a build/install error), that's the spec §3 risk materializing — stop and re-open the design, do not patch around it here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Resources/Template/src/components/esi/esi-components.build.test.ts
+git commit -m "test(template): verify ESI markup survives a real astro build"
+```
+
+---
+
+## Task 5: `AppSettings` — global ESI preview mode key
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/AppSettings.swift`
+
+**Interfaces:**
+- Produces: `AppSettings.Key.esiPreviewUnprocessed: String`, `AppSettings.esiPreviewUnprocessed: Bool` (get/set) — consumed by Task 7 (`PreviewModel`) and Task 8 (`DebugPaneView`).
+
+- [ ] **Step 1: Add the key**
+
+In `Sources/AnglesiteCore/AppSettings.swift`, inside `public enum Key`, add directly below the existing `debugPaneEnabled` line (`Sources/AnglesiteCore/AppSettings.swift:21`):
+
+```swift
+        public static let esiPreviewUnprocessed = "anglesite.esiPreviewUnprocessed"
+```
+
+- [ ] **Step 2: Add the computed property**
+
+Directly below the existing `debugPaneEnabled` computed property (`Sources/AnglesiteCore/AppSettings.swift:127-130`), add:
+
+```swift
+    /// Forces local preview to skip `EsiInclude`'s dev-only fetch shim, so `EsiRemove`'s fallback
+    /// content can be previewed on demand instead of only by sabotaging the fragment URL
+    /// (docs/superpowers/specs/2026-07-13-esi-astro-component-design.md §4a). Global rather than
+    /// per-site: the Debug Pane this control lives in has no per-site scoping today. Defaults to
+    /// `false` (live/resolved preview, today's existing behavior).
+    public var esiPreviewUnprocessed: Bool {
+        get { defaults.bool(forKey: Key.esiPreviewUnprocessed) }
+        set { defaults.set(newValue, forKey: Key.esiPreviewUnprocessed) }
+    }
+```
+
+- [ ] **Step 3: Build**
+
+Run: `swift build --target AnglesiteCore`
+Expected: builds cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteCore/AppSettings.swift
+git commit -m "feat(core): add global ESI preview mode setting"
+```
+
+---
+
+## Task 6: `PreviewNavigation.applyingEsiPreviewMode`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/PreviewNavigation.swift`
+- Modify: `Tests/AnglesiteCoreTests/PreviewNavigationTests.swift`
+
+**Interfaces:**
+- Consumes: nothing new (pure `URL`/`Bool` in, `URL` out).
+- Produces: `PreviewNavigation.applyingEsiPreviewMode(_ url: URL, unprocessed: Bool) -> URL` — consumed by Task 7 (`PreviewModel.displayURL`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/AnglesiteCoreTests/PreviewNavigationTests.swift`, inside `struct PreviewNavigationTests`:
+
+```swift
+    @Test("applyingEsiPreviewMode: unprocessed=false leaves the URL untouched")
+    func esiPreviewModeOffIsNoop() {
+        #expect(PreviewNavigation.applyingEsiPreviewMode(Self.base, unprocessed: false) == Self.base)
+    }
+
+    @Test("applyingEsiPreviewMode: unprocessed=true appends the query parameter")
+    func esiPreviewModeOnAppendsQuery() {
+        #expect(PreviewNavigation.applyingEsiPreviewMode(Self.base, unprocessed: true)
+                == URL(string: "http://localhost:4321/?esiPreview=unprocessed")!)
+    }
+
+    @Test("applyingEsiPreviewMode: preserves an existing query item")
+    func esiPreviewModePreservesExistingQuery() {
+        let withQuery = URL(string: "http://localhost:4321/about?preview=1")!
+        let result = PreviewNavigation.applyingEsiPreviewMode(withQuery, unprocessed: true)
+        let comps = URLComponents(url: result, resolvingAgainstBaseURL: false)!
+        let items = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value) })
+        #expect(items["preview"] == "1")
+        #expect(items["esiPreview"] == "unprocessed")
+    }
+
+    @Test("applyingEsiPreviewMode: replaces a stale esiPreview value rather than duplicating it")
+    func esiPreviewModeReplacesStaleValue() {
+        let stale = URL(string: "http://localhost:4321/?esiPreview=live")!
+        let result = PreviewNavigation.applyingEsiPreviewMode(stale, unprocessed: true)
+        let comps = URLComponents(url: result, resolvingAgainstBaseURL: false)!
+        let matches = (comps.queryItems ?? []).filter { $0.name == "esiPreview" }
+        #expect(matches.count == 1)
+        #expect(matches.first?.value == "unprocessed")
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --filter PreviewNavigationTests`
+Expected: FAIL to compile — `applyingEsiPreviewMode` doesn't exist yet.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `Sources/AnglesiteCore/PreviewNavigation.swift`, inside `public enum PreviewNavigation`, add:
+
+```swift
+    /// Query-parameter key the app appends to force `EsiInclude`'s dev-preview shim into the
+    /// "unprocessed" state (spec §4a) — must match `esi-dev-shim.ts`'s `esiPreviewIsUnprocessed`.
+    public static let esiPreviewQueryKey = "esiPreview"
+    public static let esiPreviewUnprocessedValue = "unprocessed"
+
+    /// Appends (or replaces) the `esiPreview=unprocessed` query item on `url` when `unprocessed`
+    /// is `true`; returns `url` unchanged when `false`. Existing query items are preserved.
+    public static func applyingEsiPreviewMode(_ url: URL, unprocessed: Bool) -> URL {
+        guard unprocessed else { return url }
+        guard var comps = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        var items = (comps.queryItems ?? []).filter { $0.name != esiPreviewQueryKey }
+        items.append(URLQueryItem(name: esiPreviewQueryKey, value: esiPreviewUnprocessedValue))
+        comps.queryItems = items
+        return comps.url ?? url
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --filter PreviewNavigationTests`
+Expected: PASS (all `PreviewNavigationTests` cases, including the 4 new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/PreviewNavigation.swift Tests/AnglesiteCoreTests/PreviewNavigationTests.swift
+git commit -m "feat(core): add PreviewNavigation.applyingEsiPreviewMode"
+```
+
+---
+
+## Task 7: Wire the setting into `PreviewModel.displayURL`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/PreviewModel.swift:308-314`
+
+**Interfaces:**
+- Consumes: `AppSettings.shared.esiPreviewUnprocessed` (Task 5), `PreviewNavigation.applyingEsiPreviewMode` (Task 6).
+- Produces: no change to `displayURL`'s public signature (`URL?`) — callers (`PreviewView` via `SiteWindow`) need no changes.
+
+- [ ] **Step 1: Edit `displayURL`**
+
+Replace (`Sources/AnglesiteApp/PreviewModel.swift:308-314`):
+
+```swift
+    /// The URL the preview WKWebView should load: the active page route against the ready base
+    /// URL, or the base URL itself when no route is active. `nil` until the runtime is `.ready`.
+    var displayURL: URL? {
+        guard let base = readyURL else { return nil }
+        guard let route = activeRoute else { return base }
+        return PreviewNavigation.targetURL(base: base, route: route)
+    }
+```
+
+with:
+
+```swift
+    /// The URL the preview WKWebView should load: the active page route against the ready base
+    /// URL, or the base URL itself when no route is active. `nil` until the runtime is `.ready`.
+    /// Also carries the Debug Pane's global ESI preview mode (spec §4a) as a query parameter, so
+    /// `EsiInclude`'s dev shim can read it.
+    var displayURL: URL? {
+        guard let base = readyURL else { return nil }
+        let target = activeRoute.map { PreviewNavigation.targetURL(base: base, route: $0) } ?? base
+        return PreviewNavigation.applyingEsiPreviewMode(target, unprocessed: AppSettings.shared.esiPreviewUnprocessed)
+    }
+```
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+
+(Run `xcodegen generate` first if `Anglesite.xcodeproj` is missing or stale in this worktree.)
+
+Expected: builds cleanly. (No dedicated test — `AnglesiteApp`-target code, consistent with this repo's existing lack of hosted-app-target CI coverage; the logic it delegates to is already tested in Task 6.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/PreviewModel.swift
+git commit -m "feat(app): apply ESI preview mode to the preview URL"
+```
+
+---
+
+## Task 8: Debug Pane "Server" section
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DebugPaneView.swift`
+
+**Interfaces:**
+- Consumes: `AppSettings.Key.esiPreviewUnprocessed` (Task 5) via `@AppStorage`, matching the existing pattern in `Sources/AnglesiteApp/SettingsView.swift:63`.
+- Produces: no new public API — purely additive UI.
+
+- [ ] **Step 1: Add the `@AppStorage` property**
+
+In `Sources/AnglesiteApp/DebugPaneView.swift`, add to the top of `struct DebugPaneView` (alongside the existing `@State` properties, `DebugPaneView.swift:12-19`):
+
+```swift
+    @AppStorage(AppSettings.Key.esiPreviewUnprocessed) private var esiPreviewUnprocessed: Bool = false
+```
+
+- [ ] **Step 2: Add the "Server" section to `body`**
+
+Replace (`Sources/AnglesiteApp/DebugPaneView.swift:30-34`):
+
+```swift
+        VStack(alignment: .leading, spacing: 0) {
+            toolbar
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            Divider()
+```
+
+with:
+
+```swift
+        VStack(alignment: .leading, spacing: 0) {
+            toolbar
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            Divider()
+            serverSection
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            Divider()
+```
+
+- [ ] **Step 3: Add the `serverSection` view**
+
+Directly below the existing `toolbar` computed property (after `Sources/AnglesiteApp/DebugPaneView.swift:101`, i.e. right after the closing `}` of `private var toolbar: some View { ... }`), add:
+
+```swift
+    /// Production-behavior controls, distinct from the log-filtering toolbar above. ESI's
+    /// Live/Unprocessed toggle is the first control here — see
+    /// docs/superpowers/specs/2026-07-13-esi-astro-component-design.md §4a; broader controls
+    /// (running a composed Worker locally, viewing worker/analytics logs) are tracked in #699.
+    private var serverSection: some View {
+        HStack(spacing: 12) {
+            Text("Server").font(.headline)
+            Picker("ESI Fragments", selection: $esiPreviewUnprocessed) {
+                Text("Live").tag(false)
+                Text("Unprocessed (show fallbacks)").tag(true)
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 320)
+            Spacer()
+        }
+    }
+```
+
+- [ ] **Step 4: Manual verification**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`, then launch the app, open a site, open the Debug Pane (View menu → Show Debug Pane, ⌥⌘D), and confirm the new "Server" row appears between the existing toolbar and the log list, with a working Live/Unprocessed segmented control.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DebugPaneView.swift
+git commit -m "feat(app): add ESI Live/Unprocessed control to the Debug Pane"
+```
+
+---
+
+## Task 9: Final verification pass
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Re-run every new/changed test**
+
+```bash
+cd Resources/Template && npx tsx --test src/components/esi/esi-markup.test.ts src/components/esi/esi-dev-shim.test.ts
+cd Resources/Template && npx tsx --test src/components/esi/esi-components.build.test.ts
+```
+
+Then, from the repo root:
+
+```bash
+swift test --filter PreviewNavigationTests
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Full Swift test suite (per this repo's template-change guard)**
+
+Run: `swift test --package-path .`
+Expected: PASS — in particular, confirm `IntegrationTemplateAssetsTests` and `BlogTemplateAssetsTests` still pass (memory note: template changes can trip these guards; the new `src/components/esi/` files aren't in either test's on-demand/staged-asset lists, so no update to those tests is expected, but re-run to be sure).
+
+- [ ] **Step 3: Manual GUI smoke**
+
+Open the app against a real or fixture site (e.g. `~/Sites/anglesite-smoke` via `scripts/create-smoke-fixture.sh` if not already present), add `<EsiInclude src="/some/path" onerror="continue" /><EsiRemove><span>fallback</span></EsiRemove>` to a page, confirm: (a) in Live mode the dev shim attempts a fetch (visible in the Debug Pane's log or Safari Web Inspector's Network tab), (b) toggling the Debug Pane to Unprocessed and reloading the preview shows the `EsiRemove` fallback content instead.
+
+- [ ] **Step 4: Confirm no unintended diffs**
+
+```bash
+git status --short
+git log --oneline -10
+```
+
+Expected: only the commits from Tasks 1–8, clean working tree.

--- a/docs/superpowers/specs/2026-07-13-esi-astro-component-design.md
+++ b/docs/superpowers/specs/2026-07-13-esi-astro-component-design.md
@@ -136,7 +136,44 @@ browser, so a cross-origin `src` needs that origin's own CORS headers to resolve
 in preview — the production edge Worker fetch has no such restriction, since
 `safeFetch` runs server-side. Worth a one-line note in `EsiInclude`'s doc comment
 so a site owner isn't confused why a fragment resolves in production but shows
-empty in dev preview.
+empty in dev preview. (A real local Worker execution path would sidestep this
+entirely — see §4a for why that's out of scope here.)
+
+## 4a. Forcing the unprocessed/fallback state
+
+The dev shim in §4 only ever shows the *live* state (fetch succeeds, or the
+`onerror`/`alt` rules kick in on failure) — there's no way to deliberately preview
+what `EsiRemove`'s fallback content looks like without actually breaking the
+fragment URL. A site owner needs to preview that state on purpose, not by
+sabotaging their own config.
+
+**v1 control:** the existing Debug Pane
+([`DebugPaneView.swift`](../../../Sources/AnglesiteApp/DebugPaneView.swift),
+backed by [`LogCenter.swift`](../../../Sources/AnglesiteCore/LogCenter.swift))
+gains a new "Server" section with one control: **ESI Fragments: Live |
+Unprocessed (show fallbacks)**. This reuses the existing debug window rather than
+introducing a new one, and is deliberately the seed of a broader server debug
+panel — see the follow-up issue in §8.
+
+- **Live** (default): today's §4 behavior, unchanged.
+- **Unprocessed:** the dev shim's step 3 (§4) is skipped entirely — no fetch is
+  attempted, `EsiInclude` renders empty exactly as it would to a browser with no
+  ESI-aware layer in front, and `EsiRemove`'s slotted content is what's visible.
+  This exactly matches the real "unprocessed" case from §3, just forced on demand
+  instead of depending on the fragment URL actually being unreachable.
+
+The setting is stored per-site (`SiteConfigStore` / `Config/settings.plist`, app-
+owned state, never in git per this repo's package model) and reaches the running
+page as a query parameter the app appends when it loads the preview URL into the
+WKWebView (e.g. `?esiPreview=unprocessed`); the dev shim script reads
+`location.search` before deciding whether to run its fetch step at all.
+
+**Explicitly not v1:** actually running the composed Worker (and so `@dwk/esi`
+itself) locally to get real server-side resolution without the dev shim's CORS
+limitation. That's a genuinely new runtime capability — nothing in the local
+container runtime executes `worker/worker.ts` today, it's a production-deploy
+artifact (`#353`, closed) with no local execution path — and is filed separately
+rather than folded into this spec; see §8.
 
 ## 5. Component Editor integration
 
@@ -197,8 +234,13 @@ Editor code of its own, only the one type-parsing refinement folded into #494.
 - **Dev shim test:** stub `fetch`, render `EsiInclude` in dev mode, assert resolved
   content lands in the DOM; a second case asserts the shim's `<script>` tag is
   entirely absent from a production build's output (not just inert).
-- No new Swift-side tests for this spec's own deliverable — Component Editor
-  integration rides on #493/#494's own test coverage.
+- **Unprocessed-toggle test:** with `?esiPreview=unprocessed` set, assert the dev
+  shim never calls `fetch` at all and `EsiRemove`'s slotted content is what
+  renders.
+- **Swift-side:** a test for the new Debug Pane "Server" section's Live/Unprocessed
+  control persisting to `SiteConfigStore` and producing the right query parameter
+  when the app builds the preview URL. No other new Swift-side tests — Component
+  Editor integration rides on #493/#494's own test coverage.
 
 ## 8. Explicitly out of scope / follow-ups
 
@@ -208,3 +250,9 @@ Editor code of its own, only the one type-parsing refinement folded into #494.
   proposes refinements to those issues, doesn't implement against them.
 - Choosing `@dwk` endpoints as fragment sources, and the `@dwk/esi` processor
   itself — both remain `workers`-repo concerns.
+- **General server debug panel** — running the composed Worker locally,
+  configuring production behavior beyond ESI's one toggle, and viewing worker +
+  analytics logs. Filed as
+  [#699](https://github.com/Anglesite/Anglesite-app/issues/699) for its own
+  design pass; this spec's §4a is deliberately the minimal slice of that
+  eventual panel, not a preview of its full shape.

--- a/docs/superpowers/specs/2026-07-13-esi-astro-component-design.md
+++ b/docs/superpowers/specs/2026-07-13-esi-astro-component-design.md
@@ -1,0 +1,210 @@
+# Edge Side Includes — Astro components + Component Editor integration
+
+**Date:** 2026-07-13
+**Status:** Approved design, pre-implementation
+**Related:** [davidwkeith/workers#247](https://github.com/davidwkeith/workers/issues/247) (ESI issue) and [davidwkeith/workers PR #251](https://github.com/davidwkeith/workers/pull/251) (planning-only: scopes a new `@dwk/esi` processor package, no code yet), `docs/superpowers/specs/2026-07-05-component-editor-design.md` (Component Editor), [#493](https://github.com/Anglesite/Anglesite-app/issues/493) (structure ops + palette), [#494](https://github.com/Anglesite/Anglesite-app/issues/494) (Props form + typed knobs)
+
+## 1. Summary
+
+`davidwkeith/workers` PR #251 scoped `@dwk/esi`, a Cloudflare Worker package that
+resolves `<esi:include>`/`<esi:comment>`/`<esi:remove>` markup in an outgoing
+`Response` — the *processing* side of Edge Side Includes. That PR explicitly
+carves out the *producing* side ("Anglesite-side markup generation... a separate
+feature request against `Anglesite/Anglesite-app`") as out of scope. This spec is
+that feature request: three Astro components that let a site owner author ESI
+markup, plus how they plug into the in-flight Component Editor work.
+
+The `@dwk/esi` processor doesn't exist as code yet (PR #251 is planning-only) —
+that's not a blocker here, since Anglesite only ever emits static markup; whichever
+order the two repos' work lands in, the markup is inert until some edge layer
+processes it.
+
+**Use case:** generic — a site owner points an include at any URL they control, no
+specific `@dwk` endpoint or Anglesite feature is assumed as the fragment source.
+
+**Non-goals:** `esi:choose`/`esi:vars`/`esi:try` (the processor's own v1 excludes
+them too); choosing which endpoint(s) become fragment sources; anything in the
+`workers` repo.
+
+## 2. Placement
+
+Three components at `Resources/Template/src/components/esi/`:
+`EsiInclude.astro`, `EsiComment.astro`, `EsiRemove.astro`.
+
+These are always-available core template components, like
+[`Hcard.astro`](../../../Resources/Template/src/components/Hcard.astro) — **not**
+routed through the Integration wizard/`MarkerInjector` framework used by
+`integrations/components/` (BuyButton, PodcastPlayer, etc.). That framework exists
+to interview a site owner about an external provider (API keys, a checkout URL, CSP
+domains); ESI has no external provider to configure, just an arbitrary URL the
+owner supplies per-instance, so there's nothing for an interview/wizard step to
+collect.
+
+## 3. Component shapes
+
+All three render their `esi:*` markup via `<Fragment set:html={...} />` with
+hand-escaped attribute values, rather than writing `<esi:include src={src} />`
+directly in the template. Reason: it isn't verified that Astro's compiler
+round-trips a colon-containing tag name (`esi:include`) through its self-closing/
+serialization logic byte-for-byte, and the `@dwk/esi` tokenizer needs the *exact*
+literal bytes it expects. `set:html` sidesteps that ambiguity by emitting the
+string directly. **This assumption needs an empirical spike as the first
+implementation task** (see §6) before anything else here is built on top of it.
+
+### `EsiInclude.astro`
+
+```ts
+interface Props {
+  src: string;
+  alt?: string;
+  onerror?: 'continue';
+}
+```
+
+Renders `<esi:include src="…" alt="…"? onerror="continue"?></esi:include>`
+verbatim (attribute values HTML-escaped, not URL-encoded — they're markup text,
+not a query string). In dev mode only, also emits a client-side fetch shim; see
+§4.
+
+### `EsiComment.astro`
+
+```ts
+interface Props { text: string; }
+```
+
+Renders `<esi:comment text="…"/>` verbatim. No visible content, in dev or prod —
+it's purely a template-authoring annotation that the processor drops on the floor.
+
+### `EsiRemove.astro`
+
+No props. Renders three pieces in sequence: the literal `<esi:remove>` open tag,
+`<slot />`, then the literal `</esi:remove>` close tag. This is the one component
+that needs real Astro children rather than a text macro — the fallback content it
+wraps can be arbitrary markup (an image, static text, a whole `<div>`).
+
+### Idiomatic pairing
+
+Documented in `EsiInclude`'s own doc comment: `EsiInclude` and `EsiRemove` are
+typically siblings —
+
+```astro
+<EsiInclude src="/fragments/count" onerror="continue" />
+<EsiRemove><span class="count-fallback">—</span></EsiRemove>
+```
+
+**Processed** (an ESI-aware edge Worker sits in front): the fragment is spliced in
+place of `EsiInclude`'s tag, and the `EsiRemove` block is stripped entirely — no
+duplicate content. **Unprocessed** (a browser hits the raw HTML directly, or a
+static export is opened with no edge layer at all): the unrecognized `esi:include`
+tag renders empty, while `esi:remove` — also just an unrecognized element as far as
+the browser is concerned — still renders *its children*, per ordinary HTML parsing
+rules for unknown elements. That fallback behavior falls out of plain HTML
+semantics; no shim needed for `EsiRemove` in any context.
+
+## 4. Dev-preview behavior
+
+Only `EsiInclude` needs special handling in local preview (Astro dev server, no
+edge Worker in front) — `EsiComment` is always invisible, and `EsiRemove`'s
+"unprocessed → children show" behavior described in §3 is true in dev preview for
+free.
+
+`EsiInclude.astro` conditionally emits a `<script>` block wrapped in
+`{import.meta.env.DEV && (...)}` at the template level (not inside frontmatter) —
+this makes Astro/Vite omit the script tag from the render tree entirely in a
+production build, not merely dead-code-eliminate its contents. That script, once
+per page load:
+
+1. Selects all `esi:include` elements on the page
+   (`document.querySelectorAll('esi\\:include')`, colon escaped).
+2. Skips any already marked `data-esi-dev-resolved` — an idempotency guard, since
+   every `EsiInclude` instance on the page emits this same script; running it N
+   times is harmless, each run just skips elements a prior run already finished.
+3. For each unresolved element: `fetch(src)`; on success, sets the element's
+   `innerHTML` to the fragment body (mirroring how the real processor splices
+   content in place of the tag) and marks it resolved. On failure: if `alt` is set,
+   retry once against `alt`; otherwise (or if that also fails) leave the element
+   empty. This mirrors the processor's own `onerror`/`alt`/drop rules from the
+   `@dwk/esi` design doc, so dev preview approximates production behavior rather
+   than showing an arbitrary placeholder.
+
+No caching, no retries beyond the one `alt` fallback, no loading state — this is a
+preview convenience, not a production feature. Keeping it minimal also keeps it
+easy to audit as fully inert in a production build.
+
+**Known preview limitation:** the dev shim's `fetch(src)` runs client-side in the
+browser, so a cross-origin `src` needs that origin's own CORS headers to resolve
+in preview — the production edge Worker fetch has no such restriction, since
+`safeFetch` runs server-side. Worth a one-line note in `EsiInclude`'s doc comment
+so a site owner isn't confused why a fragment resolves in production but shows
+empty in dev preview.
+
+## 5. Component Editor integration
+
+Once [#493](https://github.com/Anglesite/Anglesite-app/issues/493) (structure ops
++ palette: `insert-node`/`move-node`/`remove-node`/`set-attr`, palette listing
+project components, sealed component instances with slot-fill drop areas) lands,
+all three components need **no ESI-specific Component Editor code** to appear in
+the palette or accept prop edits — they're ordinary project components under
+`src/components/esi/`, and `EsiRemove`'s `<slot />` makes it a normal "sealed
+instance with a slot-fill drop area" per #493's existing plan.
+
+Two concrete, ESI-motivated gaps are worth folding into #493/#494 directly (issue
+bodies updated as part of this work — see §7), rather than filed as a new issue:
+
+- **#493 refinement (optional):** if a component has a leading frontmatter doc
+  comment, the palette could show it as a one-line description/tooltip — e.g.
+  `EsiInclude`'s comment would read "Edge-fetched fragment — spliced in at the
+  edge, or fetched client-side in dev preview." Not required for ESI to work, just
+  improves discoverability of components named after markup most site owners
+  won't recognize on sight. A nicety for #493's implementer to accept or drop.
+- **#494 refinement (real gap):** `EsiInclude`'s `onerror?: 'continue'` is a
+  TypeScript string-literal type, not `string`/`number`/`boolean`. Today's
+  `KnobDefaults.value(for:)`
+  ([`ComponentOutline.swift:109-121`](../../../Sources/AnglesiteCore/ComponentOutline.swift))
+  only special-cases those three primitive type names — a literal-union type falls
+  through to the empty-string default, so `onerror` would render as a blank
+  free-text field rather than a constrained choice. #494's "structured Props form"
+  work should parse simple string-literal-union prop types (`'a' | 'b' | 'c'`) and
+  render them as a picker/segmented control, the same way `boolean` already gets a
+  toggle instead of free text. `EsiInclude` becomes the concrete test case for that
+  parsing logic when #494 is implemented. `src`/`alt` stay plain `string` — no
+  dedicated URL-typed control proposed for v1.
+
+**Net effect:** the three Astro components ship independently of #493/#494's
+timeline (usable today via hand-edited markup) and automatically gain palette +
+prop-editing UX as those slices land — this spec adds no new Swift/Component
+Editor code of its own, only the one type-parsing refinement folded into #494.
+
+## 6. Error handling & edge cases
+
+- **Empty/missing `src`** — `EsiInclude.src` is a required prop; an empty string
+  is a site-owner authoring mistake surfaced by Astro/TypeScript's own prop
+  validation at build time, not a runtime case this component handles.
+- **`EsiRemove` with no children** — valid; renders `<esi:remove></esi:remove>`
+  with nothing between, trivially matching "strip the block" since there's nothing
+  to strip.
+- **Multiple `EsiInclude`s with the same `src`** — no dedup; each fetches
+  independently in dev preview (and resolves independently at the edge in prod).
+  Not worth optimizing for v1.
+
+## 7. Testing plan
+
+- **Astro build fixture test:** a page using all three components; assert the
+  built static HTML contains the literal `<esi:include>`/`<esi:comment>`/
+  `<esi:remove>` byte sequences unchanged. This is the empirical check for the §3
+  assumption about Astro's compiler behavior — **the first implementation task**,
+  before anything else in this spec is built.
+- **Dev shim test:** stub `fetch`, render `EsiInclude` in dev mode, assert resolved
+  content lands in the DOM; a second case asserts the shim's `<script>` tag is
+  entirely absent from a production build's output (not just inert).
+- No new Swift-side tests for this spec's own deliverable — Component Editor
+  integration rides on #493/#494's own test coverage.
+
+## 8. Explicitly out of scope / follow-ups
+
+- `esi:choose`/`esi:vars`/`esi:try` — deferred, matches the processor's own v1
+  scope.
+- Any Component Editor Swift code — deferred to #493/#494; this spec only
+  proposes refinements to those issues, doesn't implement against them.
+- Choosing `@dwk` endpoints as fragment sources, and the `@dwk/esi` processor
+  itself — both remain `workers`-repo concerns.

--- a/docs/superpowers/specs/2026-07-13-esi-astro-component-design.md
+++ b/docs/superpowers/specs/2026-07-13-esi-astro-component-design.md
@@ -162,11 +162,20 @@ panel — see the follow-up issue in §8.
   This exactly matches the real "unprocessed" case from §3, just forced on demand
   instead of depending on the fragment URL actually being unreachable.
 
-The setting is stored per-site (`SiteConfigStore` / `Config/settings.plist`, app-
-owned state, never in git per this repo's package model) and reaches the running
-page as a query parameter the app appends when it loads the preview URL into the
-WKWebView (e.g. `?esiPreview=unprocessed`); the dev shim script reads
-`location.search` before deciding whether to run its fetch step at all.
+**Correction from the approved draft:** the setting is stored globally via
+`AppSettings`/`UserDefaults` (`Sources/AnglesiteCore/AppSettings.swift`, same
+pattern as `Key.debugPaneEnabled`), not per-site `SiteConfigStore`. The Debug
+Pane is a single global window (`DebugPaneView`, fed by `LogCenter.shared`) with
+no per-site scoping mechanism today — it filters log lines by source tag, not by
+open site — so a per-site plist setting has nowhere to attach in that UI without
+inventing a site-selector this spec doesn't otherwise need. Since this is a
+developer preview convenience rather than a persisted production setting, a
+global toggle (affecting whichever site is currently loaded, same as every other
+Debug Pane control) is both simpler and a better fit for the existing
+architecture. It reaches the running page as a query parameter the app appends
+when it loads the preview URL into the WKWebView (e.g. `?esiPreview=unprocessed`);
+the dev shim script reads `location.search` before deciding whether to run its
+fetch step at all.
 
 **Explicitly not v1:** actually running the composed Worker (and so `@dwk/esi`
 itself) locally to get real server-side resolution without the dev shim's CORS
@@ -237,10 +246,14 @@ Editor code of its own, only the one type-parsing refinement folded into #494.
 - **Unprocessed-toggle test:** with `?esiPreview=unprocessed` set, assert the dev
   shim never calls `fetch` at all and `EsiRemove`'s slotted content is what
   renders.
-- **Swift-side:** a test for the new Debug Pane "Server" section's Live/Unprocessed
-  control persisting to `SiteConfigStore` and producing the right query parameter
-  when the app builds the preview URL. No other new Swift-side tests — Component
-  Editor integration rides on #493/#494's own test coverage.
+- **Swift-side:** an `AnglesiteCoreTests` test for the new pure `PreviewNavigation`
+  helper that appends the `esiPreview=unprocessed` query parameter, covering the
+  on/off cases and a URL that already carries other query items. No test for
+  `DebugPaneView` itself (an `AnglesiteApp`-target SwiftUI view, consistent with
+  this repo's existing lack of coverage there) or for `AppSettings`'s new key
+  (trivial `UserDefaults` get/set, same shape as every existing key, not worth a
+  dedicated test). Component Editor integration rides on #493/#494's own test
+  coverage.
 
 ## 8. Explicitly out of scope / follow-ups
 


### PR DESCRIPTION
## Summary

Scopes the Anglesite-side markup-generation half of Edge Side Includes ([davidwkeith/workers#247](https://github.com/davidwkeith/workers/issues/247)/[#251](https://github.com/davidwkeith/workers/pull/251) — the `@dwk/esi` processor is planning-only, no code yet, and isn't a blocker here since Anglesite only emits static markup).

- **Three template components** (`Resources/Template/src/components/esi/`): `EsiInclude`, `EsiComment`, `EsiRemove`, always-available (not gated behind the Integration wizard — no external provider to configure). Markup is emitted via `<Fragment set:html={expression}>` from small, unit-tested pure TS helpers (`esi-markup.ts`) — a real `astro build` empirically confirmed Astro only suppresses HTML-escaping for `set:html` when given a JS expression, not a literal string (this caught and fixed a real bug in `EsiRemove.astro` during implementation).
- **Dev-preview fetch shim** (`esi-dev-shim.ts`): `EsiInclude` approximates edge resolution client-side in local preview, mirroring the processor's `onerror`/`alt`/drop rules. Stripped entirely from production builds (verified by the build-fixture test, not just assumed).
- **Local fallback preview toggle**: a new "Server" section in the app's existing Debug Pane (Live/Unprocessed), so `EsiRemove`'s fallback content can be previewed on demand instead of by sabotaging the fragment URL. Backed by a new `@Observable` bridge (`EsiPreviewMode`) so the toggle actually propagates to the live preview — a final-review pass caught that a plain `AppSettings`/`UserDefaults` read wasn't Observation-tracked, so the toggle was initially inert.
- Filed [#699](https://github.com/Anglesite/Anglesite-app/issues/699) for the larger "run a composed Worker locally + view worker/analytics logs" capability this toggle is a first seed of — explicitly out of scope here.
- Posted refinement comments on [#493](https://github.com/Anglesite/Anglesite-app/issues/493)/[#494](https://github.com/Anglesite/Anglesite-app/issues/494) (Component Editor structure-ops/props-form slices) noting how ESI's components ride on that work for free once it lands, plus one concrete type-parsing gap (`onerror?: 'continue'` literal-union props) those slices should handle.

Design: `docs/superpowers/specs/2026-07-13-esi-astro-component-design.md`
Plan: `docs/superpowers/plans/2026-07-13-esi-astro-component.md`

Built via subagent-driven development: 9 planned tasks + one post-final-review fix, each with an independent implementer + task-scoped reviewer pass, plus a final whole-branch review.

## Test plan

- [x] `esi-markup.test.ts`, `esi-dev-shim.test.ts` (8 cases incl. no-src and fetch-throw branches) — `cd Resources/Template && npx tsx --test src/components/esi/esi-markup.test.ts src/components/esi/esi-dev-shim.test.ts`
- [x] `esi-components.build.test.ts` — real `astro build` in a temp fixture, asserts all three components' literal markup survives byte-for-byte and the dev shim is absent from production output
- [x] `swift test --filter PreviewNavigationTests` (11/11) and the full `swift test --package-path .` suite — `IntegrationTemplateAssetsTests`/`BlogTemplateAssetsTests` (template-change guards) pass clean; 2 unrelated pre-existing failures noted (`RepoBootstrapTests.publishRefusesWhenDotenvWouldBeCommitted`, a `GenerableTypes`/`ContentSummary` token-budget-off-by-2), neither touching any file in this branch
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [ ] Manual GUI smoke of the Debug Pane's Server section and the toggle → live preview reload — not performable in this session (no interactive display); a static trace during final review confirmed the Observation dependency chain is sound, but this should be confirmed visually before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)