### PR TITLE
fix(container): stop leaked VM on synchronous boot failure (#785)

### DIFF
--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -390,7 +390,13 @@ public struct ContainerizationControl: LocalContainerControl {
                     return container
                 } catch {
                     // This also covers a failure that arrives after the timeout already won.
-                    await network.release(siteID: siteID)
+                    // `stopBareContainer` (not a bare `network.release`) mirrors `onLateSuccess`
+                    // above: `container.stop()` is a no-op via `try?` when `create()`/`.start()`
+                    // never reached `.created`/`.started` state (#785), but it DOES matter when
+                    // `.start()` fails after `.create()` already succeeded — that path leaves the
+                    // VM in `.created` state, and only an explicit `stop()` releases it instead of
+                    // leaking it until the app quits.
+                    await stopBareContainer(container, siteID: siteID)
                     throw error
                 }
             }


### PR DESCRIPTION
## Summary

Fixes the Anglesite-side half of #785: a failed container VM boot leaked the underlying `Virtualization.framework` process instead of tearing it down.

- The catch around `container.create()`/`.start()` in `ContainerizationControl.swift` only released the vmnet allocation (`network.release`) — it never called `stopBareContainer(container, siteID:)`, unlike the `onLateSuccess` handler a few lines above which already does this correctly for the timeout-then-late-success race.
- This change makes the synchronous-failure path call `stopBareContainer` too, so a VM that reached `.created` state before `.start()` failed is properly stopped instead of leaking until the app quits.

## What this does *not* fix

I verified against the actual vendored `apple/containerization` 0.35.0 source that this change does **not** resolve #785's exact reported repro (the `vmnet_return_t(rawValue: 1002)` case). There, `vm.start()` throws from *inside* `LinuxContainer.create()`, which is not wrapped in a `do/catch` upstream — so `LinuxContainer`'s own state never leaves `.initialized`, and `container.stop()` becomes a no-op (`state.createdState("stop")` throws against `.initialized`) regardless of what the caller does. The leaked `VZVirtualMachine`/XPC process never escapes that vendored function, so there's no reference Anglesite can act on.

That's a real gap in the pinned dependency, not something fixable from this call site. Filed upstream: apple/containerization#804.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

> `ContainerizationControl.swift`'s failure-path cleanup touches only local VM lifecycle management — no MCP message schema, plugin hook contract, or site template is affected, so no paired `Anglesite/anglesite` PR is needed.

## Test plan

- [x] `swift build` — clean, no new warnings introduced by this change
- [x] `swift test --package-path .` — full suite run; 3 pre-existing failures in `AnglesiteCoreTests` (`RepoBootstrapTests` dotenv-status expectation, two live-model `FoundationModelAssistantTests`/`GenerableTypesTests` token-limit edge cases) are unrelated — that target has zero dependency on `AnglesiteContainer`
- [ ] No isolated unit test added for this specific catch block: `ContainerizationControl.network` is a hardcoded `SharedVmnetNetwork.shared` singleton (not injectable), and the one existing boot test (`bootsAndServes`) is already gated behind `ANGLESITE_CONTAINER_E2E=1` requiring real entitled hardware — matches the existing precedent for this file rather than introducing a new DI seam out of scope for this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
