### PR TITLE
Remove deleted sites from recents at launch

### DIFF
--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -169,11 +169,14 @@ public actor SiteStore {
             var scoped: URL?
             var existenceURL = site.packageURL
             var canDetermineExistence = true
-            if let bookmark = site.bookmarkData,
-               let resolved = try? bookmarker.resolve(bookmark) {
-                existenceURL = resolved.url
-                if bookmarker.startAccessing(resolved.url) {
-                    scoped = resolved.url
+            if let bookmark = site.bookmarkData {
+                if let resolved = try? bookmarker.resolve(bookmark) {
+                    existenceURL = resolved.url
+                    if bookmarker.startAccessing(resolved.url) {
+                        scoped = resolved.url
+                    } else {
+                        canDetermineExistence = false
+                    }
                 } else {
                     canDetermineExistence = false
                 }

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -10,7 +10,8 @@ import AnglesiteSiteModel
 /// after a create/open that already called `record`).
 ///
 /// The persisted list is the canonical source between launches: validity and last-seen
-/// timestamps are cached so the UI renders immediately. `load()` restores the list on startup.
+/// timestamps are cached so the UI renders immediately. `load()` restores the list on startup,
+/// dropping entries whose package directories no longer exist.
 public actor SiteStore {
     /// Process-wide shared instance.
     public static let shared = SiteStore()
@@ -133,13 +134,11 @@ public actor SiteStore {
     /// when the UI wants to render quickly. Skips the change emit on a fresh-install no-file
     /// path — there's nothing to propagate.
     ///
-    /// Validity is **recomputed live** here rather than trusted from disk: `isValid` /
-    /// `missingSentinels` are filesystem-derived and go stale between launches (files added or
-    /// removed outside the app, or a change to the sentinel set itself), so a cached verdict can
-    /// be wrong — which once left every scaffolded site greyed-out in the launcher even after the
-    /// sentinel list was corrected, because the launcher reads only the cached value. When the
-    /// fresh check disagrees, the corrected list is persisted back so the next launch and the
-    /// Spotlight change-handler start from the right values.
+    /// Filesystem-derived state is **recomputed live** here rather than trusted from disk. Entries
+    /// whose package directories were deleted outside the app are removed; existing packages have
+    /// `isValid` / `missingSentinels` refreshed because files can change between launches. When the
+    /// loaded list changes, it is persisted back so the launcher, Open Recent, Dock menu, and
+    /// Spotlight all start from the same healed registry.
     public func load() async throws {
         guard fileManager.fileExists(atPath: persistenceURL.path) else {
             sites = []
@@ -147,34 +146,58 @@ public actor SiteStore {
         }
         let data = try Data(contentsOf: persistenceURL)
         var loaded = try Self.decoder.decode([Site].self, from: data)
-        let changed = Self.revalidate(&loaded, fileManager: fileManager)
+        let changed = Self.refreshFilesystemState(&loaded, fileManager: fileManager)
         sites = loaded
         if changed { try? persist() }
         await emitChange()
     }
 
-    /// Recompute each entry's filesystem-derived `isValid` / `missingSentinels`. On MAS the package
-    /// lives behind a security-scoped grant, so resolve and start the per-site bookmark for the
-    /// duration of the check; in package tests there may be no bookmark and the read just works. Returns `true`
-    /// if any entry's verdict changed (so the caller can persist the correction).
-    private static func revalidate(_ sites: inout [Site], fileManager: FileManager) -> Bool {
+    /// Drop entries whose package directory no longer exists, then recompute each survivor's
+    /// `isValid` / `missingSentinels`. On MAS the package lives behind a security-scoped grant, so
+    /// resolve and start the per-site bookmark for the duration of the checks. A bookmark can
+    /// follow a package that moved, so existence is checked at its resolved URL while validation
+    /// continues to use the registry URL until the package is explicitly reopened and recorded.
+    /// If a resolved bookmark cannot start access, retain the entry: an unavailable grant does not
+    /// prove that the user's files were deleted. Returns `true` when the registry changed.
+    private static func refreshFilesystemState(_ sites: inout [Site], fileManager: FileManager) -> Bool {
         var changed = false
         let bookmarker = PlatformSecurityScopedBookmark.make()
-        for index in sites.indices {
+        var refreshed: [Site] = []
+        refreshed.reserveCapacity(sites.count)
+
+        for var site in sites {
             var scoped: URL?
-            if let bookmark = sites[index].bookmarkData,
-               let resolved = try? bookmarker.resolve(bookmark),
-               bookmarker.startAccessing(resolved.url) {
-                scoped = resolved.url
+            var existenceURL = site.packageURL
+            var canDetermineExistence = true
+            if let bookmark = site.bookmarkData,
+               let resolved = try? bookmarker.resolve(bookmark) {
+                existenceURL = resolved.url
+                if bookmarker.startAccessing(resolved.url) {
+                    scoped = resolved.url
+                } else {
+                    canDetermineExistence = false
+                }
             }
-            let validation = AnglesitePackage(url: sites[index].packageURL).sourceValidation(fileManager: fileManager)
+
+            var isDirectory: ObjCBool = false
+            let packageExists = fileManager.fileExists(atPath: existenceURL.path, isDirectory: &isDirectory)
+                && isDirectory.boolValue
+            guard !canDetermineExistence || packageExists else {
+                if let scoped { bookmarker.stopAccessing(scoped) }
+                changed = true
+                continue
+            }
+
+            let validation = AnglesitePackage(url: site.packageURL).sourceValidation(fileManager: fileManager)
             if let scoped { bookmarker.stopAccessing(scoped) }
-            if sites[index].isValid != validation.isValid || sites[index].missingSentinels != validation.missing {
-                sites[index].isValid = validation.isValid
-                sites[index].missingSentinels = validation.missing
+            if site.isValid != validation.isValid || site.missingSentinels != validation.missing {
+                site.isValid = validation.isValid
+                site.missingSentinels = validation.missing
                 changed = true
             }
+            refreshed.append(site)
         }
+        sites = refreshed
         return changed
     }
 

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -94,6 +94,21 @@ final class SiteStoreTests {
         #expect(loaded?.isValid == false)
     }
 
+    /// A missing path is not proof of deletion when its security-scoped bookmark cannot resolve:
+    /// the package may live on a temporarily unavailable external or network volume (#749).
+    @Test("load retains a missing package when its bookmark cannot resolve")
+    func loadRetainsMissingPackageWithUnresolvableBookmark() async throws {
+        let pkg = try makeValidPackage(named: "temporarily-unavailable")
+        let writer = SiteStore(persistenceURL: persistenceURL)
+        let site = try await writer.record(pkg)
+        try await writer.setBookmark(Data("not-a-bookmark".utf8), for: site.id)
+        try fileManager.removeItem(at: pkg.url)
+
+        let reader = SiteStore(persistenceURL: persistenceURL)
+        try await reader.load()
+        #expect(await reader.find(id: site.id) != nil)
+    }
+
     /// Regression: validity is cached in `recents.json` but recomputed on `load()`. A registry
     /// written by an older build (or before a sentinel-list fix) can hold a stale `isValid:false`
     /// for a package that is actually valid on disk — that left every site greyed-out in the

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -61,6 +61,39 @@ final class SiteStoreTests {
         #expect(loaded.map(\.name) == ["alpha"])
     }
 
+    /// Regression for #749: deleting a package in Finder left its cached recents entry visible
+    /// in the launcher, File ▸ Open Recent, and the Dock menu on every subsequent launch.
+    @Test("load removes recents whose package directory was deleted")
+    func loadRemovesDeletedPackage() async throws {
+        let pkg = try makeValidPackage(named: "deleted")
+        let writer = SiteStore(persistenceURL: persistenceURL)
+        _ = try await writer.record(pkg)
+        try fileManager.removeItem(at: pkg.url)
+
+        let reader = SiteStore(persistenceURL: persistenceURL)
+        try await reader.load()
+        #expect(await reader.sites.isEmpty)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let persisted = try decoder.decode([SiteStore.Site].self, from: Data(contentsOf: persistenceURL))
+        #expect(persisted.isEmpty, "load() should heal recents.json so the ghost does not return")
+    }
+
+    @Test("load retains an existing package that is missing project sentinels")
+    func loadRetainsExistingInvalidPackage() async throws {
+        let pkg = try makeValidPackage(named: "broken")
+        let writer = SiteStore(persistenceURL: persistenceURL)
+        let site = try await writer.record(pkg)
+        try fileManager.removeItem(at: pkg.sourceURL.appendingPathComponent(ProjectValidator.requiredSentinels[0]))
+
+        let reader = SiteStore(persistenceURL: persistenceURL)
+        try await reader.load()
+        let loaded = await reader.find(id: site.id)
+        #expect(loaded != nil)
+        #expect(loaded?.isValid == false)
+    }
+
     /// Regression: validity is cached in `recents.json` but recomputed on `load()`. A registry
     /// written by an older build (or before a sentinel-list fix) can hold a stale `isValid:false`
     /// for a package that is actually valid on disk — that left every site greyed-out in the


### PR DESCRIPTION
## Summary
- prune recents entries when their .anglesite package directory no longer exists
- retain existing packages that are merely invalid or temporarily inaccessible through a security-scoped bookmark
- persist the healed registry so launcher, Open Recent, Dock menu, and Spotlight stay consistent

Closes #749

## Validation
- `swift test --package-path . --filter SiteStore` (34 tests passed)
- `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build CODE_SIGNING_ALLOWED=NO`