### PR TITLE
Fix invisible image-drop targets

### DIFF
--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -41,8 +41,8 @@ function installStyles(): void {
     `.${EDITABLE_CLASS} { outline: 2px solid rgba(0, 122, 255, 1); outline-offset: 2px; background: rgba(0, 122, 255, 0.05); }`,
     // !important here (unlike HOVER_CLASS/EDITABLE_CLASS above): site stylesheets commonly reset
     // `img { outline: none }`, and the drop-target ring needs to survive that.
-    `.${IMAGE_DROP_TARGET_CLASS} { outline: 3px dashed rgba(0, 122, 255, 0.9) !important; outline-offset: 4px !important; filter: brightness(0.9); }`,
-    `.${IMAGE_DROP_ACTIVE_CLASS} { outline-style: solid !important; filter: brightness(1.05); cursor: copy; }`,
+    `.${IMAGE_DROP_TARGET_CLASS} { outline: 3px dashed rgba(0, 122, 255, 0.9) !important; outline-offset: 4px !important; filter: brightness(0.9) !important; }`,
+    `.${IMAGE_DROP_ACTIVE_CLASS} { outline-style: solid !important; filter: brightness(1.05) !important; cursor: copy; }`,
     `[${IMAGE_DROP_HINT_ATTRIBUTE}] { position: fixed; z-index: 2147483647; left: 50%; top: 16px; transform: translateX(-50%); padding: 8px 12px; border-radius: 9px; background: rgba(28, 28, 30, 0.92); color: white; font: 600 13px/1.25 -apple-system, BlinkMacSystemFont, sans-serif; box-shadow: 0 4px 18px rgba(0, 0, 0, 0.25); pointer-events: none; }`,
   ].join("\n");
   document.head.appendChild(style);

--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -39,6 +39,8 @@ function installStyles(): void {
   style.textContent = [
     `.${HOVER_CLASS} { outline: 2px solid rgba(0, 122, 255, 0.8); outline-offset: 2px; cursor: text; }`,
     `.${EDITABLE_CLASS} { outline: 2px solid rgba(0, 122, 255, 1); outline-offset: 2px; background: rgba(0, 122, 255, 0.05); }`,
+    // !important here (unlike HOVER_CLASS/EDITABLE_CLASS above): site stylesheets commonly reset
+    // `img { outline: none }`, and the drop-target ring needs to survive that.
     `.${IMAGE_DROP_TARGET_CLASS} { outline: 3px dashed rgba(0, 122, 255, 0.9) !important; outline-offset: 4px !important; filter: brightness(0.9); }`,
     `.${IMAGE_DROP_ACTIVE_CLASS} { outline-style: solid !important; filter: brightness(1.05); cursor: copy; }`,
     `[${IMAGE_DROP_HINT_ATTRIBUTE}] { position: fixed; z-index: 2147483647; left: 50%; top: 16px; transform: translateX(-50%); padding: 8px 12px; border-radius: 9px; background: rgba(28, 28, 30, 0.92); color: white; font: 600 13px/1.25 -apple-system, BlinkMacSystemFont, sans-serif; box-shadow: 0 4px 18px rgba(0, 0, 0, 0.25); pointer-events: none; }`,
@@ -168,9 +170,15 @@ function attachImageDrop(awaitReply: (id: string, handler: (r: EditReply) => voi
     showTargets();
   });
   document.addEventListener("dragover", (ev) => {
-    if (!dragIsFile && !isFileDrag(ev.dataTransfer)) return;
-    dragIsFile = true;
-    showTargets();
+    // showTargets() re-scans the whole document, so only pay for it on the dragenter → dragover
+    // transition (normally already done by dragenter; this is just the fallback for the rare case
+    // where dataTransfer didn't read as a file drag until dragover). Every later dragover in the
+    // same drag only needs to move the active-target highlight, not re-highlight everything.
+    if (!dragIsFile) {
+      if (!isFileDrag(ev.dataTransfer)) return;
+      dragIsFile = true;
+      showTargets();
+    }
     const target = imageAtEvent(ev);
     setActiveTarget(target);
     // Prevent WKWebView from navigating to a dropped local file. A target outside an image is
@@ -184,15 +192,20 @@ function attachImageDrop(awaitReply: (id: string, handler: (r: EditReply) => voi
     ev.preventDefault();
     const target = imageAtEvent(ev as DragEvent);
     const hadTargets = imageTargets().length > 0;
+    const isImageFile = file.type.startsWith("image/");
     clearTargets();
-    if (!file.type.startsWith("image/")) {
-      showToast("Choose an image file to replace this image");
+    // Target-existence is checked before file-type so a dropped non-image file never gets the
+    // has-a-target wording ("replace this image") when there wasn't a target to replace.
+    if (!target) {
+      showToast(!hadTargets
+        ? "This page has no images to replace"
+        : isImageFile
+          ? "Drop onto a highlighted image to replace it"
+          : "Drop an image file onto a highlighted image to replace it");
       return;
     }
-    if (!target) {
-      showToast(hadTargets
-        ? "Drop onto a highlighted image to replace it"
-        : "This page has no images to replace");
+    if (!isImageFile) {
+      showToast("Choose an image file to replace this image");
       return;
     }
 
@@ -272,6 +285,9 @@ function attachImageDrop(awaitReply: (id: string, handler: (r: EditReply) => voi
     dragDepth = Math.max(0, dragDepth - 1);
     if (dragDepth === 0) clearTargets();
   });
+  // dragend fires on the drag's source node — for a real Finder→WKWebView drag that's outside
+  // this document, so this rarely fires in production. dragleave's depth counter above is the
+  // real cleanup path; this is a defensive backstop (and what lets tests reset state between runs).
   document.addEventListener("dragend", clearTargets);
 }
 

--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -168,6 +168,9 @@ function attachImageDrop(awaitReply: (id: string, handler: (r: EditReply) => voi
     dragIsFile = true;
     dragDepth += 1;
     showTargets();
+    // Prevented here too (not just on dragover below) so WKWebView doesn't show a "not allowed"
+    // cursor for the first frame of the drag, before the first dragover fires.
+    ev.preventDefault();
   });
   document.addEventListener("dragover", (ev) => {
     // showTargets() re-scans the whole document, so only pay for it on the dragenter → dragover
@@ -188,7 +191,18 @@ function attachImageDrop(awaitReply: (id: string, handler: (r: EditReply) => voi
   });
   document.addEventListener("drop", (ev) => {
     const file = (ev as DragEvent).dataTransfer?.files[0];
-    if (!file) return;
+    if (!file) {
+      // dragover already recognized this as a file drag (dragIsFile true) using the always-
+      // available types/items — but dataTransfer.files can still come back empty at drop time
+      // for some promise-backed/multi-item drag sources. Still prevent WKWebView's default file
+      // navigation and clear the stuck highlight state instead of silently discarding the drop.
+      if (dragIsFile) {
+        ev.preventDefault();
+        clearTargets();
+        showToast("Couldn't read the dropped file");
+      }
+      return;
+    }
     ev.preventDefault();
     const target = imageAtEvent(ev as DragEvent);
     const hadTargets = imageTargets().length > 0;

--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -165,9 +165,12 @@ function attachImageDrop(awaitReply: (id: string, handler: (r: EditReply) => voi
 
   document.addEventListener("dragenter", (ev) => {
     if (!isFileDrag(ev.dataTransfer)) return;
+    // dragenter fires once per DOM element boundary the pointer crosses, not once per page
+    // entry — so only rescan/highlight on the transition into a file drag, same as dragover.
+    const wasFileDrag = dragIsFile;
     dragIsFile = true;
     dragDepth += 1;
-    showTargets();
+    if (!wasFileDrag) showTargets();
     // Prevented here too (not just on dragover below) so WKWebView doesn't show a "not allowed"
     // cursor for the first frame of the drag, before the first dragover fires.
     ev.preventDefault();

--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -17,6 +17,9 @@ import { installVisibleElementsReporter } from "./visible-elements.js";
 
 export const HOVER_CLASS = "anglesite-hover";
 export const EDITABLE_CLASS = "anglesite-editing";
+export const IMAGE_DROP_TARGET_CLASS = "anglesite-image-drop-target";
+export const IMAGE_DROP_ACTIVE_CLASS = "anglesite-image-drop-active";
+export const IMAGE_DROP_HINT_ATTRIBUTE = "data-anglesite-image-drop-hint";
 const INSTALLED_FLAG = "__anglesiteOverlayInstalled" as const;
 const STYLE_TAG_MARKER = "data-anglesite-overlay";
 
@@ -36,6 +39,9 @@ function installStyles(): void {
   style.textContent = [
     `.${HOVER_CLASS} { outline: 2px solid rgba(0, 122, 255, 0.8); outline-offset: 2px; cursor: text; }`,
     `.${EDITABLE_CLASS} { outline: 2px solid rgba(0, 122, 255, 1); outline-offset: 2px; background: rgba(0, 122, 255, 0.05); }`,
+    `.${IMAGE_DROP_TARGET_CLASS} { outline: 3px dashed rgba(0, 122, 255, 0.9) !important; outline-offset: 4px !important; filter: brightness(0.9); }`,
+    `.${IMAGE_DROP_ACTIVE_CLASS} { outline-style: solid !important; filter: brightness(1.05); cursor: copy; }`,
+    `[${IMAGE_DROP_HINT_ATTRIBUTE}] { position: fixed; z-index: 2147483647; left: 50%; top: 16px; transform: translateX(-50%); padding: 8px 12px; border-radius: 9px; background: rgba(28, 28, 30, 0.92); color: white; font: 600 13px/1.25 -apple-system, BlinkMacSystemFont, sans-serif; box-shadow: 0 4px 18px rgba(0, 0, 0, 0.25); pointer-events: none; }`,
   ].join("\n");
   document.head.appendChild(style);
 }
@@ -108,17 +114,87 @@ function attachClickToEdit(awaitReply: (id: string, handler: (r: { status: strin
 }
 
 function attachImageDrop(awaitReply: (id: string, handler: (r: EditReply) => void) => void): void {
+  let dragIsFile = false;
+  let dragDepth = 0;
+  let activeTarget: HTMLImageElement | null = null;
+
+  const imageTargets = (): HTMLImageElement[] => Array.from(document.querySelectorAll("img"));
+
+  const isFileDrag = (dataTransfer: DataTransfer | null): boolean => {
+    if (!dataTransfer) return false;
+    if (Array.from(dataTransfer.types).includes("Files")) return true;
+    return Array.from(dataTransfer.items).some((item) => item.kind === "file");
+  };
+
+  const setActiveTarget = (target: HTMLImageElement | null): void => {
+    if (activeTarget === target) return;
+    activeTarget?.classList.remove(IMAGE_DROP_ACTIVE_CLASS);
+    target?.classList.add(IMAGE_DROP_ACTIVE_CLASS);
+    activeTarget = target;
+  };
+
+  const showTargets = (): void => {
+    const targets = imageTargets();
+    for (const target of targets) target.classList.add(IMAGE_DROP_TARGET_CLASS);
+
+    let hint = document.querySelector(`[${IMAGE_DROP_HINT_ATTRIBUTE}]`) as HTMLDivElement | null;
+    if (!hint) {
+      hint = document.createElement("div");
+      hint.setAttribute(IMAGE_DROP_HINT_ATTRIBUTE, "");
+      document.body.appendChild(hint);
+    }
+    hint.textContent = targets.length > 0
+      ? "Drop onto a highlighted image to replace it"
+      : "This page has no images to replace";
+  };
+
+  const clearTargets = (): void => {
+    setActiveTarget(null);
+    for (const target of imageTargets()) target.classList.remove(IMAGE_DROP_TARGET_CLASS);
+    document.querySelector(`[${IMAGE_DROP_HINT_ATTRIBUTE}]`)?.remove();
+    dragIsFile = false;
+    dragDepth = 0;
+  };
+
+  const imageAtEvent = (ev: DragEvent): HTMLImageElement | null => {
+    const element = ev.target instanceof Element ? ev.target : null;
+    return element?.closest("img") as HTMLImageElement | null;
+  };
+
+  document.addEventListener("dragenter", (ev) => {
+    if (!isFileDrag(ev.dataTransfer)) return;
+    dragIsFile = true;
+    dragDepth += 1;
+    showTargets();
+  });
   document.addEventListener("dragover", (ev) => {
-    const target = ev.target as Element | null;
-    if (target?.tagName !== "IMG") return;
+    if (!dragIsFile && !isFileDrag(ev.dataTransfer)) return;
+    dragIsFile = true;
+    showTargets();
+    const target = imageAtEvent(ev);
+    setActiveTarget(target);
+    // Prevent WKWebView from navigating to a dropped local file. A target outside an image is
+    // still handled below with guidance instead of silently discarding the gesture.
     ev.preventDefault();
+    if (ev.dataTransfer) ev.dataTransfer.dropEffect = target ? "copy" : "none";
   });
   document.addEventListener("drop", (ev) => {
-    const target = ev.target as HTMLImageElement | null;
-    if (target?.tagName !== "IMG") return;
     const file = (ev as DragEvent).dataTransfer?.files[0];
-    if (!file || !file.type.startsWith("image/")) return;
+    if (!file) return;
     ev.preventDefault();
+    const target = imageAtEvent(ev as DragEvent);
+    const hadTargets = imageTargets().length > 0;
+    clearTargets();
+    if (!file.type.startsWith("image/")) {
+      showToast("Choose an image file to replace this image");
+      return;
+    }
+    if (!target) {
+      showToast(hadTargets
+        ? "Drop onto a highlighted image to replace it"
+        : "This page has no images to replace");
+      return;
+    }
 
     // Save originals before the optimistic swap so we can revert on failure.
     const savedSrc = target.src;
@@ -191,6 +267,12 @@ function attachImageDrop(awaitReply: (id: string, handler: (r: EditReply) => voi
     reader.onerror = () => revertWithToast("Couldn't read the dropped file");
     reader.readAsDataURL(file);
   });
+  document.addEventListener("dragleave", () => {
+    if (!dragIsFile) return;
+    dragDepth = Math.max(0, dragDepth - 1);
+    if (dragDepth === 0) clearTargets();
+  });
+  document.addEventListener("dragend", clearTargets);
 }
 
 /** Mount the overlay onto `window`/`document`. Safe to call more than once. */

--- a/JS/edit-overlay/test/overlay.test.ts
+++ b/JS/edit-overlay/test/overlay.test.ts
@@ -242,6 +242,19 @@ describe("image drop", () => {
     expect(document.querySelector(".anglesite-toast")?.textContent).toMatch(/highlighted image/i);
   });
 
+  it("explains a non-image file dropped outside a replaceable image without implying one was targeted", () => {
+    makeImg("/images/hero.jpg");
+    const file = new File(["notes"], "notes.txt", { type: "text/plain" });
+
+    dropOn(document.body, file);
+
+    expect(sent.length).toBe(0);
+    const toastText = document.querySelector(".anglesite-toast")?.textContent ?? "";
+    expect(toastText).toMatch(/image file/i);
+    expect(toastText).toMatch(/highlighted image/i);
+    expect(toastText).not.toMatch(/replace this image/i);
+  });
+
   it("rejects a non-image file with guidance and prevents WKWebView navigation", () => {
     const img = makeImg("/images/hero.jpg");
     const file = new File(["notes"], "notes.txt", { type: "text/plain" });

--- a/JS/edit-overlay/test/overlay.test.ts
+++ b/JS/edit-overlay/test/overlay.test.ts
@@ -168,7 +168,7 @@ describe("image drop", () => {
 
   /** jsdom 25 doesn't implement DragEvent or DataTransfer, so we use a plain Event
    *  and define dataTransfer directly on the instance. */
-  function dropOn(target: Element, file: File): void {
+  function dropOn(target: Element, file: File): Event {
     const fakeDataTransfer = {
       files: [file],
       items: [{ kind: "file", type: file.type }],
@@ -178,6 +178,7 @@ describe("image drop", () => {
     const drop = new Event("drop", { bubbles: true, cancelable: true });
     Object.defineProperty(drop, "dataTransfer", { value: fakeDataTransfer });
     target.dispatchEvent(drop);
+    return drop;
   }
 
   function dragOn(type: "dragenter" | "dragover" | "dragleave", target: Element, file: File): Event {
@@ -259,11 +260,31 @@ describe("image drop", () => {
     const img = makeImg("/images/hero.jpg");
     const file = new File(["notes"], "notes.txt", { type: "text/plain" });
 
-    dropOn(img, file);
+    const event = dropOn(img, file);
 
+    expect(event.defaultPrevented).toBe(true);
     expect(sent.length).toBe(0);
     expect(img.src.endsWith("/images/hero.jpg")).toBe(true);
     expect(document.querySelector(".anglesite-toast")?.textContent).toMatch(/choose an image file/i);
+  });
+
+  it("still prevents WKWebView navigation and clears the highlight when dataTransfer.files is empty at drop time", () => {
+    // A recognized file drag (dragenter/dragover already saw "Files" in dataTransfer.types) can
+    // still arrive at drop with an empty .files — e.g. a promise-backed/multi-item drag source.
+    const img = makeImg("/images/hero.jpg");
+    const file = new File([new Uint8Array([0xff, 0xd8])], "vacation.jpg", { type: "image/jpeg" });
+    dragOn("dragenter", document.body, file);
+
+    const fakeDataTransfer = { files: [], items: [{ kind: "file", type: "image/jpeg" }], types: ["Files"], dropEffect: "none" };
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", { value: fakeDataTransfer });
+    document.body.dispatchEvent(drop);
+
+    expect(drop.defaultPrevented).toBe(true);
+    expect(sent.length).toBe(0);
+    expect(img.classList.contains(IMAGE_DROP_TARGET_CLASS)).toBe(false);
+    expect(document.querySelector(`[${IMAGE_DROP_HINT_ATTRIBUTE}]`)).toBeNull();
+    expect(document.querySelector(".anglesite-toast")?.textContent).toMatch(/couldn't read/i);
   });
 
   it("sets img.src to a blob URL immediately on drop", async () => {

--- a/JS/edit-overlay/test/overlay.test.ts
+++ b/JS/edit-overlay/test/overlay.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
-import { install, HOVER_CLASS, EDITABLE_CLASS } from "../src/overlay.js";
+import {
+  install,
+  HOVER_CLASS,
+  EDITABLE_CLASS,
+  IMAGE_DROP_TARGET_CLASS,
+  IMAGE_DROP_ACTIVE_CLASS,
+  IMAGE_DROP_HINT_ATTRIBUTE,
+} from "../src/overlay.js";
 
 interface WebKit {
   messageHandlers: { anglesite: { postMessage: (body: unknown) => void } };
@@ -40,6 +47,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  document.dispatchEvent(new Event("dragend", { bubbles: true }));
   clearBody();
   sent = [];
   stubWebKit();
@@ -161,10 +169,28 @@ describe("image drop", () => {
   /** jsdom 25 doesn't implement DragEvent or DataTransfer, so we use a plain Event
    *  and define dataTransfer directly on the instance. */
   function dropOn(target: Element, file: File): void {
-    const fakeDataTransfer = { files: [file] };
+    const fakeDataTransfer = {
+      files: [file],
+      items: [{ kind: "file", type: file.type }],
+      types: ["Files"],
+      dropEffect: "none",
+    };
     const drop = new Event("drop", { bubbles: true, cancelable: true });
     Object.defineProperty(drop, "dataTransfer", { value: fakeDataTransfer });
     target.dispatchEvent(drop);
+  }
+
+  function dragOn(type: "dragenter" | "dragover" | "dragleave", target: Element, file: File): Event {
+    const fakeDataTransfer = {
+      files: [file],
+      items: [{ kind: "file", type: file.type }],
+      types: ["Files"],
+      dropEffect: "none",
+    };
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "dataTransfer", { value: fakeDataTransfer });
+    target.dispatchEvent(event);
+    return event;
   }
 
   /** jsdom's FileReader fires its onload callback after two macrotask ticks. */
@@ -172,6 +198,60 @@ describe("image drop", () => {
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
   }
+
+  it("highlights every replaceable image while a Finder file is dragged over the page", () => {
+    const first = makeImg("/images/first.jpg");
+    const second = makeImg("/images/second.jpg");
+    const file = new File([new Uint8Array([0xff, 0xd8])], "vacation.jpg", { type: "image/jpeg" });
+
+    dragOn("dragenter", document.body, file);
+
+    expect(first.classList.contains(IMAGE_DROP_TARGET_CLASS)).toBe(true);
+    expect(second.classList.contains(IMAGE_DROP_TARGET_CLASS)).toBe(true);
+    expect(document.querySelector(`[${IMAGE_DROP_HINT_ATTRIBUTE}]`)?.textContent).toMatch(/highlighted image/i);
+  });
+
+  it("shows which image will receive the drop", () => {
+    const img = makeImg("/images/hero.jpg");
+    const file = new File([new Uint8Array([0xff, 0xd8])], "vacation.jpg", { type: "image/jpeg" });
+
+    const event = dragOn("dragover", img, file);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(img.classList.contains(IMAGE_DROP_ACTIVE_CLASS)).toBe(true);
+  });
+
+  it("clears image targets when the drag leaves the page", () => {
+    const img = makeImg("/images/hero.jpg");
+    const file = new File([new Uint8Array([0xff, 0xd8])], "vacation.jpg", { type: "image/jpeg" });
+    dragOn("dragenter", document.body, file);
+
+    dragOn("dragleave", document.body, file);
+
+    expect(img.classList.contains(IMAGE_DROP_TARGET_CLASS)).toBe(false);
+    expect(document.querySelector(`[${IMAGE_DROP_HINT_ATTRIBUTE}]`)).toBeNull();
+  });
+
+  it("explains an image drop outside a replaceable image instead of failing silently", () => {
+    makeImg("/images/hero.jpg");
+    const file = new File([new Uint8Array([0xff, 0xd8])], "vacation.jpg", { type: "image/jpeg" });
+
+    dropOn(document.body, file);
+
+    expect(sent.length).toBe(0);
+    expect(document.querySelector(".anglesite-toast")?.textContent).toMatch(/highlighted image/i);
+  });
+
+  it("rejects a non-image file with guidance and prevents WKWebView navigation", () => {
+    const img = makeImg("/images/hero.jpg");
+    const file = new File(["notes"], "notes.txt", { type: "text/plain" });
+
+    dropOn(img, file);
+
+    expect(sent.length).toBe(0);
+    expect(img.src.endsWith("/images/hero.jpg")).toBe(true);
+    expect(document.querySelector(".anglesite-toast")?.textContent).toMatch(/choose an image file/i);
+  });
 
   it("sets img.src to a blob URL immediately on drop", async () => {
     const img = makeImg("/images/hero.jpg");

--- a/JS/edit-overlay/test/overlay.test.ts
+++ b/JS/edit-overlay/test/overlay.test.ts
@@ -205,8 +205,9 @@ describe("image drop", () => {
     const second = makeImg("/images/second.jpg");
     const file = new File([new Uint8Array([0xff, 0xd8])], "vacation.jpg", { type: "image/jpeg" });
 
-    dragOn("dragenter", document.body, file);
+    const event = dragOn("dragenter", document.body, file);
 
+    expect(event.defaultPrevented).toBe(true);
     expect(first.classList.contains(IMAGE_DROP_TARGET_CLASS)).toBe(true);
     expect(second.classList.contains(IMAGE_DROP_TARGET_CLASS)).toBe(true);
     expect(document.querySelector(`[${IMAGE_DROP_HINT_ATTRIBUTE}]`)?.textContent).toMatch(/highlighted image/i);
@@ -229,6 +230,21 @@ describe("image drop", () => {
 
     dragOn("dragleave", document.body, file);
 
+    expect(img.classList.contains(IMAGE_DROP_TARGET_CLASS)).toBe(false);
+    expect(document.querySelector(`[${IMAGE_DROP_HINT_ATTRIBUTE}]`)).toBeNull();
+  });
+
+  it("keeps targets visible until nested dragenter and dragleave events balance", () => {
+    const img = makeImg("/images/hero.jpg");
+    const file = new File([new Uint8Array([0xff, 0xd8])], "vacation.jpg", { type: "image/jpeg" });
+    dragOn("dragenter", document.body, file);
+    dragOn("dragenter", img, file);
+
+    dragOn("dragleave", img, file);
+    expect(img.classList.contains(IMAGE_DROP_TARGET_CLASS)).toBe(true);
+    expect(document.querySelector(`[${IMAGE_DROP_HINT_ATTRIBUTE}]`)).not.toBeNull();
+
+    dragOn("dragleave", document.body, file);
     expect(img.classList.contains(IMAGE_DROP_TARGET_CLASS)).toBe(false);
     expect(document.querySelector(`[${IMAGE_DROP_HINT_ATTRIBUTE}]`)).toBeNull();
   });

--- a/Resources/Template/public/images/hello.svg
+++ b/Resources/Template/public/images/hello.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title description">
+  <title id="title">A coastal landscape</title>
+  <desc id="description">A warm sunset over blue hills and the ocean.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f5b67f"/>
+      <stop offset="0.55" stop-color="#f8d9a7"/>
+      <stop offset="1" stop-color="#8ec5d6"/>
+    </linearGradient>
+    <linearGradient id="water" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#4b91aa"/>
+      <stop offset="1" stop-color="#20566f"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#sky)"/>
+  <circle cx="880" cy="235" r="82" fill="#fff1bd" opacity="0.95"/>
+  <path d="M0 510 210 330 390 505 570 285 820 515 1015 355 1200 495V800H0Z" fill="#436e78"/>
+  <path d="M0 555 260 435 455 570 690 410 905 565 1090 470 1200 540V800H0Z" fill="#315968"/>
+  <path d="M0 590C250 550 430 635 650 580s370-60 550 5v215H0Z" fill="url(#water)"/>
+  <path d="M0 650c260-55 405 45 655-10 210-46 365-36 545 20" fill="none" stroke="#cbe7e5" stroke-width="12" opacity="0.55"/>
+</svg>

--- a/Resources/Template/src/content/photos/hello-photo.md
+++ b/Resources/Template/src/content/photos/hello-photo.md
@@ -1,5 +1,5 @@
 ---
-image: "/images/hello.jpg"
+image: "/images/hello.svg"
 caption: "An example photo."
 publishDate: 2026-06-26T12:00:00.000Z
 tags: ["hello"]

--- a/docs/qa/app-store-container-smoke-test.md
+++ b/docs/qa/app-store-container-smoke-test.md
@@ -60,7 +60,7 @@ The script prints the built app path and the interactive steps. Copy the built a
 | No host Node preview fallback starts |  |  |
 | Preview loads through loopback proxy |  |  |
 | MCP/edit path applies a text edit through the in-container sidecar |  |  |
-| Image drop writes optimized assets under `Source/public/images/` |  |  |
+| Example photo highlights as an image drop target; dropping a Finder image writes optimized assets under `Source/public/images/` |  |  |
 | Build/preflight/deploy path reaches the expected Cloudflare token or wrangler result |  |  |
 | Foundation Models chat is present |  |  |
 | GitHub `gh` settings/auth UI is absent in App Store build |  |  |
@@ -88,4 +88,3 @@ Also save the app debug pane logs for these sources when present:
 ## Acceptance
 
 #81 can close when the matrix passes on a real-signed App Store-target build, or when every failure has a follow-up issue with captured logs and a clear owner.
-

--- a/scripts/create-smoke-fixture.sh
+++ b/scripts/create-smoke-fixture.sh
@@ -152,8 +152,10 @@ cat <<EOF
        then the pre-deploy scan runs. A real 'wrangler deploy' needs a Cloudflare
        token; if no token is configured, capture the prompt/error instead of
        treating it as a sandbox failure.
-    4. Drag an image onto an <img> in the preview → bytes write to public/images/
-       through the container-backed edit path. Record any sandbox denial.
+    4. Open the example photo page, then drag an image from Finder. Existing
+       images highlight as drop targets; drop onto the example image and confirm
+       the optimized bytes write to public/images/ through the container-backed
+       edit path. Record any sandbox denial.
     5. Close the window → runtime children reaped. Quit → no orphan runtime process.
     6. Foundation Models chat should be present. Settings → no GitHub Connect
        row, and updates are handled by the App Store.


### PR DESCRIPTION
## Summary
- highlight every replaceable image during Finder drags and show the active target
- explain invalid drops instead of silently discarding them, while preventing WKWebView file navigation
- add a real example image to the template and make the #81 smoke instructions explicit

## Verification
- npm test (69 tests)
- npm run typecheck
- npm run lint
- npm run build (edit overlay)
- direct Astro production build
- bash syntax and SVG validation

Part of #81.