### PR TITLE
Unify pre-deploy scan JSON envelope (#742)

### DIFF
--- a/Resources/Template/scripts/pre-deploy-check.test.ts
+++ b/Resources/Template/scripts/pre-deploy-check.test.ts
@@ -10,18 +10,21 @@ test("missing _headers is an error", () => {
   const issues = checkHeaders(null, "");
   assert.equal(issues.length, 1);
   assert.equal(issues[0].severity, "error");
+  assert.equal(issues[0].category, "csp-misconfigured");
   assert.match(issues[0].message, /not enforced/);
 });
 
 test("_headers without a CSP is an error", () => {
   const issues = checkHeaders("/*\n  X-Frame-Options: DENY\n", "");
   assert.equal(issues.length, 1);
+  assert.equal(issues[0].category, "csp-misconfigured");
   assert.match(issues[0].message, /no Content-Security-Policy/);
 });
 
 test("configured domain missing from CSP is an error naming the domain", () => {
   const issues = checkHeaders(GOOD, "SCRIPT_ALLOW=js.stripe.com,giscus.app");
   assert.equal(issues.length, 1);
+  assert.equal(issues[0].category, "csp-misconfigured");
   assert.match(issues[0].message, /giscus\.app/);
 });
 
@@ -37,6 +40,7 @@ test("multiple configured domains missing from CSP each produce an error", () =>
   const issues = checkHeaders(GOOD, "SCRIPT_ALLOW=giscus.app,assets.calendly.com");
   assert.equal(issues.length, 2);
   assert.ok(issues.every((i) => i.severity === "error"));
+  assert.ok(issues.every((i) => i.category === "csp-misconfigured"));
   assert.ok(issues.some((i) => /giscus\.app/.test(i.message)));
   assert.ok(issues.some((i) => /assets\.calendly\.com/.test(i.message)));
 });
@@ -53,6 +57,7 @@ test("checkPII: flags a bare email in page content", () => {
   const issues = checkPII("<p>Contact us at hello@example.com</p>", "dist/index.html");
   assert.equal(issues.length, 1);
   assert.equal(issues[0].severity, "error");
+  assert.equal(issues[0].category, "pii-email");
   assert.match(issues[0].message, /email/);
 });
 
@@ -65,19 +70,28 @@ test("checkPII: still flags a bare email elsewhere on a page that also has a mai
   const html = '<a href="mailto:hello@example.com">Email us</a><p>debug: admin@internal.example.com</p>';
   const issues = checkPII(html, "dist/contact.html");
   assert.equal(issues.length, 1);
+  assert.equal(issues[0].category, "pii-email");
   assert.match(issues[0].message, /email/);
 });
 
 test("checkPII: still flags phone numbers regardless of mailto content", () => {
   const issues = checkPII('<a href="mailto:hello@example.com">Email</a> Call 555-123-4567', "dist/contact.html");
   assert.equal(issues.length, 1);
+  assert.equal(issues[0].category, "pii-phone");
   assert.match(issues[0].message, /phone/);
+});
+
+test("checkPII: flags an SSN with the pii-ssn category", () => {
+  const issues = checkPII("<p>SSN: 123-45-6789</p>", "dist/contact.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].category, "pii-ssn");
 });
 
 test("checkMixedContent: flags an insecure src", () => {
   const issues = checkMixedContent('<img src="http://example.com/a.png">', "dist/index.html");
   assert.equal(issues.length, 1);
   assert.equal(issues[0].severity, "warning");
+  assert.equal(issues[0].category, "mixed-content");
   assert.match(issues[0].message, /mixed content/i);
   assert.equal(issues[0].file, "dist/index.html");
 });
@@ -106,6 +120,7 @@ test("checkSRI: external script without integrity is a warning", () => {
   const issues = checkSRI('<script src="https://cdn.x.com/a.js"></script>', "dist/index.html");
   assert.equal(issues.length, 1);
   assert.equal(issues[0].severity, "warning");
+  assert.equal(issues[0].category, "sri-missing");
   assert.match(issues[0].message, /integrity/i);
 });
 
@@ -137,6 +152,7 @@ test("checkExternalLinkRel: target=_blank without rel=noopener is a warning", ()
   const issues = checkExternalLinkRel('<a href="https://x.com" target="_blank">x</a>', "dist/index.html");
   assert.equal(issues.length, 1);
   assert.equal(issues[0].severity, "warning");
+  assert.equal(issues[0].category, "external-link-rel");
   assert.match(issues[0].message, /noopener/i);
 });
 
@@ -168,6 +184,7 @@ test("checkArtifactPresence: missing robots.txt is a warning", () => {
   const issues = checkArtifactPresence(["dist/index.html", "dist/.well-known/security.txt"]);
   assert.equal(issues.length, 1);
   assert.equal(issues[0].severity, "warning");
+  assert.equal(issues[0].category, "missing-security-artifact");
   assert.match(issues[0].message, /robots\.txt/);
 });
 

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -11,7 +11,7 @@
  * Usage: npx tsx scripts/pre-deploy-check.ts [--json]
  *
  * Exit code 0: all clear. Exit code 1: issues found.
- * With --json: prints a JSON array of { severity, message, file } objects.
+ * With --json: prints the versioned {version, ok, failures, warnings} envelope (#742).
  */
 
 import { readdir, readFile, stat } from "node:fs/promises";
@@ -21,8 +21,16 @@ import { parseAllowedDomains } from "./csp";
 
 interface Issue {
   severity: "error" | "warning";
+  category: string;
   message: string;
   file?: string;
+}
+
+interface ScanReport {
+  version: 1;
+  ok: boolean;
+  failures: Issue[];
+  warnings: Issue[];
 }
 
 const JSON_MODE = process.argv.includes("--json");
@@ -69,7 +77,7 @@ async function* walk(dir: string): AsyncGenerator<string> {
 export function checkHeaders(headersContent: string | null, configContent: string): Issue[] {
   const issues: Issue[] = [];
   if (headersContent === null) {
-    issues.push({ severity: "error", message: "No dist/_headers — CSP is not enforced.", file: "_headers" });
+    issues.push({ severity: "error", category: "csp-misconfigured", message: "No dist/_headers — CSP is not enforced.", file: "_headers" });
     return issues;
   }
   const cspLine = headersContent
@@ -77,7 +85,7 @@ export function checkHeaders(headersContent: string | null, configContent: strin
     .map((l) => l.trim())
     .find((l) => l.startsWith("Content-Security-Policy:"));
   if (!cspLine) {
-    issues.push({ severity: "error", message: "dist/_headers has no Content-Security-Policy.", file: "_headers" });
+    issues.push({ severity: "error", category: "csp-misconfigured", message: "dist/_headers has no Content-Security-Policy.", file: "_headers" });
     return issues;
   }
   const cspTokens = new Set(
@@ -91,6 +99,7 @@ export function checkHeaders(headersContent: string | null, configContent: strin
     if (!cspTokens.has(domain)) {
       issues.push({
         severity: "error",
+        category: "csp-misconfigured",
         message: `Configured integration domain "${domain}" is missing from the CSP.`,
         file: "_headers",
       });
@@ -116,7 +125,12 @@ export function checkPII(content: string, file: string): Issue[] {
     pattern.lastIndex = 0;
     const haystack = name === "email" ? withoutMailtoLinks : content;
     if (pattern.test(haystack)) {
-      issues.push({ severity: "error", message: `Possible ${name} found`, file });
+      issues.push({
+        severity: "error",
+        category: `pii-${name.toLowerCase()}`,
+        message: `Possible ${name} found`,
+        file,
+      });
     }
   }
   return issues;
@@ -132,7 +146,7 @@ export function checkMixedContent(content: string, file: string): Issue[] {
   const patterns = [/\bsrc\s*=\s*["']http:\/\//i, /url\(\s*["']?http:\/\//i];
   for (const pattern of patterns) {
     if (pattern.test(content)) {
-      return [{ severity: "warning", message: "Mixed content: insecure http:// resource reference", file }];
+      return [{ severity: "warning", category: "mixed-content", message: "Mixed content: insecure http:// resource reference", file }];
     }
   }
   return [];
@@ -160,10 +174,11 @@ export function checkSRI(content: string, file: string): Issue[] {
     if (!isScript && !/\brel\s*=\s*["'][^"']*stylesheet/i.test(tag)) continue;
     const kind = isScript ? "script" : "stylesheet";
     if (!/\bintegrity\s*=/i.test(tag)) {
-      issues.push({ severity: "warning", message: `External ${kind} without subresource integrity (SRI)`, file });
+      issues.push({ severity: "warning", category: "sri-missing", message: `External ${kind} without subresource integrity (SRI)`, file });
     } else if (!/\scrossorigin\b/i.test(tag)) {
       issues.push({
         severity: "warning",
+        category: "sri-missing",
         message: `External ${kind} has integrity but is missing crossorigin (will fail CORS)`,
         file,
       });
@@ -189,7 +204,7 @@ export function checkExternalLinkRel(content: string, file: string): Issue[] {
     const relMatch = tag.match(/\brel\s*=\s*["']([^"']*)["']/i);
     const rel = relMatch ? relMatch[1].toLowerCase() : "";
     if (!/\bnoopener\b|\bnoreferrer\b/.test(rel)) {
-      issues.push({ severity: "warning", message: 'Link with target="_blank" missing rel="noopener"', file });
+      issues.push({ severity: "warning", category: "external-link-rel", message: 'Link with target="_blank" missing rel="noopener"', file });
     }
   }
   return issues;
@@ -206,7 +221,12 @@ export function checkArtifactPresence(relPaths: string[]): Issue[] {
   const issues: Issue[] = [];
   for (const path of required) {
     if (!set.has(path)) {
-      issues.push({ severity: "warning", message: `Missing security artifact: ${path.replace(/^dist\//, "")}`, file: path });
+      issues.push({
+        severity: "warning",
+        category: "missing-security-artifact",
+        message: `Missing security artifact: ${path.replace(/^dist\//, "")}`,
+        file: path,
+      });
     }
   }
   return issues;
@@ -218,7 +238,7 @@ async function scan(): Promise<Issue[]> {
   try {
     await stat(DIST_DIR);
   } catch {
-    issues.push({ severity: "warning", message: "No dist/ directory found — nothing to scan." });
+    issues.push({ severity: "warning", category: "missing-security-artifact", message: "No dist/ directory found — nothing to scan." });
     return issues;
   }
 
@@ -243,7 +263,7 @@ async function scan(): Promise<Issue[]> {
     for (const { name, pattern } of SECRET_PATTERNS) {
       pattern.lastIndex = 0;
       if (pattern.test(content)) {
-        issues.push({ severity: "error", message: `Possible ${name} exposed`, file: rel });
+        issues.push({ severity: "error", category: "exposed-token", message: `Possible ${name} exposed`, file: rel });
       }
     }
 
@@ -256,6 +276,7 @@ async function scan(): Promise<Issue[]> {
         if (pattern.test(content)) {
           issues.push({
             severity: "warning",
+            category: "third-party-script",
             message: `Third-party tracking script detected: ${pattern.source}`,
             file: rel,
           });
@@ -266,6 +287,7 @@ async function scan(): Promise<Issue[]> {
         if (pattern.test(content)) {
           issues.push({
             severity: "error",
+            category: "keystatic-route",
             message: "Keystatic admin route found in production output",
             file: rel,
           });
@@ -284,9 +306,12 @@ async function scan(): Promise<Issue[]> {
 
 async function main() {
   const issues = await scan();
+  const failures = issues.filter((i) => i.severity === "error");
+  const warnings = issues.filter((i) => i.severity === "warning");
 
   if (JSON_MODE) {
-    process.stdout.write(JSON.stringify(issues, null, 2) + "\n");
+    const report: ScanReport = { version: 1, ok: failures.length === 0, failures, warnings };
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n");
   } else {
     if (issues.length === 0) {
       console.log("Pre-deploy check passed — no issues found.");
@@ -299,8 +324,7 @@ async function main() {
     }
   }
 
-  const hasErrors = issues.some((i) => i.severity === "error");
-  process.exit(hasErrors ? 1 : 0);
+  process.exit(failures.length > 0 ? 1 : 0);
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/Sources/AnglesiteApp/BlockedDeploySheetView.swift
+++ b/Sources/AnglesiteApp/BlockedDeploySheetView.swift
@@ -82,9 +82,11 @@ private struct FailureCard: View {
                         .accessibilityValue(file)
                 }
             }
-            Text(failure.detail).font(.callout)
-            Text(failure.remediation)
-                .font(.caption).foregroundStyle(.secondary)
+            Text(failure.detail ?? failure.message).font(.callout)
+            if let remediation = failure.remediation {
+                Text(remediation)
+                    .font(.caption).foregroundStyle(.secondary)
+            }
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -95,10 +97,12 @@ private struct FailureCard: View {
 
     private func categoryIcon(_ category: PreDeployCheck.ScanFailure.Category) -> String {
         switch category {
-        case .piiEmail, .piiPhone: return "person.crop.circle.badge.exclamationmark"
+        case .piiEmail, .piiPhone, .piiSSN: return "person.crop.circle.badge.exclamationmark"
         case .exposedToken: return "key.fill"
         case .thirdPartyScript: return "network"
         case .keystaticRoute: return "lock.shield"
+        case .cspMisconfigured: return "shield.slash"
+        case .other: return "exclamationmark.triangle"
         }
     }
 
@@ -106,9 +110,12 @@ private struct FailureCard: View {
         switch category {
         case .piiEmail: return "PII — email address"
         case .piiPhone: return "PII — phone number"
+        case .piiSSN: return "PII — SSN"
         case .exposedToken: return "Exposed token"
         case .thirdPartyScript: return "Third-party script"
         case .keystaticRoute: return "Keystatic admin route"
+        case .cspMisconfigured: return "CSP misconfigured"
+        case .other: return "Other"
         }
     }
 }
@@ -125,9 +132,11 @@ private struct WarningCard: View {
                 Text(categoryLabel(warning.category))
                     .font(.subheadline).fontWeight(.semibold)
             }
-            Text(warning.detail).font(.callout)
-            Text(warning.remediation)
-                .font(.caption).foregroundStyle(.secondary)
+            Text(warning.detail ?? warning.message).font(.callout)
+            if let remediation = warning.remediation {
+                Text(remediation)
+                    .font(.caption).foregroundStyle(.secondary)
+            }
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -143,6 +152,12 @@ private struct WarningCard: View {
         case .seoCritical: return "SEO — critical"
         case .seoWarning: return "SEO — warning"
         case .orphanedRoute: return "Orphaned route"
+        case .mixedContent: return "Mixed content"
+        case .sriMissing: return "Missing subresource integrity"
+        case .externalLinkRel: return "Missing rel=noopener"
+        case .missingSecurityArtifact: return "Missing security artifact"
+        case .thirdPartyScript: return "Third-party script"
+        case .other: return "Other"
         }
     }
 }

--- a/Sources/AnglesiteApp/HealthBadgeView.swift
+++ b/Sources/AnglesiteApp/HealthBadgeView.swift
@@ -179,11 +179,13 @@ struct HealthBadgeView: View {
                         Image(systemName: "xmark.circle.fill").foregroundStyle(.red)
                             .accessibilityHidden(true)
                         VStack(alignment: .leading, spacing: 2) {
-                            Text(f.detail).font(.callout)
+                            Text(f.detail ?? f.message).font(.callout)
                             if let file = f.file {
                                 Text(file).font(.caption.monospaced()).foregroundStyle(.secondary)
                             }
-                            Text(f.remediation).font(.caption).foregroundStyle(.secondary)
+                            if let remediation = f.remediation {
+                                Text(remediation).font(.caption).foregroundStyle(.secondary)
+                            }
                         }
                     }
                 }
@@ -196,8 +198,10 @@ struct HealthBadgeView: View {
                         Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.yellow)
                             .accessibilityHidden(true)
                         VStack(alignment: .leading, spacing: 2) {
-                            Text(w.detail).font(.callout)
-                            Text(w.remediation).font(.caption).foregroundStyle(.secondary)
+                            Text(w.detail ?? w.message).font(.callout)
+                            if let remediation = w.remediation {
+                                Text(remediation).font(.caption).foregroundStyle(.secondary)
+                            }
                         }
                     }
                 }

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -205,33 +205,10 @@ public actor DeployCommand {
     // MARK: Scan report parsing
 
     /// Parses the captured stdout of the pre-deploy scan (`scripts/pre-deploy-check.ts --json`)
-    /// into a `PreDeployCheck.Outcome`. Mirrors the JSON contract owned by the plugin; a
-    /// non-decodable payload maps to `.error` with an exit-code-aware remediation (this is the
-    /// decoding that previously lived inside `PreDeployCheck.check` / `defaultPreflight`).
+    /// into a `PreDeployCheck.Outcome`. Thin forwarding wrapper — `PreDeployCheck.parse` is the
+    /// one real decoder (#742); this keeps the existing public call-site signature stable.
     public static func parseScanReport(output: String, exitCode: Int32?) -> PreDeployCheck.Outcome {
-        struct RawReport: Decodable {
-            let ok: Bool
-            let failures: [PreDeployCheck.ScanFailure]
-            let warnings: [PreDeployCheck.ScanWarning]
-        }
-
-        let report: RawReport
-        do {
-            report = try JSONDecoder().decode(RawReport.self, from: Data(output.utf8))
-        } catch {
-            // No parseable JSON — the script most likely errored out (missing dist/, missing tsx,
-            // or an outdated script that predates `--json`). Exit 0 with no JSON is distinct from a
-            // non-zero exit so the remediation can be specific.
-            let exit = exitCode ?? -1
-            return .error(reason: exit == 0
-                ? "pre-deploy scan emitted no JSON (exit 0) — is the site's scripts/pre-deploy-check.ts up to date?"
-                : "pre-deploy scan failed (exit \(exit)) — run `npm run build` and try again, or run `/anglesite:update` if the script is outdated")
-        }
-
-        if report.ok {
-            return .passed(warnings: report.warnings)
-        }
-        return .blocked(failures: report.failures, warnings: report.warnings)
+        PreDeployCheck.parse(output: output, exitCode: exitCode)
     }
 
     // MARK: URL extraction

--- a/Sources/AnglesiteCore/PreDeployCheck.swift
+++ b/Sources/AnglesiteCore/PreDeployCheck.swift
@@ -18,27 +18,45 @@ public actor PreDeployCheck {
         case passed(warnings: [ScanWarning])
         case blocked(failures: [ScanFailure], warnings: [ScanWarning])
         /// Script error — couldn't run the scan at all (missing tsx, missing
-        /// dist/, malformed JSON). Distinct from `.blocked` so callers can
-        /// surface the right remediation.
+        /// dist/, malformed JSON, unsupported envelope version). Distinct from
+        /// `.blocked` so callers can surface the right remediation.
         case error(reason: String)
     }
 
     public struct ScanFailure: Sendable, Equatable, Codable {
-        public enum Category: String, Sendable, Codable {
+        public enum Category: String, Sendable, Codable, CaseIterable {
             case piiEmail = "pii-email"
             case piiPhone = "pii-phone"
+            case piiSSN = "pii-ssn"
             case exposedToken = "exposed-token"
             case thirdPartyScript = "third-party-script"
             case keystaticRoute = "keystatic-route"
+            case cspMisconfigured = "csp-misconfigured"
+            /// Any category code this build doesn't recognize yet — decoding falls back here
+            /// instead of throwing, so a future/typo'd category can't crash the whole scan (#742).
+            case other = "other"
+
+            public init(from decoder: Decoder) throws {
+                let raw = try decoder.singleValueContainer().decode(String.self)
+                self = Category(rawValue: raw) ?? .other
+            }
         }
         public let category: Category
+        public let message: String
         /// Repo-relative path of the file where the issue was found, when known.
         public let file: String?
-        public let detail: String
-        public let remediation: String
+        public let detail: String?
+        public let remediation: String?
 
-        public init(category: Category, file: String?, detail: String, remediation: String) {
+        public init(
+            category: Category,
+            message: String,
+            file: String? = nil,
+            detail: String? = nil,
+            remediation: String? = nil
+        ) {
             self.category = category
+            self.message = message
             self.file = file
             self.detail = detail
             self.remediation = remediation
@@ -46,7 +64,7 @@ public actor PreDeployCheck {
     }
 
     public struct ScanWarning: Sendable, Equatable, Codable {
-        public enum Category: String, Sendable, Codable {
+        public enum Category: String, Sendable, Codable, CaseIterable {
             case missingOgImage = "missing-og-image"
             case maintenanceOverdue = "maintenance-overdue"
             case seoCritical = "seo-critical"
@@ -55,16 +73,80 @@ public actor PreDeployCheck {
             /// `redirects.json` entry covering it. Computed by `RouteCoverageScanner`, not the
             /// JS-side scan script — merged into the `Outcome` by `DeployCommand.deploy`.
             case orphanedRoute = "orphaned-route"
+            case mixedContent = "mixed-content"
+            case sriMissing = "sri-missing"
+            case externalLinkRel = "external-link-rel"
+            case missingSecurityArtifact = "missing-security-artifact"
+            case thirdPartyScript = "third-party-script"
+            /// Any category code this build doesn't recognize yet — decoding falls back here
+            /// instead of throwing, so a future/typo'd category can't crash the whole scan (#742).
+            case other = "other"
+
+            public init(from decoder: Decoder) throws {
+                let raw = try decoder.singleValueContainer().decode(String.self)
+                self = Category(rawValue: raw) ?? .other
+            }
         }
         public let category: Category
-        public let detail: String
-        public let remediation: String
+        public let message: String
+        public let file: String?
+        public let detail: String?
+        public let remediation: String?
 
-        public init(category: Category, detail: String, remediation: String) {
+        public init(
+            category: Category,
+            message: String,
+            file: String? = nil,
+            detail: String? = nil,
+            remediation: String? = nil
+        ) {
             self.category = category
+            self.message = message
+            self.file = file
             self.detail = detail
             self.remediation = remediation
         }
+    }
+
+    /// The versioned JSON envelope emitted by `pre-deploy-check.ts --json` (#742).
+    struct ScanReport: Decodable {
+        let version: Int
+        let ok: Bool
+        let failures: [ScanFailure]
+        let warnings: [ScanWarning]
+    }
+
+    /// Checked before a full `ScanReport` decode so an unsupported future envelope version
+    /// reports a specific remediation instead of a generic malformed-JSON error.
+    private struct VersionProbe: Decodable { let version: Int }
+
+    /// The single decoder for `pre-deploy-check.ts --json` output (#742). Both `check` below and
+    /// `DeployCommand.parseScanReport` call this — neither re-declares its own JSON shape.
+    /// Anglesite is pre-1.0, so there is no legacy bare-array fallback: anything that isn't the
+    /// current versioned envelope is an explicit `.error`.
+    public static func parse(output: String, exitCode: Int32?) -> Outcome {
+        let data = Data(output.utf8)
+        guard let probe = try? JSONDecoder().decode(VersionProbe.self, from: data) else {
+            return .error(reason: decodeErrorReason(exitCode: exitCode))
+        }
+        guard probe.version == 1 else {
+            return .error(reason: "pre-deploy scan emitted an unsupported envelope version (\(probe.version)) — run `/anglesite:update`")
+        }
+        guard let report = try? JSONDecoder().decode(ScanReport.self, from: data) else {
+            return .error(reason: decodeErrorReason(exitCode: exitCode))
+        }
+        return report.ok
+            ? .passed(warnings: report.warnings)
+            : .blocked(failures: report.failures, warnings: report.warnings)
+    }
+
+    /// No parseable envelope at all — either fully malformed JSON, or well-formed JSON missing
+    /// `version` (including the pre-#742 bare-array shape, which has no `version` key).
+    private static func decodeErrorReason(exitCode: Int32?) -> String {
+        let exit = exitCode ?? -1
+        return exit == 0
+            ? "pre-deploy scan emitted no JSON (exit 0) — is the site's scripts/pre-deploy-check.ts up to date?"
+            : "pre-deploy scan failed (exit \(exit)) — run `npm run build` and try again, or run `/anglesite:update` if the script is outdated"
     }
 
     /// Spawns the scan script and returns its stdout + exit code. Tests inject
@@ -85,28 +167,6 @@ public actor PreDeployCheck {
         } catch {
             return .error(reason: "couldn't run pre-deploy scan: \(error)")
         }
-
-        struct RawReport: Decodable {
-            let ok: Bool
-            let failures: [ScanFailure]
-            let warnings: [ScanWarning]
-        }
-
-        let stdoutData = Data(result.stdout.utf8)
-        let report: RawReport
-        do {
-            report = try JSONDecoder().decode(RawReport.self, from: stdoutData)
-        } catch {
-            // No parseable JSON — the script most likely errored out. Exit
-            // code 1 with no JSON typically means missing dist/ or missing tsx.
-            return .error(reason: result.exitCode == 0
-                ? "pre-deploy scan emitted no JSON (exit 0) — is the site's scripts/pre-deploy-check.ts up to date?"
-                : "pre-deploy scan failed (exit \(result.exitCode)) — run `npm run build` and try again, or run `/anglesite:update` if the script is outdated")
-        }
-
-        if report.ok {
-            return .passed(warnings: report.warnings)
-        }
-        return .blocked(failures: report.failures, warnings: report.warnings)
+        return Self.parse(output: result.stdout, exitCode: result.exitCode)
     }
 }

--- a/Sources/AnglesiteCore/RouteCoverageScanner.swift
+++ b/Sources/AnglesiteCore/RouteCoverageScanner.swift
@@ -16,7 +16,7 @@ public enum RouteCoverageScanner {
         return vanished.sorted().map { route in
             PreDeployCheck.ScanWarning(
                 category: .orphanedRoute,
-                detail: "\(route) is no longer published and has no redirect covering it.",
+                message: "\(route) is no longer published and has no redirect covering it.",
                 remediation: "Add a redirect for \(route) in Site Settings → Redirects, or ignore if the removal is intentional."
             )
         }

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -19,7 +19,7 @@ private actor GatedDeployExecutor: DeployExecutor {
         case .preflight:
             return DeployStepResult(
                 exitCode: 0,
-                output: #"{"ok":true,"failures":[],"warnings":[]}"#
+                output: #"{"version":1,"ok":true,"failures":[],"warnings":[]}"#
             )
         case .wrangler:
             return DeployStepResult(

--- a/Tests/AnglesiteCoreTests/DeployCommandProgressTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandProgressTests.swift
@@ -25,7 +25,7 @@ private struct BlockingPreflightExecutor: DeployExecutor {
         case .build:
             return DeployStepResult(exitCode: 0, output: "")
         case .preflight:
-            return DeployStepResult(exitCode: 0, output: #"{"ok":false,"failures":[],"warnings":[]}"#)
+            return DeployStepResult(exitCode: 0, output: #"{"version":1,"ok":false,"failures":[],"warnings":[]}"#)
         case .wrangler:
             return DeployStepResult(exitCode: 0, output: "")
         }

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -67,8 +67,8 @@ struct DeployCommandTests {
 
     /// Build the JSON payload the plugin's `pre-deploy-check.ts --json` emits.
     private func scanJSON(ok: Bool) -> String {
-        ok ? #"{"ok":true,"failures":[],"warnings":[]}"#
-           : #"{"ok":false,"failures":[{"category":"pii-email","file":"dist/index.html","detail":"email","remediation":"wrap it"}],"warnings":[]}"#
+        ok ? #"{"version":1,"ok":true,"failures":[],"warnings":[]}"#
+           : #"{"version":1,"ok":false,"failures":[{"category":"pii-email","message":"email","file":"dist/index.html","remediation":"wrap it"}],"warnings":[]}"#
     }
 
     @Test("default host resolvers fail explicitly after host Node retirement")
@@ -271,7 +271,7 @@ struct DeployCommandTests {
     func firesOnPreflight() async {
         let exec = FakeExecutor()
             .set(.build, exitCode: 0, output: "")
-            .set(.preflight, exitCode: 0, output: #"{"ok":true,"failures":[],"warnings":[{"category":"missing-og-image","detail":"no og image","remediation":"add one"}]}"#)
+            .set(.preflight, exitCode: 0, output: #"{"version":1,"ok":true,"failures":[],"warnings":[{"category":"missing-og-image","message":"no og image","remediation":"add one"}]}"#)
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
         let observed = Mutex<PreDeployCheck.Outcome?>(nil)
         let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
@@ -366,7 +366,7 @@ struct DeployCommandTests {
                     case .build:
                         return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", "echo building; exit 0"])
                     case .preflight:
-                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", #"echo '{"ok":true,"failures":[],"warnings":[]}'; exit 0"#])
+                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", #"echo '{"version":1,"ok":true,"failures":[],"warnings":[]}'; exit 0"#])
                     case .wrangler:
                         return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", "echo 'Published angle-app (1.23 sec)'; echo '  https://angle-app.example.workers.dev'; exit 0"])
                     }
@@ -396,7 +396,7 @@ struct DeployCommandTests {
                     case .build:
                         return .run(executable: URL(fileURLWithPath: "/usr/bin/true"), arguments: [])
                     case .preflight:
-                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", #"echo '{"ok":true,"failures":[],"warnings":[]}'"#])
+                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", #"echo '{"version":1,"ok":true,"failures":[],"warnings":[]}'"#])
                     case .wrangler:
                         return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", "echo \"TOKEN=$CLOUDFLARE_API_TOKEN\"; echo 'Published x (0.1 sec)'; echo '  https://x.workers.dev'"])
                     }
@@ -442,7 +442,7 @@ struct DeployCommandTests {
                     case .build:
                         return .run(executable: URL(fileURLWithPath: "/usr/bin/true"), arguments: [])
                     case .preflight:
-                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", #"echo '{"ok":true,"failures":[],"warnings":[]}'"#])
+                        return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", #"echo '{"version":1,"ok":true,"failures":[],"warnings":[]}'"#])
                     case .wrangler:
                         return .run(executable: URL(fileURLWithPath: "/bin/sh"), arguments: ["-c", "trap 'echo __SIGTERM__; exit 143' TERM; echo __STARTED__; sleep 20; echo __COMPLETED__"])
                     }
@@ -503,7 +503,7 @@ struct DeployCommandTests {
         guard case .passed(let warnings) = outcomes.get().first else {
             Issue.record("expected .passed"); return
         }
-        #expect(warnings.contains { $0.category == .orphanedRoute && $0.detail.contains("/old-page") })
+        #expect(warnings.contains { $0.category == .orphanedRoute && $0.message.contains("/old-page") })
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
         #expect(DeployedRoutesSnapshot.load(from: configDir) == ["/about"])
     }

--- a/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
@@ -16,7 +16,7 @@ import Foundation
 struct DeployExecutorSelectionTests {
 
     // A successful scan JSON so the full build→preflight→wrangler flow runs without blocking.
-    private let scanOK = #"{"ok":true,"failures":[],"warnings":[]}"#
+    private let scanOK = #"{"version":1,"ok":true,"failures":[],"warnings":[]}"#
     private let wranglerOut = "Published site (1s)\n  https://site.example.workers.dev"
     private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
 
@@ -216,7 +216,7 @@ private actor StepAwareFakeContainerControl: LocalContainerControl {
     private(set) var calls: [(siteID: String, argv: [String])] = []
     private var callCount = 0
 
-    private let scanOK = #"{"ok":true,"failures":[],"warnings":[]}"#
+    private let scanOK = #"{"version":1,"ok":true,"failures":[],"warnings":[]}"#
     private let wranglerOut = "Published site (1s)\n  https://site.example.workers.dev"
 
     func start(

--- a/Tests/AnglesiteCoreTests/HealthModelTests.swift
+++ b/Tests/AnglesiteCoreTests/HealthModelTests.swift
@@ -172,11 +172,11 @@ final class HealthModelTests: XCTestCase {
     private var tmpURL: URL { URL(fileURLWithPath: "/tmp/health-test") }
 
     private var sampleFailure: PreDeployCheck.ScanFailure {
-        .init(category: .exposedToken, file: "src/x.astro", detail: "token in src", remediation: "remove it")
+        .init(category: .exposedToken, message: "token in src", file: "src/x.astro", remediation: "remove it")
     }
 
     private var sampleWarning: PreDeployCheck.ScanWarning {
-        .init(category: .missingOgImage, detail: "no og image", remediation: "add one")
+        .init(category: .missingOgImage, message: "no og image", remediation: "add one")
     }
 }
 

--- a/Tests/AnglesiteCoreTests/PreDeployCheckFixtureTests.swift
+++ b/Tests/AnglesiteCoreTests/PreDeployCheckFixtureTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Runs the REAL `pre-deploy-check.ts --json` (not a hand-authored JSON string) against a small
+/// fixture `dist/` and decodes its actual stdout through `PreDeployCheck.parse` — the
+/// producer→consumer test #742 exists to add. Every other test in this suite hand-authors JSON in
+/// the Swift-expected shape, which is exactly how the envelope mismatch this issue fixes went
+/// uncaught for so long.
+struct PreDeployCheckFixtureTests {
+    private static var templateScriptsDirectory: URL {
+        // Tests/AnglesiteCoreTests/PreDeployCheckFixtureTests.swift -> repo root -> Resources/Template/scripts
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources/Template/scripts", isDirectory: true)
+    }
+
+    private func makeFixtureDist(html: String) throws -> URL {
+        let siteDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PreDeployCheckFixtureTests-\(UUID().uuidString)", isDirectory: true)
+        let distDir = siteDir.appendingPathComponent("dist", isDirectory: true)
+        try FileManager.default.createDirectory(at: distDir, withIntermediateDirectories: true)
+        try html.write(to: distDir.appendingPathComponent("index.html"), atomically: true, encoding: .utf8)
+        return siteDir
+    }
+
+    /// Runs `npx tsx <template>/scripts/pre-deploy-check.ts --json` with `siteDir` as cwd and
+    /// returns captured stdout + exit code.
+    private func runRealScript(siteDir: URL) throws -> (stdout: String, exitCode: Int32) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["npx", "tsx", Self.templateScriptsDirectory.appendingPathComponent("pre-deploy-check.ts").path, "--json"]
+        process.currentDirectoryURL = siteDir
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (stdout: String(data: data, encoding: .utf8) ?? "", exitCode: process.terminationStatus)
+    }
+
+    @Test("Real script output with a PII hit decodes to .blocked with the pii-email category")
+    func realScriptWithPIIDecodesToBlocked() throws {
+        let siteDir = try makeFixtureDist(html: "<html><body><p>Contact us at hello@example.com</p></body></html>")
+        defer { try? FileManager.default.removeItem(at: siteDir) }
+
+        let result = try runRealScript(siteDir: siteDir)
+        #expect(result.exitCode == 1)
+
+        let outcome = PreDeployCheck.parse(output: result.stdout, exitCode: result.exitCode)
+        guard case .blocked(let failures, let warnings) = outcome else {
+            Issue.record("expected .blocked, got \(outcome) — raw stdout: \(result.stdout)")
+            return
+        }
+        #expect(failures.contains { $0.category == .piiEmail })
+        // No dist/_headers in this minimal fixture — CSP misconfiguration is also expected.
+        #expect(failures.contains { $0.category == .cspMisconfigured })
+        // No robots.txt / security.txt in this minimal fixture.
+        #expect(warnings.contains { $0.category == .missingSecurityArtifact })
+    }
+
+    @Test("Real script output with no issues decodes to .passed")
+    func realScriptWithNoIssuesDecodesToPassed() throws {
+        let siteDir = try makeFixtureDist(html: "<html><body><p>Nothing sensitive here.</p></body></html>")
+        defer { try? FileManager.default.removeItem(at: siteDir) }
+        // A CSP-satisfying _headers file and both security artifacts, so this fixture is fully clean.
+        try "/*\n  Content-Security-Policy: default-src 'self'\n".write(
+            to: siteDir.appendingPathComponent("dist/_headers"), atomically: true, encoding: .utf8)
+        try "User-agent: *\n".write(
+            to: siteDir.appendingPathComponent("dist/robots.txt"), atomically: true, encoding: .utf8)
+        let wellKnown = siteDir.appendingPathComponent("dist/.well-known", isDirectory: true)
+        try FileManager.default.createDirectory(at: wellKnown, withIntermediateDirectories: true)
+        try "Contact: mailto:security@example.com\n".write(
+            to: wellKnown.appendingPathComponent("security.txt"), atomically: true, encoding: .utf8)
+
+        let result = try runRealScript(siteDir: siteDir)
+        #expect(result.exitCode == 0)
+
+        let outcome = PreDeployCheck.parse(output: result.stdout, exitCode: result.exitCode)
+        guard case .passed(let warnings) = outcome else {
+            Issue.record("expected .passed, got \(outcome) — raw stdout: \(result.stdout)")
+            return
+        }
+        #expect(warnings.isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/PreDeployCheckFixtureTests.swift
+++ b/Tests/AnglesiteCoreTests/PreDeployCheckFixtureTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 /// Runs the REAL `pre-deploy-check.ts --json` (not a hand-authored JSON string) against a small
@@ -8,6 +9,41 @@ import Foundation
 /// the Swift-expected shape, which is exactly how the envelope mismatch this issue fixes went
 /// uncaught for so long.
 struct PreDeployCheckFixtureTests {
+    /// True when both a Node binary is available and `tsx` is resolvable via `npx` *without*
+    /// hitting the network. `Resources/Template` has no installed `node_modules` in this repo, so
+    /// gating on a local `tsx` install (like the render-smoke suites gate on `node_modules/astro`)
+    /// would make this test skip almost always, defeating its purpose. Instead this checks whether
+    /// `npx` can resolve `tsx` from a global install or its own on-disk cache — the state that lets
+    /// the test run cleanly without a live registry fetch.
+    static var buildable: Bool {
+        guard E2EPrerequisites.locateNode() != nil else { return false }
+        return tsxResolvableOffline
+    }
+
+    /// Runs `npx --offline tsx --version` and reports whether it exits zero.
+    ///
+    /// `--offline` puts npm's cache resolution in `only-if-cached` mode, so a cache hit (global
+    /// install or npx's package cache) succeeds immediately and a cache miss fails immediately with
+    /// `ENOTCACHED` — no registry request either way. This is deliberately `--offline` rather than
+    /// the more commonly suggested `--no-install`: recent npm (tested here against npm 11) no
+    /// longer honors `--no-install` as a hard "don't touch the network" switch — a cache miss with
+    /// `--no-install` still fell through to a live `GET https://registry.npmjs.org/...` in local
+    /// testing, which is exactly the network dependency this gate exists to avoid.
+    private static var tsxResolvableOffline: Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["npx", "--offline", "tsx", "--version"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
+
     private static var templateScriptsDirectory: URL {
         // Tests/AnglesiteCoreTests/PreDeployCheckFixtureTests.swift -> repo root -> Resources/Template/scripts
         URL(fileURLWithPath: #filePath)
@@ -42,7 +78,8 @@ struct PreDeployCheckFixtureTests {
         return (stdout: String(data: data, encoding: .utf8) ?? "", exitCode: process.terminationStatus)
     }
 
-    @Test("Real script output with a PII hit decodes to .blocked with the pii-email category")
+    @Test("Real script output with a PII hit decodes to .blocked with the pii-email category",
+          .enabled(if: PreDeployCheckFixtureTests.buildable))
     func realScriptWithPIIDecodesToBlocked() throws {
         let siteDir = try makeFixtureDist(html: "<html><body><p>Contact us at hello@example.com</p></body></html>")
         defer { try? FileManager.default.removeItem(at: siteDir) }
@@ -62,7 +99,8 @@ struct PreDeployCheckFixtureTests {
         #expect(warnings.contains { $0.category == .missingSecurityArtifact })
     }
 
-    @Test("Real script output with no issues decodes to .passed")
+    @Test("Real script output with no issues decodes to .passed",
+          .enabled(if: PreDeployCheckFixtureTests.buildable))
     func realScriptWithNoIssuesDecodesToPassed() throws {
         let siteDir = try makeFixtureDist(html: "<html><body><p>Nothing sensitive here.</p></body></html>")
         defer { try? FileManager.default.removeItem(at: siteDir) }

--- a/Tests/AnglesiteCoreTests/PreDeployCheckTests.swift
+++ b/Tests/AnglesiteCoreTests/PreDeployCheckTests.swift
@@ -53,7 +53,7 @@ struct PreDeployCheckTests {
         #expect(failures[0].remediation?.contains("PII_EMAIL_ALLOW") == true)
     }
 
-    @Test("Parses all five failure categories") func parsesAllFiveFailureCategories() async {
+    @Test("Parses all seven concrete failure categories") func parsesAllSevenConcreteFailureCategories() async {
         let json = """
         {
           "version": 1,
@@ -61,9 +61,11 @@ struct PreDeployCheckTests {
           "failures": [
             {"category": "pii-email", "message": "m", "file": "a", "remediation": "r"},
             {"category": "pii-phone", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "pii-ssn", "message": "m", "file": "a", "remediation": "r"},
             {"category": "exposed-token", "message": "m", "file": "a", "remediation": "r"},
             {"category": "third-party-script", "message": "m", "file": "a", "remediation": "r"},
-            {"category": "keystatic-route", "message": "m", "file": "a", "remediation": "r"}
+            {"category": "keystatic-route", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "csp-misconfigured", "message": "m", "file": "a", "remediation": "r"}
           ],
           "warnings": []
         }
@@ -74,8 +76,12 @@ struct PreDeployCheckTests {
             Issue.record("expected .blocked")
             return
         }
+        // Every concrete ScanFailure.Category case except `.other`, which has its own dedicated
+        // test (`unknownCategoryDecodesToOther`) covering the forward-compatible fallback.
         #expect(
-            Set(failures.map(\.category)) == Set([.piiEmail, .piiPhone, .exposedToken, .thirdPartyScript, .keystaticRoute])
+            Set(failures.map(\.category)) == Set([
+                .piiEmail, .piiPhone, .piiSSN, .exposedToken, .thirdPartyScript, .keystaticRoute, .cspMisconfigured,
+            ])
         )
     }
 

--- a/Tests/AnglesiteCoreTests/PreDeployCheckTests.swift
+++ b/Tests/AnglesiteCoreTests/PreDeployCheckTests.swift
@@ -8,7 +8,7 @@ struct PreDeployCheckTests {
     // MARK: Happy path
 
     @Test("Returns passed when script emits ok-true JSON") func returnsPassedWhenScriptEmitsOkTrueJSON() async {
-        let json = #"{"ok": true, "failures": [], "warnings": []}"#
+        let json = #"{"version": 1, "ok": true, "failures": [], "warnings": []}"#
         let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 0) })
 
         let outcome = await check.check(siteID: "mysite", siteDirectory: siteDir)
@@ -25,12 +25,13 @@ struct PreDeployCheckTests {
     @Test("Returns blocked when script emits ok-false with failures") func returnsBlockedWhenScriptEmitsOkFalseWithFailures() async {
         let json = """
         {
+          "version": 1,
           "ok": false,
           "failures": [
             {
               "category": "pii-email",
+              "message": "Possible email address: jane@yourbusiness.com",
               "file": "dist/index.html",
-              "detail": "Possible email address: jane@yourbusiness.com",
               "remediation": "Wrap the address in a `mailto:` link if it should be published, or add it to PII_EMAIL_ALLOW in .site-config."
             }
           ],
@@ -48,20 +49,21 @@ struct PreDeployCheckTests {
         #expect(failures.count == 1)
         #expect(failures[0].category == .piiEmail)
         #expect(failures[0].file == "dist/index.html")
-        #expect(failures[0].detail.contains("jane@yourbusiness.com"))
-        #expect(failures[0].remediation.contains("PII_EMAIL_ALLOW"))
+        #expect(failures[0].message.contains("jane@yourbusiness.com"))
+        #expect(failures[0].remediation?.contains("PII_EMAIL_ALLOW") == true)
     }
 
     @Test("Parses all five failure categories") func parsesAllFiveFailureCategories() async {
         let json = """
         {
+          "version": 1,
           "ok": false,
           "failures": [
-            {"category": "pii-email", "file": "a", "detail": "d", "remediation": "r"},
-            {"category": "pii-phone", "file": "a", "detail": "d", "remediation": "r"},
-            {"category": "exposed-token", "file": "a", "detail": "d", "remediation": "r"},
-            {"category": "third-party-script", "file": "a", "detail": "d", "remediation": "r"},
-            {"category": "keystatic-route", "file": "a", "detail": "d", "remediation": "r"}
+            {"category": "pii-email", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "pii-phone", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "exposed-token", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "third-party-script", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "keystatic-route", "message": "m", "file": "a", "remediation": "r"}
           ],
           "warnings": []
         }
@@ -75,6 +77,29 @@ struct PreDeployCheckTests {
         #expect(
             Set(failures.map(\.category)) == Set([.piiEmail, .piiPhone, .exposedToken, .thirdPartyScript, .keystaticRoute])
         )
+    }
+
+    @Test("Unknown category decodes to .other instead of failing the scan") func unknownCategoryDecodesToOther() async {
+        let json = """
+        {
+          "version": 1,
+          "ok": false,
+          "failures": [
+            {"category": "some-future-category", "message": "m", "file": "a"}
+          ],
+          "warnings": [
+            {"category": "another-future-category", "message": "m"}
+          ]
+        }
+        """
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 1) })
+
+        guard case .blocked(let failures, let warnings) = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .blocked")
+            return
+        }
+        #expect(failures.first?.category == .other)
+        #expect(warnings.first?.category == .other)
     }
 
     // MARK: Error paths
@@ -112,18 +137,40 @@ struct PreDeployCheckTests {
         }
     }
 
+    @Test("Returns error when the version field is missing (no legacy-array fallback)") func returnsErrorWhenVersionIsMissing() async {
+        // Pre-#742 shape: a bare array, no envelope at all.
+        let json = #"[{"severity":"error","message":"Possible email found","file":"dist/index.html"}]"#
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 1) })
+
+        guard case .error = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .error for pre-envelope legacy array output")
+            return
+        }
+    }
+
+    @Test("Returns error when the envelope version is unsupported") func returnsErrorWhenVersionIsUnsupported() async {
+        let json = #"{"version": 2, "ok": true, "failures": [], "warnings": []}"#
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 0) })
+
+        guard case .error(let reason) = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .error")
+            return
+        }
+        #expect(reason.contains("unsupported envelope version"), "\(reason)")
+    }
+
     // MARK: Warnings pass-through
 
     @Test("Warnings are returned alongside passed and blocked outcomes") func warningsAreReturnedAlongsidePassedAndBlockedOutcomes() async {
         let warningJSON = """
         "warnings": [
-          {"category": "missing-og-image", "detail": "No og:image meta tag.", "remediation": "Run `npm run ai-images`."}
+          {"category": "missing-og-image", "message": "No og:image meta tag.", "remediation": "Run `npm run ai-images`."}
         ]
         """
-        let passedJSON = "{ \"ok\": true, \"failures\": [], \(warningJSON) }"
+        let passedJSON = "{ \"version\": 1, \"ok\": true, \"failures\": [], \(warningJSON) }"
         let blockedJSON = """
-        { "ok": false,
-          "failures": [{"category": "pii-email", "file": "a", "detail": "d", "remediation": "r"}],
+        { "version": 1, "ok": false,
+          "failures": [{"category": "pii-email", "message": "m", "file": "a", "remediation": "r"}],
           \(warningJSON) }
         """
 

--- a/Tests/AnglesiteCoreTests/RouteCoverageScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/RouteCoverageScannerTests.swift
@@ -23,7 +23,7 @@ struct RouteCoverageScannerTests {
             currentRoutes: ["/about"], previousRoutes: ["/about", "/old-page"], redirectSources: [])
         #expect(warnings.count == 1)
         #expect(warnings[0].category == .orphanedRoute)
-        #expect(warnings[0].detail.contains("/old-page"))
+        #expect(warnings[0].message.contains("/old-page"))
     }
 
     @Test("a vanished route covered by a redirect produces no warning")

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -116,7 +116,7 @@ struct SiteOperationsTests {
     @Test("deploy blocked dialog reports the issue count and never offers an override")
     func deployBlockedDialog() {
         let failure = PreDeployCheck.ScanFailure(
-            category: .exposedToken, file: "src/index.md", detail: "API key committed", remediation: "Remove it"
+            category: .exposedToken, message: "API key committed", file: "src/index.md", remediation: "Remove it"
         )
         let dialog = SiteOperations.dialog(forDeploy: .blocked(failures: [failure], warnings: []))
         #expect(dialog == "Deploy blocked by the pre-deploy security scan (1 issue). Resolve these in Anglesite first.")
@@ -203,8 +203,8 @@ struct SiteOperationsTests {
     func socialWorkerProvisionBlockedDialog() {
         let failure = PreDeployCheck.ScanFailure(
             category: .exposedToken,
+            message: "API key committed",
             file: "dist/index.html",
-            detail: "API key committed",
             remediation: "Remove it"
         )
         let result = SocialWorkerProvisionCommand.Result.blocked(

--- a/Tests/AnglesiteIntentsTests/DeploySiteIntentTests.swift
+++ b/Tests/AnglesiteIntentsTests/DeploySiteIntentTests.swift
@@ -30,8 +30,8 @@ extension AppIntentsTests {
             let (fake, site) = makeFakeAndSite()
             let failure = PreDeployCheck.ScanFailure(
                 category: .exposedToken,
+                message: "API key committed",
                 file: "src/index.md",
-                detail: "API key committed",
                 remediation: "Remove it"
             )
             fake.deployResult = .blocked(failures: [failure], warnings: [])

--- a/docs/superpowers/plans/2026-07-15-pre-deploy-scan-envelope.md
+++ b/docs/superpowers/plans/2026-07-15-pre-deploy-scan-envelope.md
@@ -1,0 +1,1494 @@
+# Pre-deploy Scan JSON Envelope Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `pre-deploy-check.ts --json` and both Swift decoders agree on one versioned JSON envelope, so a real deploy's pre-deploy scan actually decodes (today it always fails to decode and maps to `.error`), and add a real producer→consumer test so this can't silently drift again.
+
+**Architecture:** Define `{version: 1, ok, failures: Finding[], warnings: Finding[]}` (`Finding = {severity, category, message, file?, detail?, remediation?}`) as the shared shape. `PreDeployCheck.parse(output:exitCode:)` becomes the single Swift decoder; `PreDeployCheck.check` and `DeployCommand.parseScanReport` both delegate to it. `Category` decodes unknown raw values to `.other` instead of throwing. No legacy-array fallback — Anglesite is pre-1.0.
+
+**Tech Stack:** Swift 6 (Testing framework, `Codable`), TypeScript (`tsx`, `node:test`).
+
+## Global Constraints
+
+- No legacy `Issue[]` fallback decoding — pre-1.0, no shipped sites to support (per spec's "No legacy fallback" section).
+- Don't reclassify any check's severity (e.g. `third-party-script` stays a warning) — preserve current exit-code semantics.
+- `detail`/`remediation` are optional on every finding; don't write remediation copy for every check in this pass.
+- One shared Swift decoder (`PreDeployCheck.parse`) — no duplicate `RawReport`-style structs.
+- Full design: [`docs/superpowers/specs/2026-07-15-pre-deploy-scan-envelope-design.md`](../specs/2026-07-15-pre-deploy-scan-envelope-design.md).
+
+---
+
+### Task 1: Rewrite scan-result types, consolidate the decoder, migrate `AnglesiteCoreTests`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/PreDeployCheck.swift` (full rewrite)
+- Modify: `Sources/AnglesiteCore/DeployCommand.swift:205-235` (`parseScanReport`)
+- Modify: `Sources/AnglesiteCore/RouteCoverageScanner.swift:17-22`
+- Modify: `Tests/AnglesiteCoreTests/PreDeployCheckTests.swift` (full rewrite)
+- Modify: `Tests/AnglesiteCoreTests/DeployCommandTests.swift:69-72,274,506`
+- Modify: `Tests/AnglesiteCoreTests/HealthModelTests.swift:174-180`
+- Modify: `Tests/AnglesiteCoreTests/SiteOperationsTests.swift:118-120,204-209`
+
+**Interfaces:**
+- Produces: `PreDeployCheck.ScanFailure(category:message:file:detail:remediation:)`, `PreDeployCheck.ScanWarning(category:message:file:detail:remediation:)` — `message` required, `file`/`detail`/`remediation` default to `nil`. `PreDeployCheck.ScanFailure.Category` / `PreDeployCheck.ScanWarning.Category` — `String`-backed enums that decode any unrecognized raw value to `.other`. `PreDeployCheck.parse(output: String, exitCode: Int32?) -> PreDeployCheck.Outcome` — the one shared decoder.
+- Consumes: nothing from other tasks (this is the foundation task).
+
+This task changes a type used across `Sources/AnglesiteCore`, so partial compilation isn't possible — all of `AnglesiteCore` and `AnglesiteCoreTests` must be updated together for the target to build. `AnglesiteApp`/`AnglesiteIntents` targets (Task 2/3) will still fail to build after this task — that's expected until those tasks land.
+
+- [ ] **Step 1: Rewrite `Sources/AnglesiteCore/PreDeployCheck.swift`**
+
+```swift
+import Foundation
+
+/// Runs the bundled plugin's pre-deploy scans against a site directory and
+/// returns a structured outcome the app can render.
+///
+/// The four mandatory blockers (PII, exposed tokens, third-party scripts,
+/// Keystatic admin routes) come from `template/scripts/pre-deploy-check.ts`
+/// invoked with `--json`. The JSON contract is owned by the plugin — this
+/// actor is just a typed shell around `JSONDecoder` and a script invocation.
+///
+/// `PreDeployCheck` is intentionally minimal: no Cloudflare token resolution,
+/// no `npm run build`, no UI. Callers (today: `DeployCommand`) decide what to
+/// do with the `Outcome`. The build step lands with the deploy-flow polish in
+/// #22; this actor presumes `dist/` already exists and surfaces a `.error`
+/// outcome when it does not.
+public actor PreDeployCheck {
+    public enum Outcome: Sendable, Equatable {
+        case passed(warnings: [ScanWarning])
+        case blocked(failures: [ScanFailure], warnings: [ScanWarning])
+        /// Script error — couldn't run the scan at all (missing tsx, missing
+        /// dist/, malformed JSON, unsupported envelope version). Distinct from
+        /// `.blocked` so callers can surface the right remediation.
+        case error(reason: String)
+    }
+
+    public struct ScanFailure: Sendable, Equatable, Codable {
+        public enum Category: String, Sendable, Codable, CaseIterable {
+            case piiEmail = "pii-email"
+            case piiPhone = "pii-phone"
+            case piiSSN = "pii-ssn"
+            case exposedToken = "exposed-token"
+            case thirdPartyScript = "third-party-script"
+            case keystaticRoute = "keystatic-route"
+            case cspMisconfigured = "csp-misconfigured"
+            /// Any category code this build doesn't recognize yet — decoding falls back here
+            /// instead of throwing, so a future/typo'd category can't crash the whole scan (#742).
+            case other = "other"
+
+            public init(from decoder: Decoder) throws {
+                let raw = try decoder.singleValueContainer().decode(String.self)
+                self = Category(rawValue: raw) ?? .other
+            }
+        }
+        public let category: Category
+        public let message: String
+        /// Repo-relative path of the file where the issue was found, when known.
+        public let file: String?
+        public let detail: String?
+        public let remediation: String?
+
+        public init(
+            category: Category,
+            message: String,
+            file: String? = nil,
+            detail: String? = nil,
+            remediation: String? = nil
+        ) {
+            self.category = category
+            self.message = message
+            self.file = file
+            self.detail = detail
+            self.remediation = remediation
+        }
+    }
+
+    public struct ScanWarning: Sendable, Equatable, Codable {
+        public enum Category: String, Sendable, Codable, CaseIterable {
+            case missingOgImage = "missing-og-image"
+            case maintenanceOverdue = "maintenance-overdue"
+            case seoCritical = "seo-critical"
+            case seoWarning = "seo-warning"
+            /// A route published by the previous deploy is no longer published and has no
+            /// `redirects.json` entry covering it. Computed by `RouteCoverageScanner`, not the
+            /// JS-side scan script — merged into the `Outcome` by `DeployCommand.deploy`.
+            case orphanedRoute = "orphaned-route"
+            case mixedContent = "mixed-content"
+            case sriMissing = "sri-missing"
+            case externalLinkRel = "external-link-rel"
+            case missingSecurityArtifact = "missing-security-artifact"
+            case thirdPartyScript = "third-party-script"
+            /// Any category code this build doesn't recognize yet — decoding falls back here
+            /// instead of throwing, so a future/typo'd category can't crash the whole scan (#742).
+            case other = "other"
+
+            public init(from decoder: Decoder) throws {
+                let raw = try decoder.singleValueContainer().decode(String.self)
+                self = Category(rawValue: raw) ?? .other
+            }
+        }
+        public let category: Category
+        public let message: String
+        public let file: String?
+        public let detail: String?
+        public let remediation: String?
+
+        public init(
+            category: Category,
+            message: String,
+            file: String? = nil,
+            detail: String? = nil,
+            remediation: String? = nil
+        ) {
+            self.category = category
+            self.message = message
+            self.file = file
+            self.detail = detail
+            self.remediation = remediation
+        }
+    }
+
+    /// The versioned JSON envelope emitted by `pre-deploy-check.ts --json` (#742).
+    struct ScanReport: Decodable {
+        let version: Int
+        let ok: Bool
+        let failures: [ScanFailure]
+        let warnings: [ScanWarning]
+    }
+
+    /// Checked before a full `ScanReport` decode so an unsupported future envelope version
+    /// reports a specific remediation instead of a generic malformed-JSON error.
+    private struct VersionProbe: Decodable { let version: Int }
+
+    /// The single decoder for `pre-deploy-check.ts --json` output (#742). Both `check` below and
+    /// `DeployCommand.parseScanReport` call this — neither re-declares its own JSON shape.
+    /// Anglesite is pre-1.0, so there is no legacy bare-array fallback: anything that isn't the
+    /// current versioned envelope is an explicit `.error`.
+    public static func parse(output: String, exitCode: Int32?) -> Outcome {
+        let data = Data(output.utf8)
+        guard let probe = try? JSONDecoder().decode(VersionProbe.self, from: data) else {
+            return .error(reason: decodeErrorReason(exitCode: exitCode))
+        }
+        guard probe.version == 1 else {
+            return .error(reason: "pre-deploy scan emitted an unsupported envelope version (\(probe.version)) — run `/anglesite:update`")
+        }
+        guard let report = try? JSONDecoder().decode(ScanReport.self, from: data) else {
+            return .error(reason: decodeErrorReason(exitCode: exitCode))
+        }
+        return report.ok
+            ? .passed(warnings: report.warnings)
+            : .blocked(failures: report.failures, warnings: report.warnings)
+    }
+
+    /// No parseable envelope at all — either fully malformed JSON, or well-formed JSON missing
+    /// `version` (including the pre-#742 bare-array shape, which has no `version` key).
+    private static func decodeErrorReason(exitCode: Int32?) -> String {
+        let exit = exitCode ?? -1
+        return exit == 0
+            ? "pre-deploy scan emitted no JSON (exit 0) — is the site's scripts/pre-deploy-check.ts up to date?"
+            : "pre-deploy scan failed (exit \(exit)) — run `npm run build` and try again, or run `/anglesite:update` if the script is outdated"
+    }
+
+    /// Spawns the scan script and returns its stdout + exit code. Tests inject
+    /// a fake; the default invoker shells out to `npx tsx scripts/pre-deploy-check.ts --json`
+    /// with `siteDirectory` as cwd.
+    public typealias ScriptInvoker = @Sendable (_ siteDirectory: URL) async throws -> (stdout: String, exitCode: Int32)
+
+    private let invoke: ScriptInvoker
+
+    public init(invoke: @escaping ScriptInvoker) {
+        self.invoke = invoke
+    }
+
+    public func check(siteID: String, siteDirectory: URL) async -> Outcome {
+        let result: (stdout: String, exitCode: Int32)
+        do {
+            result = try await invoke(siteDirectory)
+        } catch {
+            return .error(reason: "couldn't run pre-deploy scan: \(error)")
+        }
+        return Self.parse(output: result.stdout, exitCode: result.exitCode)
+    }
+}
+```
+
+- [ ] **Step 2: Update `Sources/AnglesiteCore/DeployCommand.swift`'s `parseScanReport` to delegate**
+
+Replace lines 205-235 (the `// MARK: Scan report parsing` block through the end of `parseScanReport`) with:
+
+```swift
+    // MARK: Scan report parsing
+
+    /// Parses the captured stdout of the pre-deploy scan (`scripts/pre-deploy-check.ts --json`)
+    /// into a `PreDeployCheck.Outcome`. Thin forwarding wrapper — `PreDeployCheck.parse` is the
+    /// one real decoder (#742); this keeps the existing public call-site signature stable.
+    public static func parseScanReport(output: String, exitCode: Int32?) -> PreDeployCheck.Outcome {
+        PreDeployCheck.parse(output: output, exitCode: exitCode)
+    }
+```
+
+- [ ] **Step 3: Update `Sources/AnglesiteCore/RouteCoverageScanner.swift`'s construction call**
+
+Replace the `return vanished.sorted().map { ... }` body with:
+
+```swift
+        return vanished.sorted().map { route in
+            PreDeployCheck.ScanWarning(
+                category: .orphanedRoute,
+                message: "\(route) is no longer published and has no redirect covering it.",
+                remediation: "Add a redirect for \(route) in Site Settings → Redirects, or ignore if the removal is intentional."
+            )
+        }
+```
+
+- [ ] **Step 4: Verify the library targets build**
+
+Run: `swift build --package-path .`
+Expected: `Build complete!` — `AnglesiteCore`'s library target compiles cleanly. (Test targets will not build yet; that's expected until this task's remaining steps land.)
+
+- [ ] **Step 5: Rewrite `Tests/AnglesiteCoreTests/PreDeployCheckTests.swift`**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct PreDeployCheckTests {
+    private let siteDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+    // MARK: Happy path
+
+    @Test("Returns passed when script emits ok-true JSON") func returnsPassedWhenScriptEmitsOkTrueJSON() async {
+        let json = #"{"version": 1, "ok": true, "failures": [], "warnings": []}"#
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 0) })
+
+        let outcome = await check.check(siteID: "mysite", siteDirectory: siteDir)
+
+        guard case .passed(let warnings) = outcome else {
+            Issue.record("expected .passed, got \(outcome)")
+            return
+        }
+        #expect(warnings == [])
+    }
+
+    // MARK: Blocked
+
+    @Test("Returns blocked when script emits ok-false with failures") func returnsBlockedWhenScriptEmitsOkFalseWithFailures() async {
+        let json = """
+        {
+          "version": 1,
+          "ok": false,
+          "failures": [
+            {
+              "category": "pii-email",
+              "message": "Possible email address: jane@yourbusiness.com",
+              "file": "dist/index.html",
+              "remediation": "Wrap the address in a `mailto:` link if it should be published, or add it to PII_EMAIL_ALLOW in .site-config."
+            }
+          ],
+          "warnings": []
+        }
+        """
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 1) })
+
+        let outcome = await check.check(siteID: "mysite", siteDirectory: siteDir)
+
+        guard case .blocked(let failures, _) = outcome else {
+            Issue.record("expected .blocked, got \(outcome)")
+            return
+        }
+        #expect(failures.count == 1)
+        #expect(failures[0].category == .piiEmail)
+        #expect(failures[0].file == "dist/index.html")
+        #expect(failures[0].message.contains("jane@yourbusiness.com"))
+        #expect(failures[0].remediation?.contains("PII_EMAIL_ALLOW") == true)
+    }
+
+    @Test("Parses all five failure categories") func parsesAllFiveFailureCategories() async {
+        let json = """
+        {
+          "version": 1,
+          "ok": false,
+          "failures": [
+            {"category": "pii-email", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "pii-phone", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "exposed-token", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "third-party-script", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "keystatic-route", "message": "m", "file": "a", "remediation": "r"}
+          ],
+          "warnings": []
+        }
+        """
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 1) })
+
+        guard case .blocked(let failures, _) = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .blocked")
+            return
+        }
+        #expect(
+            Set(failures.map(\.category)) == Set([.piiEmail, .piiPhone, .exposedToken, .thirdPartyScript, .keystaticRoute])
+        )
+    }
+
+    @Test("Unknown category decodes to .other instead of failing the scan") func unknownCategoryDecodesToOther() async {
+        let json = """
+        {
+          "version": 1,
+          "ok": false,
+          "failures": [
+            {"category": "some-future-category", "message": "m", "file": "a"}
+          ],
+          "warnings": [
+            {"category": "another-future-category", "message": "m"}
+          ]
+        }
+        """
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 1) })
+
+        guard case .blocked(let failures, let warnings) = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .blocked")
+            return
+        }
+        #expect(failures.first?.category == .other)
+        #expect(warnings.first?.category == .other)
+    }
+
+    // MARK: Error paths
+
+    @Test("Returns error when invoker throws") func returnsErrorWhenInvokerThrows() async {
+        struct SpawnFailed: Error {}
+        let check = PreDeployCheck(invoke: { _ in throw SpawnFailed() })
+
+        let outcome = await check.check(siteID: "mysite", siteDirectory: siteDir)
+
+        guard case .error(let reason) = outcome else {
+            Issue.record("expected .error, got \(outcome)")
+            return
+        }
+        #expect(reason.contains("couldn't run"), "\(reason)")
+    }
+
+    @Test("Returns error when stdout is not parseable JSON") func returnsErrorWhenStdoutIsNotParseableJSON() async {
+        // tsx not installed → "command not found" on stderr, no stdout, exit 127
+        let check = PreDeployCheck(invoke: { _ in (stdout: "", exitCode: 127) })
+
+        guard case .error(let reason) = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .error")
+            return
+        }
+        #expect(reason.contains("exit 127") || reason.contains("npm run build") || reason.contains("update"), "\(reason)")
+    }
+
+    @Test("Returns error when JSON is malformed") func returnsErrorWhenJSONIsMalformed() async {
+        let check = PreDeployCheck(invoke: { _ in (stdout: "not json at all", exitCode: 0) })
+
+        guard case .error = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .error")
+            return
+        }
+    }
+
+    @Test("Returns error when the version field is missing (no legacy-array fallback)") func returnsErrorWhenVersionIsMissing() async {
+        // Pre-#742 shape: a bare array, no envelope at all.
+        let json = #"[{"severity":"error","message":"Possible email found","file":"dist/index.html"}]"#
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 1) })
+
+        guard case .error = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .error for pre-envelope legacy array output")
+            return
+        }
+    }
+
+    @Test("Returns error when the envelope version is unsupported") func returnsErrorWhenVersionIsUnsupported() async {
+        let json = #"{"version": 2, "ok": true, "failures": [], "warnings": []}"#
+        let check = PreDeployCheck(invoke: { _ in (stdout: json, exitCode: 0) })
+
+        guard case .error(let reason) = await check.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .error")
+            return
+        }
+        #expect(reason.contains("unsupported envelope version"), "\(reason)")
+    }
+
+    // MARK: Warnings pass-through
+
+    @Test("Warnings are returned alongside passed and blocked outcomes") func warningsAreReturnedAlongsidePassedAndBlockedOutcomes() async {
+        let warningJSON = """
+        "warnings": [
+          {"category": "missing-og-image", "message": "No og:image meta tag.", "remediation": "Run `npm run ai-images`."}
+        ]
+        """
+        let passedJSON = "{ \"version\": 1, \"ok\": true, \"failures\": [], \(warningJSON) }"
+        let blockedJSON = """
+        { "version": 1, "ok": false,
+          "failures": [{"category": "pii-email", "message": "m", "file": "a", "remediation": "r"}],
+          \(warningJSON) }
+        """
+
+        let passedCheck = PreDeployCheck(invoke: { _ in (stdout: passedJSON, exitCode: 0) })
+        guard case .passed(let pw) = await passedCheck.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .passed")
+            return
+        }
+        #expect(pw.count == 1)
+        #expect(pw[0].category == .missingOgImage)
+
+        let blockedCheck = PreDeployCheck(invoke: { _ in (stdout: blockedJSON, exitCode: 1) })
+        guard case .blocked(_, let bw) = await blockedCheck.check(siteID: "mysite", siteDirectory: siteDir) else {
+            Issue.record("expected .blocked")
+            return
+        }
+        #expect(bw.count == 1)
+        #expect(bw[0].category == .missingOgImage)
+    }
+}
+```
+
+- [ ] **Step 6: Update `Tests/AnglesiteCoreTests/DeployCommandTests.swift`**
+
+First, a project-wide-in-file replace: every occurrence of the literal `{"ok":true,"failures":[],"warnings":[]}` becomes `{"version":1,"ok":true,"failures":[],"warnings":[]}` (this covers `scanJSON(ok: true)` and all three `/bin/sh` echo fixtures at once, since they share the exact substring).
+
+Then replace the `scanJSON` helper (originally lines 69-72) with:
+
+```swift
+    /// Build the JSON payload the plugin's `pre-deploy-check.ts --json` emits.
+    private func scanJSON(ok: Bool) -> String {
+        ok ? #"{"version":1,"ok":true,"failures":[],"warnings":[]}"#
+           : #"{"version":1,"ok":false,"failures":[{"category":"pii-email","message":"email","file":"dist/index.html","remediation":"wrap it"}],"warnings":[]}"#
+    }
+```
+
+Then replace the inline fixture (originally line 274):
+
+```swift
+            .set(.preflight, exitCode: 0, output: #"{"version":1,"ok":true,"failures":[],"warnings":[{"category":"missing-og-image","message":"no og image","remediation":"add one"}]}"#)
+```
+
+Then replace the assertion (originally line 506):
+
+```swift
+        #expect(warnings.contains { $0.category == .orphanedRoute && $0.message.contains("/old-page") })
+```
+
+- [ ] **Step 7: Update `Tests/AnglesiteCoreTests/HealthModelTests.swift`'s fixtures**
+
+Replace (originally lines 174-180):
+
+```swift
+    private var sampleFailure: PreDeployCheck.ScanFailure {
+        .init(category: .exposedToken, message: "token in src", file: "src/x.astro", remediation: "remove it")
+    }
+
+    private var sampleWarning: PreDeployCheck.ScanWarning {
+        .init(category: .missingOgImage, message: "no og image", remediation: "add one")
+    }
+```
+
+- [ ] **Step 8: Update `Tests/AnglesiteCoreTests/SiteOperationsTests.swift`'s two construction sites**
+
+Replace (originally lines 118-120):
+
+```swift
+        let failure = PreDeployCheck.ScanFailure(
+            category: .exposedToken, message: "API key committed", file: "src/index.md", remediation: "Remove it"
+        )
+```
+
+Replace (originally lines 204-209):
+
+```swift
+        let failure = PreDeployCheck.ScanFailure(
+            category: .exposedToken,
+            message: "API key committed",
+            file: "dist/index.html",
+            remediation: "Remove it"
+        )
+```
+
+- [ ] **Step 9: Run the `AnglesiteCore` test suite**
+
+Run: `swift test --package-path . --filter AnglesiteCoreTests`
+Expected: all tests pass, including the 3 new tests added in Step 5 (`unknownCategoryDecodesToOther`, `returnsErrorWhenVersionIsMissing`, `returnsErrorWhenVersionIsUnsupported`).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Sources/AnglesiteCore/PreDeployCheck.swift Sources/AnglesiteCore/DeployCommand.swift Sources/AnglesiteCore/RouteCoverageScanner.swift Tests/AnglesiteCoreTests/PreDeployCheckTests.swift Tests/AnglesiteCoreTests/DeployCommandTests.swift Tests/AnglesiteCoreTests/HealthModelTests.swift Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+git commit -m "feat(core): unify pre-deploy scan JSON envelope for #742
+
+Replace the two divergent Swift decoders with one PreDeployCheck.parse,
+add the versioned {version,ok,failures,warnings} envelope shape, and
+make category decoding forward-compatible (unknown -> .other)."
+```
+
+---
+
+### Task 2: Migrate `AnglesiteApp` (UI + `DeployModelTests`)
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/BlockedDeploySheetView.swift`
+- Modify: `Sources/AnglesiteApp/HealthBadgeView.swift:182,186,199,200`
+- Modify: `Tests/AnglesiteAppTests/DeployModelTests.swift:22`
+
+**Interfaces:**
+- Consumes: `PreDeployCheck.ScanFailure`/`ScanWarning` from Task 1 (`message` required, `file`/`detail`/`remediation` optional; `Category` includes `.other`).
+- Produces: nothing new — this task only fixes call sites broken by Task 1's type change.
+
+- [ ] **Step 1: Update `Sources/AnglesiteApp/BlockedDeploySheetView.swift`**
+
+Replace `FailureCard`'s body text and category functions:
+
+```swift
+private struct FailureCard: View {
+    let failure: PreDeployCheck.ScanFailure
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: categoryIcon(failure.category))
+                    .foregroundStyle(.red)
+                    .accessibilityHidden(true)
+                Text(categoryLabel(failure.category))
+                    .font(.subheadline).fontWeight(.semibold)
+                if let file = failure.file {
+                    Text(file)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1).truncationMode(.middle)
+                        // Path is middle-truncated for layout; read the whole thing aloud.
+                        .accessibilityLabel("File")
+                        .accessibilityValue(file)
+                }
+            }
+            Text(failure.detail ?? failure.message).font(.callout)
+            if let remediation = failure.remediation {
+                Text(remediation)
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(NSColor.controlBackgroundColor))
+        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(.red.opacity(0.25)))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func categoryIcon(_ category: PreDeployCheck.ScanFailure.Category) -> String {
+        switch category {
+        case .piiEmail, .piiPhone, .piiSSN: return "person.crop.circle.badge.exclamationmark"
+        case .exposedToken: return "key.fill"
+        case .thirdPartyScript: return "network"
+        case .keystaticRoute: return "lock.shield"
+        case .cspMisconfigured: return "shield.slash"
+        case .other: return "exclamationmark.triangle"
+        }
+    }
+
+    private func categoryLabel(_ category: PreDeployCheck.ScanFailure.Category) -> String {
+        switch category {
+        case .piiEmail: return "PII — email address"
+        case .piiPhone: return "PII — phone number"
+        case .piiSSN: return "PII — SSN"
+        case .exposedToken: return "Exposed token"
+        case .thirdPartyScript: return "Third-party script"
+        case .keystaticRoute: return "Keystatic admin route"
+        case .cspMisconfigured: return "CSP misconfigured"
+        case .other: return "Other"
+        }
+    }
+```
+
+Replace `WarningCard`'s body text and category label:
+
+```swift
+private struct WarningCard: View {
+    let warning: PreDeployCheck.ScanWarning
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .accessibilityHidden(true)
+                Text(categoryLabel(warning.category))
+                    .font(.subheadline).fontWeight(.semibold)
+            }
+            Text(warning.detail ?? warning.message).font(.callout)
+            if let remediation = warning.remediation {
+                Text(remediation)
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(NSColor.controlBackgroundColor))
+        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(.orange.opacity(0.25)))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func categoryLabel(_ category: PreDeployCheck.ScanWarning.Category) -> String {
+        switch category {
+        case .missingOgImage: return "Missing OG image"
+        case .maintenanceOverdue: return "Maintenance overdue"
+        case .seoCritical: return "SEO — critical"
+        case .seoWarning: return "SEO — warning"
+        case .orphanedRoute: return "Orphaned route"
+        case .mixedContent: return "Mixed content"
+        case .sriMissing: return "Missing subresource integrity"
+        case .externalLinkRel: return "Missing rel=noopener"
+        case .missingSecurityArtifact: return "Missing security artifact"
+        case .thirdPartyScript: return "Third-party script"
+        case .other: return "Other"
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update `Sources/AnglesiteApp/HealthBadgeView.swift`'s `findingsList`**
+
+Replace lines 171-206 (`findingsList`) with:
+
+```swift
+    @ViewBuilder
+    private func findingsList(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if !failures.isEmpty {
+                Text("Blocking (\(failures.count))").font(.subheadline.weight(.semibold))
+                ForEach(failures.indices, id: \.self) { i in
+                    let f = failures[i]
+                    HStack(alignment: .top, spacing: 6) {
+                        Image(systemName: "xmark.circle.fill").foregroundStyle(.red)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(f.detail ?? f.message).font(.callout)
+                            if let file = f.file {
+                                Text(file).font(.caption.monospaced()).foregroundStyle(.secondary)
+                            }
+                            if let remediation = f.remediation {
+                                Text(remediation).font(.caption).foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+            if !warnings.isEmpty {
+                Text("Warnings (\(warnings.count))").font(.subheadline.weight(.semibold))
+                ForEach(warnings.indices, id: \.self) { i in
+                    let w = warnings[i]
+                    HStack(alignment: .top, spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.yellow)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(w.detail ?? w.message).font(.callout)
+                            if let remediation = w.remediation {
+                                Text(remediation).font(.caption).foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Update `Tests/AnglesiteAppTests/DeployModelTests.swift`'s fixture**
+
+Replace line 22:
+
+```swift
+                output: #"{"version":1,"ok":true,"failures":[],"warnings":[]}"#
+```
+
+- [ ] **Step 4: Run the `AnglesiteApp` test suite**
+
+Run: `swift test --package-path . --filter AnglesiteAppTests`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/BlockedDeploySheetView.swift Sources/AnglesiteApp/HealthBadgeView.swift Tests/AnglesiteAppTests/DeployModelTests.swift
+git commit -m "fix(app): render optional detail/remediation and .other category for #742"
+```
+
+---
+
+### Task 3: Migrate `AnglesiteIntentsTests`
+
+**Files:**
+- Modify: `Tests/AnglesiteIntentsTests/DeploySiteIntentTests.swift:31-36`
+
+**Interfaces:**
+- Consumes: `PreDeployCheck.ScanFailure(category:message:file:detail:remediation:)` from Task 1.
+
+- [ ] **Step 1: Update the construction site**
+
+Replace (originally lines 31-36):
+
+```swift
+            let failure = PreDeployCheck.ScanFailure(
+                category: .exposedToken,
+                message: "API key committed",
+                file: "src/index.md",
+                remediation: "Remove it"
+            )
+```
+
+- [ ] **Step 2: Run the `AnglesiteIntents` test suite**
+
+Run: `swift test --package-path . --filter AnglesiteIntentsTests`
+Expected: all tests pass. (Per CLAUDE.md, `AnglesiteIntentsTests` requires Swift 6.4+/Xcode 27 — if the toolchain doesn't support it, this filter yields no tests to run; that's expected in that environment, not a failure.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/AnglesiteIntentsTests/DeploySiteIntentTests.swift
+git commit -m "fix(intents): migrate ScanFailure fixture to the #742 envelope shape"
+```
+
+---
+
+### Task 4: Update `pre-deploy-check.ts` to emit the versioned envelope
+
+**Files:**
+- Modify: `Resources/Template/scripts/pre-deploy-check.ts` (full rewrite)
+- Modify: `Resources/Template/scripts/pre-deploy-check.test.ts`
+
+**Interfaces:**
+- Produces: `npx tsx scripts/pre-deploy-check.ts --json` now prints `{"version":1,"ok":bool,"failures":[...],"warnings":[...]}` instead of a flat array. Each finding has `severity`, `category`, `message`, optional `file`.
+- Consumes: nothing from earlier tasks (independent toolchain; only Task 5's fixture test bridges the two).
+
+- [ ] **Step 1: Rewrite `Resources/Template/scripts/pre-deploy-check.ts`**
+
+```typescript
+#!/usr/bin/env npx tsx
+/**
+ * Pre-deploy security scan. Runs from the scaffolded site directory (not the template).
+ *
+ * Checks:
+ * - No PII patterns (emails, phone numbers) in generated output
+ * - No exposed API tokens or secrets
+ * - No third-party tracking scripts
+ * - No Keystatic admin routes in production output
+ *
+ * Usage: npx tsx scripts/pre-deploy-check.ts [--json]
+ *
+ * Exit code 0: all clear. Exit code 1: issues found.
+ * With --json: prints the versioned {version, ok, failures, warnings} envelope (#742).
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseAllowedDomains } from "./csp";
+
+interface Issue {
+  severity: "error" | "warning";
+  category: string;
+  message: string;
+  file?: string;
+}
+
+interface ScanReport {
+  version: 1;
+  ok: boolean;
+  failures: Issue[];
+  warnings: Issue[];
+}
+
+const JSON_MODE = process.argv.includes("--json");
+const DIST_DIR = join(process.cwd(), "dist");
+const HEADERS_FILE = join(DIST_DIR, "_headers");
+const CONFIG_FILE = join(process.cwd(), ".site-config");
+
+const PII_PATTERNS = [
+  { name: "email", pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g },
+  { name: "phone", pattern: /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/g },
+  { name: "SSN", pattern: /\b\d{3}-\d{2}-\d{4}\b/g },
+];
+
+const SECRET_PATTERNS = [
+  { name: "API key", pattern: /(?:api[_-]?key|apikey)\s*[:=]\s*["']?[a-zA-Z0-9_-]{20,}/gi },
+  { name: "AWS key", pattern: /AKIA[0-9A-Z]{16}/g },
+  { name: "private key", pattern: /-----BEGIN (?:RSA |EC )?PRIVATE KEY-----/g },
+];
+
+// Trackers with no first-party integration in this catalog. Google Analytics/Tag
+// Manager are deliberately absent — the `tracking` integration (ga4 provider) makes
+// them a supported, owner-opted-in choice, the same way Plausible/Fathom always were.
+const BLOCKED_SCRIPTS = [
+  /facebook\.net.*fbevents/i,
+  /hotjar\.com/i,
+];
+
+const BLOCKED_ROUTES = [/\/keystatic(?:\/|$)/i, /\/api\/keystatic/i];
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+/**
+ * Validate the generated CSP. Returns one error Issue per problem:
+ * missing _headers, no CSP directive, or a configured SCRIPT_ALLOW domain
+ * absent from the CSP.
+ */
+export function checkHeaders(headersContent: string | null, configContent: string): Issue[] {
+  const issues: Issue[] = [];
+  if (headersContent === null) {
+    issues.push({ severity: "error", category: "csp-misconfigured", message: "No dist/_headers — CSP is not enforced.", file: "_headers" });
+    return issues;
+  }
+  const cspLine = headersContent
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.startsWith("Content-Security-Policy:"));
+  if (!cspLine) {
+    issues.push({ severity: "error", category: "csp-misconfigured", message: "dist/_headers has no Content-Security-Policy.", file: "_headers" });
+    return issues;
+  }
+  const cspTokens = new Set(
+    cspLine
+      .replace(/^Content-Security-Policy:/, "")
+      .split(/[\s;]+/)
+      .filter((t) => t.length > 0),
+  );
+  const allow = parseAllowedDomains(configContent);
+  for (const domain of allow) {
+    if (!cspTokens.has(domain)) {
+      issues.push({
+        severity: "error",
+        category: "csp-misconfigured",
+        message: `Configured integration domain "${domain}" is missing from the CSP.`,
+        file: "_headers",
+      });
+    }
+  }
+  return issues;
+}
+
+/**
+ * Scan built content for likely PII (email, phone, SSN). An email that appears only as a
+ * `mailto:` link target is published intent — e.g. a contact-form fallback the site owner
+ * deliberately configured — not accidental exposure, so it's stripped before the email check.
+ * Phone/SSN patterns are unaffected. One issue per pattern per file, matching the prior inline
+ * scan's behavior.
+ */
+export function checkPII(content: string, file: string): Issue[] {
+  const issues: Issue[] = [];
+  const withoutMailtoLinks = content.replace(
+    /mailto:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+    "",
+  );
+  for (const { name, pattern } of PII_PATTERNS) {
+    pattern.lastIndex = 0;
+    const haystack = name === "email" ? withoutMailtoLinks : content;
+    if (pattern.test(haystack)) {
+      issues.push({
+        severity: "error",
+        category: `pii-${name.toLowerCase()}`,
+        message: `Possible ${name} found`,
+        file,
+      });
+    }
+  }
+  return issues;
+}
+
+/**
+ * Insecure (http://) subresource references in built HTML/CSS. Targets resource
+ * attributes (`src`) and CSS `url(...)` only — NOT `href` — so anchor links and
+ * `xmlns="http://..."` declarations do not false-positive. Advisory: slice A's
+ * `upgrade-insecure-requests` auto-upgrades these at runtime. One issue per file.
+ */
+export function checkMixedContent(content: string, file: string): Issue[] {
+  const patterns = [/\bsrc\s*=\s*["']http:\/\//i, /url\(\s*["']?http:\/\//i];
+  for (const pattern of patterns) {
+    if (pattern.test(content)) {
+      return [{ severity: "warning", category: "mixed-content", message: "Mixed content: insecure http:// resource reference", file }];
+    }
+  }
+  return [];
+}
+
+/**
+ * External (absolute or protocol-relative) <script> and stylesheet <link> tags
+ * with a subresource-integrity problem: either missing `integrity`, or carrying
+ * `integrity` without the `crossorigin` attribute it requires — the browser
+ * blocks the response on CORS before integrity is evaluated, so the resource
+ * silently fails to load. Heuristic tag-level regex match; multi-line tag
+ * attributes are not matched. One issue per offending tag.
+ */
+export function checkSRI(content: string, file: string): Issue[] {
+  const issues: Issue[] = [];
+  const tagPattern = /<(script|link)\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = tagPattern.exec(content)) !== null) {
+    const tag = m[0];
+    const isScript = m[1].toLowerCase() === "script";
+    const urlAttr = isScript
+      ? /\bsrc\s*=\s*["'](?:https?:)?\/\//i
+      : /\bhref\s*=\s*["'](?:https?:)?\/\//i;
+    if (!urlAttr.test(tag)) continue;
+    if (!isScript && !/\brel\s*=\s*["'][^"']*stylesheet/i.test(tag)) continue;
+    const kind = isScript ? "script" : "stylesheet";
+    if (!/\bintegrity\s*=/i.test(tag)) {
+      issues.push({ severity: "warning", category: "sri-missing", message: `External ${kind} without subresource integrity (SRI)`, file });
+    } else if (!/\scrossorigin\b/i.test(tag)) {
+      issues.push({
+        severity: "warning",
+        category: "sri-missing",
+        message: `External ${kind} has integrity but is missing crossorigin (will fail CORS)`,
+        file,
+      });
+    }
+  }
+  return issues;
+}
+
+/**
+ * Anchors that open a new tab (`target="_blank"`) without `rel="noopener"`,
+ * which can expose `window.opener`. `rel="noreferrer"` also implies noopener
+ * (per the HTML spec and all modern browsers), so either token is accepted.
+ * Advisory — modern browsers imply noopener, but explicit is safer. One issue
+ * per offending anchor.
+ */
+export function checkExternalLinkRel(content: string, file: string): Issue[] {
+  const issues: Issue[] = [];
+  const anchorPattern = /<a\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = anchorPattern.exec(content)) !== null) {
+    const tag = m[0];
+    if (!/\btarget\s*=\s*["']_blank["']/i.test(tag)) continue;
+    const relMatch = tag.match(/\brel\s*=\s*["']([^"']*)["']/i);
+    const rel = relMatch ? relMatch[1].toLowerCase() : "";
+    if (!/\bnoopener\b|\bnoreferrer\b/.test(rel)) {
+      issues.push({ severity: "warning", category: "external-link-rel", message: 'Link with target="_blank" missing rel="noopener"', file });
+    }
+  }
+  return issues;
+}
+
+/**
+ * Warn when expected security artifacts are absent from the built output.
+ * `scripts/edge-artifacts.ts` (C1) generates these at build: robots.txt always,
+ * security.txt only when `SECURITY_CONTACT` is set in `.site-config`.
+ */
+export function checkArtifactPresence(relPaths: string[]): Issue[] {
+  const set = new Set(relPaths.map((p) => p.replace(/\\/g, "/")));
+  const required = ["dist/robots.txt", "dist/.well-known/security.txt"];
+  const issues: Issue[] = [];
+  for (const path of required) {
+    if (!set.has(path)) {
+      issues.push({
+        severity: "warning",
+        category: "missing-security-artifact",
+        message: `Missing security artifact: ${path.replace(/^dist\//, "")}`,
+        file: path,
+      });
+    }
+  }
+  return issues;
+}
+
+async function scan(): Promise<Issue[]> {
+  const issues: Issue[] = [];
+
+  try {
+    await stat(DIST_DIR);
+  } catch {
+    issues.push({ severity: "warning", category: "missing-security-artifact", message: "No dist/ directory found — nothing to scan." });
+    return issues;
+  }
+
+  const headersContent = await readFile(HEADERS_FILE, "utf-8").catch((e: NodeJS.ErrnoException) =>
+    e.code === "ENOENT" ? null : Promise.reject(e),
+  );
+  const configContent = await readFile(CONFIG_FILE, "utf-8").catch((e: NodeJS.ErrnoException) =>
+    e.code === "ENOENT" ? "" : Promise.reject(e),
+  );
+  issues.push(...checkHeaders(headersContent, configContent));
+
+  const relPaths: string[] = [];
+
+  for await (const file of walk(DIST_DIR)) {
+    if (!/\.(html?|js|css|json|xml|txt)$/i.test(file)) continue;
+    const content = await readFile(file, "utf-8");
+    const rel = relative(process.cwd(), file);
+    relPaths.push(rel);
+
+    issues.push(...checkPII(content, rel));
+
+    for (const { name, pattern } of SECRET_PATTERNS) {
+      pattern.lastIndex = 0;
+      if (pattern.test(content)) {
+        issues.push({ severity: "error", category: "exposed-token", message: `Possible ${name} exposed`, file: rel });
+      }
+    }
+
+    if (/\.(html?|css)$/i.test(file)) {
+      issues.push(...checkMixedContent(content, rel));
+    }
+
+    if (/\.html?$/i.test(file)) {
+      for (const pattern of BLOCKED_SCRIPTS) {
+        if (pattern.test(content)) {
+          issues.push({
+            severity: "warning",
+            category: "third-party-script",
+            message: `Third-party tracking script detected: ${pattern.source}`,
+            file: rel,
+          });
+        }
+      }
+
+      for (const pattern of BLOCKED_ROUTES) {
+        if (pattern.test(content)) {
+          issues.push({
+            severity: "error",
+            category: "keystatic-route",
+            message: "Keystatic admin route found in production output",
+            file: rel,
+          });
+        }
+      }
+
+      issues.push(...checkSRI(content, rel));
+      issues.push(...checkExternalLinkRel(content, rel));
+    }
+  }
+
+  issues.push(...checkArtifactPresence(relPaths));
+
+  return issues;
+}
+
+async function main() {
+  const issues = await scan();
+  const failures = issues.filter((i) => i.severity === "error");
+  const warnings = issues.filter((i) => i.severity === "warning");
+
+  if (JSON_MODE) {
+    const report: ScanReport = { version: 1, ok: failures.length === 0, failures, warnings };
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+  } else {
+    if (issues.length === 0) {
+      console.log("Pre-deploy check passed — no issues found.");
+    } else {
+      for (const issue of issues) {
+        const prefix = issue.severity === "error" ? "ERROR" : "WARN";
+        const loc = issue.file ? ` (${issue.file})` : "";
+        console.log(`[${prefix}] ${issue.message}${loc}`);
+      }
+    }
+  }
+
+  process.exit(failures.length > 0 ? 1 : 0);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}
+```
+
+- [ ] **Step 2: Update `Resources/Template/scripts/pre-deploy-check.test.ts` with category assertions**
+
+Add a `category` assertion to each test that previously only checked `severity`/`message`. Replace the full file contents:
+
+```typescript
+import test from "node:test";
+import assert from "node:assert/strict";
+import { checkHeaders, checkMixedContent, checkSRI, checkExternalLinkRel, checkArtifactPresence, checkPII } from "./pre-deploy-check";
+
+const GOOD = `/*
+  Content-Security-Policy: default-src 'self'; frame-src 'self' js.stripe.com
+`;
+
+test("missing _headers is an error", () => {
+  const issues = checkHeaders(null, "");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "error");
+  assert.equal(issues[0].category, "csp-misconfigured");
+  assert.match(issues[0].message, /not enforced/);
+});
+
+test("_headers without a CSP is an error", () => {
+  const issues = checkHeaders("/*\n  X-Frame-Options: DENY\n", "");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].category, "csp-misconfigured");
+  assert.match(issues[0].message, /no Content-Security-Policy/);
+});
+
+test("configured domain missing from CSP is an error naming the domain", () => {
+  const issues = checkHeaders(GOOD, "SCRIPT_ALLOW=js.stripe.com,giscus.app");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].category, "csp-misconfigured");
+  assert.match(issues[0].message, /giscus\.app/);
+});
+
+test("CSP covering all configured domains passes", () => {
+  assert.deepEqual(checkHeaders(GOOD, "SCRIPT_ALLOW=js.stripe.com"), []);
+});
+
+test("no SCRIPT_ALLOW: a present CSP passes", () => {
+  assert.deepEqual(checkHeaders(GOOD, ""), []);
+});
+
+test("multiple configured domains missing from CSP each produce an error", () => {
+  const issues = checkHeaders(GOOD, "SCRIPT_ALLOW=giscus.app,assets.calendly.com");
+  assert.equal(issues.length, 2);
+  assert.ok(issues.every((i) => i.severity === "error"));
+  assert.ok(issues.every((i) => i.category === "csp-misconfigured"));
+  assert.ok(issues.some((i) => /giscus\.app/.test(i.message)));
+  assert.ok(issues.some((i) => /assets\.calendly\.com/.test(i.message)));
+});
+
+test("substring of an allowed domain does not satisfy coverage", () => {
+  const headers = `/*\n  Content-Security-Policy: default-src 'self'; frame-src 'self' app.cal.com\n`;
+  const issues = checkHeaders(headers, "SCRIPT_ALLOW=cal.com");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "error");
+  assert.match(issues[0].message, /cal\.com/);
+});
+
+test("checkPII: flags a bare email in page content", () => {
+  const issues = checkPII("<p>Contact us at hello@example.com</p>", "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "error");
+  assert.equal(issues[0].category, "pii-email");
+  assert.match(issues[0].message, /email/);
+});
+
+test("checkPII: does not flag an email that only appears as a mailto: link target", () => {
+  const issues = checkPII('<a href="mailto:hello@example.com">Email us</a>', "dist/contact.html");
+  assert.deepEqual(issues, []);
+});
+
+test("checkPII: still flags a bare email elsewhere on a page that also has a mailto link", () => {
+  const html = '<a href="mailto:hello@example.com">Email us</a><p>debug: admin@internal.example.com</p>';
+  const issues = checkPII(html, "dist/contact.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].category, "pii-email");
+  assert.match(issues[0].message, /email/);
+});
+
+test("checkPII: still flags phone numbers regardless of mailto content", () => {
+  const issues = checkPII('<a href="mailto:hello@example.com">Email</a> Call 555-123-4567', "dist/contact.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].category, "pii-phone");
+  assert.match(issues[0].message, /phone/);
+});
+
+test("checkPII: flags an SSN with the pii-ssn category", () => {
+  const issues = checkPII("<p>SSN: 123-45-6789</p>", "dist/contact.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].category, "pii-ssn");
+});
+
+test("checkMixedContent: flags an insecure src", () => {
+  const issues = checkMixedContent('<img src="http://example.com/a.png">', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.equal(issues[0].category, "mixed-content");
+  assert.match(issues[0].message, /mixed content/i);
+  assert.equal(issues[0].file, "dist/index.html");
+});
+
+test("checkMixedContent: flags an insecure url() in CSS", () => {
+  const issues = checkMixedContent("body { background: url(http://x.com/bg.png); }", "dist/a.css");
+  assert.equal(issues.length, 1);
+});
+
+test("checkMixedContent: https and relative refs are clean", () => {
+  const ok = '<img src="https://x.com/a.png"><script src="/local.js"></script>';
+  assert.deepEqual(checkMixedContent(ok, "dist/index.html"), []);
+});
+
+test("checkMixedContent: svg xmlns http URL is not flagged", () => {
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+  assert.deepEqual(checkMixedContent(svg, "dist/index.html"), []);
+});
+
+test("checkMixedContent: at most one issue per file", () => {
+  const two = '<img src="http://a.com/1.png"><img src="http://b.com/2.png">';
+  assert.equal(checkMixedContent(two, "dist/index.html").length, 1);
+});
+
+test("checkSRI: external script without integrity is a warning", () => {
+  const issues = checkSRI('<script src="https://cdn.x.com/a.js"></script>', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.equal(issues[0].category, "sri-missing");
+  assert.match(issues[0].message, /integrity/i);
+});
+
+test("checkSRI: external script with integrity AND crossorigin is clean", () => {
+  const ok = '<script src="https://cdn.x.com/a.js" integrity="sha384-abc" crossorigin="anonymous"></script>';
+  assert.deepEqual(checkSRI(ok, "dist/index.html"), []);
+});
+
+test("checkSRI: integrity without crossorigin is a warning (CORS would block it)", () => {
+  const issues = checkSRI('<script src="https://cdn.x.com/a.js" integrity="sha384-abc"></script>', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.match(issues[0].message, /crossorigin/i);
+});
+
+test("checkSRI: relative script is clean", () => {
+  assert.deepEqual(checkSRI('<script src="/local.js"></script>', "dist/index.html"), []);
+});
+
+test("checkSRI: external stylesheet link without integrity is a warning", () => {
+  const issues = checkSRI('<link rel="stylesheet" href="https://cdn.x.com/a.css">', "dist/index.html");
+  assert.equal(issues.length, 1);
+});
+
+test("checkSRI: non-stylesheet link is ignored", () => {
+  assert.deepEqual(checkSRI('<link rel="preconnect" href="https://x.com">', "dist/index.html"), []);
+});
+
+test("checkExternalLinkRel: target=_blank without rel=noopener is a warning", () => {
+  const issues = checkExternalLinkRel('<a href="https://x.com" target="_blank">x</a>', "dist/index.html");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.equal(issues[0].category, "external-link-rel");
+  assert.match(issues[0].message, /noopener/i);
+});
+
+test("checkExternalLinkRel: rel=noopener is clean", () => {
+  const ok = '<a href="https://x.com" target="_blank" rel="noopener">x</a>';
+  assert.deepEqual(checkExternalLinkRel(ok, "dist/index.html"), []);
+});
+
+test("checkExternalLinkRel: rel with noopener among others is clean", () => {
+  const ok = '<a href="https://x.com" target="_blank" rel="noopener noreferrer">x</a>';
+  assert.deepEqual(checkExternalLinkRel(ok, "dist/index.html"), []);
+});
+
+test("checkExternalLinkRel: rel=noreferrer alone is clean (implies noopener)", () => {
+  const ok = '<a href="https://x.com" target="_blank" rel="noreferrer">x</a>';
+  assert.deepEqual(checkExternalLinkRel(ok, "dist/index.html"), []);
+});
+
+test("checkExternalLinkRel: link without target=_blank is ignored", () => {
+  assert.deepEqual(checkExternalLinkRel('<a href="https://x.com">x</a>', "dist/index.html"), []);
+});
+
+test("checkArtifactPresence: both present is clean", () => {
+  const paths = ["dist/index.html", "dist/robots.txt", "dist/.well-known/security.txt"];
+  assert.deepEqual(checkArtifactPresence(paths), []);
+});
+
+test("checkArtifactPresence: missing robots.txt is a warning", () => {
+  const issues = checkArtifactPresence(["dist/index.html", "dist/.well-known/security.txt"]);
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "warning");
+  assert.equal(issues[0].category, "missing-security-artifact");
+  assert.match(issues[0].message, /robots\.txt/);
+});
+
+test("checkArtifactPresence: missing both yields two warnings", () => {
+  const issues = checkArtifactPresence(["dist/index.html"]);
+  assert.equal(issues.length, 2);
+});
+
+test("checkArtifactPresence: backslash paths are normalized", () => {
+  const paths = ["dist\\robots.txt", "dist\\.well-known\\security.txt"];
+  assert.deepEqual(checkArtifactPresence(paths), []);
+});
+```
+
+- [ ] **Step 3: Run the TS test suite**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: all tests pass (32 tests — the 31 existing plus the new `pii-ssn` category test).
+
+- [ ] **Step 4: Manually verify the envelope shape against a real fixture**
+
+Run:
+```bash
+cd /tmp && rm -rf pdc-verify && mkdir -p pdc-verify/dist && cd pdc-verify
+echo '<html><body><p>Contact us at hello@example.com</p></body></html>' > dist/index.html
+npx --prefix /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/focused-shaw-9f716a/Resources/Template tsx /Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/focused-shaw-9f716a/Resources/Template/scripts/pre-deploy-check.ts --json
+```
+Expected output (exit code 1):
+```json
+{
+  "version": 1,
+  "ok": false,
+  "failures": [
+    { "severity": "error", "category": "csp-misconfigured", "message": "No dist/_headers — CSP is not enforced.", "file": "_headers" },
+    { "severity": "error", "category": "pii-email", "message": "Possible email found", "file": "dist/index.html" }
+  ],
+  "warnings": [
+    { "severity": "warning", "category": "missing-security-artifact", "message": "Missing security artifact: robots.txt", "file": "dist/robots.txt" },
+    { "severity": "warning", "category": "missing-security-artifact", "message": "Missing security artifact: .well-known/security.txt", "file": "dist/.well-known/security.txt" }
+  ]
+}
+```
+Then clean up: `rm -rf /tmp/pdc-verify`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Resources/Template/scripts/pre-deploy-check.ts Resources/Template/scripts/pre-deploy-check.test.ts
+git commit -m "feat(template): emit the versioned pre-deploy scan envelope for #742
+
+Every Issue now carries a stable category code; main() wraps the flat
+issue list into {version, ok, failures, warnings} for --json output.
+Human-readable output and exit-code semantics are unchanged."
+```
+
+---
+
+### Task 5: Add the producer→consumer fixture test
+
+**Files:**
+- Create: `Tests/AnglesiteCoreTests/PreDeployCheckFixtureTests.swift`
+
+**Interfaces:**
+- Consumes: `PreDeployCheck.parse(output:exitCode:)` (Task 1), the real `Resources/Template/scripts/pre-deploy-check.ts` (Task 4) — this is the test that proves those two agree.
+
+This is the gap #742 exists to close: every other test hand-authors JSON in the Swift-expected shape. This test runs the actual TypeScript script and feeds its actual stdout through the actual Swift decoder.
+
+- [ ] **Step 1: Write the fixture test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Runs the REAL `pre-deploy-check.ts --json` (not a hand-authored JSON string) against a small
+/// fixture `dist/` and decodes its actual stdout through `PreDeployCheck.parse` — the
+/// producer→consumer test #742 exists to add. Every other test in this suite hand-authors JSON in
+/// the Swift-expected shape, which is exactly how the envelope mismatch this issue fixes went
+/// uncaught for so long.
+struct PreDeployCheckFixtureTests {
+    private static var templateScriptsDirectory: URL {
+        // Tests/AnglesiteCoreTests/PreDeployCheckFixtureTests.swift -> repo root -> Resources/Template/scripts
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources/Template/scripts", isDirectory: true)
+    }
+
+    private func makeFixtureDist(html: String) throws -> URL {
+        let siteDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PreDeployCheckFixtureTests-\(UUID().uuidString)", isDirectory: true)
+        let distDir = siteDir.appendingPathComponent("dist", isDirectory: true)
+        try FileManager.default.createDirectory(at: distDir, withIntermediateDirectories: true)
+        try html.write(to: distDir.appendingPathComponent("index.html"), atomically: true, encoding: .utf8)
+        return siteDir
+    }
+
+    /// Runs `npx tsx <template>/scripts/pre-deploy-check.ts --json` with `siteDir` as cwd and
+    /// returns captured stdout + exit code.
+    private func runRealScript(siteDir: URL) throws -> (stdout: String, exitCode: Int32) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["npx", "tsx", Self.templateScriptsDirectory.appendingPathComponent("pre-deploy-check.ts").path, "--json"]
+        process.currentDirectoryURL = siteDir
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (stdout: String(data: data, encoding: .utf8) ?? "", exitCode: process.terminationStatus)
+    }
+
+    @Test("Real script output with a PII hit decodes to .blocked with the pii-email category")
+    func realScriptWithPIIDecodesToBlocked() throws {
+        let siteDir = try makeFixtureDist(html: "<html><body><p>Contact us at hello@example.com</p></body></html>")
+        defer { try? FileManager.default.removeItem(at: siteDir) }
+
+        let result = try runRealScript(siteDir: siteDir)
+        #expect(result.exitCode == 1)
+
+        let outcome = PreDeployCheck.parse(output: result.stdout, exitCode: result.exitCode)
+        guard case .blocked(let failures, let warnings) = outcome else {
+            Issue.record("expected .blocked, got \(outcome) — raw stdout: \(result.stdout)")
+            return
+        }
+        #expect(failures.contains { $0.category == .piiEmail })
+        // No dist/_headers in this minimal fixture — CSP misconfiguration is also expected.
+        #expect(failures.contains { $0.category == .cspMisconfigured })
+        // No robots.txt / security.txt in this minimal fixture.
+        #expect(warnings.contains { $0.category == .missingSecurityArtifact })
+    }
+
+    @Test("Real script output with no issues decodes to .passed")
+    func realScriptWithNoIssuesDecodesToPassed() throws {
+        let siteDir = try makeFixtureDist(html: "<html><body><p>Nothing sensitive here.</p></body></html>")
+        defer { try? FileManager.default.removeItem(at: siteDir) }
+        // A CSP-satisfying _headers file and both security artifacts, so this fixture is fully clean.
+        try "/*\n  Content-Security-Policy: default-src 'self'\n".write(
+            to: siteDir.appendingPathComponent("dist/_headers"), atomically: true, encoding: .utf8)
+        try "User-agent: *\n".write(
+            to: siteDir.appendingPathComponent("dist/robots.txt"), atomically: true, encoding: .utf8)
+        let wellKnown = siteDir.appendingPathComponent("dist/.well-known", isDirectory: true)
+        try FileManager.default.createDirectory(at: wellKnown, withIntermediateDirectories: true)
+        try "Contact: mailto:security@example.com\n".write(
+            to: wellKnown.appendingPathComponent("security.txt"), atomically: true, encoding: .utf8)
+
+        let result = try runRealScript(siteDir: siteDir)
+        #expect(result.exitCode == 0)
+
+        let outcome = PreDeployCheck.parse(output: result.stdout, exitCode: result.exitCode)
+        guard case .passed(let warnings) = outcome else {
+            Issue.record("expected .passed, got \(outcome) — raw stdout: \(result.stdout)")
+            return
+        }
+        #expect(warnings.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `swift test --package-path . --filter PreDeployCheckFixtureTests`
+Expected: both tests pass. (Requires `npx`/`tsx` to be resolvable on `PATH`, same as the rest of the deploy pipeline's dev dependency — if `npx` isn't available in this environment, these two tests will fail with a spawn error; that's an environment gap, not a logic bug, and matches how `HostExecutorParity` in `DeployCommandTests.swift` already depends on `/bin/sh` being present.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/AnglesiteCoreTests/PreDeployCheckFixtureTests.swift
+git commit -m "test(core): add real producer->consumer fixture test for #742
+
+Runs the actual pre-deploy-check.ts --json and decodes its actual
+stdout through PreDeployCheck.parse, closing the gap where every other
+test hand-authored JSON in the Swift-expected shape."
+```
+
+---
+
+### Task 6: Full verification and wrap-up
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full Swift test suite**
+
+Run: `swift test --package-path .`
+Expected: all suites pass (`AnglesiteSiteModelTests`, `AnglesiteCoreTests`, `AnglesiteBridgeTests`, `AnglesiteAppTests`, and `AnglesiteIntentsTests` if the toolchain supports it per CLAUDE.md). If any failure is unrelated to this change (e.g. a known-flaky FM/live-model test), note it explicitly rather than treating the run as failed.
+
+- [ ] **Step 2: Run the TS test suite once more**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 3: Confirm `xcodebuild` still builds the app target**
+
+Run: `xcodegen generate && xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **` — confirms `BlockedDeploySheetView`/`HealthBadgeView`'s UI changes compile in the real app target, not just the SwiftPM test targets.
+
+- [ ] **Step 4: Update the GitHub issue**
+
+```bash
+gh issue edit 742 --remove-label status:in-progress
+```
+
+(Leave the actual issue-closing to the PR — per repo convention, "Closes #742" belongs in the PR description, not a manual close here.)

--- a/docs/superpowers/specs/2026-07-15-pre-deploy-scan-envelope-design.md
+++ b/docs/superpowers/specs/2026-07-15-pre-deploy-scan-envelope-design.md
@@ -124,23 +124,14 @@ Re-scoring it to an error is a separate product decision, out of scope here.
 `PreDeployCheck.check` calls it instead of re-declaring its own `RawReport`; its inline struct is
 deleted.
 
-### Legacy fallback
+### No legacy fallback
 
-Existing scaffolded sites keep their already-checked-in `pre-deploy-check.ts` until template
-Dependency Sync updates it — until then, they still emit the bare `Issue[]` with no envelope. The
-shared decoder:
-
-1. Tries decoding `ScanReport` (the new envelope). On success, use it directly.
-2. On failure, tries decoding `[Issue]` where `Issue = { severity, message, file? }` (today's
-   shape). On success, splits by `severity` into `failures`/`warnings`, synthesizes
-   `category: .other` and `detail: nil, remediation: nil` for each, and computes
-   `ok = failures.isEmpty`.
-3. If neither decodes, or `version` is present but not `1`, or stdout is empty/malformed: `.error(...)`
-   with the existing exit-code-aware remediation message. This is unchanged from today's behavior,
-   just reached via an explicit version/shape check instead of "any decode failure."
-
-This is a decode-time compatibility branch, not a second code path to maintain going forward — it
-can be deleted once #745 (existing-site template migration) ships and old sites have upgraded.
+Anglesite is pre-1.0 with no shipped sites to keep decoding for, so the decoder does **not**
+attempt to read the old bare `Issue[]` shape. It decodes `ScanReport` (the new envelope) directly;
+missing/wrong `version`, or stdout that's empty/malformed/doesn't match the envelope, is always
+`.error(...)` with the existing exit-code-aware remediation message. If a stable-release migration
+concern arises later (post-1.0), it gets its own issue at that time — not speculative compat code
+now.
 
 ### UI fallout
 
@@ -152,15 +143,14 @@ optional:
 - The remediation `Text` is wrapped in `if let remediation = f.remediation { Text(remediation)... }`
   and omitted entirely when `nil`.
 - `categoryIcon`/`categoryLabel` switches gain a `.other` case: a generic icon (`exclamationmark.triangle`)
-  and the raw category string as the label, so an unrecognized/legacy category still renders
+  and the raw category string as the label, so an unrecognized category still renders
   something reasonable instead of failing to compile or falling through.
 
 ### Testing
 
 - Unit tests for the new envelope: full success, mixed failures/warnings, unknown category →
-  `.other`, missing/wrong `version`, empty stdout, malformed JSON.
-- Legacy-array fallback test: today's `Issue[]` shape decodes correctly into the same `Outcome`
-  shape (categories as `.other`).
+  `.other`, missing/wrong `version`, empty stdout, malformed JSON. The old bare `Issue[]` shape is
+  one of the malformed-input cases — it no longer decodes, and that's expected.
 - **Producer→consumer fixture test** (the gap this issue exists to close): a Swift test that runs
   the real `Resources/Template/scripts/pre-deploy-check.ts --json` via `npx tsx` against a small
   fixture site directory with a known PII hit and a clean case, feeds the actual captured stdout
@@ -186,5 +176,5 @@ optional:
 - A real deploy's scan result decodes successfully and reflects the site's actual findings, not a
   decode-failure `.error`.
 - An unrecognized category never crashes decoding or breaks a UI switch.
-- Legacy (pre-#742) scaffolded sites keep working via the array fallback until they migrate.
-- Malformed, empty, or unsupported-version output is always an explicit error, never a false pass.
+- Malformed, empty, unsupported-version, or pre-envelope output is always an explicit error, never
+  a false pass.

--- a/docs/superpowers/specs/2026-07-15-pre-deploy-scan-envelope-design.md
+++ b/docs/superpowers/specs/2026-07-15-pre-deploy-scan-envelope-design.md
@@ -1,0 +1,190 @@
+# Pre-deploy scan JSON envelope — design (#742)
+
+- **Date:** 2026-07-15
+- **Status:** Proposed
+- **Issue:** [#742 — Pre-deploy scan: version and unify the JSON contract](https://github.com/Anglesite/Anglesite-app/issues/742)
+- **Related:** first step of the V-2 IndieAuth chain ([#355](https://github.com/Anglesite/Anglesite-app/issues/355) via #746/#744/#708/#709/#748/#743); blocks [#743](https://github.com/Anglesite/Anglesite-app/issues/743) and [#744](https://github.com/Anglesite/Anglesite-app/issues/744)
+
+## Problem
+
+`Resources/Template/scripts/pre-deploy-check.ts --json` emits a flat `Issue[]` array:
+`{ severity: "error" | "warning", message: string, file?: string }`.
+
+Both Swift consumers instead decode `{ ok: Bool, failures: [ScanFailure], warnings: [ScanWarning] }`,
+where `ScanFailure`/`ScanWarning` require a closed-enum `category` plus non-optional `detail` and
+`remediation` fields the script never emits:
+
+- `Sources/AnglesiteCore/PreDeployCheck.swift`'s `check(siteID:siteDirectory:)` — declares its own
+  inline `RawReport` struct. **Dead code**: nothing in `Sources/` calls it.
+- `Sources/AnglesiteCore/DeployCommand.swift`'s `parseScanReport(output:exitCode:)` — the live path,
+  invoked from `DeployCommand.deploy` via `DeployExecutor`.
+
+Because the real script's output is a top-level JSON *array* and the decoder expects an *object*,
+`JSONDecoder` throws on every real invocation, and `parseScanReport` maps that straight to
+`.error("pre-deploy scan emitted no JSON...")` — **every real deploy's pre-deploy scan currently
+fails to decode**, regardless of whether the site actually has any PII/secret/tracking-script
+issues. This has gone uncaught because every existing test (`PreDeployCheckTests`,
+`DeployCommandTests`, `DeployModelTests`, `HealthModelTests`, `SiteOperationsTests`,
+`DeploySiteIntentTests`) hand-authors JSON fixtures in the *Swift-expected* shape — none run the
+actual TypeScript script and feed its real stdout through the decoder.
+
+The category taxonomies are also out of sync with reality:
+
+- `ScanFailure.Category` has `piiEmail`, `piiPhone`, `exposedToken`, `thirdPartyScript`,
+  `keystaticRoute` — but the script's `checkPII` also matches SSNs (no category), and
+  `checkHeaders`'s three `error`-severity findings (missing `_headers`, missing CSP directive,
+  missing configured domain) have no category at all.
+- `ScanWarning.Category` has `missingOgImage`, `maintenanceOverdue`, `seoCritical`, `seoWarning`,
+  `orphanedRoute` — but **none of the first four are ever constructed anywhere in `Sources/`**
+  (dead, forward-declared cases). Only `orphanedRoute` is real, computed by `RouteCoverageScanner`
+  and merged into the `Outcome` by `DeployCommand.deploy` — it never comes from the script's JSON
+  at all. Meanwhile the script's real `warning`-severity findings (`checkMixedContent`, `checkSRI`
+  ×2, `checkExternalLinkRel`, `checkArtifactPresence`, and `BLOCKED_SCRIPTS`'s third-party-script
+  detection, which today is scored a *warning*, not an error) have no matching category.
+
+## Decision
+
+Define one versioned JSON envelope, shared by TypeScript and Swift, replace the two divergent
+Swift decoders with one, and add a real producer→consumer fixture test.
+
+### Envelope shape
+
+```ts
+// Resources/Template/scripts/pre-deploy-check.ts
+interface ScanFinding {
+  severity: "error" | "warning";
+  category: string;        // stable kebab-case code; see taxonomy below
+  message: string;         // required — today's Issue.message
+  file?: string;
+  detail?: string;         // optional richer elaboration; script may omit
+  remediation?: string;    // optional "how to fix"; script may omit
+}
+interface ScanReport {
+  version: 1;
+  ok: boolean;             // true iff failures is empty
+  failures: ScanFinding[]; // severity: "error"
+  warnings: ScanFinding[]; // severity: "warning"
+}
+```
+
+```swift
+// Sources/AnglesiteCore/PreDeployCheck.swift
+public struct ScanFailure: Sendable, Equatable, Codable {
+    public enum Category: String, Sendable, Codable, CaseIterable {
+        case piiEmail = "pii-email"
+        case piiPhone = "pii-phone"
+        case piiSSN = "pii-ssn"
+        case exposedToken = "exposed-token"
+        case thirdPartyScript = "third-party-script"   // unused by the script (see below); kept for compatibility
+        case keystaticRoute = "keystatic-route"
+        case cspMisconfigured = "csp-misconfigured"
+        case other
+    }
+    public let category: Category
+    public let message: String
+    public let file: String?
+    public let detail: String?
+    public let remediation: String?
+}
+
+public struct ScanWarning: Sendable, Equatable, Codable {
+    public enum Category: String, Sendable, Codable, CaseIterable {
+        case missingOgImage = "missing-og-image"       // unused today; kept, no producer yet
+        case maintenanceOverdue = "maintenance-overdue" // unused today; kept, no producer yet
+        case seoCritical = "seo-critical"               // unused today; kept, no producer yet
+        case seoWarning = "seo-warning"                 // unused today; kept, no producer yet
+        case orphanedRoute = "orphaned-route"           // RouteCoverageScanner, merged separately
+        case mixedContent = "mixed-content"
+        case sriMissing = "sri-missing"
+        case externalLinkRel = "external-link-rel"
+        case missingSecurityArtifact = "missing-security-artifact"
+        case thirdPartyScript = "third-party-script"    // script currently scores this a warning
+        case other
+    }
+    public let category: Category
+    public let message: String
+    public let file: String?
+    public let detail: String?
+    public let remediation: String?
+}
+```
+
+`Category` decodes any unrecognized raw value to `.other` rather than throwing — a custom
+`init(from:)` catches the enum-decode failure and falls back, so a future/typo'd category code
+never crashes the whole scan result. `.other` renders with a generic icon/label in the UI (see
+below) instead of extending the exhaustive switch.
+
+Severities are **not** being reclassified in this change — `third-party-script` stays a warning,
+matching the script's current behavior, per the issue's "preserving current exit-code semantics."
+Re-scoring it to an error is a separate product decision, out of scope here.
+
+### One shared decoder
+
+`DeployCommand.parseScanReport(output:exitCode:)` becomes the single implementation.
+`PreDeployCheck.check` calls it instead of re-declaring its own `RawReport`; its inline struct is
+deleted.
+
+### Legacy fallback
+
+Existing scaffolded sites keep their already-checked-in `pre-deploy-check.ts` until template
+Dependency Sync updates it — until then, they still emit the bare `Issue[]` with no envelope. The
+shared decoder:
+
+1. Tries decoding `ScanReport` (the new envelope). On success, use it directly.
+2. On failure, tries decoding `[Issue]` where `Issue = { severity, message, file? }` (today's
+   shape). On success, splits by `severity` into `failures`/`warnings`, synthesizes
+   `category: .other` and `detail: nil, remediation: nil` for each, and computes
+   `ok = failures.isEmpty`.
+3. If neither decodes, or `version` is present but not `1`, or stdout is empty/malformed: `.error(...)`
+   with the existing exit-code-aware remediation message. This is unchanged from today's behavior,
+   just reached via an explicit version/shape check instead of "any decode failure."
+
+This is a decode-time compatibility branch, not a second code path to maintain going forward — it
+can be deleted once #745 (existing-site template migration) ships and old sites have upgraded.
+
+### UI fallout
+
+`BlockedDeploySheetView.swift` and `HealthBadgeView.swift` currently do
+`Text(failure.detail)` / `Text(failure.remediation)` as non-optional. Since both fields become
+optional:
+
+- `Text(f.detail ?? f.message)` — always show *something* descriptive.
+- The remediation `Text` is wrapped in `if let remediation = f.remediation { Text(remediation)... }`
+  and omitted entirely when `nil`.
+- `categoryIcon`/`categoryLabel` switches gain a `.other` case: a generic icon (`exclamationmark.triangle`)
+  and the raw category string as the label, so an unrecognized/legacy category still renders
+  something reasonable instead of failing to compile or falling through.
+
+### Testing
+
+- Unit tests for the new envelope: full success, mixed failures/warnings, unknown category →
+  `.other`, missing/wrong `version`, empty stdout, malformed JSON.
+- Legacy-array fallback test: today's `Issue[]` shape decodes correctly into the same `Outcome`
+  shape (categories as `.other`).
+- **Producer→consumer fixture test** (the gap this issue exists to close): a Swift test that runs
+  the real `Resources/Template/scripts/pre-deploy-check.ts --json` via `npx tsx` against a small
+  fixture site directory with a known PII hit and a clean case, feeds the actual captured stdout
+  through `DeployCommand.parseScanReport`, and asserts on the resulting `Outcome` — not a
+  hand-authored fixture string.
+- Existing hand-authored fixtures in `PreDeployCheckTests`/`DeployCommandTests`/etc. are updated to
+  the new envelope shape (`message` added, `detail`/`remediation` made optional in the JSON,
+  `version: 1` added).
+
+## Non-goals
+
+- Reclassifying any check's severity (e.g. third-party-script error vs. warning).
+- Writing `detail`/`remediation` copy for every check — optional fields may stay `nil` until a
+  follow-up wants richer UI copy.
+- Removing the four unused `ScanWarning` cases (`missingOgImage`, `maintenanceOverdue`,
+  `seoCritical`, `seoWarning`) — they're harmless forward declarations, not this issue's concern.
+- Any `.well-known` inventory, collision, or Worker-routing work — that's #744/#746, which build on
+  this envelope but are separate specs.
+
+## Target architecture invariants
+
+- `pre-deploy-check.ts --json` and both Swift call sites agree on one versioned envelope.
+- A real deploy's scan result decodes successfully and reflects the site's actual findings, not a
+  decode-failure `.error`.
+- An unrecognized category never crashes decoding or breaks a UI switch.
+- Legacy (pre-#742) scaffolded sites keep working via the array fallback until they migrate.
+- Malformed, empty, or unsupported-version output is always an explicit error, never a false pass.


### PR DESCRIPTION
## Summary

Fixes #742. `Resources/Template/scripts/pre-deploy-check.ts --json` emitted a flat `Issue[]` array, while both Swift decoders (`PreDeployCheck.check` and `DeployCommand.parseScanReport`) each independently expected a different, incompatible shape (`{ok, failures, warnings}` with a closed-enum `category` and non-optional `detail`/`remediation` the script never emitted). Because the top-level JSON was an array where the decoder expected an object, decoding failed on **every real deploy** — the pre-deploy security scan silently mapped to a generic `.error`, regardless of the site's actual content. No test caught this because every existing test hand-authored JSON in the Swift-expected shape rather than running the real script.

- Defines one versioned envelope — `{version: 1, ok, failures, warnings}`, each finding `{severity, category, message, file?, detail?, remediation?}` — shared by the TypeScript producer and the Swift consumer.
- Consolidates the two duplicate Swift decoders into one: `PreDeployCheck.parse(output:exitCode:)`.
- Makes `Category` decoding forward-compatible: an unrecognized category falls back to `.other` instead of throwing.
- Expands the category taxonomy to match what the script actually produces (`pii-ssn`, `csp-misconfigured`, `mixed-content`, `sri-missing`, `external-link-rel`, `missing-security-artifact`, etc.), preserving every check's existing severity classification exactly (no error/warning reclassification).
- No legacy bare-array fallback — Anglesite is pre-1.0 with no shipped sites to support, so anything that isn't the current envelope is an explicit, actionable `.error` (including an unsupported future `version`).
- Adds `PreDeployCheckFixtureTests`, which spawns the *real* `pre-deploy-check.ts --json` against a fixture `dist/` and decodes its *real* stdout through the *real* Swift decoder — closing the gap that let the original mismatch ship silently. Gated on Node + tsx availability (`.enabled(if:)`, matching this repo's other e2e-test convention) so it skips cleanly rather than hard-failing when the tool isn't resolvable without a network fetch.

Design: [docs/superpowers/specs/2026-07-15-pre-deploy-scan-envelope-design.md](docs/superpowers/specs/2026-07-15-pre-deploy-scan-envelope-design.md)
Plan: [docs/superpowers/plans/2026-07-15-pre-deploy-scan-envelope.md](docs/superpowers/plans/2026-07-15-pre-deploy-scan-envelope.md)

Built via subagent-driven development: 6 plan tasks, each independently implemented and reviewed (spec compliance + code quality), plus a final whole-branch review that caught and fixed one real issue (see below). Two tasks' file inventories in the plan were incomplete — implementers caught and fixed 3 additional test files with the same broken shape that the plan's grep missed (`RouteCoverageScannerTests`, `DeployExecutorSelectionTests`, `DeployCommandProgressTests`); one runtime regression among them (`DeployExecutorSelectionTests`) would have silently broken a deploy-flow test, not just failed to compile.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

Only touches `Resources/Template/scripts/pre-deploy-check.ts` (template changes are app-only per `CONTRIBUTING.md`) and Swift decoder/UI code in `Sources/AnglesiteCore`/`Sources/AnglesiteApp` — no MCP message schema or plugin skill changes.

## Context: this is the entry point of a larger blocked chain

This branch originated from a request to implement #355 (V-2.3 IndieAuth site identity). Tracing #355's dependencies surfaced a 7-issue chain (#742 → #748 → #743 → #744 → #708 → #709 → #746 → #355) that must land in order before IndieAuth can actually work — the later issues need a working Worker-routing/`.well-known` collision system that doesn't exist yet. #742 is the one true zero-dependency entry point in that chain, so it's the scope of this PR. #355 itself remains blocked; the remaining chain issues are tracked separately.

## Test plan

- [x] `swift test --package-path .` — full suite green: 1933 tests in `AnglesiteCoreTests` (277 suites) plus every other bundle (`AnglesiteAppTests` 67/67, `AnglesiteIntentsTests`, `AnglesiteBridgeTests`, `AnglesiteSiteModelTests`, smaller XCTest bundles) — 0 failures anywhere, re-verified independently after the final-review fix.
- [x] `npx tsx --test scripts/pre-deploy-check.test.ts` (in `Resources/Template/`) — 32/32 passing, including a new `pii-ssn` category test.
- [x] `xcodebuild -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **`, confirms the UI changes compile in the real hosted app target, not just the SwiftPM test target.
- [x] Manual fixture verification of the real script's `--json` output against the documented envelope shape.
- [x] `PreDeployCheckFixtureTests` (the new producer→consumer test) independently re-run and confirmed to actually execute (not skip) in this environment, both before and after the tsx-gating fix.

## Follow-ups (non-blocking, noted for awareness)

- `pre-deploy-check.ts`'s "no dist/ directory" warning reuses the `missing-security-artifact` category — semantically loose but harmless; a dedicated category would be more precise.
- `CaseIterable` was added to both `Category` enums per the design doc but isn't yet exercised by an automated taxonomy-alignment test (something that decodes one issue per Swift category and asserts none land on `.other`) — would catch a future category being added to one side without the other.
- `ScanFailure.Category.thirdPartyScript` is now a vestigial case — the script only ever emits `third-party-script` as a `warning` (on `ScanWarning.Category`), never as a `failure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
