### PR TITLE
fix(test): isolate RepoBootstrapTests dotenv fixture from ambient global gitignore

### DIFF
--- a/Tests/AnglesiteCoreTests/RepoBootstrapTests.swift
+++ b/Tests/AnglesiteCoreTests/RepoBootstrapTests.swift
@@ -71,6 +71,13 @@ import Foundation
         try await run(["init"])
         try await run(["config", "user.email", "t@t.io"])
         try await run(["config", "user.name", "t"])
+        // Isolate from the developer's ambient global excludesFile (e.g. `~/.gitignore`
+        // containing `.env`, common on real dev machines) the same way user.email/user.name
+        // are pinned above — otherwise a repo-local `.env` that also matches the *global*
+        // ignore rules is classified "ignored" rather than "untracked" by both real git and
+        // libgit2, so it never reaches `git status`/`repo.status(...)` and the dotenv-secret
+        // guard under test never sees it.
+        try await run(["config", "core.excludesFile", "/dev/null"])
         if let remoteURL { try await run(["remote", "add", "origin", remoteURL]) }
         if commit {
             try "seed".write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)


### PR DESCRIPTION
## Summary

- `publishRefusesWhenDotenvWouldBeCommitted` failed deterministically on any machine whose global `core.excludesFile` (e.g. `~/.gitignore`) lists `.env`: both real git and libgit2 classify a globally-ignored `.env` as **ignored** rather than **untracked**, so it never reaches `git status`/`repo.status(...)`, and the dotenv-secret guard under test never sees it.
- Root-caused via `superpowers:systematic-debugging` (confirmed by overriding `HOME` to isolate ambient config, which made the test pass) — this is a test-fixture hermeticity gap, **not** a production regression. A real `git add -A` also skips ignored files without `-f`, so a globally-ignored `.env` was never actually at risk of being committed.
- Fix: `makeSourceDir` now pins `core.excludesFile` to `/dev/null` per fixture repo, alongside the existing local `user.email`/`user.name` pins that already exist for the same reason (avoid depending on ambient global config).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (plugin / MCP server / template / hooks). Link it here:

## Test plan

- [x] `swift test --filter RepoBootstrapTests` — all 16 tests pass (previously 1 failed with this machine's ambient `~/.gitignore` containing `.env`)
- [x] `swift test --filter AnglesiteCoreTests` — full target passes except one pre-existing, unrelated on-device Foundation Models flake (`GenerableTypesTests.swift:58`, token-context-window overflow), untouched by this change
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; this is a test-only change with no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)