### PR TITLE
Fix import git bootstrap for plain site directories

### DIFF
--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -44,6 +44,39 @@ enum SiteActions {
         return site
     }
 
+    /// Copy a plain Anglesite directory into a package, bootstrap its `Source/` as a committable
+    /// git repo, then register the package. Kept separate from the panel flow so the migration
+    /// behavior is unit-testable without driving AppKit.
+    static func importDirectory(
+        _ sourceDir: URL,
+        toPackageAt dest: URL,
+        displayName: String,
+        bootstrapGit: @escaping @Sendable (_ sourceDirectory: URL) async throws -> Void = { sourceDirectory in
+            try await RepoBootstrap.live().commitAll(source: sourceDirectory)
+        },
+        register: @escaping @MainActor @Sendable (_ package: AnglesitePackage) async throws -> SiteStore.Site = { package in
+            try await registerPackage(package)
+        }
+    ) async throws -> SiteStore.Site {
+        // The tree copy can be large (it may include node_modules) — run it off the main actor so
+        // the import doesn't stall the UI. On failure after the copy created the package, clean up
+        // the orphan; a `destinationExists` throw comes from importDirectory itself (before it
+        // creates anything), so it lands in the caller's catch and never deletes a pre-existing dir.
+        let pkg = try await Task.detached {
+            try PackageTransfer.importDirectory(sourceDir, toPackageAt: dest, displayName: displayName)
+        }.value
+        do {
+            try await bootstrapGit(pkg.sourceURL)
+            return try await register(pkg)
+        } catch {
+            // Git bootstrap or record/bookmark failed after importDirectory wrote the package —
+            // remove the orphan (we created it this call) so it isn't left invisible-and-unopenable
+            // on disk.
+            try? FileManager.default.removeItem(at: pkg.url)
+            throw error
+        }
+    }
+
     /// Pick a plain Anglesite directory, choose where to save the new package, copy it in, and
     /// register the package. Returns the new site, or nil if either panel was cancelled.
     static func importPackage() async throws -> SiteStore.Site? {
@@ -62,24 +95,9 @@ enum SiteActions {
         save.directoryURL = AppSettings.shared.sitesRoot
         guard save.runModal() == .OK, let dest = save.url else { return nil }
 
-        // The tree copy can be large (it may include node_modules) — run it off the main actor so
-        // the import doesn't stall the UI. On failure after the copy created the package, clean up
-        // the orphan; a `destinationExists` throw comes from importDirectory itself (before it
-        // creates anything), so it lands in the outer catch and never deletes a pre-existing dir.
-        let pkg: AnglesitePackage
         do {
-            pkg = try await Task.detached {
-                try PackageTransfer.importDirectory(sourceDir, toPackageAt: dest, displayName: name)
-            }.value
+            return try await importDirectory(sourceDir, toPackageAt: dest, displayName: name)
         } catch {
-            throw ImportError(folderName: sourceDir.lastPathComponent, underlying: error)
-        }
-        do {
-            return try await registerPackage(pkg)
-        } catch {
-            // record/bookmark failed after importDirectory wrote the package — remove the orphan
-            // (we created it this call) so it isn't left invisible-and-unopenable on disk.
-            try? FileManager.default.removeItem(at: pkg.url)
             throw ImportError(folderName: sourceDir.lastPathComponent, underlying: error)
         }
     }

--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -66,15 +66,46 @@ enum SiteActions {
             try PackageTransfer.importDirectory(sourceDir, toPackageAt: dest, displayName: displayName)
         }.value
         do {
+            try ensureImportGitignore(in: pkg.sourceURL)
             try await bootstrapGit(pkg.sourceURL)
             return try await register(pkg)
         } catch {
             // Git bootstrap or record/bookmark failed after importDirectory wrote the package —
             // remove the orphan (we created it this call) so it isn't left invisible-and-unopenable
-            // on disk.
+            // on disk. If registration persisted the recents entry before a later failure (for
+            // example bookmark minting in MAS), unwind that entry too.
+            if let marker = try? pkg.readMarker() {
+                try? await SiteStore.shared.remove(id: marker.siteID.uuidString)
+            }
             try? FileManager.default.removeItem(at: pkg.url)
             throw error
         }
+    }
+
+    /// Import can receive a plain, non-git working directory that already has local build output
+    /// or secrets. Seed the baseline ignores before `RepoBootstrap.commitAll` stages everything.
+    private static func ensureImportGitignore(in sourceDirectory: URL, fileManager: FileManager = .default) throws {
+        let url = sourceDirectory.appendingPathComponent(".gitignore")
+        let required = [
+            "node_modules/",
+            "dist/",
+            ".astro/",
+            ".wrangler/",
+            ".env*",
+        ]
+        var existing = fileManager.fileExists(atPath: url.path)
+            ? try String(contentsOf: url, encoding: .utf8)
+            : ""
+        let lines = Set(existing.split(whereSeparator: \.isNewline).map(String.init))
+        let missing = required.filter { !lines.contains($0) }
+        guard !missing.isEmpty else { return }
+
+        if !existing.isEmpty && !existing.hasSuffix("\n") { existing += "\n" }
+        if !existing.isEmpty { existing += "\n" }
+        existing += "# Local build artifacts and secrets are not committed by Anglesite imports.\n"
+        existing += missing.joined(separator: "\n")
+        existing += "\n"
+        try existing.write(to: url, atomically: true, encoding: .utf8)
     }
 
     /// Pick a plain Anglesite directory, choose where to save the new package, copy it in, and

--- a/Tests/AnglesiteAppTests/SiteActionsImportTests.swift
+++ b/Tests/AnglesiteAppTests/SiteActionsImportTests.swift
@@ -73,6 +73,53 @@ struct SiteActionsImportTests {
         #expect(registeredPackage?.url == dest)
     }
 
+    @Test("import seeds gitignore before git bootstrap stages the copied Source")
+    func importSeedsGitignoreBeforeBootstrap() async throws {
+        let root = try tempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("plain-site", isDirectory: true)
+        try makePlainSite(at: source)
+        try "custom-cache/\n".write(to: source.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        try "SECRET=1\n".write(to: source.appendingPathComponent(".env"), atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(
+            at: source.appendingPathComponent("node_modules/@rollup/rollup-darwin-arm64"),
+            withIntermediateDirectories: true
+        )
+        try "binary\n".write(
+            to: source.appendingPathComponent("node_modules/@rollup/rollup-darwin-arm64/index.js"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let dest = root.appendingPathComponent("Imported.anglesite", isDirectory: true)
+        _ = try await SiteActions.importDirectory(
+            source,
+            toPackageAt: dest,
+            displayName: "Imported",
+            bootstrapGit: { sourceDirectory in
+                let gitignore = try String(
+                    contentsOf: sourceDirectory.appendingPathComponent(".gitignore"),
+                    encoding: .utf8
+                )
+                #expect(gitignore.contains("custom-cache/"))
+                #expect(gitignore.contains("node_modules/"))
+                #expect(gitignore.contains("dist/"))
+                #expect(gitignore.contains(".astro/"))
+                #expect(gitignore.contains(".wrangler/"))
+                #expect(gitignore.contains(".env*"))
+            },
+            register: { package in
+                SiteStore.Site(
+                    id: "site-id",
+                    name: "Imported",
+                    packageURL: package.url,
+                    isValid: true,
+                    missingSentinels: []
+                )
+            }
+        )
+    }
+
     @Test("import removes copied package when git bootstrap fails")
     func importCleansUpWhenBootstrapFails() async throws {
         struct Boom: Error {}

--- a/Tests/AnglesiteAppTests/SiteActionsImportTests.swift
+++ b/Tests/AnglesiteAppTests/SiteActionsImportTests.swift
@@ -1,0 +1,106 @@
+import Testing
+import Foundation
+import AnglesiteCore
+import AnglesiteSiteModel
+@testable import AnglesiteAppCore
+
+@Suite("SiteActions import")
+@MainActor
+struct SiteActionsImportTests {
+    actor ImportRecorder {
+        private(set) var bootstrappedSource: URL?
+
+        func recordBootstrap(_ sourceDirectory: URL) {
+            bootstrappedSource = sourceDirectory
+        }
+    }
+
+    private func tempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("site-actions-import-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func makePlainSite(at url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        for sentinel in ProjectValidator.requiredSentinels {
+            let file = url.appendingPathComponent(sentinel)
+            try FileManager.default.createDirectory(
+                at: file.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try "{}\n".write(to: file, atomically: true, encoding: .utf8)
+        }
+    }
+
+    @Test("import bootstraps git in the copied Source before registering")
+    func importBootstrapsSourceBeforeRegistering() async throws {
+        let root = try tempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("plain-site", isDirectory: true)
+        try makePlainSite(at: source)
+        let dest = root.appendingPathComponent("Imported.anglesite", isDirectory: true)
+
+        let recorder = ImportRecorder()
+        var registeredPackage: AnglesitePackage?
+        let site = try await SiteActions.importDirectory(
+            source,
+            toPackageAt: dest,
+            displayName: "Imported",
+            bootstrapGit: { sourceDirectory in
+                await recorder.recordBootstrap(sourceDirectory)
+                try FileManager.default.createDirectory(
+                    at: sourceDirectory.appendingPathComponent(".git"),
+                    withIntermediateDirectories: true
+                )
+            },
+            register: { package in
+                registeredPackage = package
+                #expect(FileManager.default.fileExists(atPath: package.sourceURL.appendingPathComponent(".git").path))
+                return SiteStore.Site(
+                    id: "site-id",
+                    name: "Imported",
+                    packageURL: package.url,
+                    isValid: true,
+                    missingSentinels: []
+                )
+            }
+        )
+
+        #expect(site.id == "site-id")
+        #expect(await recorder.bootstrappedSource == dest.appendingPathComponent("Source", isDirectory: true))
+        #expect(registeredPackage?.url == dest)
+    }
+
+    @Test("import removes copied package when git bootstrap fails")
+    func importCleansUpWhenBootstrapFails() async throws {
+        struct Boom: Error {}
+
+        let root = try tempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("plain-site", isDirectory: true)
+        try makePlainSite(at: source)
+        let dest = root.appendingPathComponent("Imported.anglesite", isDirectory: true)
+
+        await #expect(throws: Boom.self) {
+            _ = try await SiteActions.importDirectory(
+                source,
+                toPackageAt: dest,
+                displayName: "Imported",
+                bootstrapGit: { _ in throw Boom() },
+                register: { _ in
+                    Issue.record("register must not run when bootstrap fails")
+                    return SiteStore.Site(
+                        id: "site-id",
+                        name: "Imported",
+                        packageURL: dest,
+                        isValid: true,
+                        missingSentinels: []
+                    )
+                }
+            )
+        }
+        #expect(!FileManager.default.fileExists(atPath: dest.path))
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap an imported plain site package's Source/ with the existing local git commit path before registration
- keep import cleanup behavior for bootstrap/register failures
- add app-level regression tests for bootstrap ordering and cleanup

## Tests
- xcodegen generate
- swift test --filter SiteActionsImportTests
- swift test --filter AnglesiteAppTests

Note: I also started a full swift test run, but stopped it after it stayed silent for several minutes inside AnglesiteCoreTests; the targeted/app-suite coverage for this change passed.

Closes #720