### PR TITLE
Design local Workers debugging (#700); implement worker catalog (#708 slice 1)

### DIFF
--- a/Sources/AnglesiteCore/WorkerCatalog.swift
+++ b/Sources/AnglesiteCore/WorkerCatalog.swift
@@ -83,3 +83,18 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
         }
     }
 }
+
+/// Parses `catalog.json` (the `@dwk/workers` monorepo's published worker manifest) into
+/// `WorkerDescriptor`s. Stateless — call `parse(_:)` directly, mirroring
+/// `WorkersConformanceReader`'s shape.
+public enum WorkerCatalogReader {
+    private struct Root: Decodable {
+        let workers: [WorkerDescriptor]
+    }
+
+    /// Decodes `data` (UTF-8 JSON matching the `catalog.json` schema) and returns its
+    /// `WorkerDescriptor`s. Throws a `DecodingError` if the JSON is malformed.
+    public static func parse(_ data: Data) throws -> [WorkerDescriptor] {
+        try JSONDecoder().decode(Root.self, from: data).workers
+    }
+}

--- a/Sources/AnglesiteCore/WorkerCatalog.swift
+++ b/Sources/AnglesiteCore/WorkerCatalog.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// One `@dwk/workers` package as described by the monorepo's published catalog manifest
+/// (`catalog.json`). Intentionally generic — this app never hardcodes specific worker names
+/// (design doc §3): whatever the manifest lists is what the Workers tab shows and what deploy
+/// composition can activate.
+public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
+    public let id: String
+    public let displayName: String
+    public let description: String
+    /// Free-text grouping key the Workers tab sections by (e.g. `"social"`, `"storage"`) — never
+    /// enumerated in Swift, since the manifest owns the set of groups.
+    public let group: String
+    public let binding: Binding
+    public let resources: Resources
+
+    public init(
+        id: String,
+        displayName: String,
+        description: String,
+        group: String,
+        binding: Binding,
+        resources: Resources
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.description = description
+        self.group = group
+        self.binding = binding
+        self.resources = resources
+    }
+
+    /// How a worker becomes active. `componentTied` workers are never manually toggled — their
+    /// active state is always recomputed from Site Graph Explorer's `ImpactAnalysis` against
+    /// `componentIDs` (design doc §4). `settingsActivated` workers are toggled in the Workers tab.
+    public enum Binding: Sendable, Equatable, Codable {
+        case componentTied(componentIDs: [String])
+        case settingsActivated
+
+        private enum CodingKeys: String, CodingKey {
+            case kind
+            case componentIDs
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let kind = try container.decode(String.self, forKey: .kind)
+            switch kind {
+            case "componentTied":
+                let componentIDs = try container.decode([String].self, forKey: .componentIDs)
+                self = .componentTied(componentIDs: componentIDs)
+            case "settingsActivated":
+                self = .settingsActivated
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: .kind, in: container, debugDescription: "unknown binding kind \"\(kind)\"")
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .componentTied(let componentIDs):
+                try container.encode("componentTied", forKey: .kind)
+                try container.encode(componentIDs, forKey: .componentIDs)
+            case .settingsActivated:
+                try container.encode("settingsActivated", forKey: .kind)
+            }
+        }
+    }
+
+    /// Generalizes `WorkerComposition.Feature`'s hand-maintained `needsD1`/`needsKV`/`needsR2`
+    /// switch statements (`WorkerComposition.swift:28-53`) into manifest-driven data.
+    public struct Resources: Sendable, Equatable, Codable {
+        public let needsD1: Bool
+        public let needsKV: Bool
+        public let needsR2: Bool
+
+        public init(needsD1: Bool, needsKV: Bool, needsR2: Bool) {
+            self.needsD1 = needsD1
+            self.needsKV = needsKV
+            self.needsR2 = needsR2
+        }
+    }
+}

--- a/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
+++ b/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 // URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
 // platforms (swift-corelibs-foundation); this import is a no-op on macOS.
 #if canImport(FoundationNetworking)
@@ -18,6 +19,8 @@ public enum WorkerCatalogFetchError: Error, Sendable, Equatable {
 ///   yet published `catalog.json` — callers must supply the real manifest URL once the monorepo
 ///   publishes one.
 public actor WorkerCatalogFetcher {
+    private static let logger = Logger(subsystem: "io.dwk.anglesite", category: "WorkerCatalogFetcher")
+
     private let catalogURL: URL
     private let cacheURL: URL
     private let session: URLSession
@@ -39,10 +42,17 @@ public actor WorkerCatalogFetcher {
     /// failure (network error, non-2xx response, malformed JSON), falls back to the last cached
     /// catalog; if there is no cache either, returns an empty catalog. Never throws.
     public func catalog() async -> [WorkerDescriptor] {
-        if let fresh = try? await fetchAndCache() {
-            return fresh
+        do {
+            return try await fetchAndCache()
+        } catch {
+            Self.logger.error("catalog fetch failed, falling back to cache: \(String(describing: error), privacy: .public)")
         }
-        return (try? Self.readCache(cacheURL)) ?? []
+        do {
+            return try Self.readCache(cacheURL)
+        } catch {
+            Self.logger.error("catalog cache read failed, falling back to empty catalog: \(String(describing: error), privacy: .public)")
+            return []
+        }
     }
 
     private func fetchAndCache() async throws -> [WorkerDescriptor] {
@@ -51,7 +61,11 @@ public actor WorkerCatalogFetcher {
             throw WorkerCatalogFetchError.fetchFailed("bad response from \(catalogURL)")
         }
         let descriptors = try WorkerCatalogReader.parse(data)
-        try? Self.writeCache(data, to: cacheURL, fileManager: fileManager)
+        do {
+            try Self.writeCache(data, to: cacheURL, fileManager: fileManager)
+        } catch {
+            Self.logger.error("catalog cache write failed (serving fresh data anyway): \(String(describing: error), privacy: .public)")
+        }
         return descriptors
     }
 

--- a/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
+++ b/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
@@ -1,0 +1,83 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum WorkerCatalogFetchError: Error, Sendable, Equatable {
+    case fetchFailed(String)
+}
+
+/// Fetches, parses, and disk-caches the `@dwk/workers` catalog manifest (`catalog.json`).
+/// Network or parse failures degrade to the last successfully cached copy, then to an empty
+/// catalog — the Workers Settings tab and deploy composition must never block or crash on a
+/// catalog fetch failure (design doc §3).
+///
+/// - Important: `catalogURL` has no in-app default. As of this writing `@dwk/workers` has not
+///   yet published `catalog.json` — callers must supply the real manifest URL once the monorepo
+///   publishes one.
+public actor WorkerCatalogFetcher {
+    private let catalogURL: URL
+    private let cacheURL: URL
+    private let session: URLSession
+    private let fileManager: FileManager
+
+    public init(
+        catalogURL: URL,
+        cacheURL: URL = WorkerCatalogFetcher.defaultCacheURL(),
+        session: URLSession = .shared,
+        fileManager: FileManager = .default
+    ) {
+        self.catalogURL = catalogURL
+        self.cacheURL = cacheURL
+        self.session = session
+        self.fileManager = fileManager
+    }
+
+    /// Fetches the latest catalog and caches the raw manifest bytes to disk on success. On any
+    /// failure (network error, non-2xx response, malformed JSON), falls back to the last cached
+    /// catalog; if there is no cache either, returns an empty catalog. Never throws.
+    public func catalog() async -> [WorkerDescriptor] {
+        if let fresh = try? await fetchAndCache() {
+            return fresh
+        }
+        return (try? Self.readCache(cacheURL)) ?? []
+    }
+
+    private func fetchAndCache() async throws -> [WorkerDescriptor] {
+        let (data, response) = try await session.data(from: catalogURL)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw WorkerCatalogFetchError.fetchFailed("bad response from \(catalogURL)")
+        }
+        let descriptors = try WorkerCatalogReader.parse(data)
+        try Self.writeCache(data, to: cacheURL, fileManager: fileManager)
+        return descriptors
+    }
+
+    private static func readCache(_ url: URL) throws -> [WorkerDescriptor] {
+        let data = try Data(contentsOf: url)
+        return try WorkerCatalogReader.parse(data)
+    }
+
+    private static func writeCache(_ data: Data, to url: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: [.atomic])
+    }
+
+    /// `~/Library/Application Support/Anglesite/worker-catalog-cache.json` — mirrors
+    /// `SiteStore`'s `defaultPersistenceURL` convention (`SiteStore.swift:323-333`).
+    public static func defaultCacheURL(fileManager: FileManager = .default) -> URL {
+        let support = (try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return support
+            .appendingPathComponent("Anglesite", isDirectory: true)
+            .appendingPathComponent("worker-catalog-cache.json")
+    }
+}

--- a/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
+++ b/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
@@ -1,9 +1,13 @@
 import Foundation
-import OSLog
 // URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
 // platforms (swift-corelibs-foundation); this import is a no-op on macOS.
 #if canImport(FoundationNetworking)
 import FoundationNetworking
+#endif
+// OSLog is Darwin-only; AnglesiteCore is part of the Linux-portable target set (Package.swift,
+// cross-platform port design §9/§10), so logging falls back to stderr off-Darwin.
+#if canImport(OSLog)
+import OSLog
 #endif
 
 public enum WorkerCatalogFetchError: Error, Sendable, Equatable {
@@ -19,7 +23,19 @@ public enum WorkerCatalogFetchError: Error, Sendable, Equatable {
 ///   yet published `catalog.json` — callers must supply the real manifest URL once the monorepo
 ///   publishes one.
 public actor WorkerCatalogFetcher {
+    #if canImport(OSLog)
     private static let logger = Logger(subsystem: "io.dwk.anglesite", category: "WorkerCatalogFetcher")
+    #endif
+
+    /// Degraded-path logging, portable off-Darwin (no OSLog on Linux — cross-platform port
+    /// design §9/§10).
+    private static func logDegradation(_ message: String) {
+        #if canImport(OSLog)
+        logger.error("\(message, privacy: .public)")
+        #else
+        FileHandle.standardError.write(Data("[WorkerCatalogFetcher] \(message)\n".utf8))
+        #endif
+    }
 
     private let catalogURL: URL
     private let cacheURL: URL
@@ -45,12 +61,12 @@ public actor WorkerCatalogFetcher {
         do {
             return try await fetchAndCache()
         } catch {
-            Self.logger.error("catalog fetch failed, falling back to cache: \(String(describing: error), privacy: .public)")
+            Self.logDegradation("catalog fetch failed, falling back to cache: \(error)")
         }
         do {
             return try Self.readCache(cacheURL)
         } catch {
-            Self.logger.error("catalog cache read failed, falling back to empty catalog: \(String(describing: error), privacy: .public)")
+            Self.logDegradation("catalog cache read failed, falling back to empty catalog: \(error)")
             return []
         }
     }
@@ -64,7 +80,7 @@ public actor WorkerCatalogFetcher {
         do {
             try Self.writeCache(data, to: cacheURL, fileManager: fileManager)
         } catch {
-            Self.logger.error("catalog cache write failed (serving fresh data anyway): \(String(describing: error), privacy: .public)")
+            Self.logDegradation("catalog cache write failed (serving fresh data anyway): \(error)")
         }
         return descriptors
     }

--- a/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
+++ b/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
@@ -51,7 +51,7 @@ public actor WorkerCatalogFetcher {
             throw WorkerCatalogFetchError.fetchFailed("bad response from \(catalogURL)")
         }
         let descriptors = try WorkerCatalogReader.parse(data)
-        try Self.writeCache(data, to: cacheURL, fileManager: fileManager)
+        try? Self.writeCache(data, to: cacheURL, fileManager: fileManager)
         return descriptors
     }
 

--- a/Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift
@@ -133,4 +133,44 @@ private final class WorkerCatalogStubURLProtocol: URLProtocol, @unchecked Sendab
         let workers = await fetcher.catalog()
         #expect(workers.isEmpty)
     }
+
+    @Test("falls back to the cached catalog when the response is 200 but the body is malformed JSON")
+    func fallsBackToCacheOnMalformedJSONBody() async throws {
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(sampleJSON.utf8).write(to: cacheURL)
+
+        WorkerCatalogStubURLProtocol.shouldFailToLoad = false
+        WorkerCatalogStubURLProtocol.statusCode = 200
+        WorkerCatalogStubURLProtocol.body = "{ not valid json"
+        let fetcher = WorkerCatalogFetcher(
+            catalogURL: URL(string: "https://example.invalid/catalog.json")!,
+            cacheURL: cacheURL,
+            session: WorkerCatalogStubURLProtocol.makeSession()
+        )
+
+        let workers = await fetcher.catalog()
+        #expect(workers.map(\.id) == ["webmention"])
+    }
+
+    @Test("returns an empty catalog when the cache file on disk is corrupted and the fetch also fails")
+    func returnsEmptyWhenCacheIsCorruptedAndFetchFails() async throws {
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("{ not valid json".utf8).write(to: cacheURL)
+
+        WorkerCatalogStubURLProtocol.shouldFailToLoad = true
+        let fetcher = WorkerCatalogFetcher(
+            catalogURL: URL(string: "https://example.invalid/catalog.json")!,
+            cacheURL: cacheURL,
+            session: WorkerCatalogStubURLProtocol.makeSession()
+        )
+
+        let workers = await fetcher.catalog()
+        #expect(workers.isEmpty)
+    }
 }

--- a/Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift
@@ -1,0 +1,136 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Stub `URLProtocol` returning a canned status/body for every request, so
+/// `WorkerCatalogFetcher` can be exercised without a real network call — mirrors
+/// `FreedesignmdCatalogTests`' `FreedesignmdStubURLProtocol`.
+private final class WorkerCatalogStubURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var statusCode = 200
+    nonisolated(unsafe) static var body = ""
+    nonisolated(unsafe) static var shouldFailToLoad = false
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        if Self.shouldFailToLoad {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(Self.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [WorkerCatalogStubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+// .serialized: tests share WorkerCatalogStubURLProtocol's mutable static status/body/failure
+// flag, which would race under Swift Testing's default parallel execution.
+@Suite(.serialized) struct WorkerCatalogFetcherTests {
+    private let sampleJSON = """
+    {
+      "workers": [
+        {
+          "id": "webmention",
+          "displayName": "Webmentions",
+          "description": "Receive and verify webmentions for posts",
+          "group": "social",
+          "binding": { "kind": "componentTied", "componentIDs": ["webmention-form"] },
+          "resources": { "needsD1": true, "needsKV": true, "needsR2": false }
+        }
+      ]
+    }
+    """
+
+    private func tempCacheURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("worker-catalog-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("worker-catalog-cache.json")
+    }
+
+    @Test("fetches, parses, and writes the cache file on success")
+    func fetchesAndCachesOnSuccess() async throws {
+        WorkerCatalogStubURLProtocol.shouldFailToLoad = false
+        WorkerCatalogStubURLProtocol.statusCode = 200
+        WorkerCatalogStubURLProtocol.body = sampleJSON
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let fetcher = WorkerCatalogFetcher(
+            catalogURL: URL(string: "https://example.invalid/catalog.json")!,
+            cacheURL: cacheURL,
+            session: WorkerCatalogStubURLProtocol.makeSession()
+        )
+
+        let workers = await fetcher.catalog()
+        #expect(workers.map(\.id) == ["webmention"])
+        #expect(FileManager.default.fileExists(atPath: cacheURL.path))
+    }
+
+    @Test("falls back to the cached catalog when the fetch fails")
+    func fallsBackToCacheOnFetchFailure() async throws {
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(sampleJSON.utf8).write(to: cacheURL)
+
+        WorkerCatalogStubURLProtocol.shouldFailToLoad = true
+        let fetcher = WorkerCatalogFetcher(
+            catalogURL: URL(string: "https://example.invalid/catalog.json")!,
+            cacheURL: cacheURL,
+            session: WorkerCatalogStubURLProtocol.makeSession()
+        )
+
+        let workers = await fetcher.catalog()
+        #expect(workers.map(\.id) == ["webmention"])
+    }
+
+    @Test("returns an empty catalog when the fetch fails and there is no cache")
+    func returnsEmptyWhenNoCacheAndFetchFails() async {
+        WorkerCatalogStubURLProtocol.shouldFailToLoad = true
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let fetcher = WorkerCatalogFetcher(
+            catalogURL: URL(string: "https://example.invalid/catalog.json")!,
+            cacheURL: cacheURL,
+            session: WorkerCatalogStubURLProtocol.makeSession()
+        )
+
+        let workers = await fetcher.catalog()
+        #expect(workers.isEmpty)
+    }
+
+    @Test("returns an empty catalog on a non-2xx response with no cache")
+    func returnsEmptyOnBadStatusWithNoCache() async {
+        WorkerCatalogStubURLProtocol.shouldFailToLoad = false
+        WorkerCatalogStubURLProtocol.statusCode = 404
+        WorkerCatalogStubURLProtocol.body = "not found"
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let fetcher = WorkerCatalogFetcher(
+            catalogURL: URL(string: "https://example.invalid/catalog.json")!,
+            cacheURL: cacheURL,
+            session: WorkerCatalogStubURLProtocol.makeSession()
+        )
+
+        let workers = await fetcher.catalog()
+        #expect(workers.isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WorkerDescriptor")
+struct WorkerDescriptorTests {
+    @Test("round-trips a componentTied worker through JSONEncoder/JSONDecoder")
+    func roundTripsComponentTied() throws {
+        let worker = WorkerDescriptor(
+            id: "webmention",
+            displayName: "Webmentions",
+            description: "Receive and verify webmentions for posts",
+            group: "social",
+            binding: .componentTied(componentIDs: ["webmention-form"]),
+            resources: WorkerDescriptor.Resources(needsD1: true, needsKV: true, needsR2: false)
+        )
+
+        let data = try JSONEncoder().encode(worker)
+        let decoded = try JSONDecoder().decode(WorkerDescriptor.self, from: data)
+
+        #expect(decoded == worker)
+        #expect(decoded.binding == .componentTied(componentIDs: ["webmention-form"]))
+    }
+
+    @Test("round-trips a settingsActivated worker with no componentIDs")
+    func roundTripsSettingsActivated() throws {
+        let worker = WorkerDescriptor(
+            id: "solid-pod",
+            displayName: "Solid Pod",
+            description: "Expose a Solid-compatible personal data store for this site",
+            group: "storage",
+            binding: .settingsActivated,
+            resources: WorkerDescriptor.Resources(needsD1: false, needsKV: true, needsR2: true)
+        )
+
+        let data = try JSONEncoder().encode(worker)
+        let decoded = try JSONDecoder().decode(WorkerDescriptor.self, from: data)
+
+        #expect(decoded == worker)
+        #expect(decoded.binding == .settingsActivated)
+    }
+
+    @Test("decoding an unknown binding kind throws")
+    func unknownBindingKindThrows() {
+        let json = """
+        { "kind": "somethingElse" }
+        """.data(using: .utf8)!
+
+        #expect(throws: (any Error).self) {
+            _ = try JSONDecoder().decode(WorkerDescriptor.Binding.self, from: json)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
@@ -51,3 +51,52 @@ struct WorkerDescriptorTests {
         }
     }
 }
+
+@Suite("WorkerCatalogReader")
+struct WorkerCatalogReaderTests {
+    private let sampleJSON = """
+    {
+      "workers": [
+        {
+          "id": "webmention",
+          "displayName": "Webmentions",
+          "description": "Receive and verify webmentions for posts",
+          "group": "social",
+          "binding": { "kind": "componentTied", "componentIDs": ["webmention-form"] },
+          "resources": { "needsD1": true, "needsKV": true, "needsR2": false }
+        },
+        {
+          "id": "solid-pod",
+          "displayName": "Solid Pod",
+          "description": "Expose a Solid-compatible personal data store for this site",
+          "group": "storage",
+          "binding": { "kind": "settingsActivated" },
+          "resources": { "needsD1": false, "needsKV": true, "needsR2": true }
+        }
+      ]
+    }
+    """.data(using: .utf8)!
+
+    @Test("parses a two-worker manifest with both binding kinds")
+    func parsesTwoWorkers() throws {
+        let workers = try WorkerCatalogReader.parse(sampleJSON)
+        #expect(workers.count == 2)
+
+        let webmention = try #require(workers.first { $0.id == "webmention" })
+        #expect(webmention.group == "social")
+        #expect(webmention.binding == .componentTied(componentIDs: ["webmention-form"]))
+        #expect(webmention.resources.needsD1)
+        #expect(!webmention.resources.needsR2)
+
+        let solidPod = try #require(workers.first { $0.id == "solid-pod" })
+        #expect(solidPod.binding == .settingsActivated)
+    }
+
+    @Test("throws on malformed JSON")
+    func throwsOnMalformedJSON() {
+        let json = "{ \"not-workers\": [] }".data(using: .utf8)!
+        #expect(throws: (any Error).self) {
+            _ = try WorkerCatalogReader.parse(json)
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-07-13-worker-catalog.md
+++ b/docs/superpowers/plans/2026-07-13-worker-catalog.md
@@ -1,0 +1,623 @@
+# Worker Catalog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the app a typed, testable model for the `@dwk/workers` catalog (worker id, name,
+description, group, binding rule, resource requirements) plus a resilient fetch-and-cache layer,
+so later work (deploy composition, the Workers Settings tab) has a single source of truth for
+"what workers exist" that never blocks or crashes on a network failure.
+
+**Architecture:** Two new files in `AnglesiteCore`. `WorkerCatalog.swift` defines the pure data
+model (`WorkerDescriptor`) and a stateless JSON parser (`WorkerCatalogReader`), mirroring the
+existing `WorkersConformanceReader` shape. `WorkerCatalogFetcher.swift` is a small actor that
+fetches the manifest over HTTP, disk-caches the raw bytes on success, and falls back to the last
+cached copy (then to an empty catalog) on any failure — modeled on `SiteStore`'s
+`applicationSupportDirectory`/atomic-write cache convention and `FreedesignmdCatalog`'s
+stub-`URLProtocol` test pattern.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`Testing` module, `@Suite`/`@Test`/`#expect`), Foundation
+(`URLSession`, `JSONDecoder`, `PropertyListEncoder`-adjacent atomic file writes).
+
+## Global Constraints
+
+- Every new public type lives in `Sources/AnglesiteCore/` (this is core model/business logic, not
+  a view) per this repo's module layout (CLAUDE.md).
+- `WorkerCatalogReader.parse` must throw on malformed input (matches `WorkersConformanceReader`'s
+  contract) — resilience (never-throw, degrade-to-cache-or-empty) lives one layer up, in
+  `WorkerCatalogFetcher.catalog()`, not in the parser.
+- `WorkerCatalogFetcher` takes `catalogURL` as a required constructor parameter with **no
+  in-app default** — `@dwk/workers` has not published `catalog.json` yet (design doc §10), so
+  there is no real URL to hardcode. Wiring a concrete production URL is out of scope for this
+  plan; it happens once the monorepo publishes the manifest.
+- Tests use Swift Testing (`import Testing`), not XCTest — this matches `WorkersConformanceTests`/
+  `FreedesignmdCatalogTests`, the two existing files this plan's tests sit alongside.
+- Run `swift build --package-path .` after each task to catch compile errors before running tests.
+
+---
+
+### Task 1: `WorkerDescriptor` data model
+
+**Files:**
+- Create: `Sources/AnglesiteCore/WorkerCatalog.swift`
+- Test: `Tests/AnglesiteCoreTests/WorkerCatalogTests.swift`
+
+**Interfaces:**
+- Produces: `WorkerDescriptor` (`Sendable, Equatable, Codable, Identifiable`) with fields `id: String`,
+  `displayName: String`, `description: String`, `group: String`, `binding: WorkerDescriptor.Binding`,
+  `resources: WorkerDescriptor.Resources`. Nested `Binding` enum: `.componentTied(componentIDs: [String])`
+  or `.settingsActivated`, `Codable` via an explicit `"kind"` discriminator (`"componentTied"` /
+  `"settingsActivated"`). Nested `Resources` struct: `needsD1: Bool`, `needsKV: Bool`, `needsR2: Bool`,
+  all with a memberwise `public init`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteCoreTests/WorkerCatalogTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WorkerDescriptor")
+struct WorkerDescriptorTests {
+    @Test("round-trips a componentTied worker through JSONEncoder/JSONDecoder")
+    func roundTripsComponentTied() throws {
+        let worker = WorkerDescriptor(
+            id: "webmention",
+            displayName: "Webmentions",
+            description: "Receive and verify webmentions for posts",
+            group: "social",
+            binding: .componentTied(componentIDs: ["webmention-form"]),
+            resources: WorkerDescriptor.Resources(needsD1: true, needsKV: true, needsR2: false)
+        )
+
+        let data = try JSONEncoder().encode(worker)
+        let decoded = try JSONDecoder().decode(WorkerDescriptor.self, from: data)
+
+        #expect(decoded == worker)
+        #expect(decoded.binding == .componentTied(componentIDs: ["webmention-form"]))
+    }
+
+    @Test("round-trips a settingsActivated worker with no componentIDs")
+    func roundTripsSettingsActivated() throws {
+        let worker = WorkerDescriptor(
+            id: "solid-pod",
+            displayName: "Solid Pod",
+            description: "Expose a Solid-compatible personal data store for this site",
+            group: "storage",
+            binding: .settingsActivated,
+            resources: WorkerDescriptor.Resources(needsD1: false, needsKV: true, needsR2: true)
+        )
+
+        let data = try JSONEncoder().encode(worker)
+        let decoded = try JSONDecoder().decode(WorkerDescriptor.self, from: data)
+
+        #expect(decoded == worker)
+        #expect(decoded.binding == .settingsActivated)
+    }
+
+    @Test("decoding an unknown binding kind throws")
+    func unknownBindingKindThrows() {
+        let json = """
+        { "kind": "somethingElse" }
+        """.data(using: .utf8)!
+
+        #expect(throws: (any Error).self) {
+            _ = try JSONDecoder().decode(WorkerDescriptor.Binding.self, from: json)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter WorkerDescriptorTests`
+Expected: FAIL — `WorkerDescriptor` (and `WorkerDescriptor.Binding`/`WorkerDescriptor.Resources`)
+do not exist yet, so this fails to compile.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `Sources/AnglesiteCore/WorkerCatalog.swift`:
+
+```swift
+import Foundation
+
+/// One `@dwk/workers` package as described by the monorepo's published catalog manifest
+/// (`catalog.json`). Intentionally generic — this app never hardcodes specific worker names
+/// (design doc §3): whatever the manifest lists is what the Workers tab shows and what deploy
+/// composition can activate.
+public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
+    public let id: String
+    public let displayName: String
+    public let description: String
+    /// Free-text grouping key the Workers tab sections by (e.g. `"social"`, `"storage"`) — never
+    /// enumerated in Swift, since the manifest owns the set of groups.
+    public let group: String
+    public let binding: Binding
+    public let resources: Resources
+
+    public init(
+        id: String,
+        displayName: String,
+        description: String,
+        group: String,
+        binding: Binding,
+        resources: Resources
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.description = description
+        self.group = group
+        self.binding = binding
+        self.resources = resources
+    }
+
+    /// How a worker becomes active. `componentTied` workers are never manually toggled — their
+    /// active state is always recomputed from Site Graph Explorer's `ImpactAnalysis` against
+    /// `componentIDs` (design doc §4). `settingsActivated` workers are toggled in the Workers tab.
+    public enum Binding: Sendable, Equatable, Codable {
+        case componentTied(componentIDs: [String])
+        case settingsActivated
+
+        private enum CodingKeys: String, CodingKey {
+            case kind
+            case componentIDs
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let kind = try container.decode(String.self, forKey: .kind)
+            switch kind {
+            case "componentTied":
+                let componentIDs = try container.decode([String].self, forKey: .componentIDs)
+                self = .componentTied(componentIDs: componentIDs)
+            case "settingsActivated":
+                self = .settingsActivated
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: .kind, in: container, debugDescription: "unknown binding kind \"\(kind)\"")
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .componentTied(let componentIDs):
+                try container.encode("componentTied", forKey: .kind)
+                try container.encode(componentIDs, forKey: .componentIDs)
+            case .settingsActivated:
+                try container.encode("settingsActivated", forKey: .kind)
+            }
+        }
+    }
+
+    /// Generalizes `WorkerComposition.Feature`'s hand-maintained `needsD1`/`needsKV`/`needsR2`
+    /// switch statements (`WorkerComposition.swift:28-53`) into manifest-driven data.
+    public struct Resources: Sendable, Equatable, Codable {
+        public let needsD1: Bool
+        public let needsKV: Bool
+        public let needsR2: Bool
+
+        public init(needsD1: Bool, needsKV: Bool, needsR2: Bool) {
+            self.needsD1 = needsD1
+            self.needsKV = needsKV
+            self.needsR2 = needsR2
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter WorkerDescriptorTests`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerCatalog.swift Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
+git commit -m "feat(workers): add WorkerDescriptor catalog model"
+```
+
+---
+
+### Task 2: `WorkerCatalogReader.parse`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/WorkerCatalog.swift`
+- Modify: `Tests/AnglesiteCoreTests/WorkerCatalogTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerDescriptor` from Task 1.
+- Produces: `WorkerCatalogReader.parse(_ data: Data) throws -> [WorkerDescriptor]` — decodes a
+  `{ "workers": [...] }` root object. Throws `DecodingError` on malformed JSON (mirrors
+  `WorkersConformanceReader.parse`'s contract — this function does not degrade gracefully; that's
+  `WorkerCatalogFetcher`'s job in Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/AnglesiteCoreTests/WorkerCatalogTests.swift`:
+
+```swift
+@Suite("WorkerCatalogReader")
+struct WorkerCatalogReaderTests {
+    private let sampleJSON = """
+    {
+      "workers": [
+        {
+          "id": "webmention",
+          "displayName": "Webmentions",
+          "description": "Receive and verify webmentions for posts",
+          "group": "social",
+          "binding": { "kind": "componentTied", "componentIDs": ["webmention-form"] },
+          "resources": { "needsD1": true, "needsKV": true, "needsR2": false }
+        },
+        {
+          "id": "solid-pod",
+          "displayName": "Solid Pod",
+          "description": "Expose a Solid-compatible personal data store for this site",
+          "group": "storage",
+          "binding": { "kind": "settingsActivated" },
+          "resources": { "needsD1": false, "needsKV": true, "needsR2": true }
+        }
+      ]
+    }
+    """.data(using: .utf8)!
+
+    @Test("parses a two-worker manifest with both binding kinds")
+    func parsesTwoWorkers() throws {
+        let workers = try WorkerCatalogReader.parse(sampleJSON)
+        #expect(workers.count == 2)
+
+        let webmention = try #require(workers.first { $0.id == "webmention" })
+        #expect(webmention.group == "social")
+        #expect(webmention.binding == .componentTied(componentIDs: ["webmention-form"]))
+        #expect(webmention.resources.needsD1)
+        #expect(!webmention.resources.needsR2)
+
+        let solidPod = try #require(workers.first { $0.id == "solid-pod" })
+        #expect(solidPod.binding == .settingsActivated)
+    }
+
+    @Test("throws on malformed JSON")
+    func throwsOnMalformedJSON() {
+        let json = "{ \"not-workers\": [] }".data(using: .utf8)!
+        #expect(throws: (any Error).self) {
+            _ = try WorkerCatalogReader.parse(json)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter WorkerCatalogReaderTests`
+Expected: FAIL — `WorkerCatalogReader` does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `Sources/AnglesiteCore/WorkerCatalog.swift`:
+
+```swift
+/// Parses `catalog.json` (the `@dwk/workers` monorepo's published worker manifest) into
+/// `WorkerDescriptor`s. Stateless — call `parse(_:)` directly, mirroring
+/// `WorkersConformanceReader`'s shape.
+public enum WorkerCatalogReader {
+    private struct Root: Decodable {
+        let workers: [WorkerDescriptor]
+    }
+
+    /// Decodes `data` (UTF-8 JSON matching the `catalog.json` schema) and returns its
+    /// `WorkerDescriptor`s. Throws a `DecodingError` if the JSON is malformed.
+    public static func parse(_ data: Data) throws -> [WorkerDescriptor] {
+        try JSONDecoder().decode(Root.self, from: data).workers
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter WorkerCatalogReaderTests`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerCatalog.swift Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
+git commit -m "feat(workers): add WorkerCatalogReader.parse"
+```
+
+---
+
+### Task 3: `WorkerCatalogFetcher` — fetch, cache, degrade
+
+**Files:**
+- Create: `Sources/AnglesiteCore/WorkerCatalogFetcher.swift`
+- Create: `Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerDescriptor`, `WorkerCatalogReader.parse(_:)` from Tasks 1–2.
+- Produces: `WorkerCatalogFetchError.fetchFailed(String)` (`Error, Sendable, Equatable`);
+  `WorkerCatalogFetcher` (`actor`) with
+  `init(catalogURL: URL, cacheURL: URL = WorkerCatalogFetcher.defaultCacheURL(), session: URLSession = .shared, fileManager: FileManager = .default)`
+  and `func catalog() async -> [WorkerDescriptor]` (never throws — degrades to cache, then to `[]`).
+  Also `static func defaultCacheURL(fileManager: FileManager = .default) -> URL`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Stub `URLProtocol` returning a canned status/body for every request, so
+/// `WorkerCatalogFetcher` can be exercised without a real network call — mirrors
+/// `FreedesignmdCatalogTests`' `FreedesignmdStubURLProtocol`.
+private final class WorkerCatalogStubURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var statusCode = 200
+    nonisolated(unsafe) static var body = ""
+    nonisolated(unsafe) static var shouldFailToLoad = false
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        if Self.shouldFailToLoad {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(Self.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [WorkerCatalogStubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+// .serialized: tests share WorkerCatalogStubURLProtocol's mutable static status/body/failure
+// flag, which would race under Swift Testing's default parallel execution.
+@Suite(.serialized) struct WorkerCatalogFetcherTests {
+    private let sampleJSON = """
+    {
+      "workers": [
+        {
+          "id": "webmention",
+          "displayName": "Webmentions",
+          "description": "Receive and verify webmentions for posts",
+          "group": "social",
+          "binding": { "kind": "componentTied", "componentIDs": ["webmention-form"] },
+          "resources": { "needsD1": true, "needsKV": true, "needsR2": false }
+        }
+      ]
+    }
+    """
+
+    private func tempCacheURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("worker-catalog-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("worker-catalog-cache.json")
+    }
+
+    @Test("fetches, parses, and writes the cache file on success")
+    func fetchesAndCachesOnSuccess() async throws {
+        WorkerCatalogStubURLProtocol.shouldFailToLoad = false
+        WorkerCatalogStubURLProtocol.statusCode = 200
+        WorkerCatalogStubURLProtocol.body = sampleJSON
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let fetcher = WorkerCatalogFetcher(
+            catalogURL: URL(string: "https://example.invalid/catalog.json")!,
+            cacheURL: cacheURL,
+            session: WorkerCatalogStubURLProtocol.makeSession()
+        )
+
+        let workers = await fetcher.catalog()
+        #expect(workers.map(\.id) == ["webmention"])
+        #expect(FileManager.default.fileExists(atPath: cacheURL.path))
+    }
+
+    @Test("falls back to the cached catalog when the fetch fails")
+    func fallsBackToCacheOnFetchFailure() async throws {
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(sampleJSON.utf8).write(to: cacheURL)
+
+        WorkerCatalogStubURLProtocol.shouldFailToLoad = true
+        let fetcher = WorkerCatalogFetcher(
+            catalogURL: URL(string: "https://example.invalid/catalog.json")!,
+            cacheURL: cacheURL,
+            session: WorkerCatalogStubURLProtocol.makeSession()
+        )
+
+        let workers = await fetcher.catalog()
+        #expect(workers.map(\.id) == ["webmention"])
+    }
+
+    @Test("returns an empty catalog when the fetch fails and there is no cache")
+    func returnsEmptyWhenNoCacheAndFetchFails() async {
+        WorkerCatalogStubURLProtocol.shouldFailToLoad = true
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let fetcher = WorkerCatalogFetcher(
+            catalogURL: URL(string: "https://example.invalid/catalog.json")!,
+            cacheURL: cacheURL,
+            session: WorkerCatalogStubURLProtocol.makeSession()
+        )
+
+        let workers = await fetcher.catalog()
+        #expect(workers.isEmpty)
+    }
+
+    @Test("returns an empty catalog on a non-2xx response with no cache")
+    func returnsEmptyOnBadStatusWithNoCache() async {
+        WorkerCatalogStubURLProtocol.shouldFailToLoad = false
+        WorkerCatalogStubURLProtocol.statusCode = 404
+        WorkerCatalogStubURLProtocol.body = "not found"
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let fetcher = WorkerCatalogFetcher(
+            catalogURL: URL(string: "https://example.invalid/catalog.json")!,
+            cacheURL: cacheURL,
+            session: WorkerCatalogStubURLProtocol.makeSession()
+        )
+
+        let workers = await fetcher.catalog()
+        #expect(workers.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter WorkerCatalogFetcherTests`
+Expected: FAIL — `WorkerCatalogFetcher`/`WorkerCatalogFetchError` do not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `Sources/AnglesiteCore/WorkerCatalogFetcher.swift`:
+
+```swift
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum WorkerCatalogFetchError: Error, Sendable, Equatable {
+    case fetchFailed(String)
+}
+
+/// Fetches, parses, and disk-caches the `@dwk/workers` catalog manifest (`catalog.json`).
+/// Network or parse failures degrade to the last successfully cached copy, then to an empty
+/// catalog — the Workers Settings tab and deploy composition must never block or crash on a
+/// catalog fetch failure (design doc §3).
+///
+/// - Important: `catalogURL` has no in-app default. As of this writing `@dwk/workers` has not
+///   yet published `catalog.json` — callers must supply the real manifest URL once the monorepo
+///   publishes one.
+public actor WorkerCatalogFetcher {
+    private let catalogURL: URL
+    private let cacheURL: URL
+    private let session: URLSession
+    private let fileManager: FileManager
+
+    public init(
+        catalogURL: URL,
+        cacheURL: URL = WorkerCatalogFetcher.defaultCacheURL(),
+        session: URLSession = .shared,
+        fileManager: FileManager = .default
+    ) {
+        self.catalogURL = catalogURL
+        self.cacheURL = cacheURL
+        self.session = session
+        self.fileManager = fileManager
+    }
+
+    /// Fetches the latest catalog and caches the raw manifest bytes to disk on success. On any
+    /// failure (network error, non-2xx response, malformed JSON), falls back to the last cached
+    /// catalog; if there is no cache either, returns an empty catalog. Never throws.
+    public func catalog() async -> [WorkerDescriptor] {
+        if let fresh = try? await fetchAndCache() {
+            return fresh
+        }
+        return (try? Self.readCache(cacheURL)) ?? []
+    }
+
+    private func fetchAndCache() async throws -> [WorkerDescriptor] {
+        let (data, response) = try await session.data(from: catalogURL)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw WorkerCatalogFetchError.fetchFailed("bad response from \(catalogURL)")
+        }
+        let descriptors = try WorkerCatalogReader.parse(data)
+        try Self.writeCache(data, to: cacheURL, fileManager: fileManager)
+        return descriptors
+    }
+
+    private static func readCache(_ url: URL) throws -> [WorkerDescriptor] {
+        let data = try Data(contentsOf: url)
+        return try WorkerCatalogReader.parse(data)
+    }
+
+    private static func writeCache(_ data: Data, to url: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: [.atomic])
+    }
+
+    /// `~/Library/Application Support/Anglesite/worker-catalog-cache.json` — mirrors
+    /// `SiteStore`'s `defaultPersistenceURL` convention (`SiteStore.swift:323-333`).
+    public static func defaultCacheURL(fileManager: FileManager = .default) -> URL {
+        let support = (try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return support
+            .appendingPathComponent("Anglesite", isDirectory: true)
+            .appendingPathComponent("worker-catalog-cache.json")
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter WorkerCatalogFetcherTests`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Run the full AnglesiteCoreTests suite to confirm no regressions**
+
+Run: `swift test --package-path . --filter AnglesiteCoreTests`
+Expected: PASS (all existing tests plus the 9 new ones from this plan)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerCatalogFetcher.swift Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift
+git commit -m "feat(workers): add WorkerCatalogFetcher with disk-cache fallback"
+```
+
+---
+
+## What this plan does not cover
+
+This plan is the first of two implementation plans under sub-issue
+[#708](https://github.com/Anglesite/Anglesite-app/issues/708) ("Worker catalog + local
+wrangler-dev runtime"). It covers only the catalog data model and fetch/cache layer (design doc
+§3). It deliberately does **not** cover:
+
+- Wiring a real production `catalogURL` anywhere in the app (blocked on `@dwk/workers` publishing
+  `catalog.json` — design doc §10).
+- Migrating `WorkerComposition.Feature` from its closed enum to `[WorkerDescriptor]` (design doc
+  §3's "existing code that changes shape" note) — that lands with sub-issue #709's deploy
+  integration work, since it's deploy-composition logic, not catalog logic.
+- The local `wrangler dev` container runtime (design doc §7) — extending `LocalContainerControl`,
+  `LocalContainerSiteRuntime`, and the container images (`Containers/anglesite-dev/Dockerfile`,
+  `container/Dockerfile`) to run a worker dev server needs its own plan: it touches a carefully
+  reentrancy-guarded actor (`LocalContainerSiteRuntime`'s generation-tracking, see its extensive
+  comments on superseded-attempt handling) and requires baking `wrangler` into two Dockerfiles that
+  currently only bake Node/git/the MCP sidecar — neither of which this plan's file list touches.
+  Write that as a follow-up plan once `LocalContainerControl`'s production conformer
+  (`ContainerizationControl` in `AnglesiteContainer`) and the vsock port-allocation path have been
+  read in full.

--- a/docs/superpowers/specs/2026-07-13-workers-local-debugging-design.md
+++ b/docs/superpowers/specs/2026-07-13-workers-local-debugging-design.md
@@ -1,0 +1,247 @@
+# Running Workers locally for debugging — design
+
+**Issue:** [#700](https://github.com/Anglesite/Anglesite-app/issues/700) (becomes a tracking epic)
+**Date:** 2026-07-13
+**Status:** Proposed
+
+## 1. Problem
+
+A site's Cloudflare Worker composes `@dwk/workers` packages (webmention, indieauth, micropub,
+websub, activitypub, microsub, webfinger today; more — including packages not yet named in this
+codebase, e.g. the issue's ESI/Solid-Pod/WebDav examples — as `@dwk/workers` grows) behind the
+site's static assets. Today the only way to see a Worker run is a real Cloudflare deploy. There is
+no local dev/debug path, no per-site record of which workers are active, and no UI for turning
+them on or off. The result: every Worker iteration costs a deploy, and there's no visibility into
+which workers a site is actually running or why.
+
+## 2. Scope
+
+This spec covers three implementation slices, each independently shippable as a paired PR against
+`Anglesite/anglesite` (where `@dwk/workers` publishes its manifest) where needed:
+
+- **700a — Worker catalog + local runtime.** Fetch the `@dwk/workers` catalog; run a local
+  `wrangler dev` session alongside the existing Astro dev server inside `LocalContainerSiteRuntime`.
+- **700b — Persisted worker state + deploy integration.** Per-site active-worker state; generate
+  `wrangler.toml` from the effective active set; remove workers from Cloudflare when deactivated.
+- **700c — Site Settings: Workers tab.** A new tab in the existing per-site settings surface
+  (`PlistEditorView`) showing every catalog worker, grouped, with component-tied workers shown
+  read-only and settings-activated workers toggleable.
+
+**Deferred, not in this spec:** a "Webserver" menu-bar menu with per-open-site submenus and
+Cloudflare dashboard deep-links (the issue's fourth bullet). Cut from scope during design review —
+worth revisiting once 700a–c ship and it's clear what other affordances people actually reach for.
+File as a follow-on issue against #700 if picked up later; do not build it as part of this work.
+
+**Out of scope entirely:** anything about *which* packages `@dwk/workers` ships (ESI, Solid-Pod,
+WebDav, or otherwise) — that's the monorepo's decision, not this app's. This design treats the
+catalog as opaque data (§3).
+
+## 3. Worker catalog
+
+`@dwk/workers` publishes `catalog.json` at the monorepo root, alongside the existing
+`conformance/status.json` that `WorkersConformanceReader` (`Sources/AnglesiteCore/WorkersConformance.swift`)
+already knows how to parse — same publishing channel, new file. Shape:
+
+```json
+{
+  "workers": [
+    {
+      "id": "webmention",
+      "displayName": "Webmentions",
+      "description": "Receive and verify webmentions for posts",
+      "group": "social",
+      "binding": { "kind": "componentTied", "componentIDs": ["webmention-form"] },
+      "resources": { "needsD1": true, "needsKV": true, "needsR2": false }
+    },
+    {
+      "id": "solid-pod",
+      "displayName": "Solid Pod",
+      "description": "Expose a Solid-compatible personal data store for this site",
+      "group": "storage",
+      "binding": { "kind": "settingsActivated" },
+      "resources": { "needsD1": false, "needsKV": true, "needsR2": true }
+    }
+  ]
+}
+```
+
+- `binding.kind` is either `componentTied` (active iff a bound component is used on ≥1 page —
+  never manually toggled, §5) or `settingsActivated` (manually toggled in the Workers tab, §5).
+  `componentIDs` are Site Graph Explorer node IDs (§4).
+- `group` is a free-text grouping key the Workers tab sections by (`social`, `storage`, whatever
+  the manifest declares) — never hardcoded in Swift, per the decision to keep the app's catalog
+  model generic rather than enumerate specific worker names.
+- `resources` generalizes `WorkerComposition.Feature`'s existing `needsD1`/`needsKV`/`needsR2`
+  flags (`Sources/AnglesiteCore/WorkerComposition.swift:28-53`) from a closed, hand-maintained
+  Swift enum to manifest-driven data.
+
+**New type:** `Sources/AnglesiteCore/WorkerCatalog.swift` — `WorkerDescriptor` (Codable struct
+matching the shape above) plus `WorkerCatalogReader.parse(_:) -> [WorkerDescriptor]`, mirroring
+`WorkersConformanceReader`'s stateless-parser shape. Unlike `WorkersConformanceReader` — which has
+no fetch/cache call site anywhere in the codebase today, only the parser — `WorkerCatalog` needs an
+actual fetch-and-cache layer (this is genuinely new infrastructure, not an extension of existing
+plumbing): fetch on Workers-tab open and at deploy time, cache the last-known-good catalog to disk,
+and degrade to the cached (or empty) catalog — never a crash or a blocked UI — if the network fetch
+fails. `WorkersConformance` could adopt the same fetch/cache layer later; not required for this work.
+
+**Existing code that changes shape:** `WorkerComposition.Feature` (`WorkerComposition.swift:12-54`)
+is today a closed `CaseIterable` enum hardcoding exactly the seven V-2..V-4 package names, with
+`needsD1`/`needsKV`/`needsR2` as switch statements over those cases. `generateWranglerToml` needs
+to accept `[WorkerDescriptor]` (or an equivalent id+resources value) instead of `[Feature]`, since
+manifest-driven workers (Solid-Pod, WebDav, whatever ships later) won't have enum cases. The
+existing `Feature.v2`/`.v3`/`.v4` phase lists and `WorkersConformanceStatus.phaseRequirements`
+(`WorkersConformance.swift:47-51`) keep working by mapping npm package name → catalog `id` rather
+than enum case — phase-gating logic is unchanged, only its input type is.
+
+## 4. Component-tied workers reuse Site Graph Explorer
+
+"Which pages use component X" is already a solved, queryable problem — no new tracking needed.
+`ImpactAnalysis.analyze(snapshot:targetID:)` (`Sources/AnglesiteCore/ImpactAnalysis.swift`) walks
+the reverse transitive closure of the Site Graph Explorer's dependency graph
+(`Sources/AnglesiteCore/SiteGraphExplorer.swift`, which already models `component` as a distinct
+node kind) and returns `report.affectedPages`. For each `componentTied` worker, the Workers tab
+runs `ImpactAnalysis.analyze` against the worker's `componentIDs` and shows the resulting page list
+directly — no new usage-tracking infrastructure, just a new caller of an existing API.
+
+## 5. Persisted state (700b)
+
+Extend `SiteSettings` (`Sources/AnglesiteCore/SiteConfigStore.swift:12-30`), preserving the file's
+hard rule that every field is `Optional` for forward-compat decoding:
+
+```swift
+/// Worker catalog IDs the user has manually toggled on (settingsActivated workers only).
+/// Component-tied workers are never stored here — their active state is always recomputed
+/// live from Site Graph Explorer / ImpactAnalysis (§4), so it can't drift from site content.
+public var activeWorkerIDs: [String]?
+
+/// The full effective active set (component-tied + settings-activated) as of the last
+/// successful deploy — the diff baseline for removing deactivated workers (§6).
+public var lastDeployedWorkerIDs: [String]?
+```
+
+**Effective active set** (computed, never stored as its own field):
+`{ componentTied workers with ≥1 ImpactAnalysis-affected page } ∪ { activeWorkerIDs }`.
+
+## 6. Deploy integration (700b)
+
+At deploy time, `WorkerComposition` computes the effective active set (§5) and generates
+`wrangler.toml` from it (generalizing `generateWranglerToml` per §3). Before deploying, it diffs
+the effective set against `lastDeployedWorkerIDs`: any worker present in the old set but absent
+from the new one gets an explicit Cloudflare-side removal (route/binding teardown) ahead of the new
+deploy — deactivating a worker is a real security/cost action, not just an omission from the next
+bundle, per the issue's "respecting security, performance, cost" framing. After a successful
+deploy, `lastDeployedWorkerIDs` is updated to the new effective set.
+
+`lastDeployedWorkerIDs` lives in `Config/` (app-owned, never git) rather than being inferred from
+`Source/`'s current `wrangler.toml`, because `Source/` is a git repo — a teammate's pull or a
+hand-edit could change `wrangler.toml` between app sessions. The diff baseline must reflect what
+the app actually told Cloudflare last, not whatever a file currently says.
+
+## 7. Local runtime (700a)
+
+`LocalContainerSiteRuntime` (`Sources/AnglesiteCore/LocalContainerSiteRuntime.swift`) gains a
+second guest process, sibling to the existing `astro dev` + MCP sidecar (`container/start-dev-server.sh`):
+`wrangler dev --local` (Miniflare-backed local emulation — **no calls to the user's real Cloudflare
+account**; KV/D1/R2 are locally persisted, matching wrangler's own default local mode). This keeps
+a debug session from touching production data or incurring cost, and means it works without the
+Cloudflare token having been onboarded at all.
+
+- **Started on demand**, not unconditionally: only when the site's effective active set (§5) is
+  non-empty. A site with no active workers pays no extra container cost.
+- **New vsock-proxied port** carries the worker's local URL, exposed alongside the existing
+  `previewURL`/`mcpURL` on the runtime's session/state payload — extending `SiteRuntimeState`
+  rather than changing the `SiteRuntime` protocol's shape (`start`/`observe`/`mcpClient` stay as
+  they are; see the architecture note below).
+- **Logs stream into the existing debug pane** via the same `LogCenter` path other container
+  subprocesses already use — no `/dev/null`, consistent with "logs are sacred."
+- **Toggling a worker in the Workers tab** (§8) while a local session is running restarts the local
+  `wrangler dev` process with the new active set, so the debug session reflects the change
+  immediately without a full container reboot. Production deploy is unaffected until the next
+  explicit deploy (§6).
+- **Process isolation:** a `wrangler dev` crash must not take down the Astro session. The
+  container's process supervisor needs independent restart/health tracking per child process
+  (Astro, MCP sidecar, wrangler dev), not just a single "container is up" signal.
+
+`SiteRuntime`'s minimal contract (one `start`, one `observe` state stream, one `mcpClient`) is what
+makes this additive rather than a breaking change to all three conformers (`LocalContainerSiteRuntime`,
+`RemoteSandboxSiteRuntime`, `UnavailableSiteRuntime`) — the protocol only ever exposed a state
+stream and an MCP client, never raw ports or process handles, so a second live process is a change
+to the *state payload*, not the protocol surface. `RemoteSandboxSiteRuntime` and
+`UnavailableSiteRuntime` are unaffected by this slice — the local Workers dev server is a
+local-container-only capability for V1 (remote-sandbox parity, if wanted, is future work).
+
+## 8. Site Settings: Workers tab (700c)
+
+**Tab mechanism:** add `.workers` to `PlistEditorView`'s existing `SettingsTab` enum (alongside
+`.website`/`.analytics`/`.redirects`, `Sources/AnglesiteApp/PlistEditorView.swift`) — reuses the
+segmented `Picker` already there. `PlistEditorModel` becomes the first UI consumer of
+`SiteConfigStore` beyond the existing `displayName`-override path: on tab select it loads
+`SiteSettings`, fetches/reads the cached `WorkerCatalog`, and runs `ImpactAnalysis` for each
+component-tied worker.
+
+**Layout**, grouped by the catalog's `group` field:
+
+```
+┌─ Workers ──────────────────────────────────────────────┐
+│ [Production Logs]  [Analytics]   ← disabled until       │
+│                                     lastDeployedWorkerIDs≠[] │
+│                                                           │
+│ ▼ Social                                                 │
+│   Webmentions          Active — used on 3 pages →       │  read-only, component-tied
+│   IndieAuth            Inactive — not used               │
+│                                                           │
+│ ▼ Storage                                                │
+│   Solid Pod            [off ⇄]                            │  toggle, settings-activated
+│   WebDav               [on  ⇄]                            │
+└────────────────────────────────────────────────────────────┘
+```
+
+- Component-tied rows are **read-only** — never a manual toggle. "Active — used on N pages" links
+  to the `ImpactAnalysis` result (exact interaction — popover vs. Navigator selection — is an
+  implementation-time UI call, not a design fork).
+- Settings-activated rows get a toggle bound to `activeWorkerIDs` membership; flipping it writes
+  `SiteSettings` immediately via `SiteConfigStore.save` and triggers the local-runtime restart
+  described in §7.
+- The top-of-pane Logs/Analytics buttons are `NSWorkspace.shared.open()` deep-links into the
+  Cloudflare dashboard (no in-app API wrapper exists for Cloudflare Logs/Analytics, and building
+  one is out of scope here) — disabled until `lastDeployedWorkerIDs` is non-empty, i.e. after the
+  site's first deploy that included at least one worker.
+
+## 9. Testing
+
+- `WorkerCatalogReader.parse` — unit tests over fixture JSON (valid, missing optional fields,
+  malformed → graceful empty result), mirroring `WorkersConformanceReader`'s existing test shape.
+- `WorkerComposition.generateWranglerToml` — existing tests migrate from `[Feature]` fixtures to
+  `[WorkerDescriptor]` fixtures; add cases for a manifest-only worker with no historical `Feature`
+  case, to prove the generalization didn't silently drop coverage.
+- `SiteConfigStore` — round-trip test for the two new fields, plus a decode test with an
+  old-format `settings.plist` (missing the new keys) to confirm forward-compat still holds.
+- Deploy diff/removal logic — unit test the diff computation (old set vs. new effective set →
+  removal list) independent of actual Cloudflare API calls.
+- `LocalContainerSiteRuntime`'s new process — covered by the existing `ANGLESITE_CONTAINER_TESTS=1`
+  / `ANGLESITE_CONTAINER_E2E=1` opt-in suites (per CLAUDE.md, `swift test` alone can't boot VMs);
+  add a case that toggles a worker on and asserts the local worker URL becomes reachable.
+- Workers tab — `PlistEditorModel` unit tests for load/toggle/save; a manual GUI smoke pass
+  (per this repo's pattern of owed manual-smoke follow-ups on new UI, e.g. #491) rather than a new
+  hosted-app UI test, consistent with how other `PlistEditorView` tabs are covered today.
+
+## 10. Open questions / risks
+
+- **`@dwk/workers` catalog.json doesn't exist yet** — this spec assumes the monorepo will publish
+  it; 700a is blocked on that landing, the same way V-2..V-4 are blocked on conformance status
+  today. Coordinate as a paired-repo change per this repo's existing cross-repo convention.
+  Worth confirming with the monorepo maintainer (same author) before implementation starts.
+  `@dwk/workers` is pre-1.0 (0.1.0-beta.2), so treat catalog.json's shape as provisional until
+  the monorepo stabilizes it.
+- **Cloudflare dashboard URL scheme** for the Logs/Analytics deep-links (§8) needs confirming
+  against Cloudflare's actual current dashboard paths at implementation time — a lookup detail,
+  not a design fork, but worth verifying before 700c ships rather than assuming.
+- **`WorkerComposition.Feature` → `WorkerDescriptor` migration** touches existing, working V-2..V-4
+  gating code (`SocialWorkerProvisionCommand.swift`, `SocialPublishPlan.swift`, both only skimmed
+  during research) — 700b's implementer should read those fully before changing `Feature`'s shape,
+  to avoid silently breaking the social-phase rollout this design doesn't otherwise touch.
+- **Newsletter integration's bespoke Worker** (`Resources/Template/integrations/worker/subscribe-worker.js`,
+  from the Integration wizard framework, #462) is a second, independent per-site Worker deployment
+  path that predates and doesn't go through `@dwk/workers`/`WorkerComposition` at all. This spec
+  doesn't reconcile it — it's a pre-existing inconsistency, not one this work introduces — but a
+  future pass should decide whether newsletter's worker ever moves onto this catalog model.


### PR DESCRIPTION
## Summary

- Design spec for epic #700 ("Running Workers locally for debugging"), covering three slices: worker catalog + local `wrangler dev` runtime, persisted active-worker state + deploy diff/removal, and a Workers tab in the per-site settings surface. A fourth idea (Webserver menu bar) was cut from scope during design review.
- #700 converted into a tracking epic; sub-issues filed: #708 (catalog + local runtime), #709 (persisted state + deploy integration), #710 (Site Settings: Workers tab).
- This PR implements the first slice of #708: a typed `WorkerDescriptor` catalog model, `WorkerCatalogReader.parse(_:)`, and a `WorkerCatalogFetcher` actor with disk-cache fallback (`Sources/AnglesiteCore/WorkerCatalog.swift`, `WorkerCatalogFetcher.swift`). No production call site is wired yet — intentionally deferred until `@dwk/workers` publishes `catalog.json` (see design doc §10).

## Test plan

- [x] `swift test --package-path . --filter WorkerCatalog` — 9/9 passing (WorkerDescriptor round-trip/decode, WorkerCatalogReader parse, WorkerCatalogFetcher fetch/cache/degrade, all 4 branches)
- [x] Full `swift test --package-path .` run — only 5 unrelated pre-existing failures (RepoBootstrapTests dotenv test, two Foundation Models on-device context-window overflow tests), none in files this branch touches
- [x] Per-task subagent code review (3 tasks, 1 fix round for a cache-write robustness issue) plus a final whole-branch review — "Ready to merge", no Critical/Important issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)