### PR TITLE
Address sudden termination review feedback

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -80,6 +80,7 @@ final class DeployModel {
     private var summarizationGeneration: UInt = 0
     private var inFlight: Task<Void, Never>?
     private let suddenTerminationController: SuddenTerminationController
+    private let tokenAvailabilityOverride: (() -> Bool)?
     /// Site to retry once the user pastes a token. `nil` outside the prompt flow.
     /// Carries the container control (if any) so the parked-then-retried deploy
     /// uses the same executor as the original dispatch.
@@ -97,7 +98,8 @@ final class DeployModel {
         keychain: KeychainStore = KeychainStore(),
         verifier: TokenVerifying = CloudflareAPITokenVerifier(),
         summarizer: any DeployFailureSummarizing = DeploySummarizerFactory.makeDefault(),
-        suddenTerminationController: SuddenTerminationController = .shared
+        suddenTerminationController: SuddenTerminationController = .shared,
+        tokenAvailabilityOverride: (() -> Bool)? = nil
     ) {
         self.command = command
         self.logCenter = logCenter
@@ -105,6 +107,7 @@ final class DeployModel {
         self.onboarding = TokenOnboarding(verifier: verifier)
         self.summarizer = summarizer
         self.suddenTerminationController = suddenTerminationController
+        self.tokenAvailabilityOverride = tokenAvailabilityOverride
     }
 
     var isRunning: Bool {
@@ -216,6 +219,9 @@ final class DeployModel {
     /// True if either the env var or the Keychain currently holds a non-empty Cloudflare token.
     /// Keychain errors are treated as "no token" — the user can recover by pasting fresh.
     private func hasUsableToken() -> Bool {
+        if let tokenAvailabilityOverride {
+            return tokenAvailabilityOverride()
+        }
         if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
             return true
         }

--- a/Sources/AnglesiteCore/SuddenTerminationController.swift
+++ b/Sources/AnglesiteCore/SuddenTerminationController.swift
@@ -1,10 +1,19 @@
 import Foundation
+#if canImport(os)
+import os
+#endif
 
 /// Process-wide reference counting for work that must finish before macOS may suddenly terminate
 /// Anglesite. Callers retain the returned lease for exactly as long as their critical state exists;
 /// releasing (or deinitializing) the last lease re-enables sudden termination.
 public final class SuddenTerminationController: @unchecked Sendable {
     public static let shared = SuddenTerminationController()
+#if canImport(os)
+    private static let logger = Logger(
+        subsystem: "io.dwk.anglesite",
+        category: "SuddenTerminationController"
+    )
+#endif
 
     public final class Lease: @unchecked Sendable {
         private let lock = NSLock()
@@ -68,6 +77,9 @@ public final class SuddenTerminationController: @unchecked Sendable {
         lock.lock()
         guard leaseCount > 0 else {
             lock.unlock()
+#if canImport(os)
+            Self.logger.fault("Ignoring an unbalanced sudden-termination lease release")
+#endif
             assertionFailure("Sudden-termination lease count became unbalanced")
             return
         }

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+private actor GatedDeployExecutor: DeployExecutor {
+    private var buildContinuation: CheckedContinuation<Void, Never>?
+
+    func run(
+        step: DeployStep,
+        siteDirectory: URL,
+        environment: [String: String],
+        source: String
+    ) async -> DeployStepResult {
+        switch step {
+        case .build:
+            await withCheckedContinuation { buildContinuation = $0 }
+            return DeployStepResult(exitCode: 0, output: "")
+        case .preflight:
+            return DeployStepResult(
+                exitCode: 0,
+                output: #"{"ok":true,"failures":[],"warnings":[]}"#
+            )
+        case .wrangler:
+            return DeployStepResult(
+                exitCode: 0,
+                output: "Published test (0.1 sec)\n  https://test.example.workers.dev"
+            )
+        }
+    }
+
+    func waitUntilBuildIsParked() async {
+        while buildContinuation == nil {
+            await Task.yield()
+        }
+    }
+
+    func resumeBuild() {
+        buildContinuation?.resume()
+        buildContinuation = nil
+    }
+}
+
+@Suite("DeployModel")
+@MainActor
+struct DeployModelTests {
+    @Test("sudden termination stays disabled until a deploy finishes")
+    func suddenTerminationLeaseBracketsDeploy() async {
+        let executor = GatedDeployExecutor()
+        let controller = SuddenTerminationController(disable: {}, enable: {})
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command,
+            logCenter: LogCenter(),
+            suddenTerminationController: controller,
+            tokenAvailabilityOverride: { true }
+        )
+        let directory = FileManager.default.temporaryDirectory
+
+        model.deploy(
+            siteID: "test-site",
+            siteDirectory: directory,
+            configDirectory: directory,
+            currentRoutes: []
+        )
+        await executor.waitUntilBuildIsParked()
+
+        #expect(model.isRunning)
+        #expect(controller.activeLeaseCount == 1)
+
+        await executor.resumeBuild()
+        while model.isRunning {
+            await Task.yield()
+        }
+
+        #expect(controller.activeLeaseCount == 0)
+        guard case .succeeded = model.phase else {
+            Issue.record("Expected deploy to succeed, got \(model.phase)")
+            return
+        }
+    }
+}

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -46,6 +46,36 @@ struct SiteWindowModelTests {
         #expect(model.site == nil)
         #expect(model.paneSelection == 0)
     }
+
+    @Test("close retains its sudden-termination lease until a dirty editor is saved")
+    func closeRetainsLeaseUntilEditorSaveFinishes() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("site-window-close-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let fileURL = root.appendingPathComponent("page.astro")
+        try Data("original".utf8).write(to: fileURL)
+        let editor = FileEditorModel(
+            file: FileRef(url: fileURL, group: .pages, name: "page.astro")
+        )
+        await editor.load()
+        editor.text = "saved during close"
+
+        let model = makeModel()
+        model.activeEditor = .text(editor)
+        let controller = SuddenTerminationController(disable: {}, enable: {})
+        let lease = controller.acquire()
+
+        model.close(suddenTerminationLease: lease)
+        while controller.activeLeaseCount > 0 {
+            await Task.yield()
+        }
+
+        let saved = try String(contentsOf: fileURL, encoding: .utf8)
+        #expect(saved == "saved during close")
+        #expect(controller.activeLeaseCount == 0)
+    }
 }
 
 extension SiteWindowModelTests {


### PR DESCRIPTION
Follow-up to #732, which was merged before its review-feedback commit was pushed.

## Summary
- emit an OSLog fault for unbalanced sudden-termination lease releases in production builds
- add a gated DeployModel test proving the lease brackets the full deploy
- add SiteWindowModel.close coverage proving the transferred lease is held until dirty editor persistence completes

## Testing
- `swift test --filter 'DeployModelTests|SiteWindowModelTests|SuddenTerminationControllerTests'` (28 tests passed)