### PR TITLE
fix(deployment): harden extractDeployedURL against wrangler output drift (#704)

### DIFF
--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -216,36 +216,32 @@ public actor DeployCommand {
 
     // MARK: URL extraction
 
-    /// Extracts the deployed URL from wrangler's captured stdout. Two signals are tried, in
-    /// order, because wrangler's exact wording has already drifted across major versions (older
-    /// wrangler printed a `Published <name> (1.23 sec)` status line; current wrangler instead
-    /// prints separate `Uploaded <name> (…)` / `Deployed <name> triggers (…)` lines) and `wrangler
-    /// deploy` (unlike `wrangler pages deploy`) has no `--json` output mode to depend on instead:
+    /// Extracts the deployed URL from wrangler's captured stdout. Wrangler's exact wording has
+    /// already drifted across major versions (older wrangler printed a `Published <name> (1.23
+    /// sec)` status line; current wrangler instead prints separate `Uploaded <name> (…)` /
+    /// `Deployed <name> triggers (…)` lines), and `wrangler deploy` (unlike `wrangler pages
+    /// deploy`) has no `--json` output mode to depend on instead, so multiple status-line prefixes
+    /// are recognized as the anchor:
     ///
-    /// 1. The first `https://*.workers.dev` URL anywhere in the output. A workers.dev subdomain is
-    ///    a distinctive, version-independent signature of a genuine deploy result — it never
-    ///    appears in wrangler's help/informational text (which points at developers.cloudflare.com
-    ///    / dash.cloudflare.com) — so this is checked first, regardless of which status-line
-    ///    wording the installed wrangler prints.
-    /// 2. For custom-domain deploys (no workers.dev URL present): anchor on a recognized
-    ///    start-of-line status prefix and take the first URL on/after that line. Multiple prefixes
-    ///    are recognized to tolerate wrangler renaming this line across versions.
+    /// 1. Anchor on a recognized start-of-line status prefix (`Published`/`Deployed`/`Uploaded`)
+    ///    and search only the anchor line and lines after it — never anything before it — for a
+    ///    URL. A `*.workers.dev` URL there is preferred (the common case); any URL is accepted as a
+    ///    fallback for custom-domain deploys, which have no workers.dev host in their output.
+    ///    Scoping to at/after the anchor (rather than the whole output) matters because this
+    ///    result gets persisted as the site's live URL: an incidental workers.dev mention earlier
+    ///    in the log (e.g. a subdomain-already-exists notice) must not outrank the real result.
+    /// 2. If no anchor line is recognized at all (a future wrangler layout this doesn't know
+    ///    about), fall back to a whole-output scan for a `*.workers.dev` URL — still a
+    ///    distinctive, version-independent signature of a genuine deploy result, just without
+    ///    anchor confirmation.
     public static func extractDeployedURL(from output: String) -> URL? {
-        if let url = firstURL(in: output, requiringHostSuffix: ".workers.dev") {
-            return url
-        }
         let anchors = ["Published", "Deployed", "Uploaded"]
         let lines = output.split(separator: "\n", omittingEmptySubsequences: false)
-        guard let anchorIdx = lines.firstIndex(where: { line in anchors.contains(where: line.hasPrefix) }) else {
-            return nil
+        if let anchorIdx = lines.firstIndex(where: { line in anchors.contains(where: line.hasPrefix) }) {
+            let tail = lines[anchorIdx...].joined(separator: "\n")
+            return firstURL(in: tail, requiringHostSuffix: ".workers.dev") ?? firstURL(in: tail)
         }
-        // Search the anchor line itself, then subsequent lines, for the first URL.
-        for line in lines[anchorIdx...] {
-            if let url = firstURL(in: String(line)) {
-                return url
-            }
-        }
-        return nil
+        return firstURL(in: output, requiringHostSuffix: ".workers.dev")
     }
 
     /// The first `http(s)` URL in `text` — optionally required to have a host ending in

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -197,7 +197,10 @@ public actor DeployCommand {
                 Self.persistSiteURL(url, siteDirectory: siteDirectory)
                 return .succeeded(url: url, duration: duration)
             }
-            return .failed(reason: "wrangler exited cleanly but no deployed URL was found in its output", exitCode: 0)
+            return .failed(
+                reason: "wrangler exited successfully (code 0), but no deployed URL could be found in its output — the deploy likely succeeded; check the deploy log for the URL",
+                exitCode: 0
+            )
         }
         return .failed(reason: "wrangler exited with code \(code)", exitCode: code)
     }
@@ -213,29 +216,56 @@ public actor DeployCommand {
 
     // MARK: URL extraction
 
-    /// Scans for the wrangler "Published" anchor and the first URL after it. The line shape is
+    /// Extracts the deployed URL from wrangler's captured stdout. Two signals are tried, in
+    /// order, because wrangler's exact wording has already drifted across major versions (older
+    /// wrangler printed a `Published <name> (1.23 sec)` status line; current wrangler instead
+    /// prints separate `Uploaded <name> (…)` / `Deployed <name> triggers (…)` lines) and `wrangler
+    /// deploy` (unlike `wrangler pages deploy`) has no `--json` output mode to depend on instead:
     ///
-    ///     Published <name> (1.23 sec)
-    ///       https://<name>.<acct>.workers.dev
-    ///
-    /// Anchoring on `Published` (start-of-line, case-sensitive) prevents help-text URLs from
-    /// being mistaken for the deploy result. We accept the URL on the same line or any
-    /// subsequent line — wrangler has shipped multiple layouts of this block over the years.
+    /// 1. The first `https://*.workers.dev` URL anywhere in the output. A workers.dev subdomain is
+    ///    a distinctive, version-independent signature of a genuine deploy result — it never
+    ///    appears in wrangler's help/informational text (which points at developers.cloudflare.com
+    ///    / dash.cloudflare.com) — so this is checked first, regardless of which status-line
+    ///    wording the installed wrangler prints.
+    /// 2. For custom-domain deploys (no workers.dev URL present): anchor on a recognized
+    ///    start-of-line status prefix and take the first URL on/after that line. Multiple prefixes
+    ///    are recognized to tolerate wrangler renaming this line across versions.
     public static func extractDeployedURL(from output: String) -> URL? {
+        if let url = firstURL(in: output, requiringHostSuffix: ".workers.dev") {
+            return url
+        }
+        let anchors = ["Published", "Deployed", "Uploaded"]
         let lines = output.split(separator: "\n", omittingEmptySubsequences: false)
-        guard let publishedIdx = lines.firstIndex(where: { $0.hasPrefix("Published") || $0.hasPrefix("Published ") }) else {
+        guard let anchorIdx = lines.firstIndex(where: { line in anchors.contains(where: line.hasPrefix) }) else {
             return nil
         }
-        // Search the Published line itself, then subsequent lines, for the first URL.
-        for line in lines[publishedIdx...] {
-            if let urlRange = line.range(of: #"https?://[^\s]+"#, options: [.regularExpression]) {
-                // Strip trailing punctuation a terminal might tack on (commas, periods, closing parens).
-                var raw = String(line[urlRange])
-                while let last = raw.last, ",.)]}>".contains(last) {
-                    raw.removeLast()
-                }
-                return URL(string: raw)
+        // Search the anchor line itself, then subsequent lines, for the first URL.
+        for line in lines[anchorIdx...] {
+            if let url = firstURL(in: String(line)) {
+                return url
             }
+        }
+        return nil
+    }
+
+    /// The first `http(s)` URL in `text` — optionally required to have a host ending in
+    /// `hostSuffix` — with trailing punctuation a terminal might tack on (commas, periods, closing
+    /// parens) stripped. Scans the whole string (not line-by-line), so callers doing a
+    /// version-independent signature scan can pass multi-line output directly.
+    private static func firstURL(in text: String, requiringHostSuffix hostSuffix: String? = nil) -> URL? {
+        guard let regex = try? NSRegularExpression(pattern: #"https?://\S+"#) else { return nil }
+        let fullRange = NSRange(text.startIndex..., in: text)
+        for match in regex.matches(in: text, range: fullRange) {
+            guard let range = Range(match.range, in: text) else { continue }
+            var raw = String(text[range])
+            while let last = raw.last, ",.)]}>".contains(last) {
+                raw.removeLast()
+            }
+            guard let url = URL(string: raw) else { continue }
+            if let hostSuffix {
+                guard let host = url.host, host.hasSuffix(hostSuffix) else { continue }
+            }
+            return url
         }
         return nil
     }

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -363,6 +363,18 @@ struct DeployCommandTests {
         #expect(url == URL(string: "https://example.com"))
     }
 
+    @Test("extractDeployedURL prefers the anchored workers.dev URL over an incidental one mentioned earlier")
+    func extractDeployedURLIgnoresIncidentalWorkersDevBeforeAnchor() {
+        // A workers.dev URL mentioned before the anchor line (e.g. an "you already have a
+        // subdomain" notice) must not outrank the actual deploy result after the anchor.
+        let url = DeployCommand.extractDeployedURL(from: """
+            Note: your account already has a workers.dev subdomain: https://myaccount.workers.dev
+            Deployed angle-app triggers (0.45 sec)
+              https://angle-app.example.workers.dev
+            """)
+        #expect(url?.host == "angle-app.example.workers.dev")
+    }
+
     // MARK: Scan report parsing helper
 
     @Test("parseScanReport maps ok/blocked/error correctly")

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -328,6 +328,41 @@ struct DeployCommandTests {
         #expect(url.host == "angle-app.example.workers.dev")
     }
 
+    @Test("Finds the URL when wrangler uses current Uploaded/Deployed wording instead of Published")
+    func findsURLWithUploadedDeployedWording() async {
+        // Current wrangler (4.x) no longer prints a "Published" line — it prints separate
+        // "Uploaded"/"Deployed" status lines. The workers.dev URL itself is the version-independent
+        // signal `extractDeployedURL` should key off.
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: """
+                Total Upload: 12.34 KiB / gzip: 5.67 KiB
+                Uploaded angle-app (1.23 sec)
+                Deployed angle-app triggers (0.45 sec)
+                  https://angle-app.example.workers.dev
+                Current Version ID: abc-123
+                """)
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
+        guard case .succeeded(let url, _) = result else {
+            Issue.record("expected .succeeded, got \(result)"); return
+        }
+        #expect(url.host == "angle-app.example.workers.dev")
+    }
+
+    @Test("extractDeployedURL finds a workers.dev URL with no recognized anchor line at all")
+    func extractDeployedURLFindsWorkersDevWithoutAnchor() {
+        let url = DeployCommand.extractDeployedURL(from: "some future wrangler wording\n  https://angle-app.example.workers.dev\ndone")
+        #expect(url?.host == "angle-app.example.workers.dev")
+    }
+
+    @Test("extractDeployedURL falls back to the Deployed/Uploaded anchor for a custom-domain deploy with no workers.dev URL")
+    func extractDeployedURLCustomDomainAnchorFallback() {
+        let url = DeployCommand.extractDeployedURL(from: "Deployed angle-app triggers (0.45 sec)\n  https://example.com")
+        #expect(url == URL(string: "https://example.com"))
+    }
+
     // MARK: Scan report parsing helper
 
     @Test("parseScanReport maps ok/blocked/error correctly")


### PR DESCRIPTION
## Summary

- `DeployCommand.extractDeployedURL` (`Sources/AnglesiteCore/DeployCommand.swift`) anchored solely on a literal `"Published"` status line from wrangler's stdout. Current wrangler (4.x, vendored at 4.111.0 in `Resources/Template/package-lock.json`) has renamed this to separate `"Uploaded"`/`"Deployed"` lines, so a genuinely successful deploy could surface as `"wrangler exited cleanly but no deployed URL was found in its output"` (exit code 0) — a confusing failure for a live site.
- `wrangler deploy` (unlike `wrangler pages deploy`) has no documented `--json` output mode to switch to instead (confirmed against Cloudflare's own Workers CLI command docs), so the fix hardens the stdout parser itself: it now checks for a `*.workers.dev` URL anywhere in the output first — a distinctive, version-independent signature of a real deploy result that never appears in wrangler's help text — then falls back to a broadened anchor set (`Published`/`Deployed`/`Uploaded`) for custom-domain deploys with no workers.dev URL.
- The residual "genuinely no URL found" failure message is reworded to say the deploy likely succeeded and to check the log, instead of reading as an outright failure, per the issue's own suggested minimum fix.

Closes #704.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change needs a paired PR in `Anglesite/anglesite`.

## Test plan

- [x] `swift test --package-path . --filter DeployCommandTests` — 30/30 pass, including 3 new tests covering the `Uploaded`/`Deployed` wording, the anchor-less workers.dev fallback, and the custom-domain anchor fallback.
- [x] `swift test --package-path .` (full suite) — passes except the pre-existing, branch-independent environmental failures in `AnglesiteIntentsTests`/`SiteEntityQueryTests` tracked in #771 (unrelated to this change).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run in this worktree session; source-only change to `AnglesiteCore`, no UI surface to smoke.