### PR TITLE
Send webmentions on publish (#354)

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -69,6 +69,7 @@ final class DeployModel {
     @ObservationIgnored var onMilestone: ((_ siteID: String, _ progress: OperationProgress) -> Void)?
 
     private let command: DeployCommand
+    private let webmentionCommand: WebmentionSendCommand
     private let logCenter: LogCenter
     private let keychain: KeychainStore
     private let onboarding: TokenOnboarding
@@ -94,6 +95,7 @@ final class DeployModel {
 
     init(
         command: DeployCommand = DeployCommand(),
+        webmentionCommand: WebmentionSendCommand = WebmentionSendCommand(),
         logCenter: LogCenter = .shared,
         keychain: KeychainStore = KeychainStore(),
         verifier: TokenVerifying = CloudflareAPITokenVerifier(),
@@ -102,6 +104,7 @@ final class DeployModel {
         tokenAvailabilityOverride: (() -> Bool)? = nil
     ) {
         self.command = command
+        self.webmentionCommand = webmentionCommand
         self.logCenter = logCenter
         self.keychain = keychain
         self.onboarding = TokenOnboarding(verifier: verifier)
@@ -319,6 +322,16 @@ final class DeployModel {
         switch result {
         case .succeeded(let url, let duration):
             transition(siteID: siteID, to: .succeeded(url: url, duration: duration))
+            // Fire-and-forget: webmention sends are best-effort and must never block or affect
+            // the deploy result the user watches. Progress/failures surface only in LogCenter.
+            Task.detached { [webmentionCommand] in
+                await webmentionCommand.send(
+                    siteID: siteID,
+                    siteDirectory: siteDirectory,
+                    configDirectory: configDirectory,
+                    siteBase: url
+                )
+            }
         case .failed(let reason, let exit):
             transition(siteID: siteID, to: .failed(reason: reason, exitCode: exit))
             let capturedLog = logText   // snapshot before the suspension; a later deploy clears logLines

--- a/Sources/AnglesiteCore/WebmentionEndpointDiscovery.swift
+++ b/Sources/AnglesiteCore/WebmentionEndpointDiscovery.swift
@@ -1,0 +1,132 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Discovers a target URL's declared Webmention receiver endpoint per the webmention.org spec:
+/// fetch the target once, prefer an HTTP `Link` header with `rel=webmention` (or the legacy
+/// `rel="http://webmention.org/"` form), falling back to the first `<link>` or `<a>` element (in
+/// document order) with `rel=webmention` in the HTML body. A relative endpoint URL is resolved
+/// against the *final* response URL (after redirects), not the originally-requested target —
+/// required for pages like webmention.rocks' redirect test.
+public enum WebmentionEndpointDiscovery {
+    /// Performs one HTTP request and returns its body + response. Throws on connection failure.
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    /// `nil` means the target declares no Webmention endpoint — not an error condition.
+    public static func discover(target: URL, transport: Transport) async throws -> URL? {
+        var request = URLRequest(url: target)
+        request.setValue("text/html", forHTTPHeaderField: "Accept")
+        let (data, http) = try await transport(request)
+        let finalURL = http.url ?? target
+
+        if let linkHeader = http.value(forHTTPHeaderField: "Link"),
+           let endpoint = endpoint(fromLinkHeader: linkHeader, relativeTo: finalURL) {
+            return endpoint
+        }
+        guard let html = String(data: data, encoding: .utf8) else { return nil }
+        return endpoint(fromHTML: html, relativeTo: finalURL)
+    }
+
+    // MARK: Link header
+
+    static func endpoint(fromLinkHeader header: String, relativeTo baseURL: URL) -> URL? {
+        for value in splitLinkHeaderValues(header) {
+            guard let start = value.firstIndex(of: "<"),
+                  let end = value.firstIndex(of: ">"),
+                  start < end
+            else { continue }
+            let urlString = String(value[value.index(after: start)..<end])
+            let params = String(value[value.index(after: end)...])
+            guard let rel = attributeValue("rel", in: params), isWebmentionRel(rel) else { continue }
+            return URL(string: urlString, relativeTo: baseURL)?.absoluteURL
+        }
+        return nil
+    }
+
+    /// Splits a `Link` header on top-level commas — commas inside `<...>` (the URL itself) don't
+    /// separate link-values.
+    private static func splitLinkHeaderValues(_ header: String) -> [String] {
+        var values: [String] = []
+        var depth = 0
+        var current = ""
+        for char in header {
+            switch char {
+            case "<":
+                depth += 1
+                current.append(char)
+            case ">":
+                depth -= 1
+                current.append(char)
+            case "," where depth == 0:
+                values.append(current)
+                current = ""
+            default:
+                current.append(char)
+            }
+        }
+        if !current.trimmingCharacters(in: .whitespaces).isEmpty { values.append(current) }
+        return values
+    }
+
+    // MARK: HTML
+
+    /// Matches `<link ...>` and `<a ...>` tags in document order; the first with a `webmention`
+    /// rel wins, per the spec ("the first link or a element ... in document order").
+    private static let tagPattern: NSRegularExpression = {
+        do {
+            return try NSRegularExpression(pattern: #"<(?:link|a)\b([^>]*)>"#, options: [.caseInsensitive])
+        } catch {
+            fatalError("Invalid webmention discovery tag regex: \(error)")
+        }
+    }()
+
+    static func endpoint(fromHTML html: String, relativeTo baseURL: URL) -> URL? {
+        let range = NSRange(html.startIndex..<html.endIndex, in: html)
+        for match in tagPattern.matches(in: html, range: range) {
+            guard let attrsRange = Range(match.range(at: 1), in: html) else { continue }
+            let attrs = String(html[attrsRange])
+            guard let rel = attributeValue("rel", in: attrs), isWebmentionRel(rel) else { continue }
+            guard let href = attributeValue("href", in: attrs) else { continue }
+            if let url = URL(string: href, relativeTo: baseURL)?.absoluteURL {
+                return url
+            }
+        }
+        return nil
+    }
+
+    // MARK: Shared attribute/rel helpers
+
+    private static let legacyWebmentionRels: Set<String> = [
+        "http://webmention.org/", "https://webmention.org/",
+        "http://webmention.org", "https://webmention.org",
+    ]
+
+    private static func isWebmentionRel(_ rel: String) -> Bool {
+        rel.split(whereSeparator: { $0.isWhitespace }).contains { token in
+            token.caseInsensitiveCompare("webmention") == .orderedSame
+                || legacyWebmentionRels.contains(String(token).lowercased())
+        }
+    }
+
+    /// Extracts `name="value"` / `name='value'` / `name=value` from an HTML tag's attribute
+    /// string or an HTTP Link-header parameter string. `\b` before `name` prevents matching
+    /// inside a longer attribute name (e.g. `data-rel=` must not match a lookup for `rel`).
+    private static func attributeValue(_ name: String, in source: String) -> String? {
+        guard let regex = try? NSRegularExpression(
+            pattern: "\\b\(name)\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s\"'>]+))",
+            options: [.caseInsensitive]
+        ) else { return nil }
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        guard let match = regex.firstMatch(in: source, range: range) else { return nil }
+        for groupIndex in [2, 3, 4] {
+            let group = match.range(at: groupIndex)
+            if group.location != NSNotFound, let r = Range(group, in: source) {
+                return String(source[r])
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/AnglesiteCore/WebmentionEndpointDiscovery.swift
+++ b/Sources/AnglesiteCore/WebmentionEndpointDiscovery.swift
@@ -26,8 +26,19 @@ public enum WebmentionEndpointDiscovery {
            let endpoint = endpoint(fromLinkHeader: linkHeader, relativeTo: finalURL) {
             return endpoint
         }
-        guard let html = String(data: data, encoding: .utf8) else { return nil }
+        guard let html = decodeHTML(data) else { return nil }
         return endpoint(fromHTML: html, relativeTo: finalURL)
+    }
+
+    /// Decodes the response body as text for markup scanning. Tries UTF-8 first (the HTML5-
+    /// mandated default), then falls back to ISO Latin-1 — which never fails, since every byte
+    /// maps to a valid Latin-1 codepoint — so a non-UTF-8 page (Latin-1/Windows-1252, no charset
+    /// declared) is never silently indistinguishable from "this page declares no endpoint." The
+    /// webmention tag/attribute syntax scanned for below is always plain ASCII, which decodes
+    /// identically under UTF-8 and Latin-1, so this fallback still finds real endpoints even when
+    /// it can't correctly render the surrounding prose.
+    private static func decodeHTML(_ data: Data) -> String? {
+        String(data: data, encoding: .utf8) ?? String(data: data, encoding: .isoLatin1)
     }
 
     // MARK: Link header
@@ -75,6 +86,14 @@ public enum WebmentionEndpointDiscovery {
 
     /// Matches `<link ...>` and `<a ...>` tags in document order; the first with a `webmention`
     /// rel wins, per the spec ("the first link or a element ... in document order").
+    ///
+    /// Known, accepted limitation: `[^>]*` truncates the tag at the first literal `>`, including
+    /// one embedded inside a quoted attribute value (e.g. `href="/x?a=1>2"`). A correct HTML
+    /// tokenizer would track quote state to know that `>` isn't a tag terminator there. This is a
+    /// conscious won't-fix, not an oversight — a literal, unencoded `>` inside an attribute value
+    /// is invalid per the URL spec (it must be percent-encoded as `%3E`) and vanishingly rare in
+    /// real-world markup; handling it would mean replacing this regex scan with a full tokenizer
+    /// for a case that essentially never occurs.
     private static let tagPattern: NSRegularExpression = {
         do {
             return try NSRegularExpression(pattern: #"<(?:link|a)\b([^>]*)>"#, options: [.caseInsensitive])

--- a/Sources/AnglesiteCore/WebmentionEndpointDiscovery.swift
+++ b/Sources/AnglesiteCore/WebmentionEndpointDiscovery.swift
@@ -112,13 +112,33 @@ public enum WebmentionEndpointDiscovery {
     }
 
     /// Extracts `name="value"` / `name='value'` / `name=value` from an HTML tag's attribute
-    /// string or an HTTP Link-header parameter string. `\b` before `name` prevents matching
-    /// inside a longer attribute name (e.g. `data-rel=` must not match a lookup for `rel`).
+    /// string or an HTTP Link-header parameter string. The lookahead-free anchor
+    /// `(?:^|[\s;<])` before `name` requires the name to start at the beginning of the source,
+    /// or be preceded by whitespace, a `;` (Link-header parameter separator), or `<` — so a
+    /// lookup for `rel` does not match inside a longer attribute name like `data-rel=`. (A
+    /// plain `\b` word-boundary anchor does *not* achieve this: `-` is a non-word character, so
+    /// `\brel\b` still matches the `rel` inside `data-rel=`.)
+    private static let relRegex = attributeRegex(for: "rel")
+    private static let hrefRegex = attributeRegex(for: "href")
+
+    private static func attributeRegex(for name: String) -> NSRegularExpression {
+        do {
+            return try NSRegularExpression(
+                pattern: "(?:^|[\\s;<])\(name)\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s\"'>]+))",
+                options: [.caseInsensitive]
+            )
+        } catch {
+            fatalError("Invalid webmention discovery attribute regex for \(name): \(error)")
+        }
+    }
+
     private static func attributeValue(_ name: String, in source: String) -> String? {
-        guard let regex = try? NSRegularExpression(
-            pattern: "\\b\(name)\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s\"'>]+))",
-            options: [.caseInsensitive]
-        ) else { return nil }
+        let regex: NSRegularExpression
+        switch name {
+        case "rel": regex = relRegex
+        case "href": regex = hrefRegex
+        default: regex = attributeRegex(for: name)
+        }
         let range = NSRange(source.startIndex..<source.endIndex, in: source)
         guard let match = regex.firstMatch(in: source, range: range) else { return nil }
         for groupIndex in [2, 3, 4] {

--- a/Sources/AnglesiteCore/WebmentionSendCommand.swift
+++ b/Sources/AnglesiteCore/WebmentionSendCommand.swift
@@ -1,0 +1,92 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Actor orchestrator for one site's webmention-send pass, run after a successful deploy.
+/// Builds the site's `SocialPublishPlan` (siteBase = the just-deployed URL), diffs it against the
+/// site's `WebmentionSentLog`, sends each pending pair, persists successes, and streams
+/// progress/results into `LogCenter` under source `"webmention:<siteID>"`. Best-effort — never
+/// throws; failures are logged, not surfaced as a thrown error, since this runs detached from the
+/// deploy result the user actually watches (`DeployModel.runDeploy`).
+public actor WebmentionSendCommand {
+    private let transport: WebmentionEndpointDiscovery.Transport
+    private let logCenter: LogCenter
+    private let now: () -> Date
+
+    public init(
+        transport: @escaping WebmentionEndpointDiscovery.Transport = WebmentionSendCommand.defaultTransport,
+        logCenter: LogCenter = .shared,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.transport = transport
+        self.logCenter = logCenter
+        self.now = now
+    }
+
+    public func send(siteID: String, siteDirectory: URL, configDirectory: URL, siteBase: URL) async {
+        let logSource = "webmention:\(siteID)"
+
+        let plan: SocialPublishPlan.Plan
+        do {
+            plan = try SocialPublishPlan.build(projectRoot: siteDirectory, siteBase: siteBase)
+        } catch {
+            await logCenter.append(
+                source: logSource, stream: .stderr,
+                text: "webmention: couldn't build publish plan: \(error)"
+            )
+            return
+        }
+        guard plan.webmentionCount > 0 else { return }
+
+        let log = WebmentionSentLog.load(from: configDirectory) ?? WebmentionSentLog()
+        let pending = log.pending(in: plan)
+        guard !pending.isEmpty else { return }
+
+        await logCenter.append(
+            source: logSource, stream: .stdout,
+            text: "webmention: sending \(pending.count) webmention(s)"
+        )
+
+        var sentPairs: [WebmentionTargetPair] = []
+        for pair in pending {
+            let outcome = await WebmentionSender.send(source: pair.source, target: pair.target, transport: transport)
+            switch outcome {
+            case .sent(let endpoint, let statusCode):
+                await logCenter.append(
+                    source: logSource, stream: .stdout,
+                    text: "webmention: sent \(pair.source.absoluteString) -> \(pair.target.absoluteString) via \(endpoint.absoluteString) (HTTP \(statusCode))"
+                )
+                sentPairs.append(pair)
+            case .noEndpointDiscovered:
+                await logCenter.append(
+                    source: logSource, stream: .stdout,
+                    text: "webmention: no endpoint declared by \(pair.target.absoluteString), skipping"
+                )
+            case .requestFailed(let reason):
+                await logCenter.append(
+                    source: logSource, stream: .stderr,
+                    text: "webmention: \(pair.source.absoluteString) -> \(pair.target.absoluteString) failed: \(reason)"
+                )
+            }
+        }
+
+        guard !sentPairs.isEmpty else { return }
+        let updated = log.recording(sentPairs, now: now)
+        do {
+            try updated.save(to: configDirectory)
+        } catch {
+            await logCenter.append(
+                source: logSource, stream: .stderr,
+                text: "webmention: couldn't persist sent log: \(error)"
+            )
+        }
+    }
+
+    /// Production transport: a plain `URLSession` request.
+    public static let defaultTransport: WebmentionEndpointDiscovery.Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+}

--- a/Sources/AnglesiteCore/WebmentionSendCommand.swift
+++ b/Sources/AnglesiteCore/WebmentionSendCommand.swift
@@ -107,6 +107,16 @@ public actor WebmentionSendCommand {
     }
 
     /// Production transport: a plain `URLSession` request.
+    ///
+    /// **Accepted risk (SSRF surface):** no check against loopback/link-local/private-range hosts
+    /// before either the discovery GET or the send POST. Target URLs come from the site's own
+    /// content (`SocialPublishPlan` parses outbound links from frontmatter and post bodies), so
+    /// anyone who can land a link in that content — a contributor, or in future an imported/
+    /// inbound post — can make the app fetch an internal address (e.g. `127.0.0.1`, a link-local
+    /// metadata endpoint). This is inherent to the webmention protocol (a sender always fetches
+    /// attacker-influenced target URLs) and is treated the same way here as any other outbound
+    /// link the site owner chooses to publish. If an untrusted/anonymous content source ever feeds
+    /// this pipeline without review, revisit with a private-range denylist before that lands.
     public static let defaultTransport: WebmentionEndpointDiscovery.Transport = { request in
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }

--- a/Sources/AnglesiteCore/WebmentionSendCommand.swift
+++ b/Sources/AnglesiteCore/WebmentionSendCommand.swift
@@ -13,6 +13,14 @@ public actor WebmentionSendCommand {
     private let transport: WebmentionEndpointDiscovery.Transport
     private let logCenter: LogCenter
     private let now: () -> Date
+    /// The latest `send()` call per `siteID`, so a new call for a site already in flight (e.g. a
+    /// quick redeploy before the prior webmention pass finished) chains after it instead of
+    /// racing it. Without this, two overlapping calls could both `WebmentionSentLog.load(...)`
+    /// before either `.save()`s — duplicate POSTs, and whichever save finishes last silently
+    /// drops the other call's newly-recorded entries. Never pruned: bounded by the number of
+    /// distinct sites this instance ever sends for, which is small (each entry is overwritten,
+    /// not appended, on every call for that site).
+    private var inFlight: [String: Task<Void, Never>] = [:]
 
     public init(
         transport: @escaping WebmentionEndpointDiscovery.Transport = WebmentionSendCommand.defaultTransport,
@@ -24,7 +32,22 @@ public actor WebmentionSendCommand {
         self.now = now
     }
 
+    /// Serializes per `siteID`: chains behind any still-running `send()` for the same site before
+    /// starting its own read-diff-send-persist pass, so `Config/webmention-sent.json` never has
+    /// two overlapping readers/writers for the same site. Different sites run fully in parallel.
     public func send(siteID: String, siteDirectory: URL, configDirectory: URL, siteBase: URL) async {
+        let previous = inFlight[siteID]
+        let task = Task<Void, Never> { [weak self] in
+            _ = await previous?.value
+            await self?.performSend(
+                siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: siteBase
+            )
+        }
+        inFlight[siteID] = task
+        await task.value
+    }
+
+    private func performSend(siteID: String, siteDirectory: URL, configDirectory: URL, siteBase: URL) async {
         let logSource = "webmention:\(siteID)"
 
         let plan: SocialPublishPlan.Plan

--- a/Sources/AnglesiteCore/WebmentionSender.swift
+++ b/Sources/AnglesiteCore/WebmentionSender.swift
@@ -1,0 +1,57 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Outcome of one webmention send attempt for a single (source, target) pair.
+public enum WebmentionSendOutcome: Equatable, Sendable {
+    case sent(endpoint: URL, statusCode: Int)
+    case noEndpointDiscovered
+    case requestFailed(reason: String)
+}
+
+/// Sends one Webmention: discovers `target`'s declared endpoint via `WebmentionEndpointDiscovery`,
+/// then POSTs `source`+`target` form-encoded per the webmention.org spec. No retry logic here —
+/// a caller that doesn't record a `.requestFailed` pair as sent gets a free retry on its next
+/// pass (see `WebmentionSendCommand`).
+public enum WebmentionSender {
+    public static func send(
+        source: URL,
+        target: URL,
+        transport: WebmentionEndpointDiscovery.Transport
+    ) async -> WebmentionSendOutcome {
+        let endpoint: URL?
+        do {
+            endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport)
+        } catch {
+            return .requestFailed(reason: "endpoint discovery failed: \(error)")
+        }
+        guard let endpoint else { return .noEndpointDiscovered }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let body = "source=\(formEncode(source.absoluteString))&target=\(formEncode(target.absoluteString))"
+        request.httpBody = Data(body.utf8)
+
+        let http: HTTPURLResponse
+        do {
+            (_, http) = try await transport(request)
+        } catch {
+            return .requestFailed(reason: "POST to \(endpoint.absoluteString) failed: \(error)")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            return .requestFailed(reason: "\(endpoint.absoluteString) returned HTTP \(http.statusCode)")
+        }
+        return .sent(endpoint: endpoint, statusCode: http.statusCode)
+    }
+
+    /// Percent-encodes everything but RFC 3986 unreserved characters, so a source/target URL's
+    /// own `:`, `/`, `?`, `&`, `=` can't be mistaken for the outer form body's delimiters.
+    private static func formEncode(_ value: String) -> String {
+        let unreserved = CharacterSet(
+            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+        )
+        return value.addingPercentEncoding(withAllowedCharacters: unreserved) ?? value
+    }
+}

--- a/Sources/AnglesiteCore/WebmentionSentLog.swift
+++ b/Sources/AnglesiteCore/WebmentionSentLog.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// A `(source, target)` webmention pair — the unit `WebmentionSentLog` tracks and
+/// `WebmentionSendCommand` sends.
+public struct WebmentionTargetPair: Equatable, Sendable {
+    public let source: URL
+    public let target: URL
+
+    public init(source: URL, target: URL) {
+        self.source = source
+        self.target = target
+    }
+}
+
+/// Per-site record of `(source, target)` webmention pairs already sent successfully, persisted at
+/// `Config/webmention-sent.json` — app-owned state, never committed to the site's git repo (same
+/// place as `DeployedRoutesSnapshot`'s `last-deployed-routes.json`). Lets `WebmentionSendCommand`
+/// skip pairs it already notified on a prior deploy, instead of re-pinging every target's
+/// endpoint on every redeploy.
+public struct WebmentionSentLog: Equatable, Sendable {
+    public struct Entry: Codable, Equatable, Sendable {
+        public let source: URL
+        public let target: URL
+        public let sentAt: Date
+
+        public init(source: URL, target: URL, sentAt: Date) {
+            self.source = source
+            self.target = target
+            self.sentAt = sentAt
+        }
+    }
+
+    public let sent: [Entry]
+
+    public init(sent: [Entry] = []) {
+        self.sent = sent
+    }
+
+    public static let filename = "webmention-sent.json"
+
+    private struct Envelope: Codable {
+        let sent: [Entry]
+    }
+
+    /// `nil` when the file is absent or unreadable — the normal "no prior sends yet" case.
+    public static func load(from configDirectory: URL) -> WebmentionSentLog? {
+        let url = configDirectory.appendingPathComponent(filename)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let envelope = try? decoder.decode(Envelope.self, from: data) else { return nil }
+        return WebmentionSentLog(sent: envelope.sent)
+    }
+
+    public func save(to configDirectory: URL) throws {
+        let url = configDirectory.appendingPathComponent(Self.filename)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(Envelope(sent: sent))
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// Pairs from `plan`'s entries not already recorded as sent.
+    public func pending(in plan: SocialPublishPlan.Plan) -> [WebmentionTargetPair] {
+        let sentKeys = Set(sent.map { pairKey(source: $0.source, target: $0.target) })
+        var result: [WebmentionTargetPair] = []
+        for entry in plan.entries {
+            for target in entry.webmentionTargets {
+                let key = pairKey(source: entry.canonicalURL, target: target)
+                if !sentKeys.contains(key) {
+                    result.append(WebmentionTargetPair(source: entry.canonicalURL, target: target))
+                }
+            }
+        }
+        return result
+    }
+
+    /// A new log with `pairs` appended, all stamped with the same `now()` timestamp.
+    public func recording(
+        _ pairs: [WebmentionTargetPair],
+        now: @escaping () -> Date = Date.init
+    ) -> WebmentionSentLog {
+        let timestamp = now()
+        let newEntries = pairs.map { Entry(source: $0.source, target: $0.target, sentAt: timestamp) }
+        return WebmentionSentLog(sent: sent + newEntries)
+    }
+
+    private func pairKey(source: URL, target: URL) -> String {
+        "\(source.absoluteString)\n\(target.absoluteString)"
+    }
+}

--- a/Tests/AnglesiteCoreTests/WebmentionEndpointDiscoveryTests.swift
+++ b/Tests/AnglesiteCoreTests/WebmentionEndpointDiscoveryTests.swift
@@ -106,6 +106,29 @@ struct WebmentionEndpointDiscoveryTests {
         #expect(endpoint?.absoluteString == "https://target.example/webmention")
     }
 
+    @Test("Link header endpoint resolved relative to the redirected response URL")
+    func linkHeaderRelativeAfterRedirect() async throws {
+        let redirected = URL(string: "https://target.example/moved/post")!
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(
+                headers: ["Link": "<../webmention>; rel=\"webmention\""],
+                responseURL: redirected
+            )
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/webmention")
+    }
+
+    @Test("HTML: a data-rel decoy attribute does not shadow a later real rel=webmention element")
+    func htmlDataRelDecoyDoesNotMatch() async throws {
+        let html = """
+        <a data-rel="webmention" href="/decoy">wrong</a>
+        <a href="/correct" rel="webmention">right</a>
+        """
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport(html: html))
+        #expect(endpoint?.absoluteString == "https://target.example/correct")
+    }
+
     @Test("no endpoint declared returns nil")
     func noEndpoint() async throws {
         let html = "<html><body>No webmention here. <a href=\"/other\" rel=\"nofollow\">link</a></body></html>"

--- a/Tests/AnglesiteCoreTests/WebmentionEndpointDiscoveryTests.swift
+++ b/Tests/AnglesiteCoreTests/WebmentionEndpointDiscoveryTests.swift
@@ -129,6 +129,28 @@ struct WebmentionEndpointDiscoveryTests {
         #expect(endpoint?.absoluteString == "https://target.example/correct")
     }
 
+    @Test("a non-UTF-8 (Latin-1) page still discovers a real endpoint via the ISO Latin-1 fallback")
+    func nonUTF8PageFallsBackToLatin1() async throws {
+        // 0xE9 is Latin-1 "é" but is not valid as a lone UTF-8 byte (it signals a 3-byte UTF-8
+        // lead byte with no continuation bytes following) — String(data:encoding:.utf8) returns
+        // nil for this whole body, which without a fallback would look identical to "this page
+        // declares no endpoint," even though the ASCII markup after the prose is perfectly valid.
+        var bytes = Array("<p>Caf".utf8)
+        bytes.append(0xE9)
+        bytes.append(contentsOf: Array(
+            "</p><link href=\"https://target.example/wm-latin1\" rel=\"webmention\">".utf8
+        ))
+        let body = Data(bytes)
+        #expect(String(data: body, encoding: .utf8) == nil) // sanity: this body really isn't valid UTF-8
+
+        let nonUTF8Transport: WebmentionEndpointDiscovery.Transport = { _ in
+            let http = HTTPURLResponse(url: self.target, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (body, http)
+        }
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: nonUTF8Transport)
+        #expect(endpoint?.absoluteString == "https://target.example/wm-latin1")
+    }
+
     @Test("no endpoint declared returns nil")
     func noEndpoint() async throws {
         let html = "<html><body>No webmention here. <a href=\"/other\" rel=\"nofollow\">link</a></body></html>"

--- a/Tests/AnglesiteCoreTests/WebmentionEndpointDiscoveryTests.swift
+++ b/Tests/AnglesiteCoreTests/WebmentionEndpointDiscoveryTests.swift
@@ -1,0 +1,115 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WebmentionEndpointDiscovery")
+struct WebmentionEndpointDiscoveryTests {
+    private let target = URL(string: "https://target.example/post")!
+
+    private func transport(
+        status: Int = 200,
+        headers: [String: String] = [:],
+        html: String = "",
+        responseURL: URL? = nil
+    ) -> WebmentionEndpointDiscovery.Transport {
+        let url = responseURL ?? target
+        return { _ in
+            let http = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: headers)!
+            return (Data(html.utf8), http)
+        }
+    }
+
+    @Test("discovers via a simple Link header")
+    func linkHeaderSimple() async throws {
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(headers: ["Link": "<https://target.example/webmention>; rel=\"webmention\""])
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/webmention")
+    }
+
+    @Test("Link header: webmention rel among multiple link-values")
+    func linkHeaderMultipleValues() async throws {
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(headers: [
+                "Link": "<https://target.example/pgp>; rel=\"pgp-key\", <https://target.example/wm>; rel=\"webmention\"",
+            ])
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/wm")
+    }
+
+    @Test("Link header: unquoted rel value")
+    func linkHeaderUnquotedRel() async throws {
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(headers: ["Link": "</test/1/webmention?head=true>; rel=webmention"])
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/test/1/webmention?head=true")
+    }
+
+    @Test("Link header: legacy rel=\"http://webmention.org/\" form")
+    func linkHeaderLegacyRel() async throws {
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(headers: ["Link": "<https://target.example/wm>; rel=\"http://webmention.org/\""])
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/wm")
+    }
+
+    @Test("Link header endpoint relative to the response URL")
+    func linkHeaderRelative() async throws {
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(headers: ["Link": "</webmention-endpoint>; rel=\"webmention\""])
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/webmention-endpoint")
+    }
+
+    @Test("falls back to an HTML <link rel=webmention> element")
+    func htmlLinkElement() async throws {
+        let html = """
+        <html><head><link rel="stylesheet" href="/style.css">
+        <link href="https://target.example/wm-html" rel="webmention"></head></html>
+        """
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport(html: html))
+        #expect(endpoint?.absoluteString == "https://target.example/wm-html")
+    }
+
+    @Test("falls back to an HTML <a rel=webmention> element")
+    func htmlAnchorElement() async throws {
+        let html = """
+        <html><body><a href="https://target.example/wm-a" rel="webmention">webmention</a></body></html>
+        """
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport(html: html))
+        #expect(endpoint?.absoluteString == "https://target.example/wm-a")
+    }
+
+    @Test("HTML: first webmention element in document order wins")
+    func htmlDocumentOrder() async throws {
+        let html = """
+        <html><head><link rel="webmention" href="https://target.example/first"></head>
+        <body><a href="https://target.example/second" rel="webmention">webmention</a></body></html>
+        """
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport(html: html))
+        #expect(endpoint?.absoluteString == "https://target.example/first")
+    }
+
+    @Test("HTML endpoint resolved relative to the redirected response URL")
+    func htmlRelativeAfterRedirect() async throws {
+        let redirected = URL(string: "https://target.example/moved/post")!
+        let html = "<link rel=\"webmention\" href=\"../webmention\">"
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(html: html, responseURL: redirected)
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/webmention")
+    }
+
+    @Test("no endpoint declared returns nil")
+    func noEndpoint() async throws {
+        let html = "<html><body>No webmention here. <a href=\"/other\" rel=\"nofollow\">link</a></body></html>"
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport(html: html))
+        #expect(endpoint == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/WebmentionRocksLiveTests.swift
+++ b/Tests/AnglesiteCoreTests/WebmentionRocksLiveTests.swift
@@ -1,0 +1,65 @@
+// Real-network integration test against webmention.rocks — gated behind ANGLESITE_WEBMENTION_E2E
+// so CI and everyday `swift test` runs never depend on a third-party site's availability.
+// Exercises WebmentionEndpointDiscovery's Link-header/HTML/redirect logic against real markup,
+// using webmention.rocks' own documented test pages (https://webmention.rocks/about).
+//
+// Run locally with:
+//   ANGLESITE_WEBMENTION_E2E=1 swift test --filter WebmentionRocksLiveTests
+//
+// Discovery-only, not POST-acceptance: webmention.rocks validates (RFC 7565 source verification)
+// that the source document actually links back to the target before accepting a webmention, so
+// an automated test using a synthetic source URL can never get a POST accepted — that requires
+// visiting their site and using a session-specific source-URL token they crawl back to verify,
+// an interactive, one-time manual step (see the PR description), not something this automated
+// test attempts. This test only confirms discovery against real pages, as ongoing regression
+// coverage for the parsing logic.
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("Webmention send against webmention.rocks (live)")
+struct WebmentionRocksLiveTests {
+    private static var liveTestsEnabled: Bool {
+        ProcessInfo.processInfo.environment["ANGLESITE_WEBMENTION_E2E"] == "1"
+    }
+
+    private let transport: WebmentionEndpointDiscovery.Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+
+    @Test(
+        "test 1 (HTTP Link header) discovers a real endpoint",
+        .enabled(if: liveTestsEnabled, "hits the real webmention.rocks — set ANGLESITE_WEBMENTION_E2E=1 to opt in")
+    )
+    func linkHeaderTestPage() async throws {
+        let target = URL(string: "https://webmention.rocks/test/1")!
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport)
+        // Discovery-only: webmention.rocks validates (RFC 7565 source verification) that the
+        // source document actually links back to the target before accepting a POST, so a
+        // synthetic source URL always gets HTTP 400 regardless of wire-format correctness.
+        // POST-acceptance is exercised by the separate manual acceptance step instead.
+        #expect(endpoint != nil)
+    }
+
+    @Test(
+        "test 4 (HTML <link> tag, absolute URL) discovers a real endpoint",
+        .enabled(if: liveTestsEnabled, "hits the real webmention.rocks — set ANGLESITE_WEBMENTION_E2E=1 to opt in")
+    )
+    func htmlLinkElementTestPage() async throws {
+        let target = URL(string: "https://webmention.rocks/test/4")!
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport)
+        #expect(endpoint?.absoluteString == "https://webmention.rocks/test/4/webmention")
+    }
+
+    @Test(
+        "test 23 (redirect target, relative endpoint) discovers a real endpoint via the post-redirect URL",
+        .enabled(if: liveTestsEnabled, "hits the real webmention.rocks — set ANGLESITE_WEBMENTION_E2E=1 to opt in")
+    )
+    func redirectTestPage() async throws {
+        let target = URL(string: "https://webmention.rocks/test/23/page")!
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport)
+        #expect(endpoint != nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/WebmentionSendCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/WebmentionSendCommandTests.swift
@@ -1,0 +1,141 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WebmentionSendCommand")
+struct WebmentionSendCommandTests {
+    private func makeSite() throws -> (root: URL, siteDirectory: URL, configDirectory: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("webmention-send-command-\(UUID().uuidString)", isDirectory: true)
+        let siteDirectory = root.appendingPathComponent("Source", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        let post = siteDirectory.appendingPathComponent("src/content/posts/hello.md")
+        try FileManager.default.createDirectory(at: post.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("""
+        ---
+        publishDate: 2026-06-29
+        ---
+        Links to https://one.example/target and https://two.example/target.
+        """.utf8).write(to: post)
+        return (root, siteDirectory, configDirectory)
+    }
+
+    /// A transport that reports every target's endpoint as `<target>/webmention`, and accepts
+    /// every POST with 202 unless the endpoint's target is listed in `failing`.
+    private func transport(failing: Set<String> = []) -> WebmentionEndpointDiscovery.Transport {
+        { request in
+            let url = request.url!
+            if request.httpMethod == "POST" {
+                // `deletingLastPathComponent()` always returns a directory-style URL (trailing
+                // slash), even though `failing`'s entries are plain target strings with none —
+                // strip it before comparing so a POST to <target>/webmention is correctly
+                // recognized as belonging to `target`.
+                var targetForEndpoint = url.deletingLastPathComponent().absoluteString
+                if targetForEndpoint.hasSuffix("/") { targetForEndpoint.removeLast() }
+                let status = failing.contains(targetForEndpoint) ? 500 : 202
+                return (Data(), HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!)
+            }
+            let endpoint = url.appendingPathComponent("webmention")
+            let http = HTTPURLResponse(
+                url: url, statusCode: 200, httpVersion: nil,
+                headerFields: ["Link": "<\(endpoint.absoluteString)>; rel=\"webmention\""]
+            )!
+            return (Data(), http)
+        }
+    }
+
+    private actor Counter {
+        private(set) var value = 0
+        func increment() { value += 1 }
+    }
+
+    @Test("sends every pending target and persists them to the sent log")
+    func sendsAndPersists() async throws {
+        let (root, siteDirectory, configDirectory) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let logCenter = LogCenter()
+        let command = WebmentionSendCommand(
+            transport: transport(),
+            logCenter: logCenter,
+            now: { Date(timeIntervalSince1970: 1_782_777_600) }
+        )
+
+        await command.send(
+            siteID: "site1",
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            siteBase: URL(string: "https://mysite.test")!
+        )
+
+        let log = WebmentionSentLog.load(from: configDirectory)
+        #expect(log?.sent.count == 2)
+        #expect(Set(log?.sent.map(\.target.absoluteString) ?? []) == [
+            "https://one.example/target", "https://two.example/target",
+        ])
+
+        let lines = await logCenter.snapshot()
+        #expect(lines.contains { $0.source == "webmention:site1" && $0.text.contains("sending 2 webmention") })
+        #expect(lines.filter { $0.source == "webmention:site1" && $0.text.contains("sent ") }.count == 2)
+    }
+
+    @Test("a second run does not resend already-sent pairs")
+    func skipsAlreadySentPairs() async throws {
+        let (root, siteDirectory, configDirectory) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let counter = Counter()
+        let baseTransport = transport()
+        let counting: WebmentionEndpointDiscovery.Transport = { request in
+            if request.httpMethod == "POST" { await counter.increment() }
+            return try await baseTransport(request)
+        }
+        let command = WebmentionSendCommand(transport: counting, logCenter: LogCenter())
+        let siteBase = URL(string: "https://mysite.test")!
+
+        await command.send(siteID: "site1", siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: siteBase)
+        var count = await counter.value
+        #expect(count == 2)
+
+        await command.send(siteID: "site1", siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: siteBase)
+        count = await counter.value
+        #expect(count == 2) // no new POSTs on the second run
+    }
+
+    @Test("a failed send is not persisted, so it's retried on the next run")
+    func failedSendIsRetried() async throws {
+        let (root, siteDirectory, configDirectory) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let command = WebmentionSendCommand(
+            transport: transport(failing: ["https://one.example/target"]),
+            logCenter: LogCenter()
+        )
+
+        await command.send(
+            siteID: "site1", siteDirectory: siteDirectory, configDirectory: configDirectory,
+            siteBase: URL(string: "https://mysite.test")!
+        )
+
+        let log = WebmentionSentLog.load(from: configDirectory)
+        #expect(log?.sent.map(\.target.absoluteString) == ["https://two.example/target"])
+    }
+
+    @Test("a site with no outbound links sends nothing and writes no log")
+    func noPlanEntriesIsANoop() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("webmention-empty-\(UUID().uuidString)", isDirectory: true)
+        let siteDirectory = root.appendingPathComponent("Source", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: siteDirectory.appendingPathComponent("src/content"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let command = WebmentionSendCommand(transport: transport(), logCenter: LogCenter())
+        await command.send(
+            siteID: "site1", siteDirectory: siteDirectory, configDirectory: configDirectory,
+            siteBase: URL(string: "https://mysite.test")!
+        )
+
+        #expect(WebmentionSentLog.load(from: configDirectory) == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/WebmentionSendCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/WebmentionSendCommandTests.swift
@@ -102,6 +102,38 @@ struct WebmentionSendCommandTests {
         #expect(count == 2) // no new POSTs on the second run
     }
 
+    @Test("overlapping send() calls for the same site are serialized, not raced")
+    func overlappingSendsAreSerialized() async throws {
+        let (root, siteDirectory, configDirectory) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let counter = Counter()
+        let baseTransport = transport()
+        let counting: WebmentionEndpointDiscovery.Transport = { request in
+            if request.httpMethod == "POST" { await counter.increment() }
+            return try await baseTransport(request)
+        }
+        let command = WebmentionSendCommand(transport: counting, logCenter: LogCenter())
+        let siteBase = URL(string: "https://mysite.test")!
+
+        // Both calls target the same siteID/content — fired without awaiting either individually,
+        // so they genuinely overlap on the actor. Without per-site serialization, both would read
+        // the sent-log before either saved it, double-POSTing every pending target.
+        async let first: Void = command.send(
+            siteID: "site1", siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: siteBase
+        )
+        async let second: Void = command.send(
+            siteID: "site1", siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: siteBase
+        )
+        _ = await (first, second)
+
+        let postCount = await counter.value
+        #expect(postCount == 2) // serialized: the second call sees the first's persisted results, sends nothing new
+
+        let log = WebmentionSentLog.load(from: configDirectory)
+        #expect(log?.sent.count == 2)
+    }
+
     @Test("a failed send is not persisted, so it's retried on the next run")
     func failedSendIsRetried() async throws {
         let (root, siteDirectory, configDirectory) = try makeSite()

--- a/Tests/AnglesiteCoreTests/WebmentionSenderTests.swift
+++ b/Tests/AnglesiteCoreTests/WebmentionSenderTests.swift
@@ -1,0 +1,88 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WebmentionSender")
+struct WebmentionSenderTests {
+    private let source = URL(string: "https://mysite.test/posts/hello/")!
+    private let target = URL(string: "https://target.example/post")!
+    private let endpoint = URL(string: "https://target.example/webmention")!
+
+    private actor CallRecorder {
+        private(set) var requests: [URLRequest] = []
+        func record(_ request: URLRequest) { requests.append(request) }
+    }
+
+    @Test("discovers the endpoint and POSTs source+target, reporting the status code")
+    func successfulSend() async throws {
+        let recorder = CallRecorder()
+        let endpointURL = endpoint
+        let targetURL = target
+        let outcome = await WebmentionSender.send(source: source, target: target, transport: { request in
+            await recorder.record(request)
+            if request.httpMethod == "POST" {
+                let http = HTTPURLResponse(url: endpointURL, statusCode: 202, httpVersion: nil, headerFields: nil)!
+                return (Data(), http)
+            }
+            let http = HTTPURLResponse(
+                url: targetURL, statusCode: 200, httpVersion: nil,
+                headerFields: ["Link": "<\(endpointURL.absoluteString)>; rel=\"webmention\""]
+            )!
+            return (Data(), http)
+        })
+
+        #expect(outcome == .sent(endpoint: endpoint, statusCode: 202))
+        let requests = await recorder.requests
+        #expect(requests.count == 2)
+        #expect(requests[1].httpMethod == "POST")
+        #expect(requests[1].url == endpoint)
+        #expect(requests[1].value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+        let body = String(data: requests[1].httpBody ?? Data(), encoding: .utf8)
+        #expect(body == "source=https%3A%2F%2Fmysite.test%2Fposts%2Fhello%2F&target=https%3A%2F%2Ftarget.example%2Fpost")
+    }
+
+    @Test("no discovered endpoint sends no POST")
+    func noEndpointSendsNothing() async throws {
+        let recorder = CallRecorder()
+        let targetURL = target
+        let outcome = await WebmentionSender.send(source: source, target: target, transport: { request in
+            await recorder.record(request)
+            let http = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (Data("<html>no endpoint</html>".utf8), http)
+        })
+        #expect(outcome == .noEndpointDiscovered)
+        let requests = await recorder.requests
+        #expect(requests.count == 1) // only the discovery GET, no POST
+    }
+
+    @Test("a non-2xx endpoint response maps to .requestFailed")
+    func failedPost() async throws {
+        let endpointURL = endpoint
+        let targetURL = target
+        let outcome = await WebmentionSender.send(source: source, target: target, transport: { request in
+            if request.httpMethod == "POST" {
+                let http = HTTPURLResponse(url: endpointURL, statusCode: 400, httpVersion: nil, headerFields: nil)!
+                return (Data(), http)
+            }
+            let http = HTTPURLResponse(
+                url: targetURL, statusCode: 200, httpVersion: nil,
+                headerFields: ["Link": "<\(endpointURL.absoluteString)>; rel=\"webmention\""]
+            )!
+            return (Data(), http)
+        })
+        guard case .requestFailed = outcome else {
+            Issue.record("expected .requestFailed, got \(outcome)")
+            return
+        }
+    }
+
+    @Test("a discovery-phase network error maps to .requestFailed")
+    func discoveryThrows() async throws {
+        struct Boom: Error {}
+        let outcome = await WebmentionSender.send(source: source, target: target, transport: { _ in throw Boom() })
+        guard case .requestFailed = outcome else {
+            Issue.record("expected .requestFailed, got \(outcome)")
+            return
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/WebmentionSentLogTests.swift
+++ b/Tests/AnglesiteCoreTests/WebmentionSentLogTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WebmentionSentLog")
+struct WebmentionSentLogTests {
+    private func tempConfigDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WebmentionSentLogTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private let source1 = URL(string: "https://mysite.test/posts/a/")!
+    private let source2 = URL(string: "https://mysite.test/posts/b/")!
+    private let target1 = URL(string: "https://target.example/1")!
+    private let target2 = URL(string: "https://target.example/2")!
+
+    @Test("load on a missing file returns nil")
+    func loadMissingReturnsNil() throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(WebmentionSentLog.load(from: dir) == nil)
+    }
+
+    @Test("save then load round-trips entries")
+    func saveLoadRoundTrips() throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sentAt = Date(timeIntervalSince1970: 1_782_777_600) // 2026-06-30T00:00:00Z
+        let log = WebmentionSentLog(sent: [.init(source: source1, target: target1, sentAt: sentAt)])
+        try log.save(to: dir)
+        #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("webmention-sent.json").path))
+        #expect(WebmentionSentLog.load(from: dir) == log)
+    }
+
+    @Test("pending(in:) excludes already-sent pairs and includes new ones")
+    func pendingExcludesSentPairs() throws {
+        let log = WebmentionSentLog(sent: [
+            .init(source: source1, target: target1, sentAt: Date(timeIntervalSince1970: 0)),
+        ])
+        let plan = SocialPublishPlan.Plan(entries: [
+            .init(sourceFile: "a.md", canonicalURL: source1, webmentionTargets: [target1, target2], posseTargets: []),
+            .init(sourceFile: "b.md", canonicalURL: source2, webmentionTargets: [target1], posseTargets: []),
+        ])
+        let pending = log.pending(in: plan)
+        #expect(pending == [
+            WebmentionTargetPair(source: source1, target: target2),
+            WebmentionTargetPair(source: source2, target: target1),
+        ])
+    }
+
+    @Test("recording(_:now:) appends new entries stamped with the given time")
+    func recordingAppendsEntries() throws {
+        let stamp = Date(timeIntervalSince1970: 1_782_777_600)
+        let log = WebmentionSentLog()
+        let updated = log.recording([WebmentionTargetPair(source: source1, target: target1)], now: { stamp })
+        #expect(updated.sent == [.init(source: source1, target: target1, sentAt: stamp)])
+        #expect(log.sent.isEmpty) // original is untouched — recording() returns a new value
+    }
+}

--- a/docs/superpowers/plans/2026-07-14-webmention-send.md
+++ b/docs/superpowers/plans/2026-07-14-webmention-send.md
@@ -1,0 +1,1302 @@
+# Webmention Send on Publish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Send webmentions for a site's outbound links automatically after every successful deploy, without depending on the still-unpublished `@dwk/workers` package.
+
+**Architecture:** Four new pure/testable types in `AnglesiteCore` — `WebmentionEndpointDiscovery` (fetch + parse a target's declared endpoint), `WebmentionSender` (discover + POST one pair), `WebmentionSentLog` (per-site `Config/webmention-sent.json` persistence + pending-pair diff), `WebmentionSendCommand` (actor orchestrator tying the above to the existing `SocialPublishPlan`) — wired into `DeployModel.runDeploy`'s `.succeeded` case as a fire-and-forget background task.
+
+**Tech Stack:** Swift 6 / Foundation only (`URLSession`, `NSRegularExpression`) — no new package dependencies, matching CLAUDE.md's "no frameworks beyond Apple's" rule. Swift Testing (`@Suite`/`@Test`/`#expect`), matching the rest of `AnglesiteCoreTests`.
+
+## Global Constraints
+
+- No new SwiftPM dependencies — hand-roll HTML/Link-header parsing with `NSRegularExpression`, matching `SocialPublishPlan.swift`'s existing style.
+- All networking goes through an injectable `@Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)` closure (named `Transport`), matching `CloudflareAPITokenVerifier.Transport` exactly — no real network calls in the unit test suite.
+- Every file that imports `URLSession`/`URLRequest`/`HTTPURLResponse` must guard the Linux import: `#if canImport(FoundationNetworking)\nimport FoundationNetworking\n#endif` (see `HTTPTransport.swift`, `CloudflareAPITokenVerifier.swift`).
+- `Config/webmention-sent.json` is app-owned, per-site state — never write it anywhere but the `configDirectory` passed in, and never add it to the site's git repo.
+- A failed send must never be recorded as sent, so it is retried automatically on the next deploy — no separate retry/backoff logic.
+- The webmention send pass must never affect deploy success/failure or block the `.succeeded` phase transition users see.
+- Full spec: [`docs/superpowers/specs/2026-07-14-webmention-send-design.md`](../specs/2026-07-14-webmention-send-design.md).
+
+---
+
+### Task 1: `WebmentionEndpointDiscovery`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/WebmentionEndpointDiscovery.swift`
+- Test: `Tests/AnglesiteCoreTests/WebmentionEndpointDiscoveryTests.swift`
+
+**Interfaces:**
+- Produces: `WebmentionEndpointDiscovery.Transport` (`public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)`), `WebmentionEndpointDiscovery.discover(target: URL, transport: Transport) async throws -> URL?`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/WebmentionEndpointDiscoveryTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WebmentionEndpointDiscovery")
+struct WebmentionEndpointDiscoveryTests {
+    private let target = URL(string: "https://target.example/post")!
+
+    private func transport(
+        status: Int = 200,
+        headers: [String: String] = [:],
+        html: String = "",
+        responseURL: URL? = nil
+    ) -> WebmentionEndpointDiscovery.Transport {
+        let url = responseURL ?? target
+        return { _ in
+            let http = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: headers)!
+            return (Data(html.utf8), http)
+        }
+    }
+
+    @Test("discovers via a simple Link header")
+    func linkHeaderSimple() async throws {
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(headers: ["Link": "<https://target.example/webmention>; rel=\"webmention\""])
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/webmention")
+    }
+
+    @Test("Link header: webmention rel among multiple link-values")
+    func linkHeaderMultipleValues() async throws {
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(headers: [
+                "Link": "<https://target.example/pgp>; rel=\"pgp-key\", <https://target.example/wm>; rel=\"webmention\"",
+            ])
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/wm")
+    }
+
+    @Test("Link header: unquoted rel value")
+    func linkHeaderUnquotedRel() async throws {
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(headers: ["Link": "</test/1/webmention?head=true>; rel=webmention"])
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/test/1/webmention?head=true")
+    }
+
+    @Test("Link header: legacy rel=\"http://webmention.org/\" form")
+    func linkHeaderLegacyRel() async throws {
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(headers: ["Link": "<https://target.example/wm>; rel=\"http://webmention.org/\""])
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/wm")
+    }
+
+    @Test("Link header endpoint relative to the response URL")
+    func linkHeaderRelative() async throws {
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(headers: ["Link": "</webmention-endpoint>; rel=\"webmention\""])
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/webmention-endpoint")
+    }
+
+    @Test("falls back to an HTML <link rel=webmention> element")
+    func htmlLinkElement() async throws {
+        let html = """
+        <html><head><link rel="stylesheet" href="/style.css">
+        <link href="https://target.example/wm-html" rel="webmention"></head></html>
+        """
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport(html: html))
+        #expect(endpoint?.absoluteString == "https://target.example/wm-html")
+    }
+
+    @Test("falls back to an HTML <a rel=webmention> element")
+    func htmlAnchorElement() async throws {
+        let html = """
+        <html><body><a href="https://target.example/wm-a" rel="webmention">webmention</a></body></html>
+        """
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport(html: html))
+        #expect(endpoint?.absoluteString == "https://target.example/wm-a")
+    }
+
+    @Test("HTML: first webmention element in document order wins")
+    func htmlDocumentOrder() async throws {
+        let html = """
+        <html><head><link rel="webmention" href="https://target.example/first"></head>
+        <body><a href="https://target.example/second" rel="webmention">webmention</a></body></html>
+        """
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport(html: html))
+        #expect(endpoint?.absoluteString == "https://target.example/first")
+    }
+
+    @Test("HTML endpoint resolved relative to the redirected response URL")
+    func htmlRelativeAfterRedirect() async throws {
+        let redirected = URL(string: "https://target.example/moved/post")!
+        let html = "<link rel=\"webmention\" href=\"../webmention\">"
+        let endpoint = try await WebmentionEndpointDiscovery.discover(
+            target: target,
+            transport: transport(html: html, responseURL: redirected)
+        )
+        #expect(endpoint?.absoluteString == "https://target.example/webmention")
+    }
+
+    @Test("no endpoint declared returns nil")
+    func noEndpoint() async throws {
+        let html = "<html><body>No webmention here. <a href=\"/other\" rel=\"nofollow\">link</a></body></html>"
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport(html: html))
+        #expect(endpoint == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter WebmentionEndpointDiscoveryTests`
+Expected: FAIL to compile — `WebmentionEndpointDiscovery` does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/WebmentionEndpointDiscovery.swift`:
+
+```swift
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Discovers a target URL's declared Webmention receiver endpoint per the webmention.org spec:
+/// fetch the target once, prefer an HTTP `Link` header with `rel=webmention` (or the legacy
+/// `rel="http://webmention.org/"` form), falling back to the first `<link>` or `<a>` element (in
+/// document order) with `rel=webmention` in the HTML body. A relative endpoint URL is resolved
+/// against the *final* response URL (after redirects), not the originally-requested target —
+/// required for pages like webmention.rocks' redirect test.
+public enum WebmentionEndpointDiscovery {
+    /// Performs one HTTP request and returns its body + response. Throws on connection failure.
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    /// `nil` means the target declares no Webmention endpoint — not an error condition.
+    public static func discover(target: URL, transport: Transport) async throws -> URL? {
+        var request = URLRequest(url: target)
+        request.setValue("text/html", forHTTPHeaderField: "Accept")
+        let (data, http) = try await transport(request)
+        let finalURL = http.url ?? target
+
+        if let linkHeader = http.value(forHTTPHeaderField: "Link"),
+           let endpoint = endpoint(fromLinkHeader: linkHeader, relativeTo: finalURL) {
+            return endpoint
+        }
+        guard let html = String(data: data, encoding: .utf8) else { return nil }
+        return endpoint(fromHTML: html, relativeTo: finalURL)
+    }
+
+    // MARK: Link header
+
+    static func endpoint(fromLinkHeader header: String, relativeTo baseURL: URL) -> URL? {
+        for value in splitLinkHeaderValues(header) {
+            guard let start = value.firstIndex(of: "<"),
+                  let end = value.firstIndex(of: ">"),
+                  start < end
+            else { continue }
+            let urlString = String(value[value.index(after: start)..<end])
+            let params = String(value[value.index(after: end)...])
+            guard let rel = attributeValue("rel", in: params), isWebmentionRel(rel) else { continue }
+            return URL(string: urlString, relativeTo: baseURL)?.absoluteURL
+        }
+        return nil
+    }
+
+    /// Splits a `Link` header on top-level commas — commas inside `<...>` (the URL itself) don't
+    /// separate link-values.
+    private static func splitLinkHeaderValues(_ header: String) -> [String] {
+        var values: [String] = []
+        var depth = 0
+        var current = ""
+        for char in header {
+            switch char {
+            case "<":
+                depth += 1
+                current.append(char)
+            case ">":
+                depth -= 1
+                current.append(char)
+            case "," where depth == 0:
+                values.append(current)
+                current = ""
+            default:
+                current.append(char)
+            }
+        }
+        if !current.trimmingCharacters(in: .whitespaces).isEmpty { values.append(current) }
+        return values
+    }
+
+    // MARK: HTML
+
+    /// Matches `<link ...>` and `<a ...>` tags in document order; the first with a `webmention`
+    /// rel wins, per the spec ("the first link or a element ... in document order").
+    private static let tagPattern: NSRegularExpression = {
+        do {
+            return try NSRegularExpression(pattern: #"<(?:link|a)\b([^>]*)>"#, options: [.caseInsensitive])
+        } catch {
+            fatalError("Invalid webmention discovery tag regex: \(error)")
+        }
+    }()
+
+    static func endpoint(fromHTML html: String, relativeTo baseURL: URL) -> URL? {
+        let range = NSRange(html.startIndex..<html.endIndex, in: html)
+        for match in tagPattern.matches(in: html, range: range) {
+            guard let attrsRange = Range(match.range(at: 1), in: html) else { continue }
+            let attrs = String(html[attrsRange])
+            guard let rel = attributeValue("rel", in: attrs), isWebmentionRel(rel) else { continue }
+            guard let href = attributeValue("href", in: attrs) else { continue }
+            if let url = URL(string: href, relativeTo: baseURL)?.absoluteURL {
+                return url
+            }
+        }
+        return nil
+    }
+
+    // MARK: Shared attribute/rel helpers
+
+    private static let legacyWebmentionRels: Set<String> = [
+        "http://webmention.org/", "https://webmention.org/",
+        "http://webmention.org", "https://webmention.org",
+    ]
+
+    private static func isWebmentionRel(_ rel: String) -> Bool {
+        rel.split(whereSeparator: { $0.isWhitespace }).contains { token in
+            token.caseInsensitiveCompare("webmention") == .orderedSame
+                || legacyWebmentionRels.contains(String(token).lowercased())
+        }
+    }
+
+    /// Extracts `name="value"` / `name='value'` / `name=value` from an HTML tag's attribute
+    /// string or an HTTP Link-header parameter string. `\b` before `name` prevents matching
+    /// inside a longer attribute name (e.g. `data-rel=` must not match a lookup for `rel`).
+    private static func attributeValue(_ name: String, in source: String) -> String? {
+        guard let regex = try? NSRegularExpression(
+            pattern: "\\b\(name)\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s\"'>]+))",
+            options: [.caseInsensitive]
+        ) else { return nil }
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        guard let match = regex.firstMatch(in: source, range: range) else { return nil }
+        for groupIndex in [2, 3, 4] {
+            let group = match.range(at: groupIndex)
+            if group.location != NSNotFound, let r = Range(group, in: source) {
+                return String(source[r])
+            }
+        }
+        return nil
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --filter WebmentionEndpointDiscoveryTests`
+Expected: PASS (all 10 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WebmentionEndpointDiscovery.swift Tests/AnglesiteCoreTests/WebmentionEndpointDiscoveryTests.swift
+git commit -m "$(cat <<'EOF'
+Add WebmentionEndpointDiscovery for #354
+
+Discovers a target URL's declared Webmention endpoint via HTTP Link
+header or HTML <link>/<a rel=webmention>, per the webmention.org spec.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: `WebmentionSender`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/WebmentionSender.swift`
+- Test: `Tests/AnglesiteCoreTests/WebmentionSenderTests.swift`
+
+**Interfaces:**
+- Consumes: `WebmentionEndpointDiscovery.Transport`, `WebmentionEndpointDiscovery.discover(target:transport:)` (Task 1).
+- Produces: `WebmentionSendOutcome` (`.sent(endpoint: URL, statusCode: Int)`, `.noEndpointDiscovered`, `.requestFailed(reason: String)`), `WebmentionSender.send(source: URL, target: URL, transport: WebmentionEndpointDiscovery.Transport) async -> WebmentionSendOutcome`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/WebmentionSenderTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WebmentionSender")
+struct WebmentionSenderTests {
+    private let source = URL(string: "https://mysite.test/posts/hello/")!
+    private let target = URL(string: "https://target.example/post")!
+    private let endpoint = URL(string: "https://target.example/webmention")!
+
+    private actor CallRecorder {
+        private(set) var requests: [URLRequest] = []
+        func record(_ request: URLRequest) { requests.append(request) }
+    }
+
+    @Test("discovers the endpoint and POSTs source+target, reporting the status code")
+    func successfulSend() async throws {
+        let recorder = CallRecorder()
+        let endpointURL = endpoint
+        let targetURL = target
+        let outcome = await WebmentionSender.send(source: source, target: target, transport: { request in
+            await recorder.record(request)
+            if request.httpMethod == "POST" {
+                let http = HTTPURLResponse(url: endpointURL, statusCode: 202, httpVersion: nil, headerFields: nil)!
+                return (Data(), http)
+            }
+            let http = HTTPURLResponse(
+                url: targetURL, statusCode: 200, httpVersion: nil,
+                headerFields: ["Link": "<\(endpointURL.absoluteString)>; rel=\"webmention\""]
+            )!
+            return (Data(), http)
+        })
+
+        #expect(outcome == .sent(endpoint: endpoint, statusCode: 202))
+        let requests = await recorder.requests
+        #expect(requests.count == 2)
+        #expect(requests[1].httpMethod == "POST")
+        #expect(requests[1].url == endpoint)
+        #expect(requests[1].value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+        let body = String(data: requests[1].httpBody ?? Data(), encoding: .utf8)
+        #expect(body == "source=https%3A%2F%2Fmysite.test%2Fposts%2Fhello%2F&target=https%3A%2F%2Ftarget.example%2Fpost")
+    }
+
+    @Test("no discovered endpoint sends no POST")
+    func noEndpointSendsNothing() async throws {
+        let recorder = CallRecorder()
+        let targetURL = target
+        let outcome = await WebmentionSender.send(source: source, target: target, transport: { request in
+            await recorder.record(request)
+            let http = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (Data("<html>no endpoint</html>".utf8), http)
+        })
+        #expect(outcome == .noEndpointDiscovered)
+        let requests = await recorder.requests
+        #expect(requests.count == 1) // only the discovery GET, no POST
+    }
+
+    @Test("a non-2xx endpoint response maps to .requestFailed")
+    func failedPost() async throws {
+        let endpointURL = endpoint
+        let targetURL = target
+        let outcome = await WebmentionSender.send(source: source, target: target, transport: { request in
+            if request.httpMethod == "POST" {
+                let http = HTTPURLResponse(url: endpointURL, statusCode: 400, httpVersion: nil, headerFields: nil)!
+                return (Data(), http)
+            }
+            let http = HTTPURLResponse(
+                url: targetURL, statusCode: 200, httpVersion: nil,
+                headerFields: ["Link": "<\(endpointURL.absoluteString)>; rel=\"webmention\""]
+            )!
+            return (Data(), http)
+        })
+        guard case .requestFailed = outcome else {
+            Issue.record("expected .requestFailed, got \(outcome)")
+            return
+        }
+    }
+
+    @Test("a discovery-phase network error maps to .requestFailed")
+    func discoveryThrows() async throws {
+        struct Boom: Error {}
+        let outcome = await WebmentionSender.send(source: source, target: target, transport: { _ in throw Boom() })
+        guard case .requestFailed = outcome else {
+            Issue.record("expected .requestFailed, got \(outcome)")
+            return
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter WebmentionSenderTests`
+Expected: FAIL to compile — `WebmentionSendOutcome`/`WebmentionSender` do not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/WebmentionSender.swift`:
+
+```swift
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Outcome of one webmention send attempt for a single (source, target) pair.
+public enum WebmentionSendOutcome: Equatable, Sendable {
+    case sent(endpoint: URL, statusCode: Int)
+    case noEndpointDiscovered
+    case requestFailed(reason: String)
+}
+
+/// Sends one Webmention: discovers `target`'s declared endpoint via `WebmentionEndpointDiscovery`,
+/// then POSTs `source`+`target` form-encoded per the webmention.org spec. No retry logic here —
+/// a caller that doesn't record a `.requestFailed` pair as sent gets a free retry on its next
+/// pass (see `WebmentionSendCommand`).
+public enum WebmentionSender {
+    public static func send(
+        source: URL,
+        target: URL,
+        transport: WebmentionEndpointDiscovery.Transport
+    ) async -> WebmentionSendOutcome {
+        let endpoint: URL?
+        do {
+            endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport)
+        } catch {
+            return .requestFailed(reason: "endpoint discovery failed: \(error)")
+        }
+        guard let endpoint else { return .noEndpointDiscovered }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let body = "source=\(formEncode(source.absoluteString))&target=\(formEncode(target.absoluteString))"
+        request.httpBody = Data(body.utf8)
+
+        let http: HTTPURLResponse
+        do {
+            (_, http) = try await transport(request)
+        } catch {
+            return .requestFailed(reason: "POST to \(endpoint.absoluteString) failed: \(error)")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            return .requestFailed(reason: "\(endpoint.absoluteString) returned HTTP \(http.statusCode)")
+        }
+        return .sent(endpoint: endpoint, statusCode: http.statusCode)
+    }
+
+    /// Percent-encodes everything but RFC 3986 unreserved characters, so a source/target URL's
+    /// own `:`, `/`, `?`, `&`, `=` can't be mistaken for the outer form body's delimiters.
+    private static func formEncode(_ value: String) -> String {
+        let unreserved = CharacterSet(
+            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+        )
+        return value.addingPercentEncoding(withAllowedCharacters: unreserved) ?? value
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --filter WebmentionSenderTests`
+Expected: PASS (all 4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WebmentionSender.swift Tests/AnglesiteCoreTests/WebmentionSenderTests.swift
+git commit -m "$(cat <<'EOF'
+Add WebmentionSender for #354
+
+Discovers a target's endpoint and POSTs source+target form-encoded,
+per the webmention.org spec. Failures aren't retried here — the
+caller's persistence layer decides what to retry.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: `WebmentionTargetPair` + `WebmentionSentLog`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/WebmentionSentLog.swift`
+- Test: `Tests/AnglesiteCoreTests/WebmentionSentLogTests.swift`
+
+**Interfaces:**
+- Consumes: `SocialPublishPlan.Plan`, `SocialPublishPlan.Entry` (existing, `Sources/AnglesiteCore/SocialPublishPlan.swift`) — `Plan.entries: [Entry]`, `Entry.canonicalURL: URL`, `Entry.webmentionTargets: [URL]`.
+- Produces: `WebmentionTargetPair` (`public struct` with `source: URL`, `target: URL`, `public init(source:target:)`), `WebmentionSentLog` (`public struct`, `Equatable`, `Sendable`) with `Entry` (`source: URL`, `target: URL`, `sentAt: Date`), `static let filename`, `static func load(from: URL) -> WebmentionSentLog?`, `func save(to: URL) throws`, `func pending(in: SocialPublishPlan.Plan) -> [WebmentionTargetPair]`, `func recording(_: [WebmentionTargetPair], now: @escaping () -> Date = Date.init) -> WebmentionSentLog`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/WebmentionSentLogTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WebmentionSentLog")
+struct WebmentionSentLogTests {
+    private func tempConfigDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WebmentionSentLogTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private let source1 = URL(string: "https://mysite.test/posts/a/")!
+    private let source2 = URL(string: "https://mysite.test/posts/b/")!
+    private let target1 = URL(string: "https://target.example/1")!
+    private let target2 = URL(string: "https://target.example/2")!
+
+    @Test("load on a missing file returns nil")
+    func loadMissingReturnsNil() throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(WebmentionSentLog.load(from: dir) == nil)
+    }
+
+    @Test("save then load round-trips entries")
+    func saveLoadRoundTrips() throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sentAt = Date(timeIntervalSince1970: 1_782_777_600) // 2026-06-30T00:00:00Z
+        let log = WebmentionSentLog(sent: [.init(source: source1, target: target1, sentAt: sentAt)])
+        try log.save(to: dir)
+        #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("webmention-sent.json").path))
+        #expect(WebmentionSentLog.load(from: dir) == log)
+    }
+
+    @Test("pending(in:) excludes already-sent pairs and includes new ones")
+    func pendingExcludesSentPairs() throws {
+        let log = WebmentionSentLog(sent: [
+            .init(source: source1, target: target1, sentAt: Date(timeIntervalSince1970: 0)),
+        ])
+        let plan = SocialPublishPlan.Plan(entries: [
+            .init(sourceFile: "a.md", canonicalURL: source1, webmentionTargets: [target1, target2], posseTargets: []),
+            .init(sourceFile: "b.md", canonicalURL: source2, webmentionTargets: [target1], posseTargets: []),
+        ])
+        let pending = log.pending(in: plan)
+        #expect(pending == [
+            WebmentionTargetPair(source: source1, target: target2),
+            WebmentionTargetPair(source: source2, target: target1),
+        ])
+    }
+
+    @Test("recording(_:now:) appends new entries stamped with the given time")
+    func recordingAppendsEntries() throws {
+        let stamp = Date(timeIntervalSince1970: 1_782_777_600)
+        let log = WebmentionSentLog()
+        let updated = log.recording([WebmentionTargetPair(source: source1, target: target1)], now: { stamp })
+        #expect(updated.sent == [.init(source: source1, target: target1, sentAt: stamp)])
+        #expect(log.sent.isEmpty) // original is untouched — recording() returns a new value
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter WebmentionSentLogTests`
+Expected: FAIL to compile — `WebmentionTargetPair`/`WebmentionSentLog` do not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/WebmentionSentLog.swift`:
+
+```swift
+import Foundation
+
+/// A `(source, target)` webmention pair — the unit `WebmentionSentLog` tracks and
+/// `WebmentionSendCommand` sends.
+public struct WebmentionTargetPair: Equatable, Sendable {
+    public let source: URL
+    public let target: URL
+
+    public init(source: URL, target: URL) {
+        self.source = source
+        self.target = target
+    }
+}
+
+/// Per-site record of `(source, target)` webmention pairs already sent successfully, persisted at
+/// `Config/webmention-sent.json` — app-owned state, never committed to the site's git repo (same
+/// place as `DeployedRoutesSnapshot`'s `last-deployed-routes.json`). Lets `WebmentionSendCommand`
+/// skip pairs it already notified on a prior deploy, instead of re-pinging every target's
+/// endpoint on every redeploy.
+public struct WebmentionSentLog: Equatable, Sendable {
+    public struct Entry: Codable, Equatable, Sendable {
+        public let source: URL
+        public let target: URL
+        public let sentAt: Date
+
+        public init(source: URL, target: URL, sentAt: Date) {
+            self.source = source
+            self.target = target
+            self.sentAt = sentAt
+        }
+    }
+
+    public let sent: [Entry]
+
+    public init(sent: [Entry] = []) {
+        self.sent = sent
+    }
+
+    public static let filename = "webmention-sent.json"
+
+    private struct Envelope: Codable {
+        let sent: [Entry]
+    }
+
+    /// `nil` when the file is absent or unreadable — the normal "no prior sends yet" case.
+    public static func load(from configDirectory: URL) -> WebmentionSentLog? {
+        let url = configDirectory.appendingPathComponent(filename)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let envelope = try? decoder.decode(Envelope.self, from: data) else { return nil }
+        return WebmentionSentLog(sent: envelope.sent)
+    }
+
+    public func save(to configDirectory: URL) throws {
+        let url = configDirectory.appendingPathComponent(Self.filename)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(Envelope(sent: sent))
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// Pairs from `plan`'s entries not already recorded as sent.
+    public func pending(in plan: SocialPublishPlan.Plan) -> [WebmentionTargetPair] {
+        let sentKeys = Set(sent.map { pairKey(source: $0.source, target: $0.target) })
+        var result: [WebmentionTargetPair] = []
+        for entry in plan.entries {
+            for target in entry.webmentionTargets {
+                let key = pairKey(source: entry.canonicalURL, target: target)
+                if !sentKeys.contains(key) {
+                    result.append(WebmentionTargetPair(source: entry.canonicalURL, target: target))
+                }
+            }
+        }
+        return result
+    }
+
+    /// A new log with `pairs` appended, all stamped with the same `now()` timestamp.
+    public func recording(
+        _ pairs: [WebmentionTargetPair],
+        now: @escaping () -> Date = Date.init
+    ) -> WebmentionSentLog {
+        let timestamp = now()
+        let newEntries = pairs.map { Entry(source: $0.source, target: $0.target, sentAt: timestamp) }
+        return WebmentionSentLog(sent: sent + newEntries)
+    }
+
+    private func pairKey(source: URL, target: URL) -> String {
+        "\(source.absoluteString)\n\(target.absoluteString)"
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --filter WebmentionSentLogTests`
+Expected: PASS (all 4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WebmentionSentLog.swift Tests/AnglesiteCoreTests/WebmentionSentLogTests.swift
+git commit -m "$(cat <<'EOF'
+Add WebmentionSentLog for #354
+
+Per-site Config/webmention-sent.json tracking which (source, target)
+webmention pairs already sent successfully, so a redeploy only sends
+new pairs instead of re-pinging every target every time.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: `WebmentionSendCommand`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/WebmentionSendCommand.swift`
+- Test: `Tests/AnglesiteCoreTests/WebmentionSendCommandTests.swift`
+
+**Interfaces:**
+- Consumes: `SocialPublishPlan.build(projectRoot:siteBase:referenceDate:) throws -> SocialPublishPlan.Plan` (existing), `WebmentionSentLog.load(from:)`/`.pending(in:)`/`.recording(_:now:)`/`.save(to:)` (Task 3), `WebmentionSender.send(source:target:transport:)` (Task 2), `WebmentionEndpointDiscovery.Transport` (Task 1), `LogCenter.append(source:stream:text:timestamp:) async` (existing, `Sources/AnglesiteCore/LogCenter.swift:72`), `LogCenter.snapshot() async -> [LogLine]` (existing, for tests).
+- Produces: `WebmentionSendCommand` (`public actor`), `public init(transport: @escaping WebmentionEndpointDiscovery.Transport = WebmentionSendCommand.defaultTransport, logCenter: LogCenter = .shared, now: @escaping () -> Date = Date.init)`, `public func send(siteID: String, siteDirectory: URL, configDirectory: URL, siteBase: URL) async`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/WebmentionSendCommandTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WebmentionSendCommand")
+struct WebmentionSendCommandTests {
+    private func makeSite() throws -> (root: URL, siteDirectory: URL, configDirectory: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("webmention-send-command-\(UUID().uuidString)", isDirectory: true)
+        let siteDirectory = root.appendingPathComponent("Source", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        let post = siteDirectory.appendingPathComponent("src/content/posts/hello.md")
+        try FileManager.default.createDirectory(at: post.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("""
+        ---
+        publishDate: 2026-06-29
+        ---
+        Links to https://one.example/target and https://two.example/target.
+        """.utf8).write(to: post)
+        return (root, siteDirectory, configDirectory)
+    }
+
+    /// A transport that reports every target's endpoint as `<target>/webmention`, and accepts
+    /// every POST with 202 unless the endpoint's target is listed in `failing`.
+    private func transport(failing: Set<String> = []) -> WebmentionEndpointDiscovery.Transport {
+        { request in
+            let url = request.url!
+            if request.httpMethod == "POST" {
+                let targetForEndpoint = url.deletingLastPathComponent().absoluteString
+                let status = failing.contains(targetForEndpoint) ? 500 : 202
+                return (Data(), HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!)
+            }
+            let endpoint = url.appendingPathComponent("webmention")
+            let http = HTTPURLResponse(
+                url: url, statusCode: 200, httpVersion: nil,
+                headerFields: ["Link": "<\(endpoint.absoluteString)>; rel=\"webmention\""]
+            )!
+            return (Data(), http)
+        }
+    }
+
+    private actor Counter {
+        private(set) var value = 0
+        func increment() { value += 1 }
+    }
+
+    @Test("sends every pending target and persists them to the sent log")
+    func sendsAndPersists() async throws {
+        let (root, siteDirectory, configDirectory) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let logCenter = LogCenter()
+        let command = WebmentionSendCommand(
+            transport: transport(),
+            logCenter: logCenter,
+            now: { Date(timeIntervalSince1970: 1_782_777_600) }
+        )
+
+        await command.send(
+            siteID: "site1",
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            siteBase: URL(string: "https://mysite.test")!
+        )
+
+        let log = WebmentionSentLog.load(from: configDirectory)
+        #expect(log?.sent.count == 2)
+        #expect(Set(log?.sent.map(\.target.absoluteString) ?? []) == [
+            "https://one.example/target", "https://two.example/target",
+        ])
+
+        let lines = await logCenter.snapshot()
+        #expect(lines.contains { $0.source == "webmention:site1" && $0.text.contains("sending 2 webmention") })
+        #expect(lines.filter { $0.source == "webmention:site1" && $0.text.contains("sent ") }.count == 2)
+    }
+
+    @Test("a second run does not resend already-sent pairs")
+    func skipsAlreadySentPairs() async throws {
+        let (root, siteDirectory, configDirectory) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let counter = Counter()
+        let baseTransport = transport()
+        let counting: WebmentionEndpointDiscovery.Transport = { request in
+            if request.httpMethod == "POST" { await counter.increment() }
+            return try await baseTransport(request)
+        }
+        let command = WebmentionSendCommand(transport: counting, logCenter: LogCenter())
+        let siteBase = URL(string: "https://mysite.test")!
+
+        await command.send(siteID: "site1", siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: siteBase)
+        var count = await counter.value
+        #expect(count == 2)
+
+        await command.send(siteID: "site1", siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: siteBase)
+        count = await counter.value
+        #expect(count == 2) // no new POSTs on the second run
+    }
+
+    @Test("a failed send is not persisted, so it's retried on the next run")
+    func failedSendIsRetried() async throws {
+        let (root, siteDirectory, configDirectory) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let command = WebmentionSendCommand(
+            transport: transport(failing: ["https://one.example/target"]),
+            logCenter: LogCenter()
+        )
+
+        await command.send(
+            siteID: "site1", siteDirectory: siteDirectory, configDirectory: configDirectory,
+            siteBase: URL(string: "https://mysite.test")!
+        )
+
+        let log = WebmentionSentLog.load(from: configDirectory)
+        #expect(log?.sent.map(\.target.absoluteString) == ["https://two.example/target"])
+    }
+
+    @Test("a site with no outbound links sends nothing and writes no log")
+    func noPlanEntriesIsANoop() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("webmention-empty-\(UUID().uuidString)", isDirectory: true)
+        let siteDirectory = root.appendingPathComponent("Source", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: siteDirectory.appendingPathComponent("src/content"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let command = WebmentionSendCommand(transport: transport(), logCenter: LogCenter())
+        await command.send(
+            siteID: "site1", siteDirectory: siteDirectory, configDirectory: configDirectory,
+            siteBase: URL(string: "https://mysite.test")!
+        )
+
+        #expect(WebmentionSentLog.load(from: configDirectory) == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter WebmentionSendCommandTests`
+Expected: FAIL to compile — `WebmentionSendCommand` does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/WebmentionSendCommand.swift`:
+
+```swift
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Actor orchestrator for one site's webmention-send pass, run after a successful deploy.
+/// Builds the site's `SocialPublishPlan` (siteBase = the just-deployed URL), diffs it against the
+/// site's `WebmentionSentLog`, sends each pending pair, persists successes, and streams
+/// progress/results into `LogCenter` under source `"webmention:<siteID>"`. Best-effort — never
+/// throws; failures are logged, not surfaced as a thrown error, since this runs detached from the
+/// deploy result the user actually watches (`DeployModel.runDeploy`).
+public actor WebmentionSendCommand {
+    private let transport: WebmentionEndpointDiscovery.Transport
+    private let logCenter: LogCenter
+    private let now: () -> Date
+
+    public init(
+        transport: @escaping WebmentionEndpointDiscovery.Transport = WebmentionSendCommand.defaultTransport,
+        logCenter: LogCenter = .shared,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.transport = transport
+        self.logCenter = logCenter
+        self.now = now
+    }
+
+    public func send(siteID: String, siteDirectory: URL, configDirectory: URL, siteBase: URL) async {
+        let logSource = "webmention:\(siteID)"
+
+        let plan: SocialPublishPlan.Plan
+        do {
+            plan = try SocialPublishPlan.build(projectRoot: siteDirectory, siteBase: siteBase)
+        } catch {
+            await logCenter.append(
+                source: logSource, stream: .stderr,
+                text: "webmention: couldn't build publish plan: \(error)"
+            )
+            return
+        }
+        guard plan.webmentionCount > 0 else { return }
+
+        let log = WebmentionSentLog.load(from: configDirectory) ?? WebmentionSentLog()
+        let pending = log.pending(in: plan)
+        guard !pending.isEmpty else { return }
+
+        await logCenter.append(
+            source: logSource, stream: .stdout,
+            text: "webmention: sending \(pending.count) webmention(s)"
+        )
+
+        var sentPairs: [WebmentionTargetPair] = []
+        for pair in pending {
+            let outcome = await WebmentionSender.send(source: pair.source, target: pair.target, transport: transport)
+            switch outcome {
+            case .sent(let endpoint, let statusCode):
+                await logCenter.append(
+                    source: logSource, stream: .stdout,
+                    text: "webmention: sent \(pair.source.absoluteString) -> \(pair.target.absoluteString) via \(endpoint.absoluteString) (HTTP \(statusCode))"
+                )
+                sentPairs.append(pair)
+            case .noEndpointDiscovered:
+                await logCenter.append(
+                    source: logSource, stream: .stdout,
+                    text: "webmention: no endpoint declared by \(pair.target.absoluteString), skipping"
+                )
+            case .requestFailed(let reason):
+                await logCenter.append(
+                    source: logSource, stream: .stderr,
+                    text: "webmention: \(pair.source.absoluteString) -> \(pair.target.absoluteString) failed: \(reason)"
+                )
+            }
+        }
+
+        guard !sentPairs.isEmpty else { return }
+        let updated = log.recording(sentPairs, now: now)
+        do {
+            try updated.save(to: configDirectory)
+        } catch {
+            await logCenter.append(
+                source: logSource, stream: .stderr,
+                text: "webmention: couldn't persist sent log: \(error)"
+            )
+        }
+    }
+
+    /// Production transport: a plain `URLSession` request.
+    public static let defaultTransport: WebmentionEndpointDiscovery.Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --filter WebmentionSendCommandTests`
+Expected: PASS (all 4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WebmentionSendCommand.swift Tests/AnglesiteCoreTests/WebmentionSendCommandTests.swift
+git commit -m "$(cat <<'EOF'
+Add WebmentionSendCommand orchestrator for #354
+
+Ties SocialPublishPlan + WebmentionSentLog + WebmentionSender together
+into one per-site send pass, logging progress to LogCenter under
+"webmention:<siteID>".
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Wire into `DeployModel`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployModel.swift:71` (property), `:93-105` (init), `:306-308` (`.succeeded` case in `runDeploy`)
+
+**Interfaces:**
+- Consumes: `WebmentionSendCommand` (Task 4) — `public init(transport:logCenter:now:)` (all defaulted), `public func send(siteID:siteDirectory:configDirectory:siteBase:) async`.
+
+No new test file — `DeployModel` has no existing test target coverage today (`Tests/AnglesiteAppTests` doesn't yet cover it), and per CLAUDE.md's build notes, app-target logic that needs CI coverage belongs in a testable `AnglesiteCore` type rather than being tested through the app target. `WebmentionSendCommand` itself is fully covered by Task 4; this task is deliberately thin wiring. Verification is Task 7's `xcodebuild build`.
+
+- [ ] **Step 1: Add the `webmentionCommand` property**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, find:
+
+```swift
+    private let command: DeployCommand
+    private let logCenter: LogCenter
+```
+
+Replace with:
+
+```swift
+    private let command: DeployCommand
+    private let webmentionCommand: WebmentionSendCommand
+    private let logCenter: LogCenter
+```
+
+- [ ] **Step 2: Add the init parameter and assignment**
+
+Find:
+
+```swift
+    init(
+        command: DeployCommand = DeployCommand(),
+        logCenter: LogCenter = .shared,
+        keychain: KeychainStore = KeychainStore(),
+        verifier: TokenVerifying = CloudflareAPITokenVerifier(),
+        summarizer: any DeployFailureSummarizing = DeploySummarizerFactory.makeDefault()
+    ) {
+        self.command = command
+        self.logCenter = logCenter
+        self.keychain = keychain
+        self.onboarding = TokenOnboarding(verifier: verifier)
+        self.summarizer = summarizer
+    }
+```
+
+Replace with:
+
+```swift
+    init(
+        command: DeployCommand = DeployCommand(),
+        webmentionCommand: WebmentionSendCommand = WebmentionSendCommand(),
+        logCenter: LogCenter = .shared,
+        keychain: KeychainStore = KeychainStore(),
+        verifier: TokenVerifying = CloudflareAPITokenVerifier(),
+        summarizer: any DeployFailureSummarizing = DeploySummarizerFactory.makeDefault()
+    ) {
+        self.command = command
+        self.webmentionCommand = webmentionCommand
+        self.logCenter = logCenter
+        self.keychain = keychain
+        self.onboarding = TokenOnboarding(verifier: verifier)
+        self.summarizer = summarizer
+    }
+```
+
+- [ ] **Step 3: Fire the webmention send pass after a successful deploy**
+
+Find, inside `runDeploy`:
+
+```swift
+        switch result {
+        case .succeeded(let url, let duration):
+            transition(siteID: siteID, to: .succeeded(url: url, duration: duration))
+        case .failed(let reason, let exit):
+```
+
+Replace with:
+
+```swift
+        switch result {
+        case .succeeded(let url, let duration):
+            transition(siteID: siteID, to: .succeeded(url: url, duration: duration))
+            // Fire-and-forget: webmention sends are best-effort and must never block or affect
+            // the deploy result the user watches. Progress/failures surface only in LogCenter.
+            Task.detached { [webmentionCommand] in
+                await webmentionCommand.send(
+                    siteID: siteID,
+                    siteDirectory: siteDirectory,
+                    configDirectory: configDirectory,
+                    siteBase: url
+                )
+            }
+        case .failed(let reason, let exit):
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `swift build --target AnglesiteAppCore`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DeployModel.swift
+git commit -m "$(cat <<'EOF'
+Wire WebmentionSendCommand into DeployModel for #354
+
+Fires a best-effort webmention send pass after every successful
+deploy, using the deployed URL as siteBase. Runs detached so a slow
+or unreachable target endpoint can't stall the deploy UI.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Gated live e2e test against webmention.rocks
+
+**Files:**
+- Create: `Tests/AnglesiteCoreTests/WebmentionRocksLiveTests.swift`
+
+**Interfaces:**
+- Consumes: `WebmentionEndpointDiscovery.discover(target:transport:)` (Task 1), `WebmentionSender.send(source:target:transport:)` (Task 2), `WebmentionEndpointDiscovery.Transport` (Task 1).
+
+This test hits the real `webmention.rocks` and is gated off by default via `ANGLESITE_WEBMENTION_E2E`, mirroring `PodmanContainerControlIntegrationTests`'s `ANGLESITE_PODMAN_TESTS` gate (`Tests/AnglesiteCoreTests/PodmanContainerControlIntegrationTests.swift:22-24,52-55`). The three target pages below were confirmed live (2026-07-14) against `https://webmention.rocks/`'s own test index:
+- `/test/1` = "HTTP Link header, unquoted rel, relative URL" (confirmed header: `link: </test/1/webmention?head=true>; rel=webmention`)
+- `/test/4` = "HTML `<link>` tag, absolute URL" (confirmed body: `<link href="https://webmention.rocks/test/4/webmention" rel="webmention">`)
+- `/test/23/page` = "Webmention target is a redirect and the endpoint is relative" (confirmed: 302s to a session-specific `/test/23/page/<token>` URL)
+
+- [ ] **Step 1: Write the test**
+
+Create `Tests/AnglesiteCoreTests/WebmentionRocksLiveTests.swift`:
+
+```swift
+// Real-network integration test against webmention.rocks — gated behind ANGLESITE_WEBMENTION_E2E
+// so CI and everyday `swift test` runs never depend on a third-party site's availability.
+// Exercises WebmentionEndpointDiscovery's Link-header/HTML/redirect logic against real markup,
+// and confirms WebmentionSender's POST is accepted, using webmention.rocks' own documented test
+// pages (https://webmention.rocks/about).
+//
+// Run locally with:
+//   ANGLESITE_WEBMENTION_E2E=1 swift test --filter WebmentionRocksLiveTests
+//
+// webmention.rocks' full pass/fail dashboard (green checkmarks per test) requires visiting their
+// site and using a session-specific source-URL token they crawl back to verify — that's an
+// interactive, one-time manual step (see the PR description), not something this automated test
+// attempts. This test only confirms discovery + POST-accepted against real pages, as ongoing
+// regression coverage for the parsing logic.
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("Webmention send against webmention.rocks (live)")
+struct WebmentionRocksLiveTests {
+    private static var liveTestsEnabled: Bool {
+        ProcessInfo.processInfo.environment["ANGLESITE_WEBMENTION_E2E"] == "1"
+    }
+
+    private let transport: WebmentionEndpointDiscovery.Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+
+    @Test(
+        "test 1 (HTTP Link header) discovers a real endpoint and accepts a POST",
+        .enabled(if: liveTestsEnabled, "hits the real webmention.rocks — set ANGLESITE_WEBMENTION_E2E=1 to opt in")
+    )
+    func linkHeaderTestPage() async throws {
+        let target = URL(string: "https://webmention.rocks/test/1")!
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport)
+        #expect(endpoint != nil)
+
+        let outcome = await WebmentionSender.send(
+            source: URL(string: "https://anglesite.example/webmention-e2e-source")!,
+            target: target,
+            transport: transport
+        )
+        guard case .sent(_, let statusCode) = outcome else {
+            Issue.record("expected .sent, got \(outcome)")
+            return
+        }
+        #expect((200..<300).contains(statusCode))
+    }
+
+    @Test(
+        "test 4 (HTML <link> tag, absolute URL) discovers a real endpoint",
+        .enabled(if: liveTestsEnabled, "hits the real webmention.rocks — set ANGLESITE_WEBMENTION_E2E=1 to opt in")
+    )
+    func htmlLinkElementTestPage() async throws {
+        let target = URL(string: "https://webmention.rocks/test/4")!
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport)
+        #expect(endpoint?.absoluteString == "https://webmention.rocks/test/4/webmention")
+    }
+
+    @Test(
+        "test 23 (redirect target, relative endpoint) discovers a real endpoint via the post-redirect URL",
+        .enabled(if: liveTestsEnabled, "hits the real webmention.rocks — set ANGLESITE_WEBMENTION_E2E=1 to opt in")
+    )
+    func redirectTestPage() async throws {
+        let target = URL(string: "https://webmention.rocks/test/23/page")!
+        let endpoint = try await WebmentionEndpointDiscovery.discover(target: target, transport: transport)
+        #expect(endpoint != nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run gated (opt-in) to verify it passes against the real site**
+
+Run: `ANGLESITE_WEBMENTION_E2E=1 swift test --filter WebmentionRocksLiveTests`
+Expected: PASS (all 3 tests) — requires network access to webmention.rocks.
+
+- [ ] **Step 3: Run ungated to verify it's skipped by default**
+
+Run: `swift test --filter WebmentionRocksLiveTests`
+Expected: all 3 tests report as skipped ("hits the real webmention.rocks — set ANGLESITE_WEBMENTION_E2E=1 to opt in"), 0 failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Tests/AnglesiteCoreTests/WebmentionRocksLiveTests.swift
+git commit -m "$(cat <<'EOF'
+Add gated webmention.rocks live e2e test for #354
+
+Opt-in via ANGLESITE_WEBMENTION_E2E=1, mirroring the
+ANGLESITE_PODMAN_TESTS pattern — never runs in CI by default, gives
+ongoing regression coverage for discovery against real-world markup.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Full verification + manual webmention.rocks acceptance check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full AnglesiteCore/AnglesiteApp test suites**
+
+Run: `swift test --package-path .`
+Expected: all suites pass, including the four new ones from Tasks 1-4 and the (skipped-by-default) Task 6 suite.
+
+- [ ] **Step 2: Confirm the app target actually links the change**
+
+`swift test` alone doesn't prove `AnglesiteAppCore`'s change links into the real `.app` — build the Xcode target directly:
+
+```bash
+ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite \
+  xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Run the gated live e2e test once**
+
+Run: `ANGLESITE_WEBMENTION_E2E=1 swift test --filter WebmentionRocksLiveTests`
+Expected: PASS (all 3 tests) — confirms discovery + POST-accepted against the real webmention.rocks pages.
+
+- [ ] **Step 4: Manual webmention.rocks dashboard check (one-time acceptance step)**
+
+webmention.rocks' full pass/fail dashboard needs an interactive session:
+1. Visit `https://webmention.rocks/` in a browser, follow "Get Started" to obtain a personal source-URL token.
+2. Point a temporary test site's content at a couple of the numbered target pages (e.g. `/test/1`, `/test/4`, `/test/23/page`) using that source URL, or manually invoke `WebmentionSender.send(source:target:transport:)` with the session source URL against those targets (e.g. via a Swift REPL or a scratch script using `WebmentionSendCommand.defaultTransport`).
+3. Confirm webmention.rocks' dashboard shows green checkmarks for the tests exercised.
+4. Note the result in the PR description — this is documentation of a one-time manual check, not a re-runnable automated step (see the design doc's "Manual acceptance step").
+
+- [ ] **Step 5: Update the issue and open the PR**
+
+```bash
+gh issue edit 354 --remove-label status:in-progress
+git push -u origin claude/issue-354-8adbe9
+gh pr create --title "Send webmentions on publish (#354)" --body "$(cat <<'EOF'
+## Summary
+- Adds a pure-Swift webmention sender (WebmentionEndpointDiscovery + WebmentionSender +
+  WebmentionSentLog + WebmentionSendCommand) that fires automatically after every successful
+  deploy, independent of the still-unpublished @dwk/workers gate — see the design doc for why
+  sending doesn't need the per-site Worker, unlike receiving (V-3).
+- Wires it into DeployModel as a fire-and-forget background task after .succeeded.
+- Per-site Config/webmention-sent.json avoids re-pinging already-notified targets on redeploy.
+
+Design: docs/superpowers/specs/2026-07-14-webmention-send-design.md
+
+## Test plan
+- [x] swift test --package-path . (all suites, including 4 new ones)
+- [x] xcodebuild build (Anglesite scheme) — confirms DeployModel change links
+- [x] ANGLESITE_WEBMENTION_E2E=1 swift test --filter WebmentionRocksLiveTests (live discovery + POST against webmention.rocks)
+- [x] Manual webmention.rocks dashboard verification — <fill in pass/fail summary here>
+
+Closes #354
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR opens against `main`; report the PR URL back to the user.

--- a/docs/superpowers/specs/2026-07-14-webmention-send-design.md
+++ b/docs/superpowers/specs/2026-07-14-webmention-send-design.md
@@ -226,3 +226,9 @@ the PR description, not re-checked by CI.
 - POSSE syndication — V-2.4, separate sub-issue.
 - Any UI surface beyond `LogCenter` — no Settings toggle, no per-site results view. Can follow
   later if the LogCenter-only visibility proves insufficient in practice.
+- Host validation on discovery/send targets (no private-IP/loopback/link-local denylist). Target
+  URLs come from the site's own content (parsed by `SocialPublishPlan`), so a sender inherently
+  fetches attacker-influenced URLs — this is accepted as inherent to the webmention protocol, the
+  same posture as any other outbound link the site owner chooses to publish. Revisit if an
+  untrusted/anonymous content source ever feeds this pipeline without review (see
+  `WebmentionSendCommand.defaultTransport`'s doc comment for the full rationale).

--- a/docs/superpowers/specs/2026-07-14-webmention-send-design.md
+++ b/docs/superpowers/specs/2026-07-14-webmention-send-design.md
@@ -1,0 +1,228 @@
+# Webmention Send on Publish — Design
+
+**Date:** 2026-07-14
+**Status:** Decided
+**Part of:** #354 (V-2.2), #336 (V-2 epic), #334 (Personal Publishing OS pivot)
+**Relates to:** [`docs/specs/2026-06-29-c2-workers-integration-seam.md`](../../specs/2026-06-29-c2-workers-integration-seam.md)
+
+---
+
+## Decision
+
+Issue #354 and its parent epic #336 gate V-2 ("send webmentions") on a conformant `@dwk/workers`
+release (`@dwk/webmention` + `@dwk/indieauth` both release-ready per `WorkersConformanceReader`).
+As of this writing `@dwk/workers` is unpublished (`npm view @dwk/workers` 404s), so the literal
+scope — sending routed through the per-site Worker's composed `@dwk/webmention` package — remains
+blocked.
+
+**Webmention *sending* does not actually need the per-site Worker.** The c2 integration seam's
+`/webmention` route (`c2-workers-integration-seam.md:23`) is the *receiving* endpoint a site
+exposes for others to notify it — that's V-3 territory (inbound webmentions), not this issue.
+Sending is a client-side operation defined entirely by the public webmention.org spec: discover
+the target's declared endpoint, then `POST` `source`+`target` form-encoded. Nothing about that
+requires the sending site's own infrastructure.
+
+This mirrors the precedent set by V-2.1 (#353, PR #430), which shipped per-site Worker
+provisioning as pure Cloudflare/wrangler plumbing ahead of the same gate. This design ships a
+pure-Swift `WebmentionSender` in `AnglesiteCore`, wired into the existing deploy pipeline,
+independent of `@dwk/workers` publication. When `@dwk/workers` does ship, receiving (V-3) is
+unaffected by this decision, and nothing here needs to be revisited — sending stays client-side
+permanently per the webmention spec.
+
+## Components
+
+Four new types in `AnglesiteCore`, following existing conventions (`DeployCommand`'s
+closure-injected seams, `DeployedRoutesSnapshot`'s `Config/`-persistence shape):
+
+### `WebmentionEndpointDiscovery`
+
+Given a target `URL` and an injectable HTTP-fetch closure, issues one GET and determines the
+target's declared webmention endpoint:
+
+1. Check the response's `Link` header for `rel="webmention"` (or `rel="http://webmention.org/"`,
+   the legacy form some implementations still emit).
+2. If absent, parse the HTML body for `<link rel="webmention" href="...">` or
+   `<a rel="webmention" href="...">` (first match wins, matching the spec's "first" rule).
+3. Resolve a relative `href`/`Link` target against the *final* response URL (post-redirect), not
+   the originally-requested URL — required for webmention.rocks' redirect test pages.
+
+Returns `URL?` — `nil` means no endpoint declared (not an error; most links on the web don't have
+one).
+
+```swift
+public typealias WebmentionHTTPFetch = @Sendable (URL) async throws -> (data: Data, response: HTTPURLResponse)
+
+public enum WebmentionEndpointDiscovery {
+    public static func discover(target: URL, fetch: WebmentionHTTPFetch) async throws -> URL?
+}
+```
+
+### `WebmentionSender`
+
+Given a `(source, target)` pair, discovers the endpoint via `WebmentionEndpointDiscovery`, then
+`POST`s `source=<source>&target=<target>` as `application/x-www-form-urlencoded` to it.
+
+```swift
+public enum WebmentionSendOutcome: Equatable, Sendable {
+    case sent(endpoint: URL, statusCode: Int)
+    case noEndpointDiscovered
+    case requestFailed(reason: String)
+}
+
+public enum WebmentionSender {
+    public static func send(
+        source: URL,
+        target: URL,
+        fetch: WebmentionHTTPFetch,
+        post: @Sendable (URL, Data) async throws -> (data: Data, response: HTTPURLResponse)
+    ) async -> WebmentionSendOutcome
+}
+```
+
+A 2xx response (200/201/202 — 202 covers receivers that queue async processing) is `.sent`.
+Anything else is `.requestFailed`. No retry logic here — retries happen naturally at the
+`WebmentionSendCommand` level (see below): a failed pair is never recorded as sent, so it's
+retried on the next deploy.
+
+### `WebmentionSentLog`
+
+Per-site record of which `(source, target)` pairs have already been sent successfully, so
+redeploying a site doesn't re-ping every target on every deploy. Lives in the site's own
+`Config/` — per-site by construction, same place as `last-deployed-routes.json` and
+`settings.plist` (never committed to the site's git repo, per the package model).
+
+`Config/webmention-sent.json`:
+
+```json
+{
+  "sent": [
+    {
+      "source": "https://example.com/posts/foo/",
+      "target": "https://target.example/bar",
+      "sentAt": "2026-07-14T18:03:00Z"
+    }
+  ]
+}
+```
+
+```swift
+public struct WebmentionSentLog: Equatable, Sendable {
+    public struct Entry: Equatable, Sendable {
+        public let source: URL
+        public let target: URL
+        public let sentAt: Date
+    }
+    public let sent: [Entry]
+
+    public static let filename = "webmention-sent.json"
+    public static func load(from configDirectory: URL) -> WebmentionSentLog?
+    public func save(to configDirectory: URL) throws
+
+    /// Pairs present in `plan` not already recorded in `self`.
+    public func pending(in plan: SocialPublishPlan.Plan) -> [(source: URL, target: URL)]
+
+    /// Returns a new log with `pairs` appended, stamped via `now()`.
+    public func recording(
+        _ pairs: [(source: URL, target: URL)],
+        now: @escaping () -> Date = Date.init
+    ) -> WebmentionSentLog
+}
+```
+
+### `WebmentionSendCommand`
+
+Actor orchestrator, mirrors `DeployCommand`'s shape. One entry point:
+
+```swift
+public actor WebmentionSendCommand {
+    public init(
+        fetch: @escaping WebmentionHTTPFetch = Self.defaultFetch,
+        post: @escaping @Sendable (URL, Data) async throws -> (data: Data, response: HTTPURLResponse) = Self.defaultPost,
+        logCenter: LogCenter = .shared
+    )
+
+    /// Builds the site's SocialPublishPlan (siteBase = the just-deployed URL), diffs it against
+    /// the site's WebmentionSentLog, sends each pending pair, persists successes, and streams
+    /// progress/results into LogCenter under source "webmention:<siteID>". Best-effort — never
+    /// throws; failures are logged, not surfaced as a thrown error, since this runs detached
+    /// from the deploy result the user actually watches.
+    public func send(
+        siteID: String,
+        siteDirectory: URL,
+        configDirectory: URL,
+        siteBase: URL
+    ) async
+}
+```
+
+Real `fetch`/`post` defaults are thin `URLSession.shared` wrappers. Tests inject fakes — no real
+network calls in the unit suite.
+
+## Wiring into the deploy pipeline
+
+`DeployModel` (`Sources/AnglesiteApp/DeployModel.swift`) gains a new dependency, injected the same
+way `command: DeployCommand` already is:
+
+```swift
+private let webmentionCommand: WebmentionSendCommand
+
+init(
+    command: DeployCommand = DeployCommand(),
+    webmentionCommand: WebmentionSendCommand = WebmentionSendCommand(),
+    ...
+)
+```
+
+In `runDeploy`, right after the phase transition to `.succeeded`:
+
+```swift
+case .succeeded(let url, let duration):
+    transition(siteID: siteID, to: .succeeded(url: url, duration: duration))
+    Task.detached { [webmentionCommand] in
+        await webmentionCommand.send(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            siteBase: url
+        )
+    }
+```
+
+Fire-and-forget, on the deployed URL — matches the "background, after `.succeeded`" decision. The
+deploy UI (phase, drawer, Dock progress, notifications) is unaffected; webmention activity is
+visible only through `LogCenter`, same as build/wrangler output, under a distinct
+`"webmention:<siteID>"` source so it doesn't get folded into the deploy drawer's line filter. No
+new Settings toggle — this runs automatically on every successful deploy, same posture as the
+pre-deploy scan being unconditional. A failed or partial send run doesn't affect deploy success;
+it's picked up again on the next deploy via `WebmentionSentLog`'s pending-diff.
+
+## Testing strategy
+
+**Unit tests (always run, no network):**
+- `WebmentionEndpointDiscoveryTests` — fixture HTML/headers modeled on webmention.rocks' documented
+  cases: `Link` header, `<link>` element, `<a>` element, relative-URL resolution, redirect-then-
+  discover, no endpoint present, multiple candidates (first wins).
+- `WebmentionSenderTests` — fake HTTP executor; assert POST body/headers/content-type and the
+  2xx/4xx/5xx → `SendOutcome` mapping.
+- `WebmentionSentLogTests` — save/load round-trip, `pending(in:)` diff correctness.
+- `WebmentionSendCommandTests` — full orchestration against a fixture site directory (same fixture
+  style as `SocialPublishPlanTests`), fake fetch/post, asserting the log is updated only for
+  successes and `LogCenter` receives the expected lines.
+
+**Gated live e2e test:** one test hitting several real `webmention.rocks/test/N` pages, skipped
+unless `ANGLESITE_WEBMENTION_E2E=1` is set — mirrors `ANGLESITE_CONTAINER_E2E`'s pattern so CI
+doesn't depend on network/third-party availability by default. Exercises the real discovery +
+POST path against real-world markup variations.
+
+**Manual acceptance step:** webmention.rocks' full pass/fail dashboard requires visiting their
+site and using a session-specific source-URL token they crawl back to verify — that's inherently
+interactive and not something to automate. Done once during implementation; the result is noted in
+the PR description, not re-checked by CI.
+
+## Non-goals
+
+- Receiving webmentions (inbound `/webmention` route) — V-3, gated separately, unrelated to this
+  slice.
+- POSSE syndication — V-2.4, separate sub-issue.
+- Any UI surface beyond `LogCenter` — no Settings toggle, no per-site results view. Can follow
+  later if the LogCenter-only visibility proves insufficient in practice.


### PR DESCRIPTION
## Summary
- Adds a pure-Swift webmention sender (`WebmentionEndpointDiscovery` + `WebmentionSender` +
  `WebmentionSentLog` + `WebmentionSendCommand`) that fires automatically after every successful
  deploy, independent of the still-unpublished `@dwk/workers` gate — see the design doc for why
  sending doesn't need the per-site Worker, unlike receiving (V-3).
- Wires it into `DeployModel` as a fire-and-forget `Task.detached` after `.succeeded`, so a slow
  or unreachable target endpoint can't stall the deploy UI.
- Per-site `Config/webmention-sent.json` avoids re-pinging already-notified targets on redeploy —
  a failed send simply isn't recorded, so it's retried automatically next deploy.

Design: [docs/superpowers/specs/2026-07-14-webmention-send-design.md](https://github.com/Anglesite/Anglesite-app/blob/claude/issue-354-8adbe9/docs/superpowers/specs/2026-07-14-webmention-send-design.md)
Plan: [docs/superpowers/plans/2026-07-14-webmention-send.md](https://github.com/Anglesite/Anglesite-app/blob/claude/issue-354-8adbe9/docs/superpowers/plans/2026-07-14-webmention-send.md)

Built via subagent-driven development, 6 implementation tasks + task-scoped reviews. Two real bugs were found and fixed during review/implementation (not just style nits):
- `attributeValue`'s `\b` regex anchor false-matched hyphenated attributes like `data-rel=` (could pick the wrong link element on real-world markup with `data-*` attributes) — fixed with a proper delimiter anchor.
- The live e2e test's original design (POST with a synthetic source URL) could never pass webmention.rocks' real RFC 7565 source-verification — descoped to discovery-only for that case, matching the other two live tests.

## Test plan
- [x] `swift test --package-path .` — all Webmention* suites pass (5/5: Discovery, Sender, SentLog, SendCommand, live e2e). Two unrelated pre-existing failures observed (`RepoBootstrapTests.publishRefusesWhenDotenvWouldBeCommitted`, `GenerableTypesTests "ContentSummary parses numeric reading metadata"`) — both in files untouched by this branch, both showing environment/flake symptoms (empty git status stdout; live on-device FM model exceeding its context window), unrelated to this change.
- [x] `xcodebuild build` (Anglesite scheme, after `xcodegen generate` to pick up unrelated recent source additions) — `** BUILD SUCCEEDED **`, confirms the `DeployModel` change links into the real app target.
- [x] `ANGLESITE_WEBMENTION_E2E=1 swift test --filter WebmentionRocksLiveTests` — all 3 pass against the real webmention.rocks (discovery via Link header, HTML `<link>`, and redirect+relative-endpoint).
- [ ] Manual webmention.rocks dashboard verification (green checkmarks) — **not done**. This needs a real, publicly-deployed page that actually links to the webmention.rocks test targets, plus an interactive browser session with their source-URL token flow — neither is available in this dev sandbox. Recommend doing this once against a real deployed Anglesite site before considering V-2 fully proven end-to-end.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)