### PR TITLE
Add sudden-termination lifecycle guards

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -30,6 +30,8 @@
 	<string>Copyright © 2026 David W. Keith. ISC License.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSupportsSuddenTermination</key>
+	<true/>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Anglesite needs to coordinate with helper processes (Astro dev server, MCP server) to preview and edit your site.</string>
 	<key>NSUserActivityTypes</key>

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -79,6 +79,7 @@ final class DeployModel {
     /// `generateStructured` doesn't honour cooperative cancellation.
     private var summarizationGeneration: UInt = 0
     private var inFlight: Task<Void, Never>?
+    private let suddenTerminationController: SuddenTerminationController
     /// Site to retry once the user pastes a token. `nil` outside the prompt flow.
     /// Carries the container control (if any) so the parked-then-retried deploy
     /// uses the same executor as the original dispatch.
@@ -95,13 +96,15 @@ final class DeployModel {
         logCenter: LogCenter = .shared,
         keychain: KeychainStore = KeychainStore(),
         verifier: TokenVerifying = CloudflareAPITokenVerifier(),
-        summarizer: any DeployFailureSummarizing = DeploySummarizerFactory.makeDefault()
+        summarizer: any DeployFailureSummarizing = DeploySummarizerFactory.makeDefault(),
+        suddenTerminationController: SuddenTerminationController = .shared
     ) {
         self.command = command
         self.logCenter = logCenter
         self.keychain = keychain
         self.onboarding = TokenOnboarding(verifier: verifier)
         self.summarizer = summarizer
+        self.suddenTerminationController = suddenTerminationController
     }
 
     var isRunning: Bool {
@@ -143,11 +146,13 @@ final class DeployModel {
         // on the same actor hop (e.g. a rapid re-invocation before this Task starts running)
         // sees `isRunning == true` and bails via the guard above instead of racing runDeploy.
         phase = .running(siteID: siteID, since: Date())
-        inFlight = Task { @MainActor [weak self] in
+        let suddenTerminationLease = suddenTerminationController.acquire()
+        inFlight = Task { @MainActor [weak self, suddenTerminationLease] in
             await self?.runDeploy(
                 siteID: siteID, siteDirectory: siteDirectory,
                 configDirectory: configDirectory, currentRoutes: currentRoutes,
-                containerControl: containerControl)
+                containerControl: containerControl,
+                suddenTerminationLease: suddenTerminationLease)
         }
     }
 
@@ -234,8 +239,10 @@ final class DeployModel {
         siteDirectory: URL,
         configDirectory: URL,
         currentRoutes: [String],
-        containerControl: (siteID: String, control: any LocalContainerControl)? = nil
+        containerControl: (siteID: String, control: any LocalContainerControl)? = nil,
+        suddenTerminationLease: SuddenTerminationController.Lease
     ) async {
+        defer { suddenTerminationLease.release() }
         transition(siteID: siteID, to: .running(siteID: siteID, since: Date()))
         logLines = []
         currentMilestone = nil

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -30,6 +30,7 @@ struct SiteWindow: View {
     /// `model.pendingDeleteUndo` for the same dismiss-animation-stability reason as
     /// `contentDeleteTitle` above.
     @State private var deleteUndoTitle: String = ""
+    @State private var unsavedEditsTerminationLease: SuddenTerminationController.Lease?
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
@@ -68,7 +69,11 @@ struct SiteWindow: View {
                 let openWindow = openWindow
                 WindowRouter.shared.openSitesWindow = { openWindow(id: "sites") }
             }
-            .onDisappear { model.close() }
+            .onDisappear {
+                let terminationLease = unsavedEditsTerminationLease
+                unsavedEditsTerminationLease = nil
+                model.close(suddenTerminationLease: terminationLease)
+            }
     }
 
     /// The Group + lifecycle-task/onChange chain, factored out of `body` as its own type-checking
@@ -108,6 +113,16 @@ struct SiteWindow: View {
         }
         .onChange(of: model.preview.state) { _, newState in
             model.startup.ingest(state: newState)
+        }
+        .onChange(of: model.hasUnsavedEdits, initial: true) { _, hasUnsavedEdits in
+            if hasUnsavedEdits {
+                if unsavedEditsTerminationLease == nil {
+                    unsavedEditsTerminationLease = SuddenTerminationController.shared.acquire()
+                }
+            } else {
+                unsavedEditsTerminationLease?.release()
+                unsavedEditsTerminationLease = nil
+            }
         }
     }
 

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -374,7 +374,7 @@ final class SiteWindowModel {
         mainPaneMode = .preview
     }
 
-    func close() {
+    func close(suddenTerminationLease: SuddenTerminationController.Lease? = nil) {
         preview.close()
         startup.stop()
         // Note: an in-flight Deploy/Backup/Audit is intentionally NOT cancelled or cleaned up
@@ -401,17 +401,30 @@ final class SiteWindowModel {
         // Window closing: persist unsaved edits unconditionally (consistent with
         // auto-save-on-leave). No conflict dialog is possible during teardown, so we don't gate
         // on a flush return value — just write the buffer best-effort, off the main actor.
-        persistEditorBufferBestEffort()
+        let editorSaveTask = persistEditorBufferBestEffort()
         activeEditor = nil
         // Overwrite unconditionally on teardown (save(), not flushBeforeLeaving): no conflict
         // alert can be shown on a closing window, so a conflict-gated flush would silently drop
         // the edits. Last-writer-wins, matching the .text/.plist teardown above.
-        if let model = inspectorContext?.model { Task { await model.save() } }
+        let inspectorWasDirty = inspectorContext?.model.isDirty == true
+        let inspectorSaveTask = (inspectorContext?.model).map { model in
+            Task { await model.save() }
+        }
         inspectorContext = nil
+        let closeTerminationLease = suddenTerminationLease
+            ?? ((editorSaveTask != nil || inspectorWasDirty) ? SuddenTerminationController.shared.acquire() : nil)
         #if ANGLESITE_MAS
-        scopedURL?.stopAccessingSecurityScopedResource()
-        scopedURL = nil
+        let closingScopedURL = scopedURL
+        self.scopedURL = nil
         #endif
+        Task { @MainActor in
+            await editorSaveTask?.value
+            _ = await inspectorSaveTask?.value
+            #if ANGLESITE_MAS
+            closingScopedURL?.stopAccessingSecurityScopedResource()
+            #endif
+            closeTerminationLease?.release()
+        }
     }
 
     /// Flush the open editor before leaving it: auto-saves a dirty buffer, but returns false (and the
@@ -615,20 +628,22 @@ final class SiteWindowModel {
     /// Best-effort off-main save of the open editor's buffer when the editor is torn down (window
     /// close or site replay), where no conflict dialog can be shown. Consistent with the
     /// auto-save-on-leave model; last-writer-wins on the rare teardown-time external conflict.
-    private func persistEditorBufferBestEffort() {
+    @discardableResult
+    private func persistEditorBufferBestEffort() -> Task<Void, Never>? {
         switch activeEditor {
         case .text(let model) where model.isDirty:
             let url = model.file.url
             let contents = model.text
-            Task.detached(priority: .userInitiated) { try? FileDocumentIO.save(contents, to: url) }
+            return Task.detached(priority: .userInitiated) { _ = try? FileDocumentIO.save(contents, to: url) }
         case .plist(let model):
             if model.isDirty, model.validationMessage == nil {
                 let url = model.file.url
                 let entries = model.entriesForSaving()
-                Task.detached(priority: .userInitiated) { try? PlistDocumentIO.save(entries, to: url) }
+                return Task.detached(priority: .userInitiated) { _ = try? PlistDocumentIO.save(entries, to: url) }
             }
+            return nil
         case .text, nil:
-            break
+            return nil
         }
     }
 

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -14,7 +14,9 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     private let logCenter: LogCenter
     private let connect: @Sendable (MCPClient, URL) async throws -> Void
     private let makeFileWatcher: @Sendable () -> any SiteFileWatching
+    private let suddenTerminationController: SuddenTerminationController
     private var fileWatcher: (any SiteFileWatching)?
+    private var containerTerminationLease: SuddenTerminationController.Lease?
 
     private var current: SiteRuntimeState = .idle
     private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
@@ -37,7 +39,8 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         conventionsEngine: ProjectConventionsEngine? = nil,
         logCenter: LogCenter = .shared,
         connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { c, u in try await c.connect(httpEndpoint: u) },
-        makeFileWatcher: @escaping @Sendable () -> any SiteFileWatching = { PlatformFileWatcher.make() }
+        makeFileWatcher: @escaping @Sendable () -> any SiteFileWatching = { PlatformFileWatcher.make() },
+        suddenTerminationController: SuddenTerminationController = .shared
     ) {
         self.ref = ref
         self.control = control
@@ -48,6 +51,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         self.logCenter = logCenter
         self.connect = connect
         self.makeFileWatcher = makeFileWatcher
+        self.suddenTerminationController = suddenTerminationController
     }
 
     public var state: SiteRuntimeState { current }
@@ -102,6 +106,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             setState(.idle)
         }
         setState(.starting(siteID: siteID))
+        let suddenTerminationLease = suddenTerminationController.acquire()
 
         // Wire the container's boot/guest-process output (repo clone, npm install + astro dev, the
         // MCP sidecar, the vsock bridge) into LogCenter under a per-site source tag, live, the same
@@ -129,14 +134,17 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         // that discovers it has been superseded must clean up after itself.
         func abandonSupersededAttempt() async {
             try? await control.stop(siteID: siteID)
+            suddenTerminationLease.release()
             continuation.finish()
             await drainTask.value
         }
 
+        var containerStarted = false
         do {
             let session = try await control.start(
                 siteID: siteID, sourceRepo: siteDirectory, ref: ref,
                 onOutput: { line, stream in continuation.yield((line, stream)) })
+            containerStarted = true
             guard gen == generation else { await abandonSupersededAttempt(); return }
             try await connect(mcpClient, session.mcpURL)
             guard gen == generation else { await abandonSupersededAttempt(); return }
@@ -161,6 +169,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             loadedKnowledgeSiteID = siteID
             startFileWatcher(siteID: siteID, projectRoot: siteDirectory, generation: gen)
             activeSiteID = siteID
+            containerTerminationLease = suddenTerminationLease
             setState(.ready(siteID: siteID, url: session.previewURL))
         } catch {
             // Finish this attempt's own (locally-captured) boot log stream immediately rather than
@@ -172,6 +181,10 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             // those would tear down the wrong stream.
             continuation.finish()
             await drainTask.value
+            if containerStarted {
+                try? await control.stop(siteID: siteID)
+            }
+            suddenTerminationLease.release()
             guard gen == generation else { return }
             bootLogContinuation = nil
             bootLogDrainTask = nil
@@ -208,6 +221,8 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         loadedKnowledgeSiteID = nil
         let containerSiteID = activeSiteID
         activeSiteID = nil
+        let containerTerminationLease = self.containerTerminationLease
+        self.containerTerminationLease = nil
         let bootLogContinuation = self.bootLogContinuation
         let bootLogDrainTask = self.bootLogDrainTask
         self.bootLogContinuation = nil
@@ -222,6 +237,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         if let id = containerSiteID {
             try? await control.stop(siteID: id)
         }
+        containerTerminationLease?.release()
         // Stop the container first (above) so no more guest output can arrive, then finish the
         // stream and await the drain so already-buffered lines land in LogCenter — mirrors
         // `ContainerDeployExecutor`'s finish-then-await-drain discipline.

--- a/Sources/AnglesiteCore/ProcessSupervisor.swift
+++ b/Sources/AnglesiteCore/ProcessSupervisor.swift
@@ -39,6 +39,9 @@ public actor ProcessSupervisor {
 
     private let backend: SupervisorBackend
 
+    private let suddenTerminationController: SuddenTerminationController
+    private var processLeases: [UUID: SuddenTerminationController.Lease] = [:]
+
     /// Environment for spawns that don't pass one. Injectable for tests.
     private let defaultEnvironment: @Sendable () -> [String: String]?
 
@@ -58,18 +61,21 @@ public actor ProcessSupervisor {
     /// Convenience for the app and tests: the default in-process backend. The app is sandboxed and
     /// still uses subprocesses for non-Node helper tools, holding a per-`SiteWindow`
     /// security-scoped grant so spawned children inherit folder access.
-    public init() {
+    public init(suddenTerminationController: SuddenTerminationController = .shared) {
         _ = Self.ignoreSIGPIPE
         self.backend = InProcessBackend()
         self.defaultEnvironment = { nil }
+        self.suddenTerminationController = suddenTerminationController
     }
 
     /// Inject a backend explicitly (tests, future MAS wiring); `defaultEnvironment` applies to spawns that don't pass one.
     public init(backend: SupervisorBackend,
-                defaultEnvironment: @escaping @Sendable () -> [String: String]? = { nil }) {
+                defaultEnvironment: @escaping @Sendable () -> [String: String]? = { nil },
+                suddenTerminationController: SuddenTerminationController = .shared) {
         _ = Self.ignoreSIGPIPE
         self.backend = backend
         self.defaultEnvironment = defaultEnvironment
+        self.suddenTerminationController = suddenTerminationController
     }
 
     // MARK: One-shot run
@@ -101,6 +107,8 @@ public actor ProcessSupervisor {
         environment: [String: String]? = nil,
         currentDirectoryURL: URL? = nil
     ) async throws -> RunResult {
+        let suddenTerminationLease = suddenTerminationController.acquire()
+        defer { suddenTerminationLease.release() }
         let spec = SpawnSpec(
             executable: executable,
             arguments: arguments,
@@ -151,6 +159,7 @@ public actor ProcessSupervisor {
         onRespawn: RespawnHandler? = nil,
         logCenter: LogCenter = .shared
     ) async throws -> Handle {
+        let suddenTerminationLease = suddenTerminationController.acquire()
         let spec = SpawnSpec(
             executable: executable,
             arguments: arguments,
@@ -168,7 +177,17 @@ public actor ProcessSupervisor {
                 logCenter: logCenter
             )
         } catch let error as SupervisorBackendError {
+            suddenTerminationLease.release()
             throw Self.translate(error)
+        } catch {
+            suddenTerminationLease.release()
+            throw error
+        }
+        processLeases[spawned.id] = suddenTerminationLease
+        let backend = self.backend
+        Task { [weak self] in
+            _ = await backend.waitForExit(spawned)
+            await self?.releaseProcessLease(id: spawned.id)
         }
         return Handle(id: spawned.id, source: source)
     }
@@ -199,6 +218,9 @@ public actor ProcessSupervisor {
     /// Node / Astro / MCP child outlives the app process.
     public func shutdownAll(timeout: TimeInterval = 5) async {
         await backend.shutdownAll(timeout: timeout)
+        for id in Array(processLeases.keys) {
+            releaseProcessLease(id: id)
+        }
     }
 
     public func isRunning(_ handle: Handle) async -> Bool {
@@ -221,6 +243,10 @@ public actor ProcessSupervisor {
         } catch let error as SupervisorBackendError {
             throw Self.translate(error)
         }
+    }
+
+    private func releaseProcessLease(id: UUID) {
+        processLeases.removeValue(forKey: id)?.release()
     }
 
     // MARK: Error translation

--- a/Sources/AnglesiteCore/SuddenTerminationController.swift
+++ b/Sources/AnglesiteCore/SuddenTerminationController.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Process-wide reference counting for work that must finish before macOS may suddenly terminate
+/// Anglesite. Callers retain the returned lease for exactly as long as their critical state exists;
+/// releasing (or deinitializing) the last lease re-enables sudden termination.
+public final class SuddenTerminationController: @unchecked Sendable {
+    public static let shared = SuddenTerminationController()
+
+    public final class Lease: @unchecked Sendable {
+        private let lock = NSLock()
+        private var controller: SuddenTerminationController?
+
+        fileprivate init(controller: SuddenTerminationController) {
+            self.controller = controller
+        }
+
+        /// Releases this lease once. Repeated calls are harmless.
+        public func release() {
+            lock.lock()
+            let controller = self.controller
+            self.controller = nil
+            lock.unlock()
+            controller?.releaseLease()
+        }
+
+        deinit {
+            release()
+        }
+    }
+
+    private let lock = NSLock()
+    private let disable: @Sendable () -> Void
+    private let enable: @Sendable () -> Void
+    private var leaseCount = 0
+
+    public convenience init() {
+        self.init(
+            disable: { SuddenTerminationController.disableProcessSuddenTermination() },
+            enable: { SuddenTerminationController.enableProcessSuddenTermination() }
+        )
+    }
+
+    /// Closures are injectable so the balancing invariant can be tested without changing the test
+    /// runner's own sudden-termination state.
+    public init(
+        disable: @escaping @Sendable () -> Void,
+        enable: @escaping @Sendable () -> Void
+    ) {
+        self.disable = disable
+        self.enable = enable
+    }
+
+    public var activeLeaseCount: Int {
+        lock.withLock { leaseCount }
+    }
+
+    public func acquire() -> Lease {
+        lock.lock()
+        if leaseCount == 0 {
+            disable()
+        }
+        leaseCount += 1
+        lock.unlock()
+        return Lease(controller: self)
+    }
+
+    private func releaseLease() {
+        lock.lock()
+        guard leaseCount > 0 else {
+            lock.unlock()
+            assertionFailure("Sudden-termination lease count became unbalanced")
+            return
+        }
+        leaseCount -= 1
+        let shouldEnable = leaseCount == 0
+        if shouldEnable {
+            enable()
+        }
+        lock.unlock()
+    }
+
+    private static func disableProcessSuddenTermination() {
+        #if os(macOS)
+        ProcessInfo.processInfo.disableSuddenTermination()
+        #endif
+    }
+
+    private static func enableProcessSuddenTermination() {
+        #if os(macOS)
+        ProcessInfo.processInfo.enableSuddenTermination()
+        #endif
+    }
+}

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -21,6 +21,40 @@ struct LocalContainerSiteRuntimeTests {
         previewURL: URL(string: "http://127.0.0.1:51001")!,
         mcpURL: URL(string: "http://127.0.0.1:51002/mcp")!)
 
+    @Test("a booted container holds sudden termination disabled until stop")
+    func containerBracketsSuddenTermination() async {
+        let controller = SuddenTerminationController(disable: {}, enable: {})
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: fake,
+            mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
+            connect: { _, _ in },
+            suddenTerminationController: controller
+        )
+
+        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        #expect(controller.activeLeaseCount == 1)
+        await runtime.stop()
+        #expect(controller.activeLeaseCount == 0)
+    }
+
+    @Test("a failed container boot does not leak its sudden-termination lease")
+    func failedContainerDoesNotLeakSuddenTerminationLease() async {
+        let controller = SuddenTerminationController(disable: {}, enable: {})
+        let fake = FakeLocalContainerControl(startResult: .failure(.bootFailed("no boot")))
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: fake,
+            mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
+            connect: { _, _ in },
+            suddenTerminationController: controller
+        )
+
+        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        #expect(controller.activeLeaseCount == 0)
+    }
+
     @Test("start settles to .ready with the preview URL")
     func startReady() async {
         let (rt, _) = makeRuntime(.success(Self.ok))

--- a/Tests/AnglesiteCoreTests/ProcessSupervisorShutdownTests.swift
+++ b/Tests/AnglesiteCoreTests/ProcessSupervisorShutdownTests.swift
@@ -3,6 +3,22 @@ import Foundation
 @testable import AnglesiteCore
 
 struct ProcessSupervisorShutdownTests {
+    @Test("A live child holds sudden termination disabled until shutdown")
+    func liveChildBracketsSuddenTermination() async throws {
+        let controller = SuddenTerminationController(disable: {}, enable: {})
+        let supervisor = ProcessSupervisor(suddenTerminationController: controller)
+        _ = try await supervisor.launch(
+            source: "sudden-termination-test",
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "exec sleep 30"],
+            logCenter: LogCenter()
+        )
+
+        #expect(controller.activeLeaseCount == 1)
+        await supervisor.shutdownAll(timeout: 2)
+        #expect(controller.activeLeaseCount == 0)
+    }
+
     @Test("Shutdown all terminates every supervised process") func shutdownAllTerminatesEverySupervisedProcess() async throws {
         let supervisor = ProcessSupervisor()
         let center = LogCenter()

--- a/Tests/AnglesiteCoreTests/SuddenTerminationControllerTests.swift
+++ b/Tests/AnglesiteCoreTests/SuddenTerminationControllerTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("Sudden termination controller")
+struct SuddenTerminationControllerTests {
+    @Test("overlapping leases bracket ProcessInfo calls once")
+    func overlappingLeases() {
+        let calls = LockedCalls()
+        let controller = SuddenTerminationController(
+            disable: { calls.recordDisable() },
+            enable: { calls.recordEnable() }
+        )
+
+        let first = controller.acquire()
+        let second = controller.acquire()
+        #expect(controller.activeLeaseCount == 2)
+        #expect(calls.snapshot.disables == 1)
+        #expect(calls.snapshot.enables == 0)
+
+        first.release()
+        #expect(controller.activeLeaseCount == 1)
+        #expect(calls.snapshot.disables == 1)
+        #expect(calls.snapshot.enables == 0)
+
+        second.release()
+        #expect(controller.activeLeaseCount == 0)
+        #expect(calls.snapshot.disables == 1)
+        #expect(calls.snapshot.enables == 1)
+    }
+
+    @Test("a lease releases at most once")
+    func idempotentRelease() {
+        let calls = LockedCalls()
+        let controller = SuddenTerminationController(
+            disable: { calls.recordDisable() },
+            enable: { calls.recordEnable() }
+        )
+        let lease = controller.acquire()
+
+        lease.release()
+        lease.release()
+
+        #expect(controller.activeLeaseCount == 0)
+        #expect(calls.snapshot.disables == 1)
+        #expect(calls.snapshot.enables == 1)
+    }
+}
+
+private final class LockedCalls: @unchecked Sendable {
+    private let lock = NSLock()
+    private var disables = 0
+    private var enables = 0
+
+    var snapshot: (disables: Int, enables: Int) {
+        lock.withLock { (disables, enables) }
+    }
+
+    func recordDisable() {
+        lock.withLock { disables += 1 }
+    }
+
+    func recordEnable() {
+        lock.withLock { enables += 1 }
+    }
+}


### PR DESCRIPTION
Closes #673

## Summary

- opt the app into sudden termination while idle
- add a process-wide reference-counted lease around subprocesses, containers, deploys, and dirty editor buffers
- retain dirty-buffer protection and security-scoped access until close-time saves complete
- cover lease balancing and process/container lifecycle behavior with regression tests

## Verification

- `swift test --filter 'SuddenTerminationControllerTests|ProcessSupervisorShutdownTests|LocalContainerSiteRuntimeTests'` (23 tests passed)
- `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- built app Info.plist reports `NSSupportsSuddenTermination = true`
- `git diff --check`
