### PR TITLE
fix(deps): pin STTextView to an exact revision (#783)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -314,8 +314,13 @@ packageDependencies.append(
 //     the whole highlighting stack the spec calls for, with no separate grammar packages
 //     to add.
 // Both AppKit-only, so gated the same as SwiftGit2 above.
+// Pinned to a commit, not `from:` — `Package.resolved` is gitignored (no committed lockfile), so
+// every fresh checkout resolves independently, and a floating `from:` here let a fresh resolve of
+// 2.3.10 silently ship an API change (`text` became `String?`) that broke #774 (see #781, #783).
+// Matches the SwiftGit2/STTextView-Plugin-Neon policy below: deliberate bumps only. This is tag
+// 2.3.10's commit.
 packageDependencies.append(
-    .package(url: "https://github.com/krzyzanowskim/STTextView", from: "2.3.10")
+    .package(url: "https://github.com/krzyzanowskim/STTextView", revision: "8569251785daf1f0310eaa9235d1254264f0d249")
 )
 // Pinned to a commit, not `from:` — STTextView-Plugin-Neon's own manifest depends on Neon by
 // `revision:` (Neon has no tagged SPM releases), and SwiftPM refuses to resolve a stable-version


### PR DESCRIPTION
## Summary

- \`Package.resolved\` is gitignored (\`.gitignore:33\`), so every fresh checkout/worktree resolves \`Package.swift\` dependencies independently — there's no committed lockfile.
- \`STTextView\` was pinned via a floating \`.package(url: ..., from: "2.3.10")\`. A fresh resolve lands on exactly \`2.3.10\` (revision \`8569251785daf1f0310eaa9235d1254264f0d249\`), which already has \`STTextViewProtocol.text\` as \`String?\` — the API surface #774 was apparently written/tested against an older cached resolve of, causing the build break fixed in #781.
- Without a lockfile, this floating constraint means any other fresh clone/worktree/CI run can independently land on a different \`STTextView\` release and silently reintroduce this class of break.
- Pins \`STTextView\` to an exact \`revision:\`, matching the policy already documented for the adjacent \`STTextView-Plugin-Neon\` dependency two lines below ("deliberate bumps only, no silently picking up unreviewed future commits").

Fixes #783. Fast-follow suggested in review on #781.

## Paired PR check

- [x] This change is **self-contained** to \`Anglesite-app\`.
- [ ] This change needs a paired PR in \`Anglesite/anglesite\`.

## Test plan

- [x] \`swift test --package-path .\` — passes; \`AnglesiteIntentsTests\`/\`SiteEntityQueryTests\` shows the same 4 pre-existing failures tracked in #771 (verified reproduces identically on pristine \`origin/main\`, an Xcode-beta/macOS-27-beta environmental issue unrelated to this change).
- [x] \`xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build\` — BUILD SUCCEEDED.
- [ ] Manual smoke — not applicable; dependency-pin-only change, no runtime behavior differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)