### PR TITLE
docs: update in-progress issue label to match current GitHub label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing! This repo is the native macOS app that
 ## Before you start
 
 - **Issues are the source of truth.** Check [`gh issue list`](https://github.com/Anglesite/Anglesite-app/issues) and [`docs/build-plan.md`](docs/build-plan.md) for what's planned and in flight.
-- **Claim your issue.** Multiple contributors (and agents) work this repo concurrently. Before starting on a tracked issue, check it isn't already claimed (`gh issue list --label status:in-progress`), then add the `status:in-progress` label. Remove the label once your PR is open — the PR is the signal from then on.
+- **Claim your issue.** Multiple contributors (and agents) work this repo concurrently. Before starting on a tracked issue, check it isn't already claimed (`gh issue list --label "🛠️ In Progress"`), then add the `🛠️ In Progress` label. Remove the label once your PR is open — the PR is the signal from then on.
 - **Discuss big changes first.** For anything beyond a bug fix or small improvement, open an issue before writing code. In particular, new features should not add `claude --print` / markdown-skill paths — that dependency is being retired under epic [#459](https://github.com/Anglesite/Anglesite-app/issues/459).
 
 For architecture, module layout, and project direction, read [`AGENTS.md`](AGENTS.md) — it's the canonical development-context document (mirrored as `CLAUDE.md` for Claude Code users).


### PR DESCRIPTION
## Summary

- The `status:in-progress` label was retired in GitHub and replaced with `🛠️ In Progress`.
- Updated the issue-claiming instructions in `CLAUDE.md` (and its `AGENTS.md` mirror) and `CONTRIBUTING.md` to use the current label name in the `gh issue list`/`gh issue edit` examples.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.

## Test plan

- [x] Docs-only change; verified `gh issue list --label "🛠️ In Progress"` returns results with the new label.