### PR TITLE
Add carbon.txt sustainability disclosure integration

### DIFF
--- a/Resources/Template/integrations/public/carbon.txt
+++ b/Resources/Template/integrations/public/carbon.txt
@@ -1,0 +1,13 @@
+version = "0.5"
+
+# Hosting provider: {{hostingProvider}}
+[org]
+disclosures = [
+  { doc_type = "web-page", url = "{{provenanceURL}}", title = "{{hostingProvider}} sustainability source" },
+{{#disclosureURL}}  { doc_type = "web-page", url = "{{disclosureURL}}", title = "Organisation sustainability disclosure" },
+{{/disclosureURL}}]
+
+[upstream]
+services = [
+  { domain = "{{hostingProviderDomain}}", service_type = "shared-hosting" },
+]

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -30,7 +30,7 @@ public extension IntegrationDescriptor {
         }
         for (i, op) in operations.enumerated() {
             switch op {
-            case .copyFile(_, _, let w), .writeConfig(_, let w), .injectAtAnchor(_, _, _, let w, _), .appendLine(_, _, let w):
+            case .copyFile(_, _, let w), .copyTemplatedFile(_, _, let w), .writeConfig(_, let w), .injectAtAnchor(_, _, _, let w, _), .appendLine(_, _, let w):
                 check(w, "operation \(i)")
             case .addCSPDomains(let fromProvider, _, let fromFieldHost, let w):
                 check(w, "operation \(i)")
@@ -52,7 +52,7 @@ public enum IntegrationCatalog {
         tracking, share, podcast,
         indieweb, menu,
         buyButton, lemonSqueezy, paddle, snipcart, shopifyBuyButton,
-        inbox, membership,
+        inbox, membership, carbonTxt,
     ]
 
     public static func descriptor(for id: IntegrationID) -> IntegrationDescriptor {
@@ -684,5 +684,29 @@ public enum IntegrationCatalog {
             .writeConfig([
                 ConfigEntry(key: "MEMBERSHIP_DIRECTORY_TITLE", value: "{{directoryTitle}}"),
             ], when: .always),
+        ])
+
+    // MARK: carbon.txt
+    static let carbonTxt = IntegrationDescriptor(
+        id: .carbonTxt,
+        displayName: "carbon.txt",
+        summary: "Publish a machine-readable sustainability disclosure at /carbon.txt.",
+        providers: [],
+        fields: [
+            Field(key: "hostingProvider", label: "Hosting provider", kind: .text,
+                  defaultValue: "Cloudflare",
+                  help: "The provider responsible for hosting this site."),
+            Field(key: "hostingProviderDomain", label: "Hosting provider domain", kind: .text,
+                  defaultValue: "cloudflare.com",
+                  help: "The provider’s public domain, without https:// or a path."),
+            Field(key: "provenanceURL", label: "Hosting sustainability source", kind: .url,
+                  help: "A link to the provider’s sustainability report, certification, or Green Web Check result."),
+            Field(key: "disclosureURL", label: "Organisation disclosure URL", kind: .url,
+                  isOptional: true,
+                  help: "Optional link to your organisation’s own sustainability disclosure."),
+        ],
+        operations: [
+            .copyTemplatedFile(from: TemplateRef("integrations/public/carbon.txt"),
+                               to: "public/carbon.txt", when: .always),
         ])
 }

--- a/Sources/AnglesiteCore/IntegrationDescriptor.swift
+++ b/Sources/AnglesiteCore/IntegrationDescriptor.swift
@@ -3,7 +3,7 @@ public enum IntegrationID: String, Sendable, CaseIterable {
     case tracking, share, podcast
     case indieweb, menu
     case buyButton, lemonSqueezy, paddle, snipcart, shopifyBuyButton
-    case inbox, membership
+    case inbox, membership, carbonTxt
 }
 
 public struct Template: Sendable, Equatable, ExpressibleByStringLiteral {
@@ -12,6 +12,17 @@ public struct Template: Sendable, Equatable, ExpressibleByStringLiteral {
     public init(stringLiteral raw: String) { self.raw = raw }
     public func resolve(_ tokens: [String: String]) -> String {
         var out = raw
+        // A staged text asset can conditionally include a complete optional line or TOML entry
+        // without needing a bespoke operation. Sections are deliberately non-nesting.
+        while let opening = out.range(of: "{{#"),
+              let keyEnd = out[opening.upperBound...].range(of: "}}") {
+            let key = String(out[opening.upperBound..<keyEnd.lowerBound])
+            let closingMarker = "{{/\(key)}}"
+            guard let closing = out[keyEnd.upperBound...].range(of: closingMarker) else { break }
+            let content = String(out[keyEnd.upperBound..<closing.lowerBound])
+            out.replaceSubrange(opening.lowerBound..<closing.upperBound,
+                                with: tokens[key]?.isEmpty == false ? content : "")
+        }
         for (key, value) in tokens {
             out = out.replacingOccurrences(of: "{{\(key)}}", with: value)
         }
@@ -76,6 +87,9 @@ public struct TemplateRef: Sendable, Equatable { public let path: String
 
 public enum Operation: Sendable, Equatable {
     case copyFile(from: TemplateRef, to: Template, when: Condition)
+    /// Copies a staged text asset after resolving its `Template` tokens. This opt-in operation
+    /// keeps ordinary staged assets byte-for-byte intact.
+    case copyTemplatedFile(from: TemplateRef, to: Template, when: Condition)
     case writeConfig([ConfigEntry], when: Condition)
     /// `fromFieldHost` names a `.url`-kind field whose value's host (e.g. a per-site
     /// Cloudflare Worker subdomain) is extracted at plan time and added alongside

--- a/Sources/AnglesiteCore/IntegrationPlanner.swift
+++ b/Sources/AnglesiteCore/IntegrationPlanner.swift
@@ -87,6 +87,14 @@ public enum IntegrationPlanner {
                     return .failure(.missingTemplateAsset(path: from.path))
                 }
                 steps.append(.createFile(relativePath: dest, contents: contents))
+            case .copyTemplatedFile(let from, let to, let when):
+                guard isVisible(when, answers: effective, providerID: providerID) else { continue }
+                let dest = to.resolve(tokens)
+                let src = templateDirectory.appendingPathComponent(from.path)
+                guard let contents = try? String(contentsOf: src, encoding: .utf8) else {
+                    return .failure(.missingTemplateAsset(path: from.path))
+                }
+                steps.append(.createFile(relativePath: dest, contents: Template(contents).resolve(tokens)))
             case .writeConfig(let entries, let when):
                 guard isVisible(when, answers: effective, providerID: providerID) else { continue }
                 steps.append(.upsertConfig(entries.map { ConfigKV(key: $0.key, value: $0.value.resolve(tokens)) }))
@@ -137,7 +145,7 @@ public enum IntegrationPlanner {
     private static func operationReferences(_ token: String, _ op: Operation) -> Bool {
         let needle = "{{\(token)}}"
         switch op {
-        case .copyFile(_, let to, _): return to.raw.contains(needle)
+        case .copyFile(_, let to, _), .copyTemplatedFile(_, let to, _): return to.raw.contains(needle)
         case .writeConfig(let entries, _): return entries.contains { $0.value.raw.contains(needle) }
         case .injectAtAnchor(let file, _, let snippet, _, _): return file.raw.contains(needle) || snippet.raw.contains(needle)
         case .appendLine(let file, let line, _): return file.raw.contains(needle) || line.raw.contains(needle)

--- a/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
@@ -9,7 +9,7 @@ import Testing
             .tracking, .share, .podcast,
             .indieweb, .menu,
             .buyButton, .lemonSqueezy, .paddle, .snipcart, .shopifyBuyButton,
-            .inbox, .membership,
+            .inbox, .membership, .carbonTxt,
         ]))
     }
 
@@ -285,6 +285,20 @@ import Testing
     @Test func membershipWritesDirectoryTitle() {
         let keys = writtenConfigKeys(for: IntegrationCatalog.descriptor(for: .membership))
         #expect(keys.contains("MEMBERSHIP_DIRECTORY_TITLE"))
+    }
+
+    @Test func carbonTxtScaffoldsAStaticPublicFileWithoutCSP() {
+        let carbon = IntegrationCatalog.descriptor(for: .carbonTxt)
+        #expect(carbon.providers.isEmpty)
+        #expect(carbon.operations.contains {
+            if case .copyTemplatedFile(let from, let to, let when) = $0 {
+                return from.path == "integrations/public/carbon.txt"
+                    && to.raw == "public/carbon.txt"
+                    && when == .always
+            }
+            return false
+        })
+        #expect(!carbon.operations.contains { if case .addCSPDomains = $0 { return true }; return false })
     }
 
     @Test func redirectsHasNoProvidersAndAppendsToRedirectsFile() {

--- a/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationPlannerTests.swift
@@ -188,6 +188,69 @@ import Foundation
         #expect(rFail == .failure(.missingRequiredField(key: "username")))
     }
 
+    @Test func carbonTxtRendersOptionalDisclosureAndStaticAsset() throws {
+        let template = makeTemplate()
+        let asset = template.appendingPathComponent("integrations/public/carbon.txt")
+        try FileManager.default.createDirectory(at: asset.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "version = \"0.5\"\n{{#disclosureURL}}url = \"{{disclosureURL}}\"\n{{/disclosureURL}}provider = \"{{hostingProvider}}\"\n"
+            .write(to: asset, atomically: true, encoding: .utf8)
+
+        let descriptor = IntegrationCatalog.descriptor(for: .carbonTxt)
+        let withoutDisclosure = try IntegrationPlanner.plan(
+            descriptor: descriptor,
+            answers: ["provenanceURL": "https://www.cloudflare.com/sustainability/"],
+            sourceDirectory: makeSource(), templateDirectory: template
+        ).get()
+        guard case .createFile(let path, let contents) = withoutDisclosure.steps.first else {
+            Issue.record("expected carbon.txt create step")
+            return
+        }
+        #expect(path == "public/carbon.txt")
+        #expect(contents == "version = \"0.5\"\nprovider = \"Cloudflare\"\n")
+
+        let withDisclosure = try IntegrationPlanner.plan(
+            descriptor: descriptor,
+            answers: [
+                "provenanceURL": "https://www.cloudflare.com/sustainability/",
+                "disclosureURL": "https://example.com/sustainability",
+            ],
+            sourceDirectory: makeSource(), templateDirectory: template
+        ).get()
+        guard case .createFile(_, let contents) = withDisclosure.steps.first else {
+            Issue.record("expected carbon.txt create step")
+            return
+        }
+        #expect(contents.contains("url = \"https://example.com/sustainability\""))
+    }
+
+    @Test func ordinaryCopyFileLeavesTemplateMarkersUntouched() throws {
+        let template = makeTemplate()
+        let asset = template.appendingPathComponent("integrations/public/literal.txt")
+        try FileManager.default.createDirectory(at: asset.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "literal {{siteName}} and {{#optional}}markers{{/optional}}"
+            .write(to: asset, atomically: true, encoding: .utf8)
+        let descriptor = IntegrationDescriptor(
+            id: .carbonTxt,
+            displayName: "Test",
+            summary: "",
+            providers: [],
+            fields: [],
+            operations: [.copyFile(from: TemplateRef("integrations/public/literal.txt"),
+                                   to: "public/literal.txt", when: .always)]
+        )
+
+        let plan = try IntegrationPlanner.plan(
+            descriptor: descriptor,
+            answers: [:],
+            sourceDirectory: makeSource(), templateDirectory: template
+        ).get()
+        guard case .createFile(_, let contents) = plan.steps.first else {
+            Issue.record("expected literal create step")
+            return
+        }
+        #expect(contents == "literal {{siteName}} and {{#optional}}markers{{/optional}}")
+    }
+
     @Test func giscusEmitsNoBrandColorWarning() throws {
         let r = try IntegrationPlanner.plan(descriptor: IntegrationCatalog.descriptor(for: .giscus),
             answers: ["repo": "o/r", "repoId": "R", "category": "General", "categoryId": "C", "mapping": "pathname"],

--- a/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
@@ -52,7 +52,7 @@ import Foundation
                   "integrations/pages/buy.astro", "integrations/pages/shop.astro", "integrations/pages/pricing.astro",
                   "integrations/pages/store.astro", "integrations/pages/products.astro",
                   "integrations/pages/members.astro", "integrations/components/MemberCard.astro",
-                  "integrations/public/sw.js",
+                  "integrations/public/sw.js", "integrations/public/carbon.txt",
                   "integrations/worker/subscribe-worker.js", "integrations/worker/subscribe-wrangler.toml",
                   "integrations/docs/newsletter-setup.md", "integrations/docs/pwa-setup.md",
                   "integrations/docs/inbox-setup.md"] {
@@ -77,7 +77,7 @@ import Foundation
                   "src/pages/buy.astro", "src/pages/shop.astro", "src/pages/pricing.astro",
                   "src/pages/store.astro", "src/pages/products.astro",
                   "src/pages/members.astro", "src/components/MemberCard.astro",
-                  "worker/subscribe-worker.js", "worker/subscribe-wrangler.toml",
+                  "public/carbon.txt", "worker/subscribe-worker.js", "worker/subscribe-wrangler.toml",
                   "docs/newsletter-setup.md", "docs/pwa-setup.md", "docs/inbox-setup.md"] {
             #expect(!FileManager.default.fileExists(atPath: root.appendingPathComponent(p).path), "should be staged, not in src: \(p)")
         }

--- a/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
@@ -83,6 +83,72 @@ import Foundation
         }
     }
 
+    @Test func carbonTxtRendersFromShippedTemplate() throws {
+        let source = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CarbonTxtTemplateAssetsTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let descriptor = IntegrationCatalog.descriptor(for: .carbonTxt)
+        let cases: [([String: String], String)] = [
+            (
+                ["provenanceURL": "https://www.cloudflare.com/sustainability/"],
+                """
+                version = "0.5"
+
+                # Hosting provider: Cloudflare
+                [org]
+                disclosures = [
+                  { doc_type = "web-page", url = "https://www.cloudflare.com/sustainability/", title = "Cloudflare sustainability source" },
+                ]
+
+                [upstream]
+                services = [
+                  { domain = "cloudflare.com", service_type = "shared-hosting" },
+                ]
+                """
+            ),
+            (
+                [
+                    "provenanceURL": "https://www.cloudflare.com/sustainability/",
+                    "disclosureURL": "https://example.com/sustainability",
+                ],
+                """
+                version = "0.5"
+
+                # Hosting provider: Cloudflare
+                [org]
+                disclosures = [
+                  { doc_type = "web-page", url = "https://www.cloudflare.com/sustainability/", title = "Cloudflare sustainability source" },
+                  { doc_type = "web-page", url = "https://example.com/sustainability", title = "Organisation sustainability disclosure" },
+                ]
+
+                [upstream]
+                services = [
+                  { domain = "cloudflare.com", service_type = "shared-hosting" },
+                ]
+                """
+            ),
+        ]
+
+        for (answers, expected) in cases {
+            let plan = try IntegrationPlanner.plan(
+                descriptor: descriptor,
+                answers: answers,
+                sourceDirectory: source,
+                templateDirectory: templateRoot()
+            ).get()
+            guard case .createFile(let path, let contents) = plan.steps.first else {
+                Issue.record("expected carbon.txt create step")
+                return
+            }
+            #expect(path == "public/carbon.txt")
+            // Exact complete TOML output catches syntax, delimiter, and optional-section drift in
+            // the shipped asset rather than only exercising a miniature fixture.
+            #expect(contents == expected + "\n")
+        }
+    }
+
     @Test func layoutsHaveImportAndBodyAnchors() throws {
         let root = templateRoot()
         let base = try String(contentsOf: root.appendingPathComponent("src/layouts/BaseLayout.astro"), encoding: .utf8)

--- a/Tests/AnglesiteCoreTests/IntegrationTemplateTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationTemplateTests.swift
@@ -18,4 +18,10 @@ import Testing
         let t = Template("{{x}}{{x}}")
         #expect(t.resolve(["x": "ab"]) == "abab")
     }
+
+    @Test func resolvesOptionalSections() {
+        let t = Template("start {{#optional}}value={{optional}}{{/optional}} end")
+        #expect(t.resolve([:]) == "start  end")
+        #expect(t.resolve(["optional": "yes"]) == "start value=yes end")
+    }
 }


### PR DESCRIPTION
## Summary

- Add a carbon.txt integration that scaffolds a static public/carbon.txt disclosure in v0.5 TOML format.
- Keep template rendering opt-in with copyTemplatedFile; ordinary staged files preserve their exact contents.

## Paired PR check

- [x] This change is self-contained to Anglesite-app.
- [ ] This change needs a paired PR in Anglesite/anglesite (plugin / MCP server / template / hooks). Link it here:

## Test plan

- [x] swift test --package-path .
- [x] xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
- [ ] Manual smoke (if UI-touching): Not applicable; this scaffolds a static file.