### PR TITLE
feat(component-editor): "Extract into Component…" (Slice 5)

### DIFF
--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -424,18 +424,10 @@ final class ComponentEditorModel {
         }
     }
 
-    /// Whether the outline `row` can be extracted into its own component. Restricted to
-    /// `.element` and `.component` kinds: the outline root is a `.fragment` (nothing to extract),
-    /// and `.slot`/`.expression`/`.text` nodes have no meaningful standalone extraction. The
-    /// plugin op also permits a bare `<slot />`, but that isn't a useful first-pass UI affordance,
-    /// so the trigger is narrowed to elements and component instances. (A sealed component
-    /// instance's own slot-fill children never surface as outline rows — see
-    /// `ComponentOutline.rows` — so there are no "rows inside a sealed instance" to guard against;
-    /// the instance row itself stays extractable.)
+    /// Whether the outline `row` can be extracted into its own component. Delegates to
+    /// `ComponentOutline.isExtractable(_:)` (Core), which hosts the actual gating logic so it's
+    /// unit-testable on CI (app-target Swift tests don't run there).
     func canExtractComponent(_ row: ComponentOutline.Row) -> Bool {
-        switch row.node.kind {
-        case .element, .component: return true
-        case .fragment, .slot, .expression, .text: return false
-        }
+        ComponentOutline.isExtractable(row.node)
     }
 }

--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -60,6 +60,11 @@ final class ComponentEditorModel {
     /// `writeError` instead drives a small dismissible banner scoped to the Styles panel; `model`
     /// and `loadError` are left untouched so the editor pane stays live.
     var writeError: String?
+    /// Non-fatal advisories from the last `extract-component` op (e.g. a scoped style rule the
+    /// plugin couldn't migrate) — drives the dismissible warnings banner. Set only when the
+    /// extraction applied with a non-empty `warnings` list; `nil` otherwise, and cleared on the
+    /// next successful `load()` or applied edit.
+    var extractWarnings: [String]?
     /// Sibling project components for the palette — scanned once per `load()`, not per render.
     private(set) var projectComponents: [FileRef] = []
 
@@ -104,6 +109,7 @@ final class ComponentEditorModel {
             model = fetched
             loadError = nil
             loadErrorReason = nil
+            extractWarnings = nil
             knobValues = Dictionary(
                 uniqueKeysWithValues: (fetched.frontmatter?.props ?? []).map {
                     ($0.name, KnobDefaults.value(for: $0))
@@ -353,6 +359,9 @@ final class ComponentEditorModel {
         case .applied:
             conflict = false
             writeError = nil
+            // A successful unrelated edit clears any lingering extract warnings (a fresh model
+            // adoption below doesn't run `load()`, which is the other place they'd clear).
+            extractWarnings = nil
             if let freshModel = reply.model {
                 model = freshModel
             } else {
@@ -366,6 +375,67 @@ final class ComponentEditorModel {
         default:
             writeError = reply.message ?? "The edit couldn't be applied."
             return false
+        }
+    }
+
+    // MARK: - Extract into component
+
+    /// Extract the subtree rooted at `nodeId` into a brand-new `.astro` component at
+    /// `newComponentPath`, replacing the extracted markup with a self-closing instance + import.
+    /// The plugin applies this as one atomic two-file edit; the reconciliation here mirrors the
+    /// other structure writes (`applyComponentStyleEdit`) — adopt a piggybacked fresh `model` for
+    /// the original file or reload; a `stale` refusal flips `conflict` and reloads — and
+    /// additionally surfaces the op's non-fatal `warnings` via `extractWarnings` for the banner.
+    /// The `newComponentPath` client-side validation lives in `ExtractComponentSheet`; the
+    /// plugin's own `invalid-input`/`exists` refusals still surface here via `writeError`.
+    /// Returns whether the extraction applied.
+    @discardableResult
+    func extractComponent(nodeId: String, newComponentPath: String) async -> Bool {
+        guard let editRouter = context.editRouter else { return false }
+        let message = ComponentStructureEditBuilder.extractComponent(
+            id: UUID().uuidString,
+            path: relativePath,
+            baseVersion: model?.version ?? "",
+            nodeId: nodeId,
+            newComponentPath: newComponentPath
+        )
+        let reply = await editRouter.apply(message)
+        switch reply.status {
+        case .applied:
+            conflict = false
+            writeError = nil
+            if let freshModel = reply.model {
+                model = freshModel
+            } else {
+                await load()
+            }
+            // Set last: `load()` above clears `extractWarnings`, so surfacing the op's warnings
+            // must happen after the model reconciliation, not before.
+            let warnings = reply.extractResult?.warnings ?? []
+            extractWarnings = warnings.isEmpty ? nil : warnings
+            return true
+        case .failed where reply.reason == "stale":
+            conflict = true
+            await load()
+            return false
+        default:
+            writeError = reply.message ?? "The component couldn't be extracted."
+            return false
+        }
+    }
+
+    /// Whether the outline `row` can be extracted into its own component. Restricted to
+    /// `.element` and `.component` kinds: the outline root is a `.fragment` (nothing to extract),
+    /// and `.slot`/`.expression`/`.text` nodes have no meaningful standalone extraction. The
+    /// plugin op also permits a bare `<slot />`, but that isn't a useful first-pass UI affordance,
+    /// so the trigger is narrowed to elements and component instances. (A sealed component
+    /// instance's own slot-fill children never surface as outline rows — see
+    /// `ComponentOutline.rows` — so there are no "rows inside a sealed instance" to guard against;
+    /// the instance row itself stays extractable.)
+    func canExtractComponent(_ row: ComponentOutline.Row) -> Bool {
+        switch row.node.kind {
+        case .element, .component: return true
+        case .fragment, .slot, .expression, .text: return false
         }
     }
 }

--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -60,11 +60,6 @@ final class ComponentEditorModel {
     /// `writeError` instead drives a small dismissible banner scoped to the Styles panel; `model`
     /// and `loadError` are left untouched so the editor pane stays live.
     var writeError: String?
-    /// Non-fatal advisories from the last `extract-component` op (e.g. a scoped style rule the
-    /// plugin couldn't migrate) — drives the dismissible warnings banner. Set only when the
-    /// extraction applied with a non-empty `warnings` list; `nil` otherwise, and cleared on the
-    /// next successful `load()` or applied edit.
-    var extractWarnings: [String]?
     /// Sibling project components for the palette — scanned once per `load()`, not per render.
     private(set) var projectComponents: [FileRef] = []
 
@@ -109,7 +104,6 @@ final class ComponentEditorModel {
             model = fetched
             loadError = nil
             loadErrorReason = nil
-            extractWarnings = nil
             knobValues = Dictionary(
                 uniqueKeysWithValues: (fetched.frontmatter?.props ?? []).map {
                     ($0.name, KnobDefaults.value(for: $0))
@@ -359,9 +353,6 @@ final class ComponentEditorModel {
         case .applied:
             conflict = false
             writeError = nil
-            // A successful unrelated edit clears any lingering extract warnings (a fresh model
-            // adoption below doesn't run `load()`, which is the other place they'd clear).
-            extractWarnings = nil
             if let freshModel = reply.model {
                 model = freshModel
             } else {
@@ -380,24 +371,26 @@ final class ComponentEditorModel {
 
     // MARK: - Extract into component
 
-    /// Extract the subtree rooted at `nodeId` into a brand-new `.astro` component at
-    /// `newComponentPath`, replacing the extracted markup with a self-closing instance + import.
-    /// The plugin applies this as one atomic two-file edit; the reconciliation here mirrors the
-    /// other structure writes (`applyComponentStyleEdit`) — adopt a piggybacked fresh `model` for
-    /// the original file or reload; a `stale` refusal flips `conflict` and reloads — and
-    /// additionally surfaces the op's non-fatal `warnings` via `extractWarnings` for the banner.
-    /// The `newComponentPath` client-side validation lives in `ExtractComponentSheet`; the
-    /// plugin's own `invalid-input`/`exists` refusals still surface here via `writeError`.
-    /// Returns whether the extraction applied.
+    /// Extract the subtree rooted at `nodeId` into a brand-new `.astro` component. `newName` is a
+    /// bare PascalCase identifier — the plugin derives the full `src/components/<newName>.astro`
+    /// path itself. The plugin applies this as one atomic two-file edit; the reconciliation here
+    /// mirrors the other structure writes (`applyComponentStyleEdit`) — adopt a piggybacked fresh
+    /// `model` for the original file or reload; a `stale` refusal flips `conflict` and reloads.
+    /// Because this op creates a brand-new component file, the piggybacked-model fast path also
+    /// rescans `projectComponents` so the palette immediately reflects the new component (the
+    /// `load()` fallback already does this). The `newName` client-side validation lives in
+    /// `ExtractComponentSheet`; the plugin's own `invalid-input`/`already-exists`/`dynamic-expression`
+    /// refusals still surface here via `writeError` (they flow through the generic failure branch,
+    /// like every other op's non-`stale` refusal). Returns whether the extraction applied.
     @discardableResult
-    func extractComponent(nodeId: String, newComponentPath: String) async -> Bool {
+    func extractComponent(nodeId: String, newName: String) async -> Bool {
         guard let editRouter = context.editRouter else { return false }
         let message = ComponentStructureEditBuilder.extractComponent(
             id: UUID().uuidString,
             path: relativePath,
             baseVersion: model?.version ?? "",
             nodeId: nodeId,
-            newComponentPath: newComponentPath
+            newName: newName
         )
         let reply = await editRouter.apply(message)
         switch reply.status {
@@ -406,13 +399,10 @@ final class ComponentEditorModel {
             writeError = nil
             if let freshModel = reply.model {
                 model = freshModel
+                projectComponents = SiteFileTree.scan(siteRoot: context.sourceRoot)[.components] ?? []
             } else {
                 await load()
             }
-            // Set last: `load()` above clears `extractWarnings`, so surfacing the op's warnings
-            // must happen after the model reconciliation, not before.
-            let warnings = reply.extractResult?.warnings ?? []
-            extractWarnings = warnings.isEmpty ? nil : warnings
             return true
         case .failed where reply.reason == "stale":
             conflict = true

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -51,6 +51,15 @@ struct ComponentEditorView: View {
     /// Editable drafts for the two code panes, keyed by zone — dirty-tracked like
     /// `FileEditorModel` (spec §5) and saved explicitly via `setScriptZone`, not on blur.
     @State private var codeDrafts: [CodeZone: String] = [.frontmatter: "", .client: ""]
+    /// Outline node the "Extract into Component…" sheet is targeting, captured at menu-tap time.
+    /// Non-nil presents `ExtractComponentSheet` (design §6.3).
+    @State private var extractTarget: ExtractTarget?
+
+    /// Identifiable wrapper for an outline node id, so `.sheet(item:)` can drive the extract
+    /// sheet off which row was right-clicked.
+    private struct ExtractTarget: Identifiable {
+        let id: String
+    }
 
     enum Mode: String, CaseIterable { case design = "Design", source = "Source" }
 
@@ -159,6 +168,18 @@ struct ComponentEditorView: View {
                 .client: model?.model?.clientScript?.source ?? "",
             ]
         }
+        .sheet(item: $extractTarget) { target in
+            ExtractComponentSheet { name in
+                guard let model else { return "The component editor isn't ready yet." }
+                let newComponentPath = "src/components/\(name).astro"
+                let applied = await model.extractComponent(nodeId: target.id, newComponentPath: newComponentPath)
+                // On success the sheet dismisses (nil). On failure, surface the plugin's refusal
+                // (invalid-input / exists / a transient error) captured in `writeError`; a stale
+                // refusal leaves `writeError` nil, so fall back to a generic message (the conflict
+                // banner explains the reload separately).
+                return applied ? nil : (model.writeError ?? "The component couldn't be extracted.")
+            }
+        }
     }
 
     @ViewBuilder private var sourcePane: some View {
@@ -263,6 +284,13 @@ struct ComponentEditorView: View {
         .onTapGesture(count: 2) {
             guard row.isSealed else { return }
             openSealedComponent(model, row: row)
+        }
+        .contextMenu {
+            if model.canExtractComponent(row) {
+                Button("Extract into Component…") {
+                    extractTarget = ExtractTarget(id: row.node.id)
+                }
+            }
         }
     }
 
@@ -526,6 +554,9 @@ struct ComponentEditorView: View {
                 if let writeError = model.writeError {
                     writeErrorBanner(model, message: writeError)
                 }
+                if let warnings = model.extractWarnings, !warnings.isEmpty {
+                    extractWarningsBanner(model, warnings: warnings)
+                }
                 GroupBox("Styles") {
                     if let styles = model.model?.styles, !styles.isEmpty {
                         ForEach(Array(styles.enumerated()), id: \.offset) { ruleIndex, rule in
@@ -780,6 +811,32 @@ struct ComponentEditorView: View {
         }
         .padding(8)
         .background(.red.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    /// Non-fatal advisories from the last `extract-component` op (e.g. a scoped style rule left
+    /// behind) — a dismissible banner, visually distinct from the red error/conflict banners via a
+    /// yellow tint and an `exclamationmark.circle` symbol. The extraction still applied; this just
+    /// tells the user what the plugin couldn't carry over. Dismissing clears `model.extractWarnings`.
+    private func extractWarningsBanner(_ model: ComponentEditorModel, warnings: [String]) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.circle").foregroundStyle(.yellow)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Component extracted with warnings:").font(.caption).bold()
+                ForEach(warnings, id: \.self) { warning in
+                    Text("• \(warning)").font(.caption)
+                }
+            }
+            Spacer()
+            Button {
+                model.extractWarnings = nil
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+        }
+        .padding(8)
+        .background(.yellow.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
     }
 
     private func highlightInCanvas(nodeID: String?) {

--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -171,12 +171,13 @@ struct ComponentEditorView: View {
         .sheet(item: $extractTarget) { target in
             ExtractComponentSheet { name in
                 guard let model else { return "The component editor isn't ready yet." }
-                let newComponentPath = "src/components/\(name).astro"
-                let applied = await model.extractComponent(nodeId: target.id, newComponentPath: newComponentPath)
+                // Pass the bare name straight through — the plugin derives the full
+                // `src/components/<name>.astro` path itself from `newName`.
+                let applied = await model.extractComponent(nodeId: target.id, newName: name)
                 // On success the sheet dismisses (nil). On failure, surface the plugin's refusal
-                // (invalid-input / exists / a transient error) captured in `writeError`; a stale
-                // refusal leaves `writeError` nil, so fall back to a generic message (the conflict
-                // banner explains the reload separately).
+                // (invalid-input / already-exists / dynamic-expression / a transient error) captured
+                // in `writeError`; a stale refusal leaves `writeError` nil, so fall back to a generic
+                // message (the conflict banner explains the reload separately).
                 return applied ? nil : (model.writeError ?? "The component couldn't be extracted.")
             }
         }
@@ -554,9 +555,6 @@ struct ComponentEditorView: View {
                 if let writeError = model.writeError {
                     writeErrorBanner(model, message: writeError)
                 }
-                if let warnings = model.extractWarnings, !warnings.isEmpty {
-                    extractWarningsBanner(model, warnings: warnings)
-                }
                 GroupBox("Styles") {
                     if let styles = model.model?.styles, !styles.isEmpty {
                         ForEach(Array(styles.enumerated()), id: \.offset) { ruleIndex, rule in
@@ -811,32 +809,6 @@ struct ComponentEditorView: View {
         }
         .padding(8)
         .background(.red.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
-    }
-
-    /// Non-fatal advisories from the last `extract-component` op (e.g. a scoped style rule left
-    /// behind) — a dismissible banner, visually distinct from the red error/conflict banners via a
-    /// yellow tint and an `exclamationmark.circle` symbol. The extraction still applied; this just
-    /// tells the user what the plugin couldn't carry over. Dismissing clears `model.extractWarnings`.
-    private func extractWarningsBanner(_ model: ComponentEditorModel, warnings: [String]) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "exclamationmark.circle").foregroundStyle(.yellow)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Component extracted with warnings:").font(.caption).bold()
-                ForEach(warnings, id: \.self) { warning in
-                    Text("• \(warning)").font(.caption)
-                }
-            }
-            Spacer()
-            Button {
-                model.extractWarnings = nil
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
-        }
-        .padding(8)
-        .background(.yellow.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
     }
 
     private func highlightInCanvas(nodeID: String?) {

--- a/Sources/AnglesiteApp/NewContentSheets.swift
+++ b/Sources/AnglesiteApp/NewContentSheets.swift
@@ -312,6 +312,83 @@ struct NewPostSheet: View {
     }
 }
 
+/// Name prompt for "Extract into Component…" (design §6.3). Mirrors `NewComponentSheet`'s
+/// Form/toolbar shape, but prompts for a component name (combined into a
+/// `src/components/<Name>.astro` path by the caller) and validates client-side that the name
+/// starts with an uppercase letter — a UX guard, not a substitute for the plugin's own
+/// `invalid-input`/`exists` refusals, which surface via `errorMessage`.
+struct ExtractComponentSheet: View {
+    /// Called with the client-side-validated name. Returns an error message to show in-sheet, or
+    /// `nil` on success (which dismisses).
+    let onExtract: (_ name: String) async -> String?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+    @State private var isExtracting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("New Component") {
+                    TextField("Name", text: $name, prompt: Text("Hero"))
+                }
+                if !trimmedName.isEmpty && !nameIsValid {
+                    Text("Component names must start with an uppercase letter.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                }
+            }
+            .formStyle(.grouped)
+            .frame(minWidth: 380, minHeight: 180)
+            .navigationTitle("Extract into Component")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isExtracting)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isExtracting ? "Extracting…" : "Extract") {
+                        extract()
+                    }
+                    .disabled(isExtracting || !nameIsValid)
+                }
+            }
+        }
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Non-empty and starts with an uppercase letter — mirrors the plugin's capitalized-basename
+    /// requirement for `newComponentPath`.
+    private var nameIsValid: Bool {
+        trimmedName.first?.isUppercase == true
+    }
+
+    private func extract() {
+        isExtracting = true
+        errorMessage = nil
+        Task {
+            let error = await onExtract(trimmedName)
+            await MainActor.run {
+                isExtracting = false
+                if let error {
+                    errorMessage = error
+                } else {
+                    dismiss()
+                }
+            }
+        }
+    }
+}
+
 struct NewComponentSheet: View {
     let onCreate: (String) async -> ContentCreateResult
 

--- a/Sources/AnglesiteApp/NewContentSheets.swift
+++ b/Sources/AnglesiteApp/NewContentSheets.swift
@@ -313,10 +313,10 @@ struct NewPostSheet: View {
 }
 
 /// Name prompt for "Extract into Component…" (design §6.3). Mirrors `NewComponentSheet`'s
-/// Form/toolbar shape, but prompts for a component name (combined into a
-/// `src/components/<Name>.astro` path by the caller) and validates client-side that the name
-/// starts with an uppercase letter — a UX guard, not a substitute for the plugin's own
-/// `invalid-input`/`exists` refusals, which surface via `errorMessage`.
+/// Form/toolbar shape, but prompts for a bare component name passed straight through as the op's
+/// `newName` (the plugin derives the full `src/components/<Name>.astro` path itself). Validates
+/// client-side that the name starts with an uppercase letter — a UX guard, not a substitute for
+/// the plugin's own `invalid-input`/`already-exists` refusals, which surface via `errorMessage`.
 struct ExtractComponentSheet: View {
     /// Called with the client-side-validated name. Returns an error message to show in-sheet, or
     /// `nil` on success (which dismisses).
@@ -366,8 +366,8 @@ struct ExtractComponentSheet: View {
         name.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Non-empty and starts with an uppercase letter — mirrors the plugin's capitalized-basename
-    /// requirement for `newComponentPath`.
+    /// Non-empty and starts with an uppercase letter — mirrors the plugin's PascalCase-identifier
+    /// requirement for `newName`.
     private var nameIsValid: Bool {
         trimmedName.first?.isUppercase == true
     }

--- a/Sources/AnglesiteCore/ComponentOutline.swift
+++ b/Sources/AnglesiteCore/ComponentOutline.swift
@@ -45,6 +45,21 @@ public enum ComponentOutline {
         return rows
     }
 
+    /// Whether `node` can be extracted into its own component. Restricted to
+    /// `.element` and `.component` kinds: the outline root is a `.fragment` (nothing to extract),
+    /// and `.slot`/`.expression`/`.text` nodes have no meaningful standalone extraction. The
+    /// plugin op also permits a bare `<slot />`, but that isn't a useful first-pass UI affordance,
+    /// so the trigger is narrowed to elements and component instances. (A sealed component
+    /// instance's own slot-fill children never surface as outline rows — see `rows(from:)` above
+    /// — so there are no "rows inside a sealed instance" to guard against; the instance row
+    /// itself stays extractable.)
+    public static func isExtractable(_ node: ComponentModel.Node) -> Bool {
+        switch node.kind {
+        case .element, .component: return true
+        case .fragment, .slot, .expression, .text: return false
+        }
+    }
+
     /// Source-loc match — the canvas reports the loc Astro's dev server
     /// stamps on the rendered element via `data-astro-source-loc`, which is
     /// the END of the element's opening tag (verified against

--- a/Sources/AnglesiteCore/ComponentStructureEditBuilder.swift
+++ b/Sources/AnglesiteCore/ComponentStructureEditBuilder.swift
@@ -92,6 +92,33 @@ public enum ComponentStructureEditBuilder {
         )
     }
 
+    /// Carve the subtree rooted at `nodeId` out into a brand-new `.astro` component at
+    /// `newComponentPath` (a project-relative path under `src/components/` with a capitalized
+    /// basename), replacing the extracted markup with a self-closing instance + import. The
+    /// plugin applies this as one atomic two-file edit. Adds `newComponentPath` to the standard
+    /// `{ path, baseVersion, nodeId }` structure-op payload.
+    public static func extractComponent(
+        id: String,
+        path: String,
+        baseVersion: String,
+        nodeId: String,
+        newComponentPath: String
+    ) -> EditMessage {
+        EditMessage(
+            id: id,
+            path: path,
+            selector: nil,
+            op: EditMessage.Op.extractComponent,
+            component: .object([
+                "path": .string(path),
+                "baseVersion": .string(baseVersion),
+                "nodeId": .string(nodeId),
+                "newComponentPath": .string(newComponentPath),
+            ]),
+            value: nil
+        )
+    }
+
     /// `value: nil` removes the attribute (encodes as an explicit JSON `null`, distinct from
     /// omitting the field — the plugin schema treats `value === null` as "remove").
     public static func setAttr(

--- a/Sources/AnglesiteCore/ComponentStructureEditBuilder.swift
+++ b/Sources/AnglesiteCore/ComponentStructureEditBuilder.swift
@@ -92,17 +92,18 @@ public enum ComponentStructureEditBuilder {
         )
     }
 
-    /// Carve the subtree rooted at `nodeId` out into a brand-new `.astro` component at
-    /// `newComponentPath` (a project-relative path under `src/components/` with a capitalized
-    /// basename), replacing the extracted markup with a self-closing instance + import. The
-    /// plugin applies this as one atomic two-file edit. Adds `newComponentPath` to the standard
-    /// `{ path, baseVersion, nodeId }` structure-op payload.
+    /// Carve the subtree rooted at `nodeId` out into a brand-new `.astro` component, replacing the
+    /// extracted markup with a self-closing instance + import. The plugin applies this as one
+    /// atomic two-file edit. `newName` is a bare PascalCase identifier (no path, no `.astro`
+    /// suffix) — the server derives the full path itself as `src/components/<newName>.astro` and
+    /// validates the name against a strict PascalCase-identifier regex. Adds `newName` to the
+    /// standard `{ path, baseVersion, nodeId }` structure-op payload.
     public static func extractComponent(
         id: String,
         path: String,
         baseVersion: String,
         nodeId: String,
-        newComponentPath: String
+        newName: String
     ) -> EditMessage {
         EditMessage(
             id: id,
@@ -113,7 +114,7 @@ public enum ComponentStructureEditBuilder {
                 "path": .string(path),
                 "baseVersion": .string(baseVersion),
                 "nodeId": .string(nodeId),
-                "newComponentPath": .string(newComponentPath),
+                "newName": .string(newName),
             ]),
             value: nil
         )

--- a/Sources/AnglesiteCore/EditMessage.swift
+++ b/Sources/AnglesiteCore/EditMessage.swift
@@ -55,6 +55,11 @@ public struct EditMessage: Sendable, Equatable {
         /// `"set-attr"` — Component Editor: set or remove (nil value) an attribute/prop at
         /// the use-site. Carries a `component` payload.
         public static let setAttr = "set-attr"
+        /// `"extract-component"` — Component Editor: carve an outline subtree out into a brand-new
+        /// `.astro` component under `src/components/`, replacing the extracted markup with a
+        /// self-closing instance + import (one atomic two-file edit). Carries a `component` payload
+        /// with an added `newComponentPath`.
+        public static let extractComponent = "extract-component"
         /// `"set-props-interface"` — Component Editor: codegen/replace the frontmatter's
         /// `Props` interface + `Astro.props` destructure from a structured props array.
         /// Carries a `component` payload.

--- a/Sources/AnglesiteCore/EditMessage.swift
+++ b/Sources/AnglesiteCore/EditMessage.swift
@@ -58,7 +58,8 @@ public struct EditMessage: Sendable, Equatable {
         /// `"extract-component"` — Component Editor: carve an outline subtree out into a brand-new
         /// `.astro` component under `src/components/`, replacing the extracted markup with a
         /// self-closing instance + import (one atomic two-file edit). Carries a `component` payload
-        /// with an added `newComponentPath`.
+        /// with an added `newName` (a bare PascalCase identifier; the server derives the full
+        /// `src/components/<newName>.astro` path itself).
         public static let extractComponent = "extract-component"
         /// `"set-props-interface"` — Component Editor: codegen/replace the frontmatter's
         /// `Props` interface + `Astro.props` destructure from a structured props array.

--- a/Sources/AnglesiteCore/EditRouter.swift
+++ b/Sources/AnglesiteCore/EditRouter.swift
@@ -18,6 +18,13 @@ public struct EditReply: Sendable, Equatable, Encodable {
     /// Op-scoped metadata. For `replace-image-src` carries `{ src, srcset? }`. `nil` for ops
     /// that don't surface overlay-side metadata.
     public let result: ImageResult?
+    /// `extract-component`-scoped metadata — the new component's project-relative path, the
+    /// original component's Props the plugin hoisted into it, and any non-fatal warnings (e.g. a
+    /// scoped style rule that couldn't be migrated). Present on the `.applied` reply for that op;
+    /// `nil` for every other op. Kept as a narrowly-typed additive field alongside `result`/`model`
+    /// rather than widening `result` into an enum, matching this type's one-field-per-op-family
+    /// convention.
+    public let extractResult: ExtractComponentResult?
     /// Preview-only: the source fragment before/after the would-be change (`.preview` status).
     public let before: String?
     public let after: String?
@@ -44,6 +51,24 @@ public struct EditReply: Sendable, Equatable, Encodable {
         }
     }
 
+    /// Structured result of the `extract-component` op — mirrors the plugin's
+    /// `result: { componentPath, hoistedProps, warnings }` shape.
+    public struct ExtractComponentResult: Sendable, Equatable, Encodable {
+        /// Project-relative path of the newly-created component (e.g. `src/components/Hero.astro`).
+        public let componentPath: String
+        /// Names of the original component's declared Props the extracted subtree bare-referenced,
+        /// which the plugin hoisted into the new component's own `Props` interface.
+        public let hoistedProps: [String]
+        /// Non-fatal advisories (e.g. a complex scoped style rule left behind). Empty when clean.
+        public let warnings: [String]
+
+        public init(componentPath: String, hoistedProps: [String], warnings: [String]) {
+            self.componentPath = componentPath
+            self.hoistedProps = hoistedProps
+            self.warnings = warnings
+        }
+    }
+
     public enum Status: String, Sendable, Equatable, Encodable {
         case applied, failed, ambiguous, preview
     }
@@ -59,7 +84,8 @@ public struct EditReply: Sendable, Equatable, Encodable {
         after: String? = nil,
         op: String? = nil,
         model: ComponentModel? = nil,
-        reason: String? = nil
+        reason: String? = nil,
+        extractResult: ExtractComponentResult? = nil
     ) {
         self.id = id
         self.status = status
@@ -72,6 +98,7 @@ public struct EditReply: Sendable, Equatable, Encodable {
         self.op = op
         self.model = model
         self.reason = reason
+        self.extractResult = extractResult
     }
 }
 

--- a/Sources/AnglesiteCore/EditRouter.swift
+++ b/Sources/AnglesiteCore/EditRouter.swift
@@ -18,13 +18,13 @@ public struct EditReply: Sendable, Equatable, Encodable {
     /// Op-scoped metadata. For `replace-image-src` carries `{ src, srcset? }`. `nil` for ops
     /// that don't surface overlay-side metadata.
     public let result: ImageResult?
-    /// `extract-component`-scoped metadata — the new component's project-relative path, the
-    /// original component's Props the plugin hoisted into it, and any non-fatal warnings (e.g. a
-    /// scoped style rule that couldn't be migrated). Present on the `.applied` reply for that op;
-    /// `nil` for every other op. Kept as a narrowly-typed additive field alongside `result`/`model`
-    /// rather than widening `result` into an enum, matching this type's one-field-per-op-family
+    /// `extract-component`-scoped metadata — the project-relative path of the brand-new component
+    /// file the op created (e.g. `src/components/Hero.astro`). A plain top-level string on the
+    /// plugin's `edit-applied` body (sibling to `file`/`commit`, NOT nested under `result`).
+    /// Present on the `.applied` reply for that op; `nil` for every other op. Kept as a simple
+    /// additive optional alongside `commit`/`model`, matching this type's one-field-per-op-family
     /// convention.
-    public let extractResult: ExtractComponentResult?
+    public let newFile: String?
     /// Preview-only: the source fragment before/after the would-be change (`.preview` status).
     public let before: String?
     public let after: String?
@@ -51,24 +51,6 @@ public struct EditReply: Sendable, Equatable, Encodable {
         }
     }
 
-    /// Structured result of the `extract-component` op — mirrors the plugin's
-    /// `result: { componentPath, hoistedProps, warnings }` shape.
-    public struct ExtractComponentResult: Sendable, Equatable, Encodable {
-        /// Project-relative path of the newly-created component (e.g. `src/components/Hero.astro`).
-        public let componentPath: String
-        /// Names of the original component's declared Props the extracted subtree bare-referenced,
-        /// which the plugin hoisted into the new component's own `Props` interface.
-        public let hoistedProps: [String]
-        /// Non-fatal advisories (e.g. a complex scoped style rule left behind). Empty when clean.
-        public let warnings: [String]
-
-        public init(componentPath: String, hoistedProps: [String], warnings: [String]) {
-            self.componentPath = componentPath
-            self.hoistedProps = hoistedProps
-            self.warnings = warnings
-        }
-    }
-
     public enum Status: String, Sendable, Equatable, Encodable {
         case applied, failed, ambiguous, preview
     }
@@ -85,7 +67,7 @@ public struct EditReply: Sendable, Equatable, Encodable {
         op: String? = nil,
         model: ComponentModel? = nil,
         reason: String? = nil,
-        extractResult: ExtractComponentResult? = nil
+        newFile: String? = nil
     ) {
         self.id = id
         self.status = status
@@ -98,7 +80,7 @@ public struct EditReply: Sendable, Equatable, Encodable {
         self.op = op
         self.model = model
         self.reason = reason
-        self.extractResult = extractResult
+        self.newFile = newFile
     }
 }
 

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -103,7 +103,7 @@ public struct MCPApplyEditRouter: EditRouter {
                 commit: parsed?.commit,
                 result: parsed?.result,
                 model: parsed?.model,
-                extractResult: parsed?.extractResult
+                newFile: parsed?.newFile
             )
             if let persistEdit {
                 do {
@@ -119,7 +119,7 @@ public struct MCPApplyEditRouter: EditRouter {
                         commit: nil,
                         result: reply.result,
                         model: reply.model,
-                        extractResult: reply.extractResult
+                        newFile: reply.newFile
                     )
                 }
             }
@@ -167,21 +167,16 @@ public struct MCPApplyEditRouter: EditRouter {
         else { return nil }
         let file = json["file"] as? String
         let commit = json["commit"] as? String
-        // The `result` key is op-shaped: `replace-image-src` puts `{ src, srcset? }` there,
-        // `extract-component` puts `{ componentPath, hoistedProps, warnings }`. Discriminate on
-        // which keys are present rather than assuming one shape.
+        // The `result` key carries `replace-image-src`'s `{ src, srcset? }`.
         var image: EditReply.ImageResult?
-        var extract: EditReply.ExtractComponentResult?
-        if let resultDict = json["result"] as? [String: Any] {
-            if let src = resultDict["src"] as? String {
-                let srcset = resultDict["srcset"] as? String
-                image = EditReply.ImageResult(src: src, srcset: srcset)
-            } else if let componentPath = resultDict["componentPath"] as? String {
-                let hoisted = (resultDict["hoistedProps"] as? [Any])?.compactMap { $0 as? String } ?? []
-                let warnings = (resultDict["warnings"] as? [Any])?.compactMap { $0 as? String } ?? []
-                extract = EditReply.ExtractComponentResult(componentPath: componentPath, hoistedProps: hoisted, warnings: warnings)
-            }
+        if let resultDict = json["result"] as? [String: Any], let src = resultDict["src"] as? String {
+            let srcset = resultDict["srcset"] as? String
+            image = EditReply.ImageResult(src: src, srcset: srcset)
         }
+        // `extract-component` reports the brand-new file it created as a plain top-level string
+        // (`newFile`), a sibling of `file`/`commit` — NOT nested under `result` (that op has no
+        // `result` object at all).
+        let newFile = json["newFile"] as? String
         var model: ComponentModel?
         if let modelDict = json["model"],
            let modelData = try? JSONSerialization.data(withJSONObject: modelDict) {
@@ -190,15 +185,15 @@ public struct MCPApplyEditRouter: EditRouter {
         // Present on `anglesite:edit-failed` bodies (e.g. "stale", "no-match", "invalid-input") —
         // the machine-readable counterpart to the free-form `detail` prose folded into `message`.
         let reason = json["reason"] as? String
-        if file == nil && commit == nil && image == nil && extract == nil && model == nil && reason == nil { return nil }
-        return Parsed(file: file, commit: commit, result: image, extractResult: extract, model: model, reason: reason)
+        if file == nil && commit == nil && image == nil && newFile == nil && model == nil && reason == nil { return nil }
+        return Parsed(file: file, commit: commit, result: image, newFile: newFile, model: model, reason: reason)
     }
 
     struct Parsed: Equatable {
         let file: String?
         let commit: String?
         let result: EditReply.ImageResult?
-        let extractResult: EditReply.ExtractComponentResult?
+        let newFile: String?
         let model: ComponentModel?
         let reason: String?
     }

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -102,7 +102,8 @@ public struct MCPApplyEditRouter: EditRouter {
                 file: parsed?.file,
                 commit: parsed?.commit,
                 result: parsed?.result,
-                model: parsed?.model
+                model: parsed?.model,
+                extractResult: parsed?.extractResult
             )
             if let persistEdit {
                 do {
@@ -117,7 +118,8 @@ public struct MCPApplyEditRouter: EditRouter {
                         // `commit != nil` instead of `status` must not read this as landed.
                         commit: nil,
                         result: reply.result,
-                        model: reply.model
+                        model: reply.model,
+                        extractResult: reply.extractResult
                     )
                 }
             }
@@ -165,11 +167,20 @@ public struct MCPApplyEditRouter: EditRouter {
         else { return nil }
         let file = json["file"] as? String
         let commit = json["commit"] as? String
+        // The `result` key is op-shaped: `replace-image-src` puts `{ src, srcset? }` there,
+        // `extract-component` puts `{ componentPath, hoistedProps, warnings }`. Discriminate on
+        // which keys are present rather than assuming one shape.
         var image: EditReply.ImageResult?
-        if let resultDict = json["result"] as? [String: Any],
-           let src = resultDict["src"] as? String {
-            let srcset = resultDict["srcset"] as? String
-            image = EditReply.ImageResult(src: src, srcset: srcset)
+        var extract: EditReply.ExtractComponentResult?
+        if let resultDict = json["result"] as? [String: Any] {
+            if let src = resultDict["src"] as? String {
+                let srcset = resultDict["srcset"] as? String
+                image = EditReply.ImageResult(src: src, srcset: srcset)
+            } else if let componentPath = resultDict["componentPath"] as? String {
+                let hoisted = (resultDict["hoistedProps"] as? [Any])?.compactMap { $0 as? String } ?? []
+                let warnings = (resultDict["warnings"] as? [Any])?.compactMap { $0 as? String } ?? []
+                extract = EditReply.ExtractComponentResult(componentPath: componentPath, hoistedProps: hoisted, warnings: warnings)
+            }
         }
         var model: ComponentModel?
         if let modelDict = json["model"],
@@ -179,14 +190,15 @@ public struct MCPApplyEditRouter: EditRouter {
         // Present on `anglesite:edit-failed` bodies (e.g. "stale", "no-match", "invalid-input") —
         // the machine-readable counterpart to the free-form `detail` prose folded into `message`.
         let reason = json["reason"] as? String
-        if file == nil && commit == nil && image == nil && model == nil && reason == nil { return nil }
-        return Parsed(file: file, commit: commit, result: image, model: model, reason: reason)
+        if file == nil && commit == nil && image == nil && extract == nil && model == nil && reason == nil { return nil }
+        return Parsed(file: file, commit: commit, result: image, extractResult: extract, model: model, reason: reason)
     }
 
     struct Parsed: Equatable {
         let file: String?
         let commit: String?
         let result: EditReply.ImageResult?
+        let extractResult: EditReply.ExtractComponentResult?
         let model: ComponentModel?
         let reason: String?
     }

--- a/Tests/AnglesiteAppTests/ComponentEditorModelStructureEditTests.swift
+++ b/Tests/AnglesiteAppTests/ComponentEditorModelStructureEditTests.swift
@@ -66,4 +66,60 @@ struct ComponentEditorModelStructureEditTests {
         #expect(!applied)
         #expect(model.conflict)
     }
+
+    @Test("extractComponent sends the built EditMessage and surfaces warnings")
+    func extractComponentAppliesWithWarnings() async {
+        let router = RecordingRouter(reply: EditReply(
+            id: "x",
+            status: .applied,
+            message: nil,
+            extractResult: EditReply.ExtractComponentResult(
+                componentPath: "src/components/Hero.astro",
+                hoistedProps: ["title"],
+                warnings: ["Could not migrate a complex style rule."]
+            )
+        ))
+        let model = makeModel(router: router)
+        let applied = await model.extractComponent(nodeId: "n3", newComponentPath: "src/components/Hero.astro")
+        #expect(applied)
+        #expect(router.lastMessage?.op == EditMessage.Op.extractComponent)
+        #expect(model.extractWarnings == ["Could not migrate a complex style rule."])
+    }
+
+    @Test("extractComponent with no warnings leaves the banner state nil")
+    func extractComponentAppliesWithoutWarnings() async {
+        let router = RecordingRouter(reply: EditReply(
+            id: "x",
+            status: .applied,
+            message: nil,
+            extractResult: EditReply.ExtractComponentResult(
+                componentPath: "src/components/Hero.astro",
+                hoistedProps: [],
+                warnings: []
+            )
+        ))
+        let model = makeModel(router: router)
+        let applied = await model.extractComponent(nodeId: "n3", newComponentPath: "src/components/Hero.astro")
+        #expect(applied)
+        #expect(model.extractWarnings == nil)
+    }
+
+    @Test("extractComponent surfaces a plugin refusal via writeError")
+    func extractComponentRefusalSurfacesWriteError() async {
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .failed, message: "That component already exists.", reason: "exists"))
+        let model = makeModel(router: router)
+        let applied = await model.extractComponent(nodeId: "n3", newComponentPath: "src/components/Hero.astro")
+        #expect(!applied)
+        #expect(model.writeError == "That component already exists.")
+        #expect(!model.conflict)
+    }
+
+    @Test("extractComponent stale refusal flips conflict")
+    func extractComponentStaleFlipsConflict() async {
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .failed, message: "stale", reason: "stale"))
+        let model = makeModel(router: router)
+        let applied = await model.extractComponent(nodeId: "n3", newComponentPath: "src/components/Hero.astro")
+        #expect(!applied)
+        #expect(model.conflict)
+    }
 }

--- a/Tests/AnglesiteAppTests/ComponentEditorModelStructureEditTests.swift
+++ b/Tests/AnglesiteAppTests/ComponentEditorModelStructureEditTests.swift
@@ -67,50 +67,43 @@ struct ComponentEditorModelStructureEditTests {
         #expect(model.conflict)
     }
 
-    @Test("extractComponent sends the built EditMessage and surfaces warnings")
-    func extractComponentAppliesWithWarnings() async {
+    @Test("extractComponent sends the built EditMessage carrying a bare newName and applies success")
+    func extractComponentApplies() async {
         let router = RecordingRouter(reply: EditReply(
             id: "x",
             status: .applied,
             message: nil,
-            extractResult: EditReply.ExtractComponentResult(
-                componentPath: "src/components/Hero.astro",
-                hoistedProps: ["title"],
-                warnings: ["Could not migrate a complex style rule."]
-            )
+            newFile: "src/components/Hero.astro"
         ))
         let model = makeModel(router: router)
-        let applied = await model.extractComponent(nodeId: "n3", newComponentPath: "src/components/Hero.astro")
+        let applied = await model.extractComponent(nodeId: "n3", newName: "Hero")
         #expect(applied)
         #expect(router.lastMessage?.op == EditMessage.Op.extractComponent)
-        #expect(model.extractWarnings == ["Could not migrate a complex style rule."])
+        // The op carries the bare name straight through as `newName` — no client-side path building.
+        guard case .object(let obj)? = router.lastMessage?.component else { Issue.record("expected object component payload"); return }
+        #expect(obj["newName"] == .string("Hero"))
+        #expect(obj["nodeId"] == .string("n3"))
     }
 
-    @Test("extractComponent with no warnings leaves the banner state nil")
-    func extractComponentAppliesWithoutWarnings() async {
-        let router = RecordingRouter(reply: EditReply(
-            id: "x",
-            status: .applied,
-            message: nil,
-            extractResult: EditReply.ExtractComponentResult(
-                componentPath: "src/components/Hero.astro",
-                hoistedProps: [],
-                warnings: []
-            )
-        ))
-        let model = makeModel(router: router)
-        let applied = await model.extractComponent(nodeId: "n3", newComponentPath: "src/components/Hero.astro")
-        #expect(applied)
-        #expect(model.extractWarnings == nil)
-    }
-
-    @Test("extractComponent surfaces a plugin refusal via writeError")
+    @Test("extractComponent surfaces a plugin already-exists refusal via writeError")
     func extractComponentRefusalSurfacesWriteError() async {
-        let router = RecordingRouter(reply: EditReply(id: "x", status: .failed, message: "That component already exists.", reason: "exists"))
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .failed, message: "That component already exists.", reason: "already-exists"))
         let model = makeModel(router: router)
-        let applied = await model.extractComponent(nodeId: "n3", newComponentPath: "src/components/Hero.astro")
+        let applied = await model.extractComponent(nodeId: "n3", newName: "Hero")
         #expect(!applied)
         #expect(model.writeError == "That component already exists.")
+        #expect(!model.conflict)
+    }
+
+    @Test("extractComponent surfaces a dynamic-expression refusal via writeError")
+    func extractComponentDynamicExpressionSurfacesWriteError() async {
+        // `dynamic-expression` is a routine, non-`stale` refusal, so it flows through the generic
+        // failure branch into `writeError` exactly like `already-exists` — no special-casing.
+        let router = RecordingRouter(reply: EditReply(id: "x", status: .failed, message: "Can't extract a subtree with dynamic content.", reason: "dynamic-expression"))
+        let model = makeModel(router: router)
+        let applied = await model.extractComponent(nodeId: "n3", newName: "Hero")
+        #expect(!applied)
+        #expect(model.writeError == "Can't extract a subtree with dynamic content.")
         #expect(!model.conflict)
     }
 
@@ -118,7 +111,7 @@ struct ComponentEditorModelStructureEditTests {
     func extractComponentStaleFlipsConflict() async {
         let router = RecordingRouter(reply: EditReply(id: "x", status: .failed, message: "stale", reason: "stale"))
         let model = makeModel(router: router)
-        let applied = await model.extractComponent(nodeId: "n3", newComponentPath: "src/components/Hero.astro")
+        let applied = await model.extractComponent(nodeId: "n3", newName: "Hero")
         #expect(!applied)
         #expect(model.conflict)
     }

--- a/Tests/AnglesiteCoreTests/ComponentOutlineTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentOutlineTests.swift
@@ -35,6 +35,22 @@ struct ComponentOutlineTests {
         #expect(rows.first?.isSealed == false)
     }
 
+    @Test(
+        "isExtractable is true only for .element and .component node kinds",
+        arguments: [
+            (ComponentModel.Node.Kind.fragment, false),
+            (ComponentModel.Node.Kind.element, true),
+            (ComponentModel.Node.Kind.component, true),
+            (ComponentModel.Node.Kind.expression, false),
+            (ComponentModel.Node.Kind.slot, false),
+            (ComponentModel.Node.Kind.text, false),
+        ]
+    )
+    func isExtractable(kind: ComponentModel.Node.Kind, expected: Bool) {
+        let node = ComponentModel.Node(id: "n0", kind: kind, tag: nil, attrs: [], span: .init(start: nil, end: nil), loc: nil, text: nil, children: [])
+        #expect(ComponentOutline.isExtractable(node) == expected)
+    }
+
     @Test("Loc lookup finds an exact line+column match") func locLookupExact() throws {
         let root = try model().template
         #expect(ComponentOutline.node(atLine: 7, column: 1, in: root)?.id == "n1")

--- a/Tests/AnglesiteCoreTests/ComponentStructureEditBuilderTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentStructureEditBuilderTests.swift
@@ -71,4 +71,21 @@ import Testing
         guard case .object(let obj)? = message.component else { Issue.record("expected object component payload"); return }
         #expect(obj["value"] == .null)
     }
+
+    @Test("extractComponent carries nodeId and newComponentPath")
+    func extractComponentShape() {
+        let message = ComponentStructureEditBuilder.extractComponent(
+            id: "id-7",
+            path: "src/components/Card.astro",
+            baseVersion: "sha256:abc",
+            nodeId: "n3",
+            newComponentPath: "src/components/Hero.astro"
+        )
+        #expect(message.op == EditMessage.Op.extractComponent)
+        guard case .object(let obj)? = message.component else { Issue.record("expected object component payload"); return }
+        #expect(obj["path"] == .string("src/components/Card.astro"))
+        #expect(obj["baseVersion"] == .string("sha256:abc"))
+        #expect(obj["nodeId"] == .string("n3"))
+        #expect(obj["newComponentPath"] == .string("src/components/Hero.astro"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/ComponentStructureEditBuilderTests.swift
+++ b/Tests/AnglesiteCoreTests/ComponentStructureEditBuilderTests.swift
@@ -72,20 +72,23 @@ import Testing
         #expect(obj["value"] == .null)
     }
 
-    @Test("extractComponent carries nodeId and newComponentPath")
+    @Test("extractComponent carries nodeId and a bare newName")
     func extractComponentShape() {
         let message = ComponentStructureEditBuilder.extractComponent(
             id: "id-7",
             path: "src/components/Card.astro",
             baseVersion: "sha256:abc",
             nodeId: "n3",
-            newComponentPath: "src/components/Hero.astro"
+            newName: "Hero"
         )
         #expect(message.op == EditMessage.Op.extractComponent)
         guard case .object(let obj)? = message.component else { Issue.record("expected object component payload"); return }
         #expect(obj["path"] == .string("src/components/Card.astro"))
         #expect(obj["baseVersion"] == .string("sha256:abc"))
         #expect(obj["nodeId"] == .string("n3"))
-        #expect(obj["newComponentPath"] == .string("src/components/Hero.astro"))
+        // Bare PascalCase identifier — no path prefix, no `.astro` suffix (the server derives the
+        // full path), and no leftover `newComponentPath` key.
+        #expect(obj["newName"] == .string("Hero"))
+        #expect(obj["newComponentPath"] == nil)
     }
 }

--- a/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
@@ -96,8 +96,10 @@ struct MCPApplyEditRouterTests {
         #expect(reply.result?.srcset == "/images/hero-480w.webp 480w")
     }
 
-    @Test("Successful reply with extract result exposes componentPath, hoistedProps, warnings") func successfulReplyWithExtractResultExposesExtractResult() async {
-        let body = #"{"type":"anglesite:edit-applied","id":"e-1","file":"src/components/Card.astro","range":{"start":40,"end":120},"commit":"abc1234567890abcdef1234567890abcdef12345","result":{"componentPath":"src/components/Hero.astro","hoistedProps":["title","subtitle"],"warnings":["Left a complex style rule behind."]}}"#
+    @Test("Successful reply with a top-level newFile exposes newFile, no result object") func successfulReplyWithNewFileExposesNewFile() async {
+        // `extract-component` reports the created file as a plain top-level `newFile` string
+        // (sibling to `file`/`commit`), with NO `result` object at all.
+        let body = #"{"type":"anglesite:edit-applied","id":"e-1","file":"src/components/Card.astro","range":{"start":40,"end":120},"commit":"abc1234567890abcdef1234567890abcdef12345","newFile":"src/components/Hero.astro"}"#
         let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(
             content: [.init(type: "text", text: body)],
             isError: false
@@ -105,10 +107,9 @@ struct MCPApplyEditRouterTests {
         let router = MCPApplyEditRouter(toolCaller: { try await recorder.call(name: $0, arguments: $1) })
         let reply = await router.apply(sampleMessage)
         #expect(reply.status == .applied)
+        #expect(reply.file == "src/components/Card.astro")
+        #expect(reply.newFile == "src/components/Hero.astro")
         #expect(reply.result == nil)
-        #expect(reply.extractResult?.componentPath == "src/components/Hero.astro")
-        #expect(reply.extractResult?.hoistedProps == ["title", "subtitle"])
-        #expect(reply.extractResult?.warnings == ["Left a complex style rule behind."])
     }
 
     @Test("Malformed reply text falls back to message string") func malformedReplyTextFallsBackToMessageString() async {

--- a/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
@@ -96,6 +96,21 @@ struct MCPApplyEditRouterTests {
         #expect(reply.result?.srcset == "/images/hero-480w.webp 480w")
     }
 
+    @Test("Successful reply with extract result exposes componentPath, hoistedProps, warnings") func successfulReplyWithExtractResultExposesExtractResult() async {
+        let body = #"{"type":"anglesite:edit-applied","id":"e-1","file":"src/components/Card.astro","range":{"start":40,"end":120},"commit":"abc1234567890abcdef1234567890abcdef12345","result":{"componentPath":"src/components/Hero.astro","hoistedProps":["title","subtitle"],"warnings":["Left a complex style rule behind."]}}"#
+        let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(
+            content: [.init(type: "text", text: body)],
+            isError: false
+        )))
+        let router = MCPApplyEditRouter(toolCaller: { try await recorder.call(name: $0, arguments: $1) })
+        let reply = await router.apply(sampleMessage)
+        #expect(reply.status == .applied)
+        #expect(reply.result == nil)
+        #expect(reply.extractResult?.componentPath == "src/components/Hero.astro")
+        #expect(reply.extractResult?.hoistedProps == ["title", "subtitle"])
+        #expect(reply.extractResult?.warnings == ["Left a complex style rule behind."])
+    }
+
     @Test("Malformed reply text falls back to message string") func malformedReplyTextFallsBackToMessageString() async {
         let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(
             content: [.init(type: "text", text: "not valid json {")],


### PR DESCRIPTION
## Summary

App-side half of Component Editor Slice 5's "Extract into Component…" (#495) — the client wiring for the plugin's `extract-component` `apply_edit` op, which shipped in plugin **v1.7.0** ([Anglesite/anglesite#420](https://github.com/Anglesite/anglesite/pull/420)). This branch was reworked to match that merged wire contract exactly — an earlier revision targeted an assumed contract from a since-closed, superseded plugin PR that never landed.

- New context-menu item on the outline: **Extract into Component…**, enabled for `.element`/`.component` node kinds (gating logic lives in `ComponentOutline.isExtractable(_:)`, Core, unit-tested).
- A `NewComponentSheet`-style name-prompt sheet (`ExtractComponentSheet`) collects a bare component name and passes it straight through as the op's `newName` — the plugin derives the full `src/components/<Name>.astro` path itself. No client-side path construction.
- `EditReply` gains a simple additive `newFile: String?` — the plugin reports the brand-new file it created as a plain **top-level string** on its `edit-applied` body (sibling to `file`/`commit`, not nested under `result`). Every existing `EditReply(...)` call site compiles unchanged.
- On a successful extract, the palette (`projectComponents`) is rescanned so the newly-created component appears immediately.

### Wire contract (as merged in plugin v1.7.0)

- **Request** `component`: `{ path, baseVersion, nodeId, newName }`, where `newName` is a bare PascalCase identifier (no path, no `.astro`) validated server-side.
- **Success** `edit-applied`: existing `file` (the source file), `commit`, `model`, plus a top-level `newFile` string. There is **no** `result` object for this op.
- **Failure** `edit-failed` `reason`: `invalid-input`, `already-exists` (note: not `exists`), `no-match`, `stale`, `dynamic-expression` (the server refuses the whole extraction if the subtree has any dynamic content — it never partially hoists), `write-failed`. Dry-run is unsupported for this op.
- The server hoists obvious literal attribute/text values automatically and silently — there is **no** `hoistedProps` array and **no** non-blocking `warnings`.

### Explicitly out of scope for this PR

Per the design doc's §9 slice-5 bullet, three other items bundled with "extract-component" there are separate pieces of work deliberately **not** touched here: duplicate-and-modify, media-query editing, and viewport-preset polish. Also out of scope: `dry_run` preview UI for this op (the server refuses dry-run for extract-component anyway).

### Known follow-ups (not blocking)

- No success toast yet (e.g. "Extracted into Hero.astro") — `reply.newFile` is decoded and available to wire one up later.
- Client-side name validation is a thin non-empty + uppercase-first-letter check; it doesn't reject `/`/`.` — the plugin's own `COMPONENT_NAME_RE` validation is the real backstop and its `invalid-input`/`already-exists`/`dynamic-expression` refusals surface via the sheet's error message (all non-`stale` refusals flow through the generic `writeError` path — no per-reason special-casing needed).
- A `stale` refusal shows a generic in-sheet message rather than a stale-specific one (the separate conflict banner explains the reload); minor UX polish for later.
- No `MIN_PLUGIN_VERSION`-style pin needed — that mechanism was retired in #772; the dev container now stages whatever plugin `server/` the sibling checkout provides.

## Paired PR check

- [ ] This change is **self-contained** to `Anglesite-app`.
- [x] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link: [Anglesite/anglesite#420](https://github.com/Anglesite/anglesite/pull/420) — **already merged and released as plugin v1.7.0**, so this app PR is safe to merge on its own timeline; it consumes an already-shipped sidecar, not a pending one.

## Test plan

- [x] `swift test --package-path .` — 2033 tests / 291 suites passed, plus hosted app-test binaries, zero failures.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**, run in this session against this branch.
- [ ] Manual smoke (if UI-touching): **attempted, blocked by a pre-existing environment issue, not by this change.** Launched the freshly-built `Anglesite.app` from this branch (`open` on the built bundle, then `open_application`/computer-use) to click through: right-click an element row in a component's outline → Extract into Component… → confirm the sheet creates the new file and updates the outline/palette; a colliding/invalid name surfaces the plugin's error in-sheet. The app crashed at launch every time (6/6 attempts, `~/Library/Logs/DiagnosticReports/`), all with the identical cause: `EXC_CRASH`/`SIGABRT`, `DYLD Symbol missing` — `Symbol not found: _$s16FoundationModels10AttachmentVA2A05ImageC7ContentVRszrlE8imageURL...`, referenced from `Anglesite.debug.dylib`, expected in `FoundationModels.framework`. This is the exact issue `Package.swift` already documents for `#541` (Xcode 27 beta SDK exports a `FoundationModels` symbol the installed macOS 27 beta seed — `27A5218g` here — doesn't yet provide; SPM test targets are weak-linked around it per that comment, but the app target's own linking isn't, so the compiled `.app` aborts at `dyld` load time before any of my code runs). Not something this PR should try to work around — it's a pre-existing, tracked, environment-specific gap unrelated to the extract-component feature. Manual GUI verification still needs a human (or an agent on a non-beta macOS) pass before merge.
- [x] Reviewed against the merged wire contract; gating logic lives in Core with CI coverage (commit `8381b1c3`); wire-contract correction verified line-by-line against the plugin's merged source (commit `3a9711f3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
