### PR TITLE
docs: require agents to follow contributing workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This is the **native macOS app** that hosts the Anglesite Codex plugin. The plugin lives in a sibling repo at `../anglesite`. Both repos are under the same `github.com/Anglesite/` parent directory.
 
+## Contribution workflow (mandatory)
+
+[`CONTRIBUTING.md`](CONTRIBUTING.md) is the source of truth for contribution workflow. **Read it from the current checkout before planning or making any repository change**, even if you have worked in this repo before; do not rely on this file, a prior session, or a cached summary as a substitute. Apply every requirement relevant to the task, including issue claiming, approval for large changes or new dependencies, generated-file handling, testing, commit format, and pull-request preparation.
+
+Before handing work off, re-check the changed files against `CONTRIBUTING.md`, run the relevant test/build commands it specifies, and report any required check you could not run. When delegating work, explicitly instruct each agent to read `CONTRIBUTING.md` **in its assigned worktree before acting**; the delegating agent remains responsible for verifying compliance.
+
 ## Two-repo coordination
 
 | Repo | Role |


### PR DESCRIPTION
## Summary

- Make `CONTRIBUTING.md` the explicit source of truth for contribution workflow in agent instructions.
- Require agents to read it from the current checkout before planning or changing the repository.
- Require pre-handoff compliance checks and propagate the same instruction to delegated agents.

The existing development context summarized some contribution rules, but did not require agents to consult the complete, current workflow. This makes that expectation prominent and enforceable for every repository-changing task.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks).

## Test plan

- [x] `git diff --check`
- [x] Confirmed `AGENTS.md` reflects the update through its existing `CLAUDE.md` symlink.
- [ ] `swift test --package-path .` — not run; documentation-only change.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; documentation-only change.
- [ ] Manual smoke (if UI-touching) — not applicable.
