### PR TITLE
fix(component-editor): resolve TreeSitterLanguage build break from #774

### DIFF
--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -4,6 +4,7 @@ import AnglesiteCore
 import AnglesiteBridge
 import STTextView
 import STPluginNeon
+import TreeSitterResource
 
 /// Component Editor: outline + harness canvas + inspector (with interactive Styles panel and structure edits).
 struct ComponentEditorView: View {
@@ -1076,7 +1077,7 @@ private struct ComponentCodeEditorView: NSViewRepresentable {
 
         func textViewDidChangeText(_ notification: Notification) {
             guard !isProgrammaticUpdate, let textView = notification.object as? STTextView else { return }
-            text.wrappedValue = textView.text
+            text.wrappedValue = textView.text ?? ""
         }
     }
 


### PR DESCRIPTION
## Summary

- `main` currently fails to build the `Anglesite` app target (`xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`) — introduced by #774 ("Props form + STTextView code panes").
- `ComponentEditorView.swift` used `TreeSitterLanguage` (from STTextView-Plugin-Neon's `NeonPlugin(theme:language:)`) without importing the module that declares it. `STTextView-Plugin-Neon`'s only library product is `STTextView-Plugin-Neon` → target `STPluginNeon`, which does **not** re-export `TreeSitterResource` (the target that owns `TreeSitterLanguage`) — it's `import`ed plainly, not `@_exported`, in `STPluginNeonAppKit`. `TreeSitterResource` is still a transitive build dependency though, so its `.swiftmodule` is already built into the shared products directory — the fix is just adding `import TreeSitterResource` directly.
- Separately, the pinned STTextView release's `STTextViewProtocol.text` is `String?`, so reading `textView.text` into the `@Binding var text: String` needed `?? ""`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change needs a paired PR in `Anglesite/anglesite`.

## Test plan

- [x] `swift test --package-path .` — 71/71 pass in the affected suites. `AnglesiteIntentsTests`/`SiteEntityQueryTests` fails locally with 4 pre-existing, unrelated issues (already tracked in #771 as an environmental flake on `origin/main`; verified this branch's diff doesn't touch that module).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `BUILD SUCCEEDED`.
- [ ] Manual smoke — not UI-behavior-changing, just a compile fix; no runtime behavior differs from what #774 intended.

## Also worth flagging

CI currently never runs `xcodebuild` on the `Anglesite` app target — only `swift test` (SwiftPM library targets) plus the `project.yml` sync check. `swift test` *does* happen to compile `AnglesiteAppCore` (the SwiftPM-visible slice of `Sources/AnglesiteApp/`, since it backs `AnglesiteAppTests`), which is how this got caught locally — but nothing in CI exercises the actual `xcodebuild` app-target build, which is a different compilation unit/toolchain path and can drift from `swift test`'s view of the same sources. That's likely why this slipped through review on #774. I'd suggest a follow-up issue to add an `xcodebuild` build step (Debug, ad-hoc signed) to CI, but that's a separate scoping discussion (runner/toolchain/signing implications) from this one-line fix, so I'm not bundling it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)