### PR TITLE
test: stabilize InvisiblePublishQueue tests under parallel CI

### DIFF
--- a/Tests/AnglesiteCoreTests/InvisiblePublishQueueTests.swift
+++ b/Tests/AnglesiteCoreTests/InvisiblePublishQueueTests.swift
@@ -38,16 +38,22 @@ private actor GatedPublishProbe {
     }
 }
 
-@Suite("Invisible publish queue")
+// Serialized: each test drives real debounce timers, and running them
+// concurrently with each other amplifies scheduler starvation under
+// `swift test --parallel` on loaded CI runners (#762).
+@Suite("Invisible publish queue", .serialized)
 struct InvisiblePublishQueueTests {
     @Test("idle edits debounce into one publish")
     func debouncesEdits() async throws {
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let probe = PublishProbe()
+        // The debounce window must be comfortably wider than the sleeps
+        // between edits, or a stalled scheduler can let the timer fire
+        // mid-sequence and split the edits into two publishes (#762).
         let queue = InvisiblePublishQueue(
             configDirectory: directory,
-            debounce: .milliseconds(30),
+            debounce: .milliseconds(250),
             publisher: { await probe.publish() }
         )
 
@@ -159,8 +165,12 @@ struct InvisiblePublishQueueTests {
         return url
     }
 
+    /// Polls `condition` until it holds or `timeout` elapses. The deadline is
+    /// deliberately generous: it only bounds how long a genuine failure hangs,
+    /// while a passing test returns as soon as the condition is met — a tight
+    /// deadline just makes the suite flaky under parallel CI load (#762).
     private func waitUntil(
-        timeout: Duration = .seconds(2),
+        timeout: Duration = .seconds(30),
         condition: @escaping @Sendable () async -> Bool
     ) async throws {
         let clock = ContinuousClock()


### PR DESCRIPTION
## Summary

- Fixes the #762 CI flake: two `InvisiblePublishQueueTests` timed out under `swift test -c debug --parallel` because the helper's 2s `waitUntil` deadline is too tight under CI scheduling pressure.
- Test-only change, no production behavior: `waitUntil` deadline 2s→30s (polls every 10ms, so the happy path is unaffected), suite marked `.serialized` (all four tests drive real debounce timers), and `debouncesEdits`' window widened 30ms→250ms to fix a latent variant of the same flake. No assertions weakened.

Fixes #762

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite).

## Test plan

- [x] `swift test --package-path .` — clean full-package build; 4 consecutive green runs of the affected suite via CI's exact invocation (`swift test -c debug --parallel`), each ~0.4s (raised deadline doesn't slow the passing path)
- [x] `xcodebuild` build — unaffected (test-only diff)
- [ ] Manual smoke — N/A, no UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
