### PR TITLE
fix(sites): ProjectValidator sentinel is stale astro.config.mjs, not .ts (#786)

### DIFF
--- a/Sources/AnglesiteSiteModel/ProjectValidator.swift
+++ b/Sources/AnglesiteSiteModel/ProjectValidator.swift
@@ -4,13 +4,14 @@ import Foundation
 ///
 /// The sentinel filenames must match what the scaffolder actually writes (see
 /// `Resources/Template/` + `scaffold.sh`): the canonical markers are `.site-config` and
-/// `astro.config.mjs`. (They are *not* `anglesite.config.json` / `astro.config.ts`, which the
-/// template has never produced — using those flagged every freshly scaffolded site as invalid.)
+/// `astro.config.ts` (the template moved off `astro.config.mjs` in #380 — using the old `.mjs`
+/// name here flagged every freshly scaffolded site as invalid). They are *not*
+/// `anglesite.config.json`, which the template has never produced.
 ///
 /// Two tiers of sentinels:
 ///   - **Required** (`requiredSentinels`) — must be present for the directory to count as an
 ///     Anglesite project at all: `.site-config` (identifies the project as Anglesite-managed and
-///     is read by `scripts/config.ts`'s `readConfig`) and `astro.config.mjs` (it's an Astro site).
+///     is read by `scripts/config.ts`'s `readConfig`) and `astro.config.ts` (it's an Astro site).
 ///   - **Recommended** (`recommendedSentinels`) — optional integration markers that aren't
 ///     load-bearing for the core preview + edit pipeline. A site missing only recommended
 ///     sentinels is still valid; the UI can surface them as optional rather than blockers.
@@ -23,7 +24,7 @@ import Foundation
 public enum ProjectValidator {
     public static let requiredSentinels: [String] = [
         ".site-config",
-        "astro.config.mjs"
+        "astro.config.ts"
     ]
     public static let recommendedSentinels: [String] = []
     /// Union of required + recommended — the full set a caller can check without caring about the

--- a/Tests/AnglesiteSiteModelTests/ProjectValidatorTests.swift
+++ b/Tests/AnglesiteSiteModelTests/ProjectValidatorTests.swift
@@ -44,13 +44,13 @@ final class ProjectValidatorTests {
     }
 
     /// Regression for the Sites launcher showing every scaffolded site grayed-out with a warning
-    /// triangle: the validator required `anglesite.config.json` / `astro.config.ts`, filenames the
-    /// template never produced. The canonical scaffold (`scaffold.sh` + `Resources/Template/`)
-    /// writes `.site-config` and `astro.config.mjs`, so that exact pair must validate as a real
-    /// Anglesite site.
-    @Test("Canonical template layout (.site-config + astro.config.mjs) is valid") func canonicalTemplateLayoutIsValid() throws {
+    /// triangle: the validator required `anglesite.config.json` / `astro.config.mjs`, filenames the
+    /// template doesn't produce (it moved to `astro.config.ts` in #380). The canonical scaffold
+    /// (`scaffold.sh` + `Resources/Template/`) writes `.site-config` and `astro.config.ts`, so that
+    /// exact pair must validate as a real Anglesite site (#786).
+    @Test("Canonical template layout (.site-config + astro.config.ts) is valid") func canonicalTemplateLayoutIsValid() throws {
         try Data().write(to: tempDir.appendingPathComponent(".site-config"))
-        try Data().write(to: tempDir.appendingPathComponent("astro.config.mjs"))
+        try Data().write(to: tempDir.appendingPathComponent("astro.config.ts"))
         let result = ProjectValidator.validate(tempDir)
         #expect(result.isValid, "a site scaffolded from the template must be valid")
         #expect(result.missingRequired == [])
@@ -59,7 +59,7 @@ final class ProjectValidatorTests {
     @Test("Not valid when a required sentinel is missing") func notValidWhenARequiredSentinelIsMissing() throws {
         // Only one of the two required sentinels — still not a valid Anglesite project because
         // `.site-config` (the Anglesite-managed marker) is missing.
-        try Data().write(to: tempDir.appendingPathComponent("astro.config.mjs"))
+        try Data().write(to: tempDir.appendingPathComponent("astro.config.ts"))
         let result = ProjectValidator.validate(tempDir)
         #expect(!result.isValid)
         #expect(result.missingRequired == [".site-config"])


### PR DESCRIPTION
## Summary

- Fixes #786 (Sites-window double-click / Open Recent silently fails to open a site).
- Root cause: `ProjectValidator.requiredSentinels` still required `astro.config.mjs`, but the template moved to `astro.config.ts` in #380 (2026-06-26) and never updated the validator. Every site — freshly scaffolded or pre-existing — has computed `isValid == false` ever since.
- That silently disables the Sites launcher's row `Button` (`.disabled(!site.isValid)`), the File ▸ Open Recent menu item (same gate), and the auto-open-last-site-on-launch path — all with zero error surfaced, exactly matching the reported "click does nothing" symptom. The original theory in #786 (a `SiteWindowModel.loadAndStart`/`SiteStore.find` failure) turned out not to be it; `find(id:)` doesn't check `isValid` at all — the UI-level `.disabled` gate never let the click through in the first place.
- Also fixes the `ProjectValidatorTests` regression test, which had locked in the wrong (`.mjs`) filename as canonical.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

This is an `AnglesiteSiteModel`-only fix (a sentinel filename check) with no MCP schema or plugin impact.

## Verification

- Rebuilt the app pre/post fix. Pre-fix: every site in `~/Sites` (including one created fresh in the same session) showed the ⚠ invalid glyph; auto-open-last-site did not fire on relaunch.
- Post-fix: sites show ✓; auto-open-last-site fires correctly; confirmed via a direct accessibility `AXPress` on a Sites-list row button that the open flow completes end-to-end (opens the site's window).
- `swift test --filter ProjectValidatorTests|AnglesiteSiteModelTests|SiteStore|DeadAssetScanner|SiteKnowledgeIndex|PackageTransfer` — all pass.
- Full `swift test` run: two unrelated pre-existing failures observed, both confirmed independent of this change (diff touches only `ProjectValidator.swift` + its own test):
  - `RepoBootstrapTests.publishRefusesWhenDotenvWouldBeCommitted` — fails locally because this machine's global `~/.gitignore` excludes `.env`, so `git status --porcelain` never reports it as untracked. Environment-specific, unrelated to sentinel filenames.
  - `AnglesiteIntentsTests` flagged in the full-suite run, but passes 248/248 when run in isolation (`swift test --filter AnglesiteIntentsTests`) — looks like parallel-run interference, not a real regression.
- CI is green on this branch (all required checks passing).

## Test plan

- [x] `swift test --package-path .`
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] Manual smoke: fresh Debug build, create a site, quit/relaunch, confirm the Sites list shows it valid and opening it succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)