### PR TITLE
fix(navigator): bare Delete key deletes the selected item (#674)

### DIFF
--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -115,6 +115,14 @@ final class SiteNavigatorModel {
     /// pages too — so it checks `postIDs` rather than the page-or-post `isContentRow`.
     func canRepurpose(_ id: String) -> Bool { postIDs.contains(id) }
 
+    /// The item the bare Delete key (`.onDeleteCommand`, #674) should act on right now, or nil
+    /// when there's no selection, the selection isn't deletable, or inline-rename is in progress
+    /// (Delete should edit the text field, not delete the row, while `editingItemID` is set).
+    func deletableSelection() -> NavigatorItem? {
+        guard editingItemID == nil, let id = selection, canDelete(id) else { return nil }
+        return item(for: id)
+    }
+
     func beginEditing(_ id: String) {
         guard canRename(id) else { return }
         let current = nodesByID[id]?.title ?? ""

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -17,6 +17,14 @@ struct SiteNavigatorView: View {
             }
         }
         .listStyle(.sidebar)
+        // Bare Delete key deletes the selection, matching Xcode/Mail/Notes sidebar convention
+        // (#674). `deletableSelection()` is nil during inline-rename, so Delete edits the text
+        // field there instead — same guard the Return-to-rename affordance above uses.
+        .onDeleteCommand {
+            if let item = model.deletableSelection() {
+                onDeleteRequested(item)
+            }
+        }
         .overlay {
             if model.nodes.isEmpty {
                 ContentUnavailableView("No content yet", systemImage: "sidebar.left")

--- a/Tests/AnglesiteAppTests/SiteNavigatorModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteNavigatorModelTests.swift
@@ -67,6 +67,83 @@ struct SiteNavigatorModelTests {
         #expect(model.canDelete("nonexistent") == false)
         #expect(model.canDuplicate("nonexistent") == false)
     }
+
+    /// #674: the bare Delete key on the navigator list should act on whatever
+    /// `deletableSelection()` returns — nil disables it, non-nil is the item to delete.
+    @Test("deletableSelection returns the selected content row")
+    func deletableSelectionReturnsSelectedContentRow() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date())],
+            posts: [], images: []
+        )
+        let model = SiteNavigatorModel(graph: graph)
+        model.start(siteID: "site-1", siteRoot: root, sourceDirectory: root, websiteTitle: "Test")
+        while model.nodes.isEmpty { await Task.yield() }
+        let id = try #require(flatten(model.nodes).first { $0.title == "About" }?.id)
+
+        model.selection = id
+
+        #expect(model.deletableSelection()?.id == id)
+    }
+
+    @Test("deletableSelection is nil with no selection")
+    func deletableSelectionNilWithNoSelection() {
+        let model = SiteNavigatorModel(graph: SiteContentGraph())
+        #expect(model.deletableSelection() == nil)
+    }
+
+    @Test("deletableSelection is nil while inline-renaming the selection")
+    func deletableSelectionNilWhileEditing() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date())],
+            posts: [], images: []
+        )
+        let model = SiteNavigatorModel(graph: graph)
+        model.start(siteID: "site-1", siteRoot: root, sourceDirectory: root, websiteTitle: "Test")
+        while model.nodes.isEmpty { await Task.yield() }
+        let id = try #require(flatten(model.nodes).first { $0.title == "About" }?.id)
+        model.selection = id
+
+        model.beginEditing(id)
+
+        #expect(model.deletableSelection() == nil)
+    }
+
+    @Test("deletableSelection is nil for the non-deletable website-settings row")
+    func deletableSelectionNilForWebsiteSettingsRow() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date())],
+            posts: [], images: []
+        )
+        let model = SiteNavigatorModel(graph: graph)
+        model.start(siteID: "site-1", siteRoot: root, sourceDirectory: root, websiteTitle: "Test")
+        while model.nodes.isEmpty { await Task.yield() }
+        let id = try #require(model.nodes.first { $0.kind == .website }?.id)
+        model.selection = id
+
+        #expect(model.deletableSelection() == nil)
+    }
 }
 
 /// `saveRedirect` writes through `RedirectsStore` to `Source/redirects.json` (#530) — the


### PR DESCRIPTION
## Summary

- Fixes #674: pressing the bare Delete key with a navigator row selected did nothing — only ⌘⌫ (Edit ▸ Delete) worked, breaking the Xcode/Mail/Notes sidebar convention that bare Delete deletes the selection.
- Adds `SiteNavigatorModel.deletableSelection()`: returns the selected item when it's eligible for deletion, `nil` when there's no selection, the selection isn't a page/post, or inline-rename is in progress (so Delete edits the text field instead of deleting the row while renaming).
- Wires `.onDeleteCommand` on the navigator `List` (`SiteNavigatorView.swift`) to it, routing through the same `onDeleteRequested` closure — and therefore the same destructive-confirmation dialog — that Edit ▸ Delete already uses. ⌘⌫ is untouched.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

> Pure SwiftUI/model change to the Navigator sidebar — no MCP message schema, plugin hook contract, or site template is touched.

## Test plan

- [x] `swift test --filter SiteNavigatorModelTests` — TDD: added 4 tests for `deletableSelection()` (selected content row, no selection, mid-rename, non-deletable row), watched them fail to compile (`no member 'deletableSelection'`) before implementing.
- [x] `swift test --filter AnglesiteAppTests` — full suite, 75/75 pass, no regressions.
- [x] `swift build` — clean.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **`.
- [ ] Manual smoke: not performed in this session (headless); acceptance per #674 — select a page in the navigator, press Delete → same confirm dialog as Edit ▸ Delete; press Delete while renaming → edits text, doesn't delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
