### PR TITLE
Add AppleScript automation support

### DIFF
--- a/Resources/Anglesite.sdef
+++ b/Resources/Anglesite.sdef
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
+<dictionary title="Anglesite Terminology">
+    <suite name="Anglesite Suite" code="AngS" description="Commands for automating Anglesite.">
+        
+        <command name="open site" code="AngSopns" description="Open a site in Anglesite.">
+            <cocoa class="OpenSiteCommand"/>
+            <direct-parameter type="text" description="The name, UUID, or package path of the site."/>
+            <result type="text" description="Result message."/>
+        </command>
+        
+        <command name="deploy site" code="AngSdepl" description="Deploy a site.">
+            <cocoa class="DeploySiteCommand"/>
+            <direct-parameter type="text" description="The name, UUID, or package path of the site."/>
+            <parameter name="allowing unattended" code="alun" type="boolean" optional="yes" description="Set to true to allow a non-interactive production deploy."/>
+            <result type="text" description="Result message."/>
+        </command>
+        
+        <command name="backup site" code="AngSback" description="Back up a site.">
+            <cocoa class="BackupSiteCommand"/>
+            <direct-parameter type="text" description="The name, UUID, or package path of the site."/>
+            <result type="text" description="Result message."/>
+        </command>
+
+        <command name="audit site" code="AngSaudt" description="Audit/check a site.">
+            <cocoa class="AuditSiteCommand"/>
+            <direct-parameter type="text" description="The name, UUID, or package path of the site."/>
+            <result type="text" description="Result message."/>
+        </command>
+
+        <command name="site status" code="AngSstat" description="Get status info for a site.">
+            <cocoa class="SiteStatusCommand"/>
+            <direct-parameter type="text" description="The name, UUID, or package path of the site."/>
+            <result type="text" description="Status text."/>
+        </command>
+
+        <command name="add page" code="AngSadpg" description="Create a new page on a site.">
+            <cocoa class="AddPageCommand"/>
+            <direct-parameter type="text" description="The name, UUID, or package path of the site."/>
+            <parameter name="name" code="name" type="text" description="The page title."/>
+            <parameter name="route" code="rout" type="text" optional="yes" description="Optional route path."/>
+            <result type="text" description="Result message."/>
+        </command>
+
+        <command name="add post" code="AngSadps" description="Create a new post on a site.">
+            <cocoa class="AddPostCommand"/>
+            <direct-parameter type="text" description="The name, UUID, or package path of the site."/>
+            <parameter name="title" code="titl" type="text" description="The post title."/>
+            <parameter name="collection" code="coll" type="text" optional="yes" description="Optional collection name."/>
+            <parameter name="slug" code="slug" type="text" optional="yes" description="Optional slug."/>
+            <result type="text" description="Result message."/>
+        </command>
+        
+    </suite>
+</dictionary>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -81,5 +81,9 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSAppleScriptEnabled</key>
+	<true/>
+	<key>OSAScriptingDefinition</key>
+	<string>Anglesite.sdef</string>
 </dict>
 </plist>

--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -44,6 +44,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let contentIndexerStore = ContentIndexerStore()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        Task { await AppleScriptCommandEnvironment.shared.configure(contentGraph: contentGraph) }
+
         // Register App Intents dependencies before the app surface comes up so backgrounded
         // intent processes (and #101's system MCP entry, later) can resolve immediately.
         // `bootstrap()` is async (it awaits the Spotlight handler installation on `SiteStore`);

--- a/Sources/AnglesiteApp/AppleScriptCommands.swift
+++ b/Sources/AnglesiteApp/AppleScriptCommands.swift
@@ -16,37 +16,6 @@ actor AppleScriptCommandEnvironment {
     }
 }
 
-private enum AppleScriptAsyncBridge {
-    static func run<T>(_ operation: @escaping @Sendable () async throws -> T) throws -> T {
-        let semaphore = DispatchSemaphore(value: 0)
-        let box = AppleScriptAsyncOutcomeBox<T>()
-
-        Task {
-            do {
-                box.outcome = .success(try await operation())
-            } catch {
-                box.outcome = .failure(error)
-            }
-            semaphore.signal()
-        }
-
-        semaphore.wait()
-
-        switch box.outcome {
-        case .success(let value):
-            return value
-        case .failure(let error):
-            throw error
-        case nil:
-            throw AppleScriptCommandService.CommandError.siteNotFound("unknown")
-        }
-    }
-}
-
-private final class AppleScriptAsyncOutcomeBox<T>: @unchecked Sendable {
-    var outcome: Result<T, Error>?
-}
-
 private extension NSScriptCommand {
     var directTextParameter: String? {
         directParameter as? String
@@ -69,13 +38,13 @@ private extension NSScriptCommand {
     }
 
     func requiredStringArgument(named names: String...) throws -> String {
-        if let value = stringArgument(namedAnyOf: names)?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
+        if let value = stringArgument(named: names)?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
             return value
         }
         throw AppleScriptArgumentError.missing(names[0])
     }
 
-    private func stringArgument(namedAnyOf names: [String]) -> String? {
+    private func stringArgument(named names: [String]) -> String? {
         for name in names {
             if let value = evaluatedArguments?[name] as? String {
                 return value
@@ -97,13 +66,33 @@ private extension NSScriptCommand {
     }
 
     func runCommand(_ body: @escaping @Sendable () async throws -> String) -> Any? {
-        do {
-            return try AppleScriptAsyncBridge.run(body)
-        } catch {
-            scriptErrorNumber = -10000
-            scriptErrorString = error.localizedDescription
-            return nil
+        suspendExecution()
+        let command = AppleScriptCommandBox(self)
+
+        Task {
+            do {
+                let result = try await body()
+                await MainActor.run {
+                    command.value.resumeExecution(withResult: result)
+                }
+            } catch {
+                await MainActor.run {
+                    command.value.scriptErrorNumber = -10000
+                    command.value.scriptErrorString = error.localizedDescription
+                    command.value.resumeExecution(withResult: nil)
+                }
+            }
         }
+
+        return nil
+    }
+}
+
+private final class AppleScriptCommandBox: @unchecked Sendable {
+    let value: NSScriptCommand
+
+    init(_ value: NSScriptCommand) {
+        self.value = value
     }
 }
 
@@ -121,32 +110,21 @@ private enum AppleScriptArgumentError: LocalizedError {
 @objc(OpenSiteCommand)
 final class OpenSiteCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
+        let specifier: String
         do {
-            let specifier = try requiredDirectTextParameter()
-            let site = try AppleScriptAsyncBridge.run {
-                let service = await AppleScriptCommandEnvironment.shared.service()
-                return try await service.openSite(specifier)
-            }
-            openWindow(siteID: site.id)
-            return "Opened \(site.name)."
+            specifier = try requiredDirectTextParameter()
         } catch {
             scriptErrorNumber = -10000
             scriptErrorString = error.localizedDescription
             return nil
         }
-    }
-
-    private func openWindow(siteID: String) {
-        if Thread.isMainThread {
-            MainActor.assumeIsolated {
-                WindowRouter.shared.requestOpen(siteID: siteID)
+        return runCommand {
+            let service = await AppleScriptCommandEnvironment.shared.service()
+            let site = try await service.openSite(specifier)
+            await MainActor.run {
+                WindowRouter.shared.requestOpen(siteID: site.id)
             }
-        } else {
-            DispatchQueue.main.sync {
-                MainActor.assumeIsolated {
-                    WindowRouter.shared.requestOpen(siteID: siteID)
-                }
-            }
+            return "Opened \(site.name)."
         }
     }
 }

--- a/Sources/AnglesiteApp/AppleScriptCommands.swift
+++ b/Sources/AnglesiteApp/AppleScriptCommands.swift
@@ -1,0 +1,283 @@
+import AppKit
+import AnglesiteCore
+import AnglesiteIntents
+
+actor AppleScriptCommandEnvironment {
+    static let shared = AppleScriptCommandEnvironment()
+
+    private var contentGraph = SiteContentGraph()
+
+    func configure(contentGraph: SiteContentGraph) {
+        self.contentGraph = contentGraph
+    }
+
+    func service() -> AppleScriptCommandService {
+        AppleScriptCommandService(graph: contentGraph)
+    }
+}
+
+private enum AppleScriptAsyncBridge {
+    static func run<T>(_ operation: @escaping @Sendable () async throws -> T) throws -> T {
+        let semaphore = DispatchSemaphore(value: 0)
+        let box = AppleScriptAsyncOutcomeBox<T>()
+
+        Task {
+            do {
+                box.outcome = .success(try await operation())
+            } catch {
+                box.outcome = .failure(error)
+            }
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+
+        switch box.outcome {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        case nil:
+            throw AppleScriptCommandService.CommandError.siteNotFound("unknown")
+        }
+    }
+}
+
+private final class AppleScriptAsyncOutcomeBox<T>: @unchecked Sendable {
+    var outcome: Result<T, Error>?
+}
+
+private extension NSScriptCommand {
+    var directTextParameter: String? {
+        directParameter as? String
+    }
+
+    func requiredDirectTextParameter() throws -> String {
+        if let value = directTextParameter?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
+            return value
+        }
+        throw AppleScriptCommandService.CommandError.emptySiteSpecifier
+    }
+
+    func stringArgument(named names: String...) -> String? {
+        for name in names {
+            if let value = evaluatedArguments?[name] as? String {
+                return value
+            }
+        }
+        return nil
+    }
+
+    func requiredStringArgument(named names: String...) throws -> String {
+        if let value = stringArgument(namedAnyOf: names)?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
+            return value
+        }
+        throw AppleScriptArgumentError.missing(names[0])
+    }
+
+    private func stringArgument(namedAnyOf names: [String]) -> String? {
+        for name in names {
+            if let value = evaluatedArguments?[name] as? String {
+                return value
+            }
+        }
+        return nil
+    }
+
+    func boolArgument(named names: String...) -> Bool {
+        for name in names {
+            if let value = evaluatedArguments?[name] as? Bool {
+                return value
+            }
+            if let value = evaluatedArguments?[name] as? NSNumber {
+                return value.boolValue
+            }
+        }
+        return false
+    }
+
+    func runCommand(_ body: @escaping @Sendable () async throws -> String) -> Any? {
+        do {
+            return try AppleScriptAsyncBridge.run(body)
+        } catch {
+            scriptErrorNumber = -10000
+            scriptErrorString = error.localizedDescription
+            return nil
+        }
+    }
+}
+
+private enum AppleScriptArgumentError: LocalizedError {
+    case missing(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missing(let name):
+            return "Missing required AppleScript parameter: \(name)."
+        }
+    }
+}
+
+@objc(OpenSiteCommand)
+final class OpenSiteCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        do {
+            let specifier = try requiredDirectTextParameter()
+            let site = try AppleScriptAsyncBridge.run {
+                let service = await AppleScriptCommandEnvironment.shared.service()
+                return try await service.openSite(specifier)
+            }
+            openWindow(siteID: site.id)
+            return "Opened \(site.name)."
+        } catch {
+            scriptErrorNumber = -10000
+            scriptErrorString = error.localizedDescription
+            return nil
+        }
+    }
+
+    private func openWindow(siteID: String) {
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                WindowRouter.shared.requestOpen(siteID: siteID)
+            }
+        } else {
+            DispatchQueue.main.sync {
+                MainActor.assumeIsolated {
+                    WindowRouter.shared.requestOpen(siteID: siteID)
+                }
+            }
+        }
+    }
+}
+
+@objc(DeploySiteCommand)
+final class DeploySiteCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        let specifier: String
+        do {
+            specifier = try requiredDirectTextParameter()
+        } catch {
+            scriptErrorNumber = -10000
+            scriptErrorString = error.localizedDescription
+            return nil
+        }
+        let allowingUnattended = boolArgument(named: "allowing unattended", "allowingUnattended", "alun")
+        return runCommand {
+            let service = await AppleScriptCommandEnvironment.shared.service()
+            return try await service.deploySite(
+                specifier,
+                allowingUnattended: allowingUnattended
+            )
+        }
+    }
+}
+
+@objc(BackupSiteCommand)
+final class BackupSiteCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        let specifier: String
+        do {
+            specifier = try requiredDirectTextParameter()
+        } catch {
+            scriptErrorNumber = -10000
+            scriptErrorString = error.localizedDescription
+            return nil
+        }
+        return runCommand {
+            let service = await AppleScriptCommandEnvironment.shared.service()
+            return try await service.backupSite(specifier)
+        }
+    }
+}
+
+@objc(AuditSiteCommand)
+final class AuditSiteCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        let specifier: String
+        do {
+            specifier = try requiredDirectTextParameter()
+        } catch {
+            scriptErrorNumber = -10000
+            scriptErrorString = error.localizedDescription
+            return nil
+        }
+        return runCommand {
+            let service = await AppleScriptCommandEnvironment.shared.service()
+            return try await service.auditSite(specifier)
+        }
+    }
+}
+
+@objc(SiteStatusCommand)
+final class SiteStatusCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        let specifier: String
+        do {
+            specifier = try requiredDirectTextParameter()
+        } catch {
+            scriptErrorNumber = -10000
+            scriptErrorString = error.localizedDescription
+            return nil
+        }
+        return runCommand {
+            let service = await AppleScriptCommandEnvironment.shared.service()
+            return try await service.siteStatus(specifier)
+        }
+    }
+}
+
+@objc(AddPageCommand)
+final class AddPageCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        let specifier: String
+        let name: String
+        let route: String?
+        do {
+            specifier = try requiredDirectTextParameter()
+            name = try requiredStringArgument(named: "name")
+            route = stringArgument(named: "route", "rout")
+        } catch {
+            scriptErrorNumber = -10000
+            scriptErrorString = error.localizedDescription
+            return nil
+        }
+        return runCommand {
+            let service = await AppleScriptCommandEnvironment.shared.service()
+            return try await service.addPage(
+                specifier,
+                name: name,
+                route: route
+            )
+        }
+    }
+}
+
+@objc(AddPostCommand)
+final class AddPostCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        let specifier: String
+        let title: String
+        let collection: String?
+        let slug: String?
+        do {
+            specifier = try requiredDirectTextParameter()
+            title = try requiredStringArgument(named: "title", "titl")
+            collection = stringArgument(named: "collection", "coll")
+            slug = stringArgument(named: "slug")
+        } catch {
+            scriptErrorNumber = -10000
+            scriptErrorString = error.localizedDescription
+            return nil
+        }
+        return runCommand {
+            let service = await AppleScriptCommandEnvironment.shared.service()
+            return try await service.addPost(
+                specifier,
+                title: title,
+                collection: collection,
+                slug: slug
+            )
+        }
+    }
+}

--- a/Sources/AnglesiteCore/AppleScriptCommandService.swift
+++ b/Sources/AnglesiteCore/AppleScriptCommandService.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// Testable command kernel for the app target's Cocoa Scripting adapters.
+///
+/// AppleScript commands are synchronous Objective-C entry points, but the work they trigger is
+/// already async Swift. Keep policy, site resolution, and result formatting here so the app target
+/// can stay a small Apple Event adapter instead of growing another operation stack.
+public struct AppleScriptCommandService: Sendable {
+    public enum CommandError: LocalizedError, Equatable {
+        case emptySiteSpecifier
+        case siteNotFound(String)
+        case ambiguousSite(String, matches: [String])
+        case deployRequiresUnattendedOptIn(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .emptySiteSpecifier:
+                return "Specify a site by UUID, exact name, or registered package path."
+            case .siteNotFound(let specifier):
+                return "Could not find a registered Anglesite site matching \(specifier)."
+            case .ambiguousSite(let specifier, let matches):
+                return "More than one site matches \(specifier): \(matches.joined(separator: ", "))."
+            case .deployRequiresUnattendedOptIn(let name):
+                return "Deploying \(name) from AppleScript requires `with allowing unattended`."
+            }
+        }
+    }
+
+    private let store: SiteStore
+    private let operations: any SiteOperationsService
+    private let content: any ContentOperationsService
+    private let graph: SiteContentGraph
+    private let loadSites: @Sendable () async throws -> Void
+
+    public init(
+        store: SiteStore = .shared,
+        operations: (any SiteOperationsService)? = nil,
+        content: (any ContentOperationsService)? = nil,
+        graph: SiteContentGraph = SiteContentGraph(),
+        loadSites: (@Sendable () async throws -> Void)? = nil
+    ) {
+        self.store = store
+        self.operations = operations ?? SiteOperations(store: store)
+        self.graph = graph
+        self.loadSites = loadSites ?? { try await store.load() }
+        self.content = content ?? ContentCreationWorkflow.native(
+            contentGraph: graph,
+            siteDirectory: { id in await store.find(id: id)?.sourceDirectory }
+        )
+    }
+
+    public func resolveSite(_ specifier: String) async throws -> SiteStore.Site {
+        let needle = specifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty else { throw CommandError.emptySiteSpecifier }
+
+        try await loadSites()
+        let sites = await store.sites
+
+        if let site = sites.first(where: { $0.id.caseInsensitiveCompare(needle) == .orderedSame }) {
+            return site
+        }
+
+        let pathMatches = sites.filter { site in
+            let canonicalNeedle = Self.canonicalPath(needle)
+            guard !canonicalNeedle.isEmpty else { return false }
+            return canonicalNeedle == Self.canonicalPath(site.packageURL.path)
+                || canonicalNeedle == Self.canonicalPath(site.sourceDirectory.path)
+        }
+        if let resolved = try singleMatch(pathMatches, specifier: needle) {
+            return resolved
+        }
+
+        let nameMatches = sites.filter { $0.name.caseInsensitiveCompare(needle) == .orderedSame }
+        if let resolved = try singleMatch(nameMatches, specifier: needle) {
+            return resolved
+        }
+
+        throw CommandError.siteNotFound(needle)
+    }
+
+    public func openSite(_ specifier: String) async throws -> SiteStore.Site {
+        let site = try await resolveSite(specifier)
+        try? await store.touch(id: site.id)
+        return site
+    }
+
+    public func deploySite(_ specifier: String, allowingUnattended: Bool) async throws -> String {
+        let site = try await resolveSite(specifier)
+        guard allowingUnattended else {
+            throw CommandError.deployRequiresUnattendedOptIn(site.name)
+        }
+        return SiteOperations.dialog(forDeploy: await operations.deploy(site: site))
+    }
+
+    public func backupSite(_ specifier: String) async throws -> String {
+        let site = try await resolveSite(specifier)
+        return SiteOperations.dialog(forBackup: await operations.backup(site: site))
+    }
+
+    public func auditSite(_ specifier: String) async throws -> String {
+        let site = try await resolveSite(specifier)
+        return SiteOperations.dialog(forAudit: await operations.audit(site: site))
+    }
+
+    public func siteStatus(_ specifier: String) async throws -> String {
+        let site = try await resolveSite(specifier)
+        let posts = await graph.posts(for: site.id)
+        let pages = await graph.pages(for: site.id).count
+        let images = await graph.images(for: site.id).count
+        let drafts = posts.filter(\.draft).count
+        return "\(site.name) has \(Self.count(pages, "page")), \(Self.count(posts.count, "post")) (\(Self.count(drafts, "draft"))), and \(Self.count(images, "image"))."
+    }
+
+    public func addPage(_ specifier: String, name: String, route: String?) async throws -> String {
+        let site = try await resolveSite(specifier)
+        let cleanRoute = Self.nilIfBlank(route)
+        let result = await content.createPage(siteID: site.id, name: name, route: cleanRoute)
+        return Self.createdDialog(result, kind: "page", siteName: site.name)
+    }
+
+    public func addPost(_ specifier: String, title: String, collection: String?, slug: String?) async throws -> String {
+        let site = try await resolveSite(specifier)
+        let result = await content.createPost(
+            siteID: site.id,
+            title: title,
+            collection: Self.nilIfBlank(collection),
+            slug: Self.nilIfBlank(slug)
+        )
+        return Self.createdDialog(result, kind: "post", siteName: site.name)
+    }
+
+    private func singleMatch(_ matches: [SiteStore.Site], specifier: String) throws -> SiteStore.Site? {
+        switch matches.count {
+        case 0:
+            return nil
+        case 1:
+            return matches[0]
+        default:
+            throw CommandError.ambiguousSite(specifier, matches: matches.map(\.name).sorted())
+        }
+    }
+
+    private static func createdDialog(_ result: ContentCreateResult, kind: String, siteName: String) -> String {
+        switch result {
+        case .created(_, let identifier):
+            return "Added a \(kind) at \(identifier) on \(siteName)."
+        case .siteNotFound:
+            return "Could not find \(siteName)."
+        case .failed(let reason):
+            return "Could not add the \(kind): \(reason)"
+        }
+    }
+
+    private static func count(_ value: Int, _ singular: String) -> String {
+        value == 1 ? "1 \(singular)" : "\(value) \(singular)s"
+    }
+
+    private static func nilIfBlank(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    private static func canonicalPath(_ raw: String) -> String {
+        let expanded = (raw as NSString).expandingTildeInPath
+        guard expanded.hasPrefix("/") else { return "" }
+        return URL(fileURLWithPath: expanded)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+    }
+}

--- a/Tests/AnglesiteCoreTests/AppleScriptCommandServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/AppleScriptCommandServiceTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("AppleScriptCommandService")
+struct AppleScriptCommandServiceTests {
+    @Test("resolves by UUID, exact name, package path, and source path")
+    func resolvesExactIdentifiers() async throws {
+        let fixture = try await Fixture()
+        let service = fixture.service()
+
+        #expect(try await service.resolveSite(fixture.alpha.id).id == fixture.alpha.id)
+        #expect(try await service.resolveSite("Alpha").id == fixture.alpha.id)
+        #expect(try await service.resolveSite(fixture.alpha.packageURL.path).id == fixture.alpha.id)
+        #expect(try await service.resolveSite(fixture.alpha.sourceDirectory.path).id == fixture.alpha.id)
+    }
+
+    @Test("does not resolve name substrings")
+    func rejectsSubstringResolution() async throws {
+        let fixture = try await Fixture()
+        let service = fixture.service()
+
+        await #expect(throws: AppleScriptCommandService.CommandError.siteNotFound("Alp")) {
+            _ = try await service.resolveSite("Alp")
+        }
+    }
+
+    @Test("duplicate exact names are reported as ambiguous")
+    func reportsAmbiguousExactNames() async throws {
+        let fixture = try await Fixture()
+        _ = try await fixture.recordPackage(directoryName: "Alpha Copy", displayName: "Alpha")
+        let service = fixture.service()
+
+        await #expect(throws: AppleScriptCommandService.CommandError.ambiguousSite("Alpha", matches: ["Alpha", "Alpha"])) {
+            _ = try await service.resolveSite("Alpha")
+        }
+    }
+
+    @Test("deploy requires explicit unattended opt-in")
+    func deployRequiresOptIn() async throws {
+        let fixture = try await Fixture()
+        let service = fixture.service(
+            operations: FakeSiteOperations(deployResult: .succeeded(url: URL(string: "https://example.com")!, duration: 1))
+        )
+
+        await #expect(throws: AppleScriptCommandService.CommandError.deployRequiresUnattendedOptIn("Alpha")) {
+            _ = try await service.deploySite("Alpha", allowingUnattended: false)
+        }
+
+        let dialog = try await service.deploySite("Alpha", allowingUnattended: true)
+        #expect(dialog == "Deployed to https://example.com.")
+    }
+
+    @Test("site status reports graph counts")
+    func statusUsesContentGraph() async throws {
+        let fixture = try await Fixture()
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: fixture.alpha.id,
+            pages: [
+                .init(
+                    id: "\(fixture.alpha.id):page:/about",
+                    siteID: fixture.alpha.id,
+                    route: "/about",
+                    filePath: "src/pages/about.md",
+                    title: "About",
+                    lastModified: Date()
+                )
+            ],
+            posts: [
+                .init(
+                    id: "\(fixture.alpha.id):post:hello",
+                    siteID: fixture.alpha.id,
+                    collection: "blog",
+                    slug: "hello",
+                    title: "Hello",
+                    draft: true,
+                    publishDate: nil,
+                    tags: [],
+                    filePath: "src/content/blog/hello.md",
+                    lastModified: Date()
+                )
+            ],
+            images: [
+                .init(
+                    id: "\(fixture.alpha.id):image:/hero.png",
+                    siteID: fixture.alpha.id,
+                    relativePath: "public/hero.png",
+                    fileName: "hero.png",
+                    byteSize: 10,
+                    usedOnPages: [],
+                    lastModified: Date()
+                )
+            ]
+        )
+
+        let status = try await fixture.service(graph: graph).siteStatus("Alpha")
+        #expect(status == "Alpha has 1 page, 1 post (1 draft), and 1 image.")
+    }
+
+    @Test("add page and add post format content operation results")
+    func contentCreationDialogs() async throws {
+        let fixture = try await Fixture()
+        let content = FakeContentOperations(
+            pageResult: .created(filePath: "src/pages/about.md", identifier: "/about"),
+            postResult: .failed(reason: "slug already exists")
+        )
+        let service = fixture.service(content: content)
+
+        #expect(try await service.addPage("Alpha", name: "About", route: " /about ") == "Added a page at /about on Alpha.")
+        #expect(
+            try await service.addPost("Alpha", title: "Hello", collection: nil, slug: nil)
+                == "Could not add the post: slug already exists"
+        )
+    }
+
+    private final class Fixture {
+        let tempDir: URL
+        let store: SiteStore
+        let alpha: SiteStore.Site
+
+        init() async throws {
+            tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("applescript-service-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            store = SiteStore(persistenceURL: tempDir.appendingPathComponent("recents.json"))
+            alpha = try await Self.recordPackage(
+                in: tempDir,
+                store: store,
+                directoryName: "Alpha",
+                displayName: "Alpha"
+            )
+        }
+
+        deinit {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        func recordPackage(directoryName: String, displayName: String) async throws -> SiteStore.Site {
+            try await Self.recordPackage(
+                in: tempDir,
+                store: store,
+                directoryName: directoryName,
+                displayName: displayName
+            )
+        }
+
+        func service(
+            operations: (any SiteOperationsService)? = nil,
+            content: (any ContentOperationsService)? = nil,
+            graph: SiteContentGraph = SiteContentGraph()
+        ) -> AppleScriptCommandService {
+            AppleScriptCommandService(
+                store: store,
+                operations: operations,
+                content: content,
+                graph: graph,
+                loadSites: {}
+            )
+        }
+
+        private static func recordPackage(
+            in tempDir: URL,
+            store: SiteStore,
+            directoryName: String,
+            displayName: String
+        ) async throws -> SiteStore.Site {
+            let packageURL = tempDir.appendingPathComponent("\(directoryName).anglesite", isDirectory: true)
+            let (package, _) = try AnglesitePackage.createSkeleton(at: packageURL, displayName: displayName)
+            for sentinel in ProjectValidator.requiredSentinels {
+                let url = package.sourceURL.appendingPathComponent(sentinel)
+                try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try Data().write(to: url)
+            }
+            return try await store.record(package)
+        }
+    }
+}
+
+private struct FakeSiteOperations: SiteOperationsService {
+    var deployResult: DeployCommand.Result = .failed(reason: "unstubbed deploy", exitCode: nil)
+    var backupResult: BackupCommand.Result = .failed(reason: "unstubbed backup", exitCode: nil)
+    var auditResult: AuditCommand.Result = .failed(reason: "unstubbed audit", exitCode: nil, logTail: [])
+
+    func site(id: String) async -> SiteStore.Site? { nil }
+    func deploy(site: SiteStore.Site, onProgress: ProgressHandler?) async -> DeployCommand.Result { deployResult }
+    func backup(site: SiteStore.Site, onProgress: ProgressHandler?) async -> BackupCommand.Result { backupResult }
+    func audit(site: SiteStore.Site, onProgress: ProgressHandler?) async -> AuditCommand.Result { auditResult }
+    func provisionSocialWorker(site: SiteStore.Site) async -> SocialWorkerProvisionCommand.Result {
+        .failed(reason: "unstubbed social worker provisioning", exitCode: nil, resources: .init())
+    }
+}
+
+private struct FakeContentOperations: ContentOperationsService {
+    var pageResult: ContentCreateResult = .failed(reason: "unstubbed page")
+    var postResult: ContentCreateResult = .failed(reason: "unstubbed post")
+
+    func createPage(siteID: String, name: String, route: String?, onProgress: ProgressHandler?) async -> ContentCreateResult {
+        pageResult
+    }
+
+    func createPost(siteID: String, title: String, collection: String?, slug: String?, onProgress: ProgressHandler?) async -> ContentCreateResult {
+        postResult
+    }
+
+    func createTyped(siteID: String, typeID: String, title: String, onProgress: ProgressHandler?) async -> ContentCreateResult {
+        .failed(reason: "unstubbed typed content")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -19,6 +19,7 @@ targets:
     sources:
       - path: Sources/AnglesiteApp
       - path: Resources/Assets.xcassets
+      - path: Resources/Anglesite.sdef
       - path: Resources/Template
         type: folder
         buildPhase: resources


### PR DESCRIPTION
## Summary
- add an Anglesite AppleScript dictionary with site automation commands
- route Cocoa Scripting commands through a testable Core command service
- require explicit unattended opt-in before AppleScript-triggered deploys
- add Core tests for deterministic site resolution, deploy policy, status, and content creation dialogs

Closes #678

## Verification
- swift test --package-path . --filter AppleScriptCommandServiceTests
- env ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build

Note: xcodebuild still reports the local CoreSimulator version warning before succeeding.