### PR TITLE
fix(ui): mark PlistEditorModel.DirtyFacet as private (#741 follow-up)

### DIFF
--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -354,7 +354,7 @@ final class PlistEditorModel {
     /// over `dirtyFacets` instead of checking each pane by name, so a future settings pane (e.g. a
     /// `.well-known` tab) is registered here and needs no edits anywhere else — including
     /// `SiteWindowModel`'s save/close switch statements.
-    struct DirtyFacet {
+    private struct DirtyFacet {
         let isDirty: Bool
         let isSaving: Bool
         let save: () async -> Void


### PR DESCRIPTION
## Summary

- Follow-up to #804. Review on that PR asked for `DirtyFacet` (the `#741` dirty-facet aggregation seam's implementation-detail type) to be marked `private` before merge — I applied the edit locally but never committed it before force-pushing and merging, so #804 landed without it. This PR is that one-line fix.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change needs a paired PR in `Anglesite/anglesite`.

## Test plan

- [x] `swift test --package-path . --filter "PlistEditorModelDirtyFacetsTests|SiteWindowModelSettingsAggregationTests"` — 12/12 pass.
- [x] `swift build --package-path .` — succeeds.
- [ ] `xcodebuild` app-target build / manual smoke — not run; this is a private-access-modifier-only change with no behavior difference.