### PR TITLE
fix(sites): heal launcher/Open Recent when a bookmark stops resolving (#776)

### DIFF
--- a/Sources/AnglesiteApp/SiteActions.swift
+++ b/Sources/AnglesiteApp/SiteActions.swift
@@ -157,6 +157,56 @@ enum SiteActions {
         }
     }
 
+    /// Surfaced by `reauthorize(_:)` when the folder picked in the "Locate…" panel isn't the same
+    /// package as the site being repaired — guards against silently rebinding a recents entry to
+    /// an unrelated package that happens to share a name (#776).
+    struct ReauthorizationMismatchError: LocalizedError {
+        var errorDescription: String? {
+            String(localized: "That's a different site — choose the original package folder instead.")
+        }
+    }
+
+    /// True when `picked`'s marker UUID matches `expectedID`.
+    static func markerMatches(_ picked: AnglesitePackage, expectedID: String) -> Bool {
+        (try? picked.readMarker())?.siteID.uuidString == expectedID
+    }
+
+    /// Re-grant access to `site` after its security-scoped bookmark stopped resolving (#776 — a
+    /// reboot, or a preceding runtime failure, can invalidate the sandbox extension even though
+    /// the package on disk is untouched). Prompts an `NSOpenPanel` anchored at the site's
+    /// last-known location, confirms the chosen folder is the SAME package by marker UUID (not
+    /// just path), then re-registers it through the shared `registerPackage` path — which
+    /// re-validates against the just-granted access and mints a fresh bookmark, healing both
+    /// `isValid` and `needsReauthorization` for every observer of `SiteStore.changeStream()`.
+    ///
+    /// - Returns: the healed site, or `nil` if the panel was cancelled.
+    /// - Throws: `ImportError` wrapping `ReauthorizationMismatchError` on a mismatched pick, or any
+    ///   error from re-registration.
+    static func reauthorize(_ site: SiteStore.Site) async throws -> SiteStore.Site? {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.anglesiteSite]
+        panel.treatsFilePackagesAsDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = site.packageURL.deletingLastPathComponent()
+        panel.prompt = String(localized: "Grant Access")
+        panel.message = String(
+            localized: "Anglesite lost access to “\(site.name)”, likely after a restart. Locate it again to restore access."
+        )
+        guard panel.runModal() == .OK, let url = panel.url else { return nil }
+
+        let package = AnglesitePackage(url: url)
+        guard markerMatches(package, expectedID: site.id) else {
+            throw ImportError(folderName: url.lastPathComponent, underlying: ReauthorizationMismatchError())
+        }
+        do {
+            return try await registerPackage(package)
+        } catch {
+            throw ImportError(folderName: url.lastPathComponent, underlying: error)
+        }
+    }
+
     /// Run the package picker, register the chosen `.anglesite` package with `SiteStore`, and
     /// (on MAS) mint + persist a security-scoped bookmark so the grant survives relaunch.
     ///

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -61,6 +61,7 @@ struct SitesLauncherView: View {
             }
         }
         .task { await onFirstAppear() }
+        .task { await observeChanges() }
         .onChange(of: router.newSiteRequested) { _, requested in
             guard requested else { return }
             router.clearNewSiteRequest()
@@ -145,12 +146,20 @@ struct SitesLauncherView: View {
                 .padding(.vertical, 2)
             }
             .buttonStyle(.plain)
-            .disabled(!site.isValid)
-            .accessibilityValue(site.isValid ? "Valid" : "Missing required files")
-            .help(site.isValid
-                  ? "Open \(site.name) in its own window"
-                  : "Site is missing required files: \(site.missingSentinels.joined(separator: ", "))")
+            // A dead bookmark (needsReauthorization) still lets the row respond to a click — it
+            // routes to the same "Locate…" recovery as the context-menu action — rather than
+            // going fully dead with no way to fix it in place (#776).
+            .disabled(!site.isValid && !site.needsReauthorization)
+            .accessibilityValue(site.isValid
+                                 ? "Valid"
+                                 : (site.needsReauthorization ? "Needs re-authorization" : "Missing required files"))
+            .help(helpText(for: site))
             .contextMenu {
+                if site.needsReauthorization {
+                    Button("Locate…", systemImage: "questionmark.folder") {
+                        Task { await reauthorize(site) }
+                    }
+                }
                 Button("Rename…", systemImage: "pencil") {
                     promptRename(site)
                 }
@@ -262,9 +271,40 @@ struct SitesLauncherView: View {
 
     // MARK: - Actions
 
+    /// The row tooltip: names the actual problem rather than a generic disabled state. A dead
+    /// bookmark (needsReauthorization) is not the same failure as missing project files, and
+    /// reporting it as such sends owners chasing a fix that doesn't exist (#776).
+    private func helpText(for site: SiteStore.Site) -> String {
+        if site.isValid {
+            return "Open \(site.name) in its own window"
+        }
+        if site.needsReauthorization {
+            return "Anglesite lost access to this site, likely after a restart. Click to relocate it and restore access."
+        }
+        return "Site is missing required files: \(site.missingSentinels.joined(separator: ", "))"
+    }
+
     private func open(site: SiteStore.Site) {
+        guard site.isValid else {
+            Task { await reauthorize(site) }
+            return
+        }
         openWindow(value: site.id)
         dismissWindow()
+    }
+
+    /// Re-grant access to `site` (#776) via `SiteActions.reauthorize` — an `NSOpenPanel` anchored
+    /// at its last-known path, confirmed to be the same package by marker UUID. A successful heal
+    /// reaches this view through `observeChanges()`'s `SiteStore.changeStream()` subscription, so
+    /// there's no need to patch `sites` here directly; go ahead and open the now-healed site.
+    private func reauthorize(_ site: SiteStore.Site) async {
+        do {
+            guard let healed = try await SiteActions.reauthorize(site) else { return }
+            openWindow(value: healed.id)
+            dismissWindow()
+        } catch {
+            loadError = error.localizedDescription
+        }
     }
 
     /// Raise the remove-confirmation dialog for `site`. `siteToRemoveName` is captured here so the
@@ -452,6 +492,17 @@ struct SitesLauncherView: View {
             loadError = nil
         } catch {
             loadError = "\(error)"
+        }
+    }
+
+    /// Mirrors `RecentSitesModel`'s subscription: keeps the launcher's list live across any
+    /// registry mutation from elsewhere in the app — Open Site…, the Dock menu, drag-drop, or a
+    /// "Locate…" reauthorization — not just this view's own `refreshSites()` calls. Before this,
+    /// a site opened successfully via ⌘O in the same session still showed ⚠ here until the next
+    /// manual reload (#776).
+    private func observeChanges() async {
+        for await updated in SiteStore.shared.changeStream() {
+            sites = updated
         }
     }
 }

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -31,6 +31,13 @@ public actor SiteStore {
         /// Security-scoped bookmark for `packageURL`. One grant covers the whole package, so
         /// Source/ and Config/ are both reachable under it.
         public var bookmarkData: Data?
+        /// True when a persisted bookmark exists but could not be resolved or started during the
+        /// last `refreshFilesystemState()` pass (#776 — e.g. a reboot invalidated the sandbox
+        /// extension). This is distinct from a confirmed-invalid package (missing sentinels):
+        /// access simply couldn't be verified, so `missingSentinels` is not trustworthy either.
+        /// Lets the UI offer a re-grant affordance ("Locate…") instead of misreporting the
+        /// package as missing files, and instead of silently going dead with no explanation.
+        public var needsReauthorization: Bool
 
         /// The Astro project tree — every subprocess (scaffold, dev server, build, deploy,
         /// pre-deploy check) runs with this as its working directory.
@@ -45,7 +52,8 @@ public actor SiteStore {
             isValid: Bool,
             missingSentinels: [String],
             lastSeen: Date = Date(),
-            bookmarkData: Data? = nil
+            bookmarkData: Data? = nil,
+            needsReauthorization: Bool = false
         ) {
             self.id = id
             self.name = name
@@ -54,6 +62,26 @@ public actor SiteStore {
             self.missingSentinels = missingSentinels
             self.lastSeen = lastSeen
             self.bookmarkData = bookmarkData
+            self.needsReauthorization = needsReauthorization
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id, name, packageURL, isValid, missingSentinels, lastSeen, bookmarkData, needsReauthorization
+        }
+
+        /// Custom decoding so `recents.json` written before #776 (no `needsReauthorization` key)
+        /// still loads — a missing key defaults to `false` rather than failing `load()` entirely
+        /// (which would blank the launcher for every existing user on upgrade).
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(String.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            packageURL = try container.decode(URL.self, forKey: .packageURL)
+            isValid = try container.decode(Bool.self, forKey: .isValid)
+            missingSentinels = try container.decode([String].self, forKey: .missingSentinels)
+            lastSeen = try container.decode(Date.self, forKey: .lastSeen)
+            bookmarkData = try container.decodeIfPresent(Data.self, forKey: .bookmarkData)
+            needsReauthorization = try container.decodeIfPresent(Bool.self, forKey: .needsReauthorization) ?? false
         }
 
         /// Build a `Site` from a package on disk: id = marker UUID, name = resolved display name
@@ -169,6 +197,9 @@ public actor SiteStore {
             var scoped: URL?
             var existenceURL = site.packageURL
             var canDetermineExistence = true
+            // True only when a bookmark exists but resolving it or starting access on it failed —
+            // i.e. we hold a grant that stopped working, not "there was never a grant" (#776).
+            var needsReauthorization = false
             if let bookmark = site.bookmarkData {
                 if let resolved = try? bookmarker.resolve(bookmark) {
                     existenceURL = resolved.url
@@ -176,9 +207,11 @@ public actor SiteStore {
                         scoped = resolved.url
                     } else {
                         canDetermineExistence = false
+                        needsReauthorization = true
                     }
                 } else {
                     canDetermineExistence = false
+                    needsReauthorization = true
                 }
             }
 
@@ -191,11 +224,19 @@ public actor SiteStore {
                 continue
             }
 
+            // When access can't be verified, don't trust a validation run against the unscoped
+            // path — under sandboxing it will read as "every sentinel missing" even though the
+            // package is untouched, which is exactly the misleading state #776 reported.
             let validation = AnglesitePackage(url: site.packageURL).sourceValidation(fileManager: fileManager)
             if let scoped { bookmarker.stopAccessing(scoped) }
-            if site.isValid != validation.isValid || site.missingSentinels != validation.missing {
-                site.isValid = validation.isValid
-                site.missingSentinels = validation.missing
+            let isValid = needsReauthorization ? false : validation.isValid
+            let missing = needsReauthorization ? [] : validation.missing
+            if site.isValid != isValid
+                || site.missingSentinels != missing
+                || site.needsReauthorization != needsReauthorization {
+                site.isValid = isValid
+                site.missingSentinels = missing
+                site.needsReauthorization = needsReauthorization
                 changed = true
             }
             refreshed.append(site)
@@ -214,7 +255,8 @@ public actor SiteStore {
         if let existing = sites.first(where: { $0.id == site.id }) {
             // Carry the bookmark forward ONLY when the package is still at the same path. If it
             // moved, the old bookmark embeds the old location and would grant the wrong path on
-            // MAS — drop it so SiteWindow.acquireGrant re-prompts a grant at the new location.
+            // MAS — drop it so the next open (which just proved access via a picker/Finder/drag)
+            // mints a fresh one at the new location instead of keeping a stale grant around.
             if existing.packageURL == site.packageURL {
                 site.bookmarkData = existing.bookmarkData ?? site.bookmarkData
             }

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -109,6 +109,71 @@ final class SiteStoreTests {
         #expect(await reader.find(id: site.id) != nil)
     }
 
+    /// The #776 scenario: the package is fully intact on disk — only its persisted bookmark can
+    /// no longer be resolved (e.g. a reboot invalidated the sandbox extension). `load()` must not
+    /// report this as "missing required files" (misleading — the files are all there) and must
+    /// flag it as needing re-authorization so the UI can offer a "Locate…" recovery instead of
+    /// going dead with no explanation.
+    @Test("load flags an intact package with an unresolvable bookmark as needing reauthorization")
+    func loadFlagsIntactPackageNeedingReauthorization() async throws {
+        let pkg = try makeValidPackage(named: "lost-grant")
+        let writer = SiteStore(persistenceURL: persistenceURL)
+        let site = try await writer.record(pkg)
+        #expect(site.isValid)
+        try await writer.setBookmark(Data("not-a-bookmark".utf8), for: site.id)
+        // The package itself is untouched — only the bookmark is bad.
+
+        let reader = SiteStore(persistenceURL: persistenceURL)
+        try await reader.load()
+        let loaded = try #require(await reader.find(id: site.id))
+        #expect(loaded.needsReauthorization)
+        #expect(!loaded.isValid, "access can't be verified, so the site can't be opened until reauthorized")
+        #expect(loaded.missingSentinels.isEmpty, "must not misreport a lost grant as missing project files")
+    }
+
+    /// `record()` rebuilds the entry via `Site.make`, which recomputes validity directly (no
+    /// bookmark involved) — so it clears a stale `needsReauthorization` in memory immediately.
+    /// This is what makes `SiteActions.reauthorize`/`registerPackage` (record + a fresh
+    /// `setBookmark`, in `SiteActions.swift`) heal the visible state right away; the paired
+    /// `setBookmark` call — not tested here, it lives outside AnglesiteCore — is still what makes
+    /// the fix survive a relaunch, since `record()` alone carries the stale bookmark forward
+    /// unchanged (see `recordCarriesBookmarkForward`).
+    @Test("record clears a prior needsReauthorization flag")
+    func recordClearsNeedsReauthorization() async throws {
+        let pkg = try makeValidPackage(named: "healed")
+        let store = SiteStore(persistenceURL: persistenceURL)
+        let site = try await store.record(pkg)
+        try await store.setBookmark(Data("not-a-bookmark".utf8), for: site.id)
+        try await store.load()
+        #expect(try #require(await store.find(id: site.id)).needsReauthorization)
+
+        _ = try await store.record(pkg)
+        let healed = try #require(await store.find(id: site.id))
+        #expect(!healed.needsReauthorization)
+        #expect(healed.isValid)
+    }
+
+    /// `recents.json` written before #776 has no `needsReauthorization` key. Decoding must default
+    /// it to `false` rather than fail `load()` outright, which would blank the launcher for every
+    /// existing user on upgrade.
+    @Test("Site decodes pre-#776 JSON lacking needsReauthorization as false")
+    func siteDecodesLegacyJSONWithoutReauthorizationKey() throws {
+        let json = """
+        {
+            "id": "legacy-id",
+            "name": "legacy",
+            "packageURL": "file:///tmp/legacy.anglesite/",
+            "isValid": true,
+            "missingSentinels": [],
+            "lastSeen": "2026-01-01T00:00:00Z"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let site = try decoder.decode(SiteStore.Site.self, from: Data(json.utf8))
+        #expect(!site.needsReauthorization)
+    }
+
     /// Regression: validity is cached in `recents.json` but recomputed on `load()`. A registry
     /// written by an older build (or before a sentinel-list fix) can hold a stale `isValid:false`
     /// for a package that is actually valid on disk — that left every site greyed-out in the


### PR DESCRIPTION
## Summary

- After a reboot invalidated a site's security-scoped bookmark, the Sites launcher row and File ▸ Open Recent item went dead (⚠, unclickable, no tooltip explaining why) even though the package on disk was intact and `⌘O` could open it fine — and that successful reopen didn't heal the launcher's stale row either.
- `SiteStore.Site` gains `needsReauthorization` (true only when a persisted bookmark exists but can't be resolved/started), so the UI stops misreporting a lost grant as "missing required files".
- `SiteActions.reauthorize(_:)` adds a "Locate…" recovery flow: an `NSOpenPanel` anchored at the site's last-known path, marker-UUID verified against the original package, then re-registered through the existing `registerPackage` path (fresh bookmark, healed `isValid`).
- `SitesLauncherView` now subscribes to `SiteStore.changeStream()` (matching `RecentSitesModel`'s existing pattern), so a heal from *any* route — Open Site…, Dock menu, drag-drop, or Locate… — reflects live everywhere, not just after a manual reload.

Fixes #776.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — new/existing `SiteStoreTests` cases pass (32/32). Whole-package `swift test` currently can't build clean on `main` due to an unrelated, pre-existing break in `ComponentEditorView.swift` (`STTextView`/`STTextView-Plugin-Neon` API drift, reproduced with my changes fully reverted) — verified in isolation via a temporary local patch, then reverted before committing; flagged separately for a follow-up fix.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — blocked by the same pre-existing `ComponentEditorView.swift` break (unrelated to this change; see above).
- [ ] Manual smoke: not run (no way to actually simulate a post-reboot dead bookmark in this environment) — recommend a manual pass per the issue's repro (open a site, quit, reboot, relaunch) to confirm the "Locate…" flow and live-heal end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)