### PR TITLE
Fix vmnet memory failure recovery

### DIFF
--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -397,7 +397,9 @@ public struct ContainerizationControl: LocalContainerControl {
             onOutput("[boot] VM started", .stdout)
             return bootedContainer
         } catch {
-            onOutput("[boot] VM boot failed: \(error)", .stderr)
+            let errorDescription = "\(error)"
+            let diagnostic = VmnetFailureRecovery.message(for: errorDescription) ?? errorDescription
+            onOutput("[boot] VM boot failed: \(diagnostic)", .stderr)
             // A timeout leaves create/start running. Its operation releases on a late failure;
             // onLateSuccess stops the late VM and releases through stopBareContainer. Releasing
             // here would let another site reuse the address while that VM is still starting.
@@ -406,7 +408,7 @@ public struct ContainerizationControl: LocalContainerControl {
             }
             try? FileManager.default.removeItem(at: rootfsURL)
             try? FileManager.default.removeItem(at: initfsURL)
-            throw LocalContainerError.bootFailed("\(error)")
+            throw LocalContainerError.bootFailed(diagnostic)
         }
     }
 

--- a/Sources/AnglesiteCore/VmnetFailureRecovery.swift
+++ b/Sources/AnglesiteCore/VmnetFailureRecovery.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Turns the opaque error emitted by `VmnetNetwork()` into an operator-actionable diagnosis.
+///
+/// The app is sandboxed and must not inspect or terminate another process's Virtualization XPC
+/// VM. In particular, a stale VM can survive its owning container CLI process, so retrying a
+/// network creation cannot reliably repair this system-wide state (#753).
+public enum VmnetFailureRecovery {
+    /// Returns a stable, named recovery message for known vmnet creation failures.
+    public static func message(for errorDescription: String) -> String? {
+        guard errorDescription.contains("vmnet_return_t(rawValue: 1002)")
+        else { return nil }
+
+        return "The macOS vmnet service reported VMNET_MEM_FAILURE (1002). Another VM or a stale "
+            + "Virtualization process may still hold vmnet resources. Quit other VM/container apps and retry. "
+            + "If it persists, restart your Mac to clear the stale Virtualization state."
+    }
+}

--- a/Tests/AnglesiteCoreTests/VmnetFailureRecoveryTests.swift
+++ b/Tests/AnglesiteCoreTests/VmnetFailureRecoveryTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import AnglesiteCore
+
+struct VmnetFailureRecoveryTests {
+    @Test("VMNET_MEM_FAILURE is named and gives a bounded recovery procedure")
+    func diagnosesMemoryFailure() {
+        let error = "unsupported: failed to create vmnet network with status vmnet_return_t(rawValue: 1002)"
+        let message = VmnetFailureRecovery.message(for: error)
+
+        #expect(message?.contains("VMNET_MEM_FAILURE (1002)") == true)
+        #expect(message?.contains("Quit other VM/container apps and retry") == true)
+        #expect(message?.contains("restart your Mac") == true)
+    }
+
+    @Test("unrelated failures retain their original diagnostic")
+    func ignoresUnrelatedFailure() {
+        #expect(VmnetFailureRecovery.message(for: "permission denied") == nil)
+        #expect(VmnetFailureRecovery.message(for: "vmnet returned 1001") == nil)
+        #expect(VmnetFailureRecovery.message(for: "vmnet_return_t(rawValue: 11002)") == nil)
+        #expect(VmnetFailureRecovery.message(for: "vmnet_return_t(rawValue: 10021)") == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Name vmnet status 1002 as `VMNET_MEM_FAILURE` and provide safe recovery steps.
- Match the exact `vmnet_return_t(rawValue: 1002)` diagnostic so unrelated status values are not misclassified.
- Add regression coverage for both the recognized status and near-miss values.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks).

## Teardown / recovery scope

`SharedVmnetNetwork` releases app-owned interfaces during normal teardown. The reported `VMNET_MEM_FAILURE` occurs while constructing `VmnetNetwork`, before Anglesite owns an interface to release. The stale Virtualization XPC VM observed in the report belonged to another container-runtime process; the sandboxed app cannot enumerate or terminate it. Retrying would not safely recover system-wide vmnet state, so this change fails fast with the named diagnosis and bounded operator recovery procedure instead.

Closes #753

## Test plan

- [x] `swift test --filter VmnetFailureRecoveryTests`
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke (not required: no UI behavior changed)