### PR TITLE
Add invisible publishing pipeline

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -94,6 +94,11 @@ final class DeployModel {
         containerControl: (siteID: String, control: any LocalContainerControl)?
     )?
 
+    private enum Presentation: Equatable {
+        case foreground
+        case background
+    }
+
     init(
         command: DeployCommand = DeployCommand(),
         webmentionCommand: WebmentionSendCommand = WebmentionSendCommand(),
@@ -157,11 +162,48 @@ final class DeployModel {
         phase = .running(siteID: siteID, since: Date())
         let suddenTerminationLease = suddenTerminationController.acquire()
         inFlight = Task { @MainActor [weak self, suddenTerminationLease] in
-            await self?.runDeploy(
+            _ = await self?.runDeploy(
                 siteID: siteID, siteDirectory: siteDirectory,
                 configDirectory: configDirectory, currentRoutes: currentRoutes,
                 containerControl: containerControl,
-                suddenTerminationLease: suddenTerminationLease)
+                suddenTerminationLease: suddenTerminationLease,
+                presentation: .foreground)
+        }
+    }
+
+    /// Runs the same ordered publish pipeline without presenting foreground drawers, token sheets,
+    /// or the security-block modal. The durable invisible-publish queue uses the returned result to
+    /// decide whether its pending marker may be cleared. Terminal transitions still fire, so
+    /// completion and security-block notifications use the normal app notification path.
+    func deployAutomatically(
+        siteID: String,
+        siteDirectory: URL,
+        configDirectory: URL,
+        currentRoutes: [String],
+        containerControl: (siteID: String, control: any LocalContainerControl)?
+    ) async -> InvisiblePublishQueue.Result {
+        guard !isRunning else { return .deferred(reason: "another site operation is running") }
+        guard hasUsableToken() else { return .deferred(reason: "Cloudflare credentials are not configured") }
+        guard containerControl != nil else { return .deferred(reason: "the site runtime is not ready") }
+
+        phase = .running(siteID: siteID, since: Date.now)
+        let lease = suddenTerminationController.acquire()
+        let result = await runDeploy(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            currentRoutes: currentRoutes,
+            containerControl: containerControl,
+            suddenTerminationLease: lease,
+            presentation: .background
+        )
+        switch result {
+        case .succeeded(let url, _):
+            return .succeeded(url: url)
+        case .blocked(let failures, _):
+            return .blocked(failureCount: failures.count)
+        case .failed(let reason, _):
+            return .failed(reason: reason)
         }
     }
 
@@ -252,8 +294,9 @@ final class DeployModel {
         configDirectory: URL,
         currentRoutes: [String],
         containerControl: (siteID: String, control: any LocalContainerControl)? = nil,
-        suddenTerminationLease: SuddenTerminationController.Lease
-    ) async {
+        suddenTerminationLease: SuddenTerminationController.Lease,
+        presentation: Presentation
+    ) async -> DeployCommand.Result {
         defer { suddenTerminationLease.release() }
         transition(siteID: siteID, to: .running(siteID: siteID, since: Date()))
         logLines = []
@@ -265,7 +308,7 @@ final class DeployModel {
         // this call's summarization branch. Must NOT be re-read later via the live field, which
         // may have moved on if a second `runDeploy` call started concurrently (see guard below).
         let myGeneration = summarizationGeneration
-        drawerPresented = true
+        drawerPresented = presentation == .foreground
         blockedPresented = false
 
         let sources = Set(["deploy:\(siteID)", "deploy:\(siteID):build"])
@@ -324,29 +367,28 @@ final class DeployModel {
         currentMilestone = nil
         switch result {
         case .succeeded(let url, let duration):
+            // Astro's build above regenerates RSS/Atom/JSON feeds. Social delivery is ordered
+            // after the deployed canonical pages exist, and completion is notified only after
+            // both best-effort passes finish.
+            emitPostDeployMilestone(.deployWebmentions, siteID: siteID)
+            await webmentionCommand.send(
+                siteID: siteID,
+                siteDirectory: siteDirectory,
+                configDirectory: configDirectory,
+                siteBase: url
+            )
+            emitPostDeployMilestone(.deploySyndicating, siteID: siteID)
+            await posseCommand.syndicate(
+                siteID: siteID,
+                siteDirectory: siteDirectory,
+                configDirectory: configDirectory,
+                siteBase: url
+            )
+            currentMilestone = nil
             transition(siteID: siteID, to: .succeeded(url: url, duration: duration))
-            // Fire-and-forget: webmention sends are best-effort and must never block or affect
-            // the deploy result the user watches. Progress/failures surface only in LogCenter.
-            Task.detached { [webmentionCommand] in
-                await webmentionCommand.send(
-                    siteID: siteID,
-                    siteDirectory: siteDirectory,
-                    configDirectory: configDirectory,
-                    siteBase: url
-                )
-            }
-            // POSSE is independently best-effort so a slow social API never delays webmentions or
-            // changes the deploy result. Its own actor serializes overlapping runs per site.
-            Task.detached { [posseCommand] in
-                await posseCommand.syndicate(
-                    siteID: siteID,
-                    siteDirectory: siteDirectory,
-                    configDirectory: configDirectory,
-                    siteBase: url
-                )
-            }
         case .failed(let reason, let exit):
             transition(siteID: siteID, to: .failed(reason: reason, exitCode: exit))
+            guard presentation == .foreground else { return result }
             let capturedLog = logText   // snapshot before the suspension; a later deploy clears logLines
             summarizing = true
             let summary = await DeployFailureSummaryRequest.run(
@@ -357,7 +399,7 @@ final class DeployModel {
             )
             // Drop the result if another deploy started while we were summarizing — it has already
             // reset failureSummary/summarizing and we must not clobber its state.
-            guard summarizationGeneration == myGeneration else { return }
+            guard summarizationGeneration == myGeneration else { return result }
             failureSummary = summary
             summarizing = false
         case .blocked(let failures, let warnings):
@@ -365,7 +407,13 @@ final class DeployModel {
             // For the blocked outcome the modal sheet carries the actionable info; the
             // streaming-log drawer would just be noise.
             drawerPresented = false
-            blockedPresented = true
+            blockedPresented = presentation == .foreground
         }
+        return result
+    }
+
+    private func emitPostDeployMilestone(_ progress: OperationProgress, siteID: String) {
+        currentMilestone = progress.label
+        onMilestone?(siteID, progress)
     }
 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -112,7 +112,7 @@ struct SiteWindow: View {
             model.windowUndoManager = newValue
         }
         .onChange(of: model.preview.state) { _, newState in
-            model.startup.ingest(state: newState)
+            model.previewStateChanged(newState)
         }
         .onChange(of: model.hasUnsavedEdits, initial: true) { _, hasUnsavedEdits in
             if hasUnsavedEdits {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -49,6 +49,10 @@ final class SiteWindowModel {
     private let contentIndexerStore: ContentIndexerStore
     private let integrationOps = IntegrationOperations.live()
     private let contentCreation: ContentCreationWorkflow
+    @ObservationIgnored private var invisiblePublishQueue: InvisiblePublishQueue?
+    @ObservationIgnored private var invisiblePublishWatcher: (any SiteFileWatching)?
+    @ObservationIgnored private var connectivityMonitor: (any ConnectivityMonitoring)?
+    @ObservationIgnored private var invisiblePublishStartTask: Task<Void, Never>?
     @ObservationIgnored
     private var dismissSiteWindow: (() -> Void)?
 
@@ -68,6 +72,7 @@ final class SiteWindowModel {
     /// annotations (Siri AI Phase B / #146 + #148).
     var annotationProvider: PreviewAnnotationProvider?
     var deploy = DeployModel()
+    private(set) var invisiblePublishState: InvisiblePublishQueue.State = .idle
     #if !ANGLESITE_MAS
     var publish = PublishModel()
     #endif
@@ -361,7 +366,14 @@ final class SiteWindowModel {
         preview.startDevServer()
     }
 
+    func previewStateChanged(_ state: SiteRuntimeState) {
+        startup.ingest(state: state)
+        guard preview.canDeploy, let invisiblePublishQueue else { return }
+        Task { await invisiblePublishQueue.retryPending() }
+    }
+
     func handleSiteChanged() {
+        stopInvisiblePublishing()
         siriReadinessModel = nil
         // Persist any unsaved edits before dropping the old site's editor on replay (#188 reuse).
         persistEditorBufferBestEffort()
@@ -375,6 +387,7 @@ final class SiteWindowModel {
     }
 
     func close(suddenTerminationLease: SuddenTerminationController.Lease? = nil) {
+        stopInvisiblePublishing()
         preview.close()
         startup.stop()
         // Note: an in-flight Deploy/Backup/Audit is intentionally NOT cancelled or cleaned up
@@ -1248,6 +1261,7 @@ final class SiteWindowModel {
         // silently discarded by the runtime's fresh scan (#313).
         await styleGuide?.seedFromDisk()
         preview.open(siteID: resolved.id, siteDirectory: resolved.sourceDirectory)
+        startInvisiblePublishing(for: resolved)
         // Warm the content graph now rather than waiting for the first create/delete (#660), so
         // `SearchContentTool`'s `isPopulated` check is already reliable by the time the chat
         // assistant is wired up below. Kicked off in the background (not awaited here) so its
@@ -1328,6 +1342,91 @@ final class SiteWindowModel {
         #if !ANGLESITE_MAS
         publish.refreshRemote(source: resolved.sourceDirectory)
         #endif
+    }
+
+    // MARK: - Invisible publishing (#357)
+
+    private func startInvisiblePublishing(for site: SiteStore.Site) {
+        stopInvisiblePublishing()
+
+        let queue = InvisiblePublishQueue(
+            configDirectory: site.configDirectory,
+            publisher: { [weak self] in
+                guard let self else { return .deferred(reason: "the site window closed") }
+                return await self.performInvisiblePublish(siteID: site.id)
+            },
+            onStateChange: { [weak self] state in
+                Task { @MainActor in self?.invisiblePublishState = state }
+            }
+        )
+        invisiblePublishQueue = queue
+
+        let monitor = PlatformConnectivityMonitor.make()
+        connectivityMonitor = monitor
+        invisiblePublishStartTask = Task { [weak self, queue, monitor] in
+            await queue.start(isOnline: false)
+            guard !Task.isCancelled, self?.invisiblePublishQueue === queue else { return }
+            monitor.start { online in
+                Task { await queue.setOnline(online) }
+            }
+        }
+
+        let watcher = PlatformFileWatcher.make()
+        do {
+            try watcher.start(root: site.sourceDirectory) { [queue, root = site.sourceDirectory] batch in
+                guard Self.isPublishRelevant(batch, sourceDirectory: root) else { return }
+                Task { await queue.recordEdit() }
+            }
+            invisiblePublishWatcher = watcher
+        } catch {
+            Task {
+                await LogCenter.shared.append(
+                    source: "publish:\(site.id)", stream: .stderr,
+                    text: "invisible publish: couldn't watch source edits: \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    private func stopInvisiblePublishing() {
+        invisiblePublishStartTask?.cancel()
+        invisiblePublishStartTask = nil
+        invisiblePublishWatcher?.stop()
+        invisiblePublishWatcher = nil
+        connectivityMonitor?.stop()
+        connectivityMonitor = nil
+        if let queue = invisiblePublishQueue { Task { await queue.stop() } }
+        invisiblePublishQueue = nil
+        invisiblePublishState = .idle
+    }
+
+    private func performInvisiblePublish(siteID: String) async -> InvisiblePublishQueue.Result {
+        guard let site, site.id == siteID else { return .deferred(reason: "the site is no longer open") }
+        guard !backup.isRunning, !audit.isRunning else {
+            return .deferred(reason: "another site operation is running")
+        }
+        let containerControl = await preview.activeContainerControl()
+        let pageRoutes = await contentGraph.pages(for: site.id).map(\.route)
+        let postRoutes = await contentGraph.posts(for: site.id).map(postRoute(for:))
+        return await deploy.deployAutomatically(
+            siteID: site.id,
+            siteDirectory: site.sourceDirectory,
+            configDirectory: site.configDirectory,
+            currentRoutes: pageRoutes + postRoutes,
+            containerControl: containerControl
+        )
+    }
+
+    nonisolated private static func isPublishRelevant(_ batch: FileChangeBatch, sourceDirectory: URL) -> Bool {
+        if batch.needsFullRescan { return true }
+        let root = sourceDirectory.standardizedFileURL.pathComponents
+        let ignoredTopLevel = Set([".git", ".astro", "dist", "node_modules"])
+        return batch.paths.contains { path in
+            let components = path.standardizedFileURL.pathComponents
+            guard components.starts(with: root) else { return false }
+            guard let firstRelative = components.dropFirst(root.count).first else { return true }
+            return !ignoredTopLevel.contains(firstRelative)
+        }
     }
 
     /// Wire Deploy/Backup/Audit phase transitions to the completion notifier and the Dock-tile

--- a/Sources/AnglesiteCore/CompletionNotice.swift
+++ b/Sources/AnglesiteCore/CompletionNotice.swift
@@ -156,8 +156,8 @@ public enum CompletionNoticeBuilder {
     }
 }
 
-/// Maps deploy milestones onto Dock-tile progress (#526). The deploy pipeline has four fixed
-/// milestones (per `DeployCommand`: build → preflight scan → wrangler → finalize), so the Dock
+/// Maps deploy milestones onto Dock-tile progress (#526). The deploy pipeline has fixed
+/// milestones (build/feed generation → preflight scan → wrangler → social delivery), so the Dock
 /// bar can be *determinate per phase* even though each phase's internal progress is unknown —
 /// the fraction is "how far through the pipeline", not a fabricated percentage of wall time.
 /// Unknown phases return `nil` → the Dock overlay renders indeterminate.
@@ -170,6 +170,8 @@ public enum DeployDockProgress {
         case "preflightScan": return 0.45
         case "deploying": return 0.55
         case "finalizing": return 0.90
+        case "webmentions": return 0.94
+        case "syndicating": return 0.97
         default: return nil
         }
     }

--- a/Sources/AnglesiteCore/InvisiblePublishQueue.swift
+++ b/Sources/AnglesiteCore/InvisiblePublishQueue.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+/// Durable, debounced scheduler for the local-first publish pipeline.
+///
+/// The site's git working tree remains the content source of truth. This queue persists only the
+/// fact that the working tree still needs publishing, so an offline edit survives an app restart
+/// without duplicating source data in app-owned state.
+public actor InvisiblePublishQueue {
+    public enum State: Sendable, Equatable {
+        case idle
+        case debouncing
+        case queuedOffline
+        case publishing
+        case blocked(failureCount: Int)
+        case failed(reason: String)
+        case deferred(reason: String)
+    }
+
+    public enum Result: Sendable, Equatable {
+        case succeeded(url: URL)
+        case blocked(failureCount: Int)
+        case failed(reason: String)
+        /// A local prerequisite such as the container runtime or API token is not ready. The
+        /// durable queue remains pending and `retryPending()` may drain it later.
+        case deferred(reason: String)
+    }
+
+    public typealias Publisher = @Sendable () async -> Result
+    public typealias StateObserver = @Sendable (State) -> Void
+
+    private struct Record: Codable {
+        static let currentVersion = 1
+
+        let version: Int
+        let pending: Bool
+        let lastEditedAt: Date
+    }
+
+    public static let filename = "invisible-publish-queue.json"
+
+    private let recordURL: URL
+    private let debounce: Duration
+    private let publisher: Publisher
+    private let onStateChange: StateObserver?
+    private let now: @Sendable () -> Date
+
+    private var state: State = .idle
+    private var isOnline = false
+    private var isPending = false
+    private var generation: UInt64 = 0
+    private var lastEditedAt = Date.distantPast
+    private var debounceTask: Task<Void, Never>?
+    private var publishTask: Task<Void, Never>?
+
+    public init(
+        configDirectory: URL,
+        debounce: Duration = .seconds(3),
+        publisher: @escaping Publisher,
+        onStateChange: StateObserver? = nil,
+        now: @escaping @Sendable () -> Date = { Date.now }
+    ) {
+        self.recordURL = configDirectory.appendingPathComponent(Self.filename)
+        self.debounce = debounce
+        self.publisher = publisher
+        self.onStateChange = onStateChange
+        self.now = now
+    }
+
+    /// Loads a pending marker from disk and begins scheduling against the current connectivity.
+    public func start(isOnline: Bool) {
+        self.isOnline = isOnline
+        if let record = loadRecord(), record.version == Record.currentVersion, record.pending {
+            isPending = true
+            lastEditedAt = record.lastEditedAt
+            generation &+= 1
+        }
+        guard isPending else {
+            transition(to: .idle)
+            return
+        }
+        if isOnline {
+            scheduleDebounce()
+        } else {
+            transition(to: .queuedOffline)
+        }
+    }
+
+    /// Marks the working tree dirty and restarts the idle debounce window.
+    public func recordEdit() {
+        isPending = true
+        generation &+= 1
+        lastEditedAt = now()
+        persistRecord()
+
+        guard publishTask == nil else { return }
+        if isOnline {
+            scheduleDebounce()
+        } else {
+            transition(to: .queuedOffline)
+        }
+    }
+
+    /// Connectivity updates are idempotent. Reconnection drains a pending queue immediately;
+    /// it does not impose another edit debounce because the offline period already supplied one.
+    public func setOnline(_ online: Bool) {
+        guard online != isOnline else { return }
+        isOnline = online
+        if !online {
+            debounceTask?.cancel()
+            debounceTask = nil
+            if isPending, publishTask == nil { transition(to: .queuedOffline) }
+        } else if isPending, publishTask == nil {
+            beginPublish()
+        }
+    }
+
+    /// Retries a durable item when a non-network prerequisite becomes available (for example,
+    /// after the site's container reaches its ready state).
+    public func retryPending() {
+        guard isPending, isOnline, publishTask == nil else { return }
+        beginPublish()
+    }
+
+    public func currentState() -> State { state }
+    public func hasPendingPublish() -> Bool { isPending }
+
+    public func stop() {
+        debounceTask?.cancel()
+        debounceTask = nil
+        // A real deploy is intentionally allowed to reach its terminal result. Cancelling this
+        // wrapper task would otherwise cancel its child subprocess and leave remote state unclear.
+        if isPending { persistRecord() }
+    }
+
+    private func scheduleDebounce() {
+        debounceTask?.cancel()
+        transition(to: .debouncing)
+        let delay = debounce
+        debounceTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            await self?.beginPublish()
+        }
+    }
+
+    private func beginPublish() {
+        guard isPending, isOnline, publishTask == nil else { return }
+        debounceTask?.cancel()
+        debounceTask = nil
+        let publishingGeneration = generation
+        transition(to: .publishing)
+        // Keep the queue alive until the real publish reaches a terminal result, even if its site
+        // window closes. `finish` clears `publishTask`, breaking the temporary self/task cycle.
+        publishTask = Task { [self, publisher] in
+            let result = await publisher()
+            finish(result, publishingGeneration: publishingGeneration)
+        }
+    }
+
+    private func finish(_ result: Result, publishingGeneration: UInt64) {
+        publishTask = nil
+        switch result {
+        case .succeeded:
+            if generation == publishingGeneration {
+                isPending = false
+                try? FileManager.default.removeItem(at: recordURL)
+                transition(to: .idle)
+            } else {
+                // An edit landed while the publish was running. The completed deploy covers the
+                // old generation only, so debounce and publish the newer working tree.
+                persistRecord()
+                if isOnline { scheduleDebounce() } else { transition(to: .queuedOffline) }
+            }
+        case .blocked(let failureCount):
+            persistRecord()
+            transition(to: .blocked(failureCount: failureCount))
+        case .failed(let reason):
+            persistRecord()
+            transition(to: .failed(reason: reason))
+        case .deferred(let reason):
+            persistRecord()
+            transition(to: .deferred(reason: reason))
+        }
+    }
+
+    private func transition(to newState: State) {
+        guard state != newState else { return }
+        state = newState
+        onStateChange?(newState)
+    }
+
+    private func persistRecord() {
+        let record = Record(version: Record.currentVersion, pending: isPending, lastEditedAt: lastEditedAt)
+        guard let data = try? JSONEncoder().encode(record) else { return }
+        try? FileManager.default.createDirectory(at: recordURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        try? data.write(to: recordURL, options: .atomic)
+    }
+
+    private func loadRecord() -> Record? {
+        guard let data = try? Data(contentsOf: recordURL) else { return nil }
+        return try? JSONDecoder().decode(Record.self, from: data)
+    }
+}

--- a/Sources/AnglesiteCore/OperationProgress.swift
+++ b/Sources/AnglesiteCore/OperationProgress.swift
@@ -39,6 +39,8 @@ public extension OperationProgress {
     static let deployBuilding = OperationProgress(kind: .deploy, phase: "building", label: "Building site…")
     static let deployDeploying = OperationProgress(kind: .deploy, phase: "deploying", label: "Deploying to production…")
     static let deployFinalizing = OperationProgress(kind: .deploy, phase: "finalizing", label: "Finishing up…")
+    static let deployWebmentions = OperationProgress(kind: .deploy, phase: "webmentions", label: "Sending webmentions…")
+    static let deploySyndicating = OperationProgress(kind: .deploy, phase: "syndicating", label: "Syndicating posts…")
 
     static let backupStaging = OperationProgress(kind: .backup, phase: "staging", label: "Staging changes…")
     static let backupCommitting = OperationProgress(kind: .backup, phase: "committing", label: "Committing…")

--- a/Sources/AnglesiteCore/Platform/ConnectivityMonitoring.swift
+++ b/Sources/AnglesiteCore/Platform/ConnectivityMonitoring.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Portable connectivity seam used by the local-first publish queue. A monitor reports the
+/// initial state and subsequent transitions until `stop()`.
+public protocol ConnectivityMonitoring: Sendable {
+    func start(onChange: @escaping @Sendable (Bool) -> Void)
+    func stop()
+}
+
+public enum PlatformConnectivityMonitor {
+    public static func make() -> any ConnectivityMonitoring {
+        #if canImport(Network)
+        NWConnectivityMonitor()
+        #else
+        AssumedOnlineConnectivityMonitor()
+        #endif
+    }
+}
+
+/// Platforms without Network.framework still get deterministic foreground publishing. Their
+/// native connectivity monitor is supplied by the cross-platform port rather than guessed here.
+public final class AssumedOnlineConnectivityMonitor: ConnectivityMonitoring, @unchecked Sendable {
+    public init() {}
+    public func start(onChange: @escaping @Sendable (Bool) -> Void) { onChange(true) }
+    public func stop() {}
+}
+
+#if canImport(Network)
+import Network
+
+public final class NWConnectivityMonitor: ConnectivityMonitoring, @unchecked Sendable {
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "io.dwk.anglesite.connectivity")
+    private let lock = NSLock()
+    private var running = false
+
+    public init() {}
+
+    public func start(onChange: @escaping @Sendable (Bool) -> Void) {
+        lock.lock()
+        guard !running else { lock.unlock(); return }
+        running = true
+        lock.unlock()
+        monitor.pathUpdateHandler = { path in onChange(path.status == .satisfied) }
+        monitor.start(queue: queue)
+    }
+
+    public func stop() {
+        lock.lock()
+        guard running else { lock.unlock(); return }
+        running = false
+        lock.unlock()
+        monitor.pathUpdateHandler = nil
+        monitor.cancel()
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/CompletionNoticeTests.swift
+++ b/Tests/AnglesiteCoreTests/CompletionNoticeTests.swift
@@ -168,12 +168,13 @@ struct CompletionNoticeTests {
 /// the Dock bar is determinate per-phase; unknown phases fall back to indeterminate.
 struct DeployDockProgressTests {
 
-    /// The `OperationProgress` deploy milestones in `DeployCommand`'s emission order (build →
-    /// preflight scan → wrangler → finalize). NOTE: that order lives in `DeployCommand`'s control
-    /// flow and is not statically derivable here — if the pipeline is ever reordered, update this
-    /// list (and `DeployDockProgress`'s table) to match, or the Dock bar will move backwards.
+    /// The deploy milestones in emission order (build/feed generation → preflight scan → wrangler
+    /// → finalize → webmentions → POSSE). NOTE: that order lives across `DeployCommand` and
+    /// `DeployModel`'s post-deploy pipeline and is not statically derivable here. If it is ever
+    /// reordered, update this list (and `DeployDockProgress`'s table), or the Dock bar moves back.
     private static let pipelineOrder = [
         OperationProgress.deployBuilding, .deployPreflight, .deployDeploying, .deployFinalizing,
+        .deployWebmentions, .deploySyndicating,
     ]
 
     @Test("Known milestones map to monotonically increasing fractions in pipeline order")

--- a/Tests/AnglesiteCoreTests/InvisiblePublishQueueTests.swift
+++ b/Tests/AnglesiteCoreTests/InvisiblePublishQueueTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+private actor PublishProbe {
+    private(set) var calls = 0
+    var result: InvisiblePublishQueue.Result
+
+    init(result: InvisiblePublishQueue.Result = .succeeded(url: URL(string: "https://example.com") ?? URL(fileURLWithPath: "/"))) {
+        self.result = result
+    }
+
+    func publish() -> InvisiblePublishQueue.Result {
+        calls += 1
+        return result
+    }
+}
+
+private actor GatedPublishProbe {
+    private(set) var calls = 0
+    private var firstContinuation: CheckedContinuation<Void, Never>?
+
+    func publish() async -> InvisiblePublishQueue.Result {
+        calls += 1
+        if calls == 1 {
+            await withCheckedContinuation { firstContinuation = $0 }
+        }
+        return .succeeded(url: URL(string: "https://example.com") ?? URL(fileURLWithPath: "/"))
+    }
+
+    func waitUntilFirstPublishStarts() async {
+        while calls == 0 { await Task.yield() }
+    }
+
+    func finishFirstPublish() {
+        firstContinuation?.resume()
+        firstContinuation = nil
+    }
+}
+
+@Suite("Invisible publish queue")
+struct InvisiblePublishQueueTests {
+    @Test("idle edits debounce into one publish")
+    func debouncesEdits() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = PublishProbe()
+        let queue = InvisiblePublishQueue(
+            configDirectory: directory,
+            debounce: .milliseconds(30),
+            publisher: { await probe.publish() }
+        )
+
+        await queue.start(isOnline: true)
+        await queue.recordEdit()
+        try await Task.sleep(for: .milliseconds(10))
+        await queue.recordEdit()
+        try await Task.sleep(for: .milliseconds(10))
+        await queue.recordEdit()
+        try await waitUntil {
+            let calls = await probe.calls
+            let pending = await queue.hasPendingPublish()
+            return calls == 1 && !pending
+        }
+
+        #expect(await probe.calls == 1)
+        #expect(await queue.currentState() == .idle)
+        #expect(!FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(InvisiblePublishQueue.filename).path
+        ))
+    }
+
+    @Test("offline edits persist and drain after reconnect, including across queue recreation")
+    func offlineQueueDrains() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let firstProbe = PublishProbe()
+        let first = InvisiblePublishQueue(
+            configDirectory: directory,
+            debounce: .milliseconds(10),
+            publisher: { await firstProbe.publish() }
+        )
+        await first.start(isOnline: false)
+        await first.recordEdit()
+
+        #expect(await firstProbe.calls == 0)
+        #expect(await first.currentState() == .queuedOffline)
+        #expect(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(InvisiblePublishQueue.filename).path
+        ))
+        await first.stop()
+
+        let secondProbe = PublishProbe()
+        let restored = InvisiblePublishQueue(
+            configDirectory: directory,
+            debounce: .milliseconds(10),
+            publisher: { await secondProbe.publish() }
+        )
+        await restored.start(isOnline: false)
+        #expect(await restored.hasPendingPublish())
+        await restored.setOnline(true)
+        try await waitUntil {
+            let calls = await secondProbe.calls
+            let pending = await restored.hasPendingPublish()
+            return calls == 1 && !pending
+        }
+
+        #expect(await restored.currentState() == .idle)
+    }
+
+    @Test("security blocks remain durably queued")
+    func securityBlockStaysPending() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = PublishProbe(result: .blocked(failureCount: 2))
+        let queue = InvisiblePublishQueue(
+            configDirectory: directory,
+            debounce: .milliseconds(10),
+            publisher: { await probe.publish() }
+        )
+        await queue.start(isOnline: true)
+        await queue.recordEdit()
+        try await waitUntil { await queue.currentState() == .blocked(failureCount: 2) }
+
+        #expect(await queue.hasPendingPublish())
+        #expect(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(InvisiblePublishQueue.filename).path
+        ))
+    }
+
+    @Test("an edit during publishing schedules a second generation")
+    func editDuringPublishRunsAgain() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = GatedPublishProbe()
+        let queue = InvisiblePublishQueue(
+            configDirectory: directory,
+            debounce: .milliseconds(20),
+            publisher: { await probe.publish() }
+        )
+        await queue.start(isOnline: true)
+        await queue.recordEdit()
+        await probe.waitUntilFirstPublishStarts()
+        await queue.recordEdit()
+        await probe.finishFirstPublish()
+
+        try await waitUntil {
+            let calls = await probe.calls
+            let pending = await queue.hasPendingPublish()
+            return calls == 2 && !pending
+        }
+        #expect(await queue.currentState() == .idle)
+    }
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("InvisiblePublishQueueTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        condition: @escaping @Sendable () async -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !(await condition()) {
+            guard clock.now < deadline else {
+                Issue.record("timed out waiting for invisible-publish state")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a durable, debounced invisible-publish queue that persists offline edits and drains on reconnection.
- Run automatic publishing through the existing pre-deploy security gate while keeping background operation out of foreground drawers and sheets.
- Order feed generation, deployment, Webmention delivery, and POSSE before completion, with matching Dock progress milestones.

Closes #357.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks). Link it here:

> Cross-cutting work (extending MCP messages, changing the plugin's hook contract, adjusting the site template the app scaffolds, etc.) lands as paired PRs. The plugin PR ships first in a tagged release; the app PR consumes it and bumps `Resources/plugin/`'s source-of-truth pointer. See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [ ] `swift test --package-path .` — attempted; encountered the pre-existing `RepoBootstrapTests.publishRefusesWhenDotenvWouldBeCommitted` failure, then stopped producing output and was interrupted.
- [x] `env ANGLESITE_SKIP_CONTAINER=1 ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite swift test --filter InvisiblePublishQueueTests --filter DeployModelTests --filter DeployDockProgressTests` — passed (7 tests).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke (if UI-touching): not performed.
- [x] `git diff --check`
