### PR TITLE
fix(template): harden component harness route

### DIFF
--- a/Resources/Template/scripts/component-harness.test.ts
+++ b/Resources/Template/scripts/component-harness.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import anglesiteHarness from "./anglesite-harness";
+import { namedSlotSamples, parseProps, resolveComponentKey } from "./component-harness";
+
+test("resolveComponentKey prefers components over layouts", () => {
+  const modules = {
+    "/src/components/Card.astro": async () => ({}),
+    "/src/layouts/Card.astro": async () => ({}),
+  };
+
+  assert.equal(resolveComponentKey("Card", modules), "/src/components/Card.astro");
+});
+
+test("resolveComponentKey supports nested component names", () => {
+  const modules = {
+    "/src/components/marketing/Hero.astro": async () => ({}),
+  };
+
+  assert.equal(resolveComponentKey("marketing/Hero", modules), "/src/components/marketing/Hero.astro");
+});
+
+test("parseProps returns only JSON objects", () => {
+  assert.deepEqual(parseProps('{"title":"Hello","count":2,"enabled":true}'), {
+    title: "Hello",
+    count: 2,
+    enabled: true,
+  });
+
+  assert.deepEqual(parseProps("null"), {});
+  assert.deepEqual(parseProps('"hello"'), {});
+  assert.deepEqual(parseProps("[1,2,3]"), {});
+  assert.deepEqual(parseProps("{malformed"), {});
+  assert.deepEqual(parseProps(null), {});
+});
+
+test("namedSlotSamples extracts labeled unique named slots", () => {
+  const source = `
+    <header><slot name="header" /></header>
+    <main><slot /></main>
+    <footer><slot name='footer-links'>Fallback</slot></footer>
+    <aside><slot name={"promo_panel"} /></aside>
+    <slot name="header" />
+  `;
+
+  assert.deepEqual(namedSlotSamples(source), [
+    { name: "header", label: "Header slot content" },
+    { name: "footer-links", label: "Footer Links slot content" },
+    { name: "promo_panel", label: "Promo Panel slot content" },
+  ]);
+});
+
+test("anglesiteHarness injects the component route only in dev", async () => {
+  const integration = anglesiteHarness();
+  const setup = integration.hooks["astro:config:setup"];
+  assert.ok(setup);
+
+  const devRoutes: unknown[] = [];
+  await setup({
+    command: "dev",
+    injectRoute(route: unknown) {
+      devRoutes.push(route);
+    },
+  } as never);
+
+  assert.equal(devRoutes.length, 1);
+  assert.deepEqual(devRoutes[0], {
+    pattern: "/_anglesite/component/[...name]",
+    entrypoint: fileURLToPath(new URL("./harness/component.astro", import.meta.url)),
+    prerender: false,
+  });
+
+  const buildRoutes: unknown[] = [];
+  await setup({
+    command: "build",
+    injectRoute(route: unknown) {
+      buildRoutes.push(route);
+    },
+  } as never);
+
+  assert.deepEqual(buildRoutes, []);
+});

--- a/Resources/Template/scripts/component-harness.test.ts
+++ b/Resources/Template/scripts/component-harness.test.ts
@@ -51,6 +51,18 @@ test("namedSlotSamples extracts labeled unique named slots", () => {
   ]);
 });
 
+test("namedSlotSamples ignores frontmatter literals and explicit default slots", () => {
+  const source = `---
+const example = '<slot name="from-frontmatter" />';
+---
+<slot />
+<slot name="default" />
+<slot name="aside" />
+`;
+
+  assert.deepEqual(namedSlotSamples(source), [{ name: "aside", label: "Aside slot content" }]);
+});
+
 test("anglesiteHarness injects the component route only in dev", async () => {
   const integration = anglesiteHarness();
   const setup = integration.hooks["astro:config:setup"];

--- a/Resources/Template/scripts/component-harness.ts
+++ b/Resources/Template/scripts/component-harness.ts
@@ -1,0 +1,75 @@
+import { createComponent, renderComponent, renderTemplate } from "astro/runtime/server/index.js";
+import type { ComponentSlots } from "astro/runtime/server/index.js";
+
+export type ComponentModuleMap = Record<string, () => Promise<unknown>>;
+
+export interface SlotSample {
+  name: string;
+  label: string;
+}
+
+interface HarnessComponentProps {
+  Component: unknown;
+  props: Record<string, unknown>;
+  slotSamples: SlotSample[];
+}
+
+const renderHarnessComponent = (
+  $$result: any,
+  { Component, props, slotSamples }: HarnessComponentProps,
+) => {
+  const slots: ComponentSlots = {
+    default: () => renderTemplate`<span class="anglesite-harness-slot-sample">Slot content</span>`,
+  };
+
+  for (const sample of slotSamples) {
+    slots[sample.name] = () =>
+      renderTemplate`<span class="anglesite-harness-slot-sample">${sample.label}</span>`;
+  }
+
+  return renderComponent($$result, "HarnessComponent", Component, props, slots);
+};
+
+export const HarnessComponent = createComponent(renderHarnessComponent as any);
+
+export function resolveComponentKey(name: string, modules: ComponentModuleMap): string | undefined {
+  return [`/src/components/${name}.astro`, `/src/layouts/${name}.astro`].find((key) => key in modules);
+}
+
+export function parseProps(raw: string | null): Record<string, unknown> {
+  if (!raw) return {};
+
+  try {
+    const value: unknown = JSON.parse(raw);
+    return isPlainRecord(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+export function namedSlotSamples(source: string): SlotSample[] {
+  const names = new Set<string>();
+  const slotPattern = /<slot\b[^>]*\bname\s*=\s*(?:"([^"]+)"|'([^']+)'|{["']([^"']+)["']})[^>]*>/g;
+
+  for (const match of source.matchAll(slotPattern)) {
+    const name = match[1] ?? match[2] ?? match[3];
+    if (name) names.add(name);
+  }
+
+  return Array.from(names, (name) => ({
+    name,
+    label: `${labelForSlot(name)} slot content`,
+  }));
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function labelForSlot(name: string): string {
+  return name
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}

--- a/Resources/Template/scripts/component-harness.ts
+++ b/Resources/Template/scripts/component-harness.ts
@@ -1,5 +1,5 @@
 import { createComponent, renderComponent, renderTemplate } from "astro/runtime/server/index.js";
-import type { ComponentSlots } from "astro/runtime/server/index.js";
+import type { AstroComponentFactory, ComponentSlots } from "astro/runtime/server/index.js";
 
 export type ComponentModuleMap = Record<string, () => Promise<unknown>>;
 
@@ -14,8 +14,8 @@ interface HarnessComponentProps {
   slotSamples: SlotSample[];
 }
 
-const renderHarnessComponent = (
-  $$result: any,
+const renderHarnessComponent: AstroComponentFactory = (
+  $$result,
   { Component, props, slotSamples }: HarnessComponentProps,
 ) => {
   const slots: ComponentSlots = {
@@ -27,10 +27,10 @@ const renderHarnessComponent = (
       renderTemplate`<span class="anglesite-harness-slot-sample">${sample.label}</span>`;
   }
 
-  return renderComponent($$result, "HarnessComponent", Component, props, slots);
+  return renderTemplate`${renderComponent($$result, "HarnessComponent", Component, props, slots)}`;
 };
 
-export const HarnessComponent = createComponent(renderHarnessComponent as any);
+export const HarnessComponent = createComponent(renderHarnessComponent);
 
 export function resolveComponentKey(name: string, modules: ComponentModuleMap): string | undefined {
   return [`/src/components/${name}.astro`, `/src/layouts/${name}.astro`].find((key) => key in modules);
@@ -51,15 +51,24 @@ export function namedSlotSamples(source: string): SlotSample[] {
   const names = new Set<string>();
   const slotPattern = /<slot\b[^>]*\bname\s*=\s*(?:"([^"]+)"|'([^']+)'|{["']([^"']+)["']})[^>]*>/g;
 
-  for (const match of source.matchAll(slotPattern)) {
+  for (const match of templateMarkup(source).matchAll(slotPattern)) {
     const name = match[1] ?? match[2] ?? match[3];
-    if (name) names.add(name);
+    if (name && name !== "default") names.add(name);
   }
 
   return Array.from(names, (name) => ({
     name,
     label: `${labelForSlot(name)} slot content`,
   }));
+}
+
+function templateMarkup(source: string): string {
+  if (!source.startsWith("---")) return source;
+
+  const frontmatterEnd = source.indexOf("\n---", 3);
+  if (frontmatterEnd === -1) return source;
+
+  return source.slice(frontmatterEnd + "\n---".length);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/Resources/Template/scripts/harness/component.astro
+++ b/Resources/Template/scripts/harness/component.astro
@@ -3,15 +3,25 @@
 // Dev-only (injected by anglesite-harness.ts); never part of a build.
 export const prerender = false;
 
+import { HarnessComponent, namedSlotSamples, parseProps, resolveComponentKey } from "../component-harness";
+import type { SlotSample } from "../component-harness";
+
 const modules = import.meta.glob(["/src/components/**/*.astro", "/src/layouts/**/*.astro"]);
+const sources = import.meta.glob(["/src/components/**/*.astro", "/src/layouts/**/*.astro"], {
+  query: "?raw",
+  import: "default",
+});
 const name = Astro.params.name ?? "";
-const key = [`/src/components/${name}.astro`, `/src/layouts/${name}.astro`].find((k) => k in modules);
+const key = resolveComponentKey(name, modules);
 
 let Component: any = null;
 let error: string | null = null;
+let slotSamples: SlotSample[] = [];
 if (key) {
   try {
     Component = ((await modules[key]()) as { default: unknown }).default;
+    const source = ((await sources[key]()) as string | undefined) ?? "";
+    slotSamples = namedSlotSamples(source);
   } catch (err) {
     error = String(err);
   }
@@ -19,15 +29,7 @@ if (key) {
   error = `No component named "${name}" under src/components/ or src/layouts/.`;
 }
 
-let props: Record<string, unknown> = {};
-const raw = Astro.url.searchParams.get("props");
-if (raw) {
-  try {
-    props = JSON.parse(raw);
-  } catch {
-    /* malformed props param: render with defaults */
-  }
-}
+const props = parseProps(Astro.url.searchParams.get("props"));
 ---
 
 <!doctype html>
@@ -47,9 +49,7 @@ if (raw) {
       error ? (
         <pre class="anglesite-harness-error">{error}</pre>
       ) : (
-        <Component {...props}>
-          <span class="anglesite-harness-slot-sample">Slot content</span>
-        </Component>
+        <HarnessComponent Component={Component} props={props} slotSamples={slotSamples} />
       )
     }
   </body>


### PR DESCRIPTION
## Summary
- guard component harness props parsing so only JSON objects are spread into components
- add named-slot sample discovery/rendering for the dev-only harness route
- cover harness name resolution, props parsing, slot labels, and dev-only route injection with Node tests

Closes #490.

## Verification
- node --import tsx scripts/component-harness.test.ts
- npx astro build
- find dist -path '*_anglesite*' -print
- dev smoke: /_anglesite/component/BaseLayout returned 200 and rendered Head slot content

## Notes
- npx astro check still fails on the pre-existing src/components/esi/esi-components.build.test.ts Dirent.path type error; harness-owned diagnostics are clear.