### PR TITLE
fix(ui): aggregate Settings dirty/save/revert across Website, Analytics, and Redirects (#741)

### DIFF
--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -345,4 +345,41 @@ final class PlistEditorModel {
         merged.append(contentsOf: entries)
         return merged
     }
+
+    // MARK: - Aggregate dirty/save seam (#741)
+
+    /// One independently dirty/saveable settings-pane facet hosted by this plist editor — one
+    /// each for Website (`entries`), Analytics, and Redirects. `SiteWindowModel`'s aggregate
+    /// dirty/save accounting (`hasUnsavedEdits`, `editCommandInFlight`, `saveAllEdits()`) folds
+    /// over `dirtyFacets` instead of checking each pane by name, so a future settings pane (e.g. a
+    /// `.well-known` tab) is registered here and needs no edits anywhere else — including
+    /// `SiteWindowModel`'s save/close switch statements.
+    struct DirtyFacet {
+        let isDirty: Bool
+        let isSaving: Bool
+        let save: () async -> Void
+    }
+
+    private var dirtyFacets: [DirtyFacet] {
+        [
+            DirtyFacet(isDirty: isDirty, isSaving: isSaving) { await self.save() },
+            DirtyFacet(isDirty: isAnalyticsDirty, isSaving: isSavingAnalytics) { await self.saveAnalytics() },
+            DirtyFacet(isDirty: isRedirectsDirty, isSaving: isSavingRedirects) { await self.saveRedirects() },
+        ]
+    }
+
+    /// True if any settings-pane facet has unsaved edits.
+    var hasAnyUnsavedEdits: Bool { dirtyFacets.contains { $0.isDirty } }
+
+    /// True while any settings-pane facet's own save is in flight.
+    var isAnySaving: Bool { dirtyFacets.contains { $0.isSaving } }
+
+    /// Saves every currently-dirty settings-pane facet. Each facet's own `save()` keeps its
+    /// existing validation and error reporting (e.g. a validation failure just leaves that facet
+    /// dirty with its own error string set) — one facet failing to save does not block the others.
+    func saveAllDirty() async {
+        for facet in dirtyFacets where facet.isDirty {
+            await facet.save()
+        }
+    }
 }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -548,13 +548,13 @@ final class SiteWindowModel {
     }
 
     /// True when the main-pane editor or the inspector holds unsaved edits — drives File ▸ Save /
-    /// Revert to Saved enablement (#509). The `.plist` editor has two independent dirty flags:
-    /// plist entries (`isDirty`) and analytics settings (`isAnalyticsDirty`) — both count, matching
-    /// `PlistEditorModel.flushBeforeLeaving()` (PR #532 review).
+    /// Revert to Saved enablement (#509). The `.plist` editor hosts several independent settings-pane
+    /// dirty flags (Website, Analytics, Redirects, …); `PlistEditorModel.hasAnyUnsavedEdits` (#741)
+    /// aggregates all of them, matching `PlistEditorModel.flushBeforeLeaving()` (PR #532 review).
     var hasUnsavedEdits: Bool {
         let editorDirty = switch activeEditor {
         case .text(let model): model.isDirty
-        case .plist(let model): model.isDirty || model.isAnalyticsDirty
+        case .plist(let model): model.hasAnyUnsavedEdits
         case nil: false
         }
         return editorDirty || (inspectorContext?.model.isDirty ?? false)
@@ -567,7 +567,7 @@ final class SiteWindowModel {
         if menuEditCommandRunning { return true }
         switch activeEditor {
         case .text(let model): if model.isSaving { return true }
-        case .plist(let model): if model.isSaving || model.isSavingAnalytics { return true }
+        case .plist(let model): if model.isAnySaving { return true }
         case nil: break
         }
         return inspectorContext?.model.isSaving ?? false
@@ -579,7 +579,7 @@ final class SiteWindowModel {
 
     /// File ▸ Save. Writes every dirty editing surface: a page's content (main-pane editor) and its
     /// metadata (inspector) are one document to the user, so Save covers both. Each model's `save()`
-    /// no-ops when clean; the plist editor's analytics settings save separately (`saveAnalytics()`).
+    /// no-ops when clean; the plist editor's settings-pane facets save via `saveAllDirty()` (#741).
     func saveAllEdits() async {
         guard !menuEditCommandRunning else { return }
         menuEditCommandRunning = true
@@ -588,8 +588,7 @@ final class SiteWindowModel {
         case .text(let model):
             await model.save()
         case .plist(let model):
-            await model.save()
-            if model.isAnalyticsDirty { await model.saveAnalytics() }
+            await model.saveAllDirty()
         case nil: break
         }
         if let model = inspectorContext?.model { await model.save() }
@@ -604,15 +603,14 @@ final class SiteWindowModel {
 
     /// Discard unsaved edits by re-reading each dirty surface from disk. Uses `load()` — not
     /// `reloadFromDisk()`, which is conflict-flow-specific and no-ops without a pending conflict.
-    /// `load()` also re-reads the plist editor's analytics settings, so the `isAnalyticsDirty`
-    /// surface reverts too.
+    /// `load()` re-reads every settings-pane facet, so `hasAnyUnsavedEdits` (#741) fully reverts.
     func confirmRevertToSaved() async {
         guard !menuEditCommandRunning else { return }
         menuEditCommandRunning = true
         defer { menuEditCommandRunning = false }
         switch activeEditor {
         case .text(let model) where model.isDirty: await model.load()
-        case .plist(let model) where model.isDirty || model.isAnalyticsDirty: await model.load()
+        case .plist(let model) where model.hasAnyUnsavedEdits: await model.load()
         default: break
         }
         if let model = inspectorContext?.model, model.isDirty { await model.load() }
@@ -641,6 +639,9 @@ final class SiteWindowModel {
     /// Best-effort off-main save of the open editor's buffer when the editor is torn down (window
     /// close or site replay), where no conflict dialog can be shown. Consistent with the
     /// auto-save-on-leave model; last-writer-wins on the rare teardown-time external conflict.
+    /// The `.plist` editor flushes every dirty settings-pane facet via `saveAllDirty()` (#741) — a
+    /// prior version only ever persisted the Website entries here, silently dropping unsaved
+    /// Analytics/Redirects edits on window close.
     @discardableResult
     private func persistEditorBufferBestEffort() -> Task<Void, Never>? {
         switch activeEditor {
@@ -649,12 +650,8 @@ final class SiteWindowModel {
             let contents = model.text
             return Task.detached(priority: .userInitiated) { _ = try? FileDocumentIO.save(contents, to: url) }
         case .plist(let model):
-            if model.isDirty, model.validationMessage == nil {
-                let url = model.file.url
-                let entries = model.entriesForSaving()
-                return Task.detached(priority: .userInitiated) { _ = try? PlistDocumentIO.save(entries, to: url) }
-            }
-            return nil
+            guard model.hasAnyUnsavedEdits else { return nil }
+            return Task { await model.saveAllDirty() }
         case .text, nil:
             return nil
         }

--- a/Tests/AnglesiteAppTests/PlistEditorModelDirtyFacetsTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelDirtyFacetsTests.swift
@@ -1,0 +1,125 @@
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+/// Tests the aggregate dirty/save seam (#741) that `SiteWindowModel` folds over instead of
+/// hand-checking each settings-pane facet (Website, Analytics, Redirects) by name. These tests
+/// prove the aggregation is generic — driven by whichever facet is dirty, not hardcoded to only
+/// two of the three — so a future settings pane registered in `PlistEditorModel.dirtyFacets`
+/// needs no further edits here or in `SiteWindowModel`.
+@Suite("PlistEditorModel dirty-facet aggregation (#741)")
+@MainActor
+struct PlistEditorModelDirtyFacetsTests {
+    // Includes `displayName` (unlike the sibling `PlistEditorModelRedirectsTests` fixture) so
+    // `websiteTitle`'s setter — which only mutates an *existing* display-name entry — has one to
+    // find, letting the "every dirty facet" test dirty the Website facet realistically.
+    private static let emptyPlist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>
+            <key>displayName</key>
+            <string>Test Site</string>
+        </dict></plist>
+        """
+
+    private func makeModel() throws -> PlistEditorModel {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PlistEditorModelDirtyFacetsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let plistURL = dir.appendingPathComponent("Info.plist")
+        try Self.emptyPlist.write(to: plistURL, atomically: true, encoding: .utf8)
+        let file = FileRef(url: plistURL, group: .metadata, name: "Info.plist")
+        return PlistEditorModel(file: file, websiteTitle: "Test Site", sourceDirectory: dir)
+    }
+
+    @Test("hasAnyUnsavedEdits is false on a freshly loaded model")
+    func hasAnyUnsavedEditsFalseWhenClean() async throws {
+        let model = try makeModel()
+        await model.load()
+        #expect(model.hasAnyUnsavedEdits == false)
+    }
+
+    @Test("hasAnyUnsavedEdits reflects Redirects dirty state alone, with Website/Analytics untouched")
+    func hasAnyUnsavedEditsReflectsRedirectsAlone() async throws {
+        let model = try makeModel()
+        await model.load()
+        model.redirectEntries.append(RedirectsStore.RedirectEntry(source: "/old", destination: "/new", code: .permanent))
+        #expect(model.isDirty == false)
+        #expect(model.isAnalyticsDirty == false)
+        #expect(model.hasAnyUnsavedEdits == true)
+    }
+
+    @Test("hasAnyUnsavedEdits reflects Analytics dirty state alone")
+    func hasAnyUnsavedEditsReflectsAnalyticsAlone() async throws {
+        let model = try makeModel()
+        await model.load()
+        model.analyticsSettings.cloudflareToken = "some-site-tag"
+        #expect(model.isDirty == false)
+        #expect(model.isRedirectsDirty == false)
+        #expect(model.hasAnyUnsavedEdits == true)
+    }
+
+    @Test("saveAllDirty saves only Redirects when only Redirects is dirty")
+    func saveAllDirtySavesOnlyDirtyFacet() async throws {
+        let model = try makeModel()
+        await model.load()
+        model.redirectEntries.append(RedirectsStore.RedirectEntry(source: "/old", destination: "/new", code: .permanent))
+
+        await model.saveAllDirty()
+
+        #expect(model.isRedirectsDirty == false)
+        #expect(try RedirectsStore(sourceDirectory: model.sourceDirectory).load() == model.redirectEntries)
+        #expect(model.hasAnyUnsavedEdits == false)
+    }
+
+    @Test("saveAllDirty saves every dirty facet in one call")
+    func saveAllDirtySavesEveryDirtyFacet() async throws {
+        let model = try makeModel()
+        await model.load()
+        model.websiteTitle = "Renamed Site"
+        model.redirectEntries.append(RedirectsStore.RedirectEntry(source: "/a", destination: "/b", code: .permanent))
+        #expect(model.isDirty == true)
+        #expect(model.isRedirectsDirty == true)
+
+        await model.saveAllDirty()
+
+        #expect(model.hasAnyUnsavedEdits == false)
+        #expect(try RedirectsStore(sourceDirectory: model.sourceDirectory).load() == model.redirectEntries)
+    }
+
+    @Test("saveAllDirty leaves a facet dirty when its own validation rejects the save, without blocking the others")
+    func saveAllDirtyLeavesInvalidFacetDirty() async throws {
+        let model = try makeModel()
+        await model.load()
+        // An identical source/destination fails RedirectsStore's own validation (mirrors
+        // PlistEditorModelRedirectsTests.saveValidationFailureSurfacesError).
+        model.redirectEntries.append(RedirectsStore.RedirectEntry(source: "/a", destination: "/a", code: .permanent))
+        model.websiteTitle = "Renamed Site"
+
+        await model.saveAllDirty()
+
+        #expect(model.isRedirectsDirty == true)
+        #expect(model.redirectsError != nil)
+        #expect(model.isDirty == false, "the Website facet should still have saved despite Redirects failing validation")
+    }
+
+    @Test("isAnySaving is true while saveRedirects is in flight")
+    func isAnySavingReflectsRedirectsInFlight() async throws {
+        let model = try makeModel()
+        await model.load()
+        model.redirectEntries.append(RedirectsStore.RedirectEntry(source: "/old", destination: "/new", code: .permanent))
+
+        async let saveTask: Void = model.saveAllDirty()
+        // `isSavingRedirects` is set synchronously before the off-main write, so a single yield is
+        // enough to observe it — matching the polling pattern used elsewhere in this test target.
+        var sawSaving = false
+        for _ in 0..<1000 where !sawSaving {
+            if model.isAnySaving { sawSaving = true }
+            await Task.yield()
+        }
+        await saveTask
+        #expect(sawSaving)
+        #expect(model.isAnySaving == false)
+    }
+}

--- a/Tests/AnglesiteAppTests/SiteWindowModelSettingsAggregationTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelSettingsAggregationTests.swift
@@ -1,0 +1,137 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// #741: `SiteWindowModel.hasUnsavedEdits`/`editCommandInFlight`/`saveAllEdits`/
+/// `confirmRevertToSaved` used to hand-check `PlistEditorModel.isDirty || isAnalyticsDirty`,
+/// omitting Redirects (#530) entirely — so File ▸ Save, Revert, and the window-edited indicator
+/// could disagree with an actual Redirects edit. These tests drive `SiteWindowModel` with a real
+/// `.plist` editor whose *only* dirty facet is Redirects, proving the aggregate accessors now
+/// pick it up via `PlistEditorModel.hasAnyUnsavedEdits`/`isAnySaving`/`saveAllDirty()`.
+@Suite("SiteWindowModel settings aggregation (#741)")
+@MainActor
+struct SiteWindowModelSettingsAggregationTests {
+    private static let emptyPlist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict/></plist>
+        """
+
+    private func makeSiteWindowModel() -> SiteWindowModel {
+        SiteWindowModel(
+            contentGraph: SiteContentGraph(),
+            knowledgeIndex: SiteKnowledgeIndex(),
+            semanticRanker: nil,
+            conventionsEngine: ProjectConventionsEngine(),
+            runtimeFactory: NeverStartedSiteRuntimeFactory(),
+            contentIndexerStore: ContentIndexerStore()
+        )
+    }
+
+    /// Builds a real `PlistEditorModel` (same fixture shape as `PlistEditorModelRedirectsTests`)
+    /// against a fresh temp `sourceDirectory`, loads it, and dirties Redirects alone — Website and
+    /// Analytics both stay clean, so any test passing here can only be exercising the Redirects
+    /// facet specifically, not accidentally passing via the already-working Website/Analytics path.
+    private func makeRedirectsDirtyPlistModel() throws -> (model: PlistEditorModel, root: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SiteWindowModelSettingsAggregationTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let plistURL = root.appendingPathComponent("Info.plist")
+        try Self.emptyPlist.write(to: plistURL, atomically: true, encoding: .utf8)
+        let file = FileRef(url: plistURL, group: .metadata, name: "Info.plist")
+        let plistModel = PlistEditorModel(file: file, websiteTitle: "Test Site", sourceDirectory: root)
+        return (plistModel, root)
+    }
+
+    @Test("hasUnsavedEdits is true when only the Redirects facet is dirty")
+    func hasUnsavedEditsReflectsRedirectsOnly() async throws {
+        let (plistModel, root) = try makeRedirectsDirtyPlistModel()
+        defer { try? FileManager.default.removeItem(at: root) }
+        await plistModel.load()
+        plistModel.redirectEntries.append(RedirectsStore.RedirectEntry(source: "/old", destination: "/new", code: .permanent))
+
+        let model = makeSiteWindowModel()
+        model.activeEditor = .plist(plistModel)
+
+        #expect(model.hasUnsavedEdits == true)
+    }
+
+    @Test("editCommandInFlight is true while a Redirects-only save is in flight")
+    func editCommandInFlightReflectsRedirectsSaving() async throws {
+        let (plistModel, root) = try makeRedirectsDirtyPlistModel()
+        defer { try? FileManager.default.removeItem(at: root) }
+        await plistModel.load()
+        plistModel.redirectEntries.append(RedirectsStore.RedirectEntry(source: "/old", destination: "/new", code: .permanent))
+
+        let model = makeSiteWindowModel()
+        model.activeEditor = .plist(plistModel)
+
+        async let saveTask: Void = model.saveAllEdits()
+        var sawInFlight = false
+        for _ in 0..<1000 where !sawInFlight {
+            if model.editCommandInFlight { sawInFlight = true }
+            await Task.yield()
+        }
+        await saveTask
+        #expect(sawInFlight)
+        #expect(model.editCommandInFlight == false)
+    }
+
+    @Test("saveAllEdits persists a Redirects-only edit and clears hasUnsavedEdits")
+    func saveAllEditsPersistsRedirectsOnlyEdit() async throws {
+        let (plistModel, root) = try makeRedirectsDirtyPlistModel()
+        defer { try? FileManager.default.removeItem(at: root) }
+        await plistModel.load()
+        plistModel.redirectEntries.append(RedirectsStore.RedirectEntry(source: "/old", destination: "/new", code: .permanent))
+
+        let model = makeSiteWindowModel()
+        model.activeEditor = .plist(plistModel)
+
+        await model.saveAllEdits()
+
+        #expect(model.hasUnsavedEdits == false)
+        #expect(try RedirectsStore(sourceDirectory: root).load() == plistModel.redirectEntries)
+    }
+
+    @Test("confirmRevertToSaved discards a Redirects-only edit")
+    func confirmRevertToSavedDiscardsRedirectsOnlyEdit() async throws {
+        let (plistModel, root) = try makeRedirectsDirtyPlistModel()
+        defer { try? FileManager.default.removeItem(at: root) }
+        await plistModel.load()
+        plistModel.redirectEntries.append(RedirectsStore.RedirectEntry(source: "/old", destination: "/new", code: .permanent))
+
+        let model = makeSiteWindowModel()
+        model.activeEditor = .plist(plistModel)
+
+        await model.confirmRevertToSaved()
+
+        #expect(model.hasUnsavedEdits == false)
+        #expect(plistModel.redirectEntries.isEmpty)
+    }
+
+    /// Prior to #741, `close()`'s best-effort teardown save (`persistEditorBufferBestEffort`) only
+    /// ever inspected `PlistEditorModel.isDirty` (the Website facet) — a Redirects-only edit was
+    /// silently dropped on window close with no error and no save. This proves the fix by closing
+    /// the window and reading `redirects.json` back off disk (not just checking the in-memory
+    /// model, since a stale in-memory flag can't prove a real write happened).
+    @Test("close() flushes a Redirects-only edit to disk, not just the Website facet")
+    func closeFlushesRedirectsOnlyEditToDisk() async throws {
+        let (plistModel, root) = try makeRedirectsDirtyPlistModel()
+        defer { try? FileManager.default.removeItem(at: root) }
+        await plistModel.load()
+        plistModel.redirectEntries.append(RedirectsStore.RedirectEntry(source: "/old", destination: "/new", code: .permanent))
+
+        let model = makeSiteWindowModel()
+        model.activeEditor = .plist(plistModel)
+        let controller = SuddenTerminationController(disable: {}, enable: {})
+        let lease = controller.acquire()
+
+        model.close(suddenTerminationLease: lease)
+        while controller.activeLeaseCount > 0 { await Task.yield() }
+
+        #expect(try RedirectsStore(sourceDirectory: root).load() == [
+            RedirectsStore.RedirectEntry(source: "/old", destination: "/new", code: .permanent),
+        ])
+    }
+}


### PR DESCRIPTION
## Summary

- `SiteWindowModel.hasUnsavedEdits`/`editCommandInFlight`/`saveAllEdits`/`confirmRevertToSaved` hand-checked `PlistEditorModel.isDirty || isAnalyticsDirty`, omitting the Redirects facet (#530) entirely — so File ▸ Save, Revert to Saved, and the window-edited (unsaved-changes) indicator could disagree with an actual Redirects edit.
- `persistEditorBufferBestEffort` (the window-close/site-replay best-effort save) was a separate, worse instance of the same gap: it only ever flushed the Website facet, silently dropping unsaved Analytics *or* Redirects edits on window close with no error surfaced at all.
- `PlistEditorModel` now exposes a generic dirty-facet aggregation seam — `hasAnyUnsavedEdits`, `isAnySaving`, `saveAllDirty()` — covering all three settings panes (Website/Analytics/Redirects). `SiteWindowModel` folds over it instead of naming each pane, so a future settings pane (e.g. a `.well-known` tab, per #690/PR #738) is registered in one place and needs no further edits to `SiteWindowModel`'s save/revert/close paths. Each facet's own validation/error reporting is preserved — one facet failing to save doesn't block the others.

Closes #741.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change needs a paired PR in `Anglesite/anglesite`.

## Test plan

- [x] `swift test --package-path .` — 12 new tests (7 in `PlistEditorModelDirtyFacetsTests`, 5 in `SiteWindowModelSettingsAggregationTests`) plus the full existing suite pass; verified the new tests fail to even *compile* against the pre-fix source (the new API doesn't exist), confirming they exercise the fix rather than passing vacuously. The only residual failures are the pre-existing, branch-independent `AnglesiteIntentsTests`/`SiteEntityQueryTests` environmental failures tracked in #771.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds (after regenerating a stale worktree `.xcodeproj` via `xcodegen generate`, unrelated to this change).
- [ ] Manual smoke: not run in this session — no interactive GUI pass, but the new tests drive the exact `SiteWindowModel` accessors the toolbar/menu bind to (`hasUnsavedEdits`, `editCommandInFlight`) end-to-end against a real `PlistEditorModel`/`RedirectsStore` fixture.