### PR TITLE
Persist edit-overlay changes to canonical Source

### DIFF
--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -167,6 +167,7 @@ final class PreviewModel {
         guard let localRuntime = runtime as? LocalContainerSiteRuntime else { return nil }
         return { [weak localRuntime] reply in
             guard let localRuntime else { throw SiteRuntimePersistenceError.runtimeNotRunning }
+            guard reply.commit != nil else { return }
             try await localRuntime.persistEdit(commit: reply.commit)
         }
     }

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -105,10 +105,13 @@ final class PreviewModel {
 
     init(runtime: any SiteRuntime) {
         self.runtime = runtime
-        self.editRouter = MCPApplyEditRouter(mcpClient: { [weak runtime] in
-            // `runtime` is the actor instance; reading `mcpClient` hops onto the actor.
-            await runtime?.mcpClient
-        })
+        self.editRouter = MCPApplyEditRouter(
+            mcpClient: { [weak runtime] in
+                // `runtime` is the actor instance; reading `mcpClient` hops onto the actor.
+                await runtime?.mcpClient
+            },
+            persistEdit: Self.editPersister(for: runtime)
+        )
         // Mirror runtime state into `state`. `[weak self]` so the model can still be freed; the
         // stream itself outlives a freed model (one PreviewModel per window today, so it's moot).
         Task { @MainActor [weak self] in
@@ -148,11 +151,23 @@ final class PreviewModel {
                 return await self.runtime.mcpClient
             },
             onEdit: onEdit,
+            persistEdit: Self.editPersister(for: runtime),
             postProcess: postProcess
         )
         if let siteID = openSiteID {
             let current = self.editRouter
             Task { await EditRouterRegistry.shared.register(current, for: siteID) }
+        }
+    }
+
+    /// Local container edits happen in a hydrated clone. Their commit must be handed back to the
+    /// host repo before the bridge acknowledges success. Other runtime types retain their own
+    /// persistence semantics, so the hook is intentionally absent for them.
+    private static func editPersister(for runtime: any SiteRuntime) -> MCPApplyEditRouter.EditPersister? {
+        guard let localRuntime = runtime as? LocalContainerSiteRuntime else { return nil }
+        return { [weak localRuntime] reply in
+            guard let localRuntime else { throw SiteRuntimePersistenceError.runtimeNotRunning }
+            try await localRuntime.persistEdit(commit: reply.commit)
         }
     }
 

--- a/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
+++ b/Sources/AnglesiteApp/SiteAssistantSessionFactory.swift
@@ -82,7 +82,7 @@ enum SiteAssistantSessionFactory {
                 undoCommand: undoCommand,
                 editRouterProvider: editRouterProvider,
                 assistant: assistant,
-                altTextGenerator: { siteID, sourceDirectory, mcpClient, conventionsEngine in
+                altTextGenerator: { siteID, sourceDirectory, _, conventionsEngine in
                     AltTextGenerator(
                         siteID: siteID,
                         siteDirectory: sourceDirectory,
@@ -101,7 +101,15 @@ enum SiteAssistantSessionFactory {
                             )
                         },
                         apply: { edit in
-                            let reply = await MCPApplyEditRouter(mcpClient: mcpClient).apply(edit)
+                            // Reuse the window's registered router so generated alt-text edits go
+                            // through the same awaited runtime-to-Source persistence hook as the
+                            // originating image edit (#718).
+                            let reply = await EditRouterRegistry.shared.router(for: siteID)?.apply(edit)
+                                ?? EditReply(
+                                    id: edit.id,
+                                    status: .failed,
+                                    message: "no active edit router for \(siteID)"
+                                )
                             if reply.status == .failed {
                                 await LogCenter.shared.append(
                                     source: "alt-text:\(siteID)", stream: .stderr,

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -30,7 +30,7 @@ public struct ContainerizationControl: LocalContainerControl {
     private static let previewPort: UInt32 = 4321
     private static let mcpPort: UInt32 = 4399
 
-    /// Guest mountpoint for the virtio-fs share of the host `Source/` repo (see `start()` step 3).
+    /// Guest mountpoint for the read-only virtio-fs share of the host `Source/` repo (see `start()` step 3).
     private static let repoSharePath = "/run/anglesite-source"
 
     public init(imageLayoutURL: URL? = nil) {
@@ -48,10 +48,13 @@ public struct ContainerizationControl: LocalContainerControl {
         let container = try await makeBareContainer(siteID: siteID, sourceRepo: sourceRepo, onOutput: onOutput)
 
         // 3. Hydrate from the repo: clone the virtio-fs-shared host repo into /workspace/site, then
-        //    check out ref. Cloning from the share (not in place) keeps /workspace isolated
-        //    and preserves full git history — native, no network. The share is writable only so
-        //    `LocalContainerSiteRuntime.persistEdit` can hand successful commits back after each
-        //    edit. Two steps because `git clone
+        //    check out ref. Cloning from the read-only share (not in place) keeps /workspace
+        //    writable and preserves full git history — native, no network. The share stays
+        //    read-only for the container's whole life: `LocalContainerSiteRuntime.persistEdit`
+        //    hands a commit back by exporting a git bundle from the guest's own /workspace/site
+        //    clone over `control.exec`'s stdout, then importing it against the host's canonical
+        //    Source/ in-process (`InProcessEditPersistence`) — it never writes through this share.
+        //    Two steps because `git clone
         //    --branch` rejects "HEAD"/bare SHAs; `git checkout` accepts both.
         // The image ships no /etc/hosts: docker/containerd write one at container create, but
         // Apple Containerization boots the rootfs as-is — without it even `localhost` becomes a

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -314,18 +314,18 @@ public struct ContainerizationControl: LocalContainerControl {
                 config.memoryInBytes = 2 * 1024 * 1024 * 1024
                 config.interfaces = [nat]
                 config.dns = DNS(nameservers: ["192.168.64.1"])
-                // Host `Source/` repo shared into the guest via virtio-fs so the guest can
+                // Host `Source/` repo shared read-only into the guest via virtio-fs so the guest can
                 // `git clone` it (the macOS host path is otherwise invisible to the Linux guest).
                 // `Mount.share(source:destination:)` is the host-directory virtio-fs share — confirmed
                 // against `Mount.swift:83` and `ContainerTests.swift:628` (`.share(source: directory.path,
-                // destination: "/mnt")`). The share must be writable for the explicit, awaited
-                // guest-to-host git handoff after apply-edit (#718). NOT
+                // destination: "/mnt")`); `ro` is honoured (`ContainerTests.swift:3309`). NOT
                 // `Mount.sharedMount`, which references a named *pod volume*, not a host path.
                 // Only mounted when a repo is provided — the bare vsock-echo e2e test boots with none.
                 if let sourceRepo {
                     config.mounts.append(.share(
                         source: sourceRepo.path,
-                        destination: Self.repoSharePath
+                        destination: Self.repoSharePath,
+                        options: ["ro"]
                     ))
                 }
             }

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -30,7 +30,7 @@ public struct ContainerizationControl: LocalContainerControl {
     private static let previewPort: UInt32 = 4321
     private static let mcpPort: UInt32 = 4399
 
-    /// Guest mountpoint for the read-only virtio-fs share of the host `Source/` repo (see `start()` step 3).
+    /// Guest mountpoint for the virtio-fs share of the host `Source/` repo (see `start()` step 3).
     private static let repoSharePath = "/run/anglesite-source"
 
     public init(imageLayoutURL: URL? = nil) {
@@ -48,8 +48,10 @@ public struct ContainerizationControl: LocalContainerControl {
         let container = try await makeBareContainer(siteID: siteID, sourceRepo: sourceRepo, onOutput: onOutput)
 
         // 3. Hydrate from the repo: clone the virtio-fs-shared host repo into /workspace/site, then
-        //    check out ref. Cloning from the read-only share (not in place) keeps /workspace writable
-        //    and preserves full git history — native, no network. Two steps because `git clone
+        //    check out ref. Cloning from the share (not in place) keeps /workspace isolated
+        //    and preserves full git history — native, no network. The share is writable only so
+        //    `LocalContainerSiteRuntime.persistEdit` can hand successful commits back after each
+        //    edit. Two steps because `git clone
         //    --branch` rejects "HEAD"/bare SHAs; `git checkout` accepts both.
         // The image ships no /etc/hosts: docker/containerd write one at container create, but
         // Apple Containerization boots the rootfs as-is — without it even `localhost` becomes a
@@ -312,18 +314,18 @@ public struct ContainerizationControl: LocalContainerControl {
                 config.memoryInBytes = 2 * 1024 * 1024 * 1024
                 config.interfaces = [nat]
                 config.dns = DNS(nameservers: ["192.168.64.1"])
-                // Host `Source/` repo shared read-only into the guest via virtio-fs so the guest can
+                // Host `Source/` repo shared into the guest via virtio-fs so the guest can
                 // `git clone` it (the macOS host path is otherwise invisible to the Linux guest).
                 // `Mount.share(source:destination:)` is the host-directory virtio-fs share — confirmed
                 // against `Mount.swift:83` and `ContainerTests.swift:628` (`.share(source: directory.path,
-                // destination: "/mnt")`); `ro` is honoured (`ContainerTests.swift:3309`). NOT
+                // destination: "/mnt")`). The share must be writable for the explicit, awaited
+                // guest-to-host git handoff after apply-edit (#718). NOT
                 // `Mount.sharedMount`, which references a named *pod volume*, not a host path.
                 // Only mounted when a repo is provided — the bare vsock-echo e2e test boots with none.
                 if let sourceRepo {
                     config.mounts.append(.share(
                         source: sourceRepo.path,
-                        destination: Self.repoSharePath,
-                        options: ["ro"]
+                        destination: Self.repoSharePath
                     ))
                 }
             }

--- a/Sources/AnglesiteCore/InProcessEditPersistence.swift
+++ b/Sources/AnglesiteCore/InProcessEditPersistence.swift
@@ -1,0 +1,88 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+import SwiftGit2
+
+/// Imports the one committed overlay edit exported by a container without executing host tools.
+/// `/usr/bin/git` is unavailable to the sandboxed MAS app (#640), so this deliberately uses the
+/// already-linked libgit2 wrapper. The host must still be at the commit the container edited;
+/// refusing divergence is safer than silently overwriting a native edit.
+public enum InProcessEditPersistence {
+    public static func importBundle(_ bundleURL: URL, commit: String, into sourceDirectory: URL) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            try importBundleSync(bundleURL, commit: commit, into: sourceDirectory)
+        }.value
+    }
+
+    private static func importBundleSync(_ bundleURL: URL, commit: String, into sourceDirectory: URL) throws {
+        SwiftGit2Bootstrap.ensureInitialized
+        let canonical = try result(Repository.at(sourceDirectory))
+        guard case .success(let status) = canonical.status(), status.isEmpty else {
+            throw SiteRuntimePersistenceError.syncFailed("canonical Source repository has uncommitted changes")
+        }
+        let head = try result(canonical.HEAD())
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent("anglesite-import-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let exported = try result(Repository.clone(from: bundleURL, to: temp, localClone: true))
+        let exportedCommit = try result(exported.HEAD()).oid
+        guard exportedCommit.description == commit else {
+            throw SiteRuntimePersistenceError.syncFailed("exported commit did not match the requested edit")
+        }
+        let guestCommit = try result(exported.commit(exportedCommit))
+        guard guestCommit.parents.count == 1, guestCommit.parents[0].oid == head.oid else {
+            throw SiteRuntimePersistenceError.syncFailed("overlay edit conflicts with newer Source changes")
+        }
+
+        let sourceTree = try result(exported.object(from: guestCommit.tree)).asTree()
+        let hostTree = try result(canonical.commit(head.oid))
+        let hostRoot = try result(canonical.object(from: hostTree.tree)).asTree()
+        var sourcePaths: Set<String> = []
+        try materialize(tree: sourceTree, from: exported, into: sourceDirectory, prefix: "", paths: &sourcePaths)
+        try removeMissing(tree: hostRoot, from: canonical, root: sourceDirectory, prefix: "", keeping: sourcePaths)
+        _ = try result(canonical.addAll())
+        let signature = try result(canonical.defaultSignature())
+        _ = try result(canonical.commit(message: guestCommit.message, signature: signature))
+    }
+
+    private static func materialize(tree: Tree, from repo: Repository, into root: URL, prefix: String, paths: inout Set<String>) throws {
+        for entry in tree.entries.values {
+            let path = prefix.isEmpty ? entry.name : "\(prefix)/\(entry.name)"
+            switch entry.object {
+            case .tree:
+                let directory = root.appendingPathComponent(path, isDirectory: true)
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+                paths.insert(path)
+                try materialize(tree: try result(repo.object(from: entry.object)).asTree(), from: repo, into: root, prefix: path, paths: &paths)
+            case .blob:
+                let file = root.appendingPathComponent(path)
+                try FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try result(repo.object(from: entry.object)).asBlob().data.write(to: file, options: .atomic)
+                if entry.attributes == 0o100755 { _ = chmod(file.path, 0o755) }
+                paths.insert(path)
+            default:
+                throw SiteRuntimePersistenceError.syncFailed("overlay edit contains an unsupported git object")
+            }
+        }
+    }
+
+    private static func removeMissing(tree: Tree, from repo: Repository, root: URL, prefix: String, keeping: Set<String>) throws {
+        for entry in tree.entries.values {
+            let path = prefix.isEmpty ? entry.name : "\(prefix)/\(entry.name)"
+            if case .tree = entry.object {
+                try removeMissing(tree: try result(repo.object(from: entry.object)).asTree(), from: repo, root: root, prefix: path, keeping: keeping)
+            }
+            if !keeping.contains(path) { try? FileManager.default.removeItem(at: root.appendingPathComponent(path)) }
+        }
+    }
+
+    private static func result<T>(_ value: Result<T, NSError>) throws -> T {
+        switch value { case .success(let value): value; case .failure(let error): throw SiteRuntimePersistenceError.syncFailed(error.localizedDescription) }
+    }
+}
+
+private extension ObjectType {
+    func asTree() throws -> Tree { guard let tree = self as? Tree else { throw SiteRuntimePersistenceError.syncFailed("expected git tree") }; return tree }
+    func asCommit() throws -> Commit { guard let commit = self as? Commit else { throw SiteRuntimePersistenceError.syncFailed("expected git commit") }; return commit }
+    func asBlob() throws -> Blob { guard let blob = self as? Blob else { throw SiteRuntimePersistenceError.syncFailed("expected git blob") }; return blob }
+}
+#endif

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -14,6 +14,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     private let logCenter: LogCenter
     private let connect: @Sendable (MCPClient, URL) async throws -> Void
     private let makeFileWatcher: @Sendable () -> any SiteFileWatching
+    private let runHostCommand: @Sendable (URL, [String], URL) async throws -> ContainerExecResult
     private let suddenTerminationController: SuddenTerminationController
     private var fileWatcher: (any SiteFileWatching)?
     private var containerTerminationLease: SuddenTerminationController.Lease?
@@ -22,6 +23,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
     private var generation = 0
     private var activeSiteID: String?
+    private var activeSiteDirectory: URL?
     private var loadedKnowledgeSiteID: String?
     /// Serializes guest-to-host git handoffs. Actor isolation alone is insufficient because an
     /// actor is reentrant while `control.exec` is suspended, and two overlapping overlay edits
@@ -45,6 +47,14 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         logCenter: LogCenter = .shared,
         connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { c, u in try await c.connect(httpEndpoint: u) },
         makeFileWatcher: @escaping @Sendable () -> any SiteFileWatching = { PlatformFileWatcher.make() },
+        runHostCommand: @escaping @Sendable (URL, [String], URL) async throws -> ContainerExecResult = { executable, arguments, cwd in
+            let result = try await ProcessSupervisor.shared.run(
+                executable: executable,
+                arguments: arguments,
+                currentDirectoryURL: cwd
+            )
+            return ContainerExecResult(exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr)
+        },
         suddenTerminationController: SuddenTerminationController = .shared
     ) {
         self.ref = ref
@@ -56,6 +66,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         self.logCenter = logCenter
         self.connect = connect
         self.makeFileWatcher = makeFileWatcher
+        self.runHostCommand = runHostCommand
         self.suddenTerminationController = suddenTerminationController
     }
 
@@ -87,7 +98,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     }
 
     /// Copies one commit produced by the MCP sidecar in `/workspace/site` back into the host's
-    /// canonical `Source/` repository, which is mounted at `/run/anglesite-source`.
+    /// canonical `Source/` repository without granting the guest write access to that repository.
     ///
     /// The normal path fast-forwards the host branch. If a native host-side content operation
     /// committed after this runtime was hydrated, the histories diverge; cherry-picking the one
@@ -99,34 +110,44 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
               commit.unicodeScalars.allSatisfy({ CharacterSet(charactersIn: "0123456789abcdefABCDEF").contains($0) })
         else { throw SiteRuntimePersistenceError.missingOrInvalidCommit }
 
-        await acquirePersistenceSlot()
-        defer { releasePersistenceSlot() }
-
-        guard let siteID = activeSiteID else {
+        let expectedGeneration = generation
+        guard let siteID = activeSiteID, let siteDirectory = activeSiteDirectory else {
             throw SiteRuntimePersistenceError.runtimeNotRunning
         }
 
-        let script = #"""
+        await acquirePersistenceSlot()
+        defer { releasePersistenceSlot() }
+
+        guard expectedGeneration == generation,
+              activeSiteID == siteID,
+              activeSiteDirectory == siteDirectory
+        else {
+            throw SiteRuntimePersistenceError.runtimeNotRunning
+        }
+
+        // Export exactly the requested commit through stdout as a base64 git bundle. The canonical
+        // repo remains mounted read-only, so no guest process can alter its worktree, refs, or hooks.
+        let exportScript = #"""
         set -eu
-        canonical=/run/anglesite-source
         runtime=/workspace/site
         commit="$1"
+        ref=refs/anglesite/persist
+        bundle=/tmp/anglesite-persist-$$.bundle
+        cleanup() {
+          git -C "$runtime" update-ref -d "$ref" >/dev/null 2>&1 || true
+          rm -f "$bundle"
+        }
+        trap cleanup EXIT HUP INT TERM
 
-        if ! git -C "$canonical" diff --quiet || ! git -C "$canonical" diff --cached --quiet; then
-          echo "canonical Source repository has uncommitted changes" >&2
-          exit 20
-        fi
-
-        git -C "$canonical" fetch "$runtime" "$commit"
-        if git -C "$canonical" merge-base --is-ancestor HEAD FETCH_HEAD; then
-          git -C "$canonical" merge --ff-only FETCH_HEAD
+        full=$(git -C "$runtime" rev-parse "$commit^{commit}")
+        git -C "$runtime" update-ref "$ref" "$full"
+        if parent=$(git -C "$runtime" rev-parse "$full^" 2>/dev/null); then
+          git -C "$runtime" bundle create "$bundle" "$ref" "^$parent"
         else
-          if ! git -C "$canonical" cherry-pick FETCH_HEAD; then
-            git -C "$canonical" cherry-pick --abort || true
-            echo "overlay edit conflicts with newer Source changes" >&2
-            exit 21
-          fi
+          git -C "$runtime" bundle create "$bundle" "$ref"
         fi
+        printf '%s\n' "$full"
+        base64 "$bundle"
         """#
 
         let logCenter = self.logCenter
@@ -135,20 +156,94 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         do {
             result = try await control.exec(
                 siteID: siteID,
-                argv: ["sh", "-c", script, "anglesite-persist", commit],
+                argv: ["sh", "-c", exportScript, "anglesite-export", commit],
                 environment: [:],
                 workingDirectory: "/workspace/site",
                 onOutput: { line, stream in
+                    // stdout is the base64 bundle transport, not human-readable diagnostic output.
+                    guard stream == .stderr else { return }
                     Task { await logCenter.append(source: source, stream: stream, text: line) }
                 }
             )
         } catch {
+            guard expectedGeneration == generation, activeSiteID == siteID else {
+                throw SiteRuntimePersistenceError.runtimeNotRunning
+            }
             throw SiteRuntimePersistenceError.syncFailed(error.localizedDescription)
         }
         guard result.exitCode == 0 else {
             let detail = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             throw SiteRuntimePersistenceError.syncFailed(
                 detail.isEmpty ? "git handoff exited \(result.exitCode)" : detail)
+        }
+
+        guard expectedGeneration == generation,
+              activeSiteID == siteID,
+              activeSiteDirectory == siteDirectory
+        else {
+            throw SiteRuntimePersistenceError.runtimeNotRunning
+        }
+
+        let outputParts = result.stdout.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+        guard outputParts.count == 2 else {
+            throw SiteRuntimePersistenceError.syncFailed("container returned an invalid git bundle")
+        }
+        let fullCommit = String(outputParts[0])
+        guard (40...64).contains(fullCommit.count),
+              fullCommit.unicodeScalars.allSatisfy({ CharacterSet(charactersIn: "0123456789abcdefABCDEF").contains($0) }),
+              let bundleData = Data(base64Encoded: String(outputParts[1]), options: .ignoreUnknownCharacters)
+        else {
+            throw SiteRuntimePersistenceError.syncFailed("container returned an invalid git bundle")
+        }
+
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("anglesite-persist-\(UUID().uuidString).bundle")
+        do {
+            try bundleData.write(to: bundleURL, options: .atomic)
+        } catch {
+            throw SiteRuntimePersistenceError.syncFailed(error.localizedDescription)
+        }
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let importScript = #"""
+        set -eu
+        canonical="$1"
+        bundle="$2"
+        commit="$3"
+        git_safe() { git -c core.hooksPath=/dev/null -C "$canonical" "$@"; }
+
+        if test -n "$(git_safe status --porcelain)"; then
+          echo "canonical Source repository has uncommitted changes" >&2
+          exit 20
+        fi
+        git_safe fetch "$bundle" refs/anglesite/persist
+        if test "$(git_safe rev-parse FETCH_HEAD)" != "$commit"; then
+          echo "exported commit did not match the requested edit" >&2
+          exit 22
+        fi
+        if git_safe merge-base --is-ancestor HEAD FETCH_HEAD; then
+          git_safe merge --ff-only FETCH_HEAD
+        elif ! git_safe cherry-pick FETCH_HEAD; then
+          git_safe cherry-pick --abort || true
+          echo "overlay edit conflicts with newer Source changes" >&2
+          exit 21
+        fi
+        """#
+
+        let hostResult: ContainerExecResult
+        do {
+            hostResult = try await runHostCommand(
+                URL(fileURLWithPath: "/bin/sh"),
+                ["-c", importScript, "anglesite-persist", siteDirectory.path, bundleURL.path, fullCommit],
+                siteDirectory
+            )
+        } catch {
+            throw SiteRuntimePersistenceError.syncFailed(error.localizedDescription)
+        }
+        guard hostResult.exitCode == 0 else {
+            let detail = hostResult.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw SiteRuntimePersistenceError.syncFailed(
+                detail.isEmpty ? "git handoff exited \(hostResult.exitCode)" : detail)
         }
     }
 
@@ -240,6 +335,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             loadedKnowledgeSiteID = siteID
             startFileWatcher(siteID: siteID, projectRoot: siteDirectory, generation: gen)
             activeSiteID = siteID
+            activeSiteDirectory = siteDirectory
             containerTerminationLease = suddenTerminationLease
             setState(.ready(siteID: siteID, url: session.previewURL))
         } catch {
@@ -292,6 +388,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         loadedKnowledgeSiteID = nil
         let containerSiteID = activeSiteID
         activeSiteID = nil
+        activeSiteDirectory = nil
         let containerTerminationLease = self.containerTerminationLease
         self.containerTerminationLease = nil
         let bootLogContinuation = self.bootLogContinuation

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -14,7 +14,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     private let logCenter: LogCenter
     private let connect: @Sendable (MCPClient, URL) async throws -> Void
     private let makeFileWatcher: @Sendable () -> any SiteFileWatching
-    private let runHostCommand: @Sendable (URL, [String], URL) async throws -> ContainerExecResult
+    private let importBundle: @Sendable (URL, String, URL) async throws -> Void
     private let suddenTerminationController: SuddenTerminationController
     private var fileWatcher: (any SiteFileWatching)?
     private var containerTerminationLease: SuddenTerminationController.Lease?
@@ -47,13 +47,12 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         logCenter: LogCenter = .shared,
         connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { c, u in try await c.connect(httpEndpoint: u) },
         makeFileWatcher: @escaping @Sendable () -> any SiteFileWatching = { PlatformFileWatcher.make() },
-        runHostCommand: @escaping @Sendable (URL, [String], URL) async throws -> ContainerExecResult = { executable, arguments, cwd in
-            let result = try await ProcessSupervisor.shared.run(
-                executable: executable,
-                arguments: arguments,
-                currentDirectoryURL: cwd
-            )
-            return ContainerExecResult(exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr)
+        importBundle: @escaping @Sendable (URL, String, URL) async throws -> Void = { bundle, commit, source in
+            #if canImport(Darwin)
+            try await InProcessEditPersistence.importBundle(bundle, commit: commit, into: source)
+            #else
+            throw SiteRuntimePersistenceError.syncFailed("in-process git import is unavailable on this platform")
+            #endif
         },
         suddenTerminationController: SuddenTerminationController = .shared
     ) {
@@ -66,7 +65,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         self.logCenter = logCenter
         self.connect = connect
         self.makeFileWatcher = makeFileWatcher
-        self.runHostCommand = runHostCommand
+        self.importBundle = importBundle
         self.suddenTerminationController = suddenTerminationController
     }
 
@@ -131,7 +130,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         set -eu
         runtime=/workspace/site
         commit="$1"
-        ref=refs/anglesite/persist
+        ref=refs/heads/anglesite-persist
         bundle=/tmp/anglesite-persist-$$.bundle
         cleanup() {
           git -C "$runtime" update-ref -d "$ref" >/dev/null 2>&1 || true
@@ -205,45 +204,10 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         }
         defer { try? FileManager.default.removeItem(at: bundleURL) }
 
-        let importScript = #"""
-        set -eu
-        canonical="$1"
-        bundle="$2"
-        commit="$3"
-        git_safe() { git -c core.hooksPath=/dev/null -C "$canonical" "$@"; }
-
-        if test -n "$(git_safe status --porcelain)"; then
-          echo "canonical Source repository has uncommitted changes" >&2
-          exit 20
-        fi
-        git_safe fetch "$bundle" refs/anglesite/persist
-        if test "$(git_safe rev-parse FETCH_HEAD)" != "$commit"; then
-          echo "exported commit did not match the requested edit" >&2
-          exit 22
-        fi
-        if git_safe merge-base --is-ancestor HEAD FETCH_HEAD; then
-          git_safe merge --ff-only FETCH_HEAD
-        elif ! git_safe cherry-pick FETCH_HEAD; then
-          git_safe cherry-pick --abort || true
-          echo "overlay edit conflicts with newer Source changes" >&2
-          exit 21
-        fi
-        """#
-
-        let hostResult: ContainerExecResult
         do {
-            hostResult = try await runHostCommand(
-                URL(fileURLWithPath: "/bin/sh"),
-                ["-c", importScript, "anglesite-persist", siteDirectory.path, bundleURL.path, fullCommit],
-                siteDirectory
-            )
+            try await importBundle(bundleURL, fullCommit, siteDirectory)
         } catch {
             throw SiteRuntimePersistenceError.syncFailed(error.localizedDescription)
-        }
-        guard hostResult.exitCode == 0 else {
-            let detail = hostResult.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            throw SiteRuntimePersistenceError.syncFailed(
-                detail.isEmpty ? "git handoff exited \(hostResult.exitCode)" : detail)
         }
     }
 

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -5,6 +5,10 @@ import Foundation
 /// repo, connect the MCP client to the returned MCP endpoint, settle to `.ready`/`.failed`.
 /// Spawns nothing in-process.
 public actor LocalContainerSiteRuntime: SiteRuntime {
+    /// Shared by `persistEdit`'s two commit-hash validity checks — built once rather than per
+    /// character inside each `allSatisfy` closure.
+    private static let hexDigits = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+
     private let ref: String
     private let control: any LocalContainerControl
     public let mcpClient: MCPClient
@@ -99,14 +103,14 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     /// Copies one commit produced by the MCP sidecar in `/workspace/site` back into the host's
     /// canonical `Source/` repository without granting the guest write access to that repository.
     ///
-    /// The normal path fast-forwards the host branch. If a native host-side content operation
-    /// committed after this runtime was hydrated, the histories diverge; cherry-picking the one
-    /// overlay commit preserves both changes. A dirty host worktree is refused rather than
-    /// overwritten, and a failed cherry-pick is aborted before returning the error.
+    /// Fast-forward only: `InProcessEditPersistence` requires the exported commit's sole parent to
+    /// equal the host's current HEAD, refusing (rather than merging or cherry-picking) if a native
+    /// host-side content operation committed after this runtime was hydrated. A dirty host
+    /// worktree is refused rather than overwritten.
     public func persistEdit(commit: String?) async throws {
         guard let commit,
               (7...64).contains(commit.count),
-              commit.unicodeScalars.allSatisfy({ CharacterSet(charactersIn: "0123456789abcdefABCDEF").contains($0) })
+              commit.unicodeScalars.allSatisfy({ Self.hexDigits.contains($0) })
         else { throw SiteRuntimePersistenceError.missingOrInvalidCommit }
 
         let expectedGeneration = generation
@@ -189,7 +193,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         }
         let fullCommit = String(outputParts[0])
         guard (40...64).contains(fullCommit.count),
-              fullCommit.unicodeScalars.allSatisfy({ CharacterSet(charactersIn: "0123456789abcdefABCDEF").contains($0) }),
+              fullCommit.unicodeScalars.allSatisfy({ Self.hexDigits.contains($0) }),
               let bundleData = Data(base64Encoded: String(outputParts[1]), options: .ignoreUnknownCharacters)
         else {
             throw SiteRuntimePersistenceError.syncFailed("container returned an invalid git bundle")
@@ -206,7 +210,12 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
 
         do {
             try await importBundle(bundleURL, fullCommit, siteDirectory)
+            // The host-side import is in-process libgit2, not a subprocess — nothing else would
+            // ever put this write to the canonical repo in the debug pane (CLAUDE.md: "logs are
+            // sacred"), so log the outcome explicitly on both paths.
+            await logCenter.append(source: source, stream: .stdout, text: "persisted \(fullCommit) to Source")
         } catch {
+            await logCenter.append(source: source, stream: .stderr, text: "persist failed: \(error.localizedDescription)")
             throw SiteRuntimePersistenceError.syncFailed(error.localizedDescription)
         }
     }

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -23,6 +23,11 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     private var generation = 0
     private var activeSiteID: String?
     private var loadedKnowledgeSiteID: String?
+    /// Serializes guest-to-host git handoffs. Actor isolation alone is insufficient because an
+    /// actor is reentrant while `control.exec` is suspended, and two overlapping overlay edits
+    /// must never race in the canonical working tree.
+    private var persistenceInProgress = false
+    private var persistenceWaiters: [CheckedContinuation<Void, Never>] = []
 
     /// Drains the current container's boot/guest-process output into `logCenter`. Long-lived for
     /// the container's whole run (astro/mcp keep emitting after `start()` returns), so it's stored
@@ -79,6 +84,72 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     public func containerSnapshot() -> (control: any LocalContainerControl, siteID: String)? {
         guard let id = activeSiteID else { return nil }
         return (control: control, siteID: id)
+    }
+
+    /// Copies one commit produced by the MCP sidecar in `/workspace/site` back into the host's
+    /// canonical `Source/` repository, which is mounted at `/run/anglesite-source`.
+    ///
+    /// The normal path fast-forwards the host branch. If a native host-side content operation
+    /// committed after this runtime was hydrated, the histories diverge; cherry-picking the one
+    /// overlay commit preserves both changes. A dirty host worktree is refused rather than
+    /// overwritten, and a failed cherry-pick is aborted before returning the error.
+    public func persistEdit(commit: String?) async throws {
+        guard let commit,
+              (7...64).contains(commit.count),
+              commit.unicodeScalars.allSatisfy({ CharacterSet(charactersIn: "0123456789abcdefABCDEF").contains($0) })
+        else { throw SiteRuntimePersistenceError.missingOrInvalidCommit }
+
+        await acquirePersistenceSlot()
+        defer { releasePersistenceSlot() }
+
+        guard let siteID = activeSiteID else {
+            throw SiteRuntimePersistenceError.runtimeNotRunning
+        }
+
+        let script = #"""
+        set -eu
+        canonical=/run/anglesite-source
+        runtime=/workspace/site
+        commit="$1"
+
+        if ! git -C "$canonical" diff --quiet || ! git -C "$canonical" diff --cached --quiet; then
+          echo "canonical Source repository has uncommitted changes" >&2
+          exit 20
+        fi
+
+        git -C "$canonical" fetch "$runtime" "$commit"
+        if git -C "$canonical" merge-base --is-ancestor HEAD FETCH_HEAD; then
+          git -C "$canonical" merge --ff-only FETCH_HEAD
+        else
+          if ! git -C "$canonical" cherry-pick FETCH_HEAD; then
+            git -C "$canonical" cherry-pick --abort || true
+            echo "overlay edit conflicts with newer Source changes" >&2
+            exit 21
+          fi
+        fi
+        """#
+
+        let logCenter = self.logCenter
+        let source = "container:\(siteID):persist"
+        let result: ContainerExecResult
+        do {
+            result = try await control.exec(
+                siteID: siteID,
+                argv: ["sh", "-c", script, "anglesite-persist", commit],
+                environment: [:],
+                workingDirectory: "/workspace/site",
+                onOutput: { line, stream in
+                    Task { await logCenter.append(source: source, stream: stream, text: line) }
+                }
+            )
+        } catch {
+            throw SiteRuntimePersistenceError.syncFailed(error.localizedDescription)
+        }
+        guard result.exitCode == 0 else {
+            let detail = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw SiteRuntimePersistenceError.syncFailed(
+                detail.isEmpty ? "git handoff exited \(result.exitCode)" : detail)
+        }
     }
 
     public func observe() -> AsyncStream<SiteRuntimeState> {
@@ -266,6 +337,22 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     private func stopFileWatcher() {
         fileWatcher?.stop()
         fileWatcher = nil
+    }
+
+    private func acquirePersistenceSlot() async {
+        if !persistenceInProgress {
+            persistenceInProgress = true
+            return
+        }
+        await withCheckedContinuation { persistenceWaiters.append($0) }
+    }
+
+    private func releasePersistenceSlot() {
+        if persistenceWaiters.isEmpty {
+            persistenceInProgress = false
+        } else {
+            persistenceWaiters.removeFirst().resume()
+        }
     }
 
     private func applyFileChanges(_ batch: FileChangeBatch, siteID: String, projectRoot: URL, generation gen: Int) async {

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -13,6 +13,10 @@ import Foundation
 public struct MCPApplyEditRouter: EditRouter {
     public typealias ToolCaller = @Sendable (_ name: String, _ arguments: JSONValue) async throws -> MCPClient.ToolCallResult
     public typealias EditObserver = @Sendable (EditReply) -> Void
+    /// Persists a successful runtime edit into the canonical site repository. Unlike
+    /// ``PostProcessor``, this hook is awaited before the applied reply is returned: acknowledging
+    /// the overlay before `Source/` is durable would recreate #718's close-window data-loss race.
+    public typealias EditPersister = @Sendable (EditReply) async throws -> Void
     /// Async hook fired (fire-and-forget) when an edit is `.applied`, with both the reply and the
     /// originating message. Used by the app to run on-device alt-text generation for image drops
     /// (C.7 / `AltTextGenerator`) without coupling this router to FoundationModels. It runs detached
@@ -26,13 +30,20 @@ public struct MCPApplyEditRouter: EditRouter {
 
     private let toolCaller: ToolCaller
     private let onEdit: EditObserver?
+    private let persistEdit: EditPersister?
     private let postProcess: PostProcessor?
 
     /// Test seam — inject a closure that mimics `MCPClient.callTool` so the router's mapping
     /// logic is verifiable without a live MCP server.
-    public init(toolCaller: @escaping ToolCaller, onEdit: EditObserver? = nil, postProcess: PostProcessor? = nil) {
+    public init(
+        toolCaller: @escaping ToolCaller,
+        onEdit: EditObserver? = nil,
+        persistEdit: EditPersister? = nil,
+        postProcess: PostProcessor? = nil
+    ) {
         self.toolCaller = toolCaller
         self.onEdit = onEdit
+        self.persistEdit = persistEdit
         self.postProcess = postProcess
     }
 
@@ -41,6 +52,7 @@ public struct MCPApplyEditRouter: EditRouter {
     public init(
         mcpClient: @escaping @Sendable () async -> MCPClient?,
         onEdit: EditObserver? = nil,
+        persistEdit: EditPersister? = nil,
         postProcess: PostProcessor? = nil
     ) {
         self.toolCaller = { name, args in
@@ -48,6 +60,7 @@ public struct MCPApplyEditRouter: EditRouter {
             return try await client.callTool(name: name, arguments: args)
         }
         self.onEdit = onEdit
+        self.persistEdit = persistEdit
         self.postProcess = postProcess
     }
 
@@ -91,6 +104,21 @@ public struct MCPApplyEditRouter: EditRouter {
                 result: parsed?.result,
                 model: parsed?.model
             )
+            if let persistEdit {
+                do {
+                    try await persistEdit(reply)
+                } catch {
+                    return EditReply(
+                        id: message.id,
+                        status: .failed,
+                        message: "The edit changed the preview but couldn't be saved to Source: \(error.localizedDescription)",
+                        file: reply.file,
+                        commit: reply.commit,
+                        result: reply.result,
+                        model: reply.model
+                    )
+                }
+            }
             if reply.commit != nil { onEdit?(reply) }
             // Fire-and-forget so the overlay gets its reply immediately; alt-text generation and the
             // follow-up edit land a moment later (see `AltTextGenerator`).

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -113,7 +113,9 @@ public struct MCPApplyEditRouter: EditRouter {
                         status: .failed,
                         message: "The edit changed the preview but couldn't be saved to Source: \(error.localizedDescription)",
                         file: reply.file,
-                        commit: reply.commit,
+                        // Not persisted, so nil rather than reply.commit — a consumer keying off
+                        // `commit != nil` instead of `status` must not read this as landed.
+                        commit: nil,
                         result: reply.result,
                         model: reply.model
                     )

--- a/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
+++ b/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
@@ -114,7 +114,7 @@ public struct PodmanContainerControl: LocalContainerControl {
                 podmanExecutable: podmanExecutable,
                 arguments: [
                     "run", "-d", "--rm", "--name", name,
-                    "-v", "\(sourceRepo.path):\(Self.repoSharePath):rw",
+                    "-v", "\(sourceRepo.path):\(Self.repoSharePath):ro",
                     "-p", "127.0.0.1::\(Self.previewPort)",
                     "-p", "127.0.0.1::\(Self.mcpPort)",
                     image, "sleep", "infinity",

--- a/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
+++ b/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
@@ -95,7 +95,8 @@ public struct PodmanContainerControl: LocalContainerControl {
 
         // 1. Boot a bare, long-lived container (podman's equivalent of Apple Containerization's
         //    "makeBareContainer" step): a no-op main process so `podman exec` has something to
-        //    attach to, the host `Source/` repo bind-mounted read-only, and both guest ports
+        //    attach to, the host `Source/` repo bind-mounted for clone + explicit edit persistence,
+        //    and both guest ports
         //    published to OS-assigned host ports. `--rm` means `podman stop` alone tears down the
         //    whole thing — no separate `podman rm`.
         //
@@ -113,7 +114,7 @@ public struct PodmanContainerControl: LocalContainerControl {
                 podmanExecutable: podmanExecutable,
                 arguments: [
                     "run", "-d", "--rm", "--name", name,
-                    "-v", "\(sourceRepo.path):\(Self.repoSharePath):ro",
+                    "-v", "\(sourceRepo.path):\(Self.repoSharePath):rw",
                     "-p", "127.0.0.1::\(Self.previewPort)",
                     "-p", "127.0.0.1::\(Self.mcpPort)",
                     image, "sleep", "infinity",
@@ -137,7 +138,7 @@ public struct PodmanContainerControl: LocalContainerControl {
             throw LocalContainerError.bootFailed("guest /etc/hosts setup failed: \(error)")
         }
 
-        // 3. Clone from the read-only bind-mounted share into a writable /workspace/site, then
+        // 3. Clone from the bind-mounted share into a writable /workspace/site, then
         //    check out ref. Two steps (not `git clone --branch`) because that flag rejects
         //    "HEAD"/bare SHAs, which `git checkout` accepts.
         do {

--- a/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
+++ b/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
@@ -95,8 +95,9 @@ public struct PodmanContainerControl: LocalContainerControl {
 
         // 1. Boot a bare, long-lived container (podman's equivalent of Apple Containerization's
         //    "makeBareContainer" step): a no-op main process so `podman exec` has something to
-        //    attach to, the host `Source/` repo bind-mounted for clone + explicit edit persistence,
-        //    and both guest ports
+        //    attach to, the host `Source/` repo bind-mounted read-only (`:ro` below — edit
+        //    persistence hands commits back over exec stdout, not through this mount), and both
+        //    guest ports
         //    published to OS-assigned host ports. `--rm` means `podman stop` alone tears down the
         //    whole thing — no separate `podman rm`.
         //
@@ -138,7 +139,7 @@ public struct PodmanContainerControl: LocalContainerControl {
             throw LocalContainerError.bootFailed("guest /etc/hosts setup failed: \(error)")
         }
 
-        // 3. Clone from the bind-mounted share into a writable /workspace/site, then
+        // 3. Clone from the read-only bind-mounted share into a writable /workspace/site, then
         //    check out ref. Two steps (not `git clone --branch`) because that flag rejects
         //    "HEAD"/bare SHAs, which `git checkout` accepts.
         do {

--- a/Sources/AnglesiteCore/SiteRuntime.swift
+++ b/Sources/AnglesiteCore/SiteRuntime.swift
@@ -10,6 +10,24 @@ public enum SiteRuntimeState: Sendable, Equatable {
     case failed(siteID: String, message: String)
 }
 
+/// Failures that prevent a runtime edit from becoming durable in the canonical `Source/` repo.
+public enum SiteRuntimePersistenceError: LocalizedError, Sendable, Equatable {
+    case missingOrInvalidCommit
+    case runtimeNotRunning
+    case syncFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingOrInvalidCommit:
+            "the edit server did not return a valid git commit"
+        case .runtimeNotRunning:
+            "the site runtime is no longer running"
+        case .syncFailed(let message):
+            message
+        }
+    }
+}
+
 /// One runtime = one site's live preview. This is the seam for swapping execution substrates
 /// (see #59 / design doc §4): a container exposes an HTTP/WS URL rather than a pid + pipes, so the
 /// abstraction lives here — at `PreviewSession`'s old level — not at `SupervisorBackend`.

--- a/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
+++ b/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
@@ -54,23 +54,23 @@ actor FakeLocalContainerControl: LocalContainerControl {
     }
 }
 
-actor HostCommandRecorder {
+actor BundleImportRecorder {
     struct Call: Sendable {
-        let executable: URL
-        let arguments: [String]
-        let cwd: URL
+        let bundleURL: URL
+        let commit: String
+        let sourceDirectory: URL
     }
 
     private(set) var calls: [Call] = []
-    let result: ContainerExecResult
+    let error: Error?
 
-    init(result: ContainerExecResult = .init(exitCode: 0, stdout: "", stderr: "")) {
-        self.result = result
+    init(error: Error? = nil) {
+        self.error = error
     }
 
-    func run(executable: URL, arguments: [String], cwd: URL) -> ContainerExecResult {
-        calls.append(.init(executable: executable, arguments: arguments, cwd: cwd))
-        return result
+    func run(bundleURL: URL, commit: String, sourceDirectory: URL) throws {
+        calls.append(.init(bundleURL: bundleURL, commit: commit, sourceDirectory: sourceDirectory))
+        if let error { throw error }
     }
 }
 

--- a/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
+++ b/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
@@ -54,6 +54,76 @@ actor FakeLocalContainerControl: LocalContainerControl {
     }
 }
 
+actor HostCommandRecorder {
+    struct Call: Sendable {
+        let executable: URL
+        let arguments: [String]
+        let cwd: URL
+    }
+
+    private(set) var calls: [Call] = []
+    let result: ContainerExecResult
+
+    init(result: ContainerExecResult = .init(exitCode: 0, stdout: "", stderr: "")) {
+        self.result = result
+    }
+
+    func run(executable: URL, arguments: [String], cwd: URL) -> ContainerExecResult {
+        calls.append(.init(executable: executable, arguments: arguments, cwd: cwd))
+        return result
+    }
+}
+
+actor PersistenceGatedFakeLocalContainerControl: LocalContainerControl {
+    private let result: Result<LocalContainerSession, LocalContainerError>
+    private let execResult: ContainerExecResult
+    private var parkedContinuation: CheckedContinuation<Void, Never>?
+    private var gateContinuation: CheckedContinuation<Void, Never>?
+    private var execParked = false
+
+    init(result: Result<LocalContainerSession, LocalContainerError>, execResult: ContainerExecResult) {
+        self.result = result
+        self.execResult = execResult
+    }
+
+    func waitUntilExecParked() async {
+        if execParked { return }
+        await withCheckedContinuation { parkedContinuation = $0 }
+    }
+
+    func releaseExec() {
+        gateContinuation?.resume()
+        gateContinuation = nil
+    }
+
+    func start(
+        siteID: String,
+        sourceRepo: URL,
+        ref: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> LocalContainerSession {
+        try result.get()
+    }
+
+    func stop(siteID: String) async throws {}
+
+    func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> ContainerExecResult {
+        execParked = true
+        parkedContinuation?.resume()
+        parkedContinuation = nil
+        await withCheckedContinuation { continuation in
+            gateContinuation = continuation
+        }
+        return execResult
+    }
+}
+
 /// A `LocalContainerControl` whose `start` suspends until `release()` is called — for
 /// deterministically interleaving a concurrent `stop()`/second `start()` while the first
 /// `start()` is parked. Mirrors `GatedFakeSandboxControlClient`.

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -81,6 +81,60 @@ struct LocalContainerSiteRuntimeTests {
         #expect(await box.url == Self.ok.mcpURL)
     }
 
+    @Test("persistEdit hands the guest commit back to canonical Source")
+    func persistEditRunsCanonicalGitHandoff() async throws {
+        let commit = "abc1234567890abcdef1234567890abcdef12345"
+        let (runtime, fake) = makeRuntime(.success(Self.ok))
+        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+
+        try await runtime.persistEdit(commit: commit)
+
+        let calls = await fake.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].siteID == "s1")
+        #expect(calls[0].argv.prefix(2) == ["sh", "-c"])
+        #expect(calls[0].argv.last == commit)
+        #expect(calls[0].argv[2].contains("git -C \"$canonical\" fetch \"$runtime\" \"$commit\""))
+        #expect(calls[0].argv[2].contains("merge --ff-only FETCH_HEAD"))
+        #expect(calls[0].argv[2].contains("cherry-pick --abort"))
+        #expect(calls[0].cwd == "/workspace/site")
+    }
+
+    @Test("persistEdit refuses a missing commit without touching the container")
+    func persistEditRequiresCommit() async {
+        let (runtime, fake) = makeRuntime(.success(Self.ok))
+        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+
+        await #expect(throws: SiteRuntimePersistenceError.missingOrInvalidCommit) {
+            try await runtime.persistEdit(commit: nil)
+        }
+        #expect(await fake.execCalls.isEmpty)
+    }
+
+    @Test("persistEdit surfaces a failed canonical git handoff")
+    func persistEditSurfacesGitFailure() async {
+        let fake = FakeLocalContainerControl(
+            startResult: .success(Self.ok),
+            execResult: .init(exitCode: 20, stdout: "", stderr: "canonical Source repository has uncommitted changes")
+        )
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: fake,
+            mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
+            connect: { _, _ in }
+        )
+        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+
+        do {
+            try await runtime.persistEdit(commit: "abc1234567890abcdef1234567890abcdef12345")
+            Issue.record("expected persistence to fail")
+        } catch let error as SiteRuntimePersistenceError {
+            #expect(error == .syncFailed("canonical Source repository has uncommitted changes"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
     @Test("control failure settles to .failed with a friendly message")
     func startFailed() async {
         let (rt, _) = makeRuntime(.failure(.bootFailed("vm refused to boot")))

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -5,15 +5,20 @@ import Foundation
 struct LocalContainerSiteRuntimeTests {
     private func makeRuntime(
         _ result: Result<LocalContainerSession, LocalContainerError>,
-        connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { _, _ in }
+        connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { _, _ in },
+        execResult: ContainerExecResult = .init(exitCode: 0, stdout: "", stderr: ""),
+        runHostCommand: @escaping @Sendable (URL, [String], URL) async throws -> ContainerExecResult = { _, _, _ in
+            .init(exitCode: 0, stdout: "", stderr: "")
+        }
     ) -> (LocalContainerSiteRuntime, FakeLocalContainerControl) {
-        let fake = FakeLocalContainerControl(startResult: result)
+        let fake = FakeLocalContainerControl(startResult: result, execResult: execResult)
         let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
         let rt = LocalContainerSiteRuntime(
             ref: "HEAD",
             control: fake,
             mcpClient: mcp,
-            connect: connect)
+            connect: connect,
+            runHostCommand: runHostCommand)
         return (rt, fake)
     }
 
@@ -84,8 +89,17 @@ struct LocalContainerSiteRuntimeTests {
     @Test("persistEdit hands the guest commit back to canonical Source")
     func persistEditRunsCanonicalGitHandoff() async throws {
         let commit = "abc1234567890abcdef1234567890abcdef12345"
-        let (runtime, fake) = makeRuntime(.success(Self.ok))
-        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        let bundle = Data("test bundle".utf8).base64EncodedString()
+        let host = HostCommandRecorder()
+        let source = URL(fileURLWithPath: "/sites/Foo.anglesite/Source")
+        let (runtime, fake) = makeRuntime(
+            .success(Self.ok),
+            execResult: .init(exitCode: 0, stdout: "\(commit)\n\(bundle)\n", stderr: ""),
+            runHostCommand: { executable, arguments, cwd in
+                await host.run(executable: executable, arguments: arguments, cwd: cwd)
+            }
+        )
+        await runtime.start(siteID: "s1", siteDirectory: source)
 
         try await runtime.persistEdit(commit: commit)
 
@@ -94,10 +108,20 @@ struct LocalContainerSiteRuntimeTests {
         #expect(calls[0].siteID == "s1")
         #expect(calls[0].argv.prefix(2) == ["sh", "-c"])
         #expect(calls[0].argv.last == commit)
-        #expect(calls[0].argv[2].contains("git -C \"$canonical\" fetch \"$runtime\" \"$commit\""))
-        #expect(calls[0].argv[2].contains("merge --ff-only FETCH_HEAD"))
-        #expect(calls[0].argv[2].contains("cherry-pick --abort"))
+        #expect(calls[0].argv[2].contains("bundle create"))
+        #expect(calls[0].argv[2].contains("base64 \"$bundle\""))
+        #expect(!calls[0].argv[2].contains("/run/anglesite-source"))
         #expect(calls[0].cwd == "/workspace/site")
+
+        let hostCalls = await host.calls
+        #expect(hostCalls.count == 1)
+        #expect(hostCalls[0].executable.path == "/bin/sh")
+        #expect(hostCalls[0].arguments[3] == source.path)
+        #expect(hostCalls[0].arguments.last == commit)
+        #expect(hostCalls[0].arguments[1].contains("core.hooksPath=/dev/null"))
+        #expect(hostCalls[0].arguments[1].contains("merge --ff-only FETCH_HEAD"))
+        #expect(hostCalls[0].arguments[1].contains("cherry-pick --abort"))
+        #expect(hostCalls[0].cwd == source)
     }
 
     @Test("persistEdit refuses a missing commit without touching the container")
@@ -113,26 +137,65 @@ struct LocalContainerSiteRuntimeTests {
 
     @Test("persistEdit surfaces a failed canonical git handoff")
     func persistEditSurfacesGitFailure() async {
+        let commit = "abc1234567890abcdef1234567890abcdef12345"
+        let bundle = Data("test bundle".utf8).base64EncodedString()
+        let host = HostCommandRecorder(
+            result: .init(exitCode: 20, stdout: "", stderr: "canonical Source repository has uncommitted changes")
+        )
         let fake = FakeLocalContainerControl(
             startResult: .success(Self.ok),
-            execResult: .init(exitCode: 20, stdout: "", stderr: "canonical Source repository has uncommitted changes")
-        )
+            execResult: .init(exitCode: 0, stdout: "\(commit)\n\(bundle)\n", stderr: ""))
         let runtime = LocalContainerSiteRuntime(
             ref: "HEAD",
             control: fake,
             mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
-            connect: { _, _ in }
+            connect: { _, _ in },
+            runHostCommand: { executable, arguments, cwd in
+                await host.run(executable: executable, arguments: arguments, cwd: cwd)
+            }
         )
         await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
 
         do {
-            try await runtime.persistEdit(commit: "abc1234567890abcdef1234567890abcdef12345")
+            try await runtime.persistEdit(commit: commit)
             Issue.record("expected persistence to fail")
         } catch let error as SiteRuntimePersistenceError {
             #expect(error == .syncFailed("canonical Source repository has uncommitted changes"))
         } catch {
             Issue.record("unexpected error: \(error)")
         }
+    }
+
+    @Test("persistEdit abandons an export superseded by a site switch")
+    func persistEditRejectsSupersededGeneration() async {
+        let commit = "abc1234567890abcdef1234567890abcdef12345"
+        let bundle = Data("test bundle".utf8).base64EncodedString()
+        let fake = PersistenceGatedFakeLocalContainerControl(
+            result: .success(Self.ok),
+            execResult: .init(exitCode: 0, stdout: "\(commit)\n\(bundle)\n", stderr: "")
+        )
+        let host = HostCommandRecorder()
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: fake,
+            mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
+            connect: { _, _ in },
+            runHostCommand: { executable, arguments, cwd in
+                await host.run(executable: executable, arguments: arguments, cwd: cwd)
+            }
+        )
+        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/sites/One/Source"))
+
+        let persistence = Task { try await runtime.persistEdit(commit: commit) }
+        await fake.waitUntilExecParked()
+        await runtime.stop()
+        await runtime.start(siteID: "s2", siteDirectory: URL(fileURLWithPath: "/sites/Two/Source"))
+        await fake.releaseExec()
+
+        await #expect(throws: SiteRuntimePersistenceError.runtimeNotRunning) {
+            try await persistence.value
+        }
+        #expect(await host.calls.isEmpty)
     }
 
     @Test("control failure settles to .failed with a friendly message")

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -7,9 +7,7 @@ struct LocalContainerSiteRuntimeTests {
         _ result: Result<LocalContainerSession, LocalContainerError>,
         connect: @escaping @Sendable (MCPClient, URL) async throws -> Void = { _, _ in },
         execResult: ContainerExecResult = .init(exitCode: 0, stdout: "", stderr: ""),
-        runHostCommand: @escaping @Sendable (URL, [String], URL) async throws -> ContainerExecResult = { _, _, _ in
-            .init(exitCode: 0, stdout: "", stderr: "")
-        }
+        importBundle: @escaping @Sendable (URL, String, URL) async throws -> Void = { _, _, _ in }
     ) -> (LocalContainerSiteRuntime, FakeLocalContainerControl) {
         let fake = FakeLocalContainerControl(startResult: result, execResult: execResult)
         let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
@@ -18,7 +16,7 @@ struct LocalContainerSiteRuntimeTests {
             control: fake,
             mcpClient: mcp,
             connect: connect,
-            runHostCommand: runHostCommand)
+            importBundle: importBundle)
         return (rt, fake)
     }
 
@@ -90,13 +88,13 @@ struct LocalContainerSiteRuntimeTests {
     func persistEditRunsCanonicalGitHandoff() async throws {
         let commit = "abc1234567890abcdef1234567890abcdef12345"
         let bundle = Data("test bundle".utf8).base64EncodedString()
-        let host = HostCommandRecorder()
+        let host = BundleImportRecorder()
         let source = URL(fileURLWithPath: "/sites/Foo.anglesite/Source")
         let (runtime, fake) = makeRuntime(
             .success(Self.ok),
             execResult: .init(exitCode: 0, stdout: "\(commit)\n\(bundle)\n", stderr: ""),
-            runHostCommand: { executable, arguments, cwd in
-                await host.run(executable: executable, arguments: arguments, cwd: cwd)
+            importBundle: { bundleURL, importedCommit, sourceDirectory in
+                try await host.run(bundleURL: bundleURL, commit: importedCommit, sourceDirectory: sourceDirectory)
             }
         )
         await runtime.start(siteID: "s1", siteDirectory: source)
@@ -115,13 +113,8 @@ struct LocalContainerSiteRuntimeTests {
 
         let hostCalls = await host.calls
         #expect(hostCalls.count == 1)
-        #expect(hostCalls[0].executable.path == "/bin/sh")
-        #expect(hostCalls[0].arguments[3] == source.path)
-        #expect(hostCalls[0].arguments.last == commit)
-        #expect(hostCalls[0].arguments[1].contains("core.hooksPath=/dev/null"))
-        #expect(hostCalls[0].arguments[1].contains("merge --ff-only FETCH_HEAD"))
-        #expect(hostCalls[0].arguments[1].contains("cherry-pick --abort"))
-        #expect(hostCalls[0].cwd == source)
+        #expect(hostCalls[0].commit == commit)
+        #expect(hostCalls[0].sourceDirectory == source)
     }
 
     @Test("persistEdit refuses a missing commit without touching the container")
@@ -139,9 +132,7 @@ struct LocalContainerSiteRuntimeTests {
     func persistEditSurfacesGitFailure() async {
         let commit = "abc1234567890abcdef1234567890abcdef12345"
         let bundle = Data("test bundle".utf8).base64EncodedString()
-        let host = HostCommandRecorder(
-            result: .init(exitCode: 20, stdout: "", stderr: "canonical Source repository has uncommitted changes")
-        )
+        let host = BundleImportRecorder(error: SiteRuntimePersistenceError.syncFailed("canonical Source repository has uncommitted changes"))
         let fake = FakeLocalContainerControl(
             startResult: .success(Self.ok),
             execResult: .init(exitCode: 0, stdout: "\(commit)\n\(bundle)\n", stderr: ""))
@@ -150,8 +141,8 @@ struct LocalContainerSiteRuntimeTests {
             control: fake,
             mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
             connect: { _, _ in },
-            runHostCommand: { executable, arguments, cwd in
-                await host.run(executable: executable, arguments: arguments, cwd: cwd)
+            importBundle: { bundleURL, importedCommit, sourceDirectory in
+                try await host.run(bundleURL: bundleURL, commit: importedCommit, sourceDirectory: sourceDirectory)
             }
         )
         await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
@@ -174,14 +165,14 @@ struct LocalContainerSiteRuntimeTests {
             result: .success(Self.ok),
             execResult: .init(exitCode: 0, stdout: "\(commit)\n\(bundle)\n", stderr: "")
         )
-        let host = HostCommandRecorder()
+        let host = BundleImportRecorder()
         let runtime = LocalContainerSiteRuntime(
             ref: "HEAD",
             control: fake,
             mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
             connect: { _, _ in },
-            runHostCommand: { executable, arguments, cwd in
-                await host.run(executable: executable, arguments: arguments, cwd: cwd)
+            importBundle: { bundleURL, importedCommit, sourceDirectory in
+                try await host.run(bundleURL: bundleURL, commit: importedCommit, sourceDirectory: sourceDirectory)
             }
         )
         await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/sites/One/Source"))

--- a/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
@@ -165,6 +165,9 @@ struct MCPApplyEditRouterTests {
         #expect(reply.status == .failed)
         #expect(reply.message?.contains("couldn't be saved to Source") == true)
         #expect(reply.message?.contains("canonical repo is dirty") == true)
+        // Not persisted — a consumer keying off `commit != nil` instead of `status` must not
+        // mistake this for a landed edit.
+        #expect(reply.commit == nil)
         #expect(await observed.replies.isEmpty)
     }
 

--- a/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
@@ -127,6 +127,47 @@ struct MCPApplyEditRouterTests {
         #expect(captured.first?.commit == "abc1234567890abcdef1234567890abcdef12345")
     }
 
+    @Test("Successful edit is persisted before it is reported as applied")
+    func successfulEditAwaitsPersistence() async {
+        let body = #"{"type":"anglesite:edit-applied","id":"e-1","file":"src/pages/about.astro","commit":"abc1234567890abcdef1234567890abcdef12345"}"#
+        let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(
+            content: [.init(type: "text", text: body)],
+            isError: false
+        )))
+        let persisted = ObservedReplies()
+        let router = MCPApplyEditRouter(
+            toolCaller: { try await recorder.call(name: $0, arguments: $1) },
+            persistEdit: { await persisted.record($0) }
+        )
+
+        let reply = await router.apply(sampleMessage)
+
+        #expect(reply.status == .applied)
+        #expect(await persisted.replies.map(\.commit) == ["abc1234567890abcdef1234567890abcdef12345"])
+    }
+
+    @Test("Persistence failure turns the edit reply into a visible failure")
+    func persistenceFailureIsNotAcknowledgedAsApplied() async {
+        let body = #"{"type":"anglesite:edit-applied","id":"e-1","file":"src/pages/about.astro","commit":"abc1234567890abcdef1234567890abcdef12345"}"#
+        let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(
+            content: [.init(type: "text", text: body)],
+            isError: false
+        )))
+        let observed = ObservedReplies()
+        let router = MCPApplyEditRouter(
+            toolCaller: { try await recorder.call(name: $0, arguments: $1) },
+            onEdit: { reply in Task { await observed.record(reply) } },
+            persistEdit: { _ in throw SiteRuntimePersistenceError.syncFailed("canonical repo is dirty") }
+        )
+
+        let reply = await router.apply(sampleMessage)
+
+        #expect(reply.status == .failed)
+        #expect(reply.message?.contains("couldn't be saved to Source") == true)
+        #expect(reply.message?.contains("canonical repo is dirty") == true)
+        #expect(await observed.replies.isEmpty)
+    }
+
     @Test("On edit does not fire when reply has no commit") func onEditDoesNotFireWhenReplyHasNoCommit() async {
         // No JSON in the content — parser gives up; reply has nil commit; observer must NOT fire.
         let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(


### PR DESCRIPTION
## Summary

- await runtime-to-Source persistence before acknowledging edit-overlay writes
- fast-forward or safely cherry-pick container commits into canonical Source, with dirty/conflict failure handling and serialized handoffs
- keep generated alt-text edits on the same persistent router and support Apple Containerization and Podman mounts

## Testing

- `swift test --package-path . --filter 'MCPApplyEditRouterTests|LocalContainerSiteRuntimeTests|SiteAssistantSessionFactoryTests'` (36 tests)
- `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug CODE_SIGNING_ALLOWED=NO ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite build`
- `git diff --check`

Closes #718
