### PR TITLE
Fix host node_modules poisoning Linux containers (#719)

### DIFF
--- a/Resources/Template/.gitignore
+++ b/Resources/Template/.gitignore
@@ -1,3 +1,11 @@
+# Dependencies and generated build state must never enter a site's Source repo.
+# The runtime installs dependencies inside its Linux container, so committing a
+# host-built node_modules tree can leave native packages unusable there.
+node_modules/
+dist/
+.astro/
+.wrangler/
+
 # Generated at build by scripts/edge-artifacts.ts (Expires changes every build).
 # Scoped to the one generated file so future static well-known files
 # (apple-app-site-association, assetlinks.json, …) can still be committed.

--- a/container/hydrate.sh
+++ b/container/hydrate.sh
@@ -3,7 +3,9 @@
 # Install a cloned site's npm dependencies as fast as possible by reusing the
 # image's pre-baked toolchain (design decision #5b — skip npm ci on cold start).
 #
-#   • node_modules already present            -> nothing to do.
+#   • usable node_modules already present     -> nothing to do.
+#   • node_modules has a foreign/broken Rollup native binding
+#                                               -> discard and reinstall.
 #   • lockfile identical to the baked template -> expand the baked node_modules
 #                                                 archive (zero install — the common
 #                                                 case for template-derived sites).
@@ -18,8 +20,18 @@ BAKED_ARCHIVE="${ANGLESITE_HOME:-/opt/anglesite}/baked-node-modules.tar"
 cd "$SITE_DIR"
 
 if [ -d node_modules ]; then
-    echo "==> node_modules already present; skipping install"
-    exit 0
+    # A site repo may have been initialized after `npm install` on the host. If
+    # that host-built tree was committed, Rollup's optional native dependency is
+    # for macOS/Windows rather than this Linux guest. Requiring Rollup's loader is
+    # a cheap architecture check and also catches an incomplete native install.
+    if [ -f node_modules/rollup/dist/native.js ] \
+       && ! node -e "require('./node_modules/rollup/dist/native.js')" >/dev/null 2>&1; then
+        echo "WARN: existing node_modules has no usable Rollup native binding for this container; reinstalling dependencies" >&2
+        rm -rf node_modules
+    else
+        echo "==> node_modules already present and usable; skipping install"
+        exit 0
+    fi
 fi
 
 if [ -f package-lock.json ] && [ -f "$BAKED/package-lock.json" ] \

--- a/container/hydrate.sh
+++ b/container/hydrate.sh
@@ -4,7 +4,7 @@
 # image's pre-baked toolchain (design decision #5b — skip npm ci on cold start).
 #
 #   • usable node_modules already present     -> nothing to do.
-#   • node_modules has a foreign/broken Rollup native binding
+#   • node_modules has a foreign/broken native dependency
 #                                               -> discard and reinstall.
 #   • lockfile identical to the baked template -> expand the baked node_modules
 #                                                 archive (zero install — the common
@@ -19,14 +19,38 @@ BAKED="${ANGLESITE_HOME:-/opt/anglesite}/baked"
 BAKED_ARCHIVE="${ANGLESITE_HOME:-/opt/anglesite}/baked-node-modules.tar"
 cd "$SITE_DIR"
 
+native_dependency_usable() {
+    case "$1" in
+        rollup)
+            [ ! -f node_modules/rollup/package.json ] \
+                || node -e "require('./node_modules/rollup/dist/native.js')"
+            ;;
+        esbuild)
+            [ ! -f node_modules/esbuild/package.json ] \
+                || node node_modules/esbuild/bin/esbuild --version
+            ;;
+        sharp)
+            [ ! -f node_modules/sharp/package.json ] \
+                || node -e "require('./node_modules/sharp')"
+            ;;
+    esac
+}
+
 if [ -d node_modules ]; then
     # A site repo may have been initialized after `npm install` on the host. If
-    # that host-built tree was committed, Rollup's optional native dependency is
-    # for macOS/Windows rather than this Linux guest. Requiring Rollup's loader is
-    # a cheap architecture check and also catches an incomplete native install.
-    if [ -f node_modules/rollup/dist/native.js ] \
-       && ! node -e "require('./node_modules/rollup/dist/native.js')" >/dev/null 2>&1; then
-        echo "WARN: existing node_modules has no usable Rollup native binding for this container; reinstalling dependencies" >&2
+    # that host-built tree was committed, optional native dependencies may be for
+    # macOS/Windows rather than this Linux guest. Probe each native dependency the
+    # template currently ships; this also catches an incomplete native install.
+    incompatible_native_dependency=""
+    for dependency in rollup esbuild sharp; do
+        if ! native_dependency_usable "$dependency" >/dev/null 2>&1; then
+            incompatible_native_dependency="$dependency"
+            break
+        fi
+    done
+
+    if [ -n "$incompatible_native_dependency" ]; then
+        echo "WARN: existing node_modules has no usable $incompatible_native_dependency native binding for this container; reinstalling dependencies" >&2
         rm -rf node_modules
     else
         echo "==> node_modules already present and usable; skipping install"


### PR DESCRIPTION
Closes #719

## Summary
- ignore node_modules and generated Astro/Wrangler build state in scaffolded site repositories
- validate the existing Rollup native binding before hydration skips dependency installation
- discard incompatible host-built dependencies and reinstall through the existing warm-cache path

## Verification
- bash syntax checks for hydrate and container staging scripts
- git check-ignore checks for all four generated directories
- focused hydration fixtures covering broken binding reinstall and usable binding fast path
- git diff --check