### PR TITLE
docs(specs): blog-post Markdown editor + container-less publishing design

### DIFF
--- a/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
+++ b/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
@@ -14,10 +14,11 @@ Two coupled pieces:
    bold, task checkboxes toggleable) — not a raw monospaced buffer, and not a WYSIWYG
    that rewrites the file.
 2. **A publish flow for posts that works on desktop and mobile**, where mobile is
-   assumed to have **no container access at all** — no Apple Containerization, no Node,
-   no subprocesses, and *not* the remote Cloudflare Sandbox either (that is a container
-   too, just someone else's; it stays an orthogonal opt-in, per the
-   2026-06-23 remote-sandbox design).
+   assumed to have **no container access on the device** — no Apple Containerization,
+   no Node, no subprocesses; the phone only makes HTTPS calls — and where **Cloudflare
+   is the only required third-party dependency** (owner decision, 2026-07-17). The user
+   already needs a Cloudflare account to host the site; publishing must not
+   additionally require GitHub or any other git host.
 
 ## Current state this builds on
 
@@ -127,7 +128,14 @@ On every platform: **publish = commits on `Source/` + a deterministic pipeline t
 in a deploy, with the pre-deploy security gate running somewhere the client cannot
 skip, and build logs surfaced** (logs are sacred). No LLM in the loop anywhere.
 
-### C.2 One seam, two strategies
+### C.2 One seam, two strategies — Cloudflare-only by requirement
+
+GitHub cannot be load-bearing anywhere in the required path. That rules out Cloudflare
+Workers Builds as the container-less pipeline — Workers Builds only connects to
+GitHub/GitLab repos, so a design built on it silently reintroduces a git-host account
+as a prerequisite. Instead, the container-less path runs entirely against services in
+the **user's own Cloudflare account** (§C.4). GitHub stays what it already is via
+RepoBootstrap (#68): an optional mirror/collaboration surface, never a requirement.
 
 A `PublishPipeline` protocol in AnglesiteCore with two implementations:
 
@@ -135,16 +143,20 @@ A `PublishPipeline` protocol in AnglesiteCore with two implementations:
   `DeployCommand` runs build → pre-deploy scan (#742 envelope, `.blocked` is final) →
   `wrangler deploy` inside the container runtime. Fast local iteration, no push
   required.
-- **`GitPushPublishPipeline`** — the container-less path: commit → pull
-  (fast-forward/rebase) → push to `origin` → **Cloudflare Workers Builds** (git-connected,
-  user's account, user's billing — same BYO posture as everything else) builds and
-  deploys → the app polls the Workers Builds deployment via the Cloudflare API and
-  streams the build log into the debug pane.
+- **`CloudPublishPipeline`** — the container-less path: commit → pull
+  (fast-forward/rebase) → push to the site's **Anglesite-provisioned git origin in the
+  user's Cloudflare account** (§C.4) → the origin's publish service builds, gates, and
+  deploys in an ephemeral Cloudflare Sandbox → the app polls the control Worker for
+  status and streams the build log into the debug pane.
 
-Mobile only has the second. Desktop gets both — push-to-deploy is also the natural fit
+Mobile only has the second. Desktop gets both — push-to-publish is also the natural fit
 for the Linux/Windows ports (#571) and for users who never provision the container
 runtime. `DeployModel` picks the strategy the way it picks `ContainerDeployExecutor`
 today.
+
+**Optional Workers Builds variant:** when a site *does* have a GitHub remote (the user
+ran Publish to GitHub), Workers Builds can drive the same `build:ci` entry point (§C.3)
+off pushes to that remote. Nice-to-have, not v1-required, and never the default.
 
 ### C.3 Moving the gate server-side (template change, app-only)
 
@@ -155,30 +167,71 @@ The template's CI story gets a `build:ci` script:
 "build:ci": "npm run build && npx tsx scripts/pre-deploy-check.ts --json --strict"
 ```
 
-Workers Builds is configured with build command `npm run build:ci` and deploy command
-`npx wrangler deploy`. The scan runs **after** the build (it inspects `dist/`, matching
-`DeployCommand`'s ordering) and a blocker exits non-zero, so **the deploy step never
-runs**. This is strictly stronger than today's posture: the gate becomes unbypassable
-from *any* client — the app, a laptop with `git push`, or a compromised device — rather
-than being enforced by app code. The desktop container path keeps its local preflight
-too (better UX: blocked before pushing anything). The scan's `--json` envelope (#742)
-is emitted into the build log; on failure the app extracts it when present and renders
-the existing `Phase.blocked` UI, falling back to a raw log excerpt for ordinary build
-errors.
+`build:ci` is the single server-side entry point: the publish service (§C.4) runs it,
+and so does the optional Workers Builds variant when a GitHub remote exists. The scan
+runs **after** the build (it inspects `dist/`, matching `DeployCommand`'s ordering) and
+a blocker exits non-zero, so **the deploy step never runs**. This is strictly stronger
+than today's posture: the gate becomes unbypassable from *any* client — the app, a
+laptop with `git push`, or a compromised device — rather than being enforced by app
+code. The desktop container path keeps its local preflight too (better UX: blocked
+before pushing anything). The scan's `--json` envelope (#742) is emitted into the build
+log; on failure the app extracts it when present and renders the existing
+`Phase.blocked` UI, falling back to a raw log excerpt for ordinary build errors.
 
-### C.4 Mobile flow end-to-end (no containers anywhere)
+### C.4 The git origin + publish service (user's Cloudflare account)
 
-**Prerequisite:** the site has an `origin` remote — i.e. `RepoBootstrap` (#68,
-"Publish to GitHub") has run. Mobile onboarding surfaces this as the entry requirement;
-a site that exists only on one Mac's disk is not reachable from a phone *by design*
-(git is the sync layer; there is no bespoke Anglesite sync protocol).
+The piece that removes GitHub from the requirements: a small, Anglesite-maintained
+**site-services Worker** the user deploys into their own account **once**, via the
+Deploy-to-Cloudflare button — the same provisioning shape (and plausibly the same
+template repo) as the 2026-06-23 remote-sandbox design. It provides, per site:
 
-1. **Onboarding (once):** sign into the git host (GitHub OAuth device/web flow → token
-   in Keychain, mirroring `HTTPGitHubClient`), pick the site repo, **shallow clone**
-   `Source/` into the app's container directory via SwiftGit2 (libgit2 is already the
-   Darwin git path; no subprocess involved). Connect Cloudflare with the existing
-   verify-then-persist `TokenOnboarding` pattern; enable Workers Builds for the repo
-   (§C.6).
+- **A durable git origin.** Bare repos live in **R2**; a per-site Durable Object owns
+  each one. Serving uses *real git*, not a pack-protocol reimplementation in Workers
+  JS: the control Worker wakes an ephemeral Sandbox that restores the bare repo from
+  R2 and serves **git smart HTTP** (`git http-backend`) behind the token-checking auth
+  proxy; after a push, the repo syncs back to R2 *before* the push is reported
+  successful. Because it speaks standard smart HTTP with a token, any git client can
+  clone and push it — #72's "clonable anywhere" invariant holds with zero GitHub
+  involvement.
+- **The publish pipeline.** A push to the origin (or an explicit publish RPC) makes
+  the service check out the pushed ref in the sandbox, run `npm run build:ci` (§C.3 —
+  build, then the pre-deploy gate), and on success `wrangler deploy` in-sandbox with
+  the account's token. The control Worker exposes status + build logs for the app to
+  poll and stream (logs are sacred, on every platform).
+
+Boundaries and posture:
+
+- This sandbox is **ephemeral compute in the user's Cloudflare account, not a
+  container on the device** — the phone still only makes HTTPS calls, so the
+  no-containers-on-mobile constraint holds. It is distinct from the remote *preview*
+  sandbox (#66), which stays an opt-in live dev-server session; the publish sandbox
+  runs for seconds-to-minutes per publish, then sleeps. Disk loss on sleep is
+  immaterial — R2 is the durable home and the sandbox is always reconstructable from
+  it (the same cold-hydrate posture #66 already accepted).
+- **Single-writer safety:** the per-site DO serializes pushes; the R2 sync completes
+  before receive-pack's response is released, so a crash mid-push means the client
+  re-pushes — the R2 copy is never a torn state.
+- **Billing honesty:** Cloudflare Sandboxes/Containers require the Workers paid plan.
+  That is a real cost floor for container-less publishing, but it is a *Cloudflare*
+  cost on the account the user already bills for hosting — consistent with the BYO
+  "user bills, zero Anglesite-operated infra" posture. Surfaced plainly in onboarding,
+  never a silent failure.
+
+### C.5 Mobile flow end-to-end (no containers on the device, Cloudflare only)
+
+**Prerequisite:** the site has its Cloudflare origin (§C.4) — set up from any device
+that has the site, typically the Mac, which pushes `Source/` to the origin when
+cloud publishing is enabled. A site that exists only on one Mac's disk is not
+reachable from a phone *by design* (git is the sync layer; there is no bespoke
+Anglesite sync protocol — the origin just lives in the user's Cloudflare account
+instead of on a git host).
+
+1. **Onboarding (once):** connect Cloudflare with the existing verify-then-persist
+   `TokenOnboarding` pattern; provision the site-services Worker via the
+   Deploy-to-Cloudflare button (§C.7); pick the site and **shallow clone** `Source/`
+   from its origin into the app's container directory via SwiftGit2 (libgit2 is
+   already the Darwin git path; no subprocess involved). No GitHub sign-in exists in
+   this flow.
 2. **Edit:** the same navigator-lite → `TypedEntryEditorView` (ported off
    `NSOpenPanel`/`NSWorkspace` onto `fileImporter`/`PhotosPicker`) with
    `MarkdownTextView` bodies. `FrontmatterDocument` round-trip, per-edit commits —
@@ -189,12 +242,16 @@ a site that exists only on one Mac's disk is not reachable from a phone *by desi
    implementation that diverges from Astro's, shown in site-unlike CSS. Honest
    labeling over simulation. True preview = the deployed site post-publish (drafts
    never deploy), or the remote sandbox for users who separately opt into it.
-4. **Publish:** flip draft (§B.3) → `pull --rebase` → push over HTTPS → Workers Builds
-   builds, gates, deploys → app polls deployment status, streams the log, and on
+4. **Publish:** flip draft (§B.3) → `pull --rebase` → push to the origin → the publish
+   service builds, gates, deploys (§C.4) → app polls status, streams the log, and on
    success runs the Webmention/POSSE post-deploy steps app-side (pure Swift + HTTP,
    fully portable — same code desktop runs today).
 
-### C.5 Desktop flow
+Creating a *new* site from the phone is feasible under this design (the template is an
+app resource; scaffold + `git init` + push to a fresh origin need no Node — `npm ci`
+happens server-side in `build:ci`), but it is a follow-on, not part of this slice.
+
+### C.6 Desktop flow
 
 Unchanged core, plus the publish verbs: a post's editor and the navigator get
 **Publish/Unpublish** (menu + toolbar, proper Mac conventions per the mac-assed spec);
@@ -202,15 +259,23 @@ publish commits then triggers whichever `PublishPipeline` the site is configured
 The container path's dev-server preview keeps showing drafts (dev mode renders
 `draft: true` entries with a "Draft" badge — dev-only, filtered from builds).
 
-### C.6 Workers Builds provisioning
+### C.7 Provisioning (one-time, Cloudflare only)
 
-Connecting a Cloudflare account to the git host is a one-time dashboard OAuth step that
-cannot be done headlessly; the app deep-links the user through it, then creates/updates
-the build configuration (build command, deploy command, root directory) via the API and
-verifies with a status poll. Exact API coverage for build-config creation is an open
-item to verify during implementation (same manual-verify posture as #207's token
-onboarding). Fallback if the API gap is real: the app shows copy-paste build settings
-and verifies by observing the first deployment.
+Two steps, both against Cloudflare and nothing else:
+
+1. **API token** — the existing verify-then-persist `TokenOnboarding` flow
+   (Keychain-stored, verified before use), with scopes extended to cover the
+   site-services Worker's needs (Workers scripts, DO, R2).
+2. **Site-services Worker** — deployed into the user's account via the
+   Deploy-to-Cloudflare button against the Anglesite template repo (browser OAuth to
+   *Cloudflare*, hosted build — the exact mechanism the remote-sandbox design already
+   locked, because a phone can't run wrangler or build images). The app then verifies
+   with a status RPC and registers the site's origin URL.
+
+Per-site enablement afterward is a single control-Worker call (create the DO + R2
+prefix + origin URL). If the user later runs Publish to GitHub (#68), that adds a
+mirror remote and unlocks the optional Workers Builds variant; nothing in the required
+path changes.
 
 ## Data flow
 
@@ -223,11 +288,13 @@ and verifies by observing the first deployment.
                                         └─► wrangler deploy → URL         │
                                         └─► push origin (background)      │
                     └──────────────────────────────────────────────────────┘
-                    ┌── iOS / container-less ─────────────────────────────┐
+                    ┌── iOS / container-less (Cloudflare only) ───────────┐
  edit local clone (MarkdownTextView)                                      │
    → save → commit (SwiftGit2, offline-safe)                              │
-   → Publish: draft:false + commit → pull --rebase → push origin          │
-       └─► Workers Builds (user's CF acct): npm run build:ci              │
+   → Publish: draft:false + commit → pull --rebase                        │
+   → push → git origin (user's CF acct: DO + R2 bare repo,                │
+       │     smart HTTP via git http-backend in ephemeral sandbox)        │
+       └─► publish service (same sandbox): npm run build:ci               │
              build → pre-deploy-check --strict ✗→ deploy never runs       │
              └─► wrangler deploy → app polls status + streams log         │
                   └─► app-side Webmention/POSSE on success                │
@@ -239,10 +306,13 @@ and verifies by observing the first deployment.
 - **Non-fast-forward push** → automatic `pull --rebase`; on conflict, a per-file
   keep-mine/keep-theirs sheet scoped to content files (the same conflict posture as
   `FileEditorModel`'s external-change flow). Never silent merge, never force-push.
-- **CI build failure** → distinguish gate-blocked (scan envelope found in the log →
-  existing blocked-deploy UI with categories/remediation) from plain build errors (log
-  excerpt + link to full log). A failed CI deploy leaves the previous deploy live —
-  static hosting's natural atomicity.
+- **Pipeline build failure** → distinguish gate-blocked (scan envelope found in the log
+  → existing blocked-deploy UI with categories/remediation) from plain build errors
+  (log excerpt + link to full log). A failed pipeline run leaves the previous deploy
+  live — static hosting's natural atomicity.
+- **Cold starts** → pushing/publishing may wake the sandbox; the publish UI shows
+  determinate-ish states (waking → pushing → building → checking → deploying), the
+  same progress posture as #66's `.starting`.
 - **Draft leakage backstop** → optional pre-deploy-check addition: fail if any
   `draft: true` source entry has a corresponding page in `dist/` (cheap route check;
   belt-and-suspenders on top of route/feed filtering).
@@ -251,9 +321,11 @@ and verifies by observing the first deployment.
   registry constrain typed fields to valid shapes.
 - **Offline** → editing and committing fully work; Publish is disabled with an explicit
   "waiting for network" state, never queued silently.
-- **Missing prerequisites** → no `origin` → route to Publish-to-GitHub onboarding
-  (desktop) or "open this site on your Mac first" guidance (iOS); missing/invalid CF or
-  git token → the existing verify-then-persist reconnect flows.
+- **Missing prerequisites** → no Cloudflare origin → route to site-services
+  provisioning (§C.7) on desktop, or "enable cloud publishing on your Mac first"
+  guidance on iOS; missing/invalid token → the existing verify-then-persist reconnect
+  flows; Workers plan lacks container support → explicit upgrade guidance, never a
+  silent retry loop.
 - **Concurrent editing** (Mac + phone) → git handles it; per-edit commits keep changes
   small and rebases clean. The phone pulls on foreground/site-open, the Mac's checkout
   hydrates as today.
@@ -269,15 +341,20 @@ and verifies by observing the first deployment.
 - **Draft model:** template fixture tests — `draft: true` entry emits no `dist/` page,
   no index/feed entry, for each post-family collection; `swift test` template-coupled
   suites updated (`.strict()` schema additions).
-- **`GitPushPublishPipeline` (unit):** faked git + faked Workers Builds client — happy
-  path, non-FF → rebase, conflict surfaced, CI blocked-envelope parsed, CI plain
-  failure, offline. Same style as `RemoteSandboxSiteRuntime`'s faked control client.
+- **`CloudPublishPipeline` (unit):** faked git + faked site-services control client —
+  happy path, non-FF → rebase, conflict surfaced, blocked-envelope parsed, plain build
+  failure, offline, cold-start states. Same style as `RemoteSandboxSiteRuntime`'s
+  faked `SandboxControlClient`.
+- **Site-services Worker (its own repo's suite):** origin round-trip — clone/push
+  against the served smart HTTP with a stock git client; push → R2 sync ordering;
+  DO-serialized concurrent pushes; publish RPC drives `build:ci` and reports the
+  envelope.
 - **`build:ci` producer test:** fresh scaffold, seeded PII blocker → `npm run build:ci`
   exits non-zero *after* building; clean scaffold exits zero (extends the #742
   producer→consumer fixture lane).
-- **One opt-in live e2e** (gated like the container/e2e suites): push a draft-flip
-  commit to a real repo wired to Workers Builds, poll to deployed, assert the post URL
-  is live.
+- **One opt-in live e2e** (gated like the container/e2e suites, real Cloudflare
+  account): provision, push a draft-flip commit to the origin, poll to deployed,
+  assert the post URL is live and a re-clone of the origin matches the local repo.
 
 ## Phasing
 
@@ -286,12 +363,14 @@ and verifies by observing the first deployment.
 2. **Slice 2 — draft/publish model:** template schema + filtering, registry `draft`,
    drafts-by-default, desktop Publish/Unpublish verbs over the existing container
    pipeline.
-3. **Slice 3 — push-to-deploy on desktop:** `PublishPipeline` seam, `build:ci` gate,
-   Workers Builds client + onboarding, log streaming. Proves the container-less
-   pipeline where debugging is easy.
+3. **Slice 3 — Cloudflare publish services + desktop push-to-publish:** the
+   site-services Worker (git origin + publish pipeline, its own template repo),
+   `PublishPipeline` seam, `build:ci` gate, provisioning + log streaming in the Mac
+   app. Proves the whole container-less pipeline where debugging is easy — the phone
+   adds no new moving parts server-side.
 4. **Slice 4 — mobile:** iOS shell grows the local-checkout mode (clone/pull/push via
-   SwiftGit2), ported typed/markdown editors, mobile publish UX. Depends on #71 scope
-   decisions.
+   SwiftGit2 against the Cloudflare origin), ported typed/markdown editors, mobile
+   publish UX. Depends on #71 scope decisions.
 
 Each slice is deterministic Swift/TypeScript end-to-end (no LLM path), per the #459
 direction.
@@ -303,15 +382,19 @@ direction.
 - Media/photo posting pipeline from mobile (image import + asset commits) — the seam
   exists (`image` fields, git), but the capture/compression UX is its own design.
 - Micropub as the mobile posting protocol — deliberately *not* chosen here (server-side
-  Micropub is V-3, gated on `@dwk/workers`; this design needs no server component
-  beyond CI). Revisit posting-via-Micropub when V-3 lands.
+  Micropub is V-3, gated on `@dwk/workers`; this design's only server component is the
+  site-services Worker, which is git + build, not a posting API). Revisit
+  posting-via-Micropub when V-3 lands.
+- The Workers Builds variant for GitHub-mirrored repos (§C.2) — optional follow-on.
 - Tables/LaTeX/wiki-link editor affordances; inline image thumbnails (fast-follow).
 - Merging the template `blog` collection with typed `articles` (open question below).
 
 ## Open questions (owner input wanted)
 
-1. **Workers Builds API surface** — can the build config be created purely via API
-   once the GitHub↔Cloudflare connection exists? (Determines how hands-off §C.6 is.)
+1. **Site-services template home** — its own repo, or folded into the #66
+   remote-sandbox Deploy-to-Cloudflare template so one provisioning pass yields one
+   "Anglesite Cloud" Worker offering both preview sessions and origin/publish? (One
+   template is friendlier; one repo per concern is simpler to version.)
 2. **`blog` vs `articles`** — keep both (blog = simple starter, articles = typed
    h-entry) or migrate the starter to `articles` and retire `blog`?
 3. **iOS product shape** — does the container-less local-checkout mode *replace* the
@@ -321,3 +404,7 @@ direction.
 4. **swift-markdown-engine adoption** — if the in-house styler's macOS feel lags the
    reference, is a scoped adoption of SwiftMarkdownEngine behind the `MarkdownTextView`
    seam (macOS only, new-dep approval) acceptable as a stopgap?
+5. **Workers paid-plan floor** — is requiring the paid plan for container-less
+   publishing acceptable for v1, or does that justify prioritizing the Workers Builds
+   variant (free tier, but GitHub-gated) as a cost fallback for users who *choose* a
+   GitHub mirror?

--- a/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
+++ b/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
@@ -1,7 +1,13 @@
 # Blog-post Markdown editor + container-less publishing — design
 
 **Date:** 2026-07-17
-**Status:** Proposed (brainstorm output; needs owner sign-off before implementation)
+**Status:** Proposed; owner decisions locked 2026-07-17 during review: (1) mobile
+posting is Micropub, gated on V-3 `@dwk/workers` conformance; (2) bakes are
+**Worker-triggered**; (3) **Cloudflare is canonical for typed content** ("headless
+CMS" model) — this deliberately **re-scopes #72 and reverses C.3's canonicality for
+authored content** (git stays canonical for code/theme; content portability becomes a
+guaranteed continuous export-to-git). Cross-cutting (#340-class); flagged here so the
+reversal is explicit, not absorbed.
 **Related:** #517 (Find + Format menu, blocked on editor work) · #288 (template blog system) · #346 (typed form editors) · #68 (repo bootstrap / Publish to GitHub) · #640/#654 (in-process git) · #742 (pre-deploy scan envelope) · #71/#66 (iOS thin client + remote sandbox) · #571 (cross-platform port) · epic #496 (Component Editor, STTextView precedent) · **#334 pivot: V-2 IndieAuth (#355), V-2.1 per-site Worker (#353), V-3 Micropub, V-3.4 snapshot-to-git (#362)** · C.2 workers seam + C.3 canonicality decision docs (2026-06-29)
 
 ## Goal
@@ -36,13 +42,13 @@ Two coupled pieces:
 | iOS today is a preview `WKWebView` shell only — no editor, no files, no app entry point | `Sources/AnglesiteIOS/` |
 | Post-deploy Webmention/POSSE steps are pure Swift + HTTP | `DeployModel.swift:373-386`, `WebmentionSendCommand`, `POSSESyndicationCommand` |
 
-Two pivot decisions this design leans on directly: the **C.2 workers seam** (per-site
+Two pivot artifacts this design leans on directly: the **C.2 workers seam** (per-site
 Cloudflare Worker composing `@dwk/*` packages — `@dwk/micropub` at `/micropub` in V-3 —
 with `WorkersConformanceReader`/`gateStatus(for:)` already in AnglesiteCore to gate
-feature enablement), and **C.3 canonicality** ("git-canonical, D1-operational": the
-Worker's store is operational, git is the durable archive, reconciled by a
-snapshot-to-git step — the V-3.4/#362 flow, with #587's inbox capture + `InboxSubmissionSync`
-commit-back as the shipped precedent).
+feature enablement), and **C.3's snapshot mechanism** (D1 → markdown/JSON files → git).
+C.3's *canonicality* ruling is reversed for authored content by this spec (owner
+decision — see Status): the snapshot machinery survives, demoted from "git is canon"
+to "git receives a guaranteed continuous export."
 
 ## Part A — the Markdown editor
 
@@ -126,14 +132,23 @@ Whether the legacy template `blog` collection and the typed `articles` collectio
 merge is deliberately **not** decided here (open question); the editor and publish flow
 work identically against both since both are Markdown + frontmatter collections.
 
+Mode note: everything above is the literal mechanism for **un-provisioned (all-git)
+sites**. In CMS mode (§C.4), the same registry `draft` field and publish semantics
+apply, but the state lives as Micropub `post-status` on the canonical record, the
+loader filters drafts server-side, and exports write the `draft` frontmatter — one
+vocabulary, two storage homes.
+
 ## Part C — the publish pipelines
 
 ### C.1 Invariant
 
-On every platform: **published content ends up as commits in `Source/` (directly on
-desktop; via the C.3 snapshot for Micropub), and reaches the live site only through a
-deterministic build whose pre-deploy security gate no client can skip, with build logs
-surfaced** (logs are sacred). No LLM in the loop anywhere.
+On every platform: **typed content is canonical in the user's own Cloudflare account
+(D1/R2 behind the per-site Worker) once a site's publishing features are provisioned,
+git remains canonical for code/theme, content is continuously exportable to git, and
+nothing reaches the live site except through a deterministic build whose pre-deploy
+security gate no client can skip, with build logs surfaced** (logs are sacred). No LLM
+in the loop anywhere. Un-provisioned sites keep today's all-git file model unchanged —
+Cloudflare-canonical content is what enabling the publishing features *means*.
 
 ### C.2 Decision: mobile posting is Micropub, gated on V-3 workers
 
@@ -159,11 +174,12 @@ Why Micropub and not a bespoke transport (or the 2000s posting APIs):
   git host, no extra accounts.
 - **Third-party clients come free** — any Micropub client (including modern MarsEdit)
   can post to the user's site through the same endpoint the Anglesite app uses.
-- **MetaWeblog / AtomPub were considered and rejected** — both assume a server-side
-  CMS that owns content (inverting #72's git canonicality), can't round-trip
-  Markdown + YAML frontmatter byte-faithfully (XML-RPC HTML strings / Atom XML
-  entries), have no typed-content or draft vocabulary matching the registry, and
-  their client ecosystem has moved to Micropub anyway.
+- **MetaWeblog / AtomPub were considered and rejected** — they can't round-trip
+  Markdown + typed frontmatter faithfully (XML-RPC HTML strings / Atom XML entries),
+  have no typed-content or draft vocabulary matching the registry, carry weak auth
+  stories next to IndieAuth, and their client ecosystem has moved to Micropub
+  anyway. (Their "server owns the content" shape is no longer the objection — the
+  CMS model adopts it — but the protocol itself is the wrong vocabulary.)
 
 The `PublishPipeline` seam in AnglesiteCore then has two shapes:
 
@@ -171,10 +187,11 @@ The `PublishPipeline` seam in AnglesiteCore then has two shapes:
   `DeployCommand` runs build → pre-deploy scan (#742 envelope, `.blocked` is final) →
   `wrangler deploy` inside the container runtime. Fast local iteration, no server
   round-trip.
-- **`MicropubClient`** (container-less; iOS, and any future thin client) — not a
-  build pipeline at all: a typed client of the site's own `/micropub` endpoint
-  (create / update / delete, `post-status` for drafts, media endpoint for images),
-  with the Worker-side snapshot-to-git + bake closing the loop (§C.4).
+- **`MicropubClient`** (container-less; iOS, any future thin client, and the desktop
+  app itself for provisioned sites) — not a build pipeline at all: a typed client of
+  the site's own `/micropub` endpoint (create / update / delete, `post-status` for
+  drafts, media endpoint for images), with the Worker-triggered bake and the
+  export-to-git step closing the loop (§C.4).
 
 ### C.3 Moving the gate server-side (template change, app-only)
 
@@ -185,9 +202,9 @@ The template's CI story gets a `build:ci` script:
 "build:ci": "npm run build && npx tsx scripts/pre-deploy-check.ts --json --strict"
 ```
 
-`build:ci` is the single entry point for every non-interactive runner — whatever bake
-substrate V-3 settles on (§C.4), and Workers Builds if a site happens to have a GitHub
-mirror. The scan runs **after** the build (it inspects `dist/`, matching
+`build:ci` is the single entry point for every non-interactive runner — the
+Worker-triggered bake container (§C.4), and Workers Builds if a site happens to have a
+GitHub mirror. The scan runs **after** the build (it inspects `dist/`, matching
 `DeployCommand`'s ordering) and a blocker exits non-zero, so **the deploy step never
 runs**. Micropub-authored content gets the same treatment: it only reaches the static
 site through a bake, so the gate covers it with no special-casing — and Micropub input
@@ -197,40 +214,45 @@ emitted into the build log; on failure the app extracts it when present and rend
 the existing `Phase.blocked` UI, falling back to a raw log excerpt for ordinary build
 errors.
 
-### C.4 The Micropub data path (per-site Worker, user's Cloudflare account)
+### C.4 The CMS data path (per-site Worker, user's Cloudflare account)
 
 The server side is the pivot's per-site Worker (V-2.1, #353 — `@dwk/micropub` at
-`/micropub`, IndieAuth at `/.well-known/indieauth`, D1 + R2 bindings), not anything
-new this spec invents. What this spec pins down is how a Micropub post becomes site
-content, following the **C.3 canonicality decision** ("git-canonical,
-D1-operational") end to end:
+`/micropub`, IndieAuth at `/.well-known/indieauth`, D1 + R2 bindings). Under the
+Cloudflare-canonical model, a post's life is:
 
-1. **Accept (operational):** the Micropub endpoint validates the IndieAuth token,
-   stores the post in D1 (media uploads → R2 via the media endpoint), and assigns the
-   permalink from `mp-slug`/type rules. `post-status: draft` posts are stored but
-   never rendered publicly.
-2. **Snapshot to git (canonical):** the V-3.4 (#362) snapshot step serializes
-   authored posts into `Source/src/content/<collection>/<slug>.md` — **full-fidelity
-   Markdown + YAML frontmatter matching the registry schema** (unlike received
-   interactions, which snapshot as truncated JSON; authored content is first-class),
-   with `post-status` mapping onto Part B's `draft` field and R2 media committed as
-   site assets. From that commit on, the post is ordinary content — editable in the
-   Mac app, any git clone, or via Micropub `q=source` + update (which round-trips
-   through the same snapshot).
-3. **Bake:** the post reaches the *published* static site at the next build + deploy
-   (`build:ci`, §C.3 — the gate always runs). What triggers a bake after a mobile
-   post — the next desktop deploy, a Worker-triggered build substrate, or "fresh
-   posts render dynamically until the next bake" via the ESI seam
-   (`@dwk/esi` + the 2026-07-13 ESI components) — is a **V-3 epic decision, not
-   re-decided here** (open question 1). This spec only requires that some bake path
-   exists and that drafts never reach `dist/`.
+1. **Accept (canonical):** the Micropub endpoint validates the IndieAuth token,
+   stores the post in D1 (media → R2 via the media endpoint), and assigns the
+   permalink from `mp-slug`/type rules. **D1 acceptance *is* canonicality** — there
+   is no downstream commit the post is waiting on. `post-status: draft` posts are
+   stored but never rendered publicly.
+2. **Bake (Worker-triggered — owner decision, 2026-07-17):** on a publish-affecting
+   write, the control Worker starts an ephemeral **build container** (same compute
+   family as #66's sandbox; requires the Workers paid plan — surfaced in onboarding,
+   never a silent failure) that assembles the site and runs `build:ci` (§C.3 — the
+   gate always runs), then deploys. Rapid consecutive posts coalesce (debounced
+   rebuild), and the ESI seam (`@dwk/esi` + the 2026-07-13 components) remains an
+   optimization for showing fresh content between bakes, not a requirement.
+3. **Export to git (portability guarantee):** C.3's snapshot machinery, demoted from
+   canon to **continuous export**: authored posts serialize to full-fidelity
+   Markdown + YAML frontmatter (registry schema; `post-status` ⇄ Part B's `draft`)
+   with R2 media alongside. The desktop app syncs exports down into `Source/`
+   (one-way, the #587 `InboxSubmissionSync` shape) and **File ▸ Export** always
+   yields a complete site — code *and* content — so the site outlives Cloudflare.
+   Exports are read-side artifacts: editing an exported file does not write back to
+   the CMS (the API is the write path; the app warns if it detects divergence).
 
-The app-side precedent for step 2's commit-back is shipped code: #587's
-`InboxSubmissionSync` (Worker staging → app-side git commit). Whether V-3.4's
-snapshot commits Worker-side or app-side follows that epic's design; either way the
-phone itself never touches git — **mobile needs no local clone, no SwiftGit2, no
-push credentials**, which is the big simplification Micropub buys over any git-based
-mobile transport.
+**How the builder gets the site without git or GitHub:** the build container needs
+code + content. Content comes from D1 through an **Astro content-layer loader** in
+the template that reads the Worker's content API (drafts filtered server-side; the
+existing zod schemas validate loader output exactly as they validate `glob()` files
+today — un-provisioned sites keep the `glob()` loader and today's behavior). Code
+comes from the **deployed-source bundle**: every desktop deploy uploads the built
+site's `Source/` snapshot to R2 as a one-way artifact. No two-way git mirror, no
+sync protocol — code changes only ever arrive via desktop deploys, content changes
+only ever arrive via the API, so the two lanes never conflict.
+
+The phone therefore never touches git — **no local clone, no SwiftGit2, no push
+credentials** — and neither does the builder.
 
 ### C.5 Mobile flow end-to-end (no containers on the device, Cloudflare only)
 
@@ -253,12 +275,13 @@ site's social features, never a silent failure).
 3. **Post / draft:** submit via Micropub — `post-status: draft` for drafts,
    `mp-slug` derived the same way `NativeContentOperations` derives slugs, media
    through the media endpoint to R2. Editing an existing post = `q=source` fetch →
-   edit → Micropub update; the snapshot step (§C.4) round-trips it into git.
+   edit → Micropub update. Acceptance is canonical (§C.4); nothing else has to
+   happen for the edit to be real.
 4. **Publish:** flip the post to published (Micropub update of `post-status`) → the
-   Worker snapshot + bake path takes over (§C.4); the app reflects the state honestly
-   ("published — goes live with the next site build" until the bake confirms, then
-   the live URL). Webmention/POSSE for micropub-authored posts ride V-3's
-   server-side machinery rather than the app-side desktop commands.
+   Worker triggers the bake (§C.4); the app shows "published — site rebuilding" for
+   the seconds-to-minutes the bake takes, then the live URL. Webmention/POSSE for
+   micropub-authored posts ride V-3's server-side machinery rather than the
+   app-side desktop commands.
 
 There is **no fake local preview** — rendering Markdown to HTML app-side would be a
 second Markdown implementation diverging from Astro's, shown in site-unlike CSS. The
@@ -266,45 +289,65 @@ styled editor is the draft surface; the deployed site is the truth.
 
 ### C.6 Desktop flow
 
-Unchanged core, plus the publish verbs: a post's editor and the navigator get
-**Publish/Unpublish** (menu + toolbar, proper Mac conventions per the mac-assed spec);
-publish commits then triggers whichever `PublishPipeline` the site is configured for.
-The container path's dev-server preview keeps showing drafts (dev mode renders
-`draft: true` entries with a "Draft" badge — dev-only, filtered from builds).
+Two modes, split by provisioning state:
+
+- **Un-provisioned sites (today's model, unchanged):** file-based typed editors,
+  per-edit git commits, container build + deploy. Plus the new publish verbs: a
+  post's editor and the navigator get **Publish/Unpublish** (menu + toolbar, proper
+  Mac conventions per the mac-assed spec) flipping Part B's `draft` field. The
+  dev-server preview keeps showing drafts (dev mode renders `draft: true` entries
+  with a "Draft" badge — dev-only, filtered from builds).
+- **Provisioned sites (CMS mode):** typed content editors keep their exact UI
+  (`TypedEntryEditorView` + `MarkdownTextView`) but the model's save path writes
+  through `MicropubClient` instead of `FileDocumentIO` + git — one write path for
+  all clients, so Mac and phone edits can't diverge. Code/theme/pages stay
+  file-based and git-committed exactly as today; a desktop deploy of code also
+  uploads the deployed-source bundle (§C.4) so subsequent Worker-triggered bakes
+  build against current code. Content edits alone don't need the desktop's
+  container at all — the Worker bakes.
+- **Offline desktop editing in CMS mode** uses the same queued-local-draft posture
+  as mobile (§C.5), stated honestly in the UI rather than pretending file-grade
+  offline; the files under `Source/src/content/` are exports, labeled as such.
 
 ### C.7 Provisioning (V-2.1, reused as-is)
 
-Nothing new: enabling mobile publishing for a site *is* enabling the site's social
-features — the V-2.1 (#353) provisioning sequence run from the desktop app (existing
-`keychainTokenSource` token → D1 database → R2 bucket → `wrangler.toml` bindings →
-`worker/worker.ts` composition with `@dwk/micropub` + IndieAuth enabled → deploy).
-All of it is against the user's own Cloudflare account; the conformance gate
-(`workers-version.json` + `gateStatus(for:)`) decides when the app offers it. If the
-user later runs Publish to GitHub (#68), that remains an optional mirror; nothing in
-this path references a git host.
+Enabling publishing for a site *is* enabling the site's social features — the V-2.1
+(#353) provisioning sequence run from the desktop app (existing `keychainTokenSource`
+token → D1 database → R2 bucket → `wrangler.toml` bindings → `worker/worker.ts`
+composition with `@dwk/micropub` + IndieAuth enabled → deploy), plus two steps this
+spec adds: a one-time **content import** (existing `src/content/` entries migrate
+into D1/R2 so the CMS starts complete, with the pre-import files preserved in git
+history) and the first **deployed-source bundle** upload (§C.4). All of it is against
+the user's own Cloudflare account; the conformance gate (`workers-version.json` +
+`gateStatus(for:)`) decides when the app offers it. If the user later runs Publish to
+GitHub (#68), that remains an optional code mirror; nothing in this path references a
+git host.
 
 ## Data flow
 
 ```
-                    ┌── macOS (container) ────────────────────────────────┐
- edit (MarkdownTextView)                                                  │
-   → save → commit (SwiftGit2)                                            │
+        ┌── un-provisioned site (all-git — today's model, unchanged) ─────┐
+ edit (MarkdownTextView) → save → commit (SwiftGit2)                      │
    → Publish: draft:false + commit ──► ContainerPublishPipeline           │
                                         build → scan ✗→ blocked UI        │
                                         └─► wrangler deploy → URL         │
-                                        └─► push origin (background)      │
-                    └──────────────────────────────────────────────────────┘
-                    ┌── iOS / container-less (Micropub, gated on V-3) ────┐
- compose (MarkdownTextView + typed fields, offline-queued)                │
-   → Micropub create/update (post-status: draft|published,               │
-       │   media → R2)  [IndieAuth token, user's own site]                │
-       └─► per-site Worker: D1 (operational store)                        │
-             └─► V-3.4 snapshot → Source/src/content/<coll>/<slug>.md     │
-                   (git canonical; draft ⇄ post-status)                   │
-             └─► bake: npm run build:ci                                   │
-                   build → pre-deploy-check --strict ✗→ deploy never runs │
-                   └─► deploy → post live; app reflects state             │
-                    └──────────────────────────────────────────────────────┘
+        └─────────────────────────────────────────────────────────────────┘
+        ┌── provisioned site (CMS mode — gated on V-3 workers) ───────────┐
+ compose (MarkdownTextView + typed fields; Mac AND iOS, offline-queued)   │
+   → Micropub create/update (post-status draft|published, media → R2)    │
+       [IndieAuth token, user's own site]                                 │
+       └─► per-site Worker: D1/R2 = CANONICAL content store               │
+             ├─► continuous export → Source/src/content/ (portability;   │
+             │     one-way, File ▸ Export always yields a complete site)  │
+             └─► Worker-triggered bake (ephemeral build container):       │
+                   code    ⇐ deployed-source bundle (R2, from desktop)    │
+                   content ⇐ D1 via Astro content-layer loader            │
+                   npm run build:ci                                       │
+                     build → pre-deploy-check --strict ✗→ no deploy      │
+                     └─► deploy → post live (seconds–minutes)             │
+        └─────────────────────────────────────────────────────────────────┘
+ code/theme changes (either mode): git commit → desktop container deploy,
+ which also refreshes the deployed-source bundle for future Worker bakes
 ```
 
 ## Error handling & edge cases
@@ -319,23 +362,30 @@ this path references a git host.
 - **Offline** → composing and local drafts fully work; sending is disabled with an
   explicit "waiting for network" state; queued posts are visibly queued, never
   silently held.
-- **Snapshot/bake lag** → an accepted post that hasn't baked yet shows as
-  "published — awaiting site build," with the D1-accepted state as evidence; the app
-  never fakes a live URL before the bake confirms it.
+- **Bake lag / in flight** → an accepted publish shows "published — site rebuilding"
+  with the bake's live status; the app never fakes a live URL before the deploy
+  confirms. Rapid consecutive publishes coalesce into one rebuild.
 - **Bake build failure** → distinguish gate-blocked (scan envelope → existing
   blocked-deploy UI with categories/remediation) from plain build errors (log excerpt
-  + full log). A failed bake leaves the previous deploy live — static hosting's
-  natural atomicity.
+  + full log, streamed from the build container). A failed bake leaves the previous
+  deploy live — static hosting's natural atomicity — and the canonical content is
+  untouched in D1.
+- **Stale deployed-source bundle** → a Worker bake against an old code bundle is
+  correct-but-stale by design (content is current, code is last-deployed); the app
+  surfaces "code changes not yet deployed" as existing dirty-state UI, never as a
+  bake error.
 - **Draft leakage backstop** → optional pre-deploy-check addition: fail if any
-  `draft: true` source entry (or unsnapshotted `post-status: draft` record) has a
-  corresponding page in `dist/` (cheap route check; belt-and-suspenders on top of
-  route/feed filtering).
-- **Concurrent editing** (Mac edits the file, phone edits via Micropub) → C.3's rule
-  applies: the snapshot is idempotent and **git wins on divergence**; a Micropub
-  update against a post whose file changed since its last snapshot is rejected with a
-  refresh (`q=source` re-fetch) rather than silently clobbering the git-side edit.
+  `post-status: draft` record (or `draft: true` file entry in un-provisioned mode)
+  has a corresponding page in `dist/` (cheap route check; belt-and-suspenders on top
+  of the loader's server-side filtering).
+- **Concurrent editing** (Mac and phone both in CMS mode) → one write path: both go
+  through the API, resolved by ordinary compare-and-swap on the post record
+  (`q=source` re-fetch on conflict). Editing an *exported file* does not write back;
+  the app labels exports and warns on divergence rather than guessing intent.
 - **Media constraints** → media-endpoint upload failures and R2 size limits surface
   per-attachment with retry; a post never partially publishes with missing media.
+- **CMS unreachable at build time** → the loader fails the build loudly (no silent
+  empty collections); the previous deploy stays live.
 
 ## Testing
 
@@ -356,17 +406,22 @@ this path references a git host.
 - **Conformance gating (unit):** feature surface hidden/shown correctly from
   `WorkersConformanceStatus` fixtures (machinery already exists; these tests cover
   the new consumer).
-- **Snapshot fidelity (cross-repo, V-3.4's suite + a fixture here):** a Micropub
-  create/update serializes to Markdown + frontmatter that parses back through
-  `FrontmatterDocument`/the registry schema losslessly, and `post-status` maps to
-  `draft` exactly.
+- **Export fidelity (cross-repo, V-3.4's suite + a fixture here):** a CMS post
+  exports to Markdown + frontmatter that parses back through
+  `FrontmatterDocument`/the registry schema losslessly, `post-status` maps to
+  `draft` exactly, and import → export is the identity (so provisioning's one-time
+  content import is provably lossless).
+- **Content-layer loader (template suite):** loader output validates against the
+  same zod schemas as `glob()` files; drafts filtered; CMS-unreachable fails the
+  build; un-provisioned sites build identically to today.
 - **`build:ci` producer test:** fresh scaffold, seeded PII blocker → `npm run build:ci`
   exits non-zero *after* building; clean scaffold exits zero (extends the #742
   producer→consumer fixture lane).
 - **One opt-in live e2e** (gated like the container/e2e suites, real Cloudflare
-  account, once V-3 packages exist): provision a site's Worker, post via Micropub,
-  assert D1 accept → git snapshot → post-bake live URL, and that a draft never
-  appears in `dist/`.
+  account, once V-3 packages exist): provision (including content import + bundle
+  upload), post via Micropub, assert D1 accept → Worker-triggered bake → live URL,
+  a draft never appears in `dist/`, and File ▸ Export yields a complete buildable
+  site.
 
 ## Phasing
 
@@ -375,14 +430,17 @@ this path references a git host.
 2. **Slice 2 — draft/publish model:** template schema + filtering, registry `draft`,
    drafts-by-default, desktop Publish/Unpublish verbs over the existing container
    pipeline.
-3. **Slice 3 — `build:ci` + bake groundwork:** the template `build:ci` script and
-   envelope-from-log parsing, exercised by the desktop pipeline now so the gate
-   contract is proven before any server-side runner consumes it.
-4. **Slice 4 — mobile Micropub client** *(gated on V-3 `@dwk/workers` conformance —
-   blocked until that milestone is green, like every V-3 feature)*: `MicropubClient`
-   in AnglesiteCore, IndieAuth onboarding, iOS compose UI (ported typed/markdown
-   editors), post/draft/publish flows. The snapshot-to-git and bake-trigger work is
-   V-3.4's (#362), not this spec's — slice 4 consumes it.
+3. **Slice 3 — `build:ci` + bake groundwork:** the template `build:ci` script,
+   envelope-from-log parsing, the content-layer loader seam (glob vs API selection),
+   and the deployed-source bundle upload on desktop deploy — all exercised by the
+   desktop pipeline now, so the contracts are proven before any Worker consumes them.
+4. **Slice 4 — CMS mode** *(gated on V-3 `@dwk/workers` conformance — blocked until
+   that milestone is green, like every V-3 feature)*: `MicropubClient` in
+   AnglesiteCore (shared by the Mac editors' CMS-mode save path and iOS), IndieAuth
+   onboarding, provisioning's content import, iOS compose UI (ported typed/markdown
+   editors), post/draft/publish flows. The Worker-side pieces — content API,
+   Worker-triggered bake orchestration, continuous export (V-3.4 #362 re-scoped to
+   export) — are workers-repo deliverables slice 4 consumes.
 
 Slices 1–3 have no dependency on the workers repo and can land now; slice 4 is the
 gated feature.
@@ -395,14 +453,18 @@ direction.
 - WYSIWYG rich-text editing that rewrites Markdown; the Component Editor (#496) owns
   visual editing of components.
 - Media/photo posting *UX* from mobile — the transport is settled (Micropub media
-  endpoint → R2 → committed as assets at snapshot), but capture/compression/alt-text
-  UX is its own design.
-- **Git as the mobile transport** — an earlier revision of this spec designed a
-  phone-side SwiftGit2 clone pushing to a bespoke R2-backed git origin + build
-  sandbox in the user's Cloudflare account. Superseded by the Micropub decision
-  (§C.2): it duplicated the posting API the pivot already ships, required paid-plan
-  containers, and put git plumbing on the phone for no user-visible gain. Desktop
-  git workflows are untouched; only the *mobile transport* changed.
+  endpoint → R2, exported alongside content), but capture/compression/alt-text UX is
+  its own design.
+- **Git as the mobile transport** — an earlier revision designed a phone-side
+  SwiftGit2 clone pushing to a bespoke R2-backed git origin. Superseded by the
+  Micropub decision (§C.2): it duplicated the posting API the pivot already ships
+  and put git plumbing on the phone for no user-visible gain.
+- **Git-canonical content with a Cloudflare mirror ("option A")** — the alternative
+  to CMS canonicality: keep #72/C.3 intact and maintain a two-way-synced
+  Cloudflare-resident repo for the Worker-triggered builder. Considered and
+  rejected (owner, 2026-07-17) in favor of Cloudflare-canonical content: A keeps
+  two write paths (files and API) that must reconcile, while B has one write path
+  per lane and a strictly simpler one-way export.
 - MetaWeblog / AtomPub — rejected, rationale recorded in §C.2.
 - Workers Builds for GitHub-mirrored repos — optional follow-on, never the default.
 - Tables/LaTeX/wiki-link editor affordances; inline image thumbnails (fast-follow).
@@ -410,20 +472,24 @@ direction.
 
 ## Open questions (owner input wanted)
 
-1. **Bake trigger after a mobile post** (V-3 epic decision, flagged here): next
-   desktop deploy only, a Worker-triggered build substrate, or fresh posts rendered
-   dynamically until the next bake via the ESI seam (`@dwk/esi` + the 2026-07-13 ESI
-   components)? This spec only requires *some* bake path with the gate in it.
-2. **Snapshot commit-back locus for a mobile-only user** — #587's precedent commits
-   app-side (a Mac pulls staged submissions into git). If no Mac opens for weeks,
-   micropub posts live only in D1 (operational) — is that acceptable interim state,
-   or does V-3.4 need a Worker-side commit path (which reopens the "what repo can the
-   Worker push to without GitHub" question)?
-3. **`blog` vs `articles`** — keep both (blog = simple starter, articles = typed
-   h-entry) or migrate the starter to `articles` and retire `blog`?
-4. **iOS product shape** — is the Micropub client the *whole* default iOS experience
+1. **Bulk content read API for builds** — Micropub's `q=source` is a per-post read;
+   the content-layer loader wants a bulk, paginated content endpoint on the Worker
+   (with draft filtering and a change cursor for incremental builds). Shape belongs
+   to the workers repo; flagged so it lands in V-3's API surface.
+2. **Received interactions** — C.3 made *received* interactions git-canonical via
+   snapshot. With authored content now Cloudflare-canonical, should V-3.4 unify both
+   under the export model for consistency, or is received-interaction canonicality
+   worth keeping distinct? (Not re-decided here.)
+3. **Export transport for mobile-only users** — the desktop app syncs exports into
+   `Source/`; a user who never opens a Mac needs an equivalent guarantee. Is an
+   on-demand complete-site export from the Worker (R2-staged archive the iOS app can
+   save/share) sufficient?
+4. **`blog` vs `articles`** — keep both (blog = simple starter, articles = typed
+   h-entry) or migrate the starter to `articles` and retire `blog`? (In CMS mode the
+   distinction also decides which collections the content import migrates.)
+5. **iOS product shape** — is the Micropub client the *whole* default iOS experience
    (with the remote-sandbox thin client as the "power preview" opt-in), or do they
    ship together? This spec assumes the former.
-5. **swift-markdown-engine adoption** — if the in-house styler's macOS feel lags the
+6. **swift-markdown-engine adoption** — if the in-house styler's macOS feel lags the
    reference, is a scoped adoption of SwiftMarkdownEngine behind the `MarkdownTextView`
    seam (macOS only, new-dep approval) acceptable as a stopgap?

--- a/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
+++ b/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
@@ -54,16 +54,35 @@ to "git receives a guaranteed continuous export."
 
 ## Part A — the Markdown editor
 
-### A.1 Substrate decision
+### A.1 Substrate decision — survey first (owner requirement, 2026-07-17)
 
-**Chosen: STTextView + an in-house, UI-framework-free styling core.**
+Building a Markdown editor is complicated enough that **a package survey is a
+mandatory spike before any in-house code** — the first task of slice 1, its outcome
+recorded as an addendum to this spec. The leading direction going into the spike is
+**STTextView + an in-house, UI-framework-free styling core**, but that is a
+hypothesis to test against what exists, not a decision.
 
-| Option | Verdict |
-|---|---|
-| **SwiftMarkdownEngine** (the referenced library) | Rejected as a dependency: AppKit-only, so it cannot cover iOS at all; it would be a *second* text-view substrate living beside the already-shipped STTextView; and it's a new third-party dep (policy: Apple frameworks only unless approved). It stays the **behavioral reference** — feature set and feel are what we're matching. |
-| **STTextView** (already approved) | Chosen. TextKit 2, feature-complete AppKit *and* UIKit implementations (`STTextViewAppKit` / `STTextViewUIKit` over `STTextViewCommon`), plugin seam already proven in this app by the Component Editor code panes. One substrate for code panes and prose. |
-| **SwiftUI `TextEditor` + `AttributedString`** (macOS 26+/iOS 26+) | Fallback, recorded. Zero-dep and cross-platform, but programmatic whole-document restyling on every keystroke fights the binding model (cursor/selection stability), and there is no plugin/interaction seam for checkbox taps or link handling. Revisit if STTextView's UIKit leg disappoints in practice. |
-| **tree-sitter-markdown via the existing Neon plugin** | Insufficient alone: token *coloring* only — no per-block fonts/sizes (headings), paragraph styles (list indents, blockquotes), or interactive checkboxes. |
+Survey candidates (initial sweep, 2026-07-17 — the spike evaluates hands-on):
+
+| Package | Platforms | What it provides | Initial read |
+|---|---|---|---|
+| [SwiftMarkdownEngine](https://github.com/nodes-app/swift-markdown-engine) (nodes-app) | macOS / AppKit, TextKit 2 | The full reference behavior: live typographic styling, task checkboxes, wiki-links, code blocks, LaTeX; zero-dep core; Apache-2.0 | Closest to the target feel; AppKit-only, so iOS needs a second answer; new dep needs approval |
+| [STTextView](https://github.com/krzyzanowskim/STTextView) (+ Neon plugin) | macOS **and** iOS, TextKit 2 | Text-view substrate + tree-sitter coloring; **already approved & shipping** in the Component Editor | Substrate only — the Markdown *styling* layer would be ours |
+| [Runestone](https://github.com/simonbs/Runestone) (simonbs) | iOS / UIKit | Performant editor, tree-sitter incremental highlighting (markdown grammar exists), line numbers | Syntax *coloring*, not typographic live styling; iOS-only |
+| [SwiftDown](https://github.com/qeude/SwiftDown) (qeude) | iOS + macOS, SwiftUI | Themable Markdown editor with in-editor live preview | Both platforms — verify maintenance, fidelity, TextKit generation |
+| [Marklight](https://github.com/macteo/Marklight) | iOS, `NSTextStorage` subclass | Markdown syntax highlighter for `UITextView` | Older TextKit-1 era; pattern reference more than a dependency |
+| [MarkupEditor](https://swiftpackageindex.com/stevengharris/MarkupEditor) | iOS + macOS | WYSIWYG editing via WKWebView/contenteditable | Wrong model — HTML-rewriting WYSIWYG, not source-faithful Markdown |
+| [swift-markdown-ui](https://github.com/gonzalezreal/swift-markdown-ui) / Textual | iOS + macOS, SwiftUI | Markdown **rendering** only | Not an editor; possible preview-side reference |
+| apple/swift-markdown | all | cmark-gfm **parsing** only | Candidate parser under whichever styling layer wins |
+| SwiftUI `TextEditor` + `AttributedString` (macOS 26+/iOS 26+) | both | Zero-dep native text editing | Programmatic whole-document restyling fights the binding model; no interaction seam for checkbox taps |
+
+**Spike acceptance criteria** — each serious candidate is exercised against: AppKit
+*and* UIKit coverage (or a clean per-platform seam); attribute-only styling of raw
+source (never rewrites the buffer; byte-fidelity after an edit-free session);
+interactive task checkboxes; Writing Tools + Find integration; typing latency on a
+~100 KB document; license, maintenance cadence, and fit with the
+Apple-frameworks-only dependency policy (any new dep needs issue approval first);
+and whether core logic stays separable for the Linux/Windows port (#571).
 
 ### A.2 Styling model (the swift-markdown-engine contract)
 
@@ -84,7 +103,7 @@ to "git receives a guaranteed continuous export."
   small; a full-document restyle is the correctness backstop and is acceptable up to
   tens of KB.
 
-### A.3 Components
+### A.3 Components (leading direction — final shape follows the A.1 spike)
 
 1. **`AnglesiteMarkdown`** *(new SwiftPM target, UI-framework-free)* — the tokenizer +
    styler: `MarkdownScanner` (source → block/inline nodes with source ranges) and
@@ -130,9 +149,10 @@ the typed post-family types have nothing.
    `anglesite: publish <type> <slug>` via the existing `processGitCommit` path.
    "Unpublish" is the inverse and is allowed — static rebuild makes it cheap.
 
-Whether the legacy template `blog` collection and the typed `articles` collection should
-merge is deliberately **not** decided here (open question); the editor and publish flow
-work identically against both since both are Markdown + frontmatter collections.
+**Decided (owner, 2026-07-17): both collections stay.** `blog` remains the simple
+starter (title/pubDate/description/draft), `articles` the typed h-entry collection;
+the editor and publish flow work identically against both since both are Markdown +
+frontmatter collections, and CMS-mode provisioning's content import migrates both.
 
 Mode note: everything above is the literal mechanism for **un-provisioned (all-git)
 sites**. In CMS mode (§C.4), the same registry `draft` field and publish semantics
@@ -437,8 +457,11 @@ git host.
 
 ## Phasing
 
-1. **Slice 1 — editor on macOS:** `AnglesiteMarkdown` + `MarkdownTextView` +
-   `.markdown` routing; Format menu + Find (#517). No behavior change to saving.
+1. **Slice 1 — editor on macOS:** starts with the **A.1 package-survey spike**
+   (mandatory; outcome recorded as a spec addendum), then the chosen substrate wired
+   as `MarkdownTextView` + `.markdown` routing (+ `AnglesiteMarkdown` if the survey
+   confirms the in-house styler); Format menu + Find (#517). No behavior change to
+   saving.
 2. **Slice 2 — draft/publish model:** template schema + filtering, registry `draft`,
    drafts-by-default, desktop Publish/Unpublish verbs over the existing container
    pipeline.
@@ -464,6 +487,10 @@ direction.
 
 - WYSIWYG rich-text editing that rewrites Markdown; the Component Editor (#496) owns
   visual editing of components.
+- **Full site editing on mobile** (code/theme/pages, not just posts) — a **v2.0
+  feature** (owner, 2026-07-17): via a remote container on iOS (#66/#71) and
+  on-device on Android (the Android platform shell of #571, which can host a local
+  toolchain). This design ships mobile as a posting client only.
 - Media/photo posting *UX* from mobile — the transport is settled (Micropub media
   endpoint → R2, exported alongside content), but capture/compression/alt-text UX is
   its own design.
@@ -482,18 +509,16 @@ direction.
 - Tables/LaTeX/wiki-link editor affordances; inline image thumbnails (fast-follow).
 - Merging the template `blog` collection with typed `articles` (open question below).
 
-## Open questions (owner input wanted)
+## Resolved questions (decision log)
 
-Resolved during review (2026-07-17), recorded in §C.4: the bulk content read
-endpoint is a V-3 API requirement; received interactions unify under the
-D1-canonical + export model; export is desktop-only (no mobile export path).
+All questions raised by this spec have been resolved by the owner (2026-07-17):
 
-1. **`blog` vs `articles`** — keep both (blog = simple starter, articles = typed
-   h-entry) or migrate the starter to `articles` and retire `blog`? (In CMS mode the
-   distinction also decides which collections the content import migrates.)
-2. **iOS product shape** — is the Micropub client the *whole* default iOS experience
-   (with the remote-sandbox thin client as the "power preview" opt-in), or do they
-   ship together? This spec assumes the former.
-3. **swift-markdown-engine adoption** — if the in-house styler's macOS feel lags the
-   reference, is a scoped adoption of SwiftMarkdownEngine behind the `MarkdownTextView`
-   seam (macOS only, new-dep approval) acceptable as a stopgap?
+- **Bulk content read endpoint** — V-3 API requirement (§C.4).
+- **Received interactions** — unified under the D1-canonical + export model (§C.4).
+- **Export** — desktop-only; no mobile export path (§C.4).
+- **`blog` vs `articles`** — both stay (Part B).
+- **iOS product shape** — the Micropub client *is* the default iOS experience.
+  Full site editing on mobile — via a remote container on iOS (#66/#71) or
+  on-device on Android — is a **v2.0 feature**, out of scope for this design.
+- **Editor substrate** — decided by the mandatory A.1 package-survey spike; its
+  outcome lands as an addendum to this spec.

--- a/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
+++ b/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
@@ -1,0 +1,323 @@
+# Blog-post Markdown editor + container-less publishing — design
+
+**Date:** 2026-07-17
+**Status:** Proposed (brainstorm output; needs owner sign-off before implementation)
+**Related:** #517 (Find + Format menu, blocked on editor work) · #288 (template blog system) · #346 (typed form editors) · #68 (repo bootstrap / Publish to GitHub) · #640/#654 (in-process git) · #742 (pre-deploy scan envelope) · #71/#66 (iOS thin client + remote sandbox) · #571 (cross-platform port) · epic #496 (Component Editor, STTextView precedent)
+
+## Goal
+
+Two coupled pieces:
+
+1. **A native Markdown editor for blog posts** in the spirit of
+   [nodes-app/swift-markdown-engine](https://github.com/nodes-app/swift-markdown-engine):
+   a real text view with live in-place styling of Markdown source (headings sized, bold
+   bold, task checkboxes toggleable) — not a raw monospaced buffer, and not a WYSIWYG
+   that rewrites the file.
+2. **A publish flow for posts that works on desktop and mobile**, where mobile is
+   assumed to have **no container access at all** — no Apple Containerization, no Node,
+   no subprocesses, and *not* the remote Cloudflare Sandbox either (that is a container
+   too, just someone else's; it stays an orthogonal opt-in, per the
+   2026-06-23 remote-sandbox design).
+
+## Current state this builds on
+
+| Fact | Where |
+|---|---|
+| Markdown bodies edit in a plain monospaced `TextEditor`; no styling, no Find, no Format menu | `MainPaneEditorView.swift:36`, `TypedEntryEditorView.swift:16` (#517 deferred both "pending editor work" — this is that work) |
+| STTextView (TextKit 2, AppKit **and** UIKit) + Neon/tree-sitter are already approved, pinned dependencies, shipping in the Component Editor code panes | `Package.swift:307-333`, `ComponentEditorView.swift` |
+| Git commits run **in-process** via SwiftGit2/libgit2 (App Sandbox can't exec `/usr/bin/git`); push over HTTPS exists (`HTTPRepoProvider`, #654) | `NativeContentOperations.swift:391`, `RepoBootstrap.swift`, `InProcessGit.swift` |
+| Deploy **requires the container runtime**: build → pre-deploy scan → `wrangler deploy`, all in-container; host-Node paths are retired (#70) | `DeployCommand.swift:74-203`, `DeployModel.swift:328` |
+| The pre-deploy gate is app-enforced today, with a versioned JSON envelope (#742) | `PreDeployCheck.swift`, `Resources/Template/scripts/pre-deploy-check.ts` |
+| Template has a `blog` collection with a `draft` flag (#288); the typed post-family collections (`articles`, `notes`, …) have **no draft field**, and their zod schemas are `.strict()` | `Resources/Template/src/content.config.ts` |
+| iOS today is a preview `WKWebView` shell only — no editor, no files, no app entry point | `Sources/AnglesiteIOS/` |
+| Post-deploy Webmention/POSSE steps are pure Swift + HTTP | `DeployModel.swift:373-386`, `WebmentionSendCommand`, `POSSESyndicationCommand` |
+
+The two facts that make the mobile story cheap: **git is already in-process** (libgit2
+builds for iOS; the sandbox forced this on macOS, and iOS inherits it for free), and
+**git is already the source of truth** (#72) — the app's working copy is explicitly
+non-canonical, so a phone holding its own clone is architecturally normal, not a hack.
+
+## Part A — the Markdown editor
+
+### A.1 Substrate decision
+
+**Chosen: STTextView + an in-house, UI-framework-free styling core.**
+
+| Option | Verdict |
+|---|---|
+| **SwiftMarkdownEngine** (the referenced library) | Rejected as a dependency: AppKit-only, so it cannot cover iOS at all; it would be a *second* text-view substrate living beside the already-shipped STTextView; and it's a new third-party dep (policy: Apple frameworks only unless approved). It stays the **behavioral reference** — feature set and feel are what we're matching. |
+| **STTextView** (already approved) | Chosen. TextKit 2, feature-complete AppKit *and* UIKit implementations (`STTextViewAppKit` / `STTextViewUIKit` over `STTextViewCommon`), plugin seam already proven in this app by the Component Editor code panes. One substrate for code panes and prose. |
+| **SwiftUI `TextEditor` + `AttributedString`** (macOS 26+/iOS 26+) | Fallback, recorded. Zero-dep and cross-platform, but programmatic whole-document restyling on every keystroke fights the binding model (cursor/selection stability), and there is no plugin/interaction seam for checkbox taps or link handling. Revisit if STTextView's UIKit leg disappoints in practice. |
+| **tree-sitter-markdown via the existing Neon plugin** | Insufficient alone: token *coloring* only — no per-block fonts/sizes (headings), paragraph styles (list indents, blockquotes), or interactive checkboxes. |
+
+### A.2 Styling model (the swift-markdown-engine contract)
+
+- **Attribute-only restyling of the raw source.** The editor never rewrites the text the
+  user typed; Markdown remains byte-for-byte what lands on disk, so `git diff` stays
+  human and external editors stay first-class (#72). Syntax markers (`#`, `**`, `` ` ``)
+  remain visible, rendered dimmed.
+- **v1 construct set:** ATX headings (sized fonts), bold/italic/strikethrough, inline
+  code + fenced code blocks (monospaced, background; Neon-highlighted fences are a later
+  nicety), links (styled + ⌘-click/tap to open), ordered/unordered lists with hanging
+  indents, task-list checkboxes (tap/click toggles `[ ]`↔`[x]` — the one place the
+  editor *does* write, a 1-character replacement through the normal undoable edit path),
+  blockquotes.
+- **Out of scope for v1:** LaTeX, wiki-links, table grid rendering, image thumbnail
+  embedding (images render as styled links; inline thumbnails are a fast-follow).
+- **Restyle strategy:** line-oriented incremental pass over the edited paragraph ±
+  block-context (fences and lists need lookback), coalesced per edit. Blog posts are
+  small; a full-document restyle is the correctness backstop and is acceptable up to
+  tens of KB.
+
+### A.3 Components
+
+1. **`AnglesiteMarkdown`** *(new SwiftPM target, UI-framework-free)* — the tokenizer +
+   styler: `MarkdownScanner` (source → block/inline nodes with source ranges) and
+   `MarkdownTheme`/`MarkdownStyler` (nodes → attribute runs, platform fonts injected via
+   a small `FontProviding` seam). No AppKit/UIKit imports, so it builds and tests on the
+   Linux CI leg — consistent with the cross-platform port's purity rule (§10) and
+   reusable later by the Linux/Windows shells (#571). Hand-rolled scanner for the styled
+   subset; full CommonMark fidelity is *not* required because Astro remains the
+   authoritative renderer.
+2. **`MarkdownTextView`** *(AnglesiteApp / AnglesiteIOS)* — SwiftUI
+   `NSViewRepresentable`/`UIViewRepresentable` hosting STTextView, applying
+   `MarkdownStyler` output on text change; checkbox tap + link interaction handlers.
+   Parallels the Component Editor's existing STTextView hosting.
+3. **Editor wiring** — `EditorKind` gains `.markdown` (resolved for `.md`/`.mdx` in
+   `.text`'s current fallthrough); `MainPaneEditorView` routes it to `MarkdownTextView`;
+   `TypedEntryEditorView`'s body field swaps its `TextEditor` for `MarkdownTextView`.
+   `FileEditorModel`/`TypedEntryEditorModel`, dirty tracking, conflict detection, and
+   the per-edit-commit path are unchanged — this is a view-layer swap.
+4. **#517 lands on top:** Format menu (⌘B/⌘I toggle delimiters, ⌘K wrap link, heading
+   levels) as `MarkdownTextView` commands; Edit ▸ Find via the substrate's find support.
+   Writing Tools come free with the native text view.
+
+## Part B — the draft → publish content model
+
+Publishing needs a state to flip. Today only the template `blog` collection has `draft`;
+the typed post-family types have nothing.
+
+1. **Template:** add `draft: z.boolean().default(false)` to the post-family collection
+   schemas (`articles`, `notes`, `photos`, `albums`, `bookmarks`, `replies`, `likes`) —
+   required because the schemas are `.strict()` and would otherwise *fail the build* on
+   an unknown `draft` key. Every list route, detail-route `getStaticPaths`, and feed
+   (RSS/Atom/JSON, mf2 rollups) filters `draft` entries, exactly as `/blog/` already
+   does (#288). Business types (`announcements`, `events`, `reviews`, `members`) can
+   follow later; posts are the target here.
+2. **Registry:** the corresponding `ContentTypeRegistry` descriptors gain a
+   `draft` field (`Kind.bool`) so the schema-driven form editor, intents, and scaffold
+   see it. `ContentScaffold.renderEntry` writes new posts with `draft: true` — **new
+   posts are drafts by default**; today's create-and-it's-live behavior becomes
+   create-then-publish.
+3. **Publish semantics:** "Publish" = set `draft: false`, re-stamp `publishDate` to now
+   iff the entry has never been published (a draft's provisional date shouldn't become
+   the public one; an explicitly user-edited date is respected), commit
+   `anglesite: publish <type> <slug>` via the existing `processGitCommit` path.
+   "Unpublish" is the inverse and is allowed — static rebuild makes it cheap.
+
+Whether the legacy template `blog` collection and the typed `articles` collection should
+merge is deliberately **not** decided here (open question); the editor and publish flow
+work identically against both since both are Markdown + frontmatter collections.
+
+## Part C — the publish pipelines
+
+### C.1 Invariant
+
+On every platform: **publish = commits on `Source/` + a deterministic pipeline that ends
+in a deploy, with the pre-deploy security gate running somewhere the client cannot
+skip, and build logs surfaced** (logs are sacred). No LLM in the loop anywhere.
+
+### C.2 One seam, two strategies
+
+A `PublishPipeline` protocol in AnglesiteCore with two implementations:
+
+- **`ContainerPublishPipeline`** — the existing desktop path, unchanged:
+  `DeployCommand` runs build → pre-deploy scan (#742 envelope, `.blocked` is final) →
+  `wrangler deploy` inside the container runtime. Fast local iteration, no push
+  required.
+- **`GitPushPublishPipeline`** — the container-less path: commit → pull
+  (fast-forward/rebase) → push to `origin` → **Cloudflare Workers Builds** (git-connected,
+  user's account, user's billing — same BYO posture as everything else) builds and
+  deploys → the app polls the Workers Builds deployment via the Cloudflare API and
+  streams the build log into the debug pane.
+
+Mobile only has the second. Desktop gets both — push-to-deploy is also the natural fit
+for the Linux/Windows ports (#571) and for users who never provision the container
+runtime. `DeployModel` picks the strategy the way it picks `ContainerDeployExecutor`
+today.
+
+### C.3 Moving the gate server-side (template change, app-only)
+
+The template's CI story gets a `build:ci` script:
+
+```jsonc
+// Resources/Template/package.json
+"build:ci": "npm run build && npx tsx scripts/pre-deploy-check.ts --json --strict"
+```
+
+Workers Builds is configured with build command `npm run build:ci` and deploy command
+`npx wrangler deploy`. The scan runs **after** the build (it inspects `dist/`, matching
+`DeployCommand`'s ordering) and a blocker exits non-zero, so **the deploy step never
+runs**. This is strictly stronger than today's posture: the gate becomes unbypassable
+from *any* client — the app, a laptop with `git push`, or a compromised device — rather
+than being enforced by app code. The desktop container path keeps its local preflight
+too (better UX: blocked before pushing anything). The scan's `--json` envelope (#742)
+is emitted into the build log; on failure the app extracts it when present and renders
+the existing `Phase.blocked` UI, falling back to a raw log excerpt for ordinary build
+errors.
+
+### C.4 Mobile flow end-to-end (no containers anywhere)
+
+**Prerequisite:** the site has an `origin` remote — i.e. `RepoBootstrap` (#68,
+"Publish to GitHub") has run. Mobile onboarding surfaces this as the entry requirement;
+a site that exists only on one Mac's disk is not reachable from a phone *by design*
+(git is the sync layer; there is no bespoke Anglesite sync protocol).
+
+1. **Onboarding (once):** sign into the git host (GitHub OAuth device/web flow → token
+   in Keychain, mirroring `HTTPGitHubClient`), pick the site repo, **shallow clone**
+   `Source/` into the app's container directory via SwiftGit2 (libgit2 is already the
+   Darwin git path; no subprocess involved). Connect Cloudflare with the existing
+   verify-then-persist `TokenOnboarding` pattern; enable Workers Builds for the repo
+   (§C.6).
+2. **Edit:** the same navigator-lite → `TypedEntryEditorView` (ported off
+   `NSOpenPanel`/`NSWorkspace` onto `fileImporter`/`PhotosPicker`) with
+   `MarkdownTextView` bodies. `FrontmatterDocument` round-trip, per-edit commits —
+   identical code, running against the local checkout. Offline editing works fully;
+   commits accumulate locally.
+3. **Draft reading:** the styled editor *is* the draft surface. There is **no fake
+   local preview** — rendering Markdown to HTML app-side would be a second Markdown
+   implementation that diverges from Astro's, shown in site-unlike CSS. Honest
+   labeling over simulation. True preview = the deployed site post-publish (drafts
+   never deploy), or the remote sandbox for users who separately opt into it.
+4. **Publish:** flip draft (§B.3) → `pull --rebase` → push over HTTPS → Workers Builds
+   builds, gates, deploys → app polls deployment status, streams the log, and on
+   success runs the Webmention/POSSE post-deploy steps app-side (pure Swift + HTTP,
+   fully portable — same code desktop runs today).
+
+### C.5 Desktop flow
+
+Unchanged core, plus the publish verbs: a post's editor and the navigator get
+**Publish/Unpublish** (menu + toolbar, proper Mac conventions per the mac-assed spec);
+publish commits then triggers whichever `PublishPipeline` the site is configured for.
+The container path's dev-server preview keeps showing drafts (dev mode renders
+`draft: true` entries with a "Draft" badge — dev-only, filtered from builds).
+
+### C.6 Workers Builds provisioning
+
+Connecting a Cloudflare account to the git host is a one-time dashboard OAuth step that
+cannot be done headlessly; the app deep-links the user through it, then creates/updates
+the build configuration (build command, deploy command, root directory) via the API and
+verifies with a status poll. Exact API coverage for build-config creation is an open
+item to verify during implementation (same manual-verify posture as #207's token
+onboarding). Fallback if the API gap is real: the app shows copy-paste build settings
+and verifies by observing the first deployment.
+
+## Data flow
+
+```
+                    ┌── macOS (container) ────────────────────────────────┐
+ edit (MarkdownTextView)                                                  │
+   → save → commit (SwiftGit2)                                            │
+   → Publish: draft:false + commit ──► ContainerPublishPipeline           │
+                                        build → scan ✗→ blocked UI        │
+                                        └─► wrangler deploy → URL         │
+                                        └─► push origin (background)      │
+                    └──────────────────────────────────────────────────────┘
+                    ┌── iOS / container-less ─────────────────────────────┐
+ edit local clone (MarkdownTextView)                                      │
+   → save → commit (SwiftGit2, offline-safe)                              │
+   → Publish: draft:false + commit → pull --rebase → push origin          │
+       └─► Workers Builds (user's CF acct): npm run build:ci              │
+             build → pre-deploy-check --strict ✗→ deploy never runs       │
+             └─► wrangler deploy → app polls status + streams log         │
+                  └─► app-side Webmention/POSSE on success                │
+                    └──────────────────────────────────────────────────────┘
+```
+
+## Error handling & edge cases
+
+- **Non-fast-forward push** → automatic `pull --rebase`; on conflict, a per-file
+  keep-mine/keep-theirs sheet scoped to content files (the same conflict posture as
+  `FileEditorModel`'s external-change flow). Never silent merge, never force-push.
+- **CI build failure** → distinguish gate-blocked (scan envelope found in the log →
+  existing blocked-deploy UI with categories/remediation) from plain build errors (log
+  excerpt + link to full log). A failed CI deploy leaves the previous deploy live —
+  static hosting's natural atomicity.
+- **Draft leakage backstop** → optional pre-deploy-check addition: fail if any
+  `draft: true` source entry has a corresponding page in `dist/` (cheap route check;
+  belt-and-suspenders on top of route/feed filtering).
+- **Schema errors authored on mobile** (no `astro check` locally) → surface at CI with
+  the file/line from Astro's error output; mitigated up front because the form editor +
+  registry constrain typed fields to valid shapes.
+- **Offline** → editing and committing fully work; Publish is disabled with an explicit
+  "waiting for network" state, never queued silently.
+- **Missing prerequisites** → no `origin` → route to Publish-to-GitHub onboarding
+  (desktop) or "open this site on your Mac first" guidance (iOS); missing/invalid CF or
+  git token → the existing verify-then-persist reconnect flows.
+- **Concurrent editing** (Mac + phone) → git handles it; per-edit commits keep changes
+  small and rebases clean. The phone pulls on foreground/site-open, the Mac's checkout
+  hydrates as today.
+
+## Testing
+
+- **`AnglesiteMarkdown` (unit, runs on Linux lane):** golden tests scanner → runs for
+  every v1 construct; incremental-restyle equivalence (edited-region restyle ==
+  full-document restyle); checkbox toggle produces exactly the 1-char edit; degenerate
+  inputs (unclosed fences, 10k-line file) don't hang.
+- **Editor round-trip:** typing/styling never mutates the buffer (byte-identity after
+  an edit-free open/close); `TypedEntryEditorModel` save path unchanged.
+- **Draft model:** template fixture tests — `draft: true` entry emits no `dist/` page,
+  no index/feed entry, for each post-family collection; `swift test` template-coupled
+  suites updated (`.strict()` schema additions).
+- **`GitPushPublishPipeline` (unit):** faked git + faked Workers Builds client — happy
+  path, non-FF → rebase, conflict surfaced, CI blocked-envelope parsed, CI plain
+  failure, offline. Same style as `RemoteSandboxSiteRuntime`'s faked control client.
+- **`build:ci` producer test:** fresh scaffold, seeded PII blocker → `npm run build:ci`
+  exits non-zero *after* building; clean scaffold exits zero (extends the #742
+  producer→consumer fixture lane).
+- **One opt-in live e2e** (gated like the container/e2e suites): push a draft-flip
+  commit to a real repo wired to Workers Builds, poll to deployed, assert the post URL
+  is live.
+
+## Phasing
+
+1. **Slice 1 — editor on macOS:** `AnglesiteMarkdown` + `MarkdownTextView` +
+   `.markdown` routing; Format menu + Find (#517). No behavior change to saving.
+2. **Slice 2 — draft/publish model:** template schema + filtering, registry `draft`,
+   drafts-by-default, desktop Publish/Unpublish verbs over the existing container
+   pipeline.
+3. **Slice 3 — push-to-deploy on desktop:** `PublishPipeline` seam, `build:ci` gate,
+   Workers Builds client + onboarding, log streaming. Proves the container-less
+   pipeline where debugging is easy.
+4. **Slice 4 — mobile:** iOS shell grows the local-checkout mode (clone/pull/push via
+   SwiftGit2), ported typed/markdown editors, mobile publish UX. Depends on #71 scope
+   decisions.
+
+Each slice is deterministic Swift/TypeScript end-to-end (no LLM path), per the #459
+direction.
+
+## Out of scope
+
+- WYSIWYG rich-text editing that rewrites Markdown; the Component Editor (#496) owns
+  visual editing of components.
+- Media/photo posting pipeline from mobile (image import + asset commits) — the seam
+  exists (`image` fields, git), but the capture/compression UX is its own design.
+- Micropub as the mobile posting protocol — deliberately *not* chosen here (server-side
+  Micropub is V-3, gated on `@dwk/workers`; this design needs no server component
+  beyond CI). Revisit posting-via-Micropub when V-3 lands.
+- Tables/LaTeX/wiki-link editor affordances; inline image thumbnails (fast-follow).
+- Merging the template `blog` collection with typed `articles` (open question below).
+
+## Open questions (owner input wanted)
+
+1. **Workers Builds API surface** — can the build config be created purely via API
+   once the GitHub↔Cloudflare connection exists? (Determines how hands-off §C.6 is.)
+2. **`blog` vs `articles`** — keep both (blog = simple starter, articles = typed
+   h-entry) or migrate the starter to `articles` and retire `blog`?
+3. **iOS product shape** — does the container-less local-checkout mode *replace* the
+   remote-sandbox thin client as the default iOS experience (sandbox becomes the
+   "power preview" opt-in), or ship alongside it from day one? This spec assumes the
+   former.
+4. **swift-markdown-engine adoption** — if the in-house styler's macOS feel lags the
+   reference, is a scoped adoption of SwiftMarkdownEngine behind the `MarkdownTextView`
+   seam (macOS only, new-dep approval) acceptable as a stopgap?

--- a/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
+++ b/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
@@ -4,10 +4,12 @@
 **Status:** Proposed; owner decisions locked 2026-07-17 during review: (1) mobile
 posting is Micropub, gated on V-3 `@dwk/workers` conformance; (2) bakes are
 **Worker-triggered**; (3) **Cloudflare is canonical for typed content** ("headless
-CMS" model) — this deliberately **re-scopes #72 and reverses C.3's canonicality for
-authored content** (git stays canonical for code/theme; content portability becomes a
-guaranteed continuous export-to-git). Cross-cutting (#340-class); flagged here so the
-reversal is explicit, not absorbed.
+CMS" model) — this deliberately **re-scopes #72 and reverses C.3's canonicality**,
+for authored content and (4, unified) for received interactions too (git stays
+canonical for code/theme; content portability becomes a guaranteed continuous
+export-to-git); (5) the V-3 Worker API includes a **bulk content read endpoint** for
+builds; (6) **export is desktop-only** — mobile has no export path. Cross-cutting
+(#340-class); flagged here so the reversals are explicit, not absorbed.
 **Related:** #517 (Find + Format menu, blocked on editor work) · #288 (template blog system) · #346 (typed form editors) · #68 (repo bootstrap / Publish to GitHub) · #640/#654 (in-process git) · #742 (pre-deploy scan envelope) · #71/#66 (iOS thin client + remote sandbox) · #571 (cross-platform port) · epic #496 (Component Editor, STTextView precedent) · **#334 pivot: V-2 IndieAuth (#355), V-2.1 per-site Worker (#353), V-3 Micropub, V-3.4 snapshot-to-git (#362)** · C.2 workers seam + C.3 canonicality decision docs (2026-06-29)
 
 ## Goal
@@ -235,21 +237,31 @@ Cloudflare-canonical model, a post's life is:
 3. **Export to git (portability guarantee):** C.3's snapshot machinery, demoted from
    canon to **continuous export**: authored posts serialize to full-fidelity
    Markdown + YAML frontmatter (registry schema; `post-status` ⇄ Part B's `draft`)
-   with R2 media alongside. The desktop app syncs exports down into `Source/`
-   (one-way, the #587 `InboxSubmissionSync` shape) and **File ▸ Export** always
-   yields a complete site — code *and* content — so the site outlives Cloudflare.
-   Exports are read-side artifacts: editing an exported file does not write back to
-   the CMS (the API is the write path; the app warns if it detects divergence).
+   with R2 media alongside. **Received interactions unify under the same model**
+   (owner decision, 2026-07-17): D1-canonical, exported to
+   `Source/data/interactions/` in C.3's JSON shape — one canonicality rule for
+   everything the Worker stores, superseding C.3's git-canonical ruling for them.
+   The desktop app syncs exports down into `Source/` (one-way, the #587
+   `InboxSubmissionSync` shape) and **File ▸ Export** always yields a complete
+   site — code *and* content — so the site outlives Cloudflare. **Export is
+   desktop-only** (owner decision, 2026-07-17): mobile is a posting client, not an
+   archival one — there is no mobile export path; content remains in the user's own
+   Cloudflare account and is exportable from any desktop install. Exports are
+   read-side artifacts: editing an exported file does not write back to the CMS
+   (the API is the write path; the app warns if it detects divergence).
 
 **How the builder gets the site without git or GitHub:** the build container needs
 code + content. Content comes from D1 through an **Astro content-layer loader** in
-the template that reads the Worker's content API (drafts filtered server-side; the
-existing zod schemas validate loader output exactly as they validate `glob()` files
-today — un-provisioned sites keep the `glob()` loader and today's behavior). Code
-comes from the **deployed-source bundle**: every desktop deploy uploads the built
-site's `Source/` snapshot to R2 as a one-way artifact. No two-way git mirror, no
-sync protocol — code changes only ever arrive via desktop deploys, content changes
-only ever arrive via the API, so the two lanes never conflict.
+the template that reads the Worker's **bulk content read endpoint** — a decided V-3
+API requirement (owner, 2026-07-17): paginated, draft-filtered server-side, with a
+change cursor for incremental builds (Micropub `q=source` stays the per-post read;
+the bulk endpoint is the build-time read). The existing zod schemas validate loader
+output exactly as they validate `glob()` files today — un-provisioned sites keep the
+`glob()` loader and today's behavior. Code comes from the **deployed-source
+bundle**: every desktop deploy uploads the built site's `Source/` snapshot to R2 as
+a one-way artifact. No two-way git mirror, no sync protocol — code changes only
+ever arrive via desktop deploys, content changes only ever arrive via the API, so
+the two lanes never conflict.
 
 The phone therefore never touches git — **no local clone, no SwiftGit2, no push
 credentials** — and neither does the builder.
@@ -472,24 +484,16 @@ direction.
 
 ## Open questions (owner input wanted)
 
-1. **Bulk content read API for builds** — Micropub's `q=source` is a per-post read;
-   the content-layer loader wants a bulk, paginated content endpoint on the Worker
-   (with draft filtering and a change cursor for incremental builds). Shape belongs
-   to the workers repo; flagged so it lands in V-3's API surface.
-2. **Received interactions** — C.3 made *received* interactions git-canonical via
-   snapshot. With authored content now Cloudflare-canonical, should V-3.4 unify both
-   under the export model for consistency, or is received-interaction canonicality
-   worth keeping distinct? (Not re-decided here.)
-3. **Export transport for mobile-only users** — the desktop app syncs exports into
-   `Source/`; a user who never opens a Mac needs an equivalent guarantee. Is an
-   on-demand complete-site export from the Worker (R2-staged archive the iOS app can
-   save/share) sufficient?
-4. **`blog` vs `articles`** — keep both (blog = simple starter, articles = typed
+Resolved during review (2026-07-17), recorded in §C.4: the bulk content read
+endpoint is a V-3 API requirement; received interactions unify under the
+D1-canonical + export model; export is desktop-only (no mobile export path).
+
+1. **`blog` vs `articles`** — keep both (blog = simple starter, articles = typed
    h-entry) or migrate the starter to `articles` and retire `blog`? (In CMS mode the
    distinction also decides which collections the content import migrates.)
-5. **iOS product shape** — is the Micropub client the *whole* default iOS experience
+2. **iOS product shape** — is the Micropub client the *whole* default iOS experience
    (with the remote-sandbox thin client as the "power preview" opt-in), or do they
    ship together? This spec assumes the former.
-6. **swift-markdown-engine adoption** — if the in-house styler's macOS feel lags the
+3. **swift-markdown-engine adoption** — if the in-house styler's macOS feel lags the
    reference, is a scoped adoption of SwiftMarkdownEngine behind the `MarkdownTextView`
    seam (macOS only, new-dep approval) acceptable as a stopgap?

--- a/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
+++ b/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-17
 **Status:** Proposed (brainstorm output; needs owner sign-off before implementation)
-**Related:** #517 (Find + Format menu, blocked on editor work) · #288 (template blog system) · #346 (typed form editors) · #68 (repo bootstrap / Publish to GitHub) · #640/#654 (in-process git) · #742 (pre-deploy scan envelope) · #71/#66 (iOS thin client + remote sandbox) · #571 (cross-platform port) · epic #496 (Component Editor, STTextView precedent)
+**Related:** #517 (Find + Format menu, blocked on editor work) · #288 (template blog system) · #346 (typed form editors) · #68 (repo bootstrap / Publish to GitHub) · #640/#654 (in-process git) · #742 (pre-deploy scan envelope) · #71/#66 (iOS thin client + remote sandbox) · #571 (cross-platform port) · epic #496 (Component Editor, STTextView precedent) · **#334 pivot: V-2 IndieAuth (#355), V-2.1 per-site Worker (#353), V-3 Micropub, V-3.4 snapshot-to-git (#362)** · C.2 workers seam + C.3 canonicality decision docs (2026-06-29)
 
 ## Goal
 
@@ -18,7 +18,10 @@ Two coupled pieces:
    no Node, no subprocesses; the phone only makes HTTPS calls — and where **Cloudflare
    is the only required third-party dependency** (owner decision, 2026-07-17). The user
    already needs a Cloudflare account to host the site; publishing must not
-   additionally require GitHub or any other git host.
+   additionally require GitHub or any other git host. **Mobile posting is gated on the
+   V-3 `@dwk/workers` conformance milestone and uses Micropub as the posting protocol**
+   (owner decision, 2026-07-17) — the pivot's own standards-based posting API, rather
+   than any bespoke Anglesite transport.
 
 ## Current state this builds on
 
@@ -33,10 +36,13 @@ Two coupled pieces:
 | iOS today is a preview `WKWebView` shell only — no editor, no files, no app entry point | `Sources/AnglesiteIOS/` |
 | Post-deploy Webmention/POSSE steps are pure Swift + HTTP | `DeployModel.swift:373-386`, `WebmentionSendCommand`, `POSSESyndicationCommand` |
 
-The two facts that make the mobile story cheap: **git is already in-process** (libgit2
-builds for iOS; the sandbox forced this on macOS, and iOS inherits it for free), and
-**git is already the source of truth** (#72) — the app's working copy is explicitly
-non-canonical, so a phone holding its own clone is architecturally normal, not a hack.
+Two pivot decisions this design leans on directly: the **C.2 workers seam** (per-site
+Cloudflare Worker composing `@dwk/*` packages — `@dwk/micropub` at `/micropub` in V-3 —
+with `WorkersConformanceReader`/`gateStatus(for:)` already in AnglesiteCore to gate
+feature enablement), and **C.3 canonicality** ("git-canonical, D1-operational": the
+Worker's store is operational, git is the durable archive, reconciled by a
+snapshot-to-git step — the V-3.4/#362 flow, with #587's inbox capture + `InboxSubmissionSync`
+commit-back as the shipped precedent).
 
 ## Part A — the Markdown editor
 
@@ -124,39 +130,51 @@ work identically against both since both are Markdown + frontmatter collections.
 
 ### C.1 Invariant
 
-On every platform: **publish = commits on `Source/` + a deterministic pipeline that ends
-in a deploy, with the pre-deploy security gate running somewhere the client cannot
-skip, and build logs surfaced** (logs are sacred). No LLM in the loop anywhere.
+On every platform: **published content ends up as commits in `Source/` (directly on
+desktop; via the C.3 snapshot for Micropub), and reaches the live site only through a
+deterministic build whose pre-deploy security gate no client can skip, with build logs
+surfaced** (logs are sacred). No LLM in the loop anywhere.
 
-### C.2 One seam, two strategies — Cloudflare-only by requirement
+### C.2 Decision: mobile posting is Micropub, gated on V-3 workers
 
-GitHub cannot be load-bearing anywhere in the required path. That rules out Cloudflare
-Workers Builds as the container-less pipeline — Workers Builds only connects to
-GitHub/GitLab repos, so a design built on it silently reintroduces a git-host account
-as a prerequisite. Instead, the container-less path runs entirely against services in
-the **user's own Cloudflare account** (§C.4). GitHub stays what it already is via
-RepoBootstrap (#68): an optional mirror/collaboration surface, never a requirement.
+GitHub cannot be load-bearing anywhere in the required path, and (owner decision,
+2026-07-17) **Anglesite does not invent its own container-less publishing transport
+either**. The container-less posting protocol is **Micropub** — the W3C posting API
+the Personal Publishing OS pivot (#334) already ships in V-3 as `@dwk/micropub` on the
+per-site Worker (C.2 seam doc), authenticated by IndieAuth (V-2, #355). Mobile posting
+is therefore **feature-gated on V-3 `@dwk/workers` conformance**, using the
+`WorkersConformanceStatus.gateStatus(for:)` machinery that already exists for exactly
+this purpose: until V-3's packages are release-ready, the app does not offer mobile
+publishing (BBEdit-style honest labeling, not a silent degraded path).
 
-A `PublishPipeline` protocol in AnglesiteCore with two implementations:
+Why Micropub and not a bespoke transport (or the 2000s posting APIs):
 
-- **`ContainerPublishPipeline`** — the existing desktop path, unchanged:
+- **It's already on the roadmap** — building it for third-party clients and *not*
+  using it for our own mobile client would mean maintaining two posting paths.
+- **mf2-native** — Micropub's vocabulary (h-entry properties, `mp-slug`,
+  `post-status`, media endpoint) maps 1:1 onto the content-type registry's h-entry
+  projections; nothing is lossy for the post-family types.
+- **Cloudflare-only holds** — the per-site Worker, D1, R2, and the self-hosted
+  IndieAuth endpoint all live in the user's own Cloudflare account. No GitHub, no
+  git host, no extra accounts.
+- **Third-party clients come free** — any Micropub client (including modern MarsEdit)
+  can post to the user's site through the same endpoint the Anglesite app uses.
+- **MetaWeblog / AtomPub were considered and rejected** — both assume a server-side
+  CMS that owns content (inverting #72's git canonicality), can't round-trip
+  Markdown + YAML frontmatter byte-faithfully (XML-RPC HTML strings / Atom XML
+  entries), have no typed-content or draft vocabulary matching the registry, and
+  their client ecosystem has moved to Micropub anyway.
+
+The `PublishPipeline` seam in AnglesiteCore then has two shapes:
+
+- **`ContainerPublishPipeline`** (desktop) — the existing path, unchanged:
   `DeployCommand` runs build → pre-deploy scan (#742 envelope, `.blocked` is final) →
-  `wrangler deploy` inside the container runtime. Fast local iteration, no push
-  required.
-- **`CloudPublishPipeline`** — the container-less path: commit → pull
-  (fast-forward/rebase) → push to the site's **Anglesite-provisioned git origin in the
-  user's Cloudflare account** (§C.4) → the origin's publish service builds, gates, and
-  deploys in an ephemeral Cloudflare Sandbox → the app polls the control Worker for
-  status and streams the build log into the debug pane.
-
-Mobile only has the second. Desktop gets both — push-to-publish is also the natural fit
-for the Linux/Windows ports (#571) and for users who never provision the container
-runtime. `DeployModel` picks the strategy the way it picks `ContainerDeployExecutor`
-today.
-
-**Optional Workers Builds variant:** when a site *does* have a GitHub remote (the user
-ran Publish to GitHub), Workers Builds can drive the same `build:ci` entry point (§C.3)
-off pushes to that remote. Nice-to-have, not v1-required, and never the default.
+  `wrangler deploy` inside the container runtime. Fast local iteration, no server
+  round-trip.
+- **`MicropubClient`** (container-less; iOS, and any future thin client) — not a
+  build pipeline at all: a typed client of the site's own `/micropub` endpoint
+  (create / update / delete, `post-status` for drafts, media endpoint for images),
+  with the Worker-side snapshot-to-git + bake closing the loop (§C.4).
 
 ### C.3 Moving the gate server-side (template change, app-only)
 
@@ -167,89 +185,84 @@ The template's CI story gets a `build:ci` script:
 "build:ci": "npm run build && npx tsx scripts/pre-deploy-check.ts --json --strict"
 ```
 
-`build:ci` is the single server-side entry point: the publish service (§C.4) runs it,
-and so does the optional Workers Builds variant when a GitHub remote exists. The scan
-runs **after** the build (it inspects `dist/`, matching `DeployCommand`'s ordering) and
-a blocker exits non-zero, so **the deploy step never runs**. This is strictly stronger
-than today's posture: the gate becomes unbypassable from *any* client — the app, a
-laptop with `git push`, or a compromised device — rather than being enforced by app
-code. The desktop container path keeps its local preflight too (better UX: blocked
-before pushing anything). The scan's `--json` envelope (#742) is emitted into the build
-log; on failure the app extracts it when present and renders the existing
-`Phase.blocked` UI, falling back to a raw log excerpt for ordinary build errors.
+`build:ci` is the single entry point for every non-interactive runner — whatever bake
+substrate V-3 settles on (§C.4), and Workers Builds if a site happens to have a GitHub
+mirror. The scan runs **after** the build (it inspects `dist/`, matching
+`DeployCommand`'s ordering) and a blocker exits non-zero, so **the deploy step never
+runs**. Micropub-authored content gets the same treatment: it only reaches the static
+site through a bake, so the gate covers it with no special-casing — and Micropub input
+is additionally constrained upstream by the typed vocabulary (no script injection
+surface a form field wouldn't also have). The scan's `--json` envelope (#742) is
+emitted into the build log; on failure the app extracts it when present and renders
+the existing `Phase.blocked` UI, falling back to a raw log excerpt for ordinary build
+errors.
 
-### C.4 The git origin + publish service (user's Cloudflare account)
+### C.4 The Micropub data path (per-site Worker, user's Cloudflare account)
 
-The piece that removes GitHub from the requirements: a small, Anglesite-maintained
-**site-services Worker** the user deploys into their own account **once**, via the
-Deploy-to-Cloudflare button — the same provisioning shape (and plausibly the same
-template repo) as the 2026-06-23 remote-sandbox design. It provides, per site:
+The server side is the pivot's per-site Worker (V-2.1, #353 — `@dwk/micropub` at
+`/micropub`, IndieAuth at `/.well-known/indieauth`, D1 + R2 bindings), not anything
+new this spec invents. What this spec pins down is how a Micropub post becomes site
+content, following the **C.3 canonicality decision** ("git-canonical,
+D1-operational") end to end:
 
-- **A durable git origin.** Bare repos live in **R2**; a per-site Durable Object owns
-  each one. Serving uses *real git*, not a pack-protocol reimplementation in Workers
-  JS: the control Worker wakes an ephemeral Sandbox that restores the bare repo from
-  R2 and serves **git smart HTTP** (`git http-backend`) behind the token-checking auth
-  proxy; after a push, the repo syncs back to R2 *before* the push is reported
-  successful. Because it speaks standard smart HTTP with a token, any git client can
-  clone and push it — #72's "clonable anywhere" invariant holds with zero GitHub
-  involvement.
-- **The publish pipeline.** A push to the origin (or an explicit publish RPC) makes
-  the service check out the pushed ref in the sandbox, run `npm run build:ci` (§C.3 —
-  build, then the pre-deploy gate), and on success `wrangler deploy` in-sandbox with
-  the account's token. The control Worker exposes status + build logs for the app to
-  poll and stream (logs are sacred, on every platform).
+1. **Accept (operational):** the Micropub endpoint validates the IndieAuth token,
+   stores the post in D1 (media uploads → R2 via the media endpoint), and assigns the
+   permalink from `mp-slug`/type rules. `post-status: draft` posts are stored but
+   never rendered publicly.
+2. **Snapshot to git (canonical):** the V-3.4 (#362) snapshot step serializes
+   authored posts into `Source/src/content/<collection>/<slug>.md` — **full-fidelity
+   Markdown + YAML frontmatter matching the registry schema** (unlike received
+   interactions, which snapshot as truncated JSON; authored content is first-class),
+   with `post-status` mapping onto Part B's `draft` field and R2 media committed as
+   site assets. From that commit on, the post is ordinary content — editable in the
+   Mac app, any git clone, or via Micropub `q=source` + update (which round-trips
+   through the same snapshot).
+3. **Bake:** the post reaches the *published* static site at the next build + deploy
+   (`build:ci`, §C.3 — the gate always runs). What triggers a bake after a mobile
+   post — the next desktop deploy, a Worker-triggered build substrate, or "fresh
+   posts render dynamically until the next bake" via the ESI seam
+   (`@dwk/esi` + the 2026-07-13 ESI components) — is a **V-3 epic decision, not
+   re-decided here** (open question 1). This spec only requires that some bake path
+   exists and that drafts never reach `dist/`.
 
-Boundaries and posture:
-
-- This sandbox is **ephemeral compute in the user's Cloudflare account, not a
-  container on the device** — the phone still only makes HTTPS calls, so the
-  no-containers-on-mobile constraint holds. It is distinct from the remote *preview*
-  sandbox (#66), which stays an opt-in live dev-server session; the publish sandbox
-  runs for seconds-to-minutes per publish, then sleeps. Disk loss on sleep is
-  immaterial — R2 is the durable home and the sandbox is always reconstructable from
-  it (the same cold-hydrate posture #66 already accepted).
-- **Single-writer safety:** the per-site DO serializes pushes; the R2 sync completes
-  before receive-pack's response is released, so a crash mid-push means the client
-  re-pushes — the R2 copy is never a torn state.
-- **Billing honesty:** Cloudflare Sandboxes/Containers require the Workers paid plan.
-  That is a real cost floor for container-less publishing, but it is a *Cloudflare*
-  cost on the account the user already bills for hosting — consistent with the BYO
-  "user bills, zero Anglesite-operated infra" posture. Surfaced plainly in onboarding,
-  never a silent failure.
+The app-side precedent for step 2's commit-back is shipped code: #587's
+`InboxSubmissionSync` (Worker staging → app-side git commit). Whether V-3.4's
+snapshot commits Worker-side or app-side follows that epic's design; either way the
+phone itself never touches git — **mobile needs no local clone, no SwiftGit2, no
+push credentials**, which is the big simplification Micropub buys over any git-based
+mobile transport.
 
 ### C.5 Mobile flow end-to-end (no containers on the device, Cloudflare only)
 
-**Prerequisite:** the site has its Cloudflare origin (§C.4) — set up from any device
-that has the site, typically the Mac, which pushes `Source/` to the origin when
-cloud publishing is enabled. A site that exists only on one Mac's disk is not
-reachable from a phone *by design* (git is the sync layer; there is no bespoke
-Anglesite sync protocol — the origin just lives in the user's Cloudflare account
-instead of on a git host).
+**Prerequisites:** the site's per-site Worker is provisioned with V-2/V-3 features
+enabled (§C.7), and `WorkersConformanceStatus.gateStatus(for:)` reports V-3 ready —
+otherwise mobile publishing is not offered at all (clearly labeled as requiring the
+site's social features, never a silent failure).
 
-1. **Onboarding (once):** connect Cloudflare with the existing verify-then-persist
-   `TokenOnboarding` pattern; provision the site-services Worker via the
-   Deploy-to-Cloudflare button (§C.7); pick the site and **shallow clone** `Source/`
-   from its origin into the app's container directory via SwiftGit2 (libgit2 is
-   already the Darwin git path; no subprocess involved). No GitHub sign-in exists in
-   this flow.
-2. **Edit:** the same navigator-lite → `TypedEntryEditorView` (ported off
-   `NSOpenPanel`/`NSWorkspace` onto `fileImporter`/`PhotosPicker`) with
-   `MarkdownTextView` bodies. `FrontmatterDocument` round-trip, per-edit commits —
-   identical code, running against the local checkout. Offline editing works fully;
-   commits accumulate locally.
-3. **Draft reading:** the styled editor *is* the draft surface. There is **no fake
-   local preview** — rendering Markdown to HTML app-side would be a second Markdown
-   implementation that diverges from Astro's, shown in site-unlike CSS. Honest
-   labeling over simulation. True preview = the deployed site post-publish (drafts
-   never deploy), or the remote sandbox for users who separately opt into it.
-4. **Publish:** flip draft (§B.3) → `pull --rebase` → push to the origin → the publish
-   service builds, gates, deploys (§C.4) → app polls status, streams the log, and on
-   success runs the Webmention/POSSE post-deploy steps app-side (pure Swift + HTTP,
-   fully portable — same code desktop runs today).
+1. **Onboarding (once):** enter the site URL → the app discovers the `micropub` +
+   IndieAuth endpoints from the site's own markup/well-knowns (standard Micropub
+   client discovery) → IndieAuth sign-in (`ASWebAuthenticationSession`; the user
+   authenticates against *their own site*) → token in the Keychain. No GitHub, no
+   git credentials, no clone.
+2. **Compose:** `MarkdownTextView` (Part A) as the body surface plus the
+   registry-driven typed fields (Part B's schema, rendered with the
+   `TypedEntryEditorView` control mapping ported to iOS idioms —
+   `PhotosPicker`/`fileImporter` instead of `NSOpenPanel`). Offline composing works;
+   unsent posts persist locally as queued drafts and are labeled as *local* drafts
+   (distinct from server-side `post-status: draft`).
+3. **Post / draft:** submit via Micropub — `post-status: draft` for drafts,
+   `mp-slug` derived the same way `NativeContentOperations` derives slugs, media
+   through the media endpoint to R2. Editing an existing post = `q=source` fetch →
+   edit → Micropub update; the snapshot step (§C.4) round-trips it into git.
+4. **Publish:** flip the post to published (Micropub update of `post-status`) → the
+   Worker snapshot + bake path takes over (§C.4); the app reflects the state honestly
+   ("published — goes live with the next site build" until the bake confirms, then
+   the live URL). Webmention/POSSE for micropub-authored posts ride V-3's
+   server-side machinery rather than the app-side desktop commands.
 
-Creating a *new* site from the phone is feasible under this design (the template is an
-app resource; scaffold + `git init` + push to a fresh origin need no Node — `npm ci`
-happens server-side in `build:ci`), but it is a follow-on, not part of this slice.
+There is **no fake local preview** — rendering Markdown to HTML app-side would be a
+second Markdown implementation diverging from Astro's, shown in site-unlike CSS. The
+styled editor is the draft surface; the deployed site is the truth.
 
 ### C.6 Desktop flow
 
@@ -259,23 +272,16 @@ publish commits then triggers whichever `PublishPipeline` the site is configured
 The container path's dev-server preview keeps showing drafts (dev mode renders
 `draft: true` entries with a "Draft" badge — dev-only, filtered from builds).
 
-### C.7 Provisioning (one-time, Cloudflare only)
+### C.7 Provisioning (V-2.1, reused as-is)
 
-Two steps, both against Cloudflare and nothing else:
-
-1. **API token** — the existing verify-then-persist `TokenOnboarding` flow
-   (Keychain-stored, verified before use), with scopes extended to cover the
-   site-services Worker's needs (Workers scripts, DO, R2).
-2. **Site-services Worker** — deployed into the user's account via the
-   Deploy-to-Cloudflare button against the Anglesite template repo (browser OAuth to
-   *Cloudflare*, hosted build — the exact mechanism the remote-sandbox design already
-   locked, because a phone can't run wrangler or build images). The app then verifies
-   with a status RPC and registers the site's origin URL.
-
-Per-site enablement afterward is a single control-Worker call (create the DO + R2
-prefix + origin URL). If the user later runs Publish to GitHub (#68), that adds a
-mirror remote and unlocks the optional Workers Builds variant; nothing in the required
-path changes.
+Nothing new: enabling mobile publishing for a site *is* enabling the site's social
+features — the V-2.1 (#353) provisioning sequence run from the desktop app (existing
+`keychainTokenSource` token → D1 database → R2 bucket → `wrangler.toml` bindings →
+`worker/worker.ts` composition with `@dwk/micropub` + IndieAuth enabled → deploy).
+All of it is against the user's own Cloudflare account; the conformance gate
+(`workers-version.json` + `gateStatus(for:)`) decides when the app offers it. If the
+user later runs Publish to GitHub (#68), that remains an optional mirror; nothing in
+this path references a git host.
 
 ## Data flow
 
@@ -288,47 +294,48 @@ path changes.
                                         └─► wrangler deploy → URL         │
                                         └─► push origin (background)      │
                     └──────────────────────────────────────────────────────┘
-                    ┌── iOS / container-less (Cloudflare only) ───────────┐
- edit local clone (MarkdownTextView)                                      │
-   → save → commit (SwiftGit2, offline-safe)                              │
-   → Publish: draft:false + commit → pull --rebase                        │
-   → push → git origin (user's CF acct: DO + R2 bare repo,                │
-       │     smart HTTP via git http-backend in ephemeral sandbox)        │
-       └─► publish service (same sandbox): npm run build:ci               │
-             build → pre-deploy-check --strict ✗→ deploy never runs       │
-             └─► wrangler deploy → app polls status + streams log         │
-                  └─► app-side Webmention/POSSE on success                │
+                    ┌── iOS / container-less (Micropub, gated on V-3) ────┐
+ compose (MarkdownTextView + typed fields, offline-queued)                │
+   → Micropub create/update (post-status: draft|published,               │
+       │   media → R2)  [IndieAuth token, user's own site]                │
+       └─► per-site Worker: D1 (operational store)                        │
+             └─► V-3.4 snapshot → Source/src/content/<coll>/<slug>.md     │
+                   (git canonical; draft ⇄ post-status)                   │
+             └─► bake: npm run build:ci                                   │
+                   build → pre-deploy-check --strict ✗→ deploy never runs │
+                   └─► deploy → post live; app reflects state             │
                     └──────────────────────────────────────────────────────┘
 ```
 
 ## Error handling & edge cases
 
-- **Non-fast-forward push** → automatic `pull --rebase`; on conflict, a per-file
-  keep-mine/keep-theirs sheet scoped to content files (the same conflict posture as
-  `FileEditorModel`'s external-change flow). Never silent merge, never force-push.
-- **Pipeline build failure** → distinguish gate-blocked (scan envelope found in the log
-  → existing blocked-deploy UI with categories/remediation) from plain build errors
-  (log excerpt + link to full log). A failed pipeline run leaves the previous deploy
-  live — static hosting's natural atomicity.
-- **Cold starts** → pushing/publishing may wake the sandbox; the publish UI shows
-  determinate-ish states (waking → pushing → building → checking → deploying), the
-  same progress posture as #66's `.starting`.
+- **Conformance gate not met** → mobile publishing simply isn't offered; the UI names
+  the requirement ("needs this site's social features — V-3") rather than degrading.
+  `gateStatus(for:)` is checked at feature-surface time, not buried in a failed post.
+- **Micropub request failures** → endpoint unreachable / 5xx → the post stays a local
+  queued draft with explicit retry; 401/403 → IndieAuth re-auth flow
+  (verify-then-persist posture, matching `TokenOnboarding`); validation errors from
+  the endpoint → surfaced against the offending field (the typed form knows which one).
+- **Offline** → composing and local drafts fully work; sending is disabled with an
+  explicit "waiting for network" state; queued posts are visibly queued, never
+  silently held.
+- **Snapshot/bake lag** → an accepted post that hasn't baked yet shows as
+  "published — awaiting site build," with the D1-accepted state as evidence; the app
+  never fakes a live URL before the bake confirms it.
+- **Bake build failure** → distinguish gate-blocked (scan envelope → existing
+  blocked-deploy UI with categories/remediation) from plain build errors (log excerpt
+  + full log). A failed bake leaves the previous deploy live — static hosting's
+  natural atomicity.
 - **Draft leakage backstop** → optional pre-deploy-check addition: fail if any
-  `draft: true` source entry has a corresponding page in `dist/` (cheap route check;
-  belt-and-suspenders on top of route/feed filtering).
-- **Schema errors authored on mobile** (no `astro check` locally) → surface at CI with
-  the file/line from Astro's error output; mitigated up front because the form editor +
-  registry constrain typed fields to valid shapes.
-- **Offline** → editing and committing fully work; Publish is disabled with an explicit
-  "waiting for network" state, never queued silently.
-- **Missing prerequisites** → no Cloudflare origin → route to site-services
-  provisioning (§C.7) on desktop, or "enable cloud publishing on your Mac first"
-  guidance on iOS; missing/invalid token → the existing verify-then-persist reconnect
-  flows; Workers plan lacks container support → explicit upgrade guidance, never a
-  silent retry loop.
-- **Concurrent editing** (Mac + phone) → git handles it; per-edit commits keep changes
-  small and rebases clean. The phone pulls on foreground/site-open, the Mac's checkout
-  hydrates as today.
+  `draft: true` source entry (or unsnapshotted `post-status: draft` record) has a
+  corresponding page in `dist/` (cheap route check; belt-and-suspenders on top of
+  route/feed filtering).
+- **Concurrent editing** (Mac edits the file, phone edits via Micropub) → C.3's rule
+  applies: the snapshot is idempotent and **git wins on divergence**; a Micropub
+  update against a post whose file changed since its last snapshot is rejected with a
+  refresh (`q=source` re-fetch) rather than silently clobbering the git-side edit.
+- **Media constraints** → media-endpoint upload failures and R2 size limits surface
+  per-attachment with retry; a post never partially publishes with missing media.
 
 ## Testing
 
@@ -341,20 +348,25 @@ path changes.
 - **Draft model:** template fixture tests — `draft: true` entry emits no `dist/` page,
   no index/feed entry, for each post-family collection; `swift test` template-coupled
   suites updated (`.strict()` schema additions).
-- **`CloudPublishPipeline` (unit):** faked git + faked site-services control client —
-  happy path, non-FF → rebase, conflict surfaced, blocked-envelope parsed, plain build
-  failure, offline, cold-start states. Same style as `RemoteSandboxSiteRuntime`'s
-  faked `SandboxControlClient`.
-- **Site-services Worker (its own repo's suite):** origin round-trip — clone/push
-  against the served smart HTTP with a stock git client; push → R2 sync ordering;
-  DO-serialized concurrent pushes; publish RPC drives `build:ci` and reports the
-  envelope.
+- **`MicropubClient` (unit, AnglesiteCore):** faked endpoint — create/update/delete,
+  `post-status` draft⇄published, `mp-slug` derivation matches
+  `NativeContentOperations` slugs, media-endpoint flow, `q=source` round-trip,
+  401 → re-auth, 5xx → queued retry, offline queue. Same faked-seam style as
+  `RemoteSandboxSiteRuntime`'s `SandboxControlClient` tests.
+- **Conformance gating (unit):** feature surface hidden/shown correctly from
+  `WorkersConformanceStatus` fixtures (machinery already exists; these tests cover
+  the new consumer).
+- **Snapshot fidelity (cross-repo, V-3.4's suite + a fixture here):** a Micropub
+  create/update serializes to Markdown + frontmatter that parses back through
+  `FrontmatterDocument`/the registry schema losslessly, and `post-status` maps to
+  `draft` exactly.
 - **`build:ci` producer test:** fresh scaffold, seeded PII blocker → `npm run build:ci`
   exits non-zero *after* building; clean scaffold exits zero (extends the #742
   producer→consumer fixture lane).
 - **One opt-in live e2e** (gated like the container/e2e suites, real Cloudflare
-  account): provision, push a draft-flip commit to the origin, poll to deployed,
-  assert the post URL is live and a re-clone of the origin matches the local repo.
+  account, once V-3 packages exist): provision a site's Worker, post via Micropub,
+  assert D1 accept → git snapshot → post-bake live URL, and that a draft never
+  appears in `dist/`.
 
 ## Phasing
 
@@ -363,14 +375,17 @@ path changes.
 2. **Slice 2 — draft/publish model:** template schema + filtering, registry `draft`,
    drafts-by-default, desktop Publish/Unpublish verbs over the existing container
    pipeline.
-3. **Slice 3 — Cloudflare publish services + desktop push-to-publish:** the
-   site-services Worker (git origin + publish pipeline, its own template repo),
-   `PublishPipeline` seam, `build:ci` gate, provisioning + log streaming in the Mac
-   app. Proves the whole container-less pipeline where debugging is easy — the phone
-   adds no new moving parts server-side.
-4. **Slice 4 — mobile:** iOS shell grows the local-checkout mode (clone/pull/push via
-   SwiftGit2 against the Cloudflare origin), ported typed/markdown editors, mobile
-   publish UX. Depends on #71 scope decisions.
+3. **Slice 3 — `build:ci` + bake groundwork:** the template `build:ci` script and
+   envelope-from-log parsing, exercised by the desktop pipeline now so the gate
+   contract is proven before any server-side runner consumes it.
+4. **Slice 4 — mobile Micropub client** *(gated on V-3 `@dwk/workers` conformance —
+   blocked until that milestone is green, like every V-3 feature)*: `MicropubClient`
+   in AnglesiteCore, IndieAuth onboarding, iOS compose UI (ported typed/markdown
+   editors), post/draft/publish flows. The snapshot-to-git and bake-trigger work is
+   V-3.4's (#362), not this spec's — slice 4 consumes it.
+
+Slices 1–3 have no dependency on the workers repo and can land now; slice 4 is the
+gated feature.
 
 Each slice is deterministic Swift/TypeScript end-to-end (no LLM path), per the #459
 direction.
@@ -379,32 +394,36 @@ direction.
 
 - WYSIWYG rich-text editing that rewrites Markdown; the Component Editor (#496) owns
   visual editing of components.
-- Media/photo posting pipeline from mobile (image import + asset commits) — the seam
-  exists (`image` fields, git), but the capture/compression UX is its own design.
-- Micropub as the mobile posting protocol — deliberately *not* chosen here (server-side
-  Micropub is V-3, gated on `@dwk/workers`; this design's only server component is the
-  site-services Worker, which is git + build, not a posting API). Revisit
-  posting-via-Micropub when V-3 lands.
-- The Workers Builds variant for GitHub-mirrored repos (§C.2) — optional follow-on.
+- Media/photo posting *UX* from mobile — the transport is settled (Micropub media
+  endpoint → R2 → committed as assets at snapshot), but capture/compression/alt-text
+  UX is its own design.
+- **Git as the mobile transport** — an earlier revision of this spec designed a
+  phone-side SwiftGit2 clone pushing to a bespoke R2-backed git origin + build
+  sandbox in the user's Cloudflare account. Superseded by the Micropub decision
+  (§C.2): it duplicated the posting API the pivot already ships, required paid-plan
+  containers, and put git plumbing on the phone for no user-visible gain. Desktop
+  git workflows are untouched; only the *mobile transport* changed.
+- MetaWeblog / AtomPub — rejected, rationale recorded in §C.2.
+- Workers Builds for GitHub-mirrored repos — optional follow-on, never the default.
 - Tables/LaTeX/wiki-link editor affordances; inline image thumbnails (fast-follow).
 - Merging the template `blog` collection with typed `articles` (open question below).
 
 ## Open questions (owner input wanted)
 
-1. **Site-services template home** — its own repo, or folded into the #66
-   remote-sandbox Deploy-to-Cloudflare template so one provisioning pass yields one
-   "Anglesite Cloud" Worker offering both preview sessions and origin/publish? (One
-   template is friendlier; one repo per concern is simpler to version.)
-2. **`blog` vs `articles`** — keep both (blog = simple starter, articles = typed
+1. **Bake trigger after a mobile post** (V-3 epic decision, flagged here): next
+   desktop deploy only, a Worker-triggered build substrate, or fresh posts rendered
+   dynamically until the next bake via the ESI seam (`@dwk/esi` + the 2026-07-13 ESI
+   components)? This spec only requires *some* bake path with the gate in it.
+2. **Snapshot commit-back locus for a mobile-only user** — #587's precedent commits
+   app-side (a Mac pulls staged submissions into git). If no Mac opens for weeks,
+   micropub posts live only in D1 (operational) — is that acceptable interim state,
+   or does V-3.4 need a Worker-side commit path (which reopens the "what repo can the
+   Worker push to without GitHub" question)?
+3. **`blog` vs `articles`** — keep both (blog = simple starter, articles = typed
    h-entry) or migrate the starter to `articles` and retire `blog`?
-3. **iOS product shape** — does the container-less local-checkout mode *replace* the
-   remote-sandbox thin client as the default iOS experience (sandbox becomes the
-   "power preview" opt-in), or ship alongside it from day one? This spec assumes the
-   former.
-4. **swift-markdown-engine adoption** — if the in-house styler's macOS feel lags the
+4. **iOS product shape** — is the Micropub client the *whole* default iOS experience
+   (with the remote-sandbox thin client as the "power preview" opt-in), or do they
+   ship together? This spec assumes the former.
+5. **swift-markdown-engine adoption** — if the in-house styler's macOS feel lags the
    reference, is a scoped adoption of SwiftMarkdownEngine behind the `MarkdownTextView`
    seam (macOS only, new-dep approval) acceptable as a stopgap?
-5. **Workers paid-plan floor** — is requiring the paid plan for container-less
-   publishing acceptable for v1, or does that justify prioritizing the Workers Builds
-   variant (free tier, but GitHub-gated) as a cost fallback for users who *choose* a
-   GitHub mirror?


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md` — a spec-only PR, no code changes. All questions the spec raised were resolved with the owner during review (2026-07-17); the spec now carries a decision log instead of open questions.
- **Part A — Markdown editor:** a live-styled Markdown editor for post bodies in the spirit of [nodes-app/swift-markdown-engine](https://github.com/nodes-app/swift-markdown-engine) (attribute-only styling of raw source, byte-faithful buffer, task checkboxes). The substrate is decided by a **mandatory package-survey spike** before any in-house code — A.1 carries a candidate table (SwiftMarkdownEngine, STTextView+Neon [already approved/shipping], Runestone, SwiftDown, Marklight, MarkupEditor, swift-markdown-ui, apple/swift-markdown, SwiftUI TextEditor+AttributedString) with hands-on acceptance criteria; STTextView + an in-house styling core is the leading hypothesis. Unblocks #517 (Format menu + Find).
- **Part B — draft model:** `draft` across the post-family collections + registry; new posts are drafts; both `blog` and `articles` collections stay; one vocabulary across storage modes (`draft` frontmatter / Micropub `post-status`).
- **Part C — publishing (owner decisions locked):** posting for provisioned sites is **Micropub, gated on V-3 `@dwk/workers` conformance**, and the Micropub client **is the default iOS experience** (full site editing on mobile — remote container on iOS, on-device on Android — is v2.0). Bakes are **Worker-triggered** (ephemeral build container runs `build:ci` → the pre-deploy gate always runs → deploy). **Cloudflare is canonical for typed content** ("headless CMS") — deliberately re-scoping #72 and reversing C.3's canonicality, with received interactions **unified** under the same D1-canonical + export model. The V-3 Worker API includes a **bulk content read endpoint** (paginated, draft-filtered, change cursor) as the loader's build-time read. **Export is desktop-only**; File ▸ Export always yields a complete site. The builder needs no git host: code from a one-way deployed-source bundle in R2, content from D1 via the loader. Mac and iOS typed-content edits share one `MicropubClient` write path; un-provisioned sites keep today's all-git model unchanged. Cloudflare remains the only required third-party dependency. MetaWeblog/AtomPub, phone-side git transport, and option A (git-canonical + two-way Cloudflare mirror) are recorded as considered-and-rejected.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> Docs-only design spec; no MCP schema or sidecar impact. The template changes it proposes (`Resources/Template/`) are app-only per the two-repo coordination rules. The server-side pieces it consumes (`@dwk/micropub`, IndieAuth, bulk content API, Worker-triggered bake, export) are `davidwkeith/workers` deliverables tracked by the existing conformance gating, not paired-PR machinery. ⚠️ Note for review: the spec explicitly reverses the C.3 canonicality decision (authored content + received interactions) and re-scopes #72 — flagged in its Status block.

## Test plan

- [ ] `swift test --package-path .` — N/A (docs-only, no source changes)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — N/A (docs-only)
- [x] Manual smoke (if UI-touching): N/A — reviewed the spec renders correctly as Markdown; verified file/line references against the current checkout (`EditorKind`, `DeployCommand`, `NativeContentOperations`, `Package.swift` STTextView/SwiftGit2 pins, template `content.config.ts`) and cross-checked the pivot decision docs (C.2 seam, C.3 canonicality, #587 inbox capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Roq2fYuSVWpUZSN4UGpCRg