### PR TITLE
feat(ui): add Crawlers settings tab for BLOCK_AI and CONTENT_SIGNALS (#693)

### DIFF
--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -37,10 +37,15 @@ final class PlistEditorModel {
     private(set) var isSavingRedirects = false
     private(set) var redirectsLoadFailed = false
     var conflictDiskContents: String?
+    var crawlerPolicySettings = CrawlerPolicyAsset.Settings()
+    private(set) var savedCrawlerPolicySettings = CrawlerPolicyAsset.Settings()
+    private(set) var crawlerPolicyError: String?
+    private(set) var isSavingCrawlerPolicy = false
 
     var isDirty: Bool { entries != savedEntries && loadError == nil && !isLoading }
     var isAnalyticsDirty: Bool { analyticsSettings != savedAnalyticsSettings && loadError == nil && !isLoading }
     var isRedirectsDirty: Bool { redirectEntries != savedRedirectEntries && loadError == nil && !isLoading }
+    var isCrawlerPolicyDirty: Bool { crawlerPolicySettings != savedCrawlerPolicySettings && loadError == nil && !isLoading }
     var cloudflareAnalyticsEnabled: Bool { !analyticsSettings.cloudflareToken.isEmpty }
     var customAnalyticsValidationMessage: String? {
         WebsiteAnalyticsAsset.customHeadTagValidationMessage(analyticsSettings.customHeadTag)
@@ -113,6 +118,15 @@ final class PlistEditorModel {
                 redirectsError = "Couldn't load existing redirects.json — it may be corrupted or hand-edited with invalid entries. Fix it externally or your next save will discard it. (\(error.localizedDescription))"
                 redirectsLoadFailed = true
             }
+            do {
+                let config = try WebsiteAnalyticsAsset.loadConfig(siteDirectory: sourceDirectory)
+                let policy = CrawlerPolicyAsset.parseSettings(from: config)
+                crawlerPolicySettings = policy
+                savedCrawlerPolicySettings = policy
+                crawlerPolicyError = nil
+            } catch {
+                crawlerPolicyError = "Couldn't load crawler policy settings: \(error.localizedDescription)"
+            }
         } catch {
             loadError = error.localizedDescription
         }
@@ -161,7 +175,10 @@ final class PlistEditorModel {
             guard await saveAnalytics() else { return false }
         }
         if isRedirectsDirty {
-            return await saveRedirects()
+            guard await saveRedirects() else { return false }
+        }
+        if isCrawlerPolicyDirty {
+            return await saveCrawlerPolicy()
         }
         return true
     }
@@ -266,6 +283,27 @@ final class PlistEditorModel {
         }
     }
 
+    @discardableResult
+    func saveCrawlerPolicy() async -> Bool {
+        guard isCrawlerPolicyDirty else { return true }
+        guard !isSavingCrawlerPolicy else { return false }
+        isSavingCrawlerPolicy = true
+        crawlerPolicyError = nil
+        defer { isSavingCrawlerPolicy = false }
+        let sourceDirectory = sourceDirectory
+        let settings = crawlerPolicySettings
+        do {
+            try await Task.detached(priority: .userInitiated) {
+                try CrawlerPolicyAsset.install(settings, siteDirectory: sourceDirectory)
+            }.value
+            savedCrawlerPolicySettings = settings
+            return true
+        } catch {
+            crawlerPolicyError = "Couldn't save crawler policy: \(error.localizedDescription)"
+            return false
+        }
+    }
+
     func setCloudflareAnalyticsEnabled(_ enabled: Bool) async {
         if !enabled {
             analyticsSettings.cloudflareToken = ""
@@ -365,6 +403,7 @@ final class PlistEditorModel {
             DirtyFacet(isDirty: isDirty, isSaving: isSaving) { await self.save() },
             DirtyFacet(isDirty: isAnalyticsDirty, isSaving: isSavingAnalytics) { await self.saveAnalytics() },
             DirtyFacet(isDirty: isRedirectsDirty, isSaving: isSavingRedirects) { await self.saveRedirects() },
+            DirtyFacet(isDirty: isCrawlerPolicyDirty, isSaving: isSavingCrawlerPolicy) { await self.saveCrawlerPolicy() },
         ]
     }
 

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -102,7 +102,7 @@ final class PlistEditorModel {
             lastModified = loaded.modificationDate
             loadError = nil
             hasWebsiteIcons = WebsiteIconInstaller.hasInstalledIcons(in: sourceDirectory)
-            let analytics = try Self.loadAnalyticsSettings(sourceDirectory: sourceDirectory)
+            let (analytics, config) = try Self.loadAnalyticsSettings(sourceDirectory: sourceDirectory)
             analyticsSettings = analytics
             savedAnalyticsSettings = analytics
             analyticsError = nil
@@ -118,15 +118,13 @@ final class PlistEditorModel {
                 redirectsError = "Couldn't load existing redirects.json — it may be corrupted or hand-edited with invalid entries. Fix it externally or your next save will discard it. (\(error.localizedDescription))"
                 redirectsLoadFailed = true
             }
-            do {
-                let config = try WebsiteAnalyticsAsset.loadConfig(siteDirectory: sourceDirectory)
-                let policy = CrawlerPolicyAsset.parseSettings(from: config)
-                crawlerPolicySettings = policy
-                savedCrawlerPolicySettings = policy
-                crawlerPolicyError = nil
-            } catch {
-                crawlerPolicyError = "Couldn't load crawler policy settings: \(error.localizedDescription)"
-            }
+            // Reuses the `.site-config` contents `loadAnalyticsSettings` already read — a load
+            // failure there already aborts this whole `load()` via the outer `catch` below, so
+            // there's no separate failure mode here to handle.
+            let policy = CrawlerPolicyAsset.parseSettings(from: config)
+            crawlerPolicySettings = policy
+            savedCrawlerPolicySettings = policy
+            crawlerPolicyError = nil
         } catch {
             loadError = error.localizedDescription
         }
@@ -331,14 +329,19 @@ final class PlistEditorModel {
         }
     }
 
-    private static func loadAnalyticsSettings(sourceDirectory: URL) throws -> WebsiteAnalyticsAsset.Settings {
+    /// Also returns the raw `.site-config` contents alongside the parsed analytics settings, so
+    /// `load()` can reuse them for `CrawlerPolicyAsset.parseSettings` instead of reading the file
+    /// from disk a second time.
+    private static func loadAnalyticsSettings(
+        sourceDirectory: URL
+    ) throws -> (settings: WebsiteAnalyticsAsset.Settings, config: String) {
         let layoutURL = sourceDirectory.appendingPathComponent(WebsiteAnalyticsAsset.layoutRelativePath)
         let config = try WebsiteAnalyticsAsset.loadConfig(siteDirectory: sourceDirectory)
         guard FileManager.default.fileExists(atPath: layoutURL.path) else {
-            return WebsiteAnalyticsAsset.parseMigratingLegacySettings(layoutSource: "", config: config)
+            return (WebsiteAnalyticsAsset.parseMigratingLegacySettings(layoutSource: "", config: config), config)
         }
         let source = try String(contentsOf: layoutURL, encoding: .utf8)
-        return WebsiteAnalyticsAsset.parseMigratingLegacySettings(layoutSource: source, config: config)
+        return (WebsiteAnalyticsAsset.parseMigratingLegacySettings(layoutSource: source, config: config), config)
     }
 
     private func cloudflareToken() async throws -> String? {

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -10,6 +10,7 @@ struct PlistEditorView: View {
         case website = "Website"
         case analytics = "Analytics"
         case redirects = "Redirects"
+        case crawlers = "Crawlers"
         var id: Self { self }
     }
 
@@ -35,6 +36,8 @@ struct PlistEditorView: View {
                 Task { await model.saveAnalytics() }
             } else if oldValue == .redirects {
                 Task { await model.saveRedirects() }
+            } else if oldValue == .crawlers {
+                Task { await model.saveCrawlerPolicy() }
             }
         }
         .onChange(of: controlActiveState) { _, new in
@@ -52,7 +55,7 @@ struct PlistEditorView: View {
         HStack {
             Label("Settings", systemImage: "gearshape")
                 .font(.headline)
-            if model.isDirty || model.isAnalyticsDirty || model.isRedirectsDirty {
+            if model.hasAnyUnsavedEdits {
                 Circle().fill(.secondary).frame(width: 7, height: 7)
                     .help("Unsaved changes")
             }
@@ -106,6 +109,11 @@ struct PlistEditorView: View {
                             .foregroundStyle(.orange)
                             .font(.callout)
                     }
+                    if selectedTab != .crawlers, let crawlerPolicyError = model.crawlerPolicyError {
+                        Label(crawlerPolicyError, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .font(.callout)
+                    }
 
                     switch selectedTab {
                     case .website:
@@ -114,6 +122,8 @@ struct PlistEditorView: View {
                         analyticsTab
                     case .redirects:
                         redirectsTab
+                    case .crawlers:
+                        crawlersTab
                     }
                 }
                 .padding()
@@ -323,6 +333,72 @@ struct PlistEditorView: View {
                     model.redirectEntries[index].code = newValue
                 }
             })
+    }
+
+    private var crawlersTab: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 6) {
+                Toggle("Block AI Training Crawlers", isOn: $model.crawlerPolicySettings.blockAI)
+                    .toggleStyle(.switch)
+                Text("Adds robots.txt rules refusing known AI-training crawlers (GPTBot, ClaudeBot, and others). This reduces your site's visibility to AI assistants and AI-generated search summaries — it does not affect traditional search engines.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Content Signals")
+                    .font(.headline)
+                Text("Cloudflare's Content Signals Policy states a usage preference per purpose in robots.txt. It's a signal that well-behaved crawlers honor, not an enforced block.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                contentSignalRow(
+                    title: "Search",
+                    help: "Show this content in traditional search results.",
+                    value: $model.crawlerPolicySettings.search
+                )
+                contentSignalRow(
+                    title: "AI Answers",
+                    help: "Let AI assistants use this content to answer a live question (e.g. retrieval-augmented generation).",
+                    value: $model.crawlerPolicySettings.aiInput
+                )
+                contentSignalRow(
+                    title: "AI Training",
+                    help: "Let AI systems use this content to train models.",
+                    value: $model.crawlerPolicySettings.aiTrain
+                )
+            }
+
+            if model.isSavingCrawlerPolicy {
+                ProgressView().controlSize(.small)
+            }
+        }
+    }
+
+    private func contentSignalRow(
+        title: String,
+        help: String,
+        value: Binding<CrawlerPolicyAsset.ContentSignalValue>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(title)
+                    .frame(minWidth: 160, alignment: .leading)
+                Picker(title, selection: value) {
+                    Text("Unspecified").tag(CrawlerPolicyAsset.ContentSignalValue.unset)
+                    Text("Allow").tag(CrawlerPolicyAsset.ContentSignalValue.yes)
+                    Text("Disallow").tag(CrawlerPolicyAsset.ContentSignalValue.no)
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 260)
+            }
+            Text(help)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
     }
 
     private var conflictBinding: Binding<Bool> {

--- a/Sources/AnglesiteCore/CrawlerPolicyAsset.swift
+++ b/Sources/AnglesiteCore/CrawlerPolicyAsset.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Reads/writes the `BLOCK_AI` and `CONTENT_SIGNALS` `.site-config` keys that
+/// `Resources/Template/scripts/edge-artifacts.ts` consumes to generate `robots.txt` (#408, #693).
+/// Follows the same "read whole `.site-config`, `SiteConfigFile.upsert`, write back" pattern as
+/// `WebsiteAnalyticsAsset.install` — this asset owns no file of its own, just two keys in the
+/// site's shared `.site-config`.
+public enum CrawlerPolicyAsset {
+    /// A Cloudflare Content Signals Policy sub-directive's value
+    /// (https://blog.cloudflare.com/content-signals-policy/). `unset` means the site expresses no
+    /// preference for that purpose — `edge-artifacts.ts`'s `normalizeContentSignal` omits it from
+    /// the emitted `Content-Signal` directive entirely, it is never written as `key=unset`.
+    public enum ContentSignalValue: String, Sendable, CaseIterable, Identifiable, Equatable {
+        case unset
+        case yes
+        case no
+        public var id: Self { self }
+    }
+
+    public struct Settings: Sendable, Equatable {
+        public var blockAI: Bool
+        public var search: ContentSignalValue
+        public var aiInput: ContentSignalValue
+        public var aiTrain: ContentSignalValue
+
+        public init(
+            blockAI: Bool = false,
+            search: ContentSignalValue = .unset,
+            aiInput: ContentSignalValue = .unset,
+            aiTrain: ContentSignalValue = .unset
+        ) {
+            self.blockAI = blockAI
+            self.search = search
+            self.aiInput = aiInput
+            self.aiTrain = aiTrain
+        }
+    }
+
+    /// The three sub-directive keys `edge-artifacts.ts`'s `normalizeContentSignal` recognizes, in
+    /// the order they're emitted. Any other key in a hand-edited `CONTENT_SIGNALS` value is dropped
+    /// on the next save, matching the TS side's behavior of dropping unrecognized keys.
+    private static let contentSignalKeys: [(key: String, keyPath: WritableKeyPath<Settings, ContentSignalValue>)] = [
+        ("search", \.search),
+        ("ai-input", \.aiInput),
+        ("ai-train", \.aiTrain),
+    ]
+
+    public static func parseSettings(from config: String) -> Settings {
+        let blockAI = (SiteConfigFile.value(forKey: "BLOCK_AI", in: config) ?? "")
+            .trimmingCharacters(in: .whitespaces).lowercased() == "true"
+        var settings = Settings(blockAI: blockAI)
+        let raw = SiteConfigFile.value(forKey: "CONTENT_SIGNALS", in: config) ?? ""
+        for part in raw.split(separator: ",") {
+            let pair = part.trimmingCharacters(in: .whitespaces).split(separator: "=", maxSplits: 1)
+            guard pair.count == 2, let match = contentSignalKeys.first(where: { $0.key == pair[0] }) else { continue }
+            // Only "yes"/"no" are ever written by edge-artifacts.ts; anything else (including a
+            // hand-edited "unset") is treated the same as the key being absent.
+            guard let value = ContentSignalValue(rawValue: String(pair[1])), value != .unset else { continue }
+            settings[keyPath: match.keyPath] = value
+        }
+        return settings
+    }
+
+    public static func install(_ settings: Settings, siteDirectory: URL, fileManager: FileManager = .default) throws {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        let updatedConfig = SiteConfigFile.upsert([
+            ("BLOCK_AI", settings.blockAI ? "true" : "false"),
+            ("CONTENT_SIGNALS", contentSignalValue(for: settings)),
+        ], into: config)
+        guard updatedConfig != config else { return }
+        try updatedConfig.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func contentSignalValue(for settings: Settings) -> String {
+        contentSignalKeys
+            .compactMap { key, keyPath -> String? in
+                let value = settings[keyPath: keyPath]
+                guard value != .unset else { return nil }
+                return "\(key)=\(value.rawValue)"
+            }
+            .joined(separator: ", ")
+    }
+}

--- a/Tests/AnglesiteAppTests/PlistEditorModelCrawlerPolicyTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelCrawlerPolicyTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+@Suite("PlistEditorModel crawler policy (#693)")
+@MainActor
+struct PlistEditorModelCrawlerPolicyTests {
+    private static let emptyPlist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict/></plist>
+        """
+
+    /// Builds a `PlistEditorModel` against a fresh temp `sourceDirectory` with a minimal
+    /// `Info.plist` and, when given, a `.site-config` — `PlistEditorModel.load()` reads both.
+    private func makeModel(siteConfig: String? = nil) throws -> PlistEditorModel {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PlistEditorModelCrawlerPolicyTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let plistURL = dir.appendingPathComponent("Info.plist")
+        try Self.emptyPlist.write(to: plistURL, atomically: true, encoding: .utf8)
+        if let siteConfig {
+            try siteConfig.write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        }
+        let file = FileRef(url: plistURL, group: .metadata, name: "Info.plist")
+        return PlistEditorModel(file: file, websiteTitle: "Test Site", sourceDirectory: dir)
+    }
+
+    @Test("load() defaults crawlerPolicySettings when .site-config is absent")
+    func loadDefaultsWhenAbsent() async throws {
+        let model = try makeModel()
+        await model.load()
+        #expect(model.crawlerPolicySettings == CrawlerPolicyAsset.Settings())
+        #expect(model.isCrawlerPolicyDirty == false)
+    }
+
+    @Test("load() populates crawlerPolicySettings from an existing .site-config")
+    func loadPopulatesFromExistingConfig() async throws {
+        let model = try makeModel(siteConfig: "BLOCK_AI=true\nCONTENT_SIGNALS=search=yes, ai-train=no\n")
+        await model.load()
+        #expect(model.crawlerPolicySettings.blockAI == true)
+        #expect(model.crawlerPolicySettings.search == .yes)
+        #expect(model.crawlerPolicySettings.aiInput == .unset)
+        #expect(model.crawlerPolicySettings.aiTrain == .no)
+        #expect(model.isCrawlerPolicyDirty == false)
+    }
+
+    @Test("isCrawlerPolicyDirty flips true after an edit, false after saveCrawlerPolicy, and the write lands on disk")
+    func dirtyTrackingAndSave() async throws {
+        let model = try makeModel()
+        await model.load()
+        model.crawlerPolicySettings.blockAI = true
+        model.crawlerPolicySettings.aiInput = .no
+        #expect(model.isCrawlerPolicyDirty == true)
+
+        let saved = await model.saveCrawlerPolicy()
+
+        #expect(saved == true)
+        #expect(model.isCrawlerPolicyDirty == false)
+        let config = try String(contentsOf: model.sourceDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(CrawlerPolicyAsset.parseSettings(from: config) == model.crawlerPolicySettings)
+    }
+
+    @Test("saveCrawlerPolicy no-ops (returns true, doesn't touch disk) when not dirty")
+    func saveNoOpsWhenClean() async throws {
+        let model = try makeModel()
+        await model.load()
+        #expect(model.isCrawlerPolicyDirty == false)
+
+        let saved = await model.saveCrawlerPolicy()
+
+        #expect(saved == true)
+        #expect(!FileManager.default.fileExists(atPath: model.sourceDirectory.appendingPathComponent(".site-config").path))
+    }
+}

--- a/Tests/AnglesiteAppTests/PlistEditorModelDirtyFacetsTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelDirtyFacetsTests.swift
@@ -104,6 +104,31 @@ struct PlistEditorModelDirtyFacetsTests {
         #expect(model.isDirty == false, "the Website facet should still have saved despite Redirects failing validation")
     }
 
+    @Test("hasAnyUnsavedEdits reflects crawler-policy dirty state alone — the #693 facet added after this seam existed")
+    func hasAnyUnsavedEditsReflectsCrawlerPolicyAlone() async throws {
+        let model = try makeModel()
+        await model.load()
+        model.crawlerPolicySettings.blockAI = true
+        #expect(model.isDirty == false)
+        #expect(model.isRedirectsDirty == false)
+        #expect(model.isAnalyticsDirty == false)
+        #expect(model.hasAnyUnsavedEdits == true)
+    }
+
+    @Test("saveAllDirty saves a dirty crawler policy into .site-config")
+    func saveAllDirtySavesCrawlerPolicy() async throws {
+        let model = try makeModel()
+        await model.load()
+        model.crawlerPolicySettings.blockAI = true
+        model.crawlerPolicySettings.search = .no
+
+        await model.saveAllDirty()
+
+        #expect(model.isCrawlerPolicyDirty == false)
+        let config = try String(contentsOf: model.sourceDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(CrawlerPolicyAsset.parseSettings(from: config) == model.crawlerPolicySettings)
+    }
+
     @Test("isAnySaving is true while saveRedirects is in flight")
     func isAnySavingReflectsRedirectsInFlight() async throws {
         let model = try makeModel()

--- a/Tests/AnglesiteCoreTests/CrawlerPolicyAssetTests.swift
+++ b/Tests/AnglesiteCoreTests/CrawlerPolicyAssetTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("CrawlerPolicyAsset")
+struct CrawlerPolicyAssetTests {
+    // MARK: parseSettings
+
+    @Test("defaults to blockAI false and every content signal unset when the keys are absent")
+    func parseSettingsDefaults() {
+        let settings = CrawlerPolicyAsset.parseSettings(from: "SITE_NAME=Acme\n")
+        #expect(settings == CrawlerPolicyAsset.Settings())
+    }
+
+    @Test("parses BLOCK_AI=true case-insensitively")
+    func parseSettingsBlockAI() {
+        #expect(CrawlerPolicyAsset.parseSettings(from: "BLOCK_AI=true\n").blockAI == true)
+        #expect(CrawlerPolicyAsset.parseSettings(from: "BLOCK_AI=TRUE\n").blockAI == true)
+        #expect(CrawlerPolicyAsset.parseSettings(from: "BLOCK_AI=false\n").blockAI == false)
+        #expect(CrawlerPolicyAsset.parseSettings(from: "BLOCK_AI=nonsense\n").blockAI == false)
+    }
+
+    @Test("parses all three CONTENT_SIGNALS sub-directives")
+    func parseSettingsContentSignals() {
+        let settings = CrawlerPolicyAsset.parseSettings(
+            from: "CONTENT_SIGNALS=search=yes, ai-input=no, ai-train=yes\n"
+        )
+        #expect(settings.search == .yes)
+        #expect(settings.aiInput == .no)
+        #expect(settings.aiTrain == .yes)
+    }
+
+    @Test("drops unrecognized keys and values, matching edge-artifacts.ts's normalizeContentSignal")
+    func parseSettingsDropsUnrecognized() {
+        let settings = CrawlerPolicyAsset.parseSettings(
+            from: "CONTENT_SIGNALS=search=yes, bogus=yes, ai-train=maybe\n"
+        )
+        #expect(settings.search == .yes)
+        #expect(settings.aiInput == .unset)
+        #expect(settings.aiTrain == .unset)
+    }
+
+    @Test("a later duplicate key wins, matching edge-artifacts.ts's Map dedup")
+    func parseSettingsDedupesLastWins() {
+        let settings = CrawlerPolicyAsset.parseSettings(from: "CONTENT_SIGNALS=search=yes, search=no\n")
+        #expect(settings.search == .no)
+    }
+
+    @Test("ignores commented-out lines")
+    func parseSettingsIgnoresComments() {
+        let settings = CrawlerPolicyAsset.parseSettings(from: "# BLOCK_AI=true\n")
+        #expect(settings.blockAI == false)
+    }
+
+    // MARK: install
+
+    private func makeSiteDirectory() throws -> (root: URL, siteDir: URL, fm: FileManager) {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let siteDir = root.appendingPathComponent("Source")
+        try fm.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        return (root, siteDir, fm)
+    }
+
+    @Test("install writes BLOCK_AI and CONTENT_SIGNALS into .site-config")
+    func installWritesBothKeys() throws {
+        let (root, siteDir, fm) = try makeSiteDirectory()
+        defer { try? fm.removeItem(at: root) }
+        try "SITE_NAME=Acme\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        try CrawlerPolicyAsset.install(
+            CrawlerPolicyAsset.Settings(blockAI: true, search: .yes, aiInput: .no, aiTrain: .unset),
+            siteDirectory: siteDir,
+            fileManager: fm
+        )
+
+        let config = try String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(config.contains("BLOCK_AI=true"))
+        #expect(config.contains("CONTENT_SIGNALS=search=yes, ai-input=no"))
+        #expect(!config.contains("ai-train"), "an unset sub-directive must not be written at all")
+        #expect(config.contains("SITE_NAME=Acme"), "unrelated keys must survive the upsert")
+    }
+
+    @Test("install round-trips through parseSettings")
+    func installRoundTrips() throws {
+        let (root, siteDir, fm) = try makeSiteDirectory()
+        defer { try? fm.removeItem(at: root) }
+
+        let settings = CrawlerPolicyAsset.Settings(blockAI: true, search: .no, aiInput: .yes, aiTrain: .no)
+        try CrawlerPolicyAsset.install(settings, siteDirectory: siteDir, fileManager: fm)
+
+        let config = try String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(CrawlerPolicyAsset.parseSettings(from: config) == settings)
+    }
+
+    @Test("install with all-unset content signals writes CONTENT_SIGNALS as empty, not omitted")
+    func installAllUnsetWritesEmptyValue() throws {
+        // edge-artifacts.ts's normalizeContentSignal treats an empty string as falsy (no directive
+        // emitted), so writing the key with an empty value is equivalent to "no signals set" on
+        // the read side — this just documents that behavior rather than omitting the key.
+        let (root, siteDir, fm) = try makeSiteDirectory()
+        defer { try? fm.removeItem(at: root) }
+
+        try CrawlerPolicyAsset.install(CrawlerPolicyAsset.Settings(), siteDirectory: siteDir, fileManager: fm)
+
+        let config = try String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(config.contains("CONTENT_SIGNALS=\n"))
+    }
+}


### PR DESCRIPTION
## Summary

- #408 shipped `BLOCK_AI` (robots.txt AI-crawler blocking) and a newer `CONTENT_SIGNALS` key (Cloudflare Content Signals Policy — `search`/`ai-input`/`ai-train`, each yes/no) already exists in the TS build pipeline (`Resources/Template/scripts/edge-artifacts.ts`), but both were only configurable by hand-editing a site's `.site-config` — there was no Swift reader/writer or GUI for either.
- New `CrawlerPolicyAsset` (`Sources/AnglesiteCore/CrawlerPolicyAsset.swift`) mirrors `WebsiteAnalyticsAsset`'s install/parse pattern (`SiteConfigFile.upsert`, comment-safe reads) and matches `normalizeContentSignal`'s exact parsing rules (drop unrecognized keys/values, last-duplicate-wins) so the Swift and TS sides agree on the format.
- `PlistEditorModel` wires this in as a new dirty-facet in the `#741` aggregation seam (`dirtyFacets`) — zero further edits were needed in `SiteWindowModel`'s save/revert/close paths, which was exactly the point of that seam.
- `PlistEditorView` adds a new **Crawlers** tab (Website / Analytics / Redirects / Crawlers) with a `BLOCK_AI` toggle and three Allow/Disallow/Unspecified pickers for the Content Signals sub-directives, each with copy explaining what it actually grants (search index vs. RAG/live-answer input vs. training) and the discoverability tradeoff, per the issue's ask.

Closes #693.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change needs a paired PR in `Anglesite/anglesite`.

## Test plan

- [x] `swift test --package-path .` — full suite passes (2058 `AnglesiteCoreTests`, 94 `AnglesiteAppTests`), including 9 new `CrawlerPolicyAssetTests` (parse/install round-trip, unrecognized-key/dedup parity with `normalizeContentSignal`) and 6 new/updated `PlistEditorModel` tests for the new facet's dirty-tracking, save, and load-from-existing-config. Only the pre-existing, branch-independent `AnglesiteIntentsTests`/`SiteEntityQueryTests` environmental failures (#771) are unrelated exceptions.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds.
- [x] Manual GUI smoke (repo convention per #491/#586, since hosted UI isn't covered by CI): launched the built app against a real site, opened the new Crawlers tab, toggled `Block AI Training Crawlers` and set two Content Signal pickers, switched tabs to trigger the save-on-leave flush, and confirmed `.site-config` on disk read exactly `BLOCK_AI=true` / `CONTENT_SIGNALS=search=yes, ai-input=no` — then reselected the tab and confirmed the UI reflected the saved state. Restored the fixture site's original (unset) values afterward.