### PR TITLE
fix(intents): fix stale TestStore fixture broken by #749's filesystem pruning (#771)

### DIFF
--- a/Tests/AnglesiteIntentsTests/Support/TestStore.swift
+++ b/Tests/AnglesiteIntentsTests/Support/TestStore.swift
@@ -7,6 +7,12 @@ enum TestStore {
     static func with(_ sites: [SiteStore.Site]) async throws -> SiteStore {
         let url = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("anglesite-intents-test-\(UUID().uuidString).json")
+        // `load()` prunes any site whose `packageURL` doesn't exist on disk (#749/#776) — create
+        // each fixture's package directory so seeded sites survive the reload every
+        // `SiteEntityQuery` call triggers (#771), matching the invariant a real package satisfies.
+        for site in sites {
+            try FileManager.default.createDirectory(at: site.packageURL, withIntermediateDirectories: true)
+        }
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         try encoder.encode(sites).write(to: url)


### PR DESCRIPTION
## Summary

Fixes #771: `SiteEntityQueryTests` had 4 failing tests on a pristine `origin/main` checkout, all returning empty/nil where a populated result was expected.

**Root cause** (not a macOS 27 beta AppIntents regression, as #771 speculated): `TestStore.site()` (`Tests/AnglesiteIntentsTests/Support/TestStore.swift`) fabricates a `SiteStore.Site` with `packageURL` pointing at `/tmp/<name>.anglesite` — a path that is never actually created on disk. That was harmless until #749 (2026-07-15) added filesystem-existence pruning to `SiteStore.load()`: it now drops any site whose package directory doesn't exist. #749 updated its own `SiteStoreTests` but never touched this cross-target fixture.

`SiteEntityQuery.allSites()` (`Sources/AnglesiteIntents/SiteEntity.swift:73`) calls `store.load()` on *every* query, not just at setup — so the very first `entities(for:)`/`entities(matching:)`/`defaultResult()` call reloads from disk, prunes every fixture site as nonexistent, and returns empty. The 4 failing tests are exactly the ones expecting a non-empty/non-nil result; the tests expecting empty/nil passed vacuously (they'd pass whether the store was correctly populated-then-filtered, or just always empty).

**Fix**: `TestStore.with()` now creates each fixture site's package directory before persisting/loading, restoring the invariant `SiteStore.load()` enforces since #749.

## Test plan

- [x] `swift test --filter SiteEntityQuery` — all 9 tests pass (previously 4 failed)
- [x] `swift test --filter AnglesiteIntentsTests` — all 248 tests pass
- [x] `swift test --package-path .` — full suite; only failure is the pre-existing, unrelated `RepoBootstrapTests.publishRefusesWhenDotenvWouldBeCommitted` (a different target, observed identically on an unrelated branch/worktree — a real but separate pre-existing flake, not touched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)