### PR TITLE
feat(component-editor): media-query editing, viewport presets, duplicate & modify (#495)

### DIFF
--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -20,6 +20,10 @@ struct ComponentEditorContext {
     /// component instance to edit its own definition" (spec §4.1). `nil` in
     /// tests/previews that don't need navigation.
     var onOpenFile: ((FileRef) -> Void)? = nil
+    /// Duplicates a project-relative `.astro` component path, returning the new file's path/name
+    /// on success (design spec §6.3: "duplicate-and-modify"). `nil` in tests/previews that don't
+    /// need it — `ComponentEditorModel.duplicateComponent(path:)` no-ops when this is `nil`.
+    var duplicateComponent: ((String) async -> ContentCreateResult)? = nil
 }
 
 @MainActor
@@ -69,7 +73,11 @@ final class ComponentEditorModel {
     }
 
     /// Path of this component relative to the site's Source/ root.
-    var relativePath: String {
+    var relativePath: String { relativePath(for: file) }
+
+    /// Project-relative path of `file` under `context.sourceRoot` — the general form of
+    /// `relativePath` above (which is always `relativePath(for: self.file)`).
+    private func relativePath(for file: FileRef) -> String {
         let root = context.sourceRoot.path(percentEncoded: false)
         let full = file.url.path(percentEncoded: false)
         guard full.hasPrefix(root) else { return file.name }
@@ -140,6 +148,24 @@ final class ComponentEditorModel {
     func openReferencedComponent(tag: String?) {
         guard let tag, let match = projectComponents.first(where: { $0.name == "\(tag).astro" }) else { return }
         context.onOpenFile?(match)
+    }
+
+    /// Duplicates `path` (a project-relative `.astro` path, e.g. from a palette item's
+    /// `componentPath`) via `context.duplicateComponent` and, on success, refreshes
+    /// `projectComponents` and opens the new file through `context.onOpenFile` — "duplicate-and-
+    /// modify" (design spec §6.3). No-op (returns `nil`) if duplication isn't wired
+    /// (`context.duplicateComponent == nil`, true in tests/previews without write capability).
+    @discardableResult
+    func duplicateComponent(path: String) async -> ContentCreateResult? {
+        guard let duplicateComponent = context.duplicateComponent else { return nil }
+        let result = await duplicateComponent(path)
+        if case .created(let filePath, _) = result {
+            projectComponents = SiteFileTree.scan(siteRoot: context.sourceRoot)[.components] ?? []
+            if let match = projectComponents.first(where: { relativePath(for: $0) == filePath }) {
+                context.onOpenFile?(match)
+            }
+        }
+        return result
     }
 
     // MARK: - Style writes

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -419,8 +419,15 @@ struct ComponentEditorView: View {
                 return true
             }
             if let width = viewportPreset.width {
-                ScrollView(.horizontal) {
-                    content.frame(width: width, height: 800)
+                // Sizes to the split pane's own available height (via GeometryReader) rather
+                // than a fixed magic number — a hardcoded height either clipped the canvas on a
+                // pane shorter than it, or left dead space below it on a taller one (PR #795
+                // review). Horizontal scroll still covers the width-overflow case (preset wider
+                // than the pane), which is the whole point of a fixed-width preset.
+                GeometryReader { geometry in
+                    ScrollView(.horizontal) {
+                        content.frame(width: width, height: geometry.size.height)
+                    }
                 }
             } else {
                 content
@@ -668,13 +675,13 @@ struct ComponentEditorView: View {
                         HStack {
                             TextField("New selector, e.g. .card-footer", text: $newRuleSelector)
                                 .font(.system(.caption, design: .monospaced))
-                            TextField("@media (optional)", text: $newRuleMedia)
+                            TextField("Condition, e.g. (min-width: 768px)", text: $newRuleMedia)
                                 .font(.system(.caption, design: .monospaced))
                         }
                         Button("Add rule") {
                             let selector = newRuleSelector.trimmingCharacters(in: .whitespaces)
                             guard !selector.isEmpty else { return }
-                            let media = newRuleMedia.trimmingCharacters(in: .whitespaces)
+                            let media = ComponentStyleGrouping.normalizeMediaCondition(newRuleMedia)
                             Task {
                                 await model.addStyleRule(selector: selector, media: media.isEmpty ? nil : media, declarations: [])
                                 newRuleSelector = ""

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -16,6 +16,9 @@ struct ComponentEditorView: View {
     /// Design (three-pane) vs Source (existing text editor) — the escape hatch.
     @State private var mode: Mode = .design
     @State private var webView: WKWebView?
+    /// Canvas viewport-width preset (design spec §3/§4.2) — "Fill" (the default) matches the
+    /// pre-slice-5 behavior of the harness filling the available pane width.
+    @State private var viewportPreset: ComponentViewportPreset = .fill
 
     /// In-progress edits to a rule's selector, keyed by `spanKey(rule.span)`,
     /// pending commit (on focus loss) to `ComponentEditorModel.setRuleSelector`.
@@ -34,6 +37,12 @@ struct ComponentEditorView: View {
     @State private var colorCommitTasks: [String: Task<Void, Never>] = [:]
     /// Selector text for the inline "Add rule" form at the bottom of the Styles panel.
     @State private var newRuleSelector: String = ""
+    /// `@media` condition text for the inline "Add rule" form; blank means no wrapping media
+    /// query (same as passing `nil` to `addStyleRule`).
+    @State private var newRuleMedia: String = ""
+    /// Media keys (via `mediaGroupKey`) the user has manually collapsed — a `DisclosureGroup`
+    /// per media section defaults to expanded, matching the old flat list's always-visible rules.
+    @State private var collapsedMediaKeys: Set<String> = []
     /// In-progress edits to an attribute value, keyed by `"<nodeID>:<attrName>"`, pending
     /// commit (on submit) to `ComponentEditorModel.setAttr`.
     @State private var attrValueDrafts: [String: String] = [:]
@@ -346,32 +355,71 @@ struct ComponentEditorView: View {
         }
     }
 
+    /// Device-width preset row above the canvas (design spec §3: "A viewport-width control
+    /// (device presets + free resize)…"). "Free resize" isn't implemented in this pass — the
+    /// four fixed presets are the "polish" scope issue #495 asks for; a drag handle can follow
+    /// as its own increment if needed.
+    private var viewportToolbar: some View {
+        HStack(spacing: 2) {
+            ForEach(ComponentViewportPreset.allCases) { preset in
+                Button {
+                    viewportPreset = preset
+                } label: {
+                    Image(systemName: preset.systemImage)
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(viewportPreset == preset ? Color.accentColor : Color.secondary)
+                .help(preset.label)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+    }
+
     @ViewBuilder private func canvas(_ model: ComponentEditorModel) -> some View {
         VStack(spacing: 0) {
+            viewportToolbar
+            Divider()
             if let props = model.model?.frontmatter?.props, !props.isEmpty {
                 knobsBar(model, props: props)
                 Divider()
             }
-            // Gated directly on `context.baseURL` (not just `model.harnessURL`)
-            // so the live canvas replaces this placeholder the moment the dev
-            // server becomes ready, in lockstep with the `loadKey`-driven
-            // reload above.
-            if context.baseURL != nil, let url = model.harnessURL {
-                ComponentCanvasView(
-                    url: url,
-                    editRouter: context.editRouter,
-                    onSelection: { model.canvasSelected($0) },
-                    onComputedStyles: { model.computedStyles = $0.styles },
-                    onWebView: { webView = $0 }
-                )
-                .dropDestination(for: OutlineDragPayload.self) { items, location in
-                    guard let item = items.first, case .insert(let payload) = item, let webView else { return false }
-                    Task { await performCanvasDrop(model, payload: payload, location: location, webView: webView) }
-                    return true
+            canvasWebView(model)
+        }
+    }
+
+    /// The harness `WKWebView` itself (drop-destination wiring unchanged from before slice 5a),
+    /// width-constrained to `viewportPreset.width` when a fixed preset is active. `.fill`
+    /// (`width == nil`) renders identically to the pre-slice-5 behavior — no frame constraint,
+    /// canvas fills the available pane width.
+    @ViewBuilder private func canvasWebView(_ model: ComponentEditorModel) -> some View {
+        // Gated directly on `context.baseURL` (not just `model.harnessURL`)
+        // so the live canvas replaces this placeholder the moment the dev
+        // server becomes ready, in lockstep with the `loadKey`-driven
+        // reload above.
+        if context.baseURL != nil, let url = model.harnessURL {
+            let content = ComponentCanvasView(
+                url: url,
+                editRouter: context.editRouter,
+                onSelection: { model.canvasSelected($0) },
+                onComputedStyles: { model.computedStyles = $0.styles },
+                onWebView: { webView = $0 }
+            )
+            .dropDestination(for: OutlineDragPayload.self) { items, location in
+                guard let item = items.first, case .insert(let payload) = item, let webView else { return false }
+                Task { await performCanvasDrop(model, payload: payload, location: location, webView: webView) }
+                return true
+            }
+            if let width = viewportPreset.width {
+                ScrollView(.horizontal) {
+                    content.frame(width: width, height: 800)
                 }
             } else {
-                ContentUnavailableView("Dev Server Starting…", systemImage: "hourglass")
+                content
             }
+        } else {
+            ContentUnavailableView("Dev Server Starting…", systemImage: "hourglass")
         }
     }
 
@@ -410,6 +458,66 @@ struct ComponentEditorView: View {
         let line: Int
         let column: Int
         let zone: String
+    }
+
+    /// Stable dictionary/Set key for a media group — `""` for the unscoped "Base styles" group,
+    /// the media condition string otherwise. Mirrors `ComponentStyleGrouping.groups`' own
+    /// `key.isEmpty ? nil : key` convention so the two stay in sync.
+    private func mediaGroupKey(_ media: String?) -> String { media ?? "" }
+
+    /// Expand/collapse binding for one media group's `DisclosureGroup`, backed by
+    /// `collapsedMediaKeys` — defaults to expanded (absent from the set) so the panel reads the
+    /// same as the old always-expanded flat list until the user explicitly collapses a section.
+    private func mediaExpandedBinding(for media: String?) -> Binding<Bool> {
+        let key = mediaGroupKey(media)
+        return Binding(
+            get: { !collapsedMediaKeys.contains(key) },
+            set: { expanded in
+                if expanded {
+                    collapsedMediaKeys.remove(key)
+                } else {
+                    collapsedMediaKeys.insert(key)
+                }
+            }
+        )
+    }
+
+    /// One rule's editable selector + declaration rows — extracted from the old flat Styles
+    /// rendering so the grouped-by-media rendering above can reuse it per group.
+    @ViewBuilder
+    private func ruleRow(_ model: ComponentEditorModel, ruleIndex: Int, rule: ComponentModel.StyleRule) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            TextField("selector", text: selectorBinding(for: rule))
+                .font(.system(.caption, design: .monospaced))
+                .textFieldStyle(.plain)
+                .bold()
+                .onSubmit { commitSelector(model, rule: rule) }
+            ForEach(rule.declarations, id: \.property) { decl in
+                HStack(spacing: 4) {
+                    TextField("property", text: propertyBinding(for: decl))
+                        .font(.system(.caption, design: .monospaced))
+                        .textFieldStyle(.plain)
+                        .frame(width: 110)
+                        .onSubmit { commitDeclaration(model, ruleIndex: ruleIndex, rule: rule, decl: decl) }
+                    Text(":")
+                    declarationValueField(model, ruleIndex: ruleIndex, rule: rule, decl: decl)
+                    Button(role: .destructive) {
+                        removeDeclaration(model, rule: rule, decl: decl)
+                    } label: {
+                        Image(systemName: "minus.circle")
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            Button("Add declaration") {
+                let newProperty = "new-property-\(UUID().uuidString.prefix(8))"
+                Task { await model.setStyleProperty(ruleSpan: spanArray(rule.span), property: newProperty, value: "") }
+            }
+            .font(.caption2)
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
     }
 
     private func knobsBar(_ model: ComponentEditorModel, props: [ComponentModel.Prop]) -> some View {
@@ -528,43 +636,20 @@ struct ComponentEditorView: View {
                 }
                 GroupBox("Styles") {
                     if let styles = model.model?.styles, !styles.isEmpty {
-                        ForEach(Array(styles.enumerated()), id: \.offset) { ruleIndex, rule in
-                            VStack(alignment: .leading, spacing: 4) {
-                                if let media = rule.media {
-                                    Text("@media \(media)").font(.caption2).foregroundStyle(.secondary)
-                                }
-                                TextField("selector", text: selectorBinding(for: rule))
-                                    .font(.system(.caption, design: .monospaced))
-                                    .textFieldStyle(.plain)
-                                    .bold()
-                                    .onSubmit { commitSelector(model, rule: rule) }
-                                ForEach(rule.declarations, id: \.property) { decl in
-                                    HStack(spacing: 4) {
-                                        TextField("property", text: propertyBinding(for: decl))
-                                            .font(.system(.caption, design: .monospaced))
-                                            .textFieldStyle(.plain)
-                                            .frame(width: 110)
-                                            .onSubmit { commitDeclaration(model, ruleIndex: ruleIndex, rule: rule, decl: decl) }
-                                        Text(":")
-                                        declarationValueField(model, ruleIndex: ruleIndex, rule: rule, decl: decl)
-                                        Button(role: .destructive) {
-                                            removeDeclaration(model, rule: rule, decl: decl)
-                                        } label: {
-                                            Image(systemName: "minus.circle")
-                                        }
-                                        .buttonStyle(.plain)
+                        let groups = ComponentStyleGrouping.groups(from: styles)
+                        ForEach(Array(groups.enumerated()), id: \.offset) { groupIndex, group in
+                            DisclosureGroup(isExpanded: mediaExpandedBinding(for: group.media)) {
+                                ForEach(Array(group.rules.enumerated()), id: \.element.index) { position, indexed in
+                                    ruleRow(model, ruleIndex: indexed.index, rule: indexed.rule)
+                                    if position < group.rules.count - 1 {
+                                        Divider()
                                     }
                                 }
-                                Button("Add declaration") {
-                                    let newProperty = "new-property-\(UUID().uuidString.prefix(8))"
-                                    Task { await model.setStyleProperty(ruleSpan: spanArray(rule.span), property: newProperty, value: "") }
-                                }
-                                .font(.caption2)
-                                .buttonStyle(.plain)
+                            } label: {
+                                Text(group.media.map { "@media \($0)" } ?? "Base styles")
+                                    .font(.caption).bold()
                             }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.vertical, 4)
-                            if ruleIndex < styles.count - 1 {
+                            if groupIndex < groups.count - 1 {
                                 Divider()
                             }
                         }
@@ -572,15 +657,21 @@ struct ComponentEditorView: View {
                         Text("No scoped styles").foregroundStyle(.secondary)
                     }
                     Divider()
-                    HStack {
-                        TextField("New selector, e.g. .card-footer", text: $newRuleSelector)
-                            .font(.system(.caption, design: .monospaced))
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            TextField("New selector, e.g. .card-footer", text: $newRuleSelector)
+                                .font(.system(.caption, design: .monospaced))
+                            TextField("@media (optional)", text: $newRuleMedia)
+                                .font(.system(.caption, design: .monospaced))
+                        }
                         Button("Add rule") {
                             let selector = newRuleSelector.trimmingCharacters(in: .whitespaces)
                             guard !selector.isEmpty else { return }
+                            let media = newRuleMedia.trimmingCharacters(in: .whitespaces)
                             Task {
-                                await model.addStyleRule(selector: selector, media: nil, declarations: [])
+                                await model.addStyleRule(selector: selector, media: media.isEmpty ? nil : media, declarations: [])
                                 newRuleSelector = ""
+                                newRuleMedia = ""
                             }
                         }
                         .disabled(newRuleSelector.trimmingCharacters(in: .whitespaces).isEmpty)

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -349,6 +349,13 @@ struct ComponentEditorView: View {
                     .frame(width: 84, height: 44)
                     .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
                     .draggable(OutlineDragPayload.insert(PaletteDragPayload(label: item.label, kind: item.kind)))
+                    .contextMenu {
+                        if case .component(_, let componentPath) = item.kind {
+                            Button("Duplicate & Modify") {
+                                Task { await model.duplicateComponent(path: componentPath) }
+                            }
+                        }
+                    }
                 }
             }
             .padding(8)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -718,7 +718,8 @@ struct SiteWindow: View {
                         // would silently diverge from that once the Styles panel starts sending
                         // real edits.
                         editRouter: model.preview.editRouter,
-                        onOpenFile: { file in model.openFile(file) }
+                        onOpenFile: { file in model.openFile(file) },
+                        duplicateComponent: { relativePath in await model.duplicateComponent(relativePath: relativePath) }
                     )
                 )
             } else if case .plist(let plistEditorModel) = model.activeEditor {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -990,6 +990,19 @@ final class SiteWindowModel {
         return result
     }
 
+    /// Duplicates the component at `relativePath` (design spec §6.3: "duplicate-and-modify" —
+    /// surfaced on the Component Editor's own palette, since project components aren't tracked
+    /// in `SiteContentGraph` or shown in the page-only Navigator). Same force-refresh reasoning
+    /// as `createComponent`.
+    func duplicateComponent(relativePath: String) async -> ContentCreateResult {
+        guard let site else { return .siteNotFound }
+        let result = await contentCreation.duplicateComponent(siteID: site.id, relativePath: relativePath)
+        if case .created = result {
+            await navigator?.refreshNow()
+        }
+        return result
+    }
+
     /// Resolves `deleteConfirmation` to its page/post record, deletes via
     /// `contentCreation.deleteContent`, and clears the confirmation. Mirrors
     /// `deleteCleanupCandidate`'s ordering: editor/inspector state open on the file being deleted

--- a/Sources/AnglesiteCore/ComponentStyleGrouping.swift
+++ b/Sources/AnglesiteCore/ComponentStyleGrouping.swift
@@ -39,4 +39,17 @@ public enum ComponentStyleGrouping {
             Group(media: key.isEmpty ? nil : key, rules: byKey[key] ?? [])
         }
     }
+
+    /// Strips a redundant leading "@media" a user may have typed into the Styles panel's "Add
+    /// rule" form condition field (case-insensitive, tolerates surrounding whitespace) — the
+    /// field only asks for the condition itself (e.g. `"(min-width: 768px)"`), but typing the
+    /// literal `"@media (min-width: 768px)"` is a natural mistake given the field sits right
+    /// next to text that says "@media". Without this, the rendered section header
+    /// (`"@media \(condition)"`) would double up as `"@media @media (min-width: 768px)"`
+    /// (PR #795 review).
+    public static func normalizeMediaCondition(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard trimmed.lowercased().hasPrefix("@media") else { return trimmed }
+        return String(trimmed.dropFirst("@media".count)).trimmingCharacters(in: .whitespaces)
+    }
 }

--- a/Sources/AnglesiteCore/ComponentStyleGrouping.swift
+++ b/Sources/AnglesiteCore/ComponentStyleGrouping.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Groups a component's style rules by their `@media` condition (design spec §4.3: "Media
+/// queries as collapsible sections"), preserving the order each distinct condition first
+/// appears in the source. Pure/testable — `ComponentEditorView`'s Styles panel renders one
+/// collapsible section per group, reusing the existing per-rule editing UI inside.
+public enum ComponentStyleGrouping {
+    /// One rule plus its original index in the model's flat `styles` array — callers need the
+    /// index to re-derive a fresh span via `ComponentEditorModel.ruleSpan(atIndex:)` after a
+    /// prior write in the same gesture may have shifted byte offsets (same reason the previous
+    /// flat rendering carried `ruleIndex` alongside each rule).
+    public struct IndexedRule: Sendable, Equatable {
+        public let index: Int
+        public let rule: ComponentModel.StyleRule
+    }
+
+    /// One media-scoped (or unscoped, `media == nil`) run of rules.
+    public struct Group: Sendable, Equatable {
+        public let media: String?
+        public let rules: [IndexedRule]
+    }
+
+    /// Groups rules sharing the same `media` value into one `Group` each, in first-appearance
+    /// order — NOT sorted alphabetically, so a component whose source interleaves base and
+    /// media-scoped rules still reads top-to-bottom the way it's written. A `media` value
+    /// re-encountered later in the array joins its existing group rather than starting a new one.
+    public static func groups(from styles: [ComponentModel.StyleRule]) -> [Group] {
+        var order: [String] = []
+        var byKey: [String: [IndexedRule]] = [:]
+        for (index, rule) in styles.enumerated() {
+            let key = rule.media ?? ""
+            if byKey[key] == nil {
+                byKey[key] = []
+                order.append(key)
+            }
+            byKey[key]?.append(IndexedRule(index: index, rule: rule))
+        }
+        return order.map { key in
+            Group(media: key.isEmpty ? nil : key, rules: byKey[key] ?? [])
+        }
+    }
+}

--- a/Sources/AnglesiteCore/ComponentViewportPreset.swift
+++ b/Sources/AnglesiteCore/ComponentViewportPreset.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Canvas viewport-width presets for the Component Editor (design spec §3/§4.2): fixed device
+/// widths for responsive work, pairing with media-query editing in the Styles panel
+/// (`ComponentStyleGrouping`). Pure/testable — `ComponentEditorView` maps each case to an SF
+/// Symbol and applies `.width` as a `.frame` constraint on the harness `WKWebView`.
+public enum ComponentViewportPreset: String, CaseIterable, Identifiable, Sendable {
+    case mobile, tablet, desktop, fill
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .mobile: "Mobile"
+        case .tablet: "Tablet"
+        case .desktop: "Desktop"
+        case .fill: "Fill"
+        }
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .mobile: "iphone"
+        case .tablet: "ipad"
+        case .desktop: "display"
+        case .fill: "arrow.up.left.and.arrow.down.right"
+        }
+    }
+
+    /// Fixed viewport width in points, or `nil` for "Fill" (canvas fills the available pane width).
+    public var width: Double? {
+        switch self {
+        case .mobile: 375
+        case .tablet: 768
+        case .desktop: 1440
+        case .fill: nil
+        }
+    }
+}

--- a/Sources/AnglesiteCore/ContentCreationWorkflow.swift
+++ b/Sources/AnglesiteCore/ContentCreationWorkflow.swift
@@ -27,6 +27,7 @@ public struct ContentCreationWorkflow: ContentOperationsService {
     public typealias PageDuplicator = @Sendable (_ siteID: String, _ relativePath: String, _ title: String) async -> ContentCreateResult
     public typealias PostDuplicator = @Sendable (_ siteID: String, _ relativePath: String, _ collection: String, _ title: String) async -> ContentCreateResult
     public typealias ComponentCreator = @Sendable (_ siteID: String, _ name: String) async -> ContentCreateResult
+    public typealias ComponentDuplicator = @Sendable (_ siteID: String, _ relativePath: String) async -> ContentCreateResult
 
     private let operations: any ContentOperationsService
     private let contentGraph: SiteContentGraph?
@@ -39,6 +40,7 @@ public struct ContentCreationWorkflow: ContentOperationsService {
     private let pageDuplicator: PageDuplicator?
     private let postDuplicator: PostDuplicator?
     private let componentCreator: ComponentCreator?
+    private let componentDuplicator: ComponentDuplicator?
 
     public init(
         operations: any ContentOperationsService,
@@ -51,7 +53,8 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         contentRestorer: ContentRestorer? = nil,
         pageDuplicator: PageDuplicator? = nil,
         postDuplicator: PostDuplicator? = nil,
-        componentCreator: ComponentCreator? = nil
+        componentCreator: ComponentCreator? = nil,
+        componentDuplicator: ComponentDuplicator? = nil
     ) {
         self.operations = operations
         self.contentGraph = contentGraph
@@ -64,6 +67,7 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         self.pageDuplicator = pageDuplicator
         self.postDuplicator = postDuplicator
         self.componentCreator = componentCreator
+        self.componentDuplicator = componentDuplicator
     }
 
     public static func native(
@@ -113,6 +117,9 @@ public struct ContentCreationWorkflow: ContentOperationsService {
             },
             componentCreator: { siteID, name in
                 await native.createComponent(siteID: siteID, name: name)
+            },
+            componentDuplicator: { siteID, relativePath in
+                await native.duplicateComponent(siteID: siteID, relativePath: relativePath)
             }
         )
     }
@@ -281,5 +288,12 @@ public struct ContentCreationWorkflow: ContentOperationsService {
     public func createComponent(siteID: String, name: String) async -> ContentCreateResult {
         guard let componentCreator else { return .failed(reason: "Component creation is not configured for this workflow") }
         return await componentCreator(siteID, name)
+    }
+
+    /// Mirrors `createComponent`'s no-graph-refresh precedent (components aren't part of
+    /// `SiteContentGraph`) — the app-layer caller refreshes the Navigator itself.
+    public func duplicateComponent(siteID: String, relativePath: String) async -> ContentCreateResult {
+        guard let componentDuplicator else { return .failed(reason: "Duplicate is not configured for this workflow") }
+        return await componentDuplicator(siteID, relativePath)
     }
 }

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -338,6 +338,47 @@ public struct NativeContentOperations: ContentOperationsService {
         return .created(filePath: relPath, identifier: slug)
     }
 
+    /// Duplicate an existing `.astro` component: read its contents verbatim (no retitle —
+    /// unlike pages/posts, a component has no title to rewrite), derive a "Copy"-suffixed
+    /// PascalCase name colliding-safely with `NameCopy`/`NameCopy2`… (mirrors `createComponent`'s
+    /// PascalCase convention), write, commit. Preserves the source's subdirectory (e.g.
+    /// `src/components/esi/EsiInclude.astro` duplicates to `src/components/esi/EsiIncludeCopy.astro`)
+    /// since component grouping directories are meaningful (design spec §4.1's palette groups by
+    /// `SiteFileTree`'s components group).
+    public func duplicateComponent(siteID: String, relativePath: String) async -> ContentCreateResult {
+        guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+        let sourceAbs = root.appendingPathComponent(relativePath)
+        guard fileManager.fileExists(atPath: sourceAbs.path) else {
+            return .failed(reason: "No component exists at \(relativePath)")
+        }
+        let contents: String
+        do { contents = try FileDocumentIO.load(sourceAbs, fileManager: fileManager).contents }
+        catch { return .failed(reason: "\(error)") }
+
+        let relDir = (relativePath as NSString).deletingLastPathComponent
+        let baseName = ((relativePath as NSString).lastPathComponent as NSString).deletingPathExtension
+        func candidatePath(_ name: String) -> String {
+            relDir.isEmpty ? "\(name).astro" : "\(relDir)/\(name).astro"
+        }
+        var attempt = 1
+        var candidateName = "\(baseName)Copy"
+        var relPath = candidatePath(candidateName)
+        while attempt < 1000, fileManager.fileExists(atPath: root.appendingPathComponent(relPath).path) {
+            attempt += 1
+            candidateName = "\(baseName)Copy\(attempt)"
+            relPath = candidatePath(candidateName)
+        }
+        guard !fileManager.fileExists(atPath: root.appendingPathComponent(relPath).path) else {
+            return .failed(reason: "Couldn't find an available name for the duplicate after 1000 attempts")
+        }
+
+        do { try write(contents, to: root.appendingPathComponent(relPath)) }
+        catch { return .failed(reason: "\(error)") }
+
+        _ = await gitCommit(root, relPath, "anglesite: duplicate component \(candidateName)")
+        return .created(filePath: relPath, identifier: candidateName)
+    }
+
     /// Scaffold a minimal blank `.astro` component into `src/components/`. Derives a PascalCase
     /// file name from `name` (Astro convention) via the same `ContentScaffold.slugify` used for
     /// pages/posts, then title-cases each hyphenated segment.

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -147,6 +147,13 @@ extension SiteWindowModelTests {
         #expect(result == .siteNotFound)
     }
 
+    @Test("duplicateComponent no-ops safely when there is no open site")
+    func duplicateComponentNoSiteReturnsSiteNotFound() async {
+        let model = makeModel()
+        let result = await model.duplicateComponent(relativePath: "src/components/Card.astro")
+        #expect(result == .siteNotFound)
+    }
+
     @Test("confirmDelete clears deleteConfirmation and no-ops when there is no open site")
     func confirmDeleteNoSiteIsNoOp() async {
         let model = makeModel()

--- a/Tests/AnglesiteCoreTests/ComponentStyleGroupingTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentStyleGroupingTests.swift
@@ -46,4 +46,28 @@ struct ComponentStyleGroupingTests {
     func emptyStylesProduceNoGroups() {
         #expect(ComponentStyleGrouping.groups(from: []).isEmpty)
     }
+
+    @Test("normalizeMediaCondition passes a bare condition through unchanged")
+    func normalizeMediaConditionPassesBareConditionThrough() {
+        #expect(ComponentStyleGrouping.normalizeMediaCondition("(min-width: 768px)") == "(min-width: 768px)")
+    }
+
+    @Test("normalizeMediaCondition strips a redundant leading @media, case-insensitively")
+    func normalizeMediaConditionStripsLeadingAtMedia() {
+        #expect(ComponentStyleGrouping.normalizeMediaCondition("@media (min-width: 768px)") == "(min-width: 768px)")
+        #expect(ComponentStyleGrouping.normalizeMediaCondition("@Media (min-width: 768px)") == "(min-width: 768px)")
+        #expect(ComponentStyleGrouping.normalizeMediaCondition("@MEDIA(min-width: 768px)") == "(min-width: 768px)")
+    }
+
+    @Test("normalizeMediaCondition trims surrounding whitespace")
+    func normalizeMediaConditionTrimsWhitespace() {
+        #expect(ComponentStyleGrouping.normalizeMediaCondition("  (min-width: 768px)  ") == "(min-width: 768px)")
+        #expect(ComponentStyleGrouping.normalizeMediaCondition("  @media   (min-width: 768px)  ") == "(min-width: 768px)")
+    }
+
+    @Test("normalizeMediaCondition on just \"@media\" alone yields an empty string")
+    func normalizeMediaConditionBareAtMediaYieldsEmpty() {
+        #expect(ComponentStyleGrouping.normalizeMediaCondition("@media").isEmpty)
+        #expect(ComponentStyleGrouping.normalizeMediaCondition("  @media  ").isEmpty)
+    }
 }

--- a/Tests/AnglesiteCoreTests/ComponentStyleGroupingTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentStyleGroupingTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import AnglesiteCore
+
+struct ComponentStyleGroupingTests {
+    private func rule(_ selector: String, media: String? = nil) -> ComponentModel.StyleRule {
+        ComponentModel.StyleRule(selector: selector, media: media, span: ComponentModel.Span(start: 0, end: 0), declarations: [])
+    }
+
+    @Test("rules with no media form a single base group")
+    func baseGroupOnly() {
+        let styles = [rule(".a"), rule(".b")]
+        let groups = ComponentStyleGrouping.groups(from: styles)
+        #expect(groups.count == 1)
+        #expect(groups[0].media == nil)
+        #expect(groups[0].rules.map(\.index) == [0, 1])
+    }
+
+    @Test("rules group by distinct media condition, preserving first-appearance order")
+    func groupsByMediaInSourceOrder() {
+        let styles = [
+            rule(".a"),
+            rule(".b", media: "(min-width: 768px)"),
+            rule(".c"),
+            rule(".d", media: "(min-width: 1024px)"),
+        ]
+        let groups = ComponentStyleGrouping.groups(from: styles)
+        #expect(groups.map(\.media) == [nil, "(min-width: 768px)", "(min-width: 1024px)"])
+        #expect(groups[0].rules.map(\.index) == [0, 2])
+        #expect(groups[1].rules.map(\.index) == [1])
+        #expect(groups[2].rules.map(\.index) == [3])
+    }
+
+    @Test("a repeated media condition reuses the same group, not a second one")
+    func repeatedMediaReusesGroup() {
+        let styles = [
+            rule(".a", media: "(min-width: 768px)"),
+            rule(".b"),
+            rule(".c", media: "(min-width: 768px)"),
+        ]
+        let groups = ComponentStyleGrouping.groups(from: styles)
+        #expect(groups.map(\.media) == ["(min-width: 768px)", nil])
+        #expect(groups[0].rules.map(\.index) == [0, 2])
+    }
+
+    @Test("empty styles produce no groups")
+    func emptyStylesProduceNoGroups() {
+        #expect(ComponentStyleGrouping.groups(from: []).isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/ComponentViewportPresetTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentViewportPresetTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import AnglesiteCore
+
+struct ComponentViewportPresetTests {
+    @Test("fill has no fixed width")
+    func fillHasNoWidth() {
+        #expect(ComponentViewportPreset.fill.width == nil)
+    }
+
+    @Test("mobile, tablet, and desktop have distinct, increasing widths")
+    func devicePresetsHaveIncreasingWidths() throws {
+        let mobile = try #require(ComponentViewportPreset.mobile.width)
+        let tablet = try #require(ComponentViewportPreset.tablet.width)
+        let desktop = try #require(ComponentViewportPreset.desktop.width)
+        #expect(mobile < tablet)
+        #expect(tablet < desktop)
+    }
+
+    @Test("every case has a non-empty label and system image")
+    func allCasesHaveLabelAndImage() {
+        for preset in ComponentViewportPreset.allCases {
+            #expect(!preset.label.isEmpty)
+            #expect(!preset.systemImage.isEmpty)
+        }
+    }
+
+    @Test("id matches the raw value, for SwiftUI ForEach identity")
+    func idMatchesRawValue() {
+        for preset in ComponentViewportPreset.allCases {
+            #expect(preset.id == preset.rawValue)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
@@ -311,6 +311,45 @@ struct ContentCreationWorkflowTests {
         #expect(result == .created(filePath: "src/components/Widget.astro", identifier: "Widget"))
     }
 
+    @Test("duplicateComponent does not require content graph access and returns the operation's result")
+    func duplicateComponentPassesThrough() async throws {
+        let root = try makeSite()
+        let operations = FakeCreateOperations { _, _, _ in
+            .failed(reason: "unexpected")
+        } createPost: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        } createTyped: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        }
+        let workflow = ContentCreationWorkflow(
+            operations: operations,
+            contentGraph: nil,
+            siteDirectory: { _ in root },
+            componentDuplicator: { _, relativePath in .created(filePath: "src/components/WidgetCopy.astro", identifier: "WidgetCopy") }
+        )
+
+        let result = await workflow.duplicateComponent(siteID: Self.siteID, relativePath: "src/components/Widget.astro")
+
+        #expect(result == .created(filePath: "src/components/WidgetCopy.astro", identifier: "WidgetCopy"))
+    }
+
+    @Test("duplicateComponent reports failed when the workflow has no componentDuplicator configured")
+    func duplicateComponentUnconfigured() async throws {
+        let root = try makeSite()
+        let operations = FakeCreateOperations { _, _, _ in
+            .failed(reason: "unexpected")
+        } createPost: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        } createTyped: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        }
+        let workflow = ContentCreationWorkflow(operations: operations, contentGraph: nil, siteDirectory: { _ in root })
+
+        let result = await workflow.duplicateComponent(siteID: Self.siteID, relativePath: "src/components/Widget.astro")
+
+        guard case .failed = result else { Issue.record("expected .failed, got \(result)"); return }
+    }
+
     @Test("deleteContent reports failed when the workflow has no contentDeleter configured")
     func deleteContentUnconfigured() async throws {
         let root = try makeSite()

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -629,6 +629,95 @@ struct NativeContentOperationsComponentTests {
     }
 }
 
+@Suite("NativeContentOperations.duplicateComponent")
+struct NativeContentOperationsDuplicateComponentTests {
+    private func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("native-content-ops-dup-component-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    @Test("duplicateComponent writes a Copy-suffixed file with identical contents")
+    func duplicatesComponent() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let relPath = "src/components/Card.astro"
+        let abs = root.appendingPathComponent(relPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let original = "---\ninterface Props { title: string }\n---\n<div>{Astro.props.title}</div>\n"
+        try original.write(to: abs, atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        let result = await ops.duplicateComponent(siteID: "site-1", relativePath: relPath)
+
+        guard case .created(let filePath, let identifier) = result else {
+            Issue.record("expected .created, got \(result)"); return
+        }
+        #expect(filePath == "src/components/CardCopy.astro")
+        #expect(identifier == "CardCopy")
+        let copied = try String(contentsOf: root.appendingPathComponent(filePath), encoding: .utf8)
+        #expect(copied == original)
+    }
+
+    @Test("duplicateComponent bumps the suffix on collision")
+    func duplicatesComponentWithCollision() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let relPath = "src/components/Card.astro"
+        let abs = root.appendingPathComponent(relPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "original".write(to: abs, atomically: true, encoding: .utf8)
+        try "existing copy".write(to: root.appendingPathComponent("src/components/CardCopy.astro"), atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        let result = await ops.duplicateComponent(siteID: "site-1", relativePath: relPath)
+
+        guard case .created(let filePath, let identifier) = result else {
+            Issue.record("expected .created, got \(result)"); return
+        }
+        #expect(filePath == "src/components/CardCopy2.astro")
+        #expect(identifier == "CardCopy2")
+    }
+
+    @Test("duplicateComponent preserves a nested subdirectory")
+    func duplicatesNestedComponent() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let relPath = "src/components/esi/EsiInclude.astro"
+        let abs = root.appendingPathComponent(relPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "original".write(to: abs, atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        let result = await ops.duplicateComponent(siteID: "site-1", relativePath: relPath)
+
+        guard case .created(let filePath, _) = result else { Issue.record("expected .created, got \(result)"); return }
+        #expect(filePath == "src/components/esi/EsiIncludeCopy.astro")
+    }
+
+    @Test("duplicateComponent fails when the source file does not exist")
+    func duplicateMissingComponentFails() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let ops = NativeContentOperations(siteDirectory: { _ in root })
+
+        let result = await ops.duplicateComponent(siteID: "site-1", relativePath: "src/components/Missing.astro")
+
+        guard case .failed = result else { Issue.record("expected .failed, got \(result)"); return }
+    }
+
+    @Test("unknown site returns .siteNotFound")
+    func duplicateComponentSiteNotFound() async {
+        let ops = NativeContentOperations(siteDirectory: { _ in nil }, gitCommit: { _, _, _ in nil })
+        let result = await ops.duplicateComponent(siteID: "missing", relativePath: "src/components/Card.astro")
+        #expect(result == .siteNotFound)
+    }
+}
+
 private struct StubPageCopyGenerator: PageCopyGenerating {
     let suggestion: PageCopySuggestion?
     func suggestDescription(title: String, siteID: String, siteDirectory: URL) async -> PageCopySuggestion? {

--- a/docs/superpowers/plans/2026-07-16-component-editor-slice5a-media-viewport.md
+++ b/docs/superpowers/plans/2026-07-16-component-editor-slice5a-media-viewport.md
@@ -1,0 +1,662 @@
+# Component Editor Slice 5a: Media-Query Editing + Viewport Presets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Component Editor's Styles panel collapsible `@media`-grouped sections (with a way to add a rule under a media condition), and give its canvas a viewport-width preset toolbar (Mobile/Tablet/Desktop/Fill) — the two "polish" items from Component Editor slice 5 (issue #495) that need no plugin changes, since `add-style-rule`'s `media` param already shipped in slice 2.
+
+**Architecture:** Two new pure, testable types in `AnglesiteCore` (`ComponentStyleGrouping`, `ComponentViewportPreset`) back two `ComponentEditorView` (AnglesiteApp) changes: the Styles `GroupBox` renders one `DisclosureGroup` per media group instead of a flat rule list, and `canvas(_:)` gains a preset toolbar that constrains the harness `WKWebView`'s width. No new `EditMessage.Op`, no plugin PR, no MCP schema change — this is pure UI wired to the existing `ComponentEditorModel.addStyleRule(selector:media:declarations:)`.
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27+), Swift Testing (`import Testing`, `@testable import AnglesiteCore`), existing `ComponentModel`/`ComponentEditorModel` types.
+
+## Global Constraints
+
+- Swift 6.4 / macOS 27+ toolchain (Xcode 27+). `Anglesite.xcodeproj` is gitignored — run `xcodegen generate` first if it's missing from this worktree.
+- `ANGLESITE_PLUGIN_SRC` must point at the sibling checkout (`/Users/dwk/Developer/github.com/Anglesite/anglesite`), not the default `../anglesite` (wrong from inside a worktree).
+- No new third-party dependencies. Pure logic goes in `AnglesiteCore` so it's covered by `swift test` (hosted `xcodebuild test` doesn't run reliably on this repo's CI runners — see `AGENTS.md` "Build" section).
+- Follow existing file conventions exactly: `Sources/AnglesiteCore/Component*.swift` for pure logic, `Tests/AnglesiteCoreTests/Component*Tests.swift` (`import Testing` + `@testable import AnglesiteCore`, no XCTest) for their tests.
+- Conventional commits (`feat(component-editor): …`), reference `#495` in the PR.
+
+---
+
+## File Structure
+
+- **Create:** `Sources/AnglesiteCore/ComponentStyleGrouping.swift` — pure function grouping `[ComponentModel.StyleRule]` by `media`, preserving first-appearance order.
+- **Create:** `Tests/AnglesiteCoreTests/ComponentStyleGroupingTests.swift`
+- **Create:** `Sources/AnglesiteCore/ComponentViewportPreset.swift` — pure enum mapping a preset name to a label + fixed width (or `nil` for "Fill").
+- **Create:** `Tests/AnglesiteCoreTests/ComponentViewportPresetTests.swift`
+- **Modify:** `Sources/AnglesiteApp/ComponentEditorView.swift` — Styles `GroupBox` grouped rendering + media field on the "Add rule" form; new `viewportToolbar` + width-constrained canvas.
+
+---
+
+### Task 1: `ComponentStyleGrouping` (pure, Core)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ComponentStyleGrouping.swift`
+- Test: `Tests/AnglesiteCoreTests/ComponentStyleGroupingTests.swift`
+
+**Interfaces:**
+- Consumes: `ComponentModel.StyleRule` (already public, `Sendable, Equatable, Codable`, fields `selector: String`, `media: String?`, `span: Span`, `declarations: [Declaration]` — `Sources/AnglesiteCore/ComponentModel.swift:117-122`).
+- Produces: `ComponentStyleGrouping.IndexedRule { let index: Int; let rule: ComponentModel.StyleRule }`, `ComponentStyleGrouping.Group { let media: String?; let rules: [IndexedRule] }`, `ComponentStyleGrouping.groups(from styles: [ComponentModel.StyleRule]) -> [Group]`. Task 3 (`ComponentEditorView`) calls `groups(from:)` and reads `.media`/`.rules[].index`/`.rules[].rule`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/ComponentStyleGroupingTests.swift`:
+
+```swift
+import Testing
+@testable import AnglesiteCore
+
+struct ComponentStyleGroupingTests {
+    private func rule(_ selector: String, media: String? = nil) -> ComponentModel.StyleRule {
+        ComponentModel.StyleRule(selector: selector, media: media, span: ComponentModel.Span(start: 0, end: 0), declarations: [])
+    }
+
+    @Test("rules with no media form a single base group")
+    func baseGroupOnly() {
+        let styles = [rule(".a"), rule(".b")]
+        let groups = ComponentStyleGrouping.groups(from: styles)
+        #expect(groups.count == 1)
+        #expect(groups[0].media == nil)
+        #expect(groups[0].rules.map(\.index) == [0, 1])
+    }
+
+    @Test("rules group by distinct media condition, preserving first-appearance order")
+    func groupsByMediaInSourceOrder() {
+        let styles = [
+            rule(".a"),
+            rule(".b", media: "(min-width: 768px)"),
+            rule(".c"),
+            rule(".d", media: "(min-width: 1024px)"),
+        ]
+        let groups = ComponentStyleGrouping.groups(from: styles)
+        #expect(groups.map(\.media) == [nil, "(min-width: 768px)", "(min-width: 1024px)"])
+        #expect(groups[0].rules.map(\.index) == [0, 2])
+        #expect(groups[1].rules.map(\.index) == [1])
+        #expect(groups[2].rules.map(\.index) == [3])
+    }
+
+    @Test("a repeated media condition reuses the same group, not a second one")
+    func repeatedMediaReusesGroup() {
+        let styles = [
+            rule(".a", media: "(min-width: 768px)"),
+            rule(".b"),
+            rule(".c", media: "(min-width: 768px)"),
+        ]
+        let groups = ComponentStyleGrouping.groups(from: styles)
+        #expect(groups.map(\.media) == ["(min-width: 768px)", nil])
+        #expect(groups[0].rules.map(\.index) == [0, 2])
+    }
+
+    @Test("empty styles produce no groups")
+    func emptyStylesProduceNoGroups() {
+        #expect(ComponentStyleGrouping.groups(from: []).isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter ComponentStyleGroupingTests`
+Expected: FAIL — `ComponentStyleGrouping` does not exist (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/ComponentStyleGrouping.swift`:
+
+```swift
+import Foundation
+
+/// Groups a component's style rules by their `@media` condition (design spec §4.3: "Media
+/// queries as collapsible sections"), preserving the order each distinct condition first
+/// appears in the source. Pure/testable — `ComponentEditorView`'s Styles panel renders one
+/// collapsible section per group, reusing the existing per-rule editing UI inside.
+public enum ComponentStyleGrouping {
+    /// One rule plus its original index in the model's flat `styles` array — callers need the
+    /// index to re-derive a fresh span via `ComponentEditorModel.ruleSpan(atIndex:)` after a
+    /// prior write in the same gesture may have shifted byte offsets (same reason the previous
+    /// flat rendering carried `ruleIndex` alongside each rule).
+    public struct IndexedRule: Sendable, Equatable {
+        public let index: Int
+        public let rule: ComponentModel.StyleRule
+    }
+
+    /// One media-scoped (or unscoped, `media == nil`) run of rules.
+    public struct Group: Sendable, Equatable {
+        public let media: String?
+        public let rules: [IndexedRule]
+    }
+
+    /// Groups rules sharing the same `media` value into one `Group` each, in first-appearance
+    /// order — NOT sorted alphabetically, so a component whose source interleaves base and
+    /// media-scoped rules still reads top-to-bottom the way it's written. A `media` value
+    /// re-encountered later in the array joins its existing group rather than starting a new one.
+    public static func groups(from styles: [ComponentModel.StyleRule]) -> [Group] {
+        var order: [String] = []
+        var byKey: [String: [IndexedRule]] = [:]
+        for (index, rule) in styles.enumerated() {
+            let key = rule.media ?? ""
+            if byKey[key] == nil {
+                byKey[key] = []
+                order.append(key)
+            }
+            byKey[key]?.append(IndexedRule(index: index, rule: rule))
+        }
+        return order.map { key in
+            Group(media: key.isEmpty ? nil : key, rules: byKey[key] ?? [])
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ComponentStyleGroupingTests`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ComponentStyleGrouping.swift Tests/AnglesiteCoreTests/ComponentStyleGroupingTests.swift
+git commit -m "feat(component-editor): add ComponentStyleGrouping for media-query sections (#495)"
+```
+
+---
+
+### Task 2: `ComponentViewportPreset` (pure, Core)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ComponentViewportPreset.swift`
+- Test: `Tests/AnglesiteCoreTests/ComponentViewportPresetTests.swift`
+
+**Interfaces:**
+- Consumes: nothing (self-contained enum).
+- Produces: `public enum ComponentViewportPreset: String, CaseIterable, Identifiable, Sendable { case mobile, tablet, desktop, fill }` with `var label: String`, `var systemImage: String`, `var width: Double?` (nil for `.fill`). Task 4 (`ComponentEditorView`) iterates `ComponentViewportPreset.allCases` and reads `.label`/`.systemImage`/`.width`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/ComponentViewportPresetTests.swift`:
+
+```swift
+import Testing
+@testable import AnglesiteCore
+
+struct ComponentViewportPresetTests {
+    @Test("fill has no fixed width")
+    func fillHasNoWidth() {
+        #expect(ComponentViewportPreset.fill.width == nil)
+    }
+
+    @Test("mobile, tablet, and desktop have distinct, increasing widths")
+    func devicePresetsHaveIncreasingWidths() {
+        let mobile = try #require(ComponentViewportPreset.mobile.width)
+        let tablet = try #require(ComponentViewportPreset.tablet.width)
+        let desktop = try #require(ComponentViewportPreset.desktop.width)
+        #expect(mobile < tablet)
+        #expect(tablet < desktop)
+    }
+
+    @Test("every case has a non-empty label and system image")
+    func allCasesHaveLabelAndImage() {
+        for preset in ComponentViewportPreset.allCases {
+            #expect(!preset.label.isEmpty)
+            #expect(!preset.systemImage.isEmpty)
+        }
+    }
+
+    @Test("id matches the raw value, for SwiftUI ForEach identity")
+    func idMatchesRawValue() {
+        for preset in ComponentViewportPreset.allCases {
+            #expect(preset.id == preset.rawValue)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter ComponentViewportPresetTests`
+Expected: FAIL — `ComponentViewportPreset` does not exist (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/ComponentViewportPreset.swift`:
+
+```swift
+import Foundation
+
+/// Canvas viewport-width presets for the Component Editor (design spec §3/§4.2): fixed device
+/// widths for responsive work, pairing with media-query editing in the Styles panel (Task 1).
+/// Pure/testable — `ComponentEditorView` maps each case to an SF Symbol and applies `.width` as
+/// a `.frame` constraint on the harness `WKWebView`.
+public enum ComponentViewportPreset: String, CaseIterable, Identifiable, Sendable {
+    case mobile, tablet, desktop, fill
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .mobile: "Mobile"
+        case .tablet: "Tablet"
+        case .desktop: "Desktop"
+        case .fill: "Fill"
+        }
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .mobile: "iphone"
+        case .tablet: "ipad"
+        case .desktop: "display"
+        case .fill: "arrow.up.left.and.arrow.down.right"
+        }
+    }
+
+    /// Fixed viewport width in points, or `nil` for "Fill" (canvas fills the available pane width).
+    public var width: Double? {
+        switch self {
+        case .mobile: 375
+        case .tablet: 768
+        case .desktop: 1440
+        case .fill: nil
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ComponentViewportPresetTests`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ComponentViewportPreset.swift Tests/AnglesiteCoreTests/ComponentViewportPresetTests.swift
+git commit -m "feat(component-editor): add ComponentViewportPreset for canvas toolbar (#495)"
+```
+
+---
+
+### Task 3: Styles panel — grouped, collapsible media sections
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ComponentEditorView.swift`
+
+**Interfaces:**
+- Consumes: `ComponentStyleGrouping.groups(from:)` (Task 1); existing `ComponentEditorModel.addStyleRule(selector:media:declarations:)` (`Sources/AnglesiteApp/ComponentEditorModel.swift:196-207`, unchanged); existing `selectorBinding(for:)`, `propertyBinding(for:)`, `declarationValueField(...)`, `commitSelector(...)`, `commitDeclaration(...)`, `removeDeclaration(...)`, `spanArray(...)` (all unchanged, already defined lower in the same file).
+- Produces: no new public API — this is the Styles `GroupBox`'s rendering, consumed only by SwiftUI itself.
+
+This task has no unit test of its own (SwiftUI view bodies in this codebase are not independently unit-tested — see `AGENTS.md` "Build": hosted `xcodebuild test` doesn't run reliably on CI, so app-target logic that needs coverage is pushed into testable `AnglesiteCore` types, which Task 1 already did). Verification is an `xcodebuild` build (Step 2) plus the manual GUI check in Task 5.
+
+- [ ] **Step 1: Replace the flat Styles rendering with grouped sections**
+
+In `Sources/AnglesiteApp/ComponentEditorView.swift`, first add two new `@State` properties next to the existing `newRuleSelector` declaration (around line 35-36):
+
+```swift
+    /// Selector text for the inline "Add rule" form at the bottom of the Styles panel.
+    @State private var newRuleSelector: String = ""
+    /// `@media` condition text for the inline "Add rule" form; blank means no wrapping media
+    /// query (same as passing `nil` to `addStyleRule`).
+    @State private var newRuleMedia: String = ""
+    /// Media keys (via `mediaGroupKey`) the user has manually collapsed — a `DisclosureGroup`
+    /// per media section defaults to expanded, matching the old flat list's always-visible rules.
+    @State private var collapsedMediaKeys: Set<String> = []
+```
+
+Then replace the entire `GroupBox("Styles") { ... }` block (originally lines 529-588 — the block starting `GroupBox("Styles") {` and ending with the `Add rule` `HStack`'s closing `}` right before `GroupBox("Computed")`) with:
+
+```swift
+                GroupBox("Styles") {
+                    if let styles = model.model?.styles, !styles.isEmpty {
+                        let groups = ComponentStyleGrouping.groups(from: styles)
+                        ForEach(Array(groups.enumerated()), id: \.offset) { groupIndex, group in
+                            DisclosureGroup(isExpanded: mediaExpandedBinding(for: group.media)) {
+                                ForEach(Array(group.rules.enumerated()), id: \.element.index) { position, indexed in
+                                    ruleRow(model, ruleIndex: indexed.index, rule: indexed.rule)
+                                    if position < group.rules.count - 1 {
+                                        Divider()
+                                    }
+                                }
+                            } label: {
+                                Text(group.media.map { "@media \($0)" } ?? "Base styles")
+                                    .font(.caption).bold()
+                            }
+                            if groupIndex < groups.count - 1 {
+                                Divider()
+                            }
+                        }
+                    } else {
+                        Text("No scoped styles").foregroundStyle(.secondary)
+                    }
+                    Divider()
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            TextField("New selector, e.g. .card-footer", text: $newRuleSelector)
+                                .font(.system(.caption, design: .monospaced))
+                            TextField("@media (optional)", text: $newRuleMedia)
+                                .font(.system(.caption, design: .monospaced))
+                        }
+                        Button("Add rule") {
+                            let selector = newRuleSelector.trimmingCharacters(in: .whitespaces)
+                            guard !selector.isEmpty else { return }
+                            let media = newRuleMedia.trimmingCharacters(in: .whitespaces)
+                            Task {
+                                await model.addStyleRule(selector: selector, media: media.isEmpty ? nil : media, declarations: [])
+                                newRuleSelector = ""
+                                newRuleMedia = ""
+                            }
+                        }
+                        .disabled(newRuleSelector.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+                }
+```
+
+Then add two new helper methods right after `paletteView(_:)` (or anywhere among the other private helpers — e.g. directly above the existing `knobsBar` method):
+
+```swift
+    /// Stable dictionary/Set key for a media group — `""` for the unscoped "Base styles" group,
+    /// the media condition string otherwise. Mirrors `ComponentStyleGrouping.groups`' own
+    /// `key.isEmpty ? nil : key` convention so the two stay in sync.
+    private func mediaGroupKey(_ media: String?) -> String { media ?? "" }
+
+    /// Expand/collapse binding for one media group's `DisclosureGroup`, backed by
+    /// `collapsedMediaKeys` — defaults to expanded (absent from the set) so the panel reads the
+    /// same as the old always-expanded flat list until the user explicitly collapses a section.
+    private func mediaExpandedBinding(for media: String?) -> Binding<Bool> {
+        let key = mediaGroupKey(media)
+        return Binding(
+            get: { !collapsedMediaKeys.contains(key) },
+            set: { expanded in
+                if expanded {
+                    collapsedMediaKeys.remove(key)
+                } else {
+                    collapsedMediaKeys.insert(key)
+                }
+            }
+        )
+    }
+
+    /// One rule's editable selector + declaration rows — extracted from the old flat Styles
+    /// rendering so both the grouped (Task 3) and (unchanged) declaration-editing logic below
+    /// stay in one place.
+    @ViewBuilder
+    private func ruleRow(_ model: ComponentEditorModel, ruleIndex: Int, rule: ComponentModel.StyleRule) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            TextField("selector", text: selectorBinding(for: rule))
+                .font(.system(.caption, design: .monospaced))
+                .textFieldStyle(.plain)
+                .bold()
+                .onSubmit { commitSelector(model, rule: rule) }
+            ForEach(rule.declarations, id: \.property) { decl in
+                HStack(spacing: 4) {
+                    TextField("property", text: propertyBinding(for: decl))
+                        .font(.system(.caption, design: .monospaced))
+                        .textFieldStyle(.plain)
+                        .frame(width: 110)
+                        .onSubmit { commitDeclaration(model, ruleIndex: ruleIndex, rule: rule, decl: decl) }
+                    Text(":")
+                    declarationValueField(model, ruleIndex: ruleIndex, rule: rule, decl: decl)
+                    Button(role: .destructive) {
+                        removeDeclaration(model, rule: rule, decl: decl)
+                    } label: {
+                        Image(systemName: "minus.circle")
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            Button("Add declaration") {
+                let newProperty = "new-property-\(UUID().uuidString.prefix(8))"
+                Task { await model.setStyleProperty(ruleSpan: spanArray(rule.span), property: newProperty, value: "") }
+            }
+            .font(.caption2)
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
+    }
+```
+
+Note the old per-rule `if let media = rule.media { Text("@media \(media)") }` line is intentionally dropped from `ruleRow` — the media condition is now shown once, as the enclosing `DisclosureGroup`'s label, instead of repeated on every rule in that group.
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+
+(If `Anglesite.xcodeproj` doesn't exist yet in this worktree, run `xcodegen generate` first.)
+
+Expected: `** BUILD SUCCEEDED **`. If it fails on `ComponentStyleGrouping`/`ComponentViewportPreset` not found, confirm Task 1/2's files were saved under `Sources/AnglesiteCore/` (not `Sources/AnglesiteApp/`) — `ComponentEditorView.swift` already `import AnglesiteCore` (line 3), so no new import line is needed.
+
+- [ ] **Step 3: Run the full Swift test suite to confirm no regressions**
+
+Run: `swift test --package-path .`
+Expected: PASS — all existing `ComponentEditorModel`/`ComponentOutline`/`ComponentStyleEditBuilder` tests untouched by this task still pass, plus Task 1/2's new tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ComponentEditorView.swift
+git commit -m "feat(component-editor): group Styles panel rules into collapsible @media sections (#495)"
+```
+
+---
+
+### Task 4: Canvas viewport-preset toolbar
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ComponentEditorView.swift`
+
+**Interfaces:**
+- Consumes: `ComponentViewportPreset` (Task 2); existing `canvas(_:)`, `knobsBar(_:props:)`, `performCanvasDrop(...)`, `ComponentCanvasView` (all defined in this same file, unchanged).
+- Produces: no new public API.
+
+Same testing note as Task 3 — no unit test; verified by build (Step 2) + Task 5's manual check.
+
+- [ ] **Step 1: Add viewport state and a toolbar view**
+
+In `Sources/AnglesiteApp/ComponentEditorView.swift`, add a new `@State` property next to `webView` (around line 18):
+
+```swift
+    @State private var webView: WKWebView?
+    /// Canvas viewport-width preset (design spec §3/§4.2) — "Fill" (the default) matches the
+    /// pre-slice-5 behavior of the harness filling the available pane width.
+    @State private var viewportPreset: ComponentViewportPreset = .fill
+```
+
+Add a new `viewportToolbar` view, placed directly above the existing `canvas(_:)` method:
+
+```swift
+    /// Device-width preset row above the canvas (design spec §3: "A viewport-width control
+    /// (device presets + free resize)…"). "Free resize" isn't implemented in this pass — the
+    /// four fixed presets are the "polish" scope issue #495 asks for; a drag handle can follow
+    /// as its own increment if needed.
+    private var viewportToolbar: some View {
+        HStack(spacing: 2) {
+            ForEach(ComponentViewportPreset.allCases) { preset in
+                Button {
+                    viewportPreset = preset
+                } label: {
+                    Image(systemName: preset.systemImage)
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(viewportPreset == preset ? Color.accentColor : Color.secondary)
+                .help(preset.label)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+    }
+```
+
+- [ ] **Step 2: Extract the harness WKWebView into its own width-constrained view, and wire the toolbar into `canvas(_:)`**
+
+Replace the existing `canvas(_:)` method body:
+
+```swift
+    @ViewBuilder private func canvas(_ model: ComponentEditorModel) -> some View {
+        VStack(spacing: 0) {
+            if let props = model.model?.frontmatter?.props, !props.isEmpty {
+                knobsBar(model, props: props)
+                Divider()
+            }
+            // Gated directly on `context.baseURL` (not just `model.harnessURL`)
+            // so the live canvas replaces this placeholder the moment the dev
+            // server becomes ready, in lockstep with the `loadKey`-driven
+            // reload above.
+            if context.baseURL != nil, let url = model.harnessURL {
+                ComponentCanvasView(
+                    url: url,
+                    editRouter: context.editRouter,
+                    onSelection: { model.canvasSelected($0) },
+                    onComputedStyles: { model.computedStyles = $0.styles },
+                    onWebView: { webView = $0 }
+                )
+                .dropDestination(for: OutlineDragPayload.self) { items, location in
+                    guard let item = items.first, case .insert(let payload) = item, let webView else { return false }
+                    Task { await performCanvasDrop(model, payload: payload, location: location, webView: webView) }
+                    return true
+                }
+            } else {
+                ContentUnavailableView("Dev Server Starting…", systemImage: "hourglass")
+            }
+        }
+    }
+```
+
+with:
+
+```swift
+    @ViewBuilder private func canvas(_ model: ComponentEditorModel) -> some View {
+        VStack(spacing: 0) {
+            viewportToolbar
+            Divider()
+            if let props = model.model?.frontmatter?.props, !props.isEmpty {
+                knobsBar(model, props: props)
+                Divider()
+            }
+            canvasWebView(model)
+        }
+    }
+
+    /// The harness `WKWebView` itself (drop-destination wiring unchanged from before this
+    /// task), width-constrained to `viewportPreset.width` when a fixed preset is active. `.fill`
+    /// (`width == nil`) renders identically to the pre-slice-5 behavior — no frame constraint,
+    /// canvas fills the available pane width.
+    @ViewBuilder private func canvasWebView(_ model: ComponentEditorModel) -> some View {
+        // Gated directly on `context.baseURL` (not just `model.harnessURL`)
+        // so the live canvas replaces this placeholder the moment the dev
+        // server becomes ready, in lockstep with the `loadKey`-driven
+        // reload above.
+        if context.baseURL != nil, let url = model.harnessURL {
+            let content = ComponentCanvasView(
+                url: url,
+                editRouter: context.editRouter,
+                onSelection: { model.canvasSelected($0) },
+                onComputedStyles: { model.computedStyles = $0.styles },
+                onWebView: { webView = $0 }
+            )
+            .dropDestination(for: OutlineDragPayload.self) { items, location in
+                guard let item = items.first, case .insert(let payload) = item, let webView else { return false }
+                Task { await performCanvasDrop(model, payload: payload, location: location, webView: webView) }
+                return true
+            }
+            if let width = viewportPreset.width {
+                ScrollView(.horizontal) {
+                    content.frame(width: width, height: 800)
+                }
+            } else {
+                content
+            }
+        } else {
+            ContentUnavailableView("Dev Server Starting…", systemImage: "hourglass")
+        }
+    }
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Run the full Swift test suite to confirm no regressions**
+
+Run: `swift test --package-path .`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ComponentEditorView.swift
+git commit -m "feat(component-editor): add viewport-preset toolbar to the canvas pane (#495)"
+```
+
+---
+
+### Task 5: Manual GUI verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Launch the app and open a component with existing styles**
+
+Build and run `Anglesite` (⌘R in Xcode, or `xcodebuild ... build` then launch `Anglesite.app` from `DerivedData`). Open (or create) a site with a component under `src/components/` that has a scoped `<style>` block with at least one plain rule and one rule wrapped in `@media (min-width: 768px) { ... }` (add one by hand in the Source tab first if none exists, then reload the Design tab).
+
+- [ ] **Step 2: Verify the grouped Styles panel**
+
+Open that component in the Component Editor (Design mode). Confirm:
+- The Styles panel shows a "Base styles" section and a "@media (min-width: 768px)" section, each a collapsible `DisclosureGroup`.
+- Clicking a section's disclosure triangle collapses/expands just that section.
+- Typing a selector and a `@media` condition into the "Add rule" form's two fields and clicking "Add rule" creates a new rule that appears under a (new, if the condition didn't already exist) matching media section.
+- Leaving the `@media` field blank and adding a rule adds it to "Base styles".
+
+- [ ] **Step 3: Verify the viewport toolbar**
+
+In the same component's canvas pane, confirm a small icon row (phone/tablet/display/arrows) appears above the canvas. Click each preset and confirm:
+- "Mobile"/"Tablet"/"Desktop" visibly narrow the rendered harness to a fixed width (with horizontal scrolling available if the pane is narrower than the preset).
+- "Fill" returns the canvas to filling the full pane width (today's pre-slice-5 behavior).
+- The selected preset's icon is highlighted (accent color) vs. the others (secondary).
+
+- [ ] **Step 4: Report results**
+
+If all checks pass, proceed to Task 6. If anything fails, fix it in the relevant task's file before continuing (do not skip ahead with a known-broken UI).
+
+---
+
+### Task 6: Open the pull request
+
+**Files:** none (git/gh only).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin claude/issue-495-fd0042
+```
+
+(If this branch was already pushed earlier in the session, a plain `git push` suffices.)
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "feat(component-editor): media-query editing + viewport presets (#495)" --body "$(cat <<'EOF'
+## Summary
+- Groups the Component Editor's Styles panel rules into collapsible `@media` sections (design spec §4.3), reusing the existing `add-style-rule` op's `media` param (already shipped in slice 2 — no plugin change needed).
+- Adds a Mobile/Tablet/Desktop/Fill viewport-preset toolbar above the canvas (design spec §3/§4.2), constraining the harness `WKWebView`'s width.
+- Part of Component Editor slice 5 (#495) — the two pieces of that issue that need no plugin/MCP schema change. The `extract-component` op and the app's "Extract into Component…"/"Duplicate & Modify" UI ship as follow-up PRs.
+
+## Test plan
+- [x] `swift test --package-path .` — new `ComponentStyleGroupingTests`/`ComponentViewportPresetTests` plus full existing suite pass.
+- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` succeeds.
+- [x] Manual GUI check: grouped/collapsible media sections, add-rule-with-media, and all four viewport presets verified in a running component editor.
+EOF
+)"
+```
+
+- [ ] **Step 3: Remove the in-progress label from #495 only if this PR fully closes it**
+
+This PR does not fully close #495 (extract-component and duplicate-and-modify are still outstanding). Leave the `🛠️ In Progress` label on #495 and do NOT reference "Closes #495" in the PR body — reference it as "Part of #495" instead (already done in Step 2's body). Do not remove the label until the final follow-up PR lands.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** design spec §3 ("viewport-width control… device presets") → Task 4. §4.2 ("viewport presets") → Task 4. §4.3 ("Media queries as collapsible sections; 'add media query' scaffolds a block") → Task 3 (a new media condition typed into the Add Rule form scaffolds its own section the moment the first rule under it exists — no separate empty-section affordance needed, since sections are derived directly from existing rules). Free-resize (also mentioned in §3) is explicitly deferred — noted in Task 4 Step 1's doc comment rather than silently dropped.
+- **Out of scope for this plan (tracked separately under #495):** `extract-component` plugin op + "Extract into Component…" UI; "duplicate-and-modify" from a component-listing context menu; named-slot sample content (already shipped, #490).

--- a/docs/superpowers/plans/2026-07-16-component-editor-slice5b-duplicate-component.md
+++ b/docs/superpowers/plans/2026-07-16-component-editor-slice5b-duplicate-component.md
@@ -1,0 +1,498 @@
+# Component Editor Slice 5b: Duplicate & Modify Component Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Component Editor's palette a "Duplicate & Modify" command on project-component items — the remaining app-only piece of Component Editor slice 5 (issue #495) that needs no plugin/MCP change, since it's a pure file-copy + git-commit operation.
+
+**Architecture:** `NativeContentOperations` (already the native, in-process, MCP-free home for `createPage`/`createPost`/`createComponent`/`duplicatePage`/`duplicatePost` — see `Sources/AnglesiteCore/NativeContentOperations.swift`) gains a `duplicateComponent(siteID:relativePath:)` method following the exact same read-contents/pick-non-colliding-name/write/commit shape as `duplicatePage`. `SiteWindowModel` gains a thin wrapper (mirroring its existing `createComponent(name:)`), `ComponentEditorContext` gains a `duplicateComponent` closure (mirroring its existing `onOpenFile`), `ComponentEditorModel` gains a method that calls it and opens the result, and `ComponentEditorView`'s palette grid item gains a context menu. Design spec §6.3 calls this "duplicate-and-modify from the navigator context menu" — it's surfaced on the Component Editor's own palette rather than `SiteNavigatorView` because `SiteNavigatorView`/`SiteURLTree` deliberately excludes non-page source files (components aren't shown there at all — see `Sources/AnglesiteCore/SiteURLTree.swift`'s file-level doc comment), while the palette already lists every project component by design (spec §4.1).
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27+), Swift Testing, existing `NativeContentOperations`/`SiteWindowModel`/`ComponentEditorModel`/`ComponentEditorView` types, SwiftGit2-backed `gitCommit` closure (no plugin/MCP round-trip).
+
+## Global Constraints
+
+- Swift 6.4 / macOS 27+ toolchain. `Anglesite.xcodeproj` is gitignored — `xcodegen generate` if missing.
+- `ANGLESITE_PLUGIN_SRC=/Users/dwk/Developer/github.com/Anglesite/anglesite` for this worktree's builds (not used by this plan's code, but needed for the app build itself to stage container resources).
+- No plugin PR, no MCP schema change — this whole feature is native Swift, matching `createComponent`'s precedent.
+- Conventional commits (`feat(component-editor): …`), reference `#495`.
+- Manual GUI verification: attempt it, but if GUI automation access is unavailable/denied, say so explicitly in the PR rather than claiming it was done (do not silently skip this disclosure).
+
+---
+
+## File Structure
+
+- **Modify:** `Sources/AnglesiteCore/NativeContentOperations.swift` — new `duplicateComponent(siteID:relativePath:)` method.
+- **Modify:** `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift` — new `NativeContentOperationsDuplicateComponentTests` suite.
+- **Modify:** `Sources/AnglesiteApp/SiteWindowModel.swift` — new `duplicateComponent(relativePath:)` wrapper.
+- **Modify:** `Tests/AnglesiteAppTests/SiteWindowModelTests.swift` — one no-site no-op test.
+- **Modify:** `Sources/AnglesiteApp/SiteWindow.swift` — wire the new closure into `ComponentEditorContext(...)`.
+- **Modify:** `Sources/AnglesiteApp/ComponentEditorModel.swift` — new `duplicateComponent(path:)` field on `ComponentEditorContext` + method on `ComponentEditorModel`.
+- **Modify:** `Sources/AnglesiteApp/ComponentEditorView.swift` — context menu on palette items.
+
+---
+
+### Task 1: `NativeContentOperations.duplicateComponent`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/NativeContentOperations.swift`
+- Test: `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift`
+
+**Interfaces:**
+- Consumes: `siteDirectory: @Sendable (String) async -> URL?`, `gitCommit: GitCommit`, `fileManager: FileManager`, `write(_:to:)` (all existing private/stored members of `NativeContentOperations`), `FileDocumentIO.load(_:fileManager:)` (existing helper `duplicatePage`/`duplicatePost` already use).
+- Produces: `public func duplicateComponent(siteID: String, relativePath: String) async -> ContentCreateResult` — `.created(filePath:identifier:)` where `identifier` is the new PascalCase component name (no leading path, no `.astro`), `filePath` is the new project-relative path. Task 3 (`SiteWindowModel`) calls this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift` (a new suite, placed after the existing `NativeContentOperationsComponentTests` suite at the end of the file):
+
+```swift
+@Suite("NativeContentOperations.duplicateComponent")
+struct NativeContentOperationsDuplicateComponentTests {
+    private func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("native-content-ops-dup-component-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    @Test("duplicateComponent writes a Copy-suffixed file with identical contents")
+    func duplicatesComponent() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let relPath = "src/components/Card.astro"
+        let abs = root.appendingPathComponent(relPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let original = "---\ninterface Props { title: string }\n---\n<div>{Astro.props.title}</div>\n"
+        try original.write(to: abs, atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        let result = await ops.duplicateComponent(siteID: "site-1", relativePath: relPath)
+
+        guard case .created(let filePath, let identifier) = result else {
+            Issue.record("expected .created, got \(result)"); return
+        }
+        #expect(filePath == "src/components/CardCopy.astro")
+        #expect(identifier == "CardCopy")
+        let copied = try String(contentsOf: root.appendingPathComponent(filePath), encoding: .utf8)
+        #expect(copied == original)
+    }
+
+    @Test("duplicateComponent bumps the suffix on collision")
+    func duplicatesComponentWithCollision() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let relPath = "src/components/Card.astro"
+        let abs = root.appendingPathComponent(relPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "original".write(to: abs, atomically: true, encoding: .utf8)
+        try "existing copy".write(to: root.appendingPathComponent("src/components/CardCopy.astro"), atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        let result = await ops.duplicateComponent(siteID: "site-1", relativePath: relPath)
+
+        guard case .created(let filePath, let identifier) = result else {
+            Issue.record("expected .created, got \(result)"); return
+        }
+        #expect(filePath == "src/components/CardCopy2.astro")
+        #expect(identifier == "CardCopy2")
+    }
+
+    @Test("duplicateComponent preserves a nested subdirectory")
+    func duplicatesNestedComponent() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let relPath = "src/components/esi/EsiInclude.astro"
+        let abs = root.appendingPathComponent(relPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "original".write(to: abs, atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        let result = await ops.duplicateComponent(siteID: "site-1", relativePath: relPath)
+
+        guard case .created(let filePath, _) = result else { Issue.record("expected .created, got \(result)"); return }
+        #expect(filePath == "src/components/esi/EsiIncludeCopy.astro")
+    }
+
+    @Test("duplicateComponent fails when the source file does not exist")
+    func duplicateMissingComponentFails() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let ops = NativeContentOperations(siteDirectory: { _ in root })
+
+        let result = await ops.duplicateComponent(siteID: "site-1", relativePath: "src/components/Missing.astro")
+
+        guard case .failed = result else { Issue.record("expected .failed, got \(result)"); return }
+    }
+
+    @Test("unknown site returns .siteNotFound")
+    func duplicateComponentSiteNotFound() async {
+        let ops = NativeContentOperations(siteDirectory: { _ in nil }, gitCommit: { _, _, _ in nil })
+        let result = await ops.duplicateComponent(siteID: "missing", relativePath: "src/components/Card.astro")
+        #expect(result == .siteNotFound)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter NativeContentOperationsDuplicateComponentTests`
+Expected: FAIL — `duplicateComponent` does not exist on `NativeContentOperations` (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteCore/NativeContentOperations.swift`, add this method directly after `duplicatePost` (i.e. right before the `/// Scaffold a minimal blank .astro component…` doc comment / `createComponent` method):
+
+```swift
+    /// Duplicate an existing `.astro` component: read its contents verbatim (no retitle —
+    /// unlike pages/posts, a component has no title to rewrite), derive a "Copy"-suffixed
+    /// PascalCase name colliding-safely with `NameCopy`/`NameCopy2`… (mirrors `createComponent`'s
+    /// PascalCase convention), write, commit. Preserves the source's subdirectory (e.g.
+    /// `src/components/esi/EsiInclude.astro` duplicates to `src/components/esi/EsiIncludeCopy.astro`)
+    /// since component grouping directories are meaningful (design spec §4.1's palette groups by
+    /// `SiteFileTree`'s components group).
+    public func duplicateComponent(siteID: String, relativePath: String) async -> ContentCreateResult {
+        guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+        let sourceAbs = root.appendingPathComponent(relativePath)
+        guard fileManager.fileExists(atPath: sourceAbs.path) else {
+            return .failed(reason: "No component exists at \(relativePath)")
+        }
+        let contents: String
+        do { contents = try FileDocumentIO.load(sourceAbs, fileManager: fileManager).contents }
+        catch { return .failed(reason: "\(error)") }
+
+        let relDir = (relativePath as NSString).deletingLastPathComponent
+        let baseName = ((relativePath as NSString).lastPathComponent as NSString).deletingPathExtension
+        func candidatePath(_ name: String) -> String {
+            relDir.isEmpty ? "\(name).astro" : "\(relDir)/\(name).astro"
+        }
+        var attempt = 1
+        var candidateName = "\(baseName)Copy"
+        var relPath = candidatePath(candidateName)
+        while attempt < 1000, fileManager.fileExists(atPath: root.appendingPathComponent(relPath).path) {
+            attempt += 1
+            candidateName = "\(baseName)Copy\(attempt)"
+            relPath = candidatePath(candidateName)
+        }
+        guard !fileManager.fileExists(atPath: root.appendingPathComponent(relPath).path) else {
+            return .failed(reason: "Couldn't find an available name for the duplicate after 1000 attempts")
+        }
+
+        do { try write(contents, to: root.appendingPathComponent(relPath)) }
+        catch { return .failed(reason: "\(error)") }
+
+        _ = await gitCommit(root, relPath, "anglesite: duplicate component \(candidateName)")
+        return .created(filePath: relPath, identifier: candidateName)
+    }
+
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter NativeContentOperationsDuplicateComponentTests`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NativeContentOperations.swift Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+git commit -m "feat(component-editor): add NativeContentOperations.duplicateComponent (#495)"
+```
+
+---
+
+### Task 2: `SiteWindowModel.duplicateComponent` + wire into `ComponentEditorContext`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift`
+- Test: `Tests/AnglesiteAppTests/SiteWindowModelTests.swift`
+
+**Interfaces:**
+- Consumes: `NativeContentOperations.duplicateComponent(siteID:relativePath:)` (Task 1); existing `SiteWindowModel.site`, `SiteWindowModel.contentCreation`, `SiteWindowModel.navigator?.refreshNow()` (all existing members, same as `createComponent`).
+- Produces: `func duplicateComponent(relativePath: String) async -> ContentCreateResult` on `SiteWindowModel`. Task 3 wires this into `ComponentEditorContext.duplicateComponent`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteAppTests/SiteWindowModelTests.swift`, in the `extension SiteWindowModelTests` block that already contains `createComponentNoSiteReturnsSiteNotFound` (right after that test):
+
+```swift
+    @Test("duplicateComponent no-ops safely when there is no open site")
+    func duplicateComponentNoSiteReturnsSiteNotFound() async {
+        let model = makeModel()
+        let result = await model.duplicateComponent(relativePath: "src/components/Card.astro")
+        #expect(result == .siteNotFound)
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --package-path . --filter SiteWindowModelTests`
+Expected: FAIL — `duplicateComponent` does not exist on `SiteWindowModel` (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, add this method directly after `createComponent` (which ends around line 991):
+
+```swift
+    /// Duplicates the component at `relativePath` (design spec §6.3: "duplicate-and-modify" —
+    /// surfaced on the Component Editor's own palette, since project components aren't tracked
+    /// in `SiteContentGraph` or shown in the page-only Navigator). Same force-refresh reasoning
+    /// as `createComponent`.
+    func duplicateComponent(relativePath: String) async -> ContentCreateResult {
+        guard let site else { return .siteNotFound }
+        let result = await contentCreation.duplicateComponent(siteID: site.id, relativePath: relativePath)
+        if case .created = result {
+            await navigator?.refreshNow()
+        }
+        return result
+    }
+```
+
+- [ ] **Step 4: Wire it into `ComponentEditorContext(...)`**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, in `mainPaneContent(for:)`'s `ComponentEditorContext(...)` construction (around line 708-722), add a `duplicateComponent` argument right after `onOpenFile`:
+
+```swift
+                    componentContext: ComponentEditorContext(
+                        baseURL: model.preview.readyURL,
+                        modelClient: ComponentModelClient(mcpClient: { [preview = model.preview] in
+                            await preview.mcpClient()
+                        }),
+                        sourceRoot: site.sourceDirectory,
+                        editRouter: model.preview.editRouter,
+                        onOpenFile: { file in model.openFile(file) },
+                        duplicateComponent: { relativePath in await model.duplicateComponent(relativePath: relativePath) }
+                    )
+```
+
+(Only the trailing `onOpenFile: { file in model.openFile(file) },` line and the new `duplicateComponent:` line change — everything else in that initializer call stays as-is. Task 3 adds the `duplicateComponent` parameter to `ComponentEditorContext`'s own initializer, which this call now satisfies.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `swift test --package-path . --filter SiteWindowModelTests`
+Expected: This will still FAIL to compile until Task 3 adds the `duplicateComponent` parameter to `ComponentEditorContext` (Step 4 above references a parameter that doesn't exist yet). That's expected — proceed directly to Task 3, then come back and run the full build/test pass at the end of Task 3.
+
+- [ ] **Step 6: Commit** (deferred to the end of Task 3, since Task 2 Step 4 doesn't compile in isolation — see Task 3 Step 4's commit, which covers both)
+
+---
+
+### Task 3: `ComponentEditorContext.duplicateComponent` + `ComponentEditorModel.duplicateComponent(path:)`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ComponentEditorModel.swift`
+
+**Interfaces:**
+- Consumes: `Task 2`'s `SiteWindowModel.duplicateComponent` (via the `context.duplicateComponent` closure); existing `ComponentEditorModel.projectComponents`, `context.sourceRoot`, `context.onOpenFile`, `SiteFileTree.scan(siteRoot:)` (all existing).
+- Produces: `ComponentEditorContext.duplicateComponent: ((String) async -> ContentCreateResult)?` (new field, default `nil`); `ComponentEditorModel.duplicateComponent(path: String) async -> ContentCreateResult?` (new method). Task 4 (`ComponentEditorView`) calls the model method.
+
+- [ ] **Step 1: Add the `duplicateComponent` field to `ComponentEditorContext`**
+
+In `Sources/AnglesiteApp/ComponentEditorModel.swift`, in the `ComponentEditorContext` struct (near the top of the file), add a new field right after `onOpenFile`:
+
+```swift
+    /// Opens a different file in the main pane — used to implement "double-click a sealed
+    /// component instance to edit its own definition" (spec §4.1). `nil` in
+    /// tests/previews that don't need navigation.
+    var onOpenFile: ((FileRef) -> Void)? = nil
+    /// Duplicates a project-relative `.astro` component path, returning the new file's path/name
+    /// on success (design spec §6.3: "duplicate-and-modify"). `nil` in tests/previews that don't
+    /// need it — `ComponentEditorModel.duplicateComponent(path:)` no-ops when this is `nil`.
+    var duplicateComponent: ((String) async -> ContentCreateResult)? = nil
+```
+
+- [ ] **Step 2: Add `ComponentEditorModel.duplicateComponent(path:)`**
+
+In the same file, add this method to `ComponentEditorModel` directly after `openReferencedComponent(tag:)`:
+
+```swift
+    /// Duplicates `path` (a project-relative `.astro` path, e.g. from a palette item's
+    /// `componentPath`) via `context.duplicateComponent` and, on success, refreshes
+    /// `projectComponents` and opens the new file through `context.onOpenFile` — "duplicate-and-
+    /// modify" (design spec §6.3). No-op (returns `nil`) if duplication isn't wired
+    /// (`context.duplicateComponent == nil`, true in tests/previews without write capability).
+    @discardableResult
+    func duplicateComponent(path: String) async -> ContentCreateResult? {
+        guard let duplicateComponent = context.duplicateComponent else { return nil }
+        let result = await duplicateComponent(path)
+        if case .created(let filePath, _) = result {
+            projectComponents = SiteFileTree.scan(siteRoot: context.sourceRoot)[.components] ?? []
+            if let match = projectComponents.first(where: { relativePath(for: $0) == filePath }) {
+                context.onOpenFile?(match)
+            }
+        }
+        return result
+    }
+
+    /// Project-relative path of `file` under `context.sourceRoot` — the general form of the
+    /// `relativePath` computed property below (which is always `relativePath(for: self.file)`).
+    private func relativePath(for file: FileRef) -> String {
+        let root = context.sourceRoot.path(percentEncoded: false)
+        let full = file.url.path(percentEncoded: false)
+        guard full.hasPrefix(root) else { return file.name }
+        return String(full.dropFirst(root.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    }
+```
+
+- [ ] **Step 3: Simplify the existing `relativePath` computed property to reuse the new helper**
+
+Replace the existing `relativePath` computed property (currently):
+
+```swift
+    /// Path of this component relative to the site's Source/ root.
+    var relativePath: String {
+        let root = context.sourceRoot.path(percentEncoded: false)
+        let full = file.url.path(percentEncoded: false)
+        guard full.hasPrefix(root) else { return file.name }
+        return String(full.dropFirst(root.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    }
+```
+
+with:
+
+```swift
+    /// Path of this component relative to the site's Source/ root.
+    var relativePath: String { relativePath(for: file) }
+```
+
+- [ ] **Step 4: Build to verify Tasks 2+3 compile together**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`. (`xcodegen generate` first if `Anglesite.xcodeproj` is stale/missing.)
+
+- [ ] **Step 5: Run the full Swift test suite**
+
+Run: `swift test --package-path .`
+Expected: PASS, including Task 1's 5 new tests and Task 2's 1 new test.
+
+- [ ] **Step 6: Commit Tasks 2 and 3 together** (Task 2's wiring doesn't compile standalone — see Task 2 Step 5's note)
+
+```bash
+git add Sources/AnglesiteApp/SiteWindowModel.swift Sources/AnglesiteApp/SiteWindow.swift Sources/AnglesiteApp/ComponentEditorModel.swift Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+git commit -m "feat(component-editor): wire duplicateComponent through SiteWindowModel/ComponentEditorContext (#495)"
+```
+
+---
+
+### Task 4: Palette context menu
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ComponentEditorView.swift`
+
+**Interfaces:**
+- Consumes: `ComponentEditorModel.duplicateComponent(path:)` (Task 3); `ComponentPalette.Item.kind` (existing, `ComponentStructureEditBuilder.NodeSpec` — `.component(tag: String, componentPath: String)` is the case to match).
+- Produces: no new public API — this is `paletteView(_:)`'s rendering only.
+
+No unit test for this step — same reasoning as slice 5a's Tasks 3/4 (SwiftUI view bodies aren't independently unit-tested in this codebase; Task 3 already covers the testable logic). Verified by build (Step 2).
+
+- [ ] **Step 1: Add the context menu**
+
+In `Sources/AnglesiteApp/ComponentEditorView.swift`, in `paletteView(_:)`, find the `ForEach(items) { item in ... }` block:
+
+```swift
+                ForEach(items) { item in
+                    VStack(spacing: 2) {
+                        Image(systemName: item.systemImage)
+                        Text(item.label).font(.caption2).lineLimit(1)
+                    }
+                    .frame(width: 84, height: 44)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+                    .draggable(OutlineDragPayload.insert(PaletteDragPayload(label: item.label, kind: item.kind)))
+                }
+```
+
+Replace it with:
+
+```swift
+                ForEach(items) { item in
+                    VStack(spacing: 2) {
+                        Image(systemName: item.systemImage)
+                        Text(item.label).font(.caption2).lineLimit(1)
+                    }
+                    .frame(width: 84, height: 44)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+                    .draggable(OutlineDragPayload.insert(PaletteDragPayload(label: item.label, kind: item.kind)))
+                    .contextMenu {
+                        if case .component(_, let componentPath) = item.kind {
+                            Button("Duplicate & Modify") {
+                                Task { await model.duplicateComponent(path: componentPath) }
+                            }
+                        }
+                    }
+                }
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Run the full Swift test suite to confirm no regressions**
+
+Run: `swift test --package-path .`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ComponentEditorView.swift
+git commit -m "feat(component-editor): add Duplicate & Modify to palette context menu (#495)"
+```
+
+---
+
+### Task 5: Manual GUI verification (best-effort — disclose honestly if blocked)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Attempt GUI verification**
+
+Follow the same approach as slice 5a's Task 5 (launch the app, open a site with a project component, right-click a palette item, confirm "Duplicate & Modify" appears only for project components — not for the curated HTML elements or Slot — click it, confirm a new file appears and opens in the editor with identical contents, confirm a second duplicate of the same original bumps to `Copy2`).
+
+If GUI automation access is unavailable or denied (as it was for slice 5a in this session), do not retry the same denied request — record that verification was not completed and say so explicitly in the PR, per this repo's testing guidance (`AGENTS.md`: "if you can't test the UI, say so explicitly rather than claiming success").
+
+---
+
+### Task 6: Open the pull request
+
+**Files:** none (git/gh only).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push
+```
+
+(Same branch as slice 5a's PR — `claude/issue-495-fd0042` — already tracks `origin`.)
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "feat(component-editor): duplicate & modify a project component (#495)" --body "$(cat <<'EOF'
+## Summary
+- Adds "Duplicate & Modify" to the Component Editor palette's context menu for project components (design spec §6.3) — surfaced on the palette rather than `SiteNavigatorView`, since that navigator deliberately excludes non-page source files while the palette already lists every project component.
+- Pure native Swift, no plugin/MCP change: `NativeContentOperations.duplicateComponent` follows the exact same read/rename/write/commit shape `duplicatePage`/`duplicatePost`/`createComponent` already use.
+- Part of Component Editor slice 5 (#495). Together with the already-merged media-query/viewport PR, this closes out the app-only pieces; the `extract-component` plugin op + its app-side "Extract into Component…" UI remain as a final follow-up.
+
+## Test plan
+- [x] `swift test --package-path .` — new `NativeContentOperationsDuplicateComponentTests` (5 tests) and one `SiteWindowModelTests` no-site test pass, plus the full existing suite.
+- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` succeeds.
+- [ ] Manual GUI verification: <fill in based on Task 5's actual outcome — either the steps you drove and observed, or an explicit note that GUI automation access was unavailable/denied and a human reviewer should click through before merging>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Update issue #495**
+
+This PR plus the already-merged media-query/viewport PR cover every app-only piece of #495. Do NOT remove the `🛠️ In Progress` label yet — the `extract-component` plugin op (sidecar PR, separately in progress) and its app-side consumer are still outstanding. Leave a comment on #495 noting what's landed and what remains, if not already tracked elsewhere.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** design spec §6.3 item 3 ("duplicate-and-modify from the navigator context menu") → Tasks 1-4, with the navigator-vs-palette placement decision explicitly documented above (architecture section) since the spec text is genuinely ambiguous and `SiteNavigatorView` structurally can't show component files without a much larger, out-of-scope change.
+- **Naming convention:** `duplicateComponent` deliberately does NOT prompt for a new name upfront (unlike a hypothetical "Save As") — it follows the exact same low-friction "auto-append Copy/CopyN, user renames after via the existing Rename mechanism if they want" convention `duplicatePage`/`duplicatePost` already established, for UX consistency.
+- **Out of scope for this plan (tracked separately under #495):** `extract-component` plugin op + "Extract into Component…" UI (in progress in the sidecar repo as of this plan's writing).


### PR DESCRIPTION
## Summary

This PR grew across the session to cover both app-only pieces of Component Editor slice 5 (#495) — they landed on the same branch, so they're reviewed together here rather than as separate PRs.

**Media-query editing + viewport presets:**
- Groups the Component Editor's Styles panel rules into collapsible `@media` sections (design spec §4.3), reusing the existing `add-style-rule` op's `media` param (already shipped in slice 2 — no plugin change needed). The "Add rule" form gained an optional `@media` condition field.
- Adds a Mobile/Tablet/Desktop/Fill viewport-preset toolbar above the canvas (design spec §3/§4.2), constraining the harness `WKWebView`'s width. Free-resize (also mentioned in the spec) is deferred as a follow-up.
- Backed by two new pure/testable `AnglesiteCore` types: `ComponentStyleGrouping` (also now home to `normalizeMediaCondition`) and `ComponentViewportPreset`.

**Duplicate & Modify:**
- Adds "Duplicate & Modify" to the palette's context menu for project components (design spec §6.3) — surfaced on the palette rather than `SiteNavigatorView`, since that navigator deliberately excludes non-page source files while the palette already lists every project component.
- Pure native Swift, no plugin/MCP change: `NativeContentOperations.duplicateComponent` follows the same read/rename/write/commit shape `duplicatePage`/`duplicatePost`/`createComponent` already use. `ContentCreationWorkflow` (the facade `SiteWindowModel` actually talks to) gained a matching `componentDuplicator` seam.
- No rename prompt — matches `duplicatePage`/`duplicatePost`'s existing low-friction UX: auto-appends `Copy`/`Copy2`/…, user renames after if they want.

Together these close out the app-only pieces of #495. The `extract-component` plugin op merged in the sidecar repo (Anglesite/anglesite#420, tag pending); its app-side "Extract into Component…" UI is the final follow-up, tracked separately.

**Review fixes (this session's own review):**
- Canvas height for a fixed viewport preset (Mobile/Tablet/Desktop) no longer hardcodes `800` — it now sizes to the split pane's actual available height via `GeometryReader`, so it no longer clips on a short pane or leaves dead space on a tall one.
- The Styles panel's "Add rule" `@media` condition field now strips a redundant leading `@media` a user might type (case-insensitive) via `ComponentStyleGrouping.normalizeMediaCondition`, so the rendered section header can no longer double up as `"@media @media (...)"`. Placeholder text also clarified to ask for just the condition.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

> Both pieces in this PR are pure app-side Swift/SwiftUI — no `EditMessage.Op`, no MCP schema change, no plugin dependency. The `extract-component` op (which does need the plugin) shipped separately as Anglesite/anglesite#420, consumed by a future PR once that release is tagged — not part of this one.

## Test plan
- [x] `swift test --package-path .` — new `ComponentStyleGroupingTests` (12, incl. 4 new `normalizeMediaCondition` cases from the review fix), `ComponentViewportPresetTests` (4), `NativeContentOperationsDuplicateComponentTests` (5), `ContentCreationWorkflowTests` additions (2), and one `SiteWindowModelTests` addition all pass, plus the full existing suite with no new failures. Two pre-existing, environment-specific failures unrelated to this change: `RepoBootstrapTests.publishRefusesWhenDotenvWouldBeCommitted` (local `~/.gitignore` excludes `.env`) and a Foundation Models token-limit failure in `GenerableTypesTests`.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` succeeds.
- [ ] Manual GUI verification was **not completed** — GUI automation access for this session was denied, and the same denied request wasn't retried. A human reviewer should, before merging: (1) open a component with an existing `@media` rule and confirm the grouped/collapsible Styles sections plus the four viewport presets work as described above, including that a fixed preset's canvas now fills the pane height correctly; (2) right-click a project component in the palette and confirm "Duplicate & Modify" creates and opens a `*Copy.astro` file with identical contents; (3) confirm typing `"@media (min-width: 768px)"` (with the literal `@media` prefix) into the Add Rule condition field no longer produces a doubled section header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
