### PR TITLE
Fail fast on stale container ext4 artifacts

### DIFF
--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -219,8 +219,8 @@ public struct ContainerizationControl: LocalContainerControl {
         // refuses to overwrite an existing block device file, so a stale leftover would otherwise
         // block every subsequent start for the same site. A fresh boot never wants to reuse the
         // previous run's rootfs, so clear both unconditionally before unpacking.
-        try? FileManager.default.removeItem(at: rootfsURL)
-        try? FileManager.default.removeItem(at: initfsURL)
+        try Self.removeStaleExt4Artifact(at: rootfsURL, label: "rootfs", onOutput: onOutput)
+        try Self.removeStaleExt4Artifact(at: initfsURL, label: "initfs", onOutput: onOutput)
 
         // 1. Import the bundled OCI layouts into the on-disk ImageStore and unpack to bootable mounts.
         //    `loadOrGet` re-imports whenever the bundled layout changed since the last import (#549),
@@ -376,6 +376,37 @@ public struct ContainerizationControl: LocalContainerControl {
     /// template site with more integrations took 220s. 90s (the old default) failed both. 300s keeps
     /// meaningful margin over the worst observed case without masking a truly hung guest for minutes.
     private static let previewReadyTimeout: Duration = .seconds(300)
+
+    /// Remove a site-scoped ext4 artifact left by an interrupted prior boot before the next unpack.
+    ///
+    /// `EXT4Unpacker.unpack(at:)` and `InitImage.initBlock(at:)` do not own stale-file recovery:
+    /// passing a leftover block device path can fail late with a vague NSPOSIXErrorDomain/ENOTSUP
+    /// after the expensive image import/unpack path has already run (#721). Treat inability to clear
+    /// the old path as a provisioning failure up front, with the exact artifact path in the log.
+    static func removeStaleExt4Artifact(
+        at url: URL,
+        label: String,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
+        removeItem: (URL) throws -> Void = { try FileManager.default.removeItem(at: $0) },
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void = { _, _ in }
+    ) throws {
+        guard fileExists(url.path) else { return }
+
+        onOutput("[boot] removing stale \(label) ext4 artifact at \(url.path)", .stdout)
+        do {
+            try removeItem(url)
+        } catch {
+            let message = "could not remove stale \(label) ext4 artifact at \(url.path): \(error)"
+            onOutput("[boot] \(message)", .stderr)
+            throw LocalContainerError.imageUnavailable(message)
+        }
+
+        guard !fileExists(url.path) else {
+            let message = "stale \(label) ext4 artifact still exists after removal at \(url.path)"
+            onOutput("[boot] \(message)", .stderr)
+            throw LocalContainerError.imageUnavailable(message)
+        }
+    }
 
     /// Races `operation` against a `timeout`, resolving to whichever finishes first. Unlike a
     /// `withThrowingTaskGroup`-based race, this does NOT wait for `operation` to finish once the

--- a/Tests/AnglesiteContainerLocalTests/StaleExt4ArtifactTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/StaleExt4ArtifactTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import AnglesiteContainer
+import AnglesiteCore
+
+struct StaleExt4ArtifactTests {
+    final class CapturedLines: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [String] = []
+
+        func append(_ line: String) {
+            lock.withLock {
+                storage.append(line)
+            }
+        }
+
+        func contains(_ match: (String) -> Bool) -> Bool {
+            lock.withLock {
+                storage.contains(where: match)
+            }
+        }
+    }
+
+    @Test("stale ext4 artifact is removed before unpack")
+    func removesStaleArtifact() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("anglesite-stale-ext4-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        let artifact = dir.appendingPathComponent("rootfs-site.ext4")
+        try Data("stale".utf8).write(to: artifact)
+
+        let lines = CapturedLines()
+        try ContainerizationControl.removeStaleExt4Artifact(
+            at: artifact,
+            label: "rootfs",
+            onOutput: { line, _ in lines.append(line) })
+
+        #expect(!fm.fileExists(atPath: artifact.path))
+        #expect(lines.contains { $0.contains("removing stale rootfs ext4 artifact at \(artifact.path)") })
+    }
+
+    @Test("stale ext4 cleanup failure names the artifact path")
+    func cleanupFailureNamesArtifactPath() throws {
+        let artifact = URL(fileURLWithPath: "/tmp/rootfs-stale.ext4")
+        let failure = CocoaError(.fileWriteUnknown)
+        let lines = CapturedLines()
+
+        do {
+            try ContainerizationControl.removeStaleExt4Artifact(
+                at: artifact,
+                label: "rootfs",
+                fileExists: { _ in true },
+                removeItem: { _ in throw failure },
+                onOutput: { line, _ in lines.append(line) }
+            )
+            Issue.record("expected stale artifact cleanup to fail")
+        } catch LocalContainerError.imageUnavailable(let message) {
+            #expect(message.contains("could not remove stale rootfs ext4 artifact at \(artifact.path)"))
+            #expect(lines.contains { $0.contains("could not remove stale rootfs ext4 artifact at \(artifact.path)") })
+        } catch {
+            Issue.record("expected imageUnavailable, got \(error)")
+        }
+    }
+
+    @Test("stale ext4 cleanup fails if the path survives removal")
+    func cleanupFailsWhenArtifactSurvivesRemoval() throws {
+        let artifact = URL(fileURLWithPath: "/tmp/initfs-stale.ext4")
+
+        do {
+            try ContainerizationControl.removeStaleExt4Artifact(
+                at: artifact,
+                label: "initfs",
+                fileExists: { _ in true },
+                removeItem: { _ in }
+            )
+            Issue.record("expected stale artifact cleanup to fail")
+        } catch LocalContainerError.imageUnavailable(let message) {
+            #expect(message == "stale initfs ext4 artifact still exists after removal at \(artifact.path)")
+        } catch {
+            Issue.record("expected imageUnavailable, got \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove stale per-site rootfs/initfs ext4 artifacts before the expensive unpack path
- fail immediately with the exact artifact path when stale cleanup cannot clear the file
- add focused container-local tests for stale artifact cleanup and failure reporting

## Tests
- env ANGLESITE_CONTAINER_TESTS=1 swift test --filter StaleExt4ArtifactTests

Fixes #721