### PR TITLE
feat(core): sandbox-safe GitHub repo creation + push

### DIFF
--- a/Sources/AnglesiteCore/HTTPGitHubClient.swift
+++ b/Sources/AnglesiteCore/HTTPGitHubClient.swift
@@ -21,12 +21,8 @@ public enum GitHubRepoAPIError: Error, Equatable, Sendable {
 /// sandbox-safe Publish-to-GitHub path: `gh repo create` shells out and MAS users generally
 /// won't have `gh` installed at all.
 ///
-/// **Not yet wired into `RepoBootstrap`/`RepoProvider`.** `createRepo` only creates the remote
-/// repository — it does not (and today cannot) wire `origin` in the local repo or push to it.
-/// SwiftGit2 has no `addRemote`/`push` at the pinned revision (both land together in #659, shared
-/// with #653); wiring this client into a `RepoProvider` before then would let `RepoBootstrap`
-/// silently create an empty orphan GitHub repo with no way to push content into it. Wire it up
-/// once #659 merges.
+/// `createRepo` only creates the remote repository — wiring `origin` and pushing into it is
+/// `HTTPRepoProvider`'s job, using SwiftGit2's `addRemote`/`push` (#659).
 public struct HTTPGitHubClient: Sendable {
     private static let base = "https://api.github.com"
     private let transport: GitHubAPITokenVerifier.Transport

--- a/Sources/AnglesiteCore/HTTPRepoProvider.swift
+++ b/Sources/AnglesiteCore/HTTPRepoProvider.swift
@@ -1,0 +1,109 @@
+#if canImport(Darwin)
+import Foundation
+import SwiftGit2
+
+/// GitHub `RepoProvider` backed by the REST API (`HTTPGitHubClient.createRepo`) for repo creation
+/// plus in-process SwiftGit2 (`addRemote`/`push`, following the #659 `InProcessGit` pattern) for
+/// wiring `origin` and pushing. Sandbox-safe: no `gh` CLI, no `/usr/bin/git` subprocess — replaces
+/// `GHRepoProvider` on Darwin (see `RepoBootstrap.live()`). #654.
+public struct HTTPRepoProvider: RepoProvider {
+    private let client: HTTPGitHubClient
+    private let tokenProvider: InProcessGit.TokenProvider
+    /// Where `addRemote`/`push` target, given the just-created repo. Always the real GitHub HTTPS
+    /// clone URL in production; tests override it to point at a local bare repo instead, since
+    /// `createRepo`'s transport is mocked and there is no real GitHub repo to push into.
+    private let remoteURL: @Sendable (RemoteRepo) -> String
+
+    public init(
+        client: HTTPGitHubClient = HTTPGitHubClient(),
+        tokenProvider: @escaping InProcessGit.TokenProvider = InProcessGit.defaultTokenProvider,
+        remoteURL: @escaping @Sendable (RemoteRepo) -> String = { "https://github.com/\($0.owner)/\($0.name).git" }
+    ) {
+        self.client = client
+        self.tokenProvider = tokenProvider
+        self.remoteURL = remoteURL
+    }
+
+    /// A stored, non-empty GitHub token is all "authenticated" means here — the token was already
+    /// verified once at entry time when the user pasted it into Settings (`GitHubAPITokenVerifier`),
+    /// the same "verify once, then just check presence" shape the Cloudflare token flow uses.
+    public func isAuthenticated() async -> Bool {
+        (try? tokenProvider())?.isEmpty == false
+    }
+
+    public func createAndPush(name: String, isPrivate: Bool, source: URL) async throws -> RemoteRepo {
+        let token = try readToken()
+
+        let created: RemoteRepo
+        do {
+            created = try await client.createRepo(name: name, isPrivate: isPrivate, token: token)
+        } catch let apiError as GitHubRepoAPIError {
+            throw RepoBootstrapError(reason: Self.message(for: apiError))
+        }
+
+        // The remote repository now exists — every failure past this point must say so in its
+        // message. A silent "couldn't push" would otherwise look like nothing happened, when
+        // GitHub actually has a (possibly empty) repo the user now owns.
+        SwiftGit2Bootstrap.ensureInitialized
+        guard case .success(let repo) = Repository.at(source) else {
+            throw RepoBootstrapError(reason: "Created \(created.url.absoluteString), but \(source.path) isn't a git repository to push from.")
+        }
+
+        let url = remoteURL(created)
+        if case .failure(let error) = repo.addRemote(named: "origin", url: url) {
+            throw RepoBootstrapError(reason: "Created \(created.url.absoluteString), but couldn't set its origin remote: \(error.localizedDescription)")
+        }
+
+        // `ensureCommittable` (RepoBootstrap's preflight) has already run by the time
+        // `createAndPush` is called, so HEAD always resolves; "main" only guards a detached HEAD,
+        // which a freshly created-and-committed repo never is in practice.
+        let branch: String
+        if case .success(let head) = repo.HEAD(), let branchName = (head as? Branch)?.name {
+            branch = branchName
+        } else {
+            branch = "main"
+        }
+
+        // HTTPS remotes authenticate with the app-owned GitHub token, matching InProcessGit's
+        // push (#659); anything else (the local bare-repo fixture in tests) uses libgit2's
+        // default credential resolution.
+        let credentials: Credentials
+        if url.hasPrefix("https://") || url.hasPrefix("http://") {
+            credentials = .plaintext(username: "x-access-token", password: token)
+        } else {
+            credentials = .default
+        }
+
+        let refspec = "refs/heads/\(branch):refs/heads/\(branch)"
+        if case .failure(let error) = repo.push(remoteName: "origin", refspec: refspec, credentials: credentials) {
+            throw RepoBootstrapError(reason: "Created \(created.url.absoluteString), but the push failed: \(error.localizedDescription)")
+        }
+
+        return created
+    }
+
+    private func readToken() throws -> String {
+        let token: String?
+        do {
+            token = try tokenProvider()
+        } catch {
+            throw RepoBootstrapError(reason: "Couldn't read the GitHub token from the Keychain: \(error)")
+        }
+        guard let token, !token.isEmpty else {
+            throw RepoBootstrapError(reason: "No GitHub token found — add one in Settings → Advanced → Credentials.")
+        }
+        return token
+    }
+
+    private static func message(for error: GitHubRepoAPIError) -> String {
+        switch error {
+        case .network: return "Couldn’t reach GitHub. Check your connection and try again."
+        case .unauthorized: return "GitHub rejected the token — update it in Settings → Advanced → Credentials."
+        case .nameAlreadyExists: return "A repository with that name already exists on your GitHub account."
+        case .http(let status): return "GitHub returned an unexpected error (HTTP \(status))."
+        case .api(let message): return message
+        case .malformedResponse: return "GitHub returned an unexpected response."
+        }
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/RepoBootstrap.swift
+++ b/Sources/AnglesiteCore/RepoBootstrap.swift
@@ -7,11 +7,12 @@ import SwiftGit2
 /// delegates the create-remote-and-push step to a `RepoProvider`. See #68 / the design doc.
 ///
 /// The git `origin` is the source of truth for published state — `remote(of:)` reads it; nothing
-/// is persisted app-side. On Darwin, the preflight (`remote(of:)`, `ensureCommittable`) runs
-/// in-process via SwiftGit2 — `/usr/bin/git` cannot execute at all under App Sandbox (#640/#654).
-/// `RepoCommandRunner` remains the seam for the remaining subprocess calls (off-Darwin preflight,
-/// and `GHRepoProvider`'s `gh`/`git remote get-url` calls, which are a separate, still-blocked
-/// half of #654 pending SwiftGit2 `addRemote`/`push` support, #659).
+/// is persisted app-side. On Darwin, the preflight (`remote(of:)`, `ensureCommittable`) *and* the
+/// create-remote-and-push step run in-process — `/usr/bin/git` cannot execute at all under App
+/// Sandbox (#640/#654), and MAS users generally won't have `gh` installed either. `.live()` picks
+/// `HTTPRepoProvider` (REST API + SwiftGit2 `addRemote`/`push`, #654) on Darwin and `GHRepoProvider`
+/// (subprocess `gh`/`git`) elsewhere, where there's no sandbox to route around.
+/// `RepoCommandRunner` remains the seam `GHRepoProvider` and the off-Darwin preflight fallback use.
 public actor RepoBootstrap {
     public enum Step: Sendable, Equatable { case checkingRemote, initializing, committing, creatingRepo, pushing }
 
@@ -244,8 +245,10 @@ public actor RepoBootstrap {
         }
     }
 
-    /// Production wiring: `git`/`gh` run through `ProcessSupervisor.shared.run`. The one-shot `run`
-    /// path captures rather than streams, so the runner forwards captured stdout/stderr to
+    /// Production wiring. On Darwin, repo creation + push run in-process via `HTTPRepoProvider`
+    /// (#654) — `runner` still exists for the off-Darwin `RepoProvider`/preflight fallback, so it's
+    /// always built. Off-Darwin, `git`/`gh` run through `ProcessSupervisor.shared.run`; the one-shot
+    /// `run` path captures rather than streams, so the runner forwards captured stdout/stderr to
     /// `LogCenter` itself — per CLAUDE.md "logs are sacred", every spawned subprocess must reach
     /// the debug pane.
     public static func live(supervisor: ProcessSupervisor = .shared, logCenter: LogCenter = .shared) -> RepoBootstrap {
@@ -256,6 +259,10 @@ public actor RepoBootstrap {
             if !result.stderr.isEmpty { await logCenter.append(source: source, stream: .stderr, text: result.stderr) }
             return result
         }
+        #if canImport(Darwin)
+        return RepoBootstrap(provider: HTTPRepoProvider(), run: runner)
+        #else
         return RepoBootstrap(provider: GHRepoProvider(run: runner), run: runner)
+        #endif
     }
 }

--- a/Tests/AnglesiteCoreTests/HTTPRepoProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPRepoProviderTests.swift
@@ -1,0 +1,145 @@
+#if canImport(Darwin)
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// `HTTPRepoProvider` replaces `GHRepoProvider` on Darwin (#654): REST API repo creation
+/// (`HTTPGitHubClient`, transport mocked here) + in-process SwiftGit2 `addRemote`/`push` (real,
+/// against a local bare repo standing in for GitHub — `createRepo`'s transport being mocked means
+/// there's no real GitHub repo to push into, so `remoteURL` is overridden to point at the fixture
+/// instead of the real `https://github.com/...` URL production always uses).
+///
+/// .serialized: libgit2 isn't safe for uncoordinated concurrent use (see the fork's specs, and
+/// `InProcessGitTests`, which follows the same fixture style this file mirrors).
+@Suite("HTTPRepoProvider", .serialized) struct HTTPRepoProviderTests {
+    private func makeTempDir(_ label: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("http-repo-provider-\(label)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @discardableResult
+    private func git(_ arguments: [String], in dir: URL) async throws -> String {
+        let result = try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["git"] + arguments,
+            currentDirectoryURL: dir
+        )
+        guard result.exitCode == 0 else {
+            Issue.record("fixture git \(arguments.joined(separator: " ")) exited \(result.exitCode): \(result.stderr)")
+            throw FixtureError.gitFailed
+        }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private enum FixtureError: Error { case gitFailed }
+
+    /// A repo on `main` with local identity configured and one commit — mirrors `ensureCommittable`
+    /// having already run by the time `createAndPush` is called in the real `publish` flow.
+    private func makeRepo() async throws -> URL {
+        let dir = try makeTempDir("work")
+        try await git(["init", "-b", "main"], in: dir)
+        try await git(["config", "user.name", "Test"], in: dir)
+        try await git(["config", "user.email", "test@example.com"], in: dir)
+        try "hello".write(to: dir.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: dir)
+        try await git(["commit", "-m", "first"], in: dir)
+        return dir
+    }
+
+    /// Empty bare repo standing in for the "GitHub repo" `createRepo`'s mocked transport reports
+    /// as created — `addRemote`/`push` target this for real.
+    private func makeBareRemote() async throws -> URL {
+        let dir = try makeTempDir("origin")
+        try await git(["init", "--bare"], in: dir)
+        return dir
+    }
+
+    private func transport(status: Int, json: String) -> GitHubAPITokenVerifier.Transport {
+        { request in
+            let http = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(json.utf8), http)
+        }
+    }
+
+    @Test("isAuthenticated reflects whether a token is stored")
+    func isAuthenticatedReflectsToken() async {
+        let withToken = HTTPRepoProvider(tokenProvider: { "tok" })
+        let withoutToken = HTTPRepoProvider(tokenProvider: { nil })
+        #expect(await withToken.isAuthenticated() == true)
+        #expect(await withoutToken.isAuthenticated() == false)
+    }
+
+    @Test("createAndPush creates the repo, wires origin, and pushes the current branch")
+    func createAndPushSucceeds() async throws {
+        let repoDir = try await makeRepo()
+        let remote = try await makeBareRemote()
+        let localHEAD = try await git(["rev-parse", "HEAD"], in: repoDir)
+
+        let client = HTTPGitHubClient(transport: transport(
+            status: 201,
+            json: #"{"name":"site","html_url":"https://github.com/acme/site","owner":{"login":"acme"}}"#))
+        let provider = HTTPRepoProvider(
+            client: client,
+            tokenProvider: { "tok" },
+            remoteURL: { _ in remote.absoluteString }
+        )
+
+        let created = try await provider.createAndPush(name: "site", isPrivate: true, source: repoDir)
+        #expect(created.owner == "acme")
+        #expect(created.name == "site")
+        #expect(created.url == URL(string: "https://github.com/acme/site"))
+
+        // The push actually landed: the bare "remote" now has the same commit as local HEAD.
+        let remoteHEAD = try await git(["rev-parse", "main"], in: remote)
+        #expect(remoteHEAD == localHEAD)
+
+        // origin is wired in the local repo too — remote(of:) (the SwiftGit2 preflight read) can
+        // find it on a subsequent publish/open.
+        let originURL = try await git(["remote", "get-url", "origin"], in: repoDir)
+        #expect(originURL == remote.absoluteString)
+    }
+
+    @Test("createAndPush throws before hitting the network when no token is stored")
+    func createAndPushRequiresToken() async throws {
+        let repoDir = try await makeRepo()
+        let provider = HTTPRepoProvider(tokenProvider: { nil })
+        await #expect(throws: RepoBootstrapError.self) {
+            _ = try await provider.createAndPush(name: "site", isPrivate: true, source: repoDir)
+        }
+    }
+
+    @Test("a name-conflict from the API surfaces as a user-facing RepoBootstrapError")
+    func createAndPushMapsNameConflict() async throws {
+        let repoDir = try await makeRepo()
+        let client = HTTPGitHubClient(transport: transport(
+            status: 422,
+            json: #"{"message":"Repository creation failed.","errors":[{"message":"name already exists on this account"}]}"#))
+        let provider = HTTPRepoProvider(client: client, tokenProvider: { "tok" })
+        do {
+            _ = try await provider.createAndPush(name: "site", isPrivate: true, source: repoDir)
+            Issue.record("expected a throw")
+        } catch let error as RepoBootstrapError {
+            #expect(error.reason.contains("already exists"))
+        }
+    }
+
+    @Test("a repo created but not pushable (source isn't a git repo) still names the created URL")
+    func createAndPushSurfacesCreatedURLWhenSourceIsNotARepo() async throws {
+        // The remote repository now genuinely exists on GitHub even though the local push can't
+        // happen — the failure message must say so, not read like nothing happened.
+        let notARepo = try makeTempDir("not-a-repo")
+        let client = HTTPGitHubClient(transport: transport(
+            status: 201,
+            json: #"{"name":"site","html_url":"https://github.com/acme/site","owner":{"login":"acme"}}"#))
+        let provider = HTTPRepoProvider(client: client, tokenProvider: { "tok" })
+        do {
+            _ = try await provider.createAndPush(name: "site", isPrivate: true, source: notARepo)
+            Issue.record("expected a throw")
+        } catch let error as RepoBootstrapError {
+            #expect(error.reason.contains("https://github.com/acme/site"))
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- Adds `HTTPRepoProvider`, a `RepoProvider` using `HTTPGitHubClient`'s REST create (`POST /user/repos`) plus in-process SwiftGit2 `addRemote`/`push` (the #659 `InProcessGit` pattern) — no `gh` CLI, no `/usr/bin/git` subprocess.
- `RepoBootstrap.live()` now picks `HTTPRepoProvider` on Darwin; `GHRepoProvider` (subprocess `gh`/`git`) remains the off-Darwin implementation, where there's no App Sandbox to route around.
- This was the one piece #654's own issue thread said was still missing: the git preflight (init/commit) was already sandbox-safe via SwiftGit2 (#663), and #659 landed the `addRemote`/`push` support this provider needed — the last blocker. `isAuthenticated()` now checks for a stored GitHub token (`SecretAccounts.gitHubToken`, #659) instead of `gh auth status`.
- Tests mirror `InProcessGitTests`' fixture style: real temp git repos, a local bare repo standing in for GitHub (`HTTPGitHubClient`'s transport is mocked, so there's no real GitHub repo to push into — an injectable `remoteURL` closure points `addRemote`/`push` at the fixture in tests while production always uses the real `https://github.com/<owner>/<name>.git` URL), covering the success path (repo created, origin wired, push lands), the no-token fast-fail, and that failures past repo-creation still name the created URL rather than reading like nothing happened.

## Scope note — what this does *not* fix yet

This fixes the git/GitHub **plumbing**. The "Publish to GitHub" **UI** (toolbar item, Site menu, `PublishSheet`, and the old `GitHubAuthSheetView` `gh auth login` flow) is still compiled out of the MAS build entirely via `#if !ANGLESITE_MAS` in `SiteWindow.swift`, `WebsiteCommands.swift`, and `PublishSheet.swift` itself — meaning **the feature isn't reachable by a user in the shipping app yet even after this PR merges**. Re-enabling it, and replacing `.needsAuth`'s routing to `GitHubAuthSheetView` (itself `gh`-CLI-based and still sandbox-broken) with a path to the GitHub-token Settings row #659 added, is a distinct, UI-facing follow-up — SwiftUI wiring across several files that I'd rather have build/click-tested by a session with real Xcode than land blind. Flagging this explicitly on #654 so it's a visible decision point, not a silent gap.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — not run in this session (no Xcode/macOS/Swift toolchain available); relying on CI's macOS lane. `HTTPRepoProviderTests` and the SwiftGit2 API calls in `HTTPRepoProvider` (`addRemote`, `push`, `Credentials.plaintext`) are unverified against the real `Anglesite/SwiftGit2` fork source — I inferred the `addRemote(named:url:)` signature from #659's PR description and this codebase's consistent `Result<T, NSError>` wrapper convention (matching every other SwiftGit2 call in `InProcessGit.swift`/`RepoBootstrap.swift`), since I couldn't resolve the package to check directly.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run, same reason.
- [ ] Manual smoke: not performed — needs a real Mac and, per the scope note above, the feature isn't UI-reachable yet regardless.

Given the above, this should stay in draft until CI confirms the build/tests are green.

Ref #654.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NuUatsxTAEpjxCogpas6ww)_