### PR TITLE
fix(container): hold an activity assertion during first-boot provisioning

### DIFF
--- a/Sources/AnglesiteCore/ActivityAssertion.swift
+++ b/Sources/AnglesiteCore/ActivityAssertion.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Thin wrapper around `ProcessInfo`'s activity-assertion API (macOS-only) so long-running,
+/// user-initiated work — first-boot container provisioning in particular — isn't silently
+/// suspended by App Nap / idle-sleep throttling when the app is occluded, e.g. the screen locks
+/// mid-boot (#773). A user who creates a site and walks away should come back to a completed (or
+/// cleanly failed) boot, not a "Building site…" that silently made no progress for 40 minutes.
+///
+/// Each `begin(reason:)` call acquires its own independent token — unlike
+/// `SuddenTerminationController`, there is no shared ref-count to keep balanced; the OS tracks
+/// each assertion separately, so two overlapping callers (a superseded and a superseding boot
+/// attempt, say) can't clobber each other.
+public enum ActivityAssertion {
+    /// Holds one assertion. `onRelease` (not a raw `ProcessInfo` token) is what's stored, so tests
+    /// can construct a `Lease` directly around a counting closure without ever touching the real
+    /// Darwin activity API — faking a bogus token into `endActivity` would be unsafe.
+    public final class Lease: @unchecked Sendable {
+        private let lock = NSLock()
+        private var onRelease: (@Sendable () -> Void)?
+
+        public init(onRelease: @escaping @Sendable () -> Void) {
+            self.onRelease = onRelease
+        }
+
+        /// Ends this assertion once. Repeated calls are harmless.
+        public func release() {
+            lock.lock()
+            let action = onRelease
+            onRelease = nil
+            lock.unlock()
+            action?()
+        }
+
+        deinit { release() }
+    }
+
+    /// Begins an activity assertion with `reason` (surfaced in Activity Monitor's "reason" column
+    /// for the process). No-op off macOS — the assertion API doesn't exist there, and there's no
+    /// App Nap/occlusion throttling to route around on the platforms `#os(macOS)` excludes.
+    ///
+    /// `.userInitiated` requests the system not throttle this work for App Nap purposes;
+    /// `.idleSystemSleepDisabled` additionally covers the "walked away and the *system* idle-sleeps"
+    /// case, not just app-level occlusion throttling — both apply to "user created a site and the
+    /// screen locked mid-boot."
+    public static func begin(reason: String) -> Lease {
+        #if os(macOS)
+        let token = ProcessInfo.processInfo.beginActivity(
+            options: [.userInitiated, .idleSystemSleepDisabled],
+            reason: reason
+        )
+        return Lease(onRelease: { ProcessInfo.processInfo.endActivity(token) })
+        #else
+        return Lease(onRelease: {})
+        #endif
+    }
+}

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -20,6 +20,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     private let makeFileWatcher: @Sendable () -> any SiteFileWatching
     private let importBundle: @Sendable (URL, String, URL) async throws -> Void
     private let suddenTerminationController: SuddenTerminationController
+    private let beginActivity: @Sendable (String) -> ActivityAssertion.Lease
     private var fileWatcher: (any SiteFileWatching)?
     private var containerTerminationLease: SuddenTerminationController.Lease?
 
@@ -58,7 +59,8 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             throw SiteRuntimePersistenceError.syncFailed("in-process git import is unavailable on this platform")
             #endif
         },
-        suddenTerminationController: SuddenTerminationController = .shared
+        suddenTerminationController: SuddenTerminationController = .shared,
+        beginActivity: @escaping @Sendable (String) -> ActivityAssertion.Lease = ActivityAssertion.begin
     ) {
         self.ref = ref
         self.control = control
@@ -71,6 +73,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         self.makeFileWatcher = makeFileWatcher
         self.importBundle = importBundle
         self.suddenTerminationController = suddenTerminationController
+        self.beginActivity = beginActivity
     }
 
     public var state: SiteRuntimeState { current }
@@ -246,6 +249,11 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         }
         setState(.starting(siteID: siteID))
         let suddenTerminationLease = suddenTerminationController.acquire()
+        // Scoped to the boot window only (unlike suddenTerminationLease, which outlives it as
+        // containerTerminationLease) — released on every exit path below, including success:
+        // once .ready/.failed is reached there's no more provisioning work an occluded app could
+        // silently stall on. #773.
+        let activityLease = beginActivity("Starting local preview for \(siteID)")
 
         // Wire the container's boot/guest-process output (repo clone, npm install + astro dev, the
         // MCP sidecar, the vsock bridge) into LogCenter under a per-site source tag, live, the same
@@ -274,6 +282,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         func abandonSupersededAttempt() async {
             try? await control.stop(siteID: siteID)
             suddenTerminationLease.release()
+            activityLease.release()
             continuation.finish()
             await drainTask.value
         }
@@ -310,6 +319,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             activeSiteID = siteID
             activeSiteDirectory = siteDirectory
             containerTerminationLease = suddenTerminationLease
+            activityLease.release()
             setState(.ready(siteID: siteID, url: session.previewURL))
         } catch {
             // Finish this attempt's own (locally-captured) boot log stream immediately rather than
@@ -325,6 +335,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
                 try? await control.stop(siteID: siteID)
             }
             suddenTerminationLease.release()
+            activityLease.release()
             guard gen == generation else { return }
             bootLogContinuation = nil
             bootLogDrainTask = nil

--- a/Tests/AnglesiteCoreTests/ActivityAssertionTests.swift
+++ b/Tests/AnglesiteCoreTests/ActivityAssertionTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("Activity assertion")
+struct ActivityAssertionTests {
+    @Test("release invokes the release action exactly once")
+    func releaseInvokesActionOnce() {
+        let calls = LockedCount()
+        let lease = ActivityAssertion.Lease(onRelease: { calls.increment() })
+
+        lease.release()
+        #expect(calls.value == 1)
+    }
+
+    @Test("a lease releases at most once, even called repeatedly")
+    func idempotentRelease() {
+        let calls = LockedCount()
+        let lease = ActivityAssertion.Lease(onRelease: { calls.increment() })
+
+        lease.release()
+        lease.release()
+        lease.release()
+
+        #expect(calls.value == 1)
+    }
+
+    @Test("deinit releases an un-released lease as a safety net")
+    func deinitReleases() {
+        let calls = LockedCount()
+        do {
+            _ = ActivityAssertion.Lease(onRelease: { calls.increment() })
+        }
+        #expect(calls.value == 1)
+    }
+
+    @Test("deinit does not double-release an already-released lease")
+    func deinitAfterExplicitReleaseDoesNotDoubleRelease() {
+        let calls = LockedCount()
+        do {
+            let lease = ActivityAssertion.Lease(onRelease: { calls.increment() })
+            lease.release()
+        }
+        #expect(calls.value == 1)
+    }
+
+    @Test("begin(reason:) returns a lease that can be released without crashing")
+    func beginReturnsAReleasableLease() {
+        // Exercises the real #os(macOS)/off-macOS branches in begin(_:) — on macOS this makes a
+        // real ProcessInfo.beginActivity/endActivity round trip; off-macOS it's a no-op. Either
+        // way, a caller that never inspects the token shouldn't be able to observe the difference.
+        let lease = ActivityAssertion.begin(reason: "test")
+        lease.release()
+    }
+}
+
+private final class LockedCount: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int { lock.withLock { count } }
+
+    func increment() {
+        lock.withLock { count += 1 }
+    }
+}

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -58,6 +58,78 @@ struct LocalContainerSiteRuntimeTests {
         #expect(controller.activeLeaseCount == 0)
     }
 
+    /// Thread-safe begin/release counter for `ActivityAssertion.Lease` — mirrors
+    /// `SuddenTerminationController`'s injectability but with independent per-call leases (no
+    /// shared ref-count to assert on), so the test asserts the counts balance instead.
+    private final class ActivityAssertionCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var beginCount = 0
+        private(set) var releaseCount = 0
+
+        func beginActivity(_ reason: String) -> ActivityAssertion.Lease {
+            lock.lock(); beginCount += 1; lock.unlock()
+            return ActivityAssertion.Lease(onRelease: { [weak self] in
+                guard let self else { return }
+                self.lock.lock(); self.releaseCount += 1; self.lock.unlock()
+            })
+        }
+    }
+
+    @Test("a successful boot begins and releases exactly one activity assertion")
+    func successfulBootBalancesActivityAssertion() async {
+        let counter = ActivityAssertionCounter()
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: fake,
+            mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
+            connect: { _, _ in },
+            beginActivity: counter.beginActivity
+        )
+
+        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        #expect(counter.beginCount == 1)
+        #expect(counter.releaseCount == 1)
+    }
+
+    @Test("a failed boot does not leak its activity assertion")
+    func failedBootDoesNotLeakActivityAssertion() async {
+        let counter = ActivityAssertionCounter()
+        let fake = FakeLocalContainerControl(startResult: .failure(.bootFailed("no boot")))
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: fake,
+            mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
+            connect: { _, _ in },
+            beginActivity: counter.beginActivity
+        )
+
+        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        #expect(counter.beginCount == 1)
+        #expect(counter.releaseCount == 1)
+    }
+
+    @Test("stop() after a successful boot does not double-release the (already-released) activity assertion")
+    func stopAfterBootDoesNotDoubleReleaseActivityAssertion() async {
+        // The activity assertion is scoped to the boot window only — it's released as soon as
+        // .ready is reached, unlike suddenTerminationLease, which lives on as
+        // containerTerminationLease until stop(). This just confirms stop() doesn't touch it again.
+        let counter = ActivityAssertionCounter()
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: fake,
+            mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
+            connect: { _, _ in },
+            beginActivity: counter.beginActivity
+        )
+
+        await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        await runtime.stop()
+        #expect(counter.beginCount == 1)
+        #expect(counter.releaseCount == 1)
+    }
+
     @Test("start settles to .ready with the preview URL")
     func startReady() async {
         let (rt, _) = makeRuntime(.success(Self.ok))


### PR DESCRIPTION
## Summary

- `LocalContainerSiteRuntime.start()` had no activity assertion around the image-import/VM-boot/guest-provisioning window, so App Nap / idle-sleep throttling could suspend it when the app is occluded (screen locked, no visible window). Found live during the #706 E2E QA run: a site created right before the screen locked sat at 0% CPU with no log output for ~40 minutes, with the "Building site…" progress never advancing and nothing communicating why.
- Adds `ActivityAssertion`, a thin `ProcessInfo.beginActivity`/`endActivity` wrapper (macOS-only, no-op elsewhere) with a closure-based `Lease` so it's fake-injectable in tests without ever touching the real Darwin API (faking a bogus token into `endActivity` would be unsafe, so the lease stores a release closure, not a raw token).
- `start()` acquires one right alongside the existing sudden-termination lease and releases it on every exit path — success, failure, and each of the four "superseded by a newer start()/stop()" early returns — mirroring the file's existing per-attempt lease-balancing discipline exactly. Unlike `suddenTerminationLease` (which outlives the boot window as `containerTerminationLease`), this lease is scoped to the boot window only: released as soon as `.ready`/`.failed` is reached, since there's no more provisioning work left for an occluded app to silently stall on past that point.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

> `ActivityAssertion` and the `LocalContainerSiteRuntime.start()` lease-balancing change touch only `AnglesiteCore`/`AnglesiteApp`. No MCP message schema, plugin hook contract, or site template is affected, so no paired `Anglesite/anglesite` PR is needed.

## Test plan

- [ ] `swift test --package-path .` — not run in this session (no Xcode/macOS/Swift toolchain available); relying on CI.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run, same reason.
- [x] `ActivityAssertionTests` covers `Lease`'s release-once/deinit-safety-net semantics directly (including exercising the real `#os(macOS)`/off-macOS branches in `begin(reason:)`).
- [x] `LocalContainerSiteRuntimeTests` adds three cases (successful boot, failed boot, `stop()` after a successful boot) that inject a counting fake and assert begin/release balance — mirroring the existing `suddenTerminationLease` leak tests already in that file.
- [ ] Manual smoke (the actual regression — create a site, lock the screen mid-boot, unlock, confirm it completed): not performed, needs a real Mac. This PR fixes the mechanism the issue's own suggested direction named; verifying the screen-lock repro itself is a manual follow-up for whoever's running #706.

Ref #773.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NuUatsxTAEpjxCogpas6ww)_
