### PR TITLE
Fix vmnet subnet allocation conflicts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -263,7 +263,12 @@ if includeContainer && ProcessInfo.processInfo.environment["ANGLESITE_CONTAINER_
     packageTargets.append(
         .testTarget(
             name: "AnglesiteContainerLocalTests",
-            dependencies: ["AnglesiteContainer", "AnglesiteCore"],
+            dependencies: [
+                "AnglesiteContainer",
+                "AnglesiteCore",
+                .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationExtras", package: "containerization")
+            ],
             path: "Tests/AnglesiteContainerLocalTests",
             swiftSettings: strictConcurrency,
             linkerSettings: weakLinkFoundationModels

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -4,6 +4,11 @@ import Containerization
 import ContainerizationOCI
 import ContainerizationExtras
 
+private struct VMBootTimeoutError: Error, CustomStringConvertible, Sendable {
+    let message: String
+    var description: String { message }
+}
+
 /// `LocalContainerControl` over Apple Containerization (package version 0.35). Imports the bundled
 /// arm64 OCI layout into an on-disk `ImageStore`, unpacks it to an ext4 rootfs, boots a Linux VM
 /// (`VZVirtualMachineManager`) with NAT outbound + vsock inbound, clones the site's `Source/` repo
@@ -26,6 +31,9 @@ public struct ContainerizationControl: LocalContainerControl {
 
     // One live container + its two proxies per siteID, kept in an actor box so start/stop are safe.
     private let live = LiveContainers()
+
+    // Process-shared and actor-serialized: one vmnet network, one releasable interface per site.
+    private let network = SharedVmnetNetwork.shared
 
     // Guest-side ports the dev server + MCP sidecar listen on (also the vsock ports the bridge maps to).
     private static let previewPort: UInt32 = 4321
@@ -174,6 +182,7 @@ public struct ContainerizationControl: LocalContainerControl {
 
     public func stop(siteID: String) async throws {
         await live.teardown(siteID: siteID)
+        await network.release(siteID: siteID)
     }
 
     /// Phases 0–2 of `start()`: resolve bundled artifacts, unpack rootfs/initfs, boot the VM.
@@ -298,15 +307,13 @@ public struct ContainerizationControl: LocalContainerControl {
             // Let vmnet choose an available shared-mode subnet. Hard-coding 192.168.64.0/24
             // works only while this is the first vmnet consumer on the host: Apple's container
             // CLI, UTM, or another VM can already own that network, leaving the guest's static
-            // route and DNS pointed at a nonexistent gateway (#715).
-            var network = try VmnetNetwork()
-            guard let interface = try network.createInterface(siteID),
-                let gateway = interface.ipv4Gateway else {
-                throw LocalContainerError.bootFailed("vmnet did not allocate an IPv4 interface and gateway")
-            }
-            let nameserver = gateway.description
+            // route and DNS pointed at a nonexistent gateway (#715). SharedVmnetNetwork keeps one
+            // process-wide network, serializes simultaneous site allocations, and releases each
+            // interface when its VM stops.
+            let allocation = try await network.allocate(siteID: siteID)
             onOutput(
-                "[boot] vmnet allocated \(interface.ipv4Address) with gateway/DNS \(nameserver)",
+                "[boot] vmnet allocated \(allocation.interface.ipv4Address) "
+                    + "with gateway/DNS \(allocation.nameserver)",
                 .stdout
             )
 
@@ -320,8 +327,8 @@ public struct ContainerizationControl: LocalContainerControl {
                 config.process.workingDirectory = "/"
                 config.cpus = 2
                 config.memoryInBytes = 2 * 1024 * 1024 * 1024
-                config.interfaces = [interface]
-                config.dns = DNS(nameservers: [nameserver])
+                config.interfaces = [allocation.interface]
+                config.dns = DNS(nameservers: [allocation.nameserver])
                 // Host `Source/` repo shared read-only into the guest via virtio-fs so the guest can
                 // `git clone` it (the macOS host path is otherwise invisible to the Linux guest).
                 // `Mount.share(source:destination:)` is the host-directory virtio-fs share — confirmed
@@ -357,12 +364,14 @@ public struct ContainerizationControl: LocalContainerControl {
             // of leaking it — otherwise nothing else in the process ever holds a reference to it, and
             // it would keep consuming host resources (2 vCPU/2GB) until the app quits, one leak per
             // timed-out retry.
+            let timeoutError = VMBootTimeoutError(
+                message: "VM did not finish booting within \(Self.vmBootTimeout) — the process may carry the "
+                    + "virtualization entitlement without being provisioned to actually use it (ad-hoc/"
+                    + "debug-signed builds); Virtualization framework can hang rather than throw in that case"
+            )
             let bootedContainer = try await Self.racingTimeout(
                 timeout: Self.vmBootTimeout,
-                timeoutError: LocalContainerError.bootFailed(
-                    "VM did not finish booting within \(Self.vmBootTimeout) — the process may carry the "
-                    + "virtualization entitlement without being provisioned to actually use it (ad-hoc/"
-                    + "debug-signed builds); Virtualization framework can hang rather than throw in that case"),
+                timeoutError: timeoutError,
                 onLateSuccess: { lateContainer in
                     onOutput(
                         "[boot] VM finished booting after its \(Self.vmBootTimeout) timeout already failed "
@@ -370,14 +379,26 @@ public struct ContainerizationControl: LocalContainerControl {
                     Task { await self.stopBareContainer(lateContainer, siteID: siteID) }
                 }
             ) {
-                try await container.create()
-                try await container.start()
-                return container
+                do {
+                    try await container.create()
+                    try await container.start()
+                    return container
+                } catch {
+                    // This also covers a failure that arrives after the timeout already won.
+                    await network.release(siteID: siteID)
+                    throw error
+                }
             }
             onOutput("[boot] VM started", .stdout)
             return bootedContainer
         } catch {
             onOutput("[boot] VM boot failed: \(error)", .stderr)
+            // A timeout leaves create/start running. Its operation releases on a late failure;
+            // onLateSuccess stops the late VM and releases through stopBareContainer. Releasing
+            // here would let another site reuse the address while that VM is still starting.
+            if !(error is VMBootTimeoutError) {
+                await network.release(siteID: siteID)
+            }
             try? FileManager.default.removeItem(at: rootfsURL)
             try? FileManager.default.removeItem(at: initfsURL)
             throw LocalContainerError.bootFailed("\(error)")
@@ -485,6 +506,7 @@ public struct ContainerizationControl: LocalContainerControl {
     /// `public` alongside `makeBareContainer` — see its doc comment.
     public func stopBareContainer(_ container: LinuxContainer, siteID: String) async {
         try? await container.stop()
+        await network.release(siteID: siteID)
         guard let storeURL = try? BundledImage.storeURL() else { return }
         try? FileManager.default.removeItem(at: storeURL.appendingPathComponent("rootfs-\(siteID).ext4"))
         try? FileManager.default.removeItem(at: storeURL.appendingPathComponent("initfs-\(siteID).ext4"))

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -15,8 +15,9 @@ import ContainerizationExtras
 /// plan's intended shapes. Notably there is no `LinuxContainer(image:networking:)` — booting needs a
 /// `Kernel` + an initfs `Mount` + an unpacked rootfs `Mount`; image import is `ImageStore.load(from:)`
 /// (not `importIfNeeded`); exec is two-phase (`exec` builds, `.start()` runs, `.wait()` blocks);
-/// networking is a `NATInterface` (not `.nat`); and `dialVsock(port:)` already returns a `FileHandle`,
-/// so it slots directly into `VsockDialer`. See `.superpowers/sdd/task-7-report.md` for the full map.
+/// networking is a vmnet-allocated `VmnetNetwork.Interface` (not `.nat`); and
+/// `dialVsock(port:)` already returns a `FileHandle`, so it slots directly into `VsockDialer`.
+/// See `.superpowers/sdd/task-7-report.md` for the full map.
 public struct ContainerizationControl: LocalContainerControl {
     /// Optional explicit OCI layout override; when nil, `start()` resolves it via `BundledImage.layoutURL()`.
     /// Kept off `init` as a non-throwing default so constructing the type can never trap (the old
@@ -294,10 +295,19 @@ public struct ContainerizationControl: LocalContainerControl {
             let kernel = Kernel(path: kernelURL, platform: .linuxArm)
             let vmm = VZVirtualMachineManager(kernel: kernel, initialFilesystem: initfs)
 
-            // Static NAT addressing: VZNATNetworkDeviceAttachment under the hood (resolved #317).
-            let nat = NATInterface(
-                ipv4Address: try CIDRv4("192.168.64.2/24"),
-                ipv4Gateway: try IPv4Address("192.168.64.1")
+            // Let vmnet choose an available shared-mode subnet. Hard-coding 192.168.64.0/24
+            // works only while this is the first vmnet consumer on the host: Apple's container
+            // CLI, UTM, or another VM can already own that network, leaving the guest's static
+            // route and DNS pointed at a nonexistent gateway (#715).
+            var network = try VmnetNetwork()
+            guard let interface = try network.createInterface(siteID),
+                let gateway = interface.ipv4Gateway else {
+                throw LocalContainerError.bootFailed("vmnet did not allocate an IPv4 interface and gateway")
+            }
+            let nameserver = gateway.description
+            onOutput(
+                "[boot] vmnet allocated \(interface.ipv4Address) with gateway/DNS \(nameserver)",
+                .stdout
             )
 
             let container = try LinuxContainer(siteID, rootfs: rootfs, vmm: vmm) { config in
@@ -310,8 +320,8 @@ public struct ContainerizationControl: LocalContainerControl {
                 config.process.workingDirectory = "/"
                 config.cpus = 2
                 config.memoryInBytes = 2 * 1024 * 1024 * 1024
-                config.interfaces = [nat]
-                config.dns = DNS(nameservers: ["192.168.64.1"])
+                config.interfaces = [interface]
+                config.dns = DNS(nameservers: [nameserver])
                 // Host `Source/` repo shared read-only into the guest via virtio-fs so the guest can
                 // `git clone` it (the macOS host path is otherwise invisible to the Linux guest).
                 // `Mount.share(source:destination:)` is the host-directory virtio-fs share — confirmed

--- a/Sources/AnglesiteContainer/SharedVmnetNetwork.swift
+++ b/Sources/AnglesiteContainer/SharedVmnetNetwork.swift
@@ -1,0 +1,59 @@
+import AnglesiteCore
+import Containerization
+
+/// The interface and DNS values allocated together from one vmnet network.
+struct VmnetNetworkAllocation: Sendable {
+    let interface: any Containerization.Interface
+    let nameserver: String
+}
+
+/// One process-wide vmnet network with actor-serialized interface allocation.
+///
+/// `VmnetNetwork` owns both the `vmnet_network_ref` and its address allocator. Constructing one
+/// per boot would consume a shared-mode network per site and discard the only value that can call
+/// `releaseInterface`. Keeping one instance here mirrors upstream Containerization's manager/CLI
+/// lifecycle, prevents concurrent site boots from racing network creation, and makes every site
+/// allocation explicitly releasable on teardown (#715).
+actor SharedVmnetNetwork {
+    typealias NetworkFactory = @Sendable () throws -> any Network
+
+    static let shared = SharedVmnetNetwork()
+
+    private let makeNetwork: NetworkFactory
+    private var network: (any Network)?
+
+    init(makeNetwork: @escaping NetworkFactory = { try VmnetNetwork() }) {
+        self.makeNetwork = makeNetwork
+    }
+
+    func allocate(siteID: String) throws -> VmnetNetworkAllocation {
+        var network = try self.network ?? makeNetwork()
+
+        do {
+            guard let interface = try network.createInterface(siteID) else {
+                self.network = network
+                throw LocalContainerError.bootFailed("vmnet did not allocate an IPv4 interface")
+            }
+            guard let gateway = interface.ipv4Gateway else {
+                try? network.releaseInterface(siteID)
+                self.network = network
+                throw LocalContainerError.bootFailed("vmnet did not allocate an IPv4 gateway")
+            }
+
+            self.network = network
+            return VmnetNetworkAllocation(interface: interface, nameserver: gateway.description)
+        } catch {
+            // `Network` has mutating allocation methods, so persist its state even when an
+            // implementation throws after partially handling a request.
+            self.network = network
+            throw error
+        }
+    }
+
+    /// Best-effort and idempotent, matching the rest of container teardown.
+    func release(siteID: String) {
+        guard var network else { return }
+        try? network.releaseInterface(siteID)
+        self.network = network
+    }
+}

--- a/Tests/AnglesiteContainerLocalTests/SharedVmnetNetworkTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/SharedVmnetNetworkTests.swift
@@ -1,0 +1,102 @@
+import Containerization
+import ContainerizationExtras
+import Foundation
+import Testing
+@testable import AnglesiteContainer
+import AnglesiteCore
+
+struct SharedVmnetNetworkTests {
+    @Test("concurrent site allocations share one serialized network and release for reuse")
+    func sharesNetworkAndReleasesInterfaces() async throws {
+        let recorder = FakeNetworkRecorder()
+        let allocator = SharedVmnetNetwork {
+            recorder.recordFactoryCall()
+            return FakeNetwork(recorder: recorder)
+        }
+
+        async let first = allocator.allocate(siteID: "first")
+        async let second = allocator.allocate(siteID: "second")
+        let (firstAllocation, secondAllocation) = try await (first, second)
+
+        #expect(recorder.factoryCallCount == 1)
+        #expect(firstAllocation.nameserver == "10.0.0.1")
+        #expect(secondAllocation.nameserver == "10.0.0.1")
+        #expect(firstAllocation.interface.ipv4Address != secondAllocation.interface.ipv4Address)
+        #expect(recorder.activeSiteIDs == ["first", "second"])
+
+        await allocator.release(siteID: "first")
+        _ = try await allocator.allocate(siteID: "first")
+
+        #expect(recorder.factoryCallCount == 1)
+        #expect(recorder.releaseCalls == ["first"])
+        #expect(recorder.activeSiteIDs == ["first", "second"])
+    }
+
+    @Test("an unusable allocation is released before the error escapes")
+    func missingGatewayReleasesAllocation() async {
+        let recorder = FakeNetworkRecorder(gateway: nil)
+        let allocator = SharedVmnetNetwork { FakeNetwork(recorder: recorder) }
+
+        await #expect(throws: LocalContainerError.bootFailed("vmnet did not allocate an IPv4 gateway")) {
+            _ = try await allocator.allocate(siteID: "missing-gateway")
+        }
+        #expect(recorder.releaseCalls == ["missing-gateway"])
+        #expect(recorder.activeSiteIDs.isEmpty)
+    }
+}
+
+private struct FakeNetwork: Network {
+    let recorder: FakeNetworkRecorder
+
+    mutating func createInterface(_ id: String) throws -> (any Containerization.Interface)? {
+        let host = try recorder.allocate(id)
+        return NATInterface(
+            ipv4Address: try CIDRv4("10.0.0.\(host)/24"),
+            ipv4Gateway: recorder.gateway
+        )
+    }
+
+    mutating func releaseInterface(_ id: String) throws {
+        recorder.release(id)
+    }
+}
+
+private final class FakeNetworkRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let configuredGateway: IPv4Address?
+    private var factoryCalls = 0
+    private var nextHost = 2
+    private var active: Set<String> = []
+    private var releases: [String] = []
+
+    init(gateway: IPv4Address? = try? IPv4Address("10.0.0.1")) {
+        self.configuredGateway = gateway
+    }
+
+    var gateway: IPv4Address? { configuredGateway }
+    var factoryCallCount: Int { lock.withLock { factoryCalls } }
+    var activeSiteIDs: Set<String> { lock.withLock { active } }
+    var releaseCalls: [String] { lock.withLock { releases } }
+
+    func recordFactoryCall() {
+        lock.withLock { factoryCalls += 1 }
+    }
+
+    func allocate(_ id: String) throws -> Int {
+        try lock.withLock {
+            guard active.insert(id).inserted else { throw FakeNetworkError.duplicate(id) }
+            defer { nextHost += 1 }
+            return nextHost
+        }
+    }
+
+    func release(_ id: String) {
+        lock.withLock {
+            if active.remove(id) != nil { releases.append(id) }
+        }
+    }
+}
+
+private enum FakeNetworkError: Error {
+    case duplicate(String)
+}

--- a/docs/qa/app-store-container-smoke-test.md
+++ b/docs/qa/app-store-container-smoke-test.md
@@ -36,10 +36,26 @@ scripts/run-container-probe.sh boot
 
 (The probe's default ad-hoc signing is sufficient — the entitlement needs no real identity.)
 
-If Apple's `container` CLI apiserver or a UTM VM normally runs on the test Mac, leave it
-running during `boot`. This is the #715 regression gate: the guest must negotiate a distinct
-vmnet subnet and retain outbound DNS/HTTPS while another vmnet NAT consumer is active. The
-runtime log should include the dynamically allocated guest address and gateway/DNS pair.
+Make the #715 concurrent-vmnet regression gate deterministic instead of relying on ambient
+machine state. Create and inspect a second shared-mode network, keep it alive during `boot`,
+then remove it:
+
+```sh
+(
+    set -e
+    container system start
+    container network create anglesite-715-regression
+    trap 'container network delete anglesite-715-regression' EXIT
+    container network inspect anglesite-715-regression
+    scripts/run-container-probe.sh boot
+)
+```
+
+The probe runtime log must show an allocated guest subnet that does not overlap the subnet in
+the `container network inspect` output. The probe fixture has no lockfile, so reaching `BOOT:
+PASS` also proves its in-guest `npm install` retained outbound DNS and HTTPS while the second
+vmnet consumer was active. The subshell trap removes the regression network even when the probe
+fails.
 
 Both must pass, or the App Store smoke is expected to fail at runtime startup.
 

--- a/docs/qa/app-store-container-smoke-test.md
+++ b/docs/qa/app-store-container-smoke-test.md
@@ -36,6 +36,11 @@ scripts/run-container-probe.sh boot
 
 (The probe's default ad-hoc signing is sufficient — the entitlement needs no real identity.)
 
+If Apple's `container` CLI apiserver or a UTM VM normally runs on the test Mac, leave it
+running during `boot`. This is the #715 regression gate: the guest must negotiate a distinct
+vmnet subnet and retain outbound DNS/HTTPS while another vmnet NAT consumer is active. The
+runtime log should include the dynamically allocated guest address and gateway/DNS pair.
+
 Both must pass, or the App Store smoke is expected to fail at runtime startup.
 
 ## Build Fixture And App
@@ -88,4 +93,3 @@ Also save the app debug pane logs for these sources when present:
 ## Acceptance
 
 #81 can close when the matrix passes on a real-signed App Store-target build, or when every failure has a follow-up issue with captured logs and a clear owner.
-

--- a/scripts/run-container-probe.sh
+++ b/scripts/run-container-probe.sh
@@ -14,10 +14,9 @@
 #   scripts/run-container-probe.sh echo   # THE Task 4b decision gate (vsock round-trip)
 #   scripts/run-container-probe.sh boot    # Task 5's gate (full boot + preview HTTP poll)
 #
-# The boot probe is also the #715 concurrent-vmnet regression gate. If Apple's `container`
-# CLI apiserver or a UTM VM normally runs on this host, leave it running: Anglesite must use
-# vmnet's dynamically allocated subnet and retain outbound npm/DNS connectivity alongside it.
-# Do not stop other vmnet consumers to make this probe pass.
+# The boot probe is also the #715 concurrent-vmnet regression gate. Before running it, use
+# `container network create anglesite-715-regression` to hold a second vmnet shared-mode network;
+# see docs/qa/app-store-container-smoke-test.md for the deterministic setup and cleanup steps.
 #
 # The default ad-hoc signing is sufficient: `com.apple.security.virtualization` is an
 # unrestricted entitlement, honored under `codesign --sign -` with no provisioning profile

--- a/scripts/run-container-probe.sh
+++ b/scripts/run-container-probe.sh
@@ -14,6 +14,11 @@
 #   scripts/run-container-probe.sh echo   # THE Task 4b decision gate (vsock round-trip)
 #   scripts/run-container-probe.sh boot    # Task 5's gate (full boot + preview HTTP poll)
 #
+# The boot probe is also the #715 concurrent-vmnet regression gate. If Apple's `container`
+# CLI apiserver or a UTM VM normally runs on this host, leave it running: Anglesite must use
+# vmnet's dynamically allocated subnet and retain outbound npm/DNS connectivity alongside it.
+# Do not stop other vmnet consumers to make this probe pass.
+#
 # The default ad-hoc signing is sufficient: `com.apple.security.virtualization` is an
 # unrestricted entitlement, honored under `codesign --sign -` with no provisioning profile
 # (verified 2026-07-07: the echo gate passed ad-hoc). SIGN_IDENTITY remains as an override for


### PR DESCRIPTION
## Summary

- replace the hard-coded 192.168.64.0/24 NAT interface with a dynamically allocated vmnet interface
- keep one process-wide, actor-serialized VmnetNetwork and explicitly release each site interface after normal, failed, and late-timeout teardown
- derive guest routing and DNS from the vmnet-provided gateway and log the negotiated allocation
- add fake-backed tests for concurrent allocation, single-network reuse, release/reallocation, and malformed-allocation cleanup
- make the concurrent-vmnet probe gate deterministic by creating, inspecting, and automatically deleting a second Apple container CLI network

## Verification

- `swift build --disable-sandbox --product anglesite-container-probe`
- `swift test --disable-sandbox --filter SharedVmnetNetworkTests` (2 passed)
- `swift test --disable-sandbox --skip-build --filter RacingTimeoutTests` (4 passed)
- `bash -n scripts/run-container-probe.sh`
- `git diff --check`

The allocator lifecycle and concurrency behavior now have executed fake-backed coverage. The entitled VZ integration probe was not run in this worktree because the vendored container image, kernel, and initfs directories contain only their committed placeholders; the updated smoke-test runbook provides a deterministic second-vmnet setup for that hardware/artifact gate.

Fixes #715
