### PR TITLE
Fix new-site bootstrap and container preview startup

### DIFF
--- a/Containers/anglesite-dev/Dockerfile
+++ b/Containers/anglesite-dev/Dockerfile
@@ -46,12 +46,19 @@ RUN cd /usr/local/lib/anglesite-mcp \
 # zero install (anglesite-hydrate), AND leaves npm's cache (/root/.npm) in the layer so a
 # drifted-lockfile site's `npm ci --prefer-offline` mostly avoids the network. Full closure
 # (no --omit=dev): astro dev/check need devDependencies (tsx, @astrojs/check, typescript).
+#
+# Keep node_modules as one tar entry in the OCI layer instead of ~19,000 individual entries.
+# Apple Containerization's Swift EXT4 formatter performs path-tree lookups for every OCI entry;
+# the expanded tree made first boot take tens of minutes. Linux tar expands the same trusted,
+# build-time archive into the writable site workspace much faster during hydration.
 ENV ANGLESITE_HOME=/opt/anglesite
 COPY template/package.json template/package-lock.json ${ANGLESITE_HOME}/baked/
 RUN cd ${ANGLESITE_HOME}/baked \
     && ( npm ci \
          || { echo "WARN: template lockfile out of sync — falling back to npm install" >&2; \
-              npm install; } )
+              npm install; } ) \
+    && tar -cf ${ANGLESITE_HOME}/baked-node-modules.tar node_modules \
+    && rm -rf node_modules
 COPY hydrate.sh /usr/local/bin/anglesite-hydrate
 RUN chmod +x /usr/local/bin/anglesite-hydrate
 

--- a/Containers/anglesite-dev/Dockerfile
+++ b/Containers/anglesite-dev/Dockerfile
@@ -7,18 +7,13 @@
 # (the plugin's server/, npm ci'd for the build's native arch so sharp's native binary is
 # correct) so a fresh container needs no in-guest install.
 
-# Per-arch digest pin (reproducible; re-bump periodically for base security updates). Selecting
-# the base by stage name (rather than a single floating digest) keeps the pin exact for whichever
-# arch is being built instead of only covering arm64. scripts/vendor-container-image.sh and
-# scripts/build-podman-image.sh both pass `--build-arg TARGETARCH=<arch>` explicitly rather than
-# relying on the builder to inject it automatically. The default below covers building this file
-# directly (`podman build .` / `container build .`, e.g. manual testing or a future CI job that
-# doesn't go through either wrapper script) — it falls back to arm64, matching this image's
-# single-arch behavior before this change, rather than failing opaquely on an empty ARG.
-ARG TARGETARCH=arm64
-FROM node:22-bookworm-slim@sha256:6db9be2ebb4bafb687a078ef5ba1b1dd256e8004d246a31fd210b6b848ab6be2 AS base-arm64
-FROM node:22-bookworm-slim@sha256:a149cd71dccd68704a07d4e4ca3e610c27301852b0f556865cfdb6e2856f8bed AS base-amd64
-FROM base-${TARGETARCH} AS base
+# Per-arch digest pin (reproducible; re-bump periodically for base security updates). The build
+# scripts pass the matching pinned reference as BASE_IMAGE. Do not declare both architectures as
+# separate FROM stages: Apple container 1.1 resolves even the unused stage for the requested
+# platform, so an arm64 build fails while trying to fetch the amd64-only digest. The default keeps
+# direct/manual builds on arm64, matching the macOS runtime.
+ARG BASE_IMAGE=node:22-bookworm-slim@sha256:6db9be2ebb4bafb687a078ef5ba1b1dd256e8004d246a31fd210b6b848ab6be2
+FROM ${BASE_IMAGE} AS base
 
 # socat is the guest-side vsock<->TCP bridge: the host reaches astro/mcp (guest-local TCP) by
 # dialing AF_VSOCK ports that socat forwards to 127.0.0.1 (no vmnet on the sandboxed host, #60).

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -241,9 +241,17 @@ public struct ContainerizationControl: LocalContainerControl {
             let appImage = try await loadOrGet(
                 store, layout: stagedImageLayout, reference: BundledImage.imageReference,
                 artifactName: "app-image", storeRoot: storeURL)
-            onOutput("[boot] unpacking app image to ext4 rootfs", .stdout)
-            rootfs = try await EXT4Unpacker(blockSizeInBytes: 8 * 1024 * 1024 * 1024)
-                .unpack(appImage, for: .current, at: rootfsURL)
+            // Materialize one pristine rootfs per image digest, then APFS-clone it for each boot.
+            // `EXT4Unpacker` walks every OCI entry through an in-memory path tree; the bundled
+            // toolchain makes that first import expensive, while `Mount.clone(to:)` is copy-on-write
+            // and near-instant. The digest-keyed template stays immutable and automatically rolls
+            // forward when an app update ships a different image.
+            rootfs = try await RootfsTemplateCache.shared.clone(
+                image: appImage,
+                storeRoot: storeURL,
+                destination: rootfsURL,
+                onOutput: onOutput
+            )
 
             // vminit initfs OCI layout -> ext4 init mount (the guest-agent root filesystem).
             let stagedInitfsLayout = try BundledImage.stagedLayoutURL(source: initfsLayoutURL, name: "vminit-initfs")
@@ -729,6 +737,74 @@ public struct ContainerizationControl: LocalContainerControl {
             config.stderr = stderrSink
         }
         try await proc.start()
+    }
+}
+
+/// Builds one immutable EXT4 rootfs per OCI image digest, then gives every container boot an APFS
+/// copy-on-write clone. The actor plus `inFlight` task are both required: actors are re-entrant at
+/// `await`, so actor isolation alone would still let two windows start two expensive unpack jobs.
+private actor RootfsTemplateCache {
+    static let shared = RootfsTemplateCache()
+
+    private static let prefix = "rootfs-template-"
+    private static let size: UInt64 = 8 * 1024 * 1024 * 1024
+    private var inFlight: [String: Task<URL, Error>] = [:]
+
+    func clone(
+        image: Containerization.Image,
+        storeRoot: URL,
+        destination: URL,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> Containerization.Mount {
+        let digest = image.digest.replacingOccurrences(of: ":", with: "-")
+        let templateURL = storeRoot.appendingPathComponent(Self.prefix + digest + ".ext4")
+        let fileManager = FileManager.default
+
+        if !fileManager.fileExists(atPath: templateURL.path) {
+            let task: Task<URL, Error>
+            if let existing = inFlight[digest] {
+                onOutput("[boot] waiting for another window to prepare the app rootfs", .stdout)
+                task = existing
+            } else {
+                onOutput("[boot] preparing app rootfs for this image (first launch only)", .stdout)
+                let buildingURL = storeRoot.appendingPathComponent(
+                    Self.prefix + digest + ".building-" + UUID().uuidString + ".ext4"
+                )
+                task = Task<URL, Error> {
+                    defer { try? fileManager.removeItem(at: buildingURL) }
+                    _ = try await EXT4Unpacker(blockSizeInBytes: Self.size)
+                        .unpack(image, for: .current, at: buildingURL)
+
+                    // A second app process may have won the same race. Its completed template is
+                    // equivalent (the digest is the identity), so discard ours instead of replacing it.
+                    if fileManager.fileExists(atPath: templateURL.path) {
+                        return templateURL
+                    }
+                    try fileManager.moveItem(at: buildingURL, to: templateURL)
+                    return templateURL
+                }
+                inFlight[digest] = task
+            }
+
+            do {
+                _ = try await task.value
+                inFlight[digest] = nil
+            } catch {
+                inFlight[digest] = nil
+                throw error
+            }
+        } else {
+            onOutput("[boot] reusing cached app rootfs", .stdout)
+        }
+
+        onOutput("[boot] cloning app rootfs for this site", .stdout)
+        let templateMount = Containerization.Mount.block(
+            format: "ext4",
+            source: templateURL.path,
+            destination: "/"
+        )
+        let cloned = try templateMount.clone(to: destination.path)
+        return cloned
     }
 }
 

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -780,7 +780,14 @@ private actor RootfsTemplateCache {
                     if fileManager.fileExists(atPath: templateURL.path) {
                         return templateURL
                     }
-                    try fileManager.moveItem(at: buildingURL, to: templateURL)
+                    do {
+                        try fileManager.moveItem(at: buildingURL, to: templateURL)
+                    } catch {
+                        // `fileExists` + `moveItem` cannot be atomic across app processes. If a
+                        // peer published the same digest in that gap, its immutable template is
+                        // exactly equivalent; reuse it instead of failing this site's boot.
+                        guard fileManager.fileExists(atPath: templateURL.path) else { throw error }
+                    }
                     return templateURL
                 }
                 inFlight[digest] = task
@@ -804,7 +811,41 @@ private actor RootfsTemplateCache {
             destination: "/"
         )
         let cloned = try templateMount.clone(to: destination.path)
+        removeSupersededTemplates(keeping: templateURL, in: storeRoot, onOutput: onOutput)
         return cloned
+    }
+
+    /// Reclaim completed templates from older bundled-image digests. Site VMs mount their own
+    /// copy-on-write clones, never the immutable template, so cleanup is safe after this boot's
+    /// clone exists. `.building-*` files are deliberately excluded because another app process
+    /// may still be producing one; its own task removes that file on success or failure.
+    private func removeSupersededTemplates(
+        keeping current: URL,
+        in storeRoot: URL,
+        onOutput: @Sendable (String, LogCenter.Stream) -> Void
+    ) {
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: storeRoot,
+            includingPropertiesForKeys: nil
+        ) else { return }
+
+        var removed = 0
+        for candidate in contents {
+            let name = candidate.lastPathComponent
+            guard candidate != current,
+                  name.hasPrefix(Self.prefix),
+                  name.hasSuffix(".ext4"),
+                  !name.contains(".building-") else { continue }
+            do {
+                try FileManager.default.removeItem(at: candidate)
+                removed += 1
+            } catch {
+                onOutput("[boot] stale rootfs-template cleanup failed for \(name): \(error)", .stderr)
+            }
+        }
+        if removed > 0 {
+            onOutput("[boot] reclaimed \(removed) superseded rootfs template(s)", .stdout)
+        }
     }
 }
 

--- a/Sources/AnglesiteCore/RepoBootstrap.swift
+++ b/Sources/AnglesiteCore/RepoBootstrap.swift
@@ -48,7 +48,7 @@ public actor RepoBootstrap {
     /// bulk `addAll` at the pinned revision (it lands with `push`/`addRemote` in #659).
     func ensureCommittable(
         source: URL,
-        signatureOverride: Signature? = nil,
+        signatureFallback: Signature? = nil,
         emit: @Sendable (Event) -> Void
     ) async throws {
         SwiftGit2Bootstrap.ensureInitialized
@@ -108,13 +108,12 @@ public actor RepoBootstrap {
             }
         }
         let signature: Signature
-        if let signatureOverride {
-            signature = signatureOverride
-        } else {
-            guard case .success(let configuredSignature) = repo.defaultSignature() else {
-                throw RepoBootstrapError(reason: "No git identity configured (user.name/user.email).")
-            }
+        if case .success(let configuredSignature) = repo.defaultSignature() {
             signature = configuredSignature
+        } else if let signatureFallback {
+            signature = signatureFallback
+        } else {
+            throw RepoBootstrapError(reason: "No git identity configured (user.name/user.email).")
         }
         guard case .success = repo.commit(message: "Initial commit", signature: signature) else {
             throw RepoBootstrapError(reason: "git commit failed.")
@@ -198,11 +197,11 @@ public actor RepoBootstrap {
     /// source of truth" (#72).
     public func commitAll(source: URL) async throws {
         #if canImport(Darwin)
-        // The app creates this snapshot, so give it an app identity instead of depending on the
-        // user's global git config. A sandboxed build cannot read ~/.gitconfig even when Terminal
-        // can, and a commit-less new site cannot be cloned into the container runtime.
+        // Preserve the user's configured identity when libgit2 can resolve one. The app identity
+        // is only a fallback: a sandboxed build cannot necessarily read ~/.gitconfig even when
+        // Terminal can, and a commit-less new site cannot be cloned into the container runtime.
         let signature = Signature(name: "Anglesite", email: "noreply@anglesite.app")
-        try await ensureCommittable(source: source, signatureOverride: signature, emit: { _ in })
+        try await ensureCommittable(source: source, signatureFallback: signature, emit: { _ in })
         #else
         try await ensureCommittable(source: source, emit: { _ in })
         #endif

--- a/Sources/AnglesiteCore/RepoBootstrap.swift
+++ b/Sources/AnglesiteCore/RepoBootstrap.swift
@@ -46,7 +46,11 @@ public actor RepoBootstrap {
     /// on git error. Stages by walking `status(options: [.includeUntracked])` and calling
     /// `add(path:)`/`remove(path:)` per entry — the `git add -A` equivalent; SwiftGit2 has no
     /// bulk `addAll` at the pinned revision (it lands with `push`/`addRemote` in #659).
-    func ensureCommittable(source: URL, emit: @Sendable (Event) -> Void) async throws {
+    func ensureCommittable(
+        source: URL,
+        signatureOverride: Signature? = nil,
+        emit: @Sendable (Event) -> Void
+    ) async throws {
         SwiftGit2Bootstrap.ensureInitialized
         let repo: Repository
         switch Repository.at(source) {
@@ -103,8 +107,14 @@ public actor RepoBootstrap {
                 }
             }
         }
-        guard case .success(let signature) = repo.defaultSignature() else {
-            throw RepoBootstrapError(reason: "No git identity configured (user.name/user.email).")
+        let signature: Signature
+        if let signatureOverride {
+            signature = signatureOverride
+        } else {
+            guard case .success(let configuredSignature) = repo.defaultSignature() else {
+                throw RepoBootstrapError(reason: "No git identity configured (user.name/user.email).")
+            }
+            signature = configuredSignature
         }
         guard case .success = repo.commit(message: "Initial commit", signature: signature) else {
             throw RepoBootstrapError(reason: "git commit failed.")
@@ -187,7 +197,15 @@ public actor RepoBootstrap {
     /// (an empty, commit-less repo fails `git checkout HEAD`) — see CLAUDE.md's "Git is the
     /// source of truth" (#72).
     public func commitAll(source: URL) async throws {
+        #if canImport(Darwin)
+        // The app creates this snapshot, so give it an app identity instead of depending on the
+        // user's global git config. A sandboxed build cannot read ~/.gitconfig even when Terminal
+        // can, and a commit-less new site cannot be cloned into the container runtime.
+        let signature = Signature(name: "Anglesite", email: "noreply@anglesite.app")
+        try await ensureCommittable(source: source, signatureOverride: signature, emit: { _ in })
+        #else
         try await ensureCommittable(source: source, emit: { _ in })
+        #endif
     }
 
     /// Detect → (auth) → ensure committable → create + push. Streams progress; settles to

--- a/Sources/AnglesiteCore/RepoBootstrapTypes.swift
+++ b/Sources/AnglesiteCore/RepoBootstrapTypes.swift
@@ -53,9 +53,10 @@ public struct RemoteRepo: Sendable, Equatable {
 }
 
 /// User-facing failure from the bootstrap pipeline.
-public struct RepoBootstrapError: Error, Equatable, Sendable {
+public struct RepoBootstrapError: LocalizedError, Equatable, Sendable {
     public let reason: String
     public init(reason: String) { self.reason = reason }
+    public var errorDescription: String? { reason }
 }
 
 /// Run a subprocess and capture its output. Production: `ProcessSupervisor.shared.run`.

--- a/Tests/AnglesiteCoreTests/RepoBootstrapTests.swift
+++ b/Tests/AnglesiteCoreTests/RepoBootstrapTests.swift
@@ -131,6 +131,24 @@ import Foundation
         #expect(!events.contains(.progress(step: .initializing, message: "Initializing git repository…")))
     }
 
+    @Test func scaffoldCommitPreservesConfiguredIdentity() async throws {
+        let source = try await makeSourceDir(initialized: true)
+        try "hello".write(to: source.appendingPathComponent("index.md"), atomically: true, encoding: .utf8)
+
+        let bootstrap = RepoBootstrap(
+            provider: StubProvider(authed: true, result: .success(repo())),
+            run: unusedRunner()
+        )
+        try await bootstrap.commitAll(source: source)
+
+        let result = try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/git"),
+            arguments: ["log", "-1", "--format=%an <%ae>"],
+            currentDirectoryURL: source
+        )
+        #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "t <t@t.io>")
+    }
+
     @Test func publishSurfacesProviderError() async throws {
         let source = try await makeSourceDir(initialized: true, commit: true)   // clean, has commits
         let b = RepoBootstrap(

--- a/Tests/AnglesiteCoreTests/RepoBootstrapTests.swift
+++ b/Tests/AnglesiteCoreTests/RepoBootstrapTests.swift
@@ -10,6 +10,11 @@ import Foundation
 /// code under test — off-Darwin, where `RepoBootstrap` itself still uses subprocess git, that
 /// distinction disappears but the fixtures remain valid.
 @Suite struct RepoBootstrapTests {
+    @Test func bootstrapErrorUsesItsReasonAsTheUserFacingDescription() {
+        let error = RepoBootstrapError(reason: "No git identity configured.")
+        #expect(error.localizedDescription == "No git identity configured.")
+    }
+
     struct StubProvider: RepoProvider {
         let authed: Bool
         let result: Result<RemoteRepo, RepoBootstrapError>

--- a/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
@@ -316,10 +316,6 @@ final class SiteScaffolderTests: XCTestCase {
         XCTAssertEqual(log.exitCode, 0, "git log failed — no initial commit was created: \(log.stderr)")
         XCTAssertFalse(log.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                        "expected at least one commit in the freshly scaffolded Source/ repo")
-        let author = try await ProcessSupervisor.shared.run(
-            executable: git, arguments: ["log", "-1", "--format=%an <%ae>"], currentDirectoryURL: sourceDir)
-        XCTAssertEqual(author.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
-                       "Anglesite <noreply@anglesite.app>")
     }
 }
 

--- a/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
@@ -300,14 +300,6 @@ final class SiteScaffolderTests: XCTestCase {
             run: fakeRunner(calls: CallRecorder()),
             gitInit: { sourceDir in
                 try GitInitRunner.run(in: sourceDir)
-                // Deterministic local identity so RepoBootstrap.commitAll's defaultSignature()
-                // doesn't depend on ambient global git config (which CI runners may not have) —
-                // same fixture pattern as RepoBootstrapTests.makeSourceDir.
-                let git = URL(fileURLWithPath: "/usr/bin/git")
-                _ = try await ProcessSupervisor.shared.run(
-                    executable: git, arguments: ["config", "user.email", "t@t.io"], currentDirectoryURL: sourceDir)
-                _ = try await ProcessSupervisor.shared.run(
-                    executable: git, arguments: ["config", "user.name", "t"], currentDirectoryURL: sourceDir)
             },
             gitCommit: { sourceDir in try await RepoBootstrap.live().commitAll(source: sourceDir) },
             register: { pkg in try SiteStore.Site.make(package: pkg) }
@@ -324,6 +316,10 @@ final class SiteScaffolderTests: XCTestCase {
         XCTAssertEqual(log.exitCode, 0, "git log failed — no initial commit was created: \(log.stderr)")
         XCTAssertFalse(log.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                        "expected at least one commit in the freshly scaffolded Source/ repo")
+        let author = try await ProcessSupervisor.shared.run(
+            executable: git, arguments: ["log", "-1", "--format=%an <%ae>"], currentDirectoryURL: sourceDir)
+        XCTAssertEqual(author.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+                       "Anglesite <noreply@anglesite.app>")
     }
 }
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -53,6 +53,9 @@ ENV ANGLESITE_MCP_ENTRY=${ANGLESITE_HOME}/plugin/server/index.mjs
 # Install the template's full dependency closure once, at build time. This warms
 # the npm cache for any cloned site AND keeps the resolved node_modules so a site
 # whose lockfile matches the template reuses it with zero install (hydrate.sh).
+# Store that tree as one tar entry in the OCI layer: besides shrinking the layer's
+# entry count, this avoids pathological first-boot EXT4 import time in the local
+# Apple Containerization runtime. Hydration expands it in the Linux guest.
 # `npm ci` is preferred (reproducible, and it's what hydrate.sh's zero-install
 # fast path compares against). If the template's committed lockfile has drifted
 # out of sync with its package.json, fall back to `npm install` with a loud
@@ -62,7 +65,9 @@ COPY template/package.json template/package-lock.json ${ANGLESITE_HOME}/baked/
 RUN cd ${ANGLESITE_HOME}/baked \
  && ( npm ci \
       || { echo "WARN: template lockfile out of sync — falling back to npm install" >&2; \
-           npm install; } )
+           npm install; } ) \
+ && tar -cf ${ANGLESITE_HOME}/baked-node-modules.tar node_modules \
+ && rm -rf node_modules
 
 # ---- Hydration + start helpers ------------------------------------------------
 COPY entrypoint.sh hydrate.sh start-dev-server.sh /usr/local/bin/

--- a/container/hydrate.sh
+++ b/container/hydrate.sh
@@ -4,9 +4,9 @@
 # image's pre-baked toolchain (design decision #5b — skip npm ci on cold start).
 #
 #   • node_modules already present            -> nothing to do.
-#   • lockfile identical to the baked template -> hardlink the baked node_modules
-#                                                 (zero install — the common case
-#                                                 for template-derived sites).
+#   • lockfile identical to the baked template -> expand the baked node_modules
+#                                                 archive (zero install — the common
+#                                                 case for template-derived sites).
 #   • otherwise                                -> npm ci/install against the warm
 #                                                 npm cache (offline-first).
 
@@ -14,6 +14,7 @@ set -euo pipefail
 
 SITE_DIR="${1:-${SITE_DIR:-/workspace}}"
 BAKED="${ANGLESITE_HOME:-/opt/anglesite}/baked"
+BAKED_ARCHIVE="${ANGLESITE_HOME:-/opt/anglesite}/baked-node-modules.tar"
 cd "$SITE_DIR"
 
 if [ -d node_modules ]; then
@@ -23,11 +24,22 @@ fi
 
 if [ -f package-lock.json ] && [ -f "$BAKED/package-lock.json" ] \
    && cmp -s package-lock.json "$BAKED/package-lock.json"; then
-    echo "==> Lockfile matches the pre-baked toolchain; reusing baked node_modules (zero install)"
-    # Hardlink for speed; fall back to a copy if /workspace is a separate device.
-    cp -al "$BAKED/node_modules" ./node_modules 2>/dev/null \
-        || cp -a "$BAKED/node_modules" ./node_modules
-    exit 0
+    if [ -f "$BAKED_ARCHIVE" ]; then
+        echo "==> Lockfile matches the pre-baked toolchain; expanding baked node_modules (zero install)"
+        tar -xf "$BAKED_ARCHIVE"
+        exit 0
+    fi
+
+    # Compatibility with images built before the toolchain was archived.
+    if [ -d "$BAKED/node_modules" ]; then
+        echo "==> Lockfile matches the pre-baked toolchain; reusing baked node_modules (zero install)"
+        # Hardlink for speed; fall back to a copy if /workspace is a separate device.
+        cp -al "$BAKED/node_modules" ./node_modules 2>/dev/null \
+            || cp -a "$BAKED/node_modules" ./node_modules
+        exit 0
+    fi
+
+    echo "==> Pre-baked node_modules unavailable; using the warm npm cache"
 fi
 
 if [ -f package-lock.json ]; then

--- a/scripts/build-podman-image.sh
+++ b/scripts/build-podman-image.sh
@@ -26,12 +26,16 @@ IMAGE_TAG="localhost/anglesite-dev:latest"
 
 stage_dev_image_context "$CTX"
 
-# podman's `--arch` defaults to the host's native architecture; TARGETARCH is passed explicitly
-# as a build-arg (matching vendor-container-image.sh) since it drives the Dockerfile's per-arch
-# base-image stage selection rather than relying on podman to inject it automatically.
+# Podman's `--arch` defaults to the host's native architecture. Select the corresponding pinned
+# base explicitly so the Dockerfile declares only one FROM image.
 HOST_ARCH="$(podman info --format '{{.Host.Arch}}')"
 case "$HOST_ARCH" in
-    arm64|amd64) ;;
+    arm64)
+        BASE_IMAGE="node:22-bookworm-slim@sha256:6db9be2ebb4bafb687a078ef5ba1b1dd256e8004d246a31fd210b6b848ab6be2"
+        ;;
+    amd64)
+        BASE_IMAGE="node:22-bookworm-slim@sha256:a149cd71dccd68704a07d4e4ca3e610c27301852b0f556865cfdb6e2856f8bed"
+        ;;
     *)
         echo "ERROR: unsupported host arch '$HOST_ARCH' (Dockerfile only pins arm64/amd64 bases)." >&2
         exit 1
@@ -40,7 +44,7 @@ esac
 
 echo "Building $IMAGE_TAG (linux/$HOST_ARCH, native)…"
 podman build \
-    --build-arg "TARGETARCH=$HOST_ARCH" \
+    --build-arg "BASE_IMAGE=$BASE_IMAGE" \
     --tag "$IMAGE_TAG" \
     "$CTX"
 

--- a/scripts/vendor-container-image.sh
+++ b/scripts/vendor-container-image.sh
@@ -35,12 +35,12 @@ mkdir -p "$OUT"
 # the store keeps anglesite-dev:latest between runs, so rebuilds are incremental — the same role
 # the old docker-container buildx builder's cache played.
 ARCHIVE="$OUT/image.tar"
-# --build-arg TARGETARCH is explicit rather than relying on the builder to auto-inject it
-# (unlike BuildKit, container CLI 1.1.0's docs don't confirm it sets platform ARGs
-# automatically) — the Dockerfile's per-arch base-image stage selection needs it either way.
+# Pass only the arm64 base digest. Apple container 1.1 tries to resolve every declared FROM stage,
+# including an unused amd64 stage, against the requested platform.
+ARM64_BASE="node:22-bookworm-slim@sha256:6db9be2ebb4bafb687a078ef5ba1b1dd256e8004d246a31fd210b6b848ab6be2"
 container build \
     --os linux --arch arm64 \
-    --build-arg TARGETARCH=arm64 \
+    --build-arg "BASE_IMAGE=$ARM64_BASE" \
     --tag anglesite-dev:latest \
     "$CTX"
 container image save --platform linux/arm64 --output "$ARCHIVE" anglesite-dev:latest


### PR DESCRIPTION
## Summary

- make the scaffolded repository's initial commit succeed inside the app sandbox by using an app-scoped Git identity
- package the baked site dependency tree as one archive, cutting OCI filesystem entries by about 45 percent
- cache one pristine EXT4 rootfs per image digest and use copy-on-write clones for subsequent site starts
- pass one explicitly pinned base image to Apple container and Podman builds so unused architectures are not resolved

## Validation

- full signed Debug Xcode build succeeded
- entitled container VM/vsock probe passed with the rebuilt image
- optimized first import and VM probe completed in about 80 seconds versus the observed 25-minute old import
- cached repeat probe passed in 14.6 seconds total, including a 6-second incremental rebuild
- focused archive hydration fixture passed, including the already-hydrated fast path

## Notes

The broad Swift test suite compiled and exercised the runtime/core tests, then was stopped after an unrelated existing test process stalled silently for several minutes.