### PR TITLE
Component Editor slice 4: Props form + STTextView code panes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -223,7 +223,13 @@ if includeContainer {
 packageTargets.append(
     .target(
         name: "AnglesiteAppCore",
-        dependencies: ["AnglesiteCore", "AnglesiteBridge", "AnglesiteIntents"],
+        dependencies: [
+            "AnglesiteCore", "AnglesiteBridge", "AnglesiteIntents",
+            .product(name: "STTextView", package: "STTextView"),
+            // Module name is `STPluginNeon` (the target); the product name the dependency
+            // resolver matches on is the package's own product name below.
+            .product(name: "STTextView-Plugin-Neon", package: "STTextView-Plugin-Neon"),
+        ],
         path: "Sources/AnglesiteApp",
         exclude: ["AnglesiteApp.swift", "LiveSiteRuntimeFactory.swift"],
         // #541: ChatView.swift imports FoundationModels, so without this its object code embeds a
@@ -296,6 +302,23 @@ var packageDependencies: [Package.Dependency] = []
 // deliberately.
 packageDependencies.append(
     .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "65a16e39b09c16770a684ca29f3d5b242b9d0313")
+)
+
+// Component Editor slice 4 (spec §7, §4.3): STTextView-backed code panes ("Props & Data",
+// "Behavior") with tree-sitter syntax highlighting.
+//   - STTextView is the TextKit 2 code-editing view itself (AppKit here — AnglesiteAppCore is
+//     already Darwin/macOS-only).
+//   - STTextView-Plugin-Neon wires Neon + SwiftTreeSitter highlighting into an STTextView via
+//     its `NeonPlugin(theme:language:)`, bundling its own vendored tree-sitter grammars/queries
+//     (TreeSitterResource, including CSS/JavaScript/TypeScript) — so these two packages cover
+//     the whole highlighting stack the spec calls for, with no separate grammar packages
+//     to add.
+// Both AppKit-only, so gated the same as SwiftGit2 above.
+packageDependencies.append(
+    .package(url: "https://github.com/krzyzanowskim/STTextView", from: "2.3.10")
+)
+packageDependencies.append(
+    .package(url: "https://github.com/krzyzanowskim/STTextView-Plugin-Neon", from: "0.8.1")
 )
 #endif
 

--- a/Package.swift
+++ b/Package.swift
@@ -317,8 +317,14 @@ packageDependencies.append(
 packageDependencies.append(
     .package(url: "https://github.com/krzyzanowskim/STTextView", from: "2.3.10")
 )
+// Pinned to a commit, not `from:` — STTextView-Plugin-Neon's own manifest depends on Neon by
+// `revision:` (Neon has no tagged SPM releases), and SwiftPM refuses to resolve a stable-version
+// (`from:`) requirement on a package that itself depends on an unstable-version package. Pinning
+// by revision here (rather than tracking `branch: "main"`) matches the SwiftGit2 policy above:
+// deliberate bumps only, no silently picking up unreviewed future commits. This is tag 0.8.1's
+// commit.
 packageDependencies.append(
-    .package(url: "https://github.com/krzyzanowskim/STTextView-Plugin-Neon", from: "0.8.1")
+    .package(url: "https://github.com/krzyzanowskim/STTextView-Plugin-Neon", revision: "5a30db4ce7908a5414e7b499e2379bdc49991cd1")
 )
 #endif
 

--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -280,10 +280,59 @@ final class ComponentEditorModel {
         )
     }
 
+    // MARK: - Props & code writes
+
+    /// Codegen/replace the `Props` interface + `Astro.props` destructure from a structured props
+    /// array (the Props form). An empty array removes both. `applyComponentStyleEdit`'s
+    /// piggybacked-model path adopts the fresh model but doesn't otherwise know to touch
+    /// `knobValues` (it's op-agnostic), so this op resyncs the knobs bar itself on success:
+    /// existing knob values survive for props that still exist (by name), renamed/removed props
+    /// drop out, and newly added props get their type-based default. Returns whether the write
+    /// applied.
+    @discardableResult
+    func setPropsInterface(props: [ComponentModel.Prop]) async -> Bool {
+        let applied = await applyComponentStyleEdit(
+            ComponentCodeEditBuilder.setPropsInterface(
+                id: UUID().uuidString,
+                path: relativePath,
+                baseVersion: model?.version ?? "",
+                props: props
+            )
+        )
+        if applied { syncKnobValues() }
+        return applied
+    }
+
+    /// Rebuilds `knobValues` against the current `model`'s props, keyed by name — see
+    /// `setPropsInterface`'s doc comment for why this is needed after that op specifically.
+    private func syncKnobValues() {
+        let props = model?.frontmatter?.props ?? []
+        var next: [String: String] = [:]
+        for prop in props {
+            next[prop.name] = knobValues[prop.name] ?? KnobDefaults.value(for: prop)
+        }
+        knobValues = next
+    }
+
+    /// Replace a whole script zone (`"frontmatter"` or `"client"`) wholesale — a code-pane save.
+    /// Returns whether the write actually applied.
+    @discardableResult
+    func setScriptZone(zone: String, source: String) async -> Bool {
+        await applyComponentStyleEdit(
+            ComponentCodeEditBuilder.setScriptZone(
+                id: UUID().uuidString,
+                path: relativePath,
+                baseVersion: model?.version ?? "",
+                zone: zone,
+                source: source
+            )
+        )
+    }
+
     /// Routes a built `EditMessage` to `context.editRouter` and reconciles the result. Shared by
-    /// both the style writes above and the structure writes above (`insertNode`/`moveNode`/
-    /// `removeNode`/`setAttr`) — the name is a slice-2 holdover, but the reconciliation logic is
-    /// op-agnostic:
+    /// the style writes, the structure writes (`insertNode`/`moveNode`/`removeNode`/`setAttr`),
+    /// and the props/code writes above (`setPropsInterface`/`setScriptZone`) — the name is a
+    /// slice-2 holdover, but the reconciliation logic is op-agnostic:
     /// - `.applied` with a piggybacked `reply.model` adopts it directly (no second fetch).
     /// - `.applied` without one falls back to `load()`.
     /// - `.failed` with reason `"stale"` (the plugin's machine-readable refusal code — see

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import WebKit
 import AnglesiteCore
 import AnglesiteBridge
+import STTextView
+import STPluginNeon
 
 /// Component Editor: outline + harness canvas + inspector (with interactive Styles panel and structure edits).
 struct ComponentEditorView: View {
@@ -37,8 +39,65 @@ struct ComponentEditorView: View {
     /// Name/value text for the inline "Add attribute" form in the Selection panel.
     @State private var newAttrName: String = ""
     @State private var newAttrValue: String = ""
+    /// Editable draft of the component's Props interface (Props form), seeded from
+    /// `model.model?.frontmatter?.props` whenever a fresh model loads and reconciled back via
+    /// an explicit "Save Props" action — the op replaces the whole interface atomically, so
+    /// per-field auto-commit (like the Styles panel's declaration rows) doesn't fit here.
+    @State private var propsDraft: [PropDraft] = []
+    /// Which code pane is showing — "Props & Data" (frontmatter TS) or "Behavior" (client
+    /// script). Design spec §4.3.
+    @State private var codeZone: CodeZone = .frontmatter
+    /// Editable drafts for the two code panes, keyed by zone — dirty-tracked like
+    /// `FileEditorModel` (spec §5) and saved explicitly via `setScriptZone`, not on blur.
+    @State private var codeDrafts: [CodeZone: String] = [.frontmatter: "", .client: ""]
 
     enum Mode: String, CaseIterable { case design = "Design", source = "Source" }
+
+    /// The two code panes' zones (design spec §4.3): frontmatter TS ("Props & Data") and the
+    /// client `<script>` ("Behavior"). Maps 1:1 to `EditMessage.Op.setScriptZone`'s wire values.
+    private enum CodeZone: String, CaseIterable, Hashable {
+        case frontmatter, client
+
+        var label: String {
+            switch self {
+            case .frontmatter: "Props & Data"
+            case .client: "Behavior"
+            }
+        }
+
+        var language: TreeSitterLanguage {
+            switch self {
+            case .frontmatter: .typescript
+            case .client: .javascript
+            }
+        }
+    }
+
+    /// One row in the Props form. `id` is a stable SwiftUI identity for `ForEach`/drafting —
+    /// excluded from `==` (see the custom `Equatable` below) so draft-vs-model dirty checks
+    /// compare content only, not incidental per-row identity.
+    private struct PropDraft: Identifiable, Equatable {
+        let id = UUID()
+        var name: String
+        var type: String
+        var optional: Bool
+        var defaultValue: String
+
+        init(name: String, type: String, optional: Bool, defaultValue: String) {
+            self.name = name
+            self.type = type
+            self.optional = optional
+            self.defaultValue = defaultValue
+        }
+
+        init(_ prop: ComponentModel.Prop) {
+            self.init(name: prop.name, type: prop.type, optional: prop.optional, defaultValue: prop.defaultValue ?? "")
+        }
+
+        static func == (lhs: PropDraft, rhs: PropDraft) -> Bool {
+            lhs.name == rhs.name && lhs.type == rhs.type && lhs.optional == rhs.optional && lhs.defaultValue == rhs.defaultValue
+        }
+    }
 
     init(file: FileRef, context: ComponentEditorContext, fileEditor: FileEditorModel) {
         self.file = file
@@ -88,6 +147,16 @@ struct ComponentEditorView: View {
             // compiler diagnostic in a banner, rather than a dead-end full-pane error — fixing
             // the syntax error in source is the only way out, so land the user where they can.
             if newValue == .unparseable { mode = .source }
+        }
+        .onChange(of: model?.model?.version) { _, _ in
+            // A fresh model version means a fresh Props form / code pane baseline — re-seed
+            // both drafts. Any in-progress, unsaved edits are intentionally discarded here (the
+            // same tradeoff a stale-write "Reload" already makes elsewhere in this editor).
+            propsDraft = (model?.model?.frontmatter?.props ?? []).map(PropDraft.init)
+            codeDrafts = [
+                .frontmatter: model?.model?.frontmatter?.source ?? "",
+                .client: model?.model?.clientScript?.source ?? "",
+            ]
         }
     }
 
@@ -347,13 +416,37 @@ struct ComponentEditorView: View {
             HStack {
                 ForEach(props, id: \.name) { prop in
                     LabeledContent(prop.name) {
-                        TextField(prop.type, text: knobBinding(model, name: prop.name))
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 120)
+                        knobControl(model, prop: prop)
                     }
                 }
             }
             .padding(8)
+        }
+    }
+
+    /// Type-aware harness knob control (design spec §4.2): a `boolean` prop gets a `Toggle`,
+    /// a `number` prop gets a `Stepper` alongside its text field, and everything else keeps the
+    /// plain text field slice 1 shipped. `model.knobValues` stays `[String: String]` regardless
+    /// (that's `HarnessURL.build`'s contract) — these controls just read/write it through a
+    /// typed `Binding`.
+    @ViewBuilder
+    private func knobControl(_ model: ComponentEditorModel, prop: ComponentModel.Prop) -> some View {
+        switch prop.type {
+        case "boolean":
+            Toggle("", isOn: booleanKnobBinding(model, name: prop.name))
+                .labelsHidden()
+        case "number":
+            HStack(spacing: 2) {
+                TextField(prop.type, text: knobBinding(model, name: prop.name))
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 70)
+                Stepper("", value: numberKnobBinding(model, name: prop.name))
+                    .labelsHidden()
+            }
+        default:
+            TextField(prop.type, text: knobBinding(model, name: prop.name))
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 120)
         }
     }
 
@@ -362,6 +455,26 @@ struct ComponentEditorView: View {
             get: { model.knobValues[name] ?? "" },
             set: { model.knobValues[name] = $0 }
         )
+    }
+
+    private func booleanKnobBinding(_ model: ComponentEditorModel, name: String) -> Binding<Bool> {
+        Binding(
+            get: { (model.knobValues[name] ?? "false") == "true" },
+            set: { model.knobValues[name] = $0 ? "true" : "false" }
+        )
+    }
+
+    private func numberKnobBinding(_ model: ComponentEditorModel, name: String) -> Binding<Double> {
+        Binding(
+            get: { Double(model.knobValues[name] ?? "") ?? 0 },
+            set: { model.knobValues[name] = formatKnobNumber($0) }
+        )
+    }
+
+    /// Drops a redundant trailing ".0" for whole numbers so an integer-typed prop's knob (e.g.
+    /// `count`) round-trips as "2", not "2.0".
+    private func formatKnobNumber(_ value: Double) -> String {
+        value.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(value)) : String(value)
     }
 
     private func inspector(_ model: ComponentEditorModel) -> some View {
@@ -404,6 +517,8 @@ struct ComponentEditorView: View {
                         }
                     }
                 }
+                propsForm(model)
+                codePane(model)
                 if model.conflict {
                     conflictBanner(model)
                 }
@@ -483,6 +598,134 @@ struct ComponentEditorView: View {
             }
             .padding(10)
         }
+    }
+
+    /// Structured Props form (design spec §4.3): the component's `Props` interface as
+    /// name/type/optional/default rows, independent of outline selection — props belong to the
+    /// component as a whole, not to any one template node. Edits accumulate in `propsDraft` and
+    /// commit together via "Save Props" (a `set-props-interface` op replaces the whole
+    /// interface atomically, so there's no single field to auto-commit on blur/submit the way
+    /// the Styles panel's declaration rows do).
+    private func propsForm(_ model: ComponentEditorModel) -> some View {
+        GroupBox("Props") {
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach($propsDraft) { $prop in
+                    HStack(spacing: 4) {
+                        TextField("name", text: $prop.name)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(width: 80)
+                        TextField("type", text: $prop.type)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(width: 70)
+                        Toggle("optional", isOn: $prop.optional)
+                            .labelsHidden()
+                            .help("Optional")
+                        TextField("default", text: $prop.defaultValue)
+                            .font(.system(.caption, design: .monospaced))
+                        Button(role: .destructive) {
+                            propsDraft.removeAll { $0.id == prop.id }
+                        } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                HStack {
+                    Button("Add Prop") {
+                        propsDraft.append(PropDraft(name: "", type: "string", optional: false, defaultValue: ""))
+                    }
+                    .font(.caption2)
+                    .buttonStyle(.plain)
+                    Spacer()
+                    Button("Save Props") {
+                        Task { await savePropsDraft(model) }
+                    }
+                    .disabled(!propsDraftDirty(model))
+                }
+            }
+        }
+    }
+
+    /// True when `propsDraft` differs from the current model's props — gates "Save Props" so it
+    /// only enables once there's something to save (and disables again once the piggybacked
+    /// model from a successful save re-seeds the draft via the `.onChange(of: model?.model?.version)`
+    /// handler in `body`).
+    private func propsDraftDirty(_ model: ComponentEditorModel) -> Bool {
+        propsDraft != (model.model?.frontmatter?.props ?? []).map(PropDraft.init)
+    }
+
+    /// Commits `propsDraft` via `setPropsInterface`, dropping any row with a blank name or type
+    /// (an in-progress "Add Prop" row the user hasn't filled in yet) rather than sending it as a
+    /// malformed prop the plugin would refuse outright.
+    private func savePropsDraft(_ model: ComponentEditorModel) async {
+        let props = propsDraft.compactMap { draft -> ComponentModel.Prop? in
+            let name = draft.name.trimmingCharacters(in: .whitespaces)
+            let type = draft.type.trimmingCharacters(in: .whitespaces)
+            guard !name.isEmpty, !type.isEmpty else { return nil }
+            let defaultValue = draft.defaultValue.trimmingCharacters(in: .whitespaces)
+            return ComponentModel.Prop(name: name, type: type, optional: draft.optional, defaultValue: defaultValue.isEmpty ? nil : defaultValue)
+        }
+        await model.setPropsInterface(props: props)
+    }
+
+    /// The two STTextView code panes (design spec §4.3/§7): "Props & Data" (frontmatter TS) and
+    /// "Behavior" (client script), tree-sitter highlighted, switched with a segmented picker.
+    /// Dirty-tracked like `FileEditorModel` — explicit save via the button below, not on blur
+    /// (see that button's doc comment for why it doesn't also bind ⌘S).
+    private func codePane(_ model: ComponentEditorModel) -> some View {
+        GroupBox("Code") {
+            VStack(alignment: .leading, spacing: 6) {
+                Picker("Zone", selection: $codeZone) {
+                    ForEach(CodeZone.allCases, id: \.self) { Text($0.label).tag($0) }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                ComponentCodeEditorView(
+                    text: codeDraftBinding(codeZone),
+                    language: codeZone.language
+                )
+                .frame(height: 160)
+                .border(.separator)
+                HStack {
+                    if codeDraftDirty(model, zone: codeZone) {
+                        Text("Unsaved changes").font(.caption2).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button("Save") {
+                        Task { await saveCodeDraft(model, zone: codeZone) }
+                    }
+                    // No local ⌘S: `SaveCommands`/#509 centralized File ▸ Save specifically to
+                    // avoid double-registering the shortcut when multiple editing surfaces are
+                    // on screen at once. This pane isn't wired into `SiteWindowModel.activeEditor`
+                    // (a closed `.text`/`.plist` enum) yet — a reasonable follow-up once the
+                    // Component Editor's props/code drafts need to participate in File ▸ Save /
+                    // Revert to Saved the way the main-pane editor and inspector already do.
+                    .disabled(!codeDraftDirty(model, zone: codeZone))
+                }
+            }
+        }
+    }
+
+    private func codeDraftBinding(_ zone: CodeZone) -> Binding<String> {
+        Binding(
+            get: { codeDrafts[zone] ?? "" },
+            set: { codeDrafts[zone] = $0 }
+        )
+    }
+
+    private func currentZoneSource(_ model: ComponentEditorModel, zone: CodeZone) -> String {
+        switch zone {
+        case .frontmatter: model.model?.frontmatter?.source ?? ""
+        case .client: model.model?.clientScript?.source ?? ""
+        }
+    }
+
+    private func codeDraftDirty(_ model: ComponentEditorModel, zone: CodeZone) -> Bool {
+        (codeDrafts[zone] ?? "") != currentZoneSource(model, zone: zone)
+    }
+
+    private func saveCodeDraft(_ model: ComponentEditorModel, zone: CodeZone) async {
+        await model.setScriptZone(zone: zone.rawValue, source: codeDrafts[zone] ?? "")
     }
 
     /// "This component changed outside Anglesite" banner — the edit that triggered a stale-write
@@ -793,5 +1036,53 @@ private struct ComponentCanvasView: NSViewRepresentable {
             coordinator.pendingReload = nil
             webView.load(URLRequest(url: targetURL))
         }
+    }
+}
+
+/// STTextView-backed code pane for a component script zone, tree-sitter highlighted via
+/// STTextView-Plugin-Neon's `NeonPlugin`. Wraps the AppKit view directly
+/// (`STTextView.scrollableTextView()`), matching `ComponentCanvasView` above's own
+/// NSViewRepresentable-over-AppKit pattern rather than STTextView's SwiftUI wrapper.
+private struct ComponentCodeEditorView: NSViewRepresentable {
+    @Binding var text: String
+    let language: TreeSitterLanguage
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, STTextViewDelegate {
+        let text: Binding<String>
+        /// Set while `updateNSView` is pushing the SwiftUI-side value into the text view, so
+        /// the resulting `textViewDidChangeText` notification doesn't bounce right back into
+        /// `text` (a no-op, but one that would otherwise re-trigger `updateNSView` every frame).
+        var isProgrammaticUpdate = false
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        func textViewDidChangeText(_ notification: Notification) {
+            guard !isProgrammaticUpdate, let textView = notification.object as? STTextView else { return }
+            text.wrappedValue = textView.text
+        }
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = STTextView.scrollableTextView()
+        guard let textView = scrollView.documentView as? STTextView else { return scrollView }
+        textView.text = text
+        textView.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+        textView.delegate = context.coordinator
+        textView.addPlugin(NeonPlugin(theme: .default, language: language))
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? STTextView, textView.text != text else { return }
+        context.coordinator.isProgrammaticUpdate = true
+        textView.text = text
+        context.coordinator.isProgrammaticUpdate = false
     }
 }

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -680,10 +680,21 @@ struct ComponentEditorView: View {
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
+                // `.id(codeZone)` forces SwiftUI to tear down and recreate this
+                // NSViewRepresentable (fresh Coordinator, fresh STTextView, fresh NeonPlugin) on
+                // every tab switch, rather than reusing the same underlying view/coordinator
+                // across zones. Without it, `makeCoordinator`/`makeNSView` run exactly once for
+                // the lifetime of this view's position in the tree: the coordinator's captured
+                // `text` binding and the plugin's `language` would both stay pinned to whichever
+                // zone was active at first mount, so typing after switching tabs would silently
+                // write into the wrong zone's draft and highlight with the wrong grammar (PR
+                // #774 review). Recreating the view on zone change does mean losing cursor/scroll
+                // position when switching tabs — an acceptable tradeoff over misrouted edits.
                 ComponentCodeEditorView(
                     text: codeDraftBinding(codeZone),
                     language: codeZone.language
                 )
+                .id(codeZone)
                 .frame(height: 160)
                 .border(.separator)
                 HStack {

--- a/Sources/AnglesiteCore/ComponentCodeEditBuilder.swift
+++ b/Sources/AnglesiteCore/ComponentCodeEditBuilder.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Builds the wire-format `EditMessage` payloads for the two Component Editor "Props & code"
+/// write ops (`set-props-interface`, `set-script-zone`). Pure and testable — no MCP/router
+/// dependency, mirrors `ComponentStyleEditBuilder`'s shape exactly.
+public enum ComponentCodeEditBuilder {
+    /// `props` mirrors the plugin's `component.props` schema — the same shape
+    /// `ComponentModel.Prop` decodes, so callers can pass `model.frontmatter?.props`
+    /// (edited in place) straight through. An empty array removes the Props interface
+    /// and its `Astro.props` destructure entirely.
+    public static func setPropsInterface(
+        id: String,
+        path: String,
+        baseVersion: String,
+        props: [ComponentModel.Prop]
+    ) -> EditMessage {
+        EditMessage(
+            id: id,
+            path: path,
+            selector: nil,
+            op: EditMessage.Op.setPropsInterface,
+            component: .object([
+                "path": .string(path),
+                "baseVersion": .string(baseVersion),
+                "props": .array(props.map(propValue)),
+            ]),
+            value: nil
+        )
+    }
+
+    /// `zone` is `"frontmatter"` or `"client"`; `source` replaces that zone's text wholesale
+    /// (a code-pane save), synthesizing the zone server-side if it doesn't exist yet.
+    public static func setScriptZone(
+        id: String,
+        path: String,
+        baseVersion: String,
+        zone: String,
+        source: String
+    ) -> EditMessage {
+        EditMessage(
+            id: id,
+            path: path,
+            selector: nil,
+            op: EditMessage.Op.setScriptZone,
+            component: .object([
+                "path": .string(path),
+                "baseVersion": .string(baseVersion),
+                "zone": .string(zone),
+                "source": .string(source),
+            ]),
+            value: nil
+        )
+    }
+
+    private static func propValue(_ prop: ComponentModel.Prop) -> JSONValue {
+        .object([
+            "name": .string(prop.name),
+            "type": .string(prop.type),
+            "optional": .bool(prop.optional),
+            "default": prop.defaultValue.map(JSONValue.string) ?? .null,
+        ])
+    }
+}

--- a/Sources/AnglesiteCore/EditMessage.swift
+++ b/Sources/AnglesiteCore/EditMessage.swift
@@ -55,6 +55,14 @@ public struct EditMessage: Sendable, Equatable {
         /// `"set-attr"` — Component Editor: set or remove (nil value) an attribute/prop at
         /// the use-site. Carries a `component` payload.
         public static let setAttr = "set-attr"
+        /// `"set-props-interface"` — Component Editor: codegen/replace the frontmatter's
+        /// `Props` interface + `Astro.props` destructure from a structured props array.
+        /// Carries a `component` payload.
+        public static let setPropsInterface = "set-props-interface"
+        /// `"set-script-zone"` — Component Editor: replace a whole script zone
+        /// (`frontmatter` or `client`) wholesale — a code-pane save. Carries a `component`
+        /// payload.
+        public static let setScriptZone = "set-script-zone"
     }
 
     /// Overlay-generated correlation ID so the JS side can match replies to the original message.

--- a/Tests/AnglesiteAppTests/ComponentEditorModelCodeEditTests.swift
+++ b/Tests/AnglesiteAppTests/ComponentEditorModelCodeEditTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+@Suite("ComponentEditorModel props/code writes")
+@MainActor
+struct ComponentEditorModelCodeEditTests {
+    final class RecordingRouter: EditRouter {
+        var lastMessage: EditMessage?
+        var reply: EditReply
+        init(reply: EditReply) { self.reply = reply }
+        func apply(_ message: EditMessage) async -> EditReply {
+            lastMessage = message
+            return reply
+        }
+    }
+
+    func makeModel(router: EditRouter) -> ComponentEditorModel {
+        let context = ComponentEditorContext(baseURL: nil, modelClient: nil, sourceRoot: URL(fileURLWithPath: "/tmp/site"), editRouter: router)
+        let file = FileRef(url: URL(fileURLWithPath: "/tmp/site/src/components/Card.astro"), group: .components, name: "Card.astro")
+        return ComponentEditorModel(file: file, context: context)
+    }
+
+    @Test("setPropsInterface sends the built EditMessage and applies success")
+    func setPropsInterfaceApplies() async {
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let model = makeModel(router: router)
+        let props = [ComponentModel.Prop(name: "title", type: "string", optional: false, defaultValue: nil)]
+        let applied = await model.setPropsInterface(props: props)
+        #expect(applied)
+        #expect(router.lastMessage?.op == EditMessage.Op.setPropsInterface)
+        guard case .object(let component)? = router.lastMessage?.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["props"] == .array([
+            .object(["name": .string("title"), "type": .string("string"), "optional": .bool(false), "default": .null]),
+        ]))
+    }
+
+    @Test("setScriptZone sends the built EditMessage and applies success")
+    func setScriptZoneApplies() async {
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .applied, message: nil))
+        let model = makeModel(router: router)
+        let applied = await model.setScriptZone(zone: "client", source: "console.log('hi');")
+        #expect(applied)
+        #expect(router.lastMessage?.op == EditMessage.Op.setScriptZone)
+        guard case .object(let component)? = router.lastMessage?.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["zone"] == .string("client"))
+        #expect(component["source"] == .string("console.log('hi');"))
+    }
+
+    @Test("a stale reply flips conflict, same as the style/structure-write path")
+    func staleFlipsConflict() async {
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .failed, message: "stale", reason: "stale"))
+        let model = makeModel(router: router)
+        let applied = await model.setPropsInterface(props: [])
+        #expect(!applied)
+        #expect(model.conflict)
+    }
+
+    @Test("a routine failure surfaces via writeError, not conflict")
+    func routineFailureSurfacesWriteError() async {
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .failed, message: "invalid prop", reason: "invalid-input"))
+        let model = makeModel(router: router)
+        let applied = await model.setScriptZone(zone: "frontmatter", source: "const x = 1;")
+        #expect(!applied)
+        #expect(!model.conflict)
+        #expect(model.writeError == "invalid prop")
+    }
+}

--- a/Tests/AnglesiteCoreTests/ComponentCodeEditBuilderTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentCodeEditBuilderTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import AnglesiteCore
+
+struct ComponentCodeEditBuilderTests {
+    @Test("setPropsInterface builds a component payload with the full props array")
+    func setPropsInterface() {
+        let message = ComponentCodeEditBuilder.setPropsInterface(
+            id: "1",
+            path: "src/components/Card.astro",
+            baseVersion: "sha256:abc123456789",
+            props: [
+                ComponentModel.Prop(name: "title", type: "string", optional: false, defaultValue: nil),
+                ComponentModel.Prop(name: "count", type: "number", optional: true, defaultValue: "1"),
+            ]
+        )
+        #expect(message.op == EditMessage.Op.setPropsInterface)
+        #expect(message.selector == nil)
+        #expect(message.path == "src/components/Card.astro")
+        guard case .object(let component)? = message.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["path"] == .string("src/components/Card.astro"))
+        #expect(component["baseVersion"] == .string("sha256:abc123456789"))
+        #expect(component["props"] == .array([
+            .object(["name": .string("title"), "type": .string("string"), "optional": .bool(false), "default": .null]),
+            .object(["name": .string("count"), "type": .string("number"), "optional": .bool(true), "default": .string("1")]),
+        ]))
+    }
+
+    @Test("setPropsInterface encodes an empty props array as [] (removal)")
+    func setPropsInterfaceEmpty() {
+        let message = ComponentCodeEditBuilder.setPropsInterface(
+            id: "2",
+            path: "src/components/Card.astro",
+            baseVersion: "sha256:abc123456789",
+            props: []
+        )
+        guard case .object(let component)? = message.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["props"] == .array([]))
+    }
+
+    @Test("setScriptZone builds a component payload with zone and source")
+    func setScriptZoneFrontmatter() {
+        let message = ComponentCodeEditBuilder.setScriptZone(
+            id: "3",
+            path: "src/components/Card.astro",
+            baseVersion: "sha256:abc123456789",
+            zone: "frontmatter",
+            source: "const greeting = \"hi\";"
+        )
+        #expect(message.op == EditMessage.Op.setScriptZone)
+        guard case .object(let component)? = message.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["zone"] == .string("frontmatter"))
+        #expect(component["source"] == .string("const greeting = \"hi\";"))
+    }
+
+    @Test("setScriptZone works for the client zone too")
+    func setScriptZoneClient() {
+        let message = ComponentCodeEditBuilder.setScriptZone(
+            id: "4",
+            path: "src/components/Card.astro",
+            baseVersion: "sha256:abc123456789",
+            zone: "client",
+            source: "console.log('mounted');"
+        )
+        guard case .object(let component)? = message.component else {
+            Issue.record("expected component object")
+            return
+        }
+        #expect(component["zone"] == .string("client"))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -16,9 +16,12 @@ packages:
   STTextView:
     url: https://github.com/krzyzanowskim/STTextView
     from: 2.3.10
+  # Pinned to a commit (tag 0.8.1), not `from:` — see the matching Package.swift comment: its
+  # own manifest depends on Neon by `revision:`, and SwiftPM refuses a stable-version
+  # requirement on a package that itself depends on an unstable-version one.
   STTextViewPluginNeon:
     url: https://github.com/krzyzanowskim/STTextView-Plugin-Neon
-    from: 0.8.1
+    revision: 5a30db4ce7908a5414e7b499e2379bdc49991cd1
 
 targets:
   Anglesite:

--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,14 @@ options:
 packages:
   Anglesite:
     path: .
+  # Component Editor slice 4 (spec §7): STTextView code panes with tree-sitter syntax
+  # highlighting — see the matching dependencies in Package.swift for the full rationale.
+  STTextView:
+    url: https://github.com/krzyzanowskim/STTextView
+    from: 2.3.10
+  STTextViewPluginNeon:
+    url: https://github.com/krzyzanowskim/STTextView-Plugin-Neon
+    from: 0.8.1
 
 targets:
   Anglesite:
@@ -82,6 +90,10 @@ targets:
         product: AnglesiteIntents
       - package: Anglesite
         product: AnglesiteContainer
+      - package: STTextView
+        product: STTextView
+      - package: STTextViewPluginNeon
+        product: STTextView-Plugin-Neon
       - target: AnglesiteQuickLookPreview
         embed: true
       - target: AnglesiteQuickLookThumbnail


### PR DESCRIPTION
## Summary

Closes #494 (Component Editor slice 4). Consumes the paired plugin PR's new `set-props-interface`/`set-script-zone` ops:

- **EditMessage.Op + `ComponentCodeEditBuilder`** (AnglesiteCore): wire-format builders for both ops, mirroring `ComponentStyleEditBuilder`'s shape.
- **`ComponentEditorModel`**: `setPropsInterface`/`setScriptZone`, reusing the existing apply/reconcile pipeline. `setPropsInterface` also resyncs the harness knobs bar, since the shared reconciler is op-agnostic and won't otherwise notice a prop was renamed/added/removed.
- **Structured Props form** (name/type/optional/default rows) in the inspector, independent of outline selection since props belong to the component as a whole; commits via an explicit "Save Props" action (the op replaces the whole interface atomically, so there's no single field to auto-commit).
- **Type-aware harness knobs**: a `boolean` prop gets a `Toggle`, a `number` prop gets a `Stepper` alongside the text field, everything else keeps slice 1's plain text field.
- **Two STTextView code panes** ("Props & Data" / "Behavior"), tree-sitter highlighted via STTextView-Plugin-Neon's `NeonPlugin`, dirty-tracked and saved via an explicit Save button — deliberately **without** a local ⌘S, to avoid re-introducing the double-registered-shortcut bug #509 fixed; this pane isn't wired into `SiteWindowModel`'s centralized Save command yet (noted as a follow-up in the code). Switching zones fully rebuilds the pane (`.id(codeZone)`) so the coordinator binding and tree-sitter language never go stale (PR review fix).
- New SPM dependencies: `STTextView`, `STTextView-Plugin-Neon` (bundles Neon + SwiftTreeSitter + its own vendored grammars, so no separate grammar packages needed), wired into both `Package.swift` and `project.yml`. `STTextView-Plugin-Neon` is pinned by commit revision (not `from:`) because its own manifest depends on `Neon` by revision, which SwiftPM refuses under a stable-version requirement.

**Note on plugin version gating:** an earlier revision of this PR bumped `MIN_PLUGIN_VERSION` in `scripts/copy-plugin.sh`, but slice 7 (#772) has since retired the entire Claude-plugin bundling path — `copy-plugin.sh`, `PluginRuntime`, and the `Resources/plugin` build phase are all deleted on `main`. The MCP sidecar (which carries these ops) is now staged into the container image from the plugin checkout's `server/` directory (`scripts/lib/stage-dev-image-context.sh`), with no app-side version gate. This PR has been rebased onto post-slice-7 `main`, and the obsolete `MIN_PLUGIN_VERSION` change is dropped. The plugin's `set-props-interface`/`set-script-zone` ops ship in **plugin v1.6.0** (Anglesite/anglesite#418, merged + released), which any current plugin checkout provides.

## Paired PR check

- [ ] This change is **self-contained** to `Anglesite-app`.
- [x] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP schema — two new `apply_edit` ops). Link: Anglesite/anglesite#418 — **merged, released as v1.6.0.**

## Test plan

- [ ] `swift test --package-path .` — **not run locally**: this session has no Swift toolchain (Linux container). Relying on CI's macOS runner; the new `ComponentCodeEditBuilder`/`ComponentEditorModel` logic has Swift Testing coverage that runs there.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **not run locally**, same reason. This is the first PR to add STTextView/STTextView-Plugin-Neon as SPM dependencies; CI is the verification for the dependency graph (an earlier CI run already caught + fixed a SwiftPM resolution issue with the plugin package's revision-pinned `Neon` dep).
- [ ] Manual smoke (if UI-touching): not performed — no macOS/Xcode available in this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_015B14HqxNFD7ZoB2rJb6cmt)_